### PR TITLE
fix: guard similarity comparators against division by zero on empty input

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -45,6 +45,8 @@ class CosineSimilarity(Comparator):
 
 class NormalisedLevenshteinSimilarity(Comparator):
     def compare(self, string1, string2):
+        if len(string1) == 0 and len(string2) == 0:
+            return 0.0
         return 1 - self._normalised_levenshtein_distance(string1, string2)
 
     def _normalised_levenshtein_distance(self, str1, str2):
@@ -110,7 +112,10 @@ class JaccardSimilarity(Comparator):
     def _jaccard_similarity(self, str1, str2):
         str1_tokens = set(str1.split())
         str2_tokens = set(str2.split())
-        return len(str1_tokens.intersection(str2_tokens)) / len(str1_tokens.union(str2_tokens))
+        union_tokens = str1_tokens.union(str2_tokens)
+        if not union_tokens:
+            return 0.0
+        return len(str1_tokens.intersection(str2_tokens)) / len(union_tokens)
 
 class SorensenDiceSimilarity(Comparator):
     def compare(self, string1, string2):
@@ -119,4 +124,7 @@ class SorensenDiceSimilarity(Comparator):
     def _sorensen_dice_similarity(self, str1, str2):
         str1_tokens = set(str1.split())
         str2_tokens = set(str2.split())
-        return 2 * len(str1_tokens.intersection(str2_tokens)) / (len(str1_tokens) + len(str2_tokens))
+        total_tokens = len(str1_tokens) + len(str2_tokens)
+        if total_tokens == 0:
+            return 0.0
+        return 2 * len(str1_tokens.intersection(str2_tokens)) / total_tokens

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_similarity.py
@@ -1,0 +1,70 @@
+import pytest
+
+from agentic_eval.core_evals.fi_evals.grounded.similarity import (
+    CosineSimilarity,
+    JaccardSimilarity,
+    JaroWincklerSimilarity,
+    NormalisedLevenshteinSimilarity,
+    SorensenDiceSimilarity,
+)
+
+ALL_COMPARATORS = [
+    CosineSimilarity,
+    JaccardSimilarity,
+    JaroWincklerSimilarity,
+    NormalisedLevenshteinSimilarity,
+    SorensenDiceSimilarity,
+]
+
+DEGENERATE_PAIRS = [
+    ("", ""),
+    ("   ", ""),
+    ("", "hello"),
+    ("\t\n", "  "),
+]
+
+
+class TestDegenerateInputs:
+    """Regression tests: comparators must not raise ZeroDivisionError on empty or
+    whitespace-only input (e.g. an empty model completion). All comparators return
+    0.0 for such input, matching the existing CosineSimilarity / JaroWincklerSimilarity
+    behaviour."""
+
+    @pytest.mark.parametrize("comparator_cls", ALL_COMPARATORS)
+    @pytest.mark.parametrize("string1,string2", DEGENERATE_PAIRS)
+    def test_no_zero_division_on_degenerate_input(
+        self, comparator_cls, string1, string2
+    ):
+        score = comparator_cls().compare(string1, string2)
+        assert isinstance(score, (int, float))
+        assert 0.0 <= score <= 1.0
+
+    @pytest.mark.parametrize(
+        "comparator_cls",
+        [JaccardSimilarity, SorensenDiceSimilarity, NormalisedLevenshteinSimilarity],
+    )
+    def test_both_empty_returns_zero(self, comparator_cls):
+        assert comparator_cls().compare("", "") == 0.0
+
+
+class TestKnownScores:
+    """Guard the non-empty behaviour so the degenerate-input fix cannot silently
+    change real similarity scores."""
+
+    def test_jaccard_partial_overlap(self):
+        assert JaccardSimilarity().compare(
+            "hello world", "hello there"
+        ) == pytest.approx(1 / 3)
+
+    def test_jaccard_identical(self):
+        assert JaccardSimilarity().compare("the cat sat", "the cat sat") == 1.0
+
+    def test_sorensen_dice_partial_overlap(self):
+        assert SorensenDiceSimilarity().compare(
+            "hello world", "hello there"
+        ) == pytest.approx(0.5)
+
+    def test_normalised_levenshtein_kitten_sitting(self):
+        assert NormalisedLevenshteinSimilarity().compare(
+            "kitten", "sitting"
+        ) == pytest.approx(4 / 7)


### PR DESCRIPTION
## Summary

`JaccardSimilarity`, `SorensenDiceSimilarity` and `NormalisedLevenshteinSimilarity` in `agentic_eval/core_evals/fi_evals/grounded/similarity.py` raised `ZeroDivisionError` when both inputs were empty or whitespace-only, because the denominator (token-set size or string length) was zero. Since `GroundedEvaluator._evaluate()` feeds model output and reference straight into `comparator.compare(...)`, an empty model completion crashed the evaluation instead of returning a score.

This guards all three to return `0.0` on degenerate input, matching the behaviour already present in `CosineSimilarity` (zero-magnitude guard) and `JaroWincklerSimilarity` (empty-string guard) in the same module. Non-empty scores are unchanged.

## Linked issues

Closes #980

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Added `agentic_eval/core_evals/fi_evals/grounded/tests/test_similarity.py` with:

- A parametrized test running all five comparators over degenerate inputs (`""`, whitespace-only, one-sided empty) asserting no exception and a score in `[0, 1]`.
- A both-empty `== 0.0` check for the three previously-crashing comparators.
- Known-score checks (e.g. Jaccard of `"hello world"` vs `"hello there"` == 1/3, Levenshtein of `"kitten"`/`"sitting"` == 4/7) so the guard cannot silently change real similarity values.

I verified the three comparators raise on `("", "")` / whitespace-only input before the change and return `0.0` after, and confirmed all non-empty scores are byte-identical pre/post fix. `ruff check` and `ruff format --check` pass on both changed files.

Note: I couldn't run the full backend `make check-all` locally (the suite pulls in `langchain_community` and the Django stack that only resolve inside the project's Docker image). The comparator module itself is pure Python (`math`/`re`), so the added tests run standalone; happy to adjust if CI surfaces anything.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally (see note above — ran ruff + targeted tests instead)
- [ ] I've updated the documentation where relevant (no docs affected)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) (will sign when the bot prompts)
