### PR TITLE
Fix stale destination folder state after moving a prompt

### DIFF
--- a/frontend/src/sections/workbench-v2/components/MoveItem.jsx
+++ b/frontend/src/sections/workbench-v2/components/MoveItem.jsx
@@ -37,8 +37,13 @@ const MoveItem = ({ id, open, onClose, name, folderId }) => {
         variant: "success",
       });
       onClose();
-      queryClient.invalidateQueries({
-        queryKey: ["folder-items", folder],
+      const foldersToRefresh = new Set([folder, selectedFolder, "all"]);
+
+      foldersToRefresh.forEach((folderKey) => {
+        if (!folderKey) return;
+        queryClient.invalidateQueries({
+          queryKey: ["folder-items", folderKey],
+        });
       });
     },
   });

--- a/frontend/src/sections/workbench-v2/components/MoveItem.jsx
+++ b/frontend/src/sections/workbench-v2/components/MoveItem.jsx
@@ -14,6 +14,7 @@ const MoveItem = ({ id, open, onClose, name, folderId }) => {
   const [selectedFolder, setSelectedFolder] = useState("");
   const queryClient = useQueryClient();
   const { folder } = useParams();
+  const sourceFolder = folderId || folder;
 
   const { data: folders } = useQuery({
     queryKey: ["prompt-folders"],
@@ -37,7 +38,7 @@ const MoveItem = ({ id, open, onClose, name, folderId }) => {
         variant: "success",
       });
       onClose();
-      const foldersToRefresh = new Set([folder, selectedFolder, "all"]);
+      const foldersToRefresh = new Set([sourceFolder, selectedFolder, "all"]);
 
       foldersToRefresh.forEach((folderKey) => {
         if (!folderKey) return;
@@ -107,7 +108,7 @@ const MoveItem = ({ id, open, onClose, name, folderId }) => {
         size="small"
         label="Select folder"
         value={selectedFolder}
-        options={folders?.filter((f) => f?.value !== folder)}
+        options={folders?.filter((f) => f?.value !== sourceFolder)}
         onChange={(e) => setSelectedFolder(e.target.value)}
       />
     </ModalWrapper>

--- a/frontend/src/sections/workbench-v2/components/__tests__/MoveItem.test.jsx
+++ b/frontend/src/sections/workbench-v2/components/__tests__/MoveItem.test.jsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+let MoveItem;
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockTrackEvent = vi.fn();
+const mockEnqueueSnackbar = vi.fn();
+const mockUseParams = vi.fn(() => ({ folder: "source-folder" }));
+
+vi.mock("react-router", () => ({
+  useParams: () => mockUseParams(),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: (...args) => mockGet(...args),
+    post: (...args) => mockPost(...args),
+  },
+  endpoints: {
+    develop: {
+      runPrompt: {
+        promptFolder: "/prompt-folders/",
+        movePrompt: (id) => `/prompts/${id}/move/`,
+      },
+    },
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: (...args) => mockEnqueueSnackbar(...args),
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: { promptMoveConfirmed: "prompt_move_confirmed" },
+  PropertyName: {
+    type: "type",
+    currentLocation: "currentLocation",
+    newLocation: "newLocation",
+  },
+  trackEvent: (...args) => mockTrackEvent(...args),
+}));
+
+vi.mock("../../../components/ModalWrapper/ModalWrapper", () => ({
+  default: ({ title, children, onSubmit, isValid }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+      <button onClick={onSubmit} disabled={!isValid}>
+        Move
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock(
+  "../../../components/FromSearchSelectField/FormSearchSelectFieldState",
+  () => ({
+    default: ({ value, onChange, options = [], label }) => (
+      <label>
+        {label}
+        <select
+          aria-label={label}
+          value={value}
+          onChange={(event) => onChange(event)}
+        >
+          <option value="">Select folder</option>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    ),
+  }),
+);
+
+function renderMoveItem(queryClient, props = {}) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MoveItem
+        id="prompt-1"
+        open
+        onClose={vi.fn()}
+        name="Draft prompt"
+        folderId="source-folder"
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MoveItem", () => {
+  beforeAll(async () => {
+    MoveItem = (await import("../MoveItem")).default;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({
+      data: {
+        result: [
+          { id: "source-folder", name: "Source" },
+          { id: "target-folder", name: "Target" },
+        ],
+      },
+    });
+    mockPost.mockResolvedValue({ data: { ok: true } });
+  });
+
+  it("invalidates source, destination, and all folders after a successful move", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    queryClient.setQueryData(["prompt-folders"], {
+      data: {
+        result: [
+          { id: "source-folder", name: "Source" },
+          { id: "target-folder", name: "Target" },
+        ],
+      },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const onClose = vi.fn();
+
+    renderMoveItem(queryClient, { onClose });
+
+    fireEvent.click(screen.getByLabelText("Select folder"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Target" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith("/prompts/prompt-1/move/", {
+        prompt_folder_id: "target-folder",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["folder-items", "source-folder"],
+      }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["folder-items", "target-folder"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["folder-items", "all"],
+    });
+    expect(onClose).toHaveBeenCalled();
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      "Prompt moved successfully",
+      { variant: "success" },
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith("prompt_move_confirmed", {
+      type: "PROMPT",
+      currentLocation: "source-folder",
+      newLocation: "target-folder",
+    });
+  });
+});

--- a/frontend/src/sections/workbench-v2/components/__tests__/MoveItem.test.jsx
+++ b/frontend/src/sections/workbench-v2/components/__tests__/MoveItem.test.jsx
@@ -43,7 +43,7 @@ vi.mock("src/utils/Mixpanel", () => ({
   trackEvent: (...args) => mockTrackEvent(...args),
 }));
 
-vi.mock("../../../components/ModalWrapper/ModalWrapper", () => ({
+vi.mock("../../../../components/ModalWrapper/ModalWrapper", () => ({
   default: ({ title, children, onSubmit, isValid }) => (
     <div>
       <h1>{title}</h1>
@@ -56,7 +56,7 @@ vi.mock("../../../components/ModalWrapper/ModalWrapper", () => ({
 }));
 
 vi.mock(
-  "../../../components/FromSearchSelectField/FormSearchSelectFieldState",
+  "../../../../components/FromSearchSelectField/FormSearchSelectFieldState",
   () => ({
     default: ({ value, onChange, options = [], label }) => (
       <label>
@@ -131,8 +131,9 @@ describe("MoveItem", () => {
 
     renderMoveItem(queryClient, { onClose });
 
-    fireEvent.click(screen.getByLabelText("Select folder"));
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Target" }));
+    fireEvent.change(screen.getByLabelText("Select folder"), {
+      target: { value: "target-folder" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Move" }));
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- invalidate the source folder, destination folder, and `all` prompt listing after a prompt move succeeds
- use the prompt's source folder id when moving from the All prompts view, so the cached source folder list refreshes too
- keep the existing success toast, close behavior, and Mixpanel tracking intact
- fix the component test mocks so the lightweight modal/select replacements are actually used

## Test-case scenarios covered
- Moving a prompt from a source folder to a different destination folder invalidates the source folder query key.
- Moving a prompt invalidates the destination folder query key.
- Moving a prompt invalidates the `all` prompt listing query key.
- The successful move still closes the modal, shows the success snackbar, and records the move event.

## Testing
- `corepack yarn test:run src/sections/workbench-v2/components/__tests__/MoveItem.test.jsx`

Closes #1068.