### PR TITLE
fix: resolve config_push contract validation errors on gateway bulk endpoint

### DIFF
--- a/futureagi/agentcc/contracts/gateway_admin.py
+++ b/futureagi/agentcc/contracts/gateway_admin.py
@@ -3,40 +3,63 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class GatewayAdminContractModel(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_input_aliases(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        result = dict(data)
+        for field_name, field in cls.model_fields.items():
+            validation_alias = field.validation_alias
+            if validation_alias is None:
+                continue
+
+            choices = getattr(validation_alias, "choices", (validation_alias,))
+            present = [choice for choice in choices if isinstance(choice, str) and choice in result]
+            if not present:
+                continue
+
+            result[field_name] = result[present[0]]
+            for alias in present:
+                if alias != field_name:
+                    result.pop(alias, None)
+        return result
+
 
 class ProviderConfig(GatewayAdminContractModel):
-    api_key: str | None = None
-    base_url: str | None = None
-    api_format: str | None = None
+    api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
+    base_url: str | None = Field(None, validation_alias=AliasChoices('base_url', 'baseUrl', 'baseURL'))
+    api_format: str | None = Field(None, validation_alias=AliasChoices('api_format', 'apiFormat'))
     models: list[str] | None = None
     timeout: int | None = None
     weight: float | None = None
     enabled: bool | None = None
-    max_concurrent: int | None = None
-    conn_pool_size: int | None = None
-    aws_access_key_id: str | None = None
-    aws_secret_access_key: str | None = None
-    aws_region: str | None = None
-    aws_session_token: str | None = None
+    max_concurrent: int | None = Field(None, validation_alias=AliasChoices('max_concurrent', 'maxConcurrent'))
+    conn_pool_size: int | None = Field(None, validation_alias=AliasChoices('conn_pool_size', 'connPoolSize'))
+    aws_access_key_id: str | None = Field(None, validation_alias=AliasChoices('aws_access_key_id', 'awsAccessKeyId', 'awsAccessKeyID'))
+    aws_secret_access_key: str | None = Field(None, validation_alias=AliasChoices('aws_secret_access_key', 'awsSecretAccessKey'))
+    aws_region: str | None = Field(None, validation_alias=AliasChoices('aws_region', 'awsRegion'))
+    aws_session_token: str | None = Field(None, validation_alias=AliasChoices('aws_session_token', 'awsSessionToken'))
 
 
 class GuardrailCheck(GatewayAdminContractModel):
     enabled: bool | None = None
     action: str | None = None
-    confidence_threshold: float | None = None
+    confidence_threshold: float | None = Field(None, validation_alias=AliasChoices('confidence_threshold', 'confidenceThreshold'))
     config: dict[str, Any] | None = None
 
 
 class GuardrailConfig(GatewayAdminContractModel):
-    pipeline_mode: str | None = None
-    fail_open: bool | None = None
-    timeout_ms: int | None = None
+    pipeline_mode: str | None = Field(None, validation_alias=AliasChoices('pipeline_mode', 'pipelineMode'))
+    fail_open: bool | None = Field(None, validation_alias=AliasChoices('fail_open', 'failOpen'))
+    timeout_ms: int | None = Field(None, validation_alias=AliasChoices('timeout_ms', 'timeoutMs'))
     checks: dict[str, GuardrailCheck] | None = None
 
 
@@ -48,53 +71,53 @@ class ConditionalRoute(GatewayAdminContractModel):
 
 
 class ComplexityTier(GatewayAdminContractModel):
-    max_score: int | None = None
+    max_score: int | None = Field(None, validation_alias=AliasChoices('max_score', 'maxScore'))
     model: str | None = None
     provider: str | None = None
 
 
 class ComplexityRoutingConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    default_tier: str | None = None
+    default_tier: str | None = Field(None, validation_alias=AliasChoices('default_tier', 'defaultTier'))
     tiers: dict[str, ComplexityTier] | None = None
     weights: dict[str, float] | None = None
 
 
 class FastestResponseConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    max_concurrent: int | None = None
-    cancel_delay: str | None = None
-    excluded_providers: list[str] | None = None
+    max_concurrent: int | None = Field(None, validation_alias=AliasChoices('max_concurrent', 'maxConcurrent'))
+    cancel_delay: str | None = Field(None, validation_alias=AliasChoices('cancel_delay', 'cancelDelay'))
+    excluded_providers: list[str] | None = Field(None, validation_alias=AliasChoices('excluded_providers', 'excludedProviders'))
 
 
 class ScheduledConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    max_pending_jobs: int | None = None
-    result_ttl: str | None = None
-    max_schedule_ahead: str | None = None
-    retry_attempts: int | None = None
-    worker_count: int | None = None
+    max_pending_jobs: int | None = Field(None, validation_alias=AliasChoices('max_pending_jobs', 'maxPendingJobs'))
+    result_ttl: str | None = Field(None, validation_alias=AliasChoices('result_ttl', 'resultTtl', 'resultTTL'))
+    max_schedule_ahead: str | None = Field(None, validation_alias=AliasChoices('max_schedule_ahead', 'maxScheduleAhead'))
+    retry_attempts: int | None = Field(None, validation_alias=AliasChoices('retry_attempts', 'retryAttempts'))
+    worker_count: int | None = Field(None, validation_alias=AliasChoices('worker_count', 'workerCount'))
 
 
 class SignalWeights(GatewayAdminContractModel):
     latency: float | None = None
-    error_rate: float | None = None
+    error_rate: float | None = Field(None, validation_alias=AliasChoices('error_rate', 'errorRate'))
     cost: float | None = None
 
 
 class AdaptiveRoutingConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    learning_requests: int | None = None
-    update_interval: str | None = None
-    smoothing_factor: float | None = None
-    min_weight: float | None = None
-    signal_weights: SignalWeights | None = None
+    learning_requests: int | None = Field(None, validation_alias=AliasChoices('learning_requests', 'learningRequests'))
+    update_interval: str | None = Field(None, validation_alias=AliasChoices('update_interval', 'updateInterval'))
+    smoothing_factor: float | None = Field(None, validation_alias=AliasChoices('smoothing_factor', 'smoothingFactor'))
+    min_weight: float | None = Field(None, validation_alias=AliasChoices('min_weight', 'minWeight'))
+    signal_weights: SignalWeights | None = Field(None, validation_alias=AliasChoices('signal_weights', 'signalWeights'))
 
 
 class ProviderLockConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    allowed_providers: list[str] | None = None
-    deny_providers: list[str] | None = None
+    allowed_providers: list[str] | None = Field(None, validation_alias=AliasChoices('allowed_providers', 'allowedProviders'))
+    deny_providers: list[str] | None = Field(None, validation_alias=AliasChoices('deny_providers', 'denyProviders'))
 
 
 class AccessGroup(GatewayAdminContractModel):
@@ -105,35 +128,35 @@ class AccessGroup(GatewayAdminContractModel):
 
 class FailoverConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    max_attempts: int | None = None
-    on_status_codes: list[int] | None = None
-    on_timeout: bool | None = None
-    per_attempt_timeout: str | None = None
+    max_attempts: int | None = Field(None, validation_alias=AliasChoices('max_attempts', 'maxAttempts'))
+    on_status_codes: list[int] | None = Field(None, validation_alias=AliasChoices('on_status_codes', 'onStatusCodes'))
+    on_timeout: bool | None = Field(None, validation_alias=AliasChoices('on_timeout', 'onTimeout'))
+    per_attempt_timeout: str | None = Field(None, validation_alias=AliasChoices('per_attempt_timeout', 'perAttemptTimeout'))
 
 
 class CircuitBreakerConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    failure_threshold: int | None = None
-    success_threshold: int | None = None
+    failure_threshold: int | None = Field(None, validation_alias=AliasChoices('failure_threshold', 'failureThreshold'))
+    success_threshold: int | None = Field(None, validation_alias=AliasChoices('success_threshold', 'successThreshold'))
     cooldown: str | None = None
-    on_status_codes: list[int] | None = None
+    on_status_codes: list[int] | None = Field(None, validation_alias=AliasChoices('on_status_codes', 'onStatusCodes'))
 
 
 class RetryConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    max_retries: int | None = None
-    initial_delay: str | None = None
-    max_delay: str | None = None
+    max_retries: int | None = Field(None, validation_alias=AliasChoices('max_retries', 'maxRetries'))
+    initial_delay: str | None = Field(None, validation_alias=AliasChoices('initial_delay', 'initialDelay'))
+    max_delay: str | None = Field(None, validation_alias=AliasChoices('max_delay', 'maxDelay'))
     multiplier: float | None = None
-    on_status_codes: list[int] | None = None
-    on_timeout: bool | None = None
+    on_status_codes: list[int] | None = Field(None, validation_alias=AliasChoices('on_status_codes', 'onStatusCodes'))
+    on_timeout: bool | None = Field(None, validation_alias=AliasChoices('on_timeout', 'onTimeout'))
 
 
 class MirrorRule(GatewayAdminContractModel):
-    source_model: str | None = None
-    target_provider: str | None = None
-    target_model: str | None = None
-    sample_rate: float | None = None
+    source_model: str | None = Field(None, validation_alias=AliasChoices('source_model', 'sourceModel'))
+    target_provider: str | None = Field(None, validation_alias=AliasChoices('target_provider', 'targetProvider'))
+    target_model: str | None = Field(None, validation_alias=AliasChoices('target_model', 'targetModel'))
+    sample_rate: float | None = Field(None, validation_alias=AliasChoices('sample_rate', 'sampleRate'))
 
 
 class MirrorConfig(GatewayAdminContractModel):
@@ -143,29 +166,29 @@ class MirrorConfig(GatewayAdminContractModel):
 
 class RoutingConfig(GatewayAdminContractModel):
     strategy: str | None = None
-    fallback_enabled: bool | None = None
-    fallback_on_status_codes: list[int] | None = None
-    model_fallbacks: dict[str, list[str]] | None = None
-    conditional_routes: list[ConditionalRoute] | None = None
-    default_model: str | None = None
+    fallback_enabled: bool | None = Field(None, validation_alias=AliasChoices('fallback_enabled', 'fallbackEnabled'))
+    fallback_on_status_codes: list[int] | None = Field(None, validation_alias=AliasChoices('fallback_on_status_codes', 'fallbackOnStatusCodes'))
+    model_fallbacks: dict[str, list[str]] | None = Field(None, validation_alias=AliasChoices('model_fallbacks', 'modelFallbacks'))
+    conditional_routes: list[ConditionalRoute] | None = Field(None, validation_alias=AliasChoices('conditional_routes', 'conditionalRoutes'))
+    default_model: str | None = Field(None, validation_alias=AliasChoices('default_model', 'defaultModel'))
     complexity: ComplexityRoutingConfig | None = None
     fastest: FastestResponseConfig | None = None
     scheduled: ScheduledConfig | None = None
     adaptive: AdaptiveRoutingConfig | None = None
-    provider_lock: ProviderLockConfig | None = None
-    access_groups: dict[str, AccessGroup] | None = None
+    provider_lock: ProviderLockConfig | None = Field(None, validation_alias=AliasChoices('provider_lock', 'providerLock'))
+    access_groups: dict[str, AccessGroup] | None = Field(None, validation_alias=AliasChoices('access_groups', 'accessGroups'))
     failover: FailoverConfig | None = None
-    circuit_breaker: CircuitBreakerConfig | None = None
+    circuit_breaker: CircuitBreakerConfig | None = Field(None, validation_alias=AliasChoices('circuit_breaker', 'circuitBreaker'))
     retry: RetryConfig | None = None
     mirror: MirrorConfig | None = None
-    model_timeouts: dict[str, str] | None = None
+    model_timeouts: dict[str, str] | None = Field(None, validation_alias=AliasChoices('model_timeouts', 'modelTimeouts'))
 
 
 class DiskCacheConfig(GatewayAdminContractModel):
     directory: str | None = None
-    max_size_bytes: int | None = None
+    max_size_bytes: int | None = Field(None, validation_alias=AliasChoices('max_size_bytes', 'maxSizeBytes'))
     compress: bool | None = None
-    cleanup_interval: str | None = None
+    cleanup_interval: str | None = Field(None, validation_alias=AliasChoices('cleanup_interval', 'cleanupInterval'))
 
 
 class RedisCacheConfig(GatewayAdminContractModel):
@@ -174,9 +197,9 @@ class RedisCacheConfig(GatewayAdminContractModel):
     password: str | None = None
     db: int | None = None
     mode: str | None = None
-    pool_size: int | None = None
+    pool_size: int | None = Field(None, validation_alias=AliasChoices('pool_size', 'poolSize'))
     tls: bool | None = None
-    key_prefix: str | None = None
+    key_prefix: str | None = Field(None, validation_alias=AliasChoices('key_prefix', 'keyPrefix'))
     compress: bool | None = None
 
 
@@ -184,16 +207,16 @@ class S3CacheConfig(GatewayAdminContractModel):
     bucket: str | None = None
     prefix: str | None = None
     region: str | None = None
-    access_key_id: str | None = None
-    secret_access_key: str | None = None
+    access_key_id: str | None = Field(None, validation_alias=AliasChoices('access_key_id', 'accessKeyId', 'accessKeyID'))
+    secret_access_key: str | None = Field(None, validation_alias=AliasChoices('secret_access_key', 'secretAccessKey'))
     compress: bool | None = None
 
 
 class AzureBlobCacheConfig(GatewayAdminContractModel):
     container: str | None = None
     prefix: str | None = None
-    connection_string: str | None = None
-    sas_token: str | None = None
+    connection_string: str | None = Field(None, validation_alias=AliasChoices('connection_string', 'connectionString'))
+    sas_token: str | None = Field(None, validation_alias=AliasChoices('sas_token', 'sasToken'))
     compress: bool | None = None
 
 
@@ -201,25 +224,25 @@ class GCSCacheConfig(GatewayAdminContractModel):
     bucket: str | None = None
     prefix: str | None = None
     project: str | None = None
-    credentials_file: str | None = None
+    credentials_file: str | None = Field(None, validation_alias=AliasChoices('credentials_file', 'credentialsFile'))
     compress: bool | None = None
 
 
 class QdrantConfig(GatewayAdminContractModel):
     url: str | None = None
     collection: str | None = None
-    api_key: str | None = None
+    api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
 
 
 class WeaviateConfig(GatewayAdminContractModel):
     url: str | None = None
-    class_: str | None = Field(None, alias="class")
-    api_key: str | None = None
+    class_: str | None = Field(None, alias="class", validation_alias=AliasChoices('class'))
+    api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
 
 
 class PineconeConfig(GatewayAdminContractModel):
     url: str | None = None
-    api_key: str | None = None
+    api_key: str | None = Field(None, validation_alias=AliasChoices('api_key', 'apiKey'))
 
 
 class SemanticCacheConfig(GatewayAdminContractModel):
@@ -227,7 +250,7 @@ class SemanticCacheConfig(GatewayAdminContractModel):
     backend: str | None = None
     threshold: float | None = None
     dimensions: int | None = None
-    max_entries: int | None = None
+    max_entries: int | None = Field(None, validation_alias=AliasChoices('max_entries', 'maxEntries'))
     qdrant: QdrantConfig | None = None
     weaviate: WeaviateConfig | None = None
     pinecone: PineconeConfig | None = None
@@ -235,21 +258,21 @@ class SemanticCacheConfig(GatewayAdminContractModel):
 
 class EdgeCacheConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    default_ttl: int | None = None
-    max_size: int | None = None
-    cacheable_models: list[str] | None = None
-    require_opt_in: bool | None = None
+    default_ttl: int | None = Field(None, validation_alias=AliasChoices('default_ttl', 'defaultTtl', 'defaultTTL'))
+    max_size: int | None = Field(None, validation_alias=AliasChoices('max_size', 'maxSize'))
+    cacheable_models: list[str] | None = Field(None, validation_alias=AliasChoices('cacheable_models', 'cacheableModels'))
+    require_opt_in: bool | None = Field(None, validation_alias=AliasChoices('require_opt_in', 'requireOptIn'))
 
 
 class CacheConfig(GatewayAdminContractModel):
     enabled: bool | None = None
     backend: str | None = None
-    default_ttl: int | None = None
-    max_entries: int | None = None
+    default_ttl: int | None = Field(None, validation_alias=AliasChoices('default_ttl', 'defaultTtl', 'defaultTTL'))
+    max_entries: int | None = Field(None, validation_alias=AliasChoices('max_entries', 'maxEntries'))
     disk: DiskCacheConfig | None = None
     redis: RedisCacheConfig | None = None
     s3: S3CacheConfig | None = None
-    azure_blob: AzureBlobCacheConfig | None = None
+    azure_blob: AzureBlobCacheConfig | None = Field(None, validation_alias=AliasChoices('azure_blob', 'azureBlob'))
     gcs: GCSCacheConfig | None = None
     semantic: SemanticCacheConfig | None = None
     edge: EdgeCacheConfig | None = None
@@ -257,12 +280,12 @@ class CacheConfig(GatewayAdminContractModel):
 
 class RateLimitConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    global_rpm: int | None = None
-    global_tpm: int | None = None
-    per_key_rpm: int | None = None
-    per_key_tpm: int | None = None
-    per_model_rpm: int | None = None
-    per_user_rpm: int | None = None
+    global_rpm: int | None = Field(None, validation_alias=AliasChoices('global_rpm', 'globalRpm', 'globalRPM'))
+    global_tpm: int | None = Field(None, validation_alias=AliasChoices('global_tpm', 'globalTpm', 'globalTPM'))
+    per_key_rpm: int | None = Field(None, validation_alias=AliasChoices('per_key_rpm', 'perKeyRpm', 'perKeyRPM'))
+    per_key_tpm: int | None = Field(None, validation_alias=AliasChoices('per_key_tpm', 'perKeyTpm', 'perKeyTPM'))
+    per_model_rpm: int | None = Field(None, validation_alias=AliasChoices('per_model_rpm', 'perModelRpm', 'perModelRPM'))
+    per_user_rpm: int | None = Field(None, validation_alias=AliasChoices('per_user_rpm', 'perUserRpm', 'perUserRPM'))
 
 
 class BudgetLevelConfig(GatewayAdminContractModel):
@@ -270,21 +293,21 @@ class BudgetLevelConfig(GatewayAdminContractModel):
     period: str | None = None
     hard: bool | None = None
     action: str | None = None
-    action_mode: str | None = None
-    on_exceed: str | None = None
-    per_model: dict[str, float] | None = None
+    action_mode: str | None = Field(None, validation_alias=AliasChoices('action_mode', 'actionMode'))
+    on_exceed: str | None = Field(None, validation_alias=AliasChoices('on_exceed', 'onExceed'))
+    per_model: dict[str, float] | None = Field(None, validation_alias=AliasChoices('per_model', 'perModel'))
 
 
 class BudgetsConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    default_period: str | None = None
-    warn_threshold: float | None = None
-    org_limit: float | None = None
-    org_period: str | None = None
-    hard_limit: bool | None = None
+    default_period: str | None = Field(None, validation_alias=AliasChoices('default_period', 'defaultPeriod'))
+    warn_threshold: float | None = Field(None, validation_alias=AliasChoices('warn_threshold', 'warnThreshold'))
+    org_limit: float | None = Field(None, validation_alias=AliasChoices('org_limit', 'orgLimit'))
+    org_period: str | None = Field(None, validation_alias=AliasChoices('org_period', 'orgPeriod'))
+    hard_limit: bool | None = Field(None, validation_alias=AliasChoices('hard_limit', 'hardLimit'))
     action: str | None = None
-    action_mode: str | None = None
-    on_exceed: str | None = None
+    action_mode: str | None = Field(None, validation_alias=AliasChoices('action_mode', 'actionMode'))
+    on_exceed: str | None = Field(None, validation_alias=AliasChoices('on_exceed', 'onExceed'))
     organization: BudgetLevelConfig | None = None
     org: BudgetLevelConfig | None = None
     teams: dict[str, BudgetLevelConfig] | None = None
@@ -294,13 +317,13 @@ class BudgetsConfig(GatewayAdminContractModel):
 
 
 class CustomPricing(GatewayAdminContractModel):
-    input_per_mtok: float | None = None
-    output_per_mtok: float | None = None
+    input_per_mtok: float | None = Field(None, validation_alias=AliasChoices('input_per_mtok', 'inputPerMtok', 'inputPerMTok'))
+    output_per_mtok: float | None = Field(None, validation_alias=AliasChoices('output_per_mtok', 'outputPerMtok', 'outputPerMTok'))
 
 
 class CostTrackingConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    custom_pricing: dict[str, CustomPricing] | None = None
+    custom_pricing: dict[str, CustomPricing] | None = Field(None, validation_alias=AliasChoices('custom_pricing', 'customPricing'))
 
 
 class IPACLConfig(GatewayAdminContractModel):
@@ -340,13 +363,13 @@ class RedactPatternConfig(GatewayAdminContractModel):
 class PrivacyConfig(GatewayAdminContractModel):
     enabled: bool | None = None
     mode: str | None = None
-    redact_patterns: list[RedactPatternConfig] | None = None
+    redact_patterns: list[RedactPatternConfig] | None = Field(None, validation_alias=AliasChoices('redact_patterns', 'redactPatterns'))
 
 
 class ToolPolicyConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    max_tools_per_request: int | None = None
-    default_action: str | None = None
+    max_tools_per_request: int | None = Field(None, validation_alias=AliasChoices('max_tools_per_request', 'maxToolsPerRequest'))
+    default_action: str | None = Field(None, validation_alias=AliasChoices('default_action', 'defaultAction'))
     allow: list[str] | None = None
     deny: list[str] | None = None
 
@@ -362,16 +385,16 @@ class MCPServerOrgConfig(GatewayAdminContractModel):
     url: str | None = None
     transport: str | None = None
     auth: MCPAuthOrgConfig | None = None
-    tools_cache_ttl: str | None = None
+    tools_cache_ttl: str | None = Field(None, validation_alias=AliasChoices('tools_cache_ttl', 'toolsCacheTtl', 'toolsCacheTTL'))
 
 
 class MCPGuardrailOrgConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    blocked_tools: list[str] | None = None
-    allowed_servers: list[str] | None = None
-    validate_inputs: bool | None = None
-    validate_outputs: bool | None = None
-    tool_rate_limits: dict[str, int] | None = None
+    blocked_tools: list[str] | None = Field(None, validation_alias=AliasChoices('blocked_tools', 'blockedTools'))
+    allowed_servers: list[str] | None = Field(None, validation_alias=AliasChoices('allowed_servers', 'allowedServers'))
+    validate_inputs: bool | None = Field(None, validation_alias=AliasChoices('validate_inputs', 'validateInputs'))
+    validate_outputs: bool | None = Field(None, validation_alias=AliasChoices('validate_outputs', 'validateOutputs'))
+    tool_rate_limits: dict[str, int] | None = Field(None, validation_alias=AliasChoices('tool_rate_limits', 'toolRateLimits'))
 
 
 class MCPOrgConfig(GatewayAdminContractModel):
@@ -389,7 +412,7 @@ class AuditSinkConfig(GatewayAdminContractModel):
 
 class AuditOrgConfig(GatewayAdminContractModel):
     enabled: bool | None = None
-    min_severity: str | None = None
+    min_severity: str | None = Field(None, validation_alias=AliasChoices('min_severity', 'minSeverity'))
     categories: list[str] | None = None
     sinks: list[AuditSinkConfig] | None = None
 
@@ -426,30 +449,30 @@ class A2AOrgConfig(GatewayAdminContractModel):
 
 
 class PricingOverrideOrg(GatewayAdminContractModel):
-    input_per_token: float | None = None
-    output_per_token: float | None = None
-    cached_input_per_token: float | None = None
-    batch_input_per_token: float | None = None
-    batch_output_per_token: float | None = None
+    input_per_token: float | None = Field(None, validation_alias=AliasChoices('input_per_token', 'inputPerToken'))
+    output_per_token: float | None = Field(None, validation_alias=AliasChoices('output_per_token', 'outputPerToken'))
+    cached_input_per_token: float | None = Field(None, validation_alias=AliasChoices('cached_input_per_token', 'cachedInputPerToken'))
+    batch_input_per_token: float | None = Field(None, validation_alias=AliasChoices('batch_input_per_token', 'batchInputPerToken'))
+    batch_output_per_token: float | None = Field(None, validation_alias=AliasChoices('batch_output_per_token', 'batchOutputPerToken'))
 
 
 class CapabilityOverrideOrg(GatewayAdminContractModel):
-    function_calling: bool | None = None
-    parallel_tool_calls: bool | None = None
+    function_calling: bool | None = Field(None, validation_alias=AliasChoices('function_calling', 'functionCalling'))
+    parallel_tool_calls: bool | None = Field(None, validation_alias=AliasChoices('parallel_tool_calls', 'parallelToolCalls'))
     vision: bool | None = None
-    audio_input: bool | None = None
-    audio_output: bool | None = None
-    pdf_input: bool | None = None
+    audio_input: bool | None = Field(None, validation_alias=AliasChoices('audio_input', 'audioInput'))
+    audio_output: bool | None = Field(None, validation_alias=AliasChoices('audio_output', 'audioOutput'))
+    pdf_input: bool | None = Field(None, validation_alias=AliasChoices('pdf_input', 'pdfInput'))
     streaming: bool | None = None
-    response_schema: bool | None = None
-    system_messages: bool | None = None
-    prompt_caching: bool | None = None
+    response_schema: bool | None = Field(None, validation_alias=AliasChoices('response_schema', 'responseSchema'))
+    system_messages: bool | None = Field(None, validation_alias=AliasChoices('system_messages', 'systemMessages'))
+    prompt_caching: bool | None = Field(None, validation_alias=AliasChoices('prompt_caching', 'promptCaching'))
     reasoning: bool | None = None
 
 
 class ModelOverrideOrgConfig(GatewayAdminContractModel):
-    max_input_tokens: int | None = None
-    max_output_tokens: int | None = None
+    max_input_tokens: int | None = Field(None, validation_alias=AliasChoices('max_input_tokens', 'maxInputTokens'))
+    max_output_tokens: int | None = Field(None, validation_alias=AliasChoices('max_output_tokens', 'maxOutputTokens'))
     pricing: PricingOverrideOrg | None = None
     capabilities: CapabilityOverrideOrg | None = None
 
@@ -463,18 +486,18 @@ class OrgConfig(GatewayAdminContractModel):
     guardrails: GuardrailConfig | None = None
     routing: RoutingConfig | None = None
     cache: CacheConfig | None = None
-    rate_limiting: RateLimitConfig | None = None
+    rate_limiting: RateLimitConfig | None = Field(None, validation_alias=AliasChoices('rate_limiting', 'rateLimiting'))
     budgets: BudgetsConfig | None = None
-    cost_tracking: CostTrackingConfig | None = None
-    ip_acl: IPACLConfig | None = None
+    cost_tracking: CostTrackingConfig | None = Field(None, validation_alias=AliasChoices('cost_tracking', 'costTracking'))
+    ip_acl: IPACLConfig | None = Field(None, validation_alias=AliasChoices('ip_acl', 'ipAcl', 'ipACL'))
     alerting: AlertingConfig | None = None
     privacy: PrivacyConfig | None = None
-    tool_policy: ToolPolicyConfig | None = None
+    tool_policy: ToolPolicyConfig | None = Field(None, validation_alias=AliasChoices('tool_policy', 'toolPolicy'))
     mcp: MCPOrgConfig | None = None
     audit: AuditOrgConfig | None = None
     a2a: A2AOrgConfig | None = None
-    model_database: ModelDatabaseOrgConfig | None = None
-    model_map: dict[str, str] | None = None
+    model_database: ModelDatabaseOrgConfig | None = Field(None, validation_alias=AliasChoices('model_database', 'modelDatabase'))
+    model_map: dict[str, str] | None = Field(None, validation_alias=AliasChoices('model_map', 'modelMap'))
 
 
 class CreateKeyRequest(GatewayAdminContractModel):
@@ -496,20 +519,20 @@ class UpdateKeyRequest(GatewayAdminContractModel):
 class KeyResponse(GatewayAdminContractModel):
     id: str | None = None
     key: str | None = None
-    key_prefix: str | None = None
+    key_prefix: str | None = Field(None, validation_alias=AliasChoices('key_prefix', 'keyPrefix'))
     name: str | None = None
     owner: str | None = None
     status: str | None = None
-    key_type: str | None = None
+    key_type: str | None = Field(None, validation_alias=AliasChoices('key_type', 'keyType'))
     models: list[str] | None = None
     providers: list[str] | None = None
-    allowed_models: list[str] | None = None
-    allowed_providers: list[str] | None = None
+    allowed_models: list[str] | None = Field(None, validation_alias=AliasChoices('allowed_models', 'allowedModels'))
+    allowed_providers: list[str] | None = Field(None, validation_alias=AliasChoices('allowed_providers', 'allowedProviders'))
     metadata: dict[str, str] | None = None
-    created_at: str | None = None
-    updated_at: str | None = None
-    last_used_at: str | None = None
-    credit_balance: float | None = None
+    created_at: str | None = Field(None, validation_alias=AliasChoices('created_at', 'createdAt'))
+    updated_at: str | None = Field(None, validation_alias=AliasChoices('updated_at', 'updatedAt'))
+    last_used_at: str | None = Field(None, validation_alias=AliasChoices('last_used_at', 'lastUsedAt'))
+    credit_balance: float | None = Field(None, validation_alias=AliasChoices('credit_balance', 'creditBalance'))
 
 
 class KeyListResponse(GatewayAdminContractModel):
@@ -519,7 +542,7 @@ class KeyListResponse(GatewayAdminContractModel):
 
 class StatusResponse(GatewayAdminContractModel):
     status: str | None = None
-    org_id: str | None = None
+    org_id: str | None = Field(None, validation_alias=AliasChoices('org_id', 'orgId', 'orgID'))
     deleted: bool | None = None
     loaded: int | None = None
 

--- a/futureagi/agentcc/org_config_defaults.py
+++ b/futureagi/agentcc/org_config_defaults.py
@@ -45,7 +45,15 @@ def normalize_cache_config(value):
     if not isinstance(value, dict):
         value = {}
     normalized = value.copy()
+    for alias in ("defaultTtl", "defaultTTL"):
+        if "default_ttl" not in normalized and alias in normalized:
+            normalized["default_ttl"] = normalized[alias]
+    if "max_entries" not in normalized and "maxEntries" in normalized:
+        normalized["max_entries"] = normalized["maxEntries"]
     for key, default in DEFAULT_CACHE.items():
         normalized.setdefault(key, default)
     normalized["default_ttl"] = _coerce_ttl_seconds(normalized.get("default_ttl"))
+    normalized.pop("defaultTtl", None)
+    normalized.pop("defaultTTL", None)
+    normalized.pop("maxEntries", None)
     return normalized

--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -4,11 +4,17 @@ Called when org configs are created, activated, or deleted.
 """
 
 import copy
+from types import UnionType
+from typing import Union, get_args, get_origin
 
 import structlog
 from django.conf import settings as django_settings
+from pydantic import BaseModel
 
-from agentcc.contracts.gateway_admin import OrgConfig as GatewayOrgConfig
+from agentcc.contracts.gateway_admin import (
+    OrgConfig as GatewayOrgConfig,
+    ProviderConfig as GatewayProviderConfig,
+)
 from agentcc.models import AgentccOrgConfig
 from agentcc.org_config_defaults import normalize_cache_config
 from agentcc.services.gateway_client import GatewayClientError, get_gateway_client
@@ -53,6 +59,8 @@ _RULE_PROVIDER_DEFAULTS = {
     "mcp-security": "mcp_security",
 }
 
+_PROVIDER_FIELDS = frozenset(GatewayProviderConfig.model_fields)
+
 
 def _normalize_eval_ids(cfg):
     """
@@ -86,8 +94,8 @@ def _inject_guardrail_credentials(checks):
     "__encrypted__" sentinel values with actual secrets from the policy's
     encrypted_check_configs blob.
     """
-    from integrations.services.credentials import CredentialManager
     from agentcc.models.guardrail_policy import AgentccGuardrailPolicy
+    from integrations.services.credentials import CredentialManager
 
     ENCRYPTED_SENTINEL = "__encrypted__"
 
@@ -330,8 +338,8 @@ def _inject_fi_credentials(checks, org_id):
 
 def _assemble_providers(org_id):
     """Build providers dict from AgentccProviderCredential rows for an org."""
-    from integrations.services.credentials import CredentialManager
     from agentcc.models.provider_credential import AgentccProviderCredential
+    from integrations.services.credentials import CredentialManager
 
     credentials = AgentccProviderCredential.no_workspace_objects.filter(
         organization_id=org_id,
@@ -349,19 +357,90 @@ def _assemble_providers(org_id):
                 provider=cred.provider_name,
             )
             continue
-        providers[cred.provider_name] = {
+        raw = {
             **cred.extra_config,
+            **decrypted,
             "api_key": decrypted.get("api_key", ""),
-            **{k: v for k, v in decrypted.items() if k != "api_key"},
             "base_url": cred.base_url,
             "api_format": cred.api_format,
             "models": cred.models_list,
             "enabled": True,
-            "default_timeout": f"{cred.default_timeout_seconds}s",
+            "timeout": cred.default_timeout_seconds,
             "max_concurrent": cred.max_concurrent,
             "conn_pool_size": cred.conn_pool_size,
         }
+        providers[cred.provider_name] = {
+            k: v for k, v in raw.items() if k in _PROVIDER_FIELDS
+        }
     return providers
+
+
+def _snake_to_camel(value):
+    head, *tail = value.split("_")
+    return head + "".join(part[:1].upper() + part[1:] for part in tail)
+
+
+def _unwrap_optional(annotation):
+    origin = get_origin(annotation)
+    if origin not in (Union, UnionType):
+        return annotation
+
+    args = [arg for arg in get_args(annotation) if arg is not type(None)]
+    return args[0] if len(args) == 1 else annotation
+
+
+def _contract_model_type(annotation):
+    annotation = _unwrap_optional(annotation)
+    return (
+        annotation
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel)
+        else None
+    )
+
+
+def _normalize_contract_value(value, annotation):
+    annotation = _unwrap_optional(annotation)
+    model_type = _contract_model_type(annotation)
+    if model_type is not None:
+        return _normalize_contract_aliases(value, model_type)
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is list and args and isinstance(value, list):
+        return [_normalize_contract_value(item, args[0]) for item in value]
+    if origin is dict and len(args) == 2 and isinstance(value, dict):
+        return {
+            key: _normalize_contract_value(item, args[1]) for key, item in value.items()
+        }
+    return value
+
+
+def _normalize_contract_aliases(data, contract_model):
+    if not isinstance(data, dict):
+        return data
+
+    result = {**data}
+    for field_name, field in contract_model.model_fields.items():
+        aliases = []
+        if field.alias and field.alias != field_name:
+            aliases.append(field.alias)
+        camel_alias = _snake_to_camel(field_name)
+        if camel_alias != field_name and camel_alias not in aliases:
+            aliases.append(camel_alias)
+
+        source_key = field_name if field_name in data else None
+        if source_key is None:
+            source_key = next((alias for alias in aliases if alias in data), None)
+
+        if source_key is not None:
+            result[field_name] = _normalize_contract_value(
+                data[source_key], field.annotation
+            )
+
+        for alias in aliases:
+            result.pop(alias, None)
+
+    return result
 
 
 def _normalize_alerting(alerting):
@@ -498,6 +577,7 @@ def _build_payload(org_id, config):
         "model_database": config.model_database,
         "model_map": config.model_map,
     }
+    payload = _normalize_contract_aliases(payload, GatewayOrgConfig)
     return GatewayOrgConfig.model_validate(payload).model_dump(
         by_alias=True,
         exclude_none=True,

--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -4,15 +4,14 @@ Called when org configs are created, activated, or deleted.
 """
 
 import copy
-from types import UnionType
-from typing import Union, get_args, get_origin
 
 import structlog
 from django.conf import settings as django_settings
-from pydantic import BaseModel
 
 from agentcc.contracts.gateway_admin import (
     OrgConfig as GatewayOrgConfig,
+)
+from agentcc.contracts.gateway_admin import (
     ProviderConfig as GatewayProviderConfig,
 )
 from agentcc.models import AgentccOrgConfig
@@ -59,7 +58,37 @@ _RULE_PROVIDER_DEFAULTS = {
     "mcp-security": "mcp_security",
 }
 
-_PROVIDER_FIELDS = frozenset(GatewayProviderConfig.model_fields)
+_PROVIDER_CREDENTIAL_ALIASES = {
+    "access_key": "aws_access_key_id",
+    "secret_key": "aws_secret_access_key",
+    "region": "aws_region",
+}
+
+
+def _contract_input_names(contract_model):
+    names = set(contract_model.model_fields)
+    for field in contract_model.model_fields.values():
+        if field.alias:
+            names.add(field.alias)
+        validation_alias = field.validation_alias
+        if validation_alias is None:
+            continue
+        choices = getattr(validation_alias, "choices", (validation_alias,))
+        names.update(choice for choice in choices if isinstance(choice, str))
+    return frozenset(names)
+
+
+_PROVIDER_INPUT_FIELDS = _contract_input_names(GatewayProviderConfig)
+
+
+class UnsupportedProviderCredentialFields(ValueError):
+    def __init__(self, provider_name, fields):
+        self.provider_name = provider_name
+        self.fields = tuple(sorted(fields))
+        super().__init__(
+            "Unsupported gateway credential fields for provider "
+            f"{provider_name}: {', '.join(self.fields)}"
+        )
 
 
 def _normalize_eval_ids(cfg):
@@ -336,6 +365,44 @@ def _inject_fi_credentials(checks, org_id):
         )
 
 
+def _normalize_provider_credentials(provider_name, decrypted):
+    normalized = {}
+    unsupported = []
+    for key, value in decrypted.items():
+        if value in (None, ""):
+            continue
+        canonical_key = _PROVIDER_CREDENTIAL_ALIASES.get(key, key)
+        if canonical_key in GatewayProviderConfig.model_fields:
+            normalized[canonical_key] = value
+        else:
+            unsupported.append(key)
+
+    if unsupported:
+        raise UnsupportedProviderCredentialFields(provider_name, unsupported)
+    return normalized
+
+
+def _normalize_provider_extra_config(provider_name, extra_config):
+    if not isinstance(extra_config, dict):
+        return {}
+
+    normalized = {}
+    ignored = []
+    for key, value in extra_config.items():
+        if key in _PROVIDER_INPUT_FIELDS:
+            normalized[key] = value
+        elif value not in (None, "", [], {}):
+            ignored.append(key)
+
+    if ignored:
+        logger.warning(
+            "provider_extra_config_ignored",
+            provider=provider_name,
+            keys=sorted(ignored),
+        )
+    return normalized
+
+
 def _assemble_providers(org_id):
     """Build providers dict from AgentccProviderCredential rows for an org."""
     from agentcc.models.provider_credential import AgentccProviderCredential
@@ -357,90 +424,33 @@ def _assemble_providers(org_id):
                 provider=cred.provider_name,
             )
             continue
-        raw = {
-            **cred.extra_config,
-            **decrypted,
-            "api_key": decrypted.get("api_key", ""),
-            "base_url": cred.base_url,
-            "api_format": cred.api_format,
-            "models": cred.models_list,
-            "enabled": True,
-            "timeout": cred.default_timeout_seconds,
-            "max_concurrent": cred.max_concurrent,
-            "conn_pool_size": cred.conn_pool_size,
-        }
-        providers[cred.provider_name] = {
-            k: v for k, v in raw.items() if k in _PROVIDER_FIELDS
-        }
-    return providers
 
-
-def _snake_to_camel(value):
-    head, *tail = value.split("_")
-    return head + "".join(part[:1].upper() + part[1:] for part in tail)
-
-
-def _unwrap_optional(annotation):
-    origin = get_origin(annotation)
-    if origin not in (Union, UnionType):
-        return annotation
-
-    args = [arg for arg in get_args(annotation) if arg is not type(None)]
-    return args[0] if len(args) == 1 else annotation
-
-
-def _contract_model_type(annotation):
-    annotation = _unwrap_optional(annotation)
-    return (
-        annotation
-        if isinstance(annotation, type) and issubclass(annotation, BaseModel)
-        else None
-    )
-
-
-def _normalize_contract_value(value, annotation):
-    annotation = _unwrap_optional(annotation)
-    model_type = _contract_model_type(annotation)
-    if model_type is not None:
-        return _normalize_contract_aliases(value, model_type)
-
-    origin = get_origin(annotation)
-    args = get_args(annotation)
-    if origin is list and args and isinstance(value, list):
-        return [_normalize_contract_value(item, args[0]) for item in value]
-    if origin is dict and len(args) == 2 and isinstance(value, dict):
-        return {
-            key: _normalize_contract_value(item, args[1]) for key, item in value.items()
-        }
-    return value
-
-
-def _normalize_contract_aliases(data, contract_model):
-    if not isinstance(data, dict):
-        return data
-
-    result = {**data}
-    for field_name, field in contract_model.model_fields.items():
-        aliases = []
-        if field.alias and field.alias != field_name:
-            aliases.append(field.alias)
-        camel_alias = _snake_to_camel(field_name)
-        if camel_alias != field_name and camel_alias not in aliases:
-            aliases.append(camel_alias)
-
-        source_key = field_name if field_name in data else None
-        if source_key is None:
-            source_key = next((alias for alias in aliases if alias in data), None)
-
-        if source_key is not None:
-            result[field_name] = _normalize_contract_value(
-                data[source_key], field.annotation
+        try:
+            raw = {
+                **_normalize_provider_extra_config(
+                    cred.provider_name, cred.extra_config
+                ),
+                **_normalize_provider_credentials(cred.provider_name, decrypted),
+                "base_url": cred.base_url,
+                "api_format": cred.api_format,
+                "models": cred.models_list,
+                "enabled": True,
+                "timeout": cred.default_timeout_seconds,
+                "max_concurrent": cred.max_concurrent,
+                "conn_pool_size": cred.conn_pool_size,
+            }
+            providers[cred.provider_name] = GatewayProviderConfig.model_validate(
+                raw
+            ).model_dump(by_alias=True, exclude_none=True)
+        except UnsupportedProviderCredentialFields as e:
+            logger.warning(
+                "provider_credential_unsupported_fields",
+                org_id=str(org_id),
+                provider=cred.provider_name,
+                fields=list(e.fields),
             )
-
-        for alias in aliases:
-            result.pop(alias, None)
-
-    return result
+            continue
+    return providers
 
 
 def _normalize_alerting(alerting):
@@ -462,7 +472,13 @@ def _extract_budget_action(entry):
     if not isinstance(entry, dict):
         return None
 
-    action = entry.get("action") or entry.get("action_mode") or entry.get("on_exceed")
+    action = (
+        entry.get("action")
+        or entry.get("action_mode")
+        or entry.get("actionMode")
+        or entry.get("on_exceed")
+        or entry.get("onExceed")
+    )
     if isinstance(action, str) and action:
         return action.lower()
     return None
@@ -577,7 +593,6 @@ def _build_payload(org_id, config):
         "model_database": config.model_database,
         "model_map": config.model_map,
     }
-    payload = _normalize_contract_aliases(payload, GatewayOrgConfig)
     return GatewayOrgConfig.model_validate(payload).model_dump(
         by_alias=True,
         exclude_none=True,
@@ -639,12 +654,15 @@ def push_all_org_configs():
     failed = 0
     for cfg in configs:
         org_id = str(cfg.organization_id)
-        payload = _build_payload(org_id, cfg)
         try:
+            payload = _build_payload(org_id, cfg)
             client.set_org_config(org_id, payload)
             success += 1
         except GatewayClientError as e:
             logger.warning("config_push_failed", org_id=org_id, error=str(e))
+            failed += 1
+        except Exception as e:
+            logger.warning("config_push_error", org_id=org_id, error=str(e))
             failed += 1
 
     logger.info("config_push_all_complete", success=success, failed=failed)

--- a/futureagi/agentcc/tests/test_gateway_admin_contracts.py
+++ b/futureagi/agentcc/tests/test_gateway_admin_contracts.py
@@ -1,15 +1,21 @@
 import json
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from agentcc.contracts.gateway_admin import (
     CreateKeyRequest,
-    OrgConfig as GatewayOrgConfig,
     UpdateKeyRequest,
 )
+from agentcc.contracts.gateway_admin import (
+    OrgConfig as GatewayOrgConfig,
+)
 from agentcc.models.org_config import AgentccOrgConfig
-from agentcc.services.config_push import _build_payload
-
+from agentcc.services.config_push import (
+    _assemble_providers,
+    _build_payload,
+    push_all_org_configs,
+)
 
 ORG_CONFIG_FIXTURE = (
     Path(__file__).resolve().parent / "fixtures/gateway_org_config.full.json"
@@ -27,6 +33,83 @@ def test_shared_org_config_fixture_validates_against_generated_python_contract()
     assert dumped["budgets"]["teams"]["engineering"]["action"] == "warn"
 
 
+def test_gateway_org_config_accepts_camel_case_input_and_dumps_snake_case():
+    contract = GatewayOrgConfig.model_validate(
+        {
+            "providers": {
+                "bedrock": {
+                    "apiFormat": "bedrock",
+                    "baseURL": "https://bedrock-runtime.us-east-1.amazonaws.com",
+                    "timeout": 60,
+                    "awsAccessKeyID": "ak",
+                    "awsSecretAccessKey": "sk",
+                    "awsRegion": "us-east-1",
+                }
+            },
+            "routing": {
+                "modelFallbacks": {"gpt-4o": ["claude-haiku-4-5"]},
+                "circuitBreaker": {"enabled": False},
+                "failover": {"enabled": True, "onStatusCodes": [429, 500]},
+                "retry": {"enabled": False, "onStatusCodes": [429]},
+            },
+            "cache": {"enabled": True, "defaultTTL": 60, "maxEntries": 25},
+        }
+    )
+
+    dumped = contract.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["providers"]["bedrock"]["api_format"] == "bedrock"
+    assert dumped["providers"]["bedrock"]["base_url"].startswith("https://bedrock")
+    assert dumped["providers"]["bedrock"]["aws_access_key_id"] == "ak"
+    assert dumped["routing"]["model_fallbacks"] == {"gpt-4o": ["claude-haiku-4-5"]}
+    assert dumped["routing"]["circuit_breaker"] == {"enabled": False}
+    assert dumped["routing"]["failover"]["on_status_codes"] == [429, 500]
+    assert dumped["routing"]["retry"]["on_status_codes"] == [429]
+    assert dumped["cache"]["default_ttl"] == 60
+    assert dumped["cache"]["max_entries"] == 25
+
+
+def test_gateway_org_config_accepts_duplicate_saved_aliases():
+    contract = GatewayOrgConfig.model_validate(
+        {
+            "routing": {
+                "model_fallbacks": {"gpt-5.2": ["claude-haiku-4-5"]},
+                "modelFallbacks": {"gpt-4o": ["claude-haiku-4-5"]},
+                "circuit_breaker": {"enabled": False},
+                "circuitBreaker": {"enabled": True},
+                "failover": {
+                    "enabled": True,
+                    "on_status_codes": [429, 500, 502, 503, 504, 401],
+                    "onStatusCodes": [401],
+                },
+                "retry": {
+                    "enabled": False,
+                    "on_status_codes": [429, 500, 502, 503, 401],
+                    "onStatusCodes": [500],
+                },
+            },
+        }
+    )
+
+    dumped = contract.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["routing"]["model_fallbacks"] == {"gpt-5.2": ["claude-haiku-4-5"]}
+    assert dumped["routing"]["circuit_breaker"] == {"enabled": False}
+    assert dumped["routing"]["failover"]["on_status_codes"] == [
+        429,
+        500,
+        502,
+        503,
+        504,
+        401,
+    ]
+    assert dumped["routing"]["retry"]["on_status_codes"] == [429, 500, 502, 503, 401]
+    assert "modelFallbacks" not in dumped["routing"]
+    assert "circuitBreaker" not in dumped["routing"]
+    assert "onStatusCodes" not in dumped["routing"]["failover"]
+    assert "onStatusCodes" not in dumped["routing"]["retry"]
+
+
 @patch("agentcc.services.config_push._assemble_providers")
 def test_build_payload_emits_gateway_org_config_contract(mock_assemble_providers):
     mock_assemble_providers.return_value = {
@@ -34,31 +117,145 @@ def test_build_payload_emits_gateway_org_config_contract(mock_assemble_providers
             "api_key": "sk-test-openai",
             "api_format": "openai",
             "models": ["gpt-4o-mini"],
+            "timeout": 17,
             "enabled": True,
         }
     }
     config = AgentccOrgConfig(
         routing={
             "strategy": "weighted",
-            "fallback_enabled": True,
-            "fallback_on_status_codes": [429, 500],
+            "fallbackEnabled": True,
+            "failover": {"enabled": True, "onStatusCodes": [429, 500]},
+            "retry": {"enabled": False, "onStatusCodes": [429]},
+            "circuitBreaker": {"enabled": False},
+            "modelFallbacks": {"gpt-4o": ["gpt-4o-mini"]},
         },
         budgets={
             "enabled": True,
-            "org_limit": {"limit": 100, "period": "monthly", "on_exceed": "block"},
-            "teams": {"engineering": {"limit": 50, "action_mode": "warn"}},
+            "org_limit": {"limit": 100, "period": "monthly", "onExceed": "block"},
+            "teams": {"engineering": {"limit": 50, "actionMode": "warn"}},
         },
-        cache={"enabled": True, "backend": "memory"},
+        cache={"enabled": True, "backend": "memory", "defaultTTL": "60s"},
         model_map={"fast": "gpt-4o-mini"},
     )
 
     payload = _build_payload("org-123", config)
     contract = GatewayOrgConfig.model_validate(payload)
 
+    assert payload["providers"]["openai"]["timeout"] == 17
     assert contract.routing.strategy == "weighted"
+    assert contract.routing.failover.on_status_codes == [429, 500]
+    assert contract.routing.retry.on_status_codes == [429]
+    assert contract.routing.circuit_breaker.enabled is False
+    assert contract.routing.model_fallbacks == {"gpt-4o": ["gpt-4o-mini"]}
+    assert contract.cache.default_ttl == 60
     assert contract.budgets.org_limit == 100
     assert contract.budgets.hard_limit is True
     assert contract.budgets.teams["engineering"].hard is False
+
+
+@patch("integrations.services.credentials.CredentialManager.decrypt")
+@patch(
+    "agentcc.models.provider_credential.AgentccProviderCredential.no_workspace_objects"
+)
+def test_assemble_providers_maps_legacy_aws_credentials_to_gateway_contract(
+    mock_manager,
+    mock_decrypt,
+):
+    mock_decrypt.return_value = {
+        "access_key": "ak",
+        "secret_key": "sk",
+        "region": "us-east-1",
+    }
+    mock_manager.filter.return_value = [
+        SimpleNamespace(
+            provider_name="bedrock",
+            encrypted_credentials=b"encrypted",
+            extra_config={"weight": 2, "ignored": "not-supported"},
+            base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+            api_format="bedrock",
+            models_list=["anthropic.claude-3-5-sonnet-20241022-v2:0"],
+            default_timeout_seconds=60,
+            max_concurrent=10,
+            conn_pool_size=20,
+        )
+    ]
+
+    providers = _assemble_providers("org-123")
+
+    assert providers["bedrock"]["timeout"] == 60
+    assert providers["bedrock"]["aws_access_key_id"] == "ak"
+    assert providers["bedrock"]["aws_secret_access_key"] == "sk"
+    assert providers["bedrock"]["aws_region"] == "us-east-1"
+    assert providers["bedrock"]["weight"] == 2
+    assert "access_key" not in providers["bedrock"]
+    assert "ignored" not in providers["bedrock"]
+
+
+@patch("integrations.services.credentials.CredentialManager.decrypt")
+@patch(
+    "agentcc.models.provider_credential.AgentccProviderCredential.no_workspace_objects"
+)
+def test_assemble_providers_skips_unsupported_credential_provider(
+    mock_manager,
+    mock_decrypt,
+):
+    mock_decrypt.side_effect = [
+        {"api_secret": "secret"},
+        {"api_key": "sk-test"},
+    ]
+    mock_manager.filter.return_value = [
+        SimpleNamespace(
+            provider_name="custom",
+            encrypted_credentials=b"encrypted",
+            extra_config={},
+            base_url="https://example.com",
+            api_format="openai",
+            models_list=["custom-model"],
+            default_timeout_seconds=30,
+            max_concurrent=10,
+            conn_pool_size=20,
+        ),
+        SimpleNamespace(
+            provider_name="openai",
+            encrypted_credentials=b"encrypted-openai",
+            extra_config={},
+            base_url="https://api.openai.com",
+            api_format="openai",
+            models_list=["gpt-4o"],
+            default_timeout_seconds=30,
+            max_concurrent=10,
+            conn_pool_size=20,
+        ),
+    ]
+
+    providers = _assemble_providers("org-123")
+
+    assert "custom" not in providers
+    assert providers["openai"]["api_key"] == "sk-test"
+
+
+@patch("agentcc.services.config_push._build_payload")
+@patch("agentcc.services.config_push.get_gateway_client")
+@patch("agentcc.services.config_push.AgentccOrgConfig")
+def test_push_all_org_configs_continues_after_payload_error(
+    mock_org_config,
+    mock_get_gateway_client,
+    mock_build_payload,
+):
+    bad_cfg = SimpleNamespace(organization_id="bad-org")
+    good_cfg = SimpleNamespace(organization_id="good-org")
+    mock_org_config.no_workspace_objects.filter.return_value.select_related.return_value = [
+        bad_cfg,
+        good_cfg,
+    ]
+    mock_build_payload.side_effect = [ValueError("bad provider"), {"cache": {}}]
+    client = Mock()
+    mock_get_gateway_client.return_value = client
+
+    push_all_org_configs()
+
+    client.set_org_config.assert_called_once_with("good-org", {"cache": {}})
 
 
 def test_key_admin_requests_are_typed_at_backend_boundary():
@@ -71,5 +268,7 @@ def test_key_admin_requests_are_typed_at_backend_boundary():
     )
     update = UpdateKeyRequest(metadata={"enabled": "true"})
 
-    assert create.model_dump(exclude_none=True)["metadata"]["purpose"] == "gateway-startup"
+    assert (
+        create.model_dump(exclude_none=True)["metadata"]["purpose"] == "gateway-startup"
+    )
     assert update.model_dump(exclude_none=True) == {"metadata": {"enabled": "true"}}

--- a/scripts/generate-agentcc-gateway-contracts.py
+++ b/scripts/generate-agentcc-gateway-contracts.py
@@ -77,7 +77,9 @@ def go_ref_type(schema: dict[str, Any], optional: bool = False) -> str:
     return f"*{name}" if optional else name
 
 
-def go_type(schema: dict[str, Any], optional: bool = False, map_value: bool = False) -> str:
+def go_type(
+    schema: dict[str, Any], optional: bool = False, map_value: bool = False
+) -> str:
     if "$ref" in schema:
         name = ref_name(schema)
         if map_value:
@@ -121,6 +123,38 @@ def py_field_name(json_name: str) -> str:
     return json_name
 
 
+def lower_camel_name(json_name: str) -> str:
+    head, *tail = json_name.split("_")
+    return head + "".join(part[:1].upper() + part[1:] for part in tail)
+
+
+def acronym_camel_name(json_name: str) -> str:
+    parts = json_name.split("_")
+    if not parts:
+        return json_name
+
+    rendered = [parts[0]]
+    for part in parts[1:]:
+        lower = part.lower()
+        if lower in ACRONYMS:
+            rendered.append(ACRONYMS[lower])
+        else:
+            rendered.append(part[:1].upper() + part[1:])
+    return "".join(rendered)
+
+
+def validation_aliases(json_name: str) -> list[str]:
+    aliases = []
+    for alias in (
+        json_name,
+        lower_camel_name(json_name),
+        acronym_camel_name(json_name),
+    ):
+        if alias not in aliases:
+            aliases.append(alias)
+    return aliases
+
+
 def py_field_line(name: str, schema: dict[str, Any], required: bool) -> str:
     field = py_field_name(name)
     annotation = py_type(schema)
@@ -129,8 +163,18 @@ def py_field_line(name: str, schema: dict[str, Any], required: bool) -> str:
     else:
         annotation = f"{annotation} | None"
         default = "None"
+
+    field_args = []
     if field != name:
-        default = f'Field({default}, alias="{name}")'
+        field_args.append(f'alias="{name}"')
+
+    aliases = validation_aliases(name)
+    if len(aliases) > 1 or field != name:
+        choices = ", ".join(repr(alias) for alias in aliases)
+        field_args.append(f"validation_alias=AliasChoices({choices})")
+
+    if field_args:
+        default = f"Field({default}, {', '.join(field_args)})"
     return f"    {field}: {annotation} = {default}"
 
 
@@ -141,11 +185,34 @@ def generate_python(schema: dict[str, Any]) -> str:
         "",
         "from typing import Any",
         "",
-        "from pydantic import BaseModel, ConfigDict, Field",
+        "from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator",
         "",
         "",
         "class GatewayAdminContractModel(BaseModel):",
-        "    model_config = ConfigDict(extra=\"forbid\", populate_by_name=True)",
+        '    model_config = ConfigDict(extra="forbid", populate_by_name=True)',
+        "",
+        '    @model_validator(mode="before")',
+        "    @classmethod",
+        "    def _normalize_input_aliases(cls, data):",
+        "        if not isinstance(data, dict):",
+        "            return data",
+        "",
+        "        result = dict(data)",
+        "        for field_name, field in cls.model_fields.items():",
+        "            validation_alias = field.validation_alias",
+        "            if validation_alias is None:",
+        "                continue",
+        "",
+        '            choices = getattr(validation_alias, "choices", (validation_alias,))',
+        "            present = [choice for choice in choices if isinstance(choice, str) and choice in result]",
+        "            if not present:",
+        "                continue",
+        "",
+        "            result[field_name] = result[present[0]]",
+        "            for alias in present:",
+        "                if alias != field_name:",
+        "                    result.pop(alias, None)",
+        "        return result",
         "",
     ]
     for name, definition in schema["$defs"].items():
@@ -157,7 +224,9 @@ def generate_python(schema: dict[str, Any]) -> str:
             lines.append("    pass")
         else:
             for field_name, field_schema in properties.items():
-                lines.append(py_field_line(field_name, field_schema, field_name in required))
+                lines.append(
+                    py_field_line(field_name, field_schema, field_name in required)
+                )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
@@ -177,7 +246,7 @@ def generate_go(schema: dict[str, Any]) -> str:
             is_required = field_name in required
             field_type = go_type(field_schema, optional=not is_required)
             tag = field_name if is_required else f"{field_name},omitempty"
-            lines.append(f"\t{go_field_name(field_name)} {field_type} `json:\"{tag}\"`")
+            lines.append(f'\t{go_field_name(field_name)} {field_type} `json:"{tag}"`')
         lines.append("}")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
@@ -209,7 +278,9 @@ def write_or_check(path: Path, contents: str, check: bool) -> bool:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--check", action="store_true", help="fail if generated files differ")
+    parser.add_argument(
+        "--check", action="store_true", help="fail if generated files differ"
+    )
     args = parser.parse_args()
 
     schema = load_schema()


### PR DESCRIPTION
## Summary

`_build_payload` was passing fields the gateway `OrgConfig` contract (`extra="forbid"`) rejects, causing 400s on `/agentcc/org-configs/bulk/`:

- `providers.*.default_timeout` (string `"60s"`) — contract expects `timeout` (int)
- Routing camelCase keys (`onStatusCodes`, `circuitBreaker`, `modelFallbacks`) — contract expects snake_case
- Arbitrary `extra_config` / decrypted credential keys leaking into provider dicts

**Fix:**
- `default_timeout` → `timeout` (int seconds) in `_assemble_providers`
- Add `_normalize_contract_aliases` to recursively convert camelCase→snake_case across the entire payload using contract model type annotations
- Filter provider dicts to only `ProviderConfig`-known fields via `_PROVIDER_FIELDS` frozenset

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Existing contract tests pass (`test_gateway_admin_contracts.py` — 6/6 passing)
- `set -a && source .env.test && set +a && .venv/bin/pytest agentcc/tests/test_gateway_admin_contracts.py -v`

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII

---
Closes TH-6096