### PR TITLE
feat(simulate): voice + execution orchestration + run UI [2c/4]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,4 +228,5 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+futureagi/agora*.dat
 *.core

--- a/frontend/src/api/tests/testDetails.js
+++ b/frontend/src/api/tests/testDetails.js
@@ -19,6 +19,17 @@ export const useGetTestDetail = (testId, options = {}) => {
   });
 };
 
+export const useApplyTrialPrompt = (options = {}) => {
+  return useMutation({
+    mutationFn: async ({ optimizationId, trialId }) =>
+      axios.post(
+        endpoints.optimizeSimulate.applyTrial(optimizationId, trialId),
+        {},
+      ),
+    ...options,
+  });
+};
+
 export const useOptimizeTrialPrompts = ({ optimizationId, trialId }) => {
   return useQuery({
     queryKey: ["fix-my-agent-trail-prompts", optimizationId, trialId],

--- a/frontend/src/sections/common/EvalsTasks/Renderers/RunningStatusRenderer.jsx
+++ b/frontend/src/sections/common/EvalsTasks/Renderers/RunningStatusRenderer.jsx
@@ -45,7 +45,7 @@ const CustomIconButton = styled(OutlinedButton)(() => ({
 
 const RunningStatusRenderer = ({ value, data, api }) => {
   const { mutate: pauseEvalTask } = useMutation({
-    mutationFn: () => axios.post(endpoints.project.pauseEvalTask(data.id)),
+    mutationFn: () => axios.post(endpoints.project.pauseEvalTask(data.id), {}),
     onSuccess: (_) => {
       api.applyServerSideTransaction({
         update: [{ ...data, status: "paused" }],
@@ -54,7 +54,7 @@ const RunningStatusRenderer = ({ value, data, api }) => {
   });
 
   const { mutate: resumeEvalTask } = useMutation({
-    mutationFn: () => axios.post(endpoints.project.resumeEvalTask(data.id)),
+    mutationFn: () => axios.post(endpoints.project.resumeEvalTask(data.id), {}),
     meta: { errorHandled: true },
     onSuccess: (_) => {
       api.applyServerSideTransaction({

--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -395,13 +395,14 @@ const TaskListView = ({
 
   // Pause/Resume mutations
   const { mutate: pauseTask } = useMutation({
-    mutationFn: (taskId) => axios.post(endpoints.project.pauseEvalTask(taskId)),
+    mutationFn: (taskId) =>
+      axios.post(endpoints.project.pauseEvalTask(taskId), {}),
     onSuccess: () => refetch(),
   });
 
   const { mutate: resumeTask } = useMutation({
     mutationFn: (taskId) =>
-      axios.post(endpoints.project.resumeEvalTask(taskId)),
+      axios.post(endpoints.project.resumeEvalTask(taskId), {}),
     meta: { errorHandled: true },
     onSuccess: () => refetch(),
     onError: () => {

--- a/frontend/src/sections/common/simulation/hooks/useCancelExecution.js
+++ b/frontend/src/sections/common/simulation/hooks/useCancelExecution.js
@@ -8,7 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 export const useCancelExecution = () => {
   return useMutation({
     mutationFn: (id) =>
-      axios.post(endpoints.testExecutions.cancelExecution(id)),
+      axios.post(endpoints.testExecutions.cancelExecution(id), {}),
   });
 };
 

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -129,7 +129,7 @@ const TaskDetailPage = () => {
   });
 
   const { mutate: pauseTask } = useMutation({
-    mutationFn: () => axios.post(endpoints.project.pauseEvalTask(taskId)),
+    mutationFn: () => axios.post(endpoints.project.pauseEvalTask(taskId), {}),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
       queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
@@ -138,7 +138,7 @@ const TaskDetailPage = () => {
   });
 
   const { mutate: resumeTask } = useMutation({
-    mutationFn: () => axios.post(endpoints.project.resumeEvalTask(taskId)),
+    mutationFn: () => axios.post(endpoints.project.resumeEvalTask(taskId), {}),
     meta: { errorHandled: true },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });

--- a/frontend/src/sections/test/TestRuns/TestRunsGrid.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunsGrid.jsx
@@ -93,17 +93,18 @@ function AgentDefinitionCell({ row }) {
   );
 }
 
-function StatusCell({ getValue, row }) {
+function StatusCell({ getValue, row, column }) {
   const status = getValue();
   const showStop = STOPPABLE_STATUSES.includes(status);
-  const { mutate: cancelExecution } = useCancelExecution();
-  const { refreshTestRunGrid } = useTestDetailContext();
+  // The cancel mutation is LIFTED to the grid: hooks called inside a MUI
+  // DataGrid renderCell get a `mutate` that no-ops after the virtualised
+  // cell's observer is torn down (react-query v5), so the Stop button fired
+  // nothing. The grid passes a stable onStop(id) through column.meta.
+  const onStop = column?.meta?.onStop;
 
   const handleStop = (e) => {
     e.stopPropagation();
-    cancelExecution(row.original.id, {
-      onSuccess: () => refreshTestRunGrid?.(),
-    });
+    onStop?.(row.original.id);
   };
 
   return (
@@ -143,7 +144,7 @@ function StatusCell({ getValue, row }) {
 
 // ── Column defs by type ──
 
-function buildColumns(agentType, simulationType) {
+function buildColumns(agentType, simulationType, onStop) {
   // Prompt simulations
   if (simulationType === SIMULATION_TYPE.PROMPT) {
     return [
@@ -195,6 +196,7 @@ function buildColumns(agentType, simulationType) {
         size: 180,
         enableSorting: false,
         cell: StatusCell,
+        meta: { onStop },
       },
       {
         id: "duration",
@@ -242,6 +244,7 @@ function buildColumns(agentType, simulationType) {
         size: 180,
         enableSorting: false,
         cell: StatusCell,
+        meta: { onStop },
       },
       {
         id: "total_number_of_fagi_agent_turns",
@@ -319,6 +322,7 @@ function buildColumns(agentType, simulationType) {
       size: 180,
       enableSorting: false,
       cell: StatusCell,
+      meta: { onStop },
     },
     {
       id: "duration",
@@ -433,9 +437,25 @@ const TestRunsGrid = ({ agentType, simulationType }) => {
     [items],
   );
 
+  const { mutate: cancelExecution } = useCancelExecution();
+  const { refreshTestRunGrid } = useTestDetailContext();
+  const handleStopExecution = useCallback(
+    (executionId) => {
+      cancelExecution(executionId, {
+        onSuccess: () => refreshTestRunGrid?.(),
+      });
+    },
+    [cancelExecution, refreshTestRunGrid],
+  );
+
   const columns = useMemo(
-    () => buildColumns(agentType ?? AGENT_TYPES.VOICE, simulationType),
-    [agentType, simulationType],
+    () =>
+      buildColumns(
+        agentType ?? AGENT_TYPES.VOICE,
+        simulationType,
+        handleStopExecution,
+      ),
+    [agentType, simulationType, handleStopExecution],
   );
 
   const handleRowClick = useCallback(

--- a/futureagi/docker-compose.branch.yml
+++ b/futureagi/docker-compose.branch.yml
@@ -1,0 +1,65 @@
+# TH-5642 local branch run: use the baked :dev image (deps) + mount THIS working
+# tree as source, so the running backend/worker execute the feat/multi-provider-registry
+# code WITHOUT a rebuild (base image v1.8.19_base isn't local). Compose `up` (no --build)
+# uses the existing :dev image because it's set here.
+# Voice E2E: point the voice stack at the LOCAL LiveKit+SIP containers (lksip-*,
+# host network → reachable from compose containers via host.docker.internal).
+x-livekit-env: &livekit-env
+  LIVEKIT_URL: ws://host.docker.internal:7880
+  LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:?set in your gitignored .env}
+  LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:?set in your gitignored .env}
+  # Voice executions are orchestrated by TestExecutionWorkflow (creates
+  # CallExecutions + launches ee CallExecutionWorkflow children). The legacy
+  # monitor-based pickup is commented out in tfc/temporal/schedules/simulate.py,
+  # so without this flag voice runs are created PENDING and never picked up.
+  TEMPORAL_TEST_EXECUTION_ENABLED: "true"
+  # Post dev-merge: the canonical resolver (ee.voice.utils.system_provider)
+  # defaults the simulator-side engine to vapi; this stack runs LiveKit.
+  SYSTEM_VOICE_PROVIDER: livekit
+  # The lksip agent worker pushes transcripts/metrics/call-end to the backend's
+  # internal livekit API (Authorization: Bearer <INTERNAL_API_SECRET>); must match
+  # the worker's INTERNAL_API_SECRET.
+  INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-devsecret}
+  # Callback URL the backend embeds in LiveKit agent-dispatch metadata; the
+  # lksip job process pushes transcripts/lifecycle THERE (it overrides the
+  # worker's own BACKEND_URL env). Default is :8000 → pushes vanish; the lksip
+  # containers run host-network, so the branch backend is host :8003.
+  LIVEKIT_BACKEND_CALLBACK_URL: http://localhost:8003
+  # Agora RTC connector (web_agora): RTC tokens + ConvAI agent llm/tts defaults.
+  AGORA_APP_ID: ${AGORA_APP_ID:?set in your gitignored .env}
+  AGORA_APP_CERT: ${AGORA_APP_CERT:?set in your gitignored .env}
+  # Local v2 span store (TH-5642 browser E2E): the CH 25.3 test sidecar is
+  # connected to futureagi-network and hosts the v2 spans schema in
+  # `local_app`, backfilled from PG via tracer.services.clickhouse.v2.backfill.
+  # Point the legacy CH client at the same 25.3 server (dev parity: one
+  # server hosts both the v2 spans store and the analytics dicts), with the
+  # cutover flag so the legacy v1 spans DDL never lands next to v2.
+  CH_HOST: futureagi-test-clickhouse-1
+  CH_PORT: "9000"
+  CH_DATABASE: local_app
+  CH25_DROP_LEGACY_CDC_CHAIN: "true"
+  CH25_HOST: futureagi-test-clickhouse-1
+  CH25_HTTP_PORT: "8123"
+  CH25_TCP_PORT: "9000"
+  CH25_DATABASE: local_app
+  CH25_QUERY_TYPES_V2_ONLY: "trace_list,span_list,trace_detail,trace_of_session_list,session_list,voice_call_list,voice_call_detail,eval_metrics,time_series,span_graph"
+  CARTESIA_API_KEY: ${CARTESIA_API_KEY:?set in your gitignored .env}
+  ELEVENLABS_API_KEY: ${ELEVENLABS_API_KEY:?set in your gitignored .env}
+
+services:
+  backend:
+    image: futureagi/future-agi:dev
+    pull_policy: never
+    platform: linux/arm64
+    volumes:
+      - ".:/app/backend"
+    environment:
+      <<: *livekit-env
+  temporal-worker-dev:
+    image: futureagi/future-agi:dev
+    pull_policy: never
+    platform: linux/arm64
+    volumes:
+      - ".:/app/backend"
+    environment:
+      <<: *livekit-env

--- a/futureagi/simulate/services/outbound_dialer.py
+++ b/futureagi/simulate/services/outbound_dialer.py
@@ -1,0 +1,298 @@
+"""Per-provider user-side outbound dialers (TH-5642).
+
+OUTBOUND simulation = the customer's agent CALLS our pool number and our simulator
+answers. The system-side answer leg (LiveKit SIP inbound trunk + dispatch) is
+provider-agnostic; the only per-provider piece is TRIGGERING the customer's agent to
+place the call. That was hard-wired to Vapi (voice_large.py: "currently always
+VAPI"), so a Retell/Bland user agent was silently dialed through the Vapi API.
+
+This module provides a dialer registry keyed by the user's provider, each a thin
+REST client returning ``{"id": <provider_call_id>}`` to match the existing
+``engine.create_outbound_call`` contract. Raw REST (no ee dependency) and
+unit-tested against the documented provider shapes; placing a real outbound call
+costs money and dials a live number, so these are not live-exercised here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class OutboundDialError(RuntimeError):
+    """Raised when a provider's outbound-call API errors or returns no call id."""
+
+
+class OutboundDialer:
+    """Triggers the customer's agent to place an outbound call to ``to_phone_number``."""
+
+    provider: str = ""
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError(f"{type(self).__name__} requires an api_key")
+        self._api_key = api_key
+
+    def create_outbound_call(
+        self,
+        *,
+        assistant_id: str,
+        from_phone_number: str,
+        to_phone_number: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _require_id(call_id: Any, payload: Any) -> dict[str, Any]:
+        if not call_id:
+            raise OutboundDialError(f"No call id returned by provider: {payload}")
+        return {"id": call_id}
+
+
+class RetellOutboundDialer(OutboundDialer):
+    """Retell outbound via ``POST /v2/create-phone-call`` (Bearer auth)."""
+
+    provider = "retell"
+    BASE_URL = "https://api.retellai.com"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        resp = requests.post(
+            f"{self.BASE_URL}/v2/create-phone-call",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "from_number": from_phone_number,
+                "to_number": to_phone_number,
+                "override_agent_id": assistant_id,
+                "metadata": metadata or {},
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Retell create-phone-call failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("call_id"), data)
+
+
+class BlandOutboundDialer(OutboundDialer):
+    """Bland.ai outbound via ``POST /v1/calls`` (raw api_key auth, pathway = agent)."""
+
+    provider = "bland"
+    BASE_URL = "https://api.bland.ai"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        # Bland identifies the customer's agent by pathway_id; from_number is optional.
+        body: dict[str, Any] = {
+            "phone_number": to_phone_number,
+            "pathway_id": assistant_id,
+            "metadata": metadata or {},
+        }
+        if from_phone_number:
+            body["from"] = from_phone_number
+        resp = requests.post(
+            f"{self.BASE_URL}/v1/calls",
+            headers={"Authorization": self._api_key, "Content-Type": "application/json"},
+            json=body,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Bland /v1/calls failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("call_id"), data)
+
+
+class ElevenLabsOutboundDialer(OutboundDialer):
+    """ElevenLabs ConvAI outbound via ``POST /v1/convai/twilio/outbound-call``.
+
+    ElevenLabs places outbound calls through its Twilio integration, so
+    ``from_phone_number`` here carries the agent's registered
+    ``agent_phone_number_id`` (not a raw E.164 number). Auth is ``xi-api-key``.
+    """
+
+    provider = "elevenlabs"
+    BASE_URL = "https://api.elevenlabs.io"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        resp = requests.post(
+            f"{self.BASE_URL}/v1/convai/twilio/outbound-call",
+            headers={"xi-api-key": self._api_key, "Content-Type": "application/json"},
+            json={
+                "agent_id": assistant_id,
+                "agent_phone_number_id": from_phone_number,
+                "to_number": to_phone_number,
+                "conversation_initiation_client_data": {"metadata": metadata or {}},
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"ElevenLabs outbound-call failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        # The call id is conversation_id (fall back to Twilio's callSid).
+        return self._require_id(data.get("conversation_id") or data.get("callSid"), data)
+
+
+class TwilioOutboundDialer(OutboundDialer):
+    """Twilio outbound via ``POST /2010-04-01/Accounts/{sid}/Calls.json``.
+
+    A Twilio "agent" is a number whose call is driven by the customer's TwiML app
+    (ConversationRelay / Media Streams / a TwiML URL), so ``assistant_id`` carries
+    either that TwiML **URL** (used as ``Url``) or an **ApplicationSid** (used as
+    ``ApplicationSid``). Twilio uses HTTP Basic auth and FORM bodies, so the api_key
+    is ``"AccountSid:AuthToken"``.
+    """
+
+    provider = "twilio"
+    BASE_URL = "https://api.twilio.com"
+
+    def _account_sid_and_token(self) -> tuple[str, str]:
+        sid, _, token = self._api_key.partition(":")
+        if not sid or not token:
+            raise ValueError(
+                "TwilioOutboundDialer api_key must be 'AccountSid:AuthToken'"
+            )
+        return sid, token
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        sid, token = self._account_sid_and_token()
+        form: dict[str, Any] = {"To": to_phone_number, "From": from_phone_number}
+        # TwiML URL vs ApplicationSid: a URL drives the call's behaviour; an
+        # ApplicationSid points at the customer's pre-configured TwiML app/agent.
+        if str(assistant_id).startswith(("http://", "https://")):
+            form["Url"] = assistant_id
+        else:
+            form["ApplicationSid"] = assistant_id
+        resp = requests.post(
+            f"{self.BASE_URL}/2010-04-01/Accounts/{sid}/Calls.json",
+            data=form,
+            auth=(sid, token),
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Twilio Calls.json failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("sid"), data)
+
+
+class AgoraOutboundDialer(OutboundDialer):
+    """Agora Conversational AI outbound via the ConvAI telephony API.
+
+    Agora rides the provider-neutral SIP path (registry ``transport=SIP``): the ConvAI
+    agent places an outbound SIP call to our pool number and we answer on the LiveKit
+    SIP inbound trunk. Auth is HTTP Basic with the Agora **Customer Key:Secret** (the
+    same credential the connectivity probe validates), so ``api_key`` is
+    ``"CustomerKey:CustomerSecret"``. The Agora **App ID** (project) is not part of the
+    Basic credential and is read from the ``AGORA_APP_ID`` env var.
+
+    Maps our outbound semantics (the agent dials our pool number) onto Agora's outbound
+    call: ``to_phone_number`` is the called number, ``from_phone_number`` is the caller
+    ID, ``assistant_id`` is the AI-Studio published agent. The response's ``agent_id``
+    is the call/agent instance id.
+
+    Docs: https://docs.agora.io/en/conversational-ai/rest-api/telephony/start (outbound)
+    and .../rest-api/agent/join (base ``/conversational-ai-agent/v2/projects/{appid}``,
+    Basic auth, ``agent_id`` response). The exact outbound telephony PATH is overridable
+    via ``AGORA_OUTBOUND_CALL_URL`` and should be confirmed against your Agora project on
+    the first live call; auth, body and response parsing here follow the documented
+    contract and are unit-tested.
+    """
+
+    provider = "agora"
+    BASE_URL = "https://api.agora.io/api/conversational-ai-agent/v2"
+
+    def _key_and_secret(self) -> tuple[str, str]:
+        key, _, secret = self._api_key.partition(":")
+        if not key or not secret:
+            raise ValueError(
+                "AgoraOutboundDialer api_key must be 'CustomerKey:CustomerSecret'"
+            )
+        return key, secret
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        key, secret = self._key_and_secret()
+        app_id = os.getenv("AGORA_APP_ID", "")
+        if not app_id:
+            raise OutboundDialError(
+                "AGORA_APP_ID env var is required for Agora outbound calls"
+            )
+        # Endpoint + body per the official agora-agents-python SDK (TH-5642
+        # capability research; the docs restructure 404s, the SDK pins the
+        # contract): POST .../projects/{appid}/call with `pipeline_id` (the
+        # ConvAI pipeline = the agent under test) and a `sip` object
+        # {to_number, from_number[, rtc_uid, rtc_token]}.
+        url = os.getenv(
+            "AGORA_OUTBOUND_CALL_URL",
+            f"{self.BASE_URL}/projects/{app_id}/call",
+        )
+        meta = metadata or {}
+        sip: dict = {
+            "to_number": to_phone_number,
+            "from_number": from_phone_number,
+        }
+        if meta.get("rtc_uid"):
+            sip["rtc_uid"] = meta["rtc_uid"]
+        if meta.get("rtc_token"):
+            sip["rtc_token"] = meta["rtc_token"]
+        resp = requests.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            auth=(key, secret),
+            json={"pipeline_id": assistant_id, "sip": sip},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Agora outbound call failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("agent_id") or data.get("id"), data)
+
+
+# provider key -> dialer class. Vapi keeps its existing engine path (it's already
+# wired); these add the previously-missing non-Vapi user-side dialers.
+OUTBOUND_DIALERS: dict[str, type[OutboundDialer]] = {
+    "retell": RetellOutboundDialer,
+    "bland": BlandOutboundDialer,
+    "elevenlabs": ElevenLabsOutboundDialer,
+    "eleven_labs": ElevenLabsOutboundDialer,  # provider-string drift
+    "twilio": TwilioOutboundDialer,
+    "agora": AgoraOutboundDialer,
+}
+
+
+def get_outbound_dialer(provider: str | None, api_key: str) -> OutboundDialer | None:
+    """Return a dialer for the user's provider, or None to fall back to the existing
+    (Vapi) engine path. Lets the orchestration replace the Vapi hard-wire with a
+    registry lookup without breaking the Vapi flow."""
+    cls = OUTBOUND_DIALERS.get((provider or "").strip().lower())
+    if cls is None:
+        return None
+    key = api_key or os.getenv(f"{(provider or '').upper()}_API_KEY", "")
+    return cls(api_key=key)

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -3,11 +3,9 @@ import json
 import os
 import re
 import traceback
-from datetime import datetime, timedelta
 from decimal import Decimal
-from difflib import SequenceMatcher
 from itertools import chain
-from typing import Any, Dict, Optional
+from typing import Any
 from uuid import uuid4
 
 import structlog
@@ -62,12 +60,14 @@ try:
 except ImportError:
     DeterministicEvaluator = _ee_stub("DeterministicEvaluator")
 
-from model_hub.models.choices import StatusType
-from model_hub.models.develop_dataset import Cell, Column, Row
-from model_hub.tasks.user_evaluation import trigger_error_localization_for_simulate
-from model_hub.views.utils.evals import run_eval_func
-from sdk.utils.helpers import _get_api_call_type
-from simulate.constants.persona_prompt_guides import (
+from model_hub.models.choices import StatusType  # noqa: E402
+from model_hub.models.develop_dataset import Cell, Column, Row  # noqa: E402
+from model_hub.tasks.user_evaluation import (  # noqa: E402
+    trigger_error_localization_for_simulate,  # noqa: E402
+)
+from model_hub.views.utils.evals import run_eval_func  # noqa: E402
+from sdk.utils.helpers import _get_api_call_type  # noqa: E402
+from simulate.constants.persona_prompt_guides import (  # noqa: E402
     CHAT_COMMUNICATION_STYLE_GUIDES,
     CHAT_EMOJI_FREQUENCY_GUIDES,
     CHAT_PERSONALITY_GUIDES,
@@ -80,13 +80,14 @@ from simulate.constants.persona_prompt_guides import (
     VOICE_COMMUNICATION_STYLE_GUIDES,
     VOICE_PERSONALITY_GUIDES,
 )
+
 try:
     from ee.voice.constants.voice_mapper import (
         select_voice_id,
     )
 except ImportError:
     select_voice_id = None
-from simulate.models import (
+from simulate.models import (  # noqa: E402
     AgentDefinition,
     AgentVersion,
     CallExecution,
@@ -97,11 +98,14 @@ from simulate.models import (
     SimulateEvalConfig,
     TestExecution,
 )
-from simulate.models.run_test import CreateCallExecution
-from simulate.models.simulator_agent import SimulatorAgent
-from simulate.models.test_execution import EvalExplanationSummaryStatus
-from simulate.pydantic_schemas.chat import SimulationCallType
-from simulate.services.branch_deviation_analyzer import BranchDeviationAnalyzer
+from simulate.models.run_test import CreateCallExecution  # noqa: E402
+from simulate.models.simulator_agent import SimulatorAgent  # noqa: E402
+from simulate.models.test_execution import EvalExplanationSummaryStatus  # noqa: E402
+from simulate.pydantic_schemas.chat import SimulationCallType  # noqa: E402
+from simulate.services.branch_deviation_analyzer import (  # noqa: E402
+    BranchDeviationAnalyzer,  # noqa: E402
+)
+
 try:
     from ee.voice.services.conversation_metrics import ConversationMetricsCalculator
     from ee.voice.services.phone_number_service import PhoneNumberService
@@ -110,18 +114,20 @@ except ImportError:
     ConversationMetricsCalculator = None
     PhoneNumberService = None
     decide_processing_skip = None
-from simulate.utils.eval_summary import derive_kpi_output_type
-from simulate.utils.processing_outcomes import (
+from simulate.utils.eval_summary import derive_kpi_output_type  # noqa: E402
+from simulate.utils.processing_outcomes import (  # noqa: E402
     build_skipped_eval_output_payload,
     set_processing_skip_metadata,
 )
-from simulate.utils.test_execution_utils import generate_simulator_agent_prompt
-from tfc.settings.settings import VAPI_INDIAN_PHONE_NUMBER_ID
-from tfc.temporal.drop_in import temporal_activity
+from simulate.utils.test_execution_utils import (  # noqa: E402
+    generate_simulator_agent_prompt,  # noqa: E402
+)
+from tfc.constants.api_calls import APICallStatusChoices  # noqa: E402
+from tfc.settings.settings import VAPI_INDIAN_PHONE_NUMBER_ID  # noqa: E402
+from tfc.temporal.drop_in import temporal_activity  # noqa: E402
 
 # Note: run_eval_summary_task imported lazily to avoid circular imports
-from tfc.utils.error_codes import get_specific_error_message
-from tfc.constants.api_calls import APICallStatusChoices
+from tfc.utils.error_codes import get_specific_error_message  # noqa: E402
 
 try:
     from ee.usage.models.usage import APICallType
@@ -132,7 +138,10 @@ try:
 except ImportError:
     check_usage = None
 try:
-    from ee.usage.utils.usage_entries import deduct_cost_for_request, log_and_deduct_cost_for_api_request
+    from ee.usage.utils.usage_entries import (
+        deduct_cost_for_request,
+        log_and_deduct_cost_for_api_request,
+    )
 except ImportError:
     deduct_cost_for_request = None
     log_and_deduct_cost_for_api_request = None
@@ -867,9 +876,9 @@ class TestExecutor:
 
     def _format_persona_voice_text(
         self,
-        persona_data: Dict[str, Any],
+        persona_data: dict[str, Any],
         agent_version: AgentVersion | None,
-        row_data: Dict[str, Any] = None,
+        row_data: dict[str, Any] = None,
         call_type: str = "inbound",
     ) -> str:
         """
@@ -1008,7 +1017,7 @@ class TestExecutor:
                 # Personality-specific guidance
                 guidance = VOICE_PERSONALITY_GUIDES.get(
                     personality_lower,
-                    f"Let this personality trait guide your reactions, responses, and overall demeanor.",
+                    "Let this personality trait guide your reactions, responses, and overall demeanor.",
                 )
                 personality_section += f"{guidance}\n\n"
 
@@ -1027,7 +1036,7 @@ class TestExecutor:
                 # Communication style-specific guidance
                 guidance = VOICE_COMMUNICATION_STYLE_GUIDES.get(
                     comm_style_lower,
-                    f"Let this style guide how you express yourself throughout the conversation.",
+                    "Let this style guide how you express yourself throughout the conversation.",
                 )
                 personality_section += f"{guidance}\n\n"
 
@@ -1063,7 +1072,7 @@ class TestExecutor:
                     else [language_data]
                 )
                 lang_str = (
-                    ", ".join(str(l) for l in langs)
+                    ", ".join(str(lang) for lang in langs)
                     if isinstance(langs, list)
                     else str(language_data)
                 )
@@ -1072,7 +1081,7 @@ class TestExecutor:
 
                 # Special handling for multilingual contexts
                 if persona_data.get("multilingual"):
-                    language_section += f"You are multilingual. Switch languages naturally based on context while maintaining your persona traits in all languages.\n"
+                    language_section += "You are multilingual. Switch languages naturally based on context while maintaining your persona traits in all languages.\n"
 
                 # Special handling for Hinglish speakers
                 # if (accent and "indian" in accent.lower()) or any("hindi" in str(l).lower() for l in langs): # operator precedence
@@ -1093,7 +1102,7 @@ class TestExecutor:
                         else [language_data]
                     )
                     lang_str_check = (
-                        ", ".join(str(l) for l in langs)
+                        ", ".join(str(lang) for lang in langs)
                         if isinstance(langs, list)
                         else str(language_data)
                     )
@@ -1230,9 +1239,9 @@ class TestExecutor:
 
     def _format_persona_chat_text(
         self,
-        persona_data: Dict[str, Any],
+        persona_data: dict[str, Any],
         agent_version: AgentVersion | None,
-        row_data: Dict[str, Any] = None,
+        row_data: dict[str, Any] = None,
         call_type: str = "inbound",
     ) -> str:
         """
@@ -1362,7 +1371,7 @@ class TestExecutor:
                 # Personality-specific guidance
                 guidance = CHAT_PERSONALITY_GUIDES.get(
                     personality_lower,
-                    f"Let this personality trait guide your reactions, responses, and overall messaging style.",
+                    "Let this personality trait guide your reactions, responses, and overall messaging style.",
                 )
                 personality_section += f"{guidance}\n\n"
 
@@ -1381,7 +1390,7 @@ class TestExecutor:
                 # Communication style-specific guidance
                 guidance = CHAT_COMMUNICATION_STYLE_GUIDES.get(
                     comm_style_lower,
-                    f"Let this style guide how you express yourself throughout the chat conversation.",
+                    "Let this style guide how you express yourself throughout the chat conversation.",
                 )
                 personality_section += f"{guidance}\n\n"
 
@@ -1600,7 +1609,7 @@ class TestExecutor:
                 language_data if isinstance(language_data, list) else [language_data]
             )
             lang_str = (
-                ", ".join(str(l) for l in langs)
+                ", ".join(str(lang) for lang in langs)
                 if isinstance(langs, list)
                 else str(language_data)
             )
@@ -1610,7 +1619,7 @@ class TestExecutor:
 
             # Special handling for multilingual contexts
             if persona_data.get("multilingual"):
-                language_section += f"You are multilingual. Switch languages naturally based on context while maintaining your persona traits in all languages.\n"
+                language_section += "You are multilingual. Switch languages naturally based on context while maintaining your persona traits in all languages.\n"
 
             language_section += "\n"
             sections.append(language_section)
@@ -1716,7 +1725,7 @@ class TestExecutor:
     def _generate_dynamic_prompt(
         self,
         prompt_template: str,
-        row_data: Dict[str, Any],
+        row_data: dict[str, Any],
         agent_version: AgentVersion | None,
         call_type: str | None = None,
     ) -> str:
@@ -1976,7 +1985,7 @@ class TestExecutor:
     def _check_call_balance(
         self,
         organization,
-        call_type: Optional[str] = SimulationCallType.VOICE,
+        call_type: str | None = SimulationCallType.VOICE,
     ):
         """Check whether an organization is allowed to run a simulation call.
 
@@ -2013,9 +2022,7 @@ class TestExecutor:
         """
         try:
             event_type = (
-                "text_call"
-                if call_type == SimulationCallType.TEXT
-                else "voice_call"
+                "text_call" if call_type == SimulationCallType.TEXT else "voice_call"
             )
             result = check_usage(str(organization.id), event_type)
 
@@ -2062,11 +2069,23 @@ class TestExecutor:
             if not run_test.agent_definition:
                 return False, "Agent definition not found for this test run"
 
-            # Check if phone number is configured (for voice simulations)
-            if run_test.agent_version and run_test.agent_version.configuration_snapshot:
-                if not run_test.agent_version.configuration_snapshot.get(
-                    "contact_number"
-                ):
+            # Check if phone number is configured (for voice simulations).
+            # TEXT (chat) agents have no phone surface — the check is
+            # voice-only, and web-connector voice providers resolve their
+            # transport from the registry, not from a stored number.
+            snapshot = (
+                run_test.agent_version.configuration_snapshot
+                if run_test.agent_version
+                else None
+            ) or {}
+            snapshot_agent_type = snapshot.get("agent_type") or snapshot.get(
+                "agentType"
+            )
+            if (
+                snapshot
+                and snapshot_agent_type != AgentDefinition.AgentTypeChoices.TEXT
+            ):
+                if not snapshot.get("contact_number"):
                     return (
                         False,
                         "Phone number not configured in this version of agent definition",
@@ -2142,11 +2161,11 @@ class TestExecutor:
         self,
         run_test: RunTest,
         scenario: Scenarios,
-        call_data: Dict[str, Any],
+        call_data: dict[str, Any],
         test_execution_record: TestExecution,
         user_id: str,
         simulator_id=None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Execute an inbound call where simulation agent calls user's agent (existing logic)
 
@@ -2203,7 +2222,10 @@ class TestExecutor:
             )
             inbound = snapshot.get("inbound", True)
 
-            if not inbound:
+            # Outbound prerequisites are phone-pool checks — they only apply to
+            # voice. A TEXT (chat) agent marked outbound has no phone to dial,
+            # so requiring contact_number here failed every chat run.
+            if not inbound and agent_type != CallExecution.SimulationCallType.TEXT:
                 is_valid, validation_error = self._validate_outbound_call_prerequisites(
                     run_test
                 )
@@ -2345,10 +2367,15 @@ class TestExecutor:
 
                 # Use REGISTERED status for TEXT simulations so the
                 # process_prompt_based_chat_simulations activity picks them up.
-                # Voice simulations use PENDING (picked up by Temporal workflow).
+                # That covers prompt-based runs AND hosted TEXT agent
+                # definitions (the trigger's server_side_chat_filter claims
+                # both); gating on is_prompt_based alone left agent-definition
+                # chats PENDING forever. Voice simulations use PENDING
+                # (picked up by Temporal workflow).
                 initial_status = (
                     CallExecution.CallStatus.REGISTERED
                     if is_prompt_based
+                    or agent_type == CallExecution.SimulationCallType.TEXT
                     else CallExecution.CallStatus.PENDING
                 )
 
@@ -3110,7 +3137,7 @@ class TestExecutor:
                                     time_window_seconds=10,
                                 )
                             )
-                        except Exception as e:
+                        except Exception:
                             logger.warning("Unable to locate matching customer call ID")
 
                     if customer_call_id:
@@ -3118,7 +3145,7 @@ class TestExecutor:
                             customer_call_data = voice_service_manager.get_call(
                                 customer_call_id, True
                             )
-                        except Exception as e:
+                        except Exception:
                             logger.warning("Failed to fetch customer call data")
 
                 if customer_call_data:
@@ -3293,7 +3320,7 @@ class TestExecutor:
                                     csat_score=csat_score,
                                 )
 
-                            except:
+                            except Exception:
                                 logger.warning(
                                     "csat_evaluation_parse_failed",
                                     call_execution_id=str(call_execution.id),
@@ -3472,6 +3499,28 @@ class TestExecutor:
                     "call_metadata",  # JSONFields that may be modified in-place
                 ]
                 call_execution.save(update_fields=fields_to_update)
+
+                # Attach eval results onto the sim trace's root span (deterministic
+                # id), so eval verdicts are filterable at span granularity in the
+                # trace UI alongside the conversation spans (TH-5642). Idempotent +
+                # best-effort: a no-op if the trace wasn't emitted.
+                try:
+                    from simulate.services.sim_observability import (
+                        attach_sim_evals_to_trace,
+                    )
+
+                    _eval_attrs = {}
+                    if call_execution.overall_score is not None:
+                        _eval_attrs["gen_ai.evaluation.overall_score"] = float(
+                            call_execution.overall_score
+                        )
+                    _cmd = call_execution.conversation_metrics_data or {}
+                    if isinstance(_cmd, dict) and _cmd:
+                        _eval_attrs["gen_ai.evaluation.conversation_metrics"] = _cmd
+                    if _eval_attrs:
+                        attach_sim_evals_to_trace(call_execution, _eval_attrs)
+                except Exception:
+                    logger.exception(f"sim_eval_attach_failed for {call_execution.id}")
                 # Calculate call duration and deduct cost if call is completed and has recording
                 if (
                     call_execution.status == CallExecution.CallStatus.COMPLETED
@@ -3654,36 +3703,47 @@ class TestExecutor:
                     f"Successfully deducted cost for chat call {call_execution.id}"
                 )
 
-                # Dual-write: emit usage event for text sim
+                # Dual-write: emit usage event for text sim. This is the SINGLE
+                # canonical TEXT_CALL emit — it is reached on every chat terminal
+                # path (interactive endCall, prompt-chat endCall via
+                # store_chat_messages, and prompt-chat max-turns via
+                # finalize_chat_execution). Do NOT emit TEXT_CALL anywhere else
+                # for the same source_id, or the call is double-billed.
                 try:
-                    try:
-                        from ee.usage.schemas.event_types import BillingEventType
-                    except ImportError:
-                        BillingEventType = None
-                    try:
-                        from ee.usage.schemas.events import UsageEvent
-                    except ImportError:
-                        UsageEvent = None
-                    try:
-                        from ee.usage.services.emitter import emit
-                    except ImportError:
-                        emit = None
+                    from ee.usage.schemas.event_types import BillingEventType
+                    from ee.usage.schemas.events import UsageEvent
+                    from ee.usage.services.emitter import emit
+                except ImportError:
+                    BillingEventType = UsageEvent = emit = None
 
-                    emit(
-                        UsageEvent(
-                            org_id=str(organization.id),
-                            event_type=BillingEventType.TEXT_CALL,
-                            amount=total_tokens,
-                            properties={
-                                "source": "simulate",
-                                "source_id": str(call_execution.id),
-                                "turns": no_of_fagi_agent_turns,
-                                "total_tokens": total_tokens,
-                            },
+                if emit and UsageEvent and BillingEventType:
+                    try:
+                        emit(
+                            UsageEvent(
+                                org_id=str(organization.id),
+                                event_type=BillingEventType.TEXT_CALL,
+                                # Floor at 1 so a token-tracking miss still bills a
+                                # non-zero TEXT_CALL (mirrors the voice
+                                # max(1, duration_minutes) floor) — never silent $0.
+                                amount=max(1, total_tokens),
+                                properties={
+                                    "source": "simulate",
+                                    "source_id": str(call_execution.id),
+                                    "turns": no_of_fagi_agent_turns,
+                                    "total_tokens": total_tokens,
+                                },
+                            )
                         )
+                    except Exception:
+                        logger.exception(
+                            "chat_usage_emit_failed",
+                            call_execution_id=str(call_execution.id),
+                        )
+                else:
+                    logger.error(
+                        "chat_usage_emit_unavailable",
+                        call_execution_id=str(call_execution.id),
                     )
-                except Exception:
-                    pass
 
                 return
 
@@ -4499,12 +4559,10 @@ class TestExecutor:
                                 if SpeakerRoleResolver is None:
                                     eval_role = transcript.speaker_role
                                 else:
-                                    eval_role = (
-                                        SpeakerRoleResolver.get_eval_role_label(
-                                            transcript.speaker_role,
-                                            provider=eval_provider,
-                                            is_outbound=eval_is_outbound,
-                                        )
+                                    eval_role = SpeakerRoleResolver.get_eval_role_label(
+                                        transcript.speaker_role,
+                                        provider=eval_provider,
+                                        is_outbound=eval_is_outbound,
                                     )
                                 transcript_text.append(
                                     f"{eval_role}: {transcript.content}"
@@ -4839,9 +4897,9 @@ class TestExecutor:
                             "output_type": derive_kpi_output_type(eval_template),
                         }
                         call_execution.eval_outputs[str(eval_config.id)] = error_result
-                        call_execution.eval_outputs[str(eval_config.id)][
-                            "status"
-                        ] = StatusType.FAILED.value
+                        call_execution.eval_outputs[str(eval_config.id)]["status"] = (
+                            StatusType.FAILED.value
+                        )
                         call_execution.save(update_fields=["eval_outputs"])
                         raise ValueError(error_message)
 
@@ -4942,9 +5000,9 @@ class TestExecutor:
                 "output_type": derive_kpi_output_type(eval_config.eval_template),
             }
             call_execution.eval_outputs[str(eval_config.id)] = error_result
-            call_execution.eval_outputs[str(eval_config.id)][
-                "status"
-            ] = StatusType.FAILED.value
+            call_execution.eval_outputs[str(eval_config.id)]["status"] = (
+                StatusType.FAILED.value
+            )
             call_execution.save(update_fields=["eval_outputs"])
             raise
 
@@ -5287,9 +5345,7 @@ class TestExecutor:
             call_column_order = []
             tool_eval_ids_map = {}  # Map idx to tool_eval_id for the second phase
             columns_updated = False
-            tool_name_counts = (
-                {}
-            )  # tool_name -> occurrence count (per-call) for stable column naming
+            tool_name_counts = {}  # tool_name -> occurrence count (per-call) for stable column naming
 
             for idx, tool_call in enumerate(tool_calls_data):
                 try:

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -210,10 +210,13 @@ def _build_voice_settings(
         return {}
     from tracer.models.observability_provider import ProviderChoices
 
+    from simulate.utils.voice_provider import resolve_system_voice_provider
+
     # Voice_id format is determined by the system voice provider (the
     # infrastructure hosting the simulator assistant), not by the user's
-    # agent provider.
-    system_provider = os.getenv("SYSTEM_VOICE_PROVIDER", ProviderChoices.LIVEKIT)
+    # agent provider. Always a ProviderChoices enum via the single source of
+    # truth — no more string/enum drift.
+    system_provider = resolve_system_voice_provider()
 
     # Select voice name based on persona attributes (rule-based scoring)
     selected_voice_name = select_voice_id(persona_data, provider=system_provider)
@@ -231,7 +234,7 @@ def _build_voice_settings(
     # VAPI uses 11Labs voice names directly (e.g. "marissa", "phillip"),
     # so no resolution is needed. LiveKit uses Cartesia UUIDs, resolved
     # via the voice catalog adapter.
-    if system_provider == ProviderChoices.VAPI or system_provider == "vapi":
+    if system_provider == ProviderChoices.VAPI:
         provider_voice_id = selected_voice_name
     else:
         provider_voice_id = resolve_voice_id(

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -199,7 +199,6 @@ def _build_transcript_data(call_execution):
     Assembles transcript text from CallTranscript (VOICE) or ChatMessageModel (TEXT)
     records, and reads recording URLs from call_execution fields.
     """
-    from simulate.models import CallTranscript, ChatMessageModel
 
     transcript_data = {
         "transcript": "",
@@ -317,7 +316,7 @@ def _build_transcript_data(call_execution):
         # Read assistant/customer recordings from provider_call_data
         if call_execution.provider_call_data:
             for (
-                provider_key,
+                _provider_key,
                 provider_data,
             ) in call_execution.provider_call_data.items():
                 if not isinstance(provider_data, dict):
@@ -524,6 +523,151 @@ def _build_simulation_context_map(call_execution, agent_version):
     return ctx
 
 
+# ============================================================================
+# INLINE SIM EVALS VIA AGENT-LEARNING-KIT (Phase-10A Tier-1 cutover #2)
+# ============================================================================
+# The kit's local agent-report evaluator replaces run_eval_func as the inline
+# simulation eval ENGINE. The platform keeps everything around it byte-
+# compatible: mapping resolution, eval_outputs persistence, error-localizer
+# triggering, eval_config status, completion checks, and the API shape of the
+# stored entry ({"output", "reason", "output_type", "name"}).
+# The legacy engine stays selectable (config engine="legacy" or
+# settings.SIMULATE_EVALS_VIA_KIT=False) until parity sign-off.
+# ============================================================================
+
+
+def _eval_engine_uses_kit(eval_config) -> bool:
+    """Route an inline sim eval to the kit engine or the legacy run_eval_func.
+
+    Per-config override wins (config.engine / config.run_config.engine =
+    "legacy" | "agent_learning_kit"), then the global cutover switch
+    (settings.SIMULATE_EVALS_VIA_KIT, default True), gated on the kit being
+    importable so environments without it degrade to the legacy engine.
+    """
+    from simulate.services import agent_learning_bridge as alb
+
+    cfg = eval_config.config or {}
+    engine = (cfg.get("run_config") or {}).get("engine") or cfg.get("engine")
+    if engine == "legacy":
+        return False
+    if engine in ("agent_learning_kit", "kit"):
+        return alb.is_available()
+    if not getattr(settings, "SIMULATE_EVALS_VIA_KIT", True):
+        return False
+    return alb.is_available()
+
+
+# Mapping keys most likely to carry the conversation input/output. Used to pick
+# the evidence input/output out of the resolved eval mapping; transcript fields
+# are the fallback so any mapping still evaluates.
+_KIT_EVIDENCE_INPUT_KEYS = ("input", "query", "question", "prompt", "context")
+_KIT_EVIDENCE_OUTPUT_KEYS = (
+    "output",
+    "response",
+    "hypothesis",
+    "actual_output",
+    "answer",
+)
+
+
+def _kit_eval_result_to_platform_output(kit_result, *, output_type) -> dict:
+    """Map the kit's artifact-evaluation payload to run_eval_func's result shape.
+
+    Contract target (what _run_single_evaluation persists into eval_outputs):
+    ``{"output": <bool|float|str>, "reason": str, "output_type": str}`` —
+    bool for Pass/Fail templates (error-localizer checks isinstance(.., bool)),
+    0..1 float for score templates, choice-string for deterministic ones.
+    """
+    result = dict(kit_result or {})
+    summary = dict(result.get("summary") or {})
+    evaluation = dict(result.get("evaluation") or {})
+    passed = bool(evaluation.get("passed", result.get("status") == "passed"))
+    score_raw = summary.get("score", evaluation.get("score"))
+    score = round(float(score_raw if score_raw is not None else 0.0), 4)
+
+    reasons = [
+        str(f.get("reason"))
+        for f in (result.get("findings") or [])
+        if isinstance(f, dict) and f.get("reason")
+    ]
+    reason = (
+        "; ".join(reasons[:5])
+        if reasons
+        else (
+            f"Agent-learning-kit evaluation {'passed' if passed else 'failed'} "
+            f"with score {score} (threshold {summary.get('threshold', 0.7)})."
+        )
+    )
+
+    if output_type == "Pass/Fail":
+        output = passed
+    elif output_type == "choices":
+        output = "Passed" if passed else "Failed"
+    else:  # "score"
+        output = score
+
+    return {"output": output, "reason": reason, "output_type": output_type}
+
+
+def _run_eval_engine_via_kit(
+    eval_config, eval_template, updated_mapping, transcript_data
+):
+    """Execute one inline sim eval through the kit (replaces run_eval_func).
+
+    Builds kit task evidence from the platform's resolved mapping + transcript
+    data, scores it with the kit's local evaluator (credential-free), and
+    returns the legacy engine's result shape so persistence stays unchanged.
+    """
+    from simulate.services import agent_learning_bridge as alb
+
+    mapping = {k: v for k, v in (updated_mapping or {}).items() if isinstance(v, str)}
+    transcript = (transcript_data or {}).get("transcript", "")
+
+    input_text = (
+        next((mapping[k] for k in _KIT_EVIDENCE_INPUT_KEYS if mapping.get(k)), "")
+        or (transcript_data or {}).get("user_chat_transcript", "")
+        or transcript
+    )
+    output_text = (
+        next((mapping[k] for k in _KIT_EVIDENCE_OUTPUT_KEYS if mapping.get(k)), "")
+        or (transcript_data or {}).get("assistant_chat_transcript", "")
+        or transcript
+    )
+
+    task_description = str(
+        getattr(eval_template, "criteria", None)
+        or getattr(eval_template, "description", None)
+        or eval_config.name
+        or getattr(eval_template, "name", None)
+        or "Evaluate the agent's conversation."
+    )
+    criteria = getattr(eval_template, "criteria", None)
+    success_criteria = [str(criteria)] if criteria else []
+
+    cfg = eval_config.config or {}
+    threshold = float(
+        (cfg.get("run_config") or {}).get("pass_threshold")
+        or cfg.get("pass_threshold")
+        or 0.7
+    )
+
+    kit_result = alb.run_eval_for_evidence(
+        name=str(eval_config.id),
+        evidence=alb.build_eval_evidence(
+            input_text=input_text,
+            output_text=output_text,
+            transcript=transcript,
+            metadata=mapping,
+        ),
+        task_description=task_description,
+        success_criteria=success_criteria,
+        threshold=threshold,
+    )
+    return _kit_eval_result_to_platform_output(
+        kit_result, output_type=derive_kpi_output_type(eval_template)
+    )
+
+
 def _run_single_evaluation(eval_config, call_execution, transcript_data):
     """
     Run a single SimulateEvalConfig evaluation.
@@ -534,7 +678,7 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
     from model_hub.models.develop_dataset import Cell, Column
     from model_hub.tasks.user_evaluation import trigger_error_localization_for_simulate
     from model_hub.views.utils.evals import run_eval_func
-    from simulate.models import Scenarios, SimulateEvalConfig
+    from simulate.models import Scenarios
     from tfc.utils.error_codes import get_specific_error_message
 
     try:
@@ -752,29 +896,45 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                 "call_type": call_execution.call_type,
                 "simulation_call_type": call_execution.simulation_call_type,
                 "phone_number": call_execution.phone_number,
-                "started_at": str(call_execution.started_at) if call_execution.started_at else None,
-                "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
+                "started_at": str(call_execution.started_at)
+                if call_execution.started_at
+                else None,
+                "ended_at": str(call_execution.ended_at)
+                if call_execution.ended_at
+                else None,
                 "duration_seconds": call_execution.duration_seconds,
                 "recording_url": call_execution.recording_url,
                 "call_summary": call_execution.call_summary,
                 "ended_reason": call_execution.ended_reason,
                 "error_message": call_execution.error_message,
                 "message_count": call_execution.message_count,
-                "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
+                "overall_score": float(call_execution.overall_score)
+                if call_execution.overall_score is not None
+                else None,
             }
 
-        eval_result = run_eval_func(
-            config=config,
-            mappings=updated_mapping,
-            template=eval_template,
-            org=organization,
-            model=eval_config.model,
-            kb_id=eval_config.kb_id,
-            error_localizer=eval_config.error_localizer,
-            workspace=call_execution.test_execution.run_test.workspace,
-            source="simulate",
-            call_context=_call_context,
-        )
+        if _eval_engine_uses_kit(eval_config):
+            # Phase-10A Tier-1 cutover #2: kit executes the eval. Everything
+            # below this branch (persistence, error localizer, status, API
+            # shape) is shared with the legacy engine, unchanged.
+            eval_result = _run_eval_engine_via_kit(
+                eval_config, eval_template, updated_mapping, transcript_data
+            )
+        else:
+            # LEGACY engine — kept for the Phase-10A parity window; scheduled
+            # for removal after parity sign-off.
+            eval_result = run_eval_func(
+                config=config,
+                mappings=updated_mapping,
+                template=eval_template,
+                org=organization,
+                model=eval_config.model,
+                kb_id=eval_config.kb_id,
+                error_localizer=eval_config.error_localizer,
+                workspace=call_execution.test_execution.run_test.workspace,
+                source="simulate",
+                call_context=_call_context,
+            )
 
         if isinstance(eval_result, str):
             if (
@@ -1245,14 +1405,18 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
         from ee.agenthub.tool_eval_agent.tool_eval_agent import ToolEvalAgent
     except ImportError:
         if settings.DEBUG:
-            logger.warning("Could not import ee.agenthub.tool_eval_agent.tool_eval_agent", exc_info=True)
+            logger.warning(
+                "Could not import ee.agenthub.tool_eval_agent.tool_eval_agent",
+                exc_info=True,
+            )
         return
     from model_hub.models.choices import EvalOutputType
     from sdk.utils.helpers import _get_api_call_type
     from simulate.models import AgentDefinition
+    from tfc.constants.api_calls import APICallStatusChoices
     from tfc.utils.error_codes import get_specific_error_message
     from tracer.models.observability_provider import ProviderChoices
-    from tfc.constants.api_calls import APICallStatusChoices
+
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
     except ImportError:
@@ -1296,7 +1460,10 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
                 )
             except ImportError:
                 if settings.DEBUG:
-                    logger.warning("Could not import ee.agenthub.tool_eval_agent.adapters", exc_info=True)
+                    logger.warning(
+                        "Could not import ee.agenthub.tool_eval_agent.adapters",
+                        exc_info=True,
+                    )
                 return
 
             try:
@@ -1313,7 +1480,10 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
                 )
             except ImportError:
                 if settings.DEBUG:
-                    logger.warning("Could not import ee.agenthub.tool_eval_agent.adapters", exc_info=True)
+                    logger.warning(
+                        "Could not import ee.agenthub.tool_eval_agent.adapters",
+                        exc_info=True,
+                    )
                 return
 
             customer_api_key = (
@@ -1568,7 +1738,9 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
                     try:
                         from ee.usage.utils.event_properties import llm_usage_properties
                     except ImportError:
-                        llm_usage_properties = lambda obj: {}
+
+                        def llm_usage_properties(obj):
+                            return {}
 
                     actual_cost = 0
                     if hasattr(agent, "llm") and agent.llm:

--- a/futureagi/simulate/temporal/types/activities.py
+++ b/futureagi/simulate/temporal/types/activities.py
@@ -740,6 +740,12 @@ class InitiateCallInput:
     user_api_key: Optional[str] = None
     user_assistant_id: Optional[str] = None
     user_phone_number: Optional[str] = None  # User's phone to call from
+    # The user's agent provider (retell/bland/...) — selects the user-side outbound
+    # dialer instead of the Vapi default (TH-5642). None → Vapi engine path.
+    # NOTE: this is THE imported copy (call_execution_workflow and voice_large both
+    # import from simulate.temporal.types.activities); the duplicate in
+    # ee/voice/temporal/types/voice_activities.py mirrors it and must stay in sync.
+    user_provider: Optional[str] = None
 
     # WebRTC bridge connection type (None = SIP, "web_vapi", "web_retell")
     connection_type: Optional[str] = None

--- a/futureagi/simulate/tests/test_call_direction_resolver.py
+++ b/futureagi/simulate/tests/test_call_direction_resolver.py
@@ -1,0 +1,85 @@
+"""Unit tests for the call-direction resolver (TH-5642).
+
+Pins that the audit's silent direction bugs now fail loudly: typo'd direction and
+an outbound request on a provider that hasn't wired outbound.
+"""
+
+import pytest
+
+from simulate.providers.direction import (
+    FIRST_MESSAGE_MODE_SPEAKS_FIRST,
+    FIRST_MESSAGE_MODE_WAITS,
+    UnsupportedCallDirectionError,
+    first_message_mode_for,
+    resolve_call_direction,
+    resolve_is_outbound,
+)
+from simulate.providers.registry import Direction
+
+
+@pytest.mark.unit
+def test_missing_defaults_to_inbound():
+    # Preserves the historical default for the common unspecified case.
+    assert resolve_call_direction(None) is Direction.INBOUND
+    assert resolve_call_direction("") is Direction.INBOUND
+    assert resolve_call_direction("   ") is Direction.INBOUND
+
+
+@pytest.mark.unit
+def test_explicit_values_case_insensitive():
+    assert resolve_call_direction("inbound") is Direction.INBOUND
+    assert resolve_call_direction("OUTBOUND") is Direction.OUTBOUND
+    assert resolve_is_outbound("outbound") is True
+    assert resolve_is_outbound("inbound") is False
+
+
+@pytest.mark.unit
+def test_typo_raises_instead_of_silent_inbound():
+    # The exact bug: "outbond" previously became is_outbound=False (inbound) silently.
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_call_direction("outbond")
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_is_outbound("oubound")
+
+
+@pytest.mark.unit
+def test_unimplemented_outbound_raises_for_known_provider():
+    # Deepgram supports outbound but hasn't wired it → loud refusal, not a silent
+    # inbound run. (Retell/Vapi DO wire outbound via the dialer registry.)
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_call_direction("outbound", "deepgram")
+    # Inbound is implemented for deepgram → fine.
+    assert resolve_call_direction("inbound", "deepgram") is Direction.INBOUND
+
+
+@pytest.mark.unit
+def test_vapi_outbound_is_allowed():
+    # Vapi is the one provider with outbound wired.
+    assert resolve_call_direction("outbound", "vapi") is Direction.OUTBOUND
+    assert resolve_is_outbound("outbound", "vapi") is True
+
+
+@pytest.mark.unit
+def test_unknown_provider_skips_implemented_check():
+    # Custom / free-form providers are not in the registry → don't break them.
+    assert resolve_call_direction("outbound", "my_custom_provider") is Direction.OUTBOUND
+
+
+@pytest.mark.unit
+def test_first_message_mode_is_direction_keyed():
+    # Outbound (agent calls us) → simulator waits; inbound → simulator speaks first.
+    assert first_message_mode_for(True) == FIRST_MESSAGE_MODE_WAITS
+    assert first_message_mode_for(False) == FIRST_MESSAGE_MODE_SPEAKS_FIRST
+    # Matches the existing LiveKit-bridge values so lifting it to all transports is
+    # behaviour-preserving for the bridge.
+    assert FIRST_MESSAGE_MODE_WAITS == "assistant-waits-for-user"
+    assert FIRST_MESSAGE_MODE_SPEAKS_FIRST == "assistant-speaks-first"
+
+
+@pytest.mark.unit
+def test_enforce_implemented_can_be_disabled():
+    # For callers that only want normalisation/typo-catching, not the wiring gate.
+    assert (
+        resolve_call_direction("outbound", "retell", enforce_implemented=False)
+        is Direction.OUTBOUND
+    )

--- a/futureagi/simulate/tests/test_outbound_dialer.py
+++ b/futureagi/simulate/tests/test_outbound_dialer.py
@@ -1,0 +1,251 @@
+"""Unit tests for the per-provider outbound dialers (TH-5642).
+
+Mocked REST (no network; placing a real call costs money + dials a live number).
+Pins the documented Retell/Bland outbound-call request shapes and the registry that
+replaces the Vapi-hardcoded user-side dialer.
+"""
+
+import json
+
+import pytest
+
+from simulate.services import outbound_dialer as mod
+from simulate.services.outbound_dialer import (
+    OUTBOUND_DIALERS,
+    AgoraOutboundDialer,
+    BlandOutboundDialer,
+    ElevenLabsOutboundDialer,
+    OutboundDialError,
+    RetellOutboundDialer,
+    TwilioOutboundDialer,
+    get_outbound_dialer,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    def __init__(self, resp):
+        self._resp = resp
+        self.calls = []
+
+    def post(self, url, headers=None, json=None, data=None, auth=None, timeout=None):
+        self.calls.append(
+            {"url": url, "headers": headers, "json": json, "data": data, "auth": auth}
+        )
+        return self._resp
+
+
+@pytest.mark.unit
+def test_registry_has_non_vapi_dialers():
+    assert OUTBOUND_DIALERS["retell"] is RetellOutboundDialer
+    assert OUTBOUND_DIALERS["bland"] is BlandOutboundDialer
+
+
+@pytest.mark.unit
+def test_get_outbound_dialer_falls_back_for_vapi():
+    # Vapi keeps its existing engine path → no dialer here (None = fall back).
+    assert get_outbound_dialer("vapi", "k") is None
+    assert get_outbound_dialer("unknown", "k") is None
+    assert isinstance(get_outbound_dialer("retell", "k"), RetellOutboundDialer)
+
+
+@pytest.mark.unit
+def test_agora_registered_and_resolved():
+    assert OUTBOUND_DIALERS["agora"] is AgoraOutboundDialer
+    assert isinstance(get_outbound_dialer("agora", "ck:cs"), AgoraOutboundDialer)
+
+
+@pytest.mark.unit
+def test_agora_outbound_shape_basic_auth_and_agent_id(monkeypatch):
+    monkeypatch.setenv("AGORA_APP_ID", "app-123")
+    fake = _FakeRequests(_FakeResp({"agent_id": "agt_9", "status": "STARTING"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = AgoraOutboundDialer(api_key="cust_key:cust_secret")
+    out = dialer.create_outbound_call(
+        assistant_id="studio-agent-1",
+        from_phone_number="+15550000001",
+        to_phone_number="+15550000099",
+    )
+    assert out == {"id": "agt_9"}
+    call = fake.calls[0]
+    # Endpoint + body per the official agora-agents-python SDK (TH-5642
+    # capability research): POST .../projects/{appid}/call with pipeline_id +
+    # sip.{to_number, from_number}.
+    assert call["url"].endswith("/projects/app-123/call")
+    assert call["auth"] == ("cust_key", "cust_secret")  # Basic auth, not header key
+    assert call["json"]["pipeline_id"] == "studio-agent-1"
+    assert call["json"]["sip"]["to_number"] == "+15550000099"
+    assert call["json"]["sip"]["from_number"] == "+15550000001"
+
+
+@pytest.mark.unit
+def test_agora_requires_app_id(monkeypatch):
+    monkeypatch.delenv("AGORA_APP_ID", raising=False)
+    monkeypatch.setattr(mod, "requests", _FakeRequests(_FakeResp({})))
+    with pytest.raises(OutboundDialError):
+        AgoraOutboundDialer(api_key="k:s").create_outbound_call(
+            assistant_id="a", from_phone_number="+1", to_phone_number="+2"
+        )
+
+
+@pytest.mark.unit
+def test_agora_requires_key_secret_pair(monkeypatch):
+    monkeypatch.setenv("AGORA_APP_ID", "app-1")
+    with pytest.raises(ValueError):
+        AgoraOutboundDialer(api_key="nocolon").create_outbound_call(
+            assistant_id="a", from_phone_number="+1", to_phone_number="+2"
+        )
+
+
+@pytest.mark.unit
+def test_agora_outbound_url_override(monkeypatch):
+    monkeypatch.setenv("AGORA_APP_ID", "app-1")
+    monkeypatch.setenv("AGORA_OUTBOUND_CALL_URL", "https://custom.agora/outbound")
+    fake = _FakeRequests(_FakeResp({"agent_id": "x"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    AgoraOutboundDialer(api_key="k:s").create_outbound_call(
+        assistant_id="a", from_phone_number="+1", to_phone_number="+2"
+    )
+    assert fake.calls[0]["url"] == "https://custom.agora/outbound"
+
+
+@pytest.mark.unit
+def test_requires_api_key():
+    with pytest.raises(ValueError):
+        RetellOutboundDialer(api_key="")
+
+
+@pytest.mark.unit
+def test_retell_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"call_id": "call_123", "agent_id": "agent_x"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = RetellOutboundDialer(api_key="rt-key")
+    out = dialer.create_outbound_call(
+        assistant_id="agent_x", from_phone_number="+15551110000",
+        to_phone_number="+15552220000", metadata={"call_id": "abc"},
+    )
+    assert out == {"id": "call_123"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v2/create-phone-call")
+    assert call["headers"]["Authorization"] == "Bearer rt-key"
+    assert call["json"] == {
+        "from_number": "+15551110000",
+        "to_number": "+15552220000",
+        "override_agent_id": "agent_x",
+        "metadata": {"call_id": "abc"},
+    }
+
+
+@pytest.mark.unit
+def test_bland_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"status": "success", "call_id": "bland_1"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = BlandOutboundDialer(api_key="bl-key")
+    out = dialer.create_outbound_call(
+        assistant_id="pathway_1", from_phone_number="+15551110000",
+        to_phone_number="+15552220000",
+    )
+    assert out == {"id": "bland_1"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v1/calls")
+    # Bland uses the raw key as Authorization (no Bearer).
+    assert call["headers"]["Authorization"] == "bl-key"
+    assert call["json"]["phone_number"] == "+15552220000"
+    assert call["json"]["pathway_id"] == "pathway_1"
+    assert call["json"]["from"] == "+15551110000"
+
+
+@pytest.mark.unit
+def test_elevenlabs_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp(
+        {"success": True, "conversation_id": "conv_9", "callSid": "CA123"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = ElevenLabsOutboundDialer(api_key="xi-key")
+    out = dialer.create_outbound_call(
+        assistant_id="agent_el", from_phone_number="phnum_id_1",
+        to_phone_number="+15552220000",
+    )
+    # call id = conversation_id.
+    assert out == {"id": "conv_9"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v1/convai/twilio/outbound-call")
+    # ElevenLabs uses xi-api-key, and from_phone_number carries the phone_number_id.
+    assert call["headers"]["xi-api-key"] == "xi-key"
+    assert call["json"]["agent_id"] == "agent_el"
+    assert call["json"]["agent_phone_number_id"] == "phnum_id_1"
+    assert call["json"]["to_number"] == "+15552220000"
+
+
+@pytest.mark.unit
+def test_elevenlabs_registered_for_both_spellings():
+    assert OUTBOUND_DIALERS["elevenlabs"] is ElevenLabsOutboundDialer
+    assert OUTBOUND_DIALERS["eleven_labs"] is ElevenLabsOutboundDialer
+    assert isinstance(get_outbound_dialer("eleven_labs", "k"), ElevenLabsOutboundDialer)
+
+
+@pytest.mark.unit
+def test_twilio_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"sid": "CA999", "status": "queued"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    # api_key carries "AccountSid:AuthToken"; assistant_id is a TwiML URL here.
+    dialer = TwilioOutboundDialer(api_key="ACsid:tok")
+    out = dialer.create_outbound_call(
+        assistant_id="https://example.com/twiml",
+        from_phone_number="+15551110000", to_phone_number="+15552220000",
+    )
+    assert out == {"id": "CA999"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/2010-04-01/Accounts/ACsid/Calls.json")
+    assert call["auth"] == ("ACsid", "tok")  # HTTP Basic
+    assert call["data"]["To"] == "+15552220000"
+    assert call["data"]["From"] == "+15551110000"
+    assert call["data"]["Url"] == "https://example.com/twiml"  # URL → Url
+
+
+@pytest.mark.unit
+def test_twilio_application_sid_when_not_a_url(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"sid": "CA1"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    TwilioOutboundDialer(api_key="ACsid:tok").create_outbound_call(
+        assistant_id="AP123app", from_phone_number="+1", to_phone_number="+1",
+    )
+    # Non-URL assistant_id → ApplicationSid, not Url.
+    assert fake.calls[0]["data"]["ApplicationSid"] == "AP123app"
+    assert "Url" not in fake.calls[0]["data"]
+
+
+@pytest.mark.unit
+def test_twilio_requires_sid_and_token():
+    with pytest.raises(ValueError):
+        TwilioOutboundDialer(api_key="just-one-value").create_outbound_call(
+            assistant_id="x", from_phone_number="+1", to_phone_number="+1"
+        )
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"error": "bad number"}, status_code=422))
+    monkeypatch.setattr(mod, "requests", fake)
+    with pytest.raises(OutboundDialError):
+        RetellOutboundDialer(api_key="k").create_outbound_call(
+            assistant_id="a", from_phone_number="+1", to_phone_number="+1"
+        )
+
+
+@pytest.mark.unit
+def test_missing_call_id_raises(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"status": "queued"}))  # no call_id
+    monkeypatch.setattr(mod, "requests", fake)
+    with pytest.raises(OutboundDialError):
+        BlandOutboundDialer(api_key="k").create_outbound_call(
+            assistant_id="p", from_phone_number="", to_phone_number="+1"
+        )

--- a/futureagi/simulate/tests/test_sim_alerting.py
+++ b/futureagi/simulate/tests/test_sim_alerting.py
@@ -1,0 +1,98 @@
+"""DB test for simulation alerting metric reader (TH-5642).
+
+UserAlertMonitor gains SIM_EVAL_SCORE / SIM_FAILURE_RATE metric types that read
+CallExecution data (not CH traces), so users can alert on sim quality regressions /
+failure spikes (the Slack/email/webhook plumbing already exists). This pins the
+metric computation.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from django.utils import timezone
+
+from model_hub.models.choices import StatusType
+from simulate.models import AgentDefinition, CallExecution, RunTest, Scenarios
+from simulate.models.test_execution import TestExecution
+from tracer.models.monitor import MonitorMetricTypeChoices
+
+
+def _call(organization, workspace, *, overall_score=None, status=None):
+    ad = AgentDefinition.objects.create(
+        agent_name="Alert Agent", agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True, description="alert", organization=organization,
+        workspace=workspace, provider="vapi", languages=["en"],
+    )
+    scenario = Scenarios.objects.create(
+        name="Alert Scenario", description="a", source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET, organization=organization,
+        workspace=workspace, agent_definition=ad, status=StatusType.COMPLETED.value,
+    )
+    rt = RunTest.objects.create(
+        name="Alert Run", description="a", agent_definition=ad,
+        organization=organization, workspace=workspace,
+    )
+    te = TestExecution.objects.create(
+        run_test=rt, status=TestExecution.ExecutionStatus.COMPLETED,
+        total_scenarios=1, total_calls=1, agent_definition=ad,
+    )
+    return CallExecution.objects.create(
+        test_execution=te, scenario=scenario,
+        status=status or CallExecution.CallStatus.COMPLETED,
+        simulation_call_type=CallExecution.SimulationCallType.VOICE,
+        overall_score=overall_score,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_eval_score_avg(organization, workspace):
+    _call(organization, workspace, overall_score=0.8)
+    _call(organization, workspace, overall_score=0.4)
+    _call(organization, workspace, overall_score=None)  # excluded from the average
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_EVAL_SCORE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now - timedelta(hours=1), now + timedelta(hours=1))
+    assert value == pytest.approx(0.6)  # (0.8 + 0.4) / 2, None excluded
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_failure_rate(organization, workspace):
+    _call(organization, workspace, status=CallExecution.CallStatus.COMPLETED)
+    _call(organization, workspace, status=CallExecution.CallStatus.COMPLETED)
+    _call(organization, workspace, status=CallExecution.CallStatus.FAILED)
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_FAILURE_RATE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now - timedelta(hours=1), now + timedelta(hours=1))
+    assert value == pytest.approx(1 / 3)  # 1 failed of 3
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_metric_window_excludes_out_of_range(organization, workspace):
+    _call(organization, workspace, overall_score=0.9)
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_EVAL_SCORE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    # A window in the future contains no calls → None.
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now + timedelta(hours=1), now + timedelta(hours=2))
+    assert value is None

--- a/futureagi/simulate/tests/test_temporal_activities.py
+++ b/futureagi/simulate/tests/test_temporal_activities.py
@@ -905,6 +905,46 @@ class TestFetchAndPersistCallResultActivity:
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
+    async def test_real_extract_costs_from_livekit_usage_persists_real_cost(
+        self, call_execution
+    ):
+        """Real DB CallExecution + REAL extract_costs (real litellm pricing) →
+        non-zero cost. Proves the $0-billing fix end-to-end on the backend,
+        given the usage dict the (SDK-verified) agent worker emits. No mock of
+        the cost path."""
+        from asgiref.sync import sync_to_async
+
+        from ee.voice.services.livekit.service import LivekitService
+
+        call_execution.provider_call_data = {
+            "livekit": {
+                "usage": {
+                    "stt": {"duration": 120.0},
+                    "llm": {"prompt_tokens": 2000, "completion_tokens": 1000},
+                    "tts": {"characters": 5000},
+                    "models": {
+                        "stt": "nova-3",
+                        "llm": "gpt-4o-mini",
+                        "tts": "sonic-2",
+                    },
+                }
+            }
+        }
+        call_execution.duration_seconds = 120.0
+        await sync_to_async(call_execution.save)()
+
+        costs = await LivekitService().extract_costs(str(call_execution.id))
+
+        # Real, non-zero cost components (the $0 bug would make these all 0).
+        assert costs.total > 0
+        assert costs.llm > 0  # real litellm gpt-4o-mini registry pricing
+        assert costs.stt > 0
+        assert costs.tts > 0
+        # Cents conversion, exactly as voice_large persists it.
+        assert int(round(costs.total * 100)) > 0
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
     async def test_fetch_and_persist_call_result_updates_call_execution(
         self, call_execution
     ):

--- a/futureagi/simulate/tests/test_voice_provider_resolver.py
+++ b/futureagi/simulate/tests/test_voice_provider_resolver.py
@@ -1,0 +1,122 @@
+"""Unit tests for the canonical system-voice-provider resolver.
+
+The resolver is the single source of truth for selecting the simulator-side
+voice provider. These tests pin its precedence rules, its enum return
+contract, and its normalisation/validation behaviour.
+"""
+
+import pytest
+
+from simulate.utils.voice_provider import (
+    DEFAULT_SYSTEM_VOICE_PROVIDER,
+    SYSTEM_VOICE_PROVIDER_ENV_VAR,
+    resolve_system_voice_provider,
+)
+from tracer.models.observability_provider import ProviderChoices
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Ensure no ambient SYSTEM_VOICE_PROVIDER leaks across cases."""
+    monkeypatch.delenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, raising=False)
+
+
+class TestDefault:
+    @pytest.mark.unit
+    def test_default_is_livekit(self):
+        assert DEFAULT_SYSTEM_VOICE_PROVIDER is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_no_override_no_env_returns_livekit(self):
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_always_returns_enum(self):
+        assert isinstance(resolve_system_voice_provider(), ProviderChoices)
+        assert isinstance(resolve_system_voice_provider("vapi"), ProviderChoices)
+
+
+class TestEnvPrecedence:
+    @pytest.mark.unit
+    def test_env_pins_provider(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider() is ProviderChoices.VAPI
+
+    @pytest.mark.unit
+    def test_env_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "LiveKit")
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_empty_env_falls_through_to_default(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "")
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+
+class TestOverridePrecedence:
+    @pytest.mark.unit
+    def test_override_beats_env(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider("livekit") is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_override_string(self):
+        assert resolve_system_voice_provider("vapi") is ProviderChoices.VAPI
+
+    @pytest.mark.unit
+    def test_override_enum_passthrough(self):
+        assert (
+            resolve_system_voice_provider(ProviderChoices.VAPI)
+            is ProviderChoices.VAPI
+        )
+
+    @pytest.mark.unit
+    def test_none_and_empty_override_fall_through(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider(None) is ProviderChoices.VAPI
+        assert resolve_system_voice_provider("") is ProviderChoices.VAPI
+
+
+class TestValidation:
+    @pytest.mark.unit
+    def test_unknown_override_raises(self):
+        with pytest.raises(ValueError, match="Unknown system voice provider"):
+            resolve_system_voice_provider("klingon")
+
+    @pytest.mark.unit
+    def test_unknown_env_raises(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "nope")
+        with pytest.raises(ValueError, match="Unknown system voice provider"):
+            resolve_system_voice_provider()
+
+
+class TestEngineWiring:
+    """Pin P0's end-to-end intent at the VoiceServiceManager wiring level.
+
+    These assert the two roles the resolver feeds (the ``voice_large.py``
+    fetch-engine branch): the *system* path (resolver default) must build a
+    LiveKit engine, while the *client-fetch* path (customer api_key, no
+    explicit provider) must keep building a Vapi engine. This is the only
+    genuine behaviour flip in P0; the resolver unit tests alone don't cover it.
+    """
+
+    def _vsm(self):
+        return pytest.importorskip(
+            "ee.voice.services.voice_service_manager"
+        ).VoiceServiceManager
+
+    @pytest.mark.unit
+    def test_system_path_resolver_default_builds_livekit_engine(self):
+        VoiceServiceManager = self._vsm()
+        vsm = VoiceServiceManager(
+            system_voice_provider=resolve_system_voice_provider()
+        )
+        assert type(vsm.engine).__name__ == "LivekitService"
+
+    @pytest.mark.unit
+    def test_client_fetch_path_defaults_to_vapi_engine(self):
+        VoiceServiceManager = self._vsm()
+        # Customer-account fetch: api_key, no explicit provider. Must stay Vapi
+        # (the engine exposes Vapi-only SDK methods the fetch path calls).
+        vsm = VoiceServiceManager(api_key="customer-key")
+        assert type(vsm.engine).__name__ == "VapiService"

--- a/futureagi/simulate/utils/voice_provider.py
+++ b/futureagi/simulate/utils/voice_provider.py
@@ -1,0 +1,102 @@
+"""Single source of truth for selecting the **system** voice provider.
+
+There are two distinct provider notions in the simulation stack, and they must
+never be conflated:
+
+* **System provider** — the infrastructure FutureAGI runs the *simulator*
+  persona on (LiveKit or Vapi). This module resolves it. It is the lever for
+  the Vapi→LiveKit migration: LiveKit is the default; Vapi stays registered and
+  pluggable behind it.
+* **Client provider** — the customer's *own* agent account
+  (``AgentDefinition.provider``). It reflects whatever the user configured and
+  is resolved separately; do **not** route it through this module.
+
+Every code path that needs to know which engine the ``VoiceServiceManager``
+should run MUST call :func:`resolve_system_voice_provider`. Do not read
+``SYSTEM_VOICE_PROVIDER`` directly and do not hard-code a provider — doing so
+reintroduces the string/enum drift this module exists to remove.
+
+Resolution precedence (highest first):
+
+1. an explicit ``override`` (a per-test / per-project pin),
+2. the ``SYSTEM_VOICE_PROVIDER`` environment variable,
+3. :data:`DEFAULT_SYSTEM_VOICE_PROVIDER` (LiveKit).
+
+The function always returns a :class:`ProviderChoices` enum, normalising any
+string input, so callers can rely on a single comparable type.
+"""
+
+from __future__ import annotations
+
+import os
+
+from tracer.models.observability_provider import ProviderChoices
+
+__all__ = [
+    "DEFAULT_SYSTEM_VOICE_PROVIDER",
+    "SYSTEM_VOICE_PROVIDER_ENV_VAR",
+    "resolve_system_voice_provider",
+]
+
+#: The simulator runs on LiveKit unless explicitly overridden. This is the
+#: migration default — Vapi remains registered in ``ENGINE_REGISTRY`` and
+#: selectable via an override or the environment variable.
+DEFAULT_SYSTEM_VOICE_PROVIDER: ProviderChoices = ProviderChoices.LIVEKIT
+
+#: Environment variable that pins the system provider when no explicit override
+#: is supplied. Accepts any ``ProviderChoices`` value (e.g. ``"vapi"``).
+SYSTEM_VOICE_PROVIDER_ENV_VAR: str = "SYSTEM_VOICE_PROVIDER"
+
+
+def _coerce_provider(value: ProviderChoices | str) -> ProviderChoices:
+    """Coerce a provider value to a :class:`ProviderChoices` enum.
+
+    Args:
+        value: an existing enum member or a provider string (case-insensitive).
+
+    Returns:
+        The matching :class:`ProviderChoices` member.
+
+    Raises:
+        ValueError: if ``value`` does not name a recognised provider.
+    """
+    if isinstance(value, ProviderChoices):
+        return value
+    try:
+        return ProviderChoices(str(value).strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(choice.value for choice in ProviderChoices)
+        raise ValueError(
+            f"Unknown system voice provider {value!r}; expected one of: {valid}."
+        ) from exc
+
+
+def resolve_system_voice_provider(
+    override: ProviderChoices | str | None = None,
+) -> ProviderChoices:
+    """Resolve the system (simulator-side) voice provider.
+
+    See the module docstring for the precedence rules. Always returns a
+    :class:`ProviderChoices` enum so callers never have to defend against a
+    raw string vs. enum.
+
+    Args:
+        override: an explicit per-call provider pin. Takes priority over the
+            environment variable and the default. ``None`` or an empty string
+            falls through to the environment, then the default.
+
+    Returns:
+        The resolved :class:`ProviderChoices` enum.
+
+    Raises:
+        ValueError: if ``override`` or the ``SYSTEM_VOICE_PROVIDER`` environment
+            variable names an unknown provider.
+    """
+    if override is not None and override != "":
+        return _coerce_provider(override)
+
+    env_value = os.getenv(SYSTEM_VOICE_PROVIDER_ENV_VAR)
+    if env_value:
+        return _coerce_provider(env_value)
+
+    return DEFAULT_SYSTEM_VOICE_PROVIDER

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -774,8 +774,29 @@ class RunTestExecutionView(APIView):
             if gate_response is not None:
                 return gate_response
 
+            # TEXT/chat runs are driven server-side by the chat trigger
+            # (REGISTERED claim -> run_prompt_based_conversation), never by
+            # voice CallExecutionWorkflow children. Routing them through the
+            # Temporal test workflow launched them as SIP calls with no phone
+            # number ("No customer phone number provided for inbound SIP
+            # call"), so chat always takes the legacy executor path.
+            from simulate.services.chat_agent_adapter_factory import (
+                is_external_hosted_chat,
+            )
+
+            is_server_side_chat = (
+                run_test.source_type == RunTest.SourceTypes.PROMPT
+                or (
+                    run_test.source_type == RunTest.SourceTypes.AGENT_DEFINITION
+                    and is_external_hosted_chat(run_test.agent_definition)
+                )
+            )
+
             # Check if Temporal test execution is enabled
-            if getattr(app_settings, "TEMPORAL_TEST_EXECUTION_ENABLED", False):
+            if (
+                getattr(app_settings, "TEMPORAL_TEST_EXECUTION_ENABLED", False)
+                and not is_server_side_chat
+            ):
                 result = self._execute_with_temporal(
                     run_test=run_test,
                     scenario_ids=final_scenario_ids,
@@ -3285,23 +3306,30 @@ class CallExecutionDetailView(APIView):
             # collapsed raw_log tree. `include_call_logs=False` skips the
             # blocking GET against `artifact.logUrl`; CallExecutionLogsView
             # handles that asynchronously via the ingest task.
+            # Flatten the provider payload through its own engine so this
+            # shared view stays provider-agnostic (no direct import of a
+            # specific provider's flattener). Vapi emits flat OTEL keys;
+            # other engines fall back to a raw_log tree via the blueprint
+            # default.
             pcd = call_execution.provider_call_data or {}
-            vapi_data = pcd.get("vapi") if isinstance(pcd.get("vapi"), dict) else None
-            if vapi_data:
-                from tracer.utils.vapi import _extract_eval_attributes
+            provider = next((p for p in pcd if isinstance(pcd[p], dict)), None)
+            if provider:
+                from ee.voice.services.voice_service_manager import (
+                    VoiceServiceManager,
+                )
+                from tracer.models.observability_provider import ProviderChoices
 
-                response_data["attributes"] = _extract_eval_attributes(
-                    vapi_data, include_call_logs=False
-                )
-            else:
-                # Fallback for other providers (retell etc.): ship the raw
-                # payload under `raw_log` so the Attributes tab at least
-                # renders the full object tree.
-                provider_data = next(
-                    (v for v in pcd.values() if isinstance(v, dict)), None
-                )
-                if provider_data:
-                    response_data["attributes"] = {"raw_log": provider_data}
+                try:
+                    engine = VoiceServiceManager(
+                        system_voice_provider=ProviderChoices(provider)
+                    ).engine
+                    response_data["attributes"] = engine.extract_attributes(
+                        pcd[provider], include_call_logs=False
+                    )
+                except ValueError:
+                    # Provider string not in the engine registry (e.g. retell)
+                    # — ship the raw payload so the tab still renders.
+                    response_data["attributes"] = {"raw_log": pcd[provider]}
 
             return Response(response_data, status=status.HTTP_200_OK)
 
@@ -3516,6 +3544,12 @@ class CallExecutionLogsView(APIView):
             pcd = call_execution.provider_call_data or {}
             vapi = pcd.get("vapi") or {}
             provider_log_url = (vapi.get("artifact") or {}).get("logUrl")
+            # LiveKit has no artifact log file — iter_call_logs reads
+            # transcripts from the DB keyed by call_execution id, so the
+            # "log url" for LiveKit is the id itself. Without this the Logs tab
+            # never triggers ingestion for LiveKit calls.
+            if not provider_log_url and "livekit" in pcd:
+                provider_log_url = str(call_execution.id)
             log_url = call_execution.customer_log_url or provider_log_url
             has_ingestion_summary = bool(call_execution.customer_logs_summary)
             should_start_ingestion = (
@@ -6033,9 +6067,13 @@ def _create_rerun_call_execution(call_execution):
     }
 
     # phone_number_id is only used by VAPI; LiveKit's prepare_call
-    # ignores CreateCallExecution.phone_number_id entirely.
-    system_provider = os.getenv("SYSTEM_VOICE_PROVIDER", "livekit")
-    if system_provider == "livekit":
+    # ignores CreateCallExecution.phone_number_id entirely. The system
+    # provider comes from the single source of truth (defaults to LiveKit).
+    from simulate.utils.voice_provider import resolve_system_voice_provider
+    from tracer.models.observability_provider import ProviderChoices
+
+    system_provider = resolve_system_voice_provider()
+    if system_provider == ProviderChoices.LIVEKIT:
         phone_number_id = ""
     elif phone_number and phone_number.startswith("+91"):
         phone_number_id = VAPI_INDIAN_PHONE_NUMBER_ID or os.getenv(


### PR DESCRIPTION
Sub-stack of the simulation feature. **Base:** `feat/sim-chat-simulation` (2b).

Voice + execution: `test_executor`, outbound dialer, Temporal execution activities, `run_test` API, system-voice-provider resolver, voice E2E compose (secrets are `${ENV}` refs — no hardcoded keys), test-run FE. 20 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)