### PR TITLE
fix: show copy action for tabless datapoint cards

### DIFF
--- a/frontend/src/sections/common/DatapointCard.jsx
+++ b/frontend/src/sections/common/DatapointCard.jsx
@@ -197,6 +197,25 @@ const DatapointCard = ({
     return value?.cellDiffValue;
   }, [value?.cellDiffValue, dataType]);
 
+  const copyIcon = allowCopy ? (
+    <SvgColor
+      src="/assets/icons/ic_copy.svg"
+      alt="Copy"
+      sx={{
+        width: 20,
+        height: 20,
+        color: "text.disabled",
+        cursor: "pointer",
+      }}
+      onClick={() => {
+        copyToClipboard(cellValue);
+        enqueueSnackbar("Copied to clipboard", {
+          variant: "success",
+        });
+      }}
+    />
+  ) : null;
+
   return (
     <Accordion
       sx={{
@@ -372,24 +391,7 @@ const DatapointCard = ({
                     <Tab value="raw" label="Raw" />
                     {showDiff && <Tab value="difference" label="Difference" />}
                   </Tabs>
-                  {allowCopy && (
-                    <SvgColor
-                      src="/assets/icons/ic_copy.svg"
-                      alt="Copy"
-                      sx={{
-                        width: 20,
-                        height: 20,
-                        color: "text.disabled",
-                        cursor: "pointer",
-                      }}
-                      onClick={() => {
-                        copyToClipboard(cellValue);
-                        enqueueSnackbar("Copied to clipboard", {
-                          variant: "success",
-                        });
-                      }}
-                    />
-                  )}
+                  {copyIcon}
                 </Box>
               ) : null}
               {showTabs ? (
@@ -508,6 +510,17 @@ const DatapointCard = ({
                     ...sx,
                   }}
                 >
+                  {copyIcon && (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        mb: 1,
+                      }}
+                    >
+                      {copyIcon}
+                    </Box>
+                  )}
                   <Typography
                     variant="body2"
                     sx={{

--- a/frontend/src/sections/common/__tests__/DatapointCard.test.jsx
+++ b/frontend/src/sections/common/__tests__/DatapointCard.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, waitFor } from "src/utils/test-utils";
+import { enqueueSnackbar } from "src/components/snackbar";
+import DatapointCard from "../DatapointCard";
+
+vi.mock("src/components/snackbar", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: () => null,
+}));
+
+const baseValue = {
+  cellValue: "value to copy",
+};
+
+const baseColumn = {
+  headerName: "Plain column",
+  dataType: "text",
+  originType: "OTHERS",
+};
+
+const renderCard = (props = {}) =>
+  render(
+    <DatapointCard
+      value={baseValue}
+      column={baseColumn}
+      allowCopy
+      indColsDifTracker={{}}
+      {...props}
+    />,
+  );
+
+const getCopyIcons = (container) => container.querySelectorAll('[alt="Copy"]');
+
+describe("DatapointCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("renders a copy icon for cards without tabs", async () => {
+    const { container } = renderCard({ showTabs: false });
+
+    const copyIcons = getCopyIcons(container);
+    expect(copyIcons).toHaveLength(1);
+
+    fireEvent.click(copyIcons[0]);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "value to copy",
+      );
+    });
+    expect(enqueueSnackbar).toHaveBeenCalledWith("Copied to clipboard", {
+      variant: "success",
+    });
+  });
+
+  it("keeps the existing copy icon for cards with tabs", () => {
+    const { container } = renderCard({ showTabs: true });
+
+    expect(getCopyIcons(container)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #928.

`DatapointCard` already accepted `allowCopy`, but the copy icon only rendered inside the `showTabs` header. Plain dataset columns from the datapoint drawer pass `showTabs={false}`, so those cards silently lost the copy affordance even though the drawer set `allowCopy={true}`.

This change extracts the existing copy icon/handler into a shared local element and renders it from both paths:

- tabbed cards keep the same copy icon in the tab header
- tabless cards now show the same copy action above the value body
- copy behavior still uses the existing `/assets/icons/ic_copy.svg`, `copyToClipboard(value?.cellValue)`, and success snackbar

## Tests

Added `DatapointCard.test.jsx` covering:

- tabless cards render a copy icon and copy the card value
- tabbed cards still render their existing copy icon

Local validation run:

- `npx --yes prettier@3.3.0 --check frontend/src/sections/common/DatapointCard.jsx frontend/src/sections/common/__tests__/DatapointCard.test.jsx`
- `git diff --check`
- `npx --yes esbuild@0.25.0 frontend/src/sections/common/DatapointCard.jsx --loader:.jsx=jsx --format=esm --outfile=$TEMP/DatapointCard.out.js`
- `npx --yes esbuild@0.25.0 frontend/src/sections/common/__tests__/DatapointCard.test.jsx --loader:.jsx=jsx --format=esm --outfile=$TEMP/DatapointCard.test.out.js`

Note: I could not run the full Vitest/ESLint suite locally because dependency installation did not complete in this environment: `npm ci` failed due to the checked-in `package-lock.json` being out of sync with `package.json`, and `corepack yarn --cwd frontend install --frozen-lockfile` timed out before installing `node_modules`.