### PR TITLE
fix(evals): read summary config from user eval binding, not template default (TH-5313)

### DIFF
--- a/futureagi/model_hub/tests/test_eval_runner_summary_config.py
+++ b/futureagi/model_hub/tests/test_eval_runner_summary_config.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for TH-5313:
+
+`EvaluationRunner._prepare_eval_config` (AgentEvaluator branch) must read
+`summary` from `user_eval_metric.config['run_config']['summary']` first and
+fall back to the template default only when the binding has no value.
+
+Before the fix, summary was read from `eval_template.config` only, so the
+user's per-binding setting (saved correctly to the DB) was silently ignored
+at execution time.
+"""
+import uuid
+
+import pytest
+
+from model_hub.models.choices import StatusType
+from model_hub.models.evals_metric import EvalTemplate, UserEvalMetric
+from model_hub.views.eval_runner import EvaluationRunner
+
+
+@pytest.fixture
+def organization(db):
+    from accounts.models.organization import Organization
+
+    return Organization.objects.create(name=f"org-{uuid.uuid4().hex[:6]}")
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from accounts.models.user import User
+    from accounts.models.workspace import Workspace
+
+    user = User.objects.create_user(
+        email=f"{uuid.uuid4().hex[:6]}@example.com",
+        password="x",
+        name="t",
+        organization=organization,
+    )
+    return Workspace.objects.create(
+        name="Default", organization=organization, is_default=True, created_by=user
+    )
+
+
+@pytest.fixture
+def dataset(db, organization, workspace):
+    from model_hub.models.choices import DatasetSourceChoices
+    from model_hub.models.develop_dataset import Dataset
+
+    return Dataset.objects.create(
+        name=f"ds-{uuid.uuid4().hex[:6]}",
+        organization=organization,
+        workspace=workspace,
+        source=DatasetSourceChoices.BUILD.value,
+    )
+
+
+@pytest.fixture
+def agent_template(db, organization, workspace):
+    """An AgentEvaluator template with its own summary config."""
+    return EvalTemplate.objects.create(
+        name=f"agent-{uuid.uuid4().hex[:6]}",
+        organization=organization,
+        workspace=workspace,
+        config={
+            "eval_type_id": "AgentEvaluator",
+            "rule_prompt": "test",
+            "summary": {"type": "concise"},  # template default
+            "model": "turing_large",
+        },
+    )
+
+
+def _make_runner(metric):
+    """Build an EvaluationRunner without going through DB initialization.
+
+    The init path loads `user_eval_metric` from DB which requires the column
+    setup we don't need here. We construct with `format_output=True` to skip
+    `_initialize_eval_metric` and wire the fields by hand.
+    """
+    runner = EvaluationRunner(
+        user_eval_metric_id=metric.id,
+        format_output=True,  # skips DB load in __init__
+    )
+    runner.user_eval_metric = metric
+    runner.eval_template = metric.template
+    runner.organization_id = metric.organization_id
+    runner.workspace_id = metric.workspace_id if metric.workspace_id else None
+    return runner
+
+
+@pytest.mark.django_db
+class TestSummaryConfigFromBinding:
+    """The binding's run_config.summary must reach the executor."""
+
+    def test_binding_summary_overrides_template_default(
+        self, agent_template, organization, workspace, dataset
+    ):
+        # The user explicitly chose "long" on their dataset attachment.
+        metric = UserEvalMetric.objects.create(
+            name="m",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=agent_template,
+            status=StatusType.NOT_STARTED.value,
+            config={"run_config": {"summary": {"type": "long"}}},
+        )
+        runner = _make_runner(metric)
+        config = runner._prepare_eval_config({})
+        assert config["summary"] == {"type": "long"}, (
+            "binding summary must reach the executor — not the template default"
+        )
+
+    def test_falls_back_to_template_when_binding_has_no_run_config(
+        self, agent_template, organization, workspace, dataset
+    ):
+        # Binding stored without any run_config at all.
+        metric = UserEvalMetric.objects.create(
+            name="m",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=agent_template,
+            status=StatusType.NOT_STARTED.value,
+            config={},
+        )
+        runner = _make_runner(metric)
+        config = runner._prepare_eval_config({})
+        assert config["summary"] == {"type": "concise"}
+
+    def test_falls_back_to_template_when_run_config_missing_summary_key(
+        self, agent_template, organization, workspace, dataset
+    ):
+        # Binding has run_config but no `summary` key inside it.
+        metric = UserEvalMetric.objects.create(
+            name="m",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=agent_template,
+            status=StatusType.NOT_STARTED.value,
+            config={"run_config": {"data_injection": {"variables_only": True}}},
+        )
+        runner = _make_runner(metric)
+        config = runner._prepare_eval_config({})
+        assert config["summary"] == {"type": "concise"}
+
+    def test_explicit_empty_dict_summary_honors_binding_not_template(
+        self, agent_template, organization, workspace, dataset
+    ):
+        # Nikhil's specific case: an explicit empty dict at the binding must
+        # NOT silently fall back to the template — the user set it that way
+        # for a reason. The fix uses ``is not None``, not ``or``, exactly to
+        # preserve this null-vs-falsy distinction.
+        metric = UserEvalMetric.objects.create(
+            name="m",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=agent_template,
+            status=StatusType.NOT_STARTED.value,
+            config={"run_config": {"summary": {}}},
+        )
+        runner = _make_runner(metric)
+        config = runner._prepare_eval_config({})
+        assert config["summary"] == {}, (
+            "explicit empty-dict summary must be honored (not silently swapped for template)"
+        )
+
+    def test_default_when_template_has_no_summary_at_all(
+        self, organization, workspace, dataset
+    ):
+        # No summary on template, no run_config on binding → built-in default.
+        template = EvalTemplate.objects.create(
+            name=f"agent-{uuid.uuid4().hex[:6]}",
+            organization=organization,
+            workspace=workspace,
+            config={
+                "eval_type_id": "AgentEvaluator",
+                "rule_prompt": "test",
+                "model": "turing_large",
+            },
+        )
+        metric = UserEvalMetric.objects.create(
+            name="m",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=template,
+            status=StatusType.NOT_STARTED.value,
+            config={},
+        )
+        runner = _make_runner(metric)
+        config = runner._prepare_eval_config({})
+        assert config["summary"] == {"type": "concise"}

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -2512,7 +2512,12 @@ class EvaluationRunner:
             config["data_injection"] = _di_normalize(
                 _uem_di or self.eval_template.config.get("data_injection", {})
             )
-            config["summary"] = self.eval_template.config.get(
+            # summary lives in user_eval_metric.config["run_config"]["summary"].
+            # Fall back to template default if not set.
+            _uem_summary = None
+            if self.user_eval_metric and self.user_eval_metric.config:
+                _uem_summary = self.user_eval_metric.config.get("run_config", {}).get("summary")
+            config["summary"] = _uem_summary or self.eval_template.config.get(
                 "summary", {"type": "concise"}
             )
             # Pass org/workspace context for tool resolution

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -2513,12 +2513,17 @@ class EvaluationRunner:
                 _uem_di or self.eval_template.config.get("data_injection", {})
             )
             # summary lives in user_eval_metric.config["run_config"]["summary"].
-            # Fall back to template default if not set.
+            # Use ``is not None`` rather than ``or`` so an explicit empty dict
+            # (which the UI could store as "no summary configured") still
+            # honors the binding instead of silently falling through to the
+            # template default.
             _uem_summary = None
             if self.user_eval_metric and self.user_eval_metric.config:
                 _uem_summary = self.user_eval_metric.config.get("run_config", {}).get("summary")
-            config["summary"] = _uem_summary or self.eval_template.config.get(
-                "summary", {"type": "concise"}
+            config["summary"] = (
+                _uem_summary
+                if _uem_summary is not None
+                else self.eval_template.config.get("summary", {"type": "concise"})
             )
             # Pass org/workspace context for tool resolution
             config["organization_id"] = (


### PR DESCRIPTION
## 1. What changes are done

**Bug:** the **Summary** setting on a dataset-attached eval (`concise` / `short` / `long`) was being completely **ignored at execution time**. The user could change the setting in the UI, it would persist to the database correctly, but the evaluator always used the template's default summary on the next run. No error, no toast — the user just got a "concise" summary back when they had asked for "long," with nothing in the runtime output telling them their setting had been discarded.

**Root cause:** in `EvaluationRunner._prepare_eval_config` (the `AgentEvaluator` branch), `summary` was read from the template config only:

```python
config["summary"] = self.eval_template.config.get("summary", {"type": "concise"})
```

The user's per-binding setting lives at `user_eval_metric.config["run_config"]["summary"]`. That path was never consulted. The same code block reads `data_injection` from the binding **first**, then falls back to the template — which is the correct pattern. `summary` was the lone field that missed this step.

**Fix:** mirror the `data_injection` lookup — read the binding's `run_config.summary` first, fall back to the template default only if the binding has no value. Use `is not None` rather than `or` so an **explicit empty dict** on the binding is preserved instead of silently being swapped for the template default (the user set `{}` for a reason — typically "no summary configured for this binding").

### Backend

| File | Change |
| --- | --- |
| `futureagi/model_hub/views/eval_runner.py` (`EvaluationRunner._prepare_eval_config`) | One block changed inside the `AgentEvaluator` branch. New `_uem_summary` lookup walks `self.user_eval_metric.config.get("run_config", {}).get("summary")` with a `None` default. The `config["summary"]` assignment becomes a conditional: `_uem_summary if _uem_summary is not None else self.eval_template.config.get("summary", {"type": "concise"})`. The inline comment block explicitly calls out *why* `is not None` (not `or`) — without that note a later refactor would likely "simplify" it back to `or` and reintroduce the silent-empty-dict bug. |

### Tests

| File | Change |
| --- | --- |
| `futureagi/model_hub/tests/test_eval_runner_summary_config.py` *(new)* | `TestSummaryConfigFromBinding` — 5 unit tests around `_prepare_eval_config` that wire `EvaluationRunner` with `format_output=True` and the relevant fields populated by hand, so the test exercises the resolve path in isolation without spinning up a real dataset / template / runner. Covers the binding-overrides-template case (the original bug), the two fallback shapes (no `run_config`, `run_config` without `summary`), the `is not None` vs `or` edge case (explicit `{}` honored as-is), and the no-summary-anywhere built-in default. |

## 2. Why these changes

- **Why this bug was particularly insidious:** the setting *did* persist to the DB. The UI showed "long." Reading the binding back showed "long." Only the runtime executor was reading the wrong path. From a user's perspective the whole flow looked correct except the actual output. Nothing logged or alerted that the binding was being discarded.
- **Why `is not None` instead of `or`:** Python truthiness treats `{}` as falsy. The UI can persist `{}` as the user's deliberate "no summary for this binding" state — that's a legitimate stored value, distinct from "no key at all." Using `or` would coalesce both into "fall through to template default," which:
  1. silently discards the explicit `{}` setting the user just made, and
  2. makes the bug class behind this exact PR easier to reintroduce — the original code already used a similar shortcut.

  `is not None` distinguishes "binding has no opinion" (missing key, returns `None`) from "binding's opinion is empty" (key present, value `{}`). Both are valid; only the first should fall through.
- **Why match the `data_injection` pattern verbatim:** the same code block already reads `data_injection` from the binding first, with template fallback. That established the binding-first convention for runtime config. Bringing `summary` in line is a one-block delta — no new pattern, no architectural change, just closing a known gap.
- **Why a fix this small ships with 5 tests:** the bug was invisible — no error path was wrong; the wrong value was being used. Without tests that pin "binding wins" and "explicit `{}` is honored," any future refactor that "cleans up" the conditional back to `or` would re-introduce the same silent miss. The tests are the only thing that pin the contract; the inline comment is human documentation but not enforceable.
- **Why this PR is intentionally narrow:** the deeper structural fix is "typed accessor over `binding.config['run_config']`" — that dict is hand-walked in four files with slightly different shape assumptions, which is what made the bug possible in the first place. That's a multi-day refactor and is tracked separately. This PR fixes the user-visible bug with the smallest possible delta and locks the contract.

### Sibling-field audit (from review)

Reviewer asked whether `multi_choice` / `choices` / `choice_scores` in the same code block have the same template-only-read bug. **Verified: no.** Those three are intentionally template-only:

- They are stored on `EvalTemplate` itself (`self.eval_template.choices`, `self.eval_template.choice_scores`), not in `user_eval_metric.config`.
- The list of fields the UI actually persists to `binding.config["run_config"]` lives in `model_hub/utils/eval_list.py:299-307`: `agent_mode`, `check_internet`, `summary`, `pass_threshold`, `data_injection`, `knowledge_bases`, `tools`. `multi_choice` / `choices` / `choice_scores` are absent from that allowlist.

So the UI never persists those fields per-binding, the runtime correctly reads them from the template, and there is no equivalent silent-override bug there. `summary` was the genuine lone miss.

## 3. Tests — scenarios covered

### `TestSummaryConfigFromBinding`

| # | Test | Scenario covered |
| --- | --- | --- |
| 1 | `test_binding_summary_overrides_template_default` | **The original bug.** Template has `summary: {type: "concise"}`. Binding has `config = {"run_config": {"summary": {"type": "long"}}}`. After `_prepare_eval_config` runs, `config["summary"]["type"] == "long"` — the binding wins. Pre-fix this returned `"concise"` and the user's setting was lost. |
| 2 | `test_falls_back_to_template_when_binding_has_no_run_config` | Binding has `config = {}` (no `run_config` key at all). Template has `summary: {type: "concise"}`. Asserts the runtime uses the template's value. This is the "user never customised the binding" case — must not change behaviour for them. |
| 3 | `test_falls_back_to_template_when_run_config_missing_summary_key` | Binding has `config = {"run_config": {"data_injection": {...}}}` (a `run_config` present, but no `summary` inside it). Template default still wins. Distinguishes "binding has opinions about other fields but not summary" from "binding has an explicit empty summary." |
| 4 | `test_explicit_empty_dict_summary_honors_binding_not_template` | **The `is not None` vs `or` edge case.** Binding has `config = {"run_config": {"summary": {}}}`. Template has `{type: "concise"}`. After resolve, `config["summary"]` is `{}` — the binding's explicit empty dict is honored, **not** silently coerced to the template default. If a future refactor changes the condition to `or`, this test fails. |
| 5 | `test_default_when_template_has_no_summary_at_all` | Both template and binding are silent. The built-in `{"type": "concise"}` fallback in the `.get(..., {...})` call fires. Pins the literal default value so a refactor that drops it (or changes the default) fails the test. |

## 4. What tests are there (summary)

```
futureagi/model_hub/tests/test_eval_runner_summary_config.py
  TestSummaryConfigFromBinding
    test_binding_summary_overrides_template_default
    test_falls_back_to_template_when_binding_has_no_run_config
    test_falls_back_to_template_when_run_config_missing_summary_key
    test_explicit_empty_dict_summary_honors_binding_not_template
    test_default_when_template_has_no_summary_at_all
```

## 5. Commands to run the tests

```bash
# Full file
docker exec backend bash -c "DJANGO_SETTINGS_MODULE=tfc.settings.test pytest \
  model_hub/tests/test_eval_runner_summary_config.py -v"

# Just the headline regression
docker exec backend bash -c "DJANGO_SETTINGS_MODULE=tfc.settings.test pytest \
  model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_binding_summary_overrides_template_default -v"

# Just the is-not-None edge case (the load-bearing test for the comment)
docker exec backend bash -c "DJANGO_SETTINGS_MODULE=tfc.settings.test pytest \
  model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_explicit_empty_dict_summary_honors_binding_not_template -v"
```

## What's NOT in this PR

A typed accessor for `binding.config["run_config"]` was flagged in review as the right structural fix — the same dict is hand-navigated in `eval_runner.py` (4 sites), `eval_list.py`, `composite_runner.py`, and `develop_dataset.py`, with subtly different shapes assumed at each site. That's exactly the kind of drift that lets a bug like this slip in.

That refactor is out of scope for a 1-block behavioural fix and is tracked as a follow-up. This PR fixes the immediate user-visible bug and locks the contract with tests so the typed-accessor refactor can land later without regressing the behaviour.

## How was this tested?


https://github.com/user-attachments/assets/59f8f582-7acf-4832-8ae8-2b0865a4f8c2


- 5 unit tests in `test_eval_runner_summary_config.py` — all passing locally via `docker exec backend pytest model_hub/tests/test_eval_runner_summary_config.py -v`.
- Manually traced the call path: UI sets summary → persists to `user_eval_metric.config['run_config']['summary']` → `_prepare_eval_config` now reads it → `config['summary']` reaches the AgentEvaluator at runtime.

## Linked issues

Closes **TH-5313**.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] Tests added that prove the fix and lock the regression
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA


## 7. Terminal output (evidence)

Backend unit tests (5/5 passed):

```
$ docker exec backend bash -c "DJANGO_SETTINGS_MODULE=tfc.settings.test pytest \
    model_hub/tests/test_eval_runner_summary_config.py -v"

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
django: version: 5.1.8, settings: tfc.settings.test (from env)
rootdir: /app/backend
configfile: pytest.ini
plugins: django-4.12.0, langsmith-0.4.3, anyio-4.9.0
collecting ... collected 5 items

model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_binding_summary_overrides_template_default PASSED [ 20%]
model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_falls_back_to_template_when_binding_has_no_run_config PASSED [ 40%]
model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_falls_back_to_template_when_run_config_missing_summary_key PASSED [ 60%]
model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_explicit_empty_dict_summary_honors_binding_not_template PASSED [ 80%]
model_hub/tests/test_eval_runner_summary_config.py::TestSummaryConfigFromBinding::test_default_when_template_has_no_summary_at_all PASSED [100%]

============================== 5 passed in 2.60s ===============================
```

(Covers: binding-overrides-template · two fallback shapes · `is not None` vs `or` edge case (explicit empty dict) · no-summary-anywhere built-in default.)
