### PR TITLE
fix(annotations): resolve collector (CH-only) sources in annotation queues

### DIFF
--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -27,6 +27,7 @@ from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.serializers.scores import ScoreSerializer
 from model_hub.utils.annotation_queue_helpers import (
     FIELD_MAPPING,
+    CollectorSourceCache,
     get_fk_field_name,
     resolve_source_content,
     resolve_source_object,
@@ -436,6 +437,17 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
         return instance
 
 
+class QueueItemListSerializer(serializers.ListSerializer):
+    """Builds one :class:`CollectorSourceCache` for the page so ``source_preview``
+    resolves collector spans/sessions from a single CH read instead of one point-read
+    per item. Stashed in context for the child's ``get_source_preview`` to pick up."""
+
+    def to_representation(self, data):
+        items = list(data)
+        self.context["ch_source_cache"] = CollectorSourceCache.for_items(items)
+        return super().to_representation(items)
+
+
 class QueueItemSerializer(serializers.ModelSerializer):
     source_id = serializers.CharField(write_only=True, required=False)
     source_preview = serializers.SerializerMethodField()
@@ -484,6 +496,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
             "created_at",
         ]
         read_only_fields = ["queue"]
+        list_serializer_class = QueueItemListSerializer
 
     def get_assigned_users(self, obj):
         assignments = getattr(obj, "active_assignments", None)
@@ -499,7 +512,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
         ]
 
     def get_source_preview(self, obj):
-        return resolve_source_preview(obj)
+        return resolve_source_preview(obj, ch_cache=self.context.get("ch_source_cache"))
 
     def get_workflow_status(self, obj):
         if (

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -556,12 +556,25 @@ class QueueItemSerializer(serializers.ModelSerializer):
             fk_field = get_fk_field_name(source_type)
             if fk_field:
                 request = self.context.get("request")
+                organization = (
+                    getattr(request, "organization", None) if request else None
+                )
                 workspace = getattr(request, "workspace", None) if request else None
                 source_obj = resolve_source_object(
-                    source_type, source_id, workspace=workspace
+                    source_type,
+                    source_id,
+                    organization=organization,
+                    workspace=workspace,
+                    allow_ch_fallback=True,
                 )
                 if source_obj:
-                    validated_data[fk_field] = source_obj
+                    # Store the soft id, not the FK object: a CH-resolved source
+                    # isn't a Django instance. QueueItem FKs are db_constraint=False
+                    # so a bare ``_id`` persists (and Django FKs accept it too).
+                    source_pk = getattr(source_obj, "pk", None) or getattr(
+                        source_obj, "id", None
+                    )
+                    validated_data[f"{fk_field}_id"] = source_pk
                 else:
                     raise serializers.ValidationError(
                         f"Source object not found: {source_type}={source_id}"
@@ -573,7 +586,7 @@ class QueueItemSerializer(serializers.ModelSerializer):
                     and QueueItem.objects.filter(
                         queue=queue,
                         deleted=False,
-                        **{fk_field: source_obj},
+                        **{f"{fk_field}_id": source_pk},
                     ).exists()
                 ):
                     raise serializers.ValidationError(

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -44,10 +44,19 @@ import pytest
 
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
+    AnnotationQueueAnnotator,
+    AnnotationQueueLabel,
     AnnotationQueueStatusChoices,
     QueueItem,
 )
-from model_hub.models.choices import QueueItemSourceType, QueueItemStatus
+from model_hub.models.choices import (
+    AnnotationTypeChoices,
+    AnnotatorRole,
+    QueueItemSourceType,
+    QueueItemStatus,
+)
+from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.models.score import Score
 from model_hub.utils import annotation_queue_helpers as helpers
 from tracer.models.observation_span import ObservationSpan
 from tracer.models.project import Project
@@ -663,3 +672,60 @@ def test_resolution_path_imports_no_ee():
         src = inspect.getsource(mod)
         assert "import ee" not in src
         assert "from ee" not in src
+
+
+@pytest.mark.django_db
+def test_collector_span_round_trips_create_to_annotate(
+    auth_client, organization, workspace, user
+):
+    """Full add→annotate round-trip for a CH-only collector span (NO PG row).
+
+    The resolution tests above prove the source resolves and the create persists
+    the soft id; this proves the item can actually be ANNOTATED end-to-end. The
+    submit path reads ``item.observation_span_id`` for the Score FK and
+    CH-resolves the span-notes target — without the fix it dereferences
+    ``item.observation_span`` and 500s with ``DoesNotExist``. Asserts the Score
+    persists on the soft id with no PG ``ObservationSpan`` backing it.
+    """
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    AnnotationQueueAnnotator.objects.get_or_create(
+        queue=queue, user=user, defaults={"role": AnnotatorRole.MANAGER.value}
+    )
+    label = AnnotationsLabels.objects.create(
+        name=f"rt-label-{uuid.uuid4().hex[:8]}",
+        type=AnnotationTypeChoices.TEXT.value,
+        organization=organization,
+        workspace=workspace,
+        settings={"placeholder": "", "min_length": 0, "max_length": 1000},
+    )
+    AnnotationQueueLabel.objects.create(queue=queue, label=label, required=True)
+    item = _collector_item(
+        organization=organization, workspace=workspace, queue=queue, span=span
+    )
+
+    url = (
+        f"/model-hub/annotation-queues/{queue.id}"
+        f"/items/{item.id}/annotations/submit/"
+    )
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resp = auth_client.post(
+            url,
+            {
+                "annotations": [
+                    {"label_id": str(label.id), "value": {"text": "ship it"}}
+                ],
+                "item_notes": "looks good",
+            },
+            format="json",
+        )
+
+    assert resp.status_code == 200, resp.data
+    score = Score.objects.get(queue_item=item, label=label, deleted=False)
+    assert score.source_type == QueueItemSourceType.OBSERVATION_SPAN.value
+    # Score persists the collector soft id — and NO PG ObservationSpan backs it.
+    assert str(score.observation_span_id) == str(span.id)
+    assert not ObservationSpan.objects.filter(id=span.id).exists()

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -729,3 +729,104 @@ def test_collector_span_round_trips_create_to_annotate(
     # Score persists the collector soft id — and NO PG ObservationSpan backs it.
     assert str(score.observation_span_id) == str(span.id)
     assert not ObservationSpan.objects.filter(id=span.id).exists()
+
+
+# ───────────────────── N+1 batch (CollectorSourceCache) ───────────────────────
+
+
+class _CountingReaderCM:
+    """Reader stub recording ``list_by_ids`` vs per-item ``get`` so a test can prove
+    a page does ONE batch CH read, not a point-read per item (the N+1 the cache removes)."""
+
+    def __init__(self, spans):
+        self._by_id = {str(s.id): s for s in spans}
+        self.list_by_ids_calls = []
+        self.get_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def list_by_ids(self, span_ids):
+        ids = [str(s) for s in span_ids]
+        self.list_by_ids_calls.append(ids)
+        return [self._by_id[i] for i in ids if i in self._by_id]
+
+    def get(self, span_id):  # the per-item path — must NOT be hit when batched
+        self.get_calls.append(str(span_id))
+        return self._by_id.get(str(span_id))
+
+
+@pytest.mark.django_db
+def test_list_serializer_batches_collector_ch_reads(organization, workspace, user):
+    """Serializing a page of N collector spans + M collector sessions does ONE batch
+    CH read per kind (``list_by_ids`` / ``resolve_session_fields`` once each), not a
+    per-item point-read. FAILS — per-item ``get`` / N ``resolve_session_fields`` calls
+    — if the ``CollectorSourceCache`` wiring (or its DRF context plumbing) regresses.
+    A correctness-only test would still pass on regression; this asserts call counts."""
+    from model_hub.serializers.annotation_queues import QueueItemSerializer
+
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+
+    spans = [_make_chspan(project_id=project.id) for _ in range(3)]
+    span_items = [
+        _collector_item(
+            organization=organization, workspace=workspace, queue=queue, span=s
+        )
+        for s in spans
+    ]
+
+    session_ids = [str(uuid.uuid4()) for _ in range(2)]
+    session_fields = {
+        sid: {
+            "external_session_id": f"ext-{i}",
+            "first_seen": datetime(2025, 5, 2, 9, 0, 0, tzinfo=UTC),
+            "project_id": str(project.id),
+            "bookmarked": False,
+            "display_name": None,
+        }
+        for i, sid in enumerate(session_ids)
+    }
+    session_items = [
+        QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE_SESSION.value,
+            trace_session_id=sid,
+            organization=organization,
+            workspace=workspace,
+            status=QueueItemStatus.PENDING.value,
+        )
+        for sid in session_ids
+    ]
+
+    items = span_items + session_items
+    reader_cm = _CountingReaderCM(spans)
+
+    with (
+        mock.patch(CH_READER_PATH, return_value=reader_cm) as get_reader,
+        mock.patch(
+            SESSION_FIELDS_PATH, return_value=session_fields
+        ) as resolve_sessions,
+    ):
+        data = QueueItemSerializer(items, many=True).data
+
+    # one batch span read, carrying every collector span id — never a per-item point read
+    assert len(reader_cm.list_by_ids_calls) == 1, reader_cm.list_by_ids_calls
+    assert reader_cm.get_calls == [], reader_cm.get_calls
+    assert get_reader.call_count == 1
+    assert set(reader_cm.list_by_ids_calls[0]) == {str(s.id) for s in spans}
+    # one batch session read, carrying every collector session id
+    assert resolve_sessions.call_count == 1
+    assert set(resolve_sessions.call_args.args[0]) == set(session_ids)
+
+    # previews actually resolved from CH (not the deleted sentinel)
+    previews = [row["source_preview"] for row in data]
+    assert all("deleted" not in p for p in previews), previews
+    span_previews = [p for p in previews if p["type"] == "observation_span"]
+    assert len(span_previews) == 3
+    assert all(p["name"] == "collector root span" for p in span_previews)

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -1,0 +1,665 @@
+"""CH25 wave-3 — collector (ClickHouse-only) traces/spans/sessions made usable in
+annotation queues.
+
+WHAT THIS PINS
+--------------
+The ``fi-collector`` writes spans/traces/sessions ONLY to ClickHouse (v2 schema),
+bypassing Django/PG. So a collector source has NO PG ``tracer_observation_span`` /
+``tracer_trace_session`` row. The annotation-queue source-RESOLUTION + render path
+resolved sources through PG, so "Add to queue" silently dropped every collector
+span/session and the annotate view rendered them as ``{"deleted": true}``.
+
+The fix teaches the three central selectors (``resolve_source_object``,
+``resolve_source_preview``, ``resolve_source_content``), the serializer
+``create()`` store, and the ``root_spans`` tenant gate to fall back to CH when the
+PG row is absent — re-checking tenant scope against the PG ``Project`` row (which
+DOES live in PG), fail-closed.
+
+PROOF SHAPE
+-----------
+These are UNIT tests over the REAL selector functions. The ClickHouse boundary
+(``get_reader`` → ``CHSpanReader.get`` and ``resolve_session_fields``) is mocked so
+the test needs no live CH, but the PG ``Project`` tenant gate, the FK-absent
+``RelatedObjectDoesNotExist`` collapse, and the dict-shape mapping are all
+exercised for real against a real test DB.
+
+Each test FAILS if the fix is reverted:
+  • resolve of a collector span: revert → PG ``.get`` raises DoesNotExist → the
+    function returns ``None`` (today's bug) → the "is a CHSpan" assert fails.
+  • preview/content of a collector span: revert → ``item.observation_span`` raises
+    → outer except → ``{"error": ...}`` / ``{"deleted": true}`` → the mapped-dict
+    asserts fail.
+  • root_spans gate: revert → PG ``Trace.objects`` gate returns ``[]`` for the
+    collector trace → ``{}`` → the non-empty-result assert fails.
+  • cross-org deny: the gate must NOT leak — these lock fail-closed behavior.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest import mock
+
+import pytest
+
+from model_hub.models.annotation_queues import (
+    AnnotationQueue,
+    AnnotationQueueStatusChoices,
+    QueueItem,
+)
+from model_hub.models.choices import QueueItemSourceType, QueueItemStatus
+from model_hub.utils import annotation_queue_helpers as helpers
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.project import Project
+from tracer.services.clickhouse.v2.span_reader import CHSpan
+
+CH_READER_PATH = "tracer.services.clickhouse.v2.get_reader"
+SESSION_FIELDS_PATH = (
+    "tracer.services.clickhouse.v2.trace_session_dict_reader.resolve_session_fields"
+)
+
+
+def _make_project(*, organization, workspace, name="ch25-collector-proj"):
+    return Project.objects.create(
+        name=f"{name} {uuid.uuid4().hex[:8]}",
+        organization=organization,
+        workspace=workspace,
+        model_type="GenerativeLLM",
+        trace_type="observe",
+    )
+
+
+def _make_chspan(*, project_id, span_id=None, trace_id=None, parent_span_id=""):
+    """A fully-populated CHSpan dataclass standing in for a collector span row
+    (the shape ``CHSpanReader.get`` returns). No PG row exists for it."""
+    return CHSpan(
+        id=span_id or f"ch-span-{uuid.uuid4().hex[:12]}",
+        project_id=str(project_id),
+        trace_id=trace_id or str(uuid.uuid4()),
+        parent_span_id=parent_span_id,
+        name="collector root span",
+        observation_type="agent",
+        operation_name="invoke_agent",
+        start_time=datetime(2025, 5, 1, 10, 0, 0, tzinfo=UTC),
+        end_time=datetime(2025, 5, 1, 10, 0, 2, tzinfo=UTC),
+        latency_ms=2000,
+        model="gpt-4o",
+        provider="openai",
+        prompt_tokens=11,
+        completion_tokens=7,
+        total_tokens=18,
+        cost=0.0021,
+        status="OK",
+        status_message="",
+        org_id=None,
+        project_version_id=None,
+        end_user_id=None,
+        trace_session_id=None,
+        prompt_version_id=None,
+        prompt_label_id=None,
+        custom_eval_config_id=None,
+        input='{"messages": [{"role": "user", "content": "hi"}]}',
+        output='{"role": "assistant", "content": "hello"}',
+        tags='["collector"]',
+        span_events='[{"name": "event-a"}]',
+        metadata='{"k": "v"}',
+        resource_attrs='{"service.name": "collector-svc"}',
+        attributes_extra='{"extra.key": "extra-val"}',
+        attrs_string={"gen_ai.request.model": "gpt-4o"},
+        attrs_number={"gen_ai.usage.total_tokens": 18.0},
+        attrs_bool={"gen_ai.stream": 1},
+    )
+
+
+class _ReaderCM:
+    """Context-manager stub mimicking ``get_reader()`` → ``CHSpanReader``."""
+
+    def __init__(self, span):
+        self._span = span
+        self.get_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, span_id):
+        self.get_calls.append(str(span_id))
+        if self._span is None:
+            return None
+        return self._span if str(span_id) == str(self._span.id) else None
+
+    def list_by_trace_ids(self, trace_ids):
+        if self._span is None:
+            return []
+        return [self._span] if str(self._span.trace_id) in set(trace_ids) else []
+
+
+# ─────────────────────────── observation_span: resolve ───────────────────────
+
+
+@pytest.mark.django_db
+def test_collector_span_resolves_via_ch(organization, workspace):
+    """A collector span (no PG row) resolves through the CH fallback when org +
+    workspace match, returning the CHSpan itself (FAILS if reverted → None)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            organization=organization,
+            workspace=workspace,
+            allow_ch_fallback=True,
+        )
+    assert resolved is span
+    assert resolved.id == span.id
+
+
+@pytest.mark.django_db
+def test_collector_span_cross_org_denied(organization, workspace, django_user_model):
+    """A collector span whose project belongs to a DIFFERENT org is denied (the CH
+    fallback re-checks tenant scope against PG). FAILS if the gate is removed."""
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="Other Org")
+    other_project = _make_project(organization=other_org, workspace=None)
+    span = _make_chspan(project_id=other_project.id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            organization=organization,  # requesting org != other_org
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_tenant_scoped_project_denies_without_organization(organization, workspace):
+    """Regression (cross-org leak): the CH tenant gate FAILS CLOSED when no
+    organization is supplied. A ``None`` org cannot prove ownership, so even an
+    existing project must NOT resolve — this is the chokepoint that stops a caller
+    (e.g. the single-item serializer) from silently skipping the org filter.
+    FAILS if ``_tenant_scoped_project`` resolves without an org."""
+    project = _make_project(organization=organization, workspace=workspace)
+    # With the org it resolves...
+    assert (
+        helpers._tenant_scoped_project(project.id, organization=organization)
+        is not None
+    )
+    # ...without it, never (the hole the serializer create() previously left open).
+    assert (
+        helpers._tenant_scoped_project(
+            project.id, organization=None, workspace=workspace
+        )
+        is None
+    )
+
+
+@pytest.mark.django_db
+def test_collector_span_org_omitted_denied():
+    """Regression (cross-org leak): resolving a collector span with BOTH org and
+    workspace omitted (the fully-ungated signature the serializer ``create()`` used
+    when the request carried no org) must deny — a foreign-org collector span must
+    NOT resolve when the org gate is absent. Org-gated only (no workspace arg) so
+    it FAILS on revert via the org gate, not a workspace mismatch — the case the
+    org-explicit cross-org test could not reach."""
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="Other Org (org-omitted)")
+    other_project = _make_project(organization=other_org, workspace=None)
+    span = _make_chspan(project_id=other_project.id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            # org AND workspace deliberately omitted — mirrors the serializer hole
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_collector_span_empty_project_id_denied(organization):
+    """Deny-on-ambiguity: a CHSpan with no project_id can't be tenant-verified →
+    None (never trust an untenanted span)."""
+    span = _make_chspan(project_id="")  # falsy project_id
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            organization=organization,
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_span_absent_in_both_pg_and_ch_returns_none(organization):
+    """A source id that exists in NEITHER PG NOR CH → None (add denied, no crash)."""
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(None)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            f"missing-{uuid.uuid4().hex}",
+            organization=organization,
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_pg_span_resolves_without_touching_ch(organization, workspace):
+    """Regression guard: an existing PG ObservationSpan still resolves via the PG
+    branch and the CH reader is NOT called (PG-first)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    from tracer.models.trace import Trace
+
+    trace = Trace.objects.create(project=project, name="pg-trace")
+    pg_span = ObservationSpan.objects.create(
+        id=f"pg-span-{uuid.uuid4().hex[:12]}",
+        project=project,
+        trace=trace,
+        parent_span_id=None,
+        name="pg span",
+        observation_type="agent",
+        start_time=datetime.now(tz=UTC),
+        status="OK",
+    )
+
+    with mock.patch(CH_READER_PATH) as get_reader:
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            pg_span.id,
+            organization=organization,
+            workspace=workspace,
+            allow_ch_fallback=True,  # even WITH fallback allowed, PG wins
+        )
+    assert resolved.id == pg_span.id
+    get_reader.assert_not_called()
+
+
+# ───────────────── opt-in CH fallback: out-of-scope callers stay PG-only ──────
+
+
+@pytest.mark.django_db
+def test_ch_fallback_is_opt_in(organization, workspace):
+    """``resolve_source_object`` must NOT return a CH object by default: callers
+    that dereference ``.pk`` / FK relations (scores, span-notes — out of scope)
+    keep the PG-only behavior, so my change can't turn their graceful not-found
+    into a crash. Only ``allow_ch_fallback=True`` reaches CH."""
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)) as get_reader:
+        # default (out-of-scope callers): PG-only → None, CH never queried.
+        resolved_default = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            organization=organization,
+            workspace=workspace,
+        )
+        assert resolved_default is None
+        get_reader.assert_not_called()
+
+        # opt-in (in-scope add paths): CH fallback fires.
+        resolved_optin = helpers.resolve_source_object(
+            QueueItemSourceType.OBSERVATION_SPAN.value,
+            span.id,
+            organization=organization,
+            workspace=workspace,
+            allow_ch_fallback=True,
+        )
+        assert resolved_optin is span
+
+
+# ─────────────────────── observation_span: serializer store ──────────────────
+
+
+@pytest.mark.django_db
+def test_serializer_create_persists_collector_span_soft_id(
+    organization, workspace, user
+):
+    """The serializer create() stores the soft id (not the FK object) so a CHSpan
+    persists; the QueueItem carries observation_span_id with NO PG row."""
+    from model_hub.serializers.annotation_queues import QueueItemSerializer
+
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+    queue = AnnotationQueue.objects.create(
+        name=f"q-{uuid.uuid4().hex[:8]}",
+        status=AnnotationQueueStatusChoices.ACTIVE.value,
+        organization=organization,
+        workspace=workspace,
+        project=project,
+        created_by=user,
+    )
+
+    request = mock.Mock()
+    request.organization = organization
+    request.workspace = workspace
+    serializer = QueueItemSerializer(context={"request": request})
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        item = serializer.create(
+            {
+                "queue": queue,
+                "source_type": QueueItemSourceType.OBSERVATION_SPAN.value,
+                "source_id": span.id,
+                "organization": organization,
+                "workspace": workspace,
+                "status": QueueItemStatus.PENDING.value,
+            }
+        )
+    item.refresh_from_db()
+    assert str(item.observation_span_id) == str(span.id)
+
+
+# ─────────────────────── observation_span: preview/content ────────────────────
+
+
+def _collector_item(*, organization, workspace, queue, span):
+    """A QueueItem whose observation_span_id points at a collector span (NO PG
+    ObservationSpan row exists for it)."""
+    return QueueItem.objects.create(
+        queue=queue,
+        source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+        observation_span_id=span.id,
+        organization=organization,
+        workspace=workspace,
+        status=QueueItemStatus.PENDING.value,
+    )
+
+
+def _queue(*, organization, workspace, user, project):
+    return AnnotationQueue.objects.create(
+        name=f"q-{uuid.uuid4().hex[:8]}",
+        status=AnnotationQueueStatusChoices.ACTIVE.value,
+        organization=organization,
+        workspace=workspace,
+        project=project,
+        created_by=user,
+    )
+
+
+@pytest.mark.django_db
+def test_collector_span_preview_renders_from_ch(organization, workspace, user):
+    """Preview of a collector span (no PG row) returns the mapped dict, NOT the
+    deleted sentinel. FAILS if reverted (FK access raises → error dict)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    item = _collector_item(
+        organization=organization, workspace=workspace, queue=queue, span=span
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        preview = helpers.resolve_source_preview(item)
+
+    assert preview["type"] == "observation_span"
+    assert "deleted" not in preview
+    assert preview["name"] == "collector root span"
+    assert preview["observation_type"] == "agent"
+    assert preview["latency_ms"] == 2000
+
+
+@pytest.mark.django_db
+def test_collector_span_content_renders_from_ch(organization, workspace, user):
+    """Content of a collector span returns the full mapped dict with the CHSpan
+    field renames applied (attrs_* merged, JSON strings parsed to dicts/lists)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    item = _collector_item(
+        organization=organization, workspace=workspace, queue=queue, span=span
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        content = helpers.resolve_source_content(item)
+
+    assert content["type"] == "observation_span"
+    assert "deleted" not in content
+    assert content["span_id"] == str(span.id)
+    assert content["status"] == "OK"
+    assert content["cost"] == 0.0021
+    # span_attributes is the merge of attrs_string/number/bool + attributes_extra.
+    assert content["span_attributes"]["gen_ai.request.model"] == "gpt-4o"
+    assert content["span_attributes"]["extra.key"] == "extra-val"
+    # JSON-string columns become Python containers.
+    assert content["metadata"] == {"k": "v"}
+    assert content["resource_attributes"] == {"service.name": "collector-svc"}
+    assert content["events"] == [{"name": "event-a"}]
+    # eval_attributes present (empty dict), not omitted → shape parity.
+    assert content["eval_attributes"] == {}
+
+
+@pytest.mark.django_db
+def test_collector_span_content_deleted_when_ch_missing(organization, workspace, user):
+    """If the span is gone from CH too, content returns the deleted sentinel
+    (semantically correct, same shape as today)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    item = QueueItem.objects.create(
+        queue=queue,
+        source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+        observation_span_id=f"gone-{uuid.uuid4().hex[:12]}",
+        organization=organization,
+        workspace=workspace,
+        status=QueueItemStatus.PENDING.value,
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(None)):
+        content = helpers.resolve_source_content(item)
+    assert content == {"type": "observation_span", "deleted": True}
+
+
+@pytest.mark.django_db
+def test_malformed_ch_json_does_not_raise(organization, workspace, user):
+    """A CHSpan with malformed metadata/resource_attrs/span_events JSON renders
+    safe defaults ({}/[]) instead of 500-ing the annotate-detail page."""
+    project = _make_project(organization=organization, workspace=workspace)
+    span = _make_chspan(project_id=project.id)
+    bad = {
+        "metadata": "{not json",
+        "resource_attrs": "}}}",
+        "span_events": "[oops",
+    }
+    span = CHSpan(**{**span.__dict__, **bad})
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    item = _collector_item(
+        organization=organization, workspace=workspace, queue=queue, span=span
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        content = helpers.resolve_source_content(item)
+    assert content["metadata"] == {}
+    assert content["resource_attributes"] == {}
+    assert content["events"] == []
+
+
+# ──────────────────────────── root_spans tenant gate ─────────────────────────
+
+
+@pytest.mark.django_db
+def test_allowed_root_spans_returns_collector_trace(organization, workspace):
+    """The root_spans gate returns {trace_id: root_span_id} for a collector trace
+    whose project IS org-accessible (FAILS if reverted → {} via the PG gate)."""
+    from django.db.models import Q
+
+    from tracer.views.observation_span import allowed_root_spans_for_request
+
+    project = _make_project(organization=organization, workspace=workspace)
+    trace_id = str(uuid.uuid4())
+    span = _make_chspan(project_id=project.id, trace_id=trace_id, parent_span_id="")
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        result = allowed_root_spans_for_request(
+            [trace_id], organization=organization, project_scope_q=Q()
+        )
+    assert result == {trace_id: str(span.id)}
+
+
+@pytest.mark.django_db
+def test_allowed_root_spans_cross_org_omitted(organization, workspace):
+    """A collector trace whose root-span project belongs to a DIFFERENT org is
+    omitted (cross-org leak prevented). FAILS if the gate is removed/fail-open."""
+    from django.db.models import Q
+
+    from accounts.models.organization import Organization
+    from tracer.views.observation_span import allowed_root_spans_for_request
+
+    other_org = Organization.objects.create(name="Other Org 2")
+    other_project = _make_project(organization=other_org, workspace=None)
+    trace_id = str(uuid.uuid4())
+    span = _make_chspan(
+        project_id=other_project.id, trace_id=trace_id, parent_span_id=""
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        result = allowed_root_spans_for_request(
+            [trace_id], organization=organization, project_scope_q=Q()
+        )
+    assert result == {}
+
+
+@pytest.mark.django_db
+def test_allowed_root_spans_empty_input(organization):
+    """No trace_ids → {} (unchanged shape)."""
+    from django.db.models import Q
+
+    from tracer.views.observation_span import allowed_root_spans_for_request
+
+    assert (
+        allowed_root_spans_for_request(
+            [], organization=organization, project_scope_q=Q()
+        )
+        == {}
+    )
+
+
+# ──────────────────────────── trace_session (Slice 2) ────────────────────────
+
+
+@pytest.mark.django_db
+def test_collector_session_resolves_via_ch(organization, workspace):
+    """A collector trace_session (no PG row) resolves through the CH session
+    reader + PG Project tenant gate, returning a duck-typed source object."""
+    project = _make_project(organization=organization, workspace=workspace)
+    session_id = str(uuid.uuid4())
+    fields = {
+        session_id: {
+            "external_session_id": "ext-session-1",
+            "first_seen": datetime(2025, 5, 1, tzinfo=UTC),
+            "project_id": str(project.id),
+            "bookmarked": False,
+            "display_name": None,
+        }
+    }
+
+    with mock.patch(SESSION_FIELDS_PATH, return_value=fields):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.TRACE_SESSION.value,
+            session_id,
+            organization=organization,
+            workspace=workspace,
+            allow_ch_fallback=True,
+        )
+    assert resolved is not None
+    assert str(resolved.id) == session_id
+    assert str(resolved.project_id) == str(project.id)
+
+
+@pytest.mark.django_db
+def test_collector_session_cross_project_denied(organization, workspace):
+    """A session whose project belongs to a different org is denied (no
+    cross-tenant leak)."""
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="Other Org 3")
+    other_project = _make_project(organization=other_org, workspace=None)
+    session_id = str(uuid.uuid4())
+    fields = {
+        session_id: {
+            "external_session_id": "ext",
+            "first_seen": None,
+            "project_id": str(other_project.id),
+            "bookmarked": False,
+            "display_name": None,
+        }
+    }
+
+    with mock.patch(SESSION_FIELDS_PATH, return_value=fields):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.TRACE_SESSION.value,
+            session_id,
+            organization=organization,
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_collector_session_content_renders_from_ch(organization, workspace, user):
+    """Content of a collector session returns name/project_id/created_at from CH,
+    NOT the deleted sentinel."""
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    session_id = str(uuid.uuid4())
+    item = QueueItem.objects.create(
+        queue=queue,
+        source_type=QueueItemSourceType.TRACE_SESSION.value,
+        trace_session_id=session_id,
+        organization=organization,
+        workspace=workspace,
+        status=QueueItemStatus.PENDING.value,
+    )
+    first_seen = datetime(2025, 5, 2, 9, 0, 0, tzinfo=UTC)
+    fields = {
+        session_id: {
+            "external_session_id": "ext-session-9",
+            "first_seen": first_seen,
+            "project_id": str(project.id),
+            "bookmarked": False,
+            "display_name": None,
+        }
+    }
+
+    with mock.patch(SESSION_FIELDS_PATH, return_value=fields):
+        content = helpers.resolve_source_content(item)
+    assert content["type"] == "trace_session"
+    assert "deleted" not in content
+    assert content["session_id"] == session_id
+    assert content["name"] == "ext-session-9"
+    assert content["project_id"] == str(project.id)
+    assert content["created_at"] == first_seen
+
+
+# ─────────────────────────── OSS-with-ee-stripped guard ──────────────────────
+
+
+def test_resolution_path_imports_no_ee():
+    """The annotation source-resolution modules must not couple to ``ee`` — the
+    OSS build (ee/ stripped) must still resolve collector sources."""
+    import inspect
+
+    import tracer.views.observation_span as obs_view
+
+    for mod in (helpers, obs_view):
+        src = inspect.getsource(mod)
+        assert "import ee" not in src
+        assert "from ee" not in src

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -497,12 +497,17 @@ def resolve_source_object(
     model = get_source_model(source_type)
     if not model:
         return None
-    try:
-        obj = model.objects.get(pk=source_id)
-    except model.DoesNotExist:
+
+    # PG-first by row existence, not by source type: a curated span/session has a
+    # PG row and must resolve there (richer object, no CH round-trip); only a
+    # collector one (no PG row) needs CH. `source_type` alone can't tell them apart
+    # — both are e.g. `observation_span` — so the missing row is the discriminator.
+    obj = model.objects.filter(pk=source_id).first()
+    if obj is None:
         if not allow_ch_fallback:
             return None
-        # Collector spans/sessions live only in CH; fall back there (fail closed).
+        # No PG row: collector spans/sessions live only in CH (fail closed). A
+        # PG-native source type that's genuinely absent resolves to None there.
         return _resolve_ch_source_object(
             source_type, source_id, organization=organization, workspace=workspace
         )

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -693,6 +693,93 @@ def _ch_session_fields_for_item(session_id):
         return None
 
 
+def _batch_ch_spans(span_ids):
+    """Batch CH point-read for a render path: ``{str(id): CHSpan}`` over *span_ids*
+    in one query. CH error → ``{}`` (FAIL OPEN — the per-item collector branch then
+    renders the ``deleted`` sentinel, same as a single-read miss). Backs
+    :class:`CollectorSourceCache` so list/export pages do one CH read, not one per item."""
+    if not span_ids:
+        return {}
+    from tracer.services.clickhouse.v2 import get_reader
+
+    try:
+        with get_reader() as reader:
+            spans = reader.list_by_ids([str(s) for s in span_ids])
+    except Exception as exc:
+        logger.warning(
+            "ch_span_batch_render_error", count=len(span_ids), error=str(exc)
+        )
+        return {}
+    return {str(span.id): span for span in spans}
+
+
+def _batch_ch_session_fields(session_ids):
+    """Batch CH read of session identity fields: ``{str(id): fields}`` in one query.
+    CH error → ``{}`` (FAIL OPEN). Companion to :func:`_batch_ch_spans`."""
+    if not session_ids:
+        return {}
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    try:
+        return resolve_session_fields([str(s) for s in session_ids]) or {}
+    except Exception as exc:
+        logger.warning(
+            "ch_session_batch_render_error", count=len(session_ids), error=str(exc)
+        )
+        return {}
+
+
+class CollectorSourceCache:
+    """Page-scoped batch cache of CH-resolved collector sources.
+
+    ``resolve_source_preview`` / ``resolve_source_content`` run once per item; for
+    collector spans/sessions (CH-only, no PG row) each call would otherwise do its
+    own CH point-read — an N+1 against ClickHouse on every list/export page (PG
+    sources are prefetchable, CH has no ORM prefetch). Build one cache per page with
+    :meth:`for_items` and pass it as ``ch_cache=`` so the page does a single CH read
+    per kind. Only the collector branch consults it (a PG hit never does); a cache
+    miss returns ``None`` → ``deleted`` sentinel, matching the single-read fail-open.
+    """
+
+    __slots__ = ("_spans", "_sessions")
+
+    def __init__(self, *, spans=None, sessions=None):
+        self._spans = spans or {}
+        self._sessions = sessions or {}
+
+    @classmethod
+    def for_items(cls, items):
+        """Collect the collector span/session ids across *items* and batch-resolve
+        each kind from CH in one read. ``source_type=trace`` is PG-backed this wave,
+        so only spans and sessions are cached. PG-backed ids may also be fetched (one
+        bounded query); harmless, since the cache is consulted only on a PG miss."""
+        span_ids, session_ids = set(), set()
+        for item in items or []:
+            source_type = getattr(item, "source_type", None)
+            if (
+                source_type == QueueItemSourceType.OBSERVATION_SPAN.value
+                and item.observation_span_id
+            ):
+                span_ids.add(str(item.observation_span_id))
+            elif (
+                source_type == QueueItemSourceType.TRACE_SESSION.value
+                and item.trace_session_id
+            ):
+                session_ids.add(str(item.trace_session_id))
+        return cls(
+            spans=_batch_ch_spans(span_ids),
+            sessions=_batch_ch_session_fields(session_ids),
+        )
+
+    def span(self, span_id):
+        return self._spans.get(str(span_id)) if span_id else None
+
+    def session_fields(self, session_id):
+        return self._sessions.get(str(session_id)) if session_id else None
+
+
 class _CHTraceSessionSource:
     """Duck-typed stand-in for a PG ``TraceSession`` resolved from CH. Carries only
     the attributes the annotation scope/store/render path reads off a session
@@ -798,8 +885,12 @@ def _get_source_workspace(obj):
     return None
 
 
-def resolve_source_preview(item):
-    """Return a standardized preview dict for a QueueItem's source."""
+def resolve_source_preview(item, *, ch_cache=None):
+    """Return a standardized preview dict for a QueueItem's source.
+
+    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, collector
+    span/session sources read from the page-batched map instead of a per-item CH
+    point-read. Single-item callers pass ``None`` and keep the per-item read."""
     try:
         if item.source_type == QueueItemSourceType.DATASET_ROW.value:
             row = item.dataset_row
@@ -831,7 +922,11 @@ def resolve_source_preview(item):
             span = _safe_related(item, "observation_span")
             if not span:
                 # collector span: no PG row, resolve from CH by the soft id
-                ch_span = _ch_span_for_item(item.observation_span_id)
+                ch_span = (
+                    ch_cache.span(item.observation_span_id)
+                    if ch_cache is not None
+                    else _ch_span_for_item(item.observation_span_id)
+                )
                 if ch_span is None:
                     return {"type": "observation_span", "deleted": True}
                 return {
@@ -882,7 +977,11 @@ def resolve_source_preview(item):
             session = _safe_related(item, "trace_session")
             if not session:
                 # collector session: no PG row, resolve identity from CH
-                fields = _ch_session_fields_for_item(item.trace_session_id)
+                fields = (
+                    ch_cache.session_fields(item.trace_session_id)
+                    if ch_cache is not None
+                    else _ch_session_fields_for_item(item.trace_session_id)
+                )
                 if fields is None:
                     return {"type": "trace_session", "deleted": True}
                 return {
@@ -908,8 +1007,12 @@ def resolve_source_preview(item):
     return {"type": item.source_type, "error": "Could not resolve preview"}
 
 
-def resolve_source_content(item):
-    """Return full renderable content for a QueueItem's source (used in annotation view)."""
+def resolve_source_content(item, *, ch_cache=None):
+    """Return full renderable content for a QueueItem's source (used in annotation view).
+
+    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, collector
+    span/session sources read from the page-batched map instead of a per-item CH
+    point-read. Single-item callers pass ``None`` and keep the per-item read."""
     try:
         if item.source_type == QueueItemSourceType.DATASET_ROW.value:
             row = item.dataset_row
@@ -1004,7 +1107,11 @@ def resolve_source_content(item):
             span = _safe_related(item, "observation_span")
             if not span:
                 # collector span: no PG row, rebuild content from CH via the mapper
-                ch_span = _ch_span_for_item(item.observation_span_id)
+                ch_span = (
+                    ch_cache.span(item.observation_span_id)
+                    if ch_cache is not None
+                    else _ch_span_for_item(item.observation_span_id)
+                )
                 if ch_span is None:
                     return {"type": "observation_span", "deleted": True}
                 from tracer.services.clickhouse.v2.span_reader import (
@@ -1113,7 +1220,11 @@ def resolve_source_content(item):
             if not session:
                 # collector session: no PG row, resolve from CH (first_seen is the
                 # created_at/updated_at proxy — CH has no audit columns)
-                fields = _ch_session_fields_for_item(item.trace_session_id)
+                fields = (
+                    ch_cache.session_fields(item.trace_session_id)
+                    if ch_cache is not None
+                    else _ch_session_fields_for_item(item.trace_session_id)
+                )
                 if fields is None:
                     return {"type": "trace_session", "deleted": True}
                 first_seen = fields.get("first_seen")

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -264,6 +264,17 @@ def _resolve_default_queue_scope(source_type, source_obj, organization=None):
                     project = qs.first()
         else:  # trace_session
             project = getattr(source_obj, "project", None)
+            if project is None:
+                # CH trace_session path (_CHTraceSessionSource): no FK, resolve the
+                # PG Project by the carried project_id, org-scoped (fail closed).
+                pid = getattr(source_obj, "project_id", None)
+                if pid:
+                    from tracer.models.project import Project
+
+                    qs = Project.objects.filter(id=pid)
+                    if organization is not None:
+                        qs = qs.filter(organization=organization)
+                    project = qs.first()
         if not project:
             return None, None
         scope_name = (
@@ -462,7 +473,9 @@ def resolve_default_queue_item_for_source(source_type, source_obj, organization,
     return item
 
 
-def resolve_source_object(source_type, source_id, organization=None, workspace=None):
+def resolve_source_object(
+    source_type, source_id, organization=None, workspace=None, *, allow_ch_fallback=False
+):
     """Look up a source model instance by type and ID.
 
     When *organization* is provided the returned object is verified to belong
@@ -475,6 +488,11 @@ def resolve_source_object(source_type, source_id, organization=None, workspace=N
     When *workspace* is provided, an additional check ensures the object
     belongs to that workspace (via direct FK or through a related project /
     dataset).  ``None`` is returned on mismatch.
+
+    ``allow_ch_fallback`` (opt-in): when ``True`` and no PG row exists, fall back
+    to ClickHouse for collector observation_span / trace_session sources, returning
+    a duck-typed CH object (``.id`` / ``.project_id``). Only soft-id-storing add
+    paths opt in; callers that deref ``.pk`` / FKs keep the PG-only default.
     """
     model = get_source_model(source_type)
     if not model:
@@ -482,7 +500,12 @@ def resolve_source_object(source_type, source_id, organization=None, workspace=N
     try:
         obj = model.objects.get(pk=source_id)
     except model.DoesNotExist:
-        return None
+        if not allow_ch_fallback:
+            return None
+        # Collector spans/sessions live only in CH; fall back there (fail closed).
+        return _resolve_ch_source_object(
+            source_type, source_id, organization=organization, workspace=workspace
+        )
 
     if organization is not None:
         obj_org = _get_source_organization(obj)
@@ -512,6 +535,177 @@ def resolve_source_object(source_type, source_id, organization=None, workspace=N
             return None
 
     return obj
+
+
+def _tenant_scoped_project(project_id, *, organization=None, workspace=None):
+    """Tenant gate for CH-resolved collector sources: return the PG ``Project`` for
+    *project_id* iff accessible to the org/workspace, else ``None``. ``organization``
+    is required (a CH source has no tenant of its own — the org distinguishes a
+    same-org null-workspace project from a foreign one). FAIL CLOSED: missing
+    project_id / missing organization / org or workspace mismatch all deny.
+    """
+    if not project_id or organization is None:
+        return None
+    from tracer.models.project import Project
+
+    project = Project.objects.filter(id=project_id, organization=organization).first()
+    if project is None:
+        return None
+    if workspace is not None:
+        proj_ws = getattr(project, "workspace", None)
+        ws_match = proj_ws == workspace or (
+            proj_ws is None and getattr(workspace, "is_default", False)
+        )
+        if not ws_match:
+            return None
+    return project
+
+
+def _resolve_ch_source_object(
+    source_type, source_id, *, organization=None, workspace=None
+):
+    """CH fallback for :func:`resolve_source_object` (collector data, no PG row).
+    Returns a duck-typed CH object (``.id`` / ``.project_id``) or ``None``, tenant-
+    verified against the PG ``Project``. CH errors are logged and denied (fail closed).
+    """
+    if source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
+        from tracer.services.clickhouse.v2 import get_reader
+
+        try:
+            with get_reader() as reader:
+                span = reader.get(str(source_id))
+        except Exception as exc:  # narrow: any CH read failure → deny
+            logger.warning(
+                "ch_source_resolve_error",
+                source_type=source_type,
+                source_id=str(source_id),
+                error=str(exc),
+            )
+            return None
+        if span is None:
+            return None
+        if (
+            _tenant_scoped_project(
+                getattr(span, "project_id", None),
+                organization=organization,
+                workspace=workspace,
+            )
+            is None
+        ):
+            logger.warning(
+                "ch_source_tenant_denied",
+                source_type=source_type,
+                source_id=str(source_id),
+            )
+            return None
+        return span
+
+    if source_type == QueueItemSourceType.TRACE_SESSION.value:
+        return _resolve_ch_trace_session(
+            source_id, organization=organization, workspace=workspace
+        )
+
+    # trace (voice) and other source types are not CH-resolvable in this wave.
+    return None
+
+
+def _resolve_ch_trace_session(source_id, *, organization=None, workspace=None):
+    """CH fallback for a collector ``trace_session`` (no PG row): existence +
+    project_id from the CH reader, tenant-verified against PG. Returns a duck-typed
+    object (``.id`` / ``.project_id`` / ``.name``) or ``None`` (fail closed)."""
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    try:
+        fields = resolve_session_fields([str(source_id)]).get(str(source_id))
+    except Exception as exc:  # narrow: CH read failure → deny
+        logger.warning(
+            "ch_session_resolve_error",
+            source_id=str(source_id),
+            error=str(exc),
+        )
+        return None
+    if not fields:
+        return None
+    project_id = fields.get("project_id")
+    if (
+        _tenant_scoped_project(
+            project_id, organization=organization, workspace=workspace
+        )
+        is None
+    ):
+        logger.warning("ch_session_tenant_denied", source_id=str(source_id))
+        return None
+    return _CHTraceSessionSource(
+        id=str(source_id),
+        project_id=str(project_id) if project_id else None,
+        name=fields.get("display_name") or fields.get("external_session_id") or "",
+        first_seen=fields.get("first_seen"),
+    )
+
+
+def _safe_related(item, attr):
+    """Read a ``db_constraint=False`` FK whose target row may not exist in PG
+    (collector data lives only in CH). Collapse a missing target
+    (``ObjectDoesNotExist``) to ``None`` so the caller can fall back to CH; other
+    errors propagate."""
+    from django.core.exceptions import ObjectDoesNotExist
+
+    try:
+        return getattr(item, attr)
+    except ObjectDoesNotExist:
+        return None
+
+
+def _ch_span_for_item(span_id):
+    """Best-effort CH point-read for a render path (preview/content). Returns the
+    :class:`CHSpan` or ``None`` (genuinely-gone span OR CH error). FAIL OPEN on the
+    render (None → ``deleted`` sentinel) but logs — never raises into the page."""
+    if not span_id:
+        return None
+    from tracer.services.clickhouse.v2 import get_reader
+
+    try:
+        with get_reader() as reader:
+            return reader.get(str(span_id))
+    except Exception as exc:
+        logger.warning("ch_span_render_error", span_id=str(span_id), error=str(exc))
+        return None
+
+
+def _ch_session_fields_for_item(session_id):
+    """Best-effort CH read of a session's identity fields for a render path.
+    Returns the fields dict or ``None`` (missing session OR CH error). FAIL OPEN on
+    the render but logs."""
+    if not session_id:
+        return None
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    try:
+        return resolve_session_fields([str(session_id)]).get(str(session_id))
+    except Exception as exc:
+        logger.warning(
+            "ch_session_render_error", session_id=str(session_id), error=str(exc)
+        )
+        return None
+
+
+class _CHTraceSessionSource:
+    """Duck-typed stand-in for a PG ``TraceSession`` resolved from CH. Carries only
+    the attributes the annotation scope/store/render path reads off a session
+    (``id`` / ``project_id`` / ``name`` / ``first_seen``); it is NOT a Django model
+    and must never be assigned to a relation (the store path uses the soft id)."""
+
+    __slots__ = ("id", "project_id", "name", "first_seen")
+
+    def __init__(self, *, id, project_id, name, first_seen):
+        self.id = id
+        self.project_id = project_id
+        self.name = name
+        self.first_seen = first_seen
 
 
 def _get_source_organization(obj):
@@ -634,9 +828,22 @@ def resolve_source_preview(item):
             }
 
         elif item.source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
-            span = item.observation_span
+            span = _safe_related(item, "observation_span")
             if not span:
-                return {"type": "observation_span", "deleted": True}
+                # collector span: no PG row, resolve from CH by the soft id
+                ch_span = _ch_span_for_item(item.observation_span_id)
+                if ch_span is None:
+                    return {"type": "observation_span", "deleted": True}
+                return {
+                    "type": "observation_span",
+                    "name": ch_span.name or "",
+                    "observation_type": ch_span.observation_type or "",
+                    "input_preview": _truncate(str(ch_span.input or ""), 200),
+                    "output_preview": _truncate(str(ch_span.output or ""), 200),
+                    # CH has no response_time column; latency is the only signal.
+                    "latency_ms": ch_span.latency_ms,
+                    "response_time_ms": ch_span.latency_ms,
+                }
             return {
                 "type": "observation_span",
                 "name": span.name or "",
@@ -672,9 +879,22 @@ def resolve_source_preview(item):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE_SESSION.value:
-            session = item.trace_session
+            session = _safe_related(item, "trace_session")
             if not session:
-                return {"type": "trace_session", "deleted": True}
+                # collector session: no PG row, resolve identity from CH
+                fields = _ch_session_fields_for_item(item.trace_session_id)
+                if fields is None:
+                    return {"type": "trace_session", "deleted": True}
+                return {
+                    "type": "trace_session",
+                    "session_id": str(item.trace_session_id),
+                    "name": fields.get("display_name")
+                    or fields.get("external_session_id")
+                    or "",
+                    "project_id": (
+                        str(fields["project_id"]) if fields.get("project_id") else None
+                    ),
+                }
             return {
                 "type": "trace_session",
                 "session_id": str(session.id),
@@ -781,9 +1001,17 @@ def resolve_source_content(item):
             }
 
         elif item.source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
-            span = item.observation_span
+            span = _safe_related(item, "observation_span")
             if not span:
-                return {"type": "observation_span", "deleted": True}
+                # collector span: no PG row, rebuild content from CH via the mapper
+                ch_span = _ch_span_for_item(item.observation_span_id)
+                if ch_span is None:
+                    return {"type": "observation_span", "deleted": True}
+                from tracer.services.clickhouse.v2.span_reader import (
+                    chspan_to_annotation_source_dict,
+                )
+
+                return chspan_to_annotation_source_dict(ch_span)
             return {
                 "type": "observation_span",
                 "span_id": str(span.id),
@@ -881,9 +1109,27 @@ def resolve_source_content(item):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE_SESSION.value:
-            session = item.trace_session
+            session = _safe_related(item, "trace_session")
             if not session:
-                return {"type": "trace_session", "deleted": True}
+                # collector session: no PG row, resolve from CH (first_seen is the
+                # created_at/updated_at proxy — CH has no audit columns)
+                fields = _ch_session_fields_for_item(item.trace_session_id)
+                if fields is None:
+                    return {"type": "trace_session", "deleted": True}
+                first_seen = fields.get("first_seen")
+                return {
+                    "type": "trace_session",
+                    "session_id": str(item.trace_session_id),
+                    "source_id": str(item.trace_session_id),
+                    "name": fields.get("display_name")
+                    or fields.get("external_session_id")
+                    or "",
+                    "project_id": (
+                        str(fields["project_id"]) if fields.get("project_id") else None
+                    ),
+                    "created_at": first_seen,
+                    "updated_at": first_seen,
+                }
             return {
                 "type": "trace_session",
                 "session_id": str(session.id),

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1239,13 +1239,22 @@ def _reopen_items_missing_required_labels(queue):
 def _span_notes_target_for_queue_item(item):
     """Return the span that stores whole-item notes for queue annotation.
 
-    Span-source items return the FK-loaded Django ``ObservationSpan`` (writes
-    still live in PG). Trace-source items pick the trace's root span from
+    Span-source items return the PG ``ObservationSpan`` (writes still live in
+    PG), falling back to the CH span for collector data with no PG row.
+    Trace-source items pick the trace's root span from
     CH 25 — preference order is ``observation_type="conversation"`` root span
     (voice projects) → first root span by start_time → ``None``.
     """
     if item.source_type == "observation_span" and item.observation_span_id:
-        return item.observation_span
+        try:
+            return item.observation_span
+        except ObservationSpan.DoesNotExist:
+            # Collector span: no PG row. Resolve from CH — downstream only reads
+            # `.id` (CHSpan exposes it), same as the trace-root CH spans below.
+            from tracer.services.clickhouse.v2 import get_reader
+
+            with get_reader() as reader:
+                return reader.get(str(item.observation_span_id))
     if item.source_type != "trace" or not item.trace_id:
         return None
 
@@ -5269,9 +5278,14 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         item_notes = data.get("item_notes")
         submitted = 0
 
-        # Resolve source FK for Score creation
+        # Score FK soft id: read the raw FK id column, NOT the related object —
+        # collector trace/span/session FKs (db_constraint=False) have no PG row,
+        # so getattr(item, source_fk_field) would raise DoesNotExist. The Score
+        # FK is db_constraint=False too, so the bare id persists.
         source_fk_field = SCORE_SOURCE_FK_MAP.get(item.source_type)
-        source_obj = getattr(item, source_fk_field) if source_fk_field else None
+        source_id = (
+            getattr(item, f"{source_fk_field}_id", None) if source_fk_field else None
+        )
         span_notes_target = _span_notes_target_for_queue_item(item)
         # Older clients sent one top-level `notes` field. For trace/span items that
         # can store whole-item notes, treat that legacy field as the item note so it
@@ -5320,12 +5334,12 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             # Use no_workspace_objects + _id fields to avoid the LEFT JOIN
             # on nullable workspace FK that triggers PostgreSQL's "FOR UPDATE
             # cannot be applied to the nullable side of an outer join".
-            if source_obj and source_fk_field:
+            if source_id and source_fk_field:
                 # Scope the upsert by queue_item so each queue review context
                 # owns its own Score row even when the same annotator scores
                 # the same label across multiple queues.
                 score, _ = Score.no_workspace_objects.update_or_create(
-                    **{f"{source_fk_field}_id": source_obj.pk},
+                    **{f"{source_fk_field}_id": source_id},
                     label_id=label.pk,
                     annotator_id=request.user.pk,
                     queue_item=item,
@@ -7220,9 +7234,14 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             except User.DoesNotExist:
                 return self._gm.bad_request("Annotator not found in this workspace.")
 
-        # Resolve source FK for Score creation
+        # Score FK soft id: read the raw FK id column, NOT the related object —
+        # collector trace/span/session FKs (db_constraint=False) have no PG row,
+        # so getattr(item, source_fk_field) would raise DoesNotExist. The Score
+        # FK is db_constraint=False too, so the bare id persists.
         source_fk_field = SCORE_SOURCE_FK_MAP.get(item.source_type)
-        source_obj = getattr(item, source_fk_field) if source_fk_field else None
+        source_id = (
+            getattr(item, f"{source_fk_field}_id", None) if source_fk_field else None
+        )
         queue_label_ids = set(
             item.queue.queue_labels.filter(deleted=False).values_list(
                 "label_id",
@@ -7259,14 +7278,14 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             except ValueError as exc:
                 return self._gm.bad_request(str(exc))
 
-            if source_obj and source_fk_field:
+            if source_id and source_fk_field:
                 # Scope the upsert by queue_item so an import lands in this
                 # queue's review context. Without queue_item in the lookup
                 # we'd hit the per-queue uniqueness constraint as soon as
                 # the same (source, label, annotator) is imported into a
                 # second queue.
                 score, _ = Score.no_workspace_objects.update_or_create(
-                    **{f"{source_fk_field}_id": source_obj.pk},
+                    **{f"{source_fk_field}_id": source_id},
                     label_id=label.pk,
                     annotator_id=annotator.pk,
                     queue_item=item,

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -4824,6 +4824,8 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 source_id,
                 organization=request.organization,
                 workspace=getattr(request, "workspace", None),
+                # stores the soft id below, so a CH-resolved collector source is fine
+                allow_ch_fallback=True,
             )
             if not source_obj:
                 errors.append(f"Not found: {source_type}={source_id}")
@@ -4836,9 +4838,15 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 errors.append(unavailable_reason)
                 continue
 
+            # Soft id, not the FK object (CH source isn't a Django instance;
+            # QueueItem FKs are db_constraint=False). Mirrors the serializer.
+            source_pk = getattr(source_obj, "pk", None) or getattr(
+                source_obj, "id", None
+            )
+
             dup_filter = {
                 "queue": queue,
-                fk_field: source_obj,
+                f"{fk_field}_id": source_pk,
                 "deleted": False,
             }
             if QueueItem.objects.filter(**dup_filter).exists():
@@ -4853,7 +4861,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     organization=request.organization,
                     workspace=getattr(request, "workspace", None) or queue.workspace,
                     order=max_order,
-                    **{fk_field: source_obj},
+                    **{f"{fk_field}_id": source_pk},
                 )
             )
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -114,6 +114,7 @@ from model_hub.services.bulk_selection import (
     resolve_filtered_trace_ids,
 )
 from model_hub.utils.annotation_queue_helpers import (
+    CollectorSourceCache,
     assign_items_to_all_annotators,
     auto_assign_items,
     calculate_agreement,
@@ -2298,7 +2299,10 @@ def _build_annotation_queue_export_fields(queue, sample_items=None):
         "evaluation_data",
         "customer_latency_metrics",
     )
-    sample_contents = [(item, resolve_source_content(item)) for item in sample_items]
+    ch_cache = CollectorSourceCache.for_items(sample_items)
+    sample_contents = [
+        (item, resolve_source_content(item, ch_cache=ch_cache)) for item in sample_items
+    ]
     source_types = {
         content.get("type") or item.source_type
         for item, content in sample_contents
@@ -2395,7 +2399,7 @@ def _build_annotation_queue_export_fields(queue, sample_items=None):
     }
 
 
-def _infer_attribute_field_data_type(field_id, sample_items):
+def _infer_attribute_field_data_type(field_id, sample_items, ch_cache=None):
     source_type, path = _parse_attribute_field_id(field_id)
     if not path:
         return DataTypeChoices.TEXT.value
@@ -2403,13 +2407,13 @@ def _infer_attribute_field_data_type(field_id, sample_items):
     for item in sample_items or []:
         if source_type and item.source_type != source_type:
             continue
-        value = _nested_get(resolve_source_content(item), path)
+        value = _nested_get(resolve_source_content(item, ch_cache=ch_cache), path)
         if value not in (None, ""):
             return _infer_dataset_type(value)
     return DataTypeChoices.TEXT.value
 
 
-def _custom_attribute_export_field(field_id, sample_items=None):
+def _custom_attribute_export_field(field_id, sample_items=None, ch_cache=None):
     if not field_id.startswith("attr:"):
         return None
     source_type, path = _parse_attribute_field_id(field_id)
@@ -2419,7 +2423,7 @@ def _custom_attribute_export_field(field_id, sample_items=None):
         field_id,
         path.replace("_", " "),
         path,
-        _infer_attribute_field_data_type(field_id, sample_items),
+        _infer_attribute_field_data_type(field_id, sample_items, ch_cache=ch_cache),
         f"From {_source_export_label(source_type)}" if source_type else "Attributes",
         False,
         path=path,
@@ -3380,10 +3384,11 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         scores_by_item = _scores_for_queue_items(items_list, queue_label_ids)
         item_notes_by_id = _latest_item_notes_for_queue_items(items_list)
         eval_metrics_by_item = _eval_metrics_for_queue_items(items_list)
+        ch_source_cache = CollectorSourceCache.for_items(items_list)
 
         result = []
         for item in items_list:
-            content = resolve_source_content(item)
+            content = resolve_source_content(item, ch_cache=ch_source_cache)
             annotations = [
                 _serialize_score_for_export(score)
                 for score in scores_by_item.get(item.id, [])
@@ -3697,6 +3702,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         if status_filter:
             items_qs = items_qs.filter(status=status_filter)
         items_list = list(items_qs.order_by("order", "created_at"))
+        ch_source_cache = CollectorSourceCache.for_items(items_list)
 
         export_field_defs = _build_annotation_queue_export_fields(
             queue, sample_items=items_list[:100]
@@ -3713,7 +3719,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 continue
             field_id = entry.get("field") or entry.get("id")
             field_def = fields_by_id.get(field_id) or _custom_attribute_export_field(
-                field_id or "", items_list[:100]
+                field_id or "", items_list[:100], ch_cache=ch_source_cache
             )
             if not field_def:
                 continue
@@ -3794,7 +3800,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         item_notes_by_id = _latest_item_notes_for_queue_items(items_list)
         eval_metrics_by_item = _eval_metrics_for_queue_items(items_list)
         for i, item in enumerate(items_list):
-            content = resolve_source_content(item)
+            content = resolve_source_content(item, ch_cache=ch_source_cache)
             scores = scores_by_item.get(item.id, [])
             annotations_metadata = {}
             for score in scores:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1810,17 +1810,8 @@ class CHSpanReader:
             metadata_parsed = {}
         # span_attributes is the legacy serializer field that flattens
         # attrs_string/number/bool + attributes_extra into one dict — the
-        # shape v1 consumers expect.
-        span_attributes: dict[str, Any] = {}
-        span_attributes.update(span.attrs_string or {})
-        span_attributes.update(span.attrs_number or {})
-        span_attributes.update(span.attrs_bool or {})
-        try:
-            extra = json.loads(span.attributes_extra) if span.attributes_extra else {}
-            if isinstance(extra, dict):
-                span_attributes.update(extra)
-        except json.JSONDecodeError:
-            pass
+        # shape v1 consumers expect. Single source of truth: _ch_span_attributes.
+        span_attributes = _ch_span_attributes(span)
         # tags / span_events come from CH as JSON strings; the serializer
         # returns them as Python objects.
         try:
@@ -1868,6 +1859,80 @@ class CHSpanReader:
             "eval_status": span.eval_status,
             "prompt_version": span.prompt_version_id,
         }
+
+
+def _ch_span_attributes(span: CHSpan) -> dict[str, Any]:
+    """Flatten ``attrs_string/number/bool`` + ``attributes_extra`` into the one
+    ``span_attributes`` dict v1 consumers (and the annotation render) expect.
+
+    Malformed ``attributes_extra`` JSON is skipped (not raised) so a single bad
+    span never 500s a render page.
+    """
+    out: dict[str, Any] = {}
+    out.update(span.attrs_string or {})
+    out.update(span.attrs_number or {})
+    out.update(span.attrs_bool or {})
+    try:
+        extra = json.loads(span.attributes_extra) if span.attributes_extra else {}
+        if isinstance(extra, dict):
+            out.update(extra)
+    except json.JSONDecodeError:
+        pass
+    return out
+
+
+def _ch_json_obj(raw: str, *, default: Any) -> Any:
+    """``json.loads`` a CH JSON-string column, returning *default* (``{}`` / ``[]``)
+    on null/empty/malformed input rather than raising — so one bad span row does
+    not 500 the annotate-detail render. Parse failures are the caller's to log."""
+    if not raw:
+        return default
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return default
+    return parsed
+
+
+def chspan_to_annotation_source_dict(span: CHSpan) -> dict[str, Any]:
+    """Map a :class:`CHSpan` to the ``observation_span`` content/preview dict the
+    annotation selectors emit for a PG ``ObservationSpan`` — the single place that
+    owns the CHSpan field renames (attrs_* merge, json.loads of the string columns,
+    latency→response_time, start/end→created/updated, eval_attributes={}) so the
+    preview and content branches never diverge. Pure (no IO)."""
+    metadata = _ch_json_obj(span.metadata, default={})
+    return {
+        "type": "observation_span",
+        "span_id": str(span.id),
+        "trace_id": str(span.trace_id) if span.trace_id else None,
+        "name": span.name or "",
+        "observation_type": span.observation_type or "",
+        "project_id": str(span.project_id) if span.project_id else None,
+        "created_at": span.start_time,
+        "updated_at": span.end_time,
+        "start_time": span.start_time,
+        "end_time": span.end_time,
+        "input": _maybe_json(span.input),
+        "output": _maybe_json(span.output),
+        "metadata": metadata if isinstance(metadata, dict) else {},
+        "events": _ch_json_obj(span.span_events, default=[]),
+        "latency_ms": span.latency_ms,
+        # CH has no response_time column; latency_ms is the only timing signal.
+        "response_time_ms": span.latency_ms,
+        "model": span.model or None,
+        "provider": span.provider or None,
+        "cost": span.cost,
+        "prompt_tokens": span.prompt_tokens,
+        "completion_tokens": span.completion_tokens,
+        "total_tokens": span.total_tokens,
+        "status": span.status or None,
+        "status_message": span.status_message or None,
+        "tags": _ch_json_obj(span.tags, default=[]),
+        "span_attributes": _ch_span_attributes(span),
+        "resource_attributes": _ch_json_obj(span.resource_attrs, default={}),
+        # empty (not omitted) for PG-branch shape parity — CH has no per-eval dict
+        "eval_attributes": {},
+    }
 
 
 # Provider → logo URL map. Mirrors what the serializer's get_provider_logo() does

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -284,6 +284,60 @@ def _project_workspace_scope_q(request, project_prefix="project__"):
     return Q(**{workspace_field: workspace})
 
 
+def allowed_root_spans_for_request(
+    trace_ids: list[str],
+    *,
+    organization,
+    project_scope_q,
+) -> dict[str, str]:
+    """Resolve ``{trace_id: root_span_id}`` for *trace_ids*, returning only traces
+    whose owning project is org/workspace-accessible. Collector traces have no PG
+    ``Trace`` row, so the project_id is learned from CH and re-checked against the
+    PG ``Project`` authority. FAIL CLOSED: an untenanted / cross-org trace is dropped
+    (no key) — same response shape as before.
+    """
+    if not trace_ids:
+        return {}
+
+    from tracer.services.clickhouse.v2 import get_reader
+
+    with get_reader() as reader:
+        ch_spans = reader.list_by_trace_ids([str(tid) for tid in trace_ids])
+
+    # Root spans only (CH stores parent_span_id as a non-nullable String; root
+    # spans carry ""). Collect the candidate project_ids to verify against PG.
+    root_spans = [s for s in ch_spans if not s.parent_span_id]
+    candidate_project_ids = {
+        str(s.project_id) for s in root_spans if s.project_id
+    }
+    if not candidate_project_ids:
+        return {}
+
+    allowed_project_ids = {
+        str(pid)
+        for pid in Project.objects.filter(
+            project_scope_q,
+            id__in=candidate_project_ids,
+            organization=organization,
+        ).values_list("id", flat=True)
+    }
+    if not allowed_project_ids:
+        return {}
+
+    result: dict[str, str] = {}
+    for span in root_spans:
+        pid = str(span.project_id) if span.project_id else None
+        if pid is None or pid not in allowed_project_ids:
+            # FAIL CLOSED: untenanted or cross-org span — never returned.
+            continue
+        tid = str(span.trace_id)
+        # list_by_trace_ids orders by (trace_id, start_time, id) so the first
+        # parentless span per trace wins.
+        if tid not in result:
+            result[tid] = str(span.id)
+    return result
+
+
 class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
     _gm = GeneralMethods()
     permission_classes = [IsAuthenticated]
@@ -835,43 +889,17 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             if not trace_ids:
                 return self._gm.bad_request("trace_ids is required")
 
-            # Tenant gate via PG (CH spans don't carry org_id filterability).
-            # Reduce the caller-supplied set to only those traces visible to
-            # the request org/workspace.
+            # Collector traces have no PG ``Trace`` row; the gate resolves the root
+            # span + tenant from CH/PG-Project instead (fail closed). See selector.
             org = _get_request_organization(request)
-            allowed_trace_ids = list(
-                Trace.objects.filter(
-                    _project_workspace_scope_q(request),
-                    id__in=trace_ids,
-                    project__organization=org,
-                ).values_list("id", flat=True)
+            result = allowed_root_spans_for_request(
+                trace_ids,
+                organization=org,
+                project_scope_q=_project_workspace_scope_q(request, project_prefix=""),
             )
-            if not allowed_trace_ids:
-                return self._gm.success_response({})
-
-            # Read root spans from CH and pick the first parentless span per
-            # trace_id (mirrors the pattern in feed.py::_get_root_spans_batch
-            # committed in 50561eb5c).
-            from tracer.services.clickhouse.v2 import get_reader
-
-            with get_reader() as reader:
-                ch_spans = reader.list_by_trace_ids(
-                    [str(tid) for tid in allowed_trace_ids]
-                )
-
-            result: dict[str, str] = {}
-            for span in ch_spans:
-                # CH stores parent_span_id as a non-nullable String; root
-                # spans use "" (empty). list_by_trace_ids orders by
-                # (trace_id, start_time, id) so the first parentless span
-                # per trace wins.
-                if span.parent_span_id:
-                    continue
-                tid = str(span.trace_id)
-                if tid not in result:
-                    result[tid] = str(span.id)
             return self._gm.success_response(result)
         except Exception as e:
+            # fail closed: any CH/PG error returns no data, never a partial leak
             return self._gm.bad_request(f"Error fetching root spans: {str(e)}")
 
     @action(detail=False, methods=["post"])


### PR DESCRIPTION
## Problem

Annotation queues only worked for PostgreSQL-backed sources. After the CH25 migration, `fi-collector` writes traces/spans/sessions **only to ClickHouse** (no PG row), so **From Traces / From Spans / From Sessions** silently dropped every collector item — add-to-queue resolved nothing, and any item that did land rendered as `{"deleted": true}`.

## Changes

**CH fallback for annotation source resolution**
- `resolve_source_object` gains an **opt-in** `allow_ch_fallback`: on a PG miss it resolves `observation_span` / `trace_session` from ClickHouse, returning a duck-typed CH object. **Fail-closed tenant gate** (`_tenant_scoped_project`) verifies the CH-learned `project_id` against the PG `Project` authority — **organization is required**, closing a cross-org leak the org-less single-item serializer path otherwise had.
- `root-spans` endpoint is now CH-backed (`allowed_root_spans_for_request`) — the old PG `Trace.objects` gate returned `{}` for collector traces.
- Preview/content render from CH through **one shared `CHSpan` mapper** (`chspan_to_annotation_source_dict`) so the preview/content branches can't diverge.
- Submit/Score + span-notes paths read the **soft id** (`item.<fk>_id`) instead of dereferencing `item.<fk>` (`db_constraint=False`), so a non-Django CH source persists through annotation without raising `DoesNotExist`.

**Batched CH reads (no N+1)**
- `resolve_source_preview` / `resolve_source_content` ran a per-item CH point-read for every collector span/session on a list/export page (PG sources are prefetchable; CH has no ORM prefetch). Added a page-scoped `CollectorSourceCache` — one `reader.list_by_ids` + one `resolve_session_fields` per page — threaded through the list serializer (`ListSerializer.to_representation`) and the export loops as an opt-in `ch_cache=`. Single-item callers keep the per-item read; a cache miss falls back to the `deleted` sentinel (same fail-open as the single read).

## Testing

- **Unit tests** (`test_ch25_annotation_collector_source_resolution.py`): collector span/session resolve via CH, **cross-org tenant denial**, the **org-omitted regression** (the leak), PG-first regression guard, malformed-JSON render safety, OSS-`ee`-stripped import guard, a **create→annotate round-trip** (no PG row → submit → `Score` persists on the soft id), and a **call-count test** asserting the page does one batch CH read per kind (`list_by_ids` once, per-item `get` zero, `resolve_session_fields` once) — so it fails if the batching or its DRF context plumbing regresses, which a correctness-only test would not. Fail-on-revert verified.
- End-to-end against a live collector project: all three sources **list → add (`added:1`) → render real content**.

## Notes
- Layers: CH reads go through `CHSpanReader` (data-access); resolution stays in selectors; response shapes unchanged (additive).
- Out of scope (later wave): the `source_type=trace` voice path, filter-mode "select all", and the automation-rule ORM path remain PG-bound.
