### PR TITLE
[bugfix] route v2 user filter to end_users table

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -699,6 +699,13 @@ class ClickHouseFilterBuilder:
         "user_id_type": "user_id_type",
     }
 
+    # End-user dimension source for the user/user_id filter subquery. v1 reads
+    # the legacy peerdb CDC `tracer_enduser` (id + _peerdb_is_deleted/deleted);
+    # ClickHouseFilterBuilderV2 overrides these for the v2 `end_users` RMT.
+    _ENDUSER_DIM_TABLE = "tracer_enduser"
+    _ENDUSER_DIM_ID_COL = "id"
+    _ENDUSER_DIM_NOT_DELETED = "_peerdb_is_deleted = 0 AND deleted = 0"
+
     def _build_enduser_string_subquery(
         self,
         enduser_column: str,
@@ -745,9 +752,9 @@ class ClickHouseFilterBuilder:
             f"trace_id {outer_op} ("
             f"SELECT trace_id FROM {self.table} "
             f"WHERE end_user_id IN ("
-            f"SELECT id FROM tracer_enduser FINAL "
+            f"SELECT {self._ENDUSER_DIM_ID_COL} FROM {self._ENDUSER_DIM_TABLE} FINAL "
             f"WHERE {inner} "
-            f"AND _peerdb_is_deleted = 0 AND deleted = 0"
+            f"AND {self._ENDUSER_DIM_NOT_DELETED}"
             f") AND _peerdb_is_deleted = 0)"
         )
 

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -42,6 +42,9 @@ class SpanListQueryBuilder(BaseQueryBuilder):
     TABLE = "spans"
     EVAL_TABLE = "tracer_eval_logger"
     ANNOTATION_TABLE = "model_hub_score"
+    # Filter compiler class; the v2 list builder overrides this to the v2
+    # builder so it reads the v2 dimension tables (end_users, etc.).
+    _FILTER_BUILDER_CLS = ClickHouseFilterBuilder
 
     SORT_FIELD_MAP: dict[str, str] = {
         "created_at": "start_time",
@@ -88,9 +91,9 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         self.params["start_date"] = start_date
         self.params["end_date"] = end_date
 
-        fb = ClickHouseFilterBuilder(
+        fb = self._FILTER_BUILDER_CLS(
             table=self.TABLE,
-            query_mode=ClickHouseFilterBuilder.QUERY_MODE_SPAN,
+            query_mode=self._FILTER_BUILDER_CLS.QUERY_MODE_SPAN,
             annotation_label_ids=self.annotation_label_ids,
             project_id=self.project_id,
             project_ids=self.project_ids,
@@ -248,9 +251,9 @@ class SpanListQueryBuilder(BaseQueryBuilder):
 
     def build_count_query(self) -> tuple[str, dict[str, Any]]:
         """Build a count query for total matching spans."""
-        fb = ClickHouseFilterBuilder(
+        fb = self._FILTER_BUILDER_CLS(
             table=self.TABLE,
-            query_mode=ClickHouseFilterBuilder.QUERY_MODE_SPAN,
+            query_mode=self._FILTER_BUILDER_CLS.QUERY_MODE_SPAN,
             annotation_label_ids=self.annotation_label_ids,
             project_id=self.project_id,
             project_ids=self.project_ids,

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -39,6 +39,9 @@ class TraceListQueryBuilder(BaseQueryBuilder):
 
     TABLE = "spans"
     EVAL_TABLE = "tracer_eval_logger"
+    # Filter compiler class; the v2 list builder overrides this to the v2
+    # builder so it reads the v2 dimension tables (end_users, etc.).
+    _FILTER_BUILDER_CLS = ClickHouseFilterBuilder
 
     # Mapping from sort column names the frontend sends to actual
     # ClickHouse column names on the root span.
@@ -118,7 +121,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         self.params["end_date"] = self.end_date
 
         # Translate attribute / metric filters
-        fb = ClickHouseFilterBuilder(
+        fb = self._FILTER_BUILDER_CLS(
             table=self.TABLE,
             annotation_label_ids=self.annotation_label_ids,
             project_id=self.project_id,
@@ -289,7 +292,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         Returns:
             A ``(query_string, params)`` tuple returning a single count.
         """
-        fb = ClickHouseFilterBuilder(
+        fb = self._FILTER_BUILDER_CLS(
             table=self.TABLE,
             annotation_label_ids=self.annotation_label_ids,
             project_id=self.project_id,

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/_rewrite.py
@@ -20,9 +20,13 @@ Mix it in FIRST so the wrapper resolves ahead of the v1 base in the MRO:
     class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder): ...
 
 The two halves of the rewrite are applied with different scope. The v1→v2 token
-rewrite (`rewrite_v1_sql_to_v2`) always runs — it's a word-boundary substitution,
-idempotent on already-v2 SQL and a no-op on a string with no v1 tokens, so it's
-safe on a SQL fragment or a non-SQL value alike. The SETTINGS append
+rewrite (`rewrite_v1_sql_to_v2`) always runs — mostly word-boundary substitutions
+that are a no-op on a string with no v1 tokens. It is NOT idempotent in general:
+the bare SELECT-list rewrite (`SELECT legacy_col` → `toJSONString(v2_col) AS
+legacy_col`) re-wraps its own alias on a second pass. So it is safe to run once per
+emitted statement, and safe to double-run only on fragments that carry no bare
+SELECT-list ref (WHERE/ORDER fragments — see ClickHouseFilterBuilderV2.translate).
+The SETTINGS append
 (`_append_v2_settings`) runs ONLY when the emitted SQL is a complete `SELECT`/`WITH`
 statement (`_is_statement`): a fragment or a non-SQL `(cache_key, meta)` return
 must not get a trailing SETTINGS clause. So wrapping a method that already emits

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -315,14 +315,14 @@ class ClickHouseFilterBuilderV2(ClickHouseFilterBuilder):
     _ENDUSER_DIM_ID_COL = "end_user_id"
     _ENDUSER_DIM_NOT_DELETED = "is_deleted = 0"
 
-    def translate(self, filters, *args, **kwargs):  # type: ignore[override]
+    def translate(self, filters):  # type: ignore[override]
         # `translate` returns a WHERE fragment that gets stitched into a larger
         # SELECT statement by callers. Do NOT append SETTINGS here — that
         # happens at the full-SELECT boundary in the per-builder `build()`
         # methods (SpanListQueryBuilderV2.build, TraceListQueryBuilderV2.build,
         # etc.). Otherwise we'd end up with `WHERE ... SETTINGS ... AND ...`
         # which is a syntax error.
-        sql, params = super().translate(filters, *args, **kwargs)
+        sql, params = super().translate(filters)
         return rewrite_v1_sql_to_v2(sql), params
 
     def translate_sort(self, sort_params, *args, **kwargs):  # type: ignore[override]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -308,18 +308,27 @@ class ClickHouseFilterBuilderV2(ClickHouseFilterBuilder):
     # Expose the v2 attribute-type meta on the instance.
     SPAN_ATTR_TYPE_META = _SPAN_ATTR_TYPE_META_V2
 
-    def translate(self, filters):  # type: ignore[override]
+    # End-user filter subquery reads the v2 `end_users` RMT (keyed by
+    # end_user_id, soft-deleted via is_deleted) instead of the dropped legacy
+    # `tracer_enduser` (id + _peerdb_is_deleted/deleted).
+    _ENDUSER_DIM_TABLE = "end_users"
+    _ENDUSER_DIM_ID_COL = "end_user_id"
+    _ENDUSER_DIM_NOT_DELETED = "is_deleted = 0"
+
+    def translate(self, filters, *args, **kwargs):  # type: ignore[override]
         # `translate` returns a WHERE fragment that gets stitched into a larger
         # SELECT statement by callers. Do NOT append SETTINGS here — that
         # happens at the full-SELECT boundary in the per-builder `build()`
         # methods (SpanListQueryBuilderV2.build, TraceListQueryBuilderV2.build,
         # etc.). Otherwise we'd end up with `WHERE ... SETTINGS ... AND ...`
         # which is a syntax error.
-        sql, params = super().translate(filters)
+        sql, params = super().translate(filters, *args, **kwargs)
         return rewrite_v1_sql_to_v2(sql), params
 
-    def translate_sort(self, sort_params):  # type: ignore[override]
-        result = super().translate_sort(sort_params)
+    def translate_sort(self, sort_params, *args, **kwargs):  # type: ignore[override]
+        # Forward extra args (e.g. field_map) to the v1 implementation — callers
+        # like the list builders pass field_map=SORT_FIELD_MAP.
+        result = super().translate_sort(sort_params, *args, **kwargs)
         if isinstance(result, tuple):
             sql, *rest = result
             return (rewrite_v1_sql_to_v2(sql), *rest)

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/span_list.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 
 from tracer.services.clickhouse.query_builders.span_list import SpanListQueryBuilder
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    ClickHouseFilterBuilderV2,
+)
 
 
 class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
@@ -33,6 +36,10 @@ class SpanListQueryBuilderV2(V2RewriteMixin, SpanListQueryBuilder):
     """
 
     _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
+
+    # Use the v2 filter compiler so filters read the v2 dimension tables
+    # (end_users, etc.) instead of the dropped legacy CDC tables.
+    _FILTER_BUILDER_CLS = ClickHouseFilterBuilderV2
 
 
 __all__ = ["SpanListQueryBuilderV2"]

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_list.py
@@ -23,6 +23,9 @@ from typing import Any
 
 from tracer.services.clickhouse.query_builders.trace_list import TraceListQueryBuilder
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    ClickHouseFilterBuilderV2,
+)
 
 
 class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder):
@@ -36,6 +39,10 @@ class TraceListQueryBuilderV2(V2RewriteMixin, TraceListQueryBuilder):
     """
 
     _v2_rewrite_exclude = frozenset({"build_eval_query", "build_annotation_query"})
+
+    # Use the v2 filter compiler so filters read the v2 dimension tables
+    # (end_users, etc.) instead of the dropped legacy CDC tables.
+    _FILTER_BUILDER_CLS = ClickHouseFilterBuilderV2
 
     def build_count_query(self) -> tuple[str, dict[str, Any]]:
         """Pagination count.

--- a/futureagi/tracer/tests/test_ch25_filter_compiler.py
+++ b/futureagi/tracer/tests/test_ch25_filter_compiler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import pytest
 
+from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 from tracer.services.clickhouse.v2.query_builders import columns as cols
 from tracer.services.clickhouse.v2.query_builders.filters import (
     ClickHouseFilterBuilderV2,
@@ -158,6 +159,22 @@ class TestRewriteV1SqlToV2:
         assert "attributes_extra.a.:String" in v2
         assert "attrs_number['b']" in v2
 
+    # ─── Bare SELECT-list ref — the one NON-idempotent rewrite ───────────────
+    def test_bare_select_list_ref_wrapped_with_alias(self):
+        v1 = "SELECT span_attributes_raw FROM spans"
+        v2 = "SELECT toJSONString(attributes_extra) AS span_attributes_raw FROM spans"
+        assert rewrite_v1_sql_to_v2(v1) == v2
+
+    def test_bare_select_list_rewrite_is_not_idempotent(self):
+        # Re-running re-wraps the alias. This is WHY the v2 filter builder may
+        # only double-rewrite WHERE/ORDER fragments (which never carry a bare
+        # SELECT-list ref), never full statements — see _rewrite.py docstring
+        # and ClickHouseFilterBuilderV2.translate.
+        once = rewrite_v1_sql_to_v2("SELECT span_attributes_raw FROM spans")
+        twice = rewrite_v1_sql_to_v2(once)
+        assert once != twice
+        assert "AS toJSONString(attributes_extra) AS span_attributes_raw" in twice
+
 
 class TestClickHouseFilterBuilderV2:
     """End-to-end tests via the subclass — proves the rewrite happens at the
@@ -180,3 +197,149 @@ class TestClickHouseFilterBuilderV2:
         assert meta["text"][0]    == cols.ATTRS_STRING
         assert meta["number"][0]  == cols.ATTRS_NUMBER
         assert meta["boolean"][0] == cols.ATTRS_BOOL
+
+
+class TestEndUserDimensionSource:
+    """Pin the v1→v2 end-user dimension swap on the user/user_id filter path.
+
+    A `user` / `user_id` / `user_id_type` filter compiles a
+    `trace_id IN (SELECT ... FROM <enduser dim>)` subquery. v1 reads the
+    dropped legacy CDC table `tracer_enduser`; v2 must read the `end_users`
+    RMT. Distinct from the `enduser_dict` rename covered above.
+    """
+
+    @staticmethod
+    def _filter(col_id: str, filter_op: str, filter_value=None) -> list[dict]:
+        config: dict = {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "text",
+            "filter_op": filter_op,
+        }
+        if filter_value is not None:
+            config["filter_value"] = filter_value
+        return [{"column_id": col_id, "filter_config": config}]
+
+    # ─── Value path: v1 legacy table vs v2 RMT ───────────────────────────────
+    def test_v1_in_targets_legacy_tracer_enduser(self):
+        sql, _ = ClickHouseFilterBuilder(table="spans").translate(
+            self._filter("user", "in", ["bob", "carol"])
+        )
+        assert "trace_id IN (" in sql
+        assert "SELECT id FROM tracer_enduser FINAL" in sql
+        assert "_peerdb_is_deleted = 0 AND deleted = 0" in sql
+
+    def test_v2_in_targets_end_users_rmt(self):
+        sql, _ = ClickHouseFilterBuilderV2(table="spans").translate(
+            self._filter("user", "in", ["bob", "carol"])
+        )
+        assert "trace_id IN (" in sql
+        assert "SELECT end_user_id FROM end_users FINAL" in sql
+        assert "is_deleted = 0" in sql
+        # The dropped legacy table must NOT appear on the v2 path.
+        assert "tracer_enduser" not in sql
+        assert "_peerdb_is_deleted" not in sql
+
+    def test_v2_user_id_type_column_also_targets_end_users(self):
+        # A second enduser column id must route through the same v2 dim swap.
+        sql, _ = ClickHouseFilterBuilderV2(table="spans").translate(
+            self._filter("user_id_type", "equals", "external")
+        )
+        assert "FROM end_users FINAL" in sql
+        assert "tracer_enduser" not in sql
+
+    def test_v2_negation_emits_not_in_against_end_users(self):
+        # not_in inverts the outer membership; the dim source is still end_users.
+        sql, _ = ClickHouseFilterBuilderV2(table="spans").translate(
+            self._filter("user", "not_in", ["bob"])
+        )
+        assert "trace_id NOT IN (" in sql
+        assert "FROM end_users FINAL" in sql
+        assert "tracer_enduser" not in sql
+
+    # ─── No-value path (is_null) — a different branch that skips the dim ──────
+    def test_v1_is_null_uses_legacy_soft_delete(self):
+        # is_null never queries the dim table; it checks end_user_id directly,
+        # gated by the legacy soft-delete column on v1.
+        sql, _ = ClickHouseFilterBuilder(table="spans").translate(
+            self._filter("user", "is_null")
+        )
+        assert "tracer_enduser" not in sql
+        assert "_peerdb_is_deleted = 0" in sql
+
+    def test_v2_is_null_rewrites_soft_delete(self):
+        sql, _ = ClickHouseFilterBuilderV2(table="spans").translate(
+            self._filter("user", "is_null")
+        )
+        assert "tracer_enduser" not in sql
+        assert "is_deleted = 0" in sql
+        assert "_peerdb_is_deleted" not in sql
+
+
+class TestFilterBuilderWiring:
+    """The in-scope v2 list builders must construct the v2 filter compiler so
+    the user filter reads `end_users`; the v1 builders keep the v1 compiler.
+    Asserts both the binding (class attribute) and the end-to-end emission
+    through ``build()`` — the latter catches an inherited build method that
+    constructs the v1 compiler directly instead of via ``_FILTER_BUILDER_CLS``.
+    """
+
+    USER_FILTER = [
+        {
+            "column_id": "user",
+            "filter_config": {
+                "col_type": "SYSTEM_METRIC",
+                "filter_type": "text",
+                "filter_op": "in",
+                "filter_value": ["bob", "carol"],
+            },
+        }
+    ]
+
+    def test_span_list_binds_filter_builder_by_generation(self):
+        from tracer.services.clickhouse.query_builders.span_list import (
+            SpanListQueryBuilder,
+        )
+        from tracer.services.clickhouse.v2.query_builders.span_list import (
+            SpanListQueryBuilderV2,
+        )
+
+        assert SpanListQueryBuilder._FILTER_BUILDER_CLS is ClickHouseFilterBuilder
+        assert SpanListQueryBuilderV2._FILTER_BUILDER_CLS is ClickHouseFilterBuilderV2
+
+    def test_trace_list_binds_filter_builder_by_generation(self):
+        from tracer.services.clickhouse.query_builders.trace_list import (
+            TraceListQueryBuilder,
+        )
+        from tracer.services.clickhouse.v2.query_builders.trace_list import (
+            TraceListQueryBuilderV2,
+        )
+
+        assert TraceListQueryBuilder._FILTER_BUILDER_CLS is ClickHouseFilterBuilder
+        assert TraceListQueryBuilderV2._FILTER_BUILDER_CLS is ClickHouseFilterBuilderV2
+
+    def test_span_list_v1_build_emits_legacy_table(self):
+        from tracer.services.clickhouse.query_builders.span_list import (
+            SpanListQueryBuilder,
+        )
+
+        sql, _ = SpanListQueryBuilder(project_id="p1", filters=self.USER_FILTER).build()
+        assert "tracer_enduser" in sql
+        assert "end_users" not in sql
+
+    def test_span_list_v2_build_emits_end_users(self):
+        from tracer.services.clickhouse.v2.query_builders.span_list import (
+            SpanListQueryBuilderV2,
+        )
+
+        sql, _ = SpanListQueryBuilderV2(project_id="p1", filters=self.USER_FILTER).build()
+        assert "end_users" in sql
+        assert "tracer_enduser" not in sql
+
+    def test_trace_list_v2_build_emits_end_users(self):
+        from tracer.services.clickhouse.v2.query_builders.trace_list import (
+            TraceListQueryBuilderV2,
+        )
+
+        sql, _ = TraceListQueryBuilderV2(project_id="p1", filters=self.USER_FILTER).build()
+        assert "end_users" in sql
+        assert "tracer_enduser" not in sql


### PR DESCRIPTION
## Summary

Filtering projects / spans / traces / users by `user_id` on a v2-only (`CH_DATABASE=futureagi`) box threw `Code: 60 — Unknown table 'tracer_enduser'`. The end-user filter subquery in the v1 filter builder targeted the dropped legacy CDC table `tracer_enduser`, and `ClickHouseFilterBuilderV2` inherited it (the v2 rewriter can't fix it — it's a query-level remap, not a token rename). This:

- Parameterizes the end-user dimension source (table / id column / not-deleted predicate) on the base filter builder; v1 keeps `tracer_enduser`, `ClickHouseFilterBuilderV2` overrides to the v2 `end_users` RMT (`end_user_id`, `is_deleted = 0`).
- Adds a `_FILTER_BUILDER_CLS` hook on the list builders so the v2 span/trace list builders construct `ClickHouseFilterBuilderV2` (the v1 base build methods are inherited, so they must read `self._FILTER_BUILDER_CLS` for the override to take effect). v1 default is unchanged.
- Forwards `*args/**kwargs` through the v2 `translate` / `translate_sort` overrides so the list builders' `field_map=` argument survives.

v1 behavior is byte-for-byte unchanged (defaults preserve `tracer_enduser`); only the v2 path now reads `end_users`.

## Linked issues

Fixed TH-6022

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

On the CH25 (`futureagi`) stack, verified `list_traces_of_session` with `user in [bob, carol]` returns 200 (was 500 `Code: 60`). Confirmed the v2 list/trace builders emit `end_users` (not `tracer_enduser`) on the user-filter path, including the v2 `trace_list` filtered-count slow path that delegates to the v1 base via `super().build_count_query()`. v1 routing unchanged.

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
