### PR TITLE
fix(tracer): isolate poison-pill spans so one bad row can't drop the whole batch

### DIFF
--- a/futureagi/tracer/tests/test_trace_ingestion_row_isolation.py
+++ b/futureagi/tracer/tests/test_trace_ingestion_row_isolation.py
@@ -1,0 +1,103 @@
+"""Regression tests for poison-pill isolation in span batch ingestion.
+
+A batch of spans is persisted with a single PostgreSQL ``COPY`` (all-or-nothing).
+``_serialize_json_field_value`` already scrubs the two known JSON triggers
+(non-finite floats and ``\\x00`` NUL bytes), but the COPY fast path only has a
+per-row fallback for primary-key collisions. Any *other* unwritable row — an
+over-length ``CharField`` value, a numeric overflow, a future field/constraint —
+would still fail the COPY and silently drop *every* span in the batch (the
+ingest API has already returned 200, the Temporal activity runs with
+``max_retries=0``).
+
+These tests use an over-length ``name`` (the column is ``varchar(2000)``, which
+scrubbing does not touch) to pin the contract: healthy spans persist, only the
+bad row(s) are dropped, and a batch where *nothing* writes still raises
+(systemic failure / all-bad batch must stay loud).
+"""
+
+import uuid
+from datetime import timedelta
+
+import psycopg
+import pytest
+from django.db import DatabaseError
+from django.utils import timezone
+
+from tracer.models.observation_span import ObservationSpan
+from tracer.utils.trace_ingestion import _bulk_insert_observation_spans
+
+# `name` is varchar(2000); this overflows it and is rejected by COPY with a
+# non-PK DataError (SQLSTATE 22001) that serialization scrubbing does not catch.
+_OVERLONG_NAME = "x" * 3000
+
+
+def _make_span(project, trace, *, name="span", span_input=None):
+    """Build an unsaved ObservationSpan mirroring the conftest fixture."""
+    return ObservationSpan(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name=name,
+        observation_type="llm",
+        start_time=timezone.now() - timedelta(seconds=5),
+        end_time=timezone.now(),
+        input=span_input if span_input is not None else {"content": "hello"},
+        status="OK",
+    )
+
+
+@pytest.mark.integration
+class TestSpanBatchPoisonIsolation:
+    def test_poison_row_does_not_drop_healthy_spans(self, db, project, trace):
+        """An unwritable row must not take down the rest of the batch."""
+        good_a = _make_span(project, trace, name="good_a")
+        poison = _make_span(project, trace, name=_OVERLONG_NAME)
+        good_b = _make_span(project, trace, name="good_b")
+
+        # Must not raise: the bad row is isolated, the rest is persisted.
+        _bulk_insert_observation_spans([good_a, poison, good_b])
+
+        persisted = set(
+            ObservationSpan.objects.filter(
+                id__in=[good_a.id, poison.id, good_b.id]
+            ).values_list("id", flat=True)
+        )
+        assert good_a.id in persisted
+        assert good_b.id in persisted
+        assert poison.id not in persisted
+
+    def test_all_rows_failing_stays_loud(self, db, project, trace):
+        """If nothing can be written, the DB error must propagate (stay loud).
+
+        Asserts the *specific* database error, not a bare Exception: a broad
+        ``pytest.raises(Exception)`` would stay green even if the isolation
+        fallback were removed and the raw batch error simply propagated.
+        """
+        poison_a = _make_span(project, trace, name=_OVERLONG_NAME)
+        poison_b = _make_span(project, trace, name=_OVERLONG_NAME)
+
+        with pytest.raises((DatabaseError, psycopg.Error)):
+            _bulk_insert_observation_spans([poison_a, poison_b])
+
+    def test_clean_batch_uses_fast_path(self, db, project, trace):
+        """The happy path is unchanged: a clean batch persists in full."""
+        spans = [_make_span(project, trace, name=f"clean_{i}") for i in range(3)]
+
+        _bulk_insert_observation_spans(spans)
+
+        assert (
+            ObservationSpan.objects.filter(id__in=[s.id for s in spans]).count() == 3
+        )
+
+    def test_large_batch_isolates_single_poison(self, db, project, trace):
+        """One bad row buried in a large batch drops only itself (bisection)."""
+        good = [_make_span(project, trace, name=f"good_{i}") for i in range(20)]
+        poison = _make_span(project, trace, name=_OVERLONG_NAME)
+        batch = good[:10] + [poison] + good[10:]
+
+        _bulk_insert_observation_spans(batch)
+
+        assert (
+            ObservationSpan.objects.filter(id__in=[s.id for s in good]).count() == 20
+        )
+        assert not ObservationSpan.objects.filter(id=poison.id).exists()

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -9,7 +9,14 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from django.db import IntegrityError, connection, models, transaction
+from django.db import (
+    IntegrityError,
+    InterfaceError,
+    OperationalError,
+    connection,
+    models,
+    transaction,
+)
 from django.utils import timezone
 
 from model_hub.models.prompt_label import PromptLabel
@@ -661,13 +668,127 @@ def _prepare_observation_spans_and_trace_updates(
     return spans_to_create, traces_to_update
 
 
+def _pg_error_code(exc: BaseException) -> str | None:
+    """Return the Postgres SQLSTATE for an exception, if any.
+
+    SQLSTATE (e.g. ``22001`` string-data-right-truncation, ``22003`` numeric
+    value out of range) identifies *why* a row was rejected without echoing the
+    offending value, so it is safe to log. We avoid ``str(exc)`` because some
+    psycopg ``DataError`` messages embed a fragment of the bad datum.
+    """
+    code = getattr(exc, "sqlstate", None)
+    if code is None:
+        code = getattr(getattr(exc, "__cause__", None), "sqlstate", None)
+    return code
+
+
+def _quarantine_record(span: ObservationSpan, exc: BaseException) -> dict[str, str]:
+    """Payload-free description of a dropped row, safe to log."""
+    return {
+        "span_id": str(span.id),
+        "error": type(exc).__name__,
+        "sqlstate": _pg_error_code(exc) or "",
+    }
+
+
+def _insert_spans_with_row_isolation(
+    spans_to_create: list[ObservationSpan],
+    original_exc: BaseException,
+) -> int:
+    """Fault-isolating fallback for a batch COPY that failed on a non-PK error.
+
+    ``_serialize_json_field_value`` already scrubs the two known JSON triggers
+    (non-finite floats and ``\\x00`` NUL bytes), but COPY is all-or-nothing and
+    the fast path only has a per-row fallback for primary-key collisions. Any
+    *other* unwritable row — an over-length ``CharField`` value, a numeric
+    overflow, a future field/constraint — therefore still rolls back and drops
+    *every* span in the batch. Scrubbing is a denylist of known-bad shapes; this
+    is the structural safety net beneath it.
+
+    We recover the healthy spans by **bisecting** the batch: a chunk that COPYs
+    cleanly is kept in a single statement, a chunk that fails is split in half
+    and retried, down to the individual offending row(s), which are quarantined.
+    Cost is O(k·log n) COPYs for k bad rows in a batch of n — not O(n) — and
+    every healthy span is still bulk-inserted.
+
+    Invariants that keep this correct and honest:
+
+    * Every COPY attempt runs in its own ``transaction.atomic()`` savepoint. In
+      Postgres the first failing statement aborts the surrounding transaction
+      until it is rolled back to a savepoint, so without one a single bad row
+      would take the rest of the batch (and the caller's outer transaction) down.
+    * A connection-level failure (``OperationalError``/``InterfaceError``) is
+      systemic, not a bad row, so it is re-raised immediately — we neither
+      bisect (pointless hammering of a down database) nor quarantine.
+    * If nothing else could be written either, the original error is re-raised:
+      an all-bad batch must stay loud rather than vanish silently.
+
+    Dropped rows are logged with their span id, exception class and Postgres
+    SQLSTATE only — never the payload — so the loss is observable without
+    leaking span contents.
+
+    Returns the number of spans successfully persisted.
+    """
+    from psycopg.errors import UniqueViolation as PgUniqueViolation
+
+    quarantined: list[dict[str, str]] = []
+
+    def _copy_chunk(chunk: list[ObservationSpan]) -> int:
+        if not chunk:
+            return 0
+        try:
+            with transaction.atomic():
+                _bulk_create_with_copy(ObservationSpan, chunk)
+            return len(chunk)
+        except (OperationalError, InterfaceError):
+            # Connection-level failure: systemic, not a bad row. Stay loud.
+            raise
+        except Exception as e:  # noqa: BLE001 - bisect to isolate the bad row(s)
+            if len(chunk) > 1:
+                mid = len(chunk) // 2
+                return _copy_chunk(chunk[:mid]) + _copy_chunk(chunk[mid:])
+            # Single row: a duplicate PK is already stored; anything else is
+            # genuinely unwritable and gets quarantined.
+            span = chunk[0]
+            if isinstance(
+                e, (IntegrityError, PgUniqueViolation)
+            ) and _is_pk_unique_violation(e, "tracer_observation_span"):
+                return 1
+            quarantined.append(_quarantine_record(span, e))
+            return 0
+
+    inserted = _copy_chunk(spans_to_create)
+
+    if quarantined and inserted == 0:
+        # Nothing got through and it was not a connection failure: an all-bad
+        # batch. Stay loud rather than silently dropping everything.
+        raise original_exc
+
+    if quarantined:
+        logger.error(
+            "observation_span_quarantined",
+            quarantined_count=len(quarantined),
+            inserted_count=inserted,
+            batch_size=len(spans_to_create),
+            samples=quarantined[:10],
+        )
+
+    return inserted
+
+
 def _bulk_insert_observation_spans(spans_to_create: list[ObservationSpan]):
     """Sets timestamps and bulk inserts observation spans.
 
-    Fast path: PostgreSQL COPY (all-or-nothing). On unique-key collision (e.g.
-    a client double-submitting an OTLP batch), the savepoint rolls back and we
-    re-insert via bulk_create(ignore_conflicts=True), which emits
+    Fast path: PostgreSQL COPY (all-or-nothing). On a primary-key collision
+    (e.g. a client double-submitting an OTLP batch), the savepoint rolls back
+    and we re-insert via bulk_create(ignore_conflicts=True), which emits
     INSERT ... ON CONFLICT DO NOTHING and skips only the duplicate rows.
+
+    Any other COPY failure means at least one span is unwritable for a reason
+    serialization scrubbing does not cover (an over-length value, a numeric
+    overflow, …). Because COPY is all-or-nothing, letting that propagate would
+    silently drop the whole batch, so we fall back to a bisecting insert that
+    isolates the offending rows (see ``_insert_spans_with_row_isolation``).
     """
     if not spans_to_create:
         return
@@ -685,18 +806,30 @@ def _bulk_insert_observation_spans(spans_to_create: list[ObservationSpan]):
     try:
         with transaction.atomic():
             _bulk_create_with_copy(ObservationSpan, spans_to_create)
-    except (IntegrityError, PgUniqueViolation) as e:
-        if not _is_pk_unique_violation(e, "tracer_observation_span"):
-            raise
-        logger.warning(
-            "observation_span_copy_pk_violation_falling_back",
-            batch_size=len(spans_to_create),
-        )
-        ObservationSpan.objects.bulk_create(
-            spans_to_create,
-            ignore_conflicts=True,
-            batch_size=500,
-        )
+    except Exception as e:
+        is_pk_violation = isinstance(
+            e, (IntegrityError, PgUniqueViolation)
+        ) and _is_pk_unique_violation(e, "tracer_observation_span")
+        if is_pk_violation:
+            logger.warning(
+                "observation_span_copy_pk_violation_falling_back",
+                batch_size=len(spans_to_create),
+            )
+            try:
+                with transaction.atomic():
+                    ObservationSpan.objects.bulk_create(
+                        spans_to_create,
+                        ignore_conflicts=True,
+                        batch_size=500,
+                    )
+                return
+            except Exception as e2:  # noqa: BLE001 - dups plus an unwritable row
+                # The batch had duplicates *and* at least one unwritable row,
+                # which ON CONFLICT DO NOTHING cannot rescue. Isolate instead.
+                _insert_spans_with_row_isolation(spans_to_create, e2)
+                return
+        # Non-PK failure: isolate the offending row(s), don't drop the batch.
+        _insert_spans_with_row_isolation(spans_to_create, e)
 
 
 def _bulk_update_traces(


### PR DESCRIPTION
## What

Adds a bisecting row-isolation fallback to span batch ingestion. When the batch
`COPY` fails for any reason other than a primary-key collision, the healthy
spans are recovered by isolating the offending row(s) instead of dropping the
whole batch — and the drop is logged (observable) instead of silent.

Closes #1080.

## Why

`_serialize_json_field_value` already scrubs the two known JSON triggers
(non-finite floats and `\x00` NUL bytes), which is great — but it is a denylist
of *known-bad shapes*. The COPY path itself is still all-or-nothing with a
per-row fallback only for PK collisions:

```python
except (IntegrityError, PgUniqueViolation) as e:
    if not _is_pk_unique_violation(e, "tracer_observation_span"):
        raise            # ← any other bad row → whole batch lost
```

So any unwritable row scrubbing does **not** cover — an over-length `CharField`
value (`name` is `varchar(2000)`), a numeric overflow, a future field or
constraint — still fails the COPY and silently discards **every other span in
the same batch**. The ingest API has already returned `200` and the activity
runs with `@temporal_activity(max_retries=0)`, so the loss is invisible and not
retried. This PR is the structural safety net *beneath* the scrubbing.

## How

- New `_insert_spans_with_row_isolation`: on a non-PK COPY failure, **bisect**
  the batch — a clean chunk is kept in one statement, a failing chunk is split
  in half and retried, down to the individual bad row(s), which are quarantined.
  Cost is O(k·log n) COPYs for k bad rows in n, not O(n); healthy spans are
  still bulk-inserted.
- Every COPY attempt runs in its own `transaction.atomic()` savepoint (Postgres
  aborts the surrounding transaction on the first failing statement until it is
  rolled back to a savepoint).
- Connection-level failures (`OperationalError`/`InterfaceError`) are re-raised
  immediately — systemic, not a bad row, so no pointless bisecting of a down DB.
- If nothing could be written either, the original error is re-raised: an
  all-bad batch stays loud rather than vanishing.
- Quarantined rows are logged as `observation_span_quarantined` with span id,
  exception class and Postgres **SQLSTATE** only — never the payload.

## Test plan

`futureagi/tracer/tests/test_trace_ingestion_row_isolation.py` (uses an
over-length `name`, a trigger scrubbing does not touch):

- `test_poison_row_does_not_drop_healthy_spans` — `[good, bad, good]` persists
  the two good spans, drops only the bad one.
- `test_all_rows_failing_stays_loud` — an all-bad batch re-raises a
  `DatabaseError`/`psycopg.Error` (asserts the specific error, so the test fails
  if isolation is removed).
- `test_clean_batch_uses_fast_path` — the happy path is unchanged.
- `test_large_batch_isolates_single_poison` — one bad row in 20 drops only
  itself (exercises bisection).

Run: `pytest futureagi/tracer/tests/test_trace_ingestion_row_isolation.py`
(needs the Postgres-backed test DB).
