### PR TITLE
Document Docker requirement in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Go-based gateway with **~9.9 ns weighted routing**, **~29 k req/s on t3.xlarge**
 
 Two ways, picked by how much you want to install:
 
+The self-host path requires Docker Desktop or Docker Engine with Docker Compose
+available before running the installer.
+
 <table width="100%">
 <tr>
 <th width="50%">Cloud (fastest)</th>


### PR DESCRIPTION
  Adds an explicit Docker requirement note to the README quickstart before the self-host install instructions. This
  helps first-time self-host users understand that Docker Desktop or Docker Engine with Docker Compose must be available
  before running `./bin/install