### PR TITLE
feat(agentcc-gateway): add TwelveLabs as an opt-in video provider

### DIFF
--- a/agentcc-gateway/README.md
+++ b/agentcc-gateway/README.md
@@ -454,7 +454,7 @@ Corrections welcome — open an issue or send a PR.
 
 **One gateway, every modality your providers expose.** Text · chat · vision · embeddings · reranking · speech-to-text · text-to-speech (+ streaming) · realtime WebSocket · image generation · video generation · OCR · grounded search · tool calling · structured output · Assistants + threads · vector stores · batch jobs — all have dedicated gateway routes. The specific model you reach is whatever the configured upstream provider serves at that endpoint; we pass the full provider-native payload through.
 
-**Surface area at a glance:** 🔌 **109 routes** across 23 endpoint categories · 🛡️ **18 built-in guardrails + 15 external vendor adapters** · 🧠 **15 routing strategies** · 🔧 **16 pipeline plugins** · 🔄 **2 cross-provider translators** (OpenAI ↔ Anthropic · OpenAI ↔ Gemini) · 🌐 **7 native provider packages** · 🔒 **6 secret resolvers** (AWS SM · Azure KV · GCP SM · HashiCorp Vault · env · file) · 💾 **10 cache backends** (6 exact + 4 semantic) · 🧩 **39 internal subsystems**. Every count is grep-verifiable in the tree.
+**Surface area at a glance:** 🔌 **109 routes** across 23 endpoint categories · 🛡️ **18 built-in guardrails + 15 external vendor adapters** · 🧠 **15 routing strategies** · 🔧 **16 pipeline plugins** · 🔄 **2 cross-provider translators** (OpenAI ↔ Anthropic · OpenAI ↔ Gemini) · 🌐 **8 native provider packages** · 🔒 **6 secret resolvers** (AWS SM · Azure KV · GCP SM · HashiCorp Vault · env · file) · 💾 **10 cache backends** (6 exact + 4 semantic) · 🧩 **39 internal subsystems**. Every count is grep-verifiable in the tree.
 
 ### 🌈 Modalities
 
@@ -491,7 +491,7 @@ Every modality below has dedicated routes in the gateway. The **specific models*
 <tr>
 <td><b>Embeddings &amp; Rerank</b></td>
 <td><code>POST /v1/embeddings</code><br><code>POST /v1/rerank</code></td>
-<td>OpenAI, Cohere, Voyage, Jina; text + image embeddings; batch mode</td>
+<td>OpenAI, Cohere, Voyage, Jina, TwelveLabs Marengo (512-dim multimodal); text + image embeddings; batch mode</td>
 </tr>
 <tr>
 <td><b>Audio</b></td>
@@ -850,7 +850,9 @@ Call the gateway in one format, route to a different upstream. Translator packag
 | `translation/anthropic` | OpenAI ↔ Anthropic — `cache_control` blocks, tool_use / tool_result blocks, `finish_reason` mapping |
 | `translation/gemini` | OpenAI ↔ Gemini — multi-part content, `finish_reason` mapping |
 
-Azure OpenAI, Bedrock, Cohere, and Vertex AI are handled as **native provider packages** (not translators) — the gateway speaks each one directly via its package under [`internal/providers/`](./internal/providers/), preserving SigV4 signing, Azure deployment-name routing, and similar provider-specifics.
+Azure OpenAI, Bedrock, Cohere, TwelveLabs, and Vertex AI are handled as **native provider packages** (not translators) — the gateway speaks each one directly via its package under [`internal/providers/`](./internal/providers/), preserving SigV4 signing, Azure deployment-name routing, TwelveLabs video-understanding/embedding calls, and similar provider-specifics.
+
+The TwelveLabs package (`api_format: "twelvelabs"`) is opt-in and brings **video models** under the same OpenAI-compatible surfaces: **Pegasus** answers questions about a video (passed as a public URL or asset id) through `/v1/chat/completions`, and **Marengo** serves 512-dim multimodal embeddings through `/v1/embeddings`. See [`config.example.yaml`](./config.example.yaml) for setup; grab a free key at [twelvelabs.io](https://twelvelabs.io).
 
 ### 🔒 Secrets resolution
 

--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -110,6 +110,21 @@ providers:
   #     - command-r
   #     - command
 
+  # ── TwelveLabs (video understanding + multimodal embeddings) ──
+  # Opt-in video provider. Pegasus answers video questions through the
+  # standard /v1/chat/completions surface — pass the video as a public URL
+  # in an image_url/video_url content part (or a TwelveLabs asset id).
+  # Marengo serves 512-dim multimodal embeddings through /v1/embeddings,
+  # letting you embed text queries in the same space as your video embeddings.
+  # Get a free API key at https://twelvelabs.io.
+  # twelvelabs:
+  #   type: "twelvelabs"            # auto-fills base_url + api_format
+  #   api_key: "${TWELVELABS_API_KEY}"
+  #   default_timeout: 120s         # Pegasus analysis can take a while
+  #   models:
+  #     - pegasus1.5                # video understanding (chat completions)
+  #     - marengo3.0                # multimodal embeddings (embeddings)
+
   # ── Self-Hosted / Custom Endpoints ──────────────────────────
   # vLLM, Ollama, LMStudio, TGI, LocalAI — all use OpenAI-compat format.
   # Just set api_format: "openai" and point base_url to your server.

--- a/agentcc-gateway/internal/providers/presets.go
+++ b/agentcc-gateway/internal/providers/presets.go
@@ -23,6 +23,7 @@ var KnownProviders = map[string]ProviderPreset{
 	"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
 	"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
 	"azure":       {APIFormat: "azure"},
+	"twelvelabs":  {BaseURL: "https://api.twelvelabs.io/v1.3", APIFormat: "twelvelabs"},
 }
 
 // applyProviderPreset fills in default BaseURL and APIFormat from known presets.

--- a/agentcc-gateway/internal/providers/presets_test.go
+++ b/agentcc-gateway/internal/providers/presets_test.go
@@ -147,6 +147,7 @@ func TestPreset_KnownProvidersComplete(t *testing.T) {
 		"replicate":   {BaseURL: "https://api.replicate.com", APIFormat: "openai"},
 		"openrouter":  {BaseURL: "https://openrouter.ai/api", APIFormat: "openai"},
 		"azure":       {BaseURL: "", APIFormat: "azure"},
+		"twelvelabs":  {BaseURL: "https://api.twelvelabs.io/v1.3", APIFormat: "twelvelabs"},
 	}
 
 	// Verify every expected provider is present with the correct values.

--- a/agentcc-gateway/internal/providers/registry.go
+++ b/agentcc-gateway/internal/providers/registry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/providers/cohere"
 	"github.com/futureagi/agentcc-gateway/internal/providers/gemini"
 	"github.com/futureagi/agentcc-gateway/internal/providers/openai"
+	"github.com/futureagi/agentcc-gateway/internal/providers/twelvelabs"
 	"github.com/futureagi/agentcc-gateway/internal/routing"
 )
 
@@ -126,8 +127,10 @@ func createProvider(name string, cfg config.ProviderConfig) (Provider, error) {
 		return cohere.New(name, cfg)
 	case "azure":
 		return azure.New(name, cfg)
+	case "twelvelabs":
+		return twelvelabs.New(name, cfg)
 	default:
-		return nil, fmt.Errorf("unsupported api_format %q (supported: openai, anthropic, gemini, bedrock, cohere, azure)", cfg.APIFormat)
+		return nil, fmt.Errorf("unsupported api_format %q (supported: openai, anthropic, gemini, bedrock, cohere, azure, twelvelabs)", cfg.APIFormat)
 	}
 }
 

--- a/agentcc-gateway/internal/providers/twelvelabs/translate.go
+++ b/agentcc-gateway/internal/providers/twelvelabs/translate.go
@@ -1,0 +1,297 @@
+package twelvelabs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// --- Pegasus /analyze types ---
+
+// videoContext is the TwelveLabs video reference. For public URLs use
+// {"type":"url","url":...}; for previously uploaded assets use
+// {"type":"asset","asset_id":...}.
+type videoContext struct {
+	Type    string `json:"type"`
+	URL     string `json:"url,omitempty"`
+	AssetID string `json:"asset_id,omitempty"`
+}
+
+type analyzeRequest struct {
+	ModelName   string       `json:"model_name"`
+	Video       videoContext `json:"video"`
+	Prompt      string       `json:"prompt"`
+	MaxTokens   int          `json:"max_tokens,omitempty"`
+	Temperature *float64     `json:"temperature,omitempty"`
+}
+
+type analyzeResponse struct {
+	ID    string `json:"id"`
+	Data  string `json:"data"`
+	Usage *struct {
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+// translateAnalyzeRequest builds a Pegasus analyze request from an OpenAI-style
+// chat completion request. It extracts a video URL (or asset id) and the text
+// prompt from the messages.
+func translateAnalyzeRequest(req *models.ChatCompletionRequest) (*analyzeRequest, error) {
+	model := resolveModelName(req.Model)
+	if model == "" || !strings.HasPrefix(model, "pegasus") {
+		model = defaultPegasusModel
+	}
+
+	video, prompt, err := extractVideoAndPrompt(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pegasus 1.5 requires max_tokens between 512 and 98304. The OpenAI default
+	// is much smaller, so clamp up to the model's minimum when a value is set.
+	maxTokens := 2048
+	if req.MaxTokens != nil && *req.MaxTokens > 0 {
+		maxTokens = *req.MaxTokens
+	} else if req.MaxCompletionTokens != nil && *req.MaxCompletionTokens > 0 {
+		maxTokens = *req.MaxCompletionTokens
+	}
+	if strings.HasPrefix(model, "pegasus1.5") && maxTokens < 512 {
+		maxTokens = 512
+	}
+
+	return &analyzeRequest{
+		ModelName:   model,
+		Video:       video,
+		Prompt:      prompt,
+		MaxTokens:   maxTokens,
+		Temperature: req.Temperature,
+	}, nil
+}
+
+// extractVideoAndPrompt pulls a video reference and the text prompt out of the
+// chat messages. A video may be supplied as:
+//   - a multimodal content part with type "video_url" or "image_url" whose URL
+//     points at a video, or
+//   - a TwelveLabs asset id via {"type":"input_asset","asset_id":...}, or
+//   - a bare http(s) URL in a text part.
+//
+// The prompt is the concatenation of all text parts across user messages.
+func extractVideoAndPrompt(messages []models.Message) (videoContext, string, error) {
+	var video videoContext
+	var promptParts []string
+
+	for _, msg := range messages {
+		if msg.Role != "user" && msg.Role != "system" {
+			continue
+		}
+		if len(msg.Content) == 0 {
+			continue
+		}
+
+		// Content may be a plain string or an array of content parts.
+		var asString string
+		if err := json.Unmarshal(msg.Content, &asString); err == nil {
+			if u := firstURL(asString); u != "" && video.URL == "" && video.AssetID == "" {
+				video = videoContext{Type: "url", URL: u}
+				asString = strings.TrimSpace(strings.Replace(asString, u, "", 1))
+			}
+			if asString != "" {
+				promptParts = append(promptParts, asString)
+			}
+			continue
+		}
+
+		var parts []contentPart
+		if err := json.Unmarshal(msg.Content, &parts); err != nil {
+			continue
+		}
+		for _, part := range parts {
+			switch part.Type {
+			case "text":
+				if part.Text != "" {
+					promptParts = append(promptParts, part.Text)
+				}
+			case "video_url", "image_url":
+				url := part.urlValue()
+				if url != "" && video.URL == "" && video.AssetID == "" {
+					video = videoContext{Type: "url", URL: url}
+				}
+			case "input_asset", "asset":
+				if part.AssetID != "" && video.URL == "" && video.AssetID == "" {
+					video = videoContext{Type: "asset", AssetID: part.AssetID}
+				}
+			}
+		}
+	}
+
+	if video.URL == "" && video.AssetID == "" {
+		return video, "", models.ErrBadRequest("invalid_request_error",
+			"twelvelabs: no video found in request. Provide a public video URL (image_url/video_url content part or a bare http(s) URL) "+
+				"or a TwelveLabs asset id. Note: direct asset upload is capped at 200MB; public URLs support up to 4GB.")
+	}
+	if strings.TrimSpace(strings.Join(promptParts, " ")) == "" {
+		return video, "", models.ErrBadRequest("invalid_request_error", "twelvelabs: no text prompt found in request messages")
+	}
+
+	return video, strings.TrimSpace(strings.Join(promptParts, " ")), nil
+}
+
+// contentPart is a subset of an OpenAI multimodal content part.
+type contentPart struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL json.RawMessage `json:"image_url,omitempty"`
+	VideoURL json.RawMessage `json:"video_url,omitempty"`
+	AssetID  string          `json:"asset_id,omitempty"`
+}
+
+// urlValue returns the URL from an image_url/video_url part, which may be either
+// a bare string or an object {"url": "..."}.
+func (c contentPart) urlValue() string {
+	raw := c.VideoURL
+	if len(raw) == 0 {
+		raw = c.ImageURL
+	}
+	if len(raw) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+	var obj struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj.URL
+	}
+	return ""
+}
+
+// firstURL returns the first http(s) token in s, or "".
+func firstURL(s string) string {
+	for _, tok := range strings.Fields(s) {
+		if strings.HasPrefix(tok, "http://") || strings.HasPrefix(tok, "https://") {
+			return tok
+		}
+	}
+	return ""
+}
+
+// translateAnalyzeResponse maps a Pegasus analyze result into an OpenAI chat
+// completion response.
+func translateAnalyzeResponse(resp *analyzeResponse, model string) *models.ChatCompletionResponse {
+	contentJSON, _ := json.Marshal(resp.Data)
+
+	out := &models.ChatCompletionResponse{
+		ID:      chatID(resp.ID),
+		Object:  "chat.completion",
+		Created: 0,
+		Model:   model,
+		Choices: []models.Choice{{
+			Index: 0,
+			Message: models.Message{
+				Role:    "assistant",
+				Content: contentJSON,
+			},
+			FinishReason: "stop",
+		}},
+	}
+	if resp.Usage != nil {
+		out.Usage = &models.Usage{
+			CompletionTokens: resp.Usage.OutputTokens,
+			TotalTokens:      resp.Usage.OutputTokens,
+		}
+	}
+	return out
+}
+
+func chatID(id string) string {
+	if id == "" {
+		return "chatcmpl-twelvelabs"
+	}
+	return "chatcmpl-" + id
+}
+
+// --- Marengo /embed types ---
+
+type embedResponse struct {
+	ModelName     string `json:"model_name"`
+	TextEmbedding *struct {
+		Segments []embedSegment `json:"segments"`
+	} `json:"text_embedding,omitempty"`
+}
+
+type embedSegment struct {
+	// The TwelveLabs REST API names the vector field "float" (the Python SDK
+	// aliases it to "float_").
+	Float []float64 `json:"float"`
+}
+
+// firstFloatVector returns the first segment's float vector, or nil.
+func (e *embedResponse) firstFloatVector() []float64 {
+	if e.TextEmbedding == nil || len(e.TextEmbedding.Segments) == 0 {
+		return nil
+	}
+	return e.TextEmbedding.Segments[0].Float
+}
+
+// parseEmbeddingInput parses an OpenAI embedding input (string or []string).
+func parseEmbeddingInput(input json.RawMessage) ([]string, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	var single string
+	if err := json.Unmarshal(input, &single); err == nil {
+		return []string{single}, nil
+	}
+	var many []string
+	if err := json.Unmarshal(input, &many); err == nil {
+		return many, nil
+	}
+	return nil, models.ErrBadRequest("invalid_request_error", "twelvelabs: embedding input must be a string or array of strings")
+}
+
+// --- shared helpers ---
+
+// resolveModelName strips a "provider/" prefix if present.
+func resolveModelName(model string) string {
+	if idx := strings.Index(model, "/"); idx > 0 {
+		return model[idx+1:]
+	}
+	return model
+}
+
+// parseError maps a TwelveLabs error envelope to an APIError. The envelope is
+// {"code": "...", "message": "..."}.
+func parseError(status int, body []byte) *models.APIError {
+	var errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		switch {
+		case status == http.StatusUnauthorized:
+			return models.ErrUnauthorized("twelvelabs: " + errResp.Message)
+		case status == http.StatusTooManyRequests:
+			return models.ErrTooManyRequests("twelvelabs: " + errResp.Message)
+		case status >= 400 && status < 500:
+			code := errResp.Code
+			if code == "" {
+				code = "invalid_request_error"
+			}
+			return models.ErrBadRequest(code, "twelvelabs: "+errResp.Message)
+		default:
+			return models.ErrUpstreamProvider(status, "twelvelabs: "+errResp.Message)
+		}
+	}
+
+	msg := string(body)
+	if len(msg) > 500 {
+		msg = msg[:500] + "..."
+	}
+	return models.ErrUpstreamProvider(status, fmt.Sprintf("twelvelabs error (HTTP %d): %s", status, msg))
+}

--- a/agentcc-gateway/internal/providers/twelvelabs/twelvelabs.go
+++ b/agentcc-gateway/internal/providers/twelvelabs/twelvelabs.go
@@ -1,0 +1,341 @@
+// Package twelvelabs implements an opt-in provider for the TwelveLabs video
+// understanding API (https://twelvelabs.io).
+//
+// It exposes two video-native model families through the gateway's existing
+// OpenAI-compatible surfaces, so the eval/observability platform can cover
+// video models alongside text and image providers:
+//
+//   - Pegasus (video understanding) via ChatCompletion. The video is passed as
+//     a public URL in a multimodal message; the model's analysis is returned as
+//     the assistant message content.
+//   - Marengo (multimodal embeddings) via CreateEmbedding. Text inputs return a
+//     512-dimension embedding suitable for cross-modal retrieval against video
+//     embeddings produced by the same model.
+//
+// The provider is entirely opt-in: it is only constructed when a provider with
+// api_format "twelvelabs" is configured. With no TwelveLabs provider configured,
+// gateway behavior is unchanged.
+package twelvelabs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// defaultBaseURL is the TwelveLabs REST API root. Override via provider config.
+const defaultBaseURL = "https://api.twelvelabs.io/v1.3"
+
+// defaultPegasusModel / defaultMarengoModel are used when the requested model
+// does not map to a known TwelveLabs model name.
+const (
+	defaultPegasusModel = "pegasus1.5"
+	defaultMarengoModel = "marengo3.0"
+)
+
+// Provider implements the gateway Provider and EmbeddingProvider interfaces for
+// the TwelveLabs API.
+type Provider struct {
+	id         string
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	semaphore  chan struct{}
+	headers    map[string]string
+}
+
+// New creates a new TwelveLabs provider.
+func New(id string, cfg config.ProviderConfig) (*Provider, error) {
+	timeout := cfg.DefaultTimeout
+	if timeout == 0 {
+		// Pegasus analysis can take a while on longer clips; allow generous time.
+		timeout = 120 * time.Second
+	}
+
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent == 0 {
+		maxConcurrent = 100
+	}
+
+	poolSize := cfg.ConnPoolSize
+	if poolSize == 0 {
+		poolSize = 100
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:        poolSize,
+		MaxIdleConnsPerHost: poolSize,
+		IdleConnTimeout:     90 * time.Second,
+		ForceAttemptHTTP2:   true,
+	}
+
+	return &Provider{
+		id:      id,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  cfg.APIKey,
+		httpClient: &http.Client{
+			Transport: transport,
+			Timeout:   timeout,
+		},
+		semaphore: make(chan struct{}, maxConcurrent),
+		headers:   cfg.Headers,
+	}, nil
+}
+
+func (p *Provider) ID() string { return p.id }
+
+func (p *Provider) acquireSemaphore(ctx context.Context) error {
+	select {
+	case p.semaphore <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Provider) releaseSemaphore() {
+	<-p.semaphore
+}
+
+// setHeaders applies authentication and any configured extra headers.
+// TwelveLabs authenticates with an "x-api-key" header.
+func (p *Provider) setHeaders(req *http.Request) {
+	if p.apiKey != "" {
+		req.Header.Set("x-api-key", p.apiKey)
+	}
+	for k, v := range p.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+// ChatCompletion runs Pegasus video understanding. The request must contain a
+// video URL in a multimodal message (an "image_url"/"video_url" content part or
+// a bare http(s) URL) and a text prompt. The analysis text is returned as the
+// assistant message.
+func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
+	if err := p.acquireSemaphore(ctx); err != nil {
+		return nil, models.ErrGatewayTimeout("twelvelabs: concurrency limit reached")
+	}
+	defer p.releaseSemaphore()
+
+	ar, err := translateAnalyzeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(ar)
+	if err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: marshaling analyze request: %v", err))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/analyze", bytes.NewReader(body))
+	if err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: creating analyze request: %v", err))
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	p.setHeaders(httpReq)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, models.ErrGatewayTimeout("twelvelabs: analyze request timed out")
+		}
+		return nil, models.ErrUpstreamProvider(0, fmt.Sprintf("twelvelabs: analyze request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("twelvelabs: reading analyze response: %v", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp.StatusCode, respBody)
+	}
+
+	var ar2 analyzeResponse
+	if err := json.Unmarshal(respBody, &ar2); err != nil {
+		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("twelvelabs: parsing analyze response: %v", err))
+	}
+
+	return translateAnalyzeResponse(&ar2, ar.ModelName), nil
+}
+
+// StreamChatCompletion adapts the non-streaming Pegasus analyze call into a
+// single-chunk stream. The TwelveLabs /analyze endpoint used here is synchronous,
+// so we emit the full result as one delta followed by a stop chunk.
+func (p *Provider) StreamChatCompletion(ctx context.Context, req *models.ChatCompletionRequest) (<-chan models.StreamChunk, <-chan error) {
+	chunks := make(chan models.StreamChunk, 2)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+
+		resp, err := p.ChatCompletion(ctx, req)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		var content string
+		if len(resp.Choices) > 0 {
+			// Choice.Message.Content is raw JSON (a JSON string); unwrap it.
+			_ = json.Unmarshal(resp.Choices[0].Message.Content, &content)
+		}
+
+		role := "assistant"
+		stop := "stop"
+		select {
+		case chunks <- models.StreamChunk{
+			ID:      resp.ID,
+			Object:  "chat.completion.chunk",
+			Created: resp.Created,
+			Model:   resp.Model,
+			Choices: []models.StreamChoice{{
+				Index: 0,
+				Delta: models.Delta{Role: role, Content: &content},
+			}},
+		}:
+		case <-ctx.Done():
+			return
+		}
+
+		select {
+		case chunks <- models.StreamChunk{
+			ID:      resp.ID,
+			Object:  "chat.completion.chunk",
+			Created: resp.Created,
+			Model:   resp.Model,
+			Choices: []models.StreamChoice{{Index: 0, Delta: models.Delta{}, FinishReason: &stop}},
+			Usage:   resp.Usage,
+		}:
+		case <-ctx.Done():
+		}
+	}()
+
+	return chunks, errs
+}
+
+// CreateEmbedding runs Marengo multimodal embedding for text input. Each text
+// input is embedded independently and returned in OpenAI embedding shape.
+// Marengo returns 512-dimension float vectors.
+func (p *Provider) CreateEmbedding(ctx context.Context, req *models.EmbeddingRequest) (*models.EmbeddingResponse, error) {
+	if err := p.acquireSemaphore(ctx); err != nil {
+		return nil, models.ErrGatewayTimeout("twelvelabs: concurrency limit reached")
+	}
+	defer p.releaseSemaphore()
+
+	texts, err := parseEmbeddingInput(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	if len(texts) == 0 {
+		return nil, models.ErrBadRequest("invalid_request_error", "twelvelabs: embedding input is empty")
+	}
+
+	model := resolveModelName(req.Model)
+	if model == "" || !strings.HasPrefix(model, "marengo") {
+		model = defaultMarengoModel
+	}
+
+	resp := &models.EmbeddingResponse{Object: "list", Model: model}
+
+	// The TwelveLabs /embed endpoint embeds one text per request, so iterate.
+	for i, text := range texts {
+		vec, err := p.embedText(ctx, model, text)
+		if err != nil {
+			return nil, err
+		}
+		embJSON, err := json.Marshal(vec)
+		if err != nil {
+			return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: marshaling embedding: %v", err))
+		}
+		resp.Data = append(resp.Data, models.EmbeddingData{
+			Object:    "embedding",
+			Index:     i,
+			Embedding: embJSON,
+		})
+	}
+
+	return resp, nil
+}
+
+// embedText performs a single multipart /embed call and returns the float vector.
+// The TwelveLabs /embed endpoint requires multipart/form-data for every request,
+// including text-only ones.
+func (p *Provider) embedText(ctx context.Context, model, text string) ([]float64, error) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	if err := mw.WriteField("model_name", model); err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: writing embed form: %v", err))
+	}
+	if err := mw.WriteField("text", text); err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: writing embed form: %v", err))
+	}
+	if err := mw.Close(); err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: closing embed form: %v", err))
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/embed", &buf)
+	if err != nil {
+		return nil, models.ErrInternal(fmt.Sprintf("twelvelabs: creating embed request: %v", err))
+	}
+	httpReq.Header.Set("Content-Type", mw.FormDataContentType())
+	p.setHeaders(httpReq)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, models.ErrGatewayTimeout("twelvelabs: embed request timed out")
+		}
+		return nil, models.ErrUpstreamProvider(0, fmt.Sprintf("twelvelabs: embed request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("twelvelabs: reading embed response: %v", err))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseError(resp.StatusCode, respBody)
+	}
+
+	var er embedResponse
+	if err := json.Unmarshal(respBody, &er); err != nil {
+		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("twelvelabs: parsing embed response: %v", err))
+	}
+
+	vec := er.firstFloatVector()
+	if len(vec) == 0 {
+		return nil, models.ErrUpstreamProvider(resp.StatusCode, "twelvelabs: embed response contained no embedding")
+	}
+	return vec, nil
+}
+
+// ListModels returns the configured TwelveLabs models. The TwelveLabs API has no
+// general model-listing endpoint, so models come from provider config.
+func (p *Provider) ListModels(ctx context.Context) ([]models.ModelObject, error) {
+	return nil, nil
+}
+
+// Close releases resources.
+func (p *Provider) Close() error {
+	p.httpClient.CloseIdleConnections()
+	return nil
+}

--- a/agentcc-gateway/internal/providers/twelvelabs/twelvelabs_test.go
+++ b/agentcc-gateway/internal/providers/twelvelabs/twelvelabs_test.go
@@ -1,0 +1,279 @@
+package twelvelabs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+func newTestProvider(t *testing.T, serverURL string) *Provider {
+	t.Helper()
+	p, err := New("test-twelvelabs", config.ProviderConfig{
+		BaseURL: serverURL,
+		APIKey:  "test-key",
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	return p
+}
+
+func TestNew_DefaultBaseURL(t *testing.T) {
+	p, err := New("tl", config.ProviderConfig{APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.baseURL != defaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", p.baseURL, defaultBaseURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractVideoAndPrompt
+// ---------------------------------------------------------------------------
+
+func userMessage(t *testing.T, content any) models.Message {
+	t.Helper()
+	raw, err := json.Marshal(content)
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+	return models.Message{Role: "user", Content: raw}
+}
+
+func TestExtractVideoAndPrompt_MultimodalURL(t *testing.T) {
+	msg := userMessage(t, []map[string]any{
+		{"type": "text", "text": "What happens in this video?"},
+		{"type": "video_url", "video_url": map[string]string{"url": "https://example.com/clip.mp4"}},
+	})
+	video, prompt, err := extractVideoAndPrompt([]models.Message{msg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if video.Type != "url" || video.URL != "https://example.com/clip.mp4" {
+		t.Errorf("video = %+v", video)
+	}
+	if prompt != "What happens in this video?" {
+		t.Errorf("prompt = %q", prompt)
+	}
+}
+
+func TestExtractVideoAndPrompt_ImageURLPart(t *testing.T) {
+	// OpenAI clients often only know the image_url part; accept it for video too.
+	msg := userMessage(t, []map[string]any{
+		{"type": "text", "text": "Summarize."},
+		{"type": "image_url", "image_url": map[string]string{"url": "https://example.com/v.mp4"}},
+	})
+	video, _, err := extractVideoAndPrompt([]models.Message{msg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if video.URL != "https://example.com/v.mp4" {
+		t.Errorf("video.URL = %q", video.URL)
+	}
+}
+
+func TestExtractVideoAndPrompt_AssetID(t *testing.T) {
+	msg := userMessage(t, []map[string]any{
+		{"type": "text", "text": "Describe it."},
+		{"type": "input_asset", "asset_id": "asset_123"},
+	})
+	video, _, err := extractVideoAndPrompt([]models.Message{msg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if video.Type != "asset" || video.AssetID != "asset_123" {
+		t.Errorf("video = %+v", video)
+	}
+}
+
+func TestExtractVideoAndPrompt_BareURLInString(t *testing.T) {
+	msg := models.Message{Role: "user", Content: json.RawMessage(
+		`"Describe https://example.com/clip.mp4 please"`)}
+	video, prompt, err := extractVideoAndPrompt([]models.Message{msg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if video.URL != "https://example.com/clip.mp4" {
+		t.Errorf("video.URL = %q", video.URL)
+	}
+	if !strings.Contains(prompt, "Describe") || strings.Contains(prompt, "http") {
+		t.Errorf("prompt should keep text and drop URL, got %q", prompt)
+	}
+}
+
+func TestExtractVideoAndPrompt_NoVideo(t *testing.T) {
+	msg := userMessage(t, []map[string]any{{"type": "text", "text": "hello"}})
+	_, _, err := extractVideoAndPrompt([]models.Message{msg})
+	if err == nil {
+		t.Fatal("expected error when no video present")
+	}
+	apiErr, ok := err.(*models.APIError)
+	if !ok || apiErr.Status != http.StatusBadRequest {
+		t.Errorf("expected 400 APIError, got %v", err)
+	}
+}
+
+func TestTranslateAnalyzeRequest_ClampsMaxTokens(t *testing.T) {
+	small := 10
+	req := &models.ChatCompletionRequest{
+		Model:     "pegasus1.5",
+		MaxTokens: &small,
+		Messages: []models.Message{userMessage(t, []map[string]any{
+			{"type": "text", "text": "go"},
+			{"type": "video_url", "video_url": map[string]string{"url": "https://e.com/v.mp4"}},
+		})},
+	}
+	ar, err := translateAnalyzeRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ar.MaxTokens != 512 {
+		t.Errorf("max_tokens = %d, want clamped to 512", ar.MaxTokens)
+	}
+	if ar.ModelName != "pegasus1.5" {
+		t.Errorf("model = %q", ar.ModelName)
+	}
+}
+
+func TestParseEmbeddingInput(t *testing.T) {
+	one, err := parseEmbeddingInput(json.RawMessage(`"hello"`))
+	if err != nil || len(one) != 1 || one[0] != "hello" {
+		t.Fatalf("single = %v, err = %v", one, err)
+	}
+	many, err := parseEmbeddingInput(json.RawMessage(`["a","b"]`))
+	if err != nil || len(many) != 2 {
+		t.Fatalf("many = %v, err = %v", many, err)
+	}
+}
+
+func TestEmbedResponse_FirstFloatVector(t *testing.T) {
+	body := `{"model_name":"marengo3.0","text_embedding":{"segments":[{"float":[0.1,0.2,0.3]}]}}`
+	var er embedResponse
+	if err := json.Unmarshal([]byte(body), &er); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v := er.firstFloatVector()
+	if len(v) != 3 || v[0] != 0.1 {
+		t.Errorf("vector = %v", v)
+	}
+}
+
+func TestParseError(t *testing.T) {
+	apiErr := parseError(http.StatusUnauthorized, []byte(`{"code":"api_key_invalid","message":"bad key"}`))
+	if apiErr.Status != http.StatusUnauthorized {
+		t.Errorf("status = %d", apiErr.Status)
+	}
+	apiErr = parseError(http.StatusBadRequest, []byte(`{"code":"parameter_invalid","message":"bad param"}`))
+	if apiErr.Status != http.StatusBadRequest || apiErr.Code != "parameter_invalid" {
+		t.Errorf("got %+v", apiErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// httptest round-trips (no network)
+// ---------------------------------------------------------------------------
+
+func TestChatCompletion_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/analyze" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Errorf("missing x-api-key header")
+		}
+		var req analyzeRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Video.URL != "https://e.com/v.mp4" {
+			t.Errorf("video.url = %q", req.Video.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc","data":"A cat plays.","usage":{"output_tokens":4}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL)
+	resp, err := p.ChatCompletion(context.Background(), &models.ChatCompletionRequest{
+		Model: "pegasus1.5",
+		Messages: []models.Message{userMessage(t, []map[string]any{
+			{"type": "text", "text": "Describe."},
+			{"type": "video_url", "video_url": map[string]string{"url": "https://e.com/v.mp4"}},
+		})},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion error: %v", err)
+	}
+	var content string
+	_ = json.Unmarshal(resp.Choices[0].Message.Content, &content)
+	if content != "A cat plays." {
+		t.Errorf("content = %q", content)
+	}
+	if resp.Usage == nil || resp.Usage.CompletionTokens != 4 {
+		t.Errorf("usage = %+v", resp.Usage)
+	}
+}
+
+func TestCreateEmbedding_RoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embed" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "multipart/form-data") {
+			t.Errorf("Content-Type = %q, want multipart/form-data", ct)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_name":"marengo3.0","text_embedding":{"segments":[{"float":[0.5,0.6]}]}}`))
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL)
+	resp, err := p.CreateEmbedding(context.Background(), &models.EmbeddingRequest{
+		Model: "marengo3.0",
+		Input: json.RawMessage(`"a person riding a bicycle"`),
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbedding error: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("data len = %d", len(resp.Data))
+	}
+	var vec []float64
+	_ = json.Unmarshal(resp.Data[0].Embedding, &vec)
+	if len(vec) != 2 || vec[0] != 0.5 {
+		t.Errorf("vector = %v", vec)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Live test (opt-in via TWELVELABS_API_KEY). Skipped in CI without a key.
+// ---------------------------------------------------------------------------
+
+func TestLive_MarengoEmbedding(t *testing.T) {
+	key := os.Getenv("TWELVELABS_API_KEY")
+	if key == "" {
+		t.Skip("TWELVELABS_API_KEY not set; skipping live test")
+	}
+	p, err := New("tl-live", config.ProviderConfig{APIKey: key})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	resp, err := p.CreateEmbedding(context.Background(), &models.EmbeddingRequest{
+		Model: "marengo3.0",
+		Input: json.RawMessage(`"a person riding a bicycle"`),
+	})
+	if err != nil {
+		t.Fatalf("live CreateEmbedding error: %v", err)
+	}
+	var vec []float64
+	_ = json.Unmarshal(resp.Data[0].Embedding, &vec)
+	if len(vec) != 512 {
+		t.Errorf("Marengo embedding dim = %d, want 512", len(vec))
+	}
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Summary

This adds **TwelveLabs** as an opt-in *native provider package* in `agentcc-gateway`, so the eval/observability platform can cover **video models** through the gateway's existing OpenAI-compatible surfaces — no new endpoints, no client changes.

- **Pegasus (video understanding)** via `POST /v1/chat/completions`. The video is passed as a public URL (an `image_url`/`video_url` content part, or a bare http(s) URL in the prompt) or a TwelveLabs asset id; the model's analysis comes back as the assistant message. `max_tokens` is clamped up to the model's required minimum so standard OpenAI clients work unchanged.
- **Marengo (multimodal embeddings)** via `POST /v1/embeddings`, returning **512-dim** float vectors for text input. This lets you embed text queries in the same space as your video embeddings for cross-modal retrieval. (The TwelveLabs `/embed` endpoint requires `multipart/form-data` for every request, including text-only — handled in the provider.)

It follows the same pattern as the existing native packages (Cohere, Bedrock, Azure): a package under `internal/providers/twelvelabs/` wired into the provider registry (`createProvider`) and the preset table (`type: "twelvelabs"` auto-fills `base_url` + `api_format`).

## Why it helps this project

The gateway already advertises one OpenAI-compatible API "for every modality your providers expose." Video understanding and multimodal embeddings were a gap; this closes it without touching any existing provider or default. With no `twelvelabs` provider configured, gateway behavior is completely unchanged.

## Opt-in / non-breaking

The provider is only constructed when a provider with `api_format: "twelvelabs"` is configured. No key, no behavior change. See `config.example.yaml` for the (commented-out) setup block.

## How was this tested?

- `go build ./...` — clean.
- `go vet ./internal/providers/...` — clean.
- `gofmt` — clean on all changed Go files.
- `go test ./internal/providers/twelvelabs/ ./internal/providers/` — pass. Includes no-network unit tests for message→request translation (URL / asset-id / bare-URL extraction, `max_tokens` clamping, error mapping) and `httptest` round-trips for both `/analyze` and `/embed`.
- **Live-verified** against the real TwelveLabs API: a `TWELVELABS_API_KEY`-gated test (`TestLive_MarengoEmbedding`, skipped without a key) confirms Marengo returns a **512-dim** vector through the provider code; Pegasus analyze was separately confirmed to return descriptive text.

I updated `agentcc-gateway/README.md` (embeddings row + native-provider section) and `config.example.yaml`. I did not run the repo-wide `make check-all` because this change is scoped entirely to the Go `agentcc-gateway` module; I ran that module's own `go build` / `go vet` / `gofmt` / `go test` instead.

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation only (README + config example updated alongside)

## Checklist

- [x] My code follows the style guide (mirrors the existing Cohere provider)
- [x] I've added tests (unit + httptest + a key-gated live test)
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII (the provider reads its key from config/env)
- [ ] I've signed the CLA — happy to sign the one-click CLA when the bot comments on this PR.

---

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
