### PR TITLE
feat(eval-writer): generate eval-aware test data via Falcon

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -41453,7 +41453,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "enum": [
             "prompt",
-            "messages"
+            "messages",
+            "test_data"
           ],
           "default": "prompt"
         }

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -5222,6 +5222,7 @@ export type AIEvalWriterRequestApiOutputFormat = typeof AIEvalWriterRequestApiOu
 export const AIEvalWriterRequestApiOutputFormat = {
   prompt: 'prompt',
   messages: 'messages',
+  test_data: 'test_data',
 } as const;
 
 export interface AIEvalWriterRequestApi {

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -11513,7 +11513,7 @@ export const modelHubAiEvalWriterCreateBodyOutputFormatDefault = `prompt`;
 
 export const ModelHubAiEvalWriterCreateBody = zod.object({
   "description": zod.string().min(1),
-  "output_format": zod.enum(['prompt', 'messages']).default(modelHubAiEvalWriterCreateBodyOutputFormatDefault)
+  "output_format": zod.enum(['prompt', 'messages', 'test_data']).default(modelHubAiEvalWriterCreateBodyOutputFormatDefault)
 })
 
 export const modelHubAiEvalWriterCreateResponseStatusDefault = true;

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1774,6 +1774,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <TestPlayground
                     ref={sourceRef}
                     templateId={templateId}
+                    evalName={evalName || ""}
                     instructions={evalType === "code" ? "" : instructions}
                     evalType={evalType}
                     isSystemEval={isSystemEval}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1250,6 +1250,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     <TestPlayground
                       ref={sourceRef}
                       templateId={draftId}
+                      evalName={name || ""}
                       instructions=""
                       evalType="llm"
                       requiredKeys={compositeUnionKeys}

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -1215,6 +1215,7 @@ const EvalCreatePage = () => {
                   ref={testPlaygroundRef}
                   templateId={draftId}
                   model={model}
+                  evalName={name || ""}
                   instructions={
                     mode === "composite" || evalType === "code"
                       ? ""

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1859,6 +1859,7 @@ const EvalDetailPage = () => {
                     ref={testPlaygroundRef}
                     templateId={evalId}
                     model={model}
+                    evalName={evalData?.name || ""}
                     instructions={
                       evalType === "code"
                         ? ""

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -66,6 +66,7 @@ const CustomJsonInput = ({
   const [jsonText, setJsonText] = useState("");
   const [jsonError, setJsonError] = useState(null);
   const followUpRef = useRef(null);
+  const { enqueueSnackbar } = useSnackbar();
 
   // AI bar state
   const [aiOpen, setAiOpen] = useState(false);
@@ -258,13 +259,16 @@ const CustomJsonInput = ({
           setAiPrompt(prompt.trim());
           setTimeout(() => followUpRef.current?.focus(), 100);
         }
-      } catch {
-        // silent
+      } catch (err) {
+        console.error("Falcon test-data generation failed", err);
+        enqueueSnackbar("Couldn't generate test data. Please try again.", {
+          variant: "error",
+        });
       } finally {
         setAiLoading(false);
       }
     },
-    [jsonText, originalJson, callAI, handleJsonChange],
+    [jsonText, originalJson, callAI, handleJsonChange, enqueueSnackbar],
   );
 
   const handleAccept = useCallback(() => {

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -60,6 +60,7 @@ const CustomJsonInput = ({
   inputValues,
   onInputChange,
   instructions,
+  evalName,
   onColumnsLoaded,
 }) => {
   const [jsonText, setJsonText] = useState("");
@@ -208,12 +209,27 @@ const CustomJsonInput = ({
       const varList = variables.join(", ");
       const currentData =
         jsonText && jsonText.trim() !== "{}" ? jsonText : null;
-      const description = currentData
-        ? `Current test data JSON:\n${currentData}\n\nUser wants to: ${userPrompt}\n\nGenerate updated JSON with keys: ${varList}. Return ONLY valid JSON.`
-        : `Generate realistic test data as JSON for variables: ${varList}.\n${instructions ? `Eval context: ${instructions.slice(0, 300)}` : ""}\nUser request: ${userPrompt}\nReturn ONLY valid JSON.`;
+
+      // Context so the model knows the test data is for THIS evaluation.
+      const evalContext = [
+        "The test data you generate will be used to run the following evaluation.",
+        evalName ? `Evaluation name: ${evalName}` : "",
+        instructions
+          ? `Evaluation instruction:\n${instructions.slice(0, 4000)}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+      const task = currentData
+        ? `Current test data JSON:\n${currentData}\n\nUser wants to: ${userPrompt}\n\nGenerate updated JSON with keys: ${varList}.`
+        : `User request: ${userPrompt}\n\nGenerate JSON with keys: ${varList}.`;
+
+      const description = `${evalContext}\n\n${task}`;
 
       const { data } = await axios.post(endpoints.develop.eval.aiEvalWriter, {
         description,
+        output_format: "test_data",
       });
       const raw = data?.result?.prompt;
       if (raw) {
@@ -222,7 +238,7 @@ const CustomJsonInput = ({
       }
       return null;
     },
-    [variables, jsonText, instructions],
+    [variables, jsonText, instructions, evalName],
   );
 
   // Submit prompt
@@ -607,6 +623,7 @@ CustomJsonInput.propTypes = {
   inputValues: PropTypes.object.isRequired,
   onInputChange: PropTypes.func.isRequired,
   instructions: PropTypes.string,
+  evalName: PropTypes.string,
   onColumnsLoaded: PropTypes.func,
 };
 
@@ -615,6 +632,7 @@ const TestPlayground = React.forwardRef(
     {
       templateId,
       instructions = "",
+      evalName = "",
       evalType,
       model = "turing_large",
       requiredKeys = [],
@@ -1218,6 +1236,7 @@ const TestPlayground = React.forwardRef(
                     inputValues={inputValues}
                     onInputChange={handleInputChange}
                     instructions={instructions}
+                    evalName={evalName}
                     onColumnsLoaded={onColumnsLoaded}
                   />
 
@@ -1866,6 +1885,7 @@ TestPlayground.displayName = "TestPlayground";
 TestPlayground.propTypes = {
   templateId: PropTypes.string,
   instructions: PropTypes.string,
+  evalName: PropTypes.string,
   evalType: PropTypes.string,
   requiredKeys: PropTypes.array,
   showVersions: PropTypes.bool,

--- a/futureagi/model_hub/serializers/contracts.py
+++ b/futureagi/model_hub/serializers/contracts.py
@@ -259,7 +259,7 @@ class EvalSummaryTemplateDeleteResponseSerializer(serializers.Serializer):
 class AIEvalWriterRequestSerializer(serializers.Serializer):
     description = serializers.CharField()
     output_format = serializers.ChoiceField(
-        choices=["prompt", "messages"],
+        choices=["prompt", "messages", "test_data"],
         required=False,
         default="prompt",
     )

--- a/futureagi/model_hub/services/ai_eval_writer_service.py
+++ b/futureagi/model_hub/services/ai_eval_writer_service.py
@@ -1,0 +1,135 @@
+"""Service layer for the AI eval-writer.
+
+Generates an evaluation artifact (an instruction prompt, an LLM-as-a-Judge
+message array, or test data) from a natural-language description by calling
+the LLM. Used by AIEvalWriterView; kept HTTP-free so any caller can reuse it.
+"""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+SYSTEM_PROMPT = """You are an expert AI evaluation engineer. Given a user's brief description of what they want to evaluate, generate a comprehensive evaluation instruction prompt.
+
+Rules:
+1. The prompt MUST include template variables using double curly braces: {{variable_name}}
+2. Common variables: {{input}}, {{output}}, {{expected}}, {{ground_truth}}, {{model_output}}, {{context}}, {{conversation}}
+3. The prompt should be specific, actionable, and tell the LLM evaluator exactly what to check
+4. Include clear scoring criteria (what constitutes pass/fail or a high/low score)
+5. Keep it concise but thorough — typically 5-15 lines
+6. Return ONLY the prompt text, no explanation or markdown wrapping
+
+Example input: "check if the response is factually accurate"
+Example output:
+You are an expert fact-checker evaluating AI-generated responses for factual accuracy.
+
+Given the following:
+- User Question: {{input}}
+- AI Response: {{output}}
+- Reference Answer: {{ground_truth}}
+
+Evaluate whether the AI response is factually accurate by checking:
+1. All stated facts match the reference answer
+2. No fabricated or hallucinated information is present
+3. Key details are not omitted or distorted
+
+Return "Passed" if the response is factually accurate, "Failed" otherwise."""
+
+MESSAGES_SYSTEM_PROMPT = """You are an expert AI evaluation engineer. Given a user's description of what they want to evaluate, generate an LLM-as-a-Judge prompt as a multi-message conversation.
+
+Rules:
+1. Return ONLY a valid JSON array of messages. No markdown fences, no explanation, no prose.
+2. Each array element must be an object with exactly two keys: "role" and "content".
+3. Generate ONLY "system" and "user" roles. Do NOT generate an "assistant" role — the assistant response comes from the actual LLM at evaluation time.
+4. The "system" message sets up the evaluator persona, expertise, and scoring criteria.
+5. The "user" message contains the evaluation template with variables for dynamic data.
+6. Use template variables with double curly braces: {{input}}, {{output}}, {{expected}}, {{ground_truth}}, {{context}}. Prefer whatever variables the user mentioned.
+7. If the user supplies "Existing messages" as context, treat them as the current draft and produce an IMPROVED version that preserves intent while applying the requested changes.
+
+Example user request:
+check if chatbot answers are polite and accurate
+
+Example output (return exactly this shape, no wrapping):
+[
+  {"role": "system", "content": "You are a strict evaluator judging chatbot responses for politeness and factual accuracy. Score each response on two dimensions and return a final verdict."},
+  {"role": "user", "content": "User question: {{input}}\\nChatbot response: {{output}}\\nReference answer: {{ground_truth}}\\n\\nEvaluate whether the chatbot response is (1) polite in tone and (2) factually consistent with the reference answer. Return 'Passed' only if both criteria are met, otherwise return 'Failed' with a brief reason."}
+]"""
+
+TEST_DATA_SYSTEM_PROMPT = """You generate realistic test data as a JSON object for testing an LLM evaluation.
+
+Rules:
+1. Return ONLY a valid JSON object. No markdown fences, no explanation, no prose.
+2. The object's keys must be EXACTLY the variable names the user provides — no more, no fewer.
+3. Every value must be a realistic string appropriate to the eval's scenario.
+4. If the user supplies "Current test data JSON", treat it as the current draft and return an UPDATED object that applies the requested change while keeping the same keys.
+5. If the user asks for a "failing case", craft data that should FAIL the evaluation (e.g. an unsupported claim, a factual error, an off-topic response). If they ask for a "passing case", craft data that should PASS.
+
+Example user request:
+Generate realistic test data as JSON for variables: output, context. User request: a failing case
+
+Example output (return exactly this shape, no wrapping):
+{"output": "Our revenue grew 40% driven by strong demand in Europe.", "context": "Q3 revenue was flat year over year with no regional breakdown provided."}"""
+
+OUTPUT_FORMAT_PROMPTS = {
+    "prompt": SYSTEM_PROMPT,
+    "messages": MESSAGES_SYSTEM_PROMPT,
+    "test_data": TEST_DATA_SYSTEM_PROMPT,
+}
+
+
+def _strip_markdown_fence(text: str) -> str:
+    """Drop a leading ```/```json fence (and trailing ```) some models add."""
+    if not text.startswith("```"):
+        return text
+    lines = text.split("\n")
+    body = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+    return "\n".join(body).strip()
+
+
+def generate_eval_prompt(*, description: str, output_format: str = "prompt") -> str:
+    """Generate an eval artifact from a description via the LLM.
+
+    Args:
+        description: Natural-language description of what to generate.
+        output_format: One of OUTPUT_FORMAT_PROMPTS — "prompt" (an eval
+            instruction), "messages" (a JSON array of judge messages), or
+            "test_data" (a JSON object of test data).
+
+    Returns:
+        The generated text with any markdown fence stripped. For "messages"
+        and "test_data" this is a JSON string the caller parses.
+
+    Raises:
+        ValueError: description is blank or output_format is unknown.
+    """
+    description = (description or "").strip()
+    if not description:
+        raise ValueError("Description is required")
+
+    system_prompt = OUTPUT_FORMAT_PROMPTS.get(output_format)
+    if system_prompt is None:
+        raise ValueError(
+            f"Invalid output_format: {output_format}. "
+            f"Expected one of: {list(OUTPUT_FORMAT_PROMPTS.keys())}"
+        )
+
+    # Use Haiku for speed. Imported lazily to keep module import cheap.
+    import litellm
+
+    from agentic_eval.core.utils.model_config import ModelConfigs
+
+    haiku_cfg = ModelConfigs.HAIKU_4_5_BEDROCK_ARN
+
+    response = litellm.completion(
+        model=haiku_cfg.model_name,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": description},
+        ],
+        temperature=0.3,
+        max_tokens=1500 if output_format == "messages" else 1000,
+        num_retries=2,
+    )
+
+    prompt_text = response.choices[0].message.content.strip()
+    return _strip_markdown_fence(prompt_text)

--- a/futureagi/model_hub/tests/test_ai_eval_writer_contracts.py
+++ b/futureagi/model_hub/tests/test_ai_eval_writer_contracts.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from rest_framework import status
 
@@ -5,6 +7,11 @@ from rest_framework import status
 def _assert_field_error(response, field_name):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert field_name in response.json()["details"]
+
+
+def _mock_completion(content):
+    """Build a litellm.completion return value carrying `content`."""
+    return MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
 
 
 @pytest.mark.django_db
@@ -33,3 +40,52 @@ class TestAIEvalWriterContracts:
         )
 
         _assert_field_error(response, "output_format")
+
+
+@pytest.mark.django_db
+class TestAIEvalWriterGeneration:
+    """Behavior of the generation path (litellm mocked — no network)."""
+
+    def test_test_data_format_returns_generated_json(self, auth_client):
+        # The new output_format must be accepted end-to-end and its result
+        # returned verbatim. This is the regression that strict request-contract
+        # enforcement broke when the enum lacked "test_data".
+        generated = '{"output": "Revenue grew 40%.", "context": "Flat YoY."}'
+        with patch("litellm.completion", return_value=_mock_completion(generated)):
+            response = auth_client.post(
+                "/model-hub/ai-eval-writer/",
+                {
+                    "description": "Generate a failing case for variables: output, context",
+                    "output_format": "test_data",
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"]["prompt"] == generated
+
+    def test_strips_markdown_fence_from_model_output(self, auth_client):
+        fenced = '```json\n{"output": "x", "context": "y"}\n```'
+        with patch("litellm.completion", return_value=_mock_completion(fenced)):
+            response = auth_client.post(
+                "/model-hub/ai-eval-writer/",
+                {"description": "test data please", "output_format": "test_data"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"]["prompt"] == '{"output": "x", "context": "y"}'
+
+    def test_prompt_format_still_works(self, auth_client):
+        # Regression guard for the pre-existing default format after adding the
+        # new branch.
+        generated = "You are an expert evaluator. Check {{output}} against {{ground_truth}}."
+        with patch("litellm.completion", return_value=_mock_completion(generated)):
+            response = auth_client.post(
+                "/model-hub/ai-eval-writer/",
+                {"description": "check factual accuracy"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"]["prompt"] == generated

--- a/futureagi/model_hub/views/ai_eval_writer.py
+++ b/futureagi/model_hub/views/ai_eval_writer.py
@@ -3,15 +3,14 @@ AI Eval Prompt Writer endpoint.
 
 POST /model-hub/ai-eval-writer/
 
-Takes a user's brief description of what they want to evaluate
-and generates a full, structured eval instruction prompt with
-template variables.
+Takes a user's brief description of what they want to evaluate and generates
+an eval artifact (an instruction prompt, an LLM-as-a-Judge message array, or
+test data). The generation logic lives in model_hub.services.ai_eval_writer_service.
 """
 
 import traceback
 
 import structlog
-from drf_yasg.utils import swagger_auto_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
@@ -20,77 +19,11 @@ from model_hub.serializers.contracts import (
     AIEvalWriterRequestSerializer,
     AIEvalWriterResponseSerializer,
 )
+from model_hub.services.ai_eval_writer_service import generate_eval_prompt
 from tfc.utils.api_contracts import validated_request
 from tfc.utils.general_methods import GeneralMethods
 
 logger = structlog.get_logger(__name__)
-
-SYSTEM_PROMPT = """You are an expert AI evaluation engineer. Given a user's brief description of what they want to evaluate, generate a comprehensive evaluation instruction prompt.
-
-Rules:
-1. The prompt MUST include template variables using double curly braces: {{variable_name}}
-2. Common variables: {{input}}, {{output}}, {{expected}}, {{ground_truth}}, {{model_output}}, {{context}}, {{conversation}}
-3. The prompt should be specific, actionable, and tell the LLM evaluator exactly what to check
-4. Include clear scoring criteria (what constitutes pass/fail or a high/low score)
-5. Keep it concise but thorough — typically 5-15 lines
-6. Return ONLY the prompt text, no explanation or markdown wrapping
-
-Example input: "check if the response is factually accurate"
-Example output:
-You are an expert fact-checker evaluating AI-generated responses for factual accuracy.
-
-Given the following:
-- User Question: {{input}}
-- AI Response: {{output}}
-- Reference Answer: {{ground_truth}}
-
-Evaluate whether the AI response is factually accurate by checking:
-1. All stated facts match the reference answer
-2. No fabricated or hallucinated information is present
-3. Key details are not omitted or distorted
-
-Return "Passed" if the response is factually accurate, "Failed" otherwise."""
-
-MESSAGES_SYSTEM_PROMPT = """You are an expert AI evaluation engineer. Given a user's description of what they want to evaluate, generate an LLM-as-a-Judge prompt as a multi-message conversation.
-
-Rules:
-1. Return ONLY a valid JSON array of messages. No markdown fences, no explanation, no prose.
-2. Each array element must be an object with exactly two keys: "role" and "content".
-3. Generate ONLY "system" and "user" roles. Do NOT generate an "assistant" role — the assistant response comes from the actual LLM at evaluation time.
-4. The "system" message sets up the evaluator persona, expertise, and scoring criteria.
-5. The "user" message contains the evaluation template with variables for dynamic data.
-6. Use template variables with double curly braces: {{input}}, {{output}}, {{expected}}, {{ground_truth}}, {{context}}. Prefer whatever variables the user mentioned.
-7. If the user supplies "Existing messages" as context, treat them as the current draft and produce an IMPROVED version that preserves intent while applying the requested changes.
-
-Example user request:
-check if chatbot answers are polite and accurate
-
-Example output (return exactly this shape, no wrapping):
-[
-  {"role": "system", "content": "You are a strict evaluator judging chatbot responses for politeness and factual accuracy. Score each response on two dimensions and return a final verdict."},
-  {"role": "user", "content": "User question: {{input}}\\nChatbot response: {{output}}\\nReference answer: {{ground_truth}}\\n\\nEvaluate whether the chatbot response is (1) polite in tone and (2) factually consistent with the reference answer. Return 'Passed' only if both criteria are met, otherwise return 'Failed' with a brief reason."}
-]"""
-
-TEST_DATA_SYSTEM_PROMPT = """You generate realistic test data as a JSON object for testing an LLM evaluation.
-
-Rules:
-1. Return ONLY a valid JSON object. No markdown fences, no explanation, no prose.
-2. The object's keys must be EXACTLY the variable names the user provides — no more, no fewer.
-3. Every value must be a realistic string appropriate to the eval's scenario.
-4. If the user supplies "Current test data JSON", treat it as the current draft and return an UPDATED object that applies the requested change while keeping the same keys.
-5. If the user asks for a "failing case", craft data that should FAIL the evaluation (e.g. an unsupported claim, a factual error, an off-topic response). If they ask for a "passing case", craft data that should PASS.
-
-Example user request:
-Generate realistic test data as JSON for variables: output, context. User request: a failing case
-
-Example output (return exactly this shape, no wrapping):
-{"output": "Our revenue grew 40% driven by strong demand in Europe.", "context": "Q3 revenue was flat year over year with no regional breakdown provided."}"""
-
-OUTPUT_FORMAT_PROMPTS = {
-    "prompt": SYSTEM_PROMPT,
-    "messages": MESSAGES_SYSTEM_PROMPT,
-    "test_data": TEST_DATA_SYSTEM_PROMPT,
-}
 
 
 class AIEvalWriterView(APIView):
@@ -100,13 +33,14 @@ class AIEvalWriterView(APIView):
     Request:
     {
         "description": "check if response matches ground truth",
-        "output_format": "prompt" | "messages"   # optional, defaults to "prompt"
+        "output_format": "prompt" | "messages" | "test_data"  # optional, defaults to "prompt"
     }
 
     Response: { "status": true, "result": { "prompt": "..." } }
 
-    For output_format == "messages", the "prompt" field contains a JSON string
-    that callers should JSON.parse into an array of {role, content} messages.
+    For output_format "messages" / "test_data", the "prompt" field contains a
+    JSON string that callers should JSON.parse (an array of {role, content}
+    messages, or an object of test-data values respectively).
     """
 
     _gm = GeneralMethods()
@@ -119,48 +53,14 @@ class AIEvalWriterView(APIView):
     )
     def post(self, request, *args, **kwargs):
         try:
-            description = request.validated_data.get("description", "").strip()
-            output_format = request.validated_data.get("output_format", "prompt")
-            if not description:
-                return self._gm.bad_request("Description is required")
-
-            system_prompt = OUTPUT_FORMAT_PROMPTS.get(output_format)
-            if system_prompt is None:
-                return self._gm.bad_request(
-                    f"Invalid output_format: {output_format}. "
-                    f"Expected one of: {list(OUTPUT_FORMAT_PROMPTS.keys())}"
-                )
-
-            # Use Haiku for speed
-            from agentic_eval.core.utils.model_config import ModelConfigs
-
-            haiku_cfg = ModelConfigs.HAIKU_4_5_BEDROCK_ARN
-
-            import litellm
-
-            response = litellm.completion(
-                model=haiku_cfg.model_name,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": description},
-                ],
-                temperature=0.3,
-                max_tokens=1500 if output_format == "messages" else 1000,
-                num_retries=2,
+            prompt_text = generate_eval_prompt(
+                description=request.validated_data.get("description", ""),
+                output_format=request.validated_data.get("output_format", "prompt"),
             )
-
-            prompt_text = response.choices[0].message.content.strip()
-
-            # Strip any markdown wrapping
-            if prompt_text.startswith("```"):
-                lines = prompt_text.split("\n")
-                prompt_text = "\n".join(
-                    lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
-                )
-                prompt_text = prompt_text.strip()
-
             return self._gm.success_response({"prompt": prompt_text})
 
+        except ValueError as e:
+            return self._gm.bad_request(str(e))
         except Exception as e:
             logger.error(
                 f"Error in AIEvalWriterView: {str(e)}\n{traceback.format_exc()}"

--- a/futureagi/model_hub/views/ai_eval_writer.py
+++ b/futureagi/model_hub/views/ai_eval_writer.py
@@ -71,9 +71,25 @@ Example output (return exactly this shape, no wrapping):
   {"role": "user", "content": "User question: {{input}}\\nChatbot response: {{output}}\\nReference answer: {{ground_truth}}\\n\\nEvaluate whether the chatbot response is (1) polite in tone and (2) factually consistent with the reference answer. Return 'Passed' only if both criteria are met, otherwise return 'Failed' with a brief reason."}
 ]"""
 
+TEST_DATA_SYSTEM_PROMPT = """You generate realistic test data as a JSON object for testing an LLM evaluation.
+
+Rules:
+1. Return ONLY a valid JSON object. No markdown fences, no explanation, no prose.
+2. The object's keys must be EXACTLY the variable names the user provides — no more, no fewer.
+3. Every value must be a realistic string appropriate to the eval's scenario.
+4. If the user supplies "Current test data JSON", treat it as the current draft and return an UPDATED object that applies the requested change while keeping the same keys.
+5. If the user asks for a "failing case", craft data that should FAIL the evaluation (e.g. an unsupported claim, a factual error, an off-topic response). If they ask for a "passing case", craft data that should PASS.
+
+Example user request:
+Generate realistic test data as JSON for variables: output, context. User request: a failing case
+
+Example output (return exactly this shape, no wrapping):
+{"output": "Our revenue grew 40% driven by strong demand in Europe.", "context": "Q3 revenue was flat year over year with no regional breakdown provided."}"""
+
 OUTPUT_FORMAT_PROMPTS = {
     "prompt": SYSTEM_PROMPT,
     "messages": MESSAGES_SYSTEM_PROMPT,
+    "test_data": TEST_DATA_SYSTEM_PROMPT,
 }
 
 


### PR DESCRIPTION
## Summary

Adds a dedicated `test_data` output format to the `/model-hub/ai-eval-writer/` endpoint so the **Test Evaluation** panel can generate synthetic test data that fits the evaluation being tested. Previously test-data generation reused the eval-instruction system prompt, so the model had no signal about what it was generating for; now it receives a purpose-built system prompt plus the eval's context (name + full instruction + the user's request). The change is additive — a new enum value and a new optional prop — with no impact on the existing `prompt`/`messages` formats.

## Linked issues

Closes #<5070>

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

**Backend** — `uv run pytest model_hub/tests/test_ai_eval_writer_contracts.py` → **5 passed** (litellm mocked, no network):
- `test_test_data_format_returns_generated_json` — new format accepted end-to-end, result returned verbatim
- `test_strips_markdown_fence_from_model_output` — ` ```json ` fences stripped
- `test_prompt_format_still_works` — regression guard for the existing default format
- existing contract tests (unknown-field + invalid-format rejection) still green

**Frontend** — `yarn contracts:check` → green; regenerated contracts match `swagger.json` and the endpoint is fully accounted for (789/789 apiPath calls backed by Swagger).

**Manual** — generated test data from the Test Evaluation panel against an agent eval (`customer_agent_task_completion`); confirmed the request now succeeds and the model produces a genuinely failing case aligned with the eval's FAIL criteria.

## Screenshots / recordings (if UI)

<!-- Add a before/after of the "Generate test data with Falcon AI" flow in the Test Evaluation panel. -->

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
