### PR TITLE
feat(experiments): show current row id in detail drawer header (#927)

### DIFF
--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
@@ -20,7 +20,8 @@ import DatapointCard from "src/sections/common/DatapointCard";
 import AudioDatapointCard from "src/components/custom-audio/AudioDatapointCard";
 import ViewDetailsModal from "./ViewDetailsModal";
 import { LoadingButton } from "@mui/lab";
-import { getUniqueColorPalette } from "src/utils/utils";
+import { getUniqueColorPalette, copyToClipboard } from "src/utils/utils";
+import { enqueueSnackbar } from "notistack";
 import {
   getLabel,
   getStatusColor,
@@ -157,6 +158,11 @@ export default function ExperimentDetailDrawerContent({
   const [activeTab, setActiveTab] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const [openDetailRow, setOpenDetailRow] = useState(null);
+  const handleCopyRowId = () => {
+    if(!row?.rowId) return;
+    copyToClipboard(row.rowId);
+    enqueueSnackbar("Copied to clipboard", { variant: "success" });
+  };
   const [showDescription, setShowDescription] = useState(false);
   const theme = useTheme();
   const agTheme = useAgThemeWith(EXPERIMENT_DRAWER_THEME_PARAMS);
@@ -553,9 +559,46 @@ export default function ExperimentDetailDrawerContent({
             justifyContent: "space-between",
           }}
         >
-          <Typography variant="m3" fontWeight={700} color="text.primary">
-            Experiments
-          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: "12px" }}>
+            <Typography variant="m3" fontWeight={700} color="text.primary">
+              Experiments
+            </Typography>
+            <ShowComponent condition={!!row?.rowId}>
+              <Box
+                sx={{
+                  border: "1px solid",
+                  borderColor: "divider",
+                  display: "flex",
+                  gap: "8px",
+                  alignItems: "center",
+                  borderRadius: "8px",
+                  padding: "2px 8px",
+                  maxWidth: "320px",
+                }}
+              >
+                <Typography
+                  variant="s2"
+                  fontWeight={"fontWeightRegular"}
+                  color="text.primary"
+                  noWrap
+                >
+                  Row ID: {row?.rowId}
+                </Typography>
+                <SvgColor
+                  src="/assets/icons/ic_copy.svg"
+                  alt="Copy"
+                  sx={{
+                    width: "12px",
+                    height: "12px",
+                    color: "text.disabled",
+                    cursor: "pointer",
+                    flexShrink: 0,
+                  }}
+                  onClick={handleCopyRowId}
+                />
+              </Box>
+            </ShowComponent>
+          </Box>
           <Stack direction={"row"} gap={"12px"} alignItems={"center"}>
             <ShowComponent condition={showDiff}>
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>


### PR DESCRIPTION
## What
Show the current row's `rowId` (with a copy button) in the experiment row
details drawer header, so navigation is verifiable and the id is copyable.

Closes #927

## Why
The header only ever said "Experiments" — Prev/Next swapped the content with no
identity feedback, and there was no way to copy the current row's id.

## How
- Render a bordered chip `Row ID: {rowId}` in the header when `row?.rowId` is present,
  reusing the chip-with-copy pattern from the Evaluation Logs drawer (`LogsDrawer.jsx`)
  and the `copyToClipboard` helper (`src/utils/utils.js`).
- The chip reads from `row.rowId`, so it updates automatically on Prev/Next.
- Hidden gracefully when `row?.rowId` is absent (e.g. while loading).

No backend / data-shape changes — `row.rowId` already exists on the prop.

## Screenshots
<img width="1894" height="977" alt="rowid" src="https://github.com/user-attachments/assets/0c59ad59-e1d6-40a2-8e2e-add338fbb682" />
<img width="1894" height="977" alt="norowid" src="https://github.com/user-attachments/assets/bb7b1454-ccfa-403c-b86a-cd606c239615" />