### PR TITLE
fix(develop): show typed text in synthetic dataset API request body

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -392,7 +392,7 @@ const RequestBody = ({
             border: `1px solid ${isError ? theme.palette.error.main : theme.palette.divider}`,
             borderRadius: "8px",
             outline: "none",
-            color: "transparent",
+
             caretColor: theme.palette.text.primary,
             backgroundColor: "transparent",
             position: "relative",


### PR DESCRIPTION
## Summary
Typed text was invisible in the request-body editor of the AddColumn "API call" flow used during synthetic dataset creation. The editor had `color: "transparent"`, so user input couldn't be seen. This removes it so the text renders normally.

## Why / problem
- In `RequestBody.jsx`, the editable textarea style hard-set `color: "transparent"`, hiding everything the user typed. Only the caret was visible (`caretColor` was set separately), making the request body effectively unusable.

## What changed
- **`frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx`** — removed the `color: "transparent"` style on the request-body input. Caret color and background remain unchanged.

## Tests
- [ ] Open Develop → Add Column → API call → Request Body and type: text is now visible
- [ ] Caret still visible; error border styling unchanged

## Commands
    # frontend
    yarn lint   # clean for the edited file

## Backwards compatibility
UI-only style change. No behavior, schema, or contract changes.

## Manual verification
- [ ] Created a synthetic dataset via the API-call column and confirmed the request body text is readable while typing

## Type of change
- [x] Bug fix
- [ ] Breaking change

## Checklist
- [x] Lint passes
- [ ] Self-reviewed

## Backout
Revert this commit — restores the previous (transparent text) styling.

## Linear
<!-- link the text-not-visible ticket here -->
