### PR TITLE
fix(ci): gate API Contracts on route-registration (urls.py) changes

### DIFF
--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -36,6 +36,10 @@ on:
       - "futureagi/tracer/utils/filters.py"
       - "futureagi/tracer/utils/helper.py"
       - "futureagi/tracer/views/**"
+      - "futureagi/tracer/urls.py"
+      - "futureagi/tracer/otel_compat_urls.py"
+      - "futureagi/tfc/urls.py"
+      - "futureagi/model_hub/urls.py"
       - ".github/workflows/api-contracts.yml"
   push:
     branches: [main, develop, dev]
@@ -72,6 +76,10 @@ on:
       - "futureagi/tracer/utils/filters.py"
       - "futureagi/tracer/utils/helper.py"
       - "futureagi/tracer/views/**"
+      - "futureagi/tracer/urls.py"
+      - "futureagi/tracer/otel_compat_urls.py"
+      - "futureagi/tfc/urls.py"
+      - "futureagi/model_hub/urls.py"
       - ".github/workflows/api-contracts.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem
The **API Contracts** workflow (`backend-contracts`) only triggers on a `paths:` allow-list that watches `futureagi/tracer/views/**`, `futureagi/tracer/serializers/**`, etc. — but **not the url confs where routes are actually registered**.

PR #940 (fi-collector OTLP migration, commit `3a37a489`) commented out the legacy OTLP trace-export routes in:
- `futureagi/tracer/urls.py`
- `futureagi/tracer/otel_compat_urls.py`
- `futureagi/tfc/urls.py`

None of those paths matched the filter, so the workflow **never ran on #940**. The stale `api_contracts/openapi/swagger.json` (still advertising 5 removed OTLP paths + 4 response definitions) merged into `dev` undetected — then failed `backend-contracts` on the next unrelated PR that *did* touch a watched path (#986).

Adding/removing a route is exactly the kind of change that alters the OpenAPI surface, yet it was invisible to the gate.

## Fix
Add the route registries that feed the watched contract surface to **both** the `pull_request` and `push` `paths:` lists:
- `futureagi/tracer/urls.py`
- `futureagi/tracer/otel_compat_urls.py`
- `futureagi/tfc/urls.py`
- `futureagi/model_hub/urls.py`

These are the four url confs included by the `tfc/urls.py` route hub that register the tracer + management-API surface the contract covers.

## Notes
- The contract regen that unblocks #986 is committed separately on that PR's branch; this PR only closes the CI gap so the same class of drift is caught at the source going forward.
- No behavioral/runtime change — CI trigger scope only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)