### PR TITLE
fix(annotation-rules): unblock manual rule evaluation + dataset filter editing

### DIFF
--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -1325,6 +1325,7 @@ export const useEvaluateRule = () => {
     mutationFn: ({ queueId, ruleId }) =>
       axios.post(
         annotationQueueEndpoints.automationRuleEvaluate(queueId, ruleId),
+        {},
       ),
     onSuccess: (response, variables) => {
       // 200 → ran inline (≤ sync threshold). 202 → too large; backend

--- a/frontend/src/sections/annotations/queues/__tests__/automation-rules-tab.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/automation-rules-tab.test.jsx
@@ -64,7 +64,6 @@ vi.mock("src/components/custom-dialog", () => ({
 
 vi.mock("../view/create-rule-dialog", () => ({
   default: () => null,
-  TRIGGER_FREQUENCY_OPTIONS: [{ value: "manual", label: "Manually" }],
 }));
 
 vi.mock("../view/edit-rule-dialog", () => ({

--- a/frontend/src/sections/annotations/queues/constants.js
+++ b/frontend/src/sections/annotations/queues/constants.js
@@ -1,3 +1,5 @@
+import { SIMULATION_PERSONA_FILTER_FIELDS } from "./utils/simulation-persona-filter-fields";
+
 export const QUEUE_ROLES = {
   ANNOTATOR: "annotator",
   REVIEWER: "reviewer",
@@ -42,3 +44,112 @@ export const queueViewerMembership = (queue) => {
 
 export const canViewerAddItemsToQueue = (queue) =>
   hasQueueRole(queueViewerMembership(queue), QUEUE_ROLES.MANAGER);
+
+
+export const SOURCE_OPTIONS = [
+  { value: "dataset_row", label: "Dataset Row" },
+  { value: "trace", label: "Trace" },
+  { value: "observation_span", label: "Span" },
+  { value: "trace_session", label: "Session" },
+  { value: "call_execution", label: "Simulation" },
+];
+
+export const TRIGGER_FREQUENCY_OPTIONS = [
+  { value: "manual", label: "Manually" },
+  { value: "hourly", label: "Every hour" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+export const DEFAULT_FILTER = {
+  column_id: "",
+  filter_config: {
+    filter_type: "",
+    filter_op: "",
+    filter_value: "",
+  },
+};
+
+export const SIMULATION_RULE_FILTER_FIELDS = [
+  {
+    id: "status",
+    name: "Status",
+    category: "system",
+    type: "categorical",
+    choices: ["completed", "failed", "in_progress", "pending", "cancelled"],
+  },
+  ...SIMULATION_PERSONA_FILTER_FIELDS,
+  {
+    id: "agent_definition",
+    name: "Agent Definition",
+    category: "system",
+    type: "text",
+  },
+  {
+    id: "call_type",
+    name: "Call Type",
+    category: "system",
+    type: "categorical",
+    choices: ["voice", "text"],
+  },
+  {
+    id: "simulation_call_type",
+    name: "Simulation Call Type",
+    category: "system",
+    type: "text",
+  },
+  {
+    id: "duration_seconds",
+    name: "Duration",
+    category: "system",
+    type: "number",
+  },
+  {
+    id: "overall_score",
+    name: "Overall Score",
+    category: "system",
+    type: "number",
+  },
+  {
+    id: "created_at",
+    name: "Created At",
+    category: "system",
+    type: "date",
+  },
+];
+
+export const SIMPLE_FILTER_CATEGORIES = [
+  { key: "all", label: "All", icon: "mdi:view-grid-outline" },
+  { key: "system", label: "System", icon: "mdi:tune-variant" },
+  { key: "persona", label: "Persona", icon: "mdi:account-outline" },
+];
+
+export const SESSION_RULE_FILTER_FIELDS = [
+  { id: "session_id", name: "Session ID", category: "system", type: "string" },
+  {
+    id: "first_message",
+    name: "First Message",
+    category: "system",
+    type: "string",
+  },
+  {
+    id: "last_message",
+    name: "Last Message",
+    category: "system",
+    type: "string",
+  },
+  { id: "user_id", name: "User ID", category: "system", type: "string" },
+  { id: "duration", name: "Duration", category: "system", type: "number" },
+  { id: "total_cost", name: "Total Cost", category: "system", type: "number" },
+  {
+    id: "total_traces_count",
+    name: "Total Traces",
+    category: "system",
+    type: "number",
+  },
+  { id: "start_time", name: "Start Time", category: "system", type: "date" },
+  { id: "end_time", name: "End Time", category: "system", type: "date" },
+];
+
+export const MULTI_VALUE_OPS = new Set(["in", "not_in"]);

--- a/frontend/src/sections/annotations/queues/utils/automation-rule-utils.js
+++ b/frontend/src/sections/annotations/queues/utils/automation-rule-utils.js
@@ -1,0 +1,269 @@
+import { format, isValid } from "date-fns";
+import { buildApiFilterFromPanelRow } from "src/api/contracts/filter-contract";
+import {
+  LIST_FILTER_OPS,
+  NO_VALUE_FILTER_OPS,
+} from "src/api/contracts/filter-contract.generated";
+import { getRandomId } from "src/utils/utils";
+import { apiFilterHasValue } from "./filter-operators";
+import { DEFAULT_FILTER } from "../constants";
+
+export function getQueueScopeId(queue, key) {
+  const value = queue?.[key];
+  if (!value) return "";
+  return typeof value === "object"
+    ? value.id || value.datasetId || value.dataset_id
+    : value;
+}
+
+export function getDatasetOptionId(dataset) {
+  return dataset?.dataset_id || dataset?.datasetId || dataset?.id || "";
+}
+
+export function resolveRuleScopeId(queue, queueScopeId, selectedScopeId) {
+  if (queue?.is_default) return selectedScopeId || queueScopeId;
+  return queueScopeId || selectedScopeId;
+}
+
+export function isQueueScopeLocked(queue, queueScopeId) {
+  return Boolean(queueScopeId) && !queue?.is_default;
+}
+
+export const makeDatasetDefaultFilter = () => ({
+  id: getRandomId(),
+  column_id: "",
+  filter_config: {
+    filter_type: "text",
+    filter_op: "equals",
+    filter_value: "",
+  },
+});
+
+export const datasetFilterToCamel = (filter) => ({
+  id: filter.id,
+  columnId: filter.column_id || "",
+  filterConfig: {
+    filterType: filter.filter_config?.filter_type || "",
+    filterOp: filter.filter_config?.filter_op || "",
+    filterValue: filter.filter_config?.filter_value ?? "",
+  },
+});
+
+export const datasetFilterToSnake = (filter) => ({
+  id: filter.id,
+  column_id: filter.columnId || "",
+  filter_config: {
+    filter_type: filter.filterConfig?.filterType || "",
+    filter_op: filter.filterConfig?.filterOp || "",
+    filter_value: filter.filterConfig?.filterValue ?? "",
+  },
+});
+
+export const isDatasetFilterValid = (filter) => {
+  const config = filter?.filter_config;
+  if (!config || typeof filter.column_id !== "string") return false;
+  const { filter_value: value, filter_op: op, filter_type: type } = config;
+  if (filter.column_id.length === 0 || op === "" || type === "") return false;
+
+  const isRange = op === "between" || op === "not_between";
+  const hasValue = NO_VALUE_FILTER_OPS.includes(op)
+    ? true
+    : LIST_FILTER_OPS.includes(op)
+      ? Array.isArray(value) && value.length > 0
+      : value !== "";
+  if (!hasValue) return false;
+
+  if (type === "datetime") {
+    return isRange ? isValid(value?.[0]) && isValid(value?.[1]) : isValid(value);
+  }
+  return isRange ? Array.isArray(value) && value.length === 2 : true;
+};
+
+export const formatDatasetDatetime = (value) =>
+  Array.isArray(value)
+    ? value.map((item) =>
+        item ? format(new Date(item), "yyyy-MM-dd HH:mm:ss") : item,
+      )
+    : value
+      ? format(new Date(value), "yyyy-MM-dd HH:mm:ss")
+      : value;
+
+export const transformDatasetFilter = (filter) => {
+  const config = filter.filter_config || {};
+  return buildApiFilterFromPanelRow({
+    field: filter.column_id,
+    fieldType: config.filter_type,
+    operator: config.filter_op,
+    value:
+      config.filter_type === "datetime"
+        ? formatDatasetDatetime(config.filter_value)
+        : config.filter_value,
+  });
+};
+
+export function defaultFiltersForSource(sourceType) {
+  if (sourceType === "dataset_row") {
+    return [makeDatasetDefaultFilter()];
+  }
+  return [{ ...DEFAULT_FILTER, id: getRandomId() }];
+}
+
+function filterWithValue(filter) {
+  return apiFilterHasValue(filter);
+}
+
+export function getSubmittableFilters(filters) {
+  // Drop rows that don't carry a value (or aren't a unary op like is_null).
+  // Without this, a half-filled row with just a
+  // columnId selected serialises into the API payload's `filter:` array
+  // and the backend's evaluator silently match-everythings.
+  return (filters || [])
+    .filter(filterWithValue)
+    .map(({ id, ...filter }) => filter);
+}
+
+function snakeFilterToUi(filter) {
+  const config = filter?.filter_config || {};
+  const filterType = config.filter_type || "";
+  let filterValue = "filter_value" in config ? config.filter_value : "";
+  if (filterType === "datetime") {
+    filterValue = Array.isArray(filterValue)
+      ? filterValue.map((value) => (value ? new Date(value) : value))
+      : filterValue
+        ? new Date(filterValue)
+        : filterValue;
+  }
+  return {
+    id: getRandomId(),
+    column_id: filter?.column_id || "",
+    display_name: filter?.display_name,
+    filter_config: {
+      filter_type: filterType,
+      filter_op: config.filter_op || "",
+      filter_value: filterValue,
+      ...(config.col_type ? { col_type: config.col_type } : {}),
+    },
+  };
+}
+
+export function ruleConditionsToFilters(rule) {
+  const sourceType = rule?.source_type || "trace";
+  const filterPayload = rule?.conditions?.filter;
+  if (Array.isArray(filterPayload) && filterPayload.length > 0) {
+    return filterPayload.map(snakeFilterToUi);
+  }
+  const rules = rule?.conditions?.rules || [];
+  if (rules.length === 0) return defaultFiltersForSource(sourceType);
+  return rules.map((row) => ({
+    id: getRandomId(),
+    column_id: row.field || "",
+    filter_config: {
+      filter_type: "text",
+      filter_op: row.op || "",
+      filter_value: row.value ?? "",
+    },
+  }));
+}
+
+export function ruleConditionsToScope(rule) {
+  return rule?.conditions?.scope || {};
+}
+
+export function buildConditionsForRule(sourceType, filters, scope, queue) {
+  const queueProjectId = getQueueScopeId(queue, "project");
+  const queueDatasetId = getQueueScopeId(queue, "dataset");
+  const queueAgentId = getQueueScopeId(queue, "agent_definition");
+  const nextScope = {};
+
+  if (sourceType === "dataset_row") {
+    const datasetId = resolveRuleScopeId(
+      queue,
+      queueDatasetId,
+      scope.dataset_id,
+    );
+    if (datasetId) nextScope.dataset_id = datasetId;
+    return {
+      operator: "and",
+      filter: filters.filter(isDatasetFilterValid).map(transformDatasetFilter),
+      scope: nextScope,
+    };
+  }
+
+  if (sourceType === "trace" || sourceType === "observation_span") {
+    const projectId = resolveRuleScopeId(
+      queue,
+      queueProjectId,
+      scope.project_id,
+    );
+    if (projectId) nextScope.project_id = projectId;
+    if (sourceType === "trace") {
+      nextScope.is_voice_call = !!scope.is_voice_call;
+      nextScope.remove_simulation_calls = !!scope.remove_simulation_calls;
+    }
+    const apiFilters = getSubmittableFilters(filters);
+    return {
+      operator: "and",
+      filter: apiFilters,
+      scope: nextScope,
+    };
+  }
+
+  if (sourceType === "trace_session") {
+    const projectId = resolveRuleScopeId(
+      queue,
+      queueProjectId,
+      scope.project_id,
+    );
+    if (projectId) nextScope.project_id = projectId;
+    const apiFilters = getSubmittableFilters(filters);
+    return {
+      operator: "and",
+      filter: apiFilters,
+      scope: nextScope,
+    };
+  }
+
+  if (sourceType === "call_execution") {
+    const agentId = resolveRuleScopeId(queue, queueAgentId, scope.project_id);
+    if (agentId) nextScope.project_id = agentId;
+    const apiFilters = getSubmittableFilters(filters);
+    return {
+      operator: "and",
+      filter: apiFilters,
+      ...(Object.keys(nextScope).length ? { scope: nextScope } : {}),
+    };
+  }
+
+  return {
+    operator: "and",
+    filter: getSubmittableFilters(filters),
+    ...(Object.keys(nextScope).length ? { scope: nextScope } : {}),
+  };
+}
+
+export function isScopeReady(sourceType, scope, queue) {
+  if (sourceType === "dataset_row") {
+    return Boolean(scope.dataset_id || getQueueScopeId(queue, "dataset"));
+  }
+  if (["trace", "observation_span", "trace_session"].includes(sourceType)) {
+    return Boolean(scope.project_id || getQueueScopeId(queue, "project"));
+  }
+  if (sourceType === "call_execution") {
+    return Boolean(
+      scope.project_id || getQueueScopeId(queue, "agent_definition"),
+    );
+  }
+  return true;
+}
+
+export function getRuleSubmitDisabledTooltipTitle(sourceType, scope, queue, name) {
+  if (!name.trim()) return "Enter a rule name";
+  if (!isScopeReady(sourceType, scope, queue)) {
+    if (sourceType === "dataset_row") return "Choose a dataset";
+    if (["trace", "observation_span", "trace_session"].includes(sourceType)) {
+      return "Choose a project";
+    }
+    if (sourceType === "call_execution") return "Choose an agent definition";
+  }
+  return "";
+}

--- a/frontend/src/sections/annotations/queues/view/__tests__/create-rule-dialog.test.jsx
+++ b/frontend/src/sections/annotations/queues/view/__tests__/create-rule-dialog.test.jsx
@@ -3,7 +3,7 @@ import {
   buildConditionsForRule,
   isScopeReady,
   ruleConditionsToFilters,
-} from "../create-rule-dialog";
+} from "../../utils/automation-rule-utils";
 
 vi.mock("src/api/annotation-queues/annotation-queues", () => ({
   extractErrorMessage: (_error, fallback) => fallback,

--- a/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
@@ -24,9 +24,8 @@ import { ConfirmDialog } from "src/components/custom-dialog";
 import { useAgThemeWith } from "src/hooks/use-ag-theme";
 import { AG_THEME_OVERRIDES } from "src/theme/ag-theme";
 import "src/styles/clean-data-table.css";
-import CreateRuleDialog, {
-  TRIGGER_FREQUENCY_OPTIONS,
-} from "./create-rule-dialog";
+import CreateRuleDialog from "./create-rule-dialog";
+import { TRIGGER_FREQUENCY_OPTIONS } from "../constants";
 import EditRuleDialog from "./edit-rule-dialog";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/sections/annotations/queues/view/create-rule-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/view/create-rule-dialog.jsx
@@ -27,11 +27,6 @@ import {
 } from "src/api/annotation-queues/annotation-queues";
 import { getDatasetQueryOptions } from "src/api/develop/develop-detail";
 import {
-  DefaultFilter as DatasetDefaultFilter,
-  transformFilter,
-  validateFilter,
-} from "src/sections/develop-detail/DataTab/DevelopFilters/common";
-import {
   DEVELOP_FILTER_CATEGORIES,
   DatasetColumnValuePicker,
   buildProperties as buildDatasetFilterProperties,
@@ -51,278 +46,33 @@ import {
   apiFilterToPanel,
   panelFilterToApi,
 } from "src/sections/annotations/queues/utils/api-filter-converters";
-import { SIMULATION_PERSONA_FILTER_FIELDS } from "src/sections/annotations/queues/utils/simulation-persona-filter-fields";
-
-export const SOURCE_OPTIONS = [
-  { value: "dataset_row", label: "Dataset Row" },
-  { value: "trace", label: "Trace" },
-  { value: "observation_span", label: "Span" },
-  { value: "trace_session", label: "Session" },
-  { value: "call_execution", label: "Simulation" },
-];
-
-export const TRIGGER_FREQUENCY_OPTIONS = [
-  { value: "manual", label: "Manually" },
-  { value: "hourly", label: "Every hour" },
-  { value: "daily", label: "Daily" },
-  { value: "weekly", label: "Weekly" },
-  { value: "monthly", label: "Monthly" },
-];
+import {
+  DEFAULT_FILTER,
+  MULTI_VALUE_OPS,
+  SESSION_RULE_FILTER_FIELDS,
+  SIMPLE_FILTER_CATEGORIES,
+  SIMULATION_RULE_FILTER_FIELDS,
+  SOURCE_OPTIONS,
+  TRIGGER_FREQUENCY_OPTIONS,
+} from "src/sections/annotations/queues/constants";
+import {
+  buildConditionsForRule,
+  datasetFilterToCamel,
+  datasetFilterToSnake,
+  defaultFiltersForSource,
+  getDatasetOptionId,
+  getQueueScopeId,
+  getRuleSubmitDisabledTooltipTitle,
+  getSubmittableFilters,
+  isDatasetFilterValid,
+  isQueueScopeLocked,
+  isScopeReady,
+  makeDatasetDefaultFilter,
+  resolveRuleScopeId,
+  transformDatasetFilter,
+} from "src/sections/annotations/queues/utils/automation-rule-utils";
 
 const activeFilterButtonBg = (theme) => alpha(theme.palette.primary.main, 0.12);
-
-export const DEFAULT_FILTER = {
-  column_id: "",
-  filter_config: {
-    filter_type: "",
-    filter_op: "",
-    filter_value: "",
-  },
-};
-
-const SIMULATION_RULE_FILTER_FIELDS = [
-  {
-    id: "status",
-    name: "Status",
-    category: "system",
-    type: "categorical",
-    choices: ["completed", "failed", "in_progress", "pending", "cancelled"],
-  },
-  ...SIMULATION_PERSONA_FILTER_FIELDS,
-  {
-    id: "agent_definition",
-    name: "Agent Definition",
-    category: "system",
-    type: "text",
-  },
-  {
-    id: "call_type",
-    name: "Call Type",
-    category: "system",
-    type: "categorical",
-    choices: ["voice", "text"],
-  },
-  {
-    id: "simulation_call_type",
-    name: "Simulation Call Type",
-    category: "system",
-    type: "text",
-  },
-  {
-    id: "duration_seconds",
-    name: "Duration",
-    category: "system",
-    type: "number",
-  },
-  {
-    id: "overall_score",
-    name: "Overall Score",
-    category: "system",
-    type: "number",
-  },
-  {
-    id: "created_at",
-    name: "Created At",
-    category: "system",
-    type: "date",
-  },
-];
-
-const SIMPLE_FILTER_CATEGORIES = [
-  { key: "all", label: "All", icon: "mdi:view-grid-outline" },
-  { key: "system", label: "System", icon: "mdi:tune-variant" },
-  { key: "persona", label: "Persona", icon: "mdi:account-outline" },
-];
-
-const SESSION_RULE_FILTER_FIELDS = [
-  { id: "session_id", name: "Session ID", category: "system", type: "string" },
-  {
-    id: "first_message",
-    name: "First Message",
-    category: "system",
-    type: "string",
-  },
-  {
-    id: "last_message",
-    name: "Last Message",
-    category: "system",
-    type: "string",
-  },
-  { id: "user_id", name: "User ID", category: "system", type: "string" },
-  { id: "duration", name: "Duration", category: "system", type: "number" },
-  { id: "total_cost", name: "Total Cost", category: "system", type: "number" },
-  {
-    id: "total_traces_count",
-    name: "Total Traces",
-    category: "system",
-    type: "number",
-  },
-  { id: "start_time", name: "Start Time", category: "system", type: "date" },
-  { id: "end_time", name: "End Time", category: "system", type: "date" },
-];
-
-const MULTI_VALUE_OPS = new Set(["in", "not_in"]);
-
-function getQueueScopeId(queue, key) {
-  const value = queue?.[key];
-  if (!value) return "";
-  return typeof value === "object"
-    ? value.id || value.datasetId || value.dataset_id
-    : value;
-}
-
-function getDatasetOptionId(dataset) {
-  return dataset?.dataset_id || dataset?.datasetId || dataset?.id || "";
-}
-
-function resolveRuleScopeId(queue, queueScopeId, selectedScopeId) {
-  if (queue?.is_default) return selectedScopeId || queueScopeId;
-  return queueScopeId || selectedScopeId;
-}
-
-function isQueueScopeLocked(queue, queueScopeId) {
-  return Boolean(queueScopeId) && !queue?.is_default;
-}
-
-export function defaultFiltersForSource(sourceType) {
-  if (sourceType === "dataset_row") {
-    return [{ ...DatasetDefaultFilter, id: getRandomId() }];
-  }
-  return [{ ...DEFAULT_FILTER, id: getRandomId() }];
-}
-
-function filterWithValue(filter) {
-  return apiFilterHasValue(filter);
-}
-
-function getSubmittableFilters(filters) {
-  // Drop rows that don't carry a value (or aren't a unary op like is_null).
-  // Without this, a half-filled row with just a
-  // columnId selected serialises into the API payload's `filter:` array
-  // and the backend's evaluator silently match-everythings.
-  return (filters || [])
-    .filter(filterWithValue)
-    .map(({ id, ...filter }) => filter);
-}
-
-function snakeFilterToUi(filter) {
-  const config = filter?.filter_config || {};
-  const filterType = config.filter_type || "";
-  let filterValue = "filter_value" in config ? config.filter_value : "";
-  if (filterType === "datetime") {
-    filterValue = Array.isArray(filterValue)
-      ? filterValue.map((value) => (value ? new Date(value) : value))
-      : filterValue
-        ? new Date(filterValue)
-        : filterValue;
-  }
-  return {
-    id: getRandomId(),
-    column_id: filter?.column_id || "",
-    display_name: filter?.display_name,
-    filter_config: {
-      filter_type: filterType,
-      filter_op: config.filter_op || "",
-      filter_value: filterValue,
-      ...(config.col_type ? { col_type: config.col_type } : {}),
-    },
-  };
-}
-
-export function ruleConditionsToFilters(rule) {
-  const sourceType = rule?.source_type || "trace";
-  const filterPayload = rule?.conditions?.filter;
-  if (Array.isArray(filterPayload) && filterPayload.length > 0) {
-    return filterPayload.map(snakeFilterToUi);
-  }
-  const rules = rule?.conditions?.rules || [];
-  if (rules.length === 0) return defaultFiltersForSource(sourceType);
-  return rules.map((row) => ({
-    id: getRandomId(),
-    column_id: row.field || "",
-    filter_config: {
-      filter_type: "text",
-      filter_op: row.op || "",
-      filter_value: row.value ?? "",
-    },
-  }));
-}
-
-export function ruleConditionsToScope(rule) {
-  return rule?.conditions?.scope || {};
-}
-
-export function buildConditionsForRule(sourceType, filters, scope, queue) {
-  const queueProjectId = getQueueScopeId(queue, "project");
-  const queueDatasetId = getQueueScopeId(queue, "dataset");
-  const queueAgentId = getQueueScopeId(queue, "agent_definition");
-  const nextScope = {};
-
-  if (sourceType === "dataset_row") {
-    const datasetId = resolveRuleScopeId(
-      queue,
-      queueDatasetId,
-      scope.dataset_id,
-    );
-    if (datasetId) nextScope.dataset_id = datasetId;
-    return {
-      operator: "and",
-      filter: filters.filter(validateFilter).map(transformFilter),
-      scope: nextScope,
-    };
-  }
-
-  if (sourceType === "trace" || sourceType === "observation_span") {
-    const projectId = resolveRuleScopeId(
-      queue,
-      queueProjectId,
-      scope.project_id,
-    );
-    if (projectId) nextScope.project_id = projectId;
-    if (sourceType === "trace") {
-      nextScope.is_voice_call = !!scope.is_voice_call;
-      nextScope.remove_simulation_calls = !!scope.remove_simulation_calls;
-    }
-    const apiFilters = getSubmittableFilters(filters);
-    return {
-      operator: "and",
-      filter: apiFilters,
-      scope: nextScope,
-    };
-  }
-
-  if (sourceType === "trace_session") {
-    const projectId = resolveRuleScopeId(
-      queue,
-      queueProjectId,
-      scope.project_id,
-    );
-    if (projectId) nextScope.project_id = projectId;
-    const apiFilters = getSubmittableFilters(filters);
-    return {
-      operator: "and",
-      filter: apiFilters,
-      scope: nextScope,
-    };
-  }
-
-  if (sourceType === "call_execution") {
-    const agentId = resolveRuleScopeId(queue, queueAgentId, scope.project_id);
-    if (agentId) nextScope.project_id = agentId;
-    const apiFilters = getSubmittableFilters(filters);
-    return {
-      operator: "and",
-      filter: apiFilters,
-      ...(Object.keys(nextScope).length ? { scope: nextScope } : {}),
-    };
-  }
-
-  return {
-    operator: "and",
-    filter: getSubmittableFilters(filters),
-    ...(Object.keys(nextScope).length ? { scope: nextScope } : {}),
-  };
-}
 
 export function RuleScopePicker({
   sourceType,
@@ -535,7 +285,7 @@ function DatasetRuleFilters({
   );
 
   const columnConfig = useMemo(
-    () => tableData?.data?.result?.columnConfig || [],
+    () => tableData?.data?.result?.column_config || [],
     [tableData],
   );
 
@@ -576,16 +326,18 @@ function DatasetRuleFilters({
   const panelCurrentFilters = useMemo(
     () =>
       filters
-        .filter((filter) => filter.columnId)
-        .map((filter) => datasetStoreFilterToPanel(filter, columnLookup)),
+        .filter((filter) => filter.column_id)
+        .map((filter) =>
+          datasetStoreFilterToPanel(datasetFilterToCamel(filter), columnLookup),
+        ),
     [filters, columnLookup],
   );
 
   const chipFilters = useMemo(
     () =>
       filters
-        .filter(validateFilter)
-        .map(transformFilter)
+        .filter(isDatasetFilterValid)
+        .map(transformDatasetFilter)
         .map((filter) => ({
           ...filter,
           display_name:
@@ -599,7 +351,7 @@ function DatasetRuleFilters({
   const validFilterIndices = useMemo(() => {
     const indices = [];
     filters.forEach((filter, index) => {
-      if (validateFilter(filter)) indices.push(index);
+      if (isDatasetFilterValid(filter)) indices.push(index);
     });
     return indices;
   }, [filters]);
@@ -607,13 +359,11 @@ function DatasetRuleFilters({
   const handleApply = useCallback(
     (newPanelFilters) => {
       onInteraction?.();
-      const nextFilters = (newPanelFilters || []).map(
-        datasetPanelFilterToStore,
-      );
+      const nextFilters = (newPanelFilters || [])
+        .map(datasetPanelFilterToStore)
+        .map(datasetFilterToSnake);
       setFilters(
-        nextFilters.length
-          ? nextFilters
-          : [{ ...DatasetDefaultFilter, id: getRandomId() }],
+        nextFilters.length ? nextFilters : [makeDatasetDefaultFilter()],
       );
     },
     [onInteraction, setFilters],
@@ -641,14 +391,14 @@ function DatasetRuleFilters({
         }}
         sx={{
           border: "1px solid",
-          borderColor: filters.some((filter) => filter.columnId)
+          borderColor: filters.some((filter) => filter.column_id)
             ? "primary.main"
             : "divider",
           borderRadius: 0.5,
           p: 0.75,
           mb: 1,
           bgcolor: (theme) =>
-            filters.some((filter) => filter.columnId)
+            filters.some((filter) => filter.column_id)
               ? activeFilterButtonBg(theme)
               : "transparent",
         }}
@@ -699,13 +449,13 @@ function DatasetRuleFilters({
             );
             return nextFilters.length
               ? nextFilters
-              : [{ ...DatasetDefaultFilter, id: getRandomId() }];
+              : [makeDatasetDefaultFilter()];
           });
         }}
         onClearAll={() => {
           onInteraction?.();
           setFilterAnchorEl(null);
-          setFilters([{ ...DatasetDefaultFilter, id: getRandomId() }]);
+          setFilters([makeDatasetDefaultFilter()]);
           setFilterOpen(false);
         }}
       />
@@ -1043,38 +793,6 @@ export function RuleFilterSection({
       onInteraction={onInteraction}
     />
   );
-}
-
-export function isScopeReady(sourceType, scope, queue) {
-  if (sourceType === "dataset_row") {
-    return Boolean(scope.dataset_id || getQueueScopeId(queue, "dataset"));
-  }
-  if (["trace", "observation_span", "trace_session"].includes(sourceType)) {
-    return Boolean(scope.project_id || getQueueScopeId(queue, "project"));
-  }
-  if (sourceType === "call_execution") {
-    return Boolean(
-      scope.project_id || getQueueScopeId(queue, "agent_definition"),
-    );
-  }
-  return true;
-}
-
-export function getRuleSubmitDisabledTooltipTitle(
-  sourceType,
-  scope,
-  queue,
-  name,
-) {
-  if (!name.trim()) return "Enter a rule name";
-  if (!isScopeReady(sourceType, scope, queue)) {
-    if (sourceType === "dataset_row") return "Choose a dataset";
-    if (["trace", "observation_span", "trace_session"].includes(sourceType)) {
-      return "Choose a project";
-    }
-    if (sourceType === "call_execution") return "Choose an agent definition";
-  }
-  return "";
 }
 
 export default function CreateRuleDialog({ open, onClose, queueId, queue }) {

--- a/frontend/src/sections/annotations/queues/view/edit-rule-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/view/edit-rule-dialog.jsx
@@ -16,15 +16,16 @@ import { useUpdateAutomationRule } from "src/api/annotation-queues/annotation-qu
 import {
   SOURCE_OPTIONS,
   TRIGGER_FREQUENCY_OPTIONS,
-  RuleFilterSection,
-  RuleScopePicker,
+} from "../constants";
+import { RuleFilterSection, RuleScopePicker } from "./create-rule-dialog";
+import {
   buildConditionsForRule,
   defaultFiltersForSource,
   getRuleSubmitDisabledTooltipTitle,
   isScopeReady,
   ruleConditionsToFilters,
   ruleConditionsToScope,
-} from "./create-rule-dialog";
+} from "../utils/automation-rule-utils";
 
 export default function EditRuleDialog({
   open,

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1550,7 +1550,7 @@ function FilterRow({
       );
     }
 
-    if (filter.fieldType === "text") {
+    if (filter.fieldType === "text" || filter.fieldType === "string") {
       return (
         <TextField
           size="small"


### PR DESCRIPTION
# fix(annotation-rules): unblock manual rule evaluation + dataset filter editing

## Summary

Fixes two user-facing bugs in annotation-queue automation rules and refactors the rule dialog for maintainability.

### 1. "Failed to evaluate rule" on every manual run

`useEvaluateRule` POSTed with no body, but the endpoint's contract declares a required `EmptyRequest` body. The axios request interceptor runs zod contract validation (`z.object({}).strict().safeParse(undefined)`), which threw **before the request was sent** — so the mutation always rejected and the backend was never hit. Now it sends `{}`, satisfying the contract.

### 2. Crash when editing an existing dataset-row rule

`validateFilter` reads `filter.filterConfig.filterValue` (camelCase), but saved rules hydrate into snake_case (`filter_config`), so editing a rule with filters threw `Cannot read properties of undefined (reading 'filterValue')` and took down the page via the ErrorBoundary. Dataset rule filters are now **snake_case end-to-end** — state and payload — with snake-native validation/transform, consistent with the trace/span/session sources. The shared (camelCase) Develop filter library is untouched; conversion happens only at the panel-render boundary.

### 3. Refactor (no behavior change)

- Moved rule constants (`SOURCE_OPTIONS`, `TRIGGER_FREQUENCY_OPTIONS`, `DEFAULT_FILTER`, filter-field/category lists, `MULTI_VALUE_OPS`) out of `create-rule-dialog.jsx` into `constants.js`.
- Extracted the pure logic functions (scope resolution, condition building, filter validate/transform/hydrate) into a new `utils/automation-rule-utils.js`. `create-rule-dialog.jsx` shrank ~330 lines and now holds only components.
- Repointed `edit-rule-dialog.jsx`, `automation-rules-tab.jsx`, and tests to the new modules.

### 4. TraceFilterPanel

`text` and `string` field types now render the same value input (one component for both).

## Files changed

| File | Change |
| --- | --- |
| `api/annotation-queues/annotation-queues.js` | Send `{}` body for evaluate |
| `annotations/queues/view/create-rule-dialog.jsx` | Snake-native dataset filters; extract constants/utils |
| `annotations/queues/constants.js` | Rule constants (new section) |
| `annotations/queues/utils/automation-rule-utils.js` | New utils module |
| `annotations/queues/view/edit-rule-dialog.jsx` | Repointed imports |
| `annotations/queues/view/automation-rules-tab.jsx` | Repointed imports |
| `projects/LLMTracing/TraceFilterPanel.jsx` | Unify text/string value input |
| `*/__tests__/*` | Updated to new import paths |

## Test plan

- [x] Open an annotation queue → run an automation rule manually → success toast ("Rule evaluated: N items added…"), no "Failed to evaluate rule"
- [x] Large rule run → still returns 202 / "preparing your data" path
- [x] Double-click Run within 30s → friendly "run already in progress" warning (409), not a generic failure
- [x] Edit an existing **dataset-row** rule that has filters → dialog opens without crashing and shows the saved filter rows
- [x] Save that edited dataset rule → `conditions.filter` round-trips unchanged (snake_case)
- [x] Create a fresh dataset-row rule with text / number / datetime / boolean filters → validates and serializes correctly
- [x] Half-filled dataset filter row (column but no value) → excluded from chips and payload
- [x] Clear-all / remove last filter chip → resets to one empty row
- [x] Edit trace / span / session / simulation rules → unaffected
- [x] Annotation `text` label filter and a `string` field → both render a single text input
- [x] `yarn test` for `create-rule-dialog`, `automation-rules-tab`, `TraceFilterPanel` suites pass
- [x] `yarn lint` clean on touched files

Closes TH-5673