### PR TITLE
fix: preserve image identity during drag reorder

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
@@ -30,8 +30,22 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+const createImageItem = (url) => ({
+  id: crypto.randomUUID(),
+  url,
+});
+
+const normalizeImageItems = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((url) => createImageItem(url));
+};
+
 // Sortable Image Item Component
-const SortableImageItem = ({ url, index, onDelete }) => {
+const SortableImageItem = ({ item, index, onDelete }) => {
   const {
     attributes,
     listeners,
@@ -39,7 +53,7 @@ const SortableImageItem = ({ url, index, onDelete }) => {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: `image-${index}` });
+  } = useSortable({ id: item.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -89,7 +103,7 @@ const SortableImageItem = ({ url, index, onDelete }) => {
         />
       </Box>
       <GridIcon
-        src={url}
+        src={item.url}
         alt={`Image ${index + 1}`}
         sx={{
           width: "100%",
@@ -104,7 +118,7 @@ const SortableImageItem = ({ url, index, onDelete }) => {
         size="small"
         onClick={(e) => {
           e.stopPropagation();
-          onDelete(index);
+          onDelete(item.id);
         }}
         sx={{
           position: "absolute",
@@ -129,18 +143,21 @@ const SortableImageItem = ({ url, index, onDelete }) => {
 };
 
 SortableImageItem.propTypes = {
-  url: PropTypes.string.isRequired,
+  item: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   index: PropTypes.number.isRequired,
   onDelete: PropTypes.func.isRequired,
 };
 
 const EditImages = ({ params, onClose, onCellValueChanged }) => {
   const fileInputRef = useRef(null);
-  const [imageUrls, setImageUrls] = useState([]);
+  const [imageItems, setImageItems] = useState([]);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [deleteIndex, setDeleteIndex] = useState(null);
+  const [deleteImageId, setDeleteImageId] = useState(null);
 
   // DnD sensors
   const sensors = useSensors(
@@ -159,20 +176,32 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
           typeof params.value === "string"
             ? JSON.parse(params.value)
             : params.value;
-        setImageUrls(Array.isArray(parsed) ? parsed : [parsed]);
+        setImageItems(normalizeImageItems(parsed));
       } catch {
-        setImageUrls([params.value]);
+        setImageItems(normalizeImageItems(params.value));
       }
+    } else {
+      setImageItems([]);
     }
   }, [params?.value]);
 
   const handleDragEnd = (event) => {
     const { active, over } = event;
-    if (active.id !== over?.id) {
-      const oldIndex = parseInt(active.id.replace("image-", ""), 10);
-      const newIndex = parseInt(over.id.replace("image-", ""), 10);
-      setImageUrls((items) => arrayMove(items, oldIndex, newIndex));
+
+    if (!over || active.id === over.id) {
+      return;
     }
+
+    setImageItems((items) => {
+      const oldIndex = items.findIndex((item) => item.id === active.id);
+      const newIndex = items.findIndex((item) => item.id === over.id);
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return items;
+      }
+
+      return arrayMove(items, oldIndex, newIndex);
+    });
   };
 
   const handleClose = () => {
@@ -186,7 +215,10 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
   const onSubmit = (e) => {
     e.preventDefault();
     try {
-      const newValue = imageUrls.length > 0 ? JSON.stringify(imageUrls) : null;
+      const newValue =
+        imageItems.length > 0
+          ? JSON.stringify(imageItems.map((item) => item.url))
+          : null;
       onCellValueChanged({
         ...params,
         newValue,
@@ -204,17 +236,17 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
   };
 
   const handleConfirmDelete = () => {
-    if (deleteIndex !== null) {
-      setImageUrls((prev) => prev.filter((_, i) => i !== deleteIndex));
+    if (deleteImageId !== null) {
+      setImageItems((prev) => prev.filter((item) => item.id !== deleteImageId));
     }
     setIsDeleteDialogOpen(false);
-    setDeleteIndex(null);
+    setDeleteImageId(null);
   };
 
   const handleDeleteAll = () => {
-    setImageUrls([]);
+    setImageItems([]);
     setIsDeleteDialogOpen(false);
-    setDeleteIndex(null);
+    setDeleteImageId(null);
   };
 
   const processFiles = (files) => {
@@ -234,15 +266,15 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
     }
 
     let processed = 0;
-    const newUrls = [];
+    const newImageItems = [];
 
     validFiles.forEach((file) => {
       const reader = new FileReader();
       reader.onloadend = () => {
-        newUrls.push(reader.result);
+        newImageItems.push(createImageItem(reader.result));
         processed++;
         if (processed === validFiles.length) {
-          setImageUrls((prev) => [...prev, ...newUrls]);
+          setImageItems((prev) => [...prev, ...newImageItems]);
           setIsLoading(false);
         }
       };
@@ -252,7 +284,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
         });
         processed++;
         if (processed === validFiles.length) {
-          setImageUrls((prev) => [...prev, ...newUrls]);
+          setImageItems((prev) => [...prev, ...newImageItems]);
           setIsLoading(false);
         }
       };
@@ -293,8 +325,8 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
     }
   };
 
-  const handleDeleteClick = (index) => {
-    setDeleteIndex(index);
+  const handleDeleteClick = (imageId) => {
+    setDeleteImageId(imageId);
     setIsDeleteDialogOpen(true);
   };
 
@@ -313,7 +345,12 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
     transition: "all 0.2s ease",
   };
 
-  const sortableItems = imageUrls.map((_, index) => `image-${index}`);
+  const sortableItems = imageItems.map((item) => item.id);
+
+  const deleteImageIndex =
+    deleteImageId !== null
+      ? imageItems.findIndex((item) => item.id === deleteImageId)
+      : -1;
 
   return (
     <>
@@ -350,7 +387,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
             </Box>
           </ShowComponent>
 
-          <ShowComponent condition={!isLoading && imageUrls.length === 0}>
+          <ShowComponent condition={!isLoading && imageItems.length === 0}>
             <Box {...getRootProps()} sx={containerStyles}>
               <input {...getInputProps()} />
               <Box
@@ -390,7 +427,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
             </Box>
           </ShowComponent>
 
-          <ShowComponent condition={!isLoading && imageUrls.length > 0}>
+          <ShowComponent condition={!isLoading && imageItems.length > 0}>
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
@@ -401,10 +438,10 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                 strategy={rectSortingStrategy}
               >
                 <Box sx={containerStyles}>
-                  {imageUrls.map((url, index) => (
+                  {imageItems.map((item, index) => (
                     <SortableImageItem
-                      key={`image-${index}`}
-                      url={url}
+                      key={item.id}
+                      item={item}
                       index={index}
                       onDelete={handleDeleteClick}
                     />
@@ -429,9 +466,9 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
           >
             <Box>
               <Typography variant="body2" color="text.secondary">
-                {imageUrls.length} image{imageUrls.length !== 1 ? "s" : ""}
+                {imageItems.length} image{imageItems.length !== 1 ? "s" : ""}
               </Typography>
-              {imageUrls.length > 1 && (
+              {imageItems.length > 1 && (
                 <Typography variant="caption" color="text.secondary">
                   Drag to reorder
                 </Typography>
@@ -464,7 +501,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                   onChange={handleImageChange}
                 />
               </LoadingButton>
-              {imageUrls.length > 0 && (
+              {imageItems.length > 0 && (
                 <LoadingButton
                   size="small"
                   startIcon={
@@ -474,7 +511,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                     />
                   }
                   onClick={() => {
-                    setDeleteIndex(null);
+                    setDeleteImageId(null);
                     setIsDeleteDialogOpen(true);
                   }}
                   sx={{
@@ -522,12 +559,14 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
         open={isDeleteDialogOpen}
         onClose={() => {
           setIsDeleteDialogOpen(false);
-          setDeleteIndex(null);
+          setDeleteImageId(null);
         }}
-        onDelete={deleteIndex !== null ? handleConfirmDelete : handleDeleteAll}
+        onDelete={deleteImageId !== null ? handleConfirmDelete : handleDeleteAll}
         isPending={false}
         fileName={
-          deleteIndex !== null ? `Image ${deleteIndex + 1}` : "all images"
+          deleteImageId !== null && deleteImageIndex !== -1
+            ? `Image ${deleteImageIndex + 1}`
+            : "all images"
         }
         fileType="image"
       />


### PR DESCRIPTION
## Summary
- switch image sortable items to stable ids instead of array indexes
- preserve reorder behavior for duplicate image urls
- keep the saved payload as the original plain JSON array of image urls

Fixes #931.