### PR TITLE
fix(rbac): disable write CTAs for viewer role across tasks and evals

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -18,6 +18,8 @@ import { DataTable, DataTablePagination } from "src/components/data-table";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import DeleteConfirmation from "./DeleteConfirmation";
 
 const POLL_INTERVAL_MS = 5000;
@@ -310,6 +312,7 @@ const TaskListView = ({
   _onEditTask,
   refreshKey,
 }) => {
+  const { role } = useAuthContext();
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
@@ -658,6 +661,11 @@ const TaskListView = ({
               color="primary"
               startIcon={<Iconify icon="mingcute:add-line" width={18} />}
               onClick={onCreateTask}
+              disabled={
+                !RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][
+                  role
+                ]
+              }
               sx={{ px: 2.5, typography: "body2", textTransform: "none" }}
             >
               Create Task

--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -641,6 +641,11 @@ const TaskListView = ({
                   <Iconify icon="solar:trash-bin-trash-linear" width={16} />
                 }
                 onClick={() => setDeleteTarget(selectedItems)}
+                disabled={
+                  !RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][
+                    role
+                  ]
+                }
                 sx={{ textTransform: "none", fontSize: "12px", height: 32 }}
               >
                 Delete

--- a/frontend/src/sections/evals/components/BulkActionsBar.jsx
+++ b/frontend/src/sections/evals/components/BulkActionsBar.jsx
@@ -2,7 +2,12 @@ import { Box, Button, Divider, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 
-const BulkActionsBar = ({ selectedCount, onDelete, onCancel }) => (
+const BulkActionsBar = ({
+  selectedCount,
+  onDelete,
+  onCancel,
+  canEditEvals = true,
+}) => (
   <Box
     sx={{
       display: "flex",
@@ -31,6 +36,7 @@ const BulkActionsBar = ({ selectedCount, onDelete, onCancel }) => (
       color="error"
       startIcon={<Iconify icon="solar:trash-bin-trash-bold" width={16} />}
       onClick={onDelete}
+      disabled={!canEditEvals}
       sx={{ fontSize: "13px", textTransform: "none" }}
     >
       Delete
@@ -52,6 +58,7 @@ BulkActionsBar.propTypes = {
   selectedCount: PropTypes.number.isRequired,
   onDelete: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  canEditEvals: PropTypes.bool,
 };
 
 export default BulkActionsBar;

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -37,6 +37,8 @@ import CodeEvalEditor, { PYTHON_CODE_TEMPLATE } from "./CodeEvalEditor";
 import CompositeDetailPanel from "./CompositeDetailPanel";
 import UnsavedChangesDialog from "src/sections/projects/MonitorsView/UnsavedChangesDialog";
 import { extractVariables } from "src/utils/utils";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
 
 const EVAL_TYPE_TABS = [
@@ -136,6 +138,9 @@ const resolveContextOptions = (dataInjection) => {
 const EvalCreatePage = () => {
   const { draftId: urlDraftId } = useParams();
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canEditEvals =
+    RolePermission.EVALS[PERMISSIONS.EDIT_CREATE_DELETE_EVALS][role];
   const { enqueueSnackbar } = useSnackbar();
   const { isOSS } = useDeploymentMode();
   const createEval = useCreateEval();
@@ -625,7 +630,8 @@ const EvalCreatePage = () => {
   // Single evals require a successful test run before save. Composites
   // don't have a test flow in the create page — their children already exist
   // and can be tested individually.
-  const canSave = mode === "single" ? canSaveSingle : canSaveComposite;
+  const canSave =
+    canEditEvals && (mode === "single" ? canSaveSingle : canSaveComposite);
 
   return (
     <Box
@@ -1326,10 +1332,14 @@ const EvalCreatePage = () => {
                       : evalType === "code"
                         ? hasCode
                         : instructionsReady;
-                  const testDisabled = isTesting || !hasTestInput;
+                  const testDisabled =
+                    isTesting || !hasTestInput || !canEditEvals;
 
                   let testDisabledReason = "";
-                  if (isTesting) {
+                  if (!canEditEvals) {
+                    testDisabledReason =
+                      "You don't have permission to create or edit evaluations.";
+                  } else if (isTesting) {
                     testDisabledReason = "Test is already running.";
                   } else if (mode === "composite" && !hasCompositeChildren) {
                     testDisabledReason =
@@ -1393,7 +1403,10 @@ const EvalCreatePage = () => {
                 {(() => {
                   const saveDisabled = isLoading || !canSave;
                   let saveDisabledReason = "";
-                  if (isLoading) {
+                  if (!canEditEvals) {
+                    saveDisabledReason =
+                      "You don't have permission to create or edit evaluations.";
+                  } else if (isLoading) {
                     saveDisabledReason = "Save is already in progress.";
                   } else if (mode === "composite") {
                     if (!compositeName.trim()) {

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -59,6 +59,8 @@ import BulkDeleteDialog from "./BulkDeleteDialog";
 import { EVAL_TAGS } from "../constant";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 
 const extract_selected_tools = (tools) => {
   if (Array.isArray(tools)) return tools;
@@ -115,6 +117,9 @@ const getEvalPromptText = (evalData, config = {}) =>
 const EvalDetailPage = () => {
   const { evalId } = useParams();
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canEditEvals =
+    RolePermission.EVALS[PERMISSIONS.EDIT_CREATE_DELETE_EVALS][role];
   const [searchParams, setSearchParams] = useSearchParams();
   const { enqueueSnackbar } = useSnackbar();
   const { isOSS } = useDeploymentMode();
@@ -1251,13 +1256,14 @@ const EvalDetailPage = () => {
             open={Boolean(menuAnchor)}
             onClose={() => setMenuAnchor(null)}
           >
-            <MenuItem onClick={handleDuplicate}>
+            <MenuItem onClick={handleDuplicate} disabled={!canEditEvals}>
               <Iconify icon="solar:copy-bold" width={16} sx={{ mr: 1 }} />{" "}
               Duplicate
             </MenuItem>
             {!isSystemEval && (
               <MenuItem
                 onClick={handleDeleteClick}
+                disabled={!canEditEvals}
                 sx={{ color: "error.main" }}
               >
                 <Iconify
@@ -1973,7 +1979,12 @@ const EvalDetailPage = () => {
                         variant={isComposite ? "contained" : "outlined"}
                         size="small"
                         onClick={handleTestEvaluation}
-                        disabled={isTesting || !isPlaygroundReady || needsTemplateVariable}
+                        disabled={
+                          isTesting ||
+                          !isPlaygroundReady ||
+                          needsTemplateVariable ||
+                          !canEditEvals
+                        }
                         startIcon={
                           isTesting ? (
                             <CircularProgress size={14} />
@@ -2008,7 +2019,12 @@ const EvalDetailPage = () => {
                           variant="contained"
                           size="small"
                           onClick={handleSaveVersion}
-                          disabled={isSaving || !isDirty || needsTemplateVariable}
+                          disabled={
+                            isSaving ||
+                            !isDirty ||
+                            needsTemplateVariable ||
+                            !canEditEvals
+                          }
                           startIcon={
                             isSaving ? (
                               <CircularProgress size={14} />
@@ -2040,7 +2056,8 @@ const EvalDetailPage = () => {
                           disabled={
                             isSaving ||
                             !isDirty ||
-                            compositeChildren.length === 0
+                            compositeChildren.length === 0 ||
+                            !canEditEvals
                           }
                           startIcon={
                             isSaving ? (

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -16,6 +16,8 @@ import {
 } from "src/hooks/use-local-storage";
 import { useNavigate } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 
 import {
   useBulkDeleteEvals,
@@ -310,6 +312,9 @@ const SORT_FIELD_MAP = {
 
 const EvalsListView = () => {
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canEditEvals =
+    RolePermission.EVALS[PERMISSIONS.EDIT_CREATE_DELETE_EVALS][role];
 
   // State
   const [searchQuery, setSearchQuery] = useState("");
@@ -862,6 +867,7 @@ const EvalsListView = () => {
               color="primary"
               startIcon={<Iconify icon="mingcute:add-line" width={18} />}
               onClick={() => navigate("/dashboard/evaluations/create")}
+              disabled={!canEditEvals}
               sx={{ px: 2.5, typography: "body2", textTransform: "none" }}
             >
               Create evals

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -860,6 +860,7 @@ const EvalsListView = () => {
               selectedCount={selectedItems.length}
               onDelete={() => setDeleteDialogOpen(true)}
               onCancel={handleCancelSelection}
+              canEditEvals={canEditEvals}
             />
           ) : (
             <Button

--- a/frontend/src/sections/tasks/TaskCreatePage.jsx
+++ b/frontend/src/sections/tasks/TaskCreatePage.jsx
@@ -10,6 +10,8 @@ import { useSearchParams } from "react-router-dom";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
 import { formatDate } from "src/utils/report-utils";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import Iconify from "src/components/iconify";
 import TaskHeader from "./components/TaskHeader";
@@ -20,6 +22,9 @@ import { useTaskDraft } from "./hooks/useTaskDraft";
 
 const TaskCreatePage = () => {
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canCreateTask =
+    RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][role];
   const [searchParams] = useSearchParams();
   const preselectedProject = searchParams.get("project") || "";
   const preselectedFilters = (() => {
@@ -207,7 +212,7 @@ const TaskCreatePage = () => {
           variant="outlined"
           size="small"
           loading={testState.isTesting}
-          disabled={!testState.canTest}
+          disabled={!testState.canTest || !canCreateTask}
           onClick={() => previewRef.current?.runTest()}
           startIcon={<Iconify icon="solar:play-circle-linear" width={14} />}
           sx={{ textTransform: "none", fontWeight: 500, minWidth: 120 }}
@@ -219,6 +224,7 @@ const TaskCreatePage = () => {
           size="small"
           onClick={handleSubmit(onSubmit)}
           loading={isPending}
+          disabled={!canCreateTask}
           sx={{ textTransform: "none", fontWeight: 500, minWidth: 140 }}
         >
           Create Task

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -19,6 +19,8 @@ import Iconify from "src/components/iconify";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskLogsView from "src/sections/common/EvalsTasks/TaskLogsView";
 import { useGetTaskData } from "src/sections/common/EvalsTasks/common";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import TaskHeader from "./components/TaskHeader";
 import TaskConfigPanel from "./components/TaskConfigPanel";
 import TaskLivePreview from "./components/TaskLivePreview";
@@ -66,6 +68,9 @@ const getLinkedTraceSource = (taskDetails) => {
 const TaskDetailPage = () => {
   const { taskId } = useParams();
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canEditTask =
+    RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][role];
   const queryClient = useQueryClient();
   const [tab, setTab] = useState("details");
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -462,7 +467,7 @@ const TaskDetailPage = () => {
             variant="outlined"
             size="small"
             loading={testState.isTesting}
-            disabled={!testState.canTest}
+            disabled={!testState.canTest || !canEditTask}
             onClick={() => previewRef.current?.runTest()}
             startIcon={<Iconify icon="solar:play-circle-linear" width={14} />}
             sx={{ textTransform: "none", fontWeight: 500, minWidth: 120 }}
@@ -474,6 +479,7 @@ const TaskDetailPage = () => {
             size="small"
             onClick={handleSave}
             loading={isUpdating}
+            disabled={!canEditTask}
             sx={{ textTransform: "none", fontWeight: 500, minWidth: 140 }}
           >
             Save

--- a/frontend/src/sections/tasks/components/TaskHeader.jsx
+++ b/frontend/src/sections/tasks/components/TaskHeader.jsx
@@ -13,6 +13,8 @@ import {
 import { useNavigate } from "react-router";
 import Iconify from "src/components/iconify";
 import _ from "lodash";
+import { useAuthContext } from "src/auth/hooks";
+import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 
 const STATUS_CONFIG = {
   pending: { color: "warning", icon: "solar:clock-circle-linear" },
@@ -70,6 +72,9 @@ const TaskHeader = ({
   backTo,
 }) => {
   const navigate = useNavigate();
+  const { role } = useAuthContext();
+  const canEditTask =
+    RolePermission.OBSERVABILITY[PERMISSIONS.ADD_TASKS_ALERTS][role];
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState(name || "");
 
@@ -167,6 +172,7 @@ const TaskHeader = ({
                   <IconButton
                     size="small"
                     onClick={() => setEditing(true)}
+                    disabled={!canEditTask}
                     sx={{ p: 0.25, color: "text.secondary" }}
                   >
                     <Iconify icon="solar:pen-2-linear" width={14} />


### PR DESCRIPTION
## Summary

Viewer-role users could see and click write actions across the **Tasks** and **Evaluations** screens — Create, Save, Test, Duplicate, Delete — even though the backend rejects those mutations for their role. The buttons rendered fully enabled, so a Viewer got a failed request (or a confusing no-op) instead of a clear "you can't do this" signal.

This PR gates those CTAs behind the existing role-permission map so they render disabled for roles that lack write access, matching the permission the API already enforces. Frontend-only; no API or schema change.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Log in as a **Viewer** (or Workspace Viewer).
2. Go to **Evaluations** (`/dashboard/evaluations`) — the **Create evals** button is enabled. Open any eval and the **Test**, **Save Version**, **Duplicate**, and **Delete** actions are all clickable.
3. Go to **Tasks** — **Create Task** (list + create page), the **Test** button, and **Save** on a task detail are all enabled.
4. Clicking any of them issues a request the backend refuses for the Viewer role. The UI gave no upfront indication the action wasn't allowed.

### Where it breaks

The permission contract lives in `src/utils/rolePermissionMapping.js`:

- Tasks/observability actions are governed by `OBSERVABILITY[ADD_TASKS_ALERTS]` (`false` for Viewer / Workspace Viewer).
- Eval create/edit/delete is governed by `EVALS[EDIT_CREATE_DELETE_EVALS]` (`false` for Viewer / Workspace Viewer).

The API honors these, but the corresponding buttons never read the map — they were gated only on form-validity / loading state. So the role check was enforced server-side but not reflected client-side.

## What changed

All changes read the current role via `useAuthContext()` and consult `RolePermission` from `src/utils/rolePermissionMapping.js`. Existing `disabled` conditions are extended with `|| !<permission>`; no behavior changes for roles that already have access.

### Tasks — `OBSERVABILITY[ADD_TASKS_ALERTS]`

- **`src/sections/common/EvalsTasks/TaskListView.jsx`** — "Create Task" button gated.
- **`src/sections/tasks/TaskCreatePage.jsx`** — "Create Task" and the "Test" (run preview) button gated.
- **`src/sections/tasks/TaskDetailPage.jsx`** — "Save" and the "Test" button gated.

### Evals — `EVALS[EDIT_CREATE_DELETE_EVALS]`

- **`src/sections/evals/components/EvalsListView.jsx`** — "Create evals" button gated.
- **`src/sections/evals/components/EvalCreatePage.jsx`** — `canSave` now requires the permission; "Test" gated, with a disabled-reason ("You don't have permission to create or edit evaluations.") surfaced on both Test and Save.
- **`src/sections/evals/components/EvalDetailPage.jsx`** — "Test", "Save Version", composite "Save Changes", "Duplicate", and "Delete" gated.

## Manual verification (UI)

1. Log in as a **Viewer**.
2. **Evaluations list** — "Create evals" is disabled.
3. Open an eval — **Test**, **Save Version**, **Duplicate**, **Delete** are disabled; Test/Save show the permission tooltip.
4. **Tasks list** — "Create Task" is disabled; task detail **Save** / **Test** are disabled.
5. Log back in as **Owner/Admin/Member** — every button above is enabled and behaves exactly as before.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] Uses the existing `RolePermission` map — no new permission keys introduced

## Backout / rollback

- Frontend-only, additive `disabled` conditions; no API, schema, or migration changes.
- Reverting this PR restores the prior behavior (buttons enabled for all roles) with no data impact.

## Linear

Fixes TH-5835
