### PR TITLE
fix(observe): render session table on date-range change [TH-6080]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -23,6 +23,7 @@ import {
   SPAN_DEFAULT_COLUMNS,
   mergeCellStyle,
   generateAnnotationColumnsForTracing,
+  normalizeConfigKeys,
 } from "./common";
 import CustomTraceRenderer from "./Renderers/CustomTraceRenderer";
 import CustomTraceHeaderRenderer from "./Renderers/CustomTraceHeaderRenderer";
@@ -40,16 +41,6 @@ import { APP_CONSTANTS } from "src/utils/constants";
 import { useShallowToggleAnnotationsStore } from "../../agents/store";
 
 const ROWS_LIMIT = 100;
-
-// Normalize config object keys from snake_case to camelCase while preserving id values as snake_case
-const normalizeConfigKeys = (config) =>
-  config?.map((obj) => {
-    const result = {};
-    for (const [key, value] of Object.entries(obj)) {
-      result[key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())] = value;
-    }
-    return result;
-  });
 
 const getSpanListColumnDefs = (col) => {
   const colId = col?.id;
@@ -427,7 +418,10 @@ const SpanGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -22,6 +22,7 @@ import {
   getTraceListColumnDefs,
   FILTER_FOR_HAS_EVAL,
   generateAnnotationColumnsForTracing,
+  normalizeConfigKeys,
 } from "./common";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { userTraceRowHeightMapping } from "../UsersView/common";
@@ -35,16 +36,6 @@ import { useShallowToggleAnnotationsStore } from "../../agents/store";
 
 const ROWS_LIMIT = 100;
 const EMPTY_EXTRA_FILTERS = [];
-
-// Normalize config object keys from snake_case to camelCase while preserving id values as snake_case
-const normalizeConfigKeys = (config) =>
-  config?.map((obj) => {
-    const result = {};
-    for (const [key, value] of Object.entries(obj)) {
-      result[key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())] = value;
-    }
-    return result;
-  });
 
 const TraceGrid = React.forwardRef(
   (
@@ -274,7 +265,10 @@ const TraceGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];

--- a/frontend/src/sections/projects/LLMTracing/__tests__/normalizeConfigKeys.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/normalizeConfigKeys.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { normalizeConfigKeys } from "../common";
+
+describe("normalizeConfigKeys", () => {
+  it("camelCases snake_case keys so is_visible resolves as isVisible", () => {
+    const out = normalizeConfigKeys([{ id: "trace_id", is_visible: true }]);
+    expect(out[0].isVisible).toBe(true);
+  });
+
+  it("preserves id values and converts the rest of the keys", () => {
+    expect(
+      normalizeConfigKeys([
+        { id: "x", output_type: "score", is_visible: false },
+      ]),
+    ).toEqual([{ id: "x", outputType: "score", isVisible: false }]);
+  });
+
+  it("returns undefined for a missing config", () => {
+    expect(normalizeConfigKeys(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -24,6 +24,17 @@ import AnnotationHeaderCellRenderer from "../../agents/CallLogs/AnnotationHeader
 import NewAnnotationCellRenderer from "../../agents/NewAnnotationCellRenderer";
 import { buildApiFilterFromPanelRow } from "src/api/contracts/filter-contract";
 
+// Normalize config object keys from snake_case to camelCase while preserving
+// id values as snake_case. Shared by the trace and span grids.
+export const normalizeConfigKeys = (config) =>
+  config?.map((obj) => {
+    const result = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())] = value;
+    }
+    return result;
+  });
+
 export const AllowedGroups = [
   "Evaluation Metrics",
   "Annotation Metrics",

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -19,6 +19,7 @@ import { getSessionListColumnDef } from "./common";
 import { Events, trackEvent } from "src/utils/Mixpanel";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { userTraceRowHeightMapping } from "../UsersView/common";
+import { normalizeConfigKeys } from "src/sections/projects/LLMTracing/common";
 import { useSessionsGridStoreShallow } from "./ReplaySessions/store";
 import { APP_CONSTANTS } from "src/utils/constants";
 
@@ -37,16 +38,6 @@ const getSessionGridThemeParams = (theme) => ({
 });
 
 const DATASET_ROWS_LIMIT = 30;
-
-// Normalize config object keys from snake_case to camelCase while preserving id values as snake_case
-const normalizeConfigKeys = (config) =>
-  config?.map((obj) => {
-    const result = {};
-    for (const [key, value] of Object.entries(obj)) {
-      result[key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())] = value;
-    }
-    return result;
-  });
 
 const LoadingHeader = () => {
   return <Skeleton variant="text" width={100} height={20} />;

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -316,7 +316,7 @@ const SessionGrid = React.forwardRef(
                   return updateObjRef.current?.[column.field] ?? true;
                 }
 
-                const columnConfig = (res?.config || []).find(
+                const columnConfig = (newCols || []).find(
                   (config) => config.id === column.field,
                 );
                 return columnConfig ? columnConfig.isVisible : true;


### PR DESCRIPTION
## 🐛 Bug

Changing the date range on the Observe **Sessions** tab (e.g. Past 6M → Past 12M) made the **session table disappear** — the Session Metrics chart still rendered, only the table went blank. The API was fine: `list_sessions` returned `200` with rows.

## 🔍 Root cause

The session grid's column-visibility filter read camelCase `columnConfig.isVisible` off the **raw** `res.config`, which is **snake_case** (`is_visible`). So `isVisible` was always `undefined` → falsy → **every column got filtered out → blank grid** (even with row data). It only surfaced on a date-range *change* because the first render's columns come from the `columnDefs`/`updateObj` path, while the refetch applies this (empty) filtered set.

## 🔧 What changed

- `Session-grid.jsx`: the visibility filter now reads from the already-normalized `newCols` (`normalizeConfigKeys(res.config)`, camelCase) instead of the raw snake `res.config` — matching every other column consumer (`getSessionListColumnDef`, the grid, `ColumnConfigureDropDown`).

## 🤔 Why this approach

`newCols` is the camelCase version already computed in `getRows`, and the entire column flow downstream reads camelCase. The bug was this one consumer bypassing it. Minimal and consistent — no normalizer removed, no shared-component cascade. (Per the API-contract standard's incremental-migration guidance, fully migrating the shared column model to snake-case is a separate ticket, not this bug fix.)

## 🧪 Tests

No unit test added: the filter lives inside the grid's `getRows`, and the defect was the data *source* (raw vs normalized config), not the predicate — so a predicate test wouldn't have caught it. Verified manually + via API (below).

## ▶️ How to reproduce / verify

1. Observe → **Sessions** tab → default **Past 6M** → table shows.
2. Switch to **Past 12M** → **before:** table blank; **after:** table renders.
3. Holds across any date-range change (and the 3 backend-hidden columns stay hidden).

## 💻 Commands

```bash
cd frontend
yarn dev   # http://localhost:3031
```
Backend check (dev) — `list_sessions` returns data + per-column `is_visible`:
```
GET /tracer/trace-session/list_sessions/?...&filters=[created_at between <12M range>]
→ 200, result.table: 6 rows, config[].is_visible: true/false
```

## 📹 Videos & Screenshots

https://github.com/user-attachments/assets/ef5afce1-03a9-438c-abdc-256a6c361fb7

