### PR TITLE
fix: filter_values for trace/span name on CH25

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -101,6 +101,33 @@ export const getTraceFilterFields = (tab) => {
   return BASE_TRACE_FILTER_FIELDS;
 };
 
+// Map a static trace field to a picker property. In spans view the root
+// "Trace Name" field is reused as "Span Name" — remap its id so the picker
+// fires a distinct span_name request instead of duplicating the name request.
+export const toStaticFilterProperty = (field, isSpansView = false) => {
+  if (isSpansView && field.value === "name") {
+    return {
+      id: "span_name",
+      name: "Span Name",
+      category: "system",
+      type: "string",
+      apiColType: "SYSTEM_METRIC",
+    };
+  }
+  return {
+    id: field.value,
+    name: field.label,
+    category: "system",
+    // Pinned so the eval-task wire encoding doesn't have to guess
+    // from `category` alone — without this every static field would
+    // round-trip through the chain with apiColType=undefined and
+    // get coerced to SPAN_ATTRIBUTE downstream.
+    apiColType: "SYSTEM_METRIC",
+    type: field.type === "enum" ? "string" : field.type,
+    ...(field.choices ? { choices: field.choices } : {}),
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Category config for dashboard-style property picker
 // ---------------------------------------------------------------------------
@@ -1719,29 +1746,9 @@ const TraceFilterPanel = ({
     // Start with static trace fields (trace_name, status, model, etc.) —
     // prepend trace_id / span_id when rendered inside the LLM Tracing
     // trace or span tab. In spans view, relabel "Trace Name" to "Span Name".
-    const staticProps = getTraceFilterFields(tab).map((f) => {
-      if (isSpansView && f.value === "name") {
-        return {
-          id: "span_name",
-          name: "Span Name",
-          category: "system",
-          type: "string",
-          apiColType: "SYSTEM_METRIC",
-        };
-      }
-      return {
-        id: f.value,
-        name: f.label,
-        category: "system",
-        // Pinned so the eval-task wire encoding doesn't have to guess
-        // from `category` alone — without this every static field would
-        // round-trip through the chain with apiColType=undefined and
-        // get coerced to SPAN_ATTRIBUTE downstream.
-        apiColType: "SYSTEM_METRIC",
-        type: f.type === "enum" ? "string" : f.type,
-        ...(f.choices ? { choices: f.choices } : {}),
-      };
-    });
+    const staticProps = getTraceFilterFields(tab).map((f) =>
+      toStaticFilterProperty(f, isSpansView),
+    );
     const knownIds = new Set(staticProps.map((p) => p.id));
     // Add dynamic properties not already covered by static fields
     const dynamicExtras = dynamicProperties.filter((p) => !knownIds.has(p.id));

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1722,7 +1722,7 @@ const TraceFilterPanel = ({
     const staticProps = getTraceFilterFields(tab).map((f) => {
       if (isSpansView && f.value === "name") {
         return {
-          id: "name",
+          id: "span_name",
           name: "Span Name",
           category: "system",
           type: "string",

--- a/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
@@ -4,6 +4,7 @@ import {
   filterPropertiesForPicker,
   getTraceFilterFields,
   normalizeFilterRowOperator,
+  toStaticFilterProperty,
 } from "../TraceFilterPanel";
 import {
   getPickerOptionSearchText,
@@ -42,6 +43,30 @@ describe("getTraceFilterFields (TH-4571)", () => {
     // are not required; structural equality is what consumers rely on).
     expect(fromNull).toEqual(fromUndefined);
     expect(fromNull).toEqual(fromUnknown);
+  });
+});
+
+describe("toStaticFilterProperty (spans Span Name)", () => {
+  const nameField = { value: "name", label: "Trace Name", type: "string" };
+
+  it("remaps the name field to span_name in spans view", () => {
+    expect(toStaticFilterProperty(nameField, true)).toMatchObject({
+      id: "span_name",
+      name: "Span Name",
+      type: "string",
+    });
+  });
+
+  it("keeps the name field as name outside spans view", () => {
+    expect(toStaticFilterProperty(nameField, false)).toMatchObject({
+      id: "name",
+      name: "Trace Name",
+    });
+  });
+
+  it("does not remap non-name fields in spans view", () => {
+    const field = { value: "status", label: "Status", type: "string" };
+    expect(toStaticFilterProperty(field, true).id).toBe("status");
   });
 });
 

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -839,7 +839,11 @@ class TestMetricsEndpoint:
         auth_client,
         observe_project,
     ):
-        """`metric_name=name` (Trace Name) must scope to root spans."""
+        """`metric_name=name` (Trace Name) must scope to root spans.
+
+        CH25 v2 spans write '' (not NULL) on the non-nullable parent_span_id
+        for root spans, so the clause must match both forms or it returns 0 rows.
+        """
         mock_result = MagicMock()
         mock_result.data = []
         mock_analytics_cls.return_value.execute_ch_query.return_value = mock_result
@@ -851,7 +855,7 @@ class TestMetricsEndpoint:
         )
 
         sql_arg = mock_analytics_cls.return_value.execute_ch_query.call_args[0][0]
-        assert "parent_span_id IS NULL" in sql_arg
+        assert "(parent_span_id IS NULL OR parent_span_id = '')" in sql_arg
 
     @pytest.mark.parametrize("metric_name", ["span_name", "service_name"])
     @pytest.mark.django_db

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -2214,7 +2214,9 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     null_uuid = "00000000-0000-0000-0000-000000000000"
                     # Trace Name = root span name; restrict to root spans.
                     root_only_clause = (
-                        "AND parent_span_id IS NULL " if metric_name == "name" else ""
+                        "AND (parent_span_id IS NULL OR parent_span_id = '') "
+                        if metric_name == "name"
+                        else ""
                     )
 
                     if metric_name == "session":


### PR DESCRIPTION
## Summary

On the CH25 stack the **Trace Name** and **Span Name** filter pickers returned no values and fired the *identical* request. Two causes: (1) the backend `filter_values` query restricted trace-name to root spans with `parent_span_id IS NULL`, but v2 `spans` (fi-collector) write `''` on a non-nullable `String` for root spans — never NULL — so it matched 0 rows; (2) the frontend spans view reused `id: "name"` for the Span Name picker, so it sent the same `metric_name=name` request as Trace Name instead of the distinct `span_name` metric. This fixes both so each picker returns values and issues a distinct request.

## Linked issues

Fixed TH-6053

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Manual, local CH25 (project with 346 spans / 228 root traces):

- `GET /tracer/dashboard/filter_values/?metric_name=name&metric_type=system_metric&source=traces` → 221 trace names (was 0).
- `metric_name=span_name` → 337 span names.
- Confirmed the Trace Name and Span Name pickers now send distinct `metric_name` values and both populate.

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
