### PR TITLE
fix(observe): trace/span quick filters send col_type (+ trace_name remap) [TH-6224]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -751,7 +751,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               navigate("?userTab=traces&selectedTab=spans", { replace: true });
             } else {
               navigate(
-                `/dashboard/observe/${observeId}/llm-tracing?tab=spans&selectedTab=spans`,
+                `/dashboard/observe/${observeId}/llm-tracing?tab=traces&selectedTab=spans`,
                 { replace: true },
               );
             }

--- a/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { applyQuickFilters } from "../common";
+import { AnnotationLabelTypes } from "src/utils/constants";
+
+// applyQuickFilters is curried: (setFilters, openQuickFilter, setFilterOpen)
+// => ({ col, value, filterAnchor }). It appends the built filter via
+// setFilters(updater); run the updater against [] to capture what it emits.
+function runQuickFilter(col, value) {
+  let produced;
+  const setFilters = (updater) => {
+    produced = typeof updater === "function" ? updater([]) : updater;
+  };
+  const noop = () => {};
+  applyQuickFilters(setFilters, noop, noop)({ col, value, filterAnchor: {} });
+  return produced?.[0];
+}
+
+describe("applyQuickFilters", () => {
+  it("attaches col_type SYSTEM_METRIC for a system column (without it the list 400s)", () => {
+    const f = runQuickFilter({ id: "provider", name: "Provider" }, "anthropic");
+    expect(f.column_id).toBe("provider");
+    expect(f.filter_config.col_type).toBe("SYSTEM_METRIC");
+    expect(f.filter_config.filter_op).toBe("equals");
+    expect(f.filter_config.filter_value).toBe("anthropic");
+    expect(f.display_name).toBeUndefined();
+  });
+
+  it("remaps the trace_name cell to the canonical `name` field as in + array", () => {
+    const f = runQuickFilter(
+      { id: "trace_name", name: "Trace Name" },
+      "my-trace",
+    );
+    expect(f.column_id).toBe("name");
+    expect(f.display_name).toBe("Trace Name");
+    expect(f.filter_config.col_type).toBe("SYSTEM_METRIC");
+    expect(f.filter_config.filter_op).toBe("in");
+    expect(f.filter_config.filter_value).toEqual(["my-trace"]);
+  });
+
+  it("uses col_type ANNOTATION for annotation-metric columns", () => {
+    const f = runQuickFilter(
+      {
+        id: "ann-1",
+        groupBy: "Annotation Metrics",
+        annotationLabelType: AnnotationLabelTypes.TEXT,
+      },
+      "good",
+    );
+    expect(f.column_id).toBe("ann-1");
+    expect(f.filter_config.col_type).toBe("ANNOTATION");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -370,11 +370,31 @@ export const applyQuickFilters =
     }
 
     if (filter) {
+      // Quick filters skip the toolbar normalization, so attach the col_type
+      // the backend needs — without it the list 400s on a NORMAL col_type.
+      let field = filter.column_id;
+      let fieldName;
+      const apiColType =
+        col?.groupBy === "Annotation Metrics" ? "ANNOTATION" : "SYSTEM_METRIC";
+      let operator = filter.filter_config?.filter_op;
+      let value = filter.filter_config?.filter_value;
+
+      // Trace Name's column id is `trace_name`, but the backend canonical
+      // field is `name`. Remap to the wire shape the panel sends.
+      if (field === "trace_name") {
+        field = "name";
+        fieldName = "Trace Name";
+        operator = "in";
+        value = Array.isArray(value) ? value : [value];
+      }
+
       const extraFilter = buildApiFilterFromPanelRow({
-        field: filter.column_id,
+        field,
+        fieldName,
         fieldType: filter.filter_config?.filter_type,
-        operator: filter.filter_config?.filter_op,
-        value: filter.filter_config?.filter_value,
+        apiColType,
+        operator,
+        value,
       });
       setFilters((prev) => {
         const exists = (prev || []).some(


### PR DESCRIPTION
## 🐛 Bug
Cell-click **quick filters** on the Observe **trace & span** grids errored the table with a 400 (`Unsupported col_type: 'NORMAL'`).

Root cause: `applyQuickFilters` builds its filter via `buildApiFilterFromPanelRow` but never attached `col_type`, and the quick-filter output is sent **raw** into the request — it bypasses the `ObserveToolbar` normalization that panel filters get (which defaults `col_type` to `SYSTEM_METRIC`). The ClickHouse filter builder rejects a missing/`NORMAL` `col_type`, so the trace/span list 400s.

Trace Name additionally never matched: the cell id is `trace_name`, but the backend canonical field is `name` (the root-span name).

## 🔧 What changed
- **`LLMTracing/common.js` (`applyQuickFilters`)** — attach `col_type` to the filter before building the API row: `SYSTEM_METRIC` for system columns, `ANNOTATION` for annotation-metric columns.
- Remap the **`trace_name`** cell to the canonical **`name`** field with the panel's wire shape (`col_type: SYSTEM_METRIC`, `filter_op: in`, array value).
- **`LLMTracing/LLMTracingView.jsx`** — group-by → **Span** from a saved view now navigates to `tab=traces&selectedTab=spans` (was `tab=spans`, an unknown top-level tab key that made the first *Save view* persist `tab_type: traces`).

## 🤔 Why
`col_type` is required by the CH filter pipeline. Verified directly against dev: with `col_type` → `200` + correctly filtered rows; without → `400 NORMAL`. `equals` vs `in` are **equivalent** once `col_type` is present, so no operator rewrite beyond trace_name's canonical `name`/`in` shape. Scope kept to string/system-metric columns — numeric/eval popup filters go through a separate path and are out of scope here.

## 🧪 Tests
- `applyQuickFilters` attaches `col_type: SYSTEM_METRIC` for a system column (provider).
- `applyQuickFilters` remaps `trace_name` → `name` as `in` + array with `display_name`.
- `applyQuickFilters` uses `col_type: ANNOTATION` for annotation-metric columns.

## ▶️ How to reproduce / verify
- **Pre-fix:** click the quick-filter icon on a Trace Name / provider / status cell → table shows an error (400).
- **Post-fix:** the same click filters the list with no error. Backend-confirmed on dev (`provider in [anthropic]` + `col_type` → 31 rows; same request without `col_type` → 400).

## 💻 Commands
```
cd frontend && npx vitest run src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
yarn contracts:check   # passes; no contract/serializer change
```

## 📹 Videos & Screenshots
_n/a — verified against the dev backend via curl; UI smoke pending._
