### PR TITLE
fix(simulate): match call_execution_id filter_type to frontend contract

### DIFF
--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -348,7 +348,7 @@ class TestExecutionUtils:
 
                 elif column_id == "call_execution_id":
                     # Filter by call execution IDs
-                    if filter_type == "list" and isinstance(filter_value, list):
+                    if filter_type == "categorical" and isinstance(filter_value, list):
                         # Handle list of IDs
                         if filter_op == "in":
                             call_executions = call_executions.filter(


### PR DESCRIPTION
## Summary

Fix My Agent sends `filter_type: "categorical"` when filtering calls by execution IDs, but the backend only accepted `"list"`, causing the filter to be silently ignored. Changed the condition to match the frontend contract so the calls grid actually filters when recommendations are selected.

## Linked issues

Closes #

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

* Validated Python syntax with `ast.parse`
* Verified the frontend sends `filter_type: "categorical"` (test at `frontend/src/sections/test-detail/__tests__/getSelectedCallExecutionIds.test.js:68`)
* No other callers use `"list"` for this column — confirmed via grep

## Screenshots / recordings (if UI)

https://github.com/user-attachments/assets/63c1057c-6bfe-45a6-be17-df90ba151026

## Checklist

- [X] My code follows the [style guide](<../CONTRIBUTING.md#code-style>)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [X] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](<../CONTRIBUTING.md#contributor-license-agreement-cla>)