### PR TITLE
feat(simulate): provider foundation — registry + adapters + agent-definition [2a/4]

### DIFF
--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -33,6 +33,21 @@ import { spin } from "../../../../animations/animations";
 import { pinCodeOptions } from "src/components/agent-definitions/helper";
 import { useAuthContext } from "src/auth/hooks";
 
+// Providers whose credential is two values joined by a colon (validated
+// backend-side the same way: api_key.partition(":")).
+const COMPOSITE_API_KEY_HINTS = {
+  twilio: {
+    placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:your_auth_token",
+    helper:
+      "Twilio: Account SID and Auth Token joined by a colon (SID:AUTH_TOKEN)",
+  },
+  agora: {
+    placeholder: "customer_key:customer_secret",
+    helper:
+      "Agora: RESTful API Customer Key and Secret joined by a colon (KEY:SECRET)",
+  },
+};
+
 export default function AgentVoiceForm() {
   const { orgLimit } = useAuthContext();
   const { control, setValue: setFormValue } = useFormContext();
@@ -399,7 +414,11 @@ export default function AgentVoiceForm() {
             control={control}
             fieldName="apiKey"
             label="Provider API Key"
-            placeholder="Enter your provider’s API key to authenticate the agent"
+            placeholder={
+              COMPOSITE_API_KEY_HINTS[selectedProvider]?.placeholder ||
+              "Enter your provider’s API key to authenticate the agent"
+            }
+            helperText={COMPOSITE_API_KEY_HINTS[selectedProvider]?.helper}
             required={observabilityEnabled || keysRequired}
             size="small"
             fullWidth

--- a/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
+++ b/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
@@ -158,6 +158,10 @@ const CreateNewAgentDefinitionView = () => {
 
       // Only process and include voice-specific fields for voice agents
       if (data.agentType === AGENT_TYPES.VOICE) {
+        // country_code is a UI-only field — it gets merged into
+        // contact_number below; the backend serializer rejects it as an
+        // unknown field (caught live: 400 "country_code: Unknown field").
+        delete payload.country_code;
         if (isLiveKitProvider(data.provider)) {
           // LiveKit: no phone number needed, ensure config is a dict
           payload.contact_number = "";

--- a/frontend/src/sections/agents/constants.js
+++ b/frontend/src/sections/agents/constants.js
@@ -93,12 +93,20 @@ export const AGENT_TYPES = {
   VOICE: "voice",
 };
 
+// Provider options for the Agent Definition config — values MUST match the
+// backend ProviderSpec registry keys (simulate/providers/registry.py) and
+// tracer ProviderChoices, so the agent's observability_provider + simulation
+// connector resolve. The full multi-provider set (TH-5642).
 export const VOICE_CHAT_PROVIDERS = [
   { label: "Vapi", value: "vapi" },
   { label: "Retell", value: "retell" },
-  // Hidden until LiveKit server stability is restored.
-  // { label: "LiveKit", value: "livekit_bridge" },
-  // { label: "ElevenLabs", value: "elevenlabs" },
+  { label: "ElevenLabs", value: "elevenlabs" },
+  { label: "Deepgram", value: "deepgram" },
+  { label: "Agora", value: "agora" },
+  { label: "Pipecat", value: "pipecat" },
+  { label: "Twilio", value: "twilio" },
+  { label: "Bland.ai", value: "bland" },
+  { label: "LiveKit", value: "livekit_bridge" },
   { label: "Others", value: "others" },
 ];
 
@@ -127,6 +135,12 @@ export const AUTH_METHODS_BY_PROVIDER = {
   vapi: AUTH_METHODS,
   retell: AUTH_METHODS,
   elevenlabs: AUTH_METHODS,
+  deepgram: AUTH_METHODS,
+  agora: AUTH_METHODS,
+  pipecat: AUTH_METHODS,
+  twilio: AUTH_METHODS,
+  bland: AUTH_METHODS,
+  livekit_bridge: AUTH_METHODS,
   others: OTHER_AUTH_METHODS,
 };
 

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -135,43 +135,49 @@ export const createAgentDefinitionSchema = (options) => {
         data.agentType === AGENT_TYPES.VOICE &&
         !isLiveKitProvider(data.provider)
       ) {
-        // Phone number is optional when API key + assistant ID are provided (web bridge)
-        // const hasWebBridgeCreds =
-        //   data.apiKey?.trim() && data.assistantId?.trim();
+        // Phone number is optional when API key + assistant ID are provided:
+        // the backend serializer accepts phone-less web-bridge agents
+        // ("Contact number is required (or provide API Key and Assistant ID
+        // for web bridge)"), and web-connector providers (Vapi/ElevenLabs/
+        // Deepgram/Agora/Pipecat) have no phone surface at all.
+        const hasWebBridgeCreds =
+          data.apiKey?.trim() && data.assistantId?.trim();
         const hasCountryCode = !!data.countryCode?.trim();
         const hasContactNumber = !!data.contactNumber?.trim();
-        // if (!hasWebBridgeCreds) {
-        if (!hasCountryCode) {
-          ctx.addIssue({
-            path: ["countryCode"],
-            message: "Country code is required",
-            code: z.ZodIssueCode.custom,
-          });
+        if (!hasWebBridgeCreds) {
+          if (!hasCountryCode) {
+            ctx.addIssue({
+              path: ["countryCode"],
+              message: "Country code is required",
+              code: z.ZodIssueCode.custom,
+            });
+          }
+          if (!hasContactNumber) {
+            ctx.addIssue({
+              path: ["contactNumber"],
+              message: "Contact number is required",
+              code: z.ZodIssueCode.custom,
+            });
+          }
+        } else {
+          // Both are optional, but if one is provided the other is required
+          if (hasContactNumber && !hasCountryCode) {
+            ctx.addIssue({
+              path: ["countryCode"],
+              message:
+                "Country code is required when contact number is provided",
+              code: z.ZodIssueCode.custom,
+            });
+          }
+          if (hasCountryCode && !hasContactNumber) {
+            ctx.addIssue({
+              path: ["contactNumber"],
+              message:
+                "Contact number is required when country code is provided",
+              code: z.ZodIssueCode.custom,
+            });
+          }
         }
-        if (!hasContactNumber) {
-          ctx.addIssue({
-            path: ["contactNumber"],
-            message: "Contact number is required",
-            code: z.ZodIssueCode.custom,
-          });
-        }
-        // } else {
-        // Both are optional, but if one is provided the other is required
-        if (hasContactNumber && !hasCountryCode) {
-          ctx.addIssue({
-            path: ["countryCode"],
-            message: "Country code is required when contact number is provided",
-            code: z.ZodIssueCode.custom,
-          });
-        }
-        if (hasCountryCode && !hasContactNumber) {
-          ctx.addIssue({
-            path: ["contactNumber"],
-            message: "Contact number is required when country code is provided",
-            code: z.ZodIssueCode.custom,
-          });
-        }
-        // }
         if (hasContactNumber) {
           // Validate contact number format only if it's provided
           const trimmedNumber = data.contactNumber.trim();

--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
@@ -1400,6 +1400,10 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(chunk.model, dict(chunk.usage)),
             "response_time": end_time - start_time,
+            # Expose structured tool calls (additive) so callers like the simulation
+            # mock-tool loop can intercept them instead of parsing the appended
+            # tool_calls_str out of the content (TH-5642).
+            "tool_calls": tool_calls or [],
         }
 
         # Note: Thinking content is now streamed during the loop above, not appended here
@@ -1506,6 +1510,8 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(response.model, dict(response.usage)),
             "response_time": completion_time,  # Assuming a static time or calculated elsewhere
+            # Structured tool calls (additive) for the simulation mock-tool loop.
+            "tool_calls": [],
         }
 
         if self.tools and response.choices[0].message.tool_calls:
@@ -1521,6 +1527,7 @@ class RunPrompt:
                 }
                 for tool_call in response.choices[0].message.tool_calls
             ]
+            metadata["tool_calls"] = tool_calls_list
 
             # Convert to JSON string
             tool_calls_str = json.dumps(tool_calls_list)
@@ -3110,6 +3117,10 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(chunk.model, dict(chunk.usage)),
             "response_time": end_time - start_time,
+            # Expose structured tool calls (additive) so callers like the simulation
+            # mock-tool loop can intercept them instead of parsing the appended
+            # tool_calls_str out of the content (TH-5642).
+            "tool_calls": tool_calls or [],
         }
 
         # Note: Thinking content is now streamed during the loop above, not appended here

--- a/futureagi/scripts/verify_providers_live.py
+++ b/futureagi/scripts/verify_providers_live.py
@@ -1,0 +1,219 @@
+"""Live provider verification (TH-5642) — run with keys passed via env.
+
+Drives the REAL RetellChatAgentAdapter against the live Retell API, and verifies
+the Deepgram + ElevenLabs WebSocket handshakes against the exact payload shapes
+our connectors send. Keys are read from env; nothing is printed unmasked.
+
+Usage:
+  RETELL_API_KEY=... DEEPGRAM_API_KEY=... ELEVENLABS_API_KEY=... \
+    .venv/bin/python scripts/verify_providers_live.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import aiohttp
+import requests
+
+RETELL_BASE = "https://api.retellai.com"
+DG_WS = "wss://agent.deepgram.com/v1/agent/converse"
+EL_LIST = "https://api.elevenlabs.io/v1/convai/agents"
+EL_SIGNED = "https://api.elevenlabs.io/v1/convai/conversation/get-signed-url"
+
+
+def mask(s: str) -> str:
+    if not s:
+        return "<empty>"
+    return f"{s[:6]}…{s[-4:]} (len {len(s)})"
+
+
+def hr(title: str) -> None:
+    print(f"\n{'=' * 8} {title} {'=' * 8}")
+
+
+# --------------------------------------------------------------------------
+# Retell — drive the REAL adapter end to end.
+# --------------------------------------------------------------------------
+def verify_retell() -> None:
+    hr("RETELL chat adapter (real code, live API)")
+    key = os.environ.get("RETELL_API_KEY", "")
+    if not key:
+        print("SKIP: RETELL_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+    # 1) Find a usable agent (prefer an explicit RETELL_TEST_AGENT_ID).
+    agent_id = os.environ.get("RETELL_TEST_AGENT_ID", "")
+    if not agent_id:
+        r = requests.get(f"{RETELL_BASE}/list-agents", headers=headers, timeout=30)
+        print(f"list-agents -> {r.status_code}")
+        if r.status_code >= 400:
+            print(f"FAIL list-agents: {r.text[:300]}")
+            return
+        agents = r.json() or []
+        print(f"found {len(agents)} agents")
+        if not agents:
+            print("FAIL: no agents in this Retell account to drive")
+            return
+        # Show shape of the first agent (keys only) to understand chat-capability.
+        a0 = agents[0]
+        print(f"agent[0] keys: {sorted(a0.keys())}")
+        agent_id = a0.get("agent_id") or a0.get("agent_id_")
+    print(f"using agent_id: {agent_id}")
+
+    # 2) Drive the REAL adapter.
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+
+    adapter = RetellChatAgentAdapter(agent_id=agent_id, api_key=key)
+    try:
+        # Turn 1: agent speaks first (begin_message from /create-chat).
+        t1 = adapter.generate_response([])
+        print(f"TURN1 (no user msg): content={t1['content']!r} ended={t1['chat_ended']}")
+        print(f"  chat_id cached: {adapter._chat_id}")
+        # Turn 2: send a user message, expect an agent reply.
+        t2 = adapter.generate_response(
+            [{"role": "user", "content": "Hi, what can you help me with?"}]
+        )
+        print(f"TURN2 content={t2['content']!r:.200} ended={t2['chat_ended']}")
+        print(f"  sent_user_turns={adapter._sent_user_turns}")
+        # Verdict on the parser assumptions.
+        ok = bool(adapter._chat_id) and (t2["content"] or t1["content"])
+        print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+              f"adapter created chat + parsed an agent reply via real API")
+    except Exception as e:
+        print(f"FAIL driving adapter: {type(e).__name__}: {e}")
+    finally:
+        try:
+            adapter.end()
+            print("end() called (best-effort cleanup)")
+        except Exception as e:
+            print(f"end() error: {e}")
+
+
+# --------------------------------------------------------------------------
+# Deepgram — verify the Voice Agent WS handshake with our exact Settings.
+# --------------------------------------------------------------------------
+async def verify_deepgram() -> None:
+    hr("DEEPGRAM Voice Agent WS handshake")
+    key = os.environ.get("DEEPGRAM_API_KEY", "")
+    if not key:
+        print("SKIP: DEEPGRAM_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    settings = {
+        "type": "Settings",
+        "audio": {
+            "input": {"encoding": "linear16", "sample_rate": 16000},
+            "output": {"encoding": "linear16", "sample_rate": 16000, "container": "none"},
+        },
+        "agent": {
+            "language": "en",
+            "listen": {"provider": {"type": "deepgram", "model": "nova-3"}},
+            "think": {"provider": {"type": "open_ai", "model": "gpt-4o-mini"}},
+            "speak": {"provider": {"type": "deepgram", "model": "aura-2-thalia-en"}},
+        },
+    }
+    try:
+        async with aiohttp.ClientSession() as s:
+            async with s.ws_connect(
+                DG_WS, headers={"Authorization": f"Token {key}"}, timeout=20
+            ) as ws:
+                print("WS connected (auth header accepted)")
+                await ws.send_json(settings)
+                got = []
+                for _ in range(6):
+                    try:
+                        msg = await asyncio.wait_for(ws.receive(), timeout=8)
+                    except asyncio.TimeoutError:
+                        break
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        ev = json.loads(msg.data)
+                        got.append(ev.get("type"))
+                        if ev.get("type") in ("Welcome", "SettingsApplied"):
+                            pass
+                        if ev.get("type") == "Error":
+                            print(f"  Error event: {msg.data[:300]}")
+                            break
+                    elif msg.type == aiohttp.WSMsgType.BINARY:
+                        got.append("BINARY")
+                    elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                        break
+                print(f"control frames received: {got}")
+                ok = "SettingsApplied" in got or "Welcome" in got
+                print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+                      f"handshake {'accepted our Settings' if ok else 'inconclusive'}")
+    except Exception as e:
+        print(f"FAIL: {type(e).__name__}: {e}")
+
+
+# --------------------------------------------------------------------------
+# ElevenLabs — verify signed-url + ConvAI WS handshake.
+# --------------------------------------------------------------------------
+async def verify_elevenlabs() -> None:
+    hr("ELEVENLABS ConvAI signed-url + WS handshake")
+    key = os.environ.get("ELEVENLABS_API_KEY", "")
+    if not key:
+        print("SKIP: ELEVENLABS_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    try:
+        async with aiohttp.ClientSession() as s:
+            # 1) list agents
+            async with s.get(EL_LIST, headers={"xi-api-key": key}, timeout=20) as r:
+                print(f"list agents -> {r.status}")
+                body = await r.json()
+            agents = body.get("agents") if isinstance(body, dict) else body
+            agent_id = os.environ.get("ELEVENLABS_TEST_AGENT_ID", "")
+            if not agent_id and agents:
+                agent_id = agents[0].get("agent_id")
+            print(f"agents found: {len(agents) if agents else 0}; using {agent_id}")
+            if not agent_id:
+                print("PARTIAL: auth worked (listed agents) but none to handshake")
+                return
+            # 2) signed url
+            async with s.get(
+                EL_SIGNED, params={"agent_id": agent_id},
+                headers={"xi-api-key": key}, timeout=20,
+            ) as r:
+                print(f"get-signed-url -> {r.status}")
+                sj = await r.json()
+            signed = sj.get("signed_url")
+            if not signed:
+                print(f"PARTIAL: no signed_url ({sj})")
+                return
+            print("signed_url obtained")
+            # 3) WS handshake
+            async with s.ws_connect(signed, timeout=20) as ws:
+                print("WS connected")
+                got = []
+                for _ in range(4):
+                    try:
+                        msg = await asyncio.wait_for(ws.receive(), timeout=8)
+                    except asyncio.TimeoutError:
+                        break
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        got.append(json.loads(msg.data).get("type"))
+                    elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                        break
+                print(f"frames received: {got}")
+                ok = any(g for g in got)
+                print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+                      f"{'protocol frames received' if ok else 'no frames'}")
+    except Exception as e:
+        print(f"FAIL: {type(e).__name__}: {e}")
+
+
+async def main() -> None:
+    verify_retell()
+    await verify_deepgram()
+    await verify_elevenlabs()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/futureagi/simulate/management/commands/provision_sim_phone_numbers.py
+++ b/futureagi/simulate/management/commands/provision_sim_phone_numbers.py
@@ -1,0 +1,98 @@
+"""``provision_sim_phone_numbers`` — populate the SimulationPhoneNumber pool (TH-5642).
+
+Outbound voice sims acquire an idle number from the system-level ``SimulationPhoneNumber``
+pool. When the pool is empty the call never connects (the acquire activity now fails fast
+with a clear error — see voice_small.py). This command fills the pool from a Twilio
+account's owned numbers so outbound voice simulations can run.
+
+    python manage.py provision_sim_phone_numbers --direction outbound
+    python manage.py provision_sim_phone_numbers --direction outbound --numbers +12175696753,+12068956991
+    python manage.py provision_sim_phone_numbers --direction inbound --dry-run
+
+Twilio creds are read from TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN (or --sid/--token).
+Idempotent: a number already in the pool (by provider_phone_id) is skipped. provider_phone_id
+defaults to the Twilio number SID (stable, unique); use --provider-id e164 to key by number.
+"""
+
+from __future__ import annotations
+
+import os
+
+import requests
+from django.core.management.base import BaseCommand, CommandError
+
+from simulate.models.simulation_phone_number import SimulationPhoneNumber
+
+_TWILIO_NUMBERS_URL = (
+    "https://api.twilio.com/2010-04-01/Accounts/{sid}/IncomingPhoneNumbers.json"
+)
+
+
+class Command(BaseCommand):
+    help = "Provision Twilio phone numbers into the SimulationPhoneNumber pool."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--direction", choices=["inbound", "outbound"], required=True,
+            help="call_direction to assign the provisioned numbers",
+        )
+        parser.add_argument(
+            "--numbers", default="",
+            help="comma-separated E.164 numbers to provision (default: all on the account)",
+        )
+        parser.add_argument("--sid", default=os.getenv("TWILIO_ACCOUNT_SID", ""))
+        parser.add_argument("--token", default=os.getenv("TWILIO_AUTH_TOKEN", ""))
+        parser.add_argument(
+            "--provider-id", choices=["sid", "e164"], default="sid",
+            help="what to store as provider_phone_id (Twilio number SID or the E.164 number)",
+        )
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **opts):
+        sid, token = opts["sid"], opts["token"]
+        if not sid or not token:
+            raise CommandError(
+                "Twilio creds required: set TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN or pass --sid/--token."
+            )
+        direction = opts["direction"]
+        wanted = {n.strip() for n in opts["numbers"].split(",") if n.strip()}
+
+        resp = requests.get(
+            _TWILIO_NUMBERS_URL.format(sid=sid),
+            params={"PageSize": 100}, auth=(sid, token), timeout=30,
+        )
+        if resp.status_code != 200:
+            raise CommandError(f"Twilio list numbers failed ({resp.status_code}): {resp.text}")
+        account_numbers = resp.json().get("incoming_phone_numbers", []) or []
+
+        created = skipped = filtered = 0
+        for n in account_numbers:
+            e164 = n.get("phone_number")
+            number_sid = n.get("sid")
+            if wanted and e164 not in wanted:
+                filtered += 1
+                continue
+            provider_phone_id = number_sid if opts["provider_id"] == "sid" else e164
+            if SimulationPhoneNumber.objects.filter(provider_phone_id=provider_phone_id).exists():
+                self.stdout.write(f"  skip (exists): {e164} [{provider_phone_id}]")
+                skipped += 1
+                continue
+            if opts["dry_run"]:
+                self.stdout.write(self.style.WARNING(f"  would add: {e164} [{provider_phone_id}] {direction}"))
+                created += 1
+                continue
+            SimulationPhoneNumber.objects.create(
+                phone_number=e164,
+                provider_phone_id=provider_phone_id,
+                call_direction=direction,
+                status=SimulationPhoneNumber.PhoneStatus.IDLE,
+            )
+            self.stdout.write(self.style.SUCCESS(f"  added: {e164} [{provider_phone_id}] {direction} (idle)"))
+            created += 1
+
+        verb = "would add" if opts["dry_run"] else "added"
+        self.stdout.write(self.style.MIGRATE_HEADING(
+            f"Done: {verb}={created}, skipped(existing)={skipped}, filtered_out={filtered}. "
+            f"Pool now has {SimulationPhoneNumber.objects.filter(call_direction=direction).count()} "
+            f"{direction} number(s)."
+        ))

--- a/futureagi/simulate/management/commands/verify_providers.py
+++ b/futureagi/simulate/management/commands/verify_providers.py
@@ -1,0 +1,70 @@
+"""``verify_providers`` — one-command E2E verification matrix across all providers.
+
+Examples:
+    python manage.py verify_providers                       # registry matrix (no I/O)
+    python manage.py verify_providers --mode credentials    # which creds are present
+    python manage.py verify_providers --mode connectivity   # real handshakes (creds)
+    python manage.py verify_providers --mode registry --json # machine-readable
+
+Credentials are read from SIM_VERIFY_<PROVIDER>_<FIELD> env vars (e.g.
+SIM_VERIFY_DEEPGRAM_API_KEY). Connectivity probes make read-only API calls only — they
+place no phone calls and start no billable sessions.
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from simulate.services import provider_verification as pv
+
+_STATUS_MARK = {
+    pv.OK: "PASS",
+    pv.MISSING: "MISS",
+    pv.FAILED: "FAIL",
+    pv.SKIPPED: "SKIP",
+    pv.NOT_IMPL: "----",
+}
+
+
+class Command(BaseCommand):
+    help = "Verify simulation providers across chat/voice and inbound/outbound."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--mode", choices=pv.MODES, default=pv.MODE_REGISTRY,
+            help="registry (default) | credentials | connectivity",
+        )
+        parser.add_argument(
+            "--json", action="store_true", help="emit machine-readable JSON",
+        )
+
+    def handle(self, *args, **options):
+        mode = options["mode"]
+        try:
+            report = pv.verify(mode)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        if options["json"]:
+            self.stdout.write(json.dumps(report.to_dict(), indent=2))
+            return
+
+        self.stdout.write(self.style.MIGRATE_HEADING(f"Provider verification — mode={mode}"))
+        self.stdout.write(f"{'PROVIDER':16}{'MODALITY':10}{'DIRECTION':12}{'STATUS':8}DETAIL")
+        self.stdout.write("-" * 88)
+        for c in report.cells:
+            mark = _STATUS_MARK.get(c.status, c.status)
+            styler = (
+                self.style.SUCCESS if c.status == pv.OK
+                else self.style.ERROR if c.status in (pv.FAILED, pv.MISSING)
+                else self.style.WARNING
+            )
+            self.stdout.write(
+                f"{c.provider:16}{c.modality:10}{(c.direction or '-'):12}"
+                f"{styler(mark):8}{c.detail}"
+            )
+        self.stdout.write("-" * 88)
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(report.summary().items()))
+        self.stdout.write(self.style.MIGRATE_HEADING(f"Summary: {summary}"))

--- a/futureagi/simulate/providers/__init__.py
+++ b/futureagi/simulate/providers/__init__.py
@@ -1,0 +1,40 @@
+"""Simulation provider registry (TH-5642) — the ProviderSpec single source of truth.
+
+See internal-docs/multi-provider-simulation/DESIGN.md.
+"""
+
+from simulate.providers.registry import (
+    PROVIDER_REGISTRY,
+    CredentialShape,
+    Direction,
+    ProviderSpec,
+    Role,
+    Status,
+    Transport,
+    agent_platform_keys,
+    connector_key_for,
+    get_spec,
+    implemented_directions_for,
+    implements_direction,
+    is_agent_platform,
+    provider_choices,
+    supports_direction,
+)
+
+__all__ = [
+    "PROVIDER_REGISTRY",
+    "CredentialShape",
+    "Direction",
+    "ProviderSpec",
+    "Role",
+    "Status",
+    "Transport",
+    "agent_platform_keys",
+    "connector_key_for",
+    "get_spec",
+    "implemented_directions_for",
+    "implements_direction",
+    "is_agent_platform",
+    "provider_choices",
+    "supports_direction",
+]

--- a/futureagi/simulate/providers/direction.py
+++ b/futureagi/simulate/providers/direction.py
@@ -1,0 +1,104 @@
+"""Call-direction resolution + guards (TH-5642).
+
+Fixes the audit's silent direction bugs at the point direction is decided:
+- a typo'd ``call_direction`` (e.g. "outbond") previously became INBOUND silently;
+- an OUTBOUND test on a provider that hasn't WIRED outbound silently ran the
+  simulator-initiated INBOUND path (a green result that tested the wrong direction).
+
+Both now fail LOUDLY. This module is Django-free (it only touches the pure
+ProviderSpec registry) so the Temporal voice activities can import it.
+"""
+
+from __future__ import annotations
+
+from simulate.providers.registry import (
+    Direction,
+    get_spec,
+    implements_direction,
+)
+
+
+class UnsupportedCallDirectionError(ValueError):
+    """A call_direction is malformed, or not wired for the chosen provider."""
+
+
+# Who speaks first, from the SIMULATOR's perspective (LiveKit first_message_mode).
+FIRST_MESSAGE_MODE_SPEAKS_FIRST = "assistant-speaks-first"
+FIRST_MESSAGE_MODE_WAITS = "assistant-waits-for-user"
+
+
+def first_message_mode_for(is_outbound: bool) -> str:
+    """The simulator's speaking order for a call direction.
+
+    Inbound (FutureAGI calls the agent → agent receives) → the simulator (our
+    caller) speaks first. Outbound (the agent calls us) → the simulator waits; the
+    agent speaks first. Previously this was set ONLY inside the LiveKit-bridge
+    branch, so DIRECT_WS (ElevenLabs/Deepgram) and SIP providers silently produced a
+    simulator-speaks-first transcript on outbound (audit gap). This resolver is
+    applied to every transport.
+    """
+    return (
+        FIRST_MESSAGE_MODE_WAITS if is_outbound else FIRST_MESSAGE_MODE_SPEAKS_FIRST
+    )
+
+
+def resolve_call_direction(
+    call_direction: str | None,
+    provider: str | None = None,
+    *,
+    enforce_implemented: bool = True,
+) -> Direction:
+    """Resolve a ``call_direction`` string to a :class:`Direction`, failing loudly.
+
+    - missing / None / "" → INBOUND (preserves the historical default: the common
+      case where direction is simply not specified is an inbound test);
+    - "inbound" / "outbound" (any case) → that Direction;
+    - any other non-empty value → raise (catches typos that previously became
+      INBOUND silently);
+    - if ``provider`` is a known agent platform that does NOT implement the resolved
+      direction (and ``enforce_implemented``) → raise, instead of silently running
+      the inbound path. Unknown / free-form providers skip this check so custom
+      integrations are not broken.
+    """
+    raw = (call_direction or "").strip().lower()
+    if raw == "":
+        direction = Direction.INBOUND
+    elif raw == Direction.INBOUND.value:
+        direction = Direction.INBOUND
+    elif raw == Direction.OUTBOUND.value:
+        direction = Direction.OUTBOUND
+    else:
+        raise UnsupportedCallDirectionError(
+            f"Unknown call_direction {call_direction!r} "
+            f"(expected 'inbound' or 'outbound')"
+        )
+
+    if enforce_implemented and provider:
+        spec = get_spec(provider)
+        if (
+            spec is not None
+            and spec.is_agent_platform
+            and not implements_direction(provider, direction)
+        ):
+            raise UnsupportedCallDirectionError(
+                f"Provider {provider!r} does not yet implement {direction.value} "
+                f"calls (supported={sorted(d.value for d in spec.supported_directions)}, "
+                f"implemented={sorted(d.value for d in spec.implemented_directions)}). "
+                f"Refusing to silently run the inbound path."
+            )
+    return direction
+
+
+def resolve_is_outbound(
+    call_direction: str | None,
+    provider: str | None = None,
+    *,
+    enforce_implemented: bool = True,
+) -> bool:
+    """Boolean form of :func:`resolve_call_direction` (True iff OUTBOUND)."""
+    return (
+        resolve_call_direction(
+            call_direction, provider, enforce_implemented=enforce_implemented
+        )
+        is Direction.OUTBOUND
+    )

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -1,0 +1,372 @@
+"""ProviderSpec — the single source of truth for simulation providers (TH-5642).
+
+Design: internal-docs/multi-provider-simulation/DESIGN.md §4.
+
+A "provider" is never one thing: it plays one or more of five *non-interchangeable*
+roles. Today the same provider string must be registered independently in ~8
+non-centralised places (ProviderChoices, SupportedProviders, ProviderCredentials,
+serializer choices, the ``f"web_{provider}"`` interpolation, SpeakerRole maps, the
+frontend list…), which is the source of the historical "silent Vapi" string-drift
+bugs. This module declares each provider ONCE so those surfaces can derive from it.
+
+This module is intentionally dependency-free (pure dataclasses/enums, no Django
+imports) so it is importable in isolation and trivially testable. Call sites adopt
+it incrementally; nothing is rewired by simply adding this file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Role(StrEnum):
+    """A role a provider plays. Enum/component presence != tested-platform support."""
+
+    AGENT_PLATFORM = "agent_platform"  # a customer agent we TEST (agent-under-test)
+    SYSTEM_ENGINE = "system_engine"  # infra that runs OUR simulated caller
+    TRANSPORT = "transport"  # how we reach the agent (SIP / WebRTC / PSTN)
+    STT = "stt"  # simulator-side speech-to-text component
+    TTS = "tts"  # simulator-side text-to-speech component
+    CHAT_ENGINE = "chat_engine"  # text-simulation engine
+
+
+class Transport(StrEnum):
+    """How the simulator reaches the agent-under-test."""
+
+    WEBRTC_BRIDGE = "webrtc_bridge"  # join via our LiveKit bridge connector (web_*)
+    SIP = "sip"  # dial via our LiveKit SIP trunk (provider-neutral)
+    DIRECT_WS = "direct_ws"  # raw provider WebSocket, Vapi-style
+    AGORA_RTC = "agora_rtc"  # Agora's proprietary RTC (NOT LiveKit-compatible)
+    NONE = "none"
+
+
+class CredentialShape(StrEnum):
+    """The credential field-group a provider needs (drives the agent-def form)."""
+
+    API_KEY_ASSISTANT = "api_key_assistant"  # api_key + assistant/agent_id
+    LIVEKIT_SERVER = "livekit_server"  # url + api_key + api_secret + agent_name
+    AGENT_ID = "agent_id"  # api_key + agent_id (ElevenLabs/Deepgram)
+    SIP_ONLY = "sip_only"  # just a phone number
+    WEBSOCKET_URL = "websocket_url"  # custom ws endpoint
+    NONE = "none"
+
+
+class Status(StrEnum):
+    GA = "ga"  # wired & working as a tested platform today
+    PLANNED = "planned"  # designed (DESIGN.md §5), not yet built
+    TRANSPORT_ONLY = "transport_only"  # never an agent platform (e.g. Twilio)
+    INTERNAL = "internal"  # our own engine, not a tested platform
+
+
+class Direction(StrEnum):
+    """A telephony call direction (from the agent-under-test's call perspective).
+
+    Mirrors ``simulate.semantics.CallType`` (inbound/outbound) by VALUE — the
+    registry is intentionally Django-free, and CallType lives behind a Django import,
+    so we mirror rather than import; ``test_provider_registry`` pins the equality.
+    """
+
+    INBOUND = "inbound"  # FutureAGI's simulator CALLS the agent (agent receives)
+    OUTBOUND = "outbound"  # the agent CALLS FutureAGI (our simulator answers)
+
+
+_BOTH = frozenset({Direction.INBOUND, Direction.OUTBOUND})
+_IN = frozenset({Direction.INBOUND})
+_OUT = frozenset({Direction.OUTBOUND})
+_NONE: frozenset[Direction] = frozenset()
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    key: str  # canonical client-provider string
+    label: str
+    roles: frozenset[Role]
+    transport: Transport = Transport.NONE
+    connector_key: str | None = None  # WebRTC bridge registry key (web_*), if any
+    credential_shape: CredentialShape = CredentialShape.NONE
+    chat: bool = False  # has / will have a named chat engine
+    observability_key: str | None = None  # maps to ProviderChoices value, if any
+    status: Status = Status.PLANNED
+    # Call directions the provider's API can do AND we can drive (capability).
+    supported_directions: frozenset[Direction] = _IN
+    # Subset of supported_directions actually WIRED in our orchestration today.
+    # Kept separate from `supported` (mirrors Status's planned-vs-GA intent): the
+    # orchestration must FAIL LOUDLY if a direction is requested that's supported but
+    # not yet implemented, instead of silently defaulting to inbound (audit gap).
+    implemented_directions: frozenset[Direction] = _NONE
+
+    @property
+    def is_agent_platform(self) -> bool:
+        return Role.AGENT_PLATFORM in self.roles
+
+    @property
+    def is_ga(self) -> bool:
+        return self.status in (Status.GA, Status.TRANSPORT_ONLY, Status.INTERNAL)
+
+    def supports(self, direction: Direction) -> bool:
+        return direction in self.supported_directions
+
+    def implements(self, direction: Direction) -> bool:
+        return direction in self.implemented_directions
+
+
+# Declarative registry — the ONLY place a provider is declared. See DESIGN.md §1/§5.
+_SPECS: tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        "vapi",
+        "Vapi",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_vapi",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        chat=True,
+        observability_key="vapi",
+        status=Status.GA,
+        # The only provider whose outbound (agent-dials-us) path is wired today.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    ProviderSpec(
+        "retell",
+        "Retell",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.CHAT_ENGINE}),
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_retell",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        chat=True,
+        observability_key="retell",
+        status=Status.GA,
+        # Inbound via the web_retell bridge; outbound now wired via the
+        # RetellOutboundDialer (/v2/create-phone-call). "implemented" = wired, not
+        # yet live-verified e2e (a real outbound call needs a Retell number + stack).
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).
+    ProviderSpec(
+        "livekit_bridge",
+        "LiveKit (agent)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_livekit_bridge",
+        credential_shape=CredentialShape.LIVEKIT_SERVER,
+        observability_key="livekit",
+        status=Status.GA,
+        # WebRTC bridge has NO PSTN leg: we connect to the agent the same way in
+        # both directions; the only difference is who speaks first, now handled by
+        # first_message_mode for all transports. So outbound = inbound bridge +
+        # agent-speaks-first → both wired.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # Provider-neutral catch-all: custom agents reached by phone (SIP) or websocket.
+    ProviderSpec(
+        "others",
+        "Others (custom / SIP)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.WEBSOCKET_URL,
+        observability_key="others",
+        status=Status.GA,
+        # Plain-E.164 SIP works in both directions today.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # --- Planned tested platforms (DESIGN.md §5) ---
+    ProviderSpec(
+        "elevenlabs",
+        "ElevenLabs Conversational AI",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.TTS}),
+        transport=Transport.DIRECT_WS,
+        connector_key="web_elevenlabs",
+        credential_shape=CredentialShape.AGENT_ID,
+        chat=True,
+        observability_key="eleven_labs",
+        status=Status.PLANNED,
+        # Inbound via the connect()-only WS connector; outbound now wired via
+        # ElevenLabsOutboundDialer (POST /v1/convai/twilio/outbound-call).
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    ProviderSpec(
+        "deepgram",
+        "Deepgram Voice Agent",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.STT}),
+        transport=Transport.DIRECT_WS,
+        connector_key="web_deepgram",
+        observability_key="deepgram",
+        credential_shape=CredentialShape.AGENT_ID,
+        status=Status.PLANNED,
+        supported_directions=_BOTH,
+        implemented_directions=_IN,
+    ),
+    # Agora Conversational AI Engine exposes its agents over SIP/PSTN via an
+    # Elastic SIP Trunk (import a number, assign to the agent for inbound/outbound)
+    # — so we reach it through the SAME provider-neutral SIP path as Bland/Twilio,
+    # with NO Agora RTC SDK. Native Agora-RTC (Transport.AGORA_RTC, the unbuilt
+    # web_agora connector) is only the optional WebRTC alternative and stays
+    # SDK-gated (DESIGN.md §5.4). Modeling SIP as the primary transport matches the
+    # only path achievable on our infra today.
+    ProviderSpec(
+        "agora",
+        "Agora Conversational AI",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.SIP,
+        connector_key="web_agora",
+        observability_key="agora",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        status=Status.PLANNED,
+        # Outbound wired via AgoraOutboundDialer (ConvAI telephony API). Inbound is
+        # now implemented PHONE-FREE via the native web_agora RTC connector
+        # (AgoraRTCConnector spawns the ConvAI agent into an RTC channel and the
+        # simulator joins the same channel — TH-5682).
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # Pipecat-on-LiveKit reuses the existing LiveKit bridge connector (DESIGN.md §5.5).
+    ProviderSpec(
+        "pipecat",
+        "Pipecat (LiveKit transport)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_livekit_bridge",
+        observability_key="pipecat",
+        credential_shape=CredentialShape.LIVEKIT_SERVER,
+        status=Status.PLANNED,
+        # Reuses the LiveKit bridge → same as livekit_bridge: outbound is just the
+        # agent-speaks-first opener over the same bridge connection. Both wired.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # Bland.ai agents are reached via the provider-neutral SIP/phone path (no
+    # WebRTC connector needed) — DESIGN.md §3/§6.
+    ProviderSpec(
+        "bland",
+        "Bland.ai",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        observability_key="bland",
+        status=Status.PLANNED,
+        # Outbound wired via BlandOutboundDialer (/v1/calls). INBOUND: a Bland
+        # agent with an inbound number ($15/mo purchase or BYO-Twilio/SIP)
+        # answers any PSTN caller, so the provider-neutral SIP path (dial the
+        # agent's contact_number) reaches it with NO new code — capability
+        # research 2026-06-10 (TH-5683). Live verification still needs an
+        # account with a configured pathway + inbound number.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    # --- Non-agent-platform roles ---
+    ProviderSpec(
+        "twilio",
+        "Twilio",
+        # Twilio is BOTH a carrier substrate AND a platform customers build agents on
+        # (ConversationRelay / Media Streams / TwiML routed to their logic).
+        roles=frozenset({Role.AGENT_PLATFORM, Role.TRANSPORT}),
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        observability_key="twilio",
+        status=Status.PLANNED,
+        # Inbound = dial the Twilio number over our SIP path; outbound = the
+        # TwilioOutboundDialer (Calls.json). Both wired.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    ProviderSpec(
+        "livekit",
+        "LiveKit (system engine)",
+        roles=frozenset({Role.SYSTEM_ENGINE, Role.TRANSPORT}),
+        transport=Transport.SIP,
+        observability_key="livekit",
+        status=Status.INTERNAL,
+        # The system engine drives both directions of the simulated call.
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
+    ),
+    ProviderSpec(
+        "futureagi",
+        "FutureAGI (internal simulator)",
+        roles=frozenset({Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
+        status=Status.INTERNAL,
+        # Internal chat engine — telephony direction not applicable.
+        supported_directions=_NONE,
+        implemented_directions=_NONE,
+    ),
+)
+
+PROVIDER_REGISTRY: dict[str, ProviderSpec] = {s.key: s for s in _SPECS}
+
+
+def get_spec(key: str | None) -> ProviderSpec | None:
+    """Return the ProviderSpec for a client-provider string, or None."""
+    return PROVIDER_REGISTRY.get(key or "")
+
+
+def connector_key_for(key: str | None) -> str | None:
+    """The WebRTC-bridge connector key (web_*) for a provider, or None (→ SIP).
+
+    Replaces the fragile ``f"web_{client_provider}"`` interpolation — a lookup,
+    not string math, so a typo can't silently become an unknown connection_type.
+    """
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return spec.connector_key if spec else None
+
+
+def is_agent_platform(key: str | None) -> bool:
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and spec.is_agent_platform)
+
+
+def supports_direction(key: str | None, direction: Direction) -> bool:
+    """True if the provider's API can do this direction AND we can drive it."""
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and direction in spec.supported_directions)
+
+
+def implements_direction(key: str | None, direction: Direction) -> bool:
+    """True if this direction is actually WIRED for the provider today.
+
+    Dispatch should check this (not just ``supports_direction``) and fail loudly
+    when a supported-but-unimplemented direction is requested, rather than silently
+    running the inbound path (audit: the ``is_outbound=False`` default bug).
+    """
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and direction in spec.implemented_directions)
+
+
+def implemented_directions_for(key: str | None) -> frozenset[Direction]:
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return spec.implemented_directions if spec else _NONE
+
+
+def agent_platform_keys(
+    *, include_planned: bool = True, direction: Direction | None = None
+) -> list[str]:
+    """Provider keys that can be an agent-under-test, optionally for a direction."""
+    return [
+        s.key
+        for s in _SPECS
+        if s.is_agent_platform
+        and (include_planned or s.is_ga)
+        and (direction is None or direction in s.supported_directions)
+    ]
+
+
+def provider_choices(
+    *, include_planned: bool = False, direction: Direction | None = None
+) -> list[tuple[str, str]]:
+    """Django ``choices=`` for AgentDefinition.provider, derived from the registry.
+
+    Defaults to GA agent platforms so the free-form CharField can be constrained
+    without rejecting in-flight definitions (DESIGN.md §4.1, §7 Q2). Pass
+    ``direction`` to constrain the per-provider inbound/outbound toggle in the form.
+    """
+    return [
+        (s.key, s.label)
+        for s in _SPECS
+        if s.is_agent_platform
+        and (include_planned or s.is_ga)
+        and (direction is None or direction in s.supported_directions)
+    ]

--- a/futureagi/simulate/serializers/response/agent_version.py
+++ b/futureagi/simulate/serializers/response/agent_version.py
@@ -3,6 +3,34 @@ from rest_framework import serializers
 from agentcc.services.credential_manager import mask_key
 from simulate.models import AgentVersion
 
+# Provider-secret fields that may live in an AgentVersion.configuration_snapshot
+# and must never be returned to API clients in cleartext (they mirror the
+# credentials encrypted in ProviderCredentials). "Keys" get a partial mask
+# (first/last 4) so the UI can show *which* credential is set; the raw secret is
+# fully hidden. Keep in sync with the snapshot schema.
+_SNAPSHOT_MASKED_KEYS = ("api_key", "livekit_api_key")
+_SNAPSHOT_HIDDEN_SECRETS = ("livekit_api_secret",)
+
+
+def mask_snapshot_secrets(snapshot):
+    """Return a shallow copy of an agent configuration_snapshot with every
+    provider secret masked.
+
+    Safe on any input: a non-dict is returned unchanged. Use this everywhere a
+    configuration_snapshot is embedded in an API response so plaintext provider
+    secrets never reach clients, logs, or browser history.
+    """
+    if not isinstance(snapshot, dict):
+        return snapshot
+    masked = dict(snapshot)
+    for field in _SNAPSHOT_MASKED_KEYS:
+        if masked.get(field):
+            masked[field] = mask_key(masked[field])
+    for field in _SNAPSHOT_HIDDEN_SECRETS:
+        if masked.get(field):
+            masked[field] = "********"
+    return masked
+
 
 class AgentVersionResponseSerializer(serializers.ModelSerializer):
     """
@@ -49,11 +77,10 @@ class AgentVersionResponseSerializer(serializers.ModelSerializer):
             for key in ["organization", "knowledge_base", "workspace", "id"]:
                 if key in snapshot and snapshot[key] is not None:
                     snapshot[key] = str(snapshot[key])
-            # Mask sensitive secret so frontend knows it's set but can't read it
-            if "api_key" in snapshot and snapshot["api_key"]:
-                snapshot["api_key"] = mask_key(snapshot["api_key"])
-            if "livekit_api_secret" in snapshot and snapshot["livekit_api_secret"]:
-                snapshot["livekit_api_secret"] = "********"
+            # Mask every provider secret so the frontend knows a credential is
+            # set but can't read it. livekit_api_key was previously left in
+            # cleartext — mask_snapshot_secrets closes that gap.
+            snapshot = mask_snapshot_secrets(snapshot)
         data["configuration_snapshot"] = snapshot
         return data
 

--- a/futureagi/simulate/serializers/run_test.py
+++ b/futureagi/simulate/serializers/run_test.py
@@ -171,6 +171,10 @@ class RunTestSerializer(serializers.ModelSerializer):
         # re-serializing the same queryset a third time.
         data["evals"] = data.get("evals_detail", [])
         try:
+            from simulate.serializers.response.agent_version import (
+                mask_snapshot_secrets,
+            )
+
             # Only set agent_version for agent_definition source type.
             # Check for soft-deleted agent definition first: FK traversal bypasses
             # BaseModelManager's deleted=False filter, so we check explicitly.
@@ -190,7 +194,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                     data["agent_version"] = {
                         "id": instance.agent_version.id,
                         "name": instance.agent_version.version_name,
-                        "configuration_snapshot": snapshot,
+                        "configuration_snapshot": mask_snapshot_secrets(snapshot),
                     }
                 else:
                     # Try to use prefetched versions first to avoid N+1.
@@ -218,7 +222,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                         data["agent_version"] = {
                             "id": latest_version.id,
                             "name": latest_version.version_name,
-                            "configuration_snapshot": snapshot,
+                            "configuration_snapshot": mask_snapshot_secrets(snapshot),
                         }
         except Exception as e:
             logger.exception(

--- a/futureagi/simulate/services/agent_definition_apply.py
+++ b/futureagi/simulate/services/agent_definition_apply.py
@@ -1,0 +1,80 @@
+"""Apply an optimised config to a platform AgentDefinition (TH-5642).
+
+The platform-side apply edge. For agent-definition runs whose provider has NO
+writable hosted prompt — self-hosted code agents (LiveKit, Pipecat, Deepgram) and
+non-prompt provider configs (Twilio TwiML, Bland pathway) — there is no provider
+API to write to, but the platform still owns the AgentDefinition + its versioned
+config. "Directly apply the fix" there means persisting the winning config as a
+NEW, non-destructive AgentVersion (mirrors optimizer_apply's new-PromptVersion
+pattern): the optimisation is recorded and becomes the agent's active version,
+which the customer's own deployment / the next simulation adopts.
+
+This makes apply work for ALL providers: provider-hosted agents additionally get
+a live provider-API write (see provider_prompt_apply), everything else gets the
+platform-version write here. Neither path silently drops the fix.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Keys of the kit's whole-agent candidate config that map onto an AgentDefinition
+# version snapshot. (provider/assistant_id identity keys are deliberately ignored.)
+_CONFIG_TO_SNAPSHOT = {
+    "instructions": "system_prompt",
+    "model": "model",
+    "temperature": "temperature",
+    "first_message": "first_message",
+    "voice": "voice",
+}
+
+
+def apply_config_as_new_agent_version(agent_definition, config: dict[str, Any]):
+    """Persist ``config`` as a new active AgentVersion of ``agent_definition``.
+
+    Returns the created AgentVersion. The previous version is untouched; the new
+    one becomes the latest/active version carrying the optimised config in its
+    ``configuration_snapshot`` (plus the raw config under ``optimised_config``).
+    """
+    from simulate.models import AgentVersion
+
+    latest = (
+        AgentVersion.objects.filter(agent_definition=agent_definition)
+        .order_by("-version_number")
+        .first()
+    )
+    snapshot = copy.deepcopy(getattr(latest, "configuration_snapshot", None) or {})
+
+    applied_fields: list[str] = []
+    for cfg_key, snap_key in _CONFIG_TO_SNAPSHOT.items():
+        if config.get(cfg_key) not in (None, ""):
+            snapshot[snap_key] = config[cfg_key]
+            applied_fields.append(cfg_key)
+    # Keep the full winning config addressable for downstream adopt/inspect.
+    snapshot["optimised_config"] = {
+        k: v for k, v in config.items() if k not in ("type", "name")
+    }
+
+    new_version = AgentVersion.objects.create(
+        agent_definition=agent_definition,
+        organization_id=agent_definition.organization_id,
+        workspace_id=agent_definition.workspace_id,
+        status=AgentVersion.StatusChoices.ACTIVE
+        if hasattr(AgentVersion, "StatusChoices")
+        else "active",
+        configuration_snapshot=snapshot,
+        commit_message="Applied optimised config (TH-5642 agent-learning-kit)",
+    )
+    logger.info(
+        "agent_definition_config_applied",
+        agent_definition_id=str(agent_definition.id),
+        new_version_id=str(new_version.id),
+        version_number=new_version.version_number,
+        applied_fields=applied_fields,
+    )
+    return new_version, applied_fields

--- a/futureagi/simulate/services/chat_agent_adapter_factory.py
+++ b/futureagi/simulate/services/chat_agent_adapter_factory.py
@@ -1,0 +1,136 @@
+"""Selects the agent-under-test driver for a chat simulation (TH-5642).
+
+Product decision (2026-06-05): for an external **hosted** chat agent (e.g. Retell)
+the PLATFORM drives the conversation server-side via a provider adapter; SDK-push
+stays the path for providers that support it (e.g. LiveKit, whose agent runs the
+customer's own code). Dispatch is gated on **provider + assistant_id** so an SDK
+agent — which has no external hosted assistant_id — is never double-driven.
+
+Both adapters honour the same ``generate_response(conversation_history) -> {...}``
+contract as :class:`PromptBasedAgentAdapter`, so ``run_prompt_based_conversation``
+drives any of them unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import structlog
+from django.db.models import Q
+
+from simulate.models.agent_definition import AgentDefinition
+from simulate.models.run_test import RunTest
+from simulate.services.elevenlabs_chat_agent_adapter import (
+    ElevenLabsChatAgentAdapter,
+)
+from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+from simulate.services.vapi_chat_agent_adapter import VapiChatAgentAdapter
+
+# NOTE: ``create_adapter_from_run_test`` (prompt path) is imported lazily inside
+# create_chat_agent_adapter() — it transitively pulls in litellm/gateway clients,
+# which must NOT load just because the trigger query wants EXTERNAL_HOSTED_CHAT_
+# PROVIDERS. Keeping this module light keeps the routing filter cheap to import.
+
+logger = structlog.get_logger(__name__)
+
+# Providers whose chat agent-under-test the platform drives SERVER-SIDE (hosted,
+# reached by API via assistant_id). provider key -> adapter builder(agent_id, api_key).
+EXTERNAL_HOSTED_CHAT_ADAPTERS = {
+    "retell": RetellChatAgentAdapter,
+    "vapi": VapiChatAgentAdapter,
+    # Both provider-string spellings exist in the wild (registry vs ProviderChoices).
+    "elevenlabs": ElevenLabsChatAgentAdapter,
+    "eleven_labs": ElevenLabsChatAgentAdapter,
+}
+
+# Provider keys the platform drives server-side — used by the trigger query to
+# route these agent_definition TEXT sims into run_single_prompt_chat.
+EXTERNAL_HOSTED_CHAT_PROVIDERS: tuple[str, ...] = tuple(EXTERNAL_HOSTED_CHAT_ADAPTERS)
+
+
+def _resolve_api_key(agent_definition: AgentDefinition) -> str:
+    """Prefer the encrypted ProviderCredentials, fall back to the plain field."""
+    creds = getattr(agent_definition, "credentials", None)
+    if creds is not None:
+        try:
+            key = creds.get_api_key()
+            if key:
+                return key
+        except Exception as e:  # pragma: no cover - defensive; never block on creds
+            logger.warning("chat_adapter_cred_resolve_failed", error=str(e))
+    return agent_definition.api_key or ""
+
+
+def server_side_chat_filter() -> Q:
+    """CallExecution filter for chats the platform drives SERVER-SIDE (TH-5642).
+
+    Prompt-based sims, plus agent_definition TEXT sims whose agent-under-test is an
+    external HOSTED chat provider (e.g. Retell) reachable by assistant_id. SDK-driven
+    agents (no hosted provider/assistant_id) are excluded so they stay on SDK-push and
+    are never double-driven. Lives here (not in the heavy tasks module) so it stays
+    cheap to import. Mirrors :func:`is_external_hosted_chat` at the query level.
+    """
+    rt = "test_execution__run_test"
+    ad = f"{rt}__agent_definition"
+    return Q(**{f"{rt}__source_type": RunTest.SourceTypes.PROMPT}) | (
+        Q(**{f"{rt}__source_type": RunTest.SourceTypes.AGENT_DEFINITION})
+        & Q(**{f"{ad}__agent_type": AgentDefinition.AgentTypeChoices.TEXT})
+        & Q(**{f"{ad}__provider__in": EXTERNAL_HOSTED_CHAT_PROVIDERS})
+        & ~Q(**{f"{ad}__assistant_id__isnull": True})
+        & ~Q(**{f"{ad}__assistant_id__exact": ""})
+    )
+
+
+def is_external_hosted_chat(agent_definition: AgentDefinition | None) -> bool:
+    """True iff this is a TEXT agent on an external hosted chat provider we can
+    drive server-side (provider known + assistant_id present)."""
+    if agent_definition is None:
+        return False
+    return bool(
+        agent_definition.agent_type == AgentDefinition.AgentTypeChoices.TEXT
+        and (agent_definition.provider or "") in EXTERNAL_HOSTED_CHAT_ADAPTERS
+        and (agent_definition.assistant_id or "").strip()
+    )
+
+
+def create_chat_agent_adapter(
+    run_test: RunTest,
+    organization_id: UUID,
+    workspace_id: UUID | None = None,
+    variable_values: dict[str, Any] | None = None,
+):
+    """Return the agent-under-test driver for a chat sim, or ``None`` for SDK-push.
+
+    - ``source_type == prompt`` → :class:`PromptBasedAgentAdapter` (unchanged).
+    - ``agent_definition`` + external hosted chat provider + assistant_id → the
+      provider adapter (platform drives server-side).
+    - otherwise (SDK-driven agents) → ``None``; the caller keeps the SDK-push path.
+    """
+    if run_test.source_type == RunTest.SourceTypes.PROMPT:
+        # Lazy: pulls in litellm/gateway — only needed on the prompt path.
+        from simulate.services.prompt_based_agent_adapter import (
+            create_adapter_from_run_test,
+        )
+
+        return create_adapter_from_run_test(
+            run_test, organization_id, workspace_id, variable_values
+        )
+
+    agent_definition = run_test.agent_definition
+    if is_external_hosted_chat(agent_definition):
+        builder = EXTERNAL_HOSTED_CHAT_ADAPTERS[agent_definition.provider]
+        adapter = builder(
+            agent_id=agent_definition.assistant_id,
+            api_key=_resolve_api_key(agent_definition),
+        )
+        logger.info(
+            "chat_agent_adapter_server_side",
+            provider=agent_definition.provider,
+            agent_definition_id=str(agent_definition.id),
+        )
+        return adapter
+
+    # SDK-driven agent (e.g. LiveKit / custom): the customer's SDK pushes turns
+    # to send_message_to_chat; the platform does not drive it server-side.
+    return None

--- a/futureagi/simulate/services/elevenlabs_chat_agent_adapter.py
+++ b/futureagi/simulate/services/elevenlabs_chat_agent_adapter.py
@@ -1,0 +1,197 @@
+"""ElevenLabsChatAgentAdapter — drive a real ElevenLabs ConvAI agent in TEXT mode.
+
+The chat analogue for ElevenLabs (TH-5642). Unlike Retell (stateless REST per turn),
+ElevenLabs ConvAI has no turn-by-turn REST chat endpoint — its text path is the
+stateful ConvAI WebSocket. This adapter holds one WS open for the conversation and
+bridges it to the synchronous ``generate_response(conversation_history) -> {...}``
+contract (same shape as PromptBasedAgentAdapter) via an owned event loop.
+
+ConvAI WebSocket (https://elevenlabs.io/docs/agents-platform/api-reference/...):
+- URL: signed (private agents) or ``wss://api.elevenlabs.io/v1/convai/conversation?agent_id=...``
+- Send text:  ``{"type": "user_message", "text": "..."}``
+- Receive:    ``{"type": "agent_response", "agent_response_event": {"agent_response": "..."}}``
+- Keepalive:  ``{"type": "ping", "ping_event": {"event_id": N}}`` -> ``{"type": "pong", "event_id": N}``
+- ``conversation_initiation_metadata`` / ``user_transcript`` / ``audio`` / ``interruption``
+  are control/voice frames — handled internally, not returned.
+
+The agent speaks first: on connect we read its opening ``agent_response`` (the
+agent's ``first_message``) and surface it as turn 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+ELEVENLABS_WS_URL = "wss://api.elevenlabs.io/v1/convai/conversation"
+ELEVENLABS_SIGNED_URL = "https://api.elevenlabs.io/v1/convai/conversation/get-signed-url"
+_RECV_TIMEOUT = 30.0
+# Short read for the opening greeting: many ConvAI agents have no first_message and
+# wait for the user, so we must not block a full turn-timeout on turn 1 (verified
+# live 2026-06-05: a no-greeting agent otherwise stalls ~30s before the first user
+# turn can be sent).
+_GREETING_TIMEOUT = 4.0
+_MAX_FRAMES_PER_TURN = 200
+
+
+class ElevenLabsChatAgentError(RuntimeError):
+    """Raised on ElevenLabs ConvAI protocol/transport errors."""
+
+
+class ElevenLabsChatAgentAdapter:
+    """Drives a customer's ElevenLabs ConvAI agent as the text agent-under-test."""
+
+    def __init__(self, agent_id: str, api_key: str, *, ws_url: str = ELEVENLABS_WS_URL):
+        if not agent_id:
+            raise ValueError("ElevenLabsChatAgentAdapter requires an agent_id")
+        self.agent_id = agent_id
+        self._api_key = api_key
+        self._ws_url = ws_url
+
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+        self._session = None
+        self._ws = None
+        self._connected = False
+        self._greeting: str = ""
+        self._sent_user_turns = 0
+
+    # ------------------------------------------------------------------
+    # sync <-> async bridge
+    # ------------------------------------------------------------------
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        if self._event_loop is None:
+            self._event_loop = asyncio.new_event_loop()
+        return self._event_loop
+
+    @staticmethod
+    def _user_turns(conversation_history: list[dict[str, Any]]) -> list[str]:
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    # ------------------------------------------------------------------
+    # WebSocket
+    # ------------------------------------------------------------------
+    async def _resolve_ws_url(self) -> str:
+        if not self._api_key:
+            return f"{self._ws_url}?agent_id={self.agent_id}"
+        async with self._session.get(
+            ELEVENLABS_SIGNED_URL,
+            params={"agent_id": self.agent_id},
+            headers={"xi-api-key": self._api_key},
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise ElevenLabsChatAgentError(
+                    f"ElevenLabs signed-url failed ({resp.status}): {body}"
+                )
+            data = await resp.json()
+        signed = data.get("signed_url")
+        if not signed:
+            raise ElevenLabsChatAgentError(f"No signed_url in response: {data}")
+        return signed
+
+    async def _connect(self) -> None:
+        import aiohttp
+
+        self._session = aiohttp.ClientSession()
+        url = await self._resolve_ws_url()
+        self._ws = await self._session.ws_connect(url)
+        self._connected = True
+        # Agent MAY speak first — capture its opening agent_response if it comes
+        # quickly; agents without a first_message just wait for the user (no stall).
+        self._greeting = await self._read_agent_text(timeout=_GREETING_TIMEOUT)
+        logger.info("elevenlabs_chat_connected", agent_id=self.agent_id)
+
+    async def _read_agent_text(self, timeout: float = _RECV_TIMEOUT) -> str:
+        """Read frames until an agent_response; answer pings; skip audio/control."""
+        import aiohttp
+
+        for _ in range(_MAX_FRAMES_PER_TURN):
+            try:
+                msg = await asyncio.wait_for(self._ws.receive(), timeout=timeout)
+            except TimeoutError:
+                return ""
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                import json
+
+                try:
+                    event = json.loads(msg.data)
+                except (ValueError, TypeError):
+                    continue
+                etype = event.get("type")
+                if etype == "agent_response":
+                    return str(
+                        (event.get("agent_response_event") or {}).get("agent_response")
+                        or ""
+                    )
+                if etype == "ping":
+                    event_id = (event.get("ping_event") or {}).get("event_id")
+                    await self._ws.send_json({"type": "pong", "event_id": event_id})
+                # conversation_initiation_metadata / user_transcript / audio /
+                # interruption: ignore.
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+        return ""
+
+    async def _generate_async(self, conversation_history: list[dict[str, Any]]) -> str:
+        if not self._connected:
+            await self._connect()
+
+        user_turns = self._user_turns(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+        if not new_turns:
+            # Turn 1: the agent's opening message.
+            return self._greeting
+
+        await self._ws.send_json({"type": "user_message", "text": new_turns[-1]})
+        self._sent_user_turns = len(user_turns)
+        return await self._read_agent_text()
+
+    # ------------------------------------------------------------------
+    # agent-under-test contract
+    # ------------------------------------------------------------------
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        start = time.perf_counter()
+        content = self._loop().run_until_complete(
+            self._generate_async(conversation_history)
+        )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"elevenlabs:{self.agent_id}",
+            "latency_ms": latency_ms,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": False,
+        }
+
+    def end(self) -> None:
+        if self._event_loop is None:
+            return
+        try:
+            self._event_loop.run_until_complete(self._close())
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning("elevenlabs_chat_end_failed", error=str(e))
+        finally:
+            self._event_loop.close()
+            self._event_loop = None
+
+    async def _close(self) -> None:
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._connected = False

--- a/futureagi/simulate/services/prompt_based_agent_adapter.py
+++ b/futureagi/simulate/services/prompt_based_agent_adapter.py
@@ -33,6 +33,7 @@ class PromptBasedAgentAdapter:
         organization_id: UUID,
         workspace_id: Optional[UUID] = None,
         variable_values: Optional[dict[str, Any]] = None,
+        mock_tool_returns: Optional[dict[str, Any]] = None,
     ):
         """
         Initialize the adapter with a prompt version.
@@ -42,11 +43,19 @@ class PromptBasedAgentAdapter:
             organization_id: The organization ID for API key lookup
             workspace_id: Optional workspace ID for API key lookup
             variable_values: Optional dict of variable values to inject into the prompt
+            mock_tool_returns: Optional scenario-aligned mock tool returns (TH-5642);
+                when set, the agent's tool calls are answered with these mocks so the
+                tool-call paths are exercised deterministically.
         """
         self.prompt_version = prompt_version
         self.organization_id = organization_id
         self.workspace_id = workspace_id
         self.variable_values = variable_values or {}
+        # Mock tool returns may arrive explicitly, via variable_values, or (set in
+        # _load_config) from the prompt config snapshot.
+        self.mock_tool_returns = (
+            mock_tool_returns or self.variable_values.get("mock_tool_returns") or {}
+        )
         self._load_config()
 
     def _load_config(self) -> None:
@@ -203,6 +212,29 @@ class PromptBasedAgentAdapter:
 
         return messages
 
+    def _call_llm(self, messages: list[dict[str, Any]]):
+        """One LLM completion via RunPrompt; returns ``(content, value_info)``.
+
+        ``value_info["metadata"]["tool_calls"]`` carries structured tool calls when
+        the agent invokes a tool (TH-5642), letting the mock-tool loop intercept.
+        """
+        run_prompt = RunPrompt(
+            model=self.model,
+            messages=messages,
+            organization_id=str(self.organization_id),
+            output_format=None,
+            temperature=self.temperature,
+            frequency_penalty=self.frequency_penalty,
+            presence_penalty=self.presence_penalty,
+            max_tokens=self.max_tokens,
+            top_p=self.top_p,
+            response_format=None,
+            tool_choice=self.tool_choice,
+            tools=self.tools,
+            workspace_id=str(self.workspace_id) if self.workspace_id else None,
+        )
+        return run_prompt.litellm_response()
+
     @retry(stop_max_attempt_number=3, wait_fixed=2000)
     def generate_response(
         self,
@@ -229,27 +261,30 @@ class PromptBasedAgentAdapter:
                 prompt_version_id=str(self.prompt_version.id),
             )
 
-            run_prompt = RunPrompt(
-                model=self.model,
-                messages=messages,
-                organization_id=str(self.organization_id),
-                output_format=None,
-                temperature=self.temperature,
-                frequency_penalty=self.frequency_penalty,
-                presence_penalty=self.presence_penalty,
-                max_tokens=self.max_tokens,
-                top_p=self.top_p,
-                response_format=None,
-                tool_choice=self.tool_choice,
-                tools=self.tools,
-                workspace_id=str(self.workspace_id) if self.workspace_id else None,
-            )
-
             start_time = time.perf_counter()
-            response_text, value_info = run_prompt.litellm_response()
-            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            last_info: dict[str, Any] = {}
 
-            content = response_text or ""
+            def _llm(msgs):
+                text, info = self._call_llm(msgs)
+                last_info.clear()
+                last_info.update(info or {})
+                tool_calls = (info.get("metadata") or {}).get("tool_calls") or []
+                return text, tool_calls
+
+            if self.mock_tool_returns:
+                # Drive the agent's tool calls with scenario-aligned mocks so the
+                # tool-call paths are exercised deterministically (TH-5642).
+                from simulate.services.mock_tools import run_mock_tool_loop
+
+                content, _rounds = run_mock_tool_loop(
+                    _llm, messages, self.mock_tool_returns
+                )
+            else:
+                response_text, last_info = self._call_llm(messages)
+                content = response_text or ""
+
+            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            value_info = last_info
             usage = value_info.get("metadata", {}).get("usage", {})
 
             result = {
@@ -382,6 +417,10 @@ def create_adapter_from_run_test(
         organization_id=organization_id,
         workspace_id=workspace_id,
         variable_values=variable_values,
+        # Scenario-aligned mock tool returns live in the run_test metadata (TH-5642).
+        mock_tool_returns=(getattr(run_test, "metadata", None) or {}).get(
+            "mock_tool_returns"
+        ),
     )
 
 
@@ -419,4 +458,8 @@ def create_adapter_from_scenario(
         organization_id=organization_id,
         workspace_id=workspace_id,
         variable_values=variable_values,
+        # Scenario-aligned mock tool returns live in the scenario metadata (TH-5642).
+        mock_tool_returns=(getattr(scenario, "metadata", None) or {}).get(
+            "mock_tool_returns"
+        ),
     )

--- a/futureagi/simulate/services/provider_connectivity_probes.py
+++ b/futureagi/simulate/services/provider_connectivity_probes.py
@@ -1,0 +1,183 @@
+"""Real, credential-only connectivity probes for simulation providers (TH-5642).
+
+Each probe validates that a provider's credentials are live by making a single read-only
+API call — it places NO phone calls and starts NO billable sessions. Probes return
+``(ok: bool, detail: str)`` and read credentials from the ``SIM_VERIFY_<PROVIDER>_*``
+environment convention. Only providers with a safe, proven probe are implemented here;
+the verification harness reports the rest as SKIPPED rather than implying coverage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+_TIMEOUT_SECONDS = 10.0
+
+
+def _http_get(
+    url: str,
+    headers: dict[str, str] | None = None,
+    params: dict[str, str] | None = None,
+    auth: tuple[str, str] | None = None,
+):
+    import httpx
+
+    with httpx.Client(timeout=_TIMEOUT_SECONDS) as client:
+        return client.get(url, headers=headers or {}, params=params, auth=auth)
+
+
+def _classify(resp, ok_detail: str, provider: str) -> tuple[bool, str]:
+    """Map an HTTP response to (ok, detail).
+
+    2xx -> valid credentials. 401/403 -> credentials rejected. Anything else is reported
+    verbatim so a wrong endpoint reads as an endpoint issue, not a credential failure.
+    """
+    if 200 <= resp.status_code < 300:
+        return True, ok_detail
+    if resp.status_code in (401, 403):
+        return False, f"{provider} rejected credentials ({resp.status_code})"
+    return False, f"{provider} returned {resp.status_code}"
+
+
+def deepgram_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate a Deepgram key via the read-only projects endpoint."""
+    key = env.get("SIM_VERIFY_DEEPGRAM_API_KEY")
+    if not key:
+        return False, "SIM_VERIFY_DEEPGRAM_API_KEY not set"
+    resp = _http_get(
+        "https://api.deepgram.com/v1/projects",
+        headers={"Authorization": f"Token {key}"},
+    )
+    if resp.status_code == 200:
+        return True, "deepgram key valid (GET /v1/projects 200)"
+    return False, f"deepgram returned {resp.status_code}"
+
+
+def elevenlabs_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate an ElevenLabs key (and agent, if set) via read-only endpoints."""
+    key = env.get("SIM_VERIFY_ELEVENLABS_API_KEY")
+    if not key:
+        return False, "SIM_VERIFY_ELEVENLABS_API_KEY not set"
+    headers = {"xi-api-key": key}
+    resp = _http_get("https://api.elevenlabs.io/v1/user", headers=headers)
+    if resp.status_code != 200:
+        return False, f"elevenlabs key invalid (GET /v1/user {resp.status_code})"
+    agent_id = env.get("SIM_VERIFY_ELEVENLABS_AGENT_ID")
+    if not agent_id:
+        return True, "elevenlabs key valid (agent not checked; AGENT_ID unset)"
+    signed = _http_get(
+        "https://api.elevenlabs.io/v1/convai/conversation/get-signed-url",
+        headers=headers,
+        params={"agent_id": agent_id},
+    )
+    if signed.status_code == 200:
+        return True, "elevenlabs key + agent valid (signed-url 200)"
+    return False, f"elevenlabs agent check returned {signed.status_code}"
+
+
+def vapi_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate a Vapi key via the read-only list-assistants endpoint."""
+    key = env.get("SIM_VERIFY_VAPI_API_KEY")
+    if not key:
+        return False, "SIM_VERIFY_VAPI_API_KEY not set"
+    resp = _http_get(
+        "https://api.vapi.ai/assistant",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    return _classify(resp, "vapi key valid (GET /assistant 2xx)", "vapi")
+
+
+def retell_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate a Retell key via the read-only list-agents endpoint."""
+    key = env.get("SIM_VERIFY_RETELL_API_KEY")
+    if not key:
+        return False, "SIM_VERIFY_RETELL_API_KEY not set"
+    resp = _http_get(
+        "https://api.retellai.com/list-agents",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    return _classify(resp, "retell key valid (GET /list-agents 2xx)", "retell")
+
+
+def bland_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate a Bland key via the read-only account endpoint (no call placed)."""
+    key = env.get("SIM_VERIFY_BLAND_API_KEY")
+    if not key:
+        return False, "SIM_VERIFY_BLAND_API_KEY not set"
+    # Bland uses the raw key in the `authorization` header (no Bearer prefix).
+    resp = _http_get("https://api.bland.ai/v1/me", headers={"authorization": key})
+    return _classify(resp, "bland key valid (GET /v1/me 2xx)", "bland")
+
+
+def twilio_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate Twilio creds via GET Account (Basic auth). Credential is 'AccountSid:AuthToken'."""
+    raw = env.get("SIM_VERIFY_TWILIO_API_KEY")
+    if not raw:
+        return False, "SIM_VERIFY_TWILIO_API_KEY not set (expected 'AccountSid:AuthToken')"
+    if ":" not in raw:
+        return False, "SIM_VERIFY_TWILIO_API_KEY must be 'AccountSid:AuthToken'"
+    sid, token = raw.split(":", 1)
+    resp = _http_get(
+        f"https://api.twilio.com/2010-04-01/Accounts/{sid}.json",
+        auth=(sid, token),
+    )
+    return _classify(resp, "twilio creds valid (GET Account 2xx)", "twilio")
+
+
+def agora_probe(env: Mapping[str, str]) -> tuple[bool, str]:
+    """Validate Agora REST creds via GET projects (Basic auth). Credential is 'CustomerKey:CustomerSecret'."""
+    raw = env.get("SIM_VERIFY_AGORA_API_KEY")
+    if not raw:
+        return False, "SIM_VERIFY_AGORA_API_KEY not set (expected 'CustomerKey:CustomerSecret')"
+    if ":" not in raw:
+        return False, "SIM_VERIFY_AGORA_API_KEY must be 'CustomerKey:CustomerSecret'"
+    customer_key, customer_secret = raw.split(":", 1)
+    resp = _http_get(
+        "https://api.agora.io/dev/v1/projects",
+        auth=(customer_key, customer_secret),
+    )
+    return _classify(resp, "agora creds valid (GET /dev/v1/projects 2xx)", "agora")
+
+
+def make_livekit_probe(provider_key: str):
+    """Build a LiveKit-server probe for ``provider_key`` (livekit_bridge, pipecat, ...).
+
+    Reads SIM_VERIFY_<PROVIDER>_LIVEKIT_URL/_API_KEY/_API_SECRET and lists rooms on the
+    server — a read-only call that validates the server creds without joining a room or
+    placing a call. The SDK call is async, so it is run in a fresh event loop.
+    """
+    prefix = provider_key.upper()
+    url_var = f"SIM_VERIFY_{prefix}_LIVEKIT_URL"
+    key_var = f"SIM_VERIFY_{prefix}_LIVEKIT_API_KEY"
+    secret_var = f"SIM_VERIFY_{prefix}_LIVEKIT_API_SECRET"
+
+    def _probe(env: Mapping[str, str]) -> tuple[bool, str]:
+        url = env.get(url_var)
+        api_key = env.get(key_var)
+        api_secret = env.get(secret_var)
+        missing = [
+            v for v, val in ((url_var, url), (key_var, api_key), (secret_var, api_secret))
+            if not val
+        ]
+        if missing:
+            return False, f"not set: {', '.join(missing)}"
+
+        import asyncio
+
+        async def _list_rooms() -> int:
+            from livekit import api
+
+            lkapi = api.LiveKitAPI(url, api_key, api_secret)
+            try:
+                resp = await lkapi.room.list_rooms(api.ListRoomsRequest())
+                return len(resp.rooms)
+            finally:
+                await lkapi.aclose()
+
+        try:
+            count = asyncio.run(_list_rooms())
+        except Exception as exc:
+            return False, f"{provider_key} list_rooms failed: {type(exc).__name__}: {exc}"
+        return True, f"{provider_key} server creds valid (list_rooms ok, {count} rooms)"
+
+    return _probe

--- a/futureagi/simulate/services/provider_prompt_apply.py
+++ b/futureagi/simulate/services/provider_prompt_apply.py
@@ -1,0 +1,561 @@
+"""Apply an optimised prompt to the customer's PROVIDER-SIDE agent (TH-5642).
+
+"Directly apply the fix" for agent-definition runs: unlike prompt-template runs
+(where the platform owns the prompt and applying = a new PromptVersion, see
+``optimizer_apply.py``), an AgentDefinition describes an agent hosted by a third
+party — its prompt lives on the provider. Applying there means writing through
+the provider's management API.
+
+Each writer follows the same contract:
+- read the agent's current prompt first (returned as ``previous_prompt`` so the
+  caller can surface an undo),
+- write the new prompt,
+- read it back and verify the write landed (no trust-the-200).
+
+Providers whose "agent" is not a single prompt (Bland pathways are node graphs;
+Twilio agents are the customer's own TwiML/app code; LiveKit/Pipecat agents are
+the customer's own deployment) raise ``PromptApplyUnsupported`` with the reason —
+callers turn that into a clear 400, never a silent skip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class PromptApplyError(RuntimeError):
+    """A provider API call failed or the read-back didn't match."""
+
+
+class PromptApplyUnsupported(PromptApplyError):
+    """The provider has no single-prompt agent to write to."""
+
+
+def _check(resp: requests.Response, what: str) -> dict[str, Any]:
+    if resp.status_code >= 400:
+        raise PromptApplyError(f"{what} failed ({resp.status_code}): {resp.text[:500]}")
+    try:
+        return resp.json() or {}
+    except ValueError:
+        return {}
+
+
+# Normalized whole-agent config keys (the kit's agent-config vocabulary).
+# Writers map the subset their provider supports; unknown keys are reported
+# back as ``skipped_fields`` rather than silently dropped.
+CONFIG_FIELDS = ("instructions", "model", "temperature", "first_message", "voice")
+
+
+class ProviderPromptWriter:
+    provider: str = ""
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError(f"{type(self).__name__} requires an api_key")
+        self._api_key = api_key
+
+    def get_prompt(self, assistant_id: str) -> str:
+        raise NotImplementedError
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        raise NotImplementedError
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        """Read the agent's current config in normalized CONFIG_FIELDS keys."""
+        raise NotImplementedError
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        """Write the normalized ``config`` subset; return the field names applied."""
+        raise NotImplementedError
+
+    def apply(self, assistant_id: str, prompt: str) -> dict[str, Any]:
+        """Write ``prompt`` to the provider agent and verify by read-back."""
+        previous = self.get_prompt(assistant_id)
+        self.set_prompt(assistant_id, prompt)
+        current = self.get_prompt(assistant_id)
+        if current != prompt:
+            raise PromptApplyError(
+                f"{self.provider} read-back mismatch after update: "
+                f"expected the applied prompt, got {current[:200]!r}"
+            )
+        return {
+            "provider": self.provider,
+            "assistant_id": assistant_id,
+            "applied": True,
+            "previous_prompt": previous,
+        }
+
+    def apply_config(self, assistant_id: str, config: dict[str, Any]) -> dict[str, Any]:
+        """Write a WHOLE-agent config (kit ``best_config.agent``) and verify.
+
+        Only normalized CONFIG_FIELDS are written; provider-identity keys
+        (type/name/provider/assistant_id) and unknown keys are skipped and
+        reported. Read-back verifies every field the provider echoes back.
+        """
+        desired = {
+            k: config[k] for k in CONFIG_FIELDS if config.get(k) not in (None, "")
+        }
+        if not desired:
+            raise PromptApplyError(
+                "Candidate config has no applicable fields "
+                f"(supported: {', '.join(CONFIG_FIELDS)})."
+            )
+        previous = self.get_config(assistant_id)
+        applied_fields = self.set_config(assistant_id, desired)
+        current = self.get_config(assistant_id)
+        mismatched = [
+            f
+            for f in applied_fields
+            if f in current and current.get(f) != desired.get(f)
+        ]
+        if mismatched:
+            raise PromptApplyError(
+                f"{self.provider} read-back mismatch after config update on: "
+                f"{', '.join(mismatched)}"
+            )
+        skipped = sorted(
+            k
+            for k in config
+            if k not in applied_fields
+            and k not in ("type", "name", "provider", "assistant_id")
+        )
+        return {
+            "provider": self.provider,
+            "assistant_id": assistant_id,
+            "applied": True,
+            "applied_fields": applied_fields,
+            "skipped_fields": skipped,
+            "previous_config": previous,
+        }
+
+
+class ElevenLabsPromptWriter(ProviderPromptWriter):
+    """ConvAI agent prompt at ``conversation_config.agent.prompt.prompt``."""
+
+    provider = "eleven_labs"
+    BASE_URL = "https://api.elevenlabs.io"
+
+    def _headers(self) -> dict[str, str]:
+        return {"xi-api-key": self._api_key, "Content-Type": "application/json"}
+
+    def get_prompt(self, assistant_id: str) -> str:
+        data = _check(
+            requests.get(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs get-agent",
+        )
+        return str(
+            ((data.get("conversation_config") or {}).get("agent") or {})
+            .get("prompt", {})
+            .get("prompt", "")
+        )
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                json={"conversation_config": {"agent": {"prompt": {"prompt": prompt}}}},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs update-agent",
+        )
+
+    def _get_conversation_config(self, assistant_id: str) -> dict[str, Any]:
+        data = _check(
+            requests.get(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs get-agent",
+        )
+        return data.get("conversation_config") or {}
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        cc = self._get_conversation_config(assistant_id)
+        agent = cc.get("agent") or {}
+        prompt = agent.get("prompt") or {}
+        return {
+            "instructions": str(prompt.get("prompt") or ""),
+            "model": prompt.get("llm"),
+            "temperature": prompt.get("temperature"),
+            "first_message": agent.get("first_message"),
+            "voice": (cc.get("tts") or {}).get("voice_id"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        prompt_patch: dict[str, Any] = {}
+        agent_patch: dict[str, Any] = {}
+        cc_patch: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            prompt_patch["prompt"] = str(config["instructions"])
+            applied.append("instructions")
+        if "model" in config:
+            prompt_patch["llm"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            prompt_patch["temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if "first_message" in config:
+            agent_patch["first_message"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            cc_patch["tts"] = {"voice_id": str(config["voice"])}
+            applied.append("voice")
+        if prompt_patch:
+            agent_patch["prompt"] = prompt_patch
+        if agent_patch:
+            cc_patch["agent"] = agent_patch
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                json={"conversation_config": cc_patch},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs update-agent",
+        )
+        return applied
+
+
+class VapiPromptWriter(ProviderPromptWriter):
+    """Assistant prompt = the system message in ``model.messages``.
+
+    Vapi's PATCH replaces the whole ``model`` object, so read-modify-write.
+    """
+
+    provider = "vapi"
+    BASE_URL = "https://api.vapi.ai"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_assistant(self, assistant_id: str) -> dict[str, Any]:
+        return _check(
+            requests.get(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi get-assistant",
+        )
+
+    @staticmethod
+    def _system_content(model: dict[str, Any]) -> str:
+        for msg in model.get("messages") or []:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                return str(msg.get("content") or "")
+        return ""
+
+    def get_prompt(self, assistant_id: str) -> str:
+        return self._system_content(
+            self._get_assistant(assistant_id).get("model") or {}
+        )
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        model = dict(self._get_assistant(assistant_id).get("model") or {})
+        messages = [
+            dict(m) for m in (model.get("messages") or []) if isinstance(m, dict)
+        ]
+        for msg in messages:
+            if msg.get("role") == "system":
+                msg["content"] = prompt
+                break
+        else:
+            messages.insert(0, {"role": "system", "content": prompt})
+        model["messages"] = messages
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                json={"model": model},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi update-assistant",
+        )
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        assistant = self._get_assistant(assistant_id)
+        model = assistant.get("model") or {}
+        return {
+            "instructions": self._system_content(model),
+            "model": model.get("model"),
+            "temperature": model.get("temperature"),
+            "first_message": assistant.get("firstMessage"),
+            "voice": (assistant.get("voice") or {}).get("voiceId"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        assistant = self._get_assistant(assistant_id)
+        # Vapi PATCH replaces whole sub-objects, so read-modify-write model/voice.
+        model = dict(assistant.get("model") or {})
+        body: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            messages = [
+                dict(m) for m in (model.get("messages") or []) if isinstance(m, dict)
+            ]
+            for msg in messages:
+                if msg.get("role") == "system":
+                    msg["content"] = str(config["instructions"])
+                    break
+            else:
+                messages.insert(
+                    0, {"role": "system", "content": str(config["instructions"])}
+                )
+            model["messages"] = messages
+            applied.append("instructions")
+        if "model" in config:
+            model["model"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            model["temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if applied:
+            body["model"] = model
+        if "first_message" in config:
+            body["firstMessage"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            voice = dict(assistant.get("voice") or {})
+            voice["voiceId"] = str(config["voice"])
+            body["voice"] = voice
+            applied.append("voice")
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                json=body,
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi update-assistant",
+        )
+        return applied
+
+
+class RetellPromptWriter(ProviderPromptWriter):
+    """Agent prompt = ``general_prompt`` on the agent's Retell-LLM.
+
+    The agent references its LLM via ``response_engine.llm_id``; only
+    ``response_engine.type == "retell-llm"`` agents carry an editable prompt.
+    """
+
+    provider = "retell"
+    BASE_URL = "https://api.retellai.com"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _llm_id(self, assistant_id: str) -> str:
+        agent = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-agent/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-agent",
+        )
+        engine = agent.get("response_engine") or {}
+        if engine.get("type") != "retell-llm" or not engine.get("llm_id"):
+            raise PromptApplyUnsupported(
+                "Retell agent does not use a retell-llm response engine; "
+                "its prompt is not editable via the Retell API."
+            )
+        return str(engine["llm_id"])
+
+    def get_prompt(self, assistant_id: str) -> str:
+        llm = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-retell-llm",
+        )
+        return str(llm.get("general_prompt") or "")
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/update-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                json={"general_prompt": prompt},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell update-retell-llm",
+        )
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        agent = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-agent/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-agent",
+        )
+        llm = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-retell-llm",
+        )
+        return {
+            "instructions": str(llm.get("general_prompt") or ""),
+            "model": llm.get("model"),
+            "temperature": llm.get("model_temperature"),
+            "first_message": llm.get("begin_message"),
+            "voice": agent.get("voice_id"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        llm_patch: dict[str, Any] = {}
+        agent_patch: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            llm_patch["general_prompt"] = str(config["instructions"])
+            applied.append("instructions")
+        if "model" in config:
+            llm_patch["model"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            llm_patch["model_temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if "first_message" in config:
+            llm_patch["begin_message"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            agent_patch["voice_id"] = str(config["voice"])
+            applied.append("voice")
+        if llm_patch:
+            _check(
+                requests.patch(
+                    f"{self.BASE_URL}/update-retell-llm/{self._llm_id(assistant_id)}",
+                    headers=self._headers(),
+                    json=llm_patch,
+                    timeout=REQUEST_TIMEOUT,
+                ),
+                "Retell update-retell-llm",
+            )
+        if agent_patch:
+            _check(
+                requests.patch(
+                    f"{self.BASE_URL}/update-agent/{assistant_id}",
+                    headers=self._headers(),
+                    json=agent_patch,
+                    timeout=REQUEST_TIMEOUT,
+                ),
+                "Retell update-agent",
+            )
+        return applied
+
+
+_UNSUPPORTED: dict[str, str] = {
+    "bland": "Bland pathways are node graphs, not a single prompt; apply per-node "
+    "via the Bland pathway editor/API.",
+    "twilio": "A Twilio agent is the customer's own TwiML application code; there "
+    "is no provider-side prompt to write.",
+    "livekit": "LiveKit agents are the customer's own deployment; the prompt lives "
+    "in their code.",
+    "livekit_bridge": "LiveKit agents are the customer's own deployment; the prompt "
+    "lives in their code.",
+    "pipecat": "Pipecat agents are the customer's own deployment; the prompt lives "
+    "in their code.",
+    "deepgram": "Deepgram Voice Agents are defined inline per-connection (Settings "
+    "message), not stored provider-side.",
+    "agora": "Agora ConvAI pipeline prompt updates need project access (TH-5682).",
+}
+
+PROVIDER_PROMPT_WRITERS: dict[str, type[ProviderPromptWriter]] = {
+    "vapi": VapiPromptWriter,
+    "retell": RetellPromptWriter,
+    "elevenlabs": ElevenLabsPromptWriter,
+    "eleven_labs": ElevenLabsPromptWriter,  # provider-string drift
+}
+
+
+def _writer_for_agent_definition(
+    agent_definition,
+) -> tuple[ProviderPromptWriter, str]:
+    """Resolve (writer, assistant_id) for an agent definition or raise."""
+    provider = (agent_definition.provider or "").strip().lower()
+    assistant_id = (agent_definition.assistant_id or "").strip()
+    if not provider:
+        raise PromptApplyUnsupported("Agent definition has no provider set.")
+    if provider in _UNSUPPORTED:
+        raise PromptApplyUnsupported(_UNSUPPORTED[provider])
+    writer_cls = PROVIDER_PROMPT_WRITERS.get(provider)
+    if writer_cls is None:
+        raise PromptApplyUnsupported(f"No prompt writer for provider {provider!r}.")
+    if not assistant_id:
+        raise PromptApplyUnsupported(
+            "Agent definition has no assistant_id to apply to."
+        )
+
+    from simulate.services.chat_agent_adapter_factory import _resolve_api_key
+
+    api_key = _resolve_api_key(agent_definition)
+    if not api_key:
+        raise PromptApplyError(
+            f"No {provider} credentials on the agent definition to apply with."
+        )
+    return writer_cls(api_key=api_key), assistant_id
+
+
+def apply_prompt_to_provider_agent(agent_definition, prompt: str) -> dict[str, Any]:
+    """Write ``prompt`` to the agent definition's provider-side agent.
+
+    Resolves credentials like the chat adapters do (encrypted ProviderCredentials
+    first, plain ``api_key`` field as fallback). Raises ``PromptApplyUnsupported``
+    with a per-provider reason when there is nothing writable, ``PromptApplyError``
+    on API failure or read-back mismatch.
+    """
+    writer, assistant_id = _writer_for_agent_definition(agent_definition)
+    result = writer.apply(assistant_id, prompt)
+    logger.info(
+        "provider_prompt_applied",
+        provider=writer.provider,
+        assistant_id=assistant_id,
+        agent_definition_id=str(agent_definition.id),
+    )
+    return result
+
+
+def apply_config_to_provider_agent(
+    agent_definition, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Write a WHOLE-agent config (kit candidate / ``best_config.agent``) to the
+    provider-side agent — instructions, model, temperature, first message, voice —
+    with per-field read-back verification. The kit is the engine that produced the
+    config; this is the platform's apply edge.
+    """
+    writer, assistant_id = _writer_for_agent_definition(agent_definition)
+    result = writer.apply_config(assistant_id, config)
+    logger.info(
+        "provider_config_applied",
+        provider=writer.provider,
+        assistant_id=assistant_id,
+        agent_definition_id=str(agent_definition.id),
+        applied_fields=result.get("applied_fields"),
+    )
+    return result

--- a/futureagi/simulate/services/provider_verification.py
+++ b/futureagi/simulate/services/provider_verification.py
@@ -1,0 +1,230 @@
+"""Operational E2E verification harness across all simulation providers (TH-5642).
+
+The platform code for every provider × modality × direction is implemented and
+unit-tested, but *live* end-to-end verification needs real provider credentials and (for
+telephony) a deployed SIP stack — things that live outside the codebase. This harness
+turns that manual, ad-hoc checking into one repeatable, creds-driven report:
+
+    python manage.py verify_providers --mode registry      # declared matrix, no I/O
+    python manage.py verify_providers --mode credentials   # which creds are present
+    python manage.py verify_providers --mode connectivity  # real handshakes (creds)
+
+The matrix is derived from the provider registry (the single source of truth), so it
+stays correct as providers are added/promoted. Credentials are read from environment
+variables under the ``SIM_VERIFY_<PROVIDER>_<FIELD>`` convention — deliberately separate
+from customer-owned ProviderCredentials, which must not be used for arbitrary test calls.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from simulate.providers import registry as reg
+
+# Verification modes, cheapest/safest first.
+MODE_REGISTRY = "registry"          # pure: what the registry declares is implemented
+MODE_CREDENTIALS = "credentials"    # are the env credentials present for a real run?
+MODE_CONNECTIVITY = "connectivity"  # real handshake against the provider (needs creds)
+MODES = (MODE_REGISTRY, MODE_CREDENTIALS, MODE_CONNECTIVITY)
+
+# Cell status values.
+OK = "ok"              # implemented / creds present / handshake succeeded
+MISSING = "missing"    # creds absent
+FAILED = "failed"      # handshake attempted and failed
+SKIPPED = "skipped"    # not applicable / no probe / needs deployed stack
+NOT_IMPL = "not_implemented"  # registry does not implement this cell
+
+# Required credential env-var field suffixes per registry CredentialShape. The full env
+# var is SIM_VERIFY_<PROVIDER>_<SUFFIX>, e.g. SIM_VERIFY_DEEPGRAM_API_KEY.
+_SHAPE_FIELDS: dict[str, tuple[str, ...]] = {
+    "api_key_assistant": ("API_KEY",),
+    "agent_id": ("API_KEY", "AGENT_ID"),
+    "websocket_url": ("WEBSOCKET_URL",),
+    "livekit_server": ("LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"),
+    "sip_only": (),   # no API credential — needs a deployed SIP stack instead
+    "none": (),
+}
+
+# Shapes whose live path additionally needs a deployed SIP/telephony stack, which the
+# harness cannot stand up on its own.
+_NEEDS_SIP_STACK = {"sip_only"}
+
+
+@dataclass(frozen=True)
+class VerificationCell:
+    provider: str
+    modality: str        # "chat" | "voice"
+    direction: str | None  # "inbound" | "outbound" for voice; None for chat
+    status: str
+    detail: str = ""
+
+
+@dataclass
+class VerificationReport:
+    mode: str
+    cells: list[VerificationCell] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for c in self.cells:
+            out[c.status] = out.get(c.status, 0) + 1
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "summary": self.summary(),
+            "cells": [
+                {
+                    "provider": c.provider,
+                    "modality": c.modality,
+                    "direction": c.direction,
+                    "status": c.status,
+                    "detail": c.detail,
+                }
+                for c in self.cells
+            ],
+        }
+
+
+def _env_for(provider: str, suffix: str) -> str:
+    return f"SIM_VERIFY_{provider.upper()}_{suffix}"
+
+
+def credential_status(
+    provider: str, env: Mapping[str, str] | None = None
+) -> tuple[str, str]:
+    """Is the credential set for ``provider`` present? Returns (status, detail)."""
+    env = env if env is not None else os.environ
+    spec = reg.get_spec(provider)
+    shape = str(getattr(spec, "credential_shape", "none"))
+    if shape in _NEEDS_SIP_STACK:
+        return SKIPPED, "requires a deployed SIP/telephony stack (no API credential)"
+    fields = _SHAPE_FIELDS.get(shape, ())
+    if not fields:
+        return OK, "no credential required"
+    missing = [_env_for(provider, f) for f in fields if not env.get(_env_for(provider, f))]
+    if missing:
+        return MISSING, f"set {', '.join(missing)}"
+    return OK, f"credentials present ({shape})"
+
+
+def _modality_cells(provider: str) -> list[tuple[str, str | None]]:
+    """The (modality, direction) cells the registry declares for a provider."""
+    spec = reg.get_spec(provider)
+    cells: list[tuple[str, str | None]] = []
+    if bool(getattr(spec, "chat", False)):
+        cells.append(("chat", None))
+    impl = {str(d) for d in reg.implemented_directions_for(provider)}
+    for direction in ("inbound", "outbound"):
+        if direction in impl:
+            cells.append(("voice", direction))
+    return cells
+
+
+def declared_matrix() -> VerificationReport:
+    """Registry mode: what is implemented, no I/O. Always runnable."""
+    report = VerificationReport(mode=MODE_REGISTRY)
+    for provider in reg.agent_platform_keys():
+        spec = reg.get_spec(provider)
+        status = str(getattr(spec, "status", ""))
+        cells = _modality_cells(provider)
+        if not cells:
+            report.cells.append(
+                VerificationCell(provider, "—", None, NOT_IMPL, f"status={status}")
+            )
+            continue
+        for modality, direction in cells:
+            report.cells.append(
+                VerificationCell(provider, modality, direction, OK, f"status={status}")
+            )
+    return report
+
+
+def credentials_matrix(env: Mapping[str, str] | None = None) -> VerificationReport:
+    """Credentials mode: for each declared cell, are the creds present?"""
+    report = VerificationReport(mode=MODE_CREDENTIALS)
+    for provider in reg.agent_platform_keys():
+        cstatus, cdetail = credential_status(provider, env)
+        for modality, direction in _modality_cells(provider):
+            report.cells.append(
+                VerificationCell(provider, modality, direction, cstatus, cdetail)
+            )
+    return report
+
+
+# Connectivity probes: provider -> callable(env) -> (ok: bool, detail: str). Real network
+# handshakes live here; only providers with a proven probe are registered. Others report
+# SKIPPED so the report never implies coverage it does not have.
+ConnectivityProbe = Callable[[Mapping[str, str]], "tuple[bool, str]"]
+
+
+def connectivity_matrix(
+    env: Mapping[str, str] | None = None,
+    probes: Mapping[str, ConnectivityProbe] | None = None,
+) -> VerificationReport:
+    """Connectivity mode: run a real handshake where a probe exists; else SKIP."""
+    env = env if env is not None else os.environ
+    probes = probes if probes is not None else default_connectivity_probes()
+    report = VerificationReport(mode=MODE_CONNECTIVITY)
+    for provider in reg.agent_platform_keys():
+        cells = _modality_cells(provider)
+        probe = probes.get(provider)
+        cstatus, cdetail = credential_status(provider, env)
+        for modality, direction in cells:
+            if cstatus == MISSING:
+                report.cells.append(
+                    VerificationCell(provider, modality, direction, MISSING, cdetail)
+                )
+                continue
+            if probe is None:
+                report.cells.append(
+                    VerificationCell(
+                        provider, modality, direction, SKIPPED,
+                        "no connectivity probe (needs live call / deployed stack)",
+                    )
+                )
+                continue
+            try:
+                ok, detail = probe(env)
+            except Exception as exc:  # network/handshake failure
+                ok, detail = False, f"{type(exc).__name__}: {exc}"
+            report.cells.append(
+                VerificationCell(
+                    provider, modality, direction, OK if ok else FAILED, detail
+                )
+            )
+    return report
+
+
+def default_connectivity_probes() -> dict[str, ConnectivityProbe]:
+    """Real handshake probes proven to work credential-only (no calls placed).
+
+    Imported lazily so importing this module performs no network I/O.
+    """
+    from simulate.services import provider_connectivity_probes as p
+
+    return {
+        "deepgram": p.deepgram_probe,
+        "elevenlabs": p.elevenlabs_probe,
+        "vapi": p.vapi_probe,
+        "retell": p.retell_probe,
+        "bland": p.bland_probe,
+        "twilio": p.twilio_probe,
+        "agora": p.agora_probe,
+        "livekit_bridge": p.make_livekit_probe("livekit_bridge"),
+        "pipecat": p.make_livekit_probe("pipecat"),
+    }
+
+
+def verify(mode: str, env: Mapping[str, str] | None = None) -> VerificationReport:
+    if mode == MODE_REGISTRY:
+        return declared_matrix()
+    if mode == MODE_CREDENTIALS:
+        return credentials_matrix(env)
+    if mode == MODE_CONNECTIVITY:
+        return connectivity_matrix(env)
+    raise ValueError(f"unknown mode {mode!r}; expected one of {MODES}")

--- a/futureagi/simulate/services/retell_chat_agent_adapter.py
+++ b/futureagi/simulate/services/retell_chat_agent_adapter.py
@@ -1,0 +1,253 @@
+"""RetellChatAgentAdapter — drive a real Retell *chat* agent as the agent-under-test.
+
+This is the chat analogue of the WebRTC bridge connectors (TH-5642): where the
+voice path tests a customer's Retell *voice* agent by joining it over LiveKit, the
+chat path tests a customer's Retell *chat* agent by driving its text conversation
+server-side.
+
+It deliberately mirrors the ``generate_response(conversation_history) -> {...}``
+contract of :class:`PromptBasedAgentAdapter` so it can be slotted into the same
+``run_prompt_based_conversation`` loop — the simulated customer (a
+``ChatServiceBlueprint`` engine) plays the user, and this adapter plays the agent.
+
+Retell Chat API (https://docs.retellai.com/api-references/create-chat,
+/create-chat-completion):
+- ``POST /create-chat``            ``{"agent_id": ...}`` -> ``{"chat_id", "message_with_tool_calls":[...], ...}``
+- ``POST /create-chat-completion`` ``{"chat_id", "content": <latest user turn>}`` -> ``{"messages":[{"role":"agent","content":...}], ...}``
+- ``PATCH /end-chat/{chat_id}``     ends the chat.
+
+Two protocol facts this adapter is built around (both confirmable only with a live
+Retell agent — see ``WIRING & LIVE-VERIFICATION`` below):
+1. **Retell holds conversation state server-side.** The chat is created ONCE
+   (lazily, on first turn) and ``chat_id`` cached; each completion sends only the
+   *newest* simulated-customer turn as ``content``. We never replay history — that
+   would double-send.
+2. **On turn 1 the agent speaks first.** ``/create-chat`` may return the agent's
+   ``begin_message`` in ``message_with_tool_calls``; we surface that as the first
+   response. If absent, we return empty content (the sim loop treats empty as a
+   natural end) rather than fabricating a turn.
+
+WIRING & LIVE-VERIFICATION (intentionally deferred — DESIGN.md §5):
+- No factory reads an agent-definition field here: chat agents-under-test are today
+  either prompt-templates (``source_type="prompt"``) or SDK-pushed
+  (``source_type="agent_definition"``). Hosting an *external* chat agent
+  server-side needs a new source_type + a schema field carrying ``agent_id``; that
+  product decision is out of scope for this unit (same gate as Deepgram).
+- The exact ``/create-chat-completion`` response envelope (``messages`` vs
+  ``message_with_tool_calls``) and whether token usage is returned can only be
+  pinned against a real Retell agent. The parser below accepts both message keys
+  defensively; usage defaults to zeros when Retell omits it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+RETELL_BASE_URL = "https://api.retellai.com"
+RETELL_AGENT_ROLE = "agent"  # Retell labels assistant turns "agent" in chat
+RETELL_REQUEST_TIMEOUT = 30
+
+
+class RetellChatAgentError(RuntimeError):
+    """Raised when the Retell Chat API returns an error or unexpected payload."""
+
+
+class RetellChatAgentAdapter:
+    """Drives a customer's Retell chat agent as the agent-under-test.
+
+    Implements the same ``generate_response`` contract as
+    :class:`PromptBasedAgentAdapter`; see module docstring for the protocol.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        api_key: str,
+        *,
+        base_url: str = RETELL_BASE_URL,
+        timeout: int = RETELL_REQUEST_TIMEOUT,
+    ):
+        """Initialize the adapter.
+
+        Args:
+            agent_id: The customer's Retell chat-agent id (agent-under-test).
+            api_key: Retell API key (Bearer).
+            base_url: Override for the Retell API base (tests / self-host).
+            timeout: Per-request timeout in seconds.
+        """
+        if not agent_id:
+            raise ValueError("RetellChatAgentAdapter requires an agent_id")
+        if not api_key:
+            raise ValueError("RetellChatAgentAdapter requires an api_key")
+        self.agent_id = agent_id
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+        # Server-side conversation state.
+        self._chat_id: str | None = None
+        # How many of the conversation_history "user" turns we have already
+        # forwarded to Retell — guards against re-sending the same turn.
+        self._sent_user_turns = 0
+        self._chat_ended = False
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        if resp.status_code >= 400:
+            raise RetellChatAgentError(
+                f"Retell {path} failed ({resp.status_code}): {resp.text}"
+            )
+        try:
+            return resp.json() or {}
+        except ValueError as e:
+            raise RetellChatAgentError(
+                f"Retell {path} returned non-JSON body: {resp.text}"
+            ) from e
+
+    # ------------------------------------------------------------------
+    # Protocol helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _latest_user_content(conversation_history: list[dict[str, Any]]) -> list[str]:
+        """Return the user (simulated-customer) turn contents, in order.
+
+        From the agent-under-test's perspective the simulated customer is the
+        "user"; "assistant" entries are the agent's own prior turns (which Retell
+        already tracks server-side, so we never resend them).
+        """
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    def _extract_agent_text(self, payload: dict[str, Any]) -> str:
+        """Pull the agent's reply text out of a Retell chat payload.
+
+        Accepts either ``messages`` (create-chat-completion) or
+        ``message_with_tool_calls`` (create-chat / get-chat); both are lists of
+        ``{"role", "content"}``. Only ``agent`` role messages are returned.
+        """
+        messages = payload.get("messages")
+        if messages is None:
+            messages = payload.get("message_with_tool_calls") or []
+        parts = [
+            str(m.get("content") or "")
+            for m in messages
+            if m.get("role") == RETELL_AGENT_ROLE and m.get("content")
+        ]
+        return "\n".join(p for p in parts if p)
+
+    @staticmethod
+    def _is_ended(payload: dict[str, Any]) -> bool:
+        return str(payload.get("chat_status") or "").lower() == "ended"
+
+    def _ensure_chat(self) -> dict[str, Any]:
+        """Create the Retell chat once and cache the chat_id; return the payload."""
+        if self._chat_id is not None:
+            return {}
+        payload = self._post("/create-chat", {"agent_id": self.agent_id})
+        chat_id = payload.get("chat_id")
+        if not chat_id:
+            raise RetellChatAgentError(
+                f"Retell /create-chat returned no chat_id: {payload}"
+            )
+        self._chat_id = chat_id
+        logger.info("retell_chat_agent_created", chat_id=chat_id, agent_id=self.agent_id)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Agent-under-test contract (mirrors PromptBasedAgentAdapter)
+    # ------------------------------------------------------------------
+
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Generate the Retell agent's next turn for the given conversation.
+
+        Args:
+            conversation_history: ``[{"role": "user"|"assistant", "content": ...}]``
+                from the agent-under-test's perspective (user = simulated customer).
+            additional_context: Unused; kept for contract parity.
+
+        Returns:
+            ``{"content", "role", "finish_reason", "model", "latency_ms", "usage",
+            "chat_ended"}`` — same shape PromptBasedAgentAdapter returns.
+        """
+        start = time.perf_counter()
+        create_payload = self._ensure_chat()
+
+        user_turns = self._latest_user_content(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+
+        if not new_turns:
+            # Turn 1 (agent speaks first): surface the begin_message from
+            # /create-chat if the agent has one; otherwise empty (loop ends).
+            content = self._extract_agent_text(create_payload)
+            ended = self._is_ended(create_payload)
+        else:
+            # Send only the newest customer turn; Retell holds the rest.
+            content_to_send = new_turns[-1]
+            completion = self._post(
+                "/create-chat-completion",
+                {"chat_id": self._chat_id, "content": content_to_send},
+            )
+            self._sent_user_turns = len(user_turns)
+            content = self._extract_agent_text(completion)
+            ended = self._is_ended(completion)
+
+        self._chat_ended = ended
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        logger.info(
+            "retell_chat_agent_turn",
+            chat_id=self._chat_id,
+            has_content=bool(content),
+            chat_ended=ended,
+        )
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"retell:{self.agent_id}",
+            "latency_ms": latency_ms,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": ended,
+        }
+
+    def end(self) -> None:
+        """Best-effort end of the Retell chat (idempotent)."""
+        if not self._chat_id:
+            return
+        try:
+            requests.patch(
+                f"{self._base_url}/end-chat/{self._chat_id}",
+                headers=self._headers,
+                timeout=self._timeout,
+            )
+        except requests.RequestException as e:  # pragma: no cover - best effort
+            logger.warning("retell_chat_agent_end_failed", error=str(e))

--- a/futureagi/simulate/services/vapi_chat_agent_adapter.py
+++ b/futureagi/simulate/services/vapi_chat_agent_adapter.py
@@ -1,0 +1,151 @@
+"""VapiChatAgentAdapter — drive a real Vapi assistant in chat (text) mode (TH-5642).
+
+The chat analogue for Vapi. Like Retell, Vapi exposes a turn-by-turn REST chat API
+(the same endpoints the platform's VapiService already uses for the simulator side),
+so this mirrors RetellChatAgentAdapter: a chat session is created once, then each
+turn POSTs the latest user message and returns the assistant's reply.
+
+Vapi chat API (https://docs.vapi.ai, mirrored from ee VapiService):
+- ``POST {base}/session``  ``{"assistantId": ..., "name": ...}`` -> ``{"id": <session_id>}``
+- ``POST {base}/chat/``    ``{"input": [{"role":"user","content":...}], "sessionId": ...}``
+                           -> ``{"output": [{"role":"assistant","content":...}], ...}``
+- An ``endCall`` tool call in ``output`` signals the assistant ended the chat.
+
+Built from the proven VapiService request shapes; raw REST (no ee dependency) so the
+routing factory stays light to import. Not live-verified (no Vapi key in this env) —
+unit-tested against the documented shapes; flagged for a live run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+VAPI_DEFAULT_BASE_URL = "https://api.vapi.ai"
+VAPI_REQUEST_TIMEOUT = 30
+
+
+class VapiChatAgentError(RuntimeError):
+    """Raised on Vapi chat API errors / unexpected payloads."""
+
+
+class VapiChatAgentAdapter:
+    """Drives a customer's Vapi assistant as the text agent-under-test."""
+
+    def __init__(self, agent_id: str, api_key: str, *, base_url: str | None = None):
+        if not agent_id:
+            raise ValueError("VapiChatAgentAdapter requires an agent_id (assistantId)")
+        if not api_key:
+            raise ValueError("VapiChatAgentAdapter requires an api_key")
+        self.assistant_id = agent_id
+        self._api_key = api_key
+        self._base_url = (
+            base_url or os.getenv("VAPI_API_BASE_URL") or VAPI_DEFAULT_BASE_URL
+        ).rstrip("/")
+        self._session_id: str | None = None
+        self._sent_user_turns = 0
+        self._chat_ended = False
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            headers=self._headers,
+            timeout=VAPI_REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise VapiChatAgentError(
+                f"Vapi {path} failed ({resp.status_code}): {resp.text}"
+            )
+        try:
+            return resp.json() or {}
+        except ValueError as e:
+            raise VapiChatAgentError(
+                f"Vapi {path} returned non-JSON body: {resp.text}"
+            ) from e
+
+    @staticmethod
+    def _latest_user_content(conversation_history: list[dict[str, Any]]) -> list[str]:
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    @staticmethod
+    def _extract_assistant_text(output: list[dict[str, Any]]) -> str:
+        return "\n".join(
+            str(m.get("content") or "")
+            for m in output
+            if m.get("role") == "assistant" and m.get("content")
+        )
+
+    @staticmethod
+    def _ended(output: list[dict[str, Any]]) -> bool:
+        for m in output:
+            for tc in m.get("tool_calls") or []:
+                if (tc.get("function") or {}).get("name") == "endCall":
+                    return True
+        return False
+
+    def _ensure_session(self) -> None:
+        if self._session_id is not None:
+            return
+        payload = self._post(
+            "/session", {"assistantId": self.assistant_id, "name": "FI simulation chat"}
+        )
+        session_id = payload.get("id")
+        if not session_id:
+            raise VapiChatAgentError(f"Vapi /session returned no id: {payload}")
+        self._session_id = session_id
+        logger.info("vapi_chat_session_created", session_id=session_id)
+
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        start = time.perf_counter()
+        self._ensure_session()
+
+        user_turns = self._latest_user_content(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+        if not new_turns:
+            # Vapi assistants respond to user input; no separate begin message here.
+            content, ended = "", False
+        else:
+            result = self._post(
+                "/chat/",
+                {
+                    "input": [{"role": "user", "content": new_turns[-1]}],
+                    "sessionId": self._session_id,
+                },
+            )
+            self._sent_user_turns = len(user_turns)
+            output = result.get("output") or []
+            content = self._extract_assistant_text(output)
+            ended = self._ended(output)
+
+        self._chat_ended = ended
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"vapi:{self.assistant_id}",
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": ended,
+        }

--- a/futureagi/simulate/tests/test_agent_definition_apply.py
+++ b/futureagi/simulate/tests/test_agent_definition_apply.py
@@ -1,0 +1,65 @@
+"""Platform-side apply: optimised config -> new AgentVersion (TH-5642)."""
+
+import pytest
+
+from simulate.services.agent_definition_apply import (
+    apply_config_as_new_agent_version,
+)
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+@pytest.fixture
+def agent_def(db):
+    from accounts.models import Organization
+    from simulate.models import AgentDefinition
+
+    org = Organization.objects.create(name="t5642-apply-org")
+    return AgentDefinition.objects.create(
+        agent_name="selfhosted-livekit",
+        agent_type="voice",
+        provider="livekit_bridge",
+        description="self-hosted agent under optimisation",
+        inbound=True,
+        organization=org,
+    )
+
+
+def test_apply_creates_new_active_version_with_config(agent_def):
+    from simulate.models import AgentVersion
+
+    # seed a v1
+    AgentVersion.objects.create(
+        agent_definition=agent_def,
+        organization_id=agent_def.organization_id,
+        status="active",
+        commit_message="v1",
+    )
+    cfg = {
+        "type": "llm",
+        "name": "winner",
+        "instructions": "Be concise and answer hours questions directly.",
+        "model": "gpt-4o",
+        "temperature": 0.2,
+    }
+    new_version, applied = apply_config_as_new_agent_version(agent_def, cfg)
+
+    assert set(applied) == {"instructions", "model", "temperature"}
+    # non-destructive: a brand new, higher version number
+    assert new_version.version_number >= 2
+    snap = new_version.configuration_snapshot
+    assert snap["system_prompt"] == cfg["instructions"]
+    assert snap["model"] == "gpt-4o"
+    assert snap["temperature"] == 0.2
+    # the whole winning config is retained, identity keys stripped
+    assert snap["optimised_config"]["instructions"] == cfg["instructions"]
+    assert "name" not in snap["optimised_config"]
+
+
+def test_apply_works_with_no_prior_version(agent_def):
+    new_version, applied = apply_config_as_new_agent_version(
+        agent_def, {"instructions": "x", "model": "gpt-4o-mini"}
+    )
+    assert new_version.version_number >= 1
+    assert new_version.configuration_snapshot["system_prompt"] == "x"
+    assert set(applied) == {"instructions", "model"}

--- a/futureagi/simulate/tests/test_agent_definition_new_providers.py
+++ b/futureagi/simulate/tests/test_agent_definition_new_providers.py
@@ -1,0 +1,94 @@
+"""Agent-definition support for the multi-provider roster (TH-5642).
+
+Proves — as a regression guard, not an assertion — that the existing
+AgentDefinition model + AgentDefinitionSerializer are already provider-agnostic:
+an agent definition can be CREATED (validated + saved) for each new provider
+(Deepgram / Agora / Bland / ElevenLabs voice, Retell chat) with no schema change.
+The model's `provider` is a free-form CharField and `validate()` rejects no
+provider — it only special-cases LiveKit and requires *some* way to reach the
+agent (contact_number for SIP, or api_key+assistant_id for the web bridge).
+
+If a future change reintroduces a hard provider allow-list on the write path
+(the historical bug the ProviderSpec registry exists to prevent), these tests
+fail — which is the point.
+"""
+
+import pytest
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from simulate.models import AgentDefinition
+from simulate.serializers.agent_definition import AgentDefinitionSerializer
+
+
+@pytest.fixture
+def mock_request(user):
+    request = APIRequestFactory().post("/simulate/agent-definitions/")
+    drf_request = Request(request)
+    drf_request._user = user
+    drf_request._request.user = user
+    return drf_request
+
+
+def _base(provider, agent_type, **extra):
+    data = {
+        "agent_name": f"{provider} test agent",
+        "agent_type": agent_type,
+        "inbound": True,
+        "description": f"Agent-under-test on {provider}",
+        "provider": provider,
+        "languages": ["en"],
+    }
+    data.update(extra)
+    return data
+
+
+# (provider, agent_type, reach-creds) — each new provider with a realistic way to
+# be reached: SIP providers via contact_number, web-bridge providers via api_key+id.
+NEW_PROVIDER_CASES = [
+    ("deepgram", AgentDefinition.AgentTypeChoices.VOICE,
+     {"api_key": "dg-key", "assistant_id": "dg-agent-1"}),
+    ("elevenlabs", AgentDefinition.AgentTypeChoices.VOICE,
+     {"api_key": "el-key", "assistant_id": "el-agent-1"}),
+    ("agora", AgentDefinition.AgentTypeChoices.VOICE,
+     {"contact_number": "+14155550101"}),
+    ("bland", AgentDefinition.AgentTypeChoices.VOICE,
+     {"contact_number": "+14155550102"}),
+    ("retell", AgentDefinition.AgentTypeChoices.TEXT,
+     {"api_key": "rt-key", "assistant_id": "agent_chat_1"}),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+@pytest.mark.parametrize("provider,agent_type,creds", NEW_PROVIDER_CASES)
+def test_agent_definition_creatable_for_new_provider(
+    provider, agent_type, creds, organization, workspace, mock_request
+):
+    data = _base(provider, agent_type, **creds)
+    serializer = AgentDefinitionSerializer(
+        data=data, context={"request": mock_request}
+    )
+    # The object-level validate() is exactly what would reject an unknown
+    # provider — assert it does NOT.
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["provider"] == provider
+
+    instance = serializer.save(organization=organization, workspace=workspace)
+    assert instance.pk is not None
+    assert instance.provider == provider
+    assert instance.agent_type == agent_type
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_voice_agent_requires_a_provider(organization, workspace, mock_request):
+    # The only provider constraint on voice agents is "present" — not membership
+    # in a hard-coded allow-list.
+    data = _base("", AgentDefinition.AgentTypeChoices.VOICE,
+                 contact_number="+14155550103")
+    serializer = AgentDefinitionSerializer(
+        data=data, context={"request": mock_request}
+    )
+    assert not serializer.is_valid()
+    assert "provider" in serializer.errors

--- a/futureagi/simulate/tests/test_elevenlabs_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_elevenlabs_chat_agent_adapter.py
@@ -1,0 +1,102 @@
+"""Unit tests for ElevenLabsChatAgentAdapter (TH-5642).
+
+Exercises the ConvAI text WS protocol with a fake WebSocket (no network): send a
+``user_message``, read the ``agent_response``, answer pings, ignore audio/control.
+The sync ``generate_response`` drives the adapter's owned event loop.
+"""
+
+import json
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+
+from simulate.services.chat_agent_adapter_factory import EXTERNAL_HOSTED_CHAT_ADAPTERS
+from simulate.services.elevenlabs_chat_agent_adapter import (
+    ElevenLabsChatAgentAdapter,
+)
+
+
+class _FakeWS:
+    def __init__(self, incoming=()):
+        self._incoming = list(incoming)
+        self.sent = []
+        self.closed = False
+
+    async def send_json(self, obj):
+        self.sent.append(obj)
+
+    async def receive(self):
+        if self._incoming:
+            mtype, data = self._incoming.pop(0)
+            return SimpleNamespace(type=mtype, data=data)
+        return SimpleNamespace(type=aiohttp.WSMsgType.CLOSED, data=None)
+
+    async def close(self):
+        self.closed = True
+
+
+def _agent_response(text):
+    return (aiohttp.WSMsgType.TEXT, json.dumps(
+        {"type": "agent_response", "agent_response_event": {"agent_response": text}}))
+
+
+def _connected(ws):
+    a = ElevenLabsChatAgentAdapter(agent_id="agent_x", api_key="k")
+    a._ws = ws
+    a._connected = True  # skip the real _connect()
+    return a
+
+
+@pytest.mark.unit
+def test_registered_for_both_provider_spellings():
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["elevenlabs"] is ElevenLabsChatAgentAdapter
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["eleven_labs"] is ElevenLabsChatAgentAdapter
+
+
+@pytest.mark.unit
+def test_requires_agent_id():
+    with pytest.raises(ValueError):
+        ElevenLabsChatAgentAdapter(agent_id="", api_key="k")
+
+
+@pytest.mark.unit
+def test_sends_user_text_and_returns_agent_response():
+    ws = _FakeWS([_agent_response("Hello, how can I help?")])
+    a = _connected(ws)
+    out = a.generate_response([{"role": "user", "content": "hi there"}])
+    assert out["content"] == "Hello, how can I help?"
+    assert out["role"] == "assistant"
+    # The latest user turn was sent as a ConvAI user_message text frame.
+    assert {"type": "user_message", "text": "hi there"} in ws.sent
+
+
+@pytest.mark.unit
+def test_answers_ping_then_reads_agent_response():
+    ws = _FakeWS([
+        (aiohttp.WSMsgType.TEXT, json.dumps({"type": "ping", "ping_event": {"event_id": 7}})),
+        (aiohttp.WSMsgType.TEXT, json.dumps({"type": "user_transcript",
+                                             "user_transcription_event": {"user_transcript": "hi"}})),
+        _agent_response("Answer after ping"),
+    ])
+    a = _connected(ws)
+    out = a.generate_response([{"role": "user", "content": "q"}])
+    assert out["content"] == "Answer after ping"
+    assert {"type": "pong", "event_id": 7} in ws.sent
+
+
+@pytest.mark.unit
+def test_only_latest_turn_sent_no_replay():
+    ws = _FakeWS([_agent_response("R1"), _agent_response("R2")])
+    a = _connected(ws)
+    a.generate_response([{"role": "user", "content": "first"}])
+    a.generate_response([
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "R1"},
+        {"role": "user", "content": "second"},
+    ])
+    user_msgs = [m for m in ws.sent if m.get("type") == "user_message"]
+    assert user_msgs == [
+        {"type": "user_message", "text": "first"},
+        {"type": "user_message", "text": "second"},
+    ]

--- a/futureagi/simulate/tests/test_provider_connectivity_probes.py
+++ b/futureagi/simulate/tests/test_provider_connectivity_probes.py
@@ -1,0 +1,124 @@
+"""Tests for provider connectivity probes (TH-5642).
+
+HTTP is mocked — these assert the probe contract (endpoint, auth shape, status mapping)
+without network. Real validation happens when the harness runs with live creds.
+"""
+
+import pytest
+
+from simulate.services import provider_connectivity_probes as p
+
+
+class _Resp:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def _patch_get(monkeypatch, capture):
+    def fake_get(url, headers=None, params=None, auth=None):
+        capture.update(url=url, headers=headers or {}, params=params, auth=auth)
+        return _Resp(capture.get("status", 200))
+
+    monkeypatch.setattr(p, "_http_get", fake_get)
+
+
+@pytest.mark.unit
+def test_vapi_probe_ok_and_auth_header(monkeypatch):
+    cap = {"status": 200}
+    _patch_get(monkeypatch, cap)
+    ok, detail = p.vapi_probe({"SIM_VERIFY_VAPI_API_KEY": "k"})
+    assert ok
+    assert cap["url"] == "https://api.vapi.ai/assistant"
+    assert cap["headers"]["Authorization"] == "Bearer k"
+
+
+@pytest.mark.unit
+def test_vapi_missing_key():
+    ok, detail = p.vapi_probe({})
+    assert not ok and "not set" in detail
+
+
+@pytest.mark.unit
+def test_retell_rejected_credentials(monkeypatch):
+    cap = {"status": 401}
+    _patch_get(monkeypatch, cap)
+    ok, detail = p.retell_probe({"SIM_VERIFY_RETELL_API_KEY": "bad"})
+    assert not ok and "rejected credentials" in detail
+
+
+@pytest.mark.unit
+def test_bland_uses_raw_authorization_header(monkeypatch):
+    cap = {"status": 200}
+    _patch_get(monkeypatch, cap)
+    ok, _ = p.bland_probe({"SIM_VERIFY_BLAND_API_KEY": "k"})
+    assert ok
+    # Bland uses the raw key, NOT a Bearer prefix.
+    assert cap["headers"]["authorization"] == "k"
+
+
+@pytest.mark.unit
+def test_twilio_parses_sid_token_basic_auth(monkeypatch):
+    cap = {"status": 200}
+    _patch_get(monkeypatch, cap)
+    ok, _ = p.twilio_probe({"SIM_VERIFY_TWILIO_API_KEY": "ACxxx:tok"})
+    assert ok
+    assert cap["auth"] == ("ACxxx", "tok")
+    assert "ACxxx.json" in cap["url"]
+
+
+@pytest.mark.unit
+def test_twilio_requires_colon():
+    ok, detail = p.twilio_probe({"SIM_VERIFY_TWILIO_API_KEY": "nocolon"})
+    assert not ok and "AccountSid:AuthToken" in detail
+
+
+@pytest.mark.unit
+def test_agora_parses_key_secret_basic_auth(monkeypatch):
+    cap = {"status": 200}
+    _patch_get(monkeypatch, cap)
+    ok, _ = p.agora_probe({"SIM_VERIFY_AGORA_API_KEY": "cust:secret"})
+    assert ok
+    assert cap["auth"] == ("cust", "secret")
+
+
+@pytest.mark.unit
+def test_agora_requires_colon():
+    ok, detail = p.agora_probe({"SIM_VERIFY_AGORA_API_KEY": "nocolon"})
+    assert not ok and "CustomerKey:CustomerSecret" in detail
+
+
+@pytest.mark.unit
+def test_classify_endpoint_error_is_verbatim(monkeypatch):
+    cap = {"status": 404}
+    _patch_get(monkeypatch, cap)
+    ok, detail = p.vapi_probe({"SIM_VERIFY_VAPI_API_KEY": "k"})
+    assert not ok and "404" in detail and "rejected" not in detail
+
+
+@pytest.mark.unit
+def test_default_probes_registered():
+    from simulate.services import provider_verification as pv
+
+    probes = pv.default_connectivity_probes()
+    assert {
+        "deepgram", "elevenlabs", "vapi", "retell", "bland", "twilio", "agora",
+        "livekit_bridge", "pipecat",
+    } <= set(probes)
+
+
+@pytest.mark.unit
+def test_livekit_probe_reports_missing_env():
+    probe = p.make_livekit_probe("livekit_bridge")
+    ok, detail = probe({})
+    assert not ok
+    assert "SIM_VERIFY_LIVEKIT_BRIDGE_LIVEKIT_URL" in detail
+    assert "SIM_VERIFY_LIVEKIT_BRIDGE_LIVEKIT_API_SECRET" in detail
+
+
+@pytest.mark.unit
+def test_livekit_probe_reads_provider_prefixed_vars():
+    # pipecat reuses the LiveKit probe under its own env prefix.
+    probe = p.make_livekit_probe("pipecat")
+    ok, detail = probe({"SIM_VERIFY_PIPECAT_LIVEKIT_URL": "wss://x"})
+    assert not ok
+    assert "SIM_VERIFY_PIPECAT_LIVEKIT_API_KEY" in detail

--- a/futureagi/simulate/tests/test_provider_prompt_apply.py
+++ b/futureagi/simulate/tests/test_provider_prompt_apply.py
@@ -1,0 +1,358 @@
+"""Provider-side prompt apply — "directly apply the fix" for agent-definition runs (TH-5642)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from simulate.services.provider_prompt_apply import (
+    ElevenLabsPromptWriter,
+    PromptApplyError,
+    PromptApplyUnsupported,
+    RetellPromptWriter,
+    VapiPromptWriter,
+    apply_prompt_to_provider_agent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(json_data, status=200):
+    return SimpleNamespace(
+        status_code=status, json=lambda: json_data, text=str(json_data)
+    )
+
+
+class TestElevenLabsWriter:
+    def test_apply_reads_writes_and_verifies(self):
+        state = {"prompt": "old prompt"}
+
+        def fake_get(url, **kw):
+            return _resp(
+                {
+                    "conversation_config": {
+                        "agent": {"prompt": {"prompt": state["prompt"]}}
+                    }
+                }
+            )
+
+        def fake_patch(url, **kw):
+            state["prompt"] = kw["json"]["conversation_config"]["agent"]["prompt"][
+                "prompt"
+            ]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = ElevenLabsPromptWriter(api_key="xi-key").apply(
+                "agent_1", "new prompt"
+            )
+
+        assert out["applied"] is True
+        assert out["previous_prompt"] == "old prompt"
+        assert state["prompt"] == "new prompt"
+
+    def test_readback_mismatch_raises(self):
+        with (
+            patch(
+                "simulate.services.provider_prompt_apply.requests.get",
+                lambda url, **kw: _resp(
+                    {"conversation_config": {"agent": {"prompt": {"prompt": "stale"}}}}
+                ),
+            ),
+            patch(
+                "simulate.services.provider_prompt_apply.requests.patch",
+                lambda url, **kw: _resp({}),
+            ),
+        ):
+            with pytest.raises(PromptApplyError, match="read-back mismatch"):
+                ElevenLabsPromptWriter(api_key="xi-key").apply("agent_1", "new")
+
+
+class TestVapiWriter:
+    def test_apply_replaces_system_message_in_model(self):
+        state = {
+            "model": {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "messages": [{"role": "system", "content": "old"}],
+            }
+        }
+
+        def fake_get(url, **kw):
+            return _resp({"model": state["model"]})
+
+        def fake_patch(url, **kw):
+            state["model"] = kw["json"]["model"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = VapiPromptWriter(api_key="k").apply("asst_1", "new sys")
+
+        assert out["previous_prompt"] == "old"
+        assert state["model"]["messages"] == [{"role": "system", "content": "new sys"}]
+        # The rest of the model object must be preserved (Vapi PATCH replaces model).
+        assert state["model"]["provider"] == "openai"
+
+    def test_inserts_system_message_when_absent(self):
+        state = {"model": {"provider": "openai", "model": "gpt-4o", "messages": []}}
+
+        def fake_get(url, **kw):
+            return _resp({"model": state["model"]})
+
+        def fake_patch(url, **kw):
+            state["model"] = kw["json"]["model"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            VapiPromptWriter(api_key="k").apply("asst_1", "sys")
+
+        assert state["model"]["messages"][0] == {"role": "system", "content": "sys"}
+
+
+class TestRetellWriter:
+    def test_apply_goes_through_llm_id(self):
+        state = {"general_prompt": "old"}
+
+        def fake_get(url, **kw):
+            if "/get-agent/" in url:
+                return _resp(
+                    {"response_engine": {"type": "retell-llm", "llm_id": "llm_9"}}
+                )
+            assert url.endswith("/get-retell-llm/llm_9")
+            return _resp({"general_prompt": state["general_prompt"]})
+
+        def fake_patch(url, **kw):
+            assert url.endswith("/update-retell-llm/llm_9")
+            state["general_prompt"] = kw["json"]["general_prompt"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = RetellPromptWriter(api_key="k").apply("agent_1", "new")
+
+        assert out["previous_prompt"] == "old"
+        assert state["general_prompt"] == "new"
+
+    def test_non_retell_llm_engine_unsupported(self):
+        with patch(
+            "simulate.services.provider_prompt_apply.requests.get",
+            lambda url, **kw: _resp({"response_engine": {"type": "conversation-flow"}}),
+        ):
+            with pytest.raises(PromptApplyUnsupported, match="retell-llm"):
+                RetellPromptWriter(api_key="k").get_prompt("agent_1")
+
+
+class TestDispatch:
+    def _agent_def(self, provider, assistant_id="a1", api_key="key"):
+        return SimpleNamespace(
+            id="ad-1",
+            provider=provider,
+            assistant_id=assistant_id,
+            api_key=api_key,
+            credentials=None,
+        )
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["bland", "twilio", "livekit", "pipecat", "deepgram", "agora"],
+    )
+    def test_unsupported_providers_raise_with_reason(self, provider):
+        with pytest.raises(PromptApplyUnsupported):
+            apply_prompt_to_provider_agent(self._agent_def(provider), "p")
+
+    def test_missing_assistant_id_unsupported(self):
+        with pytest.raises(PromptApplyUnsupported, match="assistant_id"):
+            apply_prompt_to_provider_agent(
+                self._agent_def("vapi", assistant_id=""), "p"
+            )
+
+    def test_missing_credentials_is_error(self):
+        with pytest.raises(PromptApplyError, match="credentials"):
+            apply_prompt_to_provider_agent(self._agent_def("vapi", api_key=""), "p")
+
+    def test_elevenlabs_alias_dispatches(self):
+        with patch.object(
+            ElevenLabsPromptWriter, "apply", return_value={"applied": True}
+        ) as mock_apply:
+            out = apply_prompt_to_provider_agent(self._agent_def("elevenlabs"), "p")
+        assert out == {"applied": True}
+        mock_apply.assert_called_once_with("a1", "p")
+
+
+class TestWholeAgentConfigApply:
+    """apply_config writes the WHOLE candidate config, not just the prompt."""
+
+    def test_elevenlabs_config_maps_all_fields(self):
+        state = {
+            "agent": {
+                "prompt": {"prompt": "old", "llm": "gpt-4o-mini", "temperature": 0.5},
+                "first_message": "Hi",
+            },
+            "tts": {"voice_id": "voice-old"},
+        }
+
+        def fake_get(url, **kw):
+            return _resp({"conversation_config": state})
+
+        def fake_patch(url, **kw):
+            cc = kw["json"]["conversation_config"]
+            agent = cc.get("agent") or {}
+            if "prompt" in agent:
+                state["agent"]["prompt"].update(agent["prompt"])
+            if "first_message" in agent:
+                state["agent"]["first_message"] = agent["first_message"]
+            if "tts" in cc:
+                state["tts"].update(cc["tts"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = ElevenLabsPromptWriter(api_key="k").apply_config(
+                "agent_1",
+                {
+                    "type": "llm",
+                    "name": "winner",
+                    "instructions": "new prompt",
+                    "model": "gpt-4o",
+                    "temperature": 0.2,
+                    "first_message": "Hello there",
+                    "voice": "voice-new",
+                },
+            )
+
+        assert out["applied"] is True
+        assert set(out["applied_fields"]) == {
+            "instructions",
+            "model",
+            "temperature",
+            "first_message",
+            "voice",
+        }
+        assert out["previous_config"]["instructions"] == "old"
+        assert state["agent"]["prompt"]["prompt"] == "new prompt"
+        assert state["agent"]["prompt"]["llm"] == "gpt-4o"
+        assert state["tts"]["voice_id"] == "voice-new"
+
+    def test_vapi_config_preserves_model_object(self):
+        state = {
+            "model": {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "system", "content": "old"}],
+            },
+            "firstMessage": "Hi",
+            "voice": {"provider": "11labs", "voiceId": "v-old"},
+        }
+
+        def fake_get(url, **kw):
+            return _resp(dict(state))
+
+        def fake_patch(url, **kw):
+            state.update(kw["json"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = VapiPromptWriter(api_key="k").apply_config(
+                "asst_1",
+                {"instructions": "new", "model": "gpt-4o", "voice": "v-new"},
+            )
+
+        assert set(out["applied_fields"]) == {"instructions", "model", "voice"}
+        assert state["model"]["provider"] == "openai"  # preserved on replace
+        assert state["model"]["model"] == "gpt-4o"
+        assert state["voice"] == {"provider": "11labs", "voiceId": "v-new"}
+
+    def test_retell_config_splits_llm_and_agent_patches(self):
+        state = {
+            "agent": {
+                "response_engine": {"type": "retell-llm", "llm_id": "llm_9"},
+                "voice_id": "v-old",
+            },
+            "llm": {"general_prompt": "old", "model": "gpt-4o-mini"},
+        }
+
+        def fake_get(url, **kw):
+            if "/get-agent/" in url:
+                return _resp(dict(state["agent"]))
+            return _resp(dict(state["llm"]))
+
+        def fake_patch(url, **kw):
+            if "/update-retell-llm/" in url:
+                state["llm"].update(kw["json"])
+            else:
+                assert url.endswith("/update-agent/agent_1")
+                state["agent"].update(kw["json"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = RetellPromptWriter(api_key="k").apply_config(
+                "agent_1",
+                {"instructions": "new", "model": "gpt-4o", "voice": "v-new"},
+            )
+
+        assert set(out["applied_fields"]) == {"instructions", "model", "voice"}
+        assert state["llm"]["general_prompt"] == "new"
+        assert state["llm"]["model"] == "gpt-4o"
+        assert state["agent"]["voice_id"] == "v-new"
+
+    def test_config_with_no_applicable_fields_errors(self):
+        with pytest.raises(PromptApplyError, match="no applicable fields"):
+            ElevenLabsPromptWriter(api_key="k").apply_config(
+                "agent_1", {"type": "llm", "name": "x"}
+            )
+
+    def test_config_readback_mismatch_raises(self):
+        def fake_get(url, **kw):
+            return _resp(
+                {"conversation_config": {"agent": {"prompt": {"prompt": "stale"}}}}
+            )
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch(
+                "simulate.services.provider_prompt_apply.requests.patch",
+                lambda url, **kw: _resp({}),
+            ),
+        ):
+            with pytest.raises(PromptApplyError, match="read-back mismatch"):
+                ElevenLabsPromptWriter(api_key="k").apply_config(
+                    "agent_1", {"instructions": "new"}
+                )
+
+    def test_dispatch_apply_config(self):
+        from simulate.services.provider_prompt_apply import (
+            apply_config_to_provider_agent,
+        )
+
+        agent_def = SimpleNamespace(
+            id="ad-1",
+            provider="elevenlabs",
+            assistant_id="a1",
+            api_key="key",
+            credentials=None,
+        )
+        with patch.object(
+            ElevenLabsPromptWriter, "apply_config", return_value={"applied": True}
+        ) as mock_apply:
+            out = apply_config_to_provider_agent(agent_def, {"instructions": "p"})
+        assert out == {"applied": True}
+        mock_apply.assert_called_once_with("a1", {"instructions": "p"})

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -1,0 +1,291 @@
+"""Tests for the ProviderSpec SSOT registry (TH-5642, DESIGN.md §4).
+
+The registry is the single place a provider is declared; these tests pin the
+taxonomy (roles are not interchangeable) and that derived values stay in sync
+with the real connector registry / ProviderChoices.
+"""
+
+import pytest
+
+from simulate.providers import (
+    PROVIDER_REGISTRY,
+    Direction,
+    Role,
+    Status,
+    Transport,
+    agent_platform_keys,
+    connector_key_for,
+    get_spec,
+    implements_direction,
+    is_agent_platform,
+    provider_choices,
+    supports_direction,
+)
+
+# The bridge connector keys that exist TODAY (ee/voice/.../bridge/connector.py).
+CURRENT_BRIDGE_KEYS = {"web_vapi", "web_retell", "web_livekit_bridge"}
+
+
+class TestRegistryShape:
+    @pytest.mark.unit
+    def test_registry_keyed_by_canonical_key(self):
+        for key, spec in PROVIDER_REGISTRY.items():
+            assert spec.key == key
+
+    @pytest.mark.unit
+    def test_specs_are_frozen(self):
+        import dataclasses
+
+        spec = get_spec("vapi")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            spec.key = "mutated"  # frozen dataclass
+
+    @pytest.mark.unit
+    def test_expected_providers_present(self):
+        for key in [
+            "vapi",
+            "retell",
+            "livekit_bridge",
+            "others",
+            "elevenlabs",
+            "deepgram",
+            "agora",
+            "pipecat",
+            "bland",
+            "twilio",
+            "livekit",
+            "futureagi",
+        ]:
+            assert get_spec(key) is not None, key
+
+
+class TestTaxonomy:
+    @pytest.mark.unit
+    def test_twilio_is_both_transport_and_agent_platform(self):
+        # Twilio is a carrier substrate AND a platform customers build agents on
+        # (ConversationRelay/TwiML) — testable inbound (SIP) + outbound (Calls.json).
+        spec = get_spec("twilio")
+        assert Role.TRANSPORT in spec.roles
+        assert spec.is_agent_platform
+        assert spec.supported_directions and spec.implemented_directions
+
+    @pytest.mark.unit
+    def test_system_livekit_distinct_from_livekit_bridge(self):
+        # 'livekit' = our SYSTEM engine; 'livekit_bridge' = the customer's agent.
+        system = get_spec("livekit")
+        bridge = get_spec("livekit_bridge")
+        assert Role.SYSTEM_ENGINE in system.roles
+        assert not system.is_agent_platform
+        assert bridge.is_agent_platform
+        assert bridge.connector_key == "web_livekit_bridge"
+
+    @pytest.mark.unit
+    def test_component_presence_is_not_platform_support(self):
+        # ElevenLabs/Deepgram are STT/TTS components but only PLANNED as platforms.
+        assert Role.TTS in get_spec("elevenlabs").roles
+        assert Role.STT in get_spec("deepgram").roles
+        assert get_spec("elevenlabs").status is Status.PLANNED
+        assert get_spec("deepgram").status is Status.PLANNED
+
+    @pytest.mark.unit
+    def test_agora_sip_primary_with_rtc_connector(self):
+        # Agora keeps SIP as primary transport (Elastic SIP Trunk parity with
+        # Bland/Twilio) but ALSO carries the native web_agora RTC connector
+        # (AgoraRTCConnector, TH-5682) for phone-free sims — same dual-path
+        # idea as the other web_* providers.
+        agora = get_spec("agora")
+        assert agora.transport is Transport.SIP
+        assert agora.connector_key == "web_agora"
+        assert agora.is_agent_platform
+        # Parity with the other SIP-reachable agent platform.
+        assert get_spec("bland").transport is Transport.SIP
+
+    @pytest.mark.unit
+    def test_pipecat_reuses_livekit_bridge_connector(self):
+        assert get_spec("pipecat").connector_key == "web_livekit_bridge"
+        assert get_spec("pipecat").transport is Transport.WEBRTC_BRIDGE
+
+    @pytest.mark.unit
+    def test_livekit_bridge_credentials_path_predicate(self):
+        # voice_small.py routes any provider whose connector IS the LiveKit
+        # bridge through the bridge-credentials path. This pins exactly which
+        # providers that is (Phase 1 wires Pipecat onto it).
+        bridge_path = {
+            s.key
+            for s in PROVIDER_REGISTRY.values()
+            if s.connector_key == "web_livekit_bridge"
+        }
+        assert bridge_path == {"livekit_bridge", "pipecat"}
+
+
+class TestDerivations:
+    @pytest.mark.unit
+    def test_connector_key_for_replaces_string_interpolation(self):
+        assert connector_key_for("vapi") == "web_vapi"
+        assert connector_key_for("retell") == "web_retell"
+        assert connector_key_for("livekit_bridge") == "web_livekit_bridge"
+        # SIP-only / unknown → None (routes to SIP, not an unknown connection_type)
+        assert connector_key_for("others") is None
+        assert connector_key_for("twilio") is None
+        assert connector_key_for("nonsense") is None
+        assert connector_key_for(None) is None
+
+    @pytest.mark.unit
+    def test_ga_webrtc_connector_keys_match_current_bridge_registry(self):
+        ga_webrtc = {
+            s.connector_key
+            for s in PROVIDER_REGISTRY.values()
+            if s.is_ga and s.transport is Transport.WEBRTC_BRIDGE and s.connector_key
+        }
+        assert ga_webrtc == CURRENT_BRIDGE_KEYS
+
+    @pytest.mark.unit
+    def test_agent_platform_keys(self):
+        ga = set(agent_platform_keys(include_planned=False))
+        assert ga == {"vapi", "retell", "livekit_bridge", "others"}
+        allp = set(agent_platform_keys(include_planned=True))
+        assert {"elevenlabs", "deepgram", "agora", "pipecat", "bland", "twilio"} <= allp
+        # system engines are never agent platforms (twilio now is, via ConvRelay)
+        assert "livekit" not in allp
+        assert "futureagi" not in allp
+
+    @pytest.mark.unit
+    def test_provider_choices_ga_only_by_default(self):
+        ga = dict(provider_choices())
+        assert set(ga) == {"vapi", "retell", "livekit_bridge", "others"}
+        withp = dict(provider_choices(include_planned=True))
+        assert "elevenlabs" in withp and "pipecat" in withp
+
+    @pytest.mark.unit
+    def test_is_agent_platform(self):
+        assert is_agent_platform("retell")
+        assert is_agent_platform("twilio")  # now an agent platform (ConvRelay/TwiML)
+        assert not is_agent_platform("unknown")
+
+    @pytest.mark.unit
+    def test_observability_keys_are_valid_provider_choices(self):
+        from tracer.models.observability_provider import ProviderChoices
+
+        valid = {c.value for c in ProviderChoices}
+        for spec in PROVIDER_REGISTRY.values():
+            if spec.observability_key is not None:
+                assert spec.observability_key in valid, spec.key
+
+    @pytest.mark.unit
+    def test_observability_key_mapping_for_voice_obs_wiring(self):
+        # The agent-def observability wiring (views/agent_definition.py) maps the
+        # client provider string to its canonical ObservabilityProvider via
+        # these keys (TH-5642 step 1). livekit_bridge -> livekit is the crux.
+        assert get_spec("livekit_bridge").observability_key == "livekit"
+        assert get_spec("elevenlabs").observability_key == "eleven_labs"
+        assert get_spec("vapi").observability_key == "vapi"
+        assert get_spec("retell").observability_key == "retell"
+        # TH-5642: observability now registered for ALL agent platforms — every key
+        # resolves to a tracer ProviderChoices value so each platform can bind to a
+        # provider-named observability project (trace emission is provider-agnostic).
+        assert get_spec("pipecat").observability_key == "pipecat"
+        assert get_spec("deepgram").observability_key == "deepgram"
+        assert get_spec("agora").observability_key == "agora"
+        assert get_spec("bland").observability_key == "bland"
+        assert get_spec("twilio").observability_key == "twilio"
+
+        from tracer.models.observability_provider import ProviderChoices
+
+        valid = set(ProviderChoices.values)
+        for key in agent_platform_keys():
+            obs = get_spec(key).observability_key
+            assert obs in valid, (
+                f"{key} observability_key {obs!r} not a ProviderChoices value"
+            )
+
+
+class TestCallDirection:
+    @pytest.mark.unit
+    def test_direction_values_mirror_calltype(self):
+        # The registry mirrors semantics.CallType by value (it can't import the
+        # Django-bound enum). Pin the equality so they can't drift.
+        from simulate.semantics import CallType
+
+        assert Direction.INBOUND.value == CallType.INBOUND.value
+        assert Direction.OUTBOUND.value == CallType.OUTBOUND.value
+
+    @pytest.mark.unit
+    def test_implemented_is_subset_of_supported(self):
+        # You can never implement a direction the provider can't support.
+        for spec in PROVIDER_REGISTRY.values():
+            assert spec.implemented_directions <= spec.supported_directions, spec.key
+
+    @pytest.mark.unit
+    def test_per_provider_direction_capability_matches_audit(self):
+        IN, OUT = Direction.INBOUND, Direction.OUTBOUND
+        # (key, supported, implemented) — from the direction audit (TH-5642).
+        expected = {
+            "vapi": ({IN, OUT}, {IN, OUT}),
+            "retell": ({IN, OUT}, {IN, OUT}),  # outbound wired via RetellOutboundDialer
+            "livekit_bridge": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # bridge: outbound = speaking-order
+            "others": ({IN, OUT}, {IN, OUT}),
+            "elevenlabs": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # outbound via ElevenLabsOutboundDialer
+            "deepgram": ({IN, OUT}, {IN}),  # no native outbound (BYO-SIP only)
+            "agora": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # outbound: AgoraOutboundDialer; inbound: web_agora RTC connector (TH-5682)
+            "pipecat": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # reuses bridge → outbound = speaking-order
+            # Inbound flipped 2026-06-10: a Bland inbound number answers any
+            # PSTN caller, so the neutral SIP path reaches it (TH-5683).
+            "bland": ({IN, OUT}, {IN, OUT}),
+            "twilio": ({IN, OUT}, {IN, OUT}),  # SIP inbound + TwilioOutboundDialer
+            "futureagi": (set(), set()),  # internal chat
+        }
+        for key, (sup, impl) in expected.items():
+            spec = get_spec(key)
+            assert set(spec.supported_directions) == sup, f"{key} supported"
+            assert set(spec.implemented_directions) == impl, f"{key} implemented"
+
+    @pytest.mark.unit
+    def test_supports_and_implements_helpers(self):
+        # Deepgram supports outbound but has not wired it — the distinction that lets
+        # dispatch fail loudly instead of silently running inbound.
+        assert supports_direction("deepgram", Direction.OUTBOUND)
+        assert not implements_direction("deepgram", Direction.OUTBOUND)
+        assert implements_direction("deepgram", Direction.INBOUND)
+        # Vapi and Retell: outbound both supported and wired (dialer registry).
+        assert implements_direction("vapi", Direction.OUTBOUND)
+        assert implements_direction("retell", Direction.OUTBOUND)
+        # Twilio is now an agent platform (both directions); only unknown is empty.
+        assert not supports_direction("nonsense", Direction.INBOUND)
+        assert supports_direction("twilio", Direction.INBOUND)
+
+    @pytest.mark.unit
+    def test_direction_filtered_selectors(self):
+        # Every GA agent platform supports both directions, so a direction filter on
+        # GA choices doesn't drop any — but it MUST exclude transport/internal rows.
+        out_keys = set(agent_platform_keys(direction=Direction.OUTBOUND))
+        assert {"vapi", "retell", "livekit_bridge", "others", "twilio"} <= out_keys
+        assert "futureagi" not in out_keys  # system engine, never an agent platform
+        ga_out = dict(provider_choices(direction=Direction.OUTBOUND))
+        assert set(ga_out) == {"vapi", "retell", "livekit_bridge", "others"}
+
+
+class TestBridgeRegistryParity:
+    @pytest.mark.unit
+    def test_cross_check_against_real_connector_registry_if_importable(self):
+        # Best-effort: the real bridge registry pulls livekit SDK deps that may be
+        # absent in the backend venv — skip if it can't import.
+        connector = pytest.importorskip("ee.voice.services.livekit.bridge.connector")
+        real_keys = set(connector.get_connector_registry().keys())
+        ga_webrtc = {
+            s.connector_key
+            for s in PROVIDER_REGISTRY.values()
+            if s.is_ga and s.transport is Transport.WEBRTC_BRIDGE and s.connector_key
+        }
+        assert ga_webrtc <= real_keys

--- a/futureagi/simulate/tests/test_provider_registry_wiring_contract.py
+++ b/futureagi/simulate/tests/test_provider_registry_wiring_contract.py
@@ -1,0 +1,107 @@
+"""Provider-wiring contract for the multi-provider simulation platform (TH-5642).
+
+These assert that the ProviderSpec registry (the single source of truth) stays
+consistent with the code that actually drives each provider — chat adapters,
+outbound dialers, and the observability ProviderChoices enum. They lock the
+*wiring* as an enforced invariant so a provider can't silently drift out of sync
+or claim a capability whose code isn't registered.
+
+Scope note: this verifies that what each provider claims is BACKED by registered
+code — NOT that a live provider call succeeds (that needs creds + runtime and is
+covered by the live/integration paths). A provider being correctly wired here and
+still gated on an external dependency (deploy / SIP runtime / provider account)
+are two different things, and this test only asserts the first.
+"""
+import pytest
+
+from simulate.providers.registry import (
+    _SPECS,
+    Direction,
+    PROVIDER_REGISTRY,
+    Role,
+    Transport,
+)
+from simulate.services.chat_agent_adapter_factory import EXTERNAL_HOSTED_CHAT_ADAPTERS
+from simulate.services.outbound_dialer import OUTBOUND_DIALERS
+from tracer.models.observability_provider import ProviderChoices
+
+# The 9 providers the TH-5642 matrix must keep modeled (+ system engines).
+TH5642_PROVIDERS = {
+    "vapi", "retell", "elevenlabs", "deepgram", "agora",
+    "pipecat", "twilio", "bland", "livekit_bridge",
+}
+
+
+@pytest.mark.unit
+def test_all_target_providers_present_in_registry():
+    missing = TH5642_PROVIDERS - set(PROVIDER_REGISTRY)
+    assert not missing, f"providers dropped from the registry: {missing}"
+
+
+@pytest.mark.unit
+def test_implemented_directions_subset_of_supported():
+    for s in _SPECS:
+        assert s.implemented_directions <= s.supported_directions, (
+            f"{s.key}: implements {s.implemented_directions} not in supported "
+            f"{s.supported_directions}"
+        )
+
+
+@pytest.mark.unit
+def test_chat_flag_matches_registered_chat_adapter():
+    """A provider may claim chat ONLY if a hosted chat adapter is registered for
+    it, and must not be silently in the adapter map without claiming chat."""
+    for s in _SPECS:
+        if s.chat:
+            assert s.key in EXTERNAL_HOSTED_CHAT_ADAPTERS, (
+                f"{s.key} claims chat but has no EXTERNAL_HOSTED_CHAT_ADAPTERS entry"
+            )
+    # Inverse: every adapter key resolves to a chat=True spec (allowing the two
+    # elevenlabs spellings the factory accepts).
+    for key in EXTERNAL_HOSTED_CHAT_ADAPTERS:
+        spec = PROVIDER_REGISTRY.get(key) or PROVIDER_REGISTRY.get(
+            "elevenlabs" if key == "eleven_labs" else key
+        )
+        assert spec is not None and spec.chat, (
+            f"chat adapter '{key}' has no chat=True ProviderSpec"
+        )
+
+
+@pytest.mark.unit
+def test_observability_key_maps_to_real_provider_choice():
+    valid = {c.value for c in ProviderChoices}
+    for s in _SPECS:
+        if s.observability_key:
+            assert s.observability_key in valid, (
+                f"{s.key}: observability_key '{s.observability_key}' is not a "
+                f"ProviderChoices value"
+            )
+
+
+@pytest.mark.unit
+def test_sip_agent_platforms_with_outbound_have_a_dialer():
+    """Any NAMED external agent-platform reached over SIP that claims OUTBOUND
+    must have a registered outbound dialer. WebRTC-bridge providers do outbound
+    via the bridge (not a dialer); the generic ``others`` catch-all + system
+    engines (livekit/futureagi) use the platform's generic SIP path, so only the
+    named external providers (the TH-5642 set) are in scope here."""
+    for s in _SPECS:
+        if (
+            s.key in TH5642_PROVIDERS
+            and Role.AGENT_PLATFORM in s.roles
+            and s.transport == Transport.SIP
+            and Direction.OUTBOUND in s.implemented_directions
+        ):
+            assert s.key in OUTBOUND_DIALERS, (
+                f"{s.key}: SIP agent-platform implements OUTBOUND but has no "
+                f"OUTBOUND_DIALERS entry"
+            )
+
+
+@pytest.mark.unit
+def test_webrtc_bridge_providers_have_web_connector_key():
+    for s in _SPECS:
+        if s.transport == Transport.WEBRTC_BRIDGE:
+            assert s.connector_key and s.connector_key.startswith("web_"), (
+                f"{s.key}: WEBRTC_BRIDGE transport must carry a web_* connector_key"
+            )

--- a/futureagi/simulate/tests/test_provider_verification.py
+++ b/futureagi/simulate/tests/test_provider_verification.py
@@ -1,0 +1,127 @@
+"""Tests for the provider verification harness (TH-5642)."""
+
+import pytest
+
+from simulate.providers import registry as reg
+from simulate.services import provider_verification as pv
+
+
+@pytest.mark.unit
+def test_registry_matrix_covers_every_provider():
+    report = pv.declared_matrix()
+    providers = {c.provider for c in report.cells}
+    assert providers == set(reg.agent_platform_keys())
+    # chat-capable providers get a chat cell; voice providers get per-direction cells.
+    by = {(c.provider, c.modality, c.direction) for c in report.cells}
+    assert ("vapi", "chat", None) in by  # vapi.chat = True
+    assert ("vapi", "voice", "inbound") in by
+    assert ("vapi", "voice", "outbound") in by
+    assert ("deepgram", "voice", "inbound") in by
+    assert ("deepgram", "voice", "outbound") not in by  # deepgram inbound-only
+    assert ("bland", "voice", "outbound") in by
+    # Inbound implemented via the neutral SIP path (registry flip, TH-5683).
+    assert ("bland", "voice", "inbound") in by
+
+
+@pytest.mark.unit
+def test_agora_both_directions_wired():
+    # Agora outbound via AgoraOutboundDialer (ConvAI telephony); inbound now
+    # implemented phone-free via the native web_agora RTC connector (TH-5682).
+    report = pv.declared_matrix()
+    agora = [c for c in report.cells if c.provider == "agora"]
+    cells = {(c.modality, c.direction): c.status for c in agora}
+    assert ("voice", "outbound") in cells and cells[("voice", "outbound")] == pv.OK
+    assert ("voice", "inbound") in cells and cells[("voice", "inbound")] == pv.OK
+    assert ("chat", None) not in cells  # no chat product
+
+
+@pytest.mark.unit
+def test_credential_status_present_and_missing():
+    # vapi shape=api_key_assistant -> needs SIM_VERIFY_VAPI_API_KEY
+    status, _ = pv.credential_status("vapi", env={})
+    assert status == pv.MISSING
+    status, detail = pv.credential_status("vapi", env={"SIM_VERIFY_VAPI_API_KEY": "x"})
+    assert status == pv.OK
+
+
+@pytest.mark.unit
+def test_credential_status_sip_only_needs_stack():
+    # 'others' shape is websocket_url; agora/twilio/bland are api_key. Find a sip_only one.
+    # 'others' = websocket_url, not sip_only; sip_only providers report SKIPPED.
+    # Verify the SIP-stack messaging path via a known sip_only shape if present.
+    sip_providers = [
+        p
+        for p in reg.agent_platform_keys()
+        if str(getattr(reg.get_spec(p), "credential_shape", "")) == "sip_only"
+    ]
+    for p in sip_providers:
+        status, detail = pv.credential_status(p, env={})
+        assert status == pv.SKIPPED
+        assert "SIP" in detail
+
+
+@pytest.mark.unit
+def test_livekit_needs_three_env_vars():
+    status, detail = pv.credential_status("livekit_bridge", env={})
+    assert status == pv.MISSING
+    assert "LIVEKIT_URL" in detail and "LIVEKIT_API_SECRET" in detail
+
+
+@pytest.mark.unit
+def test_connectivity_uses_injected_probe_and_marks_pass():
+    calls = []
+
+    def fake_probe(env):
+        calls.append(env)
+        return True, "handshake ok"
+
+    env = {"SIM_VERIFY_DEEPGRAM_API_KEY": "x", "SIM_VERIFY_DEEPGRAM_AGENT_ID": "a"}
+    report = pv.connectivity_matrix(env=env, probes={"deepgram": fake_probe})
+    dg = [c for c in report.cells if c.provider == "deepgram"]
+    assert dg and all(c.status == pv.OK for c in dg)
+    assert calls  # probe actually invoked
+
+
+@pytest.mark.unit
+def test_connectivity_missing_creds_short_circuits_probe():
+    def fake_probe(env):
+        raise AssertionError("probe must not run without creds")
+
+    report = pv.connectivity_matrix(env={}, probes={"deepgram": fake_probe})
+    dg = [c for c in report.cells if c.provider == "deepgram"]
+    assert dg and all(c.status == pv.MISSING for c in dg)
+
+
+@pytest.mark.unit
+def test_connectivity_no_probe_is_skipped():
+    env = {"SIM_VERIFY_TWILIO_API_KEY": "x"}
+    report = pv.connectivity_matrix(env=env, probes={})
+    tw = [c for c in report.cells if c.provider == "twilio"]
+    assert tw and all(c.status == pv.SKIPPED for c in tw)
+
+
+@pytest.mark.unit
+def test_probe_exception_becomes_failed():
+    def boom(env):
+        raise ConnectionError("dns")
+
+    # deepgram shape=agent_id needs both API_KEY and AGENT_ID before the probe runs.
+    env = {"SIM_VERIFY_DEEPGRAM_API_KEY": "x", "SIM_VERIFY_DEEPGRAM_AGENT_ID": "a"}
+    report = pv.connectivity_matrix(env=env, probes={"deepgram": boom})
+    dg = [c for c in report.cells if c.provider == "deepgram"]
+    assert dg and all(c.status == pv.FAILED for c in dg)
+    assert any("ConnectionError" in c.detail for c in dg)
+
+
+@pytest.mark.unit
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError):
+        pv.verify("nope")
+
+
+@pytest.mark.unit
+def test_report_to_dict_roundtrip():
+    d = pv.declared_matrix().to_dict()
+    assert d["mode"] == pv.MODE_REGISTRY
+    assert isinstance(d["summary"], dict)
+    assert d["cells"] and "provider" in d["cells"][0]

--- a/futureagi/simulate/tests/test_provision_sim_phone_numbers.py
+++ b/futureagi/simulate/tests/test_provision_sim_phone_numbers.py
@@ -1,0 +1,65 @@
+"""Tests for the provision_sim_phone_numbers management command (TH-5642)."""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from simulate.models.simulation_phone_number import SimulationPhoneNumber
+
+
+class _Resp:
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {
+            "incoming_phone_numbers": [
+                {"phone_number": "+12175696753", "sid": "PN111"},
+                {"phone_number": "+12068956991", "sid": "PN222"},
+            ]
+        }
+
+
+@pytest.mark.django_db
+def test_provisions_idle_outbound_numbers():
+    with patch("requests.get", return_value=_Resp()):
+        call_command("provision_sim_phone_numbers", "--direction", "outbound",
+                     "--sid", "ACx", "--token", "t", stdout=StringIO())
+    rows = SimulationPhoneNumber.objects.filter(call_direction="outbound")
+    assert rows.count() == 2
+    r = rows.get(provider_phone_id="PN111")
+    assert r.phone_number == "+12175696753"
+    assert r.status == SimulationPhoneNumber.PhoneStatus.IDLE
+
+
+@pytest.mark.django_db
+def test_idempotent_skips_existing():
+    SimulationPhoneNumber.objects.create(
+        phone_number="+12175696753", provider_phone_id="PN111",
+        call_direction="outbound", status=SimulationPhoneNumber.PhoneStatus.IDLE)
+    with patch("requests.get", return_value=_Resp()):
+        call_command("provision_sim_phone_numbers", "--direction", "outbound",
+                     "--sid", "ACx", "--token", "t", stdout=StringIO())
+    # PN111 already existed → only PN222 added; no duplicate.
+    assert SimulationPhoneNumber.objects.filter(provider_phone_id="PN111").count() == 1
+    assert SimulationPhoneNumber.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_numbers_filter_and_dry_run():
+    with patch("requests.get", return_value=_Resp()):
+        call_command("provision_sim_phone_numbers", "--direction", "outbound",
+                     "--numbers", "+12175696753", "--dry-run",
+                     "--sid", "ACx", "--token", "t", stdout=StringIO())
+    # dry-run creates nothing; filter would have limited to one anyway.
+    assert SimulationPhoneNumber.objects.count() == 0
+
+
+@pytest.mark.unit
+def test_requires_creds():
+    with pytest.raises(CommandError):
+        call_command("provision_sim_phone_numbers", "--direction", "outbound",
+                     "--sid", "", "--token", "", stdout=StringIO())

--- a/futureagi/simulate/tests/test_retell_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_retell_chat_agent_adapter.py
@@ -1,0 +1,212 @@
+"""Unit tests for RetellChatAgentAdapter (TH-5642 — chat agent-under-test).
+
+Exercises the Retell Chat API handling with a fake ``requests`` (no network),
+pinning the two protocol facts that are easy to get backwards:
+- the chat is created ONCE and ``chat_id`` reused (Retell holds state server-side);
+- each completion sends only the *newest* simulated-customer turn (no replay).
+"""
+
+import json
+
+import pytest
+
+from simulate.services import retell_chat_agent_adapter as mod
+from simulate.services.retell_chat_agent_adapter import (
+    RetellChatAgentAdapter,
+    RetellChatAgentError,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeRequests:
+    """Records POST/PATCH calls and replays queued responses by path."""
+
+    def __init__(self, responses):
+        # responses: dict[path_suffix -> list[_FakeResp]] (FIFO per path)
+        self._responses = {k: list(v) for k, v in responses.items()}
+        self.posts = []  # list[(url, json_payload)]
+        self.patches = []
+        self.RequestException = Exception
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.posts.append((url, json))
+        for suffix, queue in self._responses.items():
+            if url.endswith(suffix) and queue:
+                return queue.pop(0)
+        raise AssertionError(f"no fake response queued for POST {url}")
+
+    def patch(self, url, headers=None, timeout=None):
+        self.patches.append(url)
+        return _FakeResp({}, 200)
+
+
+def _adapter(monkeypatch, responses):
+    fake = _FakeRequests(responses)
+    monkeypatch.setattr(mod, "requests", fake)
+    adapter = RetellChatAgentAdapter(agent_id="agent_x", api_key="key_x")
+    return adapter, fake
+
+
+@pytest.mark.unit
+def test_requires_agent_id_and_api_key():
+    with pytest.raises(ValueError):
+        RetellChatAgentAdapter(agent_id="", api_key="k")
+    with pytest.raises(ValueError):
+        RetellChatAgentAdapter(agent_id="a", api_key="")
+
+
+@pytest.mark.unit
+def test_turn1_returns_begin_message_from_create_chat(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [
+                _FakeResp(
+                    {
+                        "chat_id": "Chat_1",
+                        "chat_status": "ongoing",
+                        "message_with_tool_calls": [
+                            {"role": "agent", "content": "Hello, how can I help?"}
+                        ],
+                    }
+                )
+            ],
+        },
+    )
+    # No user turn yet -> the agent speaks first (begin message).
+    result = adapter.generate_response([])
+    assert result["content"] == "Hello, how can I help?"
+    assert result["chat_ended"] is False
+    # create-chat called exactly once; no completion yet.
+    assert [u for u, _ in fake.posts] == ["https://api.retellai.com/create-chat"]
+
+
+@pytest.mark.unit
+def test_chat_created_once_and_only_latest_turn_sent(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [
+                _FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})
+            ],
+            "/create-chat-completion": [
+                _FakeResp({"messages": [{"role": "agent", "content": "Reply A"}]}),
+                _FakeResp({"messages": [{"role": "agent", "content": "Reply B"}]}),
+            ],
+        },
+    )
+
+    # First customer turn.
+    r1 = adapter.generate_response([{"role": "user", "content": "first"}])
+    # Second customer turn arrives; history now holds both + the agent's reply.
+    r2 = adapter.generate_response(
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "Reply A"},
+            {"role": "user", "content": "second"},
+        ]
+    )
+
+    assert r1["content"] == "Reply A"
+    assert r2["content"] == "Reply B"
+
+    # /create-chat hit exactly once (state is server-side).
+    create_calls = [u for u, _ in fake.posts if u.endswith("/create-chat")]
+    assert len(create_calls) == 1
+
+    # Each completion sent ONLY the newest turn, with the cached chat_id — no replay.
+    completion_payloads = [p for u, p in fake.posts if u.endswith("/create-chat-completion")]
+    assert completion_payloads == [
+        {"chat_id": "Chat_1", "content": "first"},
+        {"chat_id": "Chat_1", "content": "second"},
+    ]
+
+
+@pytest.mark.unit
+def test_chat_ended_detected_from_status(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})],
+            "/create-chat-completion": [
+                _FakeResp(
+                    {
+                        "chat_status": "ended",
+                        "messages": [{"role": "agent", "content": "Goodbye!"}],
+                    }
+                )
+            ],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "bye"}])
+    assert result["content"] == "Goodbye!"
+    assert result["chat_ended"] is True
+
+
+@pytest.mark.unit
+def test_only_agent_role_messages_are_returned(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})],
+            "/create-chat-completion": [
+                _FakeResp(
+                    {
+                        "messages": [
+                            {"role": "user", "content": "echoed user turn"},
+                            {"role": "agent", "content": "the answer"},
+                        ]
+                    }
+                )
+            ],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "q"}])
+    # The echoed user turn is dropped; only the agent text comes back.
+    assert result["content"] == "the answer"
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"error": "bad key"}, status_code=401)]},
+    )
+    with pytest.raises(RetellChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.unit
+def test_missing_chat_id_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"chat_status": "ongoing"})]},
+    )
+    with pytest.raises(RetellChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.unit
+def test_end_is_idempotent_and_best_effort(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})]},
+    )
+    # No chat yet -> end() is a no-op (no PATCH).
+    adapter.end()
+    assert fake.patches == []
+    # After a turn, end() PATCHes the cached chat_id.
+    adapter.generate_response([])
+    adapter.end()
+    assert fake.patches == ["https://api.retellai.com/end-chat/Chat_1"]

--- a/futureagi/simulate/tests/test_snapshot_secret_masking.py
+++ b/futureagi/simulate/tests/test_snapshot_secret_masking.py
@@ -1,0 +1,63 @@
+"""A5b: provider secrets must never leave an API response in cleartext.
+
+`mask_snapshot_secrets` is the single masking choke point used by both the
+agent-version response serializer and the run_test serializer (which previously
+embedded the raw configuration_snapshot verbatim, leaking customer api_key /
+livekit_api_key / livekit_api_secret).
+"""
+
+import pytest
+
+from simulate.serializers.response.agent_version import mask_snapshot_secrets
+
+PLAINTEXT_SECRET = "supersecretvalue1234567890"
+
+
+class TestMaskSnapshotSecrets:
+    @pytest.mark.unit
+    def test_masks_all_three_secret_fields(self):
+        raw = {
+            "api_key": "sk-vapi-1234567890abcdef",
+            "livekit_api_key": "APIabcdef123456",
+            "livekit_api_secret": PLAINTEXT_SECRET,
+            "provider": "livekit",
+            "livekit_url": "wss://example.livekit.cloud",
+        }
+        masked = mask_snapshot_secrets(raw)
+
+        # Input dict is not mutated (callers reuse the snapshot).
+        assert raw["api_key"] == "sk-vapi-1234567890abcdef"
+        assert raw["livekit_api_secret"] == PLAINTEXT_SECRET
+
+        # No secret field is returned in cleartext.
+        assert masked["api_key"] != raw["api_key"]
+        assert masked["livekit_api_key"] != raw["livekit_api_key"]
+        assert masked["livekit_api_secret"] == "********"
+
+        # Non-secret fields are preserved unchanged.
+        assert masked["provider"] == "livekit"
+        assert masked["livekit_url"] == "wss://example.livekit.cloud"
+
+        # The raw secret value appears nowhere in the masked output.
+        assert PLAINTEXT_SECRET not in masked.values()
+
+    @pytest.mark.unit
+    def test_livekit_api_key_is_masked(self):
+        # Regression for the specific gap: livekit_api_key used to pass through.
+        masked = mask_snapshot_secrets({"livekit_api_key": "APIverylongkey123"})
+        assert masked["livekit_api_key"] != "APIverylongkey123"
+        assert "verylongkey" not in masked["livekit_api_key"]
+
+    @pytest.mark.unit
+    def test_non_dict_returned_unchanged(self):
+        assert mask_snapshot_secrets(None) is None
+        assert mask_snapshot_secrets("not-a-dict") == "not-a-dict"
+
+    @pytest.mark.unit
+    def test_empty_or_missing_secrets_are_not_masked_to_noise(self):
+        masked = mask_snapshot_secrets(
+            {"api_key": "", "livekit_api_key": None, "provider": "vapi"}
+        )
+        assert masked["api_key"] == ""
+        assert masked["livekit_api_key"] is None
+        assert masked["provider"] == "vapi"

--- a/futureagi/simulate/tests/test_vapi_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_vapi_chat_agent_adapter.py
@@ -1,0 +1,115 @@
+"""Unit tests for VapiChatAgentAdapter (TH-5642).
+
+Drives the Vapi chat REST shapes with a fake ``requests`` (no network): create the
+session once, then POST the latest user turn and read the assistant output. Mirrors
+the proven VapiService request shapes.
+"""
+
+import json
+
+import pytest
+
+from simulate.services import vapi_chat_agent_adapter as mod
+from simulate.services.chat_agent_adapter_factory import EXTERNAL_HOSTED_CHAT_ADAPTERS
+from simulate.services.vapi_chat_agent_adapter import (
+    VapiChatAgentAdapter,
+    VapiChatAgentError,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    def __init__(self, responses):
+        self._responses = {k: list(v) for k, v in responses.items()}
+        self.posts = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.posts.append((url, json))
+        for suffix, queue in self._responses.items():
+            if url.endswith(suffix) and queue:
+                return queue.pop(0)
+        raise AssertionError(f"no fake response for POST {url}")
+
+
+def _adapter(monkeypatch, responses):
+    fake = _FakeRequests(responses)
+    monkeypatch.setattr(mod, "requests", fake)
+    return VapiChatAgentAdapter(agent_id="assistant_x", api_key="k"), fake
+
+
+@pytest.mark.unit
+def test_registered_in_factory():
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["vapi"] is VapiChatAgentAdapter
+
+
+@pytest.mark.unit
+def test_requires_agent_id_and_key():
+    with pytest.raises(ValueError):
+        VapiChatAgentAdapter(agent_id="", api_key="k")
+    with pytest.raises(ValueError):
+        VapiChatAgentAdapter(agent_id="a", api_key="")
+
+
+@pytest.mark.unit
+def test_session_created_once_and_only_latest_turn_sent(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/session": [_FakeResp({"id": "sess_1"})],
+            "/chat/": [
+                _FakeResp({"output": [{"role": "assistant", "content": "Reply A"}]}),
+                _FakeResp({"output": [{"role": "assistant", "content": "Reply B"}]}),
+            ],
+        },
+    )
+    r1 = adapter.generate_response([{"role": "user", "content": "first"}])
+    r2 = adapter.generate_response([
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "Reply A"},
+        {"role": "user", "content": "second"},
+    ])
+    assert r1["content"] == "Reply A"
+    assert r2["content"] == "Reply B"
+    # /session hit exactly once.
+    assert len([u for u, _ in fake.posts if u.endswith("/session")]) == 1
+    # Each /chat/ sent only the newest turn with the cached sessionId.
+    chat_payloads = [p for u, p in fake.posts if u.endswith("/chat/")]
+    assert chat_payloads == [
+        {"input": [{"role": "user", "content": "first"}], "sessionId": "sess_1"},
+        {"input": [{"role": "user", "content": "second"}], "sessionId": "sess_1"},
+    ]
+
+
+@pytest.mark.unit
+def test_endcall_tool_marks_chat_ended(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/session": [_FakeResp({"id": "sess_1"})],
+            "/chat/": [_FakeResp({"output": [
+                {"role": "assistant", "content": "Bye",
+                 "tool_calls": [{"function": {"name": "endCall"}}]},
+            ]})],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "bye"}])
+    assert result["content"] == "Bye"
+    assert result["chat_ended"] is True
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch, {"/session": [_FakeResp({"error": "bad"}, status_code=401)]}
+    )
+    with pytest.raises(VapiChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -258,16 +258,35 @@ class CreateAgentDefinitionView(APIView):
             replay_session_id = validated.get("replay_session_id")
             observability_provider = None
 
+            # Resolve the client-provider string to its canonical observability
+            # key via the registry (elevenlabs -> eleven_labs,
+            # livekit_bridge -> livekit, ...). Unknown strings fall back to the
+            # raw value ("vapi"/"retell"/"others" are already canonical).
+            from simulate.providers import get_spec
+
+            _spec = get_spec(provider)
+            _obs_key = (_spec.observability_key if _spec else None) or provider
+
+            # 3rd-party observability is PULL-based: like Vapi, we fetch the
+            # call data from the provider's API on a schedule
+            # (tracer.services.observability_providers.ObservabilityService),
+            # so credentials are required. Pull is implemented for these
+            # canonical keys; the rest (livekit/pipecat/deepgram/agora) have
+            # nothing hosted to pull — their conversation-level observability
+            # comes from the simulation side (CallTranscript -> sim trace).
+            _pull_obs_keys = [
+                ProviderChoices.VAPI,
+                ProviderChoices.RETELL,
+                ProviderChoices.ELEVEN_LABS,
+                ProviderChoices.BLAND,
+                ProviderChoices.TWILIO,
+                ProviderChoices.OTHERS,
+            ]
             if (
                 enable_observability
+                and _obs_key in _pull_obs_keys
                 and assistant_id != ""
                 and api_key != ""
-                and provider
-                in [
-                    ProviderChoices.VAPI,
-                    ProviderChoices.RETELL,
-                    ProviderChoices.OTHERS,
-                ]
             ):
                 observability_provider = create_observability_provider(
                     enabled=True,
@@ -275,7 +294,20 @@ class CreateAgentDefinitionView(APIView):
                     organization=organization,
                     workspace=workspace,
                     project_name=project_name,
-                    provider=provider,
+                    provider=_obs_key,
+                )
+            elif enable_observability and _obs_key not in _pull_obs_keys and _spec:
+                # No pull API exists: keep the agent-def -> ObservabilityProvider
+                # -> Project link so simulation-side traces land in the agent's
+                # project (no fetch creds needed; the scheduled fetcher skips
+                # these gracefully).
+                observability_provider = create_observability_provider(
+                    enabled=True,
+                    user_id=user_id,
+                    organization=organization,
+                    workspace=workspace,
+                    project_name=project_name,
+                    provider=_obs_key,
                 )
 
             # Create agent definition — livekit_* fields are NOT model

--- a/futureagi/simulate/views/agent_version.py
+++ b/futureagi/simulate/views/agent_version.py
@@ -548,9 +548,14 @@ class AgentVersionCallExecutionView(APIView):
                 deleted=False,
             )
 
+            # A completed call is a valid log entry whether or not evals ran.
+            # The old eval_outputs__isnull=False filter hid every call from
+            # runs without evaluations attached — the Call Logs tab showed
+            # "No calls found" for agents with real completed simulations
+            # (reported for Retell, applied to any provider).
             call_executions = CallExecution.objects.filter(
-                agent_version=version, status="completed", eval_outputs__isnull=False
-            ).exclude(eval_outputs={})
+                agent_version=version, status="completed"
+            ).order_by("-created_at")
 
             paginator = ExtendedPageNumberPagination()
             result_page = paginator.paginate_queryset(call_executions, request)

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -674,6 +674,7 @@ class ClickHouseFilterBuilder:
         filter_value: Any,
     ) -> str | None:
         """Dispatch to the appropriate condition builder based on column type."""
+        col_type = self._normalize_col_type_for_dispatch(col_id, col_type)
 
         # TODO: run migrations to normalize filter_op to canonical form , then remove this handling .
         if col_type != self.SPAN_ATTRIBUTE:
@@ -693,8 +694,63 @@ class ClickHouseFilterBuilder:
             return self._build_annotation_condition(
                 col_id, filter_type, filter_op, filter_value
             )
+        elif col_type == self.NORMAL:
+            return self._build_column_condition(
+                col_id, filter_type, filter_op, filter_value
+            )
         else:
             raise ValueError(f"Unsupported col_type: {col_type!r}")
+
+    def _normalize_col_type_for_dispatch(self, col_id: str, col_type: str) -> str:
+        """Normalize routing before the type-specific condition switch.
+
+        ``NORMAL`` is the default col_type the frontend sends, so columns that
+        are really top-level CH metrics / end-user fields must be promoted to
+        their real handler here (else they fall through to the bare-column path
+        or, for an unrecognised type, raise)."""
+        # Legacy ``TRACE_END_USER`` is migrated: user resolution now goes through
+        # SYSTEM_METRIC -> end_users (the legacy tracer_enduser table is gone
+        # CDC-off). Map any stale saved-filter tag onto the v2 path.
+        if col_type == self.TRACE_END_USER:
+            return self.SYSTEM_METRIC
+
+        if col_id in self._ENDUSER_STRING_COLUMNS:
+            return self.SYSTEM_METRIC
+
+        # Attribute discovery can surface denormalised columns like
+        # gen_ai.usage.total_tokens as SPAN_ATTRIBUTE. These must still route
+        # through SYSTEM_METRIC so trace-mode filters match displayed root
+        # metrics and use the top-level CH columns.
+        if col_id in self.SYSTEM_METRIC_MAP and col_type != self.SYSTEM_METRIC:
+            return self.SYSTEM_METRIC
+
+        # Voice list metrics are derived from span attributes/expressions, not
+        # top-level ClickHouse columns. Treat them as system metrics even when
+        # API callers omit col_type, matching the rest of the public filters.
+        if (
+            col_id in self.VOICE_SYSTEM_METRIC_EXPRS
+            or col_id in self.VOICE_SYSTEM_METRIC_STR_MAP
+            or col_id in self.VOICE_SYSTEM_METRIC_STR_EXPRS
+        ) and col_type != self.SYSTEM_METRIC:
+            return self.SYSTEM_METRIC
+
+        # Stale filter state may tag an eval template UUID as SYSTEM_METRIC.
+        # Keep this backend defensive because saved views can outlive FE fixes.
+        if col_type == self.SYSTEM_METRIC and col_id not in self.SYSTEM_METRIC_MAP:
+            try:
+                import uuid as _uuid
+
+                _uuid.UUID(str(col_id))
+                from model_hub.models.evals_metric import EvalTemplate
+
+                if EvalTemplate.no_workspace_objects.filter(
+                    id=col_id, deleted=False
+                ).exists():
+                    return self.EVAL_METRIC
+            except (ValueError, AttributeError, Exception):
+                pass
+
+        return col_type
 
     _ENDUSER_STRING_COLUMNS = {
         "user_id": "user_id",


### PR DESCRIPTION
Sub-stack of the simulation feature (split out of the larger #1047, now closed). **Base:** `feat/th5642-observability-cdc-off` (#1044).

The provider foundation everything else builds on: `providers/registry.py` (single source of truth for vapi/retell/elevenlabs/livekit/deepgram/agora/pipecat/bland/twilio — roles/status/transport/credential-shape), per-provider chat adapters + factory, provider connectivity/verification/prompt-apply, agent-definition CRUD/apply, `verify_providers` harness, agent-definition FE. 36 files.

Stack: #1044 → **this** → chat-sim → voice-execution → optimiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)