### PR TITLE
fix(docs): correct .env path and frontend port in contributor setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,11 @@ cd future-agi
 ### 2. Start the stack
 
 ```bash
-cp futureagi/.env.example futureagi/.env
+cp .env.example .env
 docker compose up -d
 ```
 
-The backend will be at `http://localhost:8000`, the frontend at `http://localhost:3031`.
+The backend will be at `http://localhost:8000`, the frontend at `http://localhost:3000`.
 
 ### 3. Install git hooks
 


### PR DESCRIPTION
## What

Fixes the "Development setup -> Start the stack" block in CONTRIBUTING.md.

## Why

Two issues break a first-time contributor setup:

1. `cp futureagi/.env.example futureagi/.env` points at the wrong file. `docker compose up -d` runs from the repo root and loads the **root** `.env`, so the copied `futureagi/.env` is never read. INSTALLATION.md correctly uses `cp .env.example .env`.
2. The frontend was listed at `localhost:3031`, but `docker-compose.yml` maps it to `3000` (`${FRONTEND_PORT:-3000}:80`), and the dev compose defaults to 3000 as well.

## Change

CONTRIBUTING.md now copies the root `.env` and points to port 3000, matching INSTALLATION.md and the compose files so the setup works as written.

## Notes

Docs-only change, no code paths touched. Spotted a separate item while here: `frontend/.env.example` still hardcodes `http://localhost:3031` in `VITE_ASSETS_API` and `VITE_GENERATE_LINK`. Left out of this PR to keep it focused; happy to open a follow-up issue.
