### PR TITLE
fix: handle NORMAL col_type in ClickHouse trace-list filters (TH-6179)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -680,7 +680,7 @@ class ClickHouseFilterBuilder:
             return self._build_span_attr_condition(
                 col_id, filter_type, filter_op, filter_value
             )
-        elif col_type == self.SYSTEM_METRIC:
+        elif col_type in (self.SYSTEM_METRIC, self.NORMAL):
             return self._build_system_metric_condition(
                 col_id, filter_type, filter_op, filter_value
             )

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -359,9 +359,9 @@ class TestClickHouseSchema:
         assert names.index("span_metrics_hourly_mv") < names.index(
             "span_metrics_hourly"
         ), "MV must drop before its source table"
-        assert names.index("spans_mv") < names.index(
-            "tracer_observation_span"
-        ), "spans_mv must drop before tracer_observation_span"
+        assert names.index("spans_mv") < names.index("tracer_observation_span"), (
+            "spans_mv must drop before tracer_observation_span"
+        )
         # Idempotency: every drop wraps IF EXISTS so reruns are no-ops.
         for _, sql in drops:
             assert "IF EXISTS" in sql, f"drop must be idempotent: {sql}"
@@ -716,6 +716,69 @@ class TestClickHouseFilterBuilder:
         )
         assert "project_id = %(project_id)s" in where_pid
         assert "project_id IN %(project_ids)s" not in where_pid
+
+    def test_normal_col_type_is_handled_like_system_metric(self):
+        """Filters that omit ``col_type`` default to NORMAL in ``translate``
+        (a ``status`` / ``trace_name`` quick-filter chip). ``_build_condition``
+        used to raise ``ValueError: Unsupported col_type: 'NORMAL'`` because it
+        only branched on SYSTEM_METRIC/SPAN_ATTRIBUTE/EVAL_METRIC/ANNOTATION —
+        surfaced by ``list_traces_of_session`` as a generic 400. NORMAL columns
+        are denormalised spans columns, so they must resolve through the same
+        path as SYSTEM_METRIC. Regression guard.
+        """
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        pid = "11111111-1111-1111-1111-111111111111"
+        normal_filter = {
+            "column_id": "trace_name",
+            "filter_config": {
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "RunnableSequence",
+                # col_type intentionally omitted -> defaults to NORMAL
+            },
+        }
+        explicit_system_metric = {
+            "column_id": "trace_name",
+            "filter_config": {
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "RunnableSequence",
+                "col_type": "SYSTEM_METRIC",
+            },
+        }
+
+        where_normal, params_normal = ClickHouseFilterBuilder(
+            project_id=pid,
+            query_mode=ClickHouseFilterBuilder.QUERY_MODE_TRACE,
+        ).translate([normal_filter])
+        where_system, params_system = ClickHouseFilterBuilder(
+            project_id=pid,
+            query_mode=ClickHouseFilterBuilder.QUERY_MODE_TRACE,
+        ).translate([explicit_system_metric])
+
+        # No raise, a real predicate emitted, and NORMAL == SYSTEM_METRIC.
+        assert where_normal
+        assert "trace_name" in where_normal
+        assert where_normal == where_system
+        assert params_normal == params_system
+
+        # A bare ``status`` filter (the other common quick-filter) also works.
+        where_status, _ = ClickHouseFilterBuilder(project_id=pid).translate(
+            [
+                {
+                    "column_id": "status",
+                    "filter_config": {
+                        "filter_type": "text",
+                        "filter_op": "equals",
+                        "filter_value": "ERROR",
+                    },
+                }
+            ]
+        )
+        assert "status" in where_status
 
     def test_score_date_scope_can_be_disabled_for_monitor_builders(self):
         """Monitor queries bind start_time/end_time, not start_date/end_date."""
@@ -2796,9 +2859,7 @@ class TestSessionListQueryBuilder:
         assert "ts_remap.survivor_id" in query
         assert "IN %(sess_1)s" in query
         assert "toString(trace_session_id) IN" not in query
-        assert query.index("IN %(sess_1)s") < query.index(
-            "GROUP BY trace_session_id"
-        )
+        assert query.index("IN %(sess_1)s") < query.index("GROUP BY trace_session_id")
         assert session_id in next(
             value for key, value in params.items() if key.startswith("sess_")
         )
@@ -2819,9 +2880,7 @@ class TestSessionListQueryBuilder:
                     },
                 }
             ],
-            sort_params=[
-                {"column_id": "total_traces_count", "direction": "desc"}
-            ],
+            sort_params=[{"column_id": "total_traces_count", "direction": "desc"}],
         )
 
         query, params = builder.build()
@@ -2869,7 +2928,10 @@ class TestSessionListQueryBuilder:
 
         assert "argMin(input, start_time) AS first_message" in query
         assert "argMax(input, start_time) AS last_message" in query
-        assert "SELECT trace_session_id, trace_id, start_time, end_time, cost, total_tokens, input" in query
+        assert (
+            "SELECT trace_session_id, trace_id, start_time, end_time, cost, total_tokens, input"
+            in query
+        )
         assert "ORDER BY first_message ASC" in query
 
     def test_v2_span_attributes_query_uses_native_ch25_columns(self):
@@ -6511,9 +6573,9 @@ class TestVoiceCallListPhase1bMigration:
         src = self._voice_list_source()
         # `FROM spans FINAL` collapses ReplacingMergeTree duplicates — the
         # v2 dedup contract. FINAL alone (without `spans`) is too permissive.
-        assert re.search(
-            r"FROM\s+spans\s+FINAL", src
-        ), "_list_voice_calls_clickhouse must hydrate from v2 `spans FINAL`."
+        assert re.search(r"FROM\s+spans\s+FINAL", src), (
+            "_list_voice_calls_clickhouse must hydrate from v2 `spans FINAL`."
+        )
         assert "is_deleted = 0" in src
 
     def test_phase_1b_selects_typed_map_columns_for_reconstruction(self):
@@ -6925,9 +6987,9 @@ class TestVoiceCallListQueryBuilderComprehensive:
         # Each phone number is still recognised as a simulator call in Python.
         for phone in VAPI_PHONE_NUMBERS:
             span_attrs = {"raw_log": {"customer": {"number": phone}}}
-            assert VoiceCallListQueryBuilder.is_simulator_call(
-                span_attrs, "vapi"
-            ), f"Missing phone number: {phone}"
+            assert VoiceCallListQueryBuilder.is_simulator_call(span_attrs, "vapi"), (
+                f"Missing phone number: {phone}"
+            )
 
     def test_simulation_filter_uses_json_extract(self):
         """Simulation filtering is now Python-side against parsed raw_log.
@@ -8070,9 +8132,7 @@ class TestSessionTimeSeriesQueryBuilder:
         assert "trace_session_id_remap" in query
         assert "ts_remap.survivor_id" in query
         assert "IN %(session_id_1)s" in query
-        assert query.index("IN %(session_id_1)s") < query.index(
-            "GROUP BY session_id"
-        )
+        assert query.index("IN %(session_id_1)s") < query.index("GROUP BY session_id")
         assert params["session_id_1"] == (session_id,)
 
     def test_session_aggregate_filter_uses_inner_having(self):


### PR DESCRIPTION
**Linear:** [TH-6179 — Trace list api is failing for old data](https://linear.app/future-agi/issue/TH-6179)

**FE half (split out):** [TH-6267 — strip UI-only filter keys (id, _meta)](https://linear.app/future-agi/issue/TH-6267) → @dileep.kumar

---

## What & why

`GET /tracer/trace/list_traces_of_session/` 400s with a generic `"error fetching the traces list of observe"` whenever a **bare quick-filter** (a `status` or `trace_name` chip that doesn't carry an explicit `col_type`) is applied. The swallowed exception is:

```
ValueError: Unsupported col_type: 'NORMAL'
  tracer/views/trace.py:2425                                  list_traces_of_session
  tracer/services/clickhouse/v2/query_builders/filters.py:325 translate (v2 → super())
  tracer/services/clickhouse/query_builders/filters.py:611    translate
  tracer/services/clickhouse/query_builders/filters.py:694    _build_condition → raise
```

This was the dominant failure behind **TH-6179** ("trace list api failing for old data") — 38 of 41 logged exceptions on dev in 24h. It is **not** a data/backfill problem (the wide-range requests that fail with CH `Code:241 memory-limit` are reading real rows, so the data is in CH).

## Root cause

`ClickHouseFilterBuilder.translate()` defaults a missing `col_type` to `NORMAL`:

```python
col_type = config.get("col_type") or config.get("colType") or self.NORMAL   # filters.py:567
```

…but `_build_condition` only branched on `SPAN_ATTRIBUTE / SYSTEM_METRIC / EVAL_METRIC / ANNOTATION` and then `raise ValueError(f"Unsupported col_type: {col_type!r}")`. So the class **defaults to NORMAL and then refuses NORMAL** — a self-contradiction introduced when the PG→CH migration (D-027) deleted the PG `FilterEngine` fallback without porting its NORMAL branch.

`NORMAL` is a first-class, declared col_type, not malformed input:
- defined as a constant in **both** the CH builder (`NORMAL = "NORMAL"`) and the PG `FilterEngine`,
- documented in the filter schema description ("…SYSTEM_METRIC, SPAN_ATTRIBUTE, EVAL_METRIC, ANNOTATION, or **NORMAL**"),
- the deliberate default for missing `col_type` in both engines.

## Why this is the actual fix, not a workaround

The API-contract hardening (`9e131383`, `ae36749b`) lives at the **serializer** layer, and it *correctly accepts* NORMAL — verified by replaying the real payload on dev:

```
B_normal   valid=True                                     # serializer passes a no-col_type filter
B_builder  RAISED ValueError: Unsupported col_type: 'NORMAL'   # only the downstream builder breaks
```

The crash is one layer below the contract, in the query builder, which simply lost a branch it used to have. This PR restores it; it does **not** loosen any validation. The reference PG `FilterEngine._filter_text` handles the same case as a direct-column read (`else: obj.get(column_id)`), which — because NORMAL columns (`status`, `trace_name`, `name`, `model`, …) are denormalised `spans` columns already in `SYSTEM_METRIC_MAP` — is exactly what the `SYSTEM_METRIC` path produces. So NORMAL and SYSTEM_METRIC resolve identically here, and reusing that path is the DRY, parity-preserving fix.

> The hardening's *intended* target — junk UI keys (`id`, `_meta`) the FE shouldn't send — is a **separate** bug (the `631d3043` screenshot on the ticket). That one is correctly fixed by making the FE stop sending them, tracked in **TH-6267** (FE, @dileep.kumar). BE stays strict there.

## The change

```diff
-        elif col_type == self.SYSTEM_METRIC:
+        elif col_type in (self.SYSTEM_METRIC, self.NORMAL):
+            # NORMAL is the default family the FE uses for bare/quick filters
+            # that omit col_type (a `status` / `trace_name` chip). These are
+            # denormalised spans columns and resolve via the same
+            # SYSTEM_METRIC_MAP lookup (+ span-attr fallback), so share a path.
             return self._build_system_metric_condition(...)
```

Applies to the v2 path too — `ClickHouseFilterBuilderV2.translate` delegates to this base `_build_condition`.

## Testing

- New regression guard `test_clickhouse.py::TestClickHouseFilterBuilder::test_normal_col_type_is_handled_like_system_metric`: asserts a no-`col_type` `trace_name`/`status` filter translates to the **same** WHERE fragment as explicit `SYSTEM_METRIC` and does not raise.
- **Verified it fails without the fix** (`ValueError: Unsupported col_type: 'NORMAL'`) and passes with it.
- Full filter suite green — `TestClickHouseFilterBuilder` + `test_ch25_filter_compiler` + `test_filter_engine_parity` = **155 passed**. `ruff check` clean.

## Scope

Backend half of TH-6179 only. FE half (strip `id`/`_meta` before calling `list_*`) → TH-6267.


