### PR TITLE
fix(annotations): normalize server config keys in the add-items picker

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -49,6 +49,7 @@ import { useTestRunsList } from "src/api/tests/testRuns";
 import SingleImageViewerProvider from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageViewerProvider";
 import {
   getTraceListColumnDefs,
+  normalizeConfigKeys,
   TRACE_DEFAULT_COLUMNS,
   generateObserveTraceFilterDefinition,
   generateSpanObserveFilterDefinition,
@@ -1966,10 +1967,7 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
           const res = results?.data?.result;
 
           // Update columns from response config (same as TraceGrid)
-          const newCols = res?.config?.map((o) => ({
-            ...o,
-            id: o.id,
-          }));
+          const newCols = normalizeConfigKeys(res?.config);
           if (newCols) {
             setColumns((prev) => (isEqual(prev, newCols) ? prev : newCols));
           }
@@ -2622,10 +2620,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
           const res = results?.data?.result;
 
           // Update columns from response config
-          const newCols = res?.config?.map((o) => ({
-            ...o,
-            id: o.id,
-          }));
+          const newCols = normalizeConfigKeys(res?.config);
           if (newCols) {
             setColumns((prev) => (isEqual(prev, newCols) ? prev : newCols));
           }
@@ -3188,10 +3183,7 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
           const res = results?.data?.result;
 
           // Update columns from response config
-          const newCols = res?.config?.map((o) => ({
-            ...o,
-            id: o.id,
-          }));
+          const newCols = normalizeConfigKeys(res?.config);
           if (newCols) {
             setColumns((prev) => (isEqual(prev, newCols) ? prev : newCols));
           }


### PR DESCRIPTION
## Problem

The annotation **Add Items** picker (From Traces / Spans / Sessions) rendered an **empty grid** even when the API returned rows — the data loaded but no columns showed.

## Root cause

A snake_case/camelCase mismatch. The picker set its AG-Grid column state from the server `config[]` **raw**, then `getTraceListColumnDefs` / `getSessionListColumnDef` read **`col.isVisible`** (camelCase). But the API sends **`is_visible`** (snake_case), and the axios compat bridge doesn't deep-alias nested `config[]` objects — so `isVisible` was `undefined`, `hide: !undefined` → **every column hidden** → the body rendered 0 cells.

The main `TraceGrid` works because it runs `config` through a local `normalizeConfigKeys` (snake→camel) before `setColumns`; the three picker selectors just never called it.

## Fix

- Lift `normalizeConfigKeys` from `TraceGrid.jsx` into `LLMTracing/common.js` (next to `getTraceListColumnDefs`), exported.
- `TraceGrid` now imports it (local copy deleted — one source of truth).
- All three picker selectors run `res.config` through it before `setColumns`.


## Screenshots
<img width="1100" height="850" alt="image" src="https://github.com/user-attachments/assets/bb12623b-02dc-498b-a13a-5b757db45494" />

