### PR TITLE
fix(frontend): dedupe gateway metadata camelCase aliases

### DIFF
--- a/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
@@ -26,6 +26,7 @@ import { useAnalyticsOverview } from "../analytics/hooks/useAnalyticsOverview";
 import { useAnalyticsUsage } from "../analytics/hooks/useAnalyticsUsage";
 import { val } from "../utils/analyticsHelpers";
 import { formatCost, formatDateTime as formatDate } from "../utils/formatters";
+import { canonicalKeys, canonicalizeDeep } from "src/utils/utils";
 
 const STATUS_COLORS = {
   active: "success",
@@ -282,7 +283,7 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
             </Box>
 
             {/* Metadata */}
-            {keyData.metadata && Object.keys(keyData.metadata).length > 0 && (
+            {keyData.metadata && canonicalKeys(keyData.metadata).length > 0 && (
               <Box>
                 <Typography variant="subtitle2" mb={1}>
                   Metadata
@@ -298,7 +299,7 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
                     overflowX: "auto",
                   }}
                 >
-                  {JSON.stringify(keyData.metadata, null, 2)}
+                  {JSON.stringify(canonicalizeDeep(keyData.metadata), null, 2)}
                 </Box>
               </Box>
             )}

--- a/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
@@ -29,6 +29,7 @@ import Iconify from "src/components/iconify";
 import useRequestDetail from "./hooks/useRequestDetail";
 import FeedbackWidget from "../guardrails/FeedbackWidget";
 import { formatCost } from "../utils/formatters";
+import { canonicalEntries, canonicalizeDeep } from "src/utils/utils";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -325,7 +326,7 @@ function ResponseTab({ log }) {
 MetadataTab.propTypes = { log: PropTypes.object.isRequired };
 
 function MetadataTab({ log }) {
-  const entries = Object.entries(log.metadata || {});
+  const entries = canonicalEntries(log.metadata || {});
 
   if (entries.length === 0) {
     return (
@@ -352,7 +353,7 @@ function MetadataTab({ log }) {
               <TableCell>{key}</TableCell>
               <TableCell sx={{ wordBreak: "break-all" }}>
                 {typeof value === "object"
-                  ? JSON.stringify(value)
+                  ? JSON.stringify(canonicalizeDeep(value))
                   : String(value)}
               </TableCell>
             </TableRow>

--- a/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
@@ -26,6 +26,7 @@ import {
   formatCost,
   formatTokens,
 } from "../utils/formatters";
+import { canonicalKeys, canonicalizeDeep } from "src/utils/utils";
 
 function formatMs(val) {
   if (val == null) return "\u2014";
@@ -136,7 +137,7 @@ const SessionDetailDrawer = ({ sessionId, open, onClose }) => {
               </Card>
             </Stack>
 
-            {session.metadata && Object.keys(session.metadata).length > 0 && (
+            {session.metadata && canonicalKeys(session.metadata).length > 0 && (
               <Box mb={3}>
                 <Typography variant="subtitle2" mb={1}>
                   Metadata
@@ -151,7 +152,7 @@ const SessionDetailDrawer = ({ sessionId, open, onClose }) => {
                       whiteSpace: "pre-wrap",
                     }}
                   >
-                    {JSON.stringify(session.metadata, null, 2)}
+                    {JSON.stringify(canonicalizeDeep(session.metadata), null, 2)}
                   </Typography>
                 </Card>
               </Box>

--- a/frontend/src/utils/__tests__/canonicalKeys.test.js
+++ b/frontend/src/utils/__tests__/canonicalKeys.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { canonicalKeys, canonicalEntries, canonicalValues } from "../utils";
+import { canonicalKeys, canonicalEntries, canonicalValues, canonicalizeDeep } from "../utils";
 
 // Helper that simulates a legacy object containing both canonical keys and
 // old alias keys so iteration sees both.
@@ -92,5 +92,36 @@ describe("canonicalKeys / canonicalEntries / canonicalValues", () => {
     const obj = withAliases({ tone_17_apr_2026: { neutral: 10 } });
     expect(Object.keys(obj)).toContain("tone17Apr2026");
     expect(canonicalKeys(obj)).toEqual(["tone_17_apr_2026"]);
+  });
+});
+
+describe("canonicalizeDeep", () => {
+  it("strips camelCase aliases from nested metadata objects", () => {
+    const metadata = withAliases({
+      user_id: "u1",
+      nested: withAliases({ request_count: 3 }),
+    });
+    expect(canonicalizeDeep(metadata)).toEqual({
+      user_id: "u1",
+      nested: { request_count: 3 },
+    });
+  });
+
+  it("preserves genuine camelCase keys and primitives", () => {
+    const metadata = { id: 1, name: "test", count: 0 };
+    expect(canonicalizeDeep(metadata)).toEqual(metadata);
+  });
+
+  it("handles arrays and null leaves", () => {
+    const metadata = withAliases({
+      tags: ["a", "b"],
+      optional: null,
+      user_id: 1,
+    });
+    expect(canonicalizeDeep(metadata)).toEqual({
+      tags: ["a", "b"],
+      optional: null,
+      user_id: 1,
+    });
   });
 });

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -808,6 +808,24 @@ export const canonicalValues = (obj) => {
   return canonicalKeys(obj).map((key) => obj[key]);
 };
 
+// Recursively strip camelCase aliases from nested metadata objects before
+// rendering or serializing them in gateway drawers.
+export const canonicalizeDeep = (value) => {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeDeep(item));
+  }
+  if (typeof value !== "object") return value;
+
+  const aliases = buildAliasSet(value);
+  const out = {};
+  Object.entries(value).forEach(([key, val]) => {
+    if (aliases.has(key)) return;
+    out[key] = canonicalizeDeep(val);
+  });
+  return out;
+};
+
 export const objectCamelToSnake = (obj) => {
   if (obj === null || obj === undefined) {
     return obj;


### PR DESCRIPTION
## Summary

Fixes #907.

Gateway request/session/API-key detail drawers were rendering metadata with `Object.entries()` or `JSON.stringify()` on the raw API payload. Our axios response interceptor adds camelCase aliases next to every snake_case key, so user-defined metadata showed phantom duplicate keys (e.g. `user_id` and `userId`).

This PR aligns the gateway drawers with the existing observe UI pattern (`MetadataContent`, `NestedJsonTable`):

- Use `canonicalEntries` / `canonicalKeys` when listing metadata keys
- Add `canonicalizeDeep()` to recursively strip alias keys before JSON display
- Cover the helper with unit tests

## Changes

- `frontend/src/utils/utils.js` — add `canonicalizeDeep`
- `frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx` — metadata tab
- `frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx` — metadata block
- `frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx` — metadata block
- `frontend/src/utils/__tests__/canonicalKeys.test.js` — tests for `canonicalizeDeep`

## Test plan

- [x] `canonicalizeDeep` unit tests added
- [ ] Open a gateway request/session/key with custom metadata and confirm each field appears once
- [ ] Confirm nested metadata objects still render correctly
- [ ] Confirm genuine camelCase-only keys (no snake_case twin) are preserved


Made with [Cursor](https://cursor.com)