### PR TITLE
Fix/gateway dos hardening

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -5,16 +5,18 @@ server:
   port: 8080
   host: "0.0.0.0"
   read_timeout: 5s
+  read_header_timeout: 5s # max time to read request headers (slowloris guard); defaults to 5s
   write_timeout: 300s
   idle_timeout: 120s
   shutdown_timeout: 30s
-  max_request_body_size: 10485760  # 10MB
+  max_request_body_size: 10485760 # 10MB
+  max_header_bytes: 1048576 # 1MB cap on request headers; defaults to 1MB
   default_request_timeout: 60s
 
 providers:
   openai:
     base_url: "https://api.openai.com"
-    api_key: "${OPENAI_API_KEY}"  # Set via env var
+    api_key: "${OPENAI_API_KEY}" # Set via env var
     api_format: "openai"
     default_timeout: 60s
     max_concurrent: 100
@@ -299,6 +301,7 @@ providers:
 #     claude-3-opus-20240229: 120s
 #   mirror:                                 # Traffic mirroring for shadow testing
 #     enabled: true
+#     max_concurrent: 64                    # Cap in-flight async mirrors; excess is dropped (default 64)
 #     rules:
 #       - source_model: "gpt-4o"            # Mirror gpt-4o requests
 #         target_provider: "anthropic"       # Send copy to Anthropic
@@ -362,7 +365,6 @@ logging:
   #   include_bodies: false      # Include full request/response bodies (default: false)
   #   buffer_size: 4096          # Async buffer size (default: 4096)
   #   workers: 2                 # Number of log worker goroutines (default: 2)
-
 # guardrails:
 #   enabled: true
 #   fail_open: true                     # If a guardrail times out or errors, allow the request (default: true)

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -293,10 +293,12 @@ type ServerConfig struct {
 	Port                  int           `yaml:"port" json:"port"`
 	Host                  string        `yaml:"host" json:"host"`
 	ReadTimeout           time.Duration `yaml:"read_timeout" json:"read_timeout"`
+	ReadHeaderTimeout     time.Duration `yaml:"read_header_timeout" json:"read_header_timeout"`
 	WriteTimeout          time.Duration `yaml:"write_timeout" json:"write_timeout"`
 	IdleTimeout           time.Duration `yaml:"idle_timeout" json:"idle_timeout"`
 	ShutdownTimeout       time.Duration `yaml:"shutdown_timeout" json:"shutdown_timeout"`
 	MaxRequestBodySize    int64         `yaml:"max_request_body_size" json:"max_request_body_size"`
+	MaxHeaderBytes        int           `yaml:"max_header_bytes" json:"max_header_bytes"`
 	DefaultRequestTimeout time.Duration `yaml:"default_request_timeout" json:"default_request_timeout"`
 }
 
@@ -596,7 +598,12 @@ type MirrorConfig struct {
 	CaptureResults   bool         `yaml:"capture_results" json:"capture_results"`
 	MaxStored        int          `yaml:"max_stored" json:"max_stored"`
 	FlushIntervalSec int          `yaml:"flush_interval_sec" json:"flush_interval_sec"`
-	Rules            []MirrorRule `yaml:"rules" json:"rules"`
+	// MaxConcurrent bounds the number of in-flight async mirror requests.
+	// Mirroring is fire-and-forget shadow traffic, so excess is dropped (not
+	// queued) once this budget is exhausted, preventing unbounded goroutine and
+	// upstream-connection growth under load. Defaults to 64 when unset.
+	MaxConcurrent int          `yaml:"max_concurrent" json:"max_concurrent"`
+	Rules         []MirrorRule `yaml:"rules" json:"rules"`
 }
 
 // MirrorRule defines a single traffic mirroring rule.
@@ -857,10 +864,12 @@ func DefaultConfig() *Config {
 			Port:                  8080,
 			Host:                  "0.0.0.0",
 			ReadTimeout:           5 * time.Second,
+			ReadHeaderTimeout:     5 * time.Second,
 			WriteTimeout:          300 * time.Second,
 			IdleTimeout:           120 * time.Second,
 			ShutdownTimeout:       30 * time.Second,
 			MaxRequestBodySize:    50 * 1024 * 1024, // 50MB
+			MaxHeaderBytes:        1 << 20,          // 1MB (matches Go's default)
 			DefaultRequestTimeout: 60 * time.Second,
 		},
 		Providers:    make(map[string]ProviderConfig),

--- a/agentcc-gateway/internal/config/config_test.go
+++ b/agentcc-gateway/internal/config/config_test.go
@@ -16,6 +16,12 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Server.DefaultRequestTimeout != 60*time.Second {
 		t.Errorf("default timeout = %v, want 60s", cfg.Server.DefaultRequestTimeout)
 	}
+	if cfg.Server.ReadHeaderTimeout != 5*time.Second {
+		t.Errorf("default read_header_timeout = %v, want 5s", cfg.Server.ReadHeaderTimeout)
+	}
+	if cfg.Server.MaxHeaderBytes != 1<<20 {
+		t.Errorf("default max_header_bytes = %d, want %d", cfg.Server.MaxHeaderBytes, 1<<20)
+	}
 	if cfg.Logging.Level != "info" {
 		t.Errorf("default log level = %q, want %q", cfg.Logging.Level, "info")
 	}

--- a/agentcc-gateway/internal/providers/anthropic/anthropic.go
+++ b/agentcc-gateway/internal/providers/anthropic/anthropic.go
@@ -48,6 +48,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/providers/azure/azure.go
+++ b/agentcc-gateway/internal/providers/azure/azure.go
@@ -55,6 +55,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/providers/bedrock/bedrock.go
+++ b/agentcc-gateway/internal/providers/bedrock/bedrock.go
@@ -54,6 +54,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/providers/cohere/cohere.go
+++ b/agentcc-gateway/internal/providers/cohere/cohere.go
@@ -46,6 +46,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/providers/gemini/gemini.go
+++ b/agentcc-gateway/internal/providers/gemini/gemini.go
@@ -47,6 +47,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/providers/openai/openai.go
+++ b/agentcc-gateway/internal/providers/openai/openai.go
@@ -48,6 +48,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 	transport := &http.Transport{
 		MaxIdleConns:        poolSize,
 		MaxIdleConnsPerHost: poolSize,
+		MaxConnsPerHost:     maxConcurrent,
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}

--- a/agentcc-gateway/internal/rotation/rotation.go
+++ b/agentcc-gateway/internal/rotation/rotation.go
@@ -40,6 +40,13 @@ type Manager struct {
 	states      map[string]*KeyState
 	drainPeriod time.Duration
 	onRotate    func(providerID, newKey string) // callback to update provider with new key
+
+	// done signals shutdown so in-flight drain timers exit instead of sleeping
+	// for the full (potentially long) drain period; wg tracks them so Stop can
+	// wait for a clean exit. stopOnce guards against a double close.
+	done     chan struct{}
+	wg       sync.WaitGroup
+	stopOnce sync.Once
 }
 
 // NewManager creates a key rotation manager.
@@ -49,7 +56,17 @@ func NewManager(drainPeriod time.Duration, onRotate func(providerID, newKey stri
 		states:      make(map[string]*KeyState),
 		drainPeriod: drainPeriod,
 		onRotate:    onRotate,
+		done:        make(chan struct{}),
 	}
+}
+
+// Stop cancels any in-flight drain timers and waits for their goroutines to
+// exit. Safe to call multiple times.
+func (m *Manager) Stop() {
+	m.stopOnce.Do(func() {
+		close(m.done)
+	})
+	m.wg.Wait()
 }
 
 // RegisterProvider registers a provider with its current key.
@@ -135,10 +152,19 @@ func (m *Manager) Promote(providerID string) error {
 		m.onRotate(providerID, state.Primary)
 	}
 
-	// Schedule drain completion.
+	// Schedule drain completion. Use a cancellable timer (not time.Sleep) so the
+	// goroutine exits promptly on Stop instead of leaking for the full drain
+	// period after the manager is shut down.
+	m.wg.Add(1)
 	go func() {
-		time.Sleep(m.drainPeriod)
-		m.completeDrain(providerID)
+		defer m.wg.Done()
+		timer := time.NewTimer(m.drainPeriod)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			m.completeDrain(providerID)
+		case <-m.done:
+		}
 	}()
 
 	return nil

--- a/agentcc-gateway/internal/rotation/rotation_test.go
+++ b/agentcc-gateway/internal/rotation/rotation_test.go
@@ -132,6 +132,38 @@ func TestPromote_NoPending(t *testing.T) {
 	}
 }
 
+// Stop must cancel an in-flight drain timer promptly instead of leaking a
+// goroutine that sleeps for the full (here, long) drain period.
+func TestStopCancelsDrainGoroutine(t *testing.T) {
+	m := NewManager(10*time.Second, nil) // long drain so it cannot complete on its own
+	m.RegisterProvider("openai", "sk-old")
+	m.StartRotation("openai", "sk-new")
+	if err := m.Promote("openai"); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.Stop() // blocks on the drain goroutine's WaitGroup
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Stop returned promptly — the drain goroutine observed the cancel.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return promptly — drain goroutine leaked past cancellation")
+	}
+
+	// The drain was cancelled (not completed), so the state stays draining.
+	state, _ := m.GetStatus("openai")
+	if state.Status != StatusDraining {
+		t.Fatalf("expected still draining after cancel, got %s", state.Status)
+	}
+
+	m.Stop() // must be idempotent
+}
+
 func TestRollback(t *testing.T) {
 	m := NewManager(30*time.Second, nil)
 	m.RegisterProvider("openai", "sk-old")

--- a/agentcc-gateway/internal/routing/mirror.go
+++ b/agentcc-gateway/internal/routing/mirror.go
@@ -41,11 +41,19 @@ type ProductionInfo struct {
 	StatusCode   int
 }
 
+// defaultMirrorConcurrency bounds in-flight mirror goroutines when the config
+// leaves MaxConcurrent unset.
+const defaultMirrorConcurrency = 64
+
 // Mirror manages traffic mirroring for shadow testing.
 type Mirror struct {
 	rules  []MirrorRule
 	lookup MirrorProviderLookup
 	Store  *ShadowStore // nil when capture is disabled
+	// sem bounds concurrent in-flight mirror goroutines. Shadow traffic is
+	// best-effort, so a full semaphore drops the mirror rather than queueing it,
+	// preventing unbounded goroutine/connection growth under load.
+	sem chan struct{}
 }
 
 // NewMirror creates a mirror from config rules.
@@ -72,9 +80,15 @@ func NewMirror(cfg config.MirrorConfig, lookup MirrorProviderLookup) *Mirror {
 		}
 	}
 
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMirrorConcurrency
+	}
+
 	return &Mirror{
 		rules:  rules,
 		lookup: lookup,
+		sem:    make(chan struct{}, maxConcurrent),
 	}
 }
 
@@ -139,7 +153,25 @@ func (m *Mirror) ExecuteAsync(req *models.ChatCompletionRequest, sourceProvider,
 	experimentID := rule.ExperimentID
 	promptHash := hashPrompt(req)
 
+	// Bound concurrent mirror goroutines. A full semaphore means we're already at
+	// the in-flight budget, so drop this shadow request rather than spawning an
+	// unbounded number of goroutines (and upstream connections) under load.
+	if m.sem != nil {
+		select {
+		case m.sem <- struct{}{}:
+		default:
+			slog.Debug("mirror dropped: concurrency limit reached",
+				"target_provider", rule.TargetProvider,
+				"source_model", sourceModel,
+			)
+			return
+		}
+	}
+
 	go func() {
+		if m.sem != nil {
+			defer func() { <-m.sem }()
+		}
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("mirror goroutine panicked",

--- a/agentcc-gateway/internal/routing/routing_test.go
+++ b/agentcc-gateway/internal/routing/routing_test.go
@@ -3394,6 +3394,56 @@ func TestMirror_DisabledConfig(t *testing.T) {
 	}
 }
 
+// With MaxConcurrent in-flight mirrors, an additional mirror must be dropped
+// rather than spawning an unbounded goroutine — otherwise high-rate shadow
+// traffic exhausts goroutines/connections.
+func TestMirror_ExecuteAsync_ConcurrencyLimit(t *testing.T) {
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	mockProvider := &mockMirrorProvider{
+		fn: func(ctx context.Context, req *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
+			started <- struct{}{}
+			<-release // hold the only slot until the test releases it
+			return &models.ChatCompletionResponse{ID: "resp"}, nil
+		},
+	}
+	cfg := config.MirrorConfig{
+		Enabled:       true,
+		MaxConcurrent: 1,
+		Rules: []config.MirrorRule{
+			{SourceModel: "gpt-4o", TargetProvider: "target", TargetModel: "tm", SampleRate: 1.0},
+		},
+	}
+	lookup := func(id string) (MirrorProvider, bool) {
+		if id == "target" {
+			return mockProvider, true
+		}
+		return nil, false
+	}
+	m := NewMirror(cfg, lookup)
+	req := &models.ChatCompletionRequest{Model: "gpt-4o"}
+
+	// First mirror acquires the single slot and blocks inside the provider.
+	m.ExecuteAsync(req, "openai", "gpt-4o", nil)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first mirror call never started")
+	}
+
+	// Second mirror must be dropped while the slot is held — not queued.
+	m.ExecuteAsync(req, "openai", "gpt-4o", nil)
+
+	close(release) // let the first finish and free the slot
+
+	select {
+	case <-started:
+		t.Fatal("second mirror should have been dropped, but the provider was called")
+	case <-time.After(200 * time.Millisecond):
+		// No second invocation — correctly dropped.
+	}
+}
+
 // mockMirrorProvider implements MirrorProvider for testing.
 type mockMirrorProvider struct {
 	fn func(ctx context.Context, req *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error)

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	TenantStore      *tenant.Store
 	OrgProviderCache *providers.OrgProviderCache
 	asyncWorker      *async.Worker
+	rotationMgr      *rotation.Manager
 	ready            atomic.Bool
 }
 
@@ -560,6 +561,7 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 	{
 		drainPeriod := 30 * time.Second                 // default
 		rotMgr := rotation.NewManager(drainPeriod, nil) // onRotate callback not wired for now
+		s.rotationMgr = rotMgr                          // tracked so Shutdown can stop drain timers
 
 		// Register each provider that has rotation enabled.
 		for name, pCfg := range cfg.Providers {
@@ -867,12 +869,27 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 	}
 	handler = middleware.Recovery(handler)
 
+	// ReadHeaderTimeout bounds the time to read request headers independently of
+	// the full-body ReadTimeout (slowloris defense-in-depth). MaxHeaderBytes caps
+	// header size. Fall back to safe defaults for configs that predate these
+	// fields (they deserialize to 0).
+	readHeaderTimeout := cfg.Server.ReadHeaderTimeout
+	if readHeaderTimeout <= 0 {
+		readHeaderTimeout = 5 * time.Second
+	}
+	maxHeaderBytes := cfg.Server.MaxHeaderBytes
+	if maxHeaderBytes <= 0 {
+		maxHeaderBytes = 1 << 20 // 1MB
+	}
+
 	s.httpServer = &http.Server{
-		Addr:         cfg.Addr(),
-		Handler:      handler,
-		ReadTimeout:  cfg.Server.ReadTimeout,
-		WriteTimeout: cfg.Server.WriteTimeout,
-		IdleTimeout:  cfg.Server.IdleTimeout,
+		Addr:              cfg.Addr(),
+		Handler:           handler,
+		ReadTimeout:       cfg.Server.ReadTimeout,
+		ReadHeaderTimeout: readHeaderTimeout,
+		WriteTimeout:      cfg.Server.WriteTimeout,
+		IdleTimeout:       cfg.Server.IdleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
 	}
 
 	return s
@@ -913,6 +930,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// Stop async workers.
 	if s.asyncWorker != nil {
 		s.asyncWorker.Stop()
+	}
+
+	// Cancel any in-flight key-rotation drain timers.
+	if s.rotationMgr != nil {
+		s.rotationMgr.Stop()
 	}
 
 	if err := s.httpServer.Shutdown(ctx); err != nil {

--- a/agentcc-gateway/internal/server/server_test.go
+++ b/agentcc-gateway/internal/server/server_test.go
@@ -2280,3 +2280,17 @@ func TestProviderPrefixRouting(t *testing.T) {
 		t.Fatalf("status = %d, want 200. Body: %s", w.Code, string(body))
 	}
 }
+
+func TestServerHeaderLimitsConfigured(t *testing.T) {
+	mock := startMockOpenAI(t)
+	defer mock.Close()
+
+	srv := createTestServer(t, mock.URL)
+
+	if got := srv.httpServer.ReadHeaderTimeout; got != 5*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want 5s", got)
+	}
+	if got := srv.httpServer.MaxHeaderBytes; got != 1<<20 {
+		t.Errorf("MaxHeaderBytes = %d, want %d", got, 1<<20)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the `agentcc-gateway` against resource-exhaustion / denial-of-service vectors found in the code audit. The HTTP server now bounds header read time (`read_header_timeout`, default 5s) and header size (`max_header_bytes`, default 1MB) independently of the full-body read timeout for slowloris defense-in-depth, and the outbound provider transport caps `MaxConnsPerHost`. Async traffic mirroring is bounded by a `max_concurrent` budget (default 64) that drops excess shadow traffic instead of spawning unbounded goroutines/connections under load, and key-rotation drain timers are now cancellable so `Server.Shutdown()` stops them promptly instead of leaking for the full drain period. All new config fields default to safe values, so existing configs (which deserialize the new fields to `0`) keep working unchanged.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Added/extended unit tests: `config_test.go` (new defaults), `rotation_test.go` (graceful drain-timer shutdown), `routing_test.go` (mirror concurrency cap drops excess), and `server_test.go` (header timeout/size wiring).
- Note: `make check-all` was **not** run locally (no Go toolchain in this environment); the `agentcc-gateway-ci` workflow runs build/lint/tests on the PR.

## Screenshots / recordings (if UI)

N/A — backend-only change.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally (runs in CI; no local Go toolchain)
- [x] I've updated the documentation where relevant (`config.example.yaml`)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
