### PR TITLE
fix(workbench): improve prompt stuck after execution_started (TH-5875)

### DIFF
--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -139,7 +139,7 @@ class ModelConfigs:
 
     CLAUDE_4_5_SONNET_BEDROCK_ARN: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.AWS_BEDROCK_ANTHROPIC.value,
-        model_name=os.environ.get("BEDROCK_SONNET_ARN", ""),
+        model_name=os.environ.get("BEDROCK_SONNET_ARN") or os.environ.get("TURING_SMALL_MODEL", ""),
         temperature=0.2,
         max_tokens=8100,
     )

--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -139,7 +139,7 @@ class ModelConfigs:
 
     CLAUDE_4_5_SONNET_BEDROCK_ARN: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.AWS_BEDROCK_ANTHROPIC.value,
-        model_name=os.environ.get("BEDROCK_SONNET_ARN") or os.environ.get("TURING_SMALL_MODEL", ""),
+        model_name=os.environ.get("BEDROCK_SONNET_ARN", ""),
         temperature=0.2,
         max_tokens=8100,
     )

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -90,8 +90,8 @@ async def improve_prompt_async(
                 await ws_manager.send_improve_prompt_error_message(
                     improve_id=improve_id,
                     error="Insufficient credits",
-            )
-            return
+                )
+                return
 
         # Run the improve_prompt process with WebSocket manager
         # Use async version when ws_manager is provided (WebSocket context)


### PR DESCRIPTION
## Summary

Improve Prompt was stuck after sending `execution_started` — no streaming events followed, no error shown.

## Root cause

Indentation bug in `async_improve_prompt_runner.py`. The `return` statement was at the same level as the `if` block that checks whether the cost log row succeeded, not inside it:

```python
# before — return always fires, even when call_log_row is OK
if call_log_row is None or ...:
    await ws_manager.send_improve_prompt_error_message(...)
return   # ← always exits here, _improve_prompt_async never called

# after — return only fires on failure
if call_log_row is None or ...:
    await ws_manager.send_improve_prompt_error_message(...)
    return  # ← only on failure
```

So every call to improve prompt would: create the cost log, pass the credit check, then immediately `return` — skipping `_improve_prompt_async` entirely. The FE received `execution_started` and then silence forever.

## Fix

Move `return` inside the `if` block (2-space indent change).

## Linked issues

Closes TH-5875

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA