### PR TITLE
fix(observe): sampling rate dialog defaults to 0% not 100%

### DIFF
--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -21,7 +21,6 @@ import { useGetProjectDetails } from "src/api/project/project-detail";
 import { useNavigate } from "react-router";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
-import logger from "src/utils/logger";
 
 import { projectSchema } from "./common";
 import DeleteProject from "./DeleteProject";
@@ -97,8 +96,7 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
       name: data.projectName,
     };
     if (module === "observe") {
-      payload["sampling_rate"] =
-        typeof data.samplingRate === "number" ? data.samplingRate / 100 : 0;
+      payload["sampling_rate"] = data.samplingRate / 100;
     }
     updateProject(payload);
   };
@@ -417,19 +415,8 @@ ConfigureProject.propTypes = {
 };
 
 export function getSamplingRatePercent(projectDetail, module) {
-  if (typeof projectDetail?.sampling_rate === "number") {
-    return projectDetail.sampling_rate * 100;
+  if (projectDetail == null) {
+    return module === "observe" ? 0 : undefined;
   }
-  // projectDetail is only nullish while the project is still loading — that's
-  // expected and not worth logging. Once it's loaded, sampling_rate should
-  // always be a number (backend contract); anything else means the backend
-  // handed us bad data, which we'd otherwise silently show as 0%.
-  if (projectDetail != null) {
-    logger.error(
-      "ConfigureProject: sampling_rate is not a number, defaulting display to 0%",
-      null,
-      { sampling_rate: projectDetail.sampling_rate, module },
-    );
-  }
-  return module === "observe" ? 0 : undefined;
+  return projectDetail.sampling_rate * 100;
 }

--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -21,6 +21,7 @@ import { useGetProjectDetails } from "src/api/project/project-detail";
 import { useNavigate } from "react-router";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+import logger from "src/utils/logger";
 
 import { projectSchema } from "./common";
 import DeleteProject from "./DeleteProject";
@@ -415,9 +416,20 @@ ConfigureProject.propTypes = {
   module: PropTypes.oneOf(["prototype", "observe"]),
 };
 
-function getSamplingRatePercent(projectDetail, module) {
+export function getSamplingRatePercent(projectDetail, module) {
   if (typeof projectDetail?.sampling_rate === "number") {
     return projectDetail.sampling_rate * 100;
+  }
+  // projectDetail is only nullish while the project is still loading — that's
+  // expected and not worth logging. Once it's loaded, sampling_rate should
+  // always be a number (backend contract); anything else means the backend
+  // handed us bad data, which we'd otherwise silently show as 0%.
+  if (projectDetail != null) {
+    logger.error(
+      "ConfigureProject: sampling_rate is not a number, defaulting display to 0%",
+      null,
+      { sampling_rate: projectDetail.sampling_rate, module },
+    );
   }
   return module === "observe" ? 0 : undefined;
 }

--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -97,7 +97,7 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
     };
     if (module === "observe") {
       payload["sampling_rate"] =
-        typeof data.samplingRate === "number" ? data.samplingRate / 100 : 1;
+        typeof data.samplingRate === "number" ? data.samplingRate / 100 : 0;
     }
     updateProject(payload);
   };

--- a/frontend/src/sections/project-detail/ConfigureProject.test.js
+++ b/frontend/src/sections/project-detail/ConfigureProject.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const loggerErrorMock = vi.hoisted(() => vi.fn());
+vi.mock("src/utils/logger", () => ({
+  default: { error: loggerErrorMock },
+}));
+
+import { getSamplingRatePercent } from "./ConfigureProject";
+
+describe("getSamplingRatePercent", () => {
+  beforeEach(() => {
+    loggerErrorMock.mockReset();
+  });
+
+  it("converts a numeric sampling_rate fraction to a percent", () => {
+    expect(getSamplingRatePercent({ sampling_rate: 0.35 }, "observe")).toBe(35);
+    expect(loggerErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 for a genuinely-configured 0 sampling_rate without logging", () => {
+    expect(getSamplingRatePercent({ sampling_rate: 0 }, "observe")).toBe(0);
+    expect(loggerErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not log while the project hasn't loaded yet (projectDetail undefined)", () => {
+    expect(getSamplingRatePercent(undefined, "observe")).toBe(0);
+    expect(getSamplingRatePercent(null, "prototype")).toBeUndefined();
+    expect(loggerErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to 0 for observe AND logs when sampling_rate is a non-numeric anomaly", () => {
+    const projectDetail = { id: "p1", sampling_rate: "not-a-number" };
+
+    expect(getSamplingRatePercent(projectDetail, "observe")).toBe(0);
+
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+    const [message, error, context] = loggerErrorMock.mock.calls[0];
+    expect(message).toMatch(/sampling_rate is not a number/i);
+    expect(error).toBeNull();
+    expect(context).toEqual({
+      sampling_rate: "not-a-number",
+      module: "observe",
+    });
+  });
+
+  it("falls back to undefined for prototype AND still logs the anomaly", () => {
+    const projectDetail = { id: "p1", sampling_rate: null };
+
+    expect(getSamplingRatePercent(projectDetail, "prototype")).toBeUndefined();
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+    expect(loggerErrorMock.mock.calls[0][2]).toEqual({
+      sampling_rate: null,
+      module: "prototype",
+    });
+  });
+
+  it("logs when sampling_rate is missing entirely from a loaded project", () => {
+    const projectDetail = { id: "p1", name: "Test Project" };
+
+    expect(getSamplingRatePercent(projectDetail, "observe")).toBe(0);
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/sections/project-detail/ConfigureProject.test.js
+++ b/frontend/src/sections/project-detail/ConfigureProject.test.js
@@ -1,63 +1,18 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-
-const loggerErrorMock = vi.hoisted(() => vi.fn());
-vi.mock("src/utils/logger", () => ({
-  default: { error: loggerErrorMock },
-}));
+import { describe, expect, it } from "vitest";
 
 import { getSamplingRatePercent } from "./ConfigureProject";
 
 describe("getSamplingRatePercent", () => {
-  beforeEach(() => {
-    loggerErrorMock.mockReset();
-  });
-
   it("converts a numeric sampling_rate fraction to a percent", () => {
     expect(getSamplingRatePercent({ sampling_rate: 0.35 }, "observe")).toBe(35);
-    expect(loggerErrorMock).not.toHaveBeenCalled();
   });
 
-  it("returns 0 for a genuinely-configured 0 sampling_rate without logging", () => {
+  it("returns 0 for a genuinely-configured 0 sampling_rate", () => {
     expect(getSamplingRatePercent({ sampling_rate: 0 }, "observe")).toBe(0);
-    expect(loggerErrorMock).not.toHaveBeenCalled();
   });
 
-  it("does not log while the project hasn't loaded yet (projectDetail undefined)", () => {
+  it("falls back while the project hasn't loaded yet (projectDetail nullish)", () => {
     expect(getSamplingRatePercent(undefined, "observe")).toBe(0);
     expect(getSamplingRatePercent(null, "prototype")).toBeUndefined();
-    expect(loggerErrorMock).not.toHaveBeenCalled();
-  });
-
-  it("falls back to 0 for observe AND logs when sampling_rate is a non-numeric anomaly", () => {
-    const projectDetail = { id: "p1", sampling_rate: "not-a-number" };
-
-    expect(getSamplingRatePercent(projectDetail, "observe")).toBe(0);
-
-    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
-    const [message, error, context] = loggerErrorMock.mock.calls[0];
-    expect(message).toMatch(/sampling_rate is not a number/i);
-    expect(error).toBeNull();
-    expect(context).toEqual({
-      sampling_rate: "not-a-number",
-      module: "observe",
-    });
-  });
-
-  it("falls back to undefined for prototype AND still logs the anomaly", () => {
-    const projectDetail = { id: "p1", sampling_rate: null };
-
-    expect(getSamplingRatePercent(projectDetail, "prototype")).toBeUndefined();
-    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
-    expect(loggerErrorMock.mock.calls[0][2]).toEqual({
-      sampling_rate: null,
-      module: "prototype",
-    });
-  });
-
-  it("logs when sampling_rate is missing entirely from a loaded project", () => {
-    const projectDetail = { id: "p1", name: "Test Project" };
-
-    expect(getSamplingRatePercent(projectDetail, "observe")).toBe(0);
-    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/futureagi/tracer/tests/test_project.py
+++ b/futureagi/tracer/tests/test_project.py
@@ -6,7 +6,7 @@ Tests for /tracer/project/ endpoints.
 
 import json
 import uuid
-from datetime import timedelta, timezone as datetime_timezone
+from datetime import UTC, timedelta
 
 import pytest
 from django.utils import timezone
@@ -32,7 +32,7 @@ def get_result(response):
 
 
 def _iso_z(value):
-    return value.astimezone(datetime_timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    return value.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def _chart_filter(column_id, filter_type, filter_op, filter_value, col_type=None):
@@ -335,7 +335,8 @@ class TestProjectRetrieveAPI:
         data = get_result(response)
         assert data["name"] == "Test Project"
         assert data.get("trace_type") == "experiment"
-        assert "sampling_rate" in data  # Should include sampling rate
+        assert "sampling_rate" in data
+        assert data["sampling_rate"] == 0
 
     def test_retrieve_project_not_found(self, auth_client):
         """Retrieve non-existent project returns error."""


### PR DESCRIPTION
The Configure Project dialog in Observe showed 100% as the sampling rate for every project, regardless of what the API returned. The root cause was a camelCase/snake_case field name mismatch in `getSamplingRatePercent`: the function checked `projectDetail?.samplingRate` (camelCase) but the project-detail hook returns raw snake_case JSON — so the field arrives as `sampling_rate`, the check was always `undefined`, and the hardcoded fallback `100` was returned every time. Fixed by reading `sampling_rate` and correcting both fallbacks to `0`. The BE test is also strengthened to pin the contract that new projects return `sampling_rate: 0`.

**Rebased 2026-07-09.** The `getSamplingRatePercent` read-fix itself landed independently on `dev` via #1360 (Jaya Surya, 2026-07-07) before this PR merged — same root cause, same fix. This branch has been rebased onto `dev`, so that duplicate hunk dropped out on its own. What's left and still genuinely new here: the BE test strengthening below (not on `dev` yet). See the reply thread on Atharva's comment for the prod-data-check discussion.

**Update 2026-07-09.** In response to Atharva's original comment I first added a `typeof` guard + `logger.error` on `getSamplingRatePercent` to catch a non-numeric `sampling_rate` instead of silently showing 0%. He then followed up on both that spot and the `onSubmit` else-branch asking: if the value is always going to be a number, why have the check at all. He's right — the prod trace already confirmed the backend field is a non-nullable `FloatField`, so the guard could never fire. Removed both `typeof` checks entirely (and the now-dead `logger` import); `getSamplingRatePercent` still handles `projectDetail` itself being nullish while the project is loading, since that's a real, reachable state.

## Why the changes are done — what is the problem

### Reproduce on dev/main today (before this PR)

1. Log into the platform and navigate to **Observe**.
2. Open the ⋯ menu on any project → click **Configure Project**.
3. The Sampling rate slider opens at **100%**.

Expected: slider opens at 0% for new projects (no scan config), or at the project's stored value for existing ones.

### Where it breaks — BE

No backend bug. `GET /tracer/project/<id>/` reads `TraceScanConfig.sampling_rate` (Django `FloatField(default=0)`) and injects it as `sampling_rate` in the response. When no scan config exists, the view falls to `except TraceScanConfig.DoesNotExist: data["sampling_rate"] = 0`. The field is snake_case throughout the API contract.

The existing test `test_retrieve_project_success` only asserted `"sampling_rate" in data` — it did not pin the value, so the FE mismatch was invisible to CI.

### Where it breaks — UI

`ConfigureProject.jsx` calls `getSamplingRatePercent(projectDetail, module)` in three places: form `defaultValues`, the `useEffect` reset on `projectDetail` load, and the `RHFSlider` `defaultValue` prop.

```js
// BEFORE — wrong field name, wrong fallback
function getSamplingRatePercent(projectDetail, module) {
  if (typeof projectDetail?.samplingRate === "number") {  // always undefined
    return projectDetail.samplingRate * 100;               // never executes
  }
  return module === "observe" ? 100 : undefined;           // always reached → 100%
}
```

`useGetProjectDetails` returns `d?.data?.result` with no key transformation. The response is `{ sampling_rate: 0, ... }`. `projectDetail.samplingRate` is always `undefined`; `typeof undefined === "number"` is `false`. The condition never fires.

The `onSubmit` handler also had `... : 1` as the else-branch fallback — meaning 100% would be sent if `data.samplingRate` were ever not a number (unreachable in normal flow, but incorrect).

## What changed

### `frontend/src/sections/project-detail/ConfigureProject.jsx`

- `getSamplingRatePercent`: reads `projectDetail?.sampling_rate` (snake_case) — matches the API response key. The function now correctly returns `sampling_rate * 100` for projects that have a stored value. Exported for testability. Only checks whether `projectDetail` itself is loaded yet — no `typeof` check on `sampling_rate` (removed per Atharva's follow-up, see Update above; the backend never sends anything but a number).
- `getSamplingRatePercent` fallback: `100` → `0` when `projectDetail` hasn't loaded yet. Correct default when no scan config exists or the project is still loading.
- `onSubmit`: now sends `data.samplingRate / 100` directly — no `typeof` check, no else-branch fallback. The value comes straight off the `RHFSlider`, which is always numeric.

### `frontend/src/sections/project-detail/ConfigureProject.test.js` (new)

- 3 unit tests on `getSamplingRatePercent`: numeric passthrough, genuine 0% for a loaded project, fallback while `projectDetail` is still nullish (loading).

### `futureagi/tracer/tests/test_project.py`

- `test_retrieve_project_success`: added `assert data["sampling_rate"] == 0`. Pins the contract that a project without a `TraceScanConfig` returns `0`. The previous assertion (`"sampling_rate" in data`) passed regardless of value — it would not catch a regression that changed the default.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `TestProjectRetrieveAPI::test_retrieve_project_success` | Project created, no `TraceScanConfig` row | `GET /tracer/project/<id>/` | Pins that `sampling_rate` is `0` for new projects — goes red if the `except TraceScanConfig.DoesNotExist` fallback is removed or returns a non-zero value |
| 2 | `ConfigureProject.test.js::getSamplingRatePercent` (3 cases) | Direct unit calls with numeric / zero / nullish `projectDetail` | Call the exported function | Pins numeric passthrough, genuine 0%, and the loading fallback — no `typeof` branch left to pin |

## Commands to run tests

```bash
# Run only the strengthened test
cd futureagi && .venv/bin/pytest tracer/tests/test_project.py::TestProjectRetrieveAPI::test_retrieve_project_success -v

# Run the full retrieve class
cd futureagi && .venv/bin/pytest tracer/tests/test_project.py::TestProjectRetrieveAPI -v

# Run the full project test module
cd futureagi && .venv/bin/pytest tracer/tests/test_project.py -v
```

Tests that don't match the filter appear as `deselected` — not broken, just not run.

## Local verification results

![test suite run — tracer/tests/test_project.py -v, 39 passed](https://github.com/user-attachments/assets/9412a760-610e-4dd6-90d6-7a835936a2b8)

## Video / Proof

[IMAGE PENDING — paste the before/after proof image here]

## Screenshot of test suite run

**Command** - `cd futureagi && .venv/bin/pytest tracer/tests/test_project.py -v`

![test suite run — tracer/tests/test_project.py -v, 39 passed](https://github.com/user-attachments/assets/9412a760-610e-4dd6-90d6-7a835936a2b8)

## Backwards compatibility

Schema and semantics unchanged. `GET /tracer/project/<id>/` has always returned `sampling_rate`; the FE change only affects how the dialog initializes its form state.

| Caller | Pre-PR behavior | Post-PR behavior |
|---|---|---|
| `ConfigureProject` (observe mode) | Slider always opens at 100% | Slider opens at `sampling_rate * 100`; 0 for new projects |
| `updateProject` API call | Slider value / 100 on submit; else-branch sent `1` (100%) if ever non-numeric | Slider value / 100 on submit, no else-branch — value is always numeric |

## Manual verification (UI)

1. Navigate to **Observe** → open ⋯ menu on any project → **Configure Project**.
2. Confirm the sampling rate slider opens at **0%** (was 100% before this PR).
3. Drag the slider to 50% → click **Update**.
4. Re-open Configure Project — confirm the slider opens at **50%** (stored value is read correctly on round-trip).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- FE change: reverts to prior behavior (slider opens at 100% for all observe projects). No cached or stored state affected — the value is read fresh on dialog open.
- BE test: reverts assertion to `"sampling_rate" in data`. No behavioral change to production code.
- No migrations in this PR.

Fixes TH-6255


