### PR TITLE
fix(dashboard): prune spans partitions to stop breakdown-chart timeouts (TH-6050)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1287,6 +1287,18 @@ class DashboardQueryBuilder:
             f"{time_col} < %(end_date)s",
         ]
 
+        # Partition pruning: ``spans`` is PARTITION BY toYYYYMM(created_at), but
+        # dashboard queries filter the window on ``start_time`` (event time).
+        # Without a bound on the partition key a windowed query scans the
+        # project's entire history, which times out on high-volume projects.
+        # Add a lower ``created_at`` bound (1-day skew buffer for ingestion lag)
+        # so ClickHouse prunes every partition older than the window.  Lower
+        # bound only: a qualifying in-window row always has
+        # created_at >= start_time >= start_date, so no row is ever excluded and
+        # results are unchanged.  Same pattern as ``agent_graph.py``.
+        if time_col != "created_at":
+            clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
+
         # Apply global + per-metric system_metric filters directly
         # For string-comparable system metrics, use toString() to avoid UUID parse errors
         _STRING_FILTER_COL = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -743,6 +743,52 @@ class TestDashboardQueryBuilder:
         assert "toStartOfDay" in sql
         assert params["project_ids"] == sample_query_config["project_ids"]
 
+    def test_system_metric_query_prunes_partitions(self, sample_query_config):
+        """Spans-based queries must bound created_at (the partition key) so a
+        windowed query prunes old partitions instead of scanning all history.
+        Regression for the Colektia high-volume timeout (TH-6050)."""
+        builder = DashboardQueryBuilder(sample_query_config)
+        sql, _, _ = builder.build_all_queries()[0]
+        # partition-prune bound on the partition key is present
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        # and the precise event-time window is still enforced (correctness)
+        assert "start_time >= %(start_date)s" in sql
+        assert "start_time < %(end_date)s" in sql
+
+    def test_breakdown_query_prunes_partitions(self):
+        """The exact failing widget — latency avg broken down by a custom span
+        attribute (final_status) — must emit the created_at partition-prune
+        bound while preserving the start_time window (TH-6050)."""
+        config = {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [],
+            "breakdowns": [
+                {
+                    "name": "final_status",
+                    "type": "custom_attribute",
+                    "source": "traces",
+                    "display_name": "final_status",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        # the breakdown is still applied (real call path intact)
+        assert "breakdown_value" in sql
+
     def test_all_system_metrics(self):
         for metric_name in SYSTEM_METRICS:
             config = {


### PR DESCRIPTION
## Why
Colektia's **Global** (high-traffic) dashboard charts that use a **breakdown** — Latencia por status (`final_status`), Latencia por País (country) — render **"Failed to load chart data"**. Sibling of TH-5946: #976 fixed the custom-attribute *dropdown*; the **chart-data** query was never touched.

**Linear: [TH-6050](https://linear.app/future-agi/issue/TH-6050)** — full PM write-up (PDF), live DevTools evidence, the customer report, the local partition-prune proof, and a before/after video are attached there.

## Where it breaks
`POST /tracer/dashboard/query/` → `DashboardQueryBuilder`. `spans` is `PARTITION BY toYYYYMM(created_at)` and ordered by `(project_id, toDate(created_at), …)`, but the query filters the window on **`start_time`** (event time). With no bound on the partition key, a 30-day query **scans the project's entire history** — no partition pruning, no granule skipping — exceeds the 10s ClickHouse budget, the query is killed, the broad `except Exception` returns HTTP 400, and the FE shows the generic error.

Measured live (read-only): breakdown query = **3.6s @ 1 day → killed at 10.6s @ 7 days → killed @ 30 days**; volume ≈ **1–2M spans/day**. A timeout bump is therefore not durable — the fix must make the query prune.

## What changed
**`futureagi/tracer/services/clickhouse/query_builders/dashboard.py`** — `_build_where_clauses()`: for spans-based queries (`time_col != "created_at"`), add a lower bound on the partition key:

```
created_at >= %(start_date)s - INTERVAL 1 DAY
```

so ClickHouse prunes every partition older than the window. **Lower-bound only** — a qualifying in-window row always has `created_at ≥ start_time ≥ start_date`, so no row is ever excluded and results are unchanged. The precise `start_time` window filter is untouched. This mirrors the pattern already used in `agent_graph.py` (same `spans` table).

**`futureagi/tracer/tests/test_dashboard.py`** — two behavioral tests on the real builder call-path.

## Tests
| Test | Asserts |
| --- | --- |
| `test_system_metric_query_prunes_partitions` | built SQL contains the `created_at … - INTERVAL 1 DAY` prune bound **and** retains the precise `start_time` window (correctness) |
| `test_breakdown_query_prunes_partitions` | the exact failing widget (latency avg by `final_status`, 30D) emits the prune bound **and** still applies the breakdown |

Run: `pytest tracer/tests/test_dashboard.py -k prunes_partitions -q`

## Verification / proof
- Behavioral unit tests above (assert on the real builder output).
- **Partition pruning proven on an isolated local ClickHouse** — `EXPLAIN`: old query reads all partitions → new query prunes to the window; result rows identical. Proof image + before/after video on TH-6050.
- Live "before" (failing Global dashboard) + customer report on TH-6050.
- Post-deploy: reload Global "Latencias" → 200s; Loki `query_execution_failed` goes silent.

## Backwards compatibility
No schema / migration / rollup / API / contract change. Output schema unchanged. Lower-bound-only partition filter cannot change result sets for live-ingested data (`created_at ≥ start_time`). Backend-only — no frontend change.

## Backout
Revert this commit — single-file query-builder change, no data migration.
