### PR TITLE
fix(dashboard): prune spans partitions to stop breakdown-chart timeouts (TH-6050)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1481,6 +1481,13 @@ class DashboardQueryBuilder:
             f"{time_col} < %(end_date)s",
         ]
 
+        # spans is partitioned by toYYYYMM(created_at) but the window is
+        # filtered on start_time, so bound created_at too — otherwise no
+        # partitions prune and the scan covers all history. Lower bound only
+        # (created_at >= start_time always holds), so no in-window row drops.
+        if time_col != "created_at":
+            clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
+
         # Apply global + per-metric system_metric filters directly
         # For string-comparable system metrics, use toString() to avoid UUID parse errors
         _STRING_FILTER_COL = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -990,6 +990,48 @@ class TestDashboardQueryBuilder:
         assert "toStartOfDay" in sql
         assert params["project_ids"] == sample_query_config["project_ids"]
 
+    def test_system_metric_query_prunes_partitions(self, sample_query_config):
+        """Spans-based queries must bound created_at (the partition key) so a
+        windowed query prunes old partitions instead of scanning all history."""
+        builder = DashboardQueryBuilder(sample_query_config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        assert "start_time < %(end_date)s" in sql
+
+    def test_breakdown_query_prunes_partitions(self):
+        """A latency average broken down by a custom span attribute must emit
+        the created_at partition-prune bound while preserving the start_time
+        window."""
+        config = {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [],
+            "breakdowns": [
+                {
+                    "name": "final_status",
+                    "type": "custom_attribute",
+                    "source": "traces",
+                    "display_name": "final_status",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        assert "breakdown_value" in sql
+
     def test_all_system_metrics(self):
         for metric_name in SYSTEM_METRICS:
             config = {


### PR DESCRIPTION
## Summary

On **high-volume projects**, dashboard charts that use a **breakdown** (latency averaged and grouped by a custom span attribute, or by country) render **"Failed to load chart data."** Root cause is a **partition-pruning gap**: the chart-data query filters the time window on `start_time` (event time), but the `spans` table is `PARTITION BY toYYYYMM(created_at)` — so ClickHouse can't prune partitions and a 30-day query scans the project's **entire history**, exceeds `max_execution_time`, is killed, and the broad `except Exception` returns HTTP 400. The fix adds a `created_at` partition-prune bound (mirroring `agent_graph.py`) so the scan drops to the window's partitions. **Lower-bound-only, so results are unchanged.** Adds 2 regression tests.

> Dev companion of **#994** — the same fix, already merged to `main` as a hotfix. Raising here to keep `dev` in sync.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. On a project with enough span history that a 30-day breakdown query exceeds the ClickHouse `max_execution_time` (a busy, long-lived project).
2. Open a dashboard widget that averages **latency** and **breaks it down by a custom span attribute** (or by country), over a **30-day** window.
3. The widget renders **"Failed to load chart data."** The underlying `POST /tracer/dashboard/query/` returns **HTTP 400** (`"Query execution failed. Please check your query configuration."`).
4. The same widget over a short window (e.g. Today) loads fine — confirming it is **data-volume driven**, not a config error.

### Where it breaks — BE

`DashboardViewSet.query` (`tracer/views/dashboard.py`) → `DashboardQueryBuilder._build_where_clauses` (`tracer/services/clickhouse/query_builders/dashboard.py`).

`spans` is `PARTITION BY toYYYYMM(created_at)`, `ORDER BY (project_id, toDate(created_at), trace_id, id)`. The builder bounds the window on `start_time` only:

```
{time_col} >= %(start_date)s AND {time_col} < %(end_date)s     # time_col = "start_time"
```

`start_time` is neither the partition key nor in the primary key, so ClickHouse can prune **nothing** — a windowed query reads the project's full history. On a high-volume project that exceeds `max_execution_time`; the query is killed, the broad `except Exception` in `query()` swallows it into HTTP 400, and the FE shows the generic error.

#976 capped the sibling custom-attribute *dropdown* query; this **chart-data** query was never touched. A timeout bump is not viable — it self-regresses as data grows; the query has to prune.

## What changed

### `tracer/services/clickhouse/query_builders/dashboard.py` — `_build_where_clauses`

Adds a lower bound on the partition key for spans-based queries (`time_col != "created_at"`):

```python
if time_col != "created_at":
    clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
```

ClickHouse then prunes every partition older than the window. **Lower-bound only** — a qualifying in-window row always has `created_at >= start_time >= start_date`, so no row is ever excluded (holds even under ingestion lag / backfill, the harmless direction). The precise `start_time` window filter is unchanged. Covers both spans paths through this helper (system-metric breakdown + custom-attribute query). Mirrors the existing pattern in `agent_graph.py` (same `spans` table).

### `tracer/tests/test_dashboard.py` — `TestDashboardQueryBuilder`

Two regression tests on the real builder call-path, asserting the prune bound is emitted while the precise `start_time` window is preserved.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `test_system_metric_query_prunes_partitions` | `sample_query_config` (latency avg, 7D, no breakdown) | `build_all_queries()` | Built SQL contains `created_at >= %(start_date)s - INTERVAL 1 DAY` **and** retains `start_time >= %(start_date)s` / `start_time < %(end_date)s` — pruning added, window preserved (correctness). |
| 2 | `test_breakdown_query_prunes_partitions` | latency avg, **breakdown by a custom attribute** (`final_status`), 30D | `build_all_queries()` | The breakdown call-path (the exact failing-widget shape) emits the prune bound **and** still applies the breakdown (`breakdown_value` present). |

## Commands to run tests

```bash
pytest tracer/tests/test_dashboard.py -k prunes_partitions -q
```

### Local verification results

Both tests pass against the real `DashboardQueryBuilder.build_all_queries()` (no DB required). Partition pruning additionally proven on a throwaway local ClickHouse (real `spans` schema; 20 rows seeded across two partition-months; "last 30 days" window):

| query | parts read | rows scanned | result rows |
| --- | --- | --- | --- |
| before — `start_time` filter only | **2 / 2** | 20 | 3 |
| after — this fix | **1 / 2** | 10 | 3 (identical) |

`EXPLAIN ESTIMATE` before/after; result rows byte-identical → correctness preserved while the scan collapses to the window's partitions.

![partition pruning proven on local ClickHouse — EXPLAIN 2 parts to 1, identical results](https://raw.githubusercontent.com/abhijaisrivastava15/th6050-pr-proof/main/th6050-local-proof.png)

## Video

Customer-facing before/after (live failing dashboard → fix) is on the linked Linear ticket — intentionally kept off this public repo (customer surface).

## Screenshot of test suit run

![dashboard partition-prune tests passing](https://raw.githubusercontent.com/abhijaisrivastava15/th6050-pr-proof/main/th6050-tests-pass.png)

_The two regression tests run on the real `DashboardQueryBuilder` call-path (no DB). Customer-facing before/after video stays on the Linear ticket._

## Backwards compatibility

No schema / migration / rollup / API / serializer / contract change. Output schema unchanged. The added clause cannot change result sets for live-ingested data (`created_at >= start_time`), so every existing caller of `_build_where_clauses` (system-metric, custom-attribute, breakdown paths) returns the same rows — just faster.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Performance improvement

## Checklist

- [x] No hardcoded secrets / PII / customer data in source or PR
- [x] Tests added on the real call-path
- [x] Mirrors an existing, reviewed pattern (`agent_graph.py`)
- [ ] Full local suite green (to confirm at ready-for-review)

## Backout / rollback

Revert this commit. Single-file query-builder change, no data migration.

## Linear

TH-6050 · Companion to **#994** (merged to `main` as a hotfix) · Base: `dev`.
