### PR TITLE
fix(tracer): null-safe ERROR filter in CH eval-score aggregation (closes #987)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -308,7 +308,7 @@ class AnalyticsQueryService:
             WHERE trace_id IN %(trace_ids)s
               AND custom_eval_config_id IN %(config_ids)s
               AND {eval_nd}
-              AND output_str != 'ERROR'
+              AND ifNull(output_str, '') != 'ERROR'
               AND (error = 0 OR error IS NULL)
             GROUP BY trace_id, custom_eval_config_id
         """

--- a/futureagi/tracer/tests/test_eval_config_ids_resolution.py
+++ b/futureagi/tracer/tests/test_eval_config_ids_resolution.py
@@ -242,6 +242,23 @@ class TestEvalReadSelectors:
         assert "custom_eval_config_id IN %(config_ids)s" in query
         assert captured["params"] == {"trace_ids": ["t1"], "config_ids": ["c1"]}
 
+    @override_settings(CH25_EVAL_LOGGER_TABLE="tracer_eval_logger_v2")
+    def test_trace_eval_scores_error_filter_is_null_safe(self):
+        """``output_str`` is Nullable and successful evals leave it NULL.
+
+        A bare ``output_str != 'ERROR'`` evaluates to NULL (falsy) for those
+        rows under ClickHouse three-valued logic, silently dropping every
+        successful eval from the aggregate (issue #987). The guard must be
+        null-safe, matching the already-fixed trace_list/span_list builders.
+        """
+        svc, captured = _capturing_service([{"trace_id": "t", "config_id": "c"}])
+        svc.get_trace_eval_scores_ch(["t1"], ["c1"])
+        query = captured["query"]
+
+        assert "ifNull(output_str, '') != 'ERROR'" in query
+        # The bare, null-unsafe form must not survive.
+        assert "output_str != 'ERROR'" not in query
+
     def test_trace_eval_scores_empty_short_circuits(self):
         svc, captured = _capturing_service([{"trace_id": "t"}])
         assert svc.get_trace_eval_scores_ch([], ["c1"]) == []


### PR DESCRIPTION
## What

Makes the `ERROR` filter in the ClickHouse per-(trace, config) eval-score
aggregation null-safe, so successful evaluations are no longer silently dropped
from session/trace scores.

Closes #987.

## Why

`AnalyticsQueryService.get_trace_eval_scores_ch` filtered rows with a bare
comparison:

```sql
AND output_str != 'ERROR'
```

`output_str` is `Nullable(String)` and successful evaluators typically leave it
`NULL`. Under ClickHouse three-valued logic `NULL != 'ERROR'` is `NULL` (falsy),
so every successful eval is excluded from `avg(output_float)` / `avg(output_bool)`.
On the session detail page (`GET /tracer/trace-session/:id/`, which calls this via
`TraceSessionView._retrieve_clickhouse`) the eval scores then read empty/0/NaN
even though the evals succeeded — exactly the report in #987.

## How

```sql
AND ifNull(output_str, '') != 'ERROR'
```

This mirrors the guard already applied in the `trace_list`, `span_list` and
`voice_call_list` query builders (which carry an explanatory comment about this
same three-valued-logic footgun).

**Audit:** I swept the rest of the ClickHouse query layer for the same pattern.
This was the **last unguarded instance** — the other comparison sites are either
already guarded (`ifNull` / `IS NULL OR`), target non-Nullable v2 columns
(`DEFAULT ''`), are positive-membership filters where excluding `NULL` is
intended, or run through Django's ORM `.exclude()` (which is NULL-safe by
construction).

## Test plan

Adds `test_trace_eval_scores_error_filter_is_null_safe` to
`test_eval_config_ids_resolution.py` — it captures the generated SQL (the
existing `_capturing_service` harness, no live ClickHouse needed) and asserts the
null-safe `ifNull(output_str, '') != 'ERROR'` guard is present and the bare form
is gone.
