### PR TITLE
fix: cap custom attribute scan in dashboard metrics endpointogog

### DIFF
--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1057,24 +1057,26 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     from tracer.services.clickhouse.client import get_clickhouse_client
 
                     ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
                     rows, cols, _ = ch.execute_read(
                         """
                         SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
+                            SELECT
+                                pair.1 AS key,
+                                pair.2 AS type,
+                                count() AS cnt
+                            FROM (
+                                SELECT span_attr_str, span_attr_num, span_attr_bool
+                                FROM spans
+                                WHERE project_id IN %(project_ids)s
+                                  AND _peerdb_is_deleted = 0
+                                LIMIT 100000
+                            )
+                            ARRAY JOIN arrayConcat(
+                                arrayMap(k -> (k, 'text'),    mapKeys(span_attr_str)),
+                                arrayMap(k -> (k, 'number'),  mapKeys(span_attr_num)),
+                                arrayMap(k -> (k, 'boolean'), mapKeys(span_attr_bool))
+                            ) AS pair
+                            GROUP BY pair.1, pair.2
                         )
                         GROUP BY key ORDER BY key LIMIT 2000
                         """,


### PR DESCRIPTION
## Summary

Custom attribute dropdown silently returns empty in production for projects with high-cardinality span attributes (e.g., colektia US colly agent). The ClickHouse query that enumerates `mapKeys(span_attr_*)` runs three full `UNION ALL` scans over the `spans` table, exceeds the 15s `timeout_ms`, and the resulting exception is swallowed by `except Exception: pass`.

This PR replaces the triple-scan with a single `ARRAY JOIN arrayConcat(...)` over a `LIMIT 100000` row source so the scan is bounded regardless of project size. Output schema is unchanged.

## Linked issues

Fixed TH-5946

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [x] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Reproduction of the original bug:
- Ran the affected endpoint via curl against production for the colektia US project: response took ~16s and returned zero `custom_attribute` category entries.
- Cross-checked Grafana Loki: every `GET /tracer/dashboard/metrics/?...&per_eval_config=true` request for this project completes in ~15.3s (matches `timeout_ms=15000` exactly), confirming the CH query was being killed and the exception swallowed.

Pending verification before/after merge:
- [ ] Hit the same endpoint in staging/prod after deploy and confirm `custom_attribute` entries are returned for the colektia project within the timeout budget.
- [ ] `make check-all` locally.
- [ ] Existing `futureagi/tracer/tests/test_dashboard.py` suite still green (no schema/contract change expected).

## Screenshots / recordings (if UI)

N/A — backend-only change; user-visible effect is the metric picker dropdown showing custom attribute keys instead of being empty.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] \`make check-all\` / \`yarn check-all\` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)