### PR TITLE
fix(eval-picker): created_by shows "Unknown" in dataset eval drawer (TH-6125)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
@@ -6,6 +6,57 @@ import { useEvalsList } from "src/sections/evals/hooks/useEvalsList";
 import { paramsSerializer } from "src/utils/utils";
 
 /**
+ * Map one raw eval from the old `getEvalsList(sourceId)` endpoint to the
+ * picker row shape. Extracted (and exported) so the field-mapping contract
+ * — especially that `created_by_name` is preserved as snake_case — has a
+ * regression test without rendering the whole hook (see TH-6125).
+ */
+export function normalizeOldEndpointEval(e) {
+  const owner = e.owner || (e.type === "futureagi_built" ? "system" : "user");
+  const evalType =
+    e.eval_type ||
+    (e.eval_template_tags?.includes("CODE_EVAL")
+      ? "code"
+      : e.eval_template_tags?.includes("AGENT_EVAL")
+        ? "agent"
+        : "llm");
+  const created_by_name =
+    e.created_by_name || (owner === "system" ? "System" : "User");
+  const templateId = e.template_id || e.eval_template_id || e.id;
+  return {
+    // IMPORTANT: the picker's config/detail flow operates on eval
+    // TEMPLATE ids, not user-eval binding ids. Old getEvalsList
+    // returns both (`id` = user eval, `template_id` = template). Use
+    // templateId as the canonical row id so opening the config drawer
+    // fetches the correct eval detail and renders the right type.
+    id: templateId,
+    templateId,
+    // Only already-attached UserEvalMetric rows carry a distinct
+    // `template_id` from the backend; catalog rows (preset / custom
+    // templates) return `id = template.id` with no `template_id`.
+    // Forwarding `e.id` on catalog rows would cause EvaluationDrawer
+    // to route "Add" clicks to /edit_and_run_user_eval/<template_id>
+    // and 404 with "Eval not found" (TH-4533).
+    userEvalId: e.template_id ? e.id : undefined,
+    name: e.name || e.eval_template_name,
+    templateType: e.template_type || "single",
+    evalType,
+    outputType: e.output_type || e.output || "pass_fail",
+    created_by_name,
+    lastUpdated: e.updated_at || e.created_at,
+    currentVersion: e.current_version || null,
+    isDraft: e.is_draft || false,
+    requiredKeys: e.eval_required_keys || e.required_keys || [],
+    description: e.description,
+    model: e.model || e.selected_model,
+    owner,
+    evalTemplateTags: e.eval_template_tags,
+    // Keep original for pass-through
+    _original: e,
+  };
+}
+
+/**
  * Hook for fetching eval list data in the picker context.
  *
  * Uses the old getEvalsList endpoint (which returns ALL evals including system)
@@ -98,57 +149,11 @@ export function useEvalPickerData({
   const items = useMemo(() => {
     if (!rawData) return [];
     if (isUsingOldEndpoint) {
-      // Old endpoint: { evals: [...] }. As of the GetEvalsListView patch,
-      // the backend now returns evalType / outputType / created_by_name /
-      // owner / updatedAt directly — we trust those fields. The old
-      // tag-based inference is kept as a last-resort fallback for any
-      // stale client/server version skew.
+      // Old endpoint: { evals: [...] }. See `normalizeOldEndpointEval` above
+      // for the field-mapping contract — backend returns snake_case and we
+      // preserve it as snake_case (TH-6125 regression).
       const evals = rawData?.evals || [];
-      return evals.map((e) => {
-        const owner =
-          e.owner || (e.type === "futureagi_built" ? "system" : "user");
-        const evalType =
-          e.eval_type ||
-          (e.eval_template_tags?.includes("CODE_EVAL")
-            ? "code"
-            : e.eval_template_tags?.includes("AGENT_EVAL")
-              ? "agent"
-              : "llm");
-        const created_by_name =
-          e.created_by_name || (owner === "system" ? "System" : "User");
-        const templateId = e.template_id || e.eval_template_id || e.id;
-        return {
-          // IMPORTANT: the picker's config/detail flow operates on eval
-          // TEMPLATE ids, not user-eval binding ids. Old getEvalsList
-          // returns both (`id` = user eval, `template_id` = template). Use
-          // templateId as the canonical row id so opening the config drawer
-          // fetches the correct eval detail and renders the right type.
-          id: templateId,
-          templateId,
-          // Only already-attached UserEvalMetric rows carry a distinct
-          // `template_id` from the backend; catalog rows (preset / custom
-          // templates) return `id = template.id` with no `template_id`.
-          // Forwarding `e.id` on catalog rows would cause EvaluationDrawer
-          // to route "Add" clicks to /edit_and_run_user_eval/<template_id>
-          // and 404 with "Eval not found" (TH-4533).
-          userEvalId: e.template_id ? e.id : undefined,
-          name: e.name || e.eval_template_name,
-          templateType: e.template_type || "single",
-          evalType,
-          outputType: e.output_type || e.output || "pass_fail",
-          created_by_name,
-          lastUpdated: e.updated_at || e.created_at,
-          currentVersion: e.current_version || null,
-          isDraft: e.is_draft || false,
-          requiredKeys: e.eval_required_keys || e.required_keys || [],
-          description: e.description,
-          model: e.model || e.selected_model,
-          owner,
-          evalTemplateTags: e.eval_template_tags,
-          // Keep original for pass-through
-          _original: e,
-        };
-      });
+      return evals.map(normalizeOldEndpointEval);
     }
     // New endpoint already returns normalized items; still ensure the
     // picker has a stable templateId alias for edit/config flows.

--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
@@ -99,7 +99,7 @@ export function useEvalPickerData({
     if (!rawData) return [];
     if (isUsingOldEndpoint) {
       // Old endpoint: { evals: [...] }. As of the GetEvalsListView patch,
-      // the backend now returns evalType / outputType / createdByName /
+      // the backend now returns evalType / outputType / created_by_name /
       // owner / updatedAt directly — we trust those fields. The old
       // tag-based inference is kept as a last-resort fallback for any
       // stale client/server version skew.
@@ -114,7 +114,7 @@ export function useEvalPickerData({
             : e.eval_template_tags?.includes("AGENT_EVAL")
               ? "agent"
               : "llm");
-        const createdByName =
+        const created_by_name =
           e.created_by_name || (owner === "system" ? "System" : "User");
         const templateId = e.template_id || e.eval_template_id || e.id;
         return {
@@ -136,7 +136,7 @@ export function useEvalPickerData({
           templateType: e.template_type || "single",
           evalType,
           outputType: e.output_type || e.output || "pass_fail",
-          createdByName,
+          created_by_name,
           lastUpdated: e.updated_at || e.created_at,
           currentVersion: e.current_version || null,
           isDraft: e.is_draft || false,

--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.test.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOldEndpointEval } from "./useEvalPickerData";
+
+describe("normalizeOldEndpointEval", () => {
+  // The bug TH-6125 closed: the mapper used to rename `created_by_name` to
+  // `createdByName` (camelCase). EvalPickerList reads `created_by_name`
+  // (snake_case, the backend's contract) so the rename silently produced
+  // `undefined` → fell back to "Unknown" on every row. The mapping is
+  // FE-internal so no API contract can guard it — this test is the only
+  // regression lock.
+  it("preserves created_by_name as snake_case (TH-6125 regression)", () => {
+    const out = normalizeOldEndpointEval({
+      id: "e1",
+      name: "my eval",
+      created_by_name: "Aman Sharma",
+    });
+    expect(out.created_by_name).toBe("Aman Sharma");
+    expect(out).not.toHaveProperty("createdByName");
+  });
+
+  it("falls back to System when owner is system and the field is missing", () => {
+    const out = normalizeOldEndpointEval({
+      id: "e1",
+      name: "preset",
+      type: "futureagi_built",
+    });
+    expect(out.created_by_name).toBe("System");
+    expect(out.owner).toBe("system");
+  });
+
+  it("falls back to User when owner is user and the field is missing", () => {
+    const out = normalizeOldEndpointEval({
+      id: "e1",
+      name: "custom",
+      owner: "user",
+    });
+    expect(out.created_by_name).toBe("User");
+  });
+
+  it("uses template_id as the canonical id; sets userEvalId only on attached rows", () => {
+    // Catalog row — no template_id; id IS the template id.
+    const catalog = normalizeOldEndpointEval({
+      id: "tpl-1",
+      name: "preset",
+      type: "futureagi_built",
+    });
+    expect(catalog.id).toBe("tpl-1");
+    expect(catalog.templateId).toBe("tpl-1");
+    expect(catalog.userEvalId).toBeUndefined();
+
+    // Attached UserEvalMetric row — separate template_id and id.
+    const attached = normalizeOldEndpointEval({
+      id: "uem-1",
+      template_id: "tpl-1",
+      name: "my eval",
+    });
+    expect(attached.id).toBe("tpl-1");
+    expect(attached.templateId).toBe("tpl-1");
+    expect(attached.userEvalId).toBe("uem-1");
+  });
+
+  it("derives evalType from tags when eval_type is missing", () => {
+    expect(
+      normalizeOldEndpointEval({
+        id: "e",
+        name: "n",
+        eval_template_tags: ["CODE_EVAL"],
+      }).evalType,
+    ).toBe("code");
+    expect(
+      normalizeOldEndpointEval({
+        id: "e",
+        name: "n",
+        eval_template_tags: ["AGENT_EVAL"],
+      }).evalType,
+    ).toBe("agent");
+    expect(
+      normalizeOldEndpointEval({ id: "e", name: "n" }).evalType,
+    ).toBe("llm");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **Created By** showing \"Unknown\" for every eval in the dataset \"Add Evaluation\" drawer, while the standalone evals page showed the correct name.

**Root cause:**

`useEvalPickerData.js` normalized the backend response and renamed `created_by_name` (snake_case) → `createdByName` (camelCase) in the returned object. `EvalPickerList.jsx` reads `evalItem.created_by_name` (snake_case) — the key no longer existed → `undefined` → `|| "Unknown"` fallback fired on every row.

The evals page worked because it uses a different data path that doesn't go through this normalization hook.

## Changes

**Frontend:**
- `frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js` — Remove `createdByName` camelCase local; pass `created_by_name: e.created_by_name` directly. Backend always returns snake_case; no normalization needed.

## Linked Issues

Closes TH-6125

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How Was This Tested?

- Verified on dev: opened dataset eval drawer → Created By now shows correct names (e.g. "System", actual user names) instead of "Unknown"
- Standalone evals page continues to show correct names (unaffected path)

## Notes

`useEvalPickerData` has no existing unit tests. A test covering `created_by_name` passthrough would be the right follow-up, but adding a new test suite is out of scope for a one-line field rename fix.