### PR TITLE
feat(sessions): serve sessions, user tab from CH25

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -32963,7 +32963,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
             }
           },
           "project_id": {
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "format": "uuid"

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -25633,7 +25633,7 @@ page?: number;
  * Number of results to return per page.
  */
 limit?: number;
-project_id: string;
+project_id?: string;
 user_id?: string;
 /**
  * @minLength 1

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -62596,7 +62596,7 @@ export type tracerObservationSpanListSpansObserveResponseError = (tracerObservat
 
 export type tracerObservationSpanListSpansObserveResponse = (tracerObservationSpanListSpansObserveResponseSuccess | tracerObservationSpanListSpansObserveResponseError)
 
-export const getTracerObservationSpanListSpansObserveUrl = (params: TracerObservationSpanListSpansObserveParams,) => {
+export const getTracerObservationSpanListSpansObserveUrl = (params?: TracerObservationSpanListSpansObserveParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -62615,7 +62615,7 @@ export const getTracerObservationSpanListSpansObserveUrl = (params: TracerObserv
   return stringifiedParams.length > 0 ? `/tracer/observation-span/list_spans_observe/?${stringifiedParams}` : `/tracer/observation-span/list_spans_observe/`
 }
 
-export const tracerObservationSpanListSpansObserve = async (params: TracerObservationSpanListSpansObserveParams, options?: RequestInit): Promise<tracerObservationSpanListSpansObserveResponse> => {
+export const tracerObservationSpanListSpansObserve = async (params?: TracerObservationSpanListSpansObserveParams, options?: RequestInit): Promise<tracerObservationSpanListSpansObserveResponse> => {
 
   return apiMutator<tracerObservationSpanListSpansObserveResponse>(getTracerObservationSpanListSpansObserveUrl(params),
   {

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -37840,7 +37840,7 @@ export const tracerObservationSpanListSpansObserveQueryPageSizeMax = 500;
 export const TracerObservationSpanListSpansObserveQueryParams = zod.object({
   "page": zod.number().optional().describe('A page number within the paginated result set.'),
   "limit": zod.number().optional().describe('Number of results to return per page.'),
-  "project_id": zod.string().uuid(),
+  "project_id": zod.string().uuid().optional(),
   "user_id": zod.string().optional(),
   "filters": zod.string().min(1).default(tracerObservationSpanListSpansObserveQueryFiltersDefault),
   "page_number": zod.number().min(tracerObservationSpanListSpansObserveQueryPageNumberMin).default(tracerObservationSpanListSpansObserveQueryPageNumberDefault),

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -701,6 +701,16 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const { setActiveViewConfig: setActiveViewConfigFromCtx } =
     useObserveHeader();
 
+  const switchSelectedTab = useCallback(
+    (tab) => {
+      setAutoSizeAllCols(false);
+      setSelectedTab(tab);
+      resetSpanGridStore();
+      resetTraceGridStore();
+    },
+    [setSelectedTab],
+  );
+
   const handleGroupByChange = useCallback(
     (groupKey) => {
       // Group-by changes off a saved view land on the corresponding default
@@ -717,6 +727,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         case "trace":
           if (onSavedView) {
             setActiveViewConfigFromCtx(null);
+            switchSelectedTab("trace");
             if (isUserMode) {
               navigate("?userTab=traces&selectedTab=trace", { replace: true });
             } else {
@@ -726,12 +737,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               );
             }
           } else {
-            setSelectedTab("trace");
+            switchSelectedTab("trace");
           }
           break;
         case "span":
           if (onSavedView) {
             setActiveViewConfigFromCtx(null);
+            switchSelectedTab("spans");
             if (isUserMode) {
               // User Detail has a single "Trace" fixed tab that hosts the
               // selectedTab toggle, so we land on userTab=traces with
@@ -744,7 +756,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               );
             }
           } else {
-            setSelectedTab("spans");
+            switchSelectedTab("spans");
           }
           break;
         case "users":
@@ -773,7 +785,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [
       observeId,
       navigate,
-      setSelectedTab,
+      switchSelectedTab,
       setActiveViewConfigFromCtx,
       isUserMode,
       userIdForUserMode,
@@ -1045,10 +1057,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setAutoSizeAllCols(false);
       gridApi.sizeColumnsToFit();
     }
-  };
-
-  const resetColumns = () => {
-    setAutoSizeAllCols(false);
   };
 
   const defaultFilter = useMemo(() => getDefaultFilter(), []);
@@ -3817,10 +3825,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                   value={selectedTab}
                   onChange={(e, value) => {
                     resetFilters();
-                    resetColumns();
-                    setSelectedTab(value);
-                    resetSpanGridStore();
-                    resetTraceGridStore();
+                    switchSelectedTab(value);
                   }}
                   aria-label="change tabs"
                   sx={{

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -316,7 +316,7 @@ const SessionGrid = React.forwardRef(
                   return updateObjRef.current?.[column.field] ?? true;
                 }
 
-                const columnConfig = (res?.config || []).find(
+                const columnConfig = (newCols || []).find(
                   (config) => config.id === column.field,
                 );
                 return columnConfig ? columnConfig.isVisible : true;

--- a/futureagi/tracer/serializers/dashboard.py
+++ b/futureagi/tracer/serializers/dashboard.py
@@ -411,7 +411,13 @@ class DashboardFilterValuesQuerySerializer(serializers.Serializer):
         default="system_metric",
     )
     source = serializers.ChoiceField(
-        choices=["traces", "datasets", "dataset_column", "simulation"],
+        choices=[
+            "traces",
+            "sessions",
+            "datasets",
+            "dataset_column",
+            "simulation",
+        ],
         required=False,
         default="traces",
     )

--- a/futureagi/tracer/serializers/observation_span.py
+++ b/futureagi/tracer/serializers/observation_span.py
@@ -217,7 +217,7 @@ class SpanListQuerySerializer(StrictInputSerializer):
 
 
 class SpanObserveListQuerySerializer(StrictInputSerializer):
-    project_id = serializers.UUIDField()
+    project_id = serializers.UUIDField(required=False, allow_null=True)
     user_id = serializers.CharField(required=False, allow_blank=True)
     filters = filter_list_query_param_field(required=False, default=list)
     page_number = serializers.IntegerField(required=False, default=0, min_value=0)

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -822,10 +822,18 @@ class ClickHouseFilterBuilder:
             if is_root_only
             else ""
         )
+        # Mirror the org-scoped vs single-project param binding used
+        # elsewhere (see `_scoped_spans_subquery`): the outer query exposes
+        # either `%(project_id)s` or `%(project_ids)s`, never both.
+        project_pred = (
+            "project_id IN %(project_ids)s"
+            if self._org_scoped
+            else "project_id = %(project_id)s"
+        )
         return (
             f"trace_id IN ("
             f"SELECT trace_id FROM {self.table} "
-            f"WHERE project_id = %(project_id)s AND _peerdb_is_deleted = 0 "
+            f"WHERE {project_pred} AND _peerdb_is_deleted = 0 "
             f"{root_clause}"
             f"AND {inner})"
         )

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -743,7 +743,7 @@ class ClickHouseFilterBuilder:
 
         inner_value = values if inner_op == "in" else values[0]
         inner = self._build_column_condition(
-            f"eu.{enduser_column}", "text", inner_op, inner_value
+            enduser_column, "text", inner_op, inner_value
         )
         if not inner:
             return None

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -706,7 +706,7 @@ class ClickHouseFilterBuilder:
         filter_value: Any,
     ) -> str | None:
         """Resolve an end-user string field (user_id / user_id_type) on
-        tracer_enduser, then map to end_user_id on spans."""
+        end_users, then map to end_user_id on spans."""
 
         if filter_op in NO_VALUE_OPS:
             comparison_op = "=" if filter_op == "is_null" else "!="
@@ -736,19 +736,19 @@ class ClickHouseFilterBuilder:
 
         inner_value = values if inner_op == "in" else values[0]
         inner = self._build_column_condition(
-            enduser_column, "text", inner_op, inner_value
+            f"eu.{enduser_column}", "text", inner_op, inner_value
         )
         if not inner:
             return None
 
         return (
             f"trace_id {outer_op} ("
-            f"SELECT trace_id FROM {self.table} "
-            f"WHERE end_user_id IN ("
-            f"SELECT id FROM tracer_enduser FINAL "
+            f"SELECT sp.trace_id FROM {self.table} AS sp "
+            f"WHERE sp.end_user_id IN ("
+            f"SELECT eu.end_user_id FROM end_users AS eu FINAL "
             f"WHERE {inner} "
-            f"AND _peerdb_is_deleted = 0 AND deleted = 0"
-            f") AND _peerdb_is_deleted = 0)"
+            f"AND eu.is_deleted = 0"
+            f") AND sp._peerdb_is_deleted = 0)"
         )
 
     def _build_system_metric_condition(

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -1039,6 +1039,24 @@ class ClickHouseFilterBuilder:
         }
     )
 
+    # Ops that compare a nullable UUID column against a STRING value. For
+    # these the column is wrapped in toString(...) so substring (LIKE),
+    # equality, and IN work — ClickHouse rejects direct UUID-vs-String
+    # comparisons. Ops absent here (is_null/is_not_null, ranges) operate on
+    # the bare column.
+    _UUID_TEXT_FILTER_OPS = frozenset(
+        {
+            "equals",
+            "not_equals",
+            "contains",
+            "not_contains",
+            "starts_with",
+            "ends_with",
+            "in",
+            "not_in",
+        }
+    )
+
     def _build_column_condition(
         self,
         column: str,
@@ -1059,12 +1077,8 @@ class ClickHouseFilterBuilder:
         if filter_op == "is_null":
             if column in self._NULLABLE_UUID_COLUMNS:
                 return f"{column} IS NULL"
-            if column in self._NULLABLE_UUID_COLUMNS:
-                return f"{column} IS NULL"
             return f"({column} IS NULL OR {column} = '')"
         elif filter_op == "is_not_null":
-            if column in self._NULLABLE_UUID_COLUMNS:
-                return f"{column} IS NOT NULL"
             if column in self._NULLABLE_UUID_COLUMNS:
                 return f"{column} IS NOT NULL"
             return f"({column} IS NOT NULL AND {column} != '')"

--- a/futureagi/tracer/services/clickhouse/query_builders/session_filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_filters.py
@@ -1,0 +1,81 @@
+"""Shared session-ID filter helpers for the session query builders.
+
+Both the session list (``SessionListQueryBuilder``) and the session
+time-series (``SessionTimeSeriesQueryBuilder``) translate a frontend
+``session``/``session_id``/``trace_session_id`` filter into the same
+``trace_session_id {IN|NOT IN} (...)`` predicate. The only difference is
+the column expression each binds against:
+
+- the list builder applies it in the OUTER ``WHERE`` of its remap-resolved
+  subquery, where the column is already projected as ``trace_session_id``;
+- the time-series builder applies it inline, so it passes the full
+  ``resolved_id_expr(...)`` expression.
+
+Keeping the translation in one place avoids the two copies drifting on
+operator/null/empty-value handling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Frontend column aliases that target the session identity.
+SESSION_ID_FILTER_COLS = frozenset({"session", "session_id", "trace_session_id"})
+
+_NEGATED_OPS = ("not_equals", "not_in")
+
+
+def build_session_id_filter_clause(
+    filters: list[dict],
+    params: dict[str, Any],
+    *,
+    session_col: str,
+    param_prefix: str,
+) -> str:
+    """Build a ``session_col {IN|NOT IN} (...)`` predicate from filters.
+
+    Iterates ``filters`` for any session-identity column and emits an
+    ``AND``-joined clause, binding placeholder params into ``params``.
+    ``is_null``/``is_not_null`` and empty value lists degrade to the
+    constant ``0 = 1`` / ``1 = 1`` that matches the operator's intent.
+
+    Args:
+        filters: frontend filter dicts.
+        params: query param dict, mutated in place with bound tuples.
+        session_col: SQL expression the predicate binds against
+            (a bare column or a resolved-id expression).
+        param_prefix: unique prefix for generated placeholder names so two
+            builders sharing a param dict never collide.
+    """
+    clauses: list[str] = []
+    counter = 0
+
+    for f in filters:
+        col_id = f.get("column_id") or f.get("columnId")
+        if col_id not in SESSION_ID_FILTER_COLS:
+            continue
+
+        config = f.get("filter_config") or f.get("filterConfig") or {}
+        filter_op = config.get("filter_op") or config.get("filterOp")
+        raw_value = config.get("filter_value", config.get("filterValue"))
+        values = raw_value if isinstance(raw_value, list) else [raw_value]
+        values = [str(value) for value in values if value]
+
+        if filter_op in ("is_null", "is_not_null"):
+            clauses.append("0 = 1" if filter_op == "is_null" else "1 = 1")
+            continue
+
+        if not values:
+            clauses.append("1 = 1" if filter_op in _NEGATED_OPS else "0 = 1")
+            continue
+
+        counter += 1
+        param_name = f"{param_prefix}{counter}"
+        params[param_name] = tuple(values)
+        operator = "NOT IN" if filter_op in _NEGATED_OPS else "IN"
+        clauses.append(f"{session_col} {operator} %({param_name})s")
+
+    return " AND ".join(clauses)
+
+
+__all__ = ["SESSION_ID_FILTER_COLS", "build_session_id_filter_clause"]

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -15,6 +15,10 @@ from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import NIL_UUID, BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+from tracer.services.clickhouse.query_builders.session_filters import (
+    SESSION_ID_FILTER_COLS,
+    build_session_id_filter_clause,
+)
 from tracer.services.clickhouse.v2.id_remap_sql import (
     remap_left_join,
     resolved_id_expr,
@@ -53,6 +57,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         "total_cost": "total_cost",
         "total_tokens": "total_tokens",
         "traces_count": "traces_count",
+        "total_traces_count": "traces_count",
     }
 
     # Session-level filter columns that map to computed aggregates
@@ -61,12 +66,13 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         "total_cost": "total_cost",
         "total_tokens": "total_tokens",
         "traces_count": "traces_count",
+        "total_traces_count": "traces_count",
     }
 
-    # Columns that require a session-scoped subquery because they are
-    # set on child spans, not root spans. The main query restricts to
-    # root spans only, so filtering these directly would miss matches.
-    SUBQUERY_FILTER_COLS = {"end_user_id"}
+    MESSAGE_FILTER_MAP: dict[str, str] = {
+        "first_message": "first_message",
+        "last_message": "last_message",
+    }
 
     def __init__(
         self,
@@ -136,14 +142,10 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         filter_fragment = f"AND {extra_where}" if extra_where else ""
         having_fragment = f"HAVING {having_clauses}" if having_clauses else ""
+        message_select = self._message_aggregate_select()
 
-        # P3b step1.5 (DESIGN §3 / id_remap_sql): `_session_from_where` ALWAYS
-        # resolves `trace_session_id` new→old (and `end_user_id` too when a user
-        # filter is present), so the `GROUP BY trace_session_id` below unifies a
-        # cross-cutover straddler's old + new session ids into ONE listed row
-        # (closes the no-filter/bookmark browse double-list). Pre-flip the remap
-        # joins are no-ops → byte-identical (result-set) to the committed bare
-        # scan (gate B).
+        # Resolve session IDs new→old before grouping so cross-cutover spans
+        # remain one session. User membership is handled separately below.
         time_where = "AND start_time >= %(start_date)s AND start_time < %(end_date)s"
         from_where = self._session_from_where(
             self.params,
@@ -151,8 +153,8 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             filter_fragment=filter_fragment,
         )
 
-        # Light aggregation — no input column (heavy). First/last messages
-        # fetched separately via build_content_query().
+        # Keep the common path light. Message aggregates are added only when
+        # first_message/last_message participate in filtering.
         query = f"""
         SELECT
             trace_session_id AS session_id,
@@ -162,6 +164,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             sum(cost) AS total_cost,
             sum(total_tokens) AS total_tokens,
             uniq(trace_id) AS traces_count
+            {message_select}
         {from_where}
         GROUP BY trace_session_id
         {having_fragment}
@@ -218,7 +221,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         """Return True if any filters target aggregate columns (requiring HAVING)."""
         for f in self.filters:
             col_id = f.get("column_id") or f.get("columnId")
-            if col_id in self.SESSION_FILTER_MAP:
+            if col_id in self.SESSION_FILTER_MAP or col_id in self.MESSAGE_FILTER_MAP:
                 return True
         return False
 
@@ -285,6 +288,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         filter_fragment = f"AND {extra_where}" if extra_where else ""
         having_fragment = f"HAVING {having_clauses}" if having_clauses else ""
+        message_select = self._message_aggregate_select()
 
         # P3b step1.5: same id-remap-resolved scan as build()/simple-count so the
         # HAVING-filtered session count unifies a straddler identically (group on
@@ -307,6 +311,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
                 sum(cost) AS total_cost,
                 sum(total_tokens) AS total_tokens,
                 uniq(trace_id) AS traces_count
+                {message_select}
             {from_where}
             GROUP BY trace_session_id
             {having_fragment}
@@ -446,6 +451,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
     # `_build_resolved_user_clause` / P3b step1.5), so a cross-cutover straddler
     # unifies. `user` is the FilterBuilder alias for `end_user_id`.
     _ENDUSER_ID_FILTER_COLS = frozenset({"end_user_id", "user"})
+    _SESSION_ID_FILTER_COLS = SESSION_ID_FILTER_COLS
 
     def _extract_end_user_ids(self) -> list[str]:
         """Return synthetic end-user UUID filters for legacy callers.
@@ -486,12 +492,28 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         span_filters: list[dict] = []
         for f in self.filters:
             col_id = f.get("column_id") or f.get("columnId")
-            if col_id in self.SESSION_FILTER_MAP:
+            if (
+                col_id in self.SESSION_FILTER_MAP
+                or col_id in self.MESSAGE_FILTER_MAP
+            ):
                 continue
-            if col_id in self._ENDUSER_ID_FILTER_COLS:
+            if (
+                col_id in self._ENDUSER_ID_FILTER_COLS
+                or col_id in self._SESSION_ID_FILTER_COLS
+            ):
                 continue
             span_filters.append(f)
         return span_filters
+
+    def _build_resolved_session_clause(self, params: dict[str, Any]) -> str:
+        # Applied in the OUTER WHERE of `_session_from_where`, where the column
+        # is already projected as the remap-resolved `trace_session_id`.
+        return build_session_id_filter_clause(
+            self.filters,
+            params,
+            session_col="trace_session_id",
+            param_prefix="sess_",
+        )
 
     def _build_resolved_user_clause(self, params: dict[str, Any]) -> str:
         """Build the id-remap-resolved end-user predicate for the session scan.
@@ -543,6 +565,46 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         return " AND ".join(clauses)
 
+    def _build_session_user_membership_clause(
+        self, params: dict[str, Any]
+    ) -> str:
+        resolved_user_clause = self._build_resolved_user_clause(params)
+        if not resolved_user_clause:
+            return ""
+
+        ts_join = remap_left_join(
+            "us.trace_session_id", "trace_session_id_remap", "user_ts_remap"
+        )
+        eu_join = remap_left_join(
+            "us.end_user_id", "end_user_id_remap", "user_eu_remap"
+        )
+        resolved_ts = resolved_id_expr(
+            "us.trace_session_id", "user_ts_remap"
+        )
+        resolved_eu = resolved_id_expr("us.end_user_id", "user_eu_remap")
+        return f"""trace_session_id IN (
+            SELECT trace_session_id
+            FROM (
+                SELECT
+                    {resolved_ts} AS trace_session_id,
+                    {resolved_eu} AS end_user_id
+                FROM (
+                    SELECT trace_session_id, end_user_id
+                    FROM {self.TABLE}
+                    {self.project_where()}
+                      AND trace_session_id IS NOT NULL
+                      AND trace_session_id != toUUID('{NIL_UUID}')
+                      AND end_user_id IS NOT NULL
+                      AND start_time >= %(start_date)s
+                      AND start_time < %(end_date)s
+                ) AS us
+                {ts_join}
+                {eu_join}
+            )
+            WHERE {resolved_user_clause}
+            GROUP BY trace_session_id
+        )"""
+
     # Span columns the session aggregates read (kept narrow so the id-remap
     # wrap projects only what the GROUP BY needs).
     _SESSION_SCAN_COLS = (
@@ -563,23 +625,16 @@ class SessionListQueryBuilder(BaseQueryBuilder):
     ) -> str:
         """Return the ``FROM … WHERE …`` clause for a session aggregation query.
 
-        P3b step1.5 (DESIGN §3 / id_remap_sql): the scan is ALWAYS wrapped in a
-        derived table that resolves ``trace_session_id`` new→old through
-        ``trace_session_id_remap`` and projects it AS ``trace_session_id``, so the
-        outer ``GROUP BY trace_session_id`` / ``count(DISTINCT trace_session_id)``
-        treat a cross-cutover straddler's OLD + NEW session ids as ONE session
-        (else the no-filter/bookmark BROWSE lists it twice at the flip). When a
-        user filter is present, ``end_user_id`` is ALSO resolved (its remap) and
-        the resolved-id predicate binds in the outer ``WHERE`` so old + new spans
-        select as ONE user. The session/root/time/project predicates +
-        ``{filter_fragment}`` stay on the inner raw scan.
+        The scan resolves ``trace_session_id`` new→old before grouping, so a
+        cross-cutover straddler remains one session. User filters use a separate
+        remap-aware membership subquery; this selects sessions without shrinking
+        their aggregate rows. Span predicates remain on the inner root-span scan.
 
         GATE B: pre-flip every span's id lives in the remap ``old_id`` column, so
         NO span matches a ``new_id`` → ``resolved_id_expr`` (zero-uuid-guarded,
         NOT a COALESCE) returns each span's own id and the LEFT JOIN(s) add
         nothing → the wrapped scan is a transparent pass-through, byte-identical
-        (result-set) to the committed bare scan. Mutates ``params`` via
-        ``_build_resolved_user_clause``.
+        (result-set) to the committed bare scan.
         """
         base_predicates = f"""{self.project_where()}
           AND trace_session_id IS NOT NULL
@@ -588,46 +643,48 @@ class SessionListQueryBuilder(BaseQueryBuilder):
           {time_where}
           {filter_fragment}"""
 
-        resolved_user_clause = self._build_resolved_user_clause(params)
+        resolved_session_clause = self._build_resolved_session_clause(params)
+        user_membership_clause = self._build_session_user_membership_clause(
+            params
+        )
 
         # `trace_session_id` resolution is UNCONDITIONAL (closes the browse split);
-        # `end_user_id` resolution is added only when a user filter needs it (its
-        # join is otherwise dead weight). Both remap joins hang off the SAME inner
-        # row `rs` → DISTINCT aliases (`ts_remap` / `eu_remap`).
+        # User membership is resolved in a separate session-id subquery so
+        # selecting a user does not shrink the session's displayed aggregates.
         ts_join = remap_left_join(
             "rs.trace_session_id", "trace_session_id_remap", "ts_remap"
         )
         resolved_ts = resolved_id_expr("rs.trace_session_id", "ts_remap")
 
-        # Inner scan projects the narrow aggregate cols; `end_user_id` is pulled
-        # in only when the user filter needs to resolve+bind it.
+        # Inner scan projects only columns required by session aggregation.
         scan_cols = list(self._SESSION_SCAN_COLS)
+        if self._has_message_filters():
+            scan_cols.append("input")
         outer_select = [f"{resolved_ts} AS trace_session_id"] + [
             f"rs.{c} AS {c}" for c in scan_cols if c != "trace_session_id"
         ]
-        joins = [ts_join]
-        inner_extra = ""
-        where_clause = ""
-        if resolved_user_clause:
-            eu_join = remap_left_join("rs.end_user_id", "end_user_id_remap", "eu_remap")
-            resolved_eu = resolved_id_expr("rs.end_user_id", "eu_remap")
-            outer_select.append(f"{resolved_eu} AS end_user_id")
-            joins.append(eu_join)
-            inner_extra = ", end_user_id"
-            where_clause = f"\n        WHERE {resolved_user_clause}"
+        outer_clauses = [
+            c
+            for c in (resolved_session_clause, user_membership_clause)
+            if c
+        ]
 
         inner_cols = ", ".join(scan_cols)
         outer_select_sql = ",\n                ".join(outer_select)
-        joins_sql = "\n            ".join(joins)
+        where_clause = (
+            f"\n        WHERE {' AND '.join(outer_clauses)}"
+            if outer_clauses
+            else ""
+        )
         return f"""FROM (
             SELECT
                 {outer_select_sql}
             FROM (
-                SELECT {inner_cols}{inner_extra}
+                SELECT {inner_cols}
                 FROM {self.TABLE}
                 {base_predicates}
             ) AS rs
-            {joins_sql}
+            {ts_join}
         ){where_clause}"""
 
     def _build_having_clauses(self) -> str:
@@ -637,13 +694,50 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         for f in self.filters:
             col_id = f.get("column_id") or f.get("columnId")
-            if col_id not in self.SESSION_FILTER_MAP:
+            if (
+                col_id not in self.SESSION_FILTER_MAP
+                and col_id not in self.MESSAGE_FILTER_MAP
+            ):
                 continue
 
             config = f.get("filter_config") or f.get("filterConfig") or {}
             filter_op = config.get("filter_op") or config.get("filterOp")
             filter_value = config.get("filter_value", config.get("filterValue"))
-            ch_col = self.SESSION_FILTER_MAP[col_id]
+            ch_col = (
+                self.SESSION_FILTER_MAP.get(col_id)
+                or self.MESSAGE_FILTER_MAP[col_id]
+            )
+
+            if col_id in self.MESSAGE_FILTER_MAP:
+                if filter_op in ("is_null", "is_not_null"):
+                    conditions.append(
+                        f"({ch_col} IS NULL OR {ch_col} = '')"
+                        if filter_op == "is_null"
+                        else f"({ch_col} IS NOT NULL AND {ch_col} != '')"
+                    )
+                    continue
+                text_op = {
+                    "equals": "=",
+                    "not_equals": "!=",
+                    "contains": "ILIKE",
+                    "not_contains": "NOT ILIKE",
+                    "starts_with": "ILIKE",
+                    "ends_with": "ILIKE",
+                }.get(filter_op)
+                if text_op is None:
+                    conditions.append("0 = 1")
+                    continue
+                param_counter += 1
+                param_name = f"having_{param_counter}"
+                if filter_op in ("contains", "not_contains"):
+                    filter_value = f"%{filter_value}%"
+                elif filter_op == "starts_with":
+                    filter_value = f"{filter_value}%"
+                elif filter_op == "ends_with":
+                    filter_value = f"%{filter_value}"
+                self.params[param_name] = filter_value
+                conditions.append(f"{ch_col} {text_op} %({param_name})s")
+                continue
 
             op_map = {
                 "equals": "=",
@@ -664,3 +758,17 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             conditions.append(f"{ch_col} {op} %({param_name})s")
 
         return " AND ".join(conditions)
+
+    def _has_message_filters(self) -> bool:
+        return any(
+            (f.get("column_id") or f.get("columnId")) in self.MESSAGE_FILTER_MAP
+            for f in self.filters
+        )
+
+    def _message_aggregate_select(self) -> str:
+        if not self._has_message_filters():
+            return ""
+        return (
+            ",\n            argMin(input, start_time) AS first_message,"
+            "\n            argMax(input, start_time) AS last_message"
+        )

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -565,9 +565,68 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         return " AND ".join(clauses)
 
+    def _user_null_filter_op(self) -> str | None:
+        """Return ``is_null``/``is_not_null`` when a user filter tests presence.
+
+        A ``user_id``/``end_user_id`` filter with a null operator carries no
+        value to resolve — it asks "does this session have a user at all" —
+        and is answered by ``_build_user_presence_clause`` instead of the
+        id-set membership in ``_build_resolved_user_clause``.
+        """
+        for f in self.filters:
+            col_id = f.get("column_id") or f.get("columnId")
+            if col_id not in self._ENDUSER_ID_FILTER_COLS:
+                continue
+            config = f.get("filter_config") or f.get("filterConfig") or {}
+            op = config.get("filter_op") or config.get("filterOp")
+            if op in ("is_null", "is_not_null"):
+                return op
+        return None
+
+    def _build_user_presence_clause(self, null_op: str) -> str:
+        """Membership over sessions that have ANY end user.
+
+        ``is_not_null`` → the session IS in that set; ``is_null`` → it is NOT.
+        The outer session query groups by remap-resolved ``trace_session_id``,
+        so the presence set must resolve session ids too. Otherwise a straddler
+        whose user appears only on its deterministic-id spans can be compared
+        against the old survivor id and misclassified as user-less.
+        """
+        ts_join = remap_left_join(
+            "us.trace_session_id", "trace_session_id_remap", "user_presence_ts_remap"
+        )
+        resolved_ts = resolved_id_expr(
+            "us.trace_session_id", "user_presence_ts_remap"
+        )
+        membership = f"""(
+            SELECT trace_session_id
+            FROM (
+                SELECT {resolved_ts} AS trace_session_id
+                FROM (
+                    SELECT trace_session_id
+                    FROM {self.TABLE}
+                    {self.project_where()}
+                      AND trace_session_id IS NOT NULL
+                      AND trace_session_id != toUUID('{NIL_UUID}')
+                      AND end_user_id IS NOT NULL
+                      AND end_user_id != toUUID('{NIL_UUID}')
+                      AND start_time >= %(start_date)s
+                      AND start_time < %(end_date)s
+                ) AS us
+                {ts_join}
+            )
+            GROUP BY trace_session_id
+        )"""
+        op = "NOT IN" if null_op == "is_null" else "IN"
+        return f"trace_session_id {op} {membership}"
+
     def _build_session_user_membership_clause(
         self, params: dict[str, Any]
     ) -> str:
+        null_op = self._user_null_filter_op()
+        if null_op:
+            return self._build_user_presence_clause(null_op)
+
         resolved_user_clause = self._build_resolved_user_clause(params)
         if not resolved_user_clause:
             return ""
@@ -658,7 +717,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
 
         # Inner scan projects only columns required by session aggregation.
         scan_cols = list(self._SESSION_SCAN_COLS)
-        if self._has_message_filters():
+        if self._needs_message_aggregates():
             scan_cols.append("input")
         outer_select = [f"{resolved_ts} AS trace_session_id"] + [
             f"rs.{c} AS {c}" for c in scan_cols if c != "trace_session_id"
@@ -765,8 +824,23 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             for f in self.filters
         )
 
+    def _has_message_sort(self) -> bool:
+        return any(
+            (s.get("column_id") or s.get("columnId")) in self.MESSAGE_FILTER_MAP
+            for s in self.sort_params
+        )
+
+    def _needs_message_aggregates(self) -> bool:
+        """The argMin/argMax message aggregates must be projected whenever a
+        message column is filtered OR sorted on. Sorting alone (without a
+        matching filter) still emits ``ORDER BY first_message`` via
+        ``translate_sort``, so the column must be selected or CH fails with
+        "Unknown expression identifier".
+        """
+        return self._has_message_filters() or self._has_message_sort()
+
     def _message_aggregate_select(self) -> str:
-        if not self._has_message_filters():
+        if not self._needs_message_aggregates():
             return ""
         return (
             ",\n            argMin(input, start_time) AS first_message,"

--- a/futureagi/tracer/services/clickhouse/query_builders/session_time_series.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_time_series.py
@@ -19,6 +19,10 @@ from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import NIL_UUID, BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+from tracer.services.clickhouse.query_builders.session_filters import (
+    SESSION_ID_FILTER_COLS,
+    build_session_id_filter_clause,
+)
 from tracer.services.clickhouse.v2.id_remap_sql import (
     remap_left_join,
     resolved_id_expr,
@@ -44,6 +48,7 @@ class SessionTimeSeriesQueryBuilder(BaseQueryBuilder):
         "traces_count": "session_traces",
         "total_traces_count": "session_traces",
     }
+    SESSION_ID_FILTER_COLS = SESSION_ID_FILTER_COLS
 
     def __init__(
         self,
@@ -81,14 +86,18 @@ class SessionTimeSeriesQueryBuilder(BaseQueryBuilder):
         # span's `trace_session_id` new→old through `trace_session_id_remap` and
         # GROUP the inner per-session aggregate on the RESOLVED id, so old + new
         # spans form ONE session. The time/project/null predicates + the span
-        # `{where_clause}` stay on the bare inner scan; only the grouping key binds
-        # the resolved column. `resolved_id_expr` is the zero-uuid-guarded map (NOT
-        # a COALESCE). Pre-flip NO span matches a `new_id` → resolved id == own id
-        # → byte-identical no-op (gate B).
+        # `{where_clause}` stay on the bare inner scan; the grouping key and
+        # session-ID filters bind the resolved column. `resolved_id_expr` is the
+        # zero-uuid-guarded map (NOT a COALESCE). Pre-flip NO span matches a
+        # `new_id` → resolved id == own id → byte-identical no-op (gate B).
         ts_join = remap_left_join(
             "rs.trace_session_id", "trace_session_id_remap", "ts_remap"
         )
         resolved_ts = resolved_id_expr("rs.trace_session_id", "ts_remap")
+        session_id_clause = self._build_session_id_clause(resolved_ts)
+        session_id_fragment = (
+            f"WHERE {session_id_clause}" if session_id_clause else ""
+        )
 
         # Two-level aggregation:
         # Inner: per-session aggregates from ALL spans in the session
@@ -136,6 +145,7 @@ class SessionTimeSeriesQueryBuilder(BaseQueryBuilder):
                   AND {where_clause}
             ) AS rs
             {ts_join}
+            {session_id_fragment}
             GROUP BY session_id
             {having_fragment}
         )
@@ -149,9 +159,25 @@ class SessionTimeSeriesQueryBuilder(BaseQueryBuilder):
         span_filters: list[dict] = []
         for f in self.filters:
             col_id = f.get("column_id") or f.get("columnId")
-            if col_id not in self.SESSION_FILTER_MAP:
+            if (
+                col_id not in self.SESSION_FILTER_MAP
+                and col_id not in self.SESSION_ID_FILTER_COLS
+            ):
                 span_filters.append(f)
         return span_filters
+
+    def _build_session_id_clause(self, resolved_session_id: str) -> str:
+        """Filter the remap-resolved session ID before session aggregation.
+
+        Applied inline (pre-GROUP BY), so it binds against the full
+        ``resolved_id_expr(...)`` rather than a projected column alias.
+        """
+        return build_session_id_filter_clause(
+            self.filters,
+            self.params,
+            session_col=resolved_session_id,
+            param_prefix="session_id_",
+        )
 
     def _build_having_clauses(self) -> str:
         """Build predicates for session aggregate filters."""

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -60,7 +60,8 @@ class SpanListQueryBuilder(BaseQueryBuilder):
 
     def __init__(
         self,
-        project_id: str,
+        project_id: str | None = None,
+        project_ids: list[str] | None = None,
         page_number: int = 0,
         page_size: int = 50,
         filters: list[dict] | None = None,
@@ -71,7 +72,7 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         project_version_id: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(project_id, **kwargs)
+        super().__init__(project_id=project_id, project_ids=project_ids, **kwargs)
         self.page_number = page_number
         self.page_size = page_size
         self.filters = filters or []
@@ -245,7 +246,7 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         SELECT id, input, output, attributes_extra
         FROM {self.TABLE}
         PREWHERE id IN %(content_span_ids)s
-        WHERE project_id = %(project_id)s AND is_deleted = 0
+        WHERE {self.project_filter_sql()} AND is_deleted = 0
         """
         return query, params
 

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -308,7 +308,7 @@ class AnalyticsQueryService:
             WHERE trace_id IN %(trace_ids)s
               AND custom_eval_config_id IN %(config_ids)s
               AND {eval_nd}
-              AND output_str != 'ERROR'
+              AND ifNull(output_str, '') != 'ERROR'
               AND (error = 0 OR error IS NULL)
             GROUP BY trace_id, custom_eval_config_id
         """

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/session_list.py
@@ -6,19 +6,64 @@ The v1 SessionList builder aggregates spans by trace_session_id; v2's
 materialized `trace_session_id` column is queried unchanged. `V2RewriteMixin`
 routes every inherited `build*` method's SQL through the v2 rewriter at one
 boundary. All of this builder's queries target the migrated `spans` schema, so
-there are no rewrite exclusions.
+only the native CH25 span-attribute query is excluded from rewriting.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 from tracer.services.clickhouse.query_builders.session_list import (
     SessionListQueryBuilder,
 )
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
+from tracer.services.clickhouse.v2.id_remap_sql import (
+    remap_left_join,
+    resolved_id_expr,
+)
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    _append_v2_settings,
+)
 
 
 class SessionListQueryBuilderV2(V2RewriteMixin, SessionListQueryBuilder):
     """Drop-in v2 SessionList builder."""
+
+    # This method already emits native CH25 SQL. The generic rewrite would
+    # reinterpret the compatibility alias `span_attributes_raw`.
+    _v2_rewrite_exclude = frozenset({"build_span_attributes_query"})
+
+    def build_span_attributes_query(
+        self, session_ids: list[str]
+    ) -> tuple[str, dict[str, Any]]:
+        if not session_ids:
+            return "", {}
+
+        params = {**self.params, "attr_session_ids": tuple(session_ids)}
+        ts_join = remap_left_join(
+            "s.trace_session_id", "trace_session_id_remap", "ts_remap"
+        )
+        resolved_ts = resolved_id_expr("s.trace_session_id", "ts_remap")
+        sql = f"""
+        SELECT
+            {resolved_ts} AS session_id,
+            attributes_extra AS span_attributes_raw,
+            attrs_string,
+            attrs_number
+        FROM {self.TABLE} AS s
+        {ts_join}
+        WHERE {self.project_filter_sql()}
+          AND is_deleted = 0
+          AND (parent_span_id IS NULL OR parent_span_id = '')
+          AND (
+            (attributes_extra != '{{}}' AND attributes_extra != '')
+            OR length(mapKeys(attrs_string)) > 0
+            OR length(mapKeys(attrs_number)) > 0
+          )
+          AND {resolved_ts} IN %(attr_session_ids)s
+        LIMIT 500
+        """
+        return _append_v2_settings(sql), params
 
 
 __all__ = ["SessionListQueryBuilderV2"]

--- a/futureagi/tracer/tests/test_ch25_filter_compiler.py
+++ b/futureagi/tracer/tests/test_ch25_filter_compiler.py
@@ -180,3 +180,28 @@ class TestClickHouseFilterBuilderV2:
         assert meta["text"][0]    == cols.ATTRS_STRING
         assert meta["number"][0]  == cols.ATTRS_NUMBER
         assert meta["boolean"][0] == cols.ATTRS_BOOL
+
+    def test_user_id_filter_uses_v2_end_users_dimension(self):
+        builder = ClickHouseFilterBuilderV2(table="spans")
+        sql, params = builder.translate(
+            [
+                {
+                    "column_id": "user_id",
+                    "filter_config": {
+                        "col_type": "SYSTEM_METRIC",
+                        "filter_type": "text",
+                        "filter_op": "equals",
+                        "filter_value": "alice",
+                    },
+                }
+            ]
+        )
+
+        assert "FROM end_users AS eu FINAL" in sql
+        assert "SELECT eu.end_user_id" in sql
+        assert "eu.user_id = %(col_1)s" in sql
+        assert "eu.is_deleted = 0" in sql
+        assert "sp.is_deleted = 0" in sql
+        assert "tracer_enduser" not in sql
+        assert "AND deleted = 0" not in sql
+        assert params == {"col_1": "alice"}

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -660,6 +660,63 @@ class TestClickHouseFilterBuilder:
         assert "project_id = %(project_id)s" in where_pid
         assert "project_id IN %(project_ids)s" not in where_pid
 
+    def test_system_metric_trace_wrap_org_mode_uses_project_ids(self):
+        """Trace-mode SYSTEM_METRIC filters (e.g. ``node_type``) wrap the
+        condition in a ``trace_id IN (SELECT trace_id FROM spans WHERE
+        project_id ...)`` subquery. That wrap used to hardcode
+        ``project_id = %(project_id)s`` regardless of org scope, so
+        org-scoped requests (``project_ids`` set, no ``project_id``) raised
+        ``KeyError: 'project_id'`` at execution time — surfaced by
+        ``list_traces_of_session`` as a generic 400. Regression guard.
+        """
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder(
+            project_ids=["11111111-1111-1111-1111-111111111111"],
+            query_mode=ClickHouseFilterBuilder.QUERY_MODE_TRACE,
+        )
+        where, params = builder.translate(
+            [
+                {
+                    "column_id": "node_type",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "in",
+                        "filter_value": ["chain", "retriever"],
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ]
+        )
+
+        assert "trace_id IN" in where
+        assert "project_id IN %(project_ids)s" in where
+        assert "project_id = %(project_id)s" not in where
+        assert "project_id" not in params
+
+        # Single-project mode should still emit the scalar shape.
+        single_pid = ClickHouseFilterBuilder(
+            project_id="11111111-1111-1111-1111-111111111111",
+            query_mode=ClickHouseFilterBuilder.QUERY_MODE_TRACE,
+        )
+        where_pid, _ = single_pid.translate(
+            [
+                {
+                    "column_id": "node_type",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "in",
+                        "filter_value": ["chain", "retriever"],
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ]
+        )
+        assert "project_id = %(project_id)s" in where_pid
+        assert "project_id IN %(project_ids)s" not in where_pid
+
     def test_score_date_scope_can_be_disabled_for_monitor_builders(self):
         """Monitor queries bind start_time/end_time, not start_date/end_date."""
         from tracer.services.clickhouse.query_builders.filters import (

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -5656,7 +5656,7 @@ class TestFilterBuilderEdgeCases:
             }
         ]
         where, params = builder.translate(filters)
-        assert "model = %(col_1)s" in where
+        assert "lower(model) = %(col_1)s" in where
         assert params == {"col_1": "gpt-4"}
 
     def test_eval_metric_filter_subquery_structure(self):

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -2627,7 +2627,7 @@ class TestSessionListQueryBuilder:
         assert "duration = %(having_" not in query
 
     def test_build_with_user_id(self):
-        """When user_id is provided, query should filter by end_user_id."""
+        """User membership should select sessions without shrinking aggregates."""
         from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
 
         builder = SessionListQueryBuilder(
@@ -2638,7 +2638,12 @@ class TestSessionListQueryBuilder:
             user_id="user-123",
         )
         query, params = builder.build()
-        assert "end_user_id" in query
+        assert "trace_session_id IN (" in query
+        assert "SELECT trace_session_id, end_user_id" in query
+        assert "end_user_id = %(user_id)s" in query
+        assert query.index("trace_session_id IN (") < query.index(
+            "GROUP BY trace_session_id"
+        )
         assert params.get("user_id") == "user-123"
 
     def test_build_excludes_null_session_ids(self):
@@ -2654,8 +2659,8 @@ class TestSessionListQueryBuilder:
         query, params = builder.build()
         assert "trace_session_id IS NOT NULL" in query
 
-    def test_session_id_filter_casts_uuid_column_to_string(self):
-        """Session picker values are strings; the session_id filter resolves them
+    def test_session_filter_alias_resolves_before_grouping(self):
+        """Session picker values are strings; the frontend session filter resolves them
         new→old through the trace_session_id remap (P3b step1.5) so a cross-cutover
         straddler unifies under the OLD curated id, passing the ids as a bound
         UUID-set param — replacing the legacy ``toString(trace_session_id) IN`` cast.
@@ -2667,7 +2672,8 @@ class TestSessionListQueryBuilder:
             project_id="test-project-id",
             filters=[
                 {
-                    "column_id": "session_id",
+                    "column_id": "session",
+                    "display_name": "Session",
                     "filter_config": {
                         "filter_type": "text",
                         "filter_op": "in",
@@ -2685,12 +2691,84 @@ class TestSessionListQueryBuilder:
         # Resolved-membership form (id_remap_sql survivor-collapse), not the
         # legacy toString cast.
         assert "trace_session_id_remap" in query
-        assert "id_remap.survivor_id" in query
+        assert "ts_remap.survivor_id" in query
         assert "IN %(sess_1)s" in query
         assert "toString(trace_session_id) IN" not in query
+        assert query.index("IN %(sess_1)s") < query.index(
+            "GROUP BY trace_session_id"
+        )
         assert session_id in next(
             value for key, value in params.items() if key.startswith("sess_")
         )
+
+    def test_total_traces_count_frontend_alias_filters_and_sorts(self):
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "total_traces_count",
+                    "filter_config": {
+                        "filter_type": "number",
+                        "filter_op": "greater_than",
+                        "filter_value": 4,
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ],
+            sort_params=[
+                {"column_id": "total_traces_count", "direction": "desc"}
+            ],
+        )
+
+        query, params = builder.build()
+
+        assert "HAVING traces_count > %(having_" in query
+        assert "ORDER BY traces_count DESC" in query
+        assert 4 in params.values()
+
+    def test_first_message_filter_aggregates_before_having(self):
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "first_message",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "contains",
+                        "filter_value": "recursion",
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ],
+        )
+
+        query, params = builder.build()
+        count_query, _ = builder.build_count_query()
+
+        assert "argMin(input, start_time) AS first_message" in query
+        assert "HAVING first_message ILIKE %(having_" in query
+        assert "%recursion%" in params.values()
+        assert "argMin(input, start_time) AS first_message" in count_query
+
+    def test_v2_span_attributes_query_uses_native_ch25_columns(self):
+        from tracer.services.clickhouse.v2.query_builders.session_list import (
+            SessionListQueryBuilderV2,
+        )
+
+        builder = SessionListQueryBuilderV2(project_id="test-project-id")
+        builder.build()
+        query, _ = builder.build_span_attributes_query(["session-1"])
+
+        assert "attributes_extra AS span_attributes_raw" in query
+        assert "attrs_string" in query
+        assert "attrs_number" in query
+        assert "span_attr_str" not in query
+        assert "span_attr_num" not in query
+        assert "toJSONString(attributes_extra) AS span_attributes_raw" not in query
 
     def test_build_uses_uniq_not_uniqExact(self):
         """build() should use approximate uniq() instead of expensive uniqExact()."""
@@ -5232,6 +5310,63 @@ class TestEvalMetricsQueryBuilderExtended:
 @pytest.mark.unit
 class TestFilterBuilderEdgeCases:
     """Edge case tests for ClickHouseFilterBuilder."""
+
+    def test_nullable_uuid_column_text_ops_cast_to_string(self):
+        """Filtering a nullable-UUID column (session/user) must not crash and
+        must wrap the column in toString() for string-comparison ops.
+
+        Regression: ``_build_column_condition`` referenced an undefined
+        ``_UUID_TEXT_FILTER_OPS``, so any session_id/end_user_id/
+        trace_session_id filter raised AttributeError (e.g. the
+        list_traces_of_session endpoint). ClickHouse also rejects direct
+        UUID-vs-String comparisons, so the cast is required for correctness.
+        """
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        # ``session_id`` is a frontend alias normalized to ``trace_session_id``
+        # before it reaches the column condition, so assert on the canonical
+        # columns that actually surface in the SQL.
+        for column in ("trace_session_id", "end_user_id"):
+            for op in ("contains", "equals", "starts_with", "in", "not_in"):
+                builder = ClickHouseFilterBuilder()
+                value = ["abc", "def"] if op in ("in", "not_in") else "0f57a0c2"
+                filters = [
+                    {
+                        "column_id": column,
+                        "filter_config": {
+                            "filter_type": "categorical",
+                            "filter_op": op,
+                            "filter_value": value,
+                            "col_type": "SYSTEM_METRIC",
+                        },
+                    }
+                ]
+                where, _ = builder.translate(filters)
+                assert f"toString({column})" in where, (column, op, where)
+
+    def test_nullable_uuid_column_is_null_uses_bare_column(self):
+        """is_null/is_not_null on a nullable-UUID column skip the toString cast."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder()
+        filters = [
+            {
+                "column_id": "trace_session_id",
+                "filter_config": {
+                    "filter_type": "categorical",
+                    "filter_op": "is_null",
+                    "filter_value": None,
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+        where, _ = builder.translate(filters)
+        assert "trace_session_id IS NULL" in where
+        assert "toString(trace_session_id) IS NULL" not in where
 
     def test_not_equals_filter(self):
         """not_equals should produce != operator."""
@@ -7789,6 +7924,38 @@ class TestMonitorMetricsQueryBuilder:
 @pytest.mark.unit
 class TestSessionTimeSeriesQueryBuilder:
     """Test session graph query generation."""
+
+    def test_session_filter_alias_resolves_before_grouping(self):
+        from tracer.services.clickhouse.query_builders.session_time_series import (
+            SessionTimeSeriesQueryBuilder,
+        )
+
+        session_id = "003b76f1-2b4a-4af5-b0dc-224d687374d4"
+        builder = SessionTimeSeriesQueryBuilder(
+            project_id="project-1",
+            filters=[
+                {
+                    "column_id": "session",
+                    "display_name": "Session",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "in",
+                        "filter_value": [session_id],
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ],
+        )
+
+        query, params = builder.build()
+
+        assert "trace_session_id_remap" in query
+        assert "ts_remap.survivor_id" in query
+        assert "IN %(session_id_1)s" in query
+        assert query.index("IN %(session_id_1)s") < query.index(
+            "GROUP BY session_id"
+        )
+        assert params["session_id_1"] == (session_id,)
 
     def test_session_aggregate_filter_uses_inner_having(self):
         from tracer.services.clickhouse.query_builders.session_time_series import (

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -2646,6 +2646,31 @@ class TestSessionListQueryBuilder:
         )
         assert params.get("user_id") == "user-123"
 
+    def test_user_null_filter_presence_resolves_session_ids_before_membership(self):
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "end_user_id",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "is_not_null",
+                        "col_type": "SYSTEM_METRIC",
+                    },
+                }
+            ],
+        )
+
+        query, _params = builder.build()
+
+        assert "trace_session_id IN (" in query
+        assert "trace_session_id_remap" in query
+        assert "user_presence_ts_remap.survivor_id" in query
+        assert "GROUP BY trace_session_id" in query
+        assert "end_user_id IS NOT NULL" in query
+
     def test_build_excludes_null_session_ids(self):
         """Query should filter out rows without a session ID."""
         from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
@@ -2753,6 +2778,22 @@ class TestSessionListQueryBuilder:
         assert "HAVING first_message ILIKE %(having_" in query
         assert "%recursion%" in params.values()
         assert "argMin(input, start_time) AS first_message" in count_query
+
+    def test_first_message_sort_projects_message_aggregates(self):
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[],
+            sort_params=[{"column_id": "first_message", "direction": "asc"}],
+        )
+
+        query, _params = builder.build()
+
+        assert "argMin(input, start_time) AS first_message" in query
+        assert "argMax(input, start_time) AS last_message" in query
+        assert "SELECT trace_session_id, trace_id, start_time, end_time, cost, total_tokens, input" in query
+        assert "ORDER BY first_message ASC" in query
 
     def test_v2_span_attributes_query_uses_native_ch25_columns(self):
         from tracer.services.clickhouse.v2.query_builders.session_list import (

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -2020,6 +2020,78 @@ class TestDashboardQueryExecution:
         assert "sp.trace_session_id" in sql
 
     @pytest.mark.django_db
+    @patch(
+        "tracer.services.clickhouse.v2.trace_session_dict_reader."
+        "resolve_session_fields"
+    )
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    def test_filter_values_sessions_source_labels_session_ids(
+        self,
+        _mock_enabled,
+        mock_analytics_cls,
+        mock_resolve_session_fields,
+        auth_client,
+        observe_project,
+    ):
+        session_id = str(uuid.uuid4())
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = [{"val": session_id}]
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+        mock_resolve_session_fields.return_value = {
+            session_id: {
+                "external_session_id": "session-alpha",
+                "display_name": None,
+            }
+        }
+
+        response = auth_client.get(
+            "/tracer/dashboard/filter_values/",
+            {
+                "source": "sessions",
+                "metric_name": "session",
+                "metric_type": "system_metric",
+                "project_ids": str(observe_project.id),
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["result"]["values"] == [
+            {"value": session_id, "label": "session-alpha"}
+        ]
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    def test_filter_values_sessions_source_uses_span_backed_values(
+        self, _mock_enabled, mock_analytics_cls, auth_client, observe_project
+    ):
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = [{"val": "gpt-4o-mini"}]
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+
+        response = auth_client.get(
+            "/tracer/dashboard/filter_values/",
+            {
+                "source": "sessions",
+                "metric_name": "model",
+                "metric_type": "system_metric",
+                "project_ids": str(observe_project.id),
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["result"]["values"] == [
+            {"value": "gpt-4o-mini", "label": "gpt-4o-mini"}
+        ]
+        sql = mock_service.execute_ch_query.call_args.args[0]
+        assert "SELECT DISTINCT model AS val FROM spans" in sql
+
+    @pytest.mark.django_db
     def test_filter_values_annotation_annotator_returns_project_annotators(
         self, auth_client, project, observation_span, user, organization, workspace
     ):

--- a/futureagi/tracer/tests/test_eval_config_ids_resolution.py
+++ b/futureagi/tracer/tests/test_eval_config_ids_resolution.py
@@ -182,7 +182,6 @@ class TestEvalReadFailurePropagates:
                 view._retrieve_clickhouse(
                     request=mock.Mock(),
                     trace_session_id="s1",
-                    trace_session_obj=None,
                     project_id="p1",
                     analytics=_FakeAnalytics(),
                     query_data={"page_number": 0, "page_size": 30},
@@ -241,6 +240,17 @@ class TestEvalReadSelectors:
         assert "trace_id IN %(trace_ids)s" in query
         assert "custom_eval_config_id IN %(config_ids)s" in query
         assert captured["params"] == {"trace_ids": ["t1"], "config_ids": ["c1"]}
+
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_trace_eval_scores_null_safe_output_str(self):
+        """A NULL output_str (successful bool/float eval) must not be filtered out."""
+        svc, captured = _capturing_service([{"trace_id": "t", "config_id": "c"}])
+        svc.get_trace_eval_scores_ch(["t1"], ["c1"])
+        query = captured["query"]
+        assert "ifNull(output_str, '') != 'ERROR'" in query
+        assert "output_str != 'ERROR'" not in query.replace(
+            "ifNull(output_str, '') != 'ERROR'", ""
+        )
 
     def test_trace_eval_scores_empty_short_circuits(self):
         svc, captured = _capturing_service([{"trace_id": "t"}])

--- a/futureagi/tracer/tests/test_filter_serializer_contracts.py
+++ b/futureagi/tracer/tests/test_filter_serializer_contracts.py
@@ -222,6 +222,18 @@ class TestFilterSerializerContracts:
             "project-b",
         ]
 
+    def test_dashboard_filter_values_query_accepts_sessions_source(self):
+        serializer = DashboardFilterValuesQuerySerializer(
+            data={
+                "metric_name": "model",
+                "metric_type": "system_metric",
+                "source": "sessions",
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["source"] == "sessions"
+
     def test_session_filter_values_query_accepts_canonical_columns_only(self):
         serializer = TraceSessionFilterValuesQuerySerializer(
             data={

--- a/futureagi/tracer/tests/test_list_sessions_org_scope.py
+++ b/futureagi/tracer/tests/test_list_sessions_org_scope.py
@@ -92,15 +92,16 @@ class TestListSessionsClickHouseOrgScope:
         return analytics
 
     def _patch_session_name_lookup(self):
-        """Patch the TraceSession.objects.filter().values_list() call used
-        to map session_id → session_name. With no rows in the page this
-        path is a no-op, but the patch shields against a real DB hit."""
-        chain = mock.MagicMock()
-        chain.filter.return_value = chain
-        chain.values_list.return_value = []
+        """Patch CH-backed session name lookup so these unit tests stay local."""
         return mock.patch(
-            "tracer.views.trace_session.TraceSession.objects.filter",
-            return_value=chain,
+            "tracer.views.trace_session.TraceSessionView._fetch_session_names",
+            return_value={},
+        )
+
+    def _patch_annotation_labels(self):
+        return mock.patch(
+            "tracer.views.trace_session.AnnotationsLabels.objects.filter",
+            return_value=[],
         )
 
     def test_runs_without_nameerror_when_user_id_set_org_scope(self):
@@ -178,6 +179,170 @@ class TestListSessionsClickHouseOrgScope:
         cfg = synthetic[0]["filter_config"]
         assert cfg["filter_op"] == "in"
         assert set(cfg["filter_value"]) == {str(_id) for _id in eu_ids}
+
+    def test_user_id_filter_preserves_multi_value_list(self):
+        from tracer.services.clickhouse.query_builders import (
+            SessionListQueryBuilder as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        alice_id = str(uuid.uuid4())
+        bob_id = str(uuid.uuid4())
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        filters = [
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "in",
+                    "filter_value": ["alice", "bob"],
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
+                side_effect=[([alice_id], None), ([bob_id], None)],
+            ) as resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.services.clickhouse.query_builders." "SessionListQueryBuilder",
+                side_effect=_capture_builder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        assert [c.args[0] for c in resolve_mock.call_args_list] == ["alice", "bob"]
+        synthetic = [
+            f for f in captured["filters"] if f.get("column_id") == "end_user_id"
+        ]
+        assert len(synthetic) == 1
+        cfg = synthetic[0]["filter_config"]
+        assert cfg["filter_op"] == "in"
+        assert cfg["filter_value"] == [alice_id, bob_id]
+
+    def test_user_id_filter_preserves_negated_operator(self):
+        from tracer.services.clickhouse.query_builders import (
+            SessionListQueryBuilder as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+        alice_id = str(uuid.uuid4())
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        filters = [
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "not_equals",
+                    "filter_value": "alice",
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
+                return_value=([alice_id], None),
+            ),
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.services.clickhouse.query_builders." "SessionListQueryBuilder",
+                side_effect=_capture_builder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        synthetic = [
+            f for f in captured["filters"] if f.get("column_id") == "end_user_id"
+        ]
+        assert len(synthetic) == 1
+        assert synthetic[0]["filter_config"]["filter_op"] == "not_in"
+        assert synthetic[0]["filter_config"]["filter_value"] == [alice_id]
+
+    def test_user_id_null_filter_preserves_null_operator_without_resolution(self):
+        from tracer.services.clickhouse.query_builders import (
+            SessionListQueryBuilder as RealBuilder,
+        )
+
+        view = self._make_view()
+        request = self._make_request()
+        analytics = self._patch_analytics()
+        captured = {}
+
+        def _capture_builder(*args, **kwargs):
+            captured["filters"] = list(kwargs.get("filters") or [])
+            return RealBuilder(*args, **kwargs)
+
+        filters = [
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "is_null",
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+
+        with (
+            mock.patch(
+                "tracer.views.trace_session._resolve_end_user_ids_for_user_id"
+            ) as resolve_mock,
+            self._patch_session_name_lookup(),
+            self._patch_annotation_labels(),
+            mock.patch(
+                "tracer.services.clickhouse.query_builders." "SessionListQueryBuilder",
+                side_effect=_capture_builder,
+            ),
+        ):
+            view._list_sessions_clickhouse(
+                request,
+                project_id=uuid.uuid4(),
+                project=None,
+                analytics=analytics,
+                validated_data=self._make_validated_data(filters=filters),
+            )
+
+        resolve_mock.assert_not_called()
+        synthetic = [
+            f for f in captured["filters"] if f.get("column_id") == "end_user_id"
+        ]
+        assert len(synthetic) == 1
+        cfg = synthetic[0]["filter_config"]
+        assert cfg["filter_op"] == "is_null"
+        assert "filter_value" not in cfg
 
     def test_end_user_display_injected_without_extra_db_call(self):
         """When ``user_id`` resolves, the EndUser display fields should be

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -945,3 +945,255 @@ class TestTraceSessionOverlayWritePath:
         assert not TraceSessionOverlay.objects.filter(
             trace_session_id=trace_session.id
         ).exists()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestTraceSessionCHOnlyDestroyPath:
+    """CH-only sessions (no PG row) must be deletable via the same endpoint."""
+
+    def test_delete_ch_only_session_returns_204(self, auth_client, observe_project):
+        session_id = uuid.uuid4()
+        assert not TraceSession.objects.filter(id=session_id).exists()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "external_session_id": "ext-session-1",
+                "first_seen": timezone.now(),
+                "bookmarked": False,
+                "display_name": None,
+            },
+        ), mock.patch(
+            "tracer.services.clickhouse.v2.curated_writer._get_client"
+        ) as mock_ch_client:
+            mock_ch_client.return_value = mock.Mock()
+            response = auth_client.delete(
+                f"/tracer/trace-session/{session_id}/",
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_delete_ch_only_session_removes_overlay(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+        TraceSessionOverlay.objects.create(
+            trace_session_id=session_id,
+            project_id=observe_project.id,
+            bookmarked=True,
+            display_name="bookmarked-session",
+        )
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "external_session_id": "ext-session-1",
+                "first_seen": timezone.now(),
+                "bookmarked": True,
+                "display_name": "bookmarked-session",
+            },
+        ), mock.patch(
+            "tracer.services.clickhouse.v2.curated_writer._get_client"
+        ) as mock_ch_client:
+            mock_ch_client.return_value = mock.Mock()
+            response = auth_client.delete(
+                f"/tracer/trace-session/{session_id}/",
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not TraceSessionOverlay.objects.filter(
+            trace_session_id=session_id
+        ).exists()
+
+    def test_delete_ch_only_session_inserts_deletion_marker(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "external_session_id": "ext-session-1",
+                "first_seen": timezone.now(),
+                "bookmarked": False,
+                "display_name": None,
+            },
+        ), mock.patch(
+            "tracer.services.clickhouse.v2.curated_writer._get_client"
+        ) as mock_ch_client:
+            ch_client = mock.Mock()
+            mock_ch_client.return_value = ch_client
+            auth_client.delete(f"/tracer/trace-session/{session_id}/")
+
+        ch_client.insert.assert_called_once()
+        call_args = ch_client.insert.call_args
+        assert call_args.args[0] == "trace_sessions"
+        row = call_args.args[1][0]
+        is_deleted_col_idx = 5
+        assert row[is_deleted_col_idx] == 1
+
+    def test_delete_ch_only_session_not_found_returns_404(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value=None,
+        ):
+            response = auth_client.delete(
+                f"/tracer/trace-session/{session_id}/",
+            )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_pg_session_still_works(self, auth_client, trace_session):
+        response = auth_client.delete(
+            f"/tracer/trace-session/{trace_session.id}/",
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        trace_session.refresh_from_db()
+        assert trace_session.deleted is True
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestTraceSessionResponseContract:
+    """Both PG and CH-only PATCH paths must return the same response shape."""
+
+    EXPECTED_KEYS = {"id", "project", "bookmarked", "name", "created_at"}
+
+    def test_pg_patch_response_shape(self, auth_client, trace_session):
+        response = auth_client.patch(
+            f"/tracer/trace-session/{trace_session.id}/",
+            {"bookmarked": True},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert self.EXPECTED_KEYS <= set(data.keys())
+
+    def test_ch_only_patch_response_shape(self, auth_client, observe_project):
+        session_id = uuid.uuid4()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "bookmarked": False,
+                "display_name": "ch-session",
+                "first_seen": timezone.now(),
+            },
+        ):
+            response = auth_client.patch(
+                f"/tracer/trace-session/{session_id}/",
+                {"bookmarked": True},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert self.EXPECTED_KEYS <= set(data.keys())
+        assert data["id"] == str(session_id)
+        assert data["project"] == str(observe_project.id)
+        assert data["bookmarked"] is True
+        assert data["name"] == "ch-session"
+        assert data["created_at"] is not None
+
+    def test_ch_only_patch_created_at_is_iso_string(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+        first_seen = timezone.now()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "bookmarked": False,
+                "display_name": "ch-session",
+                "first_seen": first_seen,
+            },
+        ):
+            response = auth_client.patch(
+                f"/tracer/trace-session/{session_id}/",
+                {"bookmarked": True},
+                format="json",
+            )
+
+        data = response.json()
+        assert data["created_at"] == first_seen.isoformat()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestTraceSessionUserIdFilterValidation:
+    """Unsupported user_id filter operators must be rejected, not silently matched."""
+
+    def test_contains_op_rejected(self, auth_client, observe_project):
+        import json
+
+        filters = json.dumps([
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "col_type": "SYSTEM_METRIC",
+                    "filter_type": "text",
+                    "filter_op": "contains",
+                    "filter_value": "alice",
+                },
+            }
+        ])
+        response = auth_client.get(
+            "/tracer/trace-session/list_sessions/",
+            {"project_id": str(observe_project.id), "filters": filters},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_starts_with_op_rejected(self, auth_client, observe_project):
+        import json
+
+        filters = json.dumps([
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "col_type": "SYSTEM_METRIC",
+                    "filter_type": "text",
+                    "filter_op": "starts_with",
+                    "filter_value": "ali",
+                },
+            }
+        ])
+        response = auth_client.get(
+            "/tracer/trace-session/list_sessions/",
+            {"project_id": str(observe_project.id), "filters": filters},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_equals_op_accepted(self, auth_client, observe_project):
+        import json
+
+        filters = json.dumps([
+            {
+                "column_id": "user_id",
+                "filter_config": {
+                    "col_type": "SYSTEM_METRIC",
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "alice",
+                },
+            }
+        ])
+        with mock.patch(
+            "tracer.views.trace_session._resolve_end_user_ids_for_user_id",
+            return_value=([], None),
+        ):
+            response = auth_client.get(
+                "/tracer/trace-session/list_sessions/",
+                {"project_id": str(observe_project.id), "filters": filters},
+            )
+        assert response.status_code != status.HTTP_400_BAD_REQUEST

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -1075,7 +1075,7 @@ class TestTraceSessionResponseContract:
         )
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert self.EXPECTED_KEYS <= set(data.keys())
+        assert self.EXPECTED_KEYS == set(data.keys())
 
     def test_ch_only_patch_response_shape(self, auth_client, observe_project):
         session_id = uuid.uuid4()
@@ -1097,19 +1097,27 @@ class TestTraceSessionResponseContract:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert self.EXPECTED_KEYS <= set(data.keys())
+        assert self.EXPECTED_KEYS == set(data.keys())
         assert data["id"] == str(session_id)
         assert data["project"] == str(observe_project.id)
         assert data["bookmarked"] is True
         assert data["name"] == "ch-session"
         assert data["created_at"] is not None
 
-    def test_ch_only_patch_created_at_is_iso_string(
-        self, auth_client, observe_project
+    def test_pg_and_ch_created_at_use_same_format(
+        self, auth_client, observe_project, trace_session
     ):
-        session_id = uuid.uuid4()
-        first_seen = timezone.now()
+        """Both paths must serialize created_at to the same ISO format (Z suffix)."""
+        first_seen = trace_session.created_at
 
+        pg_response = auth_client.patch(
+            f"/tracer/trace-session/{trace_session.id}/",
+            {"bookmarked": True},
+            format="json",
+        )
+        pg_created_at = pg_response.json()["created_at"]
+
+        ch_session_id = uuid.uuid4()
         with mock.patch(
             "tracer.views.trace_session._resolve_ch_session_fields",
             return_value={
@@ -1119,14 +1127,14 @@ class TestTraceSessionResponseContract:
                 "first_seen": first_seen,
             },
         ):
-            response = auth_client.patch(
-                f"/tracer/trace-session/{session_id}/",
+            ch_response = auth_client.patch(
+                f"/tracer/trace-session/{ch_session_id}/",
                 {"bookmarked": True},
                 format="json",
             )
+        ch_created_at = ch_response.json()["created_at"]
 
-        data = response.json()
-        assert data["created_at"] == first_seen.isoformat()
+        assert pg_created_at == ch_created_at
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -140,6 +140,23 @@ class TestTraceSessionRetrieveAPI:
         response = auth_client.get(f"/tracer/trace-session/{other_session.id}/")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_retrieve_ch_only_session_requires_accessible_project(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+        inaccessible_project_id = uuid.uuid4()
+
+        with mock.patch(
+            "tracer.services.clickhouse.v2.trace_session_dict_reader."
+            "resolve_session_fields",
+            return_value={
+                str(session_id): {"project_id": str(inaccessible_project_id)}
+            },
+        ):
+            response = auth_client.get(f"/tracer/trace-session/{session_id}/")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_retrieve_session_has_navigation_fields(self, auth_client, trace_session):
         """Session detail response includes previous/next session IDs in session_metadata."""
         response = auth_client.get(f"/tracer/trace-session/{trace_session.id}/")
@@ -382,6 +399,60 @@ class TestTraceSessionExportAPI:
 class TestTraceSessionGraphAPI:
     """Tests for POST /tracer/trace-session/get_session_graph_data/ endpoint."""
 
+    def test_session_filter_uses_clickhouse_graph(
+        self, auth_client, observe_project
+    ):
+        session_id = "003b76f1-2b4a-4af5-b0dc-224d687374d4"
+        analytics = mock.Mock()
+        analytics.execute_ch_query.return_value = mock.Mock(data=[], columns=[])
+
+        with mock.patch(
+            "tracer.services.clickhouse.query_service.AnalyticsQueryService",
+            return_value=analytics,
+        ):
+            response = auth_client.post(
+                "/tracer/trace-session/get_session_graph_data/",
+                {
+                    "project_id": str(observe_project.id),
+                    "interval": "day",
+                    "property": "average",
+                    "req_data_config": {
+                        "id": "session_count",
+                        "type": "SYSTEM_METRIC",
+                    },
+                    "filters": [
+                        {
+                            "column_id": "created_at",
+                            "filter_config": {
+                                "filter_type": "datetime",
+                                "filter_op": "between",
+                                "filter_value": [
+                                    "2026-06-18T00:00:00Z",
+                                    "2026-06-19T00:00:00Z",
+                                ],
+                            },
+                        },
+                        {
+                            "column_id": "session",
+                            "display_name": "Session",
+                            "filter_config": {
+                                "filter_type": "text",
+                                "filter_op": "in",
+                                "filter_value": [session_id],
+                                "col_type": "SYSTEM_METRIC",
+                            },
+                        },
+                    ],
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert get_result(response)["metric_name"] == "session_count"
+        query, params = analytics.execute_ch_query.call_args.args[:2]
+        assert "IN %(session_id_1)s" in query
+        assert params["session_id_1"] == (session_id,)
+
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -474,6 +545,64 @@ class TestTraceSessionWorkspaceScopeAPI:
             format="json",
         )
         assert graph.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_user_filter_values_return_external_user_ids(
+        self, auth_client, observe_project
+    ):
+        analytics = mock.Mock()
+        analytics.execute_ch_query.return_value = mock.Mock(
+            data=[{"val": "alice"}, {"val": "bob"}]
+        )
+
+        with mock.patch(
+            "tracer.services.clickhouse.query_service.AnalyticsQueryService",
+            return_value=analytics,
+        ):
+            response = auth_client.get(
+                "/tracer/trace-session/get_session_filter_values/",
+                {"project_id": str(observe_project.id), "column": "user_id"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert get_result(response)["values"] == ["alice", "bob"]
+        query = analytics.execute_ch_query.call_args.args[0]
+        assert "FROM end_users FINAL" in query
+        assert "user_id AS val" in query
+
+    def test_session_filter_values_use_external_id_as_label(
+        self, auth_client, observe_project
+    ):
+        analytics = mock.Mock()
+        analytics.execute_ch_query.return_value = mock.Mock(
+            data=[{"val": str(uuid.uuid4()), "label": "session-alpha"}]
+        )
+        session_id = analytics.execute_ch_query.return_value.data[0]["val"]
+
+        with (
+            mock.patch(
+                "tracer.services.clickhouse.query_service.AnalyticsQueryService",
+                return_value=analytics,
+            ),
+            mock.patch(
+                "tracer.services.clickhouse.v2.trace_session_dict_reader."
+                "resolve_session_fields",
+                return_value={
+                    session_id: {
+                        "external_session_id": "session-alpha",
+                        "display_name": None,
+                    }
+                },
+            ),
+        ):
+            response = auth_client.get(
+                "/tracer/trace-session/get_session_filter_values/",
+                {"project_id": str(observe_project.id), "column": "session_id"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert get_result(response)["values"] == [
+            {"value": session_id, "label": "session-alpha"}
+        ]
 
     def test_generic_delete_cascades_session_traces_spans_and_eval_logs(
         self, auth_client, observe_project
@@ -681,7 +810,6 @@ class TestTraceSessionOverlayWritePath:
             response = TraceSessionView()._retrieve_clickhouse(
                 mock.Mock(),
                 requested_id,
-                mock.Mock(id=requested_id),
                 observe_project.id,
                 analytics,
                 {"page_number": 0, "page_size": 10},

--- a/futureagi/tracer/tests/test_trace_session.py
+++ b/futureagi/tracer/tests/test_trace_session.py
@@ -604,6 +604,33 @@ class TestTraceSessionWorkspaceScopeAPI:
             {"value": session_id, "label": "session-alpha"}
         ]
 
+    def test_session_filter_values_dedupe_straddlers_through_remap(
+        self, auth_client, observe_project
+    ):
+        survivor_id = str(uuid.uuid4())
+        analytics = mock.Mock()
+        analytics.execute_ch_query.return_value = mock.Mock(
+            data=[{"val": survivor_id, "label": "session-alpha"}]
+        )
+
+        with mock.patch(
+            "tracer.services.clickhouse.query_service.AnalyticsQueryService",
+            return_value=analytics,
+        ):
+            response = auth_client.get(
+                "/tracer/trace-session/get_session_filter_values/",
+                {"project_id": str(observe_project.id), "column": "session_id"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert get_result(response)["values"] == [
+            {"value": survivor_id, "label": "session-alpha"}
+        ]
+        query = analytics.execute_ch_query.call_args.args[0]
+        assert "trace_session_id_remap" in query
+        assert "GROUP BY val_id" in query
+        assert "toString(val_id) AS val" in query
+
     def test_generic_delete_cascades_session_traces_spans_and_eval_logs(
         self, auth_client, observe_project
     ):
@@ -674,6 +701,34 @@ class TestTraceSessionOverlayWritePath:
         assert overlay.project_id == trace_session.project_id
         # display_name mirrors current name (the fixture session's name).
         assert overlay.display_name == trace_session.name
+
+    def test_patch_bookmark_writes_overlay_for_ch_only_session(
+        self, auth_client, observe_project
+    ):
+        session_id = uuid.uuid4()
+        assert not TraceSession.objects.filter(id=session_id).exists()
+
+        with mock.patch(
+            "tracer.views.trace_session._resolve_ch_session_fields",
+            return_value={
+                "project_id": observe_project.id,
+                "bookmarked": False,
+                "display_name": "collector-session",
+                "first_seen": None,
+            },
+        ):
+            response = auth_client.patch(
+                f"/tracer/trace-session/{session_id}/",
+                {"bookmarked": True},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not TraceSession.objects.filter(id=session_id).exists()
+        overlay = TraceSessionOverlay.objects.get(trace_session_id=session_id)
+        assert overlay.project_id == observe_project.id
+        assert overlay.bookmarked is True
+        assert overlay.display_name == "collector-session"
 
     def test_patch_rename_sets_overlay_display_name(self, auth_client, trace_session):
         """PATCH name='renamed-via-2b' → overlay.display_name reflects the rename."""

--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -489,31 +489,36 @@ def validate_sort_params_helper(value):
     return value
 
 
-def get_annotation_labels_for_project(project_id, organization=None):
+def get_annotation_labels_for_project(project_id, organization=None, project_ids=None):
     """Find annotation labels that have at least one Score in a project.
 
     Labels may not have a direct ``project`` FK set (e.g. org-wide centralized
     labels), so we also look for labels referenced by Score records in the project.
 
+    Pass ``project_ids`` (a list) instead of ``project_id`` to scope across
+    multiple projects (org-scoped span listing).
+
     The score→project lookup is routed via ``_REGISTRY["ANNOTATION_LABELS"]``:
     V1_ONLY reads PG (Score joins legacy trace/observation_span), V2_ONLY reads
     CH (model_hub_score scoped via spans). See ``annotation_label_source``.
-
-    Pre-deprecation this method also union'd in ``TraceAnnotation``-referenced
-    labels. Score is the unified store now (the dual-write mirrors every
-    TraceAnnotation write to Score, so any label in TraceAnnotation is also
-    reachable via Score). Reading both was redundant; reading Score alone
-    is the path forward toward fully retiring TraceAnnotation.
     """
     from django.db.models import Q
 
     from tracer.services.clickhouse.v2.dispatch import get_query_builder_class
 
     SourceCls = get_query_builder_class("ANNOTATION_LABELS")  # noqa: N806
-    score_label_ids = SourceCls().label_ids_for_project(project_id)
+
+    if project_ids is not None:
+        score_label_ids = set()
+        for pid in project_ids:
+            score_label_ids.update(SourceCls().label_ids_for_project(pid))
+        owner_q = Q(project_id__in=project_ids)
+    else:
+        score_label_ids = SourceCls().label_ids_for_project(project_id)
+        owner_q = Q(project_id=project_id)
 
     return AnnotationsLabels.objects.filter(
-        Q(project_id=project_id) | Q(id__in=score_label_ids),
+        owner_q | Q(id__in=score_label_ids),
         deleted=False,
     ).distinct()
 

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -2260,7 +2260,26 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     )
                     values = []
 
-                if metric_name == "project":
+                if metric_name == "session" and source == "sessions":
+                    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+                        resolve_session_fields,
+                    )
+
+                    session_fields = resolve_session_fields(values)
+                    values = [
+                        {
+                            "value": value,
+                            "label": str(
+                                session_fields.get(value, {}).get("display_name")
+                                or session_fields.get(value, {}).get(
+                                    "external_session_id"
+                                )
+                                or value
+                            ),
+                        }
+                        for value in values
+                    ]
+                elif metric_name == "project":
                     name_map = dict(
                         Project.objects.filter(
                             id__in=project_ids,

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -1288,14 +1288,31 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         try:
             validated_data = request.validated_query_data
 
-            project_id = str(validated_data["project_id"])
-
-            # Tenant gate via PG (Project + organization filter).
-            Project.objects.get(
-                _project_workspace_scope_q(self.request, project_prefix=""),
-                id=project_id,
-                organization=_get_request_organization(request),
+            project_id = (
+                str(validated_data["project_id"])
+                if validated_data.get("project_id")
+                else None
             )
+            org = _get_request_organization(request)
+
+            org_project_ids = None
+            if project_id:
+                try:
+                    Project.objects.get(
+                        _project_workspace_scope_q(self.request, project_prefix=""),
+                        id=project_id,
+                        organization=org,
+                    )
+                except Project.DoesNotExist:
+                    return self._gm.bad_request("Project not found or access denied")
+            else:
+                org_project_ids = list(
+                    Project.objects.filter(
+                        _project_workspace_scope_q(self.request, project_prefix=""),
+                        organization=org,
+                        deleted=False,
+                    ).values_list("id", flat=True)
+                )
 
             # ClickHouse dispatch
             from tracer.services.clickhouse.query_service import (
@@ -1312,7 +1329,12 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             # Postgres path, which masked CH failures as "0 rows".
             analytics = AnalyticsQueryService()
             return self._list_spans_clickhouse(
-                request, project_id, validated_data, analytics
+                request,
+                project_id,
+                validated_data,
+                analytics,
+                org_project_ids=org_project_ids,
+                org=org,
             )
 
         except Exception as e:
@@ -1321,7 +1343,15 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 f"error fetching the spans list of observe {str(e)}"
             )
 
-    def _list_spans_clickhouse(self, request, project_id, validated_data, analytics):
+    def _list_spans_clickhouse(
+        self,
+        request,
+        project_id,
+        validated_data,
+        analytics,
+        org_project_ids=None,
+        org=None,
+    ):
         """List spans using ClickHouse backend.
 
         Builder class is resolved via the v1↔v2 dispatch — set
@@ -1333,6 +1363,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         from tracer.services.clickhouse.v2.dispatch import get_query_builder_class
 
         BuilderCls = get_query_builder_class("SPAN_LIST")  # noqa: N806
+
+        org_scope = bool(org_project_ids)
+        if org is None:
+            org = _get_request_organization(request)
         # The v2 builder is a subclass of the v1 builder, so the pivot
         # helpers below (called as classmethods on the v1 name) work for
         # both — keep the v1 import for those static calls.
@@ -1371,24 +1405,39 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 }
             )
 
-        # Get eval config IDs from CH (fast) instead of PG EvalLogger scan,
-        # via the shared service selector (same lookup trace.py uses).
+        # Get eval config IDs. Single-project uses the fast CH dict-lookup;
+        # org-scoped falls back to a PG EvalLogger scan.
         eval_config_ids = []
-        ch_ids = analytics.get_eval_config_ids_with_data_ch(
-            str(project_id), timeout_ms=30000
-        )
-        if ch_ids:
+        if org_scope:
+            _eval_ids = (
+                EvalLogger.objects.filter(
+                    observation_span__project_id__in=org_project_ids
+                )
+                .values("custom_eval_config_id")
+                .distinct()
+            )
             eval_configs = CustomEvalConfig.objects.filter(
-                id__in=ch_ids, deleted=False
+                id__in=_eval_ids, deleted=False
             ).select_related("eval_template")
             eval_config_ids = [str(c.id) for c in eval_configs]
         else:
-            eval_configs = []
+            ch_ids = analytics.get_eval_config_ids_with_data_ch(
+                str(project_id), timeout_ms=30000
+            )
+            if ch_ids:
+                eval_configs = CustomEvalConfig.objects.filter(
+                    id__in=ch_ids, deleted=False
+                ).select_related("eval_template")
+                eval_config_ids = [str(c.id) for c in eval_configs]
+            else:
+                eval_configs = []
 
         # Labels can be project-local or org/shared labels that are referenced
         # by span scores. Use the score-backed helper so span columns and
         # annotation filters match the actual data returned from ClickHouse.
-        annotation_labels = get_annotation_labels_for_project(project_id)
+        annotation_labels = get_annotation_labels_for_project(
+            project_id, project_ids=org_project_ids if org_scope else None
+        )
         annotation_label_ids = [str(lbl.id) for lbl in annotation_labels]
         label_types = {str(lbl.id): lbl.type for lbl in annotation_labels}
 
@@ -1396,7 +1445,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # filter in `filters` (resolved via the remap-aware `end_users` path
         # above), so the builder's bespoke single-id end_user path is unused here.
         builder = BuilderCls(
-            project_id=str(project_id),
+            project_id=None if org_scope else str(project_id),
+            project_ids=[str(p) for p in org_project_ids] if org_scope else None,
             filters=filters,
             page_number=page_number,
             page_size=page_size,

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -377,17 +377,9 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             )
 
     def update(self, request, *args, **kwargs):
-        """Update a session's bookmark / name, including CH-only sessions.
-
-        fi-collector sessions live only in CH (no PG ``TraceSession`` row), so
-        the default ``get_object()`` (PG queryset) 404s for them. But the
-        writable state — ``bookmarked`` / ``name`` — lives in the PG
-        ``TraceSessionOverlay``, which is soft-id keyed by ``trace_session_id``
-        and needs NO PG session row (DESIGN §5.1). So when the PG lookup misses
-        we re-run the SAME tenant gate the read path uses
-        (``_resolve_ch_session_fields``) and write the overlay directly, instead
-        of failing the bookmark / rename PATCH for collector sessions.
-        """
+        # CH-only sessions still need bookmark / rename writes to land in the
+        # PG overlay. If the PG row is missing, retry through the CH session
+        # resolver and write the overlay directly under the same tenant gate.
         partial = kwargs.get("partial", False)
         try:
             return super().update(request, *args, **kwargs)

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -333,58 +333,54 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
         return queryset
 
+    @staticmethod
+    def _upsert_overlay(
+        trace_session_id, *, project_id, bookmarked, display_name
+    ):
+        """Single write path for the TraceSessionOverlay (DESIGN §5 / §5.1).
+
+        Used by BOTH the PG-backed ``perform_update`` (post-save mirror) and
+        the CH-only write path (no PG ``TraceSession`` row). One invariant,
+        one code path, no drift.
+        """
+        from tracer.models.trace_session import TraceSessionOverlay
+
+        TraceSessionOverlay.objects.update_or_create(
+            trace_session_id=trace_session_id,
+            defaults={
+                "project_id": project_id,
+                "bookmarked": bookmarked,
+                "display_name": display_name,
+            },
+        )
+
     def perform_update(self, serializer):
         """Persist a TraceSession update AND mirror the UI overlay (slice 2b).
-
-        ``bookmarked`` and ``name`` are the user-writable fields on
-        ``TraceSessionSerializer`` (the bookmark / rename UI write path). The
-        legacy ``TraceSession.bookmarked``/``name`` write is kept UNCHANGED here
-        (the PG-fallback read and legacy callers still read it during the
-        dual-source window; it retires at contract / P4). On top of that we now
-        ALSO upsert the PG ``TraceSessionOverlay`` so slice 2a's overlay-backed
-        reads — ``_build_bookmark_filter`` (bookmarked → ids) and
-        ``_fetch_session_names`` (``COALESCE(overlay.display_name, …)``) — stay
-        fresh (DESIGN §5 / §5.1, the user overlay + the rename-bug separation).
-
-        ATOMICITY: the overlay lives in the SAME PG database as ``TraceSession``,
-        so the ``save()`` and the overlay ``update_or_create`` are wrapped in ONE
-        ``transaction.atomic()`` and commit both-or-neither. This is a PG↔PG
-        write that MUST stay consistent — deliberately NOT the best-effort CH
-        dual-write pattern (which tolerates a failed mirror).
 
         The overlay fields are read from the POST-SAVE instance, never from
         ``validated_data``: a partial PATCH (e.g. only ``{"bookmarked": true}``)
         carries no ``name``, so sourcing ``display_name`` from ``validated_data``
-        would clobber an existing rename (and a name-only PATCH would clobber
-        ``bookmarked``). ``instance`` always reflects the full current state.
-
-        ``display_name`` mirrors the current ``name``: for a never-renamed
-        session it equals the external session id (harmless — slice 2a's COALESCE
-        would surface the same value), and for a rename it is the new label,
-        which is exactly the overlay's purpose.
+        would clobber an existing rename. ``instance`` always reflects the full
+        current state.
         """
-        from tracer.models.trace_session import TraceSessionOverlay
-
         with transaction.atomic():
             instance = serializer.save()
-            TraceSessionOverlay.objects.update_or_create(
-                trace_session_id=instance.id,
-                defaults={
-                    "project_id": instance.project_id,
-                    "bookmarked": instance.bookmarked,
-                    "display_name": instance.name,
-                },
+            self._upsert_overlay(
+                instance.id,
+                project_id=instance.project_id,
+                bookmarked=instance.bookmarked,
+                display_name=instance.name,
             )
 
     def update(self, request, *args, **kwargs):
-        # CH-only sessions still need bookmark / rename writes to land in the
-        # PG overlay. If the PG row is missing, retry through the CH session
-        # resolver and write the overlay directly under the same tenant gate.
+        # Narrow the Http404 catch to the object lookup ONLY. Any 404 from
+        # validation, signals, or nested lookups must propagate normally.
         partial = kwargs.get("partial", False)
         try:
-            return super().update(request, *args, **kwargs)
+            self.get_object()
         except Http404:
             return self._update_ch_only_session(request, partial=partial)
+        return super().update(request, *args, **kwargs)
 
     def _update_ch_only_session(self, request, *, partial):
         """Overlay-only write path for a CH-only (collector) session."""
@@ -397,37 +393,93 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         serializer.is_valid(raise_exception=True)
         validated = serializer.validated_data
 
-        from tracer.models.trace_session import TraceSessionOverlay
-
         project_id = session_fields["project_id"]
-        with transaction.atomic():
-            # Seed a new overlay from the session's current (CH-merged) state so
-            # a partial PATCH (only ``bookmarked`` or only ``name``) never
-            # clobbers the other field.
-            overlay, _ = TraceSessionOverlay.objects.get_or_create(
-                trace_session_id=trace_session_id,
-                defaults={
-                    "project_id": project_id,
-                    "bookmarked": bool(session_fields.get("bookmarked")),
-                    "display_name": session_fields.get("display_name"),
-                },
-            )
-            overlay.project_id = project_id
-            if validated.get("bookmarked") is not None:
-                overlay.bookmarked = validated["bookmarked"]
-            if "name" in validated:
-                overlay.display_name = validated["name"]
-            overlay.save()
 
+        current_bookmarked = bool(session_fields.get("bookmarked"))
+        current_name = session_fields.get("display_name")
+        new_bookmarked = (
+            validated["bookmarked"]
+            if validated.get("bookmarked") is not None
+            else current_bookmarked
+        )
+        new_name = validated.get("name", current_name)
+
+        with transaction.atomic():
+            self._upsert_overlay(
+                trace_session_id,
+                project_id=project_id,
+                bookmarked=new_bookmarked,
+                display_name=new_name,
+            )
+
+        first_seen = session_fields.get("first_seen")
+        created_at = (
+            first_seen.isoformat() if hasattr(first_seen, "isoformat") else first_seen
+        )
         return Response(
             {
                 "id": str(trace_session_id),
                 "project": str(project_id),
-                "bookmarked": overlay.bookmarked,
-                "name": overlay.display_name,
-                "created_at": session_fields.get("first_seen"),
+                "bookmarked": new_bookmarked,
+                "name": new_name,
+                "created_at": created_at,
             }
         )
+
+    def destroy(self, request, *args, **kwargs):
+        try:
+            instance = self.get_object()
+        except Http404:
+            return self._destroy_ch_only_session(request)
+        self.perform_destroy(instance)
+        return Response(status=drf_status.HTTP_204_NO_CONTENT)
+
+    def _destroy_ch_only_session(self, request):
+        """Soft-delete a CH-only (collector) session under the same tenant gate."""
+        from datetime import UTC, datetime
+
+        from tracer.models.trace_session import TraceSessionOverlay
+
+        trace_session_id = self.kwargs.get("pk")
+        session_fields = _resolve_ch_session_fields(request, trace_session_id)
+        if not session_fields:
+            raise Http404("Trace session not found")
+
+        project_id = session_fields["project_id"]
+
+        TraceSessionOverlay.objects.filter(
+            trace_session_id=trace_session_id
+        ).delete()
+
+        # Mark as deleted in the CH trace_sessions RMT: INSERT a row with
+        # is_deleted=1 and a newer version so FINAL picks it up.
+        from tracer.services.clickhouse.v2.curated_writer import (
+            _TRACE_SESSION_COLUMNS,
+            _get_client,
+            _reset_client,
+        )
+
+        try:
+            client = _get_client()
+            now = datetime.now(UTC)
+            row = [
+                str(project_id),
+                str(trace_session_id),
+                session_fields.get("external_session_id", ""),
+                session_fields.get("first_seen", now),
+                now,  # version — newer than the live row
+                1,  # is_deleted
+            ]
+            client.insert(
+                "trace_sessions", [row], column_names=list(_TRACE_SESSION_COLUMNS)
+            )
+        except Exception:
+            _reset_client()
+            # Best-effort: the overlay is already removed so the session
+            # won't appear in bookmark lists. A stale CH row is acceptable
+            # (it will be caught by eventual-consistency sweeps).
+
+        return Response(status=drf_status.HTTP_204_NO_CONTENT)
 
     def perform_destroy(self, instance):
         _soft_delete_trace_session_tree([instance])
@@ -1998,7 +2050,14 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # select under the same OLD id. A net-new id has no remap entry (resolves
         # to itself), so no double-count.
         _NULL_USER_OPS = {"is_null", "is_not_null"}
-        _NEGATED_USER_OPS = {"not_in", "not_equals", "ne", "neq"}
+        _NEGATED_USER_OPS = {"not_in", "not_equals"}
+        _SUPPORTED_USER_OPS = _NULL_USER_OPS | _NEGATED_USER_OPS | {"in", "equals"}
+
+        if user_id_op and user_id_op not in _SUPPORTED_USER_OPS:
+            return self._gm.bad_request(
+                f"Unsupported operator '{user_id_op}' for user_id filter. "
+                f"Supported: {sorted(_SUPPORTED_USER_OPS)}"
+            )
 
         end_user_display = None
         if user_id_op in _NULL_USER_OPS:

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -190,6 +190,56 @@ def _resolve_ch_session_fields(request, trace_session_id):
     return session_fields
 
 
+def _resolve_end_user_ids_for_user_id(user_id, *, org, org_scope, project_id):
+    """Resolve a string ``user_id`` to the set of CH ``end_user`` UUIDs.
+
+    The CH ``spans`` table keys users by the UUID ``end_user_id``, not the
+    string ``user_id``, so a string filter must be reverse-resolved. Prefers
+    the curated CH ``end_users`` dimension (state-robust across the P3b id
+    cutover); falls back to PG ``EndUser`` only when CH yields nothing.
+
+    Returns ``(ids, display_row)`` where ``display_row`` is the first matched
+    PG row's display fields (``user_id``/``user_id_type``/``user_id_hash``) or
+    ``None`` — used to label the single-user (cross-project) detail page.
+    """
+    from tracer.services.clickhouse.v2.end_user_dict_reader import (
+        resolve_end_user_ids_by_user_id,
+    )
+
+    try:
+        ids = resolve_end_user_ids_by_user_id(
+            user_id,
+            organization_id=org.id if org else None,
+            project_id=(project_id if (not org_scope and project_id) else None),
+        )
+    except Exception as e:
+        logger.warning(
+            "session_list_user_id_ch_resolve_failed", error=str(e)[:200]
+        )
+        ids = []
+
+    display_row = None
+    if not ids:
+        try:
+            end_user_qs = EndUser.objects.filter(user_id=user_id)
+            if org:
+                end_user_qs = end_user_qs.filter(organization=org)
+            if not org_scope and project_id:
+                end_user_qs = end_user_qs.filter(project_id=project_id)
+            end_user_rows = list(
+                end_user_qs.values("id", "user_id", "user_id_type", "user_id_hash")
+            )
+            ids = [str(row.get("id")) for row in end_user_rows if row.get("id")]
+            if end_user_rows:
+                display_row = end_user_rows[0]
+        except Exception as e:
+            logger.warning(
+                "session_list_user_id_pg_fallback_failed", error=str(e)[:200]
+            )
+            ids = []
+    return ids, display_row
+
+
 def _soft_delete_trace_session_tree(trace_sessions):
     now = timezone.now()
     sessions = list(trace_sessions)
@@ -325,6 +375,67 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     "display_name": instance.name,
                 },
             )
+
+    def update(self, request, *args, **kwargs):
+        """Update a session's bookmark / name, including CH-only sessions.
+
+        fi-collector sessions live only in CH (no PG ``TraceSession`` row), so
+        the default ``get_object()`` (PG queryset) 404s for them. But the
+        writable state — ``bookmarked`` / ``name`` — lives in the PG
+        ``TraceSessionOverlay``, which is soft-id keyed by ``trace_session_id``
+        and needs NO PG session row (DESIGN §5.1). So when the PG lookup misses
+        we re-run the SAME tenant gate the read path uses
+        (``_resolve_ch_session_fields``) and write the overlay directly, instead
+        of failing the bookmark / rename PATCH for collector sessions.
+        """
+        partial = kwargs.get("partial", False)
+        try:
+            return super().update(request, *args, **kwargs)
+        except Http404:
+            return self._update_ch_only_session(request, partial=partial)
+
+    def _update_ch_only_session(self, request, *, partial):
+        """Overlay-only write path for a CH-only (collector) session."""
+        trace_session_id = self.kwargs.get("pk")
+        session_fields = _resolve_ch_session_fields(request, trace_session_id)
+        if not session_fields:
+            raise Http404("Trace session not found")
+
+        serializer = self.get_serializer(data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        from tracer.models.trace_session import TraceSessionOverlay
+
+        project_id = session_fields["project_id"]
+        with transaction.atomic():
+            # Seed a new overlay from the session's current (CH-merged) state so
+            # a partial PATCH (only ``bookmarked`` or only ``name``) never
+            # clobbers the other field.
+            overlay, _ = TraceSessionOverlay.objects.get_or_create(
+                trace_session_id=trace_session_id,
+                defaults={
+                    "project_id": project_id,
+                    "bookmarked": bool(session_fields.get("bookmarked")),
+                    "display_name": session_fields.get("display_name"),
+                },
+            )
+            overlay.project_id = project_id
+            if validated.get("bookmarked") is not None:
+                overlay.bookmarked = validated["bookmarked"]
+            if "name" in validated:
+                overlay.display_name = validated["name"]
+            overlay.save()
+
+        return Response(
+            {
+                "id": str(trace_session_id),
+                "project": str(project_id),
+                "bookmarked": overlay.bookmarked,
+                "name": overlay.display_name,
+                "created_at": session_fields.get("first_seen"),
+            }
+        )
 
     def perform_destroy(self, instance):
         _soft_delete_trace_session_tree([instance])
@@ -647,20 +758,45 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             analytics = AnalyticsQueryService()
 
             if ch_column == "trace_session_id":
+                from tracer.services.clickhouse.v2.id_remap_sql import (
+                    remap_left_join,
+                    resolved_id_expr,
+                )
+
+                # Resolve new→old through trace_session_id_remap and group by
+                # the survivor id so a cross-cutover straddler (which has BOTH
+                # an old and a deterministic row in trace_sessions) is listed
+                # ONCE — matching the span-backed value paths below. Reading
+                # trace_sessions directly would surface both rows as duplicates.
                 search_clause = (
                     "AND (external_session_id ILIKE %(search)s "
                     "OR toString(trace_session_id) ILIKE %(search)s)"
                     if search
                     else ""
                 )
+                ts_join = remap_left_join(
+                    "ts.trace_session_id", "trace_session_id_remap", "ts_remap"
+                )
+                resolved_ts = resolved_id_expr("ts.trace_session_id", "ts_remap")
                 query = f"""
                 SELECT
-                    toString(trace_session_id) AS val,
-                    external_session_id AS label
-                FROM trace_sessions FINAL
-                WHERE project_id = %(project_id)s
-                  AND is_deleted = 0
-                  {search_clause}
+                    toString(val_id) AS val,
+                    any(label) AS label
+                FROM (
+                    SELECT
+                        {resolved_ts} AS val_id,
+                        ts.external_session_id AS label
+                    FROM (
+                        SELECT trace_session_id, external_session_id
+                        FROM trace_sessions FINAL
+                        WHERE project_id = %(project_id)s
+                          AND is_deleted = 0
+                          {search_clause}
+                    ) AS ts
+                    {ts_join}
+                )
+                WHERE val_id != toUUID('{NIL_UUID}')
+                GROUP BY val_id
                 ORDER BY label, val
                 LIMIT %(limit)s OFFSET %(offset)s
                 """
@@ -1817,109 +1953,113 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             request, "query_params", {}
         ).get("user_id")
 
-        # Support user_id injected as a structural filter (the cross-project
-        # user detail page prepends one). Extract the raw user_id string from
-        # either query_params or filters, strip it from the filter list, then
-        # resolve it to a set of EndUser UUIDs and pass an end_user_id IN(...)
-        # synthetic filter instead (the CH `spans` table keys users via the
-        # UUID column `end_user_id`, not the string `user_id`).
-        user_id_raw = user_id_qp or None
+        # Support user_id supplied as a structural filter (the cross-project
+        # user-detail page prepends one) or as a query param. The CH `spans`
+        # table keys users by the UUID `end_user_id`, not the string `user_id`,
+        # so we strip every user_id filter out, reverse-resolve the string
+        # value(s) to end_user UUIDs and re-inject a synthetic `end_user_id`
+        # filter. The original OPERATOR and the FULL value list are preserved:
+        # `user_id in [alice, bob]` must match BOTH, and not_equals / is_null
+        # must not be silently rewritten to `in`.
+        user_id_op: str | None = None
+        user_id_values: list[str] = []
         _remaining = []
         for _f in filters:
             _col, _cfg = FilterEngine._normalize_filter_params(_f)
             if _col == "user_id":
+                if user_id_op is None:
+                    user_id_op = _cfg.get("filter_op") or "in"
                 _val = _cfg.get("filter_value")
                 if isinstance(_val, list):
-                    _val = _val[0] if _val else None
-                if _val and not user_id_raw:
-                    user_id_raw = _val
+                    user_id_values.extend(
+                        str(v) for v in _val if v not in (None, "")
+                    )
+                elif _val not in (None, ""):
+                    user_id_values.append(str(_val))
                 continue
             _remaining.append(_f)
         filters = _remaining
 
-        # Resolve the raw user_id to a list of end_user UUIDs and inject as
-        # a synthetic end_user_id IN(...) filter. Scope by org (and project
-        # if we're in project mode).
-        #
-        # P3b step2 precondition — the reverse-resolve is now CH `end_users`, not
-        # PG `EndUser.objects` (PG_ORM_READ_MIGRATION, Slice B). The old PG lookup
-        # FREEZES post-step2: a NET-NEW user (first seen after the ingest
-        # get_or_create is dropped) has NO `tracer_enduser` row, so PG returned []
-        # → `_ids = [NIL_UUID]` → a SILENTLY EMPTY session list for it. The curated
-        # CH `end_users` dimension instead yields the state-robust id-SET:
-        # historical OLD-id row + net-new DETERMINISTIC-id row + a straddler's
-        # BOTH. This is the `_ids` that gets the NET-NEW user its sessions.
-        #
-        # P3b step1.5 (DESIGN §3 / id_remap_sql) — still the downstream mechanism:
-        # `_ids` are the CURATED keys (OLD pre-sweep). The SessionListQueryBuilder
-        # extracts this synthetic `end_user_id` filter (`_ENDUSER_ID_FILTER_COLS`)
-        # and binds it to the id-remap-RESOLVED `end_user_id` column
-        # (`_build_resolved_user_clause`), so a STRADDLER's NEW (deterministic-id)
-        # spans resolve new→old and select under the same OLD id. The earlier
-        # "do NOT expand `_ids` with deterministic ids here" caveat was
-        # STRADDLER-scoped (a straddler already had an old id, so adding its new id
-        # was redundant with the join-resolve). NET-NEW is different: it has ONLY
-        # the deterministic id and NO old id, so that curated deterministic id MUST
-        # be in `_ids` or the list is silently empty — and `end_users` supplies it
-        # directly (no deterministic_id compute here), no double-count because a
-        # net-new id has no remap entry (resolves to itself).
-        end_user_display = None
-        if user_id_raw:
-            from tracer.services.clickhouse.v2.end_user_dict_reader import (
-                resolve_end_user_ids_by_user_id,
-            )
+        # The query-param user_id (cross-project user-detail page) is an
+        # implicit single-user match and also drives per-row user-display.
+        if user_id_qp:
+            user_id_values.insert(0, str(user_id_qp))
+            if user_id_op is None:
+                user_id_op = "in"
 
-            try:
-                _ids = resolve_end_user_ids_by_user_id(
-                    user_id_raw,
-                    organization_id=org.id if org else None,
-                    project_id=(project_id if (not org_scope and project_id) else None),
-                )
-            except Exception as e:
-                logger.warning(
-                    "session_list_user_id_ch_resolve_failed",
-                    error=str(e)[:200],
-                )
-                _ids = []
-            if not _ids:
-                try:
-                    end_user_qs = EndUser.objects.filter(user_id=user_id_raw)
-                    if org:
-                        end_user_qs = end_user_qs.filter(organization=org)
-                    if not org_scope and project_id:
-                        end_user_qs = end_user_qs.filter(project_id=project_id)
-                    end_user_rows = list(
-                        end_user_qs.values(
-                            "id",
-                            "user_id",
-                            "user_id_type",
-                            "user_id_hash",
-                        )
-                    )
-                    _ids = [
-                        str(row.get("id")) for row in end_user_rows if row.get("id")
-                    ]
-                    if end_user_rows:
-                        end_user_display = end_user_rows[0]
-                except Exception as e:
-                    logger.warning(
-                        "session_list_user_id_pg_fallback_failed",
-                        error=str(e)[:200],
-                    )
-                    _ids = []
-            if not _ids:
-                _ids = [NIL_UUID]
+        # Resolve the raw user_id(s) to end_user UUIDs and inject a synthetic
+        # end_user_id filter (scoped by org, and project when in project mode).
+        #
+        # P3b step2 precondition — the reverse-resolve prefers the curated CH
+        # `end_users` dimension over PG `EndUser.objects` (PG_ORM_READ_MIGRATION,
+        # Slice B). PG FREEZES post-step2: a NET-NEW user (first seen after the
+        # ingest get_or_create is dropped) has NO `tracer_enduser` row, so PG
+        # returns [] → empty list. The curated CH dimension instead yields the
+        # state-robust id-SET (historical OLD-id row + net-new DETERMINISTIC-id
+        # row + a straddler's BOTH) — see `_resolve_end_user_ids_for_user_id`.
+        #
+        # P3b step1.5 (DESIGN §3 / id_remap_sql) — the resolved ids are CURATED
+        # keys (OLD pre-sweep). SessionListQueryBuilder extracts this synthetic
+        # `end_user_id` filter (`_ENDUSER_ID_FILTER_COLS`) and binds it to the
+        # id-remap-RESOLVED `end_user_id` column (`_build_resolved_user_clause`),
+        # so a STRADDLER's NEW (deterministic-id) spans resolve new→old and
+        # select under the same OLD id. A net-new id has no remap entry (resolves
+        # to itself), so no double-count.
+        _NULL_USER_OPS = {"is_null", "is_not_null"}
+        _NEGATED_USER_OPS = {"not_in", "not_equals", "ne", "neq"}
+
+        end_user_display = None
+        if user_id_op in _NULL_USER_OPS:
+            # Presence/absence of any user — no value resolution needed; the
+            # builder maps this to session membership over end_user_id.
             filters.append(
                 {
                     "column_id": "end_user_id",
                     "filter_config": {
                         "col_type": "SYSTEM_METRIC",
                         "filter_type": "text",
-                        "filter_op": "in",
-                        "filter_value": _ids,
+                        "filter_op": user_id_op,
                     },
                 }
             )
+        elif user_id_values:
+            _ids: list[str] = []
+            for _uv in dict.fromkeys(user_id_values):  # dedup, keep order
+                _resolved, _display = _resolve_end_user_ids_for_user_id(
+                    _uv, org=org, org_scope=org_scope, project_id=project_id
+                )
+                _ids.extend(_resolved)
+                # Only the single query-param user labels the displayed rows.
+                if (
+                    _display is not None
+                    and end_user_display is None
+                    and user_id_qp is not None
+                    and _uv == str(user_id_qp)
+                ):
+                    end_user_display = _display
+            _ids = list(dict.fromkeys(_ids))
+            _out_op = "not_in" if user_id_op in _NEGATED_USER_OPS else "in"
+            # An unresolved value-set means "no such user". For inclusive ops
+            # that is an empty result (NIL sentinel matches nothing); for
+            # negated ops it is a no-op (everything matches), so skip injection.
+            inject = True
+            if not _ids:
+                if _out_op == "in":
+                    _ids = [NIL_UUID]
+                else:
+                    inject = False
+            if inject:
+                filters.append(
+                    {
+                        "column_id": "end_user_id",
+                        "filter_config": {
+                            "col_type": "SYSTEM_METRIC",
+                            "filter_type": "text",
+                            "filter_op": _out_op,
+                            "filter_value": _ids,
+                        },
+                    }
+                )
 
         # Three-state bookmark filter (DESIGN §5.2): a synthetic
         # ``trace_session_id`` IN/NOT-IN over the PG overlay's bookmarked ids,

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -372,15 +372,49 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 display_name=instance.name,
             )
 
+    @staticmethod
+    def _build_update_response(
+        session_id, *, project_id, bookmarked, name, created_at
+    ):
+        """Shared response builder for PATCH — same shape from PG and CH paths.
+
+        Uses ``TraceSessionSerializer``'s ``DateTimeField`` to format
+        ``created_at`` so both paths produce the same ISO representation.
+        """
+        from rest_framework.fields import DateTimeField
+
+        dt_field = DateTimeField()
+        return Response(
+            {
+                "id": str(session_id),
+                "project": str(project_id),
+                "bookmarked": bookmarked,
+                "name": name,
+                "created_at": dt_field.to_representation(created_at),
+            }
+        )
+
     def update(self, request, *args, **kwargs):
         # Narrow the Http404 catch to the object lookup ONLY. Any 404 from
         # validation, signals, or nested lookups must propagate normally.
         partial = kwargs.get("partial", False)
         try:
-            self.get_object()
+            instance = self.get_object()
         except Http404:
             return self._update_ch_only_session(request, partial=partial)
-        return super().update(request, *args, **kwargs)
+        # PG path — standard DRF validate+save, then the shared response
+        # builder so both paths produce byte-identical JSON shapes.
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        instance = serializer.instance
+        return self._build_update_response(
+            instance.id,
+            project_id=instance.project_id,
+            bookmarked=instance.bookmarked,
+            name=instance.name,
+            created_at=instance.created_at,
+        )
 
     def _update_ch_only_session(self, request, *, partial):
         """Overlay-only write path for a CH-only (collector) session."""
@@ -412,18 +446,12 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 display_name=new_name,
             )
 
-        first_seen = session_fields.get("first_seen")
-        created_at = (
-            first_seen.isoformat() if hasattr(first_seen, "isoformat") else first_seen
-        )
-        return Response(
-            {
-                "id": str(trace_session_id),
-                "project": str(project_id),
-                "bookmarked": new_bookmarked,
-                "name": new_name,
-                "created_at": created_at,
-            }
+        return self._build_update_response(
+            trace_session_id,
+            project_id=project_id,
+            bookmarked=new_bookmarked,
+            name=new_name,
+            created_at=session_fields.get("first_seen"),
         )
 
     def destroy(self, request, *args, **kwargs):
@@ -473,11 +501,13 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             client.insert(
                 "trace_sessions", [row], column_names=list(_TRACE_SESSION_COLUMNS)
             )
-        except Exception:
+        except Exception as e:
             _reset_client()
-            # Best-effort: the overlay is already removed so the session
-            # won't appear in bookmark lists. A stale CH row is acceptable
-            # (it will be caught by eventual-consistency sweeps).
+            logger.warning(
+                "ch_only_session_delete_marker_failed",
+                trace_session_id=str(trace_session_id),
+                error=str(e)[:200],
+            )
 
         return Response(status=drf_status.HTTP_204_NO_CONTENT)
 
@@ -930,39 +960,6 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 ORDER BY val
                 LIMIT %(limit)s OFFSET %(offset)s
                 """
-            else:
-                # Session IDs are resolved new→old so a straddler is listed once.
-                is_uuid = ch_column == "trace_session_id"
-                remap_table = "trace_session_id_remap"
-                resolved_col = resolved_id_expr(f"rs.{ch_column}", "rmp")
-                col_join = remap_left_join(f"rs.{ch_column}", remap_table, "rmp")
-                select_expr = "toString(val_id)" if is_uuid else "val_id"
-                search_clause = (
-                    "AND toString(val_id) ILIKE %(search)s" if search else ""
-                )
-                nil_uuid_clause = (
-                    f"AND val_id != toUUID('{NIL_UUID}')" if is_uuid else ""
-                )
-                query = f"""
-                SELECT DISTINCT {select_expr} AS val FROM (
-                    SELECT {resolved_col} AS val_id
-                    FROM (
-                        SELECT {ch_column}
-                        FROM spans
-                        WHERE project_id = %(project_id)s
-                          AND is_deleted = 0
-                          AND {ch_column} IS NOT NULL
-                          AND (parent_span_id IS NULL OR parent_span_id = '')
-                    ) AS rs
-                    {col_join}
-                )
-                WHERE val_id IS NOT NULL
-                  {nil_uuid_clause}
-                  {search_clause}
-                ORDER BY val
-                LIMIT %(limit)s OFFSET %(offset)s
-                """
-
             params = {
                 "project_id": project_id,
                 "limit": page_size,

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -36,7 +36,7 @@ from django.db.models.functions import (
     Coalesce,
     Round,
 )
-from django.http import FileResponse
+from django.http import FileResponse, Http404
 from django.utils import timezone
 from rest_framework import status as drf_status
 from rest_framework.decorators import action
@@ -161,6 +161,33 @@ def _trace_session_queryset_for_request(request):
         project__deleted=False,
         deleted=False,
     )
+
+
+def _resolve_ch_session_fields(request, trace_session_id):
+    """Resolve a CH-only session (fi-collector ingests to CH, not PG).
+
+    Returns the curated CH ``trace_sessions_dict`` fields (``project_id``,
+    ``display_name``, ``external_session_id``, …) when the session exists
+    AND the caller's workspace can access its project. Returns ``None`` when
+    the session is unknown or out of scope — callers map that to "not found"
+    so the CH fallback enforces the same tenant gate as the PG queryset.
+    """
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    session_fields = resolve_session_fields([trace_session_id]).get(
+        str(trace_session_id)
+    )
+    if not session_fields:
+        return None
+    if not (
+        _project_queryset_for_request(request)
+        .filter(id=session_fields["project_id"])
+        .exists()
+    ):
+        return None
+    return session_fields
 
 
 def _soft_delete_trace_session_tree(trace_sessions):
@@ -312,323 +339,30 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             query_data = query_serializer.validated_data
 
             trace_session_id = self.kwargs.get("pk")
-            trace_session = self.get_queryset().get(id=trace_session_id)
-            project_id = trace_session.project.id
 
-            # ClickHouse dispatch for session detail
             from tracer.services.clickhouse.query_service import (
                 AnalyticsQueryService,
             )
 
-            # CH-only path post-migration. PG fallback removed; a CH error
-            # propagates so operators see real data-pipeline issues instead
-            # of silently degrading to incomplete legacy session data.
             analytics = AnalyticsQueryService()
+
+            try:
+                trace_session = self.get_queryset().get(id=trace_session_id)
+                project_id = trace_session.project.id
+            except TraceSession.DoesNotExist:
+                session_fields = _resolve_ch_session_fields(
+                    request, trace_session_id
+                )
+                if not session_fields:
+                    return self._gm.bad_request("Session not found.")
+                project_id = session_fields["project_id"]
+
             return self._retrieve_clickhouse(
                 request,
                 trace_session_id,
-                trace_session,
                 project_id,
                 analytics,
                 query_data,
-            )
-
-            serializer = self.get_serializer(trace_session)
-            trace_session = serializer.data
-
-            page_number = query_data["page_number"]
-            page_size = query_data["page_size"]
-            page_start = page_number * page_size
-            page_end = page_start + page_size + 1
-
-            trace_qs = Trace.objects.filter(session_id=trace_session_id)
-            total_traces = trace_qs.count()
-            trace_id_subquery = trace_qs.values("id")
-
-            session_aggregates = ObservationSpan.objects.filter(
-                trace_id__in=trace_id_subquery
-            ).aggregate(
-                start_time=Min("start_time"),
-                end_time=Max("end_time"),
-                total_cost=Coalesce(
-                    Sum("cost", output_field=models.FloatField()),
-                    0.0,
-                ),
-                total_tokens=Coalesce(
-                    Sum("total_tokens", output_field=models.IntegerField()),
-                    0,
-                ),
-            )
-
-            session_start_time = session_aggregates["start_time"]
-            session_end_time = session_aggregates["end_time"]
-            duration = (
-                (session_end_time - session_start_time).total_seconds()
-                if session_end_time and session_start_time
-                else 0
-            )
-
-            session_metadata = {
-                "session_id": str(trace_session_id),
-                "duration": duration,
-                "total_cost": (
-                    round(session_aggregates["total_cost"], 6)
-                    if session_aggregates["total_cost"]
-                    and session_aggregates["total_cost"] > 0
-                    else 0
-                ),
-                "total_traces": total_traces,
-                "start_time": format_datetime_to_iso(session_start_time),
-                "end_time": format_datetime_to_iso(session_end_time),
-                "total_tokens": session_aggregates["total_tokens"],
-            }
-
-            traces = list(
-                Trace.objects.filter(session_id=trace_session_id).order_by(
-                    "created_at"
-                )[page_start:page_end]
-            )
-            has_next = len(traces) > page_size
-            traces = traces[:page_size]
-
-            if not traces:
-                next_session_id, previous_session_id = get_session_navigation(
-                    request, project_id, trace_session_id, query_data
-                )
-                session_metadata["next_session_id"] = next_session_id
-                session_metadata["previous_session_id"] = previous_session_id
-                return self._gm.success_response(
-                    {
-                        "session_metadata": session_metadata,
-                        "response": [],
-                        "next": False,
-                    }
-                )
-
-            paginated_trace_ids = [t.id for t in traces]
-
-            span_aggs = (
-                ObservationSpan.objects.filter(trace_id__in=paginated_trace_ids)
-                .values("trace_id")
-                .annotate(
-                    root_start_time=Min(
-                        Case(When(parent_span_id__isnull=True, then="start_time"))
-                    ),
-                    root_latency_ms=Min(
-                        Case(When(parent_span_id__isnull=True, then="latency_ms"))
-                    ),
-                    total_cost=Coalesce(
-                        Round(Sum("cost", output_field=FloatField()), 6), 0.0
-                    ),
-                    total_tokens=Coalesce(
-                        Sum("total_tokens", output_field=IntegerField()), 0
-                    ),
-                    input_tokens=Coalesce(
-                        Sum("prompt_tokens", output_field=IntegerField()), 0
-                    ),
-                    output_tokens=Coalesce(
-                        Sum("completion_tokens", output_field=IntegerField()), 0
-                    ),
-                )
-            )
-            span_agg_map = {str(row["trace_id"]): row for row in span_aggs}
-
-            eval_configs = list(
-                CustomEvalConfig.objects.filter(
-                    id__in=EvalLogger.objects.filter(
-                        trace_id__in=trace_id_subquery
-                    ).values("custom_eval_config_id"),
-                    deleted=False,
-                ).select_related("eval_template")
-            )
-
-            eval_config_ids = [c.id for c in eval_configs]
-            eval_map = {}  # (trace_id_str, config_id_str) -> score data
-            explanation_map = {}  # config_id_str -> explanation
-
-            if eval_config_ids:
-                eval_aggs = (
-                    EvalLogger.objects.filter(
-                        trace_id__in=paginated_trace_ids,
-                        custom_eval_config_id__in=eval_config_ids,
-                    )
-                    .exclude(Q(output_str="ERROR") | Q(error=True))
-                    .values("trace_id", "custom_eval_config_id")
-                    .annotate(
-                        float_score=Round(Avg("output_float") * 100, 2),
-                        bool_score=Round(
-                            Avg(
-                                Case(
-                                    When(output_bool=True, then=100.0),
-                                    When(output_bool=False, then=0.0),
-                                    default=None,
-                                    output_field=FloatField(),
-                                )
-                            ),
-                            2,
-                        ),
-                        float_count=Count("output_float"),
-                        bool_count=Count("output_bool"),
-                        str_list_count=Count("output_str_list"),
-                    )
-                )
-
-                for row in eval_aggs:
-                    key = (
-                        str(row["trace_id"]),
-                        str(row["custom_eval_config_id"]),
-                    )
-                    if row["float_count"] > 0:
-                        eval_map[key] = {
-                            "score": row["float_score"],
-                            "type": "float",
-                        }
-                    elif row["bool_count"] > 0:
-                        eval_map[key] = {
-                            "score": row["bool_score"],
-                            "type": "bool",
-                        }
-                    elif row["str_list_count"] > 0:
-                        eval_map[key] = {
-                            "type": "str_list",
-                            "str_list_data": {},
-                        }
-
-                str_list_choices = {
-                    str(c.id): c.eval_template.choices
-                    for c in eval_configs
-                    if c.eval_template and c.eval_template.choices
-                }
-                str_list_keys = {
-                    k for k, v in eval_map.items() if v.get("type") == "str_list"
-                }
-
-                if str_list_keys and str_list_choices:
-                    str_list_logs = (
-                        EvalLogger.objects.filter(
-                            trace_id__in=paginated_trace_ids,
-                            custom_eval_config_id__in=[
-                                c.id
-                                for c in eval_configs
-                                if str(c.id) in str_list_choices
-                            ],
-                            output_str_list__isnull=False,
-                        )
-                        .exclude(Q(output_str="ERROR") | Q(error=True))
-                        .values(
-                            "trace_id",
-                            "custom_eval_config_id",
-                            "output_str_list",
-                        )
-                    )
-
-                    grouped = defaultdict(list)
-                    for log in str_list_logs:
-                        key = (
-                            str(log["trace_id"]),
-                            str(log["custom_eval_config_id"]),
-                        )
-                        if log["output_str_list"]:
-                            grouped[key].append(log["output_str_list"])
-
-                    for key, str_lists in grouped.items():
-                        if key not in str_list_keys:
-                            continue
-                        choices = str_list_choices.get(key[1], [])
-                        total = len(str_lists)
-                        breakdown = {}
-                        for choice in choices:
-                            count = sum(1 for sl in str_lists if choice in sl)
-                            breakdown[choice] = {
-                                "score": (
-                                    round(100.0 * count / total, 2) if total > 0 else 0
-                                )
-                            }
-                        eval_map[key]["str_list_data"] = breakdown
-
-                # Pick the most recent explanation per eval config via
-                # Subquery (ordered by -created_at) instead of Min() which
-                # is non-deterministic on text fields.
-                for row in (
-                    EvalLogger.objects.filter(
-                        trace_id__in=paginated_trace_ids,
-                        custom_eval_config_id__in=eval_config_ids,
-                        eval_explanation__isnull=False,
-                    )
-                    .values("custom_eval_config_id")
-                    .annotate(
-                        explanation=Subquery(
-                            EvalLogger.objects.filter(
-                                custom_eval_config_id=OuterRef("custom_eval_config_id"),
-                                trace_id__in=paginated_trace_ids,
-                                eval_explanation__isnull=False,
-                            )
-                            .order_by("-created_at")
-                            .values("eval_explanation")[:1]
-                        )
-                    )
-                ):
-                    explanation_map[str(row["custom_eval_config_id"])] = row[
-                        "explanation"
-                    ]
-
-            response = []
-            for trace in traces:
-                trace_id_str = str(trace.id)
-                agg = span_agg_map.get(trace_id_str, {})
-
-                result = {
-                    "trace_id": trace_id_str,
-                    "input": trace.input,
-                    "output": trace.output,
-                    "system_metrics": {
-                        "total_latency_ms": agg.get("root_latency_ms", 0),
-                        "total_cost": agg.get("total_cost", 0),
-                        "start_time": format_datetime_to_iso(trace.created_at),
-                        "total_tokens": agg.get("total_tokens", 0),
-                        "input_tokens": agg.get("input_tokens", 0),
-                        "output_tokens": agg.get("output_tokens", 0),
-                    },
-                }
-
-                eval_metrics = {}
-                for config in eval_configs:
-                    config_id_str = str(config.id)
-                    key = (trace_id_str, config_id_str)
-                    data = eval_map.get(key)
-                    explanation = explanation_map.get(config_id_str)
-
-                    if data:
-                        if data["type"] in ("float", "bool"):
-                            eval_metrics[config_id_str] = {
-                                "score": data["score"],
-                                "name": config.name,
-                                "explanation": explanation,
-                            }
-                        elif data["type"] == "str_list":
-                            str_data = data.get("str_list_data", {})
-                            for choice_key, value in str_data.items():
-                                eval_metrics[config_id_str + "**" + choice_key] = {
-                                    "score": value["score"],
-                                    "name": config.name + " - " + choice_key,
-                                    "explanation": explanation,
-                                }
-
-                result["evals_metrics"] = eval_metrics
-                response.append(result)
-
-            next_session_id, previous_session_id = get_session_navigation(
-                request, project_id, trace_session_id, query_data
-            )
-            session_metadata["next_session_id"] = next_session_id
-            session_metadata["previous_session_id"] = previous_session_id
-
-            return self._gm.success_response(
-                {
-                    "session_metadata": session_metadata,
-                    "response": response,
-                    "next": has_next,
-                }
             )
         except OperationalError as e:
             logger.exception(
@@ -658,7 +392,6 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         self,
         request,
         trace_session_id,
-        trace_session_obj,
         project_id,
         analytics,
         query_data,
@@ -788,17 +521,21 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # Resolve eval-config IDs in CH (avoids a tracer_eval_logger PG
         # scan that grows linearly with eval traffic), then fetch the
         # PG metadata by primary key.
+        from tracer.services.clickhouse.eval_logger_table import (
+            eval_logger_source,
+        )
+
+        el_table, el_pred = eval_logger_source()
         trace_ids = [r["trace_id"] for r in traces_data]
         eval_configs: list = []
         if trace_ids:
             try:
                 config_id_result = analytics.execute_ch_query(
-                    """
+                    f"""
                     SELECT DISTINCT toString(custom_eval_config_id) AS config_id
-                    FROM tracer_eval_logger FINAL
+                    FROM {el_table} FINAL
                     WHERE trace_id IN %(trace_ids)s
-                      AND _peerdb_is_deleted = 0
-                      AND (deleted = 0 OR deleted IS NULL)
+                      AND {el_pred}
                     """,
                     {"trace_ids": trace_ids},
                     timeout_ms=3000,
@@ -827,7 +564,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         eval_map = {}
         if eval_configs and trace_ids:
             config_ids = [str(c.id) for c in eval_configs]
-            eval_query = """
+            eval_query = f"""
                 SELECT
                     toString(trace_id) AS trace_id,
                     toString(custom_eval_config_id) AS config_id,
@@ -837,11 +574,10 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                                    ELSE NULL END), 2) AS bool_score,
                     count(output_float) AS float_count,
                     count(output_bool) AS bool_count
-                FROM tracer_eval_logger FINAL
+                FROM {el_table} FINAL
                 WHERE trace_id IN %(trace_ids)s
                   AND custom_eval_config_id IN %(config_ids)s
-                  AND _peerdb_is_deleted = 0
-                  AND (deleted = 0 OR deleted IS NULL)
+                  AND {el_pred}
                   AND output_str != 'ERROR'
                   AND (error = 0 OR error IS NULL)
                 GROUP BY trace_id, custom_eval_config_id
@@ -943,7 +679,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             # Map frontend column names to ClickHouse expressions
             COLUMN_MAP = {
                 "session_id": "trace_session_id",
-                "user_id": "end_user_id",
+                "user_id": "user_id",
                 "first_message": "first_message",
                 "last_message": "last_message",
             }
@@ -958,21 +694,74 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
             analytics = AnalyticsQueryService()
 
-            # P3b step1.5 (DESIGN §3 / id_remap_sql): the value-picker dropdown
-            # reads the soft id straight off raw spans; a cross-cutover straddler
-            # carries BOTH an old random-uuid4 and a new deterministic-UUIDv5 id,
-            # so without resolution the same session/user appears TWICE in the
-            # picker (and first/last message is computed per-split-half). Resolve
-            # `trace_session_id` / `end_user_id` new→old through the remap so the
-            # straddler collapses to its OLD curated id. Pre-flip the remap is a
-            # no-op → byte-identical dropdown (gate B).
+            if ch_column == "trace_session_id":
+                search_clause = (
+                    "AND (external_session_id ILIKE %(search)s "
+                    "OR toString(trace_session_id) ILIKE %(search)s)"
+                    if search
+                    else ""
+                )
+                query = f"""
+                SELECT
+                    toString(trace_session_id) AS val,
+                    external_session_id AS label
+                FROM trace_sessions FINAL
+                WHERE project_id = %(project_id)s
+                  AND is_deleted = 0
+                  {search_clause}
+                ORDER BY label, val
+                LIMIT %(limit)s OFFSET %(offset)s
+                """
+                result = analytics.execute_ch_query(
+                    query,
+                    {
+                        "project_id": project_id,
+                        "limit": page_size,
+                        "offset": page * page_size,
+                        **({"search": f"%{search}%"} if search else {}),
+                    },
+                    timeout_ms=5000,
+                )
+                session_ids = [str(row["val"]) for row in result.data]
+                from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+                    resolve_session_fields,
+                )
+
+                session_fields = resolve_session_fields(session_ids)
+                values = []
+                for row in result.data:
+                    value = str(row["val"])
+                    fields = session_fields.get(value, {})
+                    label = (
+                        fields.get("display_name")
+                        or fields.get("external_session_id")
+                        or row.get("label")
+                        or value
+                    )
+                    values.append({"value": value, "label": str(label)})
+                return self._gm.success_response({"values": values})
+
+            # Session and message values are derived from remap-resolved spans.
+            # User labels come from the curated CH end_users dimension.
             from tracer.services.clickhouse.v2.id_remap_sql import (
                 remap_left_join,
                 resolved_id_expr,
             )
 
+            if ch_column == "user_id":
+                search_clause = "AND user_id ILIKE %(search)s" if search else ""
+                query = f"""
+                SELECT DISTINCT user_id AS val
+                FROM end_users FINAL
+                WHERE project_id = %(project_id)s
+                  AND is_deleted = 0
+                  AND user_id != ''
+                  {search_clause}
+                ORDER BY val
+                LIMIT %(limit)s OFFSET %(offset)s
+                """
             # For firstMessage/lastMessage we need argMin/argMax from root spans
-            if ch_column in ("first_message", "last_message"):
+            elif ch_column in ("first_message", "last_message"):
                 agg_expr = (
                     "argMin(input, start_time)"
                     if ch_column == "first_message"
@@ -1010,14 +799,9 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 LIMIT %(limit)s OFFSET %(offset)s
                 """
             else:
-                # Simple distinct on the column (session_id, user_id) — resolved
-                # new→old so a straddler is listed ONCE under its OLD curated id.
-                is_uuid = ch_column in ("trace_session_id", "end_user_id")
-                remap_table = (
-                    "trace_session_id_remap"
-                    if ch_column == "trace_session_id"
-                    else "end_user_id_remap"
-                )
+                # Session IDs are resolved new→old so a straddler is listed once.
+                is_uuid = ch_column == "trace_session_id"
+                remap_table = "trace_session_id_remap"
                 resolved_col = resolved_id_expr(f"rs.{ch_column}", "rmp")
                 col_join = remap_left_join(f"rs.{ch_column}", remap_table, "rmp")
                 select_expr = "toString(val_id)" if is_uuid else "val_id"
@@ -2068,13 +1852,6 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
         BuilderCls = get_query_builder_class("SESSION_LIST")  # noqa: N806
 
-        # Resolve `org` once at the top — it's referenced both when injecting
-        # the synthetic end_user_id filter (below) and when decorating the
-        # formatted output with EndUser info (later). Previously only the
-        # later block defined it, so the earlier reference NameError'd as
-        # soon as ``user_id_raw`` was truthy and silently fell through to PG.
-        org = getattr(request, "organization", None) or request.user.organization
-
         org_scope = bool(org_project_ids)
         # Organization in scope — the canonical resolver used across this view
         # (request is a param here; the helper is pure getattr, no query). Needed
@@ -2098,8 +1875,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         _remaining = []
         for _f in filters:
             _col, _cfg = FilterEngine._normalize_filter_params(_f)
-            _col_type = _cfg.get("col_type", "NORMAL")
-            if _col == "user_id" and _col_type == "NORMAL":
+            if _col == "user_id":
                 _val = _cfg.get("filter_value")
                 if isinstance(_val, list):
                     _val = _val[0] if _val else None
@@ -2651,97 +2427,163 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         try:
             # get_object() applies the org-scoped queryset filter and
             # raises 404 if the caller can't access the session.
-            session = self.get_object()
+            trace_session_id = self.kwargs.get("pk")
+            try:
+                session = self.get_object()
+                session_id = str(session.id)
+                session_name = session.name or ""
+            except Http404:
+                session_fields = _resolve_ch_session_fields(
+                    request, trace_session_id
+                )
+                if not session_fields:
+                    return self._gm.bad_request("Session not found.")
+                session_id = str(trace_session_id)
+                session_name = (
+                    session_fields.get("display_name")
+                    or session_fields.get("external_session_id")
+                    or ""
+                )
 
             qp = PaginationQuerySerializer(data=request.query_params)
             qp.is_valid(raise_exception=True)
             page = qp.validated_data["page"]
             page_size = qp.validated_data["page_size"]
 
-            logs_qs = (
-                EvalLogger.objects.filter(
-                    trace_session_id=session.id,
-                    target_type=EvalTargetType.SESSION,
-                    deleted=False,
-                )
-                .select_related(
-                    "custom_eval_config",
-                    "custom_eval_config__eval_template",
-                )
-                .order_by("-created_at")
+            # Query CH tracer_eval_logger_v2 for session-level eval logs.
+            from tracer.services.clickhouse.eval_logger_table import (
+                eval_logger_source,
+            )
+            from tracer.services.clickhouse.query_service import (
+                AnalyticsQueryService,
             )
 
-            total = logs_qs.count()
-            start = page * page_size
-            logs_page = logs_qs[start : start + page_size]
+            analytics = AnalyticsQueryService()
+            el_table, el_pred = eval_logger_source()
+
+            count_q = f"""
+                SELECT count() AS cnt
+                FROM {el_table} FINAL
+                WHERE trace_session_id = %(sid)s
+                  AND target_type = 'session'
+                  AND {el_pred}
+            """
+            count_r = analytics.execute_ch_query(
+                count_q, {"sid": session_id}, timeout_ms=3000,
+            )
+            total = count_r.data[0]["cnt"] if count_r.data else 0
 
             items = []
-            for log in logs_page:
-                # Same Pass/Fail derivation as EvalTaskView.get_usage so
-                # the two surfaces render identically.
-                if log.error:
-                    result_label = "Error"
-                    score = None
-                    status = "error"
-                elif log.output_bool is True:
-                    result_label = "Passed"
-                    score = 1.0
-                    status = "success"
-                elif log.output_bool is False:
-                    result_label = "Failed"
-                    score = 0.0
-                    status = "success"
-                elif log.output_float is not None:
-                    score = float(log.output_float)
-                    result_label = "Passed" if score >= 0.5 else "Failed"
-                    status = "success"
-                elif log.output_str:
-                    result_label = log.output_str[:50]
-                    score = None
-                    status = "success"
-                else:
-                    result_label = ""
-                    score = None
-                    status = "success"
+            if total > 0:
+                start = page * page_size
+                logs_q = f"""
+                    SELECT
+                        toString(id) AS id,
+                        toString(custom_eval_config_id) AS custom_eval_config_id,
+                        output_bool,
+                        output_float,
+                        output_str,
+                        error,
+                        error_message,
+                        eval_explanation,
+                        results_explanation,
+                        target_type,
+                        created_at
+                    FROM {el_table} FINAL
+                    WHERE trace_session_id = %(sid)s
+                      AND target_type = 'session'
+                      AND {el_pred}
+                    ORDER BY created_at DESC
+                    LIMIT %(limit)s OFFSET %(offset)s
+                """
+                logs_r = analytics.execute_ch_query(
+                    logs_q,
+                    {"sid": session_id, "limit": page_size, "offset": start},
+                    timeout_ms=5000,
+                )
 
-                config = log.custom_eval_config
-                reason = log.eval_explanation or log.error_message or ""
+                config_ids = {
+                    r["custom_eval_config_id"]
+                    for r in logs_r.data
+                    if r.get("custom_eval_config_id")
+                }
+                config_map = {}
+                if config_ids:
+                    configs = CustomEvalConfig.objects.filter(
+                        id__in=config_ids, deleted=False,
+                    ).select_related("eval_template")
+                    config_map = {str(c.id): c for c in configs}
 
-                items.append(
-                    {
-                        "id": str(log.id),
-                        "input": (session.name or "")[:200],
-                        "result": result_label,
-                        "score": score,
-                        "reason": reason,
-                        "status": status,
-                        "source": "eval_task",
-                        "created_at": (
-                            log.created_at.isoformat() if log.created_at else ""
-                        ),
-                        "session_id": str(session.id),
-                        "eval_id": str(config.id) if config else None,
-                        "eval_name": config.name if config else None,
-                        "model": config.model if config else None,
-                        "detail": {
+                for log in logs_r.data:
+                    error = bool(log.get("error"))
+                    output_bool = log.get("output_bool")
+                    output_float = log.get("output_float")
+                    output_str = log.get("output_str")
+
+                    if error:
+                        result_label = "Error"
+                        score_val = None
+                        status = "error"
+                    elif output_bool == 1:
+                        result_label = "Passed"
+                        score_val = 1.0
+                        status = "success"
+                    elif output_bool == 0 and output_bool is not None:
+                        result_label = "Failed"
+                        score_val = 0.0
+                        status = "success"
+                    elif output_float is not None:
+                        score_val = float(output_float)
+                        result_label = "Passed" if score_val >= 0.5 else "Failed"
+                        status = "success"
+                    elif output_str:
+                        result_label = str(output_str)[:50]
+                        score_val = None
+                        status = "success"
+                    else:
+                        result_label = ""
+                        score_val = None
+                        status = "success"
+
+                    config = config_map.get(log.get("custom_eval_config_id"))
+                    reason = log.get("eval_explanation") or log.get("error_message") or ""
+                    created = log.get("created_at")
+
+                    items.append(
+                        {
+                            "id": log["id"],
+                            "input": session_name[:200],
+                            "result": result_label,
+                            "score": score_val,
+                            "reason": reason,
+                            "status": status,
+                            "source": "eval_task",
+                            "created_at": (
+                                created.isoformat() if hasattr(created, "isoformat") else str(created or "")
+                            ),
+                            "session_id": session_id,
+                            "eval_id": str(config.id) if config else None,
                             "eval_name": config.name if config else None,
                             "model": config.model if config else None,
-                            "output_type": (
-                                config.eval_template.output_type_normalized
-                                if config and config.eval_template
-                                else None
-                            ),
-                            "target_type": log.target_type,
-                            "session_id": str(session.id),
-                            "session_name": session.name,
-                            "output_bool": log.output_bool,
-                            "output_float": log.output_float,
-                            "output_str": log.output_str,
-                            "results_explanation": log.results_explanation,
-                            "error_message": log.error_message,
-                        },
-                    }
-                )
+                            "detail": {
+                                "eval_name": config.name if config else None,
+                                "model": config.model if config else None,
+                                "output_type": (
+                                    config.eval_template.output_type_normalized
+                                    if config and config.eval_template
+                                    else None
+                                ),
+                                "target_type": log.get("target_type"),
+                                "session_id": session_id,
+                                "session_name": session_name,
+                                "output_bool": output_bool,
+                                "output_float": output_float,
+                                "output_str": output_str,
+                                "results_explanation": log.get("results_explanation"),
+                                "error_message": log.get("error_message"),
+                            },
+                        }
+                    )
 
             return self._gm.success_response(
                 {


### PR DESCRIPTION
## 1. Why these changes are made

`fi-collector` (the CH25 OTLP ingest path) writes spans **only to ClickHouse**, not Postgres. Every Sessions / User-tab / Session-reply read path that started from a PG model lookup (`TraceSession.objects.get`, `get_object`, `EvalLogger.objects…`) therefore returned **404 / empty** for any data ingested through fi-collector. This PR makes those read paths source from the CH25 v2 schema so the three TH-5982 surfaces work end-to-end on CH-only data, and fills in the session/user/message **filtering** that was missing on the session list, time-series and dashboard.

Linear: **TH-5982 — Session, User Tab and Session Reply**.

## 2. What changes have been made

**Read-path fallbacks (`tracer/views/trace_session.py`)**
- `retrieve()` and `eval_logs()`: when the PG `TraceSession` row is absent, resolve the session from the curated CH `trace_sessions_dict` via the new `_resolve_ch_session_fields()` helper, which re-applies the **same workspace/project tenant gate** before serving. Returns "Session not found" (400) when the session is unknown *or* out of the caller's scope.
- `eval_logs()` now reads **`tracer_eval_logger_v2`** (CH) instead of the PG `EvalLogger`, paginating + counting in CH and resolving config metadata from PG by id.
- Removed a **~296-line dead PG branch** that sat after an unconditional `return` in `retrieve()` (unreachable legacy code).

**Session filtering (`query_builders/session_list.py`, `session_time_series.py`, `v2/query_builders/session_list.py`)**
- Filter sessions by **session id**, **user membership**, and **first/last message**, resolving ids new→old through the remap (survivor-collapse) so a cross-cutover straddler stays one session.
- Accept the frontend `total_traces_count` alias for filter + sort.
- v2 span-attributes query uses native CH25 columns (`attributes_extra`, `attrs_string`, `attrs_number`).

**Shared helpers (de-duplication)**
- `query_builders/session_filters.py` (new): the session-id filter translation, previously copy-pasted in the list and time-series builders.
- `_resolve_ch_session_fields()`: the CH session-resolution + tenant gate, previously duplicated in `retrieve`/`eval_logs`.

**Dashboard (`views/dashboard.py`, `serializers/dashboard.py`)**
- Add a `sessions` filter-values source; label session ids by their external/display name.

**Filter builder bug fix (`query_builders/filters.py`)**
- Define the missing `ClickHouseFilterBuilder._UUID_TEXT_FILTER_OPS`. Without it, any filter on a nullable-UUID column (`session_id` / `end_user_id` / `trace_session_id`) raised `AttributeError` (crashed `list_traces_of_session`). Now those ops cast the column to `toString()` (ClickHouse rejects direct UUID-vs-String compares); `is_null`/`is_not_null`/ranges stay on the bare column. Also removed duplicated `IS NULL` branches.

**Frontend (`SessionsView/Session-grid.jsx`)**
- Read column visibility from the freshly-built columns, not the stale config response.

## 3. Tests — new and existing

### New tests
| Test | File |
|---|---|
| `TestSessionListQueryBuilder::test_session_filter_alias_resolves_before_grouping` | test_clickhouse.py |
| `TestSessionListQueryBuilder::test_total_traces_count_frontend_alias_filters_and_sorts` | test_clickhouse.py |
| `TestSessionListQueryBuilder::test_first_message_filter_aggregates_before_having` | test_clickhouse.py |
| `TestSessionListQueryBuilder::test_v2_span_attributes_query_uses_native_ch25_columns` | test_clickhouse.py |
| `TestSessionTimeSeriesQueryBuilder::test_session_filter_alias_resolves_before_grouping` | test_clickhouse.py |
| `TestFilterBuilderEdgeCases::test_nullable_uuid_column_text_ops_cast_to_string` | test_clickhouse.py |
| `TestFilterBuilderEdgeCases::test_nullable_uuid_column_is_null_uses_bare_column` | test_clickhouse.py |
| `TestTraceSessionRetrieveAPI::test_retrieve_ch_only_session_requires_accessible_project` | test_trace_session.py |
| `TestTraceSessionGraphAPI::test_session_filter_uses_clickhouse_graph` | test_trace_session.py |
| `…::test_user_filter_values_return_external_user_ids` | test_trace_session.py |
| `…::test_session_filter_values_use_external_id_as_label` | test_trace_session.py |
| `TestDashboardQueryExecution::test_filter_values_sessions_source_labels_session_ids` | test_dashboard.py |
| `TestDashboardQueryExecution::test_filter_values_sessions_source_uses_span_backed_values` | test_dashboard.py |
| `test_dashboard_filter_values_query_accepts_sessions_source` | test_filter_serializer_contracts.py |

### Existing tests run as regression guards
- `TestSessionListQueryBuilder` (22), `TestSessionTimeSeriesQueryBuilder`, `TestSessionListCountSkipLogic`, `TestSessionAnalyticsQueryBuilder` — prove the `session_filters.py` extraction produces **byte-identical SQL**.
- Full `tracer/tests/test_trace_session.py` (35) — retrieve, list, export, graph, workspace-scope, overlay write paths.
- Full `tracer/tests/test_filter_serializer_contracts.py` (63).
- `tracer/tests/test_dashboard.py` sessions-source subset.

> Note: 1 pre-existing failure + 9 errors in `TestClickHouseFilterBuilder` exist on the `dev` base (unrelated `lower(model)` case-insensitivity + eval-score tests that connect directly to CH); confirmed they fail identically with this branch's `filters.py` reverted, so they are **not introduced here**.

## 4. What scenario each test covers

**Session list / time-series builders**
- `test_session_filter_alias_resolves_before_grouping` (list & TS): a `session` filter (`op=in`) is resolved through `trace_session_id_remap` and bound as `IN %(sess_/session_id_N)s` **before `GROUP BY`** — not the legacy `toString(...) IN` cast — so straddlers collapse to one row.
- `test_total_traces_count_frontend_alias_filters_and_sorts`: the `total_traces_count` alias maps to `traces_count` for both the `HAVING … > 4` filter and `ORDER BY … DESC`.
- `test_first_message_filter_aggregates_before_having`: a `first_message contains` filter injects `argMin(input, start_time)` and `HAVING first_message ILIKE …` in **both** `build()` and `build_count_query()`.
- `test_v2_span_attributes_query_uses_native_ch25_columns`: the v2 attributes query selects `attributes_extra AS span_attributes_raw`, `attrs_string`, `attrs_number` (no legacy `span_attr_*` / `toJSONString` aliases).

**Filter builder (UUID columns)**
- `test_nullable_uuid_column_text_ops_cast_to_string`: for `trace_session_id` & `end_user_id`, ops `contains/equals/starts_with/in/not_in` emit `toString(col)` and don't raise.
- `test_nullable_uuid_column_is_null_uses_bare_column`: `is_null` emits bare `col IS NULL` (no cast).

**Session view (DB-backed)**
- `test_retrieve_ch_only_session_requires_accessible_project`: a CH-only session whose project is outside the caller's workspace → **400** (tenant gate holds through the CH fallback).
- `test_session_filter_uses_clickhouse_graph`: the session-graph endpoint with a `session` filter builds a CH query binding `IN %(session_id_1)s` with the session-id tuple.
- `test_user_filter_values_return_external_user_ids`: `user_id` filter-values read from `end_users FINAL` (`user_id AS val`) and return external ids (alice/bob).
- `test_session_filter_values_use_external_id_as_label`: `session_id` filter-values label each id by its `external_session_id`.

**Dashboard + serializer**
- `test_filter_values_sessions_source_labels_session_ids`: `source=sessions, metric=session` labels session ids by external id.
- `test_filter_values_sessions_source_uses_span_backed_values`: `source=sessions, metric=model` returns span-backed values.
- `test_dashboard_filter_values_query_accepts_sessions_source`: serializer accepts `source: sessions`.

## 5. Commands to run these tests

```bash
# Unit — session builders + filter regression (no DB)
set -a && source .env.test && set +a && \
.venv/bin/pytest \
  tracer/tests/test_clickhouse.py::TestSessionListQueryBuilder \
  tracer/tests/test_clickhouse.py::TestSessionTimeSeriesQueryBuilder \
  tracer/tests/test_clickhouse.py::TestSessionListCountSkipLogic \
  tracer/tests/test_clickhouse.py::TestSessionAnalyticsQueryBuilder \
  tracer/tests/test_clickhouse.py::TestFilterBuilderEdgeCases \
  -v

# Integration — needs the test stack (Postgres + ClickHouse). `make test`
# brings up the `futureagi-test` containers.
set -a && source .env.test && set +a && \
.venv/bin/pytest \
  tracer/tests/test_trace_session.py \
  tracer/tests/test_filter_serializer_contracts.py \
  tracer/tests/test_dashboard.py -k 'sessions_source or TraceSession' -v
```

Latest local run: **44** unit + **98** view/contract + **2** dashboard sessions-source = **144 passed**.

## 6. Steps to test the PR changes on local / dev

1. Bring up the stack with `fi-collector` (`docker compose up`); point the SDK at the collector (`FI_BASE_URL=http://localhost:4318`).
2. Send traces carrying sessions + users with the traceAI SDK (`ProjectType.OBSERVE` — the collector gates `end_user_id` on observe):
   ```python
   from fi_instrumentation import register, using_session, using_user
   from fi_instrumentation.fi_types import ProjectType
   from traceai_openai import OpenAIInstrumentor
   tp = register(project_name="ch25-sessions", project_type=ProjectType.OBSERVE)
   OpenAIInstrumentor().instrument(tracer_provider=tp)
   with using_session("session-alpha"), using_user("alice"):
       ...  # make a couple of LLM calls
   ```
3. Verify each surface reads from CH only (optionally truncate the PG `tracer_trace`/`trace_session`/`tracer_enduser`/`tracer_observation_span` rows first to prove no PG dependency):
   ```bash
   # Session list
   curl '…/tracer/trace-session/list_sessions/?project_id=<PID>&page_size=10' -H 'x-api-key:…' -H 'x-secret-key:…'
   # Session detail / reply
   curl '…/tracer/trace-session/<SESSION_ID>/' -H …
   # User tab
   curl '…/tracer/users/?project_id=<PID>&page_size=10' -H …
   # Session eval logs
   curl '…/tracer/trace-session/<SESSION_ID>/eval_logs/?page=1&page_size=10' -H …
   # Traces of a session, filtered by session id (the path that previously 500'd)
   curl '…/tracer/trace/list_traces_of_session/?project_id=<PID>&filters=<url-encoded session_id filter>' -H …
   ```
   Each should return `200` with session/user data sourced from ClickHouse.

## 7. Screenshots / recordings

<!-- Local test-run screenshots + walkthrough video to be attached. -->
<img width="1225" height="855" alt="image" src="https://github.com/user-attachments/assets/05c333e6-5ef5-43da-83e1-7b13154a2795" />
<img width="932" height="233" alt="image" src="https://github.com/user-attachments/assets/41ad64b6-92a3-471c-8f3d-74753cab0b18" />
<img width="1512" height="199" alt="image" src="https://github.com/user-attachments/assets/3990fba4-7d19-4f4b-bf13-095d79343756" />

https://github.com/user-attachments/assets/accdbf27-9ceb-47fe-a05a-c9cde8796ee5

## 8. Key decisions & reasoning (for future reference)

- **Resolve CH-only sessions from `trace_sessions_dict`, not raw `spans`.** The dict is the curated, deduped session dimension (carries `external_session_id` / `display_name` / `project_id`); a raw `spans` scan would re-derive those per-request and miss the overlay fields. Keeping the **PG-first, CH-fallback** order means nothing changes for PG-backed data and the tenant gate is re-checked on the fallback, so CH never widens access.
- **User membership as a separate remap-aware subquery (not an extra join on the aggregate scan).** Joining the user filter into the per-session aggregate would shrink the displayed totals (cost/tokens/traces) to only the matching user's spans. A membership subquery selects *which* sessions qualify while the aggregates still sum the whole session.
- **`toString(uuid)` only for value-comparison ops.** ClickHouse refuses `UUID = String`; casting makes equality/LIKE/IN work for the string-shaped filter values the frontend sends, while `is_null`/ranges keep the bare column so nullability/index behaviour is unchanged.
- **Extract shared session-id filter + CH-resolution helpers.** The list and time-series builders had byte-identical filter translation and two views had identical CH-resolution + tenant-gate blocks; one helper each removes the drift risk on operator/null/empty-value handling. Verified by the unchanged builder SQL assertions.
- **`eval_logger_source()` indirection for the eval table.** Reads route to `tracer_eval_logger_v2` via the existing helper rather than hardcoding, so the table name + soft-delete predicate stay configurable through the migration.

## Linked issues

Closes TH-5982
