### PR TITLE
fix(annotation-queues): use org/workspace admin access over explicit queue role for assign + annotate

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -211,6 +211,47 @@ def _create_workspace_viewer_user(organization, workspace, *, email_prefix):
     return viewer
 
 
+def _create_workspace_admin_user(organization, workspace, *, email_prefix):
+    """Create a workspace admin who is NOT an org admin (org role = Member).
+
+    This isolates the ``WorkspaceMembership.level_or_legacy >= WORKSPACE_ADMIN``
+    branch of ``user_has_annotation_queue_admin_access`` from the org-admin path.
+    """
+    from accounts.models.organization_membership import OrganizationMembership
+    from accounts.models.user import User
+    from accounts.models.workspace import WorkspaceMembership
+    from tfc.constants.levels import Level
+    from tfc.constants.roles import OrganizationRoles
+
+    admin = User.objects.create_user(
+        email=f"{email_prefix}-{uuid.uuid4().hex[:8]}@futureagi.com",
+        password="testpassword123",
+        name="Workspace Admin",
+        organization=organization,
+        organization_role=OrganizationRoles.MEMBER,
+    )
+    org_membership, _ = OrganizationMembership.no_workspace_objects.update_or_create(
+        user=admin,
+        organization=organization,
+        defaults={
+            "role": OrganizationRoles.MEMBER,
+            "level": Level.MEMBER,
+            "is_active": True,
+        },
+    )
+    WorkspaceMembership.no_workspace_objects.update_or_create(
+        user=admin,
+        workspace=workspace,
+        defaults={
+            "role": OrganizationRoles.WORKSPACE_ADMIN,
+            "level": Level.WORKSPACE_ADMIN,
+            "organization_membership": org_membership,
+            "is_active": True,
+        },
+    )
+    return admin
+
+
 def _jwt_workspace_client(user, organization, workspace):
     """Authenticate through the real auth class so workspace write checks run."""
     from rest_framework.test import APIClient
@@ -5689,6 +5730,74 @@ class TestAssignItems:
         item.refresh_from_db()
         assert item.assigned_to_id == manager.id
 
+    def test_custom_queue_assignment_allows_workspace_admin_without_queue_membership(
+        self, dataset_rows, organization, workspace
+    ):
+        """Workspace admins (not org admins) can manage assignments via admin access.
+
+        The acting user is only an org Member but a workspace admin, with no
+        explicit queue membership. This exercises the
+        ``WorkspaceMembership.level_or_legacy >= WORKSPACE_ADMIN`` branch of
+        ``user_has_annotation_queue_admin_access``.
+        """
+        from accounts.models.user import User
+        from conftest import WorkspaceAwareAPIClient
+        from tfc.constants.roles import OrganizationRoles
+
+        dataset, rows = dataset_rows
+        manager = User.objects.create_user(
+            email=f"ws-admin-assign-owner-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Assignment Queue Owner",
+            organization=organization,
+            organization_role=OrganizationRoles.MEMBER,
+        )
+        workspace_admin = _create_workspace_admin_user(
+            organization, workspace, email_prefix="ws-admin-assign"
+        )
+        queue = AnnotationQueue.objects.create(
+            name="Workspace Admin Assignment Queue",
+            dataset=dataset,
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            created_by=manager,
+            organization=organization,
+            workspace=workspace,
+        )
+        AnnotationQueueAnnotator.objects.update_or_create(
+            queue=queue,
+            user=manager,
+            deleted=False,
+            defaults={
+                "role": AnnotatorRole.MANAGER.value,
+                "roles": [AnnotatorRole.MANAGER.value],
+            },
+        )
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.DATASET_ROW.value,
+            dataset_row=rows[0],
+            organization=organization,
+            workspace=workspace,
+        )
+
+        admin_client = WorkspaceAwareAPIClient()
+        admin_client.force_authenticate(user=workspace_admin)
+        admin_client.set_workspace(workspace)
+        resp = admin_client.post(
+            assign_url(queue.id),
+            {
+                "item_ids": [str(item.id)],
+                "user_ids": [str(manager.id)],
+                "action": "set",
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        item.refresh_from_db()
+        assert item.assigned_to_id == manager.id
+        admin_client.stop_workspace_injection()
+
     def test_custom_queue_assignment_rejects_non_admin_non_member(
         self, dataset_rows, organization, workspace
     ):
@@ -5751,7 +5860,8 @@ class TestAssignItems:
         )
 
         assert resp.status_code == status.HTTP_403_FORBIDDEN
-        assert "Only queue managers can manage queue item assignments" in str(resp.data)
+        assert resp.data["type"] == "permission_error"
+        assert resp.data["code"] == "permission_denied"
         item.refresh_from_db()
         assert item.assigned_to_id is None
         outsider_client.stop_workspace_injection()

--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -683,6 +683,119 @@ class TestSubmitAnnotations:
         ).exists()
         annotator_client.stop_workspace_injection()
 
+    def test_submit_allows_org_admin_with_reviewer_role_to_annotate(
+        self, auth_client, dataset_rows, organization, workspace, user, label
+    ):
+        """Org/workspace admins can annotate even with a non-annotator queue role.
+
+        ``auth_client`` is the org owner. On a queue created by someone else
+        where the owner is only a reviewer, admin access grants
+        manager-equivalent rights so they may submit annotations on an
+        unassigned manual item.
+        """
+        from accounts.models.user import User
+        from tfc.constants.roles import OrganizationRoles
+
+        dataset, rows = dataset_rows
+        creator = User.objects.create_user(
+            email=f"admin-annotate-owner-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Admin Annotate Owner",
+            organization=organization,
+            organization_role=OrganizationRoles.MEMBER,
+        )
+        queue = AnnotationQueue.objects.create(
+            name="Admin Annotate Queue",
+            dataset=dataset,
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            created_by=creator,
+            organization=organization,
+            workspace=workspace,
+        )
+        AnnotationQueueLabel.objects.create(
+            queue=queue,
+            label=label,
+            order=0,
+            required=True,
+        )
+        AnnotationQueueAnnotator.objects.update_or_create(
+            queue=queue,
+            user=creator,
+            deleted=False,
+            defaults={
+                "role": AnnotatorRole.MANAGER.value,
+                "roles": [AnnotatorRole.MANAGER.value],
+            },
+        )
+        # auth_client's org-owner user is only a reviewer on this queue.
+        admin_user = user
+        AnnotationQueueAnnotator.objects.update_or_create(
+            queue=queue,
+            user=admin_user,
+            deleted=False,
+            defaults={
+                "role": AnnotatorRole.REVIEWER.value,
+                "roles": [AnnotatorRole.REVIEWER.value],
+            },
+        )
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.DATASET_ROW.value,
+            dataset_row=rows[0],
+            organization=organization,
+            workspace=workspace,
+        )
+
+        resp = auth_client.post(
+            submit_annotations_url(queue.id, item.id),
+            {"annotations": [{"label_id": str(label.id), "value": "positive"}]},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert _result(resp)["submitted"] == 1
+        assert Score.objects.filter(
+            queue_item_id=item.id,
+            annotator=admin_user,
+            deleted=False,
+        ).exists()
+
+    def test_submit_allows_manager_unassigned_item_when_queue_has_assignments(
+        self, auth_client, queue_with_items, user, second_user, organization
+    ):
+        """Managers can annotate an unassigned manual item even once other items
+        in the queue are assigned to someone else."""
+        queue_id, item_ids, label = queue_with_items
+        AnnotationQueue.objects.filter(pk=queue_id).update(auto_assign=False)
+        AnnotationQueueAnnotator.objects.get_or_create(
+            queue_id=queue_id,
+            user=second_user,
+            defaults={
+                "role": AnnotatorRole.ANNOTATOR.value,
+                "roles": [AnnotatorRole.ANNOTATOR.value],
+            },
+        )
+        # Assign a different item so the queue has at least one assignment.
+        QueueItemAssignment.objects.create(
+            queue_item=QueueItem.objects.get(pk=item_ids[1]),
+            user=second_user,
+        )
+
+        # The first item stays unassigned; the manager (queue creator) submits.
+        resp = auth_client.post(
+            submit_annotations_url(queue_id, item_ids[0]),
+            {"annotations": [{"label_id": str(label.id), "value": "positive"}]},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert _result(resp)["submitted"] == 1
+        assert Score.objects.filter(
+            queue_item_id=item_ids[0],
+            annotator=user,
+            deleted=False,
+        ).exists()
+
     def test_reviewer_assigned_item_can_add_missing_annotation_during_review(
         self,
         auth_client,
@@ -5517,10 +5630,15 @@ class TestAssignItems:
 
         assert denied.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_custom_queue_assignment_rejects_admin_without_queue_membership(
+    def test_custom_queue_assignment_allows_org_admin_without_queue_membership(
         self, auth_client, dataset_rows, organization, workspace
     ):
-        """Workspace/org admins cannot manage custom queue assignments by default."""
+        """Org/workspace admins can manage custom queue assignments via admin access.
+
+        ``auth_client`` is the org owner. Even without an explicit queue
+        membership row, admin access grants manager-equivalent rights, so they
+        may assign items on a queue created by someone else.
+        """
         from accounts.models.user import User
         from tfc.constants.roles import OrganizationRoles
 
@@ -5567,10 +5685,76 @@ class TestAssignItems:
             format="json",
         )
 
+        assert resp.status_code == status.HTTP_200_OK
+        item.refresh_from_db()
+        assert item.assigned_to_id == manager.id
+
+    def test_custom_queue_assignment_rejects_non_admin_non_member(
+        self, dataset_rows, organization, workspace
+    ):
+        """Plain members without admin access or a queue manager role cannot assign."""
+        from accounts.models.user import User
+        from conftest import WorkspaceAwareAPIClient
+        from tfc.constants.roles import OrganizationRoles
+
+        dataset, rows = dataset_rows
+        manager = User.objects.create_user(
+            email=f"assignment-owner-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Assignment Queue Owner",
+            organization=organization,
+            organization_role=OrganizationRoles.MEMBER,
+        )
+        outsider = User.objects.create_user(
+            email=f"assignment-outsider-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Assignment Queue Outsider",
+            organization=organization,
+            organization_role=OrganizationRoles.MEMBER,
+        )
+        queue = AnnotationQueue.objects.create(
+            name="Non Member Assignment Queue",
+            dataset=dataset,
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            created_by=manager,
+            organization=organization,
+            workspace=workspace,
+        )
+        AnnotationQueueAnnotator.objects.update_or_create(
+            queue=queue,
+            user=manager,
+            deleted=False,
+            defaults={
+                "role": AnnotatorRole.MANAGER.value,
+                "roles": [AnnotatorRole.MANAGER.value],
+            },
+        )
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.DATASET_ROW.value,
+            dataset_row=rows[0],
+            organization=organization,
+            workspace=workspace,
+        )
+
+        outsider_client = WorkspaceAwareAPIClient()
+        outsider_client.force_authenticate(user=outsider)
+        outsider_client.set_workspace(workspace)
+        resp = outsider_client.post(
+            assign_url(queue.id),
+            {
+                "item_ids": [str(item.id)],
+                "user_ids": [str(manager.id)],
+                "action": "set",
+            },
+            format="json",
+        )
+
         assert resp.status_code == status.HTTP_403_FORBIDDEN
         assert "Only queue managers can manage queue item assignments" in str(resp.data)
         item.refresh_from_db()
         assert item.assigned_to_id is None
+        outsider_client.stop_workspace_injection()
 
     def test_assign_empty_item_ids(self, auth_client, queue_with_items):
         """Empty item_ids returns 400."""

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -290,6 +290,9 @@ def _manual_assignment_denial_reason(queue, item, user):
         return None
     if _queue_item_has_assignments(item):
         return "This item is assigned to another annotator."
+    # Managers/admins may claim any unassigned item. Checked after the
+    # "assigned to another" guard so we never steal someone else's item, and no
+    # longer gated on the queue being assignment-free.
     if _is_queue_manager(queue, user):
         return None
     return "This item must be assigned before it can be annotated."
@@ -5212,6 +5215,8 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 "Annotations can only be submitted when the queue is active."
             )
 
+        # _has_queue_role (not _has_explicit_queue_role): org/workspace admins
+        # are manager-equivalent, so they can annotate without an explicit role.
         if not _has_queue_role(
             queue_id,
             request.user,
@@ -6044,6 +6049,8 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         if getattr(queue, "is_default", False):
             _ensure_default_queue_member_can_manage(queue, request.user)
 
+        # _has_queue_role (not _has_explicit_queue_role): org/workspace admins
+        # are manager-equivalent, so they can assign without an explicit role.
         if not _has_queue_role(
             queue_id,
             request.user,

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -288,10 +288,10 @@ def _manual_assignment_denial_reason(queue, item, user):
         return None
     if _queue_item_is_assigned_to_user(item, user):
         return None
-    if _is_queue_manager(queue, user) and not _queue_has_any_item_assignments(queue.id):
-        return None
     if _queue_item_has_assignments(item):
         return "This item is assigned to another annotator."
+    if _is_queue_manager(queue, user):
+        return None
     return "This item must be assigned before it can be annotated."
 
 
@@ -5212,7 +5212,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 "Annotations can only be submitted when the queue is active."
             )
 
-        if not _has_explicit_queue_role(
+        if not _has_queue_role(
             queue_id,
             request.user,
             AnnotatorRole.ANNOTATOR.value,
@@ -6044,7 +6044,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         if getattr(queue, "is_default", False):
             _ensure_default_queue_member_can_manage(queue, request.user)
 
-        if not _has_explicit_queue_role(
+        if not _has_queue_role(
             queue_id,
             request.user,
             AnnotatorRole.MANAGER.value,


### PR DESCRIPTION
## Summary
Make annotation-queue authorization respect org/workspace admin access and let queue managers pick up unassigned work. Three fixes in `model_hub/views/annotation_queues.py`, all in the manual-assignment flow:
1. Org/workspace admins can manage queue item assignments without an explicit queue membership row.
2. Org/workspace admins can annotate items even when their explicit queue role is only reviewer.
3. Managers can annotate any unassigned item, not just when the queue has zero assignments.

## Why / problem
- **Assignment ignored admins.** The assign-items endpoint used `_has_explicit_queue_role`, which checks only the `AnnotationQueueAnnotator` membership table. An org admin who wasn't explicitly added as a queue manager got a 403 ("Only queue managers can manage queue item assignments"), even though admins are treated as manager-equivalent everywhere else in the module (`_is_queue_manager`, `_require_queue_manager`, `annotation_queue_effective_roles`).
- **Annotation ignored admins.** Same `_has_explicit_queue_role` gate on submit/annotate blocked an org admin whose queue role was reviewer from annotating, with no admin fallback.
- **Managers couldn't claim unassigned items.** `_manual_assignment_denial_reason` allowed a manager to annotate an unassigned item only via `_is_queue_manager(queue, user) and not _queue_has_any_item_assignments(queue.id)`. Once *any* item in the queue was assigned to anyone, that guard turned false, so a manager/creator opening an unassigned item hit "This item must be assigned before it can be annotated."

## What changed
- **Assign items**: `_has_explicit_queue_role` → `_has_queue_role` (includes the org/workspace-admin fallback for full-access roles).
- **Submit annotations**: `_has_explicit_queue_role` → `_has_queue_role`, so admins gain manager-equivalent annotate access. Pure non-admin reviewers stay blocked.
- **`_manual_assignment_denial_reason`**: reordered the manual branch so the `_is_queue_manager` allowance runs *after* the "assigned to another annotator" check and no longer depends on `_queue_has_any_item_assignments`. Net effect: managers can annotate any unassigned item; items assigned to someone else remain blocked; all other cases unchanged.
- **Skip** is intentionally left on `_has_explicit_queue_role` (explicit-membership-only): skipping is an annotator workflow action tied to actual queue membership/assignment, whereas assign and annotate are admin-management capabilities that org/workspace admin access legitimately grants. The asymmetry is deliberate — please don't "unify" skip onto `_has_queue_role`, as that would let admins with no queue membership skip items they were never assigned.

## Tests
- [ ] `model_hub/tests/test_annotation_workflow_api.py::TestAssignItems::test_custom_queue_assignment_allows_org_admin_without_queue_membership`
- [ ] `model_hub/tests/test_annotation_workflow_api.py::TestAssignItems::test_custom_queue_assignment_rejects_non_admin_non_member`
- [ ] `model_hub/tests/test_annotation_workflow_api.py::TestSubmitAnnotations::test_submit_allows_org_admin_with_reviewer_role_to_annotate`
- [ ] `model_hub/tests/test_annotation_workflow_api.py::TestSubmitAnnotations::test_submit_allows_manager_unassigned_item_when_queue_has_assignments`
- [ ] Regression: `test_submit_rejects_unassigned_manual_item_for_annotator` (plain annotator still blocked)
- [ ] Regression: `test_skip_rejects_non_member_even_if_workspace_admin` (skip still explicit-membership-only)

## Commands
```bash
# affected classes
bin/test app model_hub -k "TestAssignItems or TestSubmitAnnotations or TestSkipItem"
# or directly (avoids an unrelated collection error in test_user_evaluation_tasks.py)
.venv/bin/python -m pytest --reuse-db --import-mode=importlib \
  model_hub/tests/test_annotation_workflow_api.py::TestSubmitAnnotations \
  model_hub/tests/test_annotation_workflow_api.py::TestAssignItems \
  model_hub/tests/test_annotation_workflow_api.py::TestSkipItem
```
<img width="1121" height="638" alt="image" src="https://github.com/user-attachments/assets/bf66f67e-8454-4cc4-af23-caaa3f254c22" />

Result: 41 passed.

## Backwards compatibility
- No API contract or schema change. Only loosens authorization: org/workspace admins gain assign + annotate access they previously lacked; managers can claim unassigned items.
- Non-admin, non-manager users see no behavior change (assignment, annotation, and skip guards unchanged for them).
- Skip behavior is unchanged.

## Manual verification
- [ ] As org admin with no queue membership (or reviewer-only), assign items to annotators → succeeds (no 403).
- [ ] As org admin with reviewer-only queue role, annotate an unassigned manual item → succeeds.
- [ ] As manager/creator on a manual queue that already has other items assigned, open an unassigned item → editable (no "must be assigned" denial).
- [ ] As a plain member (non-admin, non-manager), assigning items → still 403.
- [ ] Item explicitly assigned to another annotator → still blocked.

## Type of change
- [x] Bug fix

## Checklist
- [x] Lint clean
- [x] Tests added/updated and passing (40 passed)
- [ ] Self-reviewed

## Backout
Revert commit `8e04d59fb`. No migrations or data changes.

## Linear
- [TH-5661](https://linear.app/future-agi/issue/TH-5661)
- [TH-5675](https://linear.app/future-agi/issue/TH-5675)
- [TH-5664](https://linear.app/future-agi/issue/TH-5664)


