### PR TITLE
fix(infra): include minio in backend and worker depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,8 @@ services:
       ENABLE_HTTP: ${ENABLE_HTTP:-true}
       ENABLE_GRPC: ${ENABLE_GRPC:-true}
     depends_on:
+      minio:
+        condition: service_started
       postgres:
         condition: service_healthy
       clickhouse:
@@ -220,6 +222,8 @@ services:
       TEMPORAL_MAX_CONCURRENT_ACTIVITIES: ${TEMPORAL_MAX_CONCURRENT_ACTIVITIES:-50}
       TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS: ${TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS:-50}
     depends_on:
+      minio:
+        condition: service_started
       temporal:
         condition: service_healthy
       postgres:


### PR DESCRIPTION
## Summary

Backend and worker containers use `S3_ENDPOINT_URL=http://minio:9000` but didn't declare `minio` as a startup dependency. Running `docker compose up backend` without the full stack leaves MinIO unstarted, causing DNS resolution failures and 500 errors on any request that touches object storage (e.g. dataset creation).

Add `minio` to `depends_on` in both services so Compose starts it automatically.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Verified YAML parses: `python3 -c "import yaml; yaml.safe_load(...)"`
- `docker compose config` resolves the dependency tree correctly
- Apply and restart the stack to confirm MinIO starts before backend

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
