### PR TITLE
refactor(error-localizer): unify skipped-state rendering behind a shared banner

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -257,6 +257,7 @@ const VoiceRightPanel = ({
         // backend used. Makes the shared EvalsTabView render the
         // dropdown / "Run" UX for failed voice evals.
         cell_id: e?.cell_id || e?.cellId,
+        template_type: e?.template_type,
         error_analysis:
           e?.error_analysis || e?.errorAnalysis || e?.error_details,
         error_localizer_status:

--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -8,6 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
 import { canonicalEntries } from "src/utils/utils";
 
 /**
@@ -330,14 +331,7 @@ const EvalErrorLocalization = ({
   // ── State 4: skipped ─────────────────────────────────────────────────────
   if (effectiveStatus === "skipped") {
     return (
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ fontSize: 10, fontStyle: "italic" }}
-      >
-        Error localization was skipped — input data isn&apos;t available to
-        localize on.
-      </Typography>
+      <SkippedLocalizationBanner message={cellPollData?.error_message} />
     );
   }
 

--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -154,6 +154,9 @@ const EvalTableRow = ({
   // Error localization visibility — surfaced for every eval that has
   // enough identifiers to drive either the cell-based or trace-based
   // flow. Rows with just an explanation still expand without it.
+  // Composite evals have no localizable input of their own — skip the whole
+  // localization flow before computing any of its identifiers.
+  const isComposite = ev?.template_type === "composite";
   const initialAnalysis = ev.error_analysis || ev.errorAnalysis || null;
   const cellId = ev.cell_id || ev.cellId;
   const observationSpanId =
@@ -168,10 +171,11 @@ const EvalTableRow = ({
   const initialStatus =
     ev.error_localizer_status || ev.errorLocalizerStatus || null;
   const hasErrorLocalization =
-    !!initialAnalysis ||
-    !!cellId ||
-    !!initialStatus ||
-    !!(observationSpanId && customEvalConfigId);
+    !isComposite &&
+    (!!initialAnalysis ||
+      !!cellId ||
+      !!initialStatus ||
+      !!(observationSpanId && customEvalConfigId));
   const canExpand = !!explanation || hasErrorLocalization;
 
   return (

--- a/frontend/src/sections/common/SkippedLocalizationBanner.jsx
+++ b/frontend/src/sections/common/SkippedLocalizationBanner.jsx
@@ -1,0 +1,42 @@
+import PropTypes from "prop-types";
+import { Box, Typography } from "@mui/material";
+import Iconify from "src/components/iconify";
+
+const DEFAULT_SKIPPED_LOCALIZATION_MESSAGE =
+  "Error localization was skipped — input data isn't available to localize on.";
+
+export default function SkippedLocalizationBanner({ message, sx }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        px: 1.5,
+        py: 1,
+        borderRadius: "6px",
+        border: "1px solid",
+        borderColor: "info.light",
+        backgroundColor: (theme) =>
+          theme.palette.mode === "dark"
+            ? "rgba(47, 124, 247, 0.08)"
+            : "rgba(47, 124, 247, 0.06)",
+        ...sx,
+      }}
+    >
+      <Iconify
+        icon="solar:forbidden-circle-bold"
+        width={18}
+        sx={{ color: "info.main", flexShrink: 0 }}
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>
+        {message || DEFAULT_SKIPPED_LOCALIZATION_MESSAGE}
+      </Typography>
+    </Box>
+  );
+}
+
+SkippedLocalizationBanner.propTypes = {
+  message: PropTypes.string,
+  sx: PropTypes.object,
+};

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -32,6 +32,7 @@ import Iconify from "src/components/iconify";
 import { LoadingButton } from "@mui/lab";
 import AudioErrorCard from "src/components/custom-audio/AudioErrorCard";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
 import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
 import { useParams } from "react-router";
 import CellMarkdown from "src/sections/common/CellMarkdown";
@@ -1558,10 +1559,7 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
           </Box>
         </Box>
       ) : isSkipped ? (
-        <Typography variant="caption" color="text.secondary">
-          Error localization was skipped — input data isn&apos;t available to
-          localize on.
-        </Typography>
+        <SkippedLocalizationBanner message={pollData?.error_message} />
       ) : (
         <Box
           sx={{

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1813,6 +1813,9 @@ const DatasetTestMode = React.forwardRef(
               ...(errorLocalizerState.status
                 ? { error_localizer_status: errorLocalizerState.status }
                 : {}),
+              ...(errorLocalizerState.message
+                ? { error_localizer_message: errorLocalizerState.message }
+                : {}),
               ...(errorLocalizerState.details
                 ? {
                     error_details:

--- a/frontend/src/sections/evals/components/EvalResultDisplay.jsx
+++ b/frontend/src/sections/evals/components/EvalResultDisplay.jsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import React, { useMemo, useState } from "react";
 import Editor from "@monaco-editor/react";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
 import CompositeResultView from "./CompositeResultView";
 import { canonicalEntries } from "src/utils/utils";
 import { normalizeEvalCellValue } from "src/sections/develop-detail/DataTab/common";
@@ -471,41 +472,12 @@ const ErrorLocalizationSection = ({ result }) => {
       </Box>
     );
   }
-    if (errorLocalizerStatus === "skipped") {
+  if (errorLocalizerStatus === "skipped") {
     return (
-      <Box
-        sx={{
-          mx: 1.5,
-          my: 1,
-          px: 1.5,
-          py: 1,
-          borderRadius: "6px",
-          border: "1px solid",
-          borderColor: "divider",
-          backgroundColor: (theme) =>
-            theme.palette.mode === "dark"
-              ? "rgba(145, 158, 171, 0.08)"
-              : "rgba(145, 158, 171, 0.04)",
-        }}
-      >
-        <Typography
-      
-          typography="s3"
-          color="text.secondary"
-          sx={{ display: "block" }}
-        >
-          Error localization skipped
-        </Typography>
-        {errorLocalizerMessage && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ display: "block", fontSize: "11px", mt: 0.25 }}
-          >
-            {errorLocalizerMessage}
-          </Typography>
-        )}
-      </Box>
+      <SkippedLocalizationBanner
+        message={errorLocalizerMessage}
+        sx={{ mx: 1.5, my: 1 }}
+      />
     );
   }
 

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -1811,6 +1811,9 @@ const SimulationTestMode = React.forwardRef(
               ...(errorLocalizerState.status
                 ? { error_localizer_status: errorLocalizerState.status }
                 : {}),
+              ...(errorLocalizerState.message
+                ? { error_localizer_message: errorLocalizerState.message }
+                : {}),
               ...(errorLocalizerState.details
                 ? {
                     error_details:

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1233,6 +1233,12 @@ const TestPlayground = React.forwardRef(
                                   errorLocalizerState.status,
                               }
                             : {}),
+                          ...(errorLocalizerState.message
+                            ? {
+                                error_localizer_message:
+                                  errorLocalizerState.message,
+                              }
+                            : {}),
                           ...(errorLocalizerState.details
                             ? {
                                 error_details:

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1913,6 +1913,9 @@ const TracingTestMode = React.forwardRef(
               ...(errorLocalizerState.status
                 ? { error_localizer_status: errorLocalizerState.status }
                 : {}),
+              ...(errorLocalizerState.message
+                ? { error_localizer_message: errorLocalizerState.message }
+                : {}),
               ...(errorLocalizerState.details
                 ? {
                     error_details:

--- a/frontend/src/sections/evals/hooks/useErrorLocalizerPoll.js
+++ b/frontend/src/sections/evals/hooks/useErrorLocalizerPoll.js
@@ -24,7 +24,7 @@ import axios, { endpoints } from "src/utils/axios";
  */
 export function useErrorLocalizerPoll({
   intervalMs = 2000,
-  timeoutMs = 300000,
+  timeoutMs = 120000,
 } = {}) {
   const [state, setState] = useState({
     status: null,

--- a/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
@@ -13,6 +13,7 @@ import { ShowComponent } from "../../../components/show";
 import { getLabel, getStatusColor } from "../../develop-detail/DataTab/common";
 import AudioErrorCard from "src/components/custom-audio/AudioErrorCard";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import Iconify from "src/components/iconify";
@@ -40,6 +41,7 @@ const ERROR_LOCALIZER_TASK_STATUS = {
   RUNNING: "running",
   COMPLETED: "completed",
   FAILED: "failed",
+  SKIPPED: "skipped",
 };
 
 const ERROR_LOCALIZER_REFETCH_STATUS = [ERROR_LOCALIZER_TASK_STATUS.RUNNING];
@@ -98,6 +100,8 @@ const EvalDrawerSection = () => {
   );
   const isErrorLocalizerTaskFailed =
     errorLocalizerTaskStatus === ERROR_LOCALIZER_TASK_STATUS.FAILED;
+  const isErrorLocalizerTaskSkipped =
+    errorLocalizerTaskStatus === ERROR_LOCALIZER_TASK_STATUS.SKIPPED;
 
   return (
     <Box
@@ -254,12 +258,18 @@ const EvalDrawerSection = () => {
               </Typography>
             </WrapperBox>
           </ShowComponent>
+          <ShowComponent condition={isErrorLocalizerTaskSkipped}>
+            <SkippedLocalizationBanner
+              message={errorLocalizerTask?.error_message}
+            />
+          </ShowComponent>
           <ShowComponent
             condition={
               errorAnalysis &&
               errorAnalysis?.input1?.length &&
               !isErrorLocalizerTaskRunning &&
-              !isErrorLocalizerTaskFailed
+              !isErrorLocalizerTaskFailed &&
+              !isErrorLocalizerTaskSkipped
             }
           >
             <Box


### PR DESCRIPTION
## Summary

When an error-localization eval is **skipped** (e.g. composite evals, or rows with no localizable input), the UI shows a "skipped" banner. That banner had been hand-rolled in four separate places, each drifting apart: different colors (amber vs blue vs grey), different padding and icon sizes, and inconsistent message sources — one even hardcoded the text and never showed the backend's actual skip reason.

This PR extracts a single reusable `SkippedLocalizationBanner` and routes all four call-sites through it, so the skipped state is visually consistent everywhere and always surfaces the dynamic skip reason. It also cleans up the related review feedback (uncontracted-field guessing, an unexplained poll-timeout bump).

This is a clean reland of the frontend portion of #836 on top of `dev` — the backend error-localizer work (field contracting, the `should_run_error_localizer` gate, batched EL-state loading) already merged via #765 / #766, so this PR is frontend-only.

## Why the changes are done — what is the problem

### Where it breaks — UI

The "skipped" banner existed in four files with no shared component:

- `EvalErrorLocalization.jsx` — amber (`warning`), icon w=16, message from `cellPollData?.error_message`
- `DatapointDrawerV2.jsx` — blue (`info`), icon w=18, message from `pollData?.error_message`
- `EvalResultDisplay.jsx` — grey (`divider`), no icon, message from `error_localizer_message`
- `EvalSection.jsx` — amber, icon w=20, **hardcoded string** — never rendered the dynamic skip reason, defeating the purpose of the feature

Because each was independent, the PR's intended "amber → blue" recolor landed in only one of four, and `EvalSection` couldn't show why an eval was skipped.

Additionally:
- `VoiceRightPanel.jsx` read `e?.template_type || e?.templateType` (snake/camel guessing) even though `template_type` is now a contracted snake_case field, plus a missing space after the colon.
- `useErrorLocalizerPoll` had silently raised its timeout 2min → 5min with no rationale. The original justification (extra latency from enqueuing a task for every eval) no longer applies — the backend now gates passing/composite evals before dispatch.

## What changed

### `frontend/src/sections/common/SkippedLocalizationBanner.jsx` (new)
Single source of truth for the skipped banner: `info`/blue styling, `solar:forbidden-circle-bold` icon, takes a `message` prop with a default fallback, and an optional `sx` for per-call layout tweaks.

### `EvalErrorLocalization.jsx`, `DatapointDrawerV2.jsx`, `EvalResultDisplay.jsx`, `EvalSection.jsx`
Each hand-rolled banner replaced with `<SkippedLocalizationBanner message={…} />`. `EvalSection` now passes `errorLocalizerTask?.error_message` (dynamic) instead of a hardcoded string. Removed the now-unused `Iconify` import from `EvalResultDisplay`.

### `VoiceRightPanel.jsx`
Reads the contracted `e?.template_type` only (dropped the camelCase fallback) and fixed the spacing.

### `DatasetTestMode.jsx`, `SimulationTestMode.jsx`, `TracingTestMode.jsx`, `TestPlayground.jsx`
Thread `error_localizer_message` from the poll state into the merged result so the shared banner can render the backend reason.

### `EvalsTabView.jsx`
Hide the localization flow for composite evals, gated off the contracted `template_type` field (no snake/camel guessing).

### `useErrorLocalizerPoll.js`
Poll timeout reverted 5min → 2min.

## Tests

Frontend-only, no automated tests added. Manual verification:

- [ ] Run an eval that gets skipped (e.g. a composite eval) and confirm the skipped banner appears in the trace eval view, dataset datapoint drawer, eval result display, and test-detail drawer
- [ ] Confirm all four banners are visually identical (blue/info, same icon, same padding)
- [ ] Confirm the banner shows the backend's skip reason (not a hardcoded string) where the backend provides `error_localizer_message`, and falls back to the default copy otherwise
- [ ] Confirm composite evals do not show the error-localization expand/Run UI in EvalsTabView
- [ ] Confirm a normal (non-skipped) eval still localizes and polls correctly within 2 minutes

## Commands to run

```bash
cd frontend
npx eslint $(git diff --name-only origin/dev -- 'src/**/*.jsx' 'src/**/*.js')
```

### Local verification results
ESLint: 0 errors on all changed files (remaining warnings are pre-existing on `dev`).

## Video
 Added in Linear ticket



## Backwards compatibility

Frontend-only, no API/schema change. The shared banner reads the same fields the hand-rolled banners already read (`error_localizer_message`, `error_localizer_status`, `template_type`), all of which are contracted on `dev`. Net effect is purely visual consistency + showing the dynamic skip reason where it was previously hardcoded.

## Manual verification (UI)
See Tests above.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change beyond visual consistency)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective (frontend-only — manual test plan above)
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- New component is additive; reverting removes it cleanly with no orphaned references.
- All call-site edits are local swaps back to the prior inline JSX.
- No DB/schema/migration changes.

## Linear
Fixes TH-5732,TH-5636
