### PR TITLE
refactor(ch-vectors): replicated-engine auto-detect + migration command

### DIFF
--- a/futureagi/agentic_eval/core/database/ch_vector.py
+++ b/futureagi/agentic_eval/core/database/ch_vector.py
@@ -33,6 +33,55 @@ def get_clickhouse_cluster_name() -> str:
     return os.getenv("CH_CLUSTER_NAME") or "cluster"
 
 
+_MERGE_TREE_ENGINE_RE = re.compile(
+    r"^\s*(?P<family>[A-Za-z]*MergeTree)\s*(?:\((?P<args>.*)\))?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def build_replicated_engine(
+    base_engine: str,
+    table_name: str,
+    *,
+    clustered: bool,
+    database: str | None = None,
+    cluster: str | None = None,
+) -> tuple[str, str]:
+    """Return ``(engine_clause, on_cluster_clause)`` for a ``CREATE TABLE``.
+
+    On a multi-replica cluster a plain ``*MergeTree[(args)]`` engine is rewritten
+    to its ``Replicated*`` form, preserving the sub-family and any version/sign
+    argument: ``MergeTree`` -> ``ReplicatedMergeTree``,
+    ``ReplacingMergeTree(ts)`` -> ``ReplicatedReplacingMergeTree('<zk>', '{replica}', ts)``.
+    The Keeper path follows the deployment convention
+    ``/clickhouse/tables/{shard}/<database>/<table>`` so two tables with the same
+    short name in different databases never share a znode.
+
+    On single-node CH the base engine is returned unchanged with an empty
+    ``ON CLUSTER`` clause, so dev and single-replica deployments keep plain
+    engines. One engine-selection rule for every legacy ``default.*`` table;
+    ``ClickHouseVectorDB.create_table`` is built on the same helper.
+    """
+    if not clustered:
+        return base_engine, ""
+    match = _MERGE_TREE_ENGINE_RE.match(base_engine)
+    if not match:
+        raise ValueError(
+            f"build_replicated_engine: {base_engine!r} is not a recognised "
+            "*MergeTree engine, so no Replicated* form can be derived."
+        )
+    family = match.group("family")
+    inner = (match.group("args") or "").strip()
+    zk_database_segment = f"{database}/" if database else ""
+    zk_path = f"/clickhouse/tables/{{shard}}/{zk_database_segment}{table_name}"
+    engine_args = [f"'{zk_path}'", "'{replica}'"]
+    if inner:
+        engine_args.append(inner)
+    engine = f"Replicated{family}({', '.join(engine_args)})"
+    on_cluster = f" ON CLUSTER '{cluster or get_clickhouse_cluster_name()}'"
+    return engine, on_cluster
+
+
 def sanitize_sql_value(value: str) -> str:
     """
     Sanitize and escape a string value to make it safe for SQL queries.
@@ -118,7 +167,8 @@ class ClickHouseVectorDB:
     ):
         self.client = clickhouse_driver.Client(**get_clickhouse_client_kwargs())
 
-    def _is_clustered(self) -> bool:
+    @classmethod
+    def is_clustered(cls, client) -> bool:
         """True iff CH has a genuinely multi-replica cluster; fails safe to False.
 
         Checking `system.macros` for the `replica` macro was too lenient: a
@@ -129,18 +179,25 @@ class ClickHouseVectorDB:
         Using `system.clusters.replica_num` is the precise check: prod multi-
         replica clusters have rows with `replica_num > 1`; a single-node
         cluster only has `replica_num = 1`.
+
+        Classmethod taking any client with `.execute`, so callers that hold a
+        raw driver client (boot-time DDL, the LLM usage logger) share the same
+        per-process answer instead of each re-probing.
         """
-        if ClickHouseVectorDB._is_clustered_cached is not None:
-            return ClickHouseVectorDB._is_clustered_cached
+        if cls._is_clustered_cached is not None:
+            return cls._is_clustered_cached
         try:
-            rows = self.client.execute(
+            rows = client.execute(
                 "SELECT count() FROM system.clusters WHERE replica_num > 1"
             )
-            ClickHouseVectorDB._is_clustered_cached = bool(rows and rows[0][0])
+            cls._is_clustered_cached = bool(rows and rows[0][0])
         except Exception:
             logger.warning("ch_vector_cluster_detect_failed", exc_info=True)
-            ClickHouseVectorDB._is_clustered_cached = False
-        return ClickHouseVectorDB._is_clustered_cached
+            cls._is_clustered_cached = False
+        return cls._is_clustered_cached
+
+    def _is_clustered(self) -> bool:
+        return self.is_clustered(self.client)
 
     def drop_table(self,table_name: str) -> None:
         """
@@ -182,19 +239,13 @@ class ClickHouseVectorDB:
         clustered = self._is_clustered()
         cluster_name = cluster or get_clickhouse_cluster_name()
         qualified = f"{database}.{table_name}" if database else table_name
-        zk_database_segment = f"{database}/" if database else ""
-
-        if clustered:
-            engine = (
-                f"ReplicatedReplacingMergeTree("
-                f"'/clickhouse/tables/{{shard}}/{zk_database_segment}{table_name}', "
-                f"'{{replica}}'"
-                f")"
-            )
-            on_cluster = f" ON CLUSTER '{cluster_name}'"
-        else:
-            engine = "ReplacingMergeTree()"
-            on_cluster = ""
+        engine, on_cluster = build_replicated_engine(
+            "ReplacingMergeTree()",
+            table_name,
+            clustered=clustered,
+            database=database,
+            cluster=cluster_name,
+        )
 
         create_table_query = f"""
         CREATE TABLE IF NOT EXISTS {qualified}{on_cluster} (

--- a/futureagi/agentic_eval/core/database/ch_vector.py
+++ b/futureagi/agentic_eval/core/database/ch_vector.py
@@ -190,10 +190,14 @@ class ClickHouseVectorDB:
             rows = client.execute(
                 "SELECT count() FROM system.clusters WHERE replica_num > 1"
             )
-            cls._is_clustered_cached = bool(rows and rows[0][0])
         except Exception:
+            # Only cache successful probes: a transient CH outage on the very
+            # first call would otherwise poison the process cache with False,
+            # and every later table create in this worker would silently emit
+            # a non-replicated engine on what is actually a clustered CH.
             logger.warning("ch_vector_cluster_detect_failed", exc_info=True)
-            cls._is_clustered_cached = False
+            return False
+        cls._is_clustered_cached = bool(rows and rows[0][0])
         return cls._is_clustered_cached
 
     def _is_clustered(self) -> bool:

--- a/futureagi/agentic_eval/core/database/ch_vector.py
+++ b/futureagi/agentic_eval/core/database/ch_vector.py
@@ -22,6 +22,17 @@ def get_clickhouse_client_kwargs() -> dict[str, str | int]:
     }
 
 
+def get_clickhouse_cluster_name() -> str:
+    """Cluster name used in `ON CLUSTER` / `clusterAllReplicas(...)` DDL and reads.
+
+    Default is `'cluster'`: every Future AGI deployment (US AWS, US GCP, EU GCP)
+    pins `name: "cluster"` in the ClickHouseInstallation manifest. Override per
+    environment via `CH_CLUSTER_NAME` if a future deployment uses a different
+    name in its `remote_servers` config.
+    """
+    return os.getenv("CH_CLUSTER_NAME") or "cluster"
+
+
 def sanitize_sql_value(value: str) -> str:
     """
     Sanitize and escape a string value to make it safe for SQL queries.
@@ -97,10 +108,39 @@ def sanitize_keys(keys: list[str]) -> list[str]:
 
 
 class ClickHouseVectorDB:
+    # Process-level cache: each Django/Celery process sees one CH cluster shape
+    # for its lifetime, so the probe can run once per process and re-use the
+    # answer across every instance.
+    _is_clustered_cached: bool | None = None
+
     def __init__(
         self,
     ):
         self.client = clickhouse_driver.Client(**get_clickhouse_client_kwargs())
+
+    def _is_clustered(self) -> bool:
+        """True iff CH has a genuinely multi-replica cluster; fails safe to False.
+
+        Checking `system.macros` for the `replica` macro was too lenient: a
+        single-node dev CH set up via Helm / docker-compose can have the macro
+        too (it's a 1-replica cluster with the macro pre-baked). Such a node
+        has no DDLWorker, so any `ON CLUSTER ...` query fails at runtime.
+
+        Using `system.clusters.replica_num` is the precise check: prod multi-
+        replica clusters have rows with `replica_num > 1`; a single-node
+        cluster only has `replica_num = 1`.
+        """
+        if ClickHouseVectorDB._is_clustered_cached is not None:
+            return ClickHouseVectorDB._is_clustered_cached
+        try:
+            rows = self.client.execute(
+                "SELECT count() FROM system.clusters WHERE replica_num > 1"
+            )
+            ClickHouseVectorDB._is_clustered_cached = bool(rows and rows[0][0])
+        except Exception:
+            logger.warning("ch_vector_cluster_detect_failed", exc_info=True)
+            ClickHouseVectorDB._is_clustered_cached = False
+        return ClickHouseVectorDB._is_clustered_cached
 
     def drop_table(self,table_name: str) -> None:
         """
@@ -115,12 +155,49 @@ class ClickHouseVectorDB:
         elapsed_time = (end_time - start_time).total_seconds()
         logger.info(f"create query took {elapsed_time:.2f} seconds to execute")
 
-    def create_table(self, table_name: str) -> None:
+    def create_table(
+        self,
+        table_name: str,
+        *,
+        cluster: str | None = None,
+        database: str | None = None,
+    ) -> None:
+        """Create a vector table. Replicated engine on clustered CH, plain otherwise.
+
+        `cluster` overrides the deployment-wide default returned by
+        `get_clickhouse_cluster_name()`. Migration paths pass it explicitly;
+        runtime callers (EmbeddingManager) use the env-driven default.
+
+        `database` qualifies the CREATE TABLE target and the Keeper path.
+        When unset the table lands in the connection's current database
+        (`CH_DATABASE`); passing it explicitly is the only way to create the
+        table in a different database on the same connection — the
+        `clickhouse-driver` HELLO-time database setting cannot be rebound by
+        mutating the connection attribute. Including the database in the
+        Keeper path matches the deployment-wide
+        `<default_replica_path>/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>`
+        convention so two replicated tables with the same short name in
+        different databases do not coordinate on the same znode.
         """
-        Creates a table in ClickHouse if it does not already exist.
-        """
+        clustered = self._is_clustered()
+        cluster_name = cluster or get_clickhouse_cluster_name()
+        qualified = f"{database}.{table_name}" if database else table_name
+        zk_database_segment = f"{database}/" if database else ""
+
+        if clustered:
+            engine = (
+                f"ReplicatedReplacingMergeTree("
+                f"'/clickhouse/tables/{{shard}}/{zk_database_segment}{table_name}', "
+                f"'{{replica}}'"
+                f")"
+            )
+            on_cluster = f" ON CLUSTER '{cluster_name}'"
+        else:
+            engine = "ReplacingMergeTree()"
+            on_cluster = ""
+
         create_table_query = f"""
-        CREATE TABLE IF NOT EXISTS {table_name} (
+        CREATE TABLE IF NOT EXISTS {qualified}{on_cluster} (
             id UUID,
             eval_id UUID,
             vector Array(Float32),
@@ -129,7 +206,7 @@ class ClickHouseVectorDB:
                 value Nullable(String)
             ),
             deleted UInt8 DEFAULT 0
-        ) ENGINE = MergeTree()
+        ) ENGINE = {engine}
         ORDER BY id
         """
         start_time = datetime.now()
@@ -140,7 +217,13 @@ class ClickHouseVectorDB:
         )
         end_time = datetime.now()
         elapsed_time = (end_time - start_time).total_seconds()
-        logger.info(f"create query took {elapsed_time:.2f} seconds to execute")
+        logger.info(
+            "ch_vector_create_table_done",
+            table=qualified,
+            engine="ReplicatedReplacingMergeTree" if clustered else "ReplacingMergeTree",
+            cluster=cluster_name if clustered else None,
+            elapsed_sec=round(elapsed_time, 3),
+        )
 
     def get_or_create_collection(self, table_name: str) -> None:
         """
@@ -173,7 +256,6 @@ class ClickHouseVectorDB:
         Returns the ID of the newly inserted or updated entry.
         """
         new_id = str(uuid.uuid4())
-        # print( "metadata" ,metadata)
         metadata = sanitize_metadata(metadata)
         unique_keys = sanitize_keys(unique_keys)
         if exclude_keys:
@@ -443,13 +525,8 @@ class ClickHouseVectorDB:
         results = None
         # Execute the query
         try:
-
             results = self.client.execute(query)
-            # print("Executing success query:", query)
         except Exception:
-            #print traceback
-            # print("Executing broken query:", query)
-            # print("len of q vector:", len(query_vector))
             import traceback
             traceback.print_exc()
         end_time = datetime.now()

--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -249,125 +249,18 @@ class ModelHubConfig(AppConfig):
         for vector_db in vector_dbs:
             db_client.create_table(vector_db)
 
+        from model_hub.services.legacy_ch_tables import (
+            ensure_events_table,
+            ensure_llm_logs_table,
+        )
         from tfc.utils.clickhouse import ClickHouseClientSingleton
 
         ch_instance = ClickHouseClientSingleton()
 
-        # Example: Check if table exists
-        result = ch_instance.execute("SHOW TABLES FROM default")
-        tables = [row[0] for row in result]
-
-        if "events" in tables:
-            # Check if original_uuid column exists
-            columns = ch_instance.execute("DESCRIBE TABLE events")
-            column_names = [col[0] for col in columns]
-
-            if "original_uuid" not in column_names:
-                # Add the original_uuid column
-                ch_instance.execute(
-                    """
-                    ALTER TABLE events
-                    ADD COLUMN IF NOT EXISTS original_uuid UUID DEFAULT UUID
-                    """
-                )
-
-        if "events" not in tables:
-            # Create the table with original_uuid included
-            ch_instance.execute(
-                """
-                CREATE TABLE IF NOT EXISTS events (
-                    UUID UUID,
-                    original_uuid UUID DEFAULT UUID,
-                    EventDate Date,
-                    EventDateTime DateTime,
-                    EventName String,
-                    EventType String,
-                    AIModel String DEFAULT '',
-                    OrgID String,
-                    PredictionID String DEFAULT '',
-                    ModelVersion String DEFAULT '',
-                    BatchID String DEFAULT '',
-                    Environment UInt8 DEFAULT 0,
-                    Properties Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Features Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    ActualLabel Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    PredictionLabel Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    EvalResults Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    ShapValues Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Tags Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Embedding Array(Float32) DEFAULT [],
-                    deleted UInt8 DEFAULT 0
-
-                ) ENGINE = MergeTree()
-                PARTITION BY toYYYYMM(EventDate)
-                ORDER BY (EventDate, EventName, OrgID, UUID);
-            """
-            )
-
-        if "llm_logs" not in tables:
-            ch_instance.execute(
-                """
-            CREATE TABLE IF NOT EXISTS llm_logs
-            (
-                `EventDateTime` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-                `EventDate` Date,
-                `TraceId` String CODEC(ZSTD(1)),
-                `SpanId` String CODEC(ZSTD(1)),
-                `SeverityText` LowCardinality(String) CODEC(ZSTD(1)),
-                `SeverityNumber` Int32 CODEC(ZSTD(1)),
-                `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
-                `LLMModelName` LowCardinality(String) CODEC(ZSTD(1)), -- Name of the LLM model used
-                `UserId` String CODEC(ZSTD(1)), -- User identifier
-                `SessionId` String CODEC(ZSTD(1)), -- Session identifier
-                `RequestBody` String CODEC(ZSTD(1)), -- Request sent to the LLM
-                `ResponseBody` String CODEC(ZSTD(1)), -- Response received from the LLM
-                `RequestTokens` Int32 CODEC(ZSTD(1)), -- Number of tokens in the request
-                `ResponseTokens` Int32 CODEC(ZSTD(1)), -- Number of tokens in the response
-                `ResponseTime` Float32 CODEC(ZSTD(1)), -- Time taken to get the response
-                `LogAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)), -- Additional log attributes
-                `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-                INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_llm_model_name LLMModelName TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_user_id UserId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_session_id SessionId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_request_body RequestBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
-                INDEX idx_response_body ResponseBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
-            )
-            ENGINE = MergeTree
-            PARTITION BY EventDate
-            ORDER BY (LLMModelName, EventDateTime)
-            SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-
-            """
-            )
+        # Idempotent CREATE TABLE IF NOT EXISTS, replicated on a multi-replica
+        # cluster. Targets the connection's current database (CH_DATABASE).
+        ensure_events_table(ch_instance)
+        ensure_llm_logs_table(ch_instance)
 
 
 ##################################################

--- a/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
+++ b/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
@@ -1,0 +1,518 @@
+"""Copy the non-vector ClickHouse tables that live in a legacy non-replicated
+location (``cluster_centroids``, ``trace_input_embeddings``, ``error_embeddings``,
+``llm_logs``, ``events``) into a replicated target database.
+
+Sibling of ``migrate_legacy_vectors_to_replicated``: same shape (read every
+replica via ``clusterAllReplicas``, create the target with the replicated
+engine, poll per-replica parity), but each table here has its own schema and
+dedup key, so the copy is driven by a per-table spec instead of a fixed
+``WHERE id NOT IN`` clause.
+
+Dedup keys
+----------
+* ``trace_input_embeddings`` -> ``(project_id, trace_id)``
+* ``error_embeddings``       -> ``id``
+* ``cluster_centroids``      -> ``cluster_id``
+* ``llm_logs`` / ``events``  -> append-only logs with no unique key. The copy is
+  one-shot: it runs only when the target is confirmed empty on EVERY replica and
+  refuses otherwise, because a second pass would duplicate every row (no key to
+  dedup on).
+
+Safety invariants
+-----------------
+* Replica awareness: the target row count and parity checks require every
+  expected replica (``system.clusters``) to be present in the
+  ``clusterAllReplicas ... GROUP BY hostName()`` result. A replica that is
+  missing (still registering) or behind is treated as not-yet-converged, never
+  as "empty" or "done".
+* Name-aligned copy: rows are copied with an explicit shared column list, not
+  ``SELECT *``. A legacy source whose column order/set has drifted from the
+  canonical target schema is copied by column name (target-only columns fall
+  back to their DEFAULT); it never silently misaligns by position.
+* Failure propagation: a table that cannot reach per-replica parity fails the
+  whole command with a non-zero exit, so an exit-code-gated cutover cannot flip
+  before the replicated copies have converged.
+
+Idempotent for the keyed tables; one-shot (guarded) for the log tables. Run from
+a backend pod that connects to the production CH cluster.
+"""
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import structlog
+from django.core.management.base import BaseCommand, CommandError
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    get_clickhouse_cluster_name,
+)
+from model_hub.services.legacy_ch_tables import (
+    EVENTS_TABLE,
+    LLM_LOGS_TABLE,
+    ensure_events_table,
+    ensure_llm_logs_table,
+)
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    ERROR_EMBEDDINGS_TABLE,
+    TRACE_INPUTS_TABLE,
+    ensure_centroid_table,
+    ensure_error_embeddings_table,
+    ensure_trace_inputs_table,
+)
+
+logger = structlog.get_logger(__name__)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class _LegacyTable:
+    """How to recreate and back-fill one legacy ``default.*`` table.
+
+    ``dedup_columns`` is the comma-separated key used for the idempotent
+    ``NOT IN`` anti-join; ``None`` marks an append-only log with no unique key
+    (copied one-shot into a confirmed-empty target only). ``pass_vectordb`` says
+    whether the ensure helper takes a ``ClickHouseVectorDB`` (the clustering
+    tables) or a raw client (the model-hub log tables).
+    """
+
+    name: str
+    dedup_columns: str | None
+    _ensure: Callable
+    pass_vectordb: bool
+
+    def ensure_target(
+        self, db: ClickHouseVectorDB, target_db: str, cluster: str
+    ) -> None:
+        client_arg = db if self.pass_vectordb else db.client
+        self._ensure(client_arg, database=target_db, cluster=cluster)
+
+    @property
+    def is_keyed(self) -> bool:
+        return self.dedup_columns is not None
+
+
+_TABLES: dict[str, _LegacyTable] = {
+    t.name: t
+    for t in (
+        _LegacyTable(
+            TRACE_INPUTS_TABLE, "project_id, trace_id", ensure_trace_inputs_table, True
+        ),
+        _LegacyTable(ERROR_EMBEDDINGS_TABLE, "id", ensure_error_embeddings_table, True),
+        _LegacyTable(CENTROIDS_TABLE, "cluster_id", ensure_centroid_table, True),
+        _LegacyTable(LLM_LOGS_TABLE, None, ensure_llm_logs_table, False),
+        _LegacyTable(EVENTS_TABLE, None, ensure_events_table, False),
+    )
+}
+
+
+def _require_identifier(value: str, flag: str) -> str:
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise CommandError(
+            f"{flag} {value!r} is not a valid ClickHouse identifier. "
+            "Allowed: letters, digits, underscores; must not start with a digit."
+        )
+    return value
+
+
+class Command(BaseCommand):
+    help = (
+        "Migrate the legacy non-replicated default-database CH tables "
+        "(cluster_centroids, trace_input_embeddings, error_embeddings, "
+        "llm_logs, events) into a replicated target database."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source-database",
+            default=os.getenv("CH_DATABASE") or "default",
+        )
+        parser.add_argument("--target-database", default=None)
+        parser.add_argument(
+            "--tables",
+            default=",".join(_TABLES),
+            help=f"Comma-separated subset of {', '.join(_TABLES)}.",
+        )
+        parser.add_argument("--cluster", default=get_clickhouse_cluster_name())
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **opts):
+        source_db = _require_identifier(opts["source_database"], "--source-database")
+        target_db = _require_identifier(
+            opts["target_database"] or source_db, "--target-database"
+        )
+        cluster = _require_identifier(opts["cluster"], "--cluster")
+        dry_run = opts["dry_run"]
+        table_names = [t.strip() for t in opts["tables"].split(",") if t.strip()]
+
+        unknown = [t for t in table_names if t not in _TABLES]
+        if unknown:
+            raise CommandError(
+                f"--tables contains unknown entries {unknown}. "
+                f"Allowed: {', '.join(_TABLES)}."
+            )
+
+        if source_db == target_db:
+            raise CommandError(
+                f"--source-database and --target-database must differ ({source_db!r})."
+            )
+
+        db_client = ClickHouseVectorDB()
+        if not dry_run and not db_client._is_clustered():
+            raise CommandError(
+                "CH server is not a multi-replica cluster member "
+                "(no row in `system.clusters` with `replica_num > 1`). "
+                "Run from a backend pod that connects to the production CH cluster."
+            )
+
+        expected_replicas = 0 if dry_run else self._expected_replica_count(
+            db_client, cluster
+        )
+
+        if not dry_run:
+            db_client.client.execute(
+                f"CREATE DATABASE IF NOT EXISTS {target_db} ON CLUSTER '{cluster}'"
+            )
+
+        logger.info(
+            "migrate_legacy_default_tables_started",
+            source_database=source_db,
+            target_database=target_db,
+            tables=table_names,
+            cluster=cluster,
+            expected_replicas=expected_replicas,
+            dry_run=dry_run,
+        )
+
+        total_copied = 0
+        failures: list[str] = []
+        for name in table_names:
+            copied, ok = self._migrate_one_table(
+                db_client=db_client,
+                spec=_TABLES[name],
+                source_db=source_db,
+                target_db=target_db,
+                cluster=cluster,
+                expected_replicas=expected_replicas,
+                dry_run=dry_run,
+            )
+            total_copied += copied
+            if not ok:
+                failures.append(name)
+
+        logger.info(
+            "migrate_legacy_default_tables_complete",
+            tables=table_names,
+            total_rows_copied=total_copied,
+            failures=failures,
+            dry_run=dry_run,
+        )
+        if failures:
+            # Non-zero exit so an exit-code-gated cutover can't flip CH_DATABASE
+            # before every replicated copy has converged.
+            raise CommandError(
+                f"Migration did not fully converge for {failures}. "
+                f"Do NOT flip CH_DATABASE. Inspect per-table logs; re-run once "
+                f"lagging replicas catch up (keyed tables are idempotent)."
+            )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Tables processed: {table_names}. "
+                f"Total rows copied: {total_copied}."
+            )
+        )
+
+    def _migrate_one_table(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        spec: _LegacyTable,
+        source_db: str,
+        target_db: str,
+        cluster: str,
+        expected_replicas: int,
+        dry_run: bool,
+    ) -> tuple[int, bool]:
+        """Return ``(rows_copied, converged_ok)``."""
+        source_qualified = f"{source_db}.{spec.name}"
+        target_qualified = f"{target_db}.{spec.name}"
+
+        source_exists = db_client.client.execute(
+            "SELECT count() FROM system.tables "
+            "WHERE database = %(db)s AND name = %(t)s",
+            {"db": source_db, "t": spec.name},
+        )[0][0]
+
+        # uniqExact over the dedup key for keyed tables; row count for the
+        # append-only log tables.
+        count_expr = f"uniqExact({spec.dedup_columns})" if spec.is_keyed else "count()"
+
+        if dry_run:
+            if not source_exists:
+                self.stdout.write(
+                    f"  dry-run: source {source_qualified} missing; "
+                    f"would create empty target {target_qualified}"
+                )
+                return 0, True
+            source_count = db_client.client.execute(
+                f"SELECT {count_expr} FROM clusterAllReplicas("
+                f"'{cluster}', {source_qualified})"
+            )[0][0]
+            mode = "idempotent" if spec.is_keyed else "one-shot (target must be empty)"
+            self.stdout.write(
+                f"  dry-run: would copy {source_count} rows from "
+                f"{source_qualified} -> {target_qualified} [{mode}]"
+            )
+            return 0, True
+
+        spec.ensure_target(db_client, target_db, cluster)
+
+        if not source_exists:
+            logger.info(
+                "migrate_target_created_source_missing",
+                source=source_qualified,
+                target=target_qualified,
+            )
+            self.stdout.write(
+                f"  {spec.name}: target ready; source {source_qualified} "
+                f"missing, nothing to copy"
+            )
+            return 0, True
+
+        source_count = db_client.client.execute(
+            f"SELECT {count_expr} FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified})"
+        )[0][0]
+
+        before_counts = self._per_replica_counts(
+            db_client, target_db, spec.name, cluster
+        )
+
+        if not spec.is_keyed:
+            # Append-only log with no dedup key. Three outcomes, decided by the
+            # FULL replica set (a replica missing from the result, or holding a
+            # different count, is never treated as "empty" or "done"):
+            #   - empty on every replica            -> safe to copy
+            #   - already >= source on every replica -> already migrated, no-op ok
+            #   - anything else (partial / diverged) -> refuse; re-copy would
+            #     duplicate the keyless log, so this needs a manual TRUNCATE.
+            # (min() across replicas would let one empty/lagging replica wave the
+            # copy through and duplicate the whole log.)
+            complete = len(before_counts) == expected_replicas
+            empty_everywhere = complete and all(
+                c == 0 for c in before_counts.values()
+            )
+            already_done = (
+                complete
+                and source_count > 0
+                and all(c >= source_count for c in before_counts.values())
+            )
+            if already_done:
+                self.stdout.write(
+                    f"  {spec.name}: already populated and converged on all "
+                    f"{expected_replicas} replicas ({before_counts}); one-shot no-op."
+                )
+                return 0, True
+            if not empty_everywhere:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  {spec.name}: append-only table is not confirmed empty on "
+                        f"all {expected_replicas} replicas (per-replica {before_counts}); "
+                        f"refusing to stay non-duplicating. TRUNCATE TABLE "
+                        f"{target_qualified} ON CLUSTER '{cluster}' and re-run to force "
+                        f"a fresh copy once every replica is up."
+                    )
+                )
+                logger.warning(
+                    "migrate_oneshot_target_not_confirmed_empty",
+                    target=target_qualified,
+                    expected_replicas=expected_replicas,
+                    per_replica_counts=before_counts,
+                )
+                return 0, False
+
+        existing_target_count = min(before_counts.values(), default=0)
+
+        # Name-aligned copy: explicit shared column list, never SELECT *. Guards
+        # against a drifted legacy source (column order/set) silently misaligning
+        # by position; target-only columns fall back to their DEFAULT.
+        shared_cols, source_only = self._shared_columns(
+            db_client, source_db, target_db, spec.name
+        )
+        if not shared_cols:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  {spec.name}: no shared columns between {source_qualified} and "
+                    f"{target_qualified}; refusing to copy."
+                )
+            )
+            return 0, False
+        if source_only:
+            logger.warning(
+                "migrate_source_only_columns_dropped",
+                table=spec.name,
+                source_only_columns=source_only,
+            )
+        col_list = ", ".join(f"`{c}`" for c in shared_cols)
+
+        where = ""
+        if spec.is_keyed:
+            where = (
+                f" WHERE ({spec.dedup_columns}) NOT IN "
+                f"(SELECT {spec.dedup_columns} FROM {target_qualified})"
+            )
+
+        insert_started = time.monotonic()
+        db_client.client.execute(
+            f"INSERT INTO {target_qualified} ({col_list}) "
+            f"SELECT {col_list} FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified}){where}"
+        )
+        insert_elapsed = time.monotonic() - insert_started
+
+        per_replica_counts, converged = self._poll_replica_parity(
+            db_client=db_client,
+            target_db=target_db,
+            table=spec.name,
+            cluster=cluster,
+            expected=source_count,
+            expected_replicas=expected_replicas,
+        )
+        after_target_count = min(per_replica_counts.values(), default=0)
+        newly_copied = after_target_count - existing_target_count
+
+        logger.info(
+            "migrate_table_complete",
+            source=source_qualified,
+            target=target_qualified,
+            source_count=source_count,
+            target_count_before=existing_target_count,
+            per_replica_counts=per_replica_counts,
+            expected_replicas=expected_replicas,
+            newly_copied=newly_copied,
+            insert_elapsed_sec=round(insert_elapsed, 3),
+            converged=converged,
+        )
+        if not converged:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  {spec.name}: NOT converged — per-replica {per_replica_counts}, "
+                    f"expected {source_count} on each of {expected_replicas} replicas."
+                )
+            )
+        else:
+            self.stdout.write(
+                f"  {spec.name}: copied {newly_copied} rows; "
+                f"per-replica counts {per_replica_counts}"
+            )
+        return newly_copied, converged
+
+    def _expected_replica_count(
+        self, db_client: ClickHouseVectorDB, cluster: str
+    ) -> int:
+        """Number of hosts the cluster spans — the number of per-replica rows a
+        complete ``_per_replica_counts`` result must contain before it is trusted
+        (an incomplete result means a replica is still registering or is down).
+        """
+        rows = db_client.client.execute(
+            "SELECT count() FROM system.clusters WHERE cluster = %(c)s",
+            {"c": cluster},
+        )
+        return rows[0][0] if rows else 0
+
+    def _shared_columns(
+        self,
+        db_client: ClickHouseVectorDB,
+        source_db: str,
+        target_db: str,
+        table: str,
+    ) -> tuple[list[str], list[str]]:
+        """Columns present in BOTH source and target, in target order, plus the
+        list of source-only columns (dropped by the copy)."""
+        def cols(db: str) -> list[str]:
+            return [
+                r[0]
+                for r in db_client.client.execute(
+                    "SELECT name FROM system.columns "
+                    "WHERE database = %(d)s AND table = %(t)s ORDER BY position",
+                    {"d": db, "t": table},
+                )
+            ]
+        src = cols(source_db)
+        tgt = cols(target_db)
+        src_set, tgt_set = set(src), set(tgt)
+        shared = [c for c in tgt if c in src_set]
+        source_only = [c for c in src if c not in tgt_set]
+        return shared, source_only
+
+    def _per_replica_counts(
+        self,
+        db_client: ClickHouseVectorDB,
+        database: str,
+        table: str,
+        cluster: str,
+    ) -> dict[str, int]:
+        """Per-replica row count via ``system.tables.total_rows``.
+
+        Read through ``clusterAllReplicas(system.tables)`` rather than
+        ``count() ... GROUP BY hostName()``: the latter yields NO group for a
+        replica where the table is empty, so a freshly-created (all-empty) target
+        would read as "zero replicas" and mislead both the one-shot guard and the
+        parity check. ``system.tables`` has one row per replica that holds the
+        table — including the empty ones — and omits a replica that is missing
+        the table entirely, which is exactly the signal we want.
+        """
+        rows = db_client.client.execute(
+            f"SELECT hostName(), total_rows FROM clusterAllReplicas("
+            f"'{cluster}', system.tables) "
+            f"WHERE database = %(d)s AND name = %(t)s",
+            {"d": database, "t": table},
+        )
+        return {host: int(cnt or 0) for host, cnt in rows}
+
+    def _poll_replica_parity(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        target_db: str,
+        table: str,
+        cluster: str,
+        expected: int,
+        expected_replicas: int,
+        max_wait_sec: float = 30.0,
+        poll_interval: float = 2.0,
+    ) -> tuple[dict[str, int], bool]:
+        """Poll until EVERY expected replica reports >= ``expected`` rows.
+
+        Returns ``(per_replica_counts, converged)``. Converged requires the full
+        set of replicas to be present AND each at/above the expected count — a
+        replica still registering (absent from the result) counts as not-yet.
+        """
+        deadline = time.monotonic() + max_wait_sec
+        counts: dict[str, int] = {}
+        while True:
+            counts = self._per_replica_counts(db_client, target_db, table, cluster)
+            converged = (
+                len(counts) >= expected_replicas
+                and bool(counts)
+                and all(c >= expected for c in counts.values())
+            )
+            if converged:
+                return counts, True
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "migrate_parity_wait_timed_out",
+                    target=f"{target_db}.{table}",
+                    expected=expected,
+                    expected_replicas=expected_replicas,
+                    per_replica_counts=counts,
+                    max_wait_sec=max_wait_sec,
+                )
+                return counts, False
+            time.sleep(poll_interval)

--- a/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
+++ b/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
@@ -39,7 +39,6 @@ a backend pod that connects to the production CH cluster.
 from __future__ import annotations
 
 import os
-import re
 import time
 from dataclasses import dataclass
 from typing import Callable
@@ -50,6 +49,13 @@ from django.core.management.base import BaseCommand, CommandError
 from agentic_eval.core.database.ch_vector import (
     ClickHouseVectorDB,
     get_clickhouse_cluster_name,
+)
+from model_hub.services.ch_migration import (
+    expected_replica_count,
+    per_replica_counts,
+    poll_replica_parity,
+    require_identifier,
+    shared_columns,
 )
 from model_hub.services.legacy_ch_tables import (
     EVENTS_TABLE,
@@ -67,8 +73,6 @@ from tracer.services.clickhouse.clustering_tables import (
 )
 
 logger = structlog.get_logger(__name__)
-
-_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass(frozen=True)
@@ -112,15 +116,6 @@ _TABLES: dict[str, _LegacyTable] = {
 }
 
 
-def _require_identifier(value: str, flag: str) -> str:
-    if not _IDENTIFIER_RE.fullmatch(value):
-        raise CommandError(
-            f"{flag} {value!r} is not a valid ClickHouse identifier. "
-            "Allowed: letters, digits, underscores; must not start with a digit."
-        )
-    return value
-
-
 class Command(BaseCommand):
     help = (
         "Migrate the legacy non-replicated default-database CH tables "
@@ -143,11 +138,11 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true")
 
     def handle(self, *args, **opts):
-        source_db = _require_identifier(opts["source_database"], "--source-database")
-        target_db = _require_identifier(
+        source_db = require_identifier(opts["source_database"], "--source-database")
+        target_db = require_identifier(
             opts["target_database"] or source_db, "--target-database"
         )
-        cluster = _require_identifier(opts["cluster"], "--cluster")
+        cluster = require_identifier(opts["cluster"], "--cluster")
         dry_run = opts["dry_run"]
         table_names = [t.strip() for t in opts["tables"].split(",") if t.strip()]
 
@@ -171,8 +166,8 @@ class Command(BaseCommand):
                 "Run from a backend pod that connects to the production CH cluster."
             )
 
-        expected_replicas = 0 if dry_run else self._expected_replica_count(
-            db_client, cluster
+        expected_replicas = (
+            0 if dry_run else expected_replica_count(db_client.client, cluster)
         )
 
         if not dry_run:
@@ -290,8 +285,8 @@ class Command(BaseCommand):
             f"'{cluster}', {source_qualified})"
         )[0][0]
 
-        before_counts = self._per_replica_counts(
-            db_client, target_db, spec.name, cluster
+        before_counts = per_replica_counts(
+            db_client.client, target_db, spec.name, cluster
         )
 
         if not spec.is_keyed:
@@ -342,8 +337,8 @@ class Command(BaseCommand):
         # Name-aligned copy: explicit shared column list, never SELECT *. Guards
         # against a drifted legacy source (column order/set) silently misaligning
         # by position; target-only columns fall back to their DEFAULT.
-        shared_cols, source_only = self._shared_columns(
-            db_client, source_db, target_db, spec.name
+        shared_cols, source_only = shared_columns(
+            db_client.client, source_db, target_db, spec.name
         )
         if not shared_cols:
             self.stderr.write(
@@ -376,15 +371,15 @@ class Command(BaseCommand):
         )
         insert_elapsed = time.monotonic() - insert_started
 
-        per_replica_counts, converged = self._poll_replica_parity(
-            db_client=db_client,
-            target_db=target_db,
+        replica_counts, converged = poll_replica_parity(
+            db_client.client,
+            database=target_db,
             table=spec.name,
             cluster=cluster,
             expected=source_count,
             expected_replicas=expected_replicas,
         )
-        after_target_count = min(per_replica_counts.values(), default=0)
+        after_target_count = min(replica_counts.values(), default=0)
         newly_copied = after_target_count - existing_target_count
 
         logger.info(
@@ -393,7 +388,7 @@ class Command(BaseCommand):
             target=target_qualified,
             source_count=source_count,
             target_count_before=existing_target_count,
-            per_replica_counts=per_replica_counts,
+            per_replica_counts=replica_counts,
             expected_replicas=expected_replicas,
             newly_copied=newly_copied,
             insert_elapsed_sec=round(insert_elapsed, 3),
@@ -402,117 +397,13 @@ class Command(BaseCommand):
         if not converged:
             self.stderr.write(
                 self.style.WARNING(
-                    f"  {spec.name}: NOT converged — per-replica {per_replica_counts}, "
+                    f"  {spec.name}: NOT converged: per-replica {replica_counts}, "
                     f"expected {source_count} on each of {expected_replicas} replicas."
                 )
             )
         else:
             self.stdout.write(
                 f"  {spec.name}: copied {newly_copied} rows; "
-                f"per-replica counts {per_replica_counts}"
+                f"per-replica counts {replica_counts}"
             )
         return newly_copied, converged
-
-    def _expected_replica_count(
-        self, db_client: ClickHouseVectorDB, cluster: str
-    ) -> int:
-        """Number of hosts the cluster spans — the number of per-replica rows a
-        complete ``_per_replica_counts`` result must contain before it is trusted
-        (an incomplete result means a replica is still registering or is down).
-        """
-        rows = db_client.client.execute(
-            "SELECT count() FROM system.clusters WHERE cluster = %(c)s",
-            {"c": cluster},
-        )
-        return rows[0][0] if rows else 0
-
-    def _shared_columns(
-        self,
-        db_client: ClickHouseVectorDB,
-        source_db: str,
-        target_db: str,
-        table: str,
-    ) -> tuple[list[str], list[str]]:
-        """Columns present in BOTH source and target, in target order, plus the
-        list of source-only columns (dropped by the copy)."""
-        def cols(db: str) -> list[str]:
-            return [
-                r[0]
-                for r in db_client.client.execute(
-                    "SELECT name FROM system.columns "
-                    "WHERE database = %(d)s AND table = %(t)s ORDER BY position",
-                    {"d": db, "t": table},
-                )
-            ]
-        src = cols(source_db)
-        tgt = cols(target_db)
-        src_set, tgt_set = set(src), set(tgt)
-        shared = [c for c in tgt if c in src_set]
-        source_only = [c for c in src if c not in tgt_set]
-        return shared, source_only
-
-    def _per_replica_counts(
-        self,
-        db_client: ClickHouseVectorDB,
-        database: str,
-        table: str,
-        cluster: str,
-    ) -> dict[str, int]:
-        """Per-replica row count via ``system.tables.total_rows``.
-
-        Read through ``clusterAllReplicas(system.tables)`` rather than
-        ``count() ... GROUP BY hostName()``: the latter yields NO group for a
-        replica where the table is empty, so a freshly-created (all-empty) target
-        would read as "zero replicas" and mislead both the one-shot guard and the
-        parity check. ``system.tables`` has one row per replica that holds the
-        table — including the empty ones — and omits a replica that is missing
-        the table entirely, which is exactly the signal we want.
-        """
-        rows = db_client.client.execute(
-            f"SELECT hostName(), total_rows FROM clusterAllReplicas("
-            f"'{cluster}', system.tables) "
-            f"WHERE database = %(d)s AND name = %(t)s",
-            {"d": database, "t": table},
-        )
-        return {host: int(cnt or 0) for host, cnt in rows}
-
-    def _poll_replica_parity(
-        self,
-        *,
-        db_client: ClickHouseVectorDB,
-        target_db: str,
-        table: str,
-        cluster: str,
-        expected: int,
-        expected_replicas: int,
-        max_wait_sec: float = 30.0,
-        poll_interval: float = 2.0,
-    ) -> tuple[dict[str, int], bool]:
-        """Poll until EVERY expected replica reports >= ``expected`` rows.
-
-        Returns ``(per_replica_counts, converged)``. Converged requires the full
-        set of replicas to be present AND each at/above the expected count — a
-        replica still registering (absent from the result) counts as not-yet.
-        """
-        deadline = time.monotonic() + max_wait_sec
-        counts: dict[str, int] = {}
-        while True:
-            counts = self._per_replica_counts(db_client, target_db, table, cluster)
-            converged = (
-                len(counts) >= expected_replicas
-                and bool(counts)
-                and all(c >= expected for c in counts.values())
-            )
-            if converged:
-                return counts, True
-            if time.monotonic() >= deadline:
-                logger.warning(
-                    "migrate_parity_wait_timed_out",
-                    target=f"{target_db}.{table}",
-                    expected=expected,
-                    expected_replicas=expected_replicas,
-                    per_replica_counts=counts,
-                    max_wait_sec=max_wait_sec,
-                )
-                return counts, False
-            time.sleep(poll_interval)

--- a/futureagi/model_hub/management/commands/migrate_legacy_vectors_to_replicated.py
+++ b/futureagi/model_hub/management/commands/migrate_legacy_vectors_to_replicated.py
@@ -5,12 +5,15 @@ Reads via ``clusterAllReplicas`` so every replica's slice is captured;
 writes via ``ClickHouseVectorDB.create_table`` so the engine auto-selects
 ``ReplicatedReplacingMergeTree`` ON CLUSTER on a multi-replica cluster.
 Idempotent: ``WHERE id NOT IN target`` makes re-runs a no-op.
+
+Parity, column-alignment, and failure-propagation semantics come from the
+shared ``model_hub.services.ch_migration`` module so both this command
+and its sibling default-tables migrator behave identically.
 """
 
 from __future__ import annotations
 
 import os
-import re
 import time
 
 import structlog
@@ -24,22 +27,23 @@ from agentic_eval.core.embeddings.embedding_manager import (
     FEEDBACK_TABLE_NAME,
     GROUND_TRUTH_TABLE_NAME,
 )
+from model_hub.services.ch_migration import (
+    expected_replica_count,
+    per_replica_counts,
+    poll_replica_parity,
+    require_identifier,
+    shared_columns,
+)
 from model_hub.utils.kb_indexer import KB_TABLE_NAME
 
 logger = structlog.get_logger(__name__)
 
 
 KNOWN_TABLES = (FEEDBACK_TABLE_NAME, GROUND_TRUTH_TABLE_NAME, KB_TABLE_NAME)
-_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-
-def _require_identifier(value: str, flag: str) -> str:
-    if not _IDENTIFIER_RE.fullmatch(value):
-        raise CommandError(
-            f"{flag} {value!r} is not a valid ClickHouse identifier. "
-            "Allowed: letters, digits, underscores; must not start with a digit."
-        )
-    return value
+# Vector-table dedup key. All three tables use `id UUID` as their
+# ReplacingMergeTree order-by, so the copy anti-joins on it.
+_DEDUP_COLUMN = "id"
 
 
 class Command(BaseCommand):
@@ -60,11 +64,11 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true")
 
     def handle(self, *args, **opts):
-        source_db = _require_identifier(opts["source_database"], "--source-database")
-        target_db = _require_identifier(
+        source_db = require_identifier(opts["source_database"], "--source-database")
+        target_db = require_identifier(
             opts["target_database"] or source_db, "--target-database"
         )
-        cluster = _require_identifier(opts["cluster"], "--cluster")
+        cluster = require_identifier(opts["cluster"], "--cluster")
         dry_run = opts["dry_run"]
         tables = [t.strip() for t in opts["tables"].split(",") if t.strip()]
 
@@ -88,6 +92,10 @@ class Command(BaseCommand):
                 "Run from a backend pod that connects to the production CH cluster."
             )
 
+        expected_replicas = (
+            0 if dry_run else expected_replica_count(db_client.client, cluster)
+        )
+
         if not dry_run:
             # Bootstrap the target DB on every replica before any CREATE TABLE.
             db_client.client.execute(
@@ -99,27 +107,42 @@ class Command(BaseCommand):
             source_database=source_db,
             target_database=target_db,
             tables=tables,
+            cluster=cluster,
+            expected_replicas=expected_replicas,
             dry_run=dry_run,
         )
 
         total_copied = 0
+        failures: list[str] = []
         for table in tables:
-            copied = self._migrate_one_table(
+            copied, ok = self._migrate_one_table(
                 db_client=db_client,
                 table=table,
                 source_db=source_db,
                 target_db=target_db,
                 cluster=cluster,
+                expected_replicas=expected_replicas,
                 dry_run=dry_run,
             )
             total_copied += copied
+            if not ok:
+                failures.append(table)
 
         logger.info(
             "migrate_legacy_vectors_to_replicated_complete",
             tables=tables,
             total_rows_copied=total_copied,
+            failures=failures,
             dry_run=dry_run,
         )
+        if failures:
+            # Non-zero exit so an exit-code-gated cutover can't flip
+            # CH_DATABASE before every replicated copy has converged.
+            raise CommandError(
+                f"Migration did not fully converge for {failures}. "
+                f"Do NOT flip CH_DATABASE. Inspect per-table logs; re-run once "
+                f"lagging replicas catch up (vector tables are idempotent)."
+            )
         self.stdout.write(
             self.style.SUCCESS(
                 f"Done. Tables processed: {tables}. "
@@ -135,8 +158,10 @@ class Command(BaseCommand):
         source_db: str,
         target_db: str,
         cluster: str,
+        expected_replicas: int,
         dry_run: bool,
-    ) -> int:
+    ) -> tuple[int, bool]:
+        """Return ``(rows_copied, converged_ok)``."""
         source_qualified = f"{source_db}.{table}"
         target_qualified = f"{target_db}.{table}"
 
@@ -152,9 +177,9 @@ class Command(BaseCommand):
                     f"  dry-run: source {source_qualified} missing; "
                     f"would create empty target {target_qualified}"
                 )
-                return 0
+                return 0, True
             source_count_row = db_client.client.execute(
-                f"SELECT uniqExact(id) FROM clusterAllReplicas("
+                f"SELECT uniqExact({_DEDUP_COLUMN}) FROM clusterAllReplicas("
                 f"'{cluster}', {source_qualified})"
             )
             source_distinct_count = source_count_row[0][0] if source_count_row else 0
@@ -162,7 +187,7 @@ class Command(BaseCommand):
                 f"  dry-run: would copy {source_distinct_count} rows from "
                 f"{source_qualified} -> {target_qualified}"
             )
-            return 0
+            return 0, True
 
         # Create target unconditionally; ground_truths may have no source yet.
         # Qualify the table explicitly with database= rather than mutating
@@ -180,45 +205,61 @@ class Command(BaseCommand):
                 f"  {table}: target ready; source {source_qualified} "
                 f"missing, nothing to copy"
             )
-            return 0
+            return 0, True
 
-        source_count_row = db_client.client.execute(
-            f"SELECT uniqExact(id) FROM clusterAllReplicas("
+        source_distinct_count = db_client.client.execute(
+            f"SELECT uniqExact({_DEDUP_COLUMN}) FROM clusterAllReplicas("
             f"'{cluster}', {source_qualified})"
-        )
-        source_distinct_count = source_count_row[0][0] if source_count_row else 0
+        )[0][0]
 
-        # Use clusterAllReplicas + min so a leader-only read can't mask a
-        # follower that's still behind from a previous half-completed run.
-        existing_target_rows = db_client.client.execute(
-            f"SELECT hostName(), count() FROM clusterAllReplicas("
-            f"'{cluster}', {target_qualified}) GROUP BY hostName()"
+        before_counts = per_replica_counts(
+            db_client.client, target_db, table, cluster
         )
-        existing_target_count = (
-            min(c for _, c in existing_target_rows) if existing_target_rows else 0
+        existing_target_count = min(before_counts.values(), default=0)
+
+        # Name-aligned copy: explicit shared column list, never SELECT *.
+        # Guards a drifted legacy source (column order/set) against silent
+        # positional misalignment; target-only columns fall back to DEFAULT.
+        shared_cols, source_only = shared_columns(
+            db_client.client, source_db, target_db, table
         )
+        if not shared_cols:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  {table}: no shared columns between {source_qualified} "
+                    f"and {target_qualified}; refusing to copy."
+                )
+            )
+            return 0, False
+        if source_only:
+            logger.warning(
+                "migrate_source_only_columns_dropped",
+                table=table,
+                source_only_columns=source_only,
+            )
+        col_list = ", ".join(f"`{c}`" for c in shared_cols)
 
         insert_started = time.monotonic()
         db_client.client.execute(
-            f"INSERT INTO {target_qualified} "
-            f"SELECT * FROM clusterAllReplicas("
+            f"INSERT INTO {target_qualified} ({col_list}) "
+            f"SELECT {col_list} FROM clusterAllReplicas("
             f"'{cluster}', {source_qualified}) "
-            f"WHERE id NOT IN (SELECT id FROM {target_qualified})"
+            f"WHERE {_DEDUP_COLUMN} NOT IN "
+            f"(SELECT {_DEDUP_COLUMN} FROM {target_qualified})"
         )
         insert_elapsed = time.monotonic() - insert_started
 
         # Keeper pull-down is async, so a fresh INSERT lags briefly on followers.
-        per_replica_counts = self._poll_replica_parity(
-            db_client=db_client,
-            target_qualified=target_qualified,
+        replica_counts, converged = poll_replica_parity(
+            db_client.client,
+            database=target_db,
+            table=table,
             cluster=cluster,
             expected=source_distinct_count,
+            expected_replicas=expected_replicas,
         )
-        after_target_count = min(per_replica_counts.values()) if per_replica_counts else 0
+        after_target_count = min(replica_counts.values(), default=0)
         newly_copied = after_target_count - existing_target_count
-        parity_ok = bool(per_replica_counts) and all(
-            c >= source_distinct_count for c in per_replica_counts.values()
-        )
 
         logger.info(
             "migrate_table_complete",
@@ -226,53 +267,23 @@ class Command(BaseCommand):
             target=target_qualified,
             source_distinct_count=source_distinct_count,
             target_count_before=existing_target_count,
-            per_replica_counts=per_replica_counts,
+            per_replica_counts=replica_counts,
+            expected_replicas=expected_replicas,
             newly_copied=newly_copied,
             insert_elapsed_sec=round(insert_elapsed, 3),
-            parity_ok=parity_ok,
+            converged=converged,
         )
-        if not parity_ok:
+        if not converged:
             self.stderr.write(
                 self.style.WARNING(
-                    f"  parity mismatch on {table}: per-replica counts "
-                    f"{per_replica_counts}, source distinct = {source_distinct_count}"
+                    f"  {table}: NOT converged: per-replica {replica_counts}, "
+                    f"expected {source_distinct_count} on each of "
+                    f"{expected_replicas} replicas."
                 )
             )
         else:
             self.stdout.write(
                 f"  {table}: copied {newly_copied} rows; "
-                f"per-replica counts {per_replica_counts}"
+                f"per-replica counts {replica_counts}"
             )
-        return newly_copied
-
-    def _poll_replica_parity(
-        self,
-        *,
-        db_client: ClickHouseVectorDB,
-        target_qualified: str,
-        cluster: str,
-        expected: int,
-        max_wait_sec: float = 30.0,
-        poll_interval: float = 2.0,
-    ) -> dict[str, int]:
-        """Return per-replica row counts, polling until every replica reaches expected."""
-        deadline = time.monotonic() + max_wait_sec
-        counts: dict[str, int] = {}
-        while True:
-            rows = db_client.client.execute(
-                f"SELECT hostName(), count() FROM clusterAllReplicas("
-                f"'{cluster}', {target_qualified}) GROUP BY hostName()"
-            )
-            counts = {host: cnt for host, cnt in rows}
-            if counts and all(c >= expected for c in counts.values()):
-                return counts
-            if time.monotonic() >= deadline:
-                logger.warning(
-                    "migrate_parity_wait_timed_out",
-                    target=target_qualified,
-                    expected=expected,
-                    per_replica_counts=counts,
-                    max_wait_sec=max_wait_sec,
-                )
-                return counts
-            time.sleep(poll_interval)
+        return newly_copied, converged

--- a/futureagi/model_hub/management/commands/migrate_legacy_vectors_to_replicated.py
+++ b/futureagi/model_hub/management/commands/migrate_legacy_vectors_to_replicated.py
@@ -1,0 +1,278 @@
+"""Copy vector tables (``feedbacks``, ``ground_truths``, ``syn``) from a
+legacy non-replicated location into a replicated target.
+
+Reads via ``clusterAllReplicas`` so every replica's slice is captured;
+writes via ``ClickHouseVectorDB.create_table`` so the engine auto-selects
+``ReplicatedReplacingMergeTree`` ON CLUSTER on a multi-replica cluster.
+Idempotent: ``WHERE id NOT IN target`` makes re-runs a no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+
+import structlog
+from django.core.management.base import BaseCommand, CommandError
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    get_clickhouse_cluster_name,
+)
+from agentic_eval.core.embeddings.embedding_manager import (
+    FEEDBACK_TABLE_NAME,
+    GROUND_TRUTH_TABLE_NAME,
+)
+from model_hub.utils.kb_indexer import KB_TABLE_NAME
+
+logger = structlog.get_logger(__name__)
+
+
+KNOWN_TABLES = (FEEDBACK_TABLE_NAME, GROUND_TRUTH_TABLE_NAME, KB_TABLE_NAME)
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _require_identifier(value: str, flag: str) -> str:
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise CommandError(
+            f"{flag} {value!r} is not a valid ClickHouse identifier. "
+            "Allowed: letters, digits, underscores; must not start with a digit."
+        )
+    return value
+
+
+class Command(BaseCommand):
+    help = "Migrate vector tables from a non-replicated source to a replicated target."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source-database",
+            default=os.getenv("CH_DATABASE") or "default",
+        )
+        parser.add_argument("--target-database", default=None)
+        parser.add_argument(
+            "--tables",
+            default=",".join(KNOWN_TABLES),
+            help=f"Comma-separated subset of {', '.join(KNOWN_TABLES)}.",
+        )
+        parser.add_argument("--cluster", default=get_clickhouse_cluster_name())
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **opts):
+        source_db = _require_identifier(opts["source_database"], "--source-database")
+        target_db = _require_identifier(
+            opts["target_database"] or source_db, "--target-database"
+        )
+        cluster = _require_identifier(opts["cluster"], "--cluster")
+        dry_run = opts["dry_run"]
+        tables = [t.strip() for t in opts["tables"].split(",") if t.strip()]
+
+        unknown = [t for t in tables if t not in KNOWN_TABLES]
+        if unknown:
+            raise CommandError(
+                f"--tables contains unknown entries {unknown}. "
+                f"Allowed: {', '.join(KNOWN_TABLES)}."
+            )
+
+        if source_db == target_db:
+            raise CommandError(
+                f"--source-database and --target-database must differ ({source_db!r})."
+            )
+
+        db_client = ClickHouseVectorDB()
+        if not dry_run and not db_client._is_clustered():
+            raise CommandError(
+                "CH server is not a multi-replica cluster member "
+                "(no row in `system.clusters` with `replica_num > 1`). "
+                "Run from a backend pod that connects to the production CH cluster."
+            )
+
+        if not dry_run:
+            # Bootstrap the target DB on every replica before any CREATE TABLE.
+            db_client.client.execute(
+                f"CREATE DATABASE IF NOT EXISTS {target_db} ON CLUSTER '{cluster}'"
+            )
+
+        logger.info(
+            "migrate_legacy_vectors_to_replicated_started",
+            source_database=source_db,
+            target_database=target_db,
+            tables=tables,
+            dry_run=dry_run,
+        )
+
+        total_copied = 0
+        for table in tables:
+            copied = self._migrate_one_table(
+                db_client=db_client,
+                table=table,
+                source_db=source_db,
+                target_db=target_db,
+                cluster=cluster,
+                dry_run=dry_run,
+            )
+            total_copied += copied
+
+        logger.info(
+            "migrate_legacy_vectors_to_replicated_complete",
+            tables=tables,
+            total_rows_copied=total_copied,
+            dry_run=dry_run,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Tables processed: {tables}. "
+                f"Total rows copied: {total_copied}."
+            )
+        )
+
+    def _migrate_one_table(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        table: str,
+        source_db: str,
+        target_db: str,
+        cluster: str,
+        dry_run: bool,
+    ) -> int:
+        source_qualified = f"{source_db}.{table}"
+        target_qualified = f"{target_db}.{table}"
+
+        source_exists = db_client.client.execute(
+            "SELECT count() FROM system.tables "
+            "WHERE database = %(db)s AND name = %(t)s",
+            {"db": source_db, "t": table},
+        )[0][0]
+
+        if dry_run:
+            if not source_exists:
+                self.stdout.write(
+                    f"  dry-run: source {source_qualified} missing; "
+                    f"would create empty target {target_qualified}"
+                )
+                return 0
+            source_count_row = db_client.client.execute(
+                f"SELECT uniqExact(id) FROM clusterAllReplicas("
+                f"'{cluster}', {source_qualified})"
+            )
+            source_distinct_count = source_count_row[0][0] if source_count_row else 0
+            self.stdout.write(
+                f"  dry-run: would copy {source_distinct_count} rows from "
+                f"{source_qualified} -> {target_qualified}"
+            )
+            return 0
+
+        # Create target unconditionally; ground_truths may have no source yet.
+        # Qualify the table explicitly with database= rather than mutating
+        # connection.database (which is HELLO-time only and would otherwise
+        # silently land the table in the connection's original database).
+        db_client.create_table(table, cluster=cluster, database=target_db)
+
+        if not source_exists:
+            logger.info(
+                "migrate_target_created_source_missing",
+                source=source_qualified,
+                target=target_qualified,
+            )
+            self.stdout.write(
+                f"  {table}: target ready; source {source_qualified} "
+                f"missing, nothing to copy"
+            )
+            return 0
+
+        source_count_row = db_client.client.execute(
+            f"SELECT uniqExact(id) FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified})"
+        )
+        source_distinct_count = source_count_row[0][0] if source_count_row else 0
+
+        # Use clusterAllReplicas + min so a leader-only read can't mask a
+        # follower that's still behind from a previous half-completed run.
+        existing_target_rows = db_client.client.execute(
+            f"SELECT hostName(), count() FROM clusterAllReplicas("
+            f"'{cluster}', {target_qualified}) GROUP BY hostName()"
+        )
+        existing_target_count = (
+            min(c for _, c in existing_target_rows) if existing_target_rows else 0
+        )
+
+        insert_started = time.monotonic()
+        db_client.client.execute(
+            f"INSERT INTO {target_qualified} "
+            f"SELECT * FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified}) "
+            f"WHERE id NOT IN (SELECT id FROM {target_qualified})"
+        )
+        insert_elapsed = time.monotonic() - insert_started
+
+        # Keeper pull-down is async, so a fresh INSERT lags briefly on followers.
+        per_replica_counts = self._poll_replica_parity(
+            db_client=db_client,
+            target_qualified=target_qualified,
+            cluster=cluster,
+            expected=source_distinct_count,
+        )
+        after_target_count = min(per_replica_counts.values()) if per_replica_counts else 0
+        newly_copied = after_target_count - existing_target_count
+        parity_ok = bool(per_replica_counts) and all(
+            c >= source_distinct_count for c in per_replica_counts.values()
+        )
+
+        logger.info(
+            "migrate_table_complete",
+            source=source_qualified,
+            target=target_qualified,
+            source_distinct_count=source_distinct_count,
+            target_count_before=existing_target_count,
+            per_replica_counts=per_replica_counts,
+            newly_copied=newly_copied,
+            insert_elapsed_sec=round(insert_elapsed, 3),
+            parity_ok=parity_ok,
+        )
+        if not parity_ok:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  parity mismatch on {table}: per-replica counts "
+                    f"{per_replica_counts}, source distinct = {source_distinct_count}"
+                )
+            )
+        else:
+            self.stdout.write(
+                f"  {table}: copied {newly_copied} rows; "
+                f"per-replica counts {per_replica_counts}"
+            )
+        return newly_copied
+
+    def _poll_replica_parity(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        target_qualified: str,
+        cluster: str,
+        expected: int,
+        max_wait_sec: float = 30.0,
+        poll_interval: float = 2.0,
+    ) -> dict[str, int]:
+        """Return per-replica row counts, polling until every replica reaches expected."""
+        deadline = time.monotonic() + max_wait_sec
+        counts: dict[str, int] = {}
+        while True:
+            rows = db_client.client.execute(
+                f"SELECT hostName(), count() FROM clusterAllReplicas("
+                f"'{cluster}', {target_qualified}) GROUP BY hostName()"
+            )
+            counts = {host: cnt for host, cnt in rows}
+            if counts and all(c >= expected for c in counts.values()):
+                return counts
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "migrate_parity_wait_timed_out",
+                    target=target_qualified,
+                    expected=expected,
+                    per_replica_counts=counts,
+                    max_wait_sec=max_wait_sec,
+                )
+                return counts
+            time.sleep(poll_interval)

--- a/futureagi/model_hub/services/ch_migration.py
+++ b/futureagi/model_hub/services/ch_migration.py
@@ -1,13 +1,4 @@
-"""Shared utilities for the legacy-to-replicated ClickHouse migration commands.
-
-Both ``migrate_legacy_vectors_to_replicated`` and
-``migrate_legacy_default_tables_to_replicated`` need the same primitives:
-identifier validation, per-replica row counts read through
-``clusterAllReplicas(system.tables)`` (so empty replicas are still counted),
-a topology-aware convergence poll, and a source/target column intersection
-for name-aligned copies. This module owns the single implementation each
-command imports.
-"""
+"""Shared parity helpers for the legacy-to-replicated ClickHouse migration commands."""
 from __future__ import annotations
 
 import re
@@ -32,12 +23,7 @@ def require_identifier(value: str, flag: str) -> str:
 
 
 def expected_replica_count(client, cluster: str) -> int:
-    """Number of hosts the cluster spans.
-
-    Used to gate ``per_replica_counts`` results: a complete parity check
-    must return one row per expected replica, else a still-registering or
-    down replica silently reads as ``converged``.
-    """
+    """Number of hosts the cluster spans; used to gate the parity result."""
     rows = client.execute(
         "SELECT count() FROM system.clusters WHERE cluster = %(c)s",
         {"c": cluster},
@@ -53,14 +39,9 @@ def per_replica_counts(
 ) -> dict[str, int]:
     """Per-replica row count via ``system.tables.total_rows``.
 
-    Reads through ``clusterAllReplicas(system.tables)`` rather than
-    ``count() ... GROUP BY hostName()`` on the target table itself: the
-    latter drops any replica whose local copy is empty, so a freshly
-    created (all-empty) target reads as "zero replicas present" and a
-    still-lagging follower disappears from the result entirely. Reading
-    ``system.tables`` yields one row per replica that holds the table,
-    including the empty ones, which is exactly the signal the parity
-    gate needs.
+    Reads ``system.tables`` (one row per replica that holds the table,
+    including empty ones) rather than ``count() GROUP BY hostName()`` on
+    the target itself; the latter drops empty replicas from the result.
     """
     rows = client.execute(
         f"SELECT hostName(), total_rows FROM clusterAllReplicas("
@@ -84,10 +65,8 @@ def poll_replica_parity(
 ) -> tuple[dict[str, int], bool]:
     """Poll until every expected replica reports ``>= expected`` rows.
 
-    Convergence requires the full replica set to be present in the
-    ``per_replica_counts`` result AND each entry to be at or above the
-    expected count. A replica still registering (absent from the result)
-    counts as not-yet-converged, never as ``done``.
+    Convergence requires ``len(counts) >= expected_replicas`` AND each
+    entry ``>= expected``: an absent replica counts as not-yet-converged.
     """
     deadline = time.monotonic() + max_wait_sec
     counts: dict[str, int] = {}
@@ -119,13 +98,7 @@ def shared_columns(
     target_db: str,
     table: str,
 ) -> tuple[list[str], list[str]]:
-    """Columns present in both source and target, in target order.
-
-    Returns ``(shared, source_only)``. Callers use ``shared`` to build an
-    explicit column list for the copy (name-aligned, not
-    positional-``SELECT *``) and log ``source_only`` for visibility when
-    the legacy source has drifted columns that the target doesn't carry.
-    """
+    """Return ``(shared_in_target_order, source_only)`` for a name-aligned copy."""
     def cols(db: str) -> list[str]:
         return [
             r[0]

--- a/futureagi/model_hub/services/ch_migration.py
+++ b/futureagi/model_hub/services/ch_migration.py
@@ -1,0 +1,143 @@
+"""Shared utilities for the legacy-to-replicated ClickHouse migration commands.
+
+Both ``migrate_legacy_vectors_to_replicated`` and
+``migrate_legacy_default_tables_to_replicated`` need the same primitives:
+identifier validation, per-replica row counts read through
+``clusterAllReplicas(system.tables)`` (so empty replicas are still counted),
+a topology-aware convergence poll, and a source/target column intersection
+for name-aligned copies. This module owns the single implementation each
+command imports.
+"""
+from __future__ import annotations
+
+import re
+import time
+
+import structlog
+from django.core.management.base import CommandError
+
+logger = structlog.get_logger(__name__)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def require_identifier(value: str, flag: str) -> str:
+    """Reject anything that could smuggle SQL through a CLI flag."""
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise CommandError(
+            f"{flag} {value!r} is not a valid ClickHouse identifier. "
+            "Allowed: letters, digits, underscores; must not start with a digit."
+        )
+    return value
+
+
+def expected_replica_count(client, cluster: str) -> int:
+    """Number of hosts the cluster spans.
+
+    Used to gate ``per_replica_counts`` results: a complete parity check
+    must return one row per expected replica, else a still-registering or
+    down replica silently reads as ``converged``.
+    """
+    rows = client.execute(
+        "SELECT count() FROM system.clusters WHERE cluster = %(c)s",
+        {"c": cluster},
+    )
+    return rows[0][0] if rows else 0
+
+
+def per_replica_counts(
+    client,
+    database: str,
+    table: str,
+    cluster: str,
+) -> dict[str, int]:
+    """Per-replica row count via ``system.tables.total_rows``.
+
+    Reads through ``clusterAllReplicas(system.tables)`` rather than
+    ``count() ... GROUP BY hostName()`` on the target table itself: the
+    latter drops any replica whose local copy is empty, so a freshly
+    created (all-empty) target reads as "zero replicas present" and a
+    still-lagging follower disappears from the result entirely. Reading
+    ``system.tables`` yields one row per replica that holds the table,
+    including the empty ones, which is exactly the signal the parity
+    gate needs.
+    """
+    rows = client.execute(
+        f"SELECT hostName(), total_rows FROM clusterAllReplicas("
+        f"'{cluster}', system.tables) "
+        f"WHERE database = %(d)s AND name = %(t)s",
+        {"d": database, "t": table},
+    )
+    return {host: int(cnt or 0) for host, cnt in rows}
+
+
+def poll_replica_parity(
+    client,
+    *,
+    database: str,
+    table: str,
+    cluster: str,
+    expected: int,
+    expected_replicas: int,
+    max_wait_sec: float = 30.0,
+    poll_interval: float = 2.0,
+) -> tuple[dict[str, int], bool]:
+    """Poll until every expected replica reports ``>= expected`` rows.
+
+    Convergence requires the full replica set to be present in the
+    ``per_replica_counts`` result AND each entry to be at or above the
+    expected count. A replica still registering (absent from the result)
+    counts as not-yet-converged, never as ``done``.
+    """
+    deadline = time.monotonic() + max_wait_sec
+    counts: dict[str, int] = {}
+    while True:
+        counts = per_replica_counts(client, database, table, cluster)
+        converged = (
+            len(counts) >= expected_replicas
+            and bool(counts)
+            and all(c >= expected for c in counts.values())
+        )
+        if converged:
+            return counts, True
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "migrate_parity_wait_timed_out",
+                target=f"{database}.{table}",
+                expected=expected,
+                expected_replicas=expected_replicas,
+                per_replica_counts=counts,
+                max_wait_sec=max_wait_sec,
+            )
+            return counts, False
+        time.sleep(poll_interval)
+
+
+def shared_columns(
+    client,
+    source_db: str,
+    target_db: str,
+    table: str,
+) -> tuple[list[str], list[str]]:
+    """Columns present in both source and target, in target order.
+
+    Returns ``(shared, source_only)``. Callers use ``shared`` to build an
+    explicit column list for the copy (name-aligned, not
+    positional-``SELECT *``) and log ``source_only`` for visibility when
+    the legacy source has drifted columns that the target doesn't carry.
+    """
+    def cols(db: str) -> list[str]:
+        return [
+            r[0]
+            for r in client.execute(
+                "SELECT name FROM system.columns "
+                "WHERE database = %(d)s AND table = %(t)s ORDER BY position",
+                {"d": db, "t": table},
+            )
+        ]
+    src = cols(source_db)
+    tgt = cols(target_db)
+    src_set, tgt_set = set(src), set(tgt)
+    shared = [c for c in tgt if c in src_set]
+    source_only = [c for c in src if c not in tgt_set]
+    return shared, source_only

--- a/futureagi/model_hub/services/legacy_ch_tables.py
+++ b/futureagi/model_hub/services/legacy_ch_tables.py
@@ -1,0 +1,139 @@
+"""DDL for the legacy ``default``-database ClickHouse tables that the model-hub
+app boots: ``events`` (ML-monitoring) and ``llm_logs`` (LLM usage telemetry).
+
+Both were plain ``MergeTree`` created inline in ``apps.py``, so on a multi-replica
+cluster each row lived on whichever replica took the write and a single-replica
+read saw only its slice. They become ``ReplicatedMergeTree`` here — plain, not
+``Replacing``: both are append-only logs whose ORDER BY keys are not unique
+(``llm_logs`` orders by ``(LLMModelName, EventDateTime)``), so a ``Replacing``
+engine would silently collapse distinct rows.
+
+Centralised so the engine choice has one home and the default-to-replicated
+migration command can recreate the same schema in a target database.
+"""
+from __future__ import annotations
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    build_replicated_engine,
+)
+
+EVENTS_TABLE = "events"
+LLM_LOGS_TABLE = "llm_logs"
+
+
+def _qualified(table: str, database: str | None) -> str:
+    return f"{database}.{table}" if database else table
+
+
+def ensure_events_table(client, *, database: str | None = None, cluster: str | None = None) -> None:
+    """Create the ML-monitoring ``events`` table if absent (idempotent)."""
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree()",
+        EVENTS_TABLE,
+        clustered=ClickHouseVectorDB.is_clustered(client),
+        database=database,
+        cluster=cluster,
+    )
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(EVENTS_TABLE, database)}{on_cluster} (
+            UUID UUID,
+            original_uuid UUID DEFAULT UUID,
+            EventDate Date,
+            EventDateTime DateTime,
+            EventName String,
+            EventType String,
+            AIModel String DEFAULT '',
+            OrgID String,
+            PredictionID String DEFAULT '',
+            ModelVersion String DEFAULT '',
+            BatchID String DEFAULT '',
+            Environment UInt8 DEFAULT 0,
+            Properties Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Features Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            ActualLabel Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            PredictionLabel Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            EvalResults Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            ShapValues Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Tags Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Embedding Array(Float32) DEFAULT [],
+            deleted UInt8 DEFAULT 0
+        ) ENGINE = {engine}
+        PARTITION BY toYYYYMM(EventDate)
+        ORDER BY (EventDate, EventName, OrgID, UUID)
+        """
+    )
+
+
+def ensure_llm_logs_table(client, *, database: str | None = None, cluster: str | None = None) -> None:
+    """Create the ``llm_logs`` usage-telemetry table if absent (idempotent)."""
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree",
+        LLM_LOGS_TABLE,
+        clustered=ClickHouseVectorDB.is_clustered(client),
+        database=database,
+        cluster=cluster,
+    )
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(LLM_LOGS_TABLE, database)}{on_cluster}
+        (
+            `EventDateTime` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+            `EventDate` Date,
+            `TraceId` String CODEC(ZSTD(1)),
+            `SpanId` String CODEC(ZSTD(1)),
+            `SeverityText` LowCardinality(String) CODEC(ZSTD(1)),
+            `SeverityNumber` Int32 CODEC(ZSTD(1)),
+            `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
+            `LLMModelName` LowCardinality(String) CODEC(ZSTD(1)),
+            `UserId` String CODEC(ZSTD(1)),
+            `SessionId` String CODEC(ZSTD(1)),
+            `RequestBody` String CODEC(ZSTD(1)),
+            `ResponseBody` String CODEC(ZSTD(1)),
+            `RequestTokens` Int32 CODEC(ZSTD(1)),
+            `ResponseTokens` Int32 CODEC(ZSTD(1)),
+            `ResponseTime` Float32 CODEC(ZSTD(1)),
+            `LogAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+            `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+            INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_llm_model_name LLMModelName TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_user_id UserId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_session_id SessionId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_request_body RequestBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+            INDEX idx_response_body ResponseBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+        )
+        ENGINE = {engine}
+        PARTITION BY EventDate
+        ORDER BY (LLMModelName, EventDateTime)
+        SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+        """
+    )

--- a/futureagi/model_hub/services/legacy_ch_tables.py
+++ b/futureagi/model_hub/services/legacy_ch_tables.py
@@ -27,17 +27,25 @@ def _qualified(table: str, database: str | None) -> str:
 
 
 def ensure_events_table(client, *, database: str | None = None, cluster: str | None = None) -> None:
-    """Create the ML-monitoring ``events`` table if absent (idempotent)."""
+    """Create the ML-monitoring ``events`` table if absent (idempotent).
+
+    Also back-fills ``original_uuid`` on pre-existing tables that predate the
+    column: several downstream readers (``SELECT DISTINCT original_uuid FROM
+    events``) fail with "Unknown identifier" without it, and a bare
+    ``CREATE TABLE IF NOT EXISTS`` is a no-op against an existing table.
+    """
+    clustered = ClickHouseVectorDB.is_clustered(client)
     engine, on_cluster = build_replicated_engine(
         "MergeTree()",
         EVENTS_TABLE,
-        clustered=ClickHouseVectorDB.is_clustered(client),
+        clustered=clustered,
         database=database,
         cluster=cluster,
     )
+    qualified = _qualified(EVENTS_TABLE, database)
     client.execute(
         f"""
-        CREATE TABLE IF NOT EXISTS {_qualified(EVENTS_TABLE, database)}{on_cluster} (
+        CREATE TABLE IF NOT EXISTS {qualified}{on_cluster} (
             UUID UUID,
             original_uuid UUID DEFAULT UUID,
             EventDate Date,
@@ -91,6 +99,23 @@ def ensure_events_table(client, *, database: str | None = None, cluster: str | N
         PARTITION BY toYYYYMM(EventDate)
         ORDER BY (EventDate, EventName, OrgID, UUID)
         """
+    )
+    _backfill_events_original_uuid(client, qualified, on_cluster)
+
+
+def _backfill_events_original_uuid(client, qualified: str, on_cluster: str) -> None:
+    """Add ``original_uuid`` to an existing events table if absent.
+
+    ``ADD COLUMN IF NOT EXISTS`` is itself idempotent, but querying
+    ``system.columns`` first avoids a DDL replication round-trip on every
+    boot in the common case.
+    """
+    columns = client.execute(f"DESCRIBE TABLE {qualified}")
+    if any(row[0] == "original_uuid" for row in columns):
+        return
+    client.execute(
+        f"ALTER TABLE {qualified}{on_cluster} "
+        f"ADD COLUMN IF NOT EXISTS original_uuid UUID DEFAULT UUID"
     )
 
 

--- a/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
+++ b/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
@@ -214,6 +214,34 @@ def test_is_clustered_fails_safe_to_false(captured_sql_client):
     assert captured_sql_client._is_clustered() is False
 
 
+def test_is_clustered_transient_probe_failure_does_not_poison_cache(
+    captured_sql_client,
+):
+    """A first-call CH outage returns ``False`` but must NOT be cached.
+
+    If a transient failure poisoned the process cache with ``False``, every
+    subsequent table create in that worker would silently emit a
+    non-replicated engine on what is actually a clustered CH — a large
+    blast radius for a low-probability event. The next call after CH comes
+    back must re-probe and return the true value.
+    """
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    captured_sql_client.client.execute.side_effect = RuntimeError("boom")
+
+    assert captured_sql_client._is_clustered() is False
+    assert ch_vector.ClickHouseVectorDB._is_clustered_cached is None, (
+        "transient probe failure must not be cached"
+    )
+
+    # CH recovers: the next probe returns a real answer and the cache picks it up.
+    captured_sql_client.client.execute.side_effect = None
+    captured_sql_client.client.execute.return_value = [[2]]
+    assert captured_sql_client._is_clustered() is True
+    assert ch_vector.ClickHouseVectorDB._is_clustered_cached is True
+
+
 def test_create_table_threads_explicit_cluster_into_on_cluster(captured_sql_client):
     """The cluster name must come from the caller (migration --cluster) or
     `get_clickhouse_cluster_name()`, not be hardcoded; otherwise a deployment

--- a/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
+++ b/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
@@ -221,7 +221,7 @@ def test_is_clustered_transient_probe_failure_does_not_poison_cache(
 
     If a transient failure poisoned the process cache with ``False``, every
     subsequent table create in that worker would silently emit a
-    non-replicated engine on what is actually a clustered CH — a large
+    non-replicated engine on what is actually a clustered CH, a large
     blast radius for a low-probability event. The next call after CH comes
     back must re-probe and return the true value.
     """

--- a/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
+++ b/futureagi/model_hub/tests/test_ch_vector_engine_selection.py
@@ -1,0 +1,255 @@
+"""Behavioural tests for ``ClickHouseVectorDB.create_table``.
+
+The engine is chosen by introspecting ``system.clusters`` for any row with
+``replica_num > 1``. Multi-replica cluster -> ReplicatedReplacingMergeTree
+ON CLUSTER; single-node -> plain ReplacingMergeTree. Each test patches the
+CH client and forces the introspection result.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_clustered_cache():
+    """The clustered-detection result is cached on the class. Reset between
+    tests so each test sees its own forced value.
+    """
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    yield
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+
+
+@pytest.fixture
+def captured_sql_client():
+    """Patch ``ClickHouseVectorDB.__init__`` so no real CH connection is made
+    and ``self.client`` is a MagicMock whose ``execute`` we can inspect.
+    """
+    from agentic_eval.core.database import ch_vector
+
+    def _no_init(self, *_args, **_kwargs):
+        self.client = MagicMock()
+
+    with patch.object(ch_vector.ClickHouseVectorDB, "__init__", _no_init):
+        instance = ch_vector.ClickHouseVectorDB()
+        yield instance
+
+
+def _last_ddl(captured_sql_client) -> str:
+    """The last execute call that isn't the system.macros probe."""
+    calls = captured_sql_client.client.execute.call_args_list
+    # The DDL CREATE TABLE is the only call carrying settings=
+    for call in reversed(calls):
+        if "settings" in call.kwargs:
+            return call.args[0]
+    raise AssertionError("no CREATE TABLE call captured")
+
+
+def _force_clustered(client_mock, clustered: bool) -> None:
+    """Stub the system.clusters probe to return the desired clustered state."""
+    client_mock.client.execute.return_value = [[1 if clustered else 0]]
+
+
+def test_create_table_single_node_emits_plain_replacing_mergetree(captured_sql_client):
+    _force_clustered(captured_sql_client, clustered=False)
+
+    captured_sql_client.create_table("feedbacks")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "ENGINE = ReplacingMergeTree()" in sql
+    assert "ReplicatedReplacingMergeTree" not in sql
+    assert "ON CLUSTER" not in sql
+
+
+def test_create_table_clustered_emits_replicated_engine_and_on_cluster(captured_sql_client):
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("ground_truths")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "ENGINE = ReplicatedReplacingMergeTree" in sql
+    assert "ON CLUSTER 'cluster'" in sql
+    assert (
+        "ReplicatedReplacingMergeTree("
+        "'/clickhouse/tables/{shard}/ground_truths', '{replica}'"
+        ")"
+    ) in sql
+
+
+def test_create_table_table_name_substituted_into_zk_path(captured_sql_client):
+    """Each table gets its own ZK path; otherwise two tables would coordinate
+    on the same Keeper znode and corrupt each other's replication queue.
+    Without an explicit database the path matches the historical convention
+    (no database segment); with `database=` the path picks up the segment
+    so two replicated tables with the same short name in different databases
+    don't collide either.
+    """
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks")
+    sql_fb = _last_ddl(captured_sql_client)
+    assert "'/clickhouse/tables/{shard}/feedbacks'" in sql_fb
+
+    captured_sql_client.client.execute.reset_mock()
+    _force_clustered(captured_sql_client, clustered=True)
+    captured_sql_client.create_table("ground_truths")
+    sql_gt = _last_ddl(captured_sql_client)
+    assert "'/clickhouse/tables/{shard}/ground_truths'" in sql_gt
+    assert "feedbacks" not in sql_gt
+
+
+def test_create_table_qualifies_table_and_zk_path_with_database(captured_sql_client):
+    """`database=` qualifies the CREATE TABLE target AND inserts a database
+    segment into the Keeper path. Mutating ``connection.database`` after the
+    handshake does NOT reroute queries on the clickhouse-driver wire — this
+    parameter is the only way to land a table in a non-default database from
+    a connection that opened against `default`.
+    """
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks", database="futureagi")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "CREATE TABLE IF NOT EXISTS futureagi.feedbacks" in sql
+    assert "'/clickhouse/tables/{shard}/futureagi/feedbacks'" in sql
+    # The bare-table variant must not still be present (regression guard).
+    assert "CREATE TABLE IF NOT EXISTS feedbacks " not in sql
+    assert "'/clickhouse/tables/{shard}/feedbacks'" not in sql
+
+
+def test_create_table_database_default_unqualified(captured_sql_client):
+    """When `database` is unset the SQL stays unqualified so the table lands
+    in the connection's current database (CH_DATABASE). This is the runtime
+    EmbeddingManager path and must not regress.
+    """
+    _force_clustered(captured_sql_client, clustered=False)
+
+    captured_sql_client.create_table("feedbacks")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "CREATE TABLE IF NOT EXISTS feedbacks " in sql
+    assert "." not in sql.split("CREATE TABLE IF NOT EXISTS")[1].split("(")[0]
+
+
+def test_create_table_clustered_keeps_required_columns(captured_sql_client):
+    """Engine swap must not silently drop columns the rest of the codebase
+    depends on (id, eval_id, vector, metadata, deleted).
+    """
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks")
+
+    sql = _last_ddl(captured_sql_client)
+    for column_signature in (
+        "id UUID",
+        "eval_id UUID",
+        "vector Array(Float32)",
+        "metadata Nested",
+        "key String",
+        "value Nullable(String)",
+        "deleted UInt8 DEFAULT 0",
+    ):
+        assert column_signature in sql, f"missing column in CREATE TABLE: {column_signature}"
+
+
+def test_create_table_order_by_preserved(captured_sql_client):
+    """ReplacingMergeTree dedups by ORDER BY; if the key is wrong, replication
+    semantics drift from the legacy table.
+    """
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "ORDER BY id" in sql
+
+
+def test_is_clustered_cached_per_process(captured_sql_client):
+    """The probe runs once; subsequent calls reuse the cached answer to avoid
+    one ``system.clusters`` round trip per create_table.
+    """
+    captured_sql_client.client.execute.return_value = [[1]]
+
+    first = captured_sql_client._is_clustered()
+    second = captured_sql_client._is_clustered()
+
+    assert first is True and second is True
+    # Only one system.clusters probe across both calls.
+    probes = [
+        c for c in captured_sql_client.client.execute.call_args_list
+        if "system.clusters" in c.args[0]
+    ]
+    assert len(probes) == 1
+
+
+def test_is_clustered_single_node_with_replica_macro_returns_false(captured_sql_client):
+    """Local single-node CH set up via Helm / docker-compose can have the
+    ``replica`` macro pre-baked even though it has only one replica and no
+    DDLWorker. The previous heuristic (probe ``system.macros``) treated such
+    a node as clustered and would emit ``ON CLUSTER`` queries that fail at
+    runtime. The replica-count check at ``system.clusters`` is the precise
+    signal: only count replicas with ``replica_num > 1`` (i.e. a sibling
+    replica exists), and a 1-replica cluster falls through to the plain
+    MergeTree path.
+    """
+    captured_sql_client.client.execute.return_value = [[0]]
+
+    assert captured_sql_client._is_clustered() is False
+    probe_sql = captured_sql_client.client.execute.call_args_list[0].args[0]
+    assert "system.clusters" in probe_sql
+    assert "replica_num > 1" in probe_sql
+
+
+def test_is_clustered_fails_safe_to_false(captured_sql_client):
+    """If the introspection itself raises, default to non-clustered so we
+    don't accidentally CREATE TABLE ON CLUSTER on a local single-node CH.
+    """
+    captured_sql_client.client.execute.side_effect = RuntimeError("boom")
+
+    assert captured_sql_client._is_clustered() is False
+
+
+def test_create_table_threads_explicit_cluster_into_on_cluster(captured_sql_client):
+    """The cluster name must come from the caller (migration --cluster) or
+    `get_clickhouse_cluster_name()`, not be hardcoded; otherwise a deployment
+    whose `remote_servers` config calls the cluster anything other than
+    `'default'` would fail every CREATE TABLE call.
+    """
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks", cluster="fi_cluster")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "ON CLUSTER 'fi_cluster'" in sql
+    assert "ON CLUSTER 'default'" not in sql
+
+
+def test_create_table_default_cluster_resolves_to_env_or_deployment_default(
+    captured_sql_client, monkeypatch
+):
+    """When the caller doesn't pass `cluster`, the helper resolves to
+    `$CH_CLUSTER_NAME` and falls back to `'cluster'` (the name pinned in every
+    Future AGI ClickHouseInstallation manifest under `deployment/*`). This is
+    the runtime path (EmbeddingManager.parallel_process_metadata) where the
+    migration's `--cluster` flag isn't in play.
+    """
+    monkeypatch.setenv("CH_CLUSTER_NAME", "future_cluster")
+    _force_clustered(captured_sql_client, clustered=True)
+
+    captured_sql_client.create_table("feedbacks")
+
+    sql = _last_ddl(captured_sql_client)
+    assert "ON CLUSTER 'future_cluster'" in sql
+
+    captured_sql_client.client.execute.reset_mock()
+    _force_clustered(captured_sql_client, clustered=True)
+    monkeypatch.delenv("CH_CLUSTER_NAME", raising=False)
+
+    captured_sql_client.create_table("feedbacks")
+    sql = _last_ddl(captured_sql_client)
+    assert "ON CLUSTER 'cluster'" in sql

--- a/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
+++ b/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
@@ -168,6 +168,77 @@ def test_append_only_and_softdelete_tables_never_become_replacing():
         assert "ENGINE = ReplicatedMergeTree(" in sql, table
 
 
+def _events_client(*, clustered: bool, existing_columns: list[tuple]):
+    """A client mock scripted for ``ensure_events_table``: replies to the
+    cluster probe, the CREATE, the DESCRIBE, and any subsequent ALTER.
+    """
+    client = MagicMock()
+
+    def execute_side_effect(sql, *args, **kwargs):
+        sql_lc = sql.lower()
+        if "from system.clusters" in sql_lc:
+            return [[1 if clustered else 0]]
+        if sql_lc.lstrip().startswith("describe table"):
+            return existing_columns
+        return []
+
+    client.execute.side_effect = execute_side_effect
+    return client
+
+
+def test_ensure_events_table_backfills_original_uuid_on_pre_existing_table():
+    """A CREATE TABLE IF NOT EXISTS against an existing pre-``original_uuid``
+    ``events`` is a no-op, so ``ensure_events_table`` must also run a
+    DESCRIBE and, if the column is missing, an idempotent
+    ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS original_uuid ...``.
+    Otherwise downstream reads (``SELECT DISTINCT original_uuid FROM events``
+    in ``model_hub/tasks/agent.py`` and ``prompt_template_optimizer.py``)
+    error with "Unknown identifier" on any pre-existing table that predates
+    the column.
+    """
+    legacy_columns_without_original_uuid = [
+        ("UUID", "UUID", "", "", "", "", ""),
+        ("EventDate", "Date", "", "", "", "", ""),
+    ]
+    client = _events_client(
+        clustered=True,
+        existing_columns=legacy_columns_without_original_uuid,
+    )
+
+    ensure_events_table(client)
+
+    executed_sqls = [c.args[0] for c in client.execute.call_args_list]
+    alter_stmts = [
+        s for s in executed_sqls if s.lstrip().upper().startswith("ALTER TABLE")
+    ]
+    assert alter_stmts, "expected ALTER TABLE ... ADD COLUMN original_uuid"
+    assert "ADD COLUMN IF NOT EXISTS original_uuid" in alter_stmts[0]
+    # Clustered path must fan the ALTER out via ON CLUSTER; a leader-only
+    # ALTER would leave followers with the pre-column schema.
+    assert "ON CLUSTER 'cluster'" in alter_stmts[0]
+
+
+def test_ensure_events_table_does_not_alter_when_column_already_present():
+    """If ``original_uuid`` is already there, the ALTER is skipped so boot
+    doesn't fire a needless DDL replication round-trip on every pod start.
+    """
+    columns_with_original_uuid = [
+        ("UUID", "UUID", "", "", "", "", ""),
+        ("original_uuid", "UUID", "DEFAULT", "UUID", "", "", ""),
+    ]
+    client = _events_client(
+        clustered=True,
+        existing_columns=columns_with_original_uuid,
+    )
+
+    ensure_events_table(client)
+
+    executed_sqls = [c.args[0] for c in client.execute.call_args_list]
+    assert not any(
+        s.lstrip().upper().startswith("ALTER TABLE") for s in executed_sqls
+    )
+
+
 def test_build_replicated_engine_rejects_unknown_engine():
     with pytest.raises(ValueError):
         build_replicated_engine("TinyLog", "whatever", clustered=True)

--- a/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
+++ b/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
@@ -1,0 +1,198 @@
+"""Engine-selection tests for the legacy ``default.*`` ClickHouse tables.
+
+These five tables (``cluster_centroids``, ``trace_input_embeddings``,
+``error_embeddings``, ``llm_logs``, ``events``) are created by ad-hoc
+``ensure_*`` helpers rather than the managed v2 schema. Each helper must emit a
+``Replicated*`` engine ``ON CLUSTER`` on a multi-replica cluster and the plain
+engine on single-node CH — and must preserve its own sub-family: the centroid /
+trace-input tables stay ``Replacing`` (with their version column), while the
+append-only / soft-delete tables stay plain ``MergeTree``.
+
+No real CH: the client is mocked and the cluster-introspection result forced.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentic_eval.core.database.ch_vector import build_replicated_engine
+from model_hub.services.legacy_ch_tables import (
+    ensure_events_table,
+    ensure_llm_logs_table,
+)
+from tracer.services.clickhouse.clustering_tables import (
+    ensure_centroid_table,
+    ensure_error_embeddings_table,
+    ensure_trace_inputs_table,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_clustered_cache():
+    """`is_clustered` caches on the class; reset so each test forces its own."""
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    yield
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+
+
+# (ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col)
+_CASES = [
+    (
+        ensure_centroid_table,
+        True,
+        "cluster_centroids",
+        "ReplicatedReplacingMergeTree",
+        "ReplacingMergeTree(last_updated)",
+        "last_updated",
+    ),
+    (
+        ensure_trace_inputs_table,
+        True,
+        "trace_input_embeddings",
+        "ReplicatedReplacingMergeTree",
+        "ReplacingMergeTree(created_at)",
+        "created_at",
+    ),
+    (
+        ensure_error_embeddings_table,
+        True,
+        "error_embeddings",
+        "ReplicatedMergeTree",
+        "MergeTree()",
+        None,
+    ),
+    (
+        ensure_events_table,
+        False,
+        "events",
+        "ReplicatedMergeTree",
+        "MergeTree()",
+        None,
+    ),
+    (
+        ensure_llm_logs_table,
+        False,
+        "llm_logs",
+        "ReplicatedMergeTree",
+        "MergeTree",
+        None,
+    ),
+]
+
+_IDS = [c[2] for c in _CASES]
+
+
+def _run_ensure(ensure_fn, takes_vectordb, *, clustered, database=None) -> str:
+    """Invoke an ensure helper with a mocked client and return the CREATE SQL."""
+    client = MagicMock()
+    # The legacy helpers probe system.clusters through this same client.
+    client.execute.return_value = [[1 if clustered else 0]]
+
+    if takes_vectordb:
+        db = MagicMock()
+        db._is_clustered.return_value = clustered
+        db.client = client
+        ensure_fn(db, database=database)
+    else:
+        ensure_fn(client, database=database)
+
+    for call in reversed(client.execute.call_args_list):
+        if "CREATE TABLE" in call.args[0]:
+            return call.args[0]
+    raise AssertionError("no CREATE TABLE call captured")
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_clustered_emits_replicated_engine_on_cluster(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True)
+
+    assert f"ENGINE = {replicated_engine}(" in sql
+    assert "ON CLUSTER 'cluster'" in sql
+    assert f"'/clickhouse/tables/{{shard}}/{table}'" in sql
+    if version_col:
+        # Replacing sub-family keeps its version column as the trailing arg.
+        assert f"'{{replica}}', {version_col})" in sql
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_single_node_emits_plain_engine_no_on_cluster(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=False)
+
+    assert f"ENGINE = {plain_engine}" in sql
+    assert "ON CLUSTER" not in sql
+    assert "Replicated" not in sql
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_database_qualifies_target_and_zk_path(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True, database="futureagi")
+
+    assert f"CREATE TABLE IF NOT EXISTS futureagi.{table}" in sql
+    assert f"'/clickhouse/tables/{{shard}}/futureagi/{table}'" in sql
+
+
+def test_append_only_and_softdelete_tables_never_become_replacing():
+    """Regression guard: the ticket title says "ReplicatedReplacingMergeTree",
+    but forcing Replacing onto llm_logs/events (no unique ORDER BY key) or
+    error_embeddings (soft-delete, no version col) would silently drop rows.
+    """
+    for ensure_fn, takes_vectordb, table in (
+        (ensure_error_embeddings_table, True, "error_embeddings"),
+        (ensure_events_table, False, "events"),
+        (ensure_llm_logs_table, False, "llm_logs"),
+    ):
+        sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True)
+        assert "ReplacingMergeTree" not in sql, table
+        assert "ENGINE = ReplicatedMergeTree(" in sql, table
+
+
+def test_build_replicated_engine_rejects_unknown_engine():
+    with pytest.raises(ValueError):
+        build_replicated_engine("TinyLog", "whatever", clustered=True)
+
+
+def test_build_replicated_engine_passthrough_when_single_node():
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(ts)", "t", clustered=False, database="futureagi"
+    )
+    assert engine == "ReplacingMergeTree(ts)"
+    assert on_cluster == ""
+
+
+def test_centroid_ddl_is_shared_across_all_three_clustering_modules():
+    """cluster_centroids had three identical DDL copies; they must now resolve
+    to the one shared helper so a schema edit can't drift between them.
+    """
+    from tracer.queries import error_clustering, eval_clustering, scan_clustering
+    from tracer.services.clickhouse import clustering_tables
+
+    assert (
+        scan_clustering.ensure_centroid_table
+        is eval_clustering.ensure_centroid_table
+        is clustering_tables.ensure_centroid_table
+    )
+    # error_clustering keeps a thin method wrapper, but it delegates to the
+    # same module function rather than carrying its own DDL string.
+    assert "clustering_tables" in error_clustering.ErrorClusteringDB.ensure_centroid_table.__code__.co_names

--- a/futureagi/model_hub/tests/test_migrate_legacy_default_tables_to_replicated.py
+++ b/futureagi/model_hub/tests/test_migrate_legacy_default_tables_to_replicated.py
@@ -1,0 +1,260 @@
+"""Behavioural tests for ``migrate_legacy_default_tables_to_replicated``.
+
+ClickHouseVectorDB is mocked; we assert on the SQL the command sends (name-
+aligned column list, per-table dedup clause, one-shot guard, CREATE DATABASE
+ordering, replica-aware parity) and on the conditions that must raise
+CommandError. No real CH — cross-replica convergence is covered by the live
+2-replica harness; here we pin the SQL and the safety branches.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+_CMD = "migrate_legacy_default_tables_to_replicated"
+_DOTTED = (
+    "model_hub.management.commands."
+    "migrate_legacy_default_tables_to_replicated.ClickHouseVectorDB"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_clustered_cache():
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    yield
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+
+
+def _make_db_client(
+    *,
+    source_count: int = 10,
+    target: dict | None = None,
+    table_exists: bool = True,
+    clustered: bool = True,
+    replicas: tuple = ("ch-0", "ch-1", "ch-2"),
+    columns: tuple = ("id", "eval_id", "vector"),
+    insert_reaches: int | None = None,
+):
+    """ClickHouseVectorDB stand-in with scripted query returns.
+
+    ``target`` is an optional per-host row-count dict (defaults to all-zero).
+    ``insert_reaches`` overrides the per-host count an INSERT drives the target
+    to (defaults to source_count, i.e. it converges); set it below source_count
+    to simulate a replica that never catches up.
+    """
+    state = {h: ((target or {}).get(h, 0)) for h in replicas}
+    reach = source_count if insert_reaches is None else insert_reaches
+    db = MagicMock()
+    executed: list[str] = []
+
+    def ex(sql, params=None, settings=None):
+        executed.append(sql)
+        lc = sql.lower()
+        if "from system.tables" in lc:
+            return [(1 if table_exists else 0,)]
+        if "from system.columns" in lc:
+            return [(c,) for c in columns]
+        if "from system.clusters" in lc:  # _expected_replica_count
+            return [(len(replicas),)]
+        if "hostname()" in lc and "clusterallreplicas" in lc:
+            return [(h, c) for h, c in state.items()]
+        if lc.lstrip().startswith("insert into"):
+            for h in state:
+                state[h] = max(state[h], reach)
+            return []
+        if "clusterallreplicas" in lc:  # source count (uniqExact / count())
+            return [(source_count,)]
+        return []
+
+    db.client.execute.side_effect = ex
+    db._is_clustered = MagicMock(return_value=clustered)
+    return db, executed, state
+
+
+def _run(*tables, db_client=None, dry_run=False, target="futureagi", source="default"):
+    out, err = StringIO(), StringIO()
+    args = [
+        _CMD,
+        f"--source-database={source}",
+        f"--target-database={target}",
+        f"--tables={','.join(tables)}",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    with patch(_DOTTED, return_value=db_client):
+        call_command(*args, stdout=out, stderr=err)
+    return out.getvalue(), err.getvalue()
+
+
+def _inserts(executed):
+    return [s for s in executed if s.lower().lstrip().startswith("insert into")]
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+def test_refuses_when_source_equals_target():
+    with pytest.raises(CommandError, match="must differ"):
+        call_command(_CMD, "--source-database=default", "--target-database=default",
+                     "--tables=llm_logs", stdout=StringIO())
+
+
+def test_refuses_invalid_identifier():
+    with pytest.raises(CommandError, match="valid ClickHouse identifier"):
+        call_command(_CMD, "--source-database=default", "--target-database=bad-name",
+                     "--tables=llm_logs", stdout=StringIO())
+
+
+def test_refuses_unknown_table():
+    with pytest.raises(CommandError, match="unknown entries"):
+        call_command(_CMD, "--source-database=default", "--target-database=futureagi",
+                     "--tables=not_a_table", stdout=StringIO())
+
+
+def test_refuses_when_not_clustered():
+    db_client, _, _ = _make_db_client(clustered=False)
+    with pytest.raises(CommandError, match="replica"):
+        _run("llm_logs", db_client=db_client)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_issues_no_writes():
+    db_client, executed, _ = _make_db_client()
+    out, _ = _run("cluster_centroids", db_client=db_client, dry_run=True)
+    joined = " ".join(executed).lower()
+    assert "create database" not in joined
+    assert "insert into" not in joined
+    assert "create table" not in joined
+    assert "would copy" in out
+
+
+# ---------------------------------------------------------------------------
+# Real run — keyed tables
+# ---------------------------------------------------------------------------
+
+def test_creates_database_on_cluster_before_table_work():
+    db_client, executed, _ = _make_db_client()
+    _run("cluster_centroids", db_client=db_client)
+    create_db = next(i for i, s in enumerate(executed) if "create database" in s.lower())
+    first_insert = next(i for i, s in enumerate(executed)
+                        if s.lower().lstrip().startswith("insert into"))
+    assert "ON CLUSTER 'cluster'" in executed[create_db]
+    assert create_db < first_insert
+
+
+@pytest.mark.parametrize("table,expected_where", [
+    ("trace_input_embeddings",
+     "WHERE (project_id, trace_id) NOT IN "
+     "(SELECT project_id, trace_id FROM futureagi.trace_input_embeddings)"),
+    ("error_embeddings",
+     "WHERE (id) NOT IN (SELECT id FROM futureagi.error_embeddings)"),
+    ("cluster_centroids",
+     "WHERE (cluster_id) NOT IN (SELECT cluster_id FROM futureagi.cluster_centroids)"),
+])
+def test_keyed_table_backfill_uses_its_dedup_clause(table, expected_where):
+    db_client, executed, _ = _make_db_client()
+    _run(table, db_client=db_client)
+    ins = _inserts(executed)
+    assert len(ins) == 1
+    assert f"INSERT INTO futureagi.{table}" in ins[0]
+    assert "clusterAllReplicas('cluster', default." in ins[0]
+    assert expected_where in ins[0]
+
+
+def test_backfill_uses_explicit_column_list_not_select_star():
+    # Regression: positional SELECT * silently misaligns a drifted source.
+    db_client, executed, _ = _make_db_client(columns=("id", "eval_id", "vector"))
+    _run("error_embeddings", db_client=db_client)
+    ins = _inserts(executed)[0]
+    assert "SELECT *" not in ins
+    assert "INSERT INTO futureagi.error_embeddings (`id`, `eval_id`, `vector`)" in ins
+    assert "SELECT `id`, `eval_id`, `vector` FROM" in ins
+
+
+def test_keyed_table_idempotent_rerun_copies_zero():
+    db_client, _, _ = _make_db_client(
+        source_count=10, target={"ch-0": 10, "ch-1": 10, "ch-2": 10})
+    out, _ = _run("error_embeddings", db_client=db_client)
+    assert "copied 0 rows" in out
+
+
+# ---------------------------------------------------------------------------
+# Real run — append-only log tables (one-shot, no key)
+# ---------------------------------------------------------------------------
+
+def test_one_shot_inserts_without_where_when_empty_everywhere():
+    db_client, executed, _ = _make_db_client(source_count=95)  # target all 0
+    _run("llm_logs", db_client=db_client)
+    ins = _inserts(executed)
+    assert len(ins) == 1
+    assert "INSERT INTO futureagi.llm_logs" in ins[0]
+    assert "NOT IN" not in ins[0] and "WHERE" not in ins[0]
+
+
+def test_one_shot_no_op_when_already_converged():
+    # Re-run after a successful one-shot: target == source on every replica.
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 95, "ch-1": 95, "ch-2": 95})
+    out, _ = _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)
+    assert "one-shot no-op" in out
+
+
+def test_one_shot_REFUSES_when_a_single_replica_is_empty():
+    # THE critical bug: min() across replicas let one empty replica wave the
+    # copy through and duplicate the keyless log. Must now refuse + fail.
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 95, "ch-1": 95, "ch-2": 0})
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)  # never inserted -> no duplication
+
+
+def test_one_shot_refuses_on_partial_target():
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 42, "ch-1": 42, "ch-2": 42})
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)
+
+
+def test_source_missing_creates_target_and_skips_copy():
+    db_client, executed, _ = _make_db_client(table_exists=False)
+    out, _ = _run("events", db_client=db_client)
+    assert not _inserts(executed)
+    assert "nothing to copy" in out
+
+
+# ---------------------------------------------------------------------------
+# Replica-aware parity + failure propagation
+# ---------------------------------------------------------------------------
+
+def test_parity_failure_raises_nonzero(monkeypatch):
+    # A replica that never reaches source_count must fail the whole command so
+    # an exit-code-gated CH_DATABASE flip cannot proceed.
+    import model_hub.management.commands.migrate_legacy_default_tables_to_replicated as m
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(m.time, "monotonic", lambda: clock.__setitem__("t", clock["t"] + 100) or clock["t"])
+    db_client, _, _ = _make_db_client(source_count=100, insert_reaches=1)  # never converges
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("cluster_centroids", db_client=db_client)
+
+
+def test_multi_table_run_processes_each():
+    db_client, executed, _ = _make_db_client()
+    _run("trace_input_embeddings", "error_embeddings", "cluster_centroids",
+         db_client=db_client)
+    for table in ("trace_input_embeddings", "error_embeddings", "cluster_centroids"):
+        assert any(f"INSERT INTO futureagi.{table}" in s for s in executed)

--- a/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
+++ b/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
@@ -15,36 +15,64 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 
+# Canonical vector-table columns for tests. The exact set only matters for
+# assertions that check the explicit column list appears in the INSERT.
+_VECTOR_COLUMNS = [
+    "id",
+    "eval_id",
+    "vector",
+    "metadata.Key",
+    "metadata.Value",
+    "deleted",
+]
+
+
 def _build_mock_db_client(
     *,
     source_distinct: int = 14,
     target_count_before: int = 0,
     table_exists: bool = True,
     clustered: bool = True,
+    expected_replicas: int = 3,
+    replicas_present: int | None = None,
+    columns: list[str] | None = None,
 ):
     """A ClickHouseVectorDB stand-in with scripted query returns.
 
-    The command issues a small set of queries per table; we dispatch by
-    substring match. ``clustered`` toggles what ``_is_clustered`` returns
-    so we can exercise the "refuse on single-node CH" path.
+    ``expected_replicas`` sets the ``system.clusters`` count.
+    ``replicas_present`` (default: same as ``expected_replicas``) sets how
+    many replicas appear in ``per_replica_counts`` — set it below
+    ``expected_replicas`` to simulate a follower that hasn't registered.
+    ``columns`` overrides the shared-columns view of ``system.columns``.
     """
     db_client = MagicMock()
     target_count_state = {"value": target_count_before}
+    cols = columns if columns is not None else _VECTOR_COLUMNS
+    present = expected_replicas if replicas_present is None else replicas_present
 
     def execute_side_effect(sql, params=None):
         sql_lc = sql.lower()
+        # system.clusters -> expected replica count
+        if "from system.clusters" in sql_lc:
+            return [(expected_replicas,)]
+        # system.columns -> shared_columns
+        if "from system.columns" in sql_lc:
+            return [(c,) for c in cols]
+        # per_replica_counts reads system.tables.total_rows via clusterAllReplicas
+        if (
+            "from clusterallreplicas" in sql_lc
+            and "system.tables" in sql_lc
+            and "total_rows" in sql_lc
+        ):
+            return [
+                (f"ch-replica-{i}", target_count_state["value"])
+                for i in range(1, present + 1)
+            ]
+        # source_exists probe against system.tables (no clusterAllReplicas)
         if "from system.tables" in sql_lc:
             return [(1 if table_exists else 0,)]
         if "uniqexact(id)" in sql_lc and "clusterallreplicas" in sql_lc:
             return [(source_distinct,)]
-        if "hostname()" in sql_lc and "clusterallreplicas" in sql_lc:
-            return [
-                ("ch-replica-1", target_count_state["value"]),
-                ("ch-replica-2", target_count_state["value"]),
-                ("ch-replica-3", target_count_state["value"]),
-            ]
-        if "select count() from" in sql_lc and "clusterallreplicas" not in sql_lc:
-            return [(target_count_state["value"],)]
         if sql_lc.lstrip().startswith("insert into"):
             target_count_state["value"] = max(
                 target_count_state["value"], source_distinct
@@ -55,12 +83,16 @@ def _build_mock_db_client(
     db_client.client.execute.side_effect = execute_side_effect
     db_client.client.connection.database = "default"
     db_client.create_table = MagicMock()
-    # Explicit return so tests don't depend on MagicMock truthiness.
     db_client._is_clustered = MagicMock(return_value=clustered)
     return db_client, target_count_state
 
 
-def _run(*tables: str, db_client=None, dry_run: bool = False) -> str:
+def _run(
+    *tables: str,
+    db_client=None,
+    dry_run: bool = False,
+    cluster: str = "cluster",
+) -> str:
     """Invoke the command with the standard source/target and return stdout."""
     out = StringIO()
     args = [
@@ -68,6 +100,7 @@ def _run(*tables: str, db_client=None, dry_run: bool = False) -> str:
         "--source-database=default",
         "--target-database=futureagi",
         f"--tables={','.join(tables)}",
+        f"--cluster={cluster}",
     ]
     if dry_run:
         args.append("--dry-run")
@@ -178,8 +211,11 @@ def test_target_database_is_created_on_cluster_before_any_table_work():
     assert create_db_idx is not None, (
         "expected CREATE DATABASE IF NOT EXISTS futureagi ON CLUSTER 'cluster'"
     )
+    # First per-table probe is the source_exists check against system.tables
+    # (without clusterAllReplicas). Confirm the CREATE DATABASE ran first.
     first_per_table_idx = next(
-        i for i, s in enumerate(executed_sqls) if "from system.tables" in s.lower()
+        i for i, s in enumerate(executed_sqls)
+        if "from system.tables" in s.lower() and "clusterallreplicas" not in s.lower()
     )
     assert create_db_idx < first_per_table_idx
 
@@ -195,10 +231,11 @@ def test_dry_run_does_not_create_target_database():
     ), "dry-run must not issue CREATE DATABASE"
 
 
-def test_real_run_emits_insert_select_clusterallreplicas_with_id_not_in_target():
-    """The core behaviour: reads from every replica via clusterAllReplicas,
-    writes only the IDs that aren't already at the target. This is what
-    makes the migration both correct (no data loss) and idempotent.
+def test_real_run_emits_insert_with_explicit_column_list_and_id_anti_join():
+    """The core behaviour: reads from every replica via clusterAllReplicas
+    with an EXPLICIT column list (never ``SELECT *``) so a drifted legacy
+    source can't silently misalign by position; writes only the IDs that
+    aren't already at the target, so re-runs are idempotent.
     """
     db_client, target_state = _build_mock_db_client(
         source_distinct=14, target_count_before=0
@@ -215,30 +252,78 @@ def test_real_run_emits_insert_select_clusterallreplicas_with_id_not_in_target()
     assert "INSERT INTO futureagi.feedbacks" in insert_sql
     assert "clusterAllReplicas('cluster', default.feedbacks)" in insert_sql
     assert "WHERE id NOT IN (SELECT id FROM futureagi.feedbacks)" in insert_sql
+    # Explicit column list must be present; SELECT * would misalign a
+    # drifted legacy source silently.
+    assert "SELECT *" not in insert_sql, (
+        "INSERT must use an explicit column list, not SELECT *"
+    )
+    for col in _VECTOR_COLUMNS:
+        assert f"`{col}`" in insert_sql, (
+            f"column `{col}` missing from explicit list"
+        )
     assert target_state["value"] == 14
     assert "copied 14 rows" in stdout
 
 
-def test_post_insert_parity_check_queries_every_replica_not_just_leader():
-    """Querying ``SELECT count() FROM target`` would only hit the leader and
-    hide a replica that hasn't pulled the new rows from Keeper yet. The
-    post-INSERT parity check must go through ``clusterAllReplicas`` and
-    ``GROUP BY hostName()`` so a lagging replica surfaces as a divergence.
+def test_parity_check_reads_system_tables_total_rows_not_leader_only_count():
+    """Post-INSERT parity is read through
+    ``clusterAllReplicas(system.tables)`` on ``total_rows``, not
+    ``count() ... GROUP BY hostName()`` on the target table.
+
+    The older ``count() GROUP BY hostName()`` idiom drops any replica whose
+    local copy is empty (no group emitted), so a follower still lagging
+    disappears from the result entirely and the parity check reads as
+    "converged" over the replicas that happen to be present.
+    ``system.tables.total_rows`` returns one row per replica that holds
+    the table — including the empty ones — which is the signal the gate
+    actually needs.
     """
     db_client, _ = _build_mock_db_client(source_distinct=14, target_count_before=0)
     _run("feedbacks", db_client=db_client)
 
     executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
-    parity_sqls = [
-        s
-        for s in executed_sqls
-        if "hostName()" in s
-        and "clusterAllReplicas" in s
-        and "GROUP BY hostName()" in s
+    system_tables_reads = [
+        s for s in executed_sqls
+        if "clusterAllReplicas" in s
+        and "system.tables" in s
+        and "total_rows" in s
     ]
-    assert len(parity_sqls) >= 1, (
-        "post-INSERT parity check must use clusterAllReplicas + GROUP BY hostName()"
+    assert system_tables_reads, (
+        "post-INSERT parity must read through system.tables.total_rows"
     )
+    legacy_group_by_reads = [
+        s for s in executed_sqls
+        if "GROUP BY hostName()" in s
+    ]
+    assert not legacy_group_by_reads, (
+        "must not fall back to the empty-replica-hiding "
+        "'count() GROUP BY hostName()' idiom"
+    )
+
+
+def test_raises_command_error_when_a_replica_is_missing_from_parity():
+    """Convergence requires the FULL replica set to be present in the
+    per-replica-counts result. If ``system.clusters`` reports 3 replicas but
+    only 2 respond, the table has not converged and the command must exit
+    non-zero so an exit-code-gated cutover can't advance.
+    """
+    db_client, _ = _build_mock_db_client(
+        source_distinct=14,
+        expected_replicas=3,
+        replicas_present=2,  # one follower still registering
+    )
+    # Shrink the polling window so the test doesn't spend 30s waiting.
+    with patch(
+        "model_hub.services.ch_migration.time.sleep",
+        return_value=None,
+    ), patch(
+        "model_hub.services.ch_migration.time.monotonic",
+        side_effect=[0.0, 0.0, 0.0, 999.0, 999.0],
+    ):
+        with pytest.raises(CommandError) as excinfo:
+            _run("feedbacks", db_client=db_client)
+    assert "did not fully converge" in str(excinfo.value).lower()
+    assert "feedbacks" in str(excinfo.value)
 
 
 def test_cluster_flag_is_threaded_into_clusterallreplicas_and_create_table():
@@ -250,19 +335,7 @@ def test_cluster_flag_is_threaded_into_clusterallreplicas_and_create_table():
     calls the cluster anything other than the hardcoded literal.
     """
     db_client, _ = _build_mock_db_client(source_distinct=3)
-    out = StringIO()
-    with patch(
-        "model_hub.management.commands.migrate_legacy_vectors_to_replicated.ClickHouseVectorDB",
-        return_value=db_client,
-    ):
-        call_command(
-            "migrate_legacy_vectors_to_replicated",
-            "--source-database=default",
-            "--target-database=futureagi",
-            "--tables=feedbacks",
-            "--cluster=fi_cluster",
-            stdout=out,
-        )
+    _run("feedbacks", db_client=db_client, cluster="fi_cluster")
 
     executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
     assert any("clusterAllReplicas('fi_cluster'," in s for s in executed_sqls)

--- a/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
+++ b/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
@@ -41,7 +41,7 @@ def _build_mock_db_client(
 
     ``expected_replicas`` sets the ``system.clusters`` count.
     ``replicas_present`` (default: same as ``expected_replicas``) sets how
-    many replicas appear in ``per_replica_counts`` — set it below
+    many replicas appear in ``per_replica_counts``: set it below
     ``expected_replicas`` to simulate a follower that hasn't registered.
     ``columns`` overrides the shared-columns view of ``system.columns``.
     """
@@ -275,7 +275,7 @@ def test_parity_check_reads_system_tables_total_rows_not_leader_only_count():
     disappears from the result entirely and the parity check reads as
     "converged" over the replicas that happen to be present.
     ``system.tables.total_rows`` returns one row per replica that holds
-    the table — including the empty ones — which is the signal the gate
+    the table, including the empty ones, which is the signal the gate
     actually needs.
     """
     db_client, _ = _build_mock_db_client(source_distinct=14, target_count_before=0)

--- a/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
+++ b/futureagi/model_hub/tests/test_migrate_legacy_vectors_to_replicated.py
@@ -1,0 +1,318 @@
+"""Behavioural tests for ``migrate_legacy_vectors_to_replicated``.
+
+ClickHouseVectorDB is mocked so no real CH is required. We assert on the
+SQL the command actually sends, the stdout it writes, and the conditions
+that should raise CommandError.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+def _build_mock_db_client(
+    *,
+    source_distinct: int = 14,
+    target_count_before: int = 0,
+    table_exists: bool = True,
+    clustered: bool = True,
+):
+    """A ClickHouseVectorDB stand-in with scripted query returns.
+
+    The command issues a small set of queries per table; we dispatch by
+    substring match. ``clustered`` toggles what ``_is_clustered`` returns
+    so we can exercise the "refuse on single-node CH" path.
+    """
+    db_client = MagicMock()
+    target_count_state = {"value": target_count_before}
+
+    def execute_side_effect(sql, params=None):
+        sql_lc = sql.lower()
+        if "from system.tables" in sql_lc:
+            return [(1 if table_exists else 0,)]
+        if "uniqexact(id)" in sql_lc and "clusterallreplicas" in sql_lc:
+            return [(source_distinct,)]
+        if "hostname()" in sql_lc and "clusterallreplicas" in sql_lc:
+            return [
+                ("ch-replica-1", target_count_state["value"]),
+                ("ch-replica-2", target_count_state["value"]),
+                ("ch-replica-3", target_count_state["value"]),
+            ]
+        if "select count() from" in sql_lc and "clusterallreplicas" not in sql_lc:
+            return [(target_count_state["value"],)]
+        if sql_lc.lstrip().startswith("insert into"):
+            target_count_state["value"] = max(
+                target_count_state["value"], source_distinct
+            )
+            return []
+        return []
+
+    db_client.client.execute.side_effect = execute_side_effect
+    db_client.client.connection.database = "default"
+    db_client.create_table = MagicMock()
+    # Explicit return so tests don't depend on MagicMock truthiness.
+    db_client._is_clustered = MagicMock(return_value=clustered)
+    return db_client, target_count_state
+
+
+def _run(*tables: str, db_client=None, dry_run: bool = False) -> str:
+    """Invoke the command with the standard source/target and return stdout."""
+    out = StringIO()
+    args = [
+        "migrate_legacy_vectors_to_replicated",
+        "--source-database=default",
+        "--target-database=futureagi",
+        f"--tables={','.join(tables)}",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    cm = patch(
+        "model_hub.management.commands.migrate_legacy_vectors_to_replicated.ClickHouseVectorDB",
+        return_value=db_client,
+    ) if db_client is not None else patch("builtins.print")  # no-op patch
+    with cm:
+        call_command(*args, stdout=out)
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Refusal cases
+# ---------------------------------------------------------------------------
+
+def test_refuses_when_source_equals_target():
+    with pytest.raises(CommandError) as excinfo:
+        call_command(
+            "migrate_legacy_vectors_to_replicated",
+            "--source-database=default",
+            "--target-database=default",
+            "--tables=feedbacks",
+            stdout=StringIO(),
+        )
+    assert "must differ" in str(excinfo.value)
+
+
+def test_refuses_when_ch_is_not_clustered():
+    """Running on a single-node CH would create the target as plain
+    ReplacingMergeTree and re-introduce the non-replicated bug.
+    """
+    db_client, _ = _build_mock_db_client(clustered=False)
+    with patch(
+        "model_hub.management.commands.migrate_legacy_vectors_to_replicated.ClickHouseVectorDB",
+        return_value=db_client,
+    ):
+        with pytest.raises(CommandError) as excinfo:
+            call_command(
+                "migrate_legacy_vectors_to_replicated",
+                "--source-database=default",
+                "--target-database=futureagi",
+                "--tables=feedbacks",
+                stdout=StringIO(),
+            )
+    assert "replica" in str(excinfo.value).lower()
+
+
+def test_refuses_unknown_table_name():
+    with pytest.raises(CommandError) as excinfo:
+        call_command(
+            "migrate_legacy_vectors_to_replicated",
+            "--source-database=default",
+            "--target-database=futureagi",
+            "--tables=feedbacks,not_a_real_table",
+            stdout=StringIO(),
+        )
+    assert "not_a_real_table" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run vs real run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_does_not_create_table_or_insert():
+    db_client, _ = _build_mock_db_client(source_distinct=14)
+    stdout = _run("feedbacks", db_client=db_client, dry_run=True)
+
+    db_client.create_table.assert_not_called()
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    assert not any(s.lower().lstrip().startswith("insert into") for s in executed_sqls), (
+        "dry-run must not emit any INSERT statement"
+    )
+    assert "would copy" in stdout.lower()
+
+
+def test_creates_target_table_when_source_is_absent_so_future_writes_have_a_home():
+    """``ground_truths`` doesn't exist in the legacy ``default`` DB yet, but
+    new write paths point at ``futureagi.ground_truths``. The command must
+    still create the target so the first runtime write doesn't error.
+    """
+    db_client, _ = _build_mock_db_client(table_exists=False)
+    stdout = _run("ground_truths", db_client=db_client)
+
+    db_client.create_table.assert_called_once_with(
+        "ground_truths", cluster="cluster", database="futureagi"
+    )
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    assert not any(s.lower().lstrip().startswith("insert into") for s in executed_sqls)
+    assert "nothing to copy" in stdout.lower()
+
+
+def test_target_database_is_created_on_cluster_before_any_table_work():
+    """``futureagi`` doesn't exist on prod yet. CREATE DATABASE has to fan
+    out to every replica via ON CLUSTER, and it must run before any per-table
+    SQL; otherwise the first CREATE TABLE hits UNKNOWN_DATABASE.
+    """
+    db_client, _ = _build_mock_db_client(source_distinct=3)
+    _run("feedbacks", db_client=db_client)
+
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    create_db_idx = next(
+        (i for i, s in enumerate(executed_sqls)
+         if "create database if not exists futureagi" in s.lower()
+         and "on cluster 'cluster'" in s.lower()),
+        None,
+    )
+    assert create_db_idx is not None, (
+        "expected CREATE DATABASE IF NOT EXISTS futureagi ON CLUSTER 'cluster'"
+    )
+    first_per_table_idx = next(
+        i for i, s in enumerate(executed_sqls) if "from system.tables" in s.lower()
+    )
+    assert create_db_idx < first_per_table_idx
+
+
+def test_dry_run_does_not_create_target_database():
+    """A dry-run must not mutate the cluster, including no CREATE DATABASE."""
+    db_client, _ = _build_mock_db_client(source_distinct=3)
+    _run("feedbacks", db_client=db_client, dry_run=True)
+
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    assert not any(
+        "create database" in s.lower() for s in executed_sqls
+    ), "dry-run must not issue CREATE DATABASE"
+
+
+def test_real_run_emits_insert_select_clusterallreplicas_with_id_not_in_target():
+    """The core behaviour: reads from every replica via clusterAllReplicas,
+    writes only the IDs that aren't already at the target. This is what
+    makes the migration both correct (no data loss) and idempotent.
+    """
+    db_client, target_state = _build_mock_db_client(
+        source_distinct=14, target_count_before=0
+    )
+    stdout = _run("feedbacks", db_client=db_client)
+
+    db_client.create_table.assert_called_once_with(
+        "feedbacks", cluster="cluster", database="futureagi"
+    )
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    insert_stmts = [s for s in executed_sqls if s.lower().lstrip().startswith("insert into")]
+    assert len(insert_stmts) == 1
+    insert_sql = insert_stmts[0]
+    assert "INSERT INTO futureagi.feedbacks" in insert_sql
+    assert "clusterAllReplicas('cluster', default.feedbacks)" in insert_sql
+    assert "WHERE id NOT IN (SELECT id FROM futureagi.feedbacks)" in insert_sql
+    assert target_state["value"] == 14
+    assert "copied 14 rows" in stdout
+
+
+def test_post_insert_parity_check_queries_every_replica_not_just_leader():
+    """Querying ``SELECT count() FROM target`` would only hit the leader and
+    hide a replica that hasn't pulled the new rows from Keeper yet. The
+    post-INSERT parity check must go through ``clusterAllReplicas`` and
+    ``GROUP BY hostName()`` so a lagging replica surfaces as a divergence.
+    """
+    db_client, _ = _build_mock_db_client(source_distinct=14, target_count_before=0)
+    _run("feedbacks", db_client=db_client)
+
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    parity_sqls = [
+        s
+        for s in executed_sqls
+        if "hostName()" in s
+        and "clusterAllReplicas" in s
+        and "GROUP BY hostName()" in s
+    ]
+    assert len(parity_sqls) >= 1, (
+        "post-INSERT parity check must use clusterAllReplicas + GROUP BY hostName()"
+    )
+
+
+def test_cluster_flag_is_threaded_into_clusterallreplicas_and_create_table():
+    """A non-default --cluster value must propagate into the INSERT SELECT,
+    the parity-check query, AND the per-table CREATE TABLE. The earlier
+    revision of this test only checked the INSERT and parity SQL; CREATE
+    TABLE goes through `db_client.create_table`, and a hardcoded cluster
+    name there would break any deployment whose `remote_servers` config
+    calls the cluster anything other than the hardcoded literal.
+    """
+    db_client, _ = _build_mock_db_client(source_distinct=3)
+    out = StringIO()
+    with patch(
+        "model_hub.management.commands.migrate_legacy_vectors_to_replicated.ClickHouseVectorDB",
+        return_value=db_client,
+    ):
+        call_command(
+            "migrate_legacy_vectors_to_replicated",
+            "--source-database=default",
+            "--target-database=futureagi",
+            "--tables=feedbacks",
+            "--cluster=fi_cluster",
+            stdout=out,
+        )
+
+    executed_sqls = [c.args[0] for c in db_client.client.execute.call_args_list]
+    assert any("clusterAllReplicas('fi_cluster'," in s for s in executed_sqls)
+    assert not any("clusterAllReplicas('cluster'," in s for s in executed_sqls)
+    # Plus the CREATE DATABASE fans out on the same cluster.
+    assert any(
+        "create database if not exists futureagi" in s.lower()
+        and "on cluster 'fi_cluster'" in s.lower()
+        for s in executed_sqls
+    )
+    # And per-table CREATE TABLE goes through db_client.create_table with the
+    # same cluster name AND the target database; otherwise the hardcoded-
+    # cluster bug ships silently OR the table lands in the source database.
+    create_calls = db_client.create_table.call_args_list
+    assert len(create_calls) == 1
+    assert create_calls[0].kwargs.get("cluster") == "fi_cluster"
+    assert create_calls[0].kwargs.get("database") == "futureagi"
+
+
+def test_second_run_is_a_no_op_when_target_already_at_parity():
+    """The id-anti-join filter means a re-run on already-migrated data
+    inserts nothing. The command must report 0 rows copied without erroring.
+    """
+    db_client, _ = _build_mock_db_client(
+        source_distinct=14, target_count_before=14
+    )
+    stdout = _run("feedbacks", db_client=db_client)
+    assert "copied 0 rows" in stdout
+
+
+def test_migrates_feedbacks_ground_truths_and_syn_in_one_invocation():
+    """End-to-end multi-table case. syn is explicitly listed because the
+    agent_evaluator search_knowledge_base tool reads from it; if a future
+    PR drops syn from KNOWN_TABLES, this test fails loudly.
+    """
+    db_client, _ = _build_mock_db_client(source_distinct=7)
+    _run("feedbacks", "ground_truths", "syn", db_client=db_client)
+
+    create_calls = [c.args[0] for c in db_client.create_table.call_args_list]
+    assert create_calls == ["feedbacks", "ground_truths", "syn"]
+
+    insert_sqls = [
+        c.args[0]
+        for c in db_client.client.execute.call_args_list
+        if c.args[0].lower().lstrip().startswith("insert into")
+    ]
+    assert len(insert_sqls) == 3
+    for table in ("feedbacks", "ground_truths", "syn"):
+        assert any(
+            f"INSERT INTO futureagi.{table}" in sql
+            and f"clusterAllReplicas('cluster', default.{table})" in sql
+            for sql in insert_sqls
+        ), f"missing INSERT for {table}"

--- a/futureagi/tracer/queries/error_clustering.py
+++ b/futureagi/tracer/queries/error_clustering.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     ErrorEmbeddingClusterer = _ee_stub("ErrorEmbeddingClusterer")
 from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
+from tracer.services.clickhouse import clustering_tables
 
 logger = structlog.get_logger(__name__)
 from tracer.models.project import Project
@@ -31,52 +32,21 @@ class ErrorClusteringDB:
 
     def __init__(self, euclidean_threshold: float = 0.6):
         self.euclidean_threshold = euclidean_threshold
-        self.table_name = "error_embeddings"
+        self.table_name = clustering_tables.ERROR_EMBEDDINGS_TABLE
 
     def ensure_centroid_table(self):
         """Ensure the cluster_centroids table exists in ClickHouse."""
-
         db = ClickHouseVectorDB()
         try:
-            # Array(...) can't sit inside Nullable; override server profiles
-            # that set data_type_default_nullable=1 so unmodified types aren't
-            # auto-wrapped.
-            query = """
-                CREATE TABLE IF NOT EXISTS cluster_centroids (
-                    cluster_id String,
-                    project_id UUID,
-                    centroid Array(Float32),
-                    member_count UInt32,
-                    family String,
-                    last_updated DateTime DEFAULT now(),
-                    PRIMARY KEY (cluster_id)
-                ) ENGINE = ReplacingMergeTree(last_updated)
-                ORDER BY (cluster_id)
-            """
-            db.client.execute(query, settings={"data_type_default_nullable": 0})
+            clustering_tables.ensure_centroid_table(db)
         finally:
             db.close()
 
     def ensure_error_embeddings_table(self):
         """Ensure the error_embeddings table exists in ClickHouse."""
-
         db = ClickHouseVectorDB()
         try:
-            # Use the standard ClickHouse vector table structure
-            query = f"""
-                CREATE TABLE IF NOT EXISTS {self.table_name} (
-                    id UUID,
-                    eval_id UUID,
-                    vector Array(Float32),
-                    metadata Nested (
-                        key String,
-                        value Nullable(String)
-                    ),
-                    deleted UInt8 DEFAULT 0
-                ) ENGINE = MergeTree()
-                ORDER BY (eval_id, id)
-            """
-            db.client.execute(query, settings={"data_type_default_nullable": 0})
+            clustering_tables.ensure_error_embeddings_table(db)
         finally:
             db.close()
 

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -27,11 +27,14 @@ from tracer.models.trace_error_analysis import (
     FeedIssueStatus,
     TraceErrorGroup,
 )
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    ensure_centroid_table,
+)
 from tracer.types.eval_cluster_types import ClusterableEvalResult, EvalClusterMeta
 
 logger = structlog.get_logger(__name__)
 
-CENTROIDS_TABLE = "cluster_centroids"  # shared with scanner — different family values
 COSINE_THRESHOLD = 0.45
 
 # Only cluster recent eval failures — old results aren't actionable and
@@ -230,27 +233,6 @@ def embed_texts(texts: List[str]) -> List[List[float]]:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_centroid_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the cluster_centroids table exists (shared with scanner)."""
-    # Array(...) can't sit inside Nullable; override server profiles that set
-    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {CENTROIDS_TABLE} (
-            cluster_id String,
-            project_id UUID,
-            centroid Array(Float32),
-            member_count UInt32,
-            family String,
-            last_updated DateTime DEFAULT now(),
-            PRIMARY KEY (cluster_id)
-        ) ENGINE = ReplacingMergeTree(last_updated)
-        ORDER BY (cluster_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
-
 def _eval_family(eval_name: str, target_type: str = "span") -> str:
     """Family key for eval centroids — keeps the three targets (and scanner)
     in separate centroid spaces.
@@ -288,7 +270,7 @@ def find_nearest_centroid(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
         family = _eval_family(eval_name, target_type)
         rows = db.client.execute(
@@ -468,7 +450,7 @@ def create_cluster(
     family = _eval_family(result.eval_name, result.target_type)
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         db.client.execute(
             f"""
             INSERT INTO {CENTROIDS_TABLE}

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -23,12 +23,17 @@ from tracer.models.trace_error_analysis import (
     TraceErrorGroup,
 )
 from tracer.models.trace_scan import TraceScanIssue, TraceScanResult
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    TRACE_INPUTS_TABLE,
+    ensure_centroid_table,
+    ensure_trace_inputs_table,
+)
 from tracer.services.clickhouse.v2 import get_reader
 from tracer.types.scan_types import ClusterableIssue, TraceInputData
 
 logger = structlog.get_logger(__name__)
 
-CENTROIDS_TABLE = "cluster_centroids"
 COSINE_THRESHOLD = 0.45  # cosine distance: 0 = identical, 2 = opposite
 
 
@@ -108,27 +113,6 @@ def embed_texts(texts: List[str]) -> List[List[float]]:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_centroid_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the cluster_centroids table exists."""
-    # Array(...) can't sit inside Nullable; override server profiles that set
-    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {CENTROIDS_TABLE} (
-            cluster_id String,
-            project_id UUID,
-            centroid Array(Float32),
-            member_count UInt32,
-            family String,
-            last_updated DateTime DEFAULT now(),
-            PRIMARY KEY (cluster_id)
-        ) ENGINE = ReplacingMergeTree(last_updated)
-        ORDER BY (cluster_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
-
 def _update_centroid(
     current: List[float], new_vector: List[float], count: int
 ) -> List[float]:
@@ -151,7 +135,7 @@ def find_nearest_centroid(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
         rows = db.client.execute(
             f"""
@@ -243,7 +227,7 @@ def create_cluster(
     # Store centroid in ClickHouse
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         db.client.execute(
             f"""
             INSERT INTO {CENTROIDS_TABLE}
@@ -359,25 +343,6 @@ def assign_to_cluster(
 # Trace input embeddings (for success trace matching)
 # ---------------------------------------------------------------------------
 
-TRACE_INPUTS_TABLE = "trace_input_embeddings"
-
-
-def _ensure_trace_inputs_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the trace_input_embeddings table exists."""
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {TRACE_INPUTS_TABLE} (
-            trace_id UUID,
-            project_id UUID,
-            embedding Array(Float32),
-            has_issues Bool,
-            created_at DateTime DEFAULT now()
-        ) ENGINE = ReplacingMergeTree(created_at)
-        ORDER BY (project_id, trace_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
 
 def get_trace_input_data(trace_ids: List[str], project_id: str) -> List[TraceInputData]:
     """
@@ -466,7 +431,7 @@ def store_trace_input_embeddings(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         rows = [
             {
                 "trace_id": inp.trace_id,
@@ -508,7 +473,7 @@ def find_success_trace_baseline(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         vector_str = "[" + ",".join(map(str, query_embedding)) + "]"
 
         exclude_clause = ""
@@ -577,7 +542,7 @@ def get_cluster_trace_embeddings(
 
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         ids_str = ",".join(f"'{tid}'" for tid in trace_ids)
         rows = db.client.execute(
             f"""

--- a/futureagi/tracer/services/clickhouse/clustering_tables.py
+++ b/futureagi/tracer/services/clickhouse/clustering_tables.py
@@ -1,0 +1,123 @@
+"""Shared DDL for the clustering ClickHouse tables that live outside the managed
+v2 schema (``cluster_centroids``, ``trace_input_embeddings``, ``error_embeddings``).
+
+These tables are created lazily by the scanner / error / eval clustering query
+paths. The DDL was duplicated across three query modules (``cluster_centroids``
+alone had three identical copies); it lives here once so the engine-selection
+rule and the column layout have a single source of truth, and so the
+default-to-replicated migration command can create the same tables in a target
+database without re-declaring their schema.
+
+Engine selection mirrors ``ClickHouseVectorDB.create_table`` via
+``build_replicated_engine``: a multi-replica cluster gets the ``Replicated*``
+form ``ON CLUSTER`` with a Keeper path; single-node CH keeps the plain engine.
+Each table preserves its own sub-family — the ``cluster_centroids`` /
+``trace_input_embeddings`` ``ReplacingMergeTree`` dedup and the
+``error_embeddings`` plain ``MergeTree`` (soft-delete via ``ALTER ... UPDATE``,
+no version column) are intentional and must not be flattened to one engine.
+"""
+from __future__ import annotations
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    build_replicated_engine,
+)
+
+CENTROIDS_TABLE = "cluster_centroids"
+TRACE_INPUTS_TABLE = "trace_input_embeddings"
+ERROR_EMBEDDINGS_TABLE = "error_embeddings"
+
+
+def _qualified(table: str, database: str | None) -> str:
+    return f"{database}.{table}" if database else table
+
+
+def ensure_centroid_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the shared ``cluster_centroids`` table (scanner + error + eval)."""
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(last_updated)",
+        CENTROIDS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    # Array(...) can't sit inside Nullable; override server profiles that set
+    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(CENTROIDS_TABLE, database)}{on_cluster} (
+            cluster_id String,
+            project_id UUID,
+            centroid Array(Float32),
+            member_count UInt32,
+            family String,
+            last_updated DateTime DEFAULT now(),
+            PRIMARY KEY (cluster_id)
+        ) ENGINE = {engine}
+        ORDER BY (cluster_id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )
+
+
+def ensure_trace_inputs_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the ``trace_input_embeddings`` table (scanner success-trace KNN)."""
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(created_at)",
+        TRACE_INPUTS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(TRACE_INPUTS_TABLE, database)}{on_cluster} (
+            trace_id UUID,
+            project_id UUID,
+            embedding Array(Float32),
+            has_issues Bool,
+            created_at DateTime DEFAULT now()
+        ) ENGINE = {engine}
+        ORDER BY (project_id, trace_id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )
+
+
+def ensure_error_embeddings_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the ``error_embeddings`` table (error-feed cluster embeddings).
+
+    Plain ``MergeTree`` -> ``ReplicatedMergeTree``: rows are soft-deleted with
+    ``ALTER ... UPDATE deleted = 1`` and read with ``deleted = 0``, so a
+    ``Replacing`` engine would change the dedup semantics. Mutations on a
+    ``ReplicatedMergeTree`` propagate through the replication log on their own.
+    """
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree()",
+        ERROR_EMBEDDINGS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(ERROR_EMBEDDINGS_TABLE, database)}{on_cluster} (
+            id UUID,
+            eval_id UUID,
+            vector Array(Float32),
+            metadata Nested (
+                key String,
+                value Nullable(String)
+            ),
+            deleted UInt8 DEFAULT 0
+        ) ENGINE = {engine}
+        ORDER BY (eval_id, id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )


### PR DESCRIPTION
## Why

The shared `ClickHouseVectorDB.create_table` helper at `agentic_eval/core/database/ch_vector.py` emitted `MergeTree()` regardless of whether it was running against a single-node CH or a multi-replica cluster. On a multi-replica cluster the non-replicated engine family does not coordinate writes across replicas, so the three vector tables (`feedbacks`, `ground_truths`, `syn`) cannot converge.

This PR makes `create_table` auto-select the engine from the runtime cluster shape, threads the cluster name and target database through every DDL path, and ships a Django management command to copy historical rows out of a legacy non-replicated source database into a replicated target.

The operator cutover runbook (per-environment `CH_DATABASE` flip, consumer coordination, canary order, rollback path) is in the Linear ticket; this description stays scoped to the code and tests so it does not drift from things not encoded in this diff.

## What changed

### Backend

| File | Change |
|---|---|
| `agentic_eval/core/database/ch_vector.py` | New `get_clickhouse_cluster_name()` helper: reads `$CH_CLUSTER_NAME`, falls back to `'cluster'`. One source of truth for the runtime `EmbeddingManager` path and for the migration command's `--cluster` flag default. |
| `agentic_eval/core/database/ch_vector.py` | `_is_clustered()` probes `SELECT count() FROM system.clusters WHERE replica_num > 1` (cached per process, fails safe to `False`). The earlier `system.macros WHERE macro = 'replica'` heuristic flagged single-node CH with the macro pre-baked (Helm / docker-compose) as clustered; such nodes have no DDLWorker and any `ON CLUSTER` query fails. The new probe returns `0` on single-replica clusters and `> 0` only when a sibling replica genuinely exists. |
| `agentic_eval/core/database/ch_vector.py` | `create_table` reads `_is_clustered()` and accepts keyword-only `cluster: str \| None` and `database: str \| None` parameters. Emits `ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/<database>/<table>', '{replica}') ON CLUSTER '<cluster>'` when clustered; `ReplacingMergeTree()` when single-node. `ORDER BY id` and the column set (id UUID, eval_id UUID, vector Array(Float32), metadata Nested, deleted UInt8) preserved verbatim. The `database` parameter qualifies the CREATE TABLE target AND the Keeper path; required because mutating `clickhouse_driver.Connection.database` after the HELLO handshake does NOT reroute server-side queries, so callers that want a non-default database must qualify explicitly. |
| `agentic_eval/core/database/ch_vector.py` | Four commented-out debug `print()` lines scrubbed from `upsert_vector` and the vector-search path while the file is open. |
| `model_hub/management/commands/migrate_legacy_vectors_to_replicated.py` | New one-shot copy command from a non-replicated source DB into a replicated target. `--cluster` default reads through `get_clickhouse_cluster_name()`; threads its value into `CREATE DATABASE ON CLUSTER`, every `clusterAllReplicas(...)` read, and `db_client.create_table(table, cluster=cluster, database=target_db)` for each per-table CREATE TABLE. Identifier guard: `--source-database`, `--target-database`, `--cluster` validated against `^[A-Za-z_][A-Za-z0-9_]*$` before any SQL is composed. Parity-wait timeout emits a `migrate_parity_wait_timed_out` warning so a slow follower surfaces in logs. `existing_target_count` (used to report `newly_copied`) reads through `clusterAllReplicas + GROUP BY hostName() + min()` so a leader-only read can't mask a follower that's still behind. |

### Migration command flags

| Flag | Default | Purpose |
|---|---|---|
| `--source-database` | `$CH_DATABASE` or `default` | Source DB |
| `--target-database` | (required) | Target DB |
| `--tables` | `feedbacks,ground_truths,syn` | Subset allowlist |
| `--cluster` | `$CH_CLUSTER_NAME` or `cluster` | Cluster name; threaded through every DDL and read |
| `--dry-run` | off | Report intent without mutating CH |

### Migration command behaviour

| Behaviour |
|---|
| Refuses on invalid `--source-database` / `--target-database` / `--cluster` identifier |
| Refuses if `--source-database == --target-database` |
| Refuses if `_is_clustered()` is `False` (would re-introduce the non-replicated engine on the target) |
| Bootstraps target DB via `CREATE DATABASE IF NOT EXISTS <target> ON CLUSTER '<cluster>'` before per-table work |
| Creates the target table unconditionally so `ground_truths` (no legacy source rows yet) still gets a home for future writes; qualified via `database=<target_db>` |
| Copies via `INSERT INTO <target>.<t> SELECT * FROM clusterAllReplicas('<cluster>', <source>.<t>) WHERE id NOT IN (SELECT id FROM <target>.<t>)`; idempotent |
| Polls per-replica parity via `SELECT hostName(), count() FROM clusterAllReplicas('<cluster>', <target>) GROUP BY hostName()` for up to 30 s; logs `migrate_parity_wait_timed_out` on deadline |

## Tests

Two test modules, 24 cases. All mock the CH client at its boundary; no real cluster is required.

### `model_hub/tests/test_ch_vector_engine_selection.py` (12)

| # | Scenario |
|---|---|
| 1 | Single-node CH emits plain `ReplacingMergeTree()`, no `ON CLUSTER`, no `Replicated*` prefix |
| 2 | Clustered CH emits `ReplicatedReplacingMergeTree(...)` with `ON CLUSTER` and the correct ZK path |
| 3 | Each table gets its own ZK path; without `database=` the path matches the historical no-database convention so the runtime EmbeddingManager path doesn't break |
| 4 | Required columns preserved when clustered |
| 5 | `ORDER BY id` preserved (drives `ReplacingMergeTree` dedup semantics) |
| 6 | `_is_clustered()` runs the `system.clusters` probe once per process and caches the answer |
| 7 | Single-node CH with `replica` macro pre-baked returns `False` (regression guard for the previous lenient heuristic) |
| 8 | `_is_clustered()` fails safe to `False` when the probe raises |
| 9 | `create_table('feedbacks', cluster='fi_cluster')` pins `ON CLUSTER 'fi_cluster'` into the SQL (regression guard for the previously-hardcoded cluster name) |
| 10 | Default cluster resolves to `$CH_CLUSTER_NAME` if set; falls back to `'cluster'` |
| 11 | `create_table('feedbacks', database='futureagi')` qualifies the CREATE TABLE target as `futureagi.feedbacks` AND inserts a `futureagi/` segment into the Keeper path (regression guard for the connection-state mutation hack that silently kept tables in the source database) |
| 12 | `create_table('feedbacks')` with `database` unset stays unqualified so the table lands in the connection's current database |

### `model_hub/tests/test_migrate_legacy_vectors_to_replicated.py` (12)

| # | Scenario |
|---|---|
| 1 | Refuses when `--source-database == --target-database` |
| 2 | Refuses when `_is_clustered()` is `False` |
| 3 | Refuses an unknown table name not in the allowlist |
| 4 | `--dry-run` emits no `CREATE TABLE` and no `INSERT`, prints intent |
| 5 | Source absent: target table is still created (covers `ground_truths`), no INSERT runs |
| 6 | `CREATE DATABASE IF NOT EXISTS <target> ON CLUSTER` runs before any per-table SQL |
| 7 | `--dry-run` does not issue `CREATE DATABASE` |
| 8 | Real run emits `INSERT INTO <target> SELECT * FROM clusterAllReplicas('<cluster>', <source>) WHERE id NOT IN <target>` |
| 9 | Post-INSERT parity check uses `hostName()` + `clusterAllReplicas` + `GROUP BY hostName()`, not a leader-only count |
| 10 | `--cluster=fi_cluster` propagates into INSERT, parity SQL, AND the per-table `db_client.create_table(table, cluster='fi_cluster', database='futureagi')` call (regression guard against both the mock-masked cluster-threading bug and the connection-state database hack) |
| 11 | Re-run on already-migrated data inserts 0 rows (idempotent) |
| 12 | Multi-table run (`feedbacks`, `ground_truths`, `syn`) creates and INSERTs all three |

## End-to-end verification against the live local CH fixture

| Check | Result |
|---|---|
| `_is_clustered()` against single-node local CH | `False` (was `True` under the lenient macro heuristic) |
| Runtime `create_table('test_local_repl_check')` (no `database`) against local | Engine `ReplacingMergeTree`, no ON CLUSTER, table created in connection's current DB |
| `create_table('reroute_probe', database='test_target_db')` against local | Table landed in `test_target_db.reroute_probe` (verified via `system.tables`); the previous `connection.database` mutation hack had silently landed it in `default.reroute_probe` |
| Migration real run on local | Refuses cleanly: `CommandError: CH server is not a multi-replica cluster member (no row in system.clusters with replica_num > 1)` |
| Migration dry-run on local | `dry-run: would copy 6 rows from default.feedbacks -> <target>.feedbacks` |

## Command to run all tests in this PR

```bash
source .venv/bin/activate && DJANGO_SETTINGS_MODULE=tfc.settings.test pytest \
  model_hub/tests/test_migrate_legacy_vectors_to_replicated.py \
  model_hub/tests/test_ch_vector_engine_selection.py -v
```

<img width="1674" height="1196" alt="image" src="https://github.com/user-attachments/assets/b7f37645-466f-423b-906b-368cd7b73b27" />


## Architectural decisions

- Engine is auto-detected from `system.clusters`, not gated by an env flag. The deployment shape is already known to CH; an env flag would let a future single-node pod accidentally fall through to `ReplicatedReplacingMergeTree` (which depends on Keeper) or vice versa.
- The default cluster name `'cluster'` is the literal used by the standard ClickHouseInstallation manifest. `$CH_CLUSTER_NAME` overrides it for any deployment that uses a different `remote_servers` name.
- `_is_clustered()` probes `system.clusters.replica_num > 1` rather than `system.macros = 'replica'`. The macro is a property of the node config; the replica count is a property of the cluster topology. Only the latter is precise enough to distinguish a single-node dev box (which has the macro pre-baked but no DDLWorker) from a real multi-replica cluster.
- `create_table(*, database=None)` is the only safe way to land a table in a non-default database on a long-lived connection. `clickhouse_driver` sets the database during the HELLO handshake and per-query routing on the wire derives from that initial setting; mutating `Connection.database` after the handshake is bookkeeping-only and the next CREATE TABLE quietly lands in the original database. The ZK path picks up the database segment for the same reason: two replicated tables with the same short name in different databases must not coordinate on the same Keeper znode.
- Single-node engine moves from `MergeTree()` to `ReplacingMergeTree()`. The upsert path always inserts a fresh UUID per row, so `ReplacingMergeTree`'s dedup-by-`ORDER BY id` never triggers; this gives the local engine the same family name as prod with no row-count effect.
- Migration command keeps a small allowlist (`feedbacks, ground_truths, syn`). The CREATE TABLE schema and dedup-by-id assumption are vector-table-specific; a generalised command would either fork on schema per table or push schema ownership onto the operator, neither of which is minimum-diff for this PR's scope.
- Per-replica parity check uses `clusterAllReplicas` + `GROUP BY hostName()` rather than `SELECT count() FROM target`. Replicated engines pull writes from Keeper asynchronously on followers; a leader-only check could pass while a follower still lagged.
- Target DB is bootstrapped with `CREATE DATABASE IF NOT EXISTS <target> ON CLUSTER '<cluster>'` before any per-table CREATE TABLE; the first per-table CREATE on a fresh target would otherwise fail with `UNKNOWN_DATABASE`.

## Out of scope

- A multi-replica CH test rig in CI. The new tests pin the SQL strings; they cannot catch runtime cross-replica behaviour. Deferred to a separate infra ticket so this PR's diff stays focused on the SDK and command surface.
- `trace_input_embeddings`, `error_embeddings`, `cluster_centroids`, `llm_logs`. These tables have different schemas and dedup-key assumptions and are tracked under a separate ticket with separate ownership.
- Dropping the legacy vector tables in the old database. Out of this PR; should happen as a follow-up after the soak.
- The operator cutover runbook lives in the Linear ticket so the specifics are reviewable alongside the consumer inventory, not buried in a PR description that can drift from those facts.

## Linear

Closes TH-5914
