### PR TITLE
feat: add JSONL source format to dataset loaders

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
@@ -12,6 +12,7 @@ class LoadFormat(Enum):
     """Supported load formats."""
 
     JSON = "json"
+    JSONL = "jsonl"
     DICT = "dict"
     FI = "fi"
 
@@ -44,6 +45,8 @@ class BaseLoader(ABC):
         """
         if format == LoadFormat.JSON.value:
             return self.load_json(**kwargs)
+        elif format == LoadFormat.JSONL.value:
+            return self.load_jsonl(**kwargs)
         elif format == LoadFormat.DICT.value:
             return self.load_dict(**kwargs)
         elif format == LoadFormat.FI.value:
@@ -66,6 +69,37 @@ class BaseLoader(ABC):
                 return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.error(f"Error loading JSON: {e}")
+            raise
+
+    def load_jsonl(self, filename: str) -> list[DataPoint]:
+        """
+        Loads and processes data from a JSON Lines (.jsonl) file, where each
+        non-empty line is a single JSON object. Blank lines are skipped.
+
+        Raises:
+            FileNotFoundError: If the specified file is not found.
+            json.JSONDecodeError: If a line cannot be decoded as JSON.
+        """
+        line_number = 0
+        try:
+            records = []
+            with open(filename) as f:
+                for _n, line in enumerate(f, start=1):
+                    line_number = _n
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    records.append(json.loads(stripped))
+            self._raw_dataset = records
+            self.process()
+            return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
+        except FileNotFoundError as e:
+            logger.error(f"Error loading JSONL file '{filename}': {e}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"Error decoding JSONL file '{filename}' at line {line_number}: {e}"
+            )
             raise
 
     def load_dict(self, data: list) -> list[DataPoint]:

--- a/futureagi/agentic_eval/core_evals/fi_utils/tests/test_jsonl_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/tests/test_jsonl_loader.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+# Import base_loader directly to avoid triggering fi_loaders/__init__.py,
+# which pulls in optional heavy dependencies (retrying, etc.) not required here.
+_spec = importlib.util.spec_from_file_location(
+    "base_loader",
+    pathlib.Path(__file__).parent.parent.parent / "fi_loaders" / "base_loader.py",
+)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+BaseLoader = _mod.BaseLoader
+LoadFormat = _mod.LoadFormat
+
+
+class _PassThroughLoader(BaseLoader):
+    """Minimal concrete loader to exercise base-class file loading in isolation."""
+
+    def __init__(self):
+        self._raw_dataset = []
+        self._processed_dataset = []
+
+    def process(self):
+        self._processed_dataset = list(self._raw_dataset)
+
+    def load_fi_inferences(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+class TestJsonlLoader:
+    def test_loads_one_object_per_line(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            '{"response": "a"}\n{"response": "b"}\n{"response": "c"}\n',
+        )
+        out = _PassThroughLoader().load_jsonl(path)
+        assert out == [{"response": "a"}, {"response": "b"}, {"response": "c"}]
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            '{"response": "a"}\n\n   \n{"response": "b"}\n',
+        )
+        out = _PassThroughLoader().load_jsonl(path)
+        assert out == [{"response": "a"}, {"response": "b"}]
+
+    def test_dispatch_via_load(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", '{"response": "x"}\n')
+        out = _PassThroughLoader().load(LoadFormat.JSONL.value, filename=path)
+        assert out == [{"response": "x"}]
+
+    def test_malformed_line_raises(self, tmp_path):
+        path = _write(tmp_path, "bad.jsonl", '{"response": "a"}\n{not valid}\n')
+        with pytest.raises(json.JSONDecodeError):
+            _PassThroughLoader().load_jsonl(path)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _PassThroughLoader().load_jsonl(str(tmp_path / "nope.jsonl"))
+
+    def test_unknown_format_still_raises(self):
+        with pytest.raises(NotImplementedError):
+            _PassThroughLoader().load("parquet", filename="x")


### PR DESCRIPTION
**What**: Adds a `JSONL` source format to the dataset loaders: a `LoadFormat.JSONL` enum value, a dispatch branch in `BaseLoader.load`, and a `load_jsonl` method that parses one JSON object per line (skipping blank lines, reporting the line number on a decode error). Mirrors `load_json`; works for every loader subclass since it produces the same `_raw_dataset` list shape.

**Why**: JSON Lines is the standard format for eval and inference datasets (Hugging Face, OpenAI fine-tune exports, most LLM benchmark datasets), but the loaders only accept a single JSON array file, an in-memory dict, or FI inferences. This lets users load streaming or large line-delimited datasets directly. No new dependencies.

## Changes

| File | Change |
|---|---|
| `futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py` | `LoadFormat.JSONL` enum value, dispatch branch, `load_jsonl()` method |
| `futureagi/agentic_eval/core_evals/fi_loaders/tests/__init__.py` | New (empty) — creates the tests package |
| `futureagi/agentic_eval/core_evals/fi_utils/tests/test_jsonl_loader.py` | 6 test cases (see note below) |

> **Note on test location**: The test is in `fi_utils/tests/` rather than `fi_loaders/tests/` because `fi_loaders/__init__.py` imports `Loader`, which in turn pulls in optional heavy dependencies (`retrying`, etc.) not available in the lightweight test environment. Pytest's package-based import mode triggers that init before the test body runs, making `fi_loaders/tests/` unworkable without a full service install. The `fi_utils/tests/` directory imports `base_loader` directly via `importlib.util.spec_from_file_location`, avoiding that chain.

## Test plan

```bash
cd futureagi/agentic_eval
python3 -m pytest core_evals/fi_utils/tests/test_jsonl_loader.py -v
```

Expected:
```
PASSED test_loads_one_object_per_line
PASSED test_skips_blank_lines
PASSED test_dispatch_via_load
PASSED test_malformed_line_raises
PASSED test_missing_file_raises
PASSED test_unknown_format_still_raises
6 passed in 0.5s
```

Closes #1095.