### PR TITLE
[TH-6256] Fix Cancel/Delete buttons looking disabled in project settings

### DIFF
--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -353,12 +353,11 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
               aria-label="Cancel-configure-project"
               variant="outlined"
               color="inherit"
+              size="small"
               onClick={handleClose}
               sx={{
                 width: "90px",
-                height: "30px",
-                fontSize: "12px",
-                color: "text.disabled",
+                textTransform: "none",
               }}
             >
               Cancel
@@ -367,11 +366,11 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
               aria-label="delete-project"
               variant="outlined"
               color="inherit"
+              size="small"
               onClick={handleDeleteClick}
               sx={{
+                minWidth: "90px",
                 textTransform: "none",
-                fontSize: "14px",
-                color: "text.disabled",
               }}
             >
               Delete
@@ -379,12 +378,12 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
             <LoadingButton
               aria-label="update-project"
               type="submit"
+              size="small"
               loading={isUpdating}
               disabled={!isValid}
               sx={{
-                textTransform: "none",
-                fontSize: "14px",
                 minWidth: "90px",
+                textTransform: "none",
               }}
               variant="contained"
               color="primary"


### PR DESCRIPTION
**Ticket:** [TH-6256](https://linear.app/future-agi/issue/TH-6256/delete-and-cancel-button-looks-disabled-in-setting-page) — Closes TH-6256

## What was the bug
In the project settings dialog (`ConfigureProject`), the **Cancel** and **Delete** buttons rendered greyed-out / disabled-looking, even though they were fully clickable. They were also visibly different sizes from each other and from the **Update** button.

## What changes have been done
`frontend/src/sections/project-detail/ConfigureProject.jsx` (the `DialogActions` block):
- Removed `color: "text.disabled"` from both the Cancel and Delete buttons.
- Added `size="small"` to all three action buttons (Cancel / Delete / Update).
- Removed the hardcoded `height: "30px"` and `fontSize` overrides; added `minWidth: "90px"` + `textTransform: "none"` for consistency.

## Why the changes
- `color: "text.disabled"` is the theme's *disabled* token. Applying it to enabled buttons made them only *look* disabled — neither button had a real `disabled` prop, so this was purely a styling bug. Removing it lets them inherit the normal enabled text color.
- The hardcoded `fontSize` / `height` made the three buttons inconsistent. Switching to the shared `size="small"` prop (the existing project-detail convention) derives height/font from the theme instead of magic numbers.
- The `Update` button's `disabled={!isValid}` is a legitimate form-validity condition and was left untouched.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open settings on an **observe** project | Cancel/Delete render in normal enabled color (not grey); all 3 buttons same size |
| 2 | Open settings on an **experiment** project | Same as #1 — confirms the single shared dialog fixes both project types |
| 3 | Form invalid (e.g. clear a required field) | Update stays disabled; Cancel/Delete remain enabled and clickable |
| 4 | Click Cancel / Delete | Dialog closes / delete-confirmation opens — behavior unchanged |

## How to reproduce (original bug)
1. Open a project → **Settings** (Configure Project).
2. Note the Cancel and Delete buttons rendered in grey (disabled-looking) and at inconsistent sizes vs. Update.

## Commands
```bash
cd frontend
yarn dev   # http://localhost:3031
```

## Videos and screenshots
<img width="788" height="418" alt="Screenshot 2026-06-27 at 4 57 37 PM" src="https://github.com/user-attachments/assets/eb6a6608-67df-40d5-b72e-3516e443c8ab" />
