### PR TITLE
fix(ch25): route v2 trace-list user-id resolution to end_users_dict

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -15,7 +15,7 @@ Supports annotation output types:
 """
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.expressions import (
@@ -52,12 +52,12 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
         project_id: str,
         annotation_label_id: str,
         annotation_name: str = "",
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
         interval: str = "hour",
         output_type: str = "float",
         value: Any = None,
-        filters: Optional[List[Dict]] = None,
+        filters: list[dict] | None = None,
         observe_type: str = "trace",
         **kwargs: Any,
     ) -> None:
@@ -93,7 +93,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
     # Public API
     # ------------------------------------------------------------------
 
-    def build(self) -> Tuple[str, Dict[str, Any]]:
+    def build(self) -> tuple[str, dict[str, Any]]:
         """Build the annotation graph query."""
         if self.output_type == "float":
             return self._build_float_query()
@@ -109,9 +109,9 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
 
     def format_result(
         self,
-        rows: List[Tuple],
-        columns: List[str],
-    ) -> Dict[str, Any]:
+        rows: list[tuple],
+        columns: list[str],
+    ) -> dict[str, Any]:
         """Format the query results into the standard annotation graph response.
 
         Returns:
@@ -191,7 +191,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
           )
         """
 
-    def _build_float_query(self) -> Tuple[str, Dict[str, Any]]:
+    def _build_float_query(self) -> tuple[str, dict[str, Any]]:
         """Average numeric/star annotation value per time bucket."""
         bucket_fn = self.time_bucket_expr(self.interval)
         # Use the nullable extractor so rows whose JSON payload is missing
@@ -214,7 +214,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def _build_bool_query(self) -> Tuple[str, Dict[str, Any]]:
+    def _build_bool_query(self) -> tuple[str, dict[str, Any]]:
         """Percentage of annotations matching the requested bool value."""
         bucket_fn = self.time_bucket_expr(self.interval)
 
@@ -246,7 +246,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def _build_str_list_query(self) -> Tuple[str, Dict[str, Any]]:
+    def _build_str_list_query(self) -> tuple[str, dict[str, Any]]:
         """Percentage of annotations containing the requested choice."""
         bucket_fn = self.time_bucket_expr(self.interval)
 
@@ -280,7 +280,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def _build_text_query(self) -> Tuple[str, Dict[str, Any]]:
+    def _build_text_query(self) -> tuple[str, dict[str, Any]]:
         """Count of annotations per time bucket."""
         bucket_fn = self.time_bucket_expr(self.interval)
         query = f"""

--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -21,11 +21,6 @@ from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.expressions import (
     annotation_numeric_value_expr,
 )
-# CH-direct: use the v2 filter builder (rewrites span_attr_* -> attrs_*) since
-# this graph reads the v2 `spans` table. Aliased to keep the call sites unchanged.
-from tracer.services.clickhouse.v2.query_builders.filters import (
-    ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
-)
 
 
 class AnnotationGraphQueryBuilder(BaseQueryBuilder):
@@ -153,6 +148,11 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
 
     def _filtered_spans_subquery(self, select_expr: str) -> str:
         """Return the row set that defines the currently visible Observe rows."""
+        # Lazy import: a module-level import would form a v1↔v2 circular import.
+        from tracer.services.clickhouse.v2.query_builders.filters import (
+            ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
+        )
+
         query_mode = (
             ClickHouseFilterBuilder.QUERY_MODE_SPAN
             if self.observe_type == "span"

--- a/futureagi/tracer/services/clickhouse/query_builders/time_series.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/time_series.py
@@ -22,13 +22,6 @@ from datetime import datetime
 from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
-# CH-direct: the embedded filter builder must emit v2 attribute columns
-# (attrs_string/number/bool) since this builder reads the v2 `spans` table.
-# The V2 subclass rewrites span_attr_* -> attrs_* in translate(); aliased to the
-# v1 name so the call sites below are unchanged.
-from tracer.services.clickhouse.v2.query_builders.filters import (
-    ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
-)
 
 
 class TimeSeriesQueryBuilder(BaseQueryBuilder):
@@ -90,6 +83,11 @@ class TimeSeriesQueryBuilder(BaseQueryBuilder):
         Returns:
             A ``(query_string, params)`` tuple.
         """
+        # Lazy import: a module-level import would form a v1↔v2 circular import.
+        from tracer.services.clickhouse.v2.query_builders.filters import (
+            ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
+        )
+
         self.start_date, self.end_date = self.parse_time_range(self.filters)
         self.params["start_date"] = self.start_date
         self.params["end_date"] = self.end_date

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
@@ -28,10 +28,11 @@ NOTE: the filter builder (`ClickHouseFilterBuilderV2`) deliberately does NOT use
 this mixin — its `translate` / `translate_sort` emit WHERE/ORDER *fragments* that
 must not carry a trailing SETTINGS clause (would be a syntax error).
 """
+
 from __future__ import annotations
 
 import functools
-from typing import Callable
+from collections.abc import Callable
 
 from tracer.services.clickhouse.v2.query_builders.filters import (
     rewrite_and_apply_v2_settings,
@@ -66,9 +67,13 @@ def _rewrite_sql_in(result: object) -> object:
         return rewrite_and_apply_v2_settings(sql), params
 
     # [(sql, params, meta), ...] — dashboard.build_all_queries.
-    if isinstance(result, list) and result and all(
-        isinstance(el, tuple) and len(el) >= 1 and isinstance(el[0], str)
-        for el in result
+    if (
+        isinstance(result, list)
+        and result
+        and all(
+            isinstance(el, tuple) and len(el) >= 1 and isinstance(el[0], str)
+            for el in result
+        )
     ):
         rewritten = []
         for el in result:

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
@@ -1,0 +1,125 @@
+"""
+Single rewrite boundary for the v2 query builders.
+
+Every v2 builder subclasses its v1 counterpart and must translate the v1-compiled
+SQL (legacy column/dict names, String-JSON access) to the CH 25.3 schema — and
+append the v2 SETTINGS — before the SQL leaves the builder. Historically each
+builder did this by hand-overriding every SQL-emitting method to call
+`rewrite_and_apply_v2_settings()`. That override list drifted out of sync with
+the v1 base class: any newly-inherited v1 method shipped raw v1 SQL and 500'd on a
+v2-only (`CH_DATABASE=futureagi`) box — `enduser_dict` / `tracer_enduser` /
+`_peerdb_is_deleted` against objects that don't exist there (TH-5911, TH-5964).
+
+`V2RewriteMixin` moves the rewrite to ONE boundary. `__init_subclass__` wraps every
+`build*` method on the subclass — inherited from the v1 base or defined locally —
+so its emitted SQL is always routed through the rewriter. A new inherited v1 method
+cannot ship un-rewritten SQL; nobody has to remember to add an override.
+
+Mix it in FIRST so the wrapper resolves ahead of the v1 base in the MRO:
+
+    class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder): ...
+
+`rewrite_and_apply_v2_settings` is idempotent on already-v2 SQL (v1 token patterns
+don't match; the SETTINGS append merges rather than duplicates), so wrapping a
+method that already emits v2-native SQL (e.g. the trace-list rollup fast-path) is a
+harmless no-op.
+
+NOTE: the filter builder (`ClickHouseFilterBuilderV2`) deliberately does NOT use
+this mixin — its `translate` / `translate_sort` emit WHERE/ORDER *fragments* that
+must not carry a trailing SETTINGS clause (would be a syntax error).
+"""
+from __future__ import annotations
+
+import functools
+from typing import Callable
+
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    rewrite_and_apply_v2_settings,
+)
+
+# Marks a method as already wrapped, so re-subclassing never double-wraps it.
+_WRAPPED_ATTR = "_v2_rewrite_wrapped"
+
+
+def _rewrite_sql_in(result: object) -> object:
+    """Apply the v1→v2 rewrite to whatever SQL a builder method returned.
+
+    Shape-aware — covers the three real return shapes across the v1 builders:
+      • ``(sql, params)``              → rewrite ``sql``, keep ``params``
+      • ``[(sql, params, meta), ...]`` → rewrite each element's ``sql``
+        (only ``dashboard.build_all_queries``)
+      • anything else                  → returned unchanged (defensive)
+
+    A falsey ``sql`` is returned untouched so the empty-input contract
+    (e.g. ``build_user_id_query([]) -> ("", {})``) is preserved.
+    """
+    # (sql, params) tuple — the common case for every build_* method.
+    if (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and isinstance(result[0], str)
+        and isinstance(result[1], dict)
+    ):
+        sql, params = result
+        if not sql:
+            return result
+        return rewrite_and_apply_v2_settings(sql), params
+
+    # [(sql, params, meta), ...] — dashboard.build_all_queries.
+    if isinstance(result, list) and result and all(
+        isinstance(el, tuple) and len(el) >= 1 and isinstance(el[0], str)
+        for el in result
+    ):
+        rewritten = []
+        for el in result:
+            sql = el[0]
+            new_sql = sql if not sql else rewrite_and_apply_v2_settings(sql)
+            rewritten.append((new_sql, *el[1:]))
+        return rewritten
+
+    return result
+
+
+def _wrap(method: Callable[..., object]) -> Callable[..., object]:
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        return _rewrite_sql_in(method(self, *args, **kwargs))
+
+    setattr(wrapper, _WRAPPED_ATTR, True)
+    return wrapper
+
+
+class V2RewriteMixin:
+    """Route every ``build*`` method's SQL output through the v2 rewriter.
+
+    Wrapping happens at subclass-creation time, so it covers methods inherited
+    from the v1 base as well as any the subclass defines itself. The default —
+    "wrap everything" — is the safe one because almost every builder method
+    targets the migrated `spans` schema.
+
+    A method is skipped only if its name is in ``_v2_rewrite_exclude``. The sole
+    legitimate exclusions are methods whose SQL targets tables that are NOT part
+    of the CH 25.3 migration and therefore still carry the legacy column names
+    (e.g. `build_eval_query` / `build_annotation_query`, which read the legacy
+    `tracer_eval_logger` / `model_hub_score` tables that keep
+    `_peerdb_is_deleted`). Rewriting those would break them. Keep the exclude set
+    small and document each entry at the subclass.
+    """
+
+    # Subclasses override with the set of `build*` method names that must NOT be
+    # rewritten (they target non-migrated legacy tables). See class docstring.
+    _v2_rewrite_exclude: frozenset[str] = frozenset()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        exclude = cls._v2_rewrite_exclude
+        for name in dir(cls):
+            if not name.startswith("build") or name in exclude:
+                continue
+            method = getattr(cls, name, None)
+            if not callable(method) or getattr(method, _WRAPPED_ATTR, False):
+                continue
+            setattr(cls, name, _wrap(method))
+
+
+__all__ = ["V2RewriteMixin"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
@@ -19,10 +19,14 @@ Mix it in FIRST so the wrapper resolves ahead of the v1 base in the MRO:
 
     class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder): ...
 
-`rewrite_and_apply_v2_settings` is idempotent on already-v2 SQL (v1 token patterns
-don't match; the SETTINGS append merges rather than duplicates), so wrapping a
-method that already emits v2-native SQL (e.g. the trace-list rollup fast-path) is a
-harmless no-op.
+The two halves of the rewrite are applied with different scope. The v1→v2 token
+rewrite (`rewrite_v1_sql_to_v2`) always runs — it's a word-boundary substitution,
+idempotent on already-v2 SQL and a no-op on a string with no v1 tokens, so it's
+safe on a SQL fragment or a non-SQL value alike. The SETTINGS append
+(`_append_v2_settings`) runs ONLY when the emitted SQL is a complete `SELECT`/`WITH`
+statement (`_is_statement`): a fragment or a non-SQL `(cache_key, meta)` return
+must not get a trailing SETTINGS clause. So wrapping a method that already emits
+v2-native SQL (e.g. the trace-list rollup fast-path) is a harmless no-op.
 
 NOTE: the filter builder (`ClickHouseFilterBuilderV2`) deliberately does NOT use
 this mixin — its `translate` / `translate_sort` emit WHERE/ORDER *fragments* that
@@ -35,11 +39,23 @@ import functools
 from collections.abc import Callable
 
 from tracer.services.clickhouse.v2.query_builders.filters import (
-    rewrite_and_apply_v2_settings,
+    _append_v2_settings,
+    rewrite_v1_sql_to_v2,
 )
 
 # Marks a method as already wrapped, so re-subclassing never double-wraps it.
 _WRAPPED_ATTR = "_v2_rewrite_wrapped"
+
+
+def _is_statement(sql: str) -> bool:
+    """True only for a complete read statement (the kind that may carry SETTINGS).
+
+    A complete query in these builders always starts with SELECT or WITH. A
+    SQL *fragment* (a bare WHERE/ORDER clause) or a non-SQL value (e.g. a future
+    ``(cache_key, meta)`` return) does not — and must NOT get a trailing SETTINGS
+    clause appended.
+    """
+    return sql.lstrip()[:6].upper().startswith(("SELECT", "WITH"))
 
 
 def _rewrite_sql_in(result: object) -> object:
@@ -64,7 +80,11 @@ def _rewrite_sql_in(result: object) -> object:
         sql, params = result
         if not sql:
             return result
-        return rewrite_and_apply_v2_settings(sql), params
+        # Token rewrite is always safe; SETTINGS only belongs on a full statement.
+        rewritten = rewrite_v1_sql_to_v2(sql)
+        if _is_statement(sql):
+            rewritten = _append_v2_settings(rewritten)
+        return rewritten, params
 
     # [(sql, params, meta), ...] — dashboard.build_all_queries.
     if (
@@ -78,7 +98,12 @@ def _rewrite_sql_in(result: object) -> object:
         rewritten = []
         for el in result:
             sql = el[0]
-            new_sql = sql if not sql else rewrite_and_apply_v2_settings(sql)
+            if sql:
+                new_sql = rewrite_v1_sql_to_v2(sql)
+                if _is_statement(sql):
+                    new_sql = _append_v2_settings(new_sql)
+            else:
+                new_sql = sql
             rewritten.append((new_sql, *el[1:]))
         return rewritten
 

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
@@ -8,6 +8,7 @@ returns `[(sql, params, meta), …]`. `V2RewriteMixin` routes both through the v
 rewriter at one boundary (it handles both the `(sql, params)` and the
 list-of-triples return shapes).
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.dashboard import DashboardQueryBuilder

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
@@ -3,33 +3,25 @@ v2 Dashboard query builder — targets the CH 25.3 spans schema.
 
 Subclass + post-rewrite. The v1 dashboard builder emits 1 SQL query per
 dashboard metric (latency, p95, model breakdown, custom-attribute pivots,
-etc.). Each metric type goes through `build_metric_query()`.
+etc.). Each metric type goes through `build_metric_query()`; `build_all_queries`
+returns `[(sql, params, meta), …]`. `V2RewriteMixin` routes both through the v2
+rewriter at one boundary (it handles both the `(sql, params)` and the
+list-of-triples return shapes).
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
-
 from tracer.services.clickhouse.query_builders.dashboard import DashboardQueryBuilder
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class DashboardQueryBuilderV2(DashboardQueryBuilder):
+class DashboardQueryBuilderV2(V2RewriteMixin, DashboardQueryBuilder):
     """Drop-in v2 Dashboard builder.
 
     The v1 builder is unusual in that it's NOT a subclass of BaseQueryBuilder —
-    it owns its own composition logic for the metric → SQL mapping. We
-    inherit it the same way and let the rewrite happen at every public
-    surface that returns SQL strings.
+    it owns its own composition logic for the metric → SQL mapping. We inherit
+    it the same way and let the mixin rewrite every public surface that returns
+    SQL strings.
     """
-
-    def build_metric_query(self, metric: dict) -> Tuple[str, dict]:
-        sql, params = super().build_metric_query(metric)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_all_queries(self) -> List[Tuple[str, dict, dict]]:
-        # v1 returns [(sql, params, meta), …]. Apply the rewrite to each sql.
-        results = super().build_all_queries()
-        return [(rewrite_and_apply_v2_settings(sql), params, meta) for sql, params, meta in results]
 
 
 __all__ = ["DashboardQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/eval_metrics.py
@@ -6,6 +6,7 @@ Subclass + post-rewrite. EvalMetrics powers the eval scoreboard panels
 tracer_eval_logger. `V2RewriteMixin` routes the inherited `build()` SQL through
 the v2 rewriter at one boundary.
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.eval_metrics import (

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/eval_metrics.py
@@ -3,24 +3,19 @@ v2 EvalMetrics query builder — targets the CH 25.3 spans schema.
 
 Subclass + post-rewrite. EvalMetrics powers the eval scoreboard panels
 (pass-rate by config, by span type, etc.). It JOINs spans to
-tracer_eval_logger; only the spans-side column refs need rewriting.
+tracer_eval_logger. `V2RewriteMixin` routes the inherited `build()` SQL through
+the v2 rewriter at one boundary.
 """
 from __future__ import annotations
-
-from typing import Any, Dict, Tuple
 
 from tracer.services.clickhouse.query_builders.eval_metrics import (
     EvalMetricsQueryBuilder,
 )
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class EvalMetricsQueryBuilderV2(EvalMetricsQueryBuilder):
+class EvalMetricsQueryBuilderV2(V2RewriteMixin, EvalMetricsQueryBuilder):
     """Drop-in v2 EvalMetrics builder."""
-
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
 
 
 __all__ = ["EvalMetricsQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -58,6 +58,15 @@ _COL_RENAME_RE = re.compile(
 )
 
 
+# Legacy CDC dict names → v2 CH-native dicts (same key/attrs, so a token rename).
+_DICT_RENAMES: Dict[str, str] = {
+    "enduser_dict": "end_users_dict",
+}
+_DICT_RENAME_RE = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _DICT_RENAMES.keys()) + r")\b"
+)
+
+
 # ─── JSON-overflow access rewrites ────────────────────────────────────────────
 # v1 emits `JSONExtractType(span_attributes_raw, 'path.with.dots')`; v2 uses
 # CH 25.x typed JSON path access `attributes_extra.path.with.dots.:Type`.
@@ -244,6 +253,8 @@ def rewrite_v1_sql_to_v2(sql: str) -> str:
     # 5. Naked simple renames (must come last so we don't accidentally rewrite
     # inside the AS aliases we just produced).
     sql = _COL_RENAME_RE.sub(lambda m: _COL_RENAMES[m.group(1)], sql)
+    # 5b. Legacy CDC dictionary names → v2 CH-native dictionary names.
+    sql = _DICT_RENAME_RE.sub(lambda m: _DICT_RENAMES[m.group(1)], sql)
     # NOTE: this function does NOT append the v2 SETTINGS clause. The settings
     # are appended at the BUILDER boundary (v2 `build()`/`build_count_query()` etc)
     # via `_append_v2_settings()` — see ClickHouseFilterBuilderV2.translate.

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -29,27 +29,27 @@ Risk mitigations:
   - Tests in `tracer/tests/test_ch25_filter_compiler.py` cover every
     column-rewrite case + every JSONExtract* pattern v1 currently emits.
 """
+
 from __future__ import annotations
 
 import re
-from typing import Any, Callable, Dict, Tuple
+from collections.abc import Callable
+from typing import Any
 
 from tracer.services.clickhouse.query_builders.filters import (
     ClickHouseFilterBuilder,
     _coerce_strict_bool,
-    _sanitize_key,
 )
 from tracer.services.clickhouse.v2.query_builders import columns as cols
 
-
 # ─── Simple column-name renames ───────────────────────────────────────────────
 # These are tokens; word-boundary regex substitutes them safely.
-_COL_RENAMES: Dict[str, str] = {
+_COL_RENAMES: dict[str, str] = {
     "_peerdb_is_deleted": cols.IS_DELETED,
-    "_peerdb_version":    cols.VERSION,
-    "span_attr_str":      cols.ATTRS_STRING,
-    "span_attr_num":      cols.ATTRS_NUMBER,
-    "span_attr_bool":     cols.ATTRS_BOOL,
+    "_peerdb_version": cols.VERSION,
+    "span_attr_str": cols.ATTRS_STRING,
+    "span_attr_num": cols.ATTRS_NUMBER,
+    "span_attr_bool": cols.ATTRS_BOOL,
 }
 
 # Pre-compile a single regex that matches any legacy column name as a whole word.
@@ -61,7 +61,7 @@ _COL_RENAME_RE = re.compile(
 # Legacy CDC dict names → v2 CH-native dicts (same key/attrs, so a token rename).
 # Sourced from the now-renamed v2 curated dimension tables (end_users RMT,
 # trace_sessions RMT) instead of the legacy CDC landing tables.
-_DICT_RENAMES: Dict[str, str] = {
+_DICT_RENAMES: dict[str, str] = {
     "enduser_dict": "end_users_dict",
     "trace_session_dict": "trace_sessions_dict",
 }
@@ -75,18 +75,38 @@ _DICT_RENAME_RE = re.compile(
 # CH 25.x typed JSON path access `attributes_extra.path.with.dots.:Type`.
 # Same translation applies to `metadata_map` (v1 Map) → `metadata` (v2 typed JSON).
 _JSON_EXTRACT_PATTERNS: list[tuple[re.Pattern, str, str]] = [
-    (re.compile(r"JSONExtractString\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
-     cols.ATTRIBUTES_EXTRA, "String"),
-    (re.compile(r"JSONExtractFloat\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
-     cols.ATTRIBUTES_EXTRA, "Float64"),
-    (re.compile(r"JSONExtractInt\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
-     cols.ATTRIBUTES_EXTRA, "Int64"),
-    (re.compile(r"JSONExtractBool\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
-     cols.ATTRIBUTES_EXTRA, "Bool"),
-    (re.compile(r"JSONExtractString\(\s*resource_attributes_raw\s*,\s*'([^']+)'\s*\)"),
-     cols.RESOURCE_ATTRS, "String"),
-    (re.compile(r"JSONExtractString\(\s*metadata_map\s*,\s*'([^']+)'\s*\)"),
-     cols.METADATA_JSON, "String"),
+    (
+        re.compile(r"JSONExtractString\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
+        cols.ATTRIBUTES_EXTRA,
+        "String",
+    ),
+    (
+        re.compile(r"JSONExtractFloat\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
+        cols.ATTRIBUTES_EXTRA,
+        "Float64",
+    ),
+    (
+        re.compile(r"JSONExtractInt\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
+        cols.ATTRIBUTES_EXTRA,
+        "Int64",
+    ),
+    (
+        re.compile(r"JSONExtractBool\(\s*span_attributes_raw\s*,\s*'([^']+)'\s*\)"),
+        cols.ATTRIBUTES_EXTRA,
+        "Bool",
+    ),
+    (
+        re.compile(
+            r"JSONExtractString\(\s*resource_attributes_raw\s*,\s*'([^']+)'\s*\)"
+        ),
+        cols.RESOURCE_ATTRS,
+        "String",
+    ),
+    (
+        re.compile(r"JSONExtractString\(\s*metadata_map\s*,\s*'([^']+)'\s*\)"),
+        cols.METADATA_JSON,
+        "String",
+    ),
 ]
 
 # `JSONHas(span_attributes_raw, 'path')` → `(attributes_extra.path.:String IS NOT NULL)`
@@ -94,9 +114,9 @@ _JSON_HAS_PATTERN = re.compile(
     r"JSONHas\(\s*(span_attributes_raw|resource_attributes_raw|metadata_map)\s*,\s*'([^']+)'\s*\)"
 )
 _JSON_HAS_TARGET = {
-    "span_attributes_raw":     (cols.ATTRIBUTES_EXTRA, "String"),
-    "resource_attributes_raw": (cols.RESOURCE_ATTRS,   "String"),
-    "metadata_map":            (cols.METADATA_JSON,    "String"),
+    "span_attributes_raw": (cols.ATTRIBUTES_EXTRA, "String"),
+    "resource_attributes_raw": (cols.RESOURCE_ATTRS, "String"),
+    "metadata_map": (cols.METADATA_JSON, "String"),
 }
 
 # Map from legacy bare JSON column → v2 typed-JSON column. Used by the bare-
@@ -107,8 +127,8 @@ _JSON_HAS_TARGET = {
 #   • In WHERE emptiness checks: rewrite to length-based predicates on the
 #     toJSONString form (semantically equivalent for "has any keys").
 _BARE_JSON_REWRITES = {
-    "span_attributes_raw":     cols.ATTRIBUTES_EXTRA,
-    "metadata_map":            cols.METADATA_JSON,
+    "span_attributes_raw": cols.ATTRIBUTES_EXTRA,
+    "metadata_map": cols.METADATA_JSON,
     "resource_attributes_raw": cols.RESOURCE_ATTRS,
 }
 
@@ -133,10 +153,10 @@ _BARE_REF_PATTERN = re.compile(
 
 
 # ─── v2 attribute-type meta (same shape as v1 module-level constant, retargeted) ─
-_SPAN_ATTR_TYPE_META_V2: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
-    "text":    (cols.ATTRS_STRING, lambda v: v if isinstance(v, str) else str(v)),
-    "number":  (cols.ATTRS_NUMBER, lambda v: float(v)),
-    "boolean": (cols.ATTRS_BOOL,   _coerce_strict_bool),
+_SPAN_ATTR_TYPE_META_V2: dict[str, tuple[str, Callable[[Any], Any]]] = {
+    "text": (cols.ATTRS_STRING, lambda v: v if isinstance(v, str) else str(v)),
+    "number": (cols.ATTRS_NUMBER, lambda v: float(v)),
+    "boolean": (cols.ATTRS_BOOL, _coerce_strict_bool),
 }
 
 
@@ -165,16 +185,17 @@ def _append_v2_settings(sql: str) -> str:
 
     Handles trailing FORMAT clause: SETTINGS must come BEFORE FORMAT.
     """
-    sql_stripped = sql.rstrip().rstrip(';').rstrip()
+    sql_stripped = sql.rstrip().rstrip(";").rstrip()
     # Check for an existing SETTINGS clause (case-insensitive, at end before
     # any FORMAT clause). Use a simple heuristic — the v1 builders rarely
     # emit SETTINGS, so the common case is "no existing clause."
     import re as _re
+
     # Pull out a trailing FORMAT clause so we can re-attach it after SETTINGS.
     fmt_match = _re.search(r"\s+FORMAT\s+\w+\s*$", sql_stripped, _re.IGNORECASE)
     if fmt_match:
         format_clause = fmt_match.group(0)
-        sql_stripped = sql_stripped[:fmt_match.start()].rstrip()
+        sql_stripped = sql_stripped[: fmt_match.start()].rstrip()
     else:
         format_clause = ""
 
@@ -220,15 +241,16 @@ def rewrite_v1_sql_to_v2(sql: str) -> str:
     def _has_repl(m):
         col, ch_type = _JSON_HAS_TARGET[m.group(1)]
         return f"({cols.json_path(col, m.group(2), ch_type)} IS NOT NULL)"
+
     sql = _JSON_HAS_PATTERN.sub(_has_repl, sql)
 
     # 3. WHERE emptiness predicates
     def _empty_repl(m):
         legacy_col = m.group(1)
-        op         = m.group(2)
-        literal    = m.group(3)
-        v2_col     = _BARE_JSON_REWRITES[legacy_col]
-        wrapped    = f"toJSONString({v2_col})"
+        op = m.group(2)
+        literal = m.group(3)
+        v2_col = _BARE_JSON_REWRITES[legacy_col]
+        wrapped = f"toJSONString({v2_col})"
         # `'{}'` or `'{{}}'` mean "empty object literal" → 2 chars (or 4 if
         # the double-brace was a Python format-string escape, which CH never
         # sees — by the time SQL reaches us, the braces are concrete).
@@ -243,6 +265,7 @@ def rewrite_v1_sql_to_v2(sql: str) -> str:
             return f"length({wrapped}) = 0"
         # Fall back — wrap with toJSONString and keep the literal compare
         return f"{wrapped} {op} '{literal}'"
+
     sql = _WHERE_EMPTY_PATTERN.sub(_empty_repl, sql)
 
     # 4. Bare SELECT-list refs — wrap with toJSONString() AS legacy_col so the
@@ -251,6 +274,7 @@ def rewrite_v1_sql_to_v2(sql: str) -> str:
         legacy_col = m.group(1)
         v2_col = _BARE_JSON_REWRITES[legacy_col]
         return f"toJSONString({v2_col}) AS {legacy_col}"
+
     sql = _BARE_REF_PATTERN.sub(_bare_repl, sql)
 
     # 5. Naked simple renames (must come last so we don't accidentally rewrite

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -59,8 +59,11 @@ _COL_RENAME_RE = re.compile(
 
 
 # Legacy CDC dict names → v2 CH-native dicts (same key/attrs, so a token rename).
+# Sourced from the now-renamed v2 curated dimension tables (end_users RMT,
+# trace_sessions RMT) instead of the legacy CDC landing tables.
 _DICT_RENAMES: Dict[str, str] = {
     "enduser_dict": "end_users_dict",
+    "trace_session_dict": "trace_sessions_dict",
 }
 _DICT_RENAME_RE = re.compile(
     r"\b(" + "|".join(re.escape(k) for k in _DICT_RENAMES.keys()) + r")\b"

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
@@ -7,6 +7,7 @@ read-only and hit `spans` heavily, so the v2 typed-Map columns reduce
 per-poll cost. `V2RewriteMixin` routes every inherited `build*` method's SQL
 through the v2 rewriter at one boundary.
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.monitor_metrics import (

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/monitor_metrics.py
@@ -4,36 +4,19 @@ v2 MonitorMetrics query builder — targets the CH 25.3 spans schema.
 Subclass + post-rewrite. Monitors poll metric values (current + historical
 + time series) for the alerting/monitoring surface; they're high-frequency
 read-only and hit `spans` heavily, so the v2 typed-Map columns reduce
-per-poll cost.
+per-poll cost. `V2RewriteMixin` routes every inherited `build*` method's SQL
+through the v2 rewriter at one boundary.
 """
 from __future__ import annotations
-
-from typing import Any, Dict, Tuple
 
 from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class MonitorMetricsQueryBuilderV2(MonitorMetricsQueryBuilder):
+class MonitorMetricsQueryBuilderV2(V2RewriteMixin, MonitorMetricsQueryBuilder):
     """Drop-in v2 MonitorMetrics builder."""
-
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_metric_value_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_metric_value_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_historical_stats_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_historical_stats_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_time_series_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_time_series_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
 
 
 __all__ = ["MonitorMetricsQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
@@ -8,6 +8,7 @@ routes every inherited `build*` method's SQL through the v2 rewriter at one
 boundary. All of this builder's queries target the migrated `spans` schema, so
 there are no rewrite exclusions.
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.session_list import (

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
@@ -3,36 +3,21 @@ v2 SessionList query builder — targets the CH 25.3 spans schema.
 
 Subclass + post-rewrite, same as v2/span_list.py and v2/trace_list.py.
 The v1 SessionList builder aggregates spans by trace_session_id; v2's
-materialized `trace_session_id` column is queried unchanged.
+materialized `trace_session_id` column is queried unchanged. `V2RewriteMixin`
+routes every inherited `build*` method's SQL through the v2 rewriter at one
+boundary. All of this builder's queries target the migrated `spans` schema, so
+there are no rewrite exclusions.
 """
 from __future__ import annotations
-
-from typing import Any, Dict, List, Tuple
 
 from tracer.services.clickhouse.query_builders.session_list import (
     SessionListQueryBuilder,
 )
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class SessionListQueryBuilderV2(SessionListQueryBuilder):
+class SessionListQueryBuilderV2(V2RewriteMixin, SessionListQueryBuilder):
     """Drop-in v2 SessionList builder."""
-
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_count_query(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_count_query()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_content_query(self, session_ids: List[str]) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_content_query(session_ids)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_span_attributes_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_span_attributes_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
 
 
 __all__ = ["SessionListQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
@@ -13,6 +13,7 @@ tables are NOT part of the CH 25.3 migration (eval results stay in PG;
 annotations live in their own CDC'd table) and still carry `_peerdb_is_deleted`.
 They are excluded from the rewrite via `_v2_rewrite_exclude`.
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.span_list import SpanListQueryBuilder

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
@@ -1,35 +1,25 @@
 """
 v2 SpanList query builder — targets the CH 25.3 spans schema.
 
-Mirrors the architecture of v2/query_builders/filters.py:
-  - SUBCLASS the v1 builder so all dashboard logic (pagination, sort, eval
-    + annotation joins, the 3-phase merge) is inherited unchanged.
-  - REWRITE column references in the compiled SQL output via the same
-    `rewrite_and_apply_v2_settings()` helper used by the v2 filter compiler. The
-    rewriter is whole-SQL: it covers both the dashboard's own column refs
-    (e.g. `WHERE _peerdb_is_deleted = 0`) AND the WHERE-clause fragments
-    the inner v1 filter compiler emits.
-
-Methods overridden:
-  - `build()` — the main query (paginated spans page)
-  - `build_content_query()` — the per-span input/output/overflow fetch
-    (attributes_extra is the v2 column name for overflow attributes)
-  - `build_count_query()` — the COUNT for pagination
+Subclass the v1 builder so all of its logic (pagination, sort, eval +
+annotation joins, the 3-phase merge) is inherited unchanged, then let
+`V2RewriteMixin` route every inherited `build*` method's compiled SQL through
+the v2 rewriter at one boundary — `build()`, `build_content_query()` and
+`build_count_query()` need no per-method overrides.
 
 The eval and annotation queries (`build_eval_query`, `build_annotation_query`)
 read from `tracer_eval_logger` and `model_hub_score` respectively — those
 tables are NOT part of the CH 25.3 migration (eval results stay in PG;
-annotations live in their own CDC'd table). No rewrite needed there.
+annotations live in their own CDC'd table) and still carry `_peerdb_is_deleted`.
+They are excluded from the rewrite via `_v2_rewrite_exclude`.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
-
 from tracer.services.clickhouse.query_builders.span_list import SpanListQueryBuilder
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class SpanListQueryBuilderV2(SpanListQueryBuilder):
+class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
     """Drop-in v2 SpanList builder.
 
     Callers can swap import lines:
@@ -41,17 +31,7 @@ class SpanListQueryBuilderV2(SpanListQueryBuilder):
     until the operator promotes the query type to v2_primary or v2_only.
     """
 
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_content_query(self, span_ids: list) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_content_query(span_ids)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_count_query(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_count_query()
-        return rewrite_and_apply_v2_settings(sql), params
+    _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
 
 
 __all__ = ["SpanListQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -16,9 +16,10 @@ NOT part of the CH 25.3 migration and still carry `_peerdb_is_deleted` (the
 spans-side `_peerdb_is_deleted` in those joins resolves via the schema-014
 ALIAS). Rewriting them would break those tables.
 """
+
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from tracer.services.clickhouse.query_builders.trace_list import TraceListQueryBuilder
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
@@ -36,7 +37,7 @@ class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder):
 
     _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
 
-    def build_count_query(self) -> Tuple[str, Dict[str, Any]]:
+    def build_count_query(self) -> tuple[str, dict[str, Any]]:
         """Pagination count.
 
         Fast path: when no per-row filter / search / project-version is set,
@@ -58,8 +59,10 @@ class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder):
         # hour so the time range applies natively). Search/project_version
         # and any attribute filter still require raw scan.
         non_time_filters = [
-            f for f in (self.filters or [])
-            if (f.get("column_id") or f.get("columnId")) not in ("created_at", "start_time")
+            f
+            for f in (self.filters or [])
+            if (f.get("column_id") or f.get("columnId"))
+            not in ("created_at", "start_time")
         ]
         if not non_time_filters and not self.search and not self.project_version_id:
             # Ensure start_date / end_date are bound even if build() wasn't

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -98,5 +98,16 @@ class TraceListQueryBuilderV2(TraceListQueryBuilder):
         sql, params = super().build_span_count_query(*args, **kwargs)
         return rewrite_and_apply_v2_settings(sql), params
 
+    def build_user_id_query(self, trace_ids: List[str]) -> Tuple[str, Dict[str, Any]]:
+        """Route the inherited user-id query through the v2 rewriter so it hits
+        `end_users_dict` / `is_deleted` instead of the v1 `enduser_dict` /
+        `_peerdb_is_deleted`. Direct dictGet on the span's `end_user_id`; the
+        remap-aware `end_user_dict_reader.resolve_user_ids` is the fallback if a
+        future id re-key ever makes that lookup miss."""
+        sql, params = super().build_user_id_query(trace_ids)
+        if not sql:
+            return sql, params
+        return rewrite_and_apply_v2_settings(sql), params
+
 
 __all__ = ["TraceListQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -4,25 +4,27 @@ v2 TraceList query builder — targets the CH 25.3 spans schema.
 Same pattern as v2/span_list.py: SUBCLASS the v1 builder, rewrite the
 compiled SQL output. The v1 TraceList builder reads from `spans` (legacy
 24.10 columns) plus joins to `tracer_eval_logger` and `model_hub_score`.
-We rewrite the `spans` table references; eval and annotation joins are
-unchanged.
 
-Methods overridden:
-  - `build()` — Phase 1: light trace+root-span page (no input/output)
-  - `build_content_query()` — Phase 2: heavy attrs maps + metadata
-  - `build_span_attributes_query()` — Phase 3: attributes_extra fetch
-  - `build_count_query()` — pagination count
-  - `build_span_count_query()` — per-trace span tally
+`V2RewriteMixin` routes every inherited `build*` method's SQL through the v2
+rewriter at one boundary (no per-method overrides). The only locally-defined
+method is `build_count_query`, which carries a rollup fast-path; its SQL is
+rewritten by the mixin just like every other.
+
+`build_eval_query` / `build_annotation_query` are excluded from the rewrite:
+they read the legacy `tracer_eval_logger` / `model_hub_score` tables, which are
+NOT part of the CH 25.3 migration and still carry `_peerdb_is_deleted` (the
+spans-side `_peerdb_is_deleted` in those joins resolves via the schema-014
+ALIAS). Rewriting them would break those tables.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 from tracer.services.clickhouse.query_builders.trace_list import TraceListQueryBuilder
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class TraceListQueryBuilderV2(TraceListQueryBuilder):
+class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder):
     """Drop-in v2 TraceList builder.
 
     Callers swap one import line:
@@ -32,17 +34,7 @@ class TraceListQueryBuilderV2(TraceListQueryBuilder):
     Or route via the shadow harness in v2/shadow.py.
     """
 
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_content_query(self, trace_ids: List[str]) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_content_query(trace_ids)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_span_attributes_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_span_attributes_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
+    _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
 
     def build_count_query(self) -> Tuple[str, Dict[str, Any]]:
         """Pagination count.
@@ -89,25 +81,11 @@ class TraceListQueryBuilderV2(TraceListQueryBuilder):
           AND hour >= toStartOfHour(toDateTime(%(start_date)s))
           AND hour <  toStartOfHour(toDateTime(%(end_date)s)) + INTERVAL 1 HOUR
             """
-            return rewrite_and_apply_v2_settings(sql), params
-
-        sql, params = super().build_count_query()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_span_count_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_span_count_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_user_id_query(self, trace_ids: List[str]) -> Tuple[str, Dict[str, Any]]:
-        """Route the inherited user-id query through the v2 rewriter so it hits
-        `end_users_dict` / `is_deleted` instead of the v1 `enduser_dict` /
-        `_peerdb_is_deleted`. Direct dictGet on the span's `end_user_id`; the
-        remap-aware `end_user_dict_reader.resolve_user_ids` is the fallback if a
-        future id re-key ever makes that lookup miss."""
-        sql, params = super().build_user_id_query(trace_ids)
-        if not sql:
+            # V2RewriteMixin appends the v2 SETTINGS to the returned SQL.
             return sql, params
-        return rewrite_and_apply_v2_settings(sql), params
+
+        # Slow path: v1's raw uniq over spans; the mixin rewrites + applies SETTINGS.
+        return super().build_count_query()
 
 
 __all__ = ["TraceListQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/voice_call_list.py
@@ -11,6 +11,7 @@ by the voice observability surface. `V2RewriteMixin` routes every inherited
 `tracer_eval_logger` / `model_hub_score` tables (not part of the CH 25.3
 migration; still carry `_peerdb_is_deleted`) and are excluded from the rewrite.
 """
+
 from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.voice_call_list import (

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/voice_call_list.py
@@ -4,36 +4,25 @@ v2 VoiceCallList query builder — targets the CH 25.3 spans schema.
 Subclass + post-rewrite. Voice calls are LLM agent calls with a specific
 attribute shape (call.total_turns, call.talk_ratio, etc.) — these live in
 `attrs_number` in v2 (was `span_attr_num` in v1) and are queried heavily
-by the voice observability surface.
+by the voice observability surface. `V2RewriteMixin` routes every inherited
+`build*` method's SQL through the v2 rewriter at one boundary.
+
+`build_eval_query` / `build_annotation_query` read the legacy
+`tracer_eval_logger` / `model_hub_score` tables (not part of the CH 25.3
+migration; still carry `_peerdb_is_deleted`) and are excluded from the rewrite.
 """
 from __future__ import annotations
-
-from typing import Any, Dict, List, Tuple
 
 from tracer.services.clickhouse.query_builders.voice_call_list import (
     VoiceCallListQueryBuilder,
 )
-from tracer.services.clickhouse.v2.query_builders.filters import rewrite_and_apply_v2_settings
+from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 
 
-class VoiceCallListQueryBuilderV2(VoiceCallListQueryBuilder):
+class VoiceCallListQueryBuilderV2(V2RewriteMixin, VoiceCallListQueryBuilder):
     """Drop-in v2 VoiceCallList builder."""
 
-    def build(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_count_query(self) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_count_query()
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_content_query(self, span_ids: List[str]) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_content_query(span_ids)
-        return rewrite_and_apply_v2_settings(sql), params
-
-    def build_child_spans_query(self, *args, **kwargs) -> Tuple[str, Dict[str, Any]]:
-        sql, params = super().build_child_spans_query(*args, **kwargs)
-        return rewrite_and_apply_v2_settings(sql), params
+    _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
 
 
 __all__ = ["VoiceCallListQueryBuilderV2"]

--- a/futureagi/tracer/tests/test_ch25_builder_contract.py
+++ b/futureagi/tracer/tests/test_ch25_builder_contract.py
@@ -25,6 +25,7 @@ Imports are lazy (inside the tests) to avoid importing the clickhouse package at
 collection time — see test_ch25_filter_compiler.py / the annotation_graph &
 time_series circular-import notes.
 """
+
 from __future__ import annotations
 
 import importlib
@@ -152,7 +153,8 @@ class TestListBuilderOutputContract:
             method = getattr(builder, name)
             sig = inspect.signature(method)
             required = [
-                p for p in sig.parameters.values()
+                p
+                for p in sig.parameters.values()
                 if p.default is inspect.Parameter.empty
                 and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
             ]

--- a/futureagi/tracer/tests/test_ch25_builder_contract.py
+++ b/futureagi/tracer/tests/test_ch25_builder_contract.py
@@ -1,0 +1,187 @@
+"""
+Contract: no v2 query builder may emit a v1-only ClickHouse reference.
+
+This is the test that catches the whole class of bug that TH-5911 and TH-5964
+were instances of: a v2 builder inheriting a v1 SQL-emitting method that ships
+legacy column/dict names (`enduser_dict`, `_peerdb_is_deleted`, `span_attr_*`,
+…) and 500s on a `CH_DATABASE=futureagi` (v2-only) box, until someone notices
+and adds the next per-method override.
+
+Two layers:
+
+  * `test_*_routes_through_rewrite_boundary` — STRUCTURAL. Every registered v2
+    builder mixes in `V2RewriteMixin`, and every `build*` method (except the
+    documented eval/annotation exclusions, which target non-migrated legacy
+    tables) is wrapped by the rewrite boundary. This is the guarantee that a
+    *newly-inherited* method cannot ship un-rewritten SQL — it does not depend
+    on anyone remembering to add an override.
+
+  * `test_list_builders_emit_no_v1_tokens` — BEHAVIOURAL. The four list builders
+    are cheap to construct (project_id only) and their `build*` methods compile
+    SQL strings without touching the DB, so we exercise each and assert the
+    emitted SQL carries none of the v1-only tokens.
+
+Imports are lazy (inside the tests) to avoid importing the clickhouse package at
+collection time — see test_ch25_filter_compiler.py / the annotation_graph &
+time_series circular-import notes.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+
+import pytest
+
+# v1-only tokens that must never survive the rewrite in v2 builder output. Scope:
+# dict + column names (the renames this boundary owns). Table names with no 1:1
+# v2 equivalent (tracer_eval_logger / model_hub_score) are intentionally out of
+# scope — they belong to the deferred eval/annotation migration.
+_V1_ONLY_TOKENS = (
+    "enduser_dict",
+    "trace_session_dict",
+    "_peerdb_is_deleted",
+    "_peerdb_version",
+    "span_attr_str",
+    "span_attr_num",
+    "span_attr_bool",
+    "span_attributes_raw",
+    "resource_attributes_raw",
+    "metadata_map",
+)
+_V1_TOKEN_RE = re.compile(r"\b(" + "|".join(_V1_ONLY_TOKENS) + r")\b")
+
+# The rewriter intentionally re-emits the typed-JSON columns as a back-compat
+# alias — `toJSONString(attributes_extra) AS span_attributes_raw` — so callers'
+# `row["span_attributes_raw"]` still works. That alias LABEL is legitimate v2
+# output; strip it before scanning so only a genuine bare-column reference trips
+# the contract.
+_LEGIT_ALIAS_RE = re.compile(
+    r"\bAS\s+(?:span_attributes_raw|resource_attributes_raw|metadata_map)\b",
+    re.IGNORECASE,
+)
+
+# Only these `build*` methods may legitimately be excluded from the rewrite:
+# they read the legacy `tracer_eval_logger` / `model_hub_score` tables, which are
+# not part of the CH 25.3 migration and still carry `_peerdb_is_deleted`.
+_ALLOWED_EXCLUSIONS = frozenset({"build_eval_query", "build_annotation_query"})
+
+# Builders cheap to construct (project_id only) whose build* methods compile SQL
+# without a DB round-trip — registry query-type → v2 class name.
+_LIST_BUILDER_TYPES = ("TRACE_LIST", "SPAN_LIST", "SESSION_LIST", "VOICE_CALL_LIST")
+
+
+def _registry():
+    from tracer.services.clickhouse.v2.dispatch import _REGISTRY
+
+    return _REGISTRY
+
+
+def _load(entry):
+    return getattr(importlib.import_module(entry.v2_module), entry.v2_class)
+
+
+def _build_method_names(cls):
+    return [n for n in dir(cls) if n.startswith("build") and callable(getattr(cls, n))]
+
+
+@pytest.mark.unit
+class TestRewriteBoundaryContract:
+    """Structural: every registered v2 builder routes its SQL through one boundary."""
+
+    def test_every_v2_builder_uses_the_rewrite_mixin(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
+        from tracer.services.clickhouse.v2.query_builders.filters import (
+            ClickHouseFilterBuilderV2,
+        )
+
+        for qt, entry in _registry().items():
+            if not entry.v2_class:
+                continue
+            cls = _load(entry)
+            # The filter builder is intentionally NOT a mixin user: it emits
+            # WHERE/ORDER *fragments* that must not get a trailing SETTINGS
+            # clause. It rewrites via its own translate()/translate_sort().
+            if cls is ClickHouseFilterBuilderV2:
+                continue
+            assert issubclass(cls, V2RewriteMixin), (
+                f"{qt} → {cls.__name__} does not mix in V2RewriteMixin; its "
+                f"inherited build* methods would ship un-rewritten v1 SQL."
+            )
+
+    def test_every_build_method_is_wrapped_or_explicitly_excluded(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import _WRAPPED_ATTR
+        from tracer.services.clickhouse.v2.query_builders.filters import (
+            ClickHouseFilterBuilderV2,
+        )
+
+        for qt, entry in _registry().items():
+            if not entry.v2_class:
+                continue
+            cls = _load(entry)
+            if cls is ClickHouseFilterBuilderV2:
+                continue
+            exclude = cls._v2_rewrite_exclude
+            assert exclude <= _ALLOWED_EXCLUSIONS, (
+                f"{qt} → {cls.__name__} excludes {set(exclude) - _ALLOWED_EXCLUSIONS} "
+                f"from the rewrite — only eval/annotation legacy-table methods "
+                f"may be excluded."
+            )
+            for name in _build_method_names(cls):
+                if name in exclude:
+                    continue
+                method = getattr(cls, name)
+                assert getattr(method, _WRAPPED_ATTR, False), (
+                    f"{qt} → {cls.__name__}.{name} is not routed through the rewrite "
+                    f"boundary (missing {_WRAPPED_ATTR}). Either it targets the "
+                    f"migrated spans schema (let the mixin wrap it) or it reads a "
+                    f"legacy table (add it to _v2_rewrite_exclude with a note)."
+                )
+
+
+@pytest.mark.unit
+class TestListBuilderOutputContract:
+    """Behavioural: the list builders' compiled SQL carries no v1-only token."""
+
+    def _exercise(self, builder):
+        """Call every non-excluded build* method with dummy ids; yield (name, sql)."""
+        exclude = type(builder)._v2_rewrite_exclude
+        for name in _build_method_names(type(builder)):
+            if name in exclude:
+                continue
+            method = getattr(builder, name)
+            sig = inspect.signature(method)
+            required = [
+                p for p in sig.parameters.values()
+                if p.default is inspect.Parameter.empty
+                and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+            ]
+            # Inherited id-list methods take one positional (trace_ids/span_ids);
+            # page/count methods take none.
+            args = [["dummy-id-1", "dummy-id-2"]] * len(required)
+            result = method(*args)
+            if isinstance(result, tuple):
+                yield name, result[0]
+            elif isinstance(result, list):
+                for el in result:
+                    yield name, el[0]
+
+    def test_list_builders_emit_no_v1_tokens(self):
+        registry = _registry()
+        exercised = 0
+        for qt in _LIST_BUILDER_TYPES:
+            cls = _load(registry[qt])
+            builder = cls(project_id="contract-test-proj")
+            for name, sql in self._exercise(builder):
+                exercised += 1
+                cleaned = _LEGIT_ALIAS_RE.sub("", sql or "")
+                hit = _V1_TOKEN_RE.search(cleaned)
+                assert hit is None, (
+                    f"{cls.__name__}.{name} emitted v1-only token "
+                    f"'{hit.group(0)}':\n{sql}"
+                )
+        # Guard against a refactor silently exercising nothing.
+        assert exercised >= len(_LIST_BUILDER_TYPES), (
+            f"expected to exercise at least one build* per list builder, "
+            f"only ran {exercised}"
+        )

--- a/futureagi/tracer/tests/test_ch25_builder_contract.py
+++ b/futureagi/tracer/tests/test_ch25_builder_contract.py
@@ -21,6 +21,16 @@ Two layers:
     SQL strings without touching the DB, so we exercise each and assert the
     emitted SQL carries none of the v1-only tokens.
 
+NOTE: this catches *over*-exclusion (a method excluded that shouldn't be) and
+pins the two *known* legacy exclusions (`build_eval_query` /
+`build_annotation_query`) so they can't silently flip to wrapped. It can NOT
+generically catch *under*-exclusion: a NEW legacy-table `build*` method that
+nobody adds to `_v2_rewrite_exclude` would be wrapped, have its v1 tokens
+stripped, pass the no-v1-token check, and 500 at runtime. Closing that fully
+would require statically knowing each method's target table. When adding a
+`build*` method that reads a non-migrated legacy table, add it to BOTH
+`_v2_rewrite_exclude` and `_ALLOWED_EXCLUSIONS` so the pin above covers it.
+
 Imports are lazy (inside the tests) to avoid importing the clickhouse package at
 collection time — see test_ch25_filter_compiler.py / the annotation_graph &
 time_series circular-import notes.
@@ -87,6 +97,44 @@ def _build_method_names(cls):
 
 
 @pytest.mark.unit
+class TestRewriteBoundarySplit:
+    """The boundary rewrites tokens on any SQL but only SETTINGS-stamps statements."""
+
+    def test_fragment_is_rewritten_but_gets_no_settings(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import (
+            _rewrite_sql_in,
+        )
+
+        # A WHERE/ORDER fragment carrying a v1 token: tokens must be rewritten,
+        # but a fragment must NOT receive a trailing SETTINGS clause.
+        frag = "AND _peerdb_is_deleted = 0"
+        sql, params = _rewrite_sql_in((frag, {}))
+        assert "_peerdb_is_deleted" not in sql  # token rewritten
+        assert "SETTINGS" not in sql  # no settings on a fragment
+
+    def test_non_sql_tuple_is_untouched(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import (
+            _rewrite_sql_in,
+        )
+
+        # A future build* returning (cache_key, meta) must pass through verbatim.
+        cache_key, meta = "trace_list:proj-1:page-2", {"ttl": 30}
+        out = _rewrite_sql_in((cache_key, meta))
+        assert out == (cache_key, meta)
+        assert "SETTINGS" not in out[0]
+
+    def test_statement_gets_both_rewrite_and_settings(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import (
+            _rewrite_sql_in,
+        )
+
+        stmt = "SELECT _peerdb_is_deleted FROM spans"
+        sql, _ = _rewrite_sql_in((stmt, {}))
+        assert "_peerdb_is_deleted" not in sql
+        assert "SETTINGS" in sql
+
+
+@pytest.mark.unit
 class TestRewriteBoundaryContract:
     """Structural: every registered v2 builder routes its SQL through one boundary."""
 
@@ -138,6 +186,33 @@ class TestRewriteBoundaryContract:
                     f"migrated spans schema (let the mixin wrap it) or it reads a "
                     f"legacy table (add it to _v2_rewrite_exclude with a note)."
                 )
+
+    def test_known_legacy_methods_stay_excluded_and_unwrapped(self):
+        from tracer.services.clickhouse.v2.query_builders._rewrite import _WRAPPED_ATTR
+
+        # build_eval_query / build_annotation_query read tracer_eval_logger /
+        # model_hub_score, which are NOT in the CH 25.3 migration and keep
+        # `_peerdb_is_deleted`. They MUST stay excluded. If one is dropped from
+        # _v2_rewrite_exclude the mixin wraps it, the rewriter strips the token,
+        # and the no-v1-token check still passes — but it 500s at runtime. Pin
+        # them: each must be listed in the exclude set AND genuinely unwrapped.
+        checked = 0
+        for qt in _LIST_BUILDER_TYPES:
+            cls = _load(_registry()[qt])
+            for name in _ALLOWED_EXCLUSIONS:
+                if not hasattr(cls, name):
+                    continue
+                assert name in cls._v2_rewrite_exclude, (
+                    f"{cls.__name__}.{name} reads a non-migrated legacy table but "
+                    f"is not in _v2_rewrite_exclude — the mixin would rewrite it "
+                    f"against the wrong schema."
+                )
+                assert not getattr(getattr(cls, name), _WRAPPED_ATTR, False), (
+                    f"{cls.__name__}.{name} is routed through the rewrite boundary "
+                    f"but reads a legacy table — it must stay excluded."
+                )
+                checked += 1
+        assert checked >= 1, "expected to pin at least one excluded legacy method"
 
 
 @pytest.mark.unit

--- a/futureagi/tracer/tests/test_ch25_filter_compiler.py
+++ b/futureagi/tracer/tests/test_ch25_filter_compiler.py
@@ -50,6 +50,24 @@ class TestRewriteV1SqlToV2:
               "FROM spans WHERE is_deleted = 0")
         assert rewrite_v1_sql_to_v2(v1) == v2
 
+    # ─── Dictionary-name renames ─────────────────────────────────────────────
+    def test_legacy_enduser_dict_renamed(self):
+        # The legacy CDC dict (source `tracer_enduser`) → the v2 CH-native dict.
+        out = rewrite_v1_sql_to_v2(
+            "dictGetOrDefault('enduser_dict', 'user_id', any(end_user_id), '')"
+        )
+        assert "end_users_dict" in out
+        assert "'enduser_dict'" not in out
+
+    def test_enduser_dict_and_soft_delete_renamed_together(self):
+        v1 = (
+            "SELECT dictGetOrDefault('enduser_dict', 'user_id', any(end_user_id), '') "
+            "FROM spans WHERE _peerdb_is_deleted = 0"
+        )
+        out = rewrite_v1_sql_to_v2(v1)
+        assert "end_users_dict" in out and "'enduser_dict'" not in out
+        assert "is_deleted = 0" in out and "_peerdb_is_deleted" not in out
+
     # ─── Negative: don't rewrite substrings of unrelated identifiers ─────────
     def test_does_not_rewrite_substring_of_another_identifier(self):
         # `is_deleted_extra` should NOT be rewritten — only the

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -2468,6 +2468,37 @@ class TestTraceListQueryBuilder:
         assert query == ""
         assert params == {}
 
+    def test_v2_build_user_id_query_uses_v2_dict_and_column(self):
+        """TraceListQueryBuilderV2 must rewrite the inherited user-id query to the
+        v2 `end_users_dict` / `is_deleted` (and append the v2 SETTINGS) — the v1
+        `enduser_dict` / `_peerdb_is_deleted` artifacts must be gone."""
+        from tracer.services.clickhouse.v2.query_builders.trace_list import (
+            TraceListQueryBuilderV2,
+        )
+
+        builder = TraceListQueryBuilderV2(project_id="test-proj-123")
+        query, params = builder.build_user_id_query(["trace-1", "trace-2"])
+
+        assert "end_users_dict" in query
+        assert "is_deleted" in query
+        assert "use_skip_indexes_if_final" in query  # v2 SETTINGS appended
+        assert "'enduser_dict'" not in query
+        assert "_peerdb_is_deleted" not in query
+        assert params["user_trace_ids"] == ("trace-1", "trace-2")
+
+    def test_v2_build_user_id_query_empty_trace_ids(self):
+        """The v2 override preserves the empty-input contract (no rewrite/SETTINGS
+        applied to an empty query)."""
+        from tracer.services.clickhouse.v2.query_builders.trace_list import (
+            TraceListQueryBuilderV2,
+        )
+
+        builder = TraceListQueryBuilderV2(project_id="test-proj-123")
+        query, params = builder.build_user_id_query([])
+
+        assert query == ""
+        assert params == {}
+
 
 @pytest.mark.unit
 class TestSessionListQueryBuilder:


### PR DESCRIPTION
## What

`GET /tracer/trace/list_traces_of_session/` (and the org-scoped twin) 500'd on a v2-only / `CH_DATABASE=futureagi` deployment with `Code: 60 — Unknown table 'tracer_enduser'`. Root cause: the v2 query builders subclass their v1 counterpart and override **each** SQL-emitting method to post-process the SQL through `rewrite_and_apply_v2_settings()`. `TraceListQueryBuilderV2` overrode 6 of its 8 methods; `build_user_id_query` was the one the list missed, so it shipped raw `enduser_dict` / `_peerdb_is_deleted`.

Sibling of TH-5911. As flagged in review, the per-method override list **is** the bug: any inherited v1 method the list misses ships raw v1 SQL and 500s on a v2 box, and the pattern guarantees a third occurrence. This PR addresses the root cause.

## Change

**One rewrite boundary instead of ~30 per-method overrides.** New `V2RewriteMixin` (`v2/query_builders/_rewrite.py`) uses `__init_subclass__` to wrap every `build*` method on each v2 builder — inherited or local — routing its compiled SQL through the existing rewriter. A newly-inherited v1 method **cannot** ship un-rewritten SQL; nobody has to remember to add an override. Emitted SQL is byte-identical to the prior overrides (pure structural refactor).

- Mix `V2RewriteMixin` into all 7 v2 builders; delete the ~28 pass-through overrides. Only two special cases remain: trace_list's rollup `build_count_query` (fast-path logic retained, rewrite delegated to the mixin) and the filter builder (emits WHERE/ORDER **fragments** that must not get a trailing SETTINGS clause, so it keeps its 2 explicit rewrite-only overrides and does not use the mixin).
- `build_eval_query` / `build_annotation_query` read the legacy `tracer_eval_logger` / `model_hub_score` tables, which are **not** part of the CH 25.3 migration and still carry `_peerdb_is_deleted` — rewriting them would break them. They are excluded via a documented `_v2_rewrite_exclude` (behavior identical to today).
- Complete the dict rename map: `enduser_dict → end_users_dict` plus `trace_session_dict → trace_sessions_dict`.

**Contract test (the lock).** `test_ch25_builder_contract.py` iterates the dispatch `_REGISTRY` and asserts (a) every registered v2 builder routes through the boundary and every `build*` is wrapped or explicitly excluded, and (b) the list builders' emitted SQL contains no v1-only token (`enduser_dict`, `_peerdb_is_deleted`, `span_attr_*`, …). Proven to fail if a builder drops the mixin. This catches the whole class (this bug + TH-5911) before prod, and folds in the dashboard `enduser_dict` check.

**Tests runnable locally.** The ch25 tests couldn't be collected locally due to a pre-existing v1↔v2 circular import (`v2/filters` → `v1 query_builders/__init__` → `annotation_graph` / `time_series` → back to `v2/filters`). Moved those two module-level imports into their using methods to break the cycle. _These two files look unrelated to the mixin but are required for local test collection — not a drive-by._

## Out of scope (separate ticket)

`tracer_eval_logger → tracer_eval_logger_v2` and the `model_hub_score` / `trace_annotation` paths have no 1:1 v2 rename and need a domain decision (PG vs CH, v2 eval wiring), so they are deferred. The contract test's forbidden-token list is scoped to dict/column tokens accordingly. On a v2-only box the trace-list eval/annotation sub-queries still reference those legacy tables and would 500 if that path runs — tracked separately.

Likewise the end-user **filter** path emits legacy `tracer_enduser` (`_build_enduser_string_subquery`) — also not a clean rename (v2 `end_users` uses `end_user_id`/`is_deleted`, not `id`/`deleted`) — tracked in **TH-6022**.

## Verification

- New contract + rewriter unit tests pass locally and are now collectable (the circular-import fix). The contract test goes red when the mixin is reverted on any one builder (sanity-checked).
- The mixin wraps the exact same method set each builder overrode before → emitted SQL is byte-identical; no behavior change.
- Endpoint returns **200** with `user_id` labels resolved via `end_users_dict` on a v2-only box.


## Review follow-ups (commit `55890232`)

Two residual sharp edges raised in review (nik13), fixed in a follow-up commit:

- **SETTINGS no longer stamped on non-statements.** `_rewrite_sql_in` previously treated any `(str, dict)` return as `(sql, params)` and appended the v2 `SETTINGS` clause — so a `WHERE`/`ORDER` fragment or a future `(cache_key, meta)` return would get a stray (and syntactically invalid) SETTINGS clause. Split the boundary by scope: the v1→v2 **token rewrite always runs** (safe on fragments, a no-op on non-SQL), while the **SETTINGS append is gated on a `SELECT`/`WITH` statement-shape check** (`_is_statement`).
- **Legacy exclusions pinned.** The contract test caught *over*-exclusion (`exclude ⊆ _ALLOWED_EXCLUSIONS`) but not *under*-exclusion — a legacy-table method wrapped instead of excluded would strip its own v1 tokens, pass the no-v1-token check, yet 500 at runtime. Added `test_known_legacy_methods_stay_excluded_and_unwrapped` to pin `build_eval_query`/`build_annotation_query` as excluded + unwrapped, and documented the residual (a *brand-new* legacy method nobody excludes) as a NOTE.

The fully heuristic-free option — builders returning a typed `RenderedQuery(NamedTuple)` so the boundary discriminates by `isinstance` — was deferred: the type tag has to originate in the v1 base builders (~25–40 `build*` across ~8 live v1 files, all unpacked `sql, params = …`), a disproportionate cross-cutting change to v1 prod paths for little upside over the statement-shape guard.

Design + caveats recorded as **ADR #033** in internal-docs ([PR #35](https://github.com/future-agi/internal-docs/pull/35)).

Closes TH-5964

🤖 Generated with [Claude Code](https://claude.com/claude-code)


