### PR TITLE
fix(observe): route saved-view tabs by tab_type — unwrap saved-views cache [TH-6089]

### DIFF
--- a/frontend/src/api/project/saved-views.js
+++ b/frontend/src/api/project/saved-views.js
@@ -131,11 +131,12 @@ const reorderCustomViewsInCache = (currentResult, order) => {
 export const useGetSavedViews = (projectId) => {
   return useQuery({
     queryKey: [SAVED_VIEWS_KEY, projectId],
-    queryFn: () =>
-      axios.get(endpoints.savedViews.list, {
+    queryFn: async () => {
+      const res = await axios.get(endpoints.savedViews.list, {
         params: { project_id: projectId },
-      }),
-    select: (d) => d.data?.result,
+      });
+      return res.data?.result;
+    },
     staleTime: 60_000,
     enabled: !!projectId,
   });
@@ -146,11 +147,12 @@ export const useGetSavedViews = (projectId) => {
 export const useGetWorkspaceSavedViews = (tabType) => {
   return useQuery({
     queryKey: [SAVED_VIEWS_KEY, "workspace", tabType],
-    queryFn: () =>
-      axios.get(endpoints.savedViews.list, {
+    queryFn: async () => {
+      const res = await axios.get(endpoints.savedViews.list, {
         params: { tab_type: tabType },
-      }),
-    select: (d) => d.data?.result,
+      });
+      return res.data?.result;
+    },
     staleTime: 60_000,
     enabled: !!tabType,
   });

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -162,11 +162,8 @@ const ObservePage = React.memo(() => {
       let viewTabType = "traces";
       if (tabKey.startsWith("view-")) {
         const viewId = tabKey.replace("view-", "");
-        const cachedResult = queryClient.getQueryData([
-          SAVED_VIEWS_KEY,
-          observeId,
-        ]);
-        const customViews = cachedResult?.custom_views ?? [];
+        const cached = queryClient.getQueryData([SAVED_VIEWS_KEY, observeId]);
+        const customViews = cached?.custom_views ?? [];
         const view = customViews.find((v) => v.id === viewId);
         activeConfig = view?.config || null;
         viewTabType = view?.tab_type ?? "traces";


### PR DESCRIPTION
## 🐛 Bug

A saved view with `tab_type: "sessions"` loaded the **trace table** instead of the sessions table — clicking a sessions saved-view chip routed to `/llm-tracing`, and a refresh stayed stuck there.

## 🔍 Root cause

`useGetSavedViews` / `useGetWorkspaceSavedViews` unwrap the response via `select: (d) => d.data?.result`. But **`select` only transforms the hook's `data`** — `queryClient.getQueryData()` / `setQueryData()` operate on the **raw** cached value (`{ data: { result } }`). Contract commit `25e443ea10` changed `ObservePage.handleTabChange` to read the cache assuming it was already unwrapped (`cachedResult.custom_views`), so the view lookup returned `undefined` → `viewTabType` fell back to `"traces"` → sessions views routed to `/llm-tracing`.

(Trace views survived by coincidence — the `"traces"` fallback is what they need; user views survived via a hook-data fallback in their tab bars. Sessions had neither, so it surfaced.)

## 🔧 What changed

- `saved-views.js` — move the unwrap into the **`queryFn`** (`return res.data?.result`) and drop `select`, for **both** `useGetSavedViews` and `useGetWorkspaceSavedViews`. The React Query cache now stores the unwrapped `{ default_tabs, custom_views }`, so hook `data` **and** `getQueryData`/`setQueryData` agree.
- `ObservePage.jsx` — `handleTabChange` reads `cached?.custom_views` (correct now that the cache is unwrapped).

## 🤔 Why

Shape in the `queryFn`, not `select`, because cache APIs bypass `select`. This also repairs two latent bugs that read the cache directly and already assumed the unwrapped shape: `UserDetailTabBar`'s view lookup, and the optimistic create/update/reorder helpers (`appendCustomViewToCache` etc.). Inner keys (`custom_views`, `default_tabs`, each view's `tab_type`/`config`/…) and the separate localStorage filter-restore flow are unaffected — only the outer HTTP envelope is stripped.

## 🧪 Tests

Full frontend suite green — **229 files / 1943 tests**. `saved-views.test.js` already seeds the **unwrapped** cache shape, so it now matches production. Audited all 9 consumers of both hooks (+ repo-wide sweep): every hook-`data` read and every `getQueryData`/`setQueryData` site reads the unwrapped shape — none break under this change.

## ▶️ How to reproduce / verify

1. Open a **sessions** saved view → click its chip → *before:* trace table (`/llm-tracing`); *after:* **sessions table** (`/sessions`).
2. **Refresh** → stays on the sessions table.
3. Sanity: **Trace** and **Users** saved-view chips still route to their own tables; creating/reordering a saved view reflects **immediately** (optimistic).

## 💻 Commands

```bash
cd frontend
yarn test:run
yarn dev
```

## 📹 Videos & Screenshots

https://github.com/user-attachments/assets/e2f98af2-8021-4621-b29a-c13d91feb4c4

