### PR TITLE
fix: strip country_code and remove unknown status param for StrictInputMixin

### DIFF
--- a/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
+++ b/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
@@ -187,6 +187,7 @@ const CreateNewAgentDefinitionView = () => {
           delete payload.livekit_config_json;
           delete payload.livekit_max_concurrency;
         }
+        delete payload.country_code;
         delete payload.model;
         delete payload.model_details;
       } else {

--- a/frontend/src/sections/agents/useAgentConfigForm.js
+++ b/frontend/src/sections/agents/useAgentConfigForm.js
@@ -99,6 +99,7 @@ export const useAgentSubmit = ({
           ? `+${data.countryCode}${data.contactNumber.trim()}`
           : data.contactNumber.trim();
         payload.contact_number = fullContactNumber;
+        delete payload.country_code;
         delete payload.model;
         delete payload.model_details;
 

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
@@ -78,7 +78,7 @@ const SyntheticDataDrawer = ({
   const navigate = useNavigate();
 
   const { data: knowledgeBaseList, refetch: refetchKnowledgeBaseList } =
-    useKnowledgeBaseList("", { enabled: !!open }, { status: true });
+    useKnowledgeBaseList("", { enabled: !!open });
 
   const knowledgeBaseOptions = useMemo(
     () =>


### PR DESCRIPTION
## Summary

The backend recently enabled `reject_unknown_fields` on management API serializers via `StrictInputMixin`. Two fields the frontend was sending were previously silently ignored but now cause 400 errors:

- **`country_code`** in agent definition create/edit payloads: this field exists in the frontend form but not on any backend serializer. Now stripped before sending for both voice and non-voice agents.
- **`status: true`** in knowledge base list queries: passed to `GET /model-hub/knowledge-base/get/` but `LegacyKnowledgeBaseTableQuerySerializer` only accepts `search`, `sort`, `page_number`, `page_size`. No other caller passes this param — removed.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- The `country_code` deletion mirrors the existing pattern used for `model` and `model_details` fields in the same code paths
- The `status` param removal aligns with how all other callers of `useKnowledgeBaseList` invoke it
- Both fixes are syntactic — no new logic introduced

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
