### PR TITLE
chore: remove table-level TTLs from v2 spans and v1 hourly rollups

### DIFF
--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -975,7 +975,6 @@ CREATE TABLE IF NOT EXISTS span_metrics_hourly (
 ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/span_metrics_hourly', '{replica}')
 PARTITION BY toYYYYMM(hour)
 ORDER BY (project_id, hour, observation_type, model, status)
-TTL hour + INTERVAL 365 DAY
 SETTINGS index_granularity = 8192, allow_nullable_key = 1;
 """
 
@@ -1037,7 +1036,6 @@ CREATE TABLE IF NOT EXISTS eval_metrics_hourly (
 ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/eval_metrics_hourly', '{replica}')
 PARTITION BY toYYYYMM(hour)
 ORDER BY (project_id, custom_eval_config_id, hour)
-TTL hour + INTERVAL 365 DAY
 SETTINGS index_granularity = 8192, allow_nullable_key = 1;
 """
 
@@ -1912,6 +1910,14 @@ POST_DDL_ALTERS: list[str] = [
     "idx_trace_session_id trace_session_id TYPE bloom_filter GRANULARITY 1",
     "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
     "idx_target_type target_type TYPE bloom_filter GRANULARITY 1",
+    # Strip the legacy 365d TTL from the v1 hourly rollup tables. The CREATE
+    # strings above no longer declare TTL, but existing prod clusters carry
+    # the original TTL on the live tables — these ALTERs remove it.
+    # In dev/test where the legacy CDC chain is gated off, the tables don't
+    # exist and these ALTERs error out; _ensure_analytics_schema() catches
+    # those as warnings (model_hub/apps.py:88-93).
+    "ALTER TABLE span_metrics_hourly REMOVE TTL",
+    "ALTER TABLE eval_metrics_hourly REMOVE TTL",
 ]
 
 

--- a/futureagi/tracer/services/clickhouse/v2/schema/020_remove_ttls.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/020_remove_ttls.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- 020 — Remove all TTLs from the v2 spans + rollup tables.
+-- =============================================================================
+--
+-- Decision: spans (and every aggregate that hangs off them) must be retained
+-- indefinitely at the storage layer. Per-org retention is enforced by
+-- ee/usage/tasks/retention.py via the `retention_traces_days` entitlement, not
+-- by ClickHouse TTL. Removing the table-level TTL stops background merges
+-- from dropping parts whose start_time exceeds the previous 90-day window.
+--
+-- This file is intentionally APPEND-ONLY (per apply_schema.py's hash-tracking
+-- contract). Do not edit 002_spans_v2.sql or any other prior file to strip
+-- their TTL clauses — that would trigger drift detection (`exit 2`) on every
+-- existing cluster and the CREATE TABLE IF NOT EXISTS would no-op anyway.
+-- 
+-- =============================================================================
+
+ALTER TABLE spans REMOVE TTL;
+
+ALTER TABLE spans_v2_dead_letter REMOVE TTL;
+
+ALTER TABLE spans_per_session REMOVE TTL;
+
+ALTER TABLE eval_per_config REMOVE TTL;
+
+ALTER TABLE spans_hourly_rollup REMOVE TTL;
+
+ALTER TABLE trace_count_rollup REMOVE TTL;
+
+ALTER TABLE span_user_rollup REMOVE TTL;


### PR DESCRIPTION
## Summary

Strip the hardcoded ClickHouse table-level TTLs from the v2 spans + rollup tables and the v1 hourly rollup tables. Retention is moving to per-org enforcement (handled by the usage/pricing team via the `retention_traces_days` entitlement), so leaving fixed 90d/365d table TTLs would silently drop parts that orgs are still entitled to keep.

- New migration `v2/schema/020_remove_ttls.sql` runs `ALTER TABLE … REMOVE TTL` against the v2 chain (`spans`, `spans_v2_dead_letter`, `spans_per_session`, `eval_per_config`, `spans_hourly_rollup`, `trace_count_rollup`, `span_user_rollup`).
- For the v1 hourly rollups (`span_metrics_hourly`, `eval_metrics_hourly`), the `CREATE TABLE` strings drop the `TTL` clause and matching `ALTER TABLE … REMOVE TTL` statements are added to `POST_DDL_ALTERS` so existing prod clusters get the TTL stripped on next boot.

## Linked issues

Fixed TH-5816

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Verified the v2 migration applies cleanly via `apply_schema.py` (hash-tracked, append-only — does not edit prior files, so no drift trip).
- Confirmed `POST_DDL_ALTERS` failures on missing v1 tables in dev/test are caught + logged as warnings by `_ensure_analytics_schema` (`model_hub/apps.py:88-93`).

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA