### PR TITLE
feat(ci): Slack alerts for new issues, issue pickup & issue-linked PRs

### DIFF
--- a/.github/scripts/issue-alerts.mjs
+++ b/.github/scripts/issue-alerts.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// Real-time issue/PR alerts to Slack so the team can triage immediately.
+// Invoked by .github/workflows/issue-alerts.yml on issue + pull_request events.
+//
+// Three alert kinds, selected via the EVENT_KIND env var:
+//   issue_opened   — a new issue was filed       → "review & triage"
+//   issue_assigned — an open issue was picked up  → "assigned to @X"
+//   pr_opened      — a PR was opened; if it links an issue, announce the pickup
+//
+// Reuses the same SLACK_WEBHOOK_URL incoming webhook as pr-digest.yml, so alerts
+// land in the same channel. The GitHub-handle → Slack-mention map is read from
+// .github/reviewer-config.json (best effort; falls back to the GitHub handle for
+// anyone not listed, e.g. external issue reporters).
+
+import { readFileSync } from 'node:fs';
+
+const {
+  GITHUB_TOKEN,
+  SLACK_WEBHOOK_URL,
+  GITHUB_REPOSITORY,
+  GITHUB_EVENT_PATH,
+  EVENT_KIND,
+} = process.env;
+
+for (const [k, v] of Object.entries({
+  GITHUB_TOKEN,
+  SLACK_WEBHOOK_URL,
+  GITHUB_REPOSITORY,
+  GITHUB_EVENT_PATH,
+  EVENT_KIND,
+})) {
+  if (!v) {
+    console.error(`Missing required env var: ${k}`);
+    process.exit(1);
+  }
+}
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
+const GH_GRAPHQL = 'https://api.github.com/graphql';
+// Issue/PR bodies can be long; keep the Slack preview readable.
+const DESC_MAX = 280;
+
+const event = JSON.parse(readFileSync(GITHUB_EVENT_PATH, 'utf8'));
+
+const ghHeaders = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': `${OWNER}-${REPO}-issue-alerts`,
+};
+
+// --- Slack mention mapping (best effort) -----------------------------------
+function loadSlackMap() {
+  try {
+    const cfg = JSON.parse(readFileSync('.github/reviewer-config.json', 'utf8'));
+    const map = new Map();
+    for (const [login, u] of Object.entries(cfg.users || {})) {
+      if (u && u.slack_id) map.set(login.toLowerCase(), u.slack_id);
+    }
+    return map;
+  } catch {
+    // Map is a nicety, not a requirement — degrade to plain handles.
+    return new Map();
+  }
+}
+const SLACK_IDS = loadSlackMap();
+
+function mention(login) {
+  if (!login) return '_unassigned_';
+  const id = SLACK_IDS.get(login.toLowerCase());
+  return id ? `<@${id}>` : `\`${login}\``;
+}
+
+function escapeMrkdwn(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function truncate(s) {
+  if (!s) return '';
+  // Collapse newlines & HTML comments (issue/PR templates often include them).
+  const cleaned = String(s)
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned.length <= DESC_MAX) return cleaned;
+  return cleaned.slice(0, DESC_MAX - 1).trimEnd() + '…';
+}
+
+// --- Slack block helpers (mirrors pr-digest.mjs) ---------------------------
+function header(text) {
+  return { type: 'header', text: { type: 'plain_text', text, emoji: true } };
+}
+function section(text) {
+  return { type: 'section', text: { type: 'mrkdwn', text } };
+}
+function context(text) {
+  return { type: 'context', elements: [{ type: 'mrkdwn', text }] };
+}
+
+async function postSlack(blocks, fallbackText) {
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      text: fallbackText,
+      blocks,
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Slack webhook failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+// --- GraphQL: issues a PR will close --------------------------------------
+// closingIssuesReferences covers BOTH closing keywords in the body
+// (Closes/Fixes/Resolves #N) and issues linked manually via the GitHub UI.
+async function linkedIssues(prNumber) {
+  const query = `
+    query($owner:String!, $repo:String!, $number:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$number) {
+          closingIssuesReferences(first: 20) {
+            nodes { number title url }
+          }
+        }
+      }
+    }`;
+  const res = await fetch(GH_GRAPHQL, {
+    method: 'POST',
+    headers: { ...ghHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables: { owner: OWNER, repo: REPO, number: prNumber } }),
+  });
+  if (!res.ok) throw new Error(`GitHub GraphQL → ${res.status} ${await res.text()}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors)}`);
+  return json.data?.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
+}
+
+// --- Handlers --------------------------------------------------------------
+async function handleIssueOpened() {
+  const i = event.issue;
+  const labels = (i.labels || []).map((l) => l.name).filter(Boolean);
+  const blocks = [
+    header('🆕 New issue filed'),
+    section(
+      `*<${i.html_url}|${escapeMrkdwn(i.title)}>* \`#${i.number}\`\n👤 Opened by ${mention(i.user?.login)}`,
+    ),
+  ];
+  if (labels.length) blocks.push(context(`🏷 ${labels.map(escapeMrkdwn).join(', ')}`));
+  const snippet = truncate(i.body);
+  if (snippet) blocks.push(section(`> ${escapeMrkdwn(snippet)}`));
+  blocks.push(context('Please review and triage. 👀'));
+  await postSlack(blocks, `New issue #${i.number}: ${i.title}`);
+  console.log(`Posted new-issue alert for #${i.number}`);
+}
+
+async function handleIssueAssigned() {
+  const i = event.issue;
+  const assignee = event.assignee?.login; // the user just added
+  const others = (i.assignees || []).map((a) => a.login).filter((l) => l && l !== assignee);
+  let who = mention(assignee);
+  if (others.length) who += ` (with ${others.map(mention).join(', ')})`;
+  const blocks = [
+    header('🙋 Issue picked up'),
+    section(`*<${i.html_url}|${escapeMrkdwn(i.title)}>* \`#${i.number}\`\nAssigned to ${who}`),
+  ];
+  await postSlack(blocks, `Issue #${i.number} assigned to ${assignee || 'someone'}`);
+  console.log(`Posted issue-assigned alert for #${i.number} → ${assignee}`);
+}
+
+async function handlePrOpened() {
+  const pr = event.pull_request;
+  const issues = await linkedIssues(pr.number);
+  if (issues.length === 0) {
+    console.log(`PR #${pr.number} links no issues; nothing to announce.`);
+    return;
+  }
+  const list = issues
+    .map((n) => `• <${n.url}|#${n.number} ${escapeMrkdwn(n.title)}>`)
+    .join('\n');
+  const verb = pr.draft ? 'opened a draft PR that will close' : 'opened a PR that closes';
+  const blocks = [
+    header('🔗 PR submitted for an open issue'),
+    section(
+      `*<${pr.html_url}|${escapeMrkdwn(pr.title)}>* \`#${pr.number}\`\n👤 ${mention(pr.user?.login)} ${verb}:\n${list}`,
+    ),
+    context(pr.draft ? 'Draft — work in progress.' : 'Ready for review. 👀'),
+  ];
+  const fallback = `PR #${pr.number} closes ${issues.map((n) => `#${n.number}`).join(', ')}`;
+  await postSlack(blocks, fallback);
+  console.log(
+    `Posted PR-pickup alert for #${pr.number} → issues ${issues.map((n) => n.number).join(',')}`,
+  );
+}
+
+async function main() {
+  switch (EVENT_KIND) {
+    case 'issue_opened':
+      return handleIssueOpened();
+    case 'issue_assigned':
+      return handleIssueAssigned();
+    case 'pr_opened':
+      return handlePrOpened();
+    default:
+      console.error(`Unknown EVENT_KIND: ${EVENT_KIND}`);
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/issue-alerts.yml
+++ b/.github/workflows/issue-alerts.yml
@@ -1,0 +1,44 @@
+name: Issue & PR Alerts to Slack
+
+# Real-time triage alerts: a new issue is filed, an open issue is picked up
+# (assigned), or a PR is opened that closes an open issue. Posts to the same
+# Slack channel as the PR digest via the SLACK_WEBHOOK_URL secret.
+on:
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  alert:
+    # Skip on forks and on fork-originated PRs: SLACK_WEBHOOK_URL isn't exposed
+    # to those runs, so the job would only ever fail and redden external PRs.
+    # (Issue events always run in the base repo, so they keep working.)
+    if: >-
+      github.repository == 'future-agi/future-agi' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Post issue/PR alert to Slack
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Map the event to the script's three modes. opened/reopened PRs both
+          # mean "a PR was just submitted", so both fall through to pr_opened.
+          EVENT_KIND: >-
+            ${{ (github.event_name == 'issues' && github.event.action == 'opened' && 'issue_opened')
+              || (github.event_name == 'issues' && github.event.action == 'assigned' && 'issue_assigned')
+              || 'pr_opened' }}
+        run: node .github/scripts/issue-alerts.mjs


### PR DESCRIPTION
Adds real-time Slack triage alerts via a new event-driven workflow, reusing the existing `SLACK_WEBHOOK_URL` (same channel as the PR digest — no new secrets).

## Triggers
- 🆕 **New issue filed** (`issues: opened`) — title, opener, labels, body snippet → "review & triage"
- 🙋 **Issue picked up** (`issues: assigned`) — who it was assigned to
- 🔗 **PR submitted for an open issue** (`pull_request: opened`/`reopened`) — only when the PR closes/links an issue, detected via GraphQL `closingIssuesReferences` (catches `Closes/Fixes/Resolves #N` keywords **and** issues linked manually in the UI)

## Implementation notes
- Mirrors the existing `pr-digest.mjs` style (plain `fetch`, Block Kit helpers, no deps; Node 20).
- GitHub-handle → Slack-mention map read from `.github/reviewer-config.json`; falls back to the plain handle for anyone not listed (e.g. external issue reporters).
- **Forks are skipped** — secrets aren't exposed to fork-originated `pull_request` runs, so the job guards on `head.repo.full_name == github.repository` to avoid reddening external PRs. Trade-off: an external contributor's PR that closes an issue won't alert; issue events and internal-branch PRs are unaffected.
- Issue-assignment fires once per assignee added.

## Testing
- Handlers unit-tested locally against fixture payloads with a local webhook capture — verified the `issue_opened`, `issue_assigned`, and external-reporter-fallback messages render correctly (mentions, label/body omission, HTML escaping).
- `pr_opened` path smoke-tested **live end-to-end** (real Actions → real Slack webhook) via a throwaway PR closing a disposable issue. Actions run [`27973447405`](https://github.com/future-agi/future-agi/actions/runs/27973447405) succeeded with `EVENT_KIND: pr_opened` and logged `Posted PR-pickup alert` — and since the script throws on any non-2xx webhook response, a green run means Slack accepted the message. The throwaway PR + disposable issue were deleted afterward.

> Note: `issues:`-triggered alerts only run from the default branch, so the new-issue / pickup alerts go live on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
