### PR TITLE
fix(tracer): scrub non-finite floats before span COPY to Postgres

### DIFF
--- a/futureagi/tracer/tests/test_trace_ingestion_serialize.py
+++ b/futureagi/tracer/tests/test_trace_ingestion_serialize.py
@@ -1,0 +1,70 @@
+"""Unit tests for JSON-field serialization in trace ingestion.
+
+Covers CORE-BACKEND-YQK: non-finite floats (Infinity/NaN) in span jsonb
+fields broke the Postgres COPY ("invalid input syntax for type json /
+Token 'Infinity' is invalid"). _serialize_json_field_value must scrub them
+to null and never emit bare Infinity/NaN tokens, while leaving clean JSON
+byte-identical.
+"""
+
+import json
+
+import pytest
+
+from tracer.utils.trace_ingestion import (
+    _sanitize_nonfinite_floats,
+    _serialize_json_field_value,
+)
+
+
+class TestSanitizeNonFiniteFloats:
+    def test_inf_and_nan_become_none(self):
+        assert _sanitize_nonfinite_floats(float("inf")) is None
+        assert _sanitize_nonfinite_floats(float("-inf")) is None
+        assert _sanitize_nonfinite_floats(float("nan")) is None
+
+    def test_finite_floats_unchanged(self):
+        assert _sanitize_nonfinite_floats(3.5) == 3.5
+        assert _sanitize_nonfinite_floats(0.0) == 0.0
+
+    def test_recurses_dict_list_tuple(self):
+        assert _sanitize_nonfinite_floats({"a": [{"b": float("inf")}]}) == {
+            "a": [{"b": None}]
+        }
+        assert _sanitize_nonfinite_floats([1, float("nan"), 3]) == [1, None, 3]
+
+    def test_non_floats_passthrough(self):
+        assert _sanitize_nonfinite_floats("x") == "x"
+        assert _sanitize_nonfinite_floats(7) == 7
+        assert _sanitize_nonfinite_floats(None) is None
+
+
+class TestSerializeJsonFieldValue:
+    def test_none_passthrough(self):
+        assert _serialize_json_field_value(None) is None
+
+    def test_clean_json_string_unchanged(self):
+        s = '{"a": 1, "b": [2, 3.5]}'
+        assert _serialize_json_field_value(s) == s
+
+    def test_dict_with_infinity_scrubbed_and_valid_json(self):
+        out = _serialize_json_field_value({"request_id": float("inf"), "ok": 1})
+        assert "Infinity" not in out
+        assert json.loads(out) == {"request_id": None, "ok": 1}
+
+    def test_dict_with_nan_scrubbed(self):
+        out = _serialize_json_field_value({"x": float("nan")})
+        assert json.loads(out)["x"] is None
+
+    def test_json_string_containing_infinity_token_is_scrubbed(self):
+        # The exact YQK shape: a JSON string whose value is the bare Infinity token.
+        s = '{"request_id": Infinity, "name": "cartesia.tts.TTS"}'
+        out = _serialize_json_field_value(s)
+        assert "Infinity" not in out
+        assert json.loads(out) == {"request_id": None, "name": "cartesia.tts.TTS"}
+
+    def test_output_is_valid_postgres_json(self):
+        # Whatever comes out must be parseable JSON (no bare NaN/Infinity tokens).
+        for val in [{"a": float("inf")}, [float("nan")], {"n": {"m": float("-inf")}}]:
+            out = _serialize_json_field_value(val)
+            json.loads(out)  # must not raise

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -71,6 +71,67 @@ def _format_if_needed(raw: str) -> str | None:
 # --- Helper Functions for Database Interaction ---
 
 
+def _sanitize_nonfinite_floats(value: Any) -> Any:
+    """Recursively replace NaN/+-Infinity floats with ``None``.
+
+    Python's ``json.dumps`` emits the bare tokens ``NaN``/``Infinity``/
+    ``-Infinity`` for non-finite floats, which PostgreSQL's json/jsonb type
+    rejects during COPY (``invalid input syntax for type json``). User-supplied
+    span attributes can carry these values, so scrub them before serialization.
+    Mirrors ``tracer.views.trace._sanitize_nonfinite_floats`` on the read path.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _sanitize_nonfinite_floats(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_nonfinite_floats(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_nonfinite_floats(v) for v in value)
+    return value
+
+
+def _strip_null_chars(value: Any) -> Any:
+    """Recursively strip NUL (``\\x00``) bytes from string keys and values.
+
+    PostgreSQL's text and json/jsonb types cannot store the NUL code point: a
+    real ``\\x00`` inside a string is emitted by ``json.dumps`` as the escape
+    ``\\u0000``, which jsonb rejects during COPY (``unsupported Unicode escape
+    sequence ... \\u0000 cannot be converted to text``). User-supplied span
+    attributes can carry NUL (e.g. extracted PDF/document text), so scrub them
+    before serialization. Distinct from ``_sanitize_nonfinite_floats``: NUL is
+    silently escaped by ``json.dumps`` rather than raising, so the strip must
+    run unconditionally on the JSON path. Only ``\\x00`` is removed; other
+    control characters (e.g. ``\\u0013``) are valid in jsonb and preserved.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {
+            (k.replace("\x00", "") if isinstance(k, str) else k): _strip_null_chars(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_strip_null_chars(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_null_chars(v) for v in value)
+    return value
+
+
+def _contains_null_char(value: Any) -> bool:
+    """Return True if any string key/value in ``value`` contains a NUL byte."""
+    if isinstance(value, str):
+        return "\x00" in value
+    if isinstance(value, dict):
+        return any(
+            (isinstance(k, str) and "\x00" in k) or _contains_null_char(v)
+            for k, v in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_null_char(v) for v in value)
+    return False
+
+
 def _serialize_json_field_value(val: Any) -> str | None:
     """
     Serialize a value for PostgreSQL JSONField in COPY operations.
@@ -86,12 +147,38 @@ def _serialize_json_field_value(val: Any) -> str | None:
 
     if isinstance(val, str):
         try:
-            json.loads(val)
-            return val
+            parsed = json.loads(val)
         except (json.JSONDecodeError, TypeError):
-            return json.dumps(val)
+            # Not JSON: COPY writes the raw string into the text-backed column,
+            # so strip NUL directly off the byte stream.
+            return json.dumps(val.replace("\x00", ""), allow_nan=False)
+        try:
+            # Fast path: already-valid JSON with no non-finite floats or NUL
+            # bytes. A NUL survives json.loads as a real \x00 inside ``parsed``
+            # (the source text held the backslash-u-0000 escape), so check ``parsed``.
+            json.dumps(parsed, allow_nan=False)
+            if not _contains_null_char(parsed):
+                return val
+            return json.dumps(_strip_null_chars(parsed), allow_nan=False)
+        except ValueError:
+            return json.dumps(
+                _strip_null_chars(_sanitize_nonfinite_floats(parsed)), allow_nan=False
+            )
 
-    return json.dumps(val)
+    # Fast path: dump directly; only pay the recursive scrub when a non-finite
+    # float or NUL byte is actually present (keeps the common clean-data path
+    # allocation-free).
+    try:
+        dumped = json.dumps(val, allow_nan=False)
+    except ValueError:
+        return json.dumps(
+            _strip_null_chars(_sanitize_nonfinite_floats(val)), allow_nan=False
+        )
+    # json.dumps does not raise on NUL; it silently emits the \u0000 escape,
+    # so guard the dumped output explicitly.
+    if "\\u0000" not in dumped:
+        return dumped
+    return json.dumps(_strip_null_chars(val), allow_nan=False)
 
 
 def _is_pk_unique_violation(exc: BaseException, table_name: str) -> bool:


### PR DESCRIPTION
## Hotfix → prod (US): traces dropped on `Infinity` in span attributes

### Symptom
Traces arrive fine (ingest API returns `200`) but are **not stored**. On US prod, the async storage worker drops ~**236 span batches / 24h** — silently.

### Root cause
`bulk_create_observation_span_task` writes spans to Postgres `tracer_observation_span` via `COPY ... FROM STDIN`. When a span attribute holds a non-finite float, `json.dumps` (default `allow_nan=True`) emits the **bare token `Infinity`/`NaN`**, which Postgres' `json` type rejects:

```
invalid input syntax for type json
DETAIL:  Token "Infinity" is invalid.
COPY tracer_observation_span, line 51, column eval_attributes
```

Because `COPY` is **all-or-nothing** over a ~50-span batch and the activity is **`max_retries=0`**, one poisoned span permanently drops its **entire batch** — including unrelated customers' valid spans.

### Offending payload
A LiveKit voice integration (project `colly`) emits:
```json
{
  "session.id": 7465043827,
  "lk.room_name": "colly_7465043827_mTx3JEHhtqv5",
  "call_id": 7465043827,
  "request_ids": { "values": [ { "string_value": Infinity } ] }
}
```
`222 / 236` failures over 24h trace to this `request_ids: Infinity` value (a `float('inf')` from overflow / divide-by-zero in their app).

### Fix
Ports the serializer hardening **already on `dev`** (#719, merged Jun 9) — but never reached `main` (the only path carrying it is the open, conflicting CH25 release PR #909):
- `_sanitize_nonfinite_floats` — recursively replace Infinity/NaN with `null`
- `_serialize_json_field_value` dumps with `allow_nan=False` (raises instead of silently emitting bare tokens, guaranteeing the scrub runs)
- NUL-byte stripping (`_strip_null_chars`) as defense-in-depth (no prod hits yet, but same COPY-rejection class)

Code is identical to the dev version, so it converges cleanly when dev→main lands.

### Test
`futureagi/tracer/tests/test_trace_ingestion_serialize.py` (Sentry `CORE-BACKEND-YQK`), incl. a case reproducing the exact prod shape (`'{"request_id": Infinity, "name": "cartesia.tts.TTS"}'`). **10/10 pass** against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)