### PR TITLE
fix: regenerate API contracts and reconcile tests after OTLP route removal

### DIFF
--- a/api_contracts/openapi/management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/management-api-contract-debt.generated.json
@@ -1,8 +1,8 @@
 {
   "generated_from": "api_contracts/openapi/swagger.json",
   "summary": {
-    "paths": 976,
-    "operations": 1323,
+    "paths": 971,
+    "operations": 1318,
     "mutation_endpoints_without_body_schema": 0,
     "operations_without_response_schema": 0,
     "broad_success_response_schemas": 0,
@@ -47,8 +47,8 @@
       "broad_error_response_schemas": 0
     },
     "api": {
-      "paths": 9,
-      "operations": 9,
+      "paths": 8,
+      "operations": 8,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,
@@ -137,8 +137,8 @@
       "broad_error_response_schemas": 0
     },
     "tracer": {
-      "paths": 157,
-      "operations": 221,
+      "paths": 154,
+      "operations": 218,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,
@@ -155,8 +155,8 @@
       "broad_error_response_schemas": 0
     },
     "v1": {
-      "paths": 2,
-      "operations": 2,
+      "paths": 1,
+      "operations": 1,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,

--- a/frontend/scripts/check-management-api-contract-coverage.mjs
+++ b/frontend/scripts/check-management-api-contract-coverage.mjs
@@ -26,7 +26,8 @@ const MIN_GROUP_PATHS = {
   "falcon-ai": 15,
   "model-hub": 360,
   simulate: 100,
-  tracer: 155,
+  // OTLP trace ingestion routes migrated to fi-collector; Django no longer serves them.
+  tracer: 154,
   usage: 55,
 };
 const MUTATION_METHODS = new Set(["post", "put", "patch"]);

--- a/frontend/src/api/contracts/__tests__/api-surface.test.js
+++ b/frontend/src/api/contracts/__tests__/api-surface.test.js
@@ -128,7 +128,7 @@ describe("api surface contract", () => {
     ).toBeGreaterThan(360);
     expect(
       Object.keys(API_SURFACE_CONTRACT.groups.tracer).length,
-    ).toBeGreaterThan(155);
+    ).toBeGreaterThan(153);
     expect(
       Object.keys(API_SURFACE_CONTRACT.groups.accounts).length,
     ).toBeGreaterThan(75);

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 976,
+  "endpointCount": 971,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -723,9 +723,6 @@ export const API_SURFACE_CONTRACT = Object.freeze({
         "get"
       ],
       "/api/public/ingestion": [
-        "post"
-      ],
-      "/api/public/otel/v1/traces": [
         "post"
       ],
       "/api/public/traces": [
@@ -2765,9 +2762,6 @@ export const API_SURFACE_CONTRACT = Object.freeze({
         "patch",
         "put"
       ],
-      "/tracer/otlp/v1/traces": [
-        "post"
-      ],
       "/tracer/project-version/": [
         "get",
         "post"
@@ -3042,12 +3036,6 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       "/tracer/v1/health": [
         "get"
       ],
-      "/tracer/v1/traces": [
-        "post"
-      ],
-      "/tracer/v1/traces/": [
-        "post"
-      ],
       "/tracer/webhook/": [
         "post"
       ]
@@ -3311,9 +3299,6 @@ export const API_SURFACE_CONTRACT = Object.freeze({
     "v1": {
       "/v1/health": [
         "get"
-      ],
-      "/v1/traces/": [
-        "post"
       ]
     }
   }
@@ -4027,9 +4012,6 @@ export const API_SURFACE_PATHS = Object.freeze({
     "get"
   ],
   "/api/public/ingestion": [
-    "post"
-  ],
-  "/api/public/otel/v1/traces": [
     "post"
   ],
   "/api/public/traces": [
@@ -6049,9 +6031,6 @@ export const API_SURFACE_PATHS = Object.freeze({
     "patch",
     "put"
   ],
-  "/tracer/otlp/v1/traces": [
-    "post"
-  ],
   "/tracer/project-version/": [
     "get",
     "post"
@@ -6326,12 +6305,6 @@ export const API_SURFACE_PATHS = Object.freeze({
   "/tracer/v1/health": [
     "get"
   ],
-  "/tracer/v1/traces": [
-    "post"
-  ],
-  "/tracer/v1/traces/": [
-    "post"
-  ],
   "/tracer/webhook/": [
     "post"
   ],
@@ -6591,8 +6564,5 @@ export const API_SURFACE_PATHS = Object.freeze({
   ],
   "/v1/health": [
     "get"
-  ],
-  "/v1/traces/": [
-    "post"
   ]
 });

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 976,
+  "endpointCount": 971,
   "endpoints": {
     "/accounts/2fa/recovery-codes/": {
       "get": {
@@ -8648,32 +8648,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           },
           "403": {
             "$ref": "#/definitions/ApiDetailErrorResponse"
-          },
-          "default": {
-            "$ref": "#/definitions/ManagementAPIErrorResponse"
-          }
-        }
-      }
-    },
-    "/api/public/otel/v1/traces": {
-      "post": {
-        "operationId": "api_public_otel_v1_traces_create",
-        "runtimeRequestValidation": true,
-        "runtimeResponseValidation": false,
-        "requestBody": {
-          "description": "Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.",
-          "type": "object"
-        },
-        "queryParameters": {},
-        "responses": {
-          "200": {
-            "$ref": "#/definitions/OTLPHTTPTraceResponse"
-          },
-          "403": {
-            "$ref": "#/definitions/OTLPHTTPErrorResponse"
-          },
-          "500": {
-            "$ref": "#/definitions/OTLPHTTPErrorResponse"
           },
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
@@ -33292,32 +33266,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
-    "/tracer/otlp/v1/traces": {
-      "post": {
-        "operationId": "tracer_otlp_v1_traces_create",
-        "runtimeRequestValidation": true,
-        "runtimeResponseValidation": false,
-        "requestBody": {
-          "description": "Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.",
-          "type": "object"
-        },
-        "queryParameters": {},
-        "responses": {
-          "200": {
-            "$ref": "#/definitions/OTLPHTTPTraceResponse"
-          },
-          "403": {
-            "$ref": "#/definitions/OTLPHTTPErrorResponse"
-          },
-          "500": {
-            "$ref": "#/definitions/OTLPHTTPErrorResponse"
-          },
-          "default": {
-            "$ref": "#/definitions/ManagementAPIErrorResponse"
-          }
-        }
-      }
-    },
     "/tracer/project-version/": {
       "get": {
         "operationId": "tracer_project-version_list",
@@ -36855,70 +36803,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           },
           "500": {
             "$ref": "#/definitions/ApiTextErrorResponse"
-          },
-          "default": {
-            "$ref": "#/definitions/ManagementAPIErrorResponse"
-          }
-        }
-      }
-    },
-    "/tracer/v1/traces": {
-      "post": {
-        "operationId": "tracer_v1_traces_create",
-        "runtimeRequestValidation": true,
-        "runtimeResponseValidation": false,
-        "requestBody": {
-          "description": "OpenTelemetry ExportTraceServiceRequest. JSON payloads use the OTLP HTTP JSON mapping; protobuf payloads use application/x-protobuf.",
-          "type": "object"
-        },
-        "queryParameters": {},
-        "responses": {
-          "200": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "400": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "403": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "429": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "500": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "default": {
-            "$ref": "#/definitions/ManagementAPIErrorResponse"
-          }
-        }
-      }
-    },
-    "/tracer/v1/traces/": {
-      "post": {
-        "operationId": "tracer_v1_traces_create",
-        "runtimeRequestValidation": true,
-        "runtimeResponseValidation": false,
-        "requestBody": {
-          "description": "OpenTelemetry ExportTraceServiceRequest. JSON payloads use the OTLP HTTP JSON mapping; protobuf payloads use application/x-protobuf.",
-          "type": "object"
-        },
-        "queryParameters": {},
-        "responses": {
-          "200": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "400": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "403": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "429": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "500": {
-            "$ref": "#/definitions/OTLPTraceResponse"
           },
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
@@ -41405,38 +41289,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           },
           "500": {
             "$ref": "#/definitions/ApiTextErrorResponse"
-          },
-          "default": {
-            "$ref": "#/definitions/ManagementAPIErrorResponse"
-          }
-        }
-      }
-    },
-    "/v1/traces/": {
-      "post": {
-        "operationId": "v1_traces_create",
-        "runtimeRequestValidation": true,
-        "runtimeResponseValidation": false,
-        "requestBody": {
-          "description": "OpenTelemetry ExportTraceServiceRequest. JSON payloads use the OTLP HTTP JSON mapping; protobuf payloads use application/x-protobuf.",
-          "type": "object"
-        },
-        "queryParameters": {},
-        "responses": {
-          "200": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "400": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "403": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "429": {
-            "$ref": "#/definitions/OTLPTraceResponse"
-          },
-          "500": {
-            "$ref": "#/definitions/OTLPTraceResponse"
           },
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
@@ -60601,83 +60453,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
-    "OTLPHTTPErrorResponse": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "title": "Status",
-          "type": "boolean",
-          "default": false
-        },
-        "type": {
-          "title": "Type",
-          "type": "string",
-          "enum": [
-            "validation_error",
-            "authentication_error",
-            "payment_required",
-            "entitlement_error",
-            "permission_error",
-            "not_found",
-            "conflict",
-            "client_error",
-            "rate_limit",
-            "server_error",
-            "service_unavailable",
-            "timeout",
-            "api_error"
-          ],
-          "x-nullable": true
-        },
-        "code": {
-          "title": "Code",
-          "type": "string",
-          "x-nullable": true
-        },
-        "detail": {
-          "title": "Detail",
-          "type": "string",
-          "x-nullable": true
-        },
-        "result": {
-          "title": "Result",
-          "type": "string",
-          "minLength": 1,
-          "x-nullable": true
-        },
-        "message": {
-          "title": "Message",
-          "type": "string",
-          "minLength": 1,
-          "x-nullable": true
-        },
-        "error": {
-          "title": "Error",
-          "type": "string",
-          "x-nullable": true
-        },
-        "attr": {
-          "title": "Attr",
-          "type": "string",
-          "x-nullable": true
-        },
-        "details": {
-          "title": "Details",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        }
-      }
-    },
-    "OTLPHTTPTraceResponse": {
-      "type": "object",
-      "properties": {}
-    },
     "OTLPHealthResponse": {
       "required": [
         "status",
@@ -60696,14 +60471,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Service",
           "type": "string",
           "minLength": 1
-        }
-      }
-    },
-    "OTLPTraceResponse": {
-      "type": "object",
-      "properties": {
-        "partial_success": {
-          "$ref": "#/definitions/OTLPPartialSuccess"
         }
       }
     },
@@ -84449,19 +84216,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "format": "uuid",
           "readOnly": true
-        }
-      }
-    },
-    "OTLPPartialSuccess": {
-      "type": "object",
-      "properties": {
-        "rejected_spans": {
-          "title": "Rejected spans",
-          "type": "integer"
-        },
-        "error_message": {
-          "title": "Error message",
-          "type": "string"
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -3721,43 +3721,6 @@ export interface LangfuseIngestionResponseApi {
   errors: LangfuseIngestionErrorApi[];
 }
 
-export interface OTLPHTTPTraceResponseApi { [key: string]: unknown }
-
-export type OTLPHTTPErrorResponseApiType = typeof OTLPHTTPErrorResponseApiType[keyof typeof OTLPHTTPErrorResponseApiType];
-
-
-export const OTLPHTTPErrorResponseApiType = {
-  validation_error: 'validation_error',
-  authentication_error: 'authentication_error',
-  payment_required: 'payment_required',
-  entitlement_error: 'entitlement_error',
-  permission_error: 'permission_error',
-  not_found: 'not_found',
-  conflict: 'conflict',
-  client_error: 'client_error',
-  rate_limit: 'rate_limit',
-  server_error: 'server_error',
-  service_unavailable: 'service_unavailable',
-  timeout: 'timeout',
-  api_error: 'api_error',
-} as const;
-
-export type OTLPHTTPErrorResponseApiDetails = {[key: string]: string[]};
-
-export interface OTLPHTTPErrorResponseApi {
-  status?: boolean;
-  type?: OTLPHTTPErrorResponseApiType;
-  code?: string;
-  detail?: string;
-  /** @minLength 1 */
-  result?: string;
-  /** @minLength 1 */
-  message?: string;
-  error?: string;
-  attr?: string;
-  details?: OTLPHTTPErrorResponseApiDetails;
-}
-
 export type LangfuseTracesResponseApiDataItem = { [key: string]: unknown };
 
 export interface LangfuseTracesMetaApi {
@@ -21092,15 +21055,6 @@ export interface OTLPHealthResponseApi {
   service: string;
 }
 
-export interface OTLPPartialSuccessApi {
-  rejected_spans?: number;
-  error_message?: string;
-}
-
-export interface OTLPTraceResponseApi {
-  partial_success?: OTLPPartialSuccessApi;
-}
-
 export type WebhookRequestApiCall = { [key: string]: unknown };
 
 export interface WebhookRequestApi {
@@ -23374,16 +23328,6 @@ export type AgentccWebhooksList200 = {
   previous?: string;
   results: AgentccWebhookApi[];
 };
-
-/**
- * Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.
- */
-export type ApiPublicOtelV1TracesCreateBodyOne = { [key: string]: unknown };
-
-/**
- * Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.
- */
-export type ApiPublicOtelV1TracesCreateBodyTwo = { [key: string]: unknown };
 
 export type ApiTracesSpanAttributeDetailListParams = {
 project_id: string;
@@ -25741,16 +25685,6 @@ export type TracerObservationSpanRootSpans200 = {
   previous?: string;
   results: ObservationSpanApi[];
 };
-
-/**
- * Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.
- */
-export type TracerOtlpV1TracesCreateBodyOne = { [key: string]: unknown };
-
-/**
- * Legacy OTLP JSON/protobuf trace payload. Prefer /tracer/v1/traces for new integrations.
- */
-export type TracerOtlpV1TracesCreateBodyTwo = { [key: string]: unknown };
 
 export type TracerProjectVersionListParams = {
 /**

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -192,8 +192,6 @@ import type {
   ApiKeyRequestApi,
   ApiKeyResponseApi,
   ApiKeySuccessResponseApi,
-  ApiPublicOtelV1TracesCreateBodyOne,
-  ApiPublicOtelV1TracesCreateBodyTwo,
   ApiSelectionTooLargeErrorApi,
   ApiTextErrorResponseApi,
   ApiTracesSpanAttributeDetailListParams,
@@ -745,10 +743,7 @@ import type {
   NodeExecutionDetailResponseApi,
   NodeReadApi,
   NodeTemplateDetailApi,
-  OTLPHTTPErrorResponseApi,
-  OTLPHTTPTraceResponseApi,
   OTLPHealthResponseApi,
-  OTLPTraceResponseApi,
   ObservabilityProviderApi,
   ObservationAttributeListResponseApi,
   ObservationSpanApi,
@@ -1161,8 +1156,6 @@ import type {
   TracerObservationSpanRetrieveLoadingParams,
   TracerObservationSpanRootSpans200,
   TracerObservationSpanRootSpansParams,
-  TracerOtlpV1TracesCreateBodyOne,
-  TracerOtlpV1TracesCreateBodyTwo,
   TracerProjectFetchSystemMetrics200,
   TracerProjectFetchSystemMetricsParams,
   TracerProjectGetGraphData200,
@@ -17265,60 +17258,6 @@ export const apiPublicIngestionCreate = async (langfuseIngestionRequestApi: Lang
     headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(
       langfuseIngestionRequestApi,)
-  }
-);}
-
-
-
-export type apiPublicOtelV1TracesCreateResponse200 = {
-  data: OTLPHTTPTraceResponseApi
-  status: 200
-}
-
-export type apiPublicOtelV1TracesCreateResponse403 = {
-  data: OTLPHTTPErrorResponseApi
-  status: 403
-}
-
-export type apiPublicOtelV1TracesCreateResponse500 = {
-  data: OTLPHTTPErrorResponseApi
-  status: 500
-}
-
-export type apiPublicOtelV1TracesCreateResponseDefault = {
-  data: ManagementAPIErrorResponseApi
-  status: Exclude<HTTPStatusCodes, 200 | 403 | 500>
-}
-
-export type apiPublicOtelV1TracesCreateResponseSuccess = (apiPublicOtelV1TracesCreateResponse200) & {
-  headers: Headers;
-};
-export type apiPublicOtelV1TracesCreateResponseError = (apiPublicOtelV1TracesCreateResponse403 | apiPublicOtelV1TracesCreateResponse500 | apiPublicOtelV1TracesCreateResponseDefault) & {
-  headers: Headers;
-};
-
-export type apiPublicOtelV1TracesCreateResponse = (apiPublicOtelV1TracesCreateResponseSuccess | apiPublicOtelV1TracesCreateResponseError)
-
-export const getApiPublicOtelV1TracesCreateUrl = () => {
-
-
-
-
-  return `/api/public/otel/v1/traces`
-}
-
-/**
- * Asynchronously handles the POST request to create ObservationSpans from OTEL data.
- */
-export const apiPublicOtelV1TracesCreate = async (apiPublicOtelV1TracesCreateBody: ApiPublicOtelV1TracesCreateBodyOne | ApiPublicOtelV1TracesCreateBodyTwo, options?: RequestInit): Promise<apiPublicOtelV1TracesCreateResponse> => {
-
-  return apiMutator<apiPublicOtelV1TracesCreateResponse>(getApiPublicOtelV1TracesCreateUrl(),
-  {
-    ...options,
-    method: 'POST'
-    ,
-    body: JSON.stringify(
-      apiPublicOtelV1TracesCreateBody,)
   }
 );}
 
@@ -63087,60 +63026,6 @@ export const tracerObservationSpanDelete = async (id: string, options?: RequestI
 
 
 
-export type tracerOtlpV1TracesCreateResponse200 = {
-  data: OTLPHTTPTraceResponseApi
-  status: 200
-}
-
-export type tracerOtlpV1TracesCreateResponse403 = {
-  data: OTLPHTTPErrorResponseApi
-  status: 403
-}
-
-export type tracerOtlpV1TracesCreateResponse500 = {
-  data: OTLPHTTPErrorResponseApi
-  status: 500
-}
-
-export type tracerOtlpV1TracesCreateResponseDefault = {
-  data: ManagementAPIErrorResponseApi
-  status: Exclude<HTTPStatusCodes, 200 | 403 | 500>
-}
-
-export type tracerOtlpV1TracesCreateResponseSuccess = (tracerOtlpV1TracesCreateResponse200) & {
-  headers: Headers;
-};
-export type tracerOtlpV1TracesCreateResponseError = (tracerOtlpV1TracesCreateResponse403 | tracerOtlpV1TracesCreateResponse500 | tracerOtlpV1TracesCreateResponseDefault) & {
-  headers: Headers;
-};
-
-export type tracerOtlpV1TracesCreateResponse = (tracerOtlpV1TracesCreateResponseSuccess | tracerOtlpV1TracesCreateResponseError)
-
-export const getTracerOtlpV1TracesCreateUrl = () => {
-
-
-
-
-  return `/tracer/otlp/v1/traces`
-}
-
-/**
- * Asynchronously handles the POST request to create ObservationSpans from OTEL data.
- */
-export const tracerOtlpV1TracesCreate = async (tracerOtlpV1TracesCreateBody: TracerOtlpV1TracesCreateBodyOne | TracerOtlpV1TracesCreateBodyTwo, options?: RequestInit): Promise<tracerOtlpV1TracesCreateResponse> => {
-
-  return apiMutator<tracerOtlpV1TracesCreateResponse>(getTracerOtlpV1TracesCreateUrl(),
-  {
-    ...options,
-    method: 'POST'
-    ,
-    body: JSON.stringify(
-      tracerOtlpV1TracesCreateBody,)
-  }
-);}
-
-
-
 export type tracerProjectVersionListResponse200 = {
   data: TracerProjectVersionList200
   status: 200
@@ -68567,70 +68452,6 @@ export const tracerV1HealthList = async ( options?: RequestInit): Promise<tracer
   {
     ...options,
     method: 'GET'
-
-
-  }
-);}
-
-
-
-export type tracerV1TracesCreateResponse200 = {
-  data: OTLPTraceResponseApi
-  status: 200
-}
-
-export type tracerV1TracesCreateResponse400 = {
-  data: OTLPTraceResponseApi
-  status: 400
-}
-
-export type tracerV1TracesCreateResponse403 = {
-  data: OTLPTraceResponseApi
-  status: 403
-}
-
-export type tracerV1TracesCreateResponse429 = {
-  data: OTLPTraceResponseApi
-  status: 429
-}
-
-export type tracerV1TracesCreateResponse500 = {
-  data: OTLPTraceResponseApi
-  status: 500
-}
-
-export type tracerV1TracesCreateResponseDefault = {
-  data: ManagementAPIErrorResponseApi
-  status: Exclude<HTTPStatusCodes, 200 | 400 | 403 | 429 | 500>
-}
-
-export type tracerV1TracesCreateResponseSuccess = (tracerV1TracesCreateResponse200) & {
-  headers: Headers;
-};
-export type tracerV1TracesCreateResponseError = (tracerV1TracesCreateResponse400 | tracerV1TracesCreateResponse403 | tracerV1TracesCreateResponse429 | tracerV1TracesCreateResponse500 | tracerV1TracesCreateResponseDefault) & {
-  headers: Headers;
-};
-
-export type tracerV1TracesCreateResponse = (tracerV1TracesCreateResponseSuccess | tracerV1TracesCreateResponseError)
-
-export const getTracerV1TracesCreateUrl = () => {
-
-
-
-
-  return `/tracer/v1/traces/`
-}
-
-/**
- * The request body contains an ExportTraceServiceRequest with resource spans.
- * @summary Handle OTLP trace export request.
- */
-export const tracerV1TracesCreate = async ( options?: RequestInit): Promise<tracerV1TracesCreateResponse> => {
-
-  return apiMutator<tracerV1TracesCreateResponse>(getTracerV1TracesCreateUrl(),
-  {
-    ...options,
-    method: 'POST'
 
 
   }
@@ -76381,70 +76202,6 @@ export const v1HealthList = async ( options?: RequestInit): Promise<v1HealthList
   {
     ...options,
     method: 'GET'
-
-
-  }
-);}
-
-
-
-export type v1TracesCreateResponse200 = {
-  data: OTLPTraceResponseApi
-  status: 200
-}
-
-export type v1TracesCreateResponse400 = {
-  data: OTLPTraceResponseApi
-  status: 400
-}
-
-export type v1TracesCreateResponse403 = {
-  data: OTLPTraceResponseApi
-  status: 403
-}
-
-export type v1TracesCreateResponse429 = {
-  data: OTLPTraceResponseApi
-  status: 429
-}
-
-export type v1TracesCreateResponse500 = {
-  data: OTLPTraceResponseApi
-  status: 500
-}
-
-export type v1TracesCreateResponseDefault = {
-  data: ManagementAPIErrorResponseApi
-  status: Exclude<HTTPStatusCodes, 200 | 400 | 403 | 429 | 500>
-}
-
-export type v1TracesCreateResponseSuccess = (v1TracesCreateResponse200) & {
-  headers: Headers;
-};
-export type v1TracesCreateResponseError = (v1TracesCreateResponse400 | v1TracesCreateResponse403 | v1TracesCreateResponse429 | v1TracesCreateResponse500 | v1TracesCreateResponseDefault) & {
-  headers: Headers;
-};
-
-export type v1TracesCreateResponse = (v1TracesCreateResponseSuccess | v1TracesCreateResponseError)
-
-export const getV1TracesCreateUrl = () => {
-
-
-
-
-  return `/v1/traces/`
-}
-
-/**
- * The request body contains an ExportTraceServiceRequest with resource spans.
- * @summary Handle OTLP trace export request.
- */
-export const v1TracesCreate = async ( options?: RequestInit): Promise<v1TracesCreateResponse> => {
-
-  return apiMutator<v1TracesCreateResponse>(getV1TracesCreateUrl(),
-  {
-    ...options,
-    method: 'POST'
 
 
   }

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -9418,18 +9418,6 @@ export const ApiPublicIngestionCreateBody = zod.object({
 
 
 /**
- * Asynchronously handles the POST request to create ObservationSpans from OTEL data.
- */
-export const ApiPublicOtelV1TracesCreateBody = zod.object({
-
-}).passthrough().describe('Legacy OTLP JSON\/protobuf trace payload. Prefer \/tracer\/v1\/traces for new integrations.')
-
-export const ApiPublicOtelV1TracesCreateResponse = zod.object({
-
-}).passthrough()
-
-
-/**
  * Vapi validates Langfuse credentials by calling this endpoint with
 ``?limit=1``.      Returns an empty list with standard pagination
 metadata so the credential check passes.
@@ -38700,18 +38688,6 @@ export const TracerObservationSpanDeleteParams = zod.object({
 })
 
 
-/**
- * Asynchronously handles the POST request to create ObservationSpans from OTEL data.
- */
-export const TracerOtlpV1TracesCreateBody = zod.object({
-
-}).passthrough().describe('Legacy OTLP JSON\/protobuf trace payload. Prefer \/tracer\/v1\/traces for new integrations.')
-
-export const TracerOtlpV1TracesCreateResponse = zod.object({
-
-}).passthrough()
-
-
 export const TracerProjectVersionListQueryParams = zod.object({
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
   "limit": zod.number().optional().describe('Number of results to return per page.')
@@ -43198,18 +43174,6 @@ export const TracerV1HealthListResponse = zod.object({
 })
 
 
-/**
- * The request body contains an ExportTraceServiceRequest with resource spans.
- * @summary Handle OTLP trace export request.
- */
-export const TracerV1TracesCreateResponse = zod.object({
-  "partial_success": zod.object({
-  "rejected_spans": zod.number().optional(),
-  "error_message": zod.string().optional()
-}).optional()
-})
-
-
 export const TracerWebhookCreateBody = zod.object({
   "call": zod.object({
 
@@ -45915,16 +45879,4 @@ export const UsageWorkspaceUsageSummaryListResponse = zod.object({
 export const V1HealthListResponse = zod.object({
   "status": zod.enum(['healthy']),
   "service": zod.string().min(1)
-})
-
-
-/**
- * The request body contains an ExportTraceServiceRequest with resource spans.
- * @summary Handle OTLP trace export request.
- */
-export const V1TracesCreateResponse = zod.object({
-  "partial_success": zod.object({
-  "rejected_spans": zod.number().optional(),
-  "error_message": zod.string().optional()
-}).optional()
 })

--- a/futureagi/tracer/tests/test_api_contract_debt.py
+++ b/futureagi/tracer/tests/test_api_contract_debt.py
@@ -319,15 +319,8 @@ def test_tracer_observe_helper_routes_reject_anonymous_before_work(
     assert response.data["code"] == "not_authenticated"
 
 
-@pytest.mark.skip(reason="OTLP trace routes migrated to fi-collector — pending PII scrubbing port")
 @pytest.mark.django_db
 def test_tracer_system_public_routes_keep_expected_boundary_semantics(api_client):
-    otlp = api_client.post("/tracer/otlp/v1/traces", data={}, format="json")
-    assert otlp.status_code == status.HTTP_401_UNAUTHORIZED
-    assert otlp["Content-Type"].startswith("application/json")
-    assert otlp.data["type"] == "authentication_error"
-    assert otlp.data["code"] == "not_authenticated"
-
     health = api_client.get("/tracer/v1/health")
     assert health.status_code == status.HTTP_200_OK
     assert health["Content-Type"].startswith("application/json")

--- a/futureagi/tracer/tests/test_tracer_feed_api_contract.py
+++ b/futureagi/tracer/tests/test_tracer_feed_api_contract.py
@@ -3,8 +3,6 @@ import uuid
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import pytest
-
 from rest_framework.test import APIRequestFactory
 
 from tracer.views.error_analysis import TraceErrorTaskUpdateRequestSerializer
@@ -94,7 +92,6 @@ def test_feed_mutations_have_runtime_request_contracts():
         assert _body_ref(_operation(path, method)) == definition_name
 
 
-@pytest.mark.skip(reason="OTLP trace routes migrated to fi-collector — pending PII scrubbing port")
 def test_feed_contract_debt_stays_burned_down():
     report = _debt_report()
     covered_paths = {
@@ -111,12 +108,9 @@ def test_feed_contract_debt_stays_burned_down():
         "/tracer/feed/issues/{cluster_id}/create-linear-issue/",
         "/tracer/imagine-analysis/",
         "/tracer/trace-error-task/{project_id}/",
-        "/tracer/otlp/v1/traces",
         "/tracer/shared/{token}/",
         "/tracer/trace-error-analysis/{trace_id}/",
         "/tracer/v1/health",
-        "/tracer/v1/traces",
-        "/tracer/v1/traces/",
         "/tracer/webhook/",
     }
 
@@ -154,23 +148,16 @@ def test_imagine_and_trace_error_task_have_runtime_contracts():
         assert _body_ref(_operation(path, method)) == definition_name
 
 
-@pytest.mark.skip(reason="OTLP trace routes migrated to fi-collector — pending PII scrubbing port")
 def test_protocol_and_public_tracer_endpoints_have_explicit_contracts():
     expected_responses = {
-        ("POST", "/tracer/otlp/v1/traces"): "OTLPHTTPTraceResponse",
         ("GET", "/tracer/shared/{token}/"): "SharedLinkResolveResponse",
         ("GET", "/tracer/trace-error-analysis/{trace_id}/"): (
             "TraceErrorAnalysisResponse"
         ),
         ("GET", "/tracer/v1/health"): "OTLPHealthResponse",
-        ("POST", "/tracer/v1/traces"): "OTLPTraceResponse",
-        ("POST", "/tracer/v1/traces/"): "OTLPTraceResponse",
         ("POST", "/tracer/webhook/"): "WebhookResponse",
     }
     expected_bodies = {
-        ("POST", "/tracer/otlp/v1/traces"): "object",
-        ("POST", "/tracer/v1/traces"): "object",
-        ("POST", "/tracer/v1/traces/"): "object",
         ("POST", "/tracer/webhook/"): "WebhookRequest",
     }
 


### PR DESCRIPTION
## Summary

PR #940 commented out the OTLP trace ingestion routes (migrated to fi-collector) but did not regenerate the committed OpenAPI spec, leaving `swagger.json` and the frontend contracts advertising endpoints Django no longer serves. That drift fails the `backend-contracts` / `frontend-contracts` CI gates (`generate-openapi-schema.sh` + `git diff --exit-code`).

This PR regenerates `swagger.json` and the orval-generated frontend artifacts from the live routes, reconciles the contract tests that referenced the removed OTLP endpoints, and lowers the `/tracer` coverage baseline from 155 to 154 to match the reduced surface. No runtime behavior change — only generated artifacts, tests, and one baseline constant.

## Linked issues

Follow-up to #940. <!-- add `Fixed TH-XXXX` here if a ticket applies -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `./scripts/generate-openapi-schema.sh` → regenerated spec; only the 5 dead `/v1/traces` paths removed (388 deletions, 0 additions).
- `cd frontend && yarn contracts:generate && yarn contracts:check` → passes with zero drift. This is the same chain CI runs, including the final `git diff --exit-code` guard.
- `pytest`:
  - `tracer/tests/test_tracer_feed_api_contract.py` → 8 passed (incl. the 2 unskipped spec tests)
  - `tracer/tests/test_api_contract_debt.py` → 70 passed (incl. the boundary test, run against a live test DB)
  - `tracer/tests/test_otlp.py` → 2 passed (health) + 14 skipped (live OTLP-route behavior tests; endpoints removed)

## Screenshots / recordings (if UI)

N/A — no UI changes.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally <!-- ran the contract subset + targeted pytest, not the full suite -->
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
