### PR TITLE
fix(simulate): strip UI-only filter keys before calling test-executions API

### DIFF
--- a/frontend/src/components/ComplexFilter/common.js
+++ b/frontend/src/components/ComplexFilter/common.js
@@ -20,6 +20,14 @@ const ListOperators = new Set(LIST_FILTER_OPS);
 const NoValueOperators = new Set(NO_VALUE_FILTER_OPS);
 const RangeOperators = new Set(RANGE_FILTER_OPS);
 
+export const stripUiFilterKeys = (filters = []) =>
+  (Array.isArray(filters) ? filters : []).map((filter) => {
+    const cleaned = { ...filter };
+    delete cleaned._meta;
+    delete cleaned.id;
+    return cleaned;
+  });
+
 export const NULL_OPERATORS = ["is_null", "is_not_null"];
 
 export const getComplexFilterValidation = (

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -4461,7 +4461,7 @@ function SimulationSelector({ onSetSelection }) {
             </MenuItem>
           )}
           {tests.map((t) => (
-            <MenuItem key={t.id} value={t.id} sx={{ maxWidth: 300 }}>
+            <MenuItem key={t.id} value={t.id} sx={{ width: "100%" }}>
               <CustomTooltip
                 size="small"
                 arrow
@@ -4537,7 +4537,7 @@ function SimulationSelector({ onSetSelection }) {
             {(executionRuns || []).map((run) => {
               const label = formatExecutionRunLabel(run);
               return (
-                <MenuItem key={run.id} value={run.id} sx={{ maxWidth: 340 }}>
+                <MenuItem key={run.id} value={run.id} sx={{ width: "100%" }}>
                   <CustomTooltip
                     size="small"
                     arrow

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -42,6 +42,7 @@ import { isEqual } from "lodash";
 import "src/sections/develop-detail/DataTab/developDataGrid.css";
 import SvgColor from "src/components/svg-color";
 import axios, { endpoints } from "src/utils/axios";
+import { stripUiFilterKeys } from "src/components/ComplexFilter/common";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import { useTestRunsList } from "src/api/tests/testRuns";
@@ -4252,7 +4253,7 @@ function SimulationSelector({ onSetSelection }) {
   );
 
   const serializedFilters = useMemo(
-    () => JSON.stringify(validatedFilters || []),
+    () => JSON.stringify(stripUiFilterKeys(validatedFilters)),
     [validatedFilters],
   );
 

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -15,6 +15,7 @@ import { transformMetricDetails } from "src/sections/agents/CallLogs/utils";
 import { enqueueSnackbar } from "notistack";
 import { deepEqual } from "src/utils/utils";
 import { useUrlState } from "src/routes/hooks/use-url-state";
+import { stripUiFilterKeys } from "src/components/ComplexFilter/common";
 import SkeltonForTestDeatilDrawer from "../Skeletons/SkeltonForTestDeatilDrawer";
 import { AGENT_TYPES } from "src/sections/agents/constants";
 import { HeaderSkeleton } from "./BasLineCompare/Skeletons";
@@ -223,7 +224,9 @@ const TestDetailSideDrawerChild = ({
     const simulateFilters =
       urlModule === "simulate"
         ? JSON.stringify(
-            Array.isArray(drawerQueryKey[3]) ? drawerQueryKey[3] : [],
+            stripUiFilterKeys(
+              Array.isArray(drawerQueryKey[3]) ? drawerQueryKey[3] : [],
+            ),
           )
         : JSON.stringify([]);
 

--- a/frontend/src/sections/test-detail/common.js
+++ b/frontend/src/sections/test-detail/common.js
@@ -8,6 +8,7 @@ import { endpoints } from "src/utils/axios";
 import ScenarioCellRenderer from "./CellRenderers/ScenarioCellRenderer";
 import { useQuery } from "@tanstack/react-query";
 import { canonicalKeys } from "src/utils/utils";
+import { stripUiFilterKeys } from "src/components/ComplexFilter/common";
 import { getAnnotationMetricFilterDefinition } from "src/utils/prototypeObserveUtils";
 import ToolEvaluationCellRenderer from "./CellRenderers/ToolEvaluationCellRenderer";
 import { getLabel } from "./PerformanceMetrics/common";
@@ -420,7 +421,7 @@ export const getTestRunDetailColumnQuery = (
           page: pageNumber + 1,
           limit: 30,
           search: debouncedSearchQuery,
-          filters: JSON.stringify(validatedFilters || []),
+          filters: JSON.stringify(stripUiFilterKeys(validatedFilters)),
           ...(pageSize && { limit: pageSize }),
         },
       }),


### PR DESCRIPTION
## Summary

The simulation test-executions API (`/simulate/test-executions/{id}/`) was being
called with filter objects that still carried **UI-only keys** (`_meta` and `id`)
inside the serialized `filters` query param. These keys are added by the
ComplexFilter component for client-side bookkeeping and are not part of the API
filter contract, which caused inconsistent/incorrect filtering when the payload
was parsed on the backend.

This PR adds a small shared helper, `stripUiFilterKeys`, that removes `_meta` and
`id` from each filter before the `filters` array is serialized into the request,
and applies it at every call site that hits the test-executions endpoint. It also
fixes a minor dropdown layout issue in the simulation selector.

### Changes

- **`ComplexFilter/common.js`** — new exported `stripUiFilterKeys(filters)` helper
  that returns a shallow copy of each filter with `_meta` and `id` removed
  (null/non-array safe).
- **`add-items-dialog.jsx`** (`SimulationSelector`) — serialize filters through
  `stripUiFilterKeys` before sending; replace fixed `maxWidth` on test/run dropdown
  `MenuItem`s with `width: 100%` so long labels lay out correctly.
- **`TestDetailSideDrawer.jsx`** — strip UI keys from the simulate drawer query filters.
- **`test-detail/common.js`** (`getTestRunDetailColumnQuery`) — strip UI keys from
  `validatedFilters` before serializing.

### Why

`_meta`/`id` are presentation-layer concerns. Forwarding them to the backend made
the `filters=[...]` payload diverge from what the API expects, producing
inconsistent results between calls. Centralizing the strip in one helper keeps
every test-executions caller consistent.

## Test cases

- [x] **Helper – strips keys:** `stripUiFilterKeys([{ field: "x", op: "equals", value: "a", _meta: {…}, id: "uuid" }])` returns `[{ field: "x", op: "equals", value: "a" }]` with `_meta` and `id` removed.
- [x] **Helper – preserves real keys:** all non-UI keys (`field`, `op`, `value`, `type`, etc.) are retained unchanged.
- [x] **Helper – null/non-array safe:** `stripUiFilterKeys(undefined)`, `stripUiFilterKeys(null)`, and `stripUiFilterKeys({})` all return `[]` without throwing.
- [x] **Helper – immutability:** original filter objects are not mutated (returns shallow copies).
- [x] **Add-items dialog:** apply a filter in the Simulation selector → inspect the network request to `/simulate/test-executions/{id}/` → `filters` query param contains no `_meta` or `id` keys, and results match the filter.
- [x] **Test detail side drawer (simulate):** open the drawer with active simulate filters → request `filters` param is stripped; non-simulate modules still send `[]`.
- [x] **Test run detail grid:** `getTestRunDetailColumnQuery` with validated filters → outgoing `filters` param has UI keys removed; pagination/search params unaffected.
- [x] **Empty filters:** with no filters applied, the `filters` param serializes to `[]` and the API returns the unfiltered page.
- [x] **Dropdown layout:** open the test and execution-run dropdowns with long labels → items span the menu width (no clipped/fixed-width truncation), tooltips still show full label.
- [ ] **No regression:** existing eval/scenario/attribute filters continue to return the same results as before for payloads that never had UI keys.

Closes: TH-5666