### PR TITLE
fix(observe): fix user-detail group switch + persist span grouping (TH-6112)

### DIFF
--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
@@ -76,6 +76,11 @@ const UserDetailPageBody = () => {
   useEffect(() => {
     if (!activeTab || !activeTab.startsWith("view-")) {
       lastHydratedTabRef.current = null;
+      // Sync subTab to userTab — the group dropdown navigates the URL directly,
+      // not via handleTabChange, so otherwise the view wouldn't switch.
+      if (activeTab === "sessions" || activeTab === "traces") {
+        if (activeTab !== subTab) setSubTab(activeTab);
+      }
       return;
     }
     if (lastHydratedTabRef.current === activeTab) return;

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
@@ -58,7 +58,7 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
 
   const queryClient = useQueryClient();
   const { getViewConfig, setActiveViewConfig } = useObserveHeader();
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Pre-seed the URL-synced state keys for the target sub-tab from the saved
   // view's config. Lets useUrlState read correct values on mount / refresh so
@@ -83,7 +83,9 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
                 JSON.stringify(display.showCompare),
               );
             }
-          } else if (subTab === "traces") {
+          } else if (subTab === "traces" || subTab === "spans") {
+            // Restore the trace/span grouping encoded in sub_tab.
+            next.set("selectedTab", subTab === "spans" ? "spans" : "trace");
             if (display.dateFilter) {
               next.set(
                 "primaryTraceDateFilter",
@@ -136,7 +138,11 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
     // transitions, e.g. handleClose at line ~230 calling
     // `onTabChange("sessions","sessions")` after deleting an active view.
     if (FIXED_TABS.some((t) => t.key === activeTab)) {
-      setSearchParams(new URLSearchParams({ userTab: activeTab }), {
+      // Preserve selectedTab (the trace/span grouping) — not a stale saved-view param.
+      const next = new URLSearchParams({ userTab: activeTab });
+      const selectedTab = searchParams.get("selectedTab");
+      if (selectedTab) next.set("selectedTab", selectedTab);
+      setSearchParams(next, {
         replace: true,
       });
       lastAppliedTabRef.current = activeTab;
@@ -173,6 +179,8 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
     // refetch will land and customViews will include the new view).
   }, [
     activeTab,
+    searchParams,
+    setSearchParams,
     setActiveViewConfig,
     onTabChange,
     customViews,
@@ -187,7 +195,12 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
       // be a custom view — in that case fall back to its underlying sub_tab.
       let targetSubTab = null;
       if (FIXED_TABS.some((t) => t.key === activeTab)) {
-        targetSubTab = activeTab;
+        // Encode the grouping in sub_tab — selectedTab isn't an allowed
+        // saved-view config key, so the backend would reject it.
+        targetSubTab =
+          activeTab === "traces" && searchParams.get("selectedTab") === "spans"
+            ? "spans"
+            : activeTab;
       } else {
         const id = activeTab?.startsWith?.("view-") ? activeTab.slice(5) : null;
         const view = id ? customViews.find((v) => v.id === id) : null;
@@ -215,7 +228,14 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
         },
       );
     },
-    [activeTab, customViews, createSavedView, getViewConfig, onTabChange],
+    [
+      activeTab,
+      searchParams,
+      customViews,
+      createSavedView,
+      getViewConfig,
+      onTabChange,
+    ],
   );
 
   const handleClose = useCallback(

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/__tests__/UserDetailTabBar.test.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/__tests__/UserDetailTabBar.test.jsx
@@ -1,0 +1,92 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithRouter, screen, userEvent } from "src/utils/test-utils";
+
+// Capture the payload the save mutation receives so we can assert the encoded
+// `sub_tab`. The grouping (trace vs span) is read from the `selectedTab` URL
+// param and encoded into config.sub_tab — span must survive as "spans".
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock("src/api/project/saved-views", () => ({
+  SAVED_VIEWS_KEY: "saved-views",
+  useGetWorkspaceSavedViews: () => ({ data: { custom_views: [] } }),
+  useCreateWorkspaceSavedView: () => ({ mutate: createMock }),
+  useUpdateWorkspaceSavedView: () => ({ mutate: vi.fn() }),
+  useDeleteWorkspaceSavedView: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("src/sections/project/context/ObserveHeaderContext", () => ({
+  useObserveHeader: () => ({
+    getViewConfig: () => ({ display: {} }),
+    setActiveViewConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ getQueryData: vi.fn() }),
+}));
+
+// Stub the save dialog to expose onSave directly (skip the popover interaction).
+vi.mock("src/components/traceDetail/SaveViewDialog", () => ({
+  default: ({ onSave }) => (
+    <button
+      type="button"
+      data-testid="save-confirm"
+      onClick={() => onSave("My View")}
+    >
+      save
+    </button>
+  ),
+}));
+
+vi.mock("src/components/observe-tabs/FixedTab", () => ({
+  default: () => null,
+}));
+vi.mock("src/components/observe-tabs/CustomViewTab", () => ({
+  default: () => null,
+}));
+vi.mock("src/components/iconify", () => ({ default: () => null }));
+vi.mock("src/components/tooltip/CustomTooltip", () => ({
+  default: ({ children }) => children,
+}));
+
+import UserDetailTabBar from "../UserDetailTabBar";
+
+const savedConfigFor = async (route, activeTab) => {
+  createMock.mockClear();
+  renderWithRouter(
+    <UserDetailTabBar activeTab={activeTab} onTabChange={vi.fn()} />,
+    { route },
+  );
+  await userEvent.click(screen.getByTestId("save-confirm"));
+  return createMock.mock.calls[0][0].config;
+};
+
+describe("UserDetailTabBar — saved-view grouping (sub_tab)", () => {
+  beforeEach(() => createMock.mockClear());
+
+  it("encodes the span grouping as sub_tab=spans", async () => {
+    const config = await savedConfigFor(
+      "/dashboard/users/bob?userTab=traces&selectedTab=spans",
+      "traces",
+    );
+    expect(config.sub_tab).toBe("spans");
+  });
+
+  it("encodes the trace grouping as sub_tab=traces", async () => {
+    const config = await savedConfigFor(
+      "/dashboard/users/bob?userTab=traces&selectedTab=trace",
+      "traces",
+    );
+    expect(config.sub_tab).toBe("traces");
+  });
+
+  it("encodes the sessions tab as sub_tab=sessions", async () => {
+    const config = await savedConfigFor(
+      "/dashboard/users/bob?userTab=sessions",
+      "sessions",
+    );
+    expect(config.sub_tab).toBe("sessions");
+  });
+});


### PR DESCRIPTION
## What & why

On the cross-project user-detail page (`/dashboard/users/:userId`), the trace/span group switch was broken:

1. **Group switch didn't switch the view** — picking Trace/Span from the Sessions view updated the URL (`userTab`) but the rendered view stayed on Sessions. `subTab` (the render selector) only synced via `handleTabChange` / saved-view hydrate, not the group dropdown's direct navigate.
2. **Saved views lost the span grouping** — a custom view saved on the span grouping serialized as `sub_tab: "traces"` (no record of span), so it reopened on the default trace grouping.

## Changes

* `CrossProjectUserDetailPage` — sync `subTab` to `userTab` for fixed-tab URL changes so the group switch renders.
* `UserDetailTabBar` — preserve `selectedTab` through the tab-bar reset; encode the grouping in `config.sub_tab` on save (`sessions|traces|spans`) and decode it on restore. Uses `sub_tab` (an allowed config key) — no backend change.

## Tests

* `UserDetailTabBar.test.jsx` — pins the `sub_tab` encode (span→`spans`, trace→`traces`, sessions→`sessions`). Full FE suite green (1969).

https://github.com/user-attachments/assets/dd471927-c533-48c5-bff2-6c857ca18cee