### PR TITLE
fix:Fix session eval scores aggregation for ClickHouse

### DIFF
--- a/agentcc-gateway/internal/auth/keystore.go
+++ b/agentcc-gateway/internal/auth/keystore.go
@@ -367,6 +367,27 @@ type SyncedKey struct {
 	Models    []string          `json:"models"`
 	Providers []string          `json:"providers"`
 	Metadata  map[string]string `json:"metadata"`
+	ExpiresAt *time.Time        `json:"expires_at"`
+}
+
+// syncedKeyToAPIKey is the single construction site for both sync paths, so a
+// field can't be wired into one and missed in the other.
+func syncedKeyToAPIKey(sk SyncedKey, id string) *APIKey {
+	return &APIKey{
+		ID:               id,
+		KeyHash:          sk.KeyHash,
+		Name:             sk.Name,
+		Owner:            sk.Owner,
+		Status:           "active",
+		KeyType:          "byok",
+		Source:           "sync",
+		AllowedModels:    sk.Models,
+		AllowedProviders: sk.Providers,
+		Metadata:         sk.Metadata,
+		ExpiresAt:        sk.ExpiresAt,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
 }
 
 // LoadFromHashes merges control-plane keys (identified by pre-computed hashes)
@@ -392,20 +413,7 @@ func (ks *KeyStore) LoadFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key
@@ -468,20 +476,7 @@ func (ks *KeyStore) SyncFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"sync"
@@ -426,6 +427,137 @@ func TestExpiresAt_FromConfig(t *testing.T) {
 	expected, _ := time.Parse(time.RFC3339, expiresStr)
 	if !k.ExpiresAt.Equal(expected) {
 		t.Errorf("expected ExpiresAt %v, got %v", expected, *k.ExpiresAt)
+	}
+}
+
+// ---------- Synced-key expiry (control-plane path) ----------
+
+func syncKeyStore() *KeyStore {
+	return NewKeyStore(authCfg())
+}
+
+// Decoding the wire payload is where the original bug lived (the field was
+// dropped); DRF emits RFC3339 with offset + fractional seconds.
+func TestSyncedKey_DecodesExpiresAt(t *testing.T) {
+	const payload = `{
+		"id": "ck_1",
+		"name": "contractor",
+		"key_hash": "abc123",
+		"expires_at": "2030-06-15T12:30:45.123456Z"
+	}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if sk.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to decode from the wire, got nil")
+	}
+	want, _ := time.Parse(time.RFC3339, "2030-06-15T12:30:45.123456Z")
+	if !sk.ExpiresAt.Equal(want) {
+		t.Errorf("expected ExpiresAt %v, got %v", want, *sk.ExpiresAt)
+	}
+
+	// Null expiry must decode to nil (never-expiring keys).
+	var nullSk SyncedKey
+	if err := json.Unmarshal([]byte(`{"key_hash":"h","expires_at":null}`), &nullSk); err != nil {
+		t.Fatalf("unmarshal null failed: %v", err)
+	}
+	if nullSk.ExpiresAt != nil {
+		t.Errorf("expected nil ExpiresAt for null wire value, got %v", *nullSk.ExpiresAt)
+	}
+}
+
+// Real wire payload with a past expiry, decoded then synced, must be rejected.
+func TestSyncedExpiredKey_DecodeToReject(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired"
+	payload := `{"id":"ck_exp","name":"c","key_hash":"` + HashKey(rawKey) +
+		`","expires_at":"2000-01-01T00:00:00Z"}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{sk})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key (decoded from wire) to be rejected")
+	}
+}
+
+func TestSyncFromHashes_ExpiredKeyRejected(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired-2"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_expired",
+		Name:      "contractor",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if k := ks.Get("ck_expired"); k == nil || k.ExpiresAt == nil {
+		t.Fatal("expected synced key to carry ExpiresAt")
+	}
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key to be rejected")
+	}
+}
+
+func TestSyncFromHashes_FutureExpiryAccepted(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-future"
+	future := time.Now().Add(1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_future",
+		Name:      "valid",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &future,
+	}})
+
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected synced key with future expiry to authenticate")
+	}
+}
+
+func TestSyncFromHashes_NilExpiryNeverExpires(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-noexpiry"
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:      "ck_noexpiry",
+		Name:    "perpetual",
+		KeyHash: HashKey(rawKey),
+		// ExpiresAt nil — must remain non-expiring.
+	}})
+
+	k := ks.Get("ck_noexpiry")
+	if k == nil || k.ExpiresAt != nil {
+		t.Fatal("expected nil ExpiresAt on synced key")
+	}
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected non-expiring synced key to authenticate")
+	}
+}
+
+func TestLoadFromHashes_PropagatesExpiry(t *testing.T) {
+	const rawKey = "sk-agentcc-loaded-expired"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.LoadFromHashes([]SyncedKey{{
+		ID:        "ck_loaded",
+		Name:      "loaded",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired key loaded via LoadFromHashes to be rejected")
 	}
 }
 

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -399,8 +399,8 @@ func TestKeyPrefix(t *testing.T) {
 
 	// Long key: len > 12, prefix is first 12 + "..."
 	long := keyPrefix("sk-agentcc-abcdef1234567890")
-	if long != "sk-agentcc-abc..." {
-		t.Errorf("expected long key prefix 'sk-agentcc-abc...', got '%s'", long)
+	if long != "sk-agentcc-a..." {
+		t.Errorf("expected long key prefix 'sk-agentcc-a...', got '%s'", long)
 	}
 }
 

--- a/frontend/src/sections/gateway/utils/formatters.js
+++ b/frontend/src/sections/gateway/utils/formatters.js
@@ -16,9 +16,16 @@ export function formatCost(value) {
   if (value == null) return "$0.00";
   const num = Number(value);
   if (Number.isNaN(num)) return "$0.00";
-  if (num >= 1000) return `$${(num / 1000).toFixed(1)}K`;
-  if (num >= 1) return `$${num.toFixed(2)}`;
-  return `$${num.toFixed(4)}`;
+
+  const abs = Math.abs(num);
+
+  if (abs >= 1000) return `$${(num / 1000).toFixed(1)}K`;
+  if (abs >= 1) return `$${num.toFixed(2)}`;
+  if (abs >= 0.01) return `$${num.toFixed(4)}`;
+  if (abs >= 0.001) return `$${num.toFixed(5)}`;
+  if (abs > 0) return `$${num.toFixed(7).replace(/0+$/, "0")}`;
+
+  return "$0.00";
 }
 
 export function formatPercent(value, decimals = 1) {

--- a/futureagi/agentcc/tests/test_api_key_bulk.py
+++ b/futureagi/agentcc/tests/test_api_key_bulk.py
@@ -1,0 +1,78 @@
+"""Bulk API-key sync endpoint: expires_at wire format and expired-key filtering."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from agentcc.models import AgentccAPIKey
+
+ADMIN_TOKEN = "agentcc-admin-secret"
+
+
+@pytest.fixture(autouse=True)
+def set_agentcc_admin_token():
+    with patch("agentcc.permissions.AGENTCC_ADMIN_TOKEN", ADMIN_TOKEN):
+        yield
+
+
+@pytest.fixture
+def admin_client():
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {ADMIN_TOKEN}")
+    return client
+
+
+def _make_key(organization, workspace, gateway_key_id, key_hash, expires_at):
+    return AgentccAPIKey.objects.create(
+        gateway_key_id=gateway_key_id,
+        name=gateway_key_id,
+        organization=organization,
+        workspace=workspace,
+        key_hash=key_hash,
+        status=AgentccAPIKey.ACTIVE,
+        expires_at=expires_at,
+    )
+
+
+class TestAPIKeyBulkExpiresAt:
+    def test_future_and_null_expiry_are_serialized_on_the_wire(
+        self, admin_client, organization, workspace
+    ):
+        future = timezone.now() + timedelta(days=7)
+        _make_key(organization, workspace, "gw-expiring", "a" * 64, future)
+        _make_key(organization, workspace, "gw-perpetual", "b" * 64, None)
+
+        response = admin_client.get("/agentcc/api-keys/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # Assert on the rendered JSON the gateway actually receives, not the
+        # pre-render Python datetime.
+        by_id = {item["id"]: item for item in response.json()["result"]}
+
+        # Future-expiry key: expires_at is an ISO 8601 string the gateway can
+        # parse as RFC3339 (DRF renders aware datetimes with a 'Z'/offset).
+        expiring = by_id["gw-expiring"]["expires_at"]
+        assert isinstance(expiring, str)
+        parsed = datetime.fromisoformat(expiring.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None  # must be timezone-aware
+
+        # Null expiry stays null (never-expiring keys).
+        assert by_id["gw-perpetual"]["expires_at"] is None
+
+    def test_expired_keys_are_not_shipped(
+        self, admin_client, organization, workspace
+    ):
+        past = timezone.now() - timedelta(days=1)
+        _make_key(organization, workspace, "gw-expired", "c" * 64, past)
+        _make_key(organization, workspace, "gw-live", "d" * 64, None)
+
+        ids = {item["id"] for item in admin_client.get(
+            "/agentcc/api-keys/bulk/"
+        ).json()["result"]}
+
+        assert "gw-expired" not in ids  # filtered at the query level
+        assert "gw-live" in ids

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -1,4 +1,6 @@
 import structlog
+from django.db.models import Q
+from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 
@@ -25,10 +27,13 @@ class APIKeyBulkView(APIView):
 
     def get(self, request):
         try:
+            # Don't ship already-expired keys, even to gateways that predate
+            # real-time expiry enforcement.
+            now = timezone.now()
             keys = AgentccAPIKey.no_workspace_objects.filter(
                 status=AgentccAPIKey.ACTIVE,
                 deleted=False,
-            )
+            ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
 
             result = []
             for key in keys:
@@ -43,6 +48,7 @@ class APIKeyBulkView(APIView):
                         "models": key.allowed_models or [],
                         "providers": key.allowed_providers or [],
                         "metadata": key.metadata or {},
+                        "expires_at": key.expires_at,
                     }
                 )
 

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -55,4 +55,4 @@ class APIKeyBulkView(APIView):
             return self._gm.success_response(result)
         except Exception as e:
             logger.exception("api_key_bulk_error", error=str(e))
-            return self._gm.bad_request(str(e))
+            return self._gm.internal_server_error_response("Internal server error")

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -544,3 +544,16 @@ class TestRetrieveClickhouseInnerPGBound:
 
         response = auth_client.get(f"/tracer/trace-session/{trace_session.id}/")
         assert response.status_code != 500
+
+
+class TestRetrieveClickhouseEvalQueryNullSafety:
+    """Guard against regressing the NULL-safe ``output_str`` filter."""
+
+    def test_eval_subquery_uses_ifnull_output_str_guard(self):
+        import inspect
+
+        from tracer.views.trace_session import TraceSessionView
+
+        source = inspect.getsource(TraceSessionView._retrieve_clickhouse)
+        assert "ifNull(output_str, '') != 'ERROR'" in source
+        assert "AND output_str != 'ERROR'" not in source

--- a/futureagi/tracer/tests/test_trace_session_ch_query.py
+++ b/futureagi/tracer/tests/test_trace_session_ch_query.py
@@ -21,13 +21,12 @@ These tests pin:
 
 import os
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 # Cycle-breaker -- same rationale as test_eval_task_runtime.
 import model_hub.tasks  # noqa: F401, E402
-
 
 _TEST_DATABASE = "test_trace_session_ch_query"
 
@@ -127,7 +126,7 @@ class TestTraceListingCHQuery:
     def _exec(self, client, query, params):
         rows, columns = client.execute(query, params, with_column_types=True)
         col_names = [c[0] for c in columns]
-        return [dict(zip(col_names, row)) for row in rows]
+        return [dict(zip(col_names, row, strict=False)) for row in rows]
 
     def test_query_parses_without_alias_collision(self, ch_spans_table):
         """The original bug raised ILLEGAL_AGGREGATION at parse/analysis
@@ -157,7 +156,7 @@ class TestTraceListingCHQuery:
         client = ch_spans_table
         project_id = str(uuid.uuid4())
         session_id = str(uuid.uuid4())
-        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=timezone.utc)
+        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=UTC)
 
         # Pick trace ids so the alphabetically-first one starts LATER.
         trace_late_alpha = "00000000-0000-0000-0000-000000000001"
@@ -233,7 +232,7 @@ class TestTraceListingCHQuery:
         client = ch_spans_table
         project_id = str(uuid.uuid4())
         session_id = str(uuid.uuid4())
-        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=timezone.utc)
+        base = datetime(2026, 5, 11, 8, 52, 9, tzinfo=UTC)
         trace_id = str(uuid.uuid4())
 
         columns = (
@@ -293,6 +292,120 @@ class TestTraceListingCHQuery:
         # clickhouse-driver returns DateTime64 as naive datetimes; the
         # value is in UTC but tzinfo is dropped, so compare via the
         # naive form of our base instant.
-        assert rows[0]["trace_min_start_time"] == (
-            base + timedelta(seconds=1)
-        ).replace(tzinfo=None)
+        assert rows[0]["trace_min_start_time"] == (base + timedelta(seconds=1)).replace(
+            tzinfo=None
+        )
+
+
+def _session_eval_aggregation_query(database: str, *, null_safe: bool) -> str:
+    """Eval subquery from ``_retrieve_clickhouse``.
+
+    ``null_safe=False`` reproduces the pre-fix filter that excluded every
+    successful row with a NULL ``output_str`` under ClickHouse's
+    three-valued logic.
+    """
+    output_str_guard = (
+        "ifNull(output_str, '') != 'ERROR'" if null_safe else "output_str != 'ERROR'"
+    )
+    return f"""
+        SELECT
+            toString(trace_id) AS trace_id,
+            toString(custom_eval_config_id) AS config_id,
+            round(avg(output_float) * 100, 2) AS float_score,
+            round(avg(CASE WHEN output_bool = 1 THEN 100.0
+                           WHEN output_bool = 0 THEN 0.0
+                           ELSE NULL END), 2) AS bool_score,
+            count(output_float) AS float_count,
+            count(output_bool) AS bool_count
+        FROM {database}.tracer_eval_logger FINAL
+        WHERE trace_id IN %(trace_ids)s
+          AND custom_eval_config_id IN %(config_ids)s
+          AND _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
+          AND {output_str_guard}
+          AND (error = 0 OR error IS NULL)
+        GROUP BY trace_id, custom_eval_config_id
+    """
+
+
+@pytest.fixture(scope="module")
+def ch_eval_logger_table(ch_client):
+    """Minimal ``tracer_eval_logger`` table for session eval aggregation."""
+    ch_client.execute(f"CREATE DATABASE IF NOT EXISTS {_TEST_DATABASE}")
+    ch_client.execute(f"DROP TABLE IF EXISTS {_TEST_DATABASE}.tracer_eval_logger")
+    ch_client.execute(
+        f"""
+        CREATE TABLE {_TEST_DATABASE}.tracer_eval_logger (
+            id UUID,
+            trace_id Nullable(UUID),
+            custom_eval_config_id UUID,
+            output_bool Nullable(UInt8),
+            output_float Nullable(Float64),
+            output_str Nullable(String),
+            error UInt8 DEFAULT 0,
+            deleted UInt8 DEFAULT 0,
+            _peerdb_is_deleted UInt8 DEFAULT 0
+        ) ENGINE = ReplacingMergeTree()
+        ORDER BY (trace_id, custom_eval_config_id, id)
+        SETTINGS allow_nullable_key = 1
+        """
+    )
+    yield ch_client
+    ch_client.execute(f"DROP TABLE IF EXISTS {_TEST_DATABASE}.tracer_eval_logger")
+
+
+@pytest.mark.integration
+class TestSessionEvalAggregationCHQuery:
+    """NULL-safe ``output_str`` guard on the session-detail eval subquery."""
+
+    def _exec(self, client, query, params):
+        rows, columns = client.execute(query, params, with_column_types=True)
+        col_names = [c[0] for c in columns]
+        return [dict(zip(col_names, row, strict=False)) for row in rows]
+
+    def test_null_output_str_included_with_ifnull_guard(self, ch_eval_logger_table):
+        """Successful eval rows with NULL ``output_str`` must aggregate.
+
+        Most evaluators leave ``output_str`` NULL; a bare
+        ``output_str != 'ERROR'`` evaluates to NULL (not TRUE) in
+        ClickHouse and silently drops the row — the bug that left
+        ``evals_metrics`` empty on session detail.
+        """
+        client = ch_eval_logger_table
+        trace_id = str(uuid.uuid4())
+        config_id = str(uuid.uuid4())
+        row_id = str(uuid.uuid4())
+
+        client.execute(
+            f"""
+            INSERT INTO {_TEST_DATABASE}.tracer_eval_logger
+                (id, trace_id, custom_eval_config_id,
+                 output_float, output_str, error, deleted, _peerdb_is_deleted)
+            VALUES
+                ('{row_id}', '{trace_id}', '{config_id}',
+                 0.85, NULL, 0, 0, 0)
+            """
+        )
+
+        params = {
+            "trace_ids": (trace_id,),
+            "config_ids": (config_id,),
+        }
+
+        buggy_rows = self._exec(
+            client,
+            _session_eval_aggregation_query(_TEST_DATABASE, null_safe=False),
+            params,
+        )
+        assert buggy_rows == [], "bare output_str != 'ERROR' must exclude NULL rows"
+
+        fixed_rows = self._exec(
+            client,
+            _session_eval_aggregation_query(_TEST_DATABASE, null_safe=True),
+            params,
+        )
+        assert len(fixed_rows) == 1
+        assert fixed_rows[0]["trace_id"] == trace_id
+        assert fixed_rows[0]["config_id"] == config_id
+        assert fixed_rows[0]["float_count"] == 1
+        assert fixed_rows[0]["float_score"] == 85.0

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1057,24 +1057,26 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     from tracer.services.clickhouse.client import get_clickhouse_client
 
                     ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
                     rows, cols, _ = ch.execute_read(
                         """
                         SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
+                            SELECT
+                                pair.1 AS key,
+                                pair.2 AS type,
+                                count() AS cnt
+                            FROM (
+                                SELECT span_attr_str, span_attr_num, span_attr_bool
+                                FROM spans
+                                WHERE project_id IN %(project_ids)s
+                                  AND _peerdb_is_deleted = 0
+                                LIMIT 100000
+                            )
+                            ARRAY JOIN arrayConcat(
+                                arrayMap(k -> (k, 'text'),    mapKeys(span_attr_str)),
+                                arrayMap(k -> (k, 'number'),  mapKeys(span_attr_num)),
+                                arrayMap(k -> (k, 'boolean'), mapKeys(span_attr_bool))
+                            ) AS pair
+                            GROUP BY pair.1, pair.2
                         )
                         GROUP BY key ORDER BY key LIMIT 2000
                         """,

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -3,7 +3,7 @@ import json
 import traceback
 from collections import defaultdict
 from dataclasses import asdict
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 try:
     import orjson
@@ -16,7 +16,7 @@ import pandas as pd
 import structlog
 
 logger = structlog.get_logger(__name__)
-from django.db import OperationalError, connection, models, transaction
+from django.db import OperationalError, models
 from django.db.models import (
     Avg,
     Case,
@@ -599,7 +599,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                   AND custom_eval_config_id IN %(config_ids)s
                   AND _peerdb_is_deleted = 0
                   AND (deleted = 0 OR deleted IS NULL)
-                  AND output_str != 'ERROR'
+                  AND ifNull(output_str, '') != 'ERROR'
                   AND (error = 0 OR error IS NULL)
                 GROUP BY trace_id, custom_eval_config_id
             """
@@ -720,7 +720,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     if ch_column == "first_message"
                     else "argMax(input, start_time)"
                 )
-                search_clause = f"AND val ILIKE %(search)s" if search else ""
+                search_clause = "AND val ILIKE %(search)s" if search else ""
                 query = f"""
                 SELECT DISTINCT val FROM (
                     SELECT {agg_expr} AS val
@@ -1479,8 +1479,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # resolve it to a set of EndUser UUIDs and pass an end_user_id IN(...)
         # synthetic filter instead (the CH `spans` table keys users via the
         # UUID column `end_user_id`, not the string `user_id`).
-        user_id_raw: Optional[str] = user_id_qp or None
-        _remaining: List[Dict] = []
+        user_id_raw: str | None = user_id_qp or None
+        _remaining: list[dict] = []
         for _f in filters:
             _col, _cfg = FilterEngine._normalize_filter_params(_f)
             _col_type = _cfg.get("col_type", "NORMAL")
@@ -1498,7 +1498,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # both the UUIDs (to inject as a synthetic end_user_id IN(...)
         # filter) and the display fields (to stitch onto the formatted
         # output later) — fetch them together to save a round-trip.
-        end_user_display: Optional[Dict[str, Any]] = None
+        end_user_display: dict[str, Any] | None = None
         if user_id_raw:
             _eu_qs = EndUser.objects.filter(
                 user_id=user_id_raw,
@@ -1634,7 +1634,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         attr_query, attr_params, timeout_ms=5000
                     )
                     # Aggregate per session: session_id -> {attr_key -> set(values)}
-                    aggregated_attrs: Dict[str, Dict] = {}
+                    aggregated_attrs: dict[str, dict] = {}
                     for attr_row in attr_result.data:
                         sid = str(attr_row.get("session_id", ""))
                         # Skip if this session already has max keys


### PR DESCRIPTION


**Summary**
When retrieving session details with ClickHouse enabled, successful evaluations were missing due to an incorrect `NULL` check. In ClickHouse, `output_str != 'ERROR'` evaluates to `NULL` (falsy) when `output_str` is `NULL`. Since most successful evaluations have a `NULL` output string, they were silently filtered out of the session evaluation aggregation.

This PR replaces the bare `output_str != 'ERROR'` clause in the ClickHouse aggregation subquery with a null-safe guard `ifNull(output_str, '') != 'ERROR'`, matching the pattern established in other list views.

**Linked issues**
Closes #987

**Type of change**
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [x] 🧪 Test-only change

**How was this tested?**
1. Added `TestRetrieveClickhouseEvalQueryNullSafety` to `futureagi/tracer/tests/test_trace_session.py` to verify the presence of the `ifNull` guard via source inspection.
2. Added `TestSessionEvalAggregationCHQuery` to `futureagi/tracer/tests/test_trace_session_ch_query.py` to verify that rows with `output_str = NULL` are correctly aggregated when the `ifNull` guard is present, and excluded when it is absent.
3. Fixed the `tracer_eval_logger` ReplacingMergeTree test fixture configuration to include `SETTINGS allow_nullable_key = 1` so that ClickHouse permits the nullable `trace_id` in the sorting key.
4. Verified that all 32 targeted unit/integration tests pass cleanly via `bin/test --no-services`.

**Checklist**
- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally (ran ruff + target tests)
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA