### PR TITLE
fix(observe): multi-select trace_id/span_id/session filters [TH-6062]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -41,6 +41,7 @@ import {
   getPickerOptionSearchText,
   getPickerOptionSecondaryLabel,
   getPickerOptionValue,
+  usesFreeTextValue,
 } from "./filterValuePickerUtils";
 import { ID_ONLY_FIELDS } from "./idFields";
 
@@ -1547,7 +1548,7 @@ function FilterRow({
       );
     }
 
-    if (filter.fieldType === "text" || filter.fieldType === "string") {
+    if (usesFreeTextValue(filter.fieldType, source)) {
       return (
         <TextField
           size="small"
@@ -1573,9 +1574,7 @@ function FilterRow({
         source={source}
         property={properties.find((p) => p.id === filter.field)}
         freeSoloValues={rowFreeSoloValues}
-        singleSelect={
-          ID_ONLY_FIELDS.has(filter.field) || SINGLE_VALUE_OPS.has(safeOperator)
-        }
+        singleSelect={SINGLE_VALUE_OPS.has(safeOperator)}
         onChange={(newVal) => updateRow({ value: newVal })}
       />
     );

--- a/frontend/src/sections/projects/LLMTracing/__tests__/filterValuePickerUtils.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/filterValuePickerUtils.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { usesFreeTextValue } from "../filterValuePickerUtils";
+
+describe("usesFreeTextValue — text vs values-picker decision", () => {
+  it("text fields always use the free-text input", () => {
+    expect(usesFreeTextValue("text", "traces")).toBe(true);
+    expect(usesFreeTextValue("text", "dataset")).toBe(true);
+  });
+
+  it("string fields use the picker in Observe sources", () => {
+    for (const source of ["traces", "sessions", "users"]) {
+      expect(usesFreeTextValue("string", source)).toBe(false);
+    }
+  });
+
+  it("string fields stay free text in non-Observe sources", () => {
+    for (const source of ["dataset", "simulation", "experiment"]) {
+      expect(usesFreeTextValue("string", source)).toBe(true);
+    }
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/filterValuePickerUtils.js
+++ b/frontend/src/sections/projects/LLMTracing/filterValuePickerUtils.js
@@ -1,3 +1,10 @@
+export const OBSERVE_FILTER_SOURCES = ["traces", "sessions", "users"];
+
+export function usesFreeTextValue(fieldType, source) {
+  if (fieldType === "text") return true;
+  return fieldType === "string" && !OBSERVE_FILTER_SOURCES.includes(source);
+}
+
 export function getPickerOptionValue(option) {
   if (typeof option === "string") return option;
   return option?.value ?? option?.label ?? "";


### PR DESCRIPTION
## 🐛 Bug

On dev, the Observe filters for `trace_id` / `span_id` / `session` rendered as a **single-select free-text** input, while prod renders them as a **multi-select values picker**. Two dev-only regressions caused it:

1. The value input forced a single value for ID fields — `ID_ONLY_FIELDS` was part of the `singleSelect` gate.
2. #984 unified `string` field types onto the text input *globally* (`fieldType === "text" || "string"` → text box), so Observe string fields (incl. the IDs) rendered as a text box instead of the values picker.

## 🔧 What changed

- Drop the `ID_ONLY_FIELDS` gate from `singleSelect`, so ID filters allow multiple values (single only when the operator itself is single-value).
- Source-scope the text/string value input via a new `usesFreeTextValue(fieldType, source)` helper:
  - **Observe** sources (`traces` / `sessions` / `users`) → string fields render the **values picker**.
  - Other sources (`dataset` / `rule` / `experiment` / `simulation`) → string fields stay **free text** (preserves #984).
- New `usesFreeTextValue` + `OBSERVE_FILTER_SOURCES` in `filterValuePickerUtils.js` + unit test.

No `ObserveToolbar`/backend change: `apiColType: "SYSTEM_METRIC"` is already pinned on the static ID fields in the panel, so the backend emits `IN (...)` for these.

## 🤔 Why

- Match prod — ID filters should be multi-select pickers.
- #984's global `text/string` unification was right for dataset/rule filters but broke Observe (string IDs need the picker). Scoping by `source` fixes Observe **without** regressing #984 (cc @cdileep23 — this scopes your change, doesn't revert it).

## 🧪 Tests (`filterValuePickerUtils.test.js`)

- **text fields always use the free-text input** — `usesFreeTextValue("text", *)` → true for any source.
- **string fields use the picker in Observe sources** — `traces` / `sessions` / `users` → false (picker). *(TH-6062)*
- **string fields stay free text in non-Observe sources** — `dataset` / `simulation` / `experiment` → true (text). *(preserves #984)*

## ▶️ How to reproduce / verify

**Bug (pre-fix):** Observe → Tracing → Filter → add **Trace ID** → value was a single free-text box.

**After:**
- Observe (Tracing / Sessions / Users → Filter → Trace ID / Span ID): multi-select checkbox picker, populated; selecting 2+ returns exactly those traces.
- Dataset filters (Develop → Dataset → Data tab → Filter) + Annotation rule dialog (Annotations → Queues → Create rule): string fields still render as free text (unchanged).

## 💻 Commands

```bash
cd frontend
yarn test:run src/sections/projects/LLMTracing/__tests__/filterValuePickerUtils.test.js
yarn dev   # http://localhost:3031
```

Backend check on dev — multi-value `trace_id` filter returns exactly the selected traces:
```
GET /tracer/trace/list_traces_of_session/?...&filters=[{ column_id: trace_id, filter_op: in,
     filter_value: [<3 ids>], col_type: SYSTEM_METRIC }]
→ total_rows: 3, exact match
```

## 📹 Videos & Screenshots

https://github.com/user-attachments/assets/76e7c5e3-6166-4181-b6ab-bf262d60c7e7

