### PR TITLE
fix: refresh eval caches after deletion

### DIFF
--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -36,6 +36,7 @@ import { useSelectedAgentDefinitionStore } from "./TestRuns/states";
 import { ComponentApiMapping } from "./TestRuns/common";
 import { AGENT_TYPES } from "../agents/constants";
 import useTestRunDetails from "src/hooks/useTestRunDetails";
+import { invalidateEvalDeletionQueries } from "./eval_cache";
 
 const TestEvaluationPage = ({
   onClose,
@@ -122,9 +123,7 @@ const TestEvaluationPage = ({
     mutationFn: (evalId) =>
       axios.delete(endpoints.runTests.deleteEvals(testId, evalId)),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["test-runs-detail", testId],
-      });
+      invalidateEvalDeletionQueries(queryClient, testId, executionIds);
       enqueueSnackbar("Eval deleted successfully", {
         variant: "success",
       });

--- a/frontend/src/sections/test/eval_cache.js
+++ b/frontend/src/sections/test/eval_cache.js
@@ -1,0 +1,21 @@
+export function invalidateEvalDeletionQueries(queryClient, testId, executionIds) {
+  queryClient.invalidateQueries({
+    queryKey: ["test-runs-detail", testId],
+  });
+
+  if (executionIds?.length) {
+    executionIds.forEach((executionId) => {
+      queryClient.invalidateQueries({
+        queryKey: ["test-execution-detail", "KPIS", executionId],
+      });
+    });
+  } else {
+    queryClient.invalidateQueries({
+      queryKey: ["test-execution-detail", "KPIS"],
+    });
+  }
+
+  queryClient.invalidateQueries({
+    queryKey: ["test-execution-analytics", testId],
+  });
+}

--- a/frontend/src/sections/test/eval_cache.test.js
+++ b/frontend/src/sections/test/eval_cache.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { invalidateEvalDeletionQueries } from "./eval_cache";
+
+describe("invalidateEvalDeletionQueries unit", () => {
+  it("invalidates eval detail, KPI, and analytics queries for selected executions", () => {
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    invalidateEvalDeletionQueries(queryClient, "test-1", [
+      "execution-1",
+      "execution-2",
+    ]);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-runs-detail", "test-1"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-execution-detail", "KPIS", "execution-1"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-execution-detail", "KPIS", "execution-2"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-execution-analytics", "test-1"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(4);
+  });
+
+  it("invalidates the KPI subtree when no execution ids are provided", () => {
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    invalidateEvalDeletionQueries(queryClient, "test-1", null);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-runs-detail", "test-1"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-execution-detail", "KPIS"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["test-execution-analytics", "test-1"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
Fixes #1073

Summary:
- Added a small helper for cache invalidation after deleting an eval.
- The delete success path now refreshes the eval detail query, affected KPI queries, and the analytics query.
- Added unit coverage for selected execution IDs and the all-runs fallback.

Validation:
- `corepack yarn vitest run src/sections/test/eval_cache.test.js --reporter=verbose --testNamePattern='unit|Unit'`
- `corepack yarn eslint src/sections/test/TestEvaluationPage.jsx src/sections/test/eval_cache.js src/sections/test/eval_cache.test.js`
  - Passed with an existing warning in `TestEvaluationPage.jsx` for `setOpenTestEvaluation`.
- `corepack yarn type-check`
  - Passed; the frontend has no `tsconfig.json`, so the script skips TypeScript checks.
- `corepack yarn test:unit`

Not run:
- `corepack yarn build`
