### PR TITLE
feat: add JSONL source format to dataset loaders

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
@@ -4,14 +4,16 @@ from enum import Enum
 
 import structlog
 
-logger = structlog.get_logger(__name__)
 from agentic_eval.core_evals.fi_utils.evals_result import DataPoint
+
+logger = structlog.get_logger(__name__)
 
 
 class LoadFormat(Enum):
     """Supported load formats."""
 
     JSON = "json"
+    JSONL = "jsonl"
     DICT = "dict"
     FI = "fi"
 
@@ -44,6 +46,8 @@ class BaseLoader(ABC):
         """
         if format == LoadFormat.JSON.value:
             return self.load_json(**kwargs)
+        elif format == LoadFormat.JSONL.value:
+            return self.load_jsonl(**kwargs)
         elif format == LoadFormat.DICT.value:
             return self.load_dict(**kwargs)
         elif format == LoadFormat.FI.value:
@@ -66,6 +70,36 @@ class BaseLoader(ABC):
                 return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.error(f"Error loading JSON: {e}")
+            raise
+
+    def load_jsonl(self, filename: str) -> list[DataPoint]:
+        """
+        Loads and processes data from a JSONL (JSON Lines) file.
+
+        Raises:
+            FileNotFoundError: If the specified JSONL file is not found.
+            json.JSONDecodeError: If there's an issue decoding the JSON.
+        """
+        raw_dataset = []
+        try:
+            with open(filename) as f:
+                for line_idx, line in enumerate(f, start=1):
+                    stripped_line = line.strip()
+                    if not stripped_line:
+                        continue
+                    try:
+                        raw_dataset.append(json.loads(stripped_line))
+                    except json.JSONDecodeError as e:
+                        raise json.JSONDecodeError(
+                            f"Failed to parse JSON on line {line_idx}: {e.msg}",
+                            e.doc,
+                            e.pos,
+                        ) from e
+            self._raw_dataset = raw_dataset
+            self.process()
+            return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.error(f"Error loading JSONL: {e}")
             raise
 
     def load_dict(self, data: list) -> list[DataPoint]:

--- a/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_loaders.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_loaders.py
@@ -1,0 +1,62 @@
+import json
+import pytest
+from agentic_eval.core_evals.fi_loaders.base_loader import LoadFormat
+from agentic_eval.core_evals.fi_loaders.json_loader import JsonLoader
+
+
+class TestLoadersJSONL:
+    def test_load_jsonl_valid(self, tmp_path):
+        # Create a valid jsonl file
+        file_path = tmp_path / "valid.jsonl"
+        content = (
+            '{"actual_json": {"a": 1}, "expected_json": {"a": 1}}\n'
+            '{"actual_json": {"b": 2}}\n'
+        )
+        file_path.write_text(content)
+
+        loader = JsonLoader()
+        result = loader.load(format="jsonl", filename=str(file_path))
+
+        assert len(result) == 2
+        assert result[0] == {"actual_json": {"a": 1}, "expected_json": {"a": 1}}
+        assert result[1] == {"actual_json": {"b": 2}}
+
+    def test_load_jsonl_skips_empty_lines(self, tmp_path):
+        # Create a jsonl file with empty lines and whitespace lines
+        file_path = tmp_path / "empty_lines.jsonl"
+        content = (
+            '{"actual_json": {"a": 1}}\n'
+            '\n'
+            '   \n'
+            '{"actual_json": {"b": 2}}\n'
+            '\n'
+        )
+        file_path.write_text(content)
+
+        loader = JsonLoader()
+        result = loader.load(format="jsonl", filename=str(file_path))
+
+        assert len(result) == 2
+        assert result[0] == {"actual_json": {"a": 1}}
+        assert result[1] == {"actual_json": {"b": 2}}
+
+    def test_load_jsonl_invalid_json_reports_line_number(self, tmp_path):
+        # Create a jsonl file with an error on line 3
+        file_path = tmp_path / "invalid.jsonl"
+        content = (
+            '{"actual_json": {"a": 1}}\n'
+            '\n'
+            '{"actual_json": {"b": 2\n'
+        )
+        file_path.write_text(content)
+
+        loader = JsonLoader()
+        with pytest.raises(json.JSONDecodeError) as exc_info:
+            loader.load(format="jsonl", filename=str(file_path))
+
+        assert "line 3" in str(exc_info.value)
+
+    def test_load_jsonl_file_not_found(self):
+        loader = JsonLoader()
+        with pytest.raises(FileNotFoundError):
+            loader.load(format="jsonl", filename="non_existent_file.jsonl")


### PR DESCRIPTION
Resolves #1095

### Description
This PR adds support for loading JSON Lines (`.jsonl`) files in the dataset loaders. This allows users to import standard benchmark and evaluation datasets directly without converting them to single JSON arrays first.

### Changes
- Added `LoadFormat.JSONL = "jsonl"` to `LoadFormat` enum in `base_loader.py`
- Added routing logic for `LoadFormat.JSONL` in `BaseLoader.load`
- Implemented `load_jsonl(self, filename: str)` in `BaseLoader` that parses JSONL line-by-line, skips empty lines, and throws `json.JSONDecodeError` with absolute line numbers.
- Added comprehensive unit tests in `futureagi/agentic_eval/core_evals/fi_loaders/tests/test_loaders.py` verifying all requirements.
- Cleaned up imports in `base_loader.py` to fix pep8/ruff E402 import order violations.
