### PR TITLE
fix(workbench): read evaluation_configs snake_case from eval configs endpoint

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/getEvalsList.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/getEvalsList.jsx
@@ -46,7 +46,7 @@ export const useEvalsList = (id, payload, module = "dataset", experimentId) => {
       const result = res?.data?.result;
       if (module === "workbench") {
         return {
-          evals: result.evaluationConfigs,
+          evals: result.evaluation_configs,
         };
       }
       if (payload?.search_text) {

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
@@ -191,6 +191,13 @@ const EvaluationData = () => {
             }
             reject(err);
           },
+          onClose: (event) => {
+            if (event?.code === 4003 || event?.code === 4004) {
+              reject(new Error(event?.reason || "Permission denied"));
+            } else {
+              reject(new Error("Stream connection closed unexpectedly"));
+            }
+          },
         });
         activeSocketsRef.current[payload.run_index] = socket;
       });
@@ -231,6 +238,12 @@ const EvaluationData = () => {
     (event) => {
       try {
         const wsData = event;
+        if (wsData?.type === "error") {
+          enqueueSnackbar(wsData?.message || "Something went wrong", {
+            variant: "error",
+          });
+          return;
+        }
         if (wsData?.type !== "run_prompt") {
           return;
         }

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
@@ -174,6 +174,10 @@ const EvaluationData = () => {
      */
     mutationFn: (payload) => {
       return new Promise((resolve, reject) => {
+        if (!promptStreamUrl) {
+          reject(new Error("Stream URL not ready. Please try again."));
+          return;
+        }
         // @ts-ignore
         const socket = runPromptOverSocket({
           url: promptStreamUrl,

--- a/frontend/src/sections/workbench/createPrompt/common.js
+++ b/frontend/src/sections/workbench/createPrompt/common.js
@@ -137,8 +137,8 @@ export function runPromptOverSocket({
     if (onError) onError(err);
   };
 
-  socket.onclose = () => {
-    if (onClose) onClose();
+  socket.onclose = (event) => {
+    if (onClose) onClose(event);
   };
 
   return socket;


### PR DESCRIPTION
## Summary

After adding an eval from the workbench Evaluation tab, the saved evals list in the drawer always showed "No evaluations added" — even though the eval was successfully saved and ran. The Re-run option was also never visible because the list never rendered.

## Root cause

One character: `evaluationConfigs` vs `evaluation_configs`.

The backend returns `evaluation_configs` (snake_case). The FE read `result.evaluationConfigs` (camelCase). This app has no axios camelCase interceptor, so the key was always `undefined` → `SavedEvals = undefined` → list never renders.

## Fix

`getEvalsList.jsx:49` — `result.evaluationConfigs` → `result.evaluation_configs`. One word.

## Linked issues

Closes TH-5967
Related to TH-5853 (re-run stuck in pending — was unreachable because the list never showed)

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA