### PR TITLE
fix(simulate): resolve masked api keys on provider verify endpoints

### DIFF
--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Box, Typography, Grid, Stack, Button } from "@mui/material";
+import { Box, Typography, Grid, Stack, Button, IconButton, InputAdornment } from "@mui/material";
 import PropTypes from "prop-types";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
@@ -42,6 +42,7 @@ import { formatDistanceToNow } from "date-fns";
 import CustomModelDropdownControl from "src/components/custom-model-dropdown/CustomModelDropdownControl";
 import { MODEL_TYPES } from "../../develop-detail/RunPrompt/common";
 import { useAuthContext } from "src/auth/hooks";
+import { useAgentDetailsStore } from "../store/agentDetailsStore";
 
 const EditAgentDetails = ({
   control,
@@ -52,6 +53,7 @@ const EditAgentDetails = ({
 }) => {
   const { orgLimit } = useAuthContext();
   const { agentDefinitionId } = useParams();
+  const { selectedVersion } = useAgentDetailsStore();
   const [lastFetchedAt, setLastFetchedAt] = useState(null);
   const [showSyncSuccess, setShowSyncSuccess] = useState(false);
   const syncSuccessTimeoutRef = useRef(null);
@@ -206,9 +208,29 @@ const EditAgentDetails = ({
         api_key: apiKey,
         assistant_id: assistantId,
         provider: provider,
+        agent_definition_id: agentDefinitionId,
       });
     }
   };
+
+  const handleCopyApiKey = useCallback(async () => {
+    if (!agentDefinitionId || !selectedVersion) return;
+    try {
+      const res = await axios.get(
+        endpoints.agentDefinitions.versionDetail(agentDefinitionId, selectedVersion),
+        { params: { include_unmasked_key: "true" } },
+      );
+      const unmaskedKey = res.data?.unmasked_api_key;
+      if (unmaskedKey) {
+        copyToClipboard(unmaskedKey);
+        enqueueSnackbar({ message: "API key copied to clipboard", variant: "success" });
+      } else {
+        enqueueSnackbar({ message: "No API key stored for this version", variant: "info" });
+      }
+    } catch {
+      enqueueSnackbar({ message: "Failed to fetch API key", variant: "error" });
+    }
+  }, [agentDefinitionId, selectedVersion]);
 
   const canEnableObservability = Boolean(apiKey && assistantId);
   const keysRequired = inbound === false;
@@ -593,6 +615,15 @@ const EditAgentDetails = ({
                       provider: selectedProvider,
                     });
                   }
+                }}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton onClick={handleCopyApiKey} size="small" edge="end">
+                        <Iconify icon="mdi:content-copy" />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
                 }}
               />
             </ShowComponent>

--- a/frontend/src/sections/agents/common.js
+++ b/frontend/src/sections/agents/common.js
@@ -22,6 +22,7 @@ export const getAgentFormValues = (agentDetails) => {
   }
 
   return {
+    agentDefinitionId: agentDetails?.agent_definition || "",
     // Basic Information
     agentName: snapshot.agent_name || "",
     agentType: snapshot.agent_type || "",

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -129,6 +129,7 @@ export const createAgentDefinitionSchema = (options) => {
         .min(1, "Must be at least 1")
         .optional()
         .nullable(),
+      agentDefinitionId: z.string().optional(),
     })
     .superRefine(async (data, ctx) => {
       if (
@@ -288,6 +289,7 @@ export const createAgentDefinitionSchema = (options) => {
               await axios.post(endpoints.agentDefinitions.verifyApiKey, {
                 provider: data.provider,
                 api_key: data.apiKey,
+                agent_definition_id: data.agentDefinitionId,
               });
             } catch (error) {
               ctx.addIssue({
@@ -322,6 +324,7 @@ export const createAgentDefinitionSchema = (options) => {
                   provider: data.provider,
                   api_key: data.apiKey,
                   assistant_id: data.assistantId,
+                  agent_definition_id: data.agentDefinitionId,
                 });
               } catch (error) {
                 ctx.addIssue({

--- a/futureagi/simulate/models/agent_version.py
+++ b/futureagi/simulate/models/agent_version.py
@@ -204,7 +204,7 @@ class AgentVersion(BaseModel):
             pass
 
         schema = AgentConfigurationSnapshot(
-            api_key=agent.api_key or "",
+            api_key=api_key or "",
             inbound=agent.inbound,
             language=agent.language,
             languages=agent.languages or [],

--- a/futureagi/simulate/serializers/requests/agent_definition.py
+++ b/futureagi/simulate/serializers/requests/agent_definition.py
@@ -444,3 +444,4 @@ class FetchAssistantRequestSerializer(serializers.Serializer):
         default=ProviderChoices.VAPI,
         help_text="Voice provider. One of: vapi, retell, eleven_labs, others.",
     )
+    agent_definition_id = serializers.UUIDField(required=False, allow_null=True)

--- a/futureagi/simulate/serializers/response/agent_version.py
+++ b/futureagi/simulate/serializers/response/agent_version.py
@@ -46,6 +46,8 @@ class AgentVersionResponseSerializer(serializers.ModelSerializer):
         data = super().to_representation(instance)
         snapshot = data.get("configuration_snapshot")
         if isinstance(snapshot, dict):
+            # Copy to avoid mutating instance.configuration_snapshot in-place
+            snapshot = dict(snapshot)
             for key in ["organization", "knowledge_base", "workspace", "id"]:
                 if key in snapshot and snapshot[key] is not None:
                     snapshot[key] = str(snapshot[key])

--- a/futureagi/simulate/services/agent_definition.py
+++ b/futureagi/simulate/services/agent_definition.py
@@ -1,0 +1,39 @@
+from simulate.models import AgentDefinition
+from simulate.serializers.agent_definition import _is_masked
+
+
+class MaskedKeyError(ValueError):
+    """Raised when a masked API key cannot be resolved."""
+
+
+def resolve_api_key(api_key: str, agent_definition_id: str | None) -> tuple[str, str]:
+    """Resolve a possibly-masked API key for upstream provider calls.
+
+    Returns (key_for_upstream, key_for_response).
+    - If key is not masked, both values are the original key.
+    - If key is masked, key_for_upstream is the decrypted key from
+      ProviderCredentials, key_for_response is the masked key.
+    - Raises MaskedKeyError if masked but can't be resolved.
+    """
+    response_key = api_key
+    if _is_masked(api_key):
+        if not agent_definition_id:
+            raise MaskedKeyError(
+                "The API key is masked. Please paste the full API key and try again."
+            )
+        try:
+            agent_def = AgentDefinition.objects.select_related("credentials").get(
+                id=agent_definition_id
+            )
+        except AgentDefinition.DoesNotExist as e:
+            raise MaskedKeyError("Agent definition not found.") from e
+        creds = getattr(agent_def, "credentials", None)
+        if creds:
+            real = creds.get_api_key()
+            if real:
+                api_key = real
+            else:
+                raise MaskedKeyError(
+                    "Stored credentials have no API key. Please re-enter the API key and try again."
+                )
+    return api_key, response_key

--- a/futureagi/simulate/tests/test_agent_definition_api.py
+++ b/futureagi/simulate/tests/test_agent_definition_api.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rest_framework import status
 
+from agentcc.services.credential_manager import mask_key
 from simulate.models import AgentDefinition, AgentVersion
 from simulate.models.agent_definition import ProviderCredentials
 
@@ -785,6 +786,90 @@ class TestFetchAssistantFromProvider:
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
         ]
+
+    def test_masked_key_with_valid_agent_definition_id(self, auth_client, db, organization, workspace):
+        """A masked API key is resolved from ProviderCredentials when
+        agent_definition_id is provided."""
+        agent = AgentDefinition.objects.create(
+            agent_name="Masked Key Sync Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="+12345678901",
+            inbound=True,
+            description="Sync test",
+            provider="vapi",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        ProviderCredentials.objects.create(
+            agent_definition=agent,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-real-key-for-sync-123456",
+            assistant_id="asst_sync_test",
+        )
+        masked = mask_key("sk-real-key-for-sync-123456")
+
+        mock_assistant = {
+            "name": "Synced Bot",
+            "model": {
+                "messages": [
+                    {"role": "system", "content": "Synced prompt."}
+                ]
+            },
+        }
+        with (
+            patch("tfc.ee_gating.check_ee_feature", return_value=None),
+            patch("simulate.views.agent_definition.VapiService") as MockVapi,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get_assistant.return_value = mock_assistant
+            MockVapi.return_value = mock_instance
+
+            response = auth_client.post(
+                self.URL,
+                {
+                    "assistant_id": "asst_sync_test",
+                    "api_key": masked,
+                    "provider": "vapi",
+                    "agent_definition_id": str(agent.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["status"] is True
+        assert data["result"]["name"] == "Synced Bot"
+        assert data["result"]["prompt"] == "Synced prompt."
+        # Response should contain the masked key, not the real one
+        assert data["result"]["api_key"] == masked
+
+    def test_masked_key_missing_agent_definition_id_returns_400(self, auth_client):
+        """When key is masked but no agent_definition_id is sent, return 400."""
+        response = auth_client.post(
+            self.URL,
+            {
+                "assistant_id": "asst_test",
+                "api_key": mask_key("sk-some-long-key"),
+                "provider": "vapi",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_masked_key_nonexistent_agent_definition_returns_400(self, auth_client):
+        """When key is masked but agent_definition_id does not exist, return 400."""
+        response = auth_client.post(
+            self.URL,
+            {
+                "assistant_id": "asst_test",
+                "api_key": mask_key("sk-some-long-key"),
+                "provider": "vapi",
+                "agent_definition_id": str(uuid.uuid4()),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.integration

--- a/futureagi/simulate/tests/test_agent_version_api.py
+++ b/futureagi/simulate/tests/test_agent_version_api.py
@@ -317,6 +317,85 @@ class TestGetAgentVersion:
         ]
 
 
+@pytest.mark.integration
+@pytest.mark.api
+class TestGetAgentVersionUnmaskedKey:
+    """Tests for GET .../versions/{id}/ with include_unmasked_key."""
+
+    def _setup_agent_with_key(self, db, organization, workspace):
+        """Helper: create an agent with a known ProviderCredentials key
+        and a version that includes that key in its snapshot."""
+        agent = AgentDefinition.objects.create(
+            agent_name="Unmasked Key Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="+12345678901",
+            inbound=True,
+            description="Test",
+            provider="vapi",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        ProviderCredentials.objects.create(
+            agent_definition=agent,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-decrypted-unmasked-key",
+            assistant_id="asst_unmasked",
+        )
+        version = agent.create_version(
+            description="Version with key",
+            commit_message="Has credentials",
+            status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        return agent, version
+
+    def test_returns_unmasked_key_when_requested(self, auth_client, db, organization, workspace):
+        agent, version = self._setup_agent_with_key(db, organization, workspace)
+        response = auth_client.get(
+            _version_url(agent.id, version.id),
+            {"include_unmasked_key": "true"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        snapshot_key = data.get("configuration_snapshot", {}).get("api_key", "")
+        unmasked = data.get("unmasked_api_key", "")
+        assert unmasked == "sk-decrypted-unmasked-key", (
+            f"snapshot api_key={snapshot_key!r}, unmasked_api_key={unmasked!r}"
+        )
+
+    def test_omits_unmasked_key_by_default(self, auth_client, db, organization, workspace):
+        agent, version = self._setup_agent_with_key(db, organization, workspace)
+        response = auth_client.get(_version_url(agent.id, version.id))
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "unmasked_api_key" not in data
+
+    def test_omits_unmasked_key_when_snapshot_has_no_key(self, auth_client, db, organization, workspace):
+        agent = AgentDefinition.objects.create(
+            agent_name="No Key Agent",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="+12345678901",
+            inbound=True,
+            description="Test",
+            provider="vapi",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        version = agent.create_version(
+            description="No key",
+            commit_message="No credentials",
+            status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        response = auth_client.get(
+            _version_url(agent.id, version.id),
+            {"include_unmasked_key": "true"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "unmasked_api_key" not in data
+
+
 # ============================================================================
 # TestActivateAgentVersion
 # ============================================================================

--- a/futureagi/simulate/tests/test_agent_version_snapshot.py
+++ b/futureagi/simulate/tests/test_agent_version_snapshot.py
@@ -9,6 +9,7 @@ These tests ensure the snapshot is correctly populated.
 import pytest
 
 from simulate.models import AgentDefinition, AgentVersion
+from simulate.models.agent_definition import ProviderCredentials
 
 
 @pytest.fixture
@@ -155,3 +156,23 @@ class TestAgentVersionSnapshot:
         # observability_enabled is False by default, may be excluded by exclude_none
         obs_value = snapshot.get("observability_enabled", False)
         assert obs_value is False
+
+    def test_snapshot_uses_provider_credentials_key(self, agent_definition):
+        """Snapshot should use the decrypted key from ProviderCredentials,
+        not the raw AgentDefinition.api_key field."""
+        agent_definition.api_key = "sk-raw-field"
+        agent_definition.save()
+        ProviderCredentials.objects.create(
+            agent_definition=agent_definition,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-decrypted-creds-key",
+            assistant_id="asst_snapshot_test",
+        )
+        version = agent_definition.create_version(
+            description="Test",
+            commit_message="Provider credentials key test",
+            status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        snapshot = version.configuration_snapshot
+        assert snapshot["api_key"] == "sk-decrypted-creds-key"
+        assert snapshot["api_key"] != "sk-raw-field"

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -17,6 +17,7 @@ from retell import Retell
 
 from simulate.models import AgentDefinition, AgentVersion
 from simulate.serializers.agent_definition import AgentDefinitionSerializer
+from simulate.services.agent_definition import MaskedKeyError, resolve_api_key
 from simulate.serializers.requests.agent_definition import (
     AgentDefinitionBulkDeleteRequestSerializer,
     AgentDefinitionCreateRequestSerializer,
@@ -520,6 +521,14 @@ class AgentDefinitionOperationsViewSet(BaseModelViewSetMixin, ModelViewSet):
             prompt = ""
             name = ""
 
+            # Resolve masked key via service function
+            try:
+                api_key, response_api_key = resolve_api_key(
+                    api_key, validated.get("agent_definition_id")
+                )
+            except MaskedKeyError as e:
+                return self._gm.bad_request(str(e))
+
             if provider == ProviderChoices.VAPI:
                 from tfc.ee_gating import EEFeature, check_ee_feature
 
@@ -561,7 +570,7 @@ class AgentDefinitionOperationsViewSet(BaseModelViewSetMixin, ModelViewSet):
 
             response_data = {
                 "assistant_id": assistant_id,
-                "api_key": api_key,
+                "api_key": response_api_key,
                 "name": name,
                 "prompt": prompt,
                 "provider": provider,

--- a/futureagi/simulate/views/agent_version.py
+++ b/futureagi/simulate/views/agent_version.py
@@ -294,7 +294,14 @@ class AgentVersionDetailView(APIView):
             version = AgentVersion.objects.get(id=version_id, agent_definition=agent)
 
             serializer = AgentVersionResponseSerializer(version)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            data = serializer.data
+
+            if request.query_params.get("include_unmasked_key") == "true":
+                snapshot = version.configuration_snapshot or {}
+                if snapshot.get("api_key"):
+                    data["unmasked_api_key"] = snapshot["api_key"]
+
+            return Response(data, status=status.HTTP_200_OK)
 
         except AgentDefinition.DoesNotExist:
             return _error_response(

--- a/futureagi/tracer/views/observability_provider.py
+++ b/futureagi/tracer/views/observability_provider.py
@@ -22,6 +22,10 @@ from tfc.utils.general_methods import GeneralMethods
 from tracer.models.observability_provider import ProviderChoices
 from tracer.models.project import ProjectSourceChoices
 from tracer.serializers.observability_provider import ObservabilityProviderSerializer
+from simulate.services.agent_definition import (
+    MaskedKeyError,
+    resolve_api_key,
+)
 from tracer.services.observability_providers import ObservabilityService
 from tracer.utils.observability_provider import normalize_and_store_logs
 from tracer.utils.otel import get_or_create_project
@@ -180,6 +184,11 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
         try:
             provider = request.data.get("provider")
             api_key = request.data.get("api_key")
+            agent_definition_id = request.data.get("agent_definition_id")
+            try:
+                api_key, _ = resolve_api_key(api_key, agent_definition_id)
+            except MaskedKeyError as e:
+                return self._gm.bad_request(str(e))
             if provider in [
                 ProviderChoices.VAPI,
                 ProviderChoices.RETELL,
@@ -210,6 +219,11 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
             assistant_id = request.data.get("assistant_id")
             api_key = request.data.get("api_key")
             provider = request.data.get("provider")
+            agent_definition_id = request.data.get("agent_definition_id")
+            try:
+                api_key, _ = resolve_api_key(api_key, agent_definition_id)
+            except MaskedKeyError as e:
+                return self._gm.bad_request(str(e))
             if provider in [
                 ProviderChoices.VAPI,
                 ProviderChoices.RETELL,


### PR DESCRIPTION
## Summary

When a saved agent definition loads with a masked API key in the form, clicking "Sync with Provider" fails because `trigger()` validation calls `verify_api_key` and `verify_assistant_id` with the masked key string — the provider rejects it and the sync call (`fetch_assistant_from_provider`) never runs.

Fix both verify endpoints to accept `agent_definition_id` and resolve masked keys via `resolve_api_key()` before making the provider call. Also adds `agentDefinitionId` to the Zod schema and form defaults so it's available during validation.

Includes the copy-icon button for retrieving the unmasked API key, and switches `VersionList` to read snake_case fields directly.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Backend tests pass: `test_agent_definition_api.py`, `test_agent_version_api.py`, `test_agent_version_snapshot.py`. Manual verification of the sync flow with a saved masked-key agent definition.

## Screenshots / recordings (if UI)


https://github.com/user-attachments/assets/0acdb341-e967-4307-b1ea-d9511a7e112f



## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
