### PR TITLE
fix(integrations): stop sync-settings radio buttons overflowing the panel

### DIFF
--- a/frontend/src/sections/settings/integrations/AddIntegrationWizard/StepSyncSettings.jsx
+++ b/frontend/src/sections/settings/integrations/AddIntegrationWizard/StepSyncSettings.jsx
@@ -162,8 +162,9 @@ export default function StepSyncSettings({
           <FormControlLabel
             value="all"
             control={<Radio size="small" />}
+            sx={{ ml: 0, alignItems: "flex-start" }}
             label={
-              <Box>
+              <Box sx={{ pt: 0.25 }}>
                 <Typography sx={{ typography: "s1", color: "text.primary" }}>
                   Import all traces
                 </Typography>
@@ -178,6 +179,7 @@ export default function StepSyncSettings({
           <FormControlLabel
             value="from_date"
             control={<Radio size="small" />}
+            sx={{ ml: 0 }}
             label={
               <Typography sx={{ typography: "s1", color: "text.primary" }}>
                 Import from a specific date
@@ -187,6 +189,7 @@ export default function StepSyncSettings({
           <FormControlLabel
             value="new_only"
             control={<Radio size="small" />}
+            sx={{ ml: 0 }}
             label={
               <Typography sx={{ typography: "s1", color: "text.primary" }}>
                 Only import new traces going forward


### PR DESCRIPTION
## Summary
In the Add Integration wizard's Sync Settings step, the "Historical Data" radio buttons overflowed the panel's left edge and overlapped the content behind them. This pulls the controls back inside the panel.

## Why / problem
- MUI's `FormControlLabel` ships a default `marginLeft: -11px` (to optically align the control with text above it). The radio group here sits flush against the wizard panel's left edge, so that negative margin pushed the radio circles outside the panel and over the underlying content.

## What changed
- **`frontend/src/sections/settings/integrations/AddIntegrationWizard/StepSyncSettings.jsx`**
  - Added `sx={{ ml: 0 }}` to all three `FormControlLabel`s so the radios align to the panel's left edge instead of overflowing.
  - For the two-line "Import all traces" option, added `alignItems: "flex-start"` + a small top padding so the radio aligns with the first line rather than centering across both lines.

## Tests
- [ ] Settings → Integrations → Add Integration → Sync Settings: the three Historical Data radios sit fully inside the panel with no overlap
- [ ] "Import all traces" radio aligns to the first line of its label

## Commands
    # frontend
    yarn lint   # clean for the edited file

## Backwards compatibility
UI-only style change. No behavior, schema, or contract changes.

## Manual verification
- [ ] Opened the Add Integration wizard and confirmed the radios no longer overlap adjacent content

## Type of change
- [x] Bug fix (UI)
- [ ] Breaking change

## Checklist
- [x] Lint passes
- [ ] Self-reviewed

## Backout
Revert this commit — restores the previous margins.

## Linear
<!-- link the sync-settings overlap ticket here -->
