### PR TITLE
fix(workbench): metrics grid hidden by snake_case field reads

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
@@ -113,11 +113,11 @@ const LinkedTracesContent = () => {
     const bottomRowObj = {};
 
     for (const eachCol of columns) {
-      if (eachCol?.groupBy) {
-        if (!grouping[eachCol?.groupBy]) {
-          grouping[eachCol?.groupBy] = [eachCol];
+      if (eachCol?.group_by) {
+        if (!grouping[eachCol?.group_by]) {
+          grouping[eachCol?.group_by] = [eachCol];
         } else {
-          grouping[eachCol?.groupBy].push(eachCol);
+          grouping[eachCol?.group_by].push(eachCol);
         }
       } else {
         grouping[getRandomId()] = [eachCol];
@@ -225,7 +225,7 @@ const LinkedTracesContent = () => {
       },
 
       // --- Row Identification ---
-      getRowId: ({ data }) => data.spanId,
+      getRowId: ({ data }) => data.span_id,
     }),
     [id, filters, debouncedSearchQuery, setColumns],
   );

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
@@ -104,11 +104,11 @@ const MetricsContent = () => {
     const bottomRowObj = {};
 
     for (const eachCol of columns) {
-      if (eachCol?.groupBy) {
-        if (!grouping[eachCol?.groupBy]) {
-          grouping[eachCol?.groupBy] = [eachCol];
+      if (eachCol?.group_by) {
+        if (!grouping[eachCol?.group_by]) {
+          grouping[eachCol?.group_by] = [eachCol];
         } else {
-          grouping[eachCol?.groupBy].push(eachCol);
+          grouping[eachCol?.group_by].push(eachCol);
         }
       } else {
         grouping[getRandomId()] = [eachCol];
@@ -203,7 +203,7 @@ const MetricsContent = () => {
         }
       },
 
-      getRowId: ({ data }) => data.promptVersionId,
+      getRowId: ({ data }) => data.prompt_version_id,
     }),
     [id, filters, setColumns],
   );

--- a/frontend/src/sections/workbench/createPrompt/Metrics/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/common.js
@@ -223,7 +223,7 @@ export const getMetricsListColumnDefs = (col) => {
   return {
     headerName: col.name,
     field: col.id,
-    hide: !col?.isVisible,
+    hide: !col?.is_visible,
     cellStyle: (params) => {
       const value = params.value;
       if (isCellValueEmpty(value)) {


### PR DESCRIPTION
## Summary

The Metrics tab on a prompt rendered an empty grid even when the API returned data. Pagination correctly showed "1 to N of N" — the rows were there, just all hidden by AG Grid because every column was getting `hide: true`.

Root cause: the API config items use snake_case keys (`is_visible`, `group_by`), but the FE was reading them as camelCase. So:

- `common.js:226` — `!col?.isVisible` → `!undefined` → `hide: true` on every column → grid renders blank.
- `MetricsContent.jsx:107` — `eachCol?.groupBy` → `undefined` → every column put under a random group id (cosmetic — wrong grouping but doesn't blank the grid).
- `MetricsContent.jsx:206` — `data.promptVersionId` → `undefined` → AG Grid lost row identity.

All three fixed to read snake_case directly, matching what the backend sends.

## Linked issues

Closes TH-5655

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested

Local docker, signed in as `tanmay@futureagi.com`. Seeded 30 spans against a prompt with 2 versions × 3 label states (production / staging / unlabeled). API returned the expected metric rows. Before this fix the grid was empty despite "1 to N of N" pagination. After this fix the grid populates with all columns visible.

Unlabeled-span dropping is intentional product behavior (metrics group by `(version, label)`), so the only thing left was the FE casing.

<img width="3022" height="1960" alt="image" src="https://github.com/user-attachments/assets/5db711a6-5b61-4807-837b-72cc901d9ad1" />


## Checklist

- [x] My code follows the style guide
- [ ] I've added tests (n/a — pure FE field-name change)
- [x] `make check-all` / `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA