### PR TITLE
fix(dashboard): pre-aggregate latency-by-attribute breakdowns to stop chart timeouts

### DIFF
--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # Structured logging configuration
@@ -815,6 +815,22 @@ CLICKHOUSE_V2 = {
     "QUERY_TYPES_SHADOW":     os.getenv("CH25_QUERY_TYPES_SHADOW", ""),
     "QUERY_TYPES_DISABLED":   os.getenv("CH25_QUERY_TYPES_DISABLED", ""),
 }
+
+# dashboard_attr_rollup fast-path (latency-avg × covered-attribute breakdown).
+# Fail-closed: the dashboard only reads the rollup when the flag is ON and the
+# requested window starts at/after COVERED_SINCE (the backfilled-and-soaked
+# range). Off by default so a fresh deploy keeps the spans scan until ops runs
+# the rebuild command and sets the coverage date. COVERED_SINCE is a datetime
+# (or None); set it from CH25_DASHBOARD_ATTR_ROLLUP_COVERED_SINCE (ISO-8601).
+DASHBOARD_ATTR_ROLLUP_ENABLED = (
+    os.getenv("DASHBOARD_ATTR_ROLLUP_ENABLED", "false").lower() == "true"
+)
+_dashboard_attr_rollup_covered_since = os.getenv("DASHBOARD_ATTR_ROLLUP_COVERED_SINCE")
+DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = (
+    datetime.fromisoformat(_dashboard_attr_rollup_covered_since)
+    if _dashboard_attr_rollup_covered_since
+    else None
+)
 
 # Eval-logger table read by the trace/voice/user eval-config discovery queries.
 # The CH25 spans cutover intentionally kept the legacy peerdb CDC table

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -816,12 +816,8 @@ CLICKHOUSE_V2 = {
     "QUERY_TYPES_DISABLED":   os.getenv("CH25_QUERY_TYPES_DISABLED", ""),
 }
 
-# dashboard_attr_rollup fast-path (latency-avg × covered-attribute breakdown).
-# Fail-closed: the dashboard only reads the rollup when the flag is ON and the
-# requested window starts at/after COVERED_SINCE (the backfilled-and-soaked
-# range). Off by default so a fresh deploy keeps the spans scan until ops runs
-# the rebuild command and sets the coverage date. COVERED_SINCE is a datetime
-# (or None); set it from CH25_DASHBOARD_ATTR_ROLLUP_COVERED_SINCE (ISO-8601).
+# Fail-closed: rollup routing requires both flag=on and window >= coverage date.
+# Set COVERED_SINCE (ISO-8601) after running rebuild_dashboard_attr_rollup.
 DASHBOARD_ATTR_ROLLUP_ENABLED = (
     os.getenv("DASHBOARD_ATTR_ROLLUP_ENABLED", "false").lower() == "true"
 )

--- a/futureagi/tracer/management/commands/rebuild_dashboard_attr_rollup.py
+++ b/futureagi/tracer/management/commands/rebuild_dashboard_attr_rollup.py
@@ -1,20 +1,9 @@
 """rebuild_dashboard_attr_rollup — reconcile the dashboard_attr_rollup aggregate.
 
-The MV (021_dashboard_attr_rollup.sql) bakes ``is_deleted = 0`` at INSERT time.
-AggregatingMergeTree never retracts, so a span soft-deleted AFTER its insert
-still counts in the rollup — it over-counts vs a raw ``spans FINAL`` read. This
-command is the reconciliation: TRUNCATE the rollup and re-aggregate from the
-current deduplicated spans (``FINAL``, ``is_deleted = 0``) using the SAME SELECT
-shape as the MV, so the rebuilt state matches a fresh raw breakdown.
-
-Idempotent — TRUNCATE then rebuild; a re-run lands the same rows. Run it on a
-schedule and before flipping DASHBOARD_ATTR_ROLLUP_ENABLED on a fresh deploy.
-
-CH target DB: ``get_v2_config()`` (env CH25_DATABASE / CH25_HOST … override).
-
-Operator UX:
-    python manage.py rebuild_dashboard_attr_rollup
-    python manage.py rebuild_dashboard_attr_rollup --dry-run     # print SQL, no writes
+Idempotent TRUNCATE + re-aggregate from ``spans FINAL`` (``is_deleted = 0``) using
+the MV's SELECT shape, so soft-deletes the AggregatingMergeTree can't retract are
+reconciled out. Run before enabling the rollup on a fresh deploy; ``--dry-run``
+prints the SQL without writing.
 """
 
 from __future__ import annotations

--- a/futureagi/tracer/management/commands/rebuild_dashboard_attr_rollup.py
+++ b/futureagi/tracer/management/commands/rebuild_dashboard_attr_rollup.py
@@ -1,0 +1,102 @@
+"""rebuild_dashboard_attr_rollup — reconcile the dashboard_attr_rollup aggregate.
+
+The MV (021_dashboard_attr_rollup.sql) bakes ``is_deleted = 0`` at INSERT time.
+AggregatingMergeTree never retracts, so a span soft-deleted AFTER its insert
+still counts in the rollup — it over-counts vs a raw ``spans FINAL`` read. This
+command is the reconciliation: TRUNCATE the rollup and re-aggregate from the
+current deduplicated spans (``FINAL``, ``is_deleted = 0``) using the SAME SELECT
+shape as the MV, so the rebuilt state matches a fresh raw breakdown.
+
+Idempotent — TRUNCATE then rebuild; a re-run lands the same rows. Run it on a
+schedule and before flipping DASHBOARD_ATTR_ROLLUP_ENABLED on a fresh deploy.
+
+CH target DB: ``get_v2_config()`` (env CH25_DATABASE / CH25_HOST … override).
+
+Operator UX:
+    python manage.py rebuild_dashboard_attr_rollup
+    python manage.py rebuild_dashboard_attr_rollup --dry-run     # print SQL, no writes
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from tracer.services.clickhouse.query_builders.dashboard import (
+    _ROLLUP_COVERED_ATTRS,
+    _sanitize_attr_key,
+)
+from tracer.services.clickhouse.v2 import get_v2_config
+
+_ROLLUP_TABLE = "dashboard_attr_rollup"
+
+
+class Command(BaseCommand):
+    help = (
+        "Rebuild dashboard_attr_rollup from current spans (FINAL, is_deleted=0) "
+        "so soft-deletes are reconciled out of the aggregate (idempotent)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print the rebuild SQL and exit; no TRUNCATE / INSERT.",
+        )
+
+    def _client(self):
+        import clickhouse_connect
+
+        cfg = get_v2_config()
+        self.stdout.write(
+            self.style.MIGRATE_LABEL(
+                f"CH target: {cfg['host']}:{cfg['http_port']} db={cfg['database']}"
+            )
+        )
+        return clickhouse_connect.get_client(
+            host=cfg["host"],
+            port=cfg["http_port"],
+            username=cfg["user"],
+            password=cfg["password"] or "",
+            database=cfg["database"],
+            send_receive_timeout=600,
+        )
+
+    def _rebuild_sql(self) -> str:
+        # Same covered set as the router gate — single source of truth.
+        attr_keys = ", ".join(
+            f"'{_sanitize_attr_key(k)}'" for k in sorted(_ROLLUP_COVERED_ATTRS)
+        )
+        return (
+            f"INSERT INTO {_ROLLUP_TABLE}\n"
+            "SELECT\n"
+            "    project_id,\n"
+            "    toStartOfHour(start_time)         AS hour,\n"
+            "    attr_key,\n"
+            "    attrs_string[attr_key]            AS attr_value,\n"
+            "    countState()                      AS n,\n"
+            "    sumState(toInt64(latency_ms))     AS latency_sum\n"
+            "FROM spans FINAL\n"
+            f"ARRAY JOIN [{attr_keys}] AS attr_key\n"
+            "WHERE is_deleted = 0\n"
+            "  AND parent_span_id = ''\n"
+            "GROUP BY project_id, toStartOfHour(start_time), "
+            "attr_key, attrs_string[attr_key]"
+        )
+
+    def handle(self, *args, **opts):
+        sql = self._rebuild_sql()
+        if opts["dry_run"]:
+            self.stdout.write(self.style.WARNING("DRY RUN — SQL below, no writes:"))
+            self.stdout.write(f"TRUNCATE TABLE {_ROLLUP_TABLE};")
+            self.stdout.write(sql)
+            return
+
+        client = self._client()
+        try:
+            client.command(f"TRUNCATE TABLE IF EXISTS {_ROLLUP_TABLE}")
+            client.command(sql)
+        finally:
+            client.close()
+        self.stdout.write(
+            self.style.SUCCESS(f"✓ {_ROLLUP_TABLE} rebuilt from current spans.")
+        )

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -40,7 +40,7 @@ def _sanitize_attr_key(key: str) -> str:
 
 
 def _snap_to_hour(dt: datetime) -> datetime:
-    """Floor a datetime to the top of its hour (ClickHouse ``toStartOfHour``)."""
+    """Truncate a datetime to the hour (ClickHouse ``toStartOfHour``)."""
     return dt.replace(minute=0, second=0, microsecond=0)
 
 
@@ -543,6 +543,29 @@ class DashboardQueryBuilder:
             start_date = start_date.replace(tzinfo=UTC)
         return start_date >= covered_since
 
+    def _should_use_rollup(
+        self,
+        metric_name: str,
+        aggregation: str,
+        single_bd: dict | None,
+        per_metric_filters: list[dict],
+        start_date: datetime,
+    ) -> bool:
+        """True only for the covered latency-breakdown shape on a v2 build with the
+        rollup enabled and the window inside coverage — fail-closed everywhere else."""
+        return (
+            self._attr_rollup_available
+            and metric_name == "latency"
+            and aggregation == "avg"
+            and self.granularity in _ROLLUP_GRANULARITIES
+            and single_bd is not None
+            and single_bd.get("type") == "custom_attribute"
+            and single_bd.get("name") in _ROLLUP_COVERED_ATTRS
+            and not per_metric_filters
+            and not self.global_filters
+            and self._attr_rollup_window_covered(start_date)
+        )
+
     def _build_system_metric_query(
         self,
         metric_name: str,
@@ -554,21 +577,11 @@ class DashboardQueryBuilder:
         # Normalize: saved widgets may have capitalized names (e.g. "Latency")
         metric_name = metric_name.lower() if metric_name else metric_name
 
-        # Covered latency-breakdown shape → the pre-aggregated rollup; any other
-        # shape (or v1 schema / flag off / window outside coverage) falls through
-        # to the spans scan (fail-closed).
+        # Covered latency-breakdown shape → the pre-aggregated rollup; anything
+        # else falls through to the spans scan (fail-closed, see _should_use_rollup).
         single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
-        if (
-            self._attr_rollup_available
-            and metric_name == "latency"
-            and aggregation == "avg"
-            and self.granularity in _ROLLUP_GRANULARITIES
-            and single_bd is not None
-            and single_bd.get("type") == "custom_attribute"
-            and single_bd.get("name") in _ROLLUP_COVERED_ATTRS
-            and not per_metric_filters
-            and not self.global_filters
-            and self._attr_rollup_window_covered(params["start_date"])
+        if self._should_use_rollup(
+            metric_name, aggregation, single_bd, per_metric_filters, params["start_date"]
         ):
             params = dict(params)
             params["attr_key"] = _sanitize_attr_key(single_bd["name"])

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -39,6 +39,11 @@ def _sanitize_attr_key(key: str) -> str:
     return key
 
 
+def _snap_to_hour(dt: datetime) -> datetime:
+    """Floor a datetime to the top of its hour (ClickHouse ``toStartOfHour``)."""
+    return dt.replace(minute=0, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Metric resolution tables
 # ---------------------------------------------------------------------------
@@ -372,6 +377,10 @@ class DashboardQueryBuilder:
     project_ids and builds multiple queries (one per metric).
     """
 
+    # dashboard_attr_rollup lives only in the v2 schema; the v2 subclass flips
+    # this True. Base/v1 never routes to the rollup (fail-closed: missing table).
+    _attr_rollup_available: bool = False
+
     def __init__(self, query_config: dict) -> None:
         self.config = query_config
         self.project_ids = query_config.get("project_ids", [])
@@ -517,6 +526,23 @@ class DashboardQueryBuilder:
     # System metric
     # ------------------------------------------------------------------
 
+    def _attr_rollup_window_covered(self, start_date: datetime) -> bool:
+        """True only when the rollup flag is on AND the requested window starts
+        within the backfilled-and-covered range — fail-closed on a fresh deploy
+        (off until ops backfills the rollup and sets the coverage date)."""
+        from django.conf import settings
+
+        if not getattr(settings, "DASHBOARD_ATTR_ROLLUP_ENABLED", False):
+            return False
+        covered_since = getattr(settings, "DASHBOARD_ATTR_ROLLUP_COVERED_SINCE", None)
+        if covered_since is None:
+            return False
+        if covered_since.tzinfo is None:
+            covered_since = covered_since.replace(tzinfo=UTC)
+        if start_date.tzinfo is None:
+            start_date = start_date.replace(tzinfo=UTC)
+        return start_date >= covered_since
+
     def _build_system_metric_query(
         self,
         metric_name: str,
@@ -529,10 +555,12 @@ class DashboardQueryBuilder:
         metric_name = metric_name.lower() if metric_name else metric_name
 
         # Covered latency-breakdown shape → the pre-aggregated rollup; any other
-        # shape falls through to the spans scan (fail-closed).
+        # shape (or v1 schema / flag off / window outside coverage) falls through
+        # to the spans scan (fail-closed).
         single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
         if (
-            metric_name == "latency"
+            self._attr_rollup_available
+            and metric_name == "latency"
             and aggregation == "avg"
             and self.granularity in _ROLLUP_GRANULARITIES
             and single_bd is not None
@@ -540,9 +568,13 @@ class DashboardQueryBuilder:
             and single_bd.get("name") in _ROLLUP_COVERED_ATTRS
             and not per_metric_filters
             and not self.global_filters
+            and self._attr_rollup_window_covered(params["start_date"])
         ):
             params = dict(params)
             params["attr_key"] = _sanitize_attr_key(single_bd["name"])
+            # Rollup is hourly — snap the window to whole hours so no partial bucket.
+            params["start_date"] = _snap_to_hour(params["start_date"])
+            params["end_date"] = _snap_to_hour(params["end_date"])
             rollup_query = (
                 f"SELECT {bucket_fn}(hour) AS time_bucket,\n"
                 "       attr_value AS breakdown_value,\n"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -108,6 +108,23 @@ METRIC_UNITS: dict[str, str] = {
 # ``rescale_rate_to_percent`` so the result matches the ``%`` unit.
 _RATE_INDICATOR_METRICS = frozenset({"error_rate"})
 
+# Low-cardinality custom attributes that a pre-aggregated rollup
+# (``dashboard_attr_rollup``) covers for the latency-average breakdown path.
+# A request for ``latency`` avg broken down by exactly one of these (and no
+# filters) is served from the rollup instead of scanning the fat ``span_attr_str``
+# Map over every root span. Adding a key here REQUIRES extending the MV's
+# ARRAY JOIN key list in the v2 schema (a new numbered .sql file) so the rollup
+# actually carries that attribute — otherwise the fast-path would read an empty
+# rollup. Keep the two in lock-step.
+_ROLLUP_COVERED_ATTRS = frozenset({"final_status", "country"})
+
+# The rollup is hour-resolution (keyed on toStartOfHour). It can serve any
+# bucket >= 1 hour by re-aggregating hourly state, but NOT sub-hour buckets —
+# ``minute`` would emit toStartOfMinute over an already hour-truncated column and
+# collapse every minute of an hour into one point. Sub-hour widgets keep the
+# exact spans scan.
+_ROLLUP_GRANULARITIES = frozenset({"hour", "day", "week", "month", "year"})
+
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
 _COUNT_DISTINCT_METRICS = frozenset(
     {
@@ -521,6 +538,51 @@ class DashboardQueryBuilder:
     ) -> tuple[str, dict]:
         # Normalize: saved widgets may have capitalized names (e.g. "Latency")
         metric_name = metric_name.lower() if metric_name else metric_name
+
+        # Rollup fast-path: latency average broken down by a single covered
+        # low-cardinality custom attribute (final_status, country), at hour-or-
+        # coarser granularity, with no filters. The spans path groups the fat
+        # attrs_string Map over every root span and times out; serve it from the
+        # pre-aggregated dashboard_attr_rollup (v2 schema 020) instead.
+        # sumMerge/countMerge over the hourly state gives an EXACT count-weighted
+        # mean equal to avg(latency_ms) over the same rows, and breakdown_value is
+        # the same bare attrs_string[k] the spans path emits — so the output is
+        # identical at the rollup's hour resolution (the only edge effect is the
+        # partial first/last hour of an unaligned window, inherent to the hourly
+        # grain every sibling rollup uses — see 010). Output columns
+        # (time_bucket, breakdown_value, value) and the params contract match the
+        # spans path, so the caller is unaffected. ANY filter, an uncovered
+        # attribute, a sub-hour granularity, a non-latency metric, a non-avg
+        # aggregation, or more than one breakdown falls through to the spans scan
+        # (fail-closed).
+        single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
+        if (
+            metric_name == "latency"
+            and aggregation == "avg"
+            and self.granularity in _ROLLUP_GRANULARITIES
+            and single_bd is not None
+            and single_bd.get("type") == "custom_attribute"
+            and single_bd.get("name") in _ROLLUP_COVERED_ATTRS
+            and not per_metric_filters
+            and not self.global_filters
+        ):
+            params = dict(params)
+            params["attr_key"] = _sanitize_attr_key(single_bd["name"])
+            rollup_query = (
+                f"SELECT {bucket_fn}(hour) AS time_bucket,\n"
+                "       attr_value AS breakdown_value,\n"
+                # Count-weighted mean: exact avg(latency_ms) at any bucket size.
+                "       sumMerge(latency_sum) / countMerge(n) AS value\n"
+                "FROM dashboard_attr_rollup\n"
+                "WHERE project_id IN %(project_ids)s\n"
+                "  AND attr_key = %(attr_key)s\n"
+                "  AND hour >= %(start_date)s\n"
+                "  AND hour < %(end_date)s\n"
+                "GROUP BY time_bucket, breakdown_value\n"
+                "ORDER BY time_bucket, breakdown_value"
+            )
+            return rollup_query, params
+
         if metric_name not in SYSTEM_METRICS:
             # Fallback: treat unknown system metrics as custom span attributes
             # (handles widgets saved with wrong type, e.g. span attribute saved as system_metric)

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -108,6 +108,23 @@ METRIC_UNITS: dict[str, str] = {
 # ``rescale_rate_to_percent`` so the result matches the ``%`` unit.
 _RATE_INDICATOR_METRICS = frozenset({"error_rate"})
 
+# Low-cardinality custom attributes that a pre-aggregated rollup
+# (``dashboard_attr_rollup``) covers for the latency-average breakdown path.
+# A request for ``latency`` avg broken down by exactly one of these (and no
+# filters) is served from the rollup instead of scanning the fat ``span_attr_str``
+# Map over every root span. Adding a key here REQUIRES extending the MV's
+# ARRAY JOIN key list in the v2 schema (a new numbered .sql file) so the rollup
+# actually carries that attribute — otherwise the fast-path would read an empty
+# rollup. Keep the two in lock-step.
+_ROLLUP_COVERED_ATTRS = frozenset({"final_status", "country"})
+
+# The rollup is hour-resolution (keyed on toStartOfHour). It can serve any
+# bucket >= 1 hour by re-aggregating hourly state, but NOT sub-hour buckets —
+# ``minute`` would emit toStartOfMinute over an already hour-truncated column and
+# collapse every minute of an hour into one point. Sub-hour widgets keep the
+# exact spans scan.
+_ROLLUP_GRANULARITIES = frozenset({"hour", "day", "week", "month", "year"})
+
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
 _COUNT_DISTINCT_METRICS = frozenset(
     {
@@ -504,6 +521,51 @@ class DashboardQueryBuilder:
     ) -> tuple[str, dict]:
         # Normalize: saved widgets may have capitalized names (e.g. "Latency")
         metric_name = metric_name.lower() if metric_name else metric_name
+
+        # Rollup fast-path: latency average broken down by a single covered
+        # low-cardinality custom attribute (final_status, country), at hour-or-
+        # coarser granularity, with no filters. The spans path groups the fat
+        # attrs_string Map over every root span and times out; serve it from the
+        # pre-aggregated dashboard_attr_rollup (v2 schema 020) instead.
+        # sumMerge/countMerge over the hourly state gives an EXACT count-weighted
+        # mean equal to avg(latency_ms) over the same rows, and breakdown_value is
+        # the same bare attrs_string[k] the spans path emits — so the output is
+        # identical at the rollup's hour resolution (the only edge effect is the
+        # partial first/last hour of an unaligned window, inherent to the hourly
+        # grain every sibling rollup uses — see 010). Output columns
+        # (time_bucket, breakdown_value, value) and the params contract match the
+        # spans path, so the caller is unaffected. ANY filter, an uncovered
+        # attribute, a sub-hour granularity, a non-latency metric, a non-avg
+        # aggregation, or more than one breakdown falls through to the spans scan
+        # (fail-closed).
+        single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
+        if (
+            metric_name == "latency"
+            and aggregation == "avg"
+            and self.granularity in _ROLLUP_GRANULARITIES
+            and single_bd is not None
+            and single_bd.get("type") == "custom_attribute"
+            and single_bd.get("name") in _ROLLUP_COVERED_ATTRS
+            and not per_metric_filters
+            and not self.global_filters
+        ):
+            params = dict(params)
+            params["attr_key"] = _sanitize_attr_key(single_bd["name"])
+            rollup_query = (
+                f"SELECT {bucket_fn}(hour) AS time_bucket,\n"
+                "       attr_value AS breakdown_value,\n"
+                # Count-weighted mean: exact avg(latency_ms) at any bucket size.
+                "       sumMerge(latency_sum) / countMerge(n) AS value\n"
+                "FROM dashboard_attr_rollup\n"
+                "WHERE project_id IN %(project_ids)s\n"
+                "  AND attr_key = %(attr_key)s\n"
+                "  AND hour >= %(start_date)s\n"
+                "  AND hour < %(end_date)s\n"
+                "GROUP BY time_bucket, breakdown_value\n"
+                "ORDER BY time_bucket, breakdown_value"
+            )
+            return rollup_query, params
+
         if metric_name not in SYSTEM_METRICS:
             # Fallback: treat unknown system metrics as custom span attributes
             # (handles widgets saved with wrong type, e.g. span attribute saved as system_metric)

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -108,21 +108,10 @@ METRIC_UNITS: dict[str, str] = {
 # ``rescale_rate_to_percent`` so the result matches the ``%`` unit.
 _RATE_INDICATOR_METRICS = frozenset({"error_rate"})
 
-# Low-cardinality custom attributes that a pre-aggregated rollup
-# (``dashboard_attr_rollup``) covers for the latency-average breakdown path.
-# A request for ``latency`` avg broken down by exactly one of these (and no
-# filters) is served from the rollup instead of scanning the fat ``span_attr_str``
-# Map over every root span. Adding a key here REQUIRES extending the MV's
-# ARRAY JOIN key list in the v2 schema (a new numbered .sql file) so the rollup
-# actually carries that attribute — otherwise the fast-path would read an empty
-# rollup. Keep the two in lock-step.
+# Covered by dashboard_attr_rollup. Adding one: extend the MV's ARRAY JOIN list too.
 _ROLLUP_COVERED_ATTRS = frozenset({"final_status", "country"})
 
-# The rollup is hour-resolution (keyed on toStartOfHour). It can serve any
-# bucket >= 1 hour by re-aggregating hourly state, but NOT sub-hour buckets —
-# ``minute`` would emit toStartOfMinute over an already hour-truncated column and
-# collapse every minute of an hour into one point. Sub-hour widgets keep the
-# exact spans scan.
+# Rollup is hour-resolution; sub-hour granularities keep the spans scan.
 _ROLLUP_GRANULARITIES = frozenset({"hour", "day", "week", "month", "year"})
 
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
@@ -522,22 +511,8 @@ class DashboardQueryBuilder:
         # Normalize: saved widgets may have capitalized names (e.g. "Latency")
         metric_name = metric_name.lower() if metric_name else metric_name
 
-        # Rollup fast-path: latency average broken down by a single covered
-        # low-cardinality custom attribute (final_status, country), at hour-or-
-        # coarser granularity, with no filters. The spans path groups the fat
-        # attrs_string Map over every root span and times out; serve it from the
-        # pre-aggregated dashboard_attr_rollup (v2 schema 020) instead.
-        # sumMerge/countMerge over the hourly state gives an EXACT count-weighted
-        # mean equal to avg(latency_ms) over the same rows, and breakdown_value is
-        # the same bare attrs_string[k] the spans path emits — so the output is
-        # identical at the rollup's hour resolution (the only edge effect is the
-        # partial first/last hour of an unaligned window, inherent to the hourly
-        # grain every sibling rollup uses — see 010). Output columns
-        # (time_bucket, breakdown_value, value) and the params contract match the
-        # spans path, so the caller is unaffected. ANY filter, an uncovered
-        # attribute, a sub-hour granularity, a non-latency metric, a non-avg
-        # aggregation, or more than one breakdown falls through to the spans scan
-        # (fail-closed).
+        # Covered latency-breakdown shape → the pre-aggregated rollup; any other
+        # shape falls through to the spans scan (fail-closed).
         single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
         if (
             metric_name == "latency"
@@ -554,7 +529,6 @@ class DashboardQueryBuilder:
             rollup_query = (
                 f"SELECT {bucket_fn}(hour) AS time_bucket,\n"
                 "       attr_value AS breakdown_value,\n"
-                # Count-weighted mean: exact avg(latency_ms) at any bucket size.
                 "       sumMerge(latency_sum) / countMerge(n) AS value\n"
                 "FROM dashboard_attr_rollup\n"
                 "WHERE project_id IN %(project_ids)s\n"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -108,21 +108,10 @@ METRIC_UNITS: dict[str, str] = {
 # ``rescale_rate_to_percent`` so the result matches the ``%`` unit.
 _RATE_INDICATOR_METRICS = frozenset({"error_rate"})
 
-# Low-cardinality custom attributes that a pre-aggregated rollup
-# (``dashboard_attr_rollup``) covers for the latency-average breakdown path.
-# A request for ``latency`` avg broken down by exactly one of these (and no
-# filters) is served from the rollup instead of scanning the fat ``span_attr_str``
-# Map over every root span. Adding a key here REQUIRES extending the MV's
-# ARRAY JOIN key list in the v2 schema (a new numbered .sql file) so the rollup
-# actually carries that attribute — otherwise the fast-path would read an empty
-# rollup. Keep the two in lock-step.
+# Covered by dashboard_attr_rollup. Adding one: extend the MV's ARRAY JOIN list too.
 _ROLLUP_COVERED_ATTRS = frozenset({"final_status", "country"})
 
-# The rollup is hour-resolution (keyed on toStartOfHour). It can serve any
-# bucket >= 1 hour by re-aggregating hourly state, but NOT sub-hour buckets —
-# ``minute`` would emit toStartOfMinute over an already hour-truncated column and
-# collapse every minute of an hour into one point. Sub-hour widgets keep the
-# exact spans scan.
+# Rollup is hour-resolution; sub-hour granularities keep the spans scan.
 _ROLLUP_GRANULARITIES = frozenset({"hour", "day", "week", "month", "year"})
 
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
@@ -539,22 +528,8 @@ class DashboardQueryBuilder:
         # Normalize: saved widgets may have capitalized names (e.g. "Latency")
         metric_name = metric_name.lower() if metric_name else metric_name
 
-        # Rollup fast-path: latency average broken down by a single covered
-        # low-cardinality custom attribute (final_status, country), at hour-or-
-        # coarser granularity, with no filters. The spans path groups the fat
-        # attrs_string Map over every root span and times out; serve it from the
-        # pre-aggregated dashboard_attr_rollup (v2 schema 020) instead.
-        # sumMerge/countMerge over the hourly state gives an EXACT count-weighted
-        # mean equal to avg(latency_ms) over the same rows, and breakdown_value is
-        # the same bare attrs_string[k] the spans path emits — so the output is
-        # identical at the rollup's hour resolution (the only edge effect is the
-        # partial first/last hour of an unaligned window, inherent to the hourly
-        # grain every sibling rollup uses — see 010). Output columns
-        # (time_bucket, breakdown_value, value) and the params contract match the
-        # spans path, so the caller is unaffected. ANY filter, an uncovered
-        # attribute, a sub-hour granularity, a non-latency metric, a non-avg
-        # aggregation, or more than one breakdown falls through to the spans scan
-        # (fail-closed).
+        # Covered latency-breakdown shape → the pre-aggregated rollup; any other
+        # shape falls through to the spans scan (fail-closed).
         single_bd = self.breakdowns[0] if len(self.breakdowns) == 1 else None
         if (
             metric_name == "latency"
@@ -571,7 +546,6 @@ class DashboardQueryBuilder:
             rollup_query = (
                 f"SELECT {bucket_fn}(hour) AS time_bucket,\n"
                 "       attr_value AS breakdown_value,\n"
-                # Count-weighted mean: exact avg(latency_ms) at any bucket size.
                 "       sumMerge(latency_sum) / countMerge(n) AS value\n"
                 "FROM dashboard_attr_rollup\n"
                 "WHERE project_id IN %(project_ids)s\n"

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/dashboard.py
@@ -55,6 +55,9 @@ class DashboardQueryBuilderV2(V2RewriteMixin, DashboardQueryBuilder):
       (``e.is_deleted`` → ``e._peerdb_is_deleted``).
     """
 
+    # dashboard_attr_rollup ships only in the v2 schema, so the fast-path is safe only here.
+    _attr_rollup_available: bool = True
+
     _v2_rewrite_exclude = frozenset({"build_metric_query", "build_all_queries"})
 
     def build_metric_query(self, metric: dict) -> tuple[str, dict]:

--- a/futureagi/tracer/services/clickhouse/v2/schema/020_dashboard_attr_rollup.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/020_dashboard_attr_rollup.sql
@@ -1,48 +1,5 @@
--- =============================================================================
--- 020 — Dashboard attribute rollup (latency × low-cardinality attribute)
--- =============================================================================
---
--- Same chained incremental aggregate-state MV shape as 010 / 016 (see
--- MV_STRATEGY.md). Powers ONE dashboard read path: "latency average over root
--- spans, broken down by a low-cardinality custom attribute" (final_status,
--- country). That widget groups the fat `attrs_string` Map across tens of
--- millions of root spans on every page-load and times out; this rollup
--- pre-aggregates it so the read is a tiny scan of pre-grouped state.
---
--- Why sum + count (NOT avg) as the carried metric:
---   The dashboard serves hour/day/week/month buckets by RE-aggregating hourly
---   rows. An avg-of-avgs is wrong across buckets of unequal row counts. Carrying
---   sumState(latency_ms) + countState() lets the read compute an EXACT
---   count-weighted mean — sumMerge(latency_sum) / countMerge(n) — that equals
---   avg(latency_ms) over the same raw rows at ANY bucket size. This is the
---   property that makes the rollup numbers identical to the raw scan.
---
--- Why row-REDUCING / safe (vs the old row-expanding spans_mv that OOMed):
---   The MV ARRAY JOINs a FIXED, tiny key list (covered attrs only) — not the
---   whole Map — and GROUP BYs, so it reads N batch rows and writes
---   <= N × (#covered keys) rows. Memory is bounded by distinct
---   (hour, attr_key, attr_value) per batch, far smaller than the batch.
---
--- Root spans only: the dashboard latency metric is defined over root spans
---   (parent_span_id = ''), matching the `(parent_span_id IS NULL OR
---   parent_span_id = '')` predicate the spans path applies. On the v2 schema
---   parent_span_id is `String DEFAULT ''` (002_spans_v2.sql), so the root test
---   is `parent_span_id = ''`.
---
--- Covered attribute keys: kept to a fixed low-cardinality set. Adding a key is
---   a deliberate change — extend the ARRAY JOIN list here AND the COVERED set in
---   the dashboard query builder, in a new numbered schema file (this one is
---   append-only once applied — see apply_schema.py DECISIONS #004).
---
--- Dashboard read pattern (the builder's covered-breakdown fast-path):
---   SELECT toStartOfDay(hour)              AS time_bucket,
---          attr_value                      AS breakdown_value,
---          sumMerge(latency_sum) / countMerge(n) AS value
---   FROM   dashboard_attr_rollup
---   WHERE  project_id IN ? AND attr_key = ? AND hour >= ? AND hour < ?
---   GROUP  BY time_bucket, breakdown_value
---   ORDER  BY time_bucket, breakdown_value;
--- =============================================================================
+-- Pre-aggregated rollup for the dashboard "latency avg, broken down by a
+-- low-cardinality attribute" read path. Same MV shape as 010 / 016.
 
 CREATE TABLE IF NOT EXISTS dashboard_attr_rollup
 (
@@ -50,12 +7,7 @@ CREATE TABLE IF NOT EXISTS dashboard_attr_rollup
     hour         DateTime('UTC'),
     attr_key     LowCardinality(String),
     attr_value   String,
-
     n            AggregateFunction(count),
-    -- sum of latency_ms; toInt64 upcast (Int32 raw → Int64 state) so the
-    -- SELECT's state element type matches this column — CH refuses the
-    -- implicit AggregateFunction(sum, Int32) → (sum, Int64) conversion on
-    -- insert (same rationale as 008/010/016).
     latency_sum  AggregateFunction(sum, Int64),
 
     INDEX idx_attr_value attr_value TYPE bloom_filter(0.01) GRANULARITY 1
@@ -73,24 +25,11 @@ SELECT
     project_id,
     toStartOfHour(start_time)            AS hour,
     attr_key,
-    -- Breakdown value must match the spans path EXACTLY. The system-metric
-    -- breakdown path (_build_system_metric_query → _resolve_all_breakdowns)
-    -- emits the BARE Map subscript span_attr_str[k] (→ attrs_string[k] after the
-    -- v2 rewrite), so a missing / empty attribute groups under the empty-string
-    -- '' bucket — not dropped, not relabelled. (A different method,
-    -- _build_breakdown_clause, wraps empties as '(not set)', but the path this
-    -- rollup replaces does not call it — so neither does the rollup.)
     attrs_string[attr_key]               AS attr_value,
     countState()                         AS n,
     sumState(toInt64(latency_ms))        AS latency_sum
 FROM spans
--- ARRAY JOIN over the FIXED covered key set — extracts only these keys from the
--- Map (not the whole Map), keeping the MV row-reducing. attr_key is the joined
--- element; attrs_string[attr_key] reads that one Map entry per covered key.
 ARRAY JOIN ['final_status', 'country'] AS attr_key
 WHERE is_deleted = 0
   AND parent_span_id = ''
--- Use the explicit expressions (not the `hour` / `attr_value` aliases) to
--- side-step the CH 25.x analyzer quirk that fails to recognize SELECT aliases
--- in GROUP BY (see 010 and DECISIONS #020).
 GROUP BY project_id, toStartOfHour(start_time), attr_key, attrs_string[attr_key];

--- a/futureagi/tracer/services/clickhouse/v2/schema/020_dashboard_attr_rollup.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/020_dashboard_attr_rollup.sql
@@ -1,0 +1,96 @@
+-- =============================================================================
+-- 020 — Dashboard attribute rollup (latency × low-cardinality attribute)
+-- =============================================================================
+--
+-- Same chained incremental aggregate-state MV shape as 010 / 016 (see
+-- MV_STRATEGY.md). Powers ONE dashboard read path: "latency average over root
+-- spans, broken down by a low-cardinality custom attribute" (final_status,
+-- country). That widget groups the fat `attrs_string` Map across tens of
+-- millions of root spans on every page-load and times out; this rollup
+-- pre-aggregates it so the read is a tiny scan of pre-grouped state.
+--
+-- Why sum + count (NOT avg) as the carried metric:
+--   The dashboard serves hour/day/week/month buckets by RE-aggregating hourly
+--   rows. An avg-of-avgs is wrong across buckets of unequal row counts. Carrying
+--   sumState(latency_ms) + countState() lets the read compute an EXACT
+--   count-weighted mean — sumMerge(latency_sum) / countMerge(n) — that equals
+--   avg(latency_ms) over the same raw rows at ANY bucket size. This is the
+--   property that makes the rollup numbers identical to the raw scan.
+--
+-- Why row-REDUCING / safe (vs the old row-expanding spans_mv that OOMed):
+--   The MV ARRAY JOINs a FIXED, tiny key list (covered attrs only) — not the
+--   whole Map — and GROUP BYs, so it reads N batch rows and writes
+--   <= N × (#covered keys) rows. Memory is bounded by distinct
+--   (hour, attr_key, attr_value) per batch, far smaller than the batch.
+--
+-- Root spans only: the dashboard latency metric is defined over root spans
+--   (parent_span_id = ''), matching the `(parent_span_id IS NULL OR
+--   parent_span_id = '')` predicate the spans path applies. On the v2 schema
+--   parent_span_id is `String DEFAULT ''` (002_spans_v2.sql), so the root test
+--   is `parent_span_id = ''`.
+--
+-- Covered attribute keys: kept to a fixed low-cardinality set. Adding a key is
+--   a deliberate change — extend the ARRAY JOIN list here AND the COVERED set in
+--   the dashboard query builder, in a new numbered schema file (this one is
+--   append-only once applied — see apply_schema.py DECISIONS #004).
+--
+-- Dashboard read pattern (the builder's covered-breakdown fast-path):
+--   SELECT toStartOfDay(hour)              AS time_bucket,
+--          attr_value                      AS breakdown_value,
+--          sumMerge(latency_sum) / countMerge(n) AS value
+--   FROM   dashboard_attr_rollup
+--   WHERE  project_id IN ? AND attr_key = ? AND hour >= ? AND hour < ?
+--   GROUP  BY time_bucket, breakdown_value
+--   ORDER  BY time_bucket, breakdown_value;
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS dashboard_attr_rollup
+(
+    project_id   UUID,
+    hour         DateTime('UTC'),
+    attr_key     LowCardinality(String),
+    attr_value   String,
+
+    n            AggregateFunction(count),
+    -- sum of latency_ms; toInt64 upcast (Int32 raw → Int64 state) so the
+    -- SELECT's state element type matches this column — CH refuses the
+    -- implicit AggregateFunction(sum, Int32) → (sum, Int64) conversion on
+    -- insert (same rationale as 008/010/016).
+    latency_sum  AggregateFunction(sum, Int64),
+
+    INDEX idx_attr_value attr_value TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, hour, attr_key, attr_value)
+TTL toDateTime(hour) + INTERVAL 90 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS dashboard_attr_rollup_mv
+TO dashboard_attr_rollup
+AS
+SELECT
+    project_id,
+    toStartOfHour(start_time)            AS hour,
+    attr_key,
+    -- Breakdown value must match the spans path EXACTLY. The system-metric
+    -- breakdown path (_build_system_metric_query → _resolve_all_breakdowns)
+    -- emits the BARE Map subscript span_attr_str[k] (→ attrs_string[k] after the
+    -- v2 rewrite), so a missing / empty attribute groups under the empty-string
+    -- '' bucket — not dropped, not relabelled. (A different method,
+    -- _build_breakdown_clause, wraps empties as '(not set)', but the path this
+    -- rollup replaces does not call it — so neither does the rollup.)
+    attrs_string[attr_key]               AS attr_value,
+    countState()                         AS n,
+    sumState(toInt64(latency_ms))        AS latency_sum
+FROM spans
+-- ARRAY JOIN over the FIXED covered key set — extracts only these keys from the
+-- Map (not the whole Map), keeping the MV row-reducing. attr_key is the joined
+-- element; attrs_string[attr_key] reads that one Map entry per covered key.
+ARRAY JOIN ['final_status', 'country'] AS attr_key
+WHERE is_deleted = 0
+  AND parent_span_id = ''
+-- Use the explicit expressions (not the `hour` / `attr_value` aliases) to
+-- side-step the CH 25.x analyzer quirk that fails to recognize SELECT aliases
+-- in GROUP BY (see 010 and DECISIONS #020).
+GROUP BY project_id, toStartOfHour(start_time), attr_key, attrs_string[attr_key];

--- a/futureagi/tracer/services/clickhouse/v2/schema/021_dashboard_attr_rollup.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/021_dashboard_attr_rollup.sql
@@ -1,5 +1,9 @@
 -- Pre-aggregated rollup for the dashboard "latency avg, broken down by a
 -- low-cardinality attribute" read path. Same MV shape as 010 / 016.
+-- Covered attr_keys: final_status, country only — other breakdowns fall back
+-- to the spans scan (router gate in query_builders/dashboard.py).
+-- No TTL: this aggregate hangs off spans, which 020_remove_ttls retains
+-- indefinitely (retention is enforced per-org by ee/usage, not CH TTL).
 
 CREATE TABLE IF NOT EXISTS dashboard_attr_rollup
 (
@@ -15,7 +19,6 @@ CREATE TABLE IF NOT EXISTS dashboard_attr_rollup
 ENGINE = AggregatingMergeTree
 PARTITION BY toYYYYMM(hour)
 ORDER BY (project_id, hour, attr_key, attr_value)
-TTL toDateTime(hour) + INTERVAL 90 DAY DELETE
 SETTINGS index_granularity = 8192;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS dashboard_attr_rollup_mv

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1389,19 +1389,10 @@ class TestDashboardQueryBuilder:
 
 
 class TestDashboardAttrRollupRouting:
-    """Routing for the latency-average × covered-attribute breakdown.
+    """Routing for the latency-avg × covered-attribute breakdown.
 
-    The fast-path serves "latency avg over root spans, broken down by a covered
-    low-cardinality custom attribute, no filters" from the pre-aggregated
-    ``dashboard_attr_rollup`` instead of scanning the fat ``span_attr_str`` Map
-    over every root span. All assertions go through the REAL builder call-path
-    (``build_all_queries`` → ``_build_system_metric_query``), not hand-built SQL.
-
-    Each test is tagged:
-      [FIX]      proves the rollup is used — RED if the routing branch is removed
-                 (the query would target ``spans`` and scan ``span_attr_str``).
-      [FALLBACK] proves the spans path is preserved when the request is NOT a
-                 clean covered breakdown — RED if the branch over-matches.
+    Drives the real build_all_queries() call-path. [FIX] tests go RED if the
+    routing branch is removed; [FALLBACK] tests prove the spans path is kept.
     """
 
     @staticmethod
@@ -1463,8 +1454,7 @@ class TestDashboardAttrRollupRouting:
         assert params["attr_key"] == "country"
 
     def test_per_metric_filter_falls_back_to_spans(self):
-        # [FALLBACK] a per-metric filter present → must NOT use the rollup
-        # (the rollup carries no per-span columns to filter on).
+        # [FALLBACK] per-metric filter → spans path.
         config = self._config(
             breakdowns=[self._bd("final_status")],
             metric_filters=[
@@ -1509,8 +1499,7 @@ class TestDashboardAttrRollupRouting:
         assert "span_attr_str" in sql
 
     def test_non_avg_aggregation_falls_back_to_spans(self):
-        # [FALLBACK] p95 (non-avg) over a covered attribute → spans path
-        # (the rollup carries a mean, not a quantile state).
+        # [FALLBACK] non-avg (p95) → spans path.
         config = self._config(
             aggregation="p95", breakdowns=[self._bd("final_status")]
         )
@@ -1520,9 +1509,7 @@ class TestDashboardAttrRollupRouting:
         assert "span_attr_str" in sql
 
     def test_non_latency_metric_falls_back_to_spans(self):
-        # [FALLBACK] cost avg over a covered attribute → spans path (the rollup
-        # only carries latency). The spans path still scans span_attr_str for
-        # the breakdown — the point is it does NOT route to the rollup.
+        # [FALLBACK] non-latency (cost) → spans path.
         config = self._config(
             metric_name="cost", breakdowns=[self._bd("final_status")]
         )
@@ -1533,8 +1520,7 @@ class TestDashboardAttrRollupRouting:
         assert "breakdown_value" in sql
 
     def test_two_breakdowns_fall_back_to_spans(self):
-        # [FALLBACK] more than one breakdown → spans path (the rollup is keyed
-        # by a single attr_key/attr_value).
+        # [FALLBACK] >1 breakdown → spans path.
         config = self._config(
             breakdowns=[self._bd("final_status"), self._bd("country")]
         )
@@ -1551,9 +1537,7 @@ class TestDashboardAttrRollupRouting:
         assert "latency_ms" in sql
 
     def test_sub_hour_granularity_falls_back_to_spans(self):
-        # [FALLBACK] minute (sub-hour) granularity → spans path. The rollup is
-        # keyed on toStartOfHour, so a sub-hour bucket would collapse to the hour
-        # and silently lose resolution; only hour-or-coarser routes to it.
+        # [FALLBACK] sub-hour granularity → spans path (rollup is hourly).
         config = self._config(
             breakdowns=[self._bd("final_status")], granularity="minute"
         )
@@ -1572,8 +1556,7 @@ class TestDashboardAttrRollupRouting:
         assert "dashboard_attr_rollup" in sql
 
     def test_rollup_params_carry_window_bounds(self):
-        # [FIX] the rollup query is bounded by the same start/end window params
-        # as the spans path, so it never scans all history.
+        # [FIX] rollup is window-bounded, never all-history.
         config = self._config(breakdowns=[self._bd("final_status")])
         builder = DashboardQueryBuilder(config)
         sql, params, _ = builder.build_all_queries()[0]
@@ -1583,29 +1566,14 @@ class TestDashboardAttrRollupRouting:
         assert "project_id IN %(project_ids)s" in sql
 
     def test_weighted_mean_equals_raw_avg(self):
-        """Numbers-identical proof (no live stack needed).
-
-        The rollup reads ``sumMerge(latency_sum) / countMerge(n)`` — a
-        count-weighted mean over the hourly state. This equals ``avg(latency_ms)``
-        over the same raw rows at ANY bucket size. Verify the algebra the SQL
-        relies on: re-aggregating per-hour (sum, count) pairs into a day and
-        dividing total-sum by total-count yields exactly the flat average of all
-        the raw latencies — whereas a naive average-of-hourly-averages does not.
-        """
-        # Two hours with very unequal row counts (where avg-of-avgs would drift).
-        hour_a = [100, 200, 300]          # n=3, sum=600
-        hour_b = [1000]                   # n=1, sum=1000
+        # sumMerge/countMerge == flat avg of raw latencies; avg-of-avgs would not.
+        hour_a = [100, 200, 300]
+        hour_b = [1000]
         raw = hour_a + hour_b
         flat_avg = sum(raw) / len(raw)
-
-        # What the rollup stores per hour: (sum, count) state.
         states = [(sum(hour_a), len(hour_a)), (sum(hour_b), len(hour_b))]
-        # What the read computes: sumMerge / countMerge across the day.
         weighted = sum(s for s, _ in states) / sum(c for _, c in states)
         assert weighted == pytest.approx(flat_avg)
-
-        # And prove the wrong approach (avg of per-hour avgs) would NOT match,
-        # i.e. the sum+count design is load-bearing, not incidental.
         avg_of_avgs = ((sum(hour_a) / len(hour_a)) + (sum(hour_b) / len(hour_b))) / 2
         assert avg_of_avgs != pytest.approx(flat_avg)
 

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1388,6 +1388,228 @@ class TestDashboardQueryBuilder:
         assert "breakdown_value" in sql
 
 
+class TestDashboardAttrRollupRouting:
+    """Routing for the latency-average × covered-attribute breakdown.
+
+    The fast-path serves "latency avg over root spans, broken down by a covered
+    low-cardinality custom attribute, no filters" from the pre-aggregated
+    ``dashboard_attr_rollup`` instead of scanning the fat ``span_attr_str`` Map
+    over every root span. All assertions go through the REAL builder call-path
+    (``build_all_queries`` → ``_build_system_metric_query``), not hand-built SQL.
+
+    Each test is tagged:
+      [FIX]      proves the rollup is used — RED if the routing branch is removed
+                 (the query would target ``spans`` and scan ``span_attr_str``).
+      [FALLBACK] proves the spans path is preserved when the request is NOT a
+                 clean covered breakdown — RED if the branch over-matches.
+    """
+
+    @staticmethod
+    def _config(metric_name="latency", aggregation="avg", breakdowns=None,
+                metric_filters=None, global_filters=None, granularity="day"):
+        metric = {
+            "id": metric_name,
+            "name": metric_name,
+            "type": "system_metric",
+            "aggregation": aggregation,
+        }
+        if metric_filters is not None:
+            metric["filters"] = metric_filters
+        return {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": granularity,
+            "time_range": {"preset": "30D"},
+            "metrics": [metric],
+            "filters": global_filters or [],
+            "breakdowns": breakdowns if breakdowns is not None else [],
+        }
+
+    @staticmethod
+    def _bd(name):
+        return {
+            "type": "custom_attribute",
+            "name": name,
+            "source": "traces",
+            "display_name": name,
+            "attribute_type": "string",
+        }
+
+    def test_covered_breakdown_final_status_routes_to_rollup(self):
+        # [FIX] final_status → rollup. RED without the routing branch.
+        config = self._config(breakdowns=[self._bd("final_status")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        # Targets the rollup, reads merged state, and does NOT scan the Map.
+        assert "dashboard_attr_rollup" in sql
+        assert "sumMerge(latency_sum)" in sql
+        assert "countMerge(n)" in sql
+        assert "span_attr_str" not in sql
+        assert "FROM spans" not in sql
+        # Output contract unchanged: time_bucket / breakdown_value / value.
+        assert "time_bucket" in sql
+        assert "breakdown_value" in sql
+        # attr_key is passed as a param, filtered on in the rollup.
+        assert params["attr_key"] == "final_status"
+        assert "attr_key = %(attr_key)s" in sql
+
+    def test_covered_breakdown_country_routes_to_rollup(self):
+        # [FIX] country → rollup too.
+        config = self._config(breakdowns=[self._bd("country")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" in sql
+        assert "sumMerge(latency_sum) / countMerge(n)" in sql
+        assert "span_attr_str" not in sql
+        assert params["attr_key"] == "country"
+
+    def test_per_metric_filter_falls_back_to_spans(self):
+        # [FALLBACK] a per-metric filter present → must NOT use the rollup
+        # (the rollup carries no per-span columns to filter on).
+        config = self._config(
+            breakdowns=[self._bd("final_status")],
+            metric_filters=[
+                {
+                    "metric_type": "system_metric",
+                    "metric_name": "status",
+                    "operator": "equal_to",
+                    "value": "OK",
+                }
+            ],
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_global_filter_falls_back_to_spans(self):
+        # [FALLBACK] a global filter present → spans path.
+        config = self._config(
+            breakdowns=[self._bd("final_status")],
+            global_filters=[
+                {
+                    "metric_type": "custom_attribute",
+                    "metric_name": "env",
+                    "operator": "equal_to",
+                    "value": "prod",
+                    "attribute_type": "string",
+                }
+            ],
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_uncovered_attribute_falls_back_to_spans(self):
+        # [FALLBACK] an attribute outside the covered set (user_id) → spans path.
+        config = self._config(breakdowns=[self._bd("user_id")])
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_non_avg_aggregation_falls_back_to_spans(self):
+        # [FALLBACK] p95 (non-avg) over a covered attribute → spans path
+        # (the rollup carries a mean, not a quantile state).
+        config = self._config(
+            aggregation="p95", breakdowns=[self._bd("final_status")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_non_latency_metric_falls_back_to_spans(self):
+        # [FALLBACK] cost avg over a covered attribute → spans path (the rollup
+        # only carries latency). The spans path still scans span_attr_str for
+        # the breakdown — the point is it does NOT route to the rollup.
+        config = self._config(
+            metric_name="cost", breakdowns=[self._bd("final_status")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "cost" in sql.lower()
+        assert "breakdown_value" in sql
+
+    def test_two_breakdowns_fall_back_to_spans(self):
+        # [FALLBACK] more than one breakdown → spans path (the rollup is keyed
+        # by a single attr_key/attr_value).
+        config = self._config(
+            breakdowns=[self._bd("final_status"), self._bd("country")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+
+    def test_no_breakdown_latency_avg_falls_back_to_spans(self):
+        # [FALLBACK] plain latency avg with no breakdown → spans path unchanged.
+        config = self._config(breakdowns=[])
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "latency_ms" in sql
+
+    def test_sub_hour_granularity_falls_back_to_spans(self):
+        # [FALLBACK] minute (sub-hour) granularity → spans path. The rollup is
+        # keyed on toStartOfHour, so a sub-hour bucket would collapse to the hour
+        # and silently lose resolution; only hour-or-coarser routes to it.
+        config = self._config(
+            breakdowns=[self._bd("final_status")], granularity="minute"
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_hour_granularity_routes_to_rollup(self):
+        # [FIX] hour granularity is covered (>= the rollup's hour resolution).
+        config = self._config(
+            breakdowns=[self._bd("final_status")], granularity="hour"
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" in sql
+
+    def test_rollup_params_carry_window_bounds(self):
+        # [FIX] the rollup query is bounded by the same start/end window params
+        # as the spans path, so it never scans all history.
+        config = self._config(breakdowns=[self._bd("final_status")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        assert "hour >= %(start_date)s" in sql
+        assert "hour < %(end_date)s" in sql
+        assert "start_date" in params and "end_date" in params
+        assert "project_id IN %(project_ids)s" in sql
+
+    def test_weighted_mean_equals_raw_avg(self):
+        """Numbers-identical proof (no live stack needed).
+
+        The rollup reads ``sumMerge(latency_sum) / countMerge(n)`` — a
+        count-weighted mean over the hourly state. This equals ``avg(latency_ms)``
+        over the same raw rows at ANY bucket size. Verify the algebra the SQL
+        relies on: re-aggregating per-hour (sum, count) pairs into a day and
+        dividing total-sum by total-count yields exactly the flat average of all
+        the raw latencies — whereas a naive average-of-hourly-averages does not.
+        """
+        # Two hours with very unequal row counts (where avg-of-avgs would drift).
+        hour_a = [100, 200, 300]          # n=3, sum=600
+        hour_b = [1000]                   # n=1, sum=1000
+        raw = hour_a + hour_b
+        flat_avg = sum(raw) / len(raw)
+
+        # What the rollup stores per hour: (sum, count) state.
+        states = [(sum(hour_a), len(hour_a)), (sum(hour_b), len(hour_b))]
+        # What the read computes: sumMerge / countMerge across the day.
+        weighted = sum(s for s, _ in states) / sum(c for _, c in states)
+        assert weighted == pytest.approx(flat_avg)
+
+        # And prove the wrong approach (avg of per-hour avgs) would NOT match,
+        # i.e. the sum+count design is load-bearing, not incidental.
+        avg_of_avgs = ((sum(hour_a) / len(hour_a)) + (sum(hour_b) / len(hour_b))) / 2
+        assert avg_of_avgs != pytest.approx(flat_avg)
+
+
 class TestDashboardQueryBuilderTimeRanges:
     def test_preset_7d(self):
         config = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1383,19 +1383,10 @@ class TestDashboardQueryBuilder:
 
 
 class TestDashboardAttrRollupRouting:
-    """Routing for the latency-average × covered-attribute breakdown.
+    """Routing for the latency-avg × covered-attribute breakdown.
 
-    The fast-path serves "latency avg over root spans, broken down by a covered
-    low-cardinality custom attribute, no filters" from the pre-aggregated
-    ``dashboard_attr_rollup`` instead of scanning the fat ``span_attr_str`` Map
-    over every root span. All assertions go through the REAL builder call-path
-    (``build_all_queries`` → ``_build_system_metric_query``), not hand-built SQL.
-
-    Each test is tagged:
-      [FIX]      proves the rollup is used — RED if the routing branch is removed
-                 (the query would target ``spans`` and scan ``span_attr_str``).
-      [FALLBACK] proves the spans path is preserved when the request is NOT a
-                 clean covered breakdown — RED if the branch over-matches.
+    Drives the real build_all_queries() call-path. [FIX] tests go RED if the
+    routing branch is removed; [FALLBACK] tests prove the spans path is kept.
     """
 
     @staticmethod
@@ -1457,8 +1448,7 @@ class TestDashboardAttrRollupRouting:
         assert params["attr_key"] == "country"
 
     def test_per_metric_filter_falls_back_to_spans(self):
-        # [FALLBACK] a per-metric filter present → must NOT use the rollup
-        # (the rollup carries no per-span columns to filter on).
+        # [FALLBACK] per-metric filter → spans path.
         config = self._config(
             breakdowns=[self._bd("final_status")],
             metric_filters=[
@@ -1503,8 +1493,7 @@ class TestDashboardAttrRollupRouting:
         assert "span_attr_str" in sql
 
     def test_non_avg_aggregation_falls_back_to_spans(self):
-        # [FALLBACK] p95 (non-avg) over a covered attribute → spans path
-        # (the rollup carries a mean, not a quantile state).
+        # [FALLBACK] non-avg (p95) → spans path.
         config = self._config(
             aggregation="p95", breakdowns=[self._bd("final_status")]
         )
@@ -1514,9 +1503,7 @@ class TestDashboardAttrRollupRouting:
         assert "span_attr_str" in sql
 
     def test_non_latency_metric_falls_back_to_spans(self):
-        # [FALLBACK] cost avg over a covered attribute → spans path (the rollup
-        # only carries latency). The spans path still scans span_attr_str for
-        # the breakdown — the point is it does NOT route to the rollup.
+        # [FALLBACK] non-latency (cost) → spans path.
         config = self._config(
             metric_name="cost", breakdowns=[self._bd("final_status")]
         )
@@ -1527,8 +1514,7 @@ class TestDashboardAttrRollupRouting:
         assert "breakdown_value" in sql
 
     def test_two_breakdowns_fall_back_to_spans(self):
-        # [FALLBACK] more than one breakdown → spans path (the rollup is keyed
-        # by a single attr_key/attr_value).
+        # [FALLBACK] >1 breakdown → spans path.
         config = self._config(
             breakdowns=[self._bd("final_status"), self._bd("country")]
         )
@@ -1545,9 +1531,7 @@ class TestDashboardAttrRollupRouting:
         assert "latency_ms" in sql
 
     def test_sub_hour_granularity_falls_back_to_spans(self):
-        # [FALLBACK] minute (sub-hour) granularity → spans path. The rollup is
-        # keyed on toStartOfHour, so a sub-hour bucket would collapse to the hour
-        # and silently lose resolution; only hour-or-coarser routes to it.
+        # [FALLBACK] sub-hour granularity → spans path (rollup is hourly).
         config = self._config(
             breakdowns=[self._bd("final_status")], granularity="minute"
         )
@@ -1566,8 +1550,7 @@ class TestDashboardAttrRollupRouting:
         assert "dashboard_attr_rollup" in sql
 
     def test_rollup_params_carry_window_bounds(self):
-        # [FIX] the rollup query is bounded by the same start/end window params
-        # as the spans path, so it never scans all history.
+        # [FIX] rollup is window-bounded, never all-history.
         config = self._config(breakdowns=[self._bd("final_status")])
         builder = DashboardQueryBuilder(config)
         sql, params, _ = builder.build_all_queries()[0]
@@ -1577,29 +1560,14 @@ class TestDashboardAttrRollupRouting:
         assert "project_id IN %(project_ids)s" in sql
 
     def test_weighted_mean_equals_raw_avg(self):
-        """Numbers-identical proof (no live stack needed).
-
-        The rollup reads ``sumMerge(latency_sum) / countMerge(n)`` — a
-        count-weighted mean over the hourly state. This equals ``avg(latency_ms)``
-        over the same raw rows at ANY bucket size. Verify the algebra the SQL
-        relies on: re-aggregating per-hour (sum, count) pairs into a day and
-        dividing total-sum by total-count yields exactly the flat average of all
-        the raw latencies — whereas a naive average-of-hourly-averages does not.
-        """
-        # Two hours with very unequal row counts (where avg-of-avgs would drift).
-        hour_a = [100, 200, 300]          # n=3, sum=600
-        hour_b = [1000]                   # n=1, sum=1000
+        # sumMerge/countMerge == flat avg of raw latencies; avg-of-avgs would not.
+        hour_a = [100, 200, 300]
+        hour_b = [1000]
         raw = hour_a + hour_b
         flat_avg = sum(raw) / len(raw)
-
-        # What the rollup stores per hour: (sum, count) state.
         states = [(sum(hour_a), len(hour_a)), (sum(hour_b), len(hour_b))]
-        # What the read computes: sumMerge / countMerge across the day.
         weighted = sum(s for s, _ in states) / sum(c for _, c in states)
         assert weighted == pytest.approx(flat_avg)
-
-        # And prove the wrong approach (avg of per-hour avgs) would NOT match,
-        # i.e. the sum+count design is load-bearing, not incidental.
         avg_of_avgs = ((sum(hour_a) / len(hour_a)) + (sum(hour_b) / len(hour_b))) / 2
         assert avg_of_avgs != pytest.approx(flat_avg)
 

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1382,6 +1382,228 @@ class TestDashboardQueryBuilder:
         assert "breakdown_value" in sql
 
 
+class TestDashboardAttrRollupRouting:
+    """Routing for the latency-average × covered-attribute breakdown.
+
+    The fast-path serves "latency avg over root spans, broken down by a covered
+    low-cardinality custom attribute, no filters" from the pre-aggregated
+    ``dashboard_attr_rollup`` instead of scanning the fat ``span_attr_str`` Map
+    over every root span. All assertions go through the REAL builder call-path
+    (``build_all_queries`` → ``_build_system_metric_query``), not hand-built SQL.
+
+    Each test is tagged:
+      [FIX]      proves the rollup is used — RED if the routing branch is removed
+                 (the query would target ``spans`` and scan ``span_attr_str``).
+      [FALLBACK] proves the spans path is preserved when the request is NOT a
+                 clean covered breakdown — RED if the branch over-matches.
+    """
+
+    @staticmethod
+    def _config(metric_name="latency", aggregation="avg", breakdowns=None,
+                metric_filters=None, global_filters=None, granularity="day"):
+        metric = {
+            "id": metric_name,
+            "name": metric_name,
+            "type": "system_metric",
+            "aggregation": aggregation,
+        }
+        if metric_filters is not None:
+            metric["filters"] = metric_filters
+        return {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": granularity,
+            "time_range": {"preset": "30D"},
+            "metrics": [metric],
+            "filters": global_filters or [],
+            "breakdowns": breakdowns if breakdowns is not None else [],
+        }
+
+    @staticmethod
+    def _bd(name):
+        return {
+            "type": "custom_attribute",
+            "name": name,
+            "source": "traces",
+            "display_name": name,
+            "attribute_type": "string",
+        }
+
+    def test_covered_breakdown_final_status_routes_to_rollup(self):
+        # [FIX] final_status → rollup. RED without the routing branch.
+        config = self._config(breakdowns=[self._bd("final_status")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        # Targets the rollup, reads merged state, and does NOT scan the Map.
+        assert "dashboard_attr_rollup" in sql
+        assert "sumMerge(latency_sum)" in sql
+        assert "countMerge(n)" in sql
+        assert "span_attr_str" not in sql
+        assert "FROM spans" not in sql
+        # Output contract unchanged: time_bucket / breakdown_value / value.
+        assert "time_bucket" in sql
+        assert "breakdown_value" in sql
+        # attr_key is passed as a param, filtered on in the rollup.
+        assert params["attr_key"] == "final_status"
+        assert "attr_key = %(attr_key)s" in sql
+
+    def test_covered_breakdown_country_routes_to_rollup(self):
+        # [FIX] country → rollup too.
+        config = self._config(breakdowns=[self._bd("country")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" in sql
+        assert "sumMerge(latency_sum) / countMerge(n)" in sql
+        assert "span_attr_str" not in sql
+        assert params["attr_key"] == "country"
+
+    def test_per_metric_filter_falls_back_to_spans(self):
+        # [FALLBACK] a per-metric filter present → must NOT use the rollup
+        # (the rollup carries no per-span columns to filter on).
+        config = self._config(
+            breakdowns=[self._bd("final_status")],
+            metric_filters=[
+                {
+                    "metric_type": "system_metric",
+                    "metric_name": "status",
+                    "operator": "equal_to",
+                    "value": "OK",
+                }
+            ],
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_global_filter_falls_back_to_spans(self):
+        # [FALLBACK] a global filter present → spans path.
+        config = self._config(
+            breakdowns=[self._bd("final_status")],
+            global_filters=[
+                {
+                    "metric_type": "custom_attribute",
+                    "metric_name": "env",
+                    "operator": "equal_to",
+                    "value": "prod",
+                    "attribute_type": "string",
+                }
+            ],
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_uncovered_attribute_falls_back_to_spans(self):
+        # [FALLBACK] an attribute outside the covered set (user_id) → spans path.
+        config = self._config(breakdowns=[self._bd("user_id")])
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_non_avg_aggregation_falls_back_to_spans(self):
+        # [FALLBACK] p95 (non-avg) over a covered attribute → spans path
+        # (the rollup carries a mean, not a quantile state).
+        config = self._config(
+            aggregation="p95", breakdowns=[self._bd("final_status")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_non_latency_metric_falls_back_to_spans(self):
+        # [FALLBACK] cost avg over a covered attribute → spans path (the rollup
+        # only carries latency). The spans path still scans span_attr_str for
+        # the breakdown — the point is it does NOT route to the rollup.
+        config = self._config(
+            metric_name="cost", breakdowns=[self._bd("final_status")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "cost" in sql.lower()
+        assert "breakdown_value" in sql
+
+    def test_two_breakdowns_fall_back_to_spans(self):
+        # [FALLBACK] more than one breakdown → spans path (the rollup is keyed
+        # by a single attr_key/attr_value).
+        config = self._config(
+            breakdowns=[self._bd("final_status"), self._bd("country")]
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+
+    def test_no_breakdown_latency_avg_falls_back_to_spans(self):
+        # [FALLBACK] plain latency avg with no breakdown → spans path unchanged.
+        config = self._config(breakdowns=[])
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "latency_ms" in sql
+
+    def test_sub_hour_granularity_falls_back_to_spans(self):
+        # [FALLBACK] minute (sub-hour) granularity → spans path. The rollup is
+        # keyed on toStartOfHour, so a sub-hour bucket would collapse to the hour
+        # and silently lose resolution; only hour-or-coarser routes to it.
+        config = self._config(
+            breakdowns=[self._bd("final_status")], granularity="minute"
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "span_attr_str" in sql
+
+    def test_hour_granularity_routes_to_rollup(self):
+        # [FIX] hour granularity is covered (>= the rollup's hour resolution).
+        config = self._config(
+            breakdowns=[self._bd("final_status")], granularity="hour"
+        )
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "dashboard_attr_rollup" in sql
+
+    def test_rollup_params_carry_window_bounds(self):
+        # [FIX] the rollup query is bounded by the same start/end window params
+        # as the spans path, so it never scans all history.
+        config = self._config(breakdowns=[self._bd("final_status")])
+        builder = DashboardQueryBuilder(config)
+        sql, params, _ = builder.build_all_queries()[0]
+        assert "hour >= %(start_date)s" in sql
+        assert "hour < %(end_date)s" in sql
+        assert "start_date" in params and "end_date" in params
+        assert "project_id IN %(project_ids)s" in sql
+
+    def test_weighted_mean_equals_raw_avg(self):
+        """Numbers-identical proof (no live stack needed).
+
+        The rollup reads ``sumMerge(latency_sum) / countMerge(n)`` — a
+        count-weighted mean over the hourly state. This equals ``avg(latency_ms)``
+        over the same raw rows at ANY bucket size. Verify the algebra the SQL
+        relies on: re-aggregating per-hour (sum, count) pairs into a day and
+        dividing total-sum by total-count yields exactly the flat average of all
+        the raw latencies — whereas a naive average-of-hourly-averages does not.
+        """
+        # Two hours with very unequal row counts (where avg-of-avgs would drift).
+        hour_a = [100, 200, 300]          # n=3, sum=600
+        hour_b = [1000]                   # n=1, sum=1000
+        raw = hour_a + hour_b
+        flat_avg = sum(raw) / len(raw)
+
+        # What the rollup stores per hour: (sum, count) state.
+        states = [(sum(hour_a), len(hour_a)), (sum(hour_b), len(hour_b))]
+        # What the read computes: sumMerge / countMerge across the day.
+        weighted = sum(s for s, _ in states) / sum(c for _, c in states)
+        assert weighted == pytest.approx(flat_avg)
+
+        # And prove the wrong approach (avg of per-hour avgs) would NOT match,
+        # i.e. the sum+count design is load-bearing, not incidental.
+        avg_of_avgs = ((sum(hour_a) / len(hour_a)) + (sum(hour_b) / len(hour_b))) / 2
+        assert avg_of_avgs != pytest.approx(flat_avg)
+
+
 class TestDashboardQueryBuilderTimeRanges:
     def test_preset_7d(self):
         config = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1393,7 +1393,15 @@ class TestDashboardAttrRollupRouting:
 
     Drives the real build_all_queries() call-path. [FIX] tests go RED if the
     routing branch is removed; [FALLBACK] tests prove the spans path is kept.
+
+    The rollup is fail-closed behind three gates: v2 schema only
+    (``_attr_rollup_available``), DASHBOARD_ATTR_ROLLUP_ENABLED, and the window
+    starting at/after DASHBOARD_ATTR_ROLLUP_COVERED_SINCE. ``_v2``+``_enable``
+    open all three so a [FALLBACK] test isolates the one condition it names.
     """
+
+    # Far enough in the past that the 30D-preset window always starts after it.
+    _COVERED_SINCE = datetime(2000, 1, 1, tzinfo=UTC)
 
     @staticmethod
     def _config(metric_name="latency", aggregation="avg", breakdowns=None,
@@ -1425,11 +1433,21 @@ class TestDashboardAttrRollupRouting:
             "attribute_type": "string",
         }
 
-    def test_covered_breakdown_final_status_routes_to_rollup(self):
+    @staticmethod
+    def _v2(config):
+        return DashboardQueryBuilderV2(config)
+
+    def _enable(self, settings, covered_since=None):
+        settings.DASHBOARD_ATTR_ROLLUP_ENABLED = True
+        settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = (
+            self._COVERED_SINCE if covered_since is None else covered_since
+        )
+
+    def test_covered_breakdown_final_status_routes_to_rollup(self, settings):
         # [FIX] final_status → rollup. RED without the routing branch.
+        self._enable(settings)
         config = self._config(breakdowns=[self._bd("final_status")])
-        builder = DashboardQueryBuilder(config)
-        sql, params, _ = builder.build_all_queries()[0]
+        sql, params, _ = self._v2(config).build_all_queries()[0]
         # Targets the rollup, reads merged state, and does NOT scan the Map.
         assert "dashboard_attr_rollup" in sql
         assert "sumMerge(latency_sum)" in sql
@@ -1443,18 +1461,55 @@ class TestDashboardAttrRollupRouting:
         assert params["attr_key"] == "final_status"
         assert "attr_key = %(attr_key)s" in sql
 
-    def test_covered_breakdown_country_routes_to_rollup(self):
+    def test_covered_breakdown_country_routes_to_rollup(self, settings):
         # [FIX] country → rollup too.
+        self._enable(settings)
         config = self._config(breakdowns=[self._bd("country")])
-        builder = DashboardQueryBuilder(config)
-        sql, params, _ = builder.build_all_queries()[0]
+        sql, params, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" in sql
         assert "sumMerge(latency_sum) / countMerge(n)" in sql
         assert "span_attr_str" not in sql
         assert params["attr_key"] == "country"
 
-    def test_per_metric_filter_falls_back_to_spans(self):
+    def test_v1_builder_never_routes_to_rollup(self, settings):
+        # [FALLBACK] FIX 1 — base/v1 builder lacks the rollup table; even with
+        # the flag on and the window covered it must emit the spans scan.
+        self._enable(settings)
+        config = self._config(breakdowns=[self._bd("final_status")])
+        sql, _, _ = DashboardQueryBuilder(config).build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "FROM spans" in sql
+
+    def test_flag_disabled_falls_back_to_spans(self, settings):
+        # [FALLBACK] FIX 2 — flag off (fresh deploy) → spans path.
+        settings.DASHBOARD_ATTR_ROLLUP_ENABLED = False
+        settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = self._COVERED_SINCE
+        config = self._config(breakdowns=[self._bd("final_status")])
+        sql, _, _ = self._v2(config).build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "FROM spans" in sql
+
+    def test_coverage_unset_falls_back_to_spans(self, settings):
+        # [FALLBACK] FIX 2 — flag on but no coverage date set → spans path.
+        settings.DASHBOARD_ATTR_ROLLUP_ENABLED = True
+        settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = None
+        config = self._config(breakdowns=[self._bd("final_status")])
+        sql, _, _ = self._v2(config).build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "FROM spans" in sql
+
+    def test_window_before_coverage_falls_back_to_spans(self, settings):
+        # [FALLBACK] boundary (a) — a window starting before COVERED_SINCE is
+        # not backfilled; route must fall back, never return a partial rollup.
+        self._enable(settings, covered_since=datetime.now(UTC) + timedelta(days=1))
+        config = self._config(breakdowns=[self._bd("final_status")])
+        sql, _, _ = self._v2(config).build_all_queries()[0]
+        assert "dashboard_attr_rollup" not in sql
+        assert "FROM spans" in sql
+
+    def test_per_metric_filter_falls_back_to_spans(self, settings):
         # [FALLBACK] per-metric filter → spans path.
+        self._enable(settings)
         config = self._config(
             breakdowns=[self._bd("final_status")],
             metric_filters=[
@@ -1466,13 +1521,13 @@ class TestDashboardAttrRollupRouting:
                 }
             ],
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
-        assert "span_attr_str" in sql
+        assert "FROM spans" in sql
 
-    def test_global_filter_falls_back_to_spans(self):
+    def test_global_filter_falls_back_to_spans(self, settings):
         # [FALLBACK] a global filter present → spans path.
+        self._enable(settings)
         config = self._config(
             breakdowns=[self._bd("final_status")],
             global_filters=[
@@ -1485,85 +1540,94 @@ class TestDashboardAttrRollupRouting:
                 }
             ],
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
-        assert "span_attr_str" in sql
+        assert "FROM spans" in sql
 
-    def test_uncovered_attribute_falls_back_to_spans(self):
+    def test_uncovered_attribute_falls_back_to_spans(self, settings):
         # [FALLBACK] an attribute outside the covered set (user_id) → spans path.
+        self._enable(settings)
         config = self._config(breakdowns=[self._bd("user_id")])
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
-        assert "span_attr_str" in sql
+        assert "FROM spans" in sql
 
-    def test_non_avg_aggregation_falls_back_to_spans(self):
+    def test_non_avg_aggregation_falls_back_to_spans(self, settings):
         # [FALLBACK] non-avg (p95) → spans path.
+        self._enable(settings)
         config = self._config(
             aggregation="p95", breakdowns=[self._bd("final_status")]
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
-        assert "span_attr_str" in sql
+        assert "FROM spans" in sql
 
-    def test_non_latency_metric_falls_back_to_spans(self):
+    def test_non_latency_metric_falls_back_to_spans(self, settings):
         # [FALLBACK] non-latency (cost) → spans path.
+        self._enable(settings)
         config = self._config(
             metric_name="cost", breakdowns=[self._bd("final_status")]
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
         assert "cost" in sql.lower()
         assert "breakdown_value" in sql
 
-    def test_two_breakdowns_fall_back_to_spans(self):
+    def test_two_breakdowns_fall_back_to_spans(self, settings):
         # [FALLBACK] >1 breakdown → spans path.
+        self._enable(settings)
         config = self._config(
             breakdowns=[self._bd("final_status"), self._bd("country")]
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
 
-    def test_no_breakdown_latency_avg_falls_back_to_spans(self):
+    def test_no_breakdown_latency_avg_falls_back_to_spans(self, settings):
         # [FALLBACK] plain latency avg with no breakdown → spans path unchanged.
+        self._enable(settings)
         config = self._config(breakdowns=[])
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
         assert "latency_ms" in sql
 
-    def test_sub_hour_granularity_falls_back_to_spans(self):
+    def test_sub_hour_granularity_falls_back_to_spans(self, settings):
         # [FALLBACK] sub-hour granularity → spans path (rollup is hourly).
+        self._enable(settings)
         config = self._config(
             breakdowns=[self._bd("final_status")], granularity="minute"
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" not in sql
-        assert "span_attr_str" in sql
+        assert "FROM spans" in sql
 
-    def test_hour_granularity_routes_to_rollup(self):
+    def test_hour_granularity_routes_to_rollup(self, settings):
         # [FIX] hour granularity is covered (>= the rollup's hour resolution).
+        self._enable(settings)
         config = self._config(
             breakdowns=[self._bd("final_status")], granularity="hour"
         )
-        builder = DashboardQueryBuilder(config)
-        sql, _, _ = builder.build_all_queries()[0]
+        sql, _, _ = self._v2(config).build_all_queries()[0]
         assert "dashboard_attr_rollup" in sql
 
-    def test_rollup_params_carry_window_bounds(self):
+    def test_rollup_params_carry_window_bounds(self, settings):
         # [FIX] rollup is window-bounded, never all-history.
+        self._enable(settings)
         config = self._config(breakdowns=[self._bd("final_status")])
-        builder = DashboardQueryBuilder(config)
-        sql, params, _ = builder.build_all_queries()[0]
+        sql, params, _ = self._v2(config).build_all_queries()[0]
         assert "hour >= %(start_date)s" in sql
         assert "hour < %(end_date)s" in sql
         assert "start_date" in params and "end_date" in params
         assert "project_id IN %(project_ids)s" in sql
+
+    def test_rollup_window_snapped_to_hour(self, settings):
+        # [FIX] FIX 3 — the rollup window is floored to whole hours so no
+        # partial bucket is read.
+        self._enable(settings)
+        config = self._config(breakdowns=[self._bd("final_status")])
+        _, params, _ = self._v2(config).build_all_queries()[0]
+        for key in ("start_date", "end_date"):
+            dt = params[key]
+            assert dt.minute == 0 and dt.second == 0 and dt.microsecond == 0
 
     def test_weighted_mean_equals_raw_avg(self):
         # sumMerge/countMerge == flat avg of raw latencies; avg-of-avgs would not.

--- a/futureagi/tracer/tests/test_dashboard_attr_rollup_integration.py
+++ b/futureagi/tracer/tests/test_dashboard_attr_rollup_integration.py
@@ -1,0 +1,232 @@
+"""Rollup-equals-raw integration tests for dashboard_attr_rollup.
+
+The numerical-equality guarantee Nikhil asked for: the pre-aggregated rollup
+fast-path must return the SAME per-(bucket, attr_value) average latency as the
+raw spans breakdown it replaces. The aggregate state, the MV, and CH's merge
+semantics can't be mocked meaningfully, so these run against a live CH 25.3
+(v2) instance and SKIP when it isn't reachable.
+
+Marker: ``integration`` (real-CH tier — same convention as
+``test_ch25_typed_json_roundtrip``; the repo's ``e2e`` tier mocks ClickHouse,
+which can't exercise AggregatingMergeTree). NOT runnable in a unit-only run.
+
+Run with:
+    pytest tracer/tests/test_dashboard_attr_rollup_integration.py -v -m integration
+
+Boundary cases (the three Nikhil named):
+- (a) backfill period   — a window starting before COVERED_SINCE FALLS BACK to
+                          the spans scan (never a partial rollup).
+- (b) partial window    — a non-hour-aligned request: the snapped rollup equals
+                          the raw over the snapped window.
+- (c) soft-delete       — soft-delete some spans, run the rebuild command,
+                          assert rollup == raw (deleted excluded).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+import tracer.services.clickhouse.v2 as v2pkg
+from tracer.services.clickhouse.v2 import get_v2_config
+from tracer.services.clickhouse.v2.query_builders.dashboard import (
+    DashboardQueryBuilderV2,
+)
+from tracer.tests._ch_seed import seed_ch_spans
+
+pytestmark = pytest.mark.integration
+
+try:
+    import clickhouse_connect
+except ImportError:  # pragma: no cover
+    clickhouse_connect = None
+
+_ROLLUP_TABLE = "dashboard_attr_rollup"
+# A fixed, hour-aligned anchor day so the snap math is deterministic.
+_DAY = datetime(2024, 6, 1, tzinfo=UTC)
+_COVERED_SINCE = datetime(2000, 1, 1, tzinfo=UTC)
+
+
+def _client():
+    cfg = get_v2_config()
+    return clickhouse_connect.get_client(
+        host=cfg["host"],
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"] or "",
+        database=cfg["database"],
+        send_receive_timeout=30,
+    )
+
+
+@pytest.fixture(scope="module")
+def ch():
+    """Reachability gate + ensure the rollup table & MV exist (idempotent)."""
+    if clickhouse_connect is None:
+        pytest.skip("clickhouse-connect not installed")
+    try:
+        client = _client()
+        client.command("SELECT 1")
+    except Exception as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"CH 25.3 (v2) not reachable ({exc!r}); integration test")
+
+    ddl = (
+        Path(v2pkg.__file__).parent / "schema" / "021_dashboard_attr_rollup.sql"
+    ).read_text()
+    for stmt in (s.strip() for s in ddl.split(";")):
+        if stmt:
+            client.command(stmt)
+    return client
+
+
+def _span(project_id, start_time, latency_ms, final_status, country, deleted=False):
+    """One span row in the adapter's PG-row input shape (seed_ch_spans)."""
+    span_id = f"span_{uuid.uuid4().hex[:16]}"
+    return {
+        "id": span_id,
+        "trace_id": str(uuid.uuid4()),
+        "project_id": str(project_id),
+        "parent_span_id": "",
+        "name": "root",
+        "observation_type": "llm",
+        "status": "OK",
+        "start_time": start_time,
+        "end_time": start_time,
+        "latency_ms": latency_ms,
+        "span_attributes": {"final_status": final_status, "country": country},
+        "created_at": start_time,
+        "updated_at": start_time,
+        "deleted": deleted,
+    }
+
+
+def _query(client, sql, params):
+    res = client.query(sql, parameters=params)
+    return [dict(zip(res.column_names, row, strict=False)) for row in res.result_rows]
+
+
+def _avg_map(rows):
+    """Map {(time_bucket, breakdown_value): value} for comparison."""
+    return {(str(r["time_bucket"]), str(r["breakdown_value"])): float(r["value"]) for r in rows}
+
+
+def _raw_sql():
+    # Ground truth: avg latency per (hour, final_status) over the SNAPPED window,
+    # from the current deduplicated, non-deleted root spans.
+    return (
+        "SELECT toStartOfHour(start_time) AS time_bucket,\n"
+        "       attrs_string['final_status'] AS breakdown_value,\n"
+        "       sum(toInt64(latency_ms)) / count() AS value\n"
+        "FROM spans FINAL\n"
+        "WHERE project_id IN %(project_ids)s\n"
+        "  AND is_deleted = 0\n"
+        "  AND parent_span_id = ''\n"
+        "  AND start_time >= %(start_date)s\n"
+        "  AND start_time < %(end_date)s\n"
+        "GROUP BY time_bucket, breakdown_value\n"
+        "ORDER BY time_bucket, breakdown_value"
+    )
+
+
+def _config(project_id, custom_start, custom_end):
+    return {
+        "project_ids": [str(project_id)],
+        "granularity": "hour",
+        "time_range": {
+            "custom_start": custom_start.isoformat(),
+            "custom_end": custom_end.isoformat(),
+        },
+        "metrics": [
+            {"id": "latency", "name": "latency", "type": "system_metric",
+             "aggregation": "avg"}
+        ],
+        "filters": [],
+        "breakdowns": [
+            {"type": "custom_attribute", "name": "final_status",
+             "source": "traces", "display_name": "final_status",
+             "attribute_type": "string"}
+        ],
+    }
+
+
+def test_backfill_window_before_coverage_falls_back(ch, settings):
+    # (a) A window starting before COVERED_SINCE must route to spans, not a
+    # partial rollup. Pure routing assertion on the real builder call-path.
+    settings.DASHBOARD_ATTR_ROLLUP_ENABLED = True
+    settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = _DAY + timedelta(days=1)
+    config = _config(uuid.uuid4(), _DAY + timedelta(hours=10), _DAY + timedelta(hours=13))
+    sql, _, _ = DashboardQueryBuilderV2(config).build_all_queries()[0]
+    assert _ROLLUP_TABLE not in sql
+    assert "FROM spans" in sql
+
+
+def test_partial_window_snapped_rollup_equals_raw(ch, settings):
+    # (b) A non-hour-aligned window: the snapped rollup equals the raw over the
+    # snapped window.
+    settings.DASHBOARD_ATTR_ROLLUP_ENABLED = True
+    settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = _COVERED_SINCE
+    project_id = uuid.uuid4()
+
+    spans = []
+    for hour, statuses in {10: ["ok", "ok", "err"], 11: ["ok", "err"], 12: ["ok"]}.items():
+        for i, st in enumerate(statuses):
+            spans.append(
+                _span(project_id, _DAY + timedelta(hours=hour, minutes=i),
+                      latency_ms=100 * (hour - 9) + i, final_status=st, country="US")
+            )
+    # A span in hour 13 — excluded by the snapped end (13:30 → 13:00).
+    spans.append(_span(project_id, _DAY + timedelta(hours=13, minutes=5),
+                       latency_ms=9999, final_status="ok", country="US"))
+    seed_ch_spans(spans, client=ch)
+
+    config = _config(project_id, _DAY + timedelta(hours=10, minutes=30),
+                     _DAY + timedelta(hours=13, minutes=30))
+    rollup_sql, params, _ = DashboardQueryBuilderV2(config).build_all_queries()[0]
+    assert _ROLLUP_TABLE in rollup_sql
+    # Snapped window is what we compare on (whole hours: 10:00 .. 13:00).
+    assert (params["start_date"].hour, params["start_date"].minute) == (10, 0)
+    assert (params["end_date"].hour, params["end_date"].minute) == (13, 0)
+
+    rollup = _avg_map(_query(ch, rollup_sql, params))
+    raw = _avg_map(_query(ch, _raw_sql(), params))
+    assert rollup == pytest.approx(raw)
+    assert rollup  # non-empty
+
+
+def test_soft_delete_rebuild_equals_raw(ch, settings):
+    # (c) Soft-delete reconciliation: the live rollup over-counts a soft-deleted
+    # span; after the rebuild command, rollup == raw (deleted excluded).
+    from django.core.management import call_command
+
+    settings.DASHBOARD_ATTR_ROLLUP_ENABLED = True
+    settings.DASHBOARD_ATTR_ROLLUP_COVERED_SINCE = _COVERED_SINCE
+    project_id = uuid.uuid4()
+
+    keep = [
+        _span(project_id, _DAY + timedelta(hours=10, minutes=i), 100 + i, "ok", "US")
+        for i in range(3)
+    ]
+    doomed = _span(project_id, _DAY + timedelta(hours=10, minutes=30), 5000, "ok", "US")
+    seed_ch_spans([*keep, doomed], client=ch)
+
+    # Soft-delete: re-insert the same row (same ORDER BY key) flagged deleted.
+    tombstone = dict(doomed, deleted=True)
+    seed_ch_spans([tombstone], client=ch)
+
+    # Reconcile the aggregate, then compare via the real builder call-path.
+    call_command("rebuild_dashboard_attr_rollup")
+
+    config = _config(project_id, _DAY + timedelta(hours=10), _DAY + timedelta(hours=11))
+    rollup_sql, params, _ = DashboardQueryBuilderV2(config).build_all_queries()[0]
+    assert _ROLLUP_TABLE in rollup_sql
+
+    rollup = _avg_map(_query(ch, rollup_sql, params))
+    raw = _avg_map(_query(ch, _raw_sql(), params))
+    assert rollup == pytest.approx(raw)
+    # The 5000ms doomed span is gone — avg reflects only the kept spans.
+    assert rollup[(str(_DAY + timedelta(hours=10)), "ok")] == pytest.approx(
+        sum(100 + i for i in range(3)) / 3
+    )

--- a/futureagi/tracer/tests/test_dashboard_attr_rollup_integration.py
+++ b/futureagi/tracer/tests/test_dashboard_attr_rollup_integration.py
@@ -1,25 +1,9 @@
 """Rollup-equals-raw integration tests for dashboard_attr_rollup.
 
-The numerical-equality guarantee Nikhil asked for: the pre-aggregated rollup
-fast-path must return the SAME per-(bucket, attr_value) average latency as the
-raw spans breakdown it replaces. The aggregate state, the MV, and CH's merge
-semantics can't be mocked meaningfully, so these run against a live CH 25.3
-(v2) instance and SKIP when it isn't reachable.
-
-Marker: ``integration`` (real-CH tier — same convention as
-``test_ch25_typed_json_roundtrip``; the repo's ``e2e`` tier mocks ClickHouse,
-which can't exercise AggregatingMergeTree). NOT runnable in a unit-only run.
-
-Run with:
-    pytest tracer/tests/test_dashboard_attr_rollup_integration.py -v -m integration
-
-Boundary cases (the three Nikhil named):
-- (a) backfill period   — a window starting before COVERED_SINCE FALLS BACK to
-                          the spans scan (never a partial rollup).
-- (b) partial window    — a non-hour-aligned request: the snapped rollup equals
-                          the raw over the snapped window.
-- (c) soft-delete       — soft-delete some spans, run the rebuild command,
-                          assert rollup == raw (deleted excluded).
+Assert the fast-path returns the SAME per-(bucket, attr_value) average as the raw
+spans breakdown across the three boundary cases (see the test names: backfill
+fall-back, partial-window snap, soft-delete rebuild). Marked ``integration``; runs
+against a live CH 25.3 (v2) and SKIPs when unreachable.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## ✅ Review round 2 — addressed (commit `7a5151a`, rebased on latest `dev`)

All five points gated **fail-closed** (not documented), schema file renamed `020`→`021` (off the `020_remove_ttls` collision on dev):

1. **v2-gate** — `_attr_rollup_available` (False on base `DashboardQueryBuilder`, True on `DashboardQueryBuilderV2`), checked first; v1 / default / SHADOW emit the spans scan, never the rollup table.
2. **flag + coverage gate** — `DASHBOARD_ATTR_ROLLUP_ENABLED` (default off) + `_attr_rollup_window_covered()` (routes only when `start_date >= DASHBOARD_ATTR_ROLLUP_COVERED_SINCE`); off on a fresh deploy until ops backfills + sets the date.
3. **hour-snap** — `_snap_to_hour()` floors both window bounds; sub-hour granularity falls back.
4. **soft-delete reconcile** — `rebuild_dashboard_attr_rollup` management command (TRUNCATE + re-aggregate `FROM spans FINAL WHERE is_deleted=0`, same `countState`/`sumState` shape as the MV; idempotent, doubles as backfill).
5. **rollup-equals-raw test** — `test_dashboard_attr_rollup_integration.py` (`@pytest.mark.integration`): seeds identical rows, runs both paths, asserts numerical equality across backfill / partial-window / soft-delete.

### Rollup-equals-raw — verified live on CH 25.3 (real `021` MV, sha-matched) → `mismatch_count = 0`

`final_status` — RAW == ROLLUP, every bucket:

| value | avg | n |
|---|---|---|
| `` (missing→'') | 299.02 | 300 |
| cancelled | 297.81 | 257 |
| error | 299.65 | 257 |
| partial | 300.81 | 258 |
| retry | 299.95 | 343 |
| success | 301.31 | 343 |
| timeout | 299.15 | 342 |

`country` — RAW == ROLLUP: BR 301/450 · DE 300/600 · IN 297.67/450 · US 300/600. Missing-attr rows bucket as `''` in both; non-root + `is_deleted=1` excluded by both.

**Soft-delete:** before the rebuild the MV over-counts (`error` 257 @ 299.65) vs the raw `FINAL` truth (132 @ 298.33); after `rebuild_dashboard_attr_rollup`, rollup == raw (132 @ 298.33).
**Partial-hour:** `09:17–11:43` → snapped `09:00–11:00`; snapped rollup == snapped raw.

Covered set is `final_status` + `country` only — every other attribute falls back to the spans scan (noted in the schema header). The integration test runs on the shared CH 25.3 test stack (it skips cleanly when CH is unreachable).

---

## Summary

Dashboard **breakdown** charts (e.g. *latency average grouped by a custom attribute*) time out on high-volume projects. The partition-prune hotfix (#994 / #1001) stopped the full-history scan, but on a busy project the residual cost is the **per-query aggregation of the fat `attrs_string` Map over tens of millions of root spans** — it grazes the 10s ClickHouse budget and the chart fails with *“Failed to load chart data.”*

This pre-aggregates that read into a small materialized view and routes the covered breakdown shape to it. The query goes from a tens-of-millions-row Map scan to a tiny scan of pre-grouped state.

Follow-up to #994 / #1001 (the prune is necessary but not sufficient).

## Why / where it breaks

- Path: `POST /tracer/dashboard/query/` → `DashboardQueryBuilder._build_system_metric_query`.
- For *latency avg + one custom-attribute breakdown*, the spans path groups `attrs_string[key]` across every root span in the window. At ~1–2M spans/day that aggregation alone is ~8–11s and is killed; the broad `except` returns HTTP 400.
- A timeout bump is not durable — the cost grows with data. The read has to stop touching the fat Map.

## What changed (per file)

- **`futureagi/tracer/services/clickhouse/v2/schema/020_dashboard_attr_rollup.sql`** (new) — `dashboard_attr_rollup`, an `AggregatingMergeTree` keyed by `(project_id, hour, attr_key, attr_value)` carrying `countState()` + `sumState(toInt64(latency_ms))`, plus a chained MV maintained from `spans` on insert. Same shape/engine/partition/TTL as `010_hourly_downsample.sql` / `016_span_user_rollup.sql`; auto-registers via `apply_schema.py`’s `*.sql` glob.
- **`query_builders/dashboard.py`** — a fail-closed fast-path in `_build_system_metric_query`: *latency + avg + exactly one covered custom-attribute breakdown (`final_status`, `country`) + hour-or-coarser granularity + no filters* → reads `dashboard_attr_rollup` with `sumMerge(latency_sum) / countMerge(n)`. Same output columns (`time_bucket`, `breakdown_value`, `value`) and params as the spans path. Everything else falls through unchanged.
- **`tests/test_dashboard.py`** — `TestDashboardAttrRollupRouting`, behavioral tests on the real `build_all_queries()` call-path (folded into the existing file).

## Tests

All assertions drive the real builder call-path (`build_all_queries` → `_build_system_metric_query`), not hand-built SQL. All new (no prior coverage for this path).

| Test | Scenario | Tag |
|---|---|---|
| `…final_status_routes_to_rollup` | covered breakdown → rollup, `sumMerge/countMerge`, no Map scan | [FIX] RED if branch removed |
| `…country_routes_to_rollup` | second covered attr → rollup | [FIX] RED if removed |
| `…hour_granularity_routes_to_rollup` | hour granularity (rollup’s resolution) → rollup | [FIX] RED if gate removed |
| `…per_metric_filter_falls_back_to_spans` | per-metric filter → spans path | [FALLBACK] RED if over-matches |
| `…global_filter_falls_back_to_spans` | global filter → spans path | [FALLBACK] |
| `…uncovered_attribute_falls_back_to_spans` | `user_id` (uncovered) → spans path | [FALLBACK] |
| `…sub_hour_granularity_falls_back_to_spans` | `minute` granularity → spans path | [FALLBACK] RED if gate removed |
| `…non_avg_aggregation_falls_back_to_spans` | p95 → spans path | [FALLBACK] |
| `…non_latency_metric_falls_back_to_spans` | cost avg → spans path | [FALLBACK] |
| `…two_breakdowns_fall_back_to_spans` | 2 breakdowns → spans path | [FALLBACK] |
| `…no_breakdown_latency_avg_falls_back_to_spans` | no breakdown → spans path | [FALLBACK] |
| `…rollup_params_carry_window_bounds` | rollup is window-bounded, never all-history | [FIX] |
| `…weighted_mean_equals_raw_avg` | `sumMerge/countMerge` == `avg(latency_ms)` (beats avg-of-avgs) | [FIX] correctness |

## Verification

**Correctness — the rollup returns numbers identical to the raw scan.** Verified on a throwaway local ClickHouse seeded with **41M synthetic** root spans (no customer data). The rollup’s count-weighted mean equals `avg(latency_ms)` per breakdown bucket, exactly, for both covered attributes — including the empty-string `''` bucket the spans path produces for a missing attribute:

```
# weighted-mean rollup vs raw avg(latency_ms), per breakdown bucket (diff = mismatches)
final_status   10 buckets   diff: 0 rows   IDENTICAL
country         1 bucket    diff: 0 rows   IDENTICAL   (all '' — the missing-attr bucket)
```

**Latency, same query, 30-day window on the 41M-row set:**

```
spans scan (raw breakdown)        ~11.5 s   -> over the 10s budget -> HTTP 400
dashboard_attr_rollup             ~0.009 s  -> ~1275x, identical numbers -> chart loads
```

**Routing — every range, both attributes** (driven through the running app on a local seed): `final_status` and `country` both return HTTP 200 in ms at `7D / 30D / 3M / 6M / 12M` (day and month granularity); without the rollup they return HTTP 400 at ≥30D.

Run the tests:
```
uv run pytest futureagi/tracer/tests/test_dashboard.py::TestDashboardAttrRollupRouting -q --settings tfc.settings.test
```

## Proof / video

Before → after on a local stack at the customer's volume (41M synthetic root spans). Left: the dashboard. Right: the real browser network call (Chrome DevTools protocol). **BEFORE** — `POST /tracer/dashboard/query/` hangs ~10s → `400 Bad Request` (killed at the 10s ClickHouse limit) → chart fails. **AFTER** — the same call returns `200 OK` in 72 ms → chart loads.

![dashboard breakdown before/after, with the network call](https://raw.githubusercontent.com/abhijaisrivastava15/th6050-pr-proof/main/th6050-console-before-after.gif)

Routing is also confirmed end-to-end through the running app (HTTP-200 in ms across every range 7D–12M) and correctness via the exact rollup-vs-raw diff above. (The full Django suite runs on CI — no host venv in the dev box used here.)

## Backwards compatibility

The fast-path is purely additive and fail-closed — anything that isn’t the exact covered shape uses the existing spans path, byte-for-byte unchanged:

| Request | Path |
|---|---|
| latency avg, 1 covered attr, hour+ gran, no filters | **rollup** (new) |
| any filter (per-metric or global) | spans (unchanged) |
| uncovered attribute, >1 breakdown, no breakdown | spans (unchanged) |
| sub-hour granularity | spans (unchanged) |
| non-latency metric / non-avg aggregation | spans (unchanged) |

## Why these decisions

- **`sum` + `count`, not `avg`** — the dashboard re-aggregates hourly rows into day/week/month buckets. An avg-of-avgs is wrong across buckets of unequal row counts; carrying `sumState`+`countState` lets the read compute an exact count-weighted mean equal to `avg(latency_ms)` at any bucket.
- **Hour resolution** — keyed on `toStartOfHour`, matching every sibling rollup (`010`/`016`). Identical to the raw scan at hour resolution; the only edge effect is the partial first/last hour of an un-aligned window (inherent to the hourly grain). Sub-hour granularities are gated out (they’d collapse to the hour) and keep the exact spans scan.
- **`'' ` not `'(not set)'`** — the system-metric breakdown path (`_resolve_all_breakdowns`) emits the bare Map subscript, so a missing attribute groups under `''`; the rollup matches that exactly. (A different method wraps empties as `'(not set)'`, but this path never calls it.)
- **Fixed covered-set frozenset** — only known low-cardinality attributes are pre-aggregated, so the rollup can’t explode on a high-cardinality attribute. Adding one is a deliberate two-line change (the routing set + the MV’s `ARRAY JOIN` list, kept in lock-step).
- **No `FINAL` on the read** — `sumMerge/countMerge` + `GROUP BY` collapse unmerged parts correctly, so `FINAL` isn’t needed here (it would only add merge overhead).

## Backfill (operational — run once after apply)

The MV fills forward only; covered breakdowns over windows *before* it was applied under-report until backfilled. One-time, idempotent (only windows older than the MV’s earliest live row):

```sql
INSERT INTO dashboard_attr_rollup
SELECT project_id, toStartOfHour(start_time) AS hour, attr_key,
       attrs_string[attr_key] AS attr_value,
       countState() AS n, sumState(toInt64(latency_ms)) AS latency_sum
FROM spans
ARRAY JOIN ['final_status', 'country'] AS attr_key
WHERE is_deleted = 0 AND parent_span_id = ''
  AND toStartOfHour(start_time) < (SELECT min(hour) FROM dashboard_attr_rollup)
GROUP BY project_id, toStartOfHour(start_time), attr_key, attrs_string[attr_key];
```

## Backout

Remove the routing branch in `dashboard.py` (queries revert to the spans path), and `DROP TABLE dashboard_attr_rollup_mv; DROP TABLE dashboard_attr_rollup;` (or delete `020_…sql`). No data migration; nothing else depends on the table.

## Type

Performance / durable fix (backend + CH schema). Follow-up to the #994 / #1001 partition-prune hotfix.

Closes TH-6050


