### PR TITLE
fix: correct internal gateway URLs from port 8090 to 8080 in .env.example (Fixes #1058)

### DIFF
--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -461,7 +461,7 @@ GUARDRAILS_TOKEN=your-guardrails-token
 # -----------------------------------------------------------------------------
 AGENTCC_GATEWAY_PORT=8090
 AGENTCC_GATEWAY_PUBLIC_URL=https://your-gateway-domain.com
-AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8090
+AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_ADMIN_TOKEN=agentcc-admin-secret
 AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 
@@ -470,7 +470,7 @@ AGENTCC_WEBHOOK_SECRET=test-webhook-secret
 # Uses the SAME agentcc-gateway, but with a dedicated API key tagged as "internal".
 # Internal calls bypass user quota but are still cost-tracked.
 # -----------------------------------------------------------------------------
-AGENTCC_INTERNAL_URL=http://agentcc-gateway:8090
+AGENTCC_INTERNAL_URL=http://agentcc-gateway:8080
 AGENTCC_INTERNAL_API_KEY=fi-internal-dev-key-change-in-prod
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1058

## Problem
`AGENTCC_GATEWAY_INTERNAL_URL` and `AGENTCC_INTERNAL_URL` in `.env.example` use port 8090 instead of 8080 for internal container-to-container communication. The agentcc-gateway Docker container maps `host:8090→container:8080`, so internal URLs must use `:8080` to reach the gateway within the Docker network.

While `docker-compose.yml` was already corrected upstream, `.env.example` still had the wrong ports — causing `Connection refused` errors when running Django directly against a gateway container for API key sync, provider setup, and admin calls.

## Solution
Changed `AGENTCC_GATEWAY_INTERNAL_URL` and `AGENTCC_INTERNAL_URL` from `:8090` to `:8080` in `futureagi/.env.example`.

(Note: `AGENTCC_GATEWAY_PORT=8090` is unchanged — that's the correct host-facing port.)

## Files Changed
- `futureagi/.env.example` — Changed 2 internal URLs from port 8090 to 8080

## Verification
- Verified `docker-compose.yml` already uses `http://agentcc-gateway:8080` for internal URLs
- Verified `docker-compose.yml` maps `host:8090→container:8080`
- `grep` confirms no other instances of incorrect internal port remain in `.env.example`

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-27 | Fixed .env.example internal gateway URLs from 8090→8080 | rtmalikian |

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek v4 Flash** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
