### PR TITLE
fix(ch25): resolve eval-logger table via eval_logger_source() in span/session reads

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -187,24 +187,137 @@ class AnalyticsQueryService:
         # has fewer than 5 keys, returning whatever we have is correct.
         return [{"key": row["key"], "type": row["type"]} for row in result.data]
 
-    def get_eval_config_ids_with_data_ch(self, project_id: str) -> list[str]:
-        """Get distinct eval config IDs that have data for a project in ClickHouse."""
-        eval_table, eval_nd = eval_logger_source()
-        query = f"""
-            SELECT DISTINCT toString(custom_eval_config_id) AS config_id
-            FROM {eval_table} FINAL
-            WHERE {eval_nd}
-              AND trace_id IN (
-                  SELECT DISTINCT trace_id
-                  FROM spans
-                  WHERE project_id = %(project_id)s
-                    AND is_deleted = 0
-              )
+    @staticmethod
+    def _eval_config_ids_query(scope_sql: str) -> str:
+        """Build the shared "distinct eval-config IDs that have data" query.
+
+        One body for every eval-config discovery read: the table and its
+        not-deleted predicate come from ``eval_logger_source()`` (so a ``_v2``
+        stack uses ``is_deleted = 0``), and callers supply only the
+        trace-scoping clause.
         """
+        eval_table, eval_nd = eval_logger_source()
+        return (
+            "SELECT DISTINCT toString(custom_eval_config_id) AS config_id "
+            f"FROM {eval_table} FINAL "
+            f"WHERE {eval_nd} "
+            f"AND {scope_sql}"
+        )
+
+    def get_eval_config_ids_with_data_ch(
+        self, project_id: str, timeout_ms: int = 5000
+    ) -> list[str]:
+        """Distinct eval config IDs that have data for a project (scoped via spans)."""
+        query = self._eval_config_ids_query(
+            "trace_id IN ("
+            "SELECT DISTINCT trace_id FROM spans "
+            "WHERE project_id = %(project_id)s AND is_deleted = 0"
+            ")"
+        )
         result = self.execute_ch_query(
-            query, {"project_id": project_id}, timeout_ms=5000
+            query, {"project_id": project_id}, timeout_ms=timeout_ms
         )
         return [row["config_id"] for row in result.data]
+
+    def get_eval_config_ids_for_traces_ch(
+        self, trace_ids: list[str], timeout_ms: int = 3000
+    ) -> list[str]:
+        """Distinct eval config IDs recorded for an explicit set of trace IDs."""
+        if not trace_ids:
+            return []
+        query = self._eval_config_ids_query("trace_id IN %(trace_ids)s")
+        result = self.execute_ch_query(
+            query, {"trace_ids": trace_ids}, timeout_ms=timeout_ms
+        )
+        return [row["config_id"] for row in result.data]
+
+    def get_children_eval_metrics_ch(
+        self, span_ids: list[str], timeout_ms: int = 5000
+    ) -> list[dict]:
+        """Per-span eval rows for a set of child observation spans."""
+        if not span_ids:
+            return []
+        eval_table, eval_nd = eval_logger_source()
+        query = f"""
+            SELECT
+                toString(observation_span_id) AS span_id,
+                toString(custom_eval_config_id) AS config_id,
+                output_float,
+                output_bool,
+                output_str_list,
+                eval_explanation,
+                error,
+                error_message,
+                output_str
+            FROM {eval_table} FINAL
+            WHERE observation_span_id IN %(span_ids)s
+              AND {eval_nd}
+        """
+        result = self.execute_ch_query(
+            query, {"span_ids": span_ids}, timeout_ms=timeout_ms
+        )
+        return result.data
+
+    def get_eval_detail_ch(
+        self, span_id: str, config_id: str, timeout_ms: int = 5000
+    ) -> dict | None:
+        """Single span/trace-target eval detail row, or ``None`` if absent."""
+        eval_table, eval_nd = eval_logger_source()
+        query = f"""
+            SELECT
+                output_float,
+                output_bool,
+                output_str_list,
+                output_str,
+                eval_explanation,
+                error,
+                error_message,
+                output_metadata
+            FROM {eval_table} FINAL
+            WHERE observation_span_id = %(span_id)s
+              AND custom_eval_config_id = %(config_id)s
+              AND target_type IN ('span', 'trace')
+              AND {eval_nd}
+            LIMIT 1
+        """
+        result = self.execute_ch_query(
+            query,
+            {"span_id": str(span_id), "config_id": str(config_id)},
+            timeout_ms=timeout_ms,
+        )
+        return result.data[0] if result.data else None
+
+    def get_trace_eval_scores_ch(
+        self, trace_ids: list[str], config_ids: list[str], timeout_ms: int = 5000
+    ) -> list[dict]:
+        """Per-(trace, config) aggregated eval scores for a session's traces."""
+        if not (trace_ids and config_ids):
+            return []
+        eval_table, eval_nd = eval_logger_source()
+        query = f"""
+            SELECT
+                toString(trace_id) AS trace_id,
+                toString(custom_eval_config_id) AS config_id,
+                round(avg(output_float) * 100, 2) AS float_score,
+                round(avg(CASE WHEN output_bool = 1 THEN 100.0
+                               WHEN output_bool = 0 THEN 0.0
+                               ELSE NULL END), 2) AS bool_score,
+                count(output_float) AS float_count,
+                count(output_bool) AS bool_count
+            FROM {eval_table} FINAL
+            WHERE trace_id IN %(trace_ids)s
+              AND custom_eval_config_id IN %(config_ids)s
+              AND {eval_nd}
+              AND output_str != 'ERROR'
+              AND (error = 0 OR error IS NULL)
+            GROUP BY trace_id, custom_eval_config_id
+        """
+        result = self.execute_ch_query(
+            query,
+            {"trace_ids": trace_ids, "config_ids": config_ids},
+            timeout_ms=timeout_ms,
+        )
+        return result.data
 
     def get_backend_status(self) -> dict[str, Any]:
         """Get the ClickHouse connectivity status."""

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -19,6 +19,7 @@ from tracer.services.clickhouse.client import (
     get_clickhouse_client,
     is_clickhouse_enabled,
 )
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 
 logger = structlog.get_logger(__name__)
 
@@ -188,11 +189,11 @@ class AnalyticsQueryService:
 
     def get_eval_config_ids_with_data_ch(self, project_id: str) -> list[str]:
         """Get distinct eval config IDs that have data for a project in ClickHouse."""
-        query = """
+        eval_table, eval_nd = eval_logger_source()
+        query = f"""
             SELECT DISTINCT toString(custom_eval_config_id) AS config_id
-            FROM tracer_eval_logger FINAL
-            WHERE _peerdb_is_deleted = 0
-              AND (deleted = 0 OR deleted IS NULL)
+            FROM {eval_table} FINAL
+            WHERE {eval_nd}
               AND trace_id IN (
                   SELECT DISTINCT trace_id
                   FROM spans

--- a/futureagi/tracer/tests/test_eval_config_ids_resolution.py
+++ b/futureagi/tracer/tests/test_eval_config_ids_resolution.py
@@ -1,0 +1,249 @@
+"""Tests for eval-logger table resolution and the shared eval-config-id selectors.
+
+Covers the CH25 fix that routes eval-logger reads through ``eval_logger_source()``
+and consolidates the "distinct eval-config IDs that have data" lookup into the
+``AnalyticsQueryService``:
+
+* ``eval_logger_source()`` picks the configured table + its not-deleted predicate.
+* ``get_eval_config_ids_with_data_ch`` / ``get_eval_config_ids_for_traces_ch``
+  generate that predicate (``is_deleted = 0`` on a ``_v2`` stack) and scope correctly.
+* A ClickHouse read failure propagates instead of being masked as "no eval scores".
+"""
+
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+
+class _Result:
+    """Minimal stand-in for ``QueryResult`` — selectors only read ``.data``."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+def _capturing_service(rows):
+    """An ``AnalyticsQueryService`` whose ``execute_ch_query`` records its args.
+
+    ``__init__`` is lazy (no CH connection), so we can construct it directly and
+    shadow ``execute_ch_query`` with a recorder that returns canned rows.
+    """
+    from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+    svc = AnalyticsQueryService()
+    captured = {}
+
+    def _recorder(query, params=None, timeout_ms=None, settings=None):
+        captured["query"] = query
+        captured["params"] = params
+        captured["timeout_ms"] = timeout_ms
+        return _Result(rows)
+
+    svc.execute_ch_query = _recorder
+    return svc, captured
+
+
+@pytest.mark.unit
+class TestEvalLoggerSource:
+    """``eval_logger_source()`` resolves the table + not-deleted predicate."""
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger")
+    def test_legacy_table_uses_peerdb_predicate(self):
+        from tracer.services.clickhouse.eval_logger_table import eval_logger_source
+
+        table, not_deleted = eval_logger_source()
+        assert table == "tracer_eval_logger"
+        assert not_deleted == (
+            "_peerdb_is_deleted = 0 AND (deleted = 0 OR deleted IS NULL)"
+        )
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_v2_table_uses_is_deleted_predicate(self):
+        from tracer.services.clickhouse.eval_logger_table import eval_logger_source
+
+        table, not_deleted = eval_logger_source()
+        assert table == "tracer_eval_logger_v2"
+        assert not_deleted == "is_deleted = 0"
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_alias_prefixes_v2_predicate(self):
+        from tracer.services.clickhouse.eval_logger_table import eval_logger_source
+
+        _, not_deleted = eval_logger_source("e")
+        assert not_deleted == "e.is_deleted = 0"
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger")
+    def test_alias_prefixes_legacy_predicate(self):
+        from tracer.services.clickhouse.eval_logger_table import eval_logger_source
+
+        _, not_deleted = eval_logger_source("e")
+        assert not_deleted == (
+            "e._peerdb_is_deleted = 0 AND (e.deleted = 0 OR e.deleted IS NULL)"
+        )
+
+
+@pytest.mark.unit
+class TestEvalConfigIdSelectors:
+    """The two service selectors generate the resolved table + predicate + scope."""
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_project_selector_v2_predicate_and_scope(self):
+        svc, captured = _capturing_service([{"config_id": "a"}, {"config_id": "b"}])
+        ids = svc.get_eval_config_ids_with_data_ch("proj-1")
+
+        assert ids == ["a", "b"]
+        query = captured["query"]
+        assert "tracer_eval_logger_v2 FINAL" in query
+        assert "is_deleted = 0" in query
+        assert "_peerdb_is_deleted" not in query
+        # project scope is the spans subquery, not dictGet
+        assert "project_id = %(project_id)s" in query
+        assert "dictGet" not in query
+        assert captured["params"] == {"project_id": "proj-1"}
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger")
+    def test_project_selector_legacy_predicate(self):
+        svc, captured = _capturing_service([])
+        svc.get_eval_config_ids_with_data_ch("proj-1")
+
+        query = captured["query"]
+        assert "tracer_eval_logger FINAL" in query
+        assert "_peerdb_is_deleted = 0" in query
+
+    def test_project_selector_forwards_timeout(self):
+        svc, captured = _capturing_service([])
+        svc.get_eval_config_ids_with_data_ch("proj-1", timeout_ms=30000)
+        assert captured["timeout_ms"] == 30000
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_traces_selector_v2_predicate_and_scope(self):
+        svc, captured = _capturing_service([{"config_id": "x"}])
+        ids = svc.get_eval_config_ids_for_traces_ch(["t1", "t2"])
+
+        assert ids == ["x"]
+        query = captured["query"]
+        assert "tracer_eval_logger_v2 FINAL" in query
+        assert "is_deleted = 0" in query
+        assert "_peerdb_is_deleted" not in query
+        assert "trace_id IN %(trace_ids)s" in query
+        assert captured["params"] == {"trace_ids": ["t1", "t2"]}
+
+    def test_traces_selector_empty_short_circuits(self):
+        svc, captured = _capturing_service([{"config_id": "x"}])
+        ids = svc.get_eval_config_ids_for_traces_ch([])
+        # No CH round-trip for an empty trace set.
+        assert ids == []
+        assert captured == {}
+
+
+@pytest.mark.unit
+class TestEvalReadFailurePropagates:
+    """A CH read failure must surface, not be masked as an empty session result."""
+
+    def test_trace_session_retrieve_propagates_ch_error(self):
+        from tracer.services.clickhouse.client import CHError
+        from tracer.views.trace_session import TraceSessionView
+
+        view = TraceSessionView()
+
+        class _FakeAnalytics:
+            def execute_ch_query(
+                self, query, params=None, timeout_ms=None, settings=None
+            ):
+                # Paginated trace list — return one trace so we reach eval discovery.
+                if "root_latency_ms" in query:
+                    return _Result(
+                        [
+                            {
+                                "trace_id": "t1",
+                                "input": None,
+                                "output": None,
+                                "root_latency_ms": 0,
+                                "total_cost": 0,
+                                "trace_min_start_time": None,
+                                "total_tokens": 0,
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                            }
+                        ]
+                    )
+                # Session aggregate (and anything else) — empty is fine.
+                return _Result([])
+
+            def get_eval_config_ids_for_traces_ch(self, trace_ids, timeout_ms=3000):
+                raise CHError("clickhouse unavailable")
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_session_ids_to_canonical",
+            return_value={"s1": "s1"},
+        ):
+            with pytest.raises(CHError):
+                view._retrieve_clickhouse(
+                    request=mock.Mock(),
+                    trace_session_id="s1",
+                    trace_session_obj=None,
+                    project_id="p1",
+                    analytics=_FakeAnalytics(),
+                    query_data={"page_number": 0, "page_size": 30},
+                )
+
+
+@pytest.mark.unit
+class TestEvalReadSelectors:
+    """The non-discovery eval reads also resolve their table via eval_logger_source()."""
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_children_eval_metrics_v2_predicate_and_scope(self):
+        svc, captured = _capturing_service([{"span_id": "s", "config_id": "c"}])
+        rows = svc.get_children_eval_metrics_ch(["s1", "s2"])
+
+        assert rows == [{"span_id": "s", "config_id": "c"}]
+        query = captured["query"]
+        assert "tracer_eval_logger_v2 FINAL" in query
+        assert "is_deleted = 0" in query
+        assert "_peerdb_is_deleted" not in query
+        assert "observation_span_id IN %(span_ids)s" in query
+        assert captured["params"] == {"span_ids": ["s1", "s2"]}
+
+    def test_children_eval_metrics_empty_short_circuits(self):
+        svc, captured = _capturing_service([{"span_id": "s"}])
+        assert svc.get_children_eval_metrics_ch([]) == []
+        assert captured == {}
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_eval_detail_v2_predicate_and_returns_first_row(self):
+        svc, captured = _capturing_service([{"output_float": 1.0}])
+        row = svc.get_eval_detail_ch("span-1", "cfg-1")
+
+        assert row == {"output_float": 1.0}
+        query = captured["query"]
+        assert "tracer_eval_logger_v2 FINAL" in query
+        assert "is_deleted = 0" in query
+        assert "target_type IN ('span', 'trace')" in query
+        assert "LIMIT 1" in query
+        assert captured["params"] == {"span_id": "span-1", "config_id": "cfg-1"}
+
+    def test_eval_detail_returns_none_when_absent(self):
+        svc, _ = _capturing_service([])
+        assert svc.get_eval_detail_ch("span-1", "cfg-1") is None
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_trace_eval_scores_v2_predicate_and_scope(self):
+        svc, captured = _capturing_service([{"trace_id": "t", "config_id": "c"}])
+        rows = svc.get_trace_eval_scores_ch(["t1"], ["c1"])
+
+        assert rows == [{"trace_id": "t", "config_id": "c"}]
+        query = captured["query"]
+        assert "tracer_eval_logger_v2 FINAL" in query
+        assert "is_deleted = 0" in query
+        assert "_peerdb_is_deleted" not in query
+        assert "trace_id IN %(trace_ids)s" in query
+        assert "custom_eval_config_id IN %(config_ids)s" in query
+        assert captured["params"] == {"trace_ids": ["t1"], "config_ids": ["c1"]}
+
+    def test_trace_eval_scores_empty_short_circuits(self):
+        svc, captured = _capturing_service([{"trace_id": "t"}])
+        assert svc.get_trace_eval_scores_ch([], ["c1"]) == []
+        assert svc.get_trace_eval_scores_ch(["t1"], []) == []
+        assert captured == {}

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -84,7 +84,6 @@ from tracer.services.clickhouse.graph_dispatch import (
     fetch_eval_graph_ch,
     fetch_system_metric_graph_ch,
 )
-from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
@@ -627,30 +626,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # Fetch eval metrics from CH
         evals_metrics = {}
         if children_span_ids:
-            eval_table, eval_nd = eval_logger_source()
-            eval_query = f"""
-                SELECT
-                    toString(observation_span_id) AS span_id,
-                    toString(custom_eval_config_id) AS config_id,
-                    output_float,
-                    output_bool,
-                    output_str_list,
-                    eval_explanation,
-                    error,
-                    error_message,
-                    output_str
-                FROM {eval_table} FINAL
-                WHERE observation_span_id IN %(span_ids)s
-                  AND {eval_nd}
-            """
-            eval_result = analytics.execute_ch_query(
-                eval_query, {"span_ids": children_span_ids}, timeout_ms=5000
-            )
+            eval_rows = analytics.get_children_eval_metrics_ch(children_span_ids)
 
             # Get config names from PG (small config table)
-            config_ids = list(
-                {r["config_id"] for r in eval_result.data if r.get("config_id")}
-            )
+            config_ids = list({r["config_id"] for r in eval_rows if r.get("config_id")})
             config_name_map = {}
             config_output_type_map = {}
             if config_ids:
@@ -661,7 +640,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                     config_name_map[str(c.id)] = c.name
                     config_output_type_map[str(c.id)] = _get_configured_output_type(c)
 
-            for eval_row in eval_result.data:
+            for eval_row in eval_rows:
                 config_id = eval_row.get("config_id")
                 span_id = eval_row.get("span_id")
                 config_name = config_name_map.get(
@@ -1328,19 +1307,13 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             # annotations + Score subqueries + Python pivot, ~350 LOC) was
             # deleted. CH is the authoritative span + eval store and the
             # pivot now lives in `_list_spans_clickhouse` via
-            # SpanListQueryBuilder.
+            # SpanListQueryBuilder. A CH read failure surfaces via the outer
+            # handler instead of silently degrading to the empty post-migration
+            # Postgres path, which masked CH failures as "0 rows".
             analytics = AnalyticsQueryService()
-            try:
-                return self._list_spans_clickhouse(
-                    request, project_id, validated_data, analytics
-                )
-            except Exception:
-                logger.warning(
-                    "list_spans_observe_clickhouse_failed, falling back to postgres",
-                    project_id=project_id,
-                    exc_info=True,
-                )
-                return self._list_spans_postgres(request, project_id, validated_data)
+            return self._list_spans_clickhouse(
+                request, project_id, validated_data, analytics
+            )
 
         except Exception as e:
             logger.exception(f"Error in fetching the spans list of observe: {str(e)}")
@@ -1398,19 +1371,12 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 }
             )
 
-        # Get eval config IDs from CH (fast) instead of PG EvalLogger scan
+        # Get eval config IDs from CH (fast) instead of PG EvalLogger scan,
+        # via the shared service selector (same lookup trace.py uses).
         eval_config_ids = []
-        eval_table, eval_nd = eval_logger_source()
-        ch_result = analytics.execute_ch_query(
-            "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            f"FROM {eval_table} FINAL "
-            f"WHERE {eval_nd} "
-            "AND dictGet('trace_dict', 'project_id', "
-            "trace_id) = toUUID(%(pid)s)",
-            {"pid": str(project_id)},
-            timeout_ms=30000,
+        ch_ids = analytics.get_eval_config_ids_with_data_ch(
+            str(project_id), timeout_ms=30000
         )
-        ch_ids = [r.get("cid", "") for r in ch_result.data if r.get("cid")]
         if ch_ids:
             eval_configs = CustomEvalConfig.objects.filter(
                 id__in=ch_ids, deleted=False
@@ -2182,39 +2148,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         """Get evaluation details from ClickHouse."""
         # Span- and trace-target rows both anchor to observation_span_id;
         # session rows don't and are served by /trace-session/:id/eval_logs/.
-        eval_table, eval_nd = eval_logger_source()
-        query = f"""
-            SELECT
-                output_float,
-                output_bool,
-                output_str_list,
-                output_str,
-                eval_explanation,
-                error,
-                error_message,
-                output_metadata
-            FROM {eval_table} FINAL
-            WHERE observation_span_id = %(span_id)s
-              AND custom_eval_config_id = %(config_id)s
-              AND target_type IN ('span', 'trace')
-              AND {eval_nd}
-            LIMIT 1
-        """
-        result = analytics.execute_ch_query(
-            query,
-            {
-                "span_id": str(observation_span_id),
-                "config_id": str(custom_eval_config_id),
-            },
-            timeout_ms=5000,
-        )
-
-        if not result.data:
+        row = analytics.get_eval_detail_ch(observation_span_id, custom_eval_config_id)
+        if not row:
             return self._gm.bad_request(
                 "No eval logger found for the given observation span id and custom eval config id"
             )
-
-        row = result.data[0]
 
         output_metadata = row.get("output_metadata")
         if not output_metadata or not isinstance(output_metadata, dict):

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -84,6 +84,7 @@ from tracer.services.clickhouse.graph_dispatch import (
     fetch_eval_graph_ch,
     fetch_system_metric_graph_ch,
 )
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
@@ -626,7 +627,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # Fetch eval metrics from CH
         evals_metrics = {}
         if children_span_ids:
-            eval_query = """
+            eval_table, eval_nd = eval_logger_source()
+            eval_query = f"""
                 SELECT
                     toString(observation_span_id) AS span_id,
                     toString(custom_eval_config_id) AS config_id,
@@ -637,10 +639,9 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                     error,
                     error_message,
                     output_str
-                FROM tracer_eval_logger FINAL
+                FROM {eval_table} FINAL
                 WHERE observation_span_id IN %(span_ids)s
-                  AND _peerdb_is_deleted = 0
-                  AND (deleted = 0 OR deleted IS NULL)
+                  AND {eval_nd}
             """
             eval_result = analytics.execute_ch_query(
                 eval_query, {"span_ids": children_span_ids}, timeout_ms=5000
@@ -1399,11 +1400,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
         # Get eval config IDs from CH (fast) instead of PG EvalLogger scan
         eval_config_ids = []
+        eval_table, eval_nd = eval_logger_source()
         ch_result = analytics.execute_ch_query(
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            "FROM tracer_eval_logger FINAL "
-            "WHERE _peerdb_is_deleted = 0 "
-            "AND (deleted = 0 OR deleted IS NULL) "
+            f"FROM {eval_table} FINAL "
+            f"WHERE {eval_nd} "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": str(project_id)},
@@ -2181,7 +2182,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         """Get evaluation details from ClickHouse."""
         # Span- and trace-target rows both anchor to observation_span_id;
         # session rows don't and are served by /trace-session/:id/eval_logs/.
-        query = """
+        eval_table, eval_nd = eval_logger_source()
+        query = f"""
             SELECT
                 output_float,
                 output_bool,
@@ -2191,12 +2193,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 error,
                 error_message,
                 output_metadata
-            FROM tracer_eval_logger FINAL
+            FROM {eval_table} FINAL
             WHERE observation_span_id = %(span_id)s
               AND custom_eval_config_id = %(config_id)s
               AND target_type IN ('span', 'trace')
-              AND _peerdb_is_deleted = 0
-              AND (deleted = 0 OR deleted IS NULL)
+              AND {eval_nd}
             LIMIT 1
         """
         result = analytics.execute_ch_query(

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -73,7 +73,6 @@ from tracer.services.clickhouse.graph_dispatch import (
     fetch_annotation_graph_ch,
     fetch_eval_graph_ch,
 )
-from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import NIL_UUID
 from tracer.utils.filters import FilterEngine, apply_created_at_filters
 from tracer.utils.helper import (
@@ -792,31 +791,9 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         trace_ids = [r["trace_id"] for r in traces_data]
         eval_configs: list = []
         if trace_ids:
-            eval_table, eval_nd = eval_logger_source()
-            try:
-                config_id_result = analytics.execute_ch_query(
-                    f"""
-                    SELECT DISTINCT toString(custom_eval_config_id) AS config_id
-                    FROM {eval_table} FINAL
-                    WHERE trace_id IN %(trace_ids)s
-                      AND {eval_nd}
-                    """,
-                    {"trace_ids": trace_ids},
-                    timeout_ms=3000,
-                )
-                pre_config_ids = [
-                    row["config_id"]
-                    for row in config_id_result.data
-                    if row.get("config_id")
-                ]
-            except Exception as e:
-                logger.warning(
-                    "ch_eval_config_id_lookup_failed",
-                    session_id=str(trace_session_id),
-                    error=str(e),
-                )
-                pre_config_ids = []
-
+            # A CH read failure must surface (via retrieve()'s outer error
+            # handler), not fail open to "this session has no eval scores".
+            pre_config_ids = analytics.get_eval_config_ids_for_traces_ch(trace_ids)
             if pre_config_ids:
                 eval_configs = list(
                     CustomEvalConfig.objects.filter(
@@ -828,30 +805,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         eval_map = {}
         if eval_configs and trace_ids:
             config_ids = [str(c.id) for c in eval_configs]
-            eval_query = f"""
-                SELECT
-                    toString(trace_id) AS trace_id,
-                    toString(custom_eval_config_id) AS config_id,
-                    round(avg(output_float) * 100, 2) AS float_score,
-                    round(avg(CASE WHEN output_bool = 1 THEN 100.0
-                                   WHEN output_bool = 0 THEN 0.0
-                                   ELSE NULL END), 2) AS bool_score,
-                    count(output_float) AS float_count,
-                    count(output_bool) AS bool_count
-                FROM {eval_table} FINAL
-                WHERE trace_id IN %(trace_ids)s
-                  AND custom_eval_config_id IN %(config_ids)s
-                  AND {eval_nd}
-                  AND output_str != 'ERROR'
-                  AND (error = 0 OR error IS NULL)
-                GROUP BY trace_id, custom_eval_config_id
-            """
-            eval_result = analytics.execute_ch_query(
-                eval_query,
-                {"trace_ids": trace_ids, "config_ids": config_ids},
-                timeout_ms=5000,
-            )
-            for row in eval_result.data:
+            eval_rows = analytics.get_trace_eval_scores_ch(trace_ids, config_ids)
+            for row in eval_rows:
                 key = (row["trace_id"], row["config_id"])
                 if row.get("float_count", 0) > 0:
                     eval_map[key] = {"score": row["float_score"], "type": "float"}

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -73,6 +73,7 @@ from tracer.services.clickhouse.graph_dispatch import (
     fetch_annotation_graph_ch,
     fetch_eval_graph_ch,
 )
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import NIL_UUID
 from tracer.utils.filters import FilterEngine, apply_created_at_filters
 from tracer.utils.helper import (
@@ -791,14 +792,14 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         trace_ids = [r["trace_id"] for r in traces_data]
         eval_configs: list = []
         if trace_ids:
+            eval_table, eval_nd = eval_logger_source()
             try:
                 config_id_result = analytics.execute_ch_query(
-                    """
+                    f"""
                     SELECT DISTINCT toString(custom_eval_config_id) AS config_id
-                    FROM tracer_eval_logger FINAL
+                    FROM {eval_table} FINAL
                     WHERE trace_id IN %(trace_ids)s
-                      AND _peerdb_is_deleted = 0
-                      AND (deleted = 0 OR deleted IS NULL)
+                      AND {eval_nd}
                     """,
                     {"trace_ids": trace_ids},
                     timeout_ms=3000,
@@ -827,7 +828,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         eval_map = {}
         if eval_configs and trace_ids:
             config_ids = [str(c.id) for c in eval_configs]
-            eval_query = """
+            eval_query = f"""
                 SELECT
                     toString(trace_id) AS trace_id,
                     toString(custom_eval_config_id) AS config_id,
@@ -837,11 +838,10 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                                    ELSE NULL END), 2) AS bool_score,
                     count(output_float) AS float_count,
                     count(output_bool) AS bool_count
-                FROM tracer_eval_logger FINAL
+                FROM {eval_table} FINAL
                 WHERE trace_id IN %(trace_ids)s
                   AND custom_eval_config_id IN %(config_ids)s
-                  AND _peerdb_is_deleted = 0
-                  AND (deleted = 0 OR deleted IS NULL)
+                  AND {eval_nd}
                   AND output_str != 'ERROR'
                   AND (error = 0 OR error IS NULL)
                 GROUP BY trace_id, custom_eval_config_id


### PR DESCRIPTION
## Problem
Several ClickHouse read paths hardcoded the legacy `tracer_eval_logger` table and its `_peerdb_is_deleted` predicate instead of the configured `CH25_EVAL_LOGGER_TABLE` (resolved by `eval_logger_source()`).

On a CH-direct deployment (`CH25_EVAL_LOGGER_TABLE=tracer_eval_logger_v2`), the eval-config discovery subquery referenced a table that doesn't exist in the `futureagi` database (the legacy `tracer_eval_logger` lives only in `default`, via PeerDB). ClickHouse raised `Code 60: Unknown table`, the CH read path caught it and **silently fell back to the (empty) PG path** — so `list_spans_observe` and sibling eval reads returned **0 rows despite spans existing in ClickHouse**.

## Fix
Route the eval-logger table + not-deleted predicate through `eval_logger_source()` — the resolver that honors `CH25_EVAL_LOGGER_TABLE` (already used by `trace.py` and `query_builders/user_list.py`):

- `observation_span.py` — `list_spans_observe` eval-config discovery, children eval metrics, eval-details
- `trace_session.py` — session eval-config discovery + per-trace eval scores
- `query_service.py` — `get_eval_config_ids_with_data_ch`

No routing-mode/flag changes; `model_hub_score` (annotation) reads are untouched.

## Verification
`GET /tracer/observation-span/list_spans_observe/` for a project with CH spans now returns rows (previously `total_rows: 0`). All three files `py_compile` clean.

## Notes
Part of the CH25 PG→ClickHouse migration. Sibling builder sites (`span_list`/`trace_list`/`voice_call_list`/`monitor_metrics`/`filters`) carry the same hardcoding and are being migrated in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)