### PR TITLE
fix(run-prompt): guard messages undefined crash + fix ReadOnlyPrompt prop type

### DIFF
--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
@@ -157,7 +157,7 @@ export const ReadOnlyPrompt = ({ title, prompt, allColumns = [] }) => {
 
 ReadOnlyPrompt.propTypes = {
   title: PropTypes.string,
-  prompt: PropTypes.string,
+  prompt: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   allColumns: PropTypes.array,
 };
 

--- a/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
@@ -68,7 +68,7 @@ const PromptTemplatesSection = ({
 
   const templateFormat = watch("config.template_format") || "mustache";
 
-  const existingRoles = messages.map((p) => p?.role);
+  const existingRoles = (messages || []).map((p) => p?.role);
   return (
     <Box sx={{ gap: "16px", display: "flex", flexDirection: "column" }}>
       <Box sx={{ display: "flex", justifyContent: "flex-end" }}>


### PR DESCRIPTION
## Summary

Two bugs causing RunPrompt to not send requests:

1. **`PromptTemplatesSection.jsx:71` crash** — `watch("config.messages")` returns `undefined` before form initializes, then `.map()` on `undefined` throws `TypeError`, ErrorBoundary catches it, entire RunPrompt section unmounts → no requests possible. Fix: `(messages || []).map(...)`.

2. **`ImportPrompt.jsx` PropTypes warning** — `ReadOnlyPrompt` already handles arrays internally (for multi-part OpenAI content format) but PropType was declared as `PropTypes.string`. Fix: `PropTypes.oneOfType([PropTypes.string, PropTypes.array])`.

## Type of change
- [x] 🐛 Bug fix