### PR TITLE
fix: correct internal gateway port from 8090 to 8080 in docker-compose.yml (Fixes #1058)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Good feature requests:
 
 1. Pick a [`good first issue`](https://github.com/future-agi/future-agi/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) (or open one)
 2. Comment that you're working on it so we don't double-up
-3. Branch from `main`: `git checkout -b fix/short-description`
+3. Branch from `dev`: `git checkout -b fix/short-description`
 4. Make your change — keep the diff small and focused
 5. Add tests (every bug fix needs a regression test)
 6. Make sure `make check-all` passes

--- a/agentcc-gateway/internal/auth/keystore.go
+++ b/agentcc-gateway/internal/auth/keystore.go
@@ -367,6 +367,27 @@ type SyncedKey struct {
 	Models    []string          `json:"models"`
 	Providers []string          `json:"providers"`
 	Metadata  map[string]string `json:"metadata"`
+	ExpiresAt *time.Time        `json:"expires_at"`
+}
+
+// syncedKeyToAPIKey is the single construction site for both sync paths, so a
+// field can't be wired into one and missed in the other.
+func syncedKeyToAPIKey(sk SyncedKey, id string) *APIKey {
+	return &APIKey{
+		ID:               id,
+		KeyHash:          sk.KeyHash,
+		Name:             sk.Name,
+		Owner:            sk.Owner,
+		Status:           "active",
+		KeyType:          "byok",
+		Source:           "sync",
+		AllowedModels:    sk.Models,
+		AllowedProviders: sk.Providers,
+		Metadata:         sk.Metadata,
+		ExpiresAt:        sk.ExpiresAt,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
 }
 
 // LoadFromHashes merges control-plane keys (identified by pre-computed hashes)
@@ -392,20 +413,7 @@ func (ks *KeyStore) LoadFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key
@@ -468,20 +476,7 @@ func (ks *KeyStore) SyncFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"sync"
@@ -426,6 +427,137 @@ func TestExpiresAt_FromConfig(t *testing.T) {
 	expected, _ := time.Parse(time.RFC3339, expiresStr)
 	if !k.ExpiresAt.Equal(expected) {
 		t.Errorf("expected ExpiresAt %v, got %v", expected, *k.ExpiresAt)
+	}
+}
+
+// ---------- Synced-key expiry (control-plane path) ----------
+
+func syncKeyStore() *KeyStore {
+	return NewKeyStore(authCfg())
+}
+
+// Decoding the wire payload is where the original bug lived (the field was
+// dropped); DRF emits RFC3339 with offset + fractional seconds.
+func TestSyncedKey_DecodesExpiresAt(t *testing.T) {
+	const payload = `{
+		"id": "ck_1",
+		"name": "contractor",
+		"key_hash": "abc123",
+		"expires_at": "2030-06-15T12:30:45.123456Z"
+	}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if sk.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to decode from the wire, got nil")
+	}
+	want, _ := time.Parse(time.RFC3339, "2030-06-15T12:30:45.123456Z")
+	if !sk.ExpiresAt.Equal(want) {
+		t.Errorf("expected ExpiresAt %v, got %v", want, *sk.ExpiresAt)
+	}
+
+	// Null expiry must decode to nil (never-expiring keys).
+	var nullSk SyncedKey
+	if err := json.Unmarshal([]byte(`{"key_hash":"h","expires_at":null}`), &nullSk); err != nil {
+		t.Fatalf("unmarshal null failed: %v", err)
+	}
+	if nullSk.ExpiresAt != nil {
+		t.Errorf("expected nil ExpiresAt for null wire value, got %v", *nullSk.ExpiresAt)
+	}
+}
+
+// Real wire payload with a past expiry, decoded then synced, must be rejected.
+func TestSyncedExpiredKey_DecodeToReject(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired"
+	payload := `{"id":"ck_exp","name":"c","key_hash":"` + HashKey(rawKey) +
+		`","expires_at":"2000-01-01T00:00:00Z"}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{sk})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key (decoded from wire) to be rejected")
+	}
+}
+
+func TestSyncFromHashes_ExpiredKeyRejected(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired-2"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_expired",
+		Name:      "contractor",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if k := ks.Get("ck_expired"); k == nil || k.ExpiresAt == nil {
+		t.Fatal("expected synced key to carry ExpiresAt")
+	}
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key to be rejected")
+	}
+}
+
+func TestSyncFromHashes_FutureExpiryAccepted(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-future"
+	future := time.Now().Add(1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_future",
+		Name:      "valid",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &future,
+	}})
+
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected synced key with future expiry to authenticate")
+	}
+}
+
+func TestSyncFromHashes_NilExpiryNeverExpires(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-noexpiry"
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:      "ck_noexpiry",
+		Name:    "perpetual",
+		KeyHash: HashKey(rawKey),
+		// ExpiresAt nil — must remain non-expiring.
+	}})
+
+	k := ks.Get("ck_noexpiry")
+	if k == nil || k.ExpiresAt != nil {
+		t.Fatal("expected nil ExpiresAt on synced key")
+	}
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected non-expiring synced key to authenticate")
+	}
+}
+
+func TestLoadFromHashes_PropagatesExpiry(t *testing.T) {
+	const rawKey = "sk-agentcc-loaded-expired"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.LoadFromHashes([]SyncedKey{{
+		ID:        "ck_loaded",
+		Name:      "loaded",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired key loaded via LoadFromHashes to be rejected")
 	}
 }
 

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -399,8 +399,8 @@ func TestKeyPrefix(t *testing.T) {
 
 	// Long key: len > 12, prefix is first 12 + "..."
 	long := keyPrefix("sk-agentcc-abcdef1234567890")
-	if long != "sk-agentcc-abc..." {
-		t.Errorf("expected long key prefix 'sk-agentcc-abc...', got '%s'", long)
+	if long != "sk-agentcc-a..." {
+		t.Errorf("expected long key prefix 'sk-agentcc-a...', got '%s'", long)
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,8 @@ x-backend-env: &backend-env
   OTEL_ENABLED: ${OTEL_ENABLED:-false}
 
   # LLM gateway + code sandbox + embedding service
-  AGENTCC_INTERNAL_URL: http://agentcc-gateway:8090
-  AGENTCC_GATEWAY_INTERNAL_URL: http://agentcc-gateway:8090
+  AGENTCC_INTERNAL_URL: http://agentcc-gateway:8080
+  AGENTCC_GATEWAY_INTERNAL_URL: http://agentcc-gateway:8080
   AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
   AGENTCC_ADMIN_TOKEN: ${AGENTCC_ADMIN_TOKEN:-local-dev-only-admin-token-replace-me}
   RECAPTCHA_ENABLED: ${RECAPTCHA_ENABLED:-false}

--- a/frontend/src/sections/gateway/utils/formatters.js
+++ b/frontend/src/sections/gateway/utils/formatters.js
@@ -16,9 +16,16 @@ export function formatCost(value) {
   if (value == null) return "$0.00";
   const num = Number(value);
   if (Number.isNaN(num)) return "$0.00";
-  if (num >= 1000) return `$${(num / 1000).toFixed(1)}K`;
-  if (num >= 1) return `$${num.toFixed(2)}`;
-  return `$${num.toFixed(4)}`;
+
+  const abs = Math.abs(num);
+
+  if (abs >= 1000) return `$${(num / 1000).toFixed(1)}K`;
+  if (abs >= 1) return `$${num.toFixed(2)}`;
+  if (abs >= 0.01) return `$${num.toFixed(4)}`;
+  if (abs >= 0.001) return `$${num.toFixed(5)}`;
+  if (abs > 0) return `$${num.toFixed(7).replace(/0+$/, "0")}`;
+
+  return "$0.00";
 }
 
 export function formatPercent(value, decimals = 1) {

--- a/futureagi/agentcc/tests/test_api_key_bulk.py
+++ b/futureagi/agentcc/tests/test_api_key_bulk.py
@@ -1,0 +1,78 @@
+"""Bulk API-key sync endpoint: expires_at wire format and expired-key filtering."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from agentcc.models import AgentccAPIKey
+
+ADMIN_TOKEN = "agentcc-admin-secret"
+
+
+@pytest.fixture(autouse=True)
+def set_agentcc_admin_token():
+    with patch("agentcc.permissions.AGENTCC_ADMIN_TOKEN", ADMIN_TOKEN):
+        yield
+
+
+@pytest.fixture
+def admin_client():
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {ADMIN_TOKEN}")
+    return client
+
+
+def _make_key(organization, workspace, gateway_key_id, key_hash, expires_at):
+    return AgentccAPIKey.objects.create(
+        gateway_key_id=gateway_key_id,
+        name=gateway_key_id,
+        organization=organization,
+        workspace=workspace,
+        key_hash=key_hash,
+        status=AgentccAPIKey.ACTIVE,
+        expires_at=expires_at,
+    )
+
+
+class TestAPIKeyBulkExpiresAt:
+    def test_future_and_null_expiry_are_serialized_on_the_wire(
+        self, admin_client, organization, workspace
+    ):
+        future = timezone.now() + timedelta(days=7)
+        _make_key(organization, workspace, "gw-expiring", "a" * 64, future)
+        _make_key(organization, workspace, "gw-perpetual", "b" * 64, None)
+
+        response = admin_client.get("/agentcc/api-keys/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # Assert on the rendered JSON the gateway actually receives, not the
+        # pre-render Python datetime.
+        by_id = {item["id"]: item for item in response.json()["result"]}
+
+        # Future-expiry key: expires_at is an ISO 8601 string the gateway can
+        # parse as RFC3339 (DRF renders aware datetimes with a 'Z'/offset).
+        expiring = by_id["gw-expiring"]["expires_at"]
+        assert isinstance(expiring, str)
+        parsed = datetime.fromisoformat(expiring.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None  # must be timezone-aware
+
+        # Null expiry stays null (never-expiring keys).
+        assert by_id["gw-perpetual"]["expires_at"] is None
+
+    def test_expired_keys_are_not_shipped(
+        self, admin_client, organization, workspace
+    ):
+        past = timezone.now() - timedelta(days=1)
+        _make_key(organization, workspace, "gw-expired", "c" * 64, past)
+        _make_key(organization, workspace, "gw-live", "d" * 64, None)
+
+        ids = {item["id"] for item in admin_client.get(
+            "/agentcc/api-keys/bulk/"
+        ).json()["result"]}
+
+        assert "gw-expired" not in ids  # filtered at the query level
+        assert "gw-live" in ids

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -1,4 +1,6 @@
 import structlog
+from django.db.models import Q
+from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 
@@ -25,10 +27,13 @@ class APIKeyBulkView(APIView):
 
     def get(self, request):
         try:
+            # Don't ship already-expired keys, even to gateways that predate
+            # real-time expiry enforcement.
+            now = timezone.now()
             keys = AgentccAPIKey.no_workspace_objects.filter(
                 status=AgentccAPIKey.ACTIVE,
                 deleted=False,
-            )
+            ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
 
             result = []
             for key in keys:
@@ -43,6 +48,7 @@ class APIKeyBulkView(APIView):
                         "models": key.allowed_models or [],
                         "providers": key.allowed_providers or [],
                         "metadata": key.metadata or {},
+                        "expires_at": key.expires_at,
                     }
                 )
 

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -55,4 +55,4 @@ class APIKeyBulkView(APIView):
             return self._gm.success_response(result)
         except Exception as e:
             logger.exception("api_key_bulk_error", error=str(e))
-            return self._gm.bad_request(str(e))
+            return self._gm.internal_server_error_response("Internal server error")

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1287,6 +1287,13 @@ class DashboardQueryBuilder:
             f"{time_col} < %(end_date)s",
         ]
 
+        # spans is partitioned by toYYYYMM(created_at) but the window is
+        # filtered on start_time, so bound created_at too — otherwise no
+        # partitions prune and the scan covers all history. Lower bound only
+        # (created_at >= start_time always holds), so no in-window row drops.
+        if time_col != "created_at":
+            clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
+
         # Apply global + per-metric system_metric filters directly
         # For string-comparable system metrics, use toString() to avoid UUID parse errors
         _STRING_FILTER_COL = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -743,6 +743,51 @@ class TestDashboardQueryBuilder:
         assert "toStartOfDay" in sql
         assert params["project_ids"] == sample_query_config["project_ids"]
 
+    def test_system_metric_query_prunes_partitions(self, sample_query_config):
+        """Spans-based queries must bound created_at (the partition key) so a
+        windowed query prunes old partitions instead of scanning all history."""
+        builder = DashboardQueryBuilder(sample_query_config)
+        sql, _, _ = builder.build_all_queries()[0]
+        # partition-prune bound on the partition key is present
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        # and the precise event-time window is still enforced (correctness)
+        assert "start_time >= %(start_date)s" in sql
+        assert "start_time < %(end_date)s" in sql
+
+    def test_breakdown_query_prunes_partitions(self):
+        """A latency average broken down by a custom span attribute must emit
+        the created_at partition-prune bound while preserving the start_time
+        window."""
+        config = {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [],
+            "breakdowns": [
+                {
+                    "name": "final_status",
+                    "type": "custom_attribute",
+                    "source": "traces",
+                    "display_name": "final_status",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        # the breakdown is still applied (real call path intact)
+        assert "breakdown_value" in sql
+
     def test_all_system_metrics(self):
         for metric_name in SYSTEM_METRICS:
             config = {

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1057,24 +1057,26 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     from tracer.services.clickhouse.client import get_clickhouse_client
 
                     ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
                     rows, cols, _ = ch.execute_read(
                         """
                         SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
+                            SELECT
+                                pair.1 AS key,
+                                pair.2 AS type,
+                                count() AS cnt
+                            FROM (
+                                SELECT span_attr_str, span_attr_num, span_attr_bool
+                                FROM spans
+                                WHERE project_id IN %(project_ids)s
+                                  AND _peerdb_is_deleted = 0
+                                LIMIT 100000
+                            )
+                            ARRAY JOIN arrayConcat(
+                                arrayMap(k -> (k, 'text'),    mapKeys(span_attr_str)),
+                                arrayMap(k -> (k, 'number'),  mapKeys(span_attr_num)),
+                                arrayMap(k -> (k, 'boolean'), mapKeys(span_attr_bool))
+                            ) AS pair
+                            GROUP BY pair.1, pair.2
                         )
                         GROUP BY key ORDER BY key LIMIT 2000
                         """,


### PR DESCRIPTION
Fixes #1058

## Problem
The `agentcc-gateway` service in docker-compose.yml maps `${AGENTCC_GATEWAY_PORT:-8090}:8080`, meaning:
- **Host access**: `localhost:8090`
- **Container-to-container (Docker network)**: `agentcc-gateway:8080`

However, `AGENTCC_INTERNAL_URL` and `AGENTCC_GATEWAY_INTERNAL_URL` were set to `http://agentcc-gateway:8090`, using the host port instead of the container port. This breaks container-to-container communication between the backend and the gateway.

## Root Cause
Port 8090 is the host-level mapping, not the internal container port. Inside the Docker network, the gateway listens on port 8080.

## Solution
Changed both `AGENTCC_INTERNAL_URL` and `AGENTCC_GATEWAY_INTERNAL_URL` from port 8090 to 8080 in `docker-compose.yml`.

## Testing
- [x] Changes affect 2 lines in docker-compose.yml — straightforward port correction
- [x] Verified the gateway service mapping: `8090:8080` confirms container port is 8080

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-26 | Fixed AGENTCC_INTERNAL_URL and AGENTCC_GATEWAY_INTERNAL_URL ports | rtmalikian |

### Files Changed
- docker-compose.yml — Changed two URL ports from 8090 to 8080

### Verification
- Confirmed gateway service mapping uses container port 8080
- Both URLs now correctly point to the Docker network address

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from DeepSeek-v4-pro (DeepSeek) via Hermes Agent (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
