### PR TITLE
fix(workbench): stop EvaluationDrawer firing dataset 404 + guard Add Message crash

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -467,7 +467,7 @@ const EvaluationDrawerChild = ({
           )}
         </Collapse>
         <Collapse
-          in={visibleSection === "config"}
+          in={visibleSection === "config" && module !== "workbench"}
           orientation="horizontal"
           sx={{ height: "100%" }}
           unmountOnExit

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -175,7 +175,7 @@ const WorkbenchProvider = ({ children }) => {
       const newPre = [...pre];
       const newValue =
         typeof valueOrUpdater === "function"
-          ? { id: pre[index]?.id, prompts: valueOrUpdater(pre[index]?.prompts) }
+          ? { id: pre[index]?.id, prompts: valueOrUpdater(pre[index]?.prompts ?? []) }
           : valueOrUpdater;
 
       newPre[index] = newValue;


### PR DESCRIPTION
## Summary

Two bugs in the prompt workbench, both caused by shared components not handling the workbench context correctly.

### 1. EvaluationDrawer fires 404 dataset request (TH-5904)

When opening the Evaluation drawer from the workbench, `EvaluationsSelectionGrid` mounts briefly before the intercept effect can redirect away from `visibleSection === "config"`. During that brief mount it calls `useEvalsList(id, { eval_categories: '' })` where `id` is the **prompt template ID** from the URL — not a dataset ID. The backend correctly returns 404 "Dataset not found".

**Fix:** Added `&& module !== "workbench"` to the `Collapse` condition so `EvaluationsSelectionGrid` never mounts in workbench context. One condition, surgical.

### 2. "Add Message" crashes with `prev is not iterable` (related workbench bug)

When a prompt version has no saved messages (`prompt_config_snapshot: null`), the `prompts` state initializes as `[]` (empty). Clicking "Add Message" calls `setPromptsByIndex(0, (prev) => [...prev, newMessage])`. Inside the updater, `pre[0]?.prompts` is `undefined` (nothing at index 0 yet) → `[...undefined, ...]` → `TypeError: prev is not iterable` → full page crash.

**Fix:** Guard `pre[index]?.prompts` with `?? []` in `setPromptsByIndex` — same pattern already used in `setPlaceholdersByIndex` on the line below.

## Linked issues

Closes TH-5904

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested

- Opened Evaluation drawer from workbench → no 404 on `get_evals_list`
- Opened a prompt with empty config → clicked Add Message → no crash
- Verified all other EvaluationDrawer callers (dataset, experiment, optimization, tasks) are unaffected — fix only blocks `EvaluationsSelectionGrid` when `module="workbench"`, which is only set from `EvaluationActions.jsx`

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests (n/a — pure FE condition guard)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA