### PR TITLE
feat: prompt to rerun dependent columns on source column rerun

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -20,7 +20,7 @@ import PreviewAddColumn from "../PreviewAddColumn";
 import { LoadingButton } from "@mui/lab";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { useAddColumnApiCallStore } from "../../states";
+import { useAddColumnApiCallStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig, useGetJsonColumnSchema } from "src/api/develop/develop-detail";
 import { ShowComponent } from "src/components/show";
@@ -66,6 +66,7 @@ export const AddColumnApiCallChild = ({
   const { dataset } = useParams();
 
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
   const queryClient = useQueryClient();
 
   const allColumns = useDatasetColumnConfig(dataset);
@@ -122,7 +123,19 @@ export const AddColumnApiCallChild = ({
       loadedEditIdRef.current = null;
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
     onError: () => {
       enqueueSnackbar("Failed to update API Call column", {
         variant: "error",

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
@@ -21,7 +21,7 @@ import { LoadingButton } from "@mui/lab";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import CustomModelDropdownControl from "src/components/custom-model-dropdown/CustomModelDropdownControl";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { useClassificationStore } from "../../states";
+import { useClassificationStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import { transformDynamicColumnConfig } from "../common";
@@ -45,6 +45,7 @@ export const ClassificationChild = ({
   editId,
 }) => {
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
 
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
@@ -117,7 +118,19 @@ export const ClassificationChild = ({
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNodeMainForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNodeMainForm.jsx
@@ -25,7 +25,7 @@ import {
 import { ShowComponent } from "../../../../components/show";
 import { useMutation } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { useConditionalNodeStoreShallow } from "../../states";
+import { useConditionalNodeStoreShallow , useRerunDependentColumnsStore } from "../../states";
 import { enqueueSnackbar } from "src/components/snackbar";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 
@@ -178,6 +178,7 @@ const ConditionalNodeMainForm = ({
     (s) => s.setOpenConditionalNode,
   );
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
 
   const onClose = () => {
     setOpenConditionalNode(false);
@@ -213,7 +214,19 @@ const ConditionalNodeMainForm = ({
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -13,7 +13,7 @@ import ExecuteCodeValidation from "./validation";
 import { LoadingButton } from "@mui/lab";
 import PreviewAddColumn from "../PreviewAddColumn";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { useExecuteCodeStore } from "../../states";
+import { useExecuteCodeStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { ShowComponent } from "../../../../components/show";
@@ -48,6 +48,7 @@ export const ExecuteCodeChild = ({
   editId,
 }) => {
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
 
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
@@ -113,7 +114,19 @@ def main(**kwargs):
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
@@ -15,7 +15,7 @@ import { LoadingButton } from "@mui/lab";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import CustomModelDropdownControl from "src/components/custom-model-dropdown/CustomModelDropdownControl";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { useExtractEntitiesStore } from "../../states";
+import { useExtractEntitiesStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
@@ -38,6 +38,7 @@ export const ExtractEntitiesChild = ({
   editId,
 }) => {
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
 
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
@@ -110,7 +111,19 @@ export const ExtractEntitiesChild = ({
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
@@ -13,7 +13,7 @@ import PreviewAddColumn from "../PreviewAddColumn";
 import { LoadingButton } from "@mui/lab";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
-import { useExtractJsonKeyStore } from "../../states";
+import { useExtractJsonKeyStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
@@ -35,6 +35,7 @@ export const ExtractJsonKeyChild = ({
   editId,
 }) => {
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
 
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
@@ -103,7 +104,19 @@ export const ExtractJsonKeyChild = ({
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
@@ -17,7 +17,7 @@ import { LoadingButton } from "@mui/lab";
 import PreviewAddColumn from "../PreviewAddColumn";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import { useRetrievalStore } from "../../states";
+import { useRetrievalStore , useRerunDependentColumnsStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
@@ -37,6 +37,7 @@ export const RetrievalChild = ({
   editId,
 }) => {
   const { refreshGrid } = useDevelopDetailContext();
+  const { setRerunDependentColumns } = useRerunDependentColumnsStore();
   // Using individual store
 
   const { control, handleSubmit, watch, reset } = useForm({
@@ -122,7 +123,19 @@ export const RetrievalChild = ({
       });
       refreshGrid();
       onClose();
-    },
+    
+      try {
+        axios.get(endpoints.develop.addColumns.getDependentColumns(editId)).then((res) => {
+          if (res.data?.result?.dependents?.length > 0) {
+            setRerunDependentColumns({
+              sourceColumnId: editId,
+              dependents: res.data.result.dependents,
+            });
+          }
+        });
+      } catch (err) {
+        console.error("Failed to check dependent columns", err);
+      }},
   });
 
   const transformFormToApi = (formValues) => {

--- a/frontend/src/sections/develop-detail/DataTab/DevelopData.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopData.jsx
@@ -31,6 +31,7 @@ import { getColumnConfig, getTypeDefinitions } from "./common";
 import "./developDataGrid.css";
 import DatapointDrawer from "./DatapointDrawer/DatapointDrawer";
 import ConfirmDeleteColumn from "./DeleteColumn";
+import RerunDependentColumns from "./RerunDependentColumns";
 import SingleImageViewerProvider from "../Common/SingleImageViewer/SingleImageViewerProvider";
 import AddRowData from "./AddRowData";
 import AddEvaluationFeeback from "./AddEvaluationFeeback/AddEvaluationFeeback";
@@ -1083,6 +1084,7 @@ const DevelopData = React.forwardRef(
           column={editColumnType}
           reset={reset}
         />
+        <RerunDependentColumns />
         <ConfirmDeleteColumn
           open={Boolean(deleteColumn)}
           onClose={() => setDeleteColumn(null)}

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -52,6 +52,7 @@ import {
 const EditColumnName = lazy(() => import("./EditColumnName"));
 const EditColumnType = lazy(() => import("./EditColumnType"));
 const ConfirmDeleteColumn = lazy(() => import("./DeleteColumn"));
+const RerunDependentColumns = lazy(() => import("./RerunDependentColumns"));
 const AddEvaluationFeeback = lazy(
   () => import("./AddEvaluationFeeback/AddEvaluationFeeback"),
 );
@@ -1346,6 +1347,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
       <Suspense fallback={null}>
         <EditColumnName />
         <EditColumnType />
+        <RerunDependentColumns />
         <ConfirmDeleteColumn dataset={dataset} />
         <AddEvaluationFeeback />
         <ImprovePrompt />

--- a/frontend/src/sections/develop-detail/DataTab/RerunDependentColumns.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/RerunDependentColumns.jsx
@@ -1,0 +1,121 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  IconButton,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import { LoadingButton } from "@mui/lab";
+import { useMutation } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useRerunDependentColumnsStore } from "../states";
+import { useDevelopDetailContext } from "../Context/DevelopDetailContext";
+
+const RerunDependentColumns = () => {
+  const { rerunDependentColumns, setRerunDependentColumns } = useRerunDependentColumnsStore();
+  const { refreshGrid } = useDevelopDetailContext();
+
+  const { mutate: rerunDependentsMutate, isPending: isLoading } = useMutation({
+    mutationFn: async (dependents) => {
+      const promises = dependents.map((dep) =>
+        axios.post(endpoints.develop.addColumns.updateDynamicColumn(dep.id), {
+          operation_type: dep.operation_type,
+        })
+      );
+      return Promise.all(promises);
+    },
+    onSuccess: () => {
+      setRerunDependentColumns(null);
+      refreshGrid();
+    },
+  });
+
+  const onConfirm = () => {
+    if (rerunDependentColumns?.dependents) {
+      rerunDependentsMutate(rerunDependentColumns.dependents);
+    }
+  };
+
+  const onClose = () => {
+    setRerunDependentColumns(null);
+  };
+
+  if (!rerunDependentColumns) return null;
+
+  return (
+    <Dialog
+      open={Boolean(rerunDependentColumns)}
+      onClose={onClose}
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-description"
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle
+        sx={{
+          gap: "10px",
+          display: "flex",
+          flexDirection: "column",
+          padding: 2,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography variant="h6">
+            Rerun dependent columns?
+          </Typography>
+          <IconButton onClick={onClose} disabled={isLoading}>
+            <Iconify icon="mdi:close" />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      
+      <DialogContent sx={{ padding: 2 }}>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          The following columns depend on the column you just reran. Would you like to rerun them as well to keep data in sync?
+        </Typography>
+        <List dense sx={{ bgcolor: "background.paper", borderRadius: 1, border: "1px solid", borderColor: "divider" }}>
+          {rerunDependentColumns.dependents?.map((col) => (
+            <ListItem key={col.id}>
+              <ListItemText 
+                primary={col.name} 
+                secondary={`Type: ${col.operation_type}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+
+      <DialogActions sx={{ padding: 2 }}>
+        <Button onClick={onClose} variant="outlined" size="small" disabled={isLoading}>
+          No
+        </Button>
+        <LoadingButton
+          onClick={onConfirm}
+          variant="contained"
+          autoFocus
+          size="small"
+          loading={isLoading}
+        >
+          Yes
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default RerunDependentColumns;

--- a/frontend/src/sections/develop-detail/states.jsx
+++ b/frontend/src/sections/develop-detail/states.jsx
@@ -204,6 +204,12 @@ export const useDeleteColumnStore = create((set) => ({
   setDeleteColumn: (value) => set(() => ({ deleteColumn: value })),
 }));
 
+export const useRerunDependentColumnsStore = create((set) => ({
+  rerunDependentColumns: null,
+  setRerunDependentColumns: (value) => set(() => ({ rerunDependentColumns: value })),
+}));
+
+
 export const useAddEvaluationFeebackStore = create((set) => ({
   addEvaluationFeeback: null,
   setAddEvaluationFeeback: (value) =>
@@ -339,6 +345,7 @@ export const resetAllStates = () => {
   useEditColumnNameStore.getState().setEditColumnName(null);
   useEditColumnTypeStore.getState().setEditColumnType(null);
   useDeleteColumnStore.getState().setDeleteColumn(null);
+  useRerunDependentColumnsStore.getState().setRerunDependentColumns(null);
   useAddEvaluationFeebackStore.getState().setAddEvaluationFeeback(null);
   useImprovePromptStore.getState().setImprovePrompt(null);
   useEditCellStore.getState().setEditCell(null);

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -729,6 +729,8 @@ export const endpoints = {
         `/model-hub/columns/${columnId}/operation-config/`,
       updateDynamicColumn: (columnId) =>
         `/model-hub/columns/${columnId}/rerun-operation/`,
+      getDependentColumns: (columnId) =>
+        `/model-hub/columns/${columnId}/dependents/`,
     },
     deleteDatasetRow: (datasetId) =>
       `/model-hub/develops/${datasetId}/delete_row/`,

--- a/futureagi/model_hub/urls.py
+++ b/futureagi/model_hub/urls.py
@@ -81,6 +81,7 @@ from model_hub.views.dynamic_columns import (
     GetOperationConfigView,
     PreviewDatasetOperationView,
     RerunOperationView,
+    GetDependentColumnsView,
 )
 from model_hub.views.eval_group import EvalGroupView
 from model_hub.views.eval_runner import (
@@ -1211,6 +1212,11 @@ urlpatterns = [
         "columns/<uuid:column_id>/rerun-operation/",
         RerunOperationView.as_view(),
         name="rerun-operation",
+    ),
+    path(
+        "columns/<uuid:column_id>/dependents/",
+        GetDependentColumnsView.as_view(),
+        name="get-dependent-columns",
     ),
     # Derived Variables endpoints
     path(

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -1624,6 +1624,52 @@ class GetOperationConfigView(APIView):
             )
 
 
+class GetDependentColumnsView(APIView):
+    _gm = GeneralMethods()
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, column_id, *args, **kwargs):
+        """Get all columns that depend on this column"""
+        try:
+            source_column = get_object_or_404(
+                Column,
+                id=column_id,
+                deleted=False,
+                dataset__organization_id=getattr(request, "organization", None)
+                or request.user.organization.id,
+            )
+
+            dependents = []
+            source_id_str = str(source_column.id)
+            source_name_ref = f"{{{{{source_column.name}}}}}"
+
+            sibling_columns = Column.objects.filter(
+                dataset=source_column.dataset, deleted=False
+            ).exclude(id=source_column.id)
+
+            for col in sibling_columns:
+                if not col.metadata:
+                    continue
+
+                metadata_str = json.dumps(col.metadata)
+                if source_id_str in metadata_str or source_name_ref in metadata_str:
+                    dependents.append(
+                        {
+                            "id": str(col.id),
+                            "name": col.name,
+                            "operation_type": col.source,
+                        }
+                    )
+
+            return self._gm.success_response({"dependents": dependents})
+
+        except Exception as e:
+            logger.exception(f"Error getting dependent columns: {str(e)}")
+            return self._gm.internal_server_error_response(
+                get_error_message("FAILED_TO_GET_DEPENDENT_COLUMNS")
+            )
+
+
 class RerunOperationView(APIView):
     _gm = GeneralMethods()
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

When a dataset column's value is derived from another column, rerunning the source column previously left all dependents stale without warning. This PR solves this by introducing a confirmation dialog that dynamically detects dependent columns and offers to batch rerun them. 

To avoid heavy schema migrations, the backend `GetDependentColumnsView` resolves dependencies on-the-fly by parsing the JSON metadata of all dataset columns. On the frontend, a new global store and `RerunDependentColumns` component intercept the `updateColumn` flow to gracefully trigger the modal and batch the API updates without prop-drilling.

## Linked issues

Closes #934

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- Bootstrapped the full stack locally via `docker-compose.dev.yml`.
- Created a standard column (`Column 1`) and a dependent extraction column (`new`) that referenced `Column 1`.
- Verified the modal successfully appeared listing `new` when `Column 1` was reran.
- Confirmed the "Yes" action correctly dispatched the `rerun-operation` API payload for the dependent column and refreshed the table.


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
