### PR TITLE
fix(dashboard): prune spans partitions to stop breakdown-chart timeouts (TH-6050)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1287,6 +1287,13 @@ class DashboardQueryBuilder:
             f"{time_col} < %(end_date)s",
         ]
 
+        # spans is partitioned by toYYYYMM(created_at) but the window is
+        # filtered on start_time, so bound created_at too — otherwise no
+        # partitions prune and the scan covers all history. Lower bound only
+        # (created_at >= start_time always holds), so no in-window row drops.
+        if time_col != "created_at":
+            clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
+
         # Apply global + per-metric system_metric filters directly
         # For string-comparable system metrics, use toString() to avoid UUID parse errors
         _STRING_FILTER_COL = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -743,6 +743,51 @@ class TestDashboardQueryBuilder:
         assert "toStartOfDay" in sql
         assert params["project_ids"] == sample_query_config["project_ids"]
 
+    def test_system_metric_query_prunes_partitions(self, sample_query_config):
+        """Spans-based queries must bound created_at (the partition key) so a
+        windowed query prunes old partitions instead of scanning all history."""
+        builder = DashboardQueryBuilder(sample_query_config)
+        sql, _, _ = builder.build_all_queries()[0]
+        # partition-prune bound on the partition key is present
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        # and the precise event-time window is still enforced (correctness)
+        assert "start_time >= %(start_date)s" in sql
+        assert "start_time < %(end_date)s" in sql
+
+    def test_breakdown_query_prunes_partitions(self):
+        """A latency average broken down by a custom span attribute must emit
+        the created_at partition-prune bound while preserving the start_time
+        window."""
+        config = {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [],
+            "breakdowns": [
+                {
+                    "name": "final_status",
+                    "type": "custom_attribute",
+                    "source": "traces",
+                    "display_name": "final_status",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        # the breakdown is still applied (real call path intact)
+        assert "breakdown_value" in sql
+
     def test_all_system_metrics(self):
         for metric_name in SYSTEM_METRICS:
             config = {


### PR DESCRIPTION
## Problem
On **high-volume projects**, dashboard charts that use a **breakdown** (e.g. latency grouped by a custom span attribute, or by country) fail with **"Failed to load chart data."**

Root cause: `POST /tracer/dashboard/query/` → `DashboardQueryBuilder` filters the time window on **`start_time`** (event time), but the `spans` table is `PARTITION BY toYYYYMM(created_at)` and ordered by `(project_id, toDate(created_at), trace_id, id)`. With no bound on the partition key, a windowed query **can't prune partitions or skip granules — it scans the project's entire history.** On a busy project that blows past the ClickHouse `max_execution_time`; the query is killed, the broad `except Exception` returns HTTP 400, and the FE renders the generic error.

This is the chart-data half of what #976 fixed for the metric *dropdown* — that query was capped, this one was not. (A timeout bump is not viable: on a busy project the breakdown query already crosses the budget at a few days of data and would re-break as data grows — it has to prune.)

## Fix
`futureagi/tracer/services/clickhouse/query_builders/dashboard.py` — `_build_where_clauses()`:
- For spans-based queries (`time_col != "created_at"`), add a lower bound on the partition key: `created_at >= %(start_date)s - INTERVAL 1 DAY`.
- ClickHouse then prunes every partition older than the window. **Lower-bound only** — a qualifying in-window row always has `created_at ≥ start_time ≥ start_date`, so no row is ever excluded (holds even under ingestion lag / backfill). The precise `start_time` window filter is unchanged.
- Mirrors the existing pattern in `agent_graph.py` (same `spans` table).

Covers both spans call paths through this helper: the system-metric breakdown and the custom-attribute query.

## Tests
| Test | Asserts |
| --- | --- |
| `test_system_metric_query_prunes_partitions` | built SQL carries the `created_at … - INTERVAL 1 DAY` prune bound **and** keeps the exact `start_time` window (correctness) |
| `test_breakdown_query_prunes_partitions` | a latency breakdown by a custom attribute emits the prune bound **and** still applies the breakdown |

Both assert on the real `DashboardQueryBuilder.build_all_queries()` output (no DB required).

## Verification
```
pytest tracer/tests/test_dashboard.py -k prunes_partitions -q
```
Partition pruning verified on a throwaway local ClickHouse (real `spans` schema; 20 rows seeded across two partition-months; "last 30 days" window):

| query | parts read | rows scanned | result rows |
| --- | --- | --- | --- |
| before — `start_time` filter only | **2 / 2** | 20 | 3 |
| after — this fix | **1 / 2** | 10 | 3 (identical) |

`EXPLAIN ESTIMATE` before/after; result rows byte-identical → correctness preserved while the scan drops to the window's partitions.

**Tests passing:**

![dashboard partition-prune tests passing](https://raw.githubusercontent.com/abhijaisrivastava15/th6050-pr-proof/main/th6050-tests-pass.png)

**Partition pruning proven (local ClickHouse):**

![EXPLAIN 2 parts to 1, identical results](https://raw.githubusercontent.com/abhijaisrivastava15/th6050-pr-proof/main/th6050-local-proof.png)

## Screenshots
N/A — backend only; before/after numbers above. (Customer-facing dashboard evidence + a before/after video live on the linked Linear ticket and are intentionally kept off this public repo.)

## Backwards compatibility
No schema / migration / rollup / API / serializer / contract change. Output schema unchanged. The added clause cannot change result sets for live-ingested data (`created_at ≥ start_time`), so every existing caller of `_build_where_clauses` (system-metric, custom-attribute, breakdown paths) returns the same rows — just faster.

## Out of scope
- Whether custom-attribute breakdowns on raw `spans` should move to a pre-aggregated rollup — partition pruning is the correct, sufficient fix here; a rollup is a separate, larger change.
- Timeout tuning — deliberately avoided; it self-regresses as data grows.

## Backout
Revert this commit. Single-file query-builder change, no data migration.

---
Linear: TH-6050 (customer context + evidence there) · Base: `main` (hotfix, mirrors #976 / v1.22.67)
