### PR TITLE
fix(tracer): bucket system metrics on start_time to match the CH dashboard (closes #1084)

### DIFF
--- a/futureagi/tracer/tests/test_system_metrics_bucketing.py
+++ b/futureagi/tracer/tests/test_system_metrics_bucketing.py
@@ -1,0 +1,69 @@
+"""Regression test: system-metric charts bucket on event time (start_time).
+
+The live ClickHouse dashboard (``TimeSeriesQueryBuilder``) buckets and windows
+metrics on ``start_time``. The Postgres path used to bucket on ``created_at``
+(ingestion time), so a backfilled or replayed span — ``created_at`` now,
+``start_time`` in the past — landed in a different time bucket depending on
+which store served the request. This pins the PG path to ``start_time``.
+
+Integration test: needs the Postgres test DB (the ORM aggregation runs real
+SQL). It does not exercise ClickHouse.
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from tracer.models.observation_span import ObservationSpan
+from tracer.utils.graphs_optimized import get_all_system_metrics
+
+
+def _make_span(project, trace, *, start_time):
+    """Create a span with a given start_time. created_at is auto-set to now."""
+    return ObservationSpan.objects.create(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name="s",
+        observation_type="llm",
+        start_time=start_time,
+        end_time=start_time + timedelta(seconds=1),
+        latency_ms=100,
+        total_tokens=10,
+        cost=0.001,
+        status="OK",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_system_metrics_bucket_on_start_time(project, trace):
+    """Spans land in their event-time bucket, not their ingestion-time bucket.
+
+    Both spans are created now (``created_at`` ~ today) but carry ``start_time``
+    on different past days inside the default 7-day window. Bucketing on
+    ``start_time`` puts each on its event day; bucketing on ``created_at`` would
+    pile both onto today and leave the event days empty.
+    """
+    now = timezone.now()
+    _make_span(project, trace, start_time=now - timedelta(days=2))
+    _make_span(project, trace, start_time=now - timedelta(days=5))
+
+    result = get_all_system_metrics(
+        interval="day",
+        filters=[],
+        property="",
+        system_metric_filters={"project_id": str(project.id)},
+    )
+
+    traffic = {p["timestamp"][:10]: p["traffic"] for p in result["traffic"]}
+    today = now.date().isoformat()
+    day2 = (now - timedelta(days=2)).date().isoformat()
+    day5 = (now - timedelta(days=5)).date().isoformat()
+
+    assert traffic.get(day2) == 1, traffic
+    assert traffic.get(day5) == 1, traffic
+    # created_at-bucketing would have put both spans here.
+    assert traffic.get(today, 0) == 0, traffic

--- a/futureagi/tracer/utils/graphs_optimized.py
+++ b/futureagi/tracer/utils/graphs_optimized.py
@@ -622,31 +622,20 @@ def get_all_system_metrics(
             "cost": {"metric_name": "cost", "data": [...]}
         }
 
-    CH25-TODO(semantic-mismatch-prevents-1-line-migration): the new
-    time_bucket_aggregate reader returns the right output shape
-    ({bucket, span_count, tokens, cost, latency_ms}) but with TWO
-    silent semantic drifts versus this PG helper:
-      (1) buckets on `start_time` (the spans column used in CH) whereas
-          this PG path uses Trunc("created_at"). For just-completed
-          spans these are usually within seconds, but for backfilled or
-          replayed spans they can diverge.
-      (2) emits `cost = sum(cost)` whereas this PG path returns
-          `cost_value = Avg("cost")` per bucket. Cost-per-bucket vs
-          total-cost-per-bucket — semantically different.
-    The sibling helper get_system_metric_graph_data (below) dispatches
-    to TimeSeriesQueryBuilder; that builder has two internal branches:
-      • the preaggregated `span_metrics_hourly.hour` path (built from
-        `created_at` in the materialized view), which matches the PG
-        `created_at` semantics here
-      • the raw filtered `start_time`-bucketed path (matches drift 1)
-    So drift (1) already exists internally inside the sibling CH
-    builder. Drift (2) is unique to `time_bucket_aggregate`.
-    A safe migration of THIS helper needs either:
-      (a) a `time_bucket_aggregate(...,  cost_agg="avg"|"sum",
-          bucket_field="start_time"|"created_at")` reader signature,
-      (b) accepting the drift and writing a product decision doc that
-          replays both paths through `start_time` + `avg(cost)`.
-    Defer.
+    Bucketing: this PG path buckets and windows on ``start_time`` (event time)
+    to match the live ClickHouse dashboard, whose ``TimeSeriesQueryBuilder``
+    buckets on ``start_time``, and the session/replay path, which orders on
+    ``Coalesce(start_time, created_at)``. Bucketing on ``created_at`` (ingestion
+    time) instead made a backfilled or replayed span — ``created_at`` now,
+    ``start_time`` in the past — land in a different time bucket here than in
+    CH, so a CH-enabled deployment switched dashboard numbers silently whenever
+    it fell back to PG.
+
+    Note: the ``sum(cost)`` vs ``avg(cost)`` mismatch once flagged here is not a
+    live drift — every dashboard path (this PG one and CH
+    ``TimeSeriesQueryBuilder``) aggregates ``avg(cost)``. The ``sum`` form lives
+    only in ``time_bucket_aggregate``, which feeds monitors, where a per-bucket
+    total is the intended metric.
     """
     # Parse time filters
     start_date, end_date = parse_time_filters(filters)
@@ -657,8 +646,8 @@ def get_all_system_metrics(
     if project_id:
         base_queryset = ObservationSpan.objects.filter(
             project_id=project_id,
-            created_at__gte=start_date,
-            created_at__lte=end_date,
+            start_time__gte=start_date,
+            start_time__lte=end_date,
         )
     else:
         raise ValueError("Either project_id or span_ids must be provided")
@@ -669,7 +658,7 @@ def get_all_system_metrics(
     trunc_func = get_truncate_function(interval)
 
     aggregated_data = (
-        base_queryset.annotate(time_bucket=trunc_func("created_at"))
+        base_queryset.annotate(time_bucket=trunc_func("start_time"))
         .values("time_bucket")
         .annotate(
             latency_value=Avg("latency_ms"),
@@ -1069,8 +1058,8 @@ def get_system_metric_data(
         # Never evaluates the trace IDs into Python memory
         base_queryset = ObservationSpan.objects.filter(
             trace_id__in=trace_ids_queryset.values("id"),
-            created_at__gte=start_date,
-            created_at__lte=end_date,
+            start_time__gte=start_date,
+            start_time__lte=end_date,
         )
 
     elif observe_type == "span":
@@ -1086,8 +1075,8 @@ def get_system_metric_data(
         # Memory efficient even with 1M+ records
         base_queryset = ObservationSpan.objects.filter(
             id__in=span_ids_queryset.values("id"),
-            created_at__gte=start_date,
-            created_at__lte=end_date,
+            start_time__gte=start_date,
+            start_time__lte=end_date,
         )
 
     elif observe_type == "charts":
@@ -1100,8 +1089,8 @@ def get_system_metric_data(
 
         base_queryset = ObservationSpan.objects.filter(
             project_id=project_id,
-            created_at__gte=start_date,
-            created_at__lte=end_date,
+            start_time__gte=start_date,
+            start_time__lte=end_date,
         )
         base_queryset = apply_chart_span_filters(base_queryset, filters)
 
@@ -1114,7 +1103,7 @@ def get_system_metric_data(
     # Aggregate based on metric type
     if metric_name == "latency":
         aggregated_data = (
-            base_queryset.annotate(time_bucket=trunc_func("created_at"))
+            base_queryset.annotate(time_bucket=trunc_func("start_time"))
             .values("time_bucket")
             .annotate(value=Avg("latency_ms"), count=Count("id"))
             .order_by("time_bucket")
@@ -1122,7 +1111,7 @@ def get_system_metric_data(
 
     elif metric_name == "tokens":
         aggregated_data = (
-            base_queryset.annotate(time_bucket=trunc_func("created_at"))
+            base_queryset.annotate(time_bucket=trunc_func("start_time"))
             .values("time_bucket")
             .annotate(value=models.Sum("total_tokens"), count=Count("id"))
             .order_by("time_bucket")
@@ -1130,7 +1119,7 @@ def get_system_metric_data(
 
     elif metric_name == "cost":
         aggregated_data = (
-            base_queryset.annotate(time_bucket=trunc_func("created_at"))
+            base_queryset.annotate(time_bucket=trunc_func("start_time"))
             .values("time_bucket")
             .annotate(value=Avg("cost"), count=Count("id"))
             .order_by("time_bucket")


### PR DESCRIPTION
## What

Buckets and windows the Postgres system-metric charts on **`start_time`** (event time) instead of `created_at` (ingestion time), so they agree with the live ClickHouse dashboard.

Closes #1084.

## Why

The live CH path (`TimeSeriesQueryBuilder`) buckets/windows on `start_time`; the PG path used `created_at`. A backfilled, replayed, or late span (`start_time` past, `created_at` now) landed in a **different time bucket** depending on which store answered — silently. CH-enabled deployments flipped on PG fallback; OSS-without-CH always used ingestion-time bucketing.

`start_time` is canonical: it's standard observability semantics, it's what CH uses, and the team already orders the session/replay path on `Coalesce(start_time, created_at)` (`utils/replay_session.py`).

## How

- `get_all_system_metrics` and `get_system_metric_data`: window on `start_time__gte/lte` and bucket on `Trunc("start_time")`.
- Rewrote the stale `CH25-TODO` in `graphs_optimized.py`: the `sum`/`avg` cost "drift" it flagged is **not live** (every dashboard path aggregates `avg(cost)`; `sum` lives only in `time_bucket_aggregate`, which feeds monitors). Only the bucket field drifted.

## Notes / scope

- **Null `start_time`** (PG `null=True`, but OTLP defaults it to `now()`, so rare): now excluded from these metrics — which matches CH, whose non-Nullable `start_time` coerces null to epoch (outside any window). Net: more CH↔PG agreement.
- **Index**: existing composites are `(project, created_at)`; `start_time` has a single-column index. A `(project, start_time)` composite is a sensible follow-up for project-scoped windows.
- **Deliberately out of scope**: the same `Trunc("created_at")` pattern in the **eval-output** (`_aggregate_for_standard_view`) and **annotation** (`_aggregate_annotation_data`) charts is left untouched — changing them needs confirmation that their CH counterparts bucket on `start_time` first, else it would *introduce* a drift.

## Test plan

Adds `test_system_metrics_bucketing.py`: two spans created now but with `start_time` on different past days; asserts they bucket on their event days and **not** on today (which `created_at`-bucketing would have done). Integration test — needs the Postgres test DB; I could not run it in my local environment (no Django deps installed), so it's validated by CI.
