### PR TITLE
fix(observe): clarify tracing tab tooltip as keyboard shortcut (TH-5681)

### DIFF
--- a/frontend/src/components/observe-tabs/CustomViewTab.jsx
+++ b/frontend/src/components/observe-tabs/CustomViewTab.jsx
@@ -59,7 +59,9 @@ const CustomViewTab = ({
   return (
     <CustomTooltip
       show
-      title={shortcut ? `${view.name} · Press ${shortcut}` : view.name}
+      title={
+        !isActive && shortcut ? `${view.name} · Press ${shortcut}` : view.name
+      }
       placement="bottom"
       arrow
       size="small"

--- a/frontend/src/components/observe-tabs/CustomViewTab.jsx
+++ b/frontend/src/components/observe-tabs/CustomViewTab.jsx
@@ -59,7 +59,7 @@ const CustomViewTab = ({
   return (
     <CustomTooltip
       show
-      title={shortcut ? `${view.name} (${shortcut})` : view.name}
+      title={shortcut ? `${view.name} · Press ${shortcut}` : view.name}
       placement="bottom"
       arrow
       size="small"

--- a/frontend/src/components/observe-tabs/FixedTab.jsx
+++ b/frontend/src/components/observe-tabs/FixedTab.jsx
@@ -7,7 +7,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 const FixedTab = ({ tabKey, label, icon, shortcut, isActive, onClick }) => (
   <CustomTooltip
     show
-    title={`${label} (${shortcut})`}
+    title={`Press ${shortcut}`}
     placement="bottom"
     arrow
     size="small"

--- a/frontend/src/components/observe-tabs/FixedTab.jsx
+++ b/frontend/src/components/observe-tabs/FixedTab.jsx
@@ -6,7 +6,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
 const FixedTab = ({ tabKey, label, icon, shortcut, isActive, onClick }) => (
   <CustomTooltip
-    show
+    show={!isActive}
     title={`Press ${shortcut}`}
     placement="bottom"
     arrow

--- a/frontend/src/components/observe-tabs/__tests__/FixedTab.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/FixedTab.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 import { render, screen } from "src/utils/test-utils";
 import FixedTab from "../FixedTab";
 
@@ -35,5 +36,11 @@ describe("FixedTab", () => {
   it("renders without icon when icon prop is not provided", () => {
     render(<FixedTab {...defaultProps} icon={undefined} />);
     expect(screen.getByText("Trace")).toBeInTheDocument();
+  });
+
+  it("shows the keyboard shortcut hint ('Press <n>') on hover, not an index like '(n)'", async () => {
+    render(<FixedTab {...defaultProps} shortcut="3" />);
+    await userEvent.hover(screen.getByRole("button"));
+    expect(await screen.findByText("Press 3")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/observe-tabs/__tests__/FixedTab.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/FixedTab.test.jsx
@@ -43,4 +43,10 @@ describe("FixedTab", () => {
     await userEvent.hover(screen.getByRole("button"));
     expect(await screen.findByText("Press 3")).toBeInTheDocument();
   });
+
+  it("does not hint the shortcut on the active tab (pressing it is a no-op)", async () => {
+    render(<FixedTab {...defaultProps} shortcut="3" isActive />);
+    await userEvent.hover(screen.getByRole("button"));
+    expect(screen.queryByText("Press 3")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What was the bug
On the Observe / Tracing dashboard, hovering the tabs showed a tooltip like **`Trace (1)` / `Users (3)`** (fixed tabs) and **`my-view (4)`** (custom saved-view tabs). The `(N)` is actually the **keyboard-shortcut number** for that tab, but it reads like an **index / row count**, so it was reported as a confusing "index tooltip." (Reported by Kartik; TH-5681.)

## What changed
Make the tab tooltips read as an unambiguous keyboard-shortcut hint, and only show the hint where the shortcut actually does something.

- **`FixedTab.jsx`** (Trace/Sessions/Users): `\`${label} (${shortcut})\`` → `\`Press ${shortcut}\`` → e.g. **`Press 3`**.
- **`CustomViewTab.jsx`** (saved views): `\`${view.name} (${shortcut})\`` → `\`${view.name} · Press ${shortcut}\`` → e.g. **`my-view · Press 4`**.
- **Active tab:** the shortcut for the already-active tab is a no-op, so the hint is suppressed there — fixed tabs show no tooltip when active; custom tabs keep just the name.

## Why
- Product/design (Vel) chose **Option 2** — keep the shortcut hint but make it unambiguous, rather than removing it (which would hide a real, working feature).
- **Why fixed tabs drop the label but custom tabs keep the name:** "Trace/Sessions/Users" never truncate, so repeating the label in the tooltip was pure redundancy. Custom **view names truncate** (`maxWidth: 200` + ellipsis), so the tab can show `my-lo…` while the tooltip is the only place to read the full name — that hover-reveal is preserved, with `· Press N` appended only as the shortcut hint.
- **Why suppress on active:** pressing `1/2/3/…` for the tab you're already on does nothing, so hinting it there is misleading.
- Keyboard shortcuts are otherwise unchanged: `ObserveTabBar` maps keys to tabs **positionally**, so it never depended on this display string.

## What each test case covers (`FixedTab.test.jsx`)
| Test | Scenario |
|---|---|
| renders the label text | tab shows its label ("Trace") |
| calls onClick with tabKey | clicking the tab fires `onClick(tabKey)` |
| active styling when `isActive` | active tab renders |
| renders without icon | renders gracefully when `icon` is omitted |
| **shows "Press &lt;n&gt;" on hover** _(new)_ | hovering an inactive tab surfaces `Press 3` — fails if reverted to `(3)` |
| **no hint on the active tab** _(new)_ | active tab does **not** show `Press 3` (shortcut is a no-op) |

## How to reproduce
1. Open the Observe / Tracing dashboard (`/dashboard/observe/<project>/llm-tracing`).
2. Hover the **Trace / Sessions / Users** tabs and any **saved-view** tab.
3. **Before:** `Trace (1)` / `Users (3)` / `my-view (4)` (looks like an index).
   **After:** `Press 1` / `Press 3` / `my-view · Press 4`; the **active** tab shows no shortcut hint.

## Commands
```bash
cd frontend
yarn test:run src/components/observe-tabs/__tests__/FixedTab.test.jsx   # passes
yarn dev   # then hover the tabs (inactive + active) to verify
```

## Screenshots
**Before:**
<img width="505" height="144" alt="Screenshot 2026-06-19 at 4 07 44 PM" src="https://github.com/user-attachments/assets/bea92cf6-5e93-4c89-8ac1-96b5336c6886" />

_<!-- attach before screenshot -->_

**After:**
<img width="689" height="190" alt="Screenshot 2026-06-19 at 3 56 13 PM" src="https://github.com/user-attachments/assets/75ab9300-6692-4582-beff-05b2f689e9ac" />


_<!-- attach after screenshot -->_

## Checklist
- [x] Follows style guide · lint clean (0 errors)
- [x] Tests added (shortcut hint + active-tab) · observe-tabs suite green
- [x] No hardcoded secrets, URLs, or PII
- [x] Before/After screenshots attached

Closes TH-5681
