### PR TITLE
fix(simulate): scope run-test create validation by active org (TH-6191)

### DIFF
--- a/futureagi/simulate/serializers/requests/run_test.py
+++ b/futureagi/simulate/serializers/requests/run_test.py
@@ -18,6 +18,19 @@ from simulate.serializers.requests.run_test_evals import EvalConfigDefinitionSer
 from tracer.serializers.filters import StrictInputSerializer
 
 
+def _active_organization(serializer):
+    """Resolve the active organization for org-scoped validation.
+
+    Prefer the request's resolved active org (set by authentication from the
+    ``X-Organization-Id`` header / last-switched config) and fall back to the
+    user's legacy ``organization`` FK. This mirrors how the create views resolve
+    the org for the write path, so validation and creation agree on the same org
+    for multi-org users whose active org differs from their legacy FK.
+    """
+    request = serializer.context["request"]
+    return getattr(request, "organization", None) or request.user.organization
+
+
 class RunTestFilterSerializer(StrictInputSerializer):
     """
     Validates GET /run-tests/ query parameters.
@@ -75,7 +88,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
 
     def validate_agent_definition_id(self, value):
         """Validate that the agent definition exists"""
-        organization = self.context["request"].user.organization
+        organization = _active_organization(self)
         if not AgentDefinition.objects.filter(
             id=value, organization=organization
         ).exists():
@@ -84,7 +97,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
 
     def validate_scenario_ids(self, value):
         """Validate that all scenario IDs exist"""
-        organization = self.context["request"].user.organization
+        organization = _active_organization(self)
         existing_ids = set(
             Scenarios.objects.filter(
                 id__in=value, organization=organization
@@ -111,7 +124,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
         if not valid_uuids:
             return []
 
-        organization = self.context["request"].user.organization
+        organization = _active_organization(self)
         existing_ids = set(
             SimulateEvalConfig.objects.filter(
                 id__in=valid_uuids, run_test__organization=organization
@@ -205,7 +218,7 @@ class CreatePromptSimulationSerializer(PromptSimulationCreateFieldsSerializer):
         """Validate that the prompt template exists"""
         from model_hub.models.run_prompt import PromptTemplate
 
-        organization = self.context["request"].user.organization
+        organization = _active_organization(self)
         if not PromptTemplate.objects.filter(
             id=value, organization=organization, deleted=False
         ).exists():
@@ -222,7 +235,7 @@ class CreatePromptSimulationSerializer(PromptSimulationCreateFieldsSerializer):
 
     def validate_scenario_ids(self, value):
         """Validate that all scenario IDs exist"""
-        organization = self.context["request"].user.organization
+        organization = _active_organization(self)
         existing_ids = set(
             Scenarios.objects.filter(
                 id__in=value, organization=organization

--- a/futureagi/simulate/serializers/requests/run_test.py
+++ b/futureagi/simulate/serializers/requests/run_test.py
@@ -16,19 +16,7 @@ from rest_framework import serializers
 from simulate.models import AgentDefinition, RunTest, Scenarios, SimulateEvalConfig
 from simulate.serializers.requests.run_test_evals import EvalConfigDefinitionSerializer
 from tracer.serializers.filters import StrictInputSerializer
-
-
-def _active_organization(serializer):
-    """Resolve the active organization for org-scoped validation.
-
-    Prefer the request's resolved active org (set by authentication from the
-    ``X-Organization-Id`` header / last-switched config) and fall back to the
-    user's legacy ``organization`` FK. This mirrors how the create views resolve
-    the org for the write path, so validation and creation agree on the same org
-    for multi-org users whose active org differs from their legacy FK.
-    """
-    request = serializer.context["request"]
-    return getattr(request, "organization", None) or request.user.organization
+from tracer.utils.workspace_scope import get_request_organization
 
 
 class RunTestFilterSerializer(StrictInputSerializer):
@@ -88,7 +76,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
 
     def validate_agent_definition_id(self, value):
         """Validate that the agent definition exists"""
-        organization = _active_organization(self)
+        organization = get_request_organization(self.context["request"])
         if not AgentDefinition.objects.filter(
             id=value, organization=organization
         ).exists():
@@ -97,7 +85,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
 
     def validate_scenario_ids(self, value):
         """Validate that all scenario IDs exist"""
-        organization = _active_organization(self)
+        organization = get_request_organization(self.context["request"])
         existing_ids = set(
             Scenarios.objects.filter(
                 id__in=value, organization=organization
@@ -124,7 +112,7 @@ class CreateRunTestSerializer(StrictInputSerializer):
         if not valid_uuids:
             return []
 
-        organization = _active_organization(self)
+        organization = get_request_organization(self.context["request"])
         existing_ids = set(
             SimulateEvalConfig.objects.filter(
                 id__in=valid_uuids, run_test__organization=organization
@@ -218,7 +206,7 @@ class CreatePromptSimulationSerializer(PromptSimulationCreateFieldsSerializer):
         """Validate that the prompt template exists"""
         from model_hub.models.run_prompt import PromptTemplate
 
-        organization = _active_organization(self)
+        organization = get_request_organization(self.context["request"])
         if not PromptTemplate.objects.filter(
             id=value, organization=organization, deleted=False
         ).exists():
@@ -235,7 +223,7 @@ class CreatePromptSimulationSerializer(PromptSimulationCreateFieldsSerializer):
 
     def validate_scenario_ids(self, value):
         """Validate that all scenario IDs exist"""
-        organization = _active_organization(self)
+        organization = get_request_organization(self.context["request"])
         existing_ids = set(
             Scenarios.objects.filter(
                 id__in=value, organization=organization

--- a/futureagi/simulate/tests/test_run_test_list_api.py
+++ b/futureagi/simulate/tests/test_run_test_list_api.py
@@ -235,6 +235,95 @@ class TestRunTestRuntimeContracts:
         run_test = RunTest.objects.get(id=response.json()["id"])
         assert run_test.organization_id == agent_definition.organization_id
 
+    def test_create_uses_active_org_for_eval_config_ids(
+        self,
+        auth_client,
+        user,
+        organization,
+        workspace,
+        agent_definition,
+        scenario_with_prompt_version,
+    ):
+        """Sibling to test_create_uses_active_org_not_legacy_user_fk, exercising
+        `CreateRunTestSerializer.validate_eval_config_ids`. Same active-org vs
+        legacy-FK divergence; the eval_config referenced in the payload lives in
+        the active org via its parent RunTest.
+        """
+        from accounts.models import Organization
+
+        seed_run_test = RunTest.objects.create(
+            name="Seed run test for eval config",
+            organization=organization,
+            workspace=workspace,
+            source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+            agent_definition=agent_definition,
+        )
+        eval_config = SimulateEvalConfig.objects.create(
+            name="Active-org eval config",
+            eval_template=EvalTemplate.objects.create(
+                name="Reusable template",
+                eval_id=99001,
+                config={},
+            ),
+            run_test=seed_run_test,
+            model="turing_small",
+            error_localizer=False,
+        )
+
+        legacy_primary_org = Organization.objects.create(name="Legacy Primary Org")
+        user.organization = legacy_primary_org
+        user.save(update_fields=["organization"])
+
+        response = auth_client.post(
+            "/simulate/run-tests/create/",
+            {
+                "name": "Multi-org run using eval_config from active org",
+                "agent_definition_id": str(agent_definition.id),
+                "scenario_ids": [str(scenario_with_prompt_version.id)],
+                "eval_config_ids": [str(eval_config.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        run_test = RunTest.objects.get(id=response.json()["id"])
+        assert run_test.organization_id == agent_definition.organization_id
+
+    def test_prompt_simulation_create_uses_active_org_not_legacy_user_fk(
+        self,
+        auth_client,
+        user,
+        prompt_template,
+        prompt_version_v10,
+        scenario_with_prompt_version,
+    ):
+        """Regression for TH-6191 on the prompt-simulation create path.
+
+        `CreatePromptSimulationSerializer.validate_prompt_template_id` and
+        `validate_scenario_ids` had the same legacy-FK vs active-org drift.
+        Multi-org users creating a prompt simulation against a template + scenario
+        that live in the active org must succeed.
+        """
+        from accounts.models import Organization
+
+        legacy_primary_org = Organization.objects.create(name="Legacy Primary Org")
+        user.organization = legacy_primary_org
+        user.save(update_fields=["organization"])
+
+        response = auth_client.post(
+            f"/simulate/prompt-templates/{prompt_template.id}/simulations/",
+            {
+                "name": "Multi-org Prompt Simulation",
+                "prompt_version_id": str(prompt_version_v10.id),
+                "scenario_ids": [str(scenario_with_prompt_version.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        run_test = RunTest.objects.get(id=response.json()["result"]["id"])
+        assert run_test.organization_id == prompt_template.organization_id
+
     def test_create_rejects_unknown_body_field(
         self, auth_client, agent_definition, scenario_with_prompt_version
     ):
@@ -390,9 +479,9 @@ class TestRunTestRuntimeContracts:
             format="json",
         )
 
-        assert (
-            create_response.status_code == status.HTTP_201_CREATED
-        ), create_response.content
+        assert create_response.status_code == status.HTTP_201_CREATED, (
+            create_response.content
+        )
         eval_config_id = create_response.json()["created_eval_configs"][0]["id"]
         eval_config = SimulateEvalConfig.objects.get(id=eval_config_id)
         assert eval_config.run_test_id == run_test_with_v10_scenario.id
@@ -405,9 +494,9 @@ class TestRunTestRuntimeContracts:
             f"{eval_config_id}/get-structure/"
         )
 
-        assert (
-            structure_response.status_code == status.HTTP_200_OK
-        ), structure_response.content
+        assert structure_response.status_code == status.HTTP_200_OK, (
+            structure_response.content
+        )
         structure = structure_response.json()["result"]["eval"]
         assert structure["id"] == eval_config_id
         assert structure["template_id"] == str(word_count_eval_template.id)
@@ -431,9 +520,9 @@ class TestRunTestRuntimeContracts:
             format="json",
         )
 
-        assert (
-            update_response.status_code == status.HTTP_200_OK
-        ), update_response.content
+        assert update_response.status_code == status.HTTP_200_OK, (
+            update_response.content
+        )
         eval_config.refresh_from_db()
         assert eval_config.name == "word_count_updated"
         assert eval_config.mapping == {"text": "agent_output"}

--- a/futureagi/simulate/tests/test_run_test_list_api.py
+++ b/futureagi/simulate/tests/test_run_test_list_api.py
@@ -199,6 +199,42 @@ class TestRunTestRuntimeContracts:
         run_test = RunTest.objects.get(id=response.json()["id"])
         assert run_test.workspace_id == workspace.id
 
+    def test_create_uses_active_org_not_legacy_user_fk(
+        self, auth_client, user, agent_definition, scenario_with_prompt_version
+    ):
+        """Regression for TH-6191.
+
+        A multi-org user whose legacy ``user.organization`` FK points at a
+        different org than the one they are actively working in must still be
+        able to create a run test against agent definitions/scenarios that live
+        in the active org. Before the fix, the create serializer scoped its
+        existence checks by ``request.user.organization`` (the legacy FK), so
+        objects in the active org were reported as "not found" even though the
+        write path (which uses ``request.organization``) would have found them.
+        """
+        from accounts.models import Organization
+
+        # agent_definition + scenario live in the active org (auth_client's
+        # org). Point the user's legacy FK at a *different* org to mimic a
+        # multi-org user operating outside their primary/legacy organization.
+        legacy_primary_org = Organization.objects.create(name="Legacy Primary Org")
+        user.organization = legacy_primary_org
+        user.save(update_fields=["organization"])
+
+        response = auth_client.post(
+            "/simulate/run-tests/create/",
+            {
+                "name": "Multi-org Active Org Run",
+                "agent_definition_id": str(agent_definition.id),
+                "scenario_ids": [str(scenario_with_prompt_version.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        run_test = RunTest.objects.get(id=response.json()["id"])
+        assert run_test.organization_id == agent_definition.organization_id
+
     def test_create_rejects_unknown_body_field(
         self, auth_client, agent_definition, scenario_with_prompt_version
     ):
@@ -354,9 +390,9 @@ class TestRunTestRuntimeContracts:
             format="json",
         )
 
-        assert create_response.status_code == status.HTTP_201_CREATED, (
-            create_response.content
-        )
+        assert (
+            create_response.status_code == status.HTTP_201_CREATED
+        ), create_response.content
         eval_config_id = create_response.json()["created_eval_configs"][0]["id"]
         eval_config = SimulateEvalConfig.objects.get(id=eval_config_id)
         assert eval_config.run_test_id == run_test_with_v10_scenario.id
@@ -369,9 +405,9 @@ class TestRunTestRuntimeContracts:
             f"{eval_config_id}/get-structure/"
         )
 
-        assert structure_response.status_code == status.HTTP_200_OK, (
-            structure_response.content
-        )
+        assert (
+            structure_response.status_code == status.HTTP_200_OK
+        ), structure_response.content
         structure = structure_response.json()["result"]["eval"]
         assert structure["id"] == eval_config_id
         assert structure["template_id"] == str(word_count_eval_template.id)
@@ -395,9 +431,9 @@ class TestRunTestRuntimeContracts:
             format="json",
         )
 
-        assert update_response.status_code == status.HTTP_200_OK, (
-            update_response.content
-        )
+        assert (
+            update_response.status_code == status.HTTP_200_OK
+        ), update_response.content
         eval_config.refresh_from_db()
         assert eval_config.name == "word_count_updated"
         assert eval_config.mapping == {"text": "agent_output"}


### PR DESCRIPTION
## What

Fixes simulation creation failing with `Agent definition not found.` / `Scenarios not found.` for multi-org users, even when the agent definition and scenarios genuinely exist.

The org-scoped validators in `simulate/serializers/requests/run_test.py` were filtering by the user's **legacy `user.organization` FK** instead of the **active organization** (`request.organization`). All five validators now resolve the org via the canonical `get_request_organization` helper (`tracer/utils/workspace_scope.py:6-9`) that the rest of the codebase already uses at 10+ call sites for the same purpose. Validation and the create-view write path now agree on the same org.

Changed validators:
- `CreateRunTestSerializer.validate_agent_definition_id`
- `CreateRunTestSerializer.validate_scenario_ids`
- `CreateRunTestSerializer.validate_eval_config_ids`
- `CreatePromptSimulationSerializer.validate_prompt_template_id`
- `CreatePromptSimulationSerializer.validate_scenario_ids`

## Why

The create **views** resolve the org for the write path as:

```python
user_organization = getattr(request, "organization", None) or request.user.organization
```

i.e. the **active org** (from the `X-Organization-Id` header / last-switched config), falling back to the legacy FK. The **serializer validators**, however, used `request.user.organization` directly — the legacy single-org FK.

For a multi-org user operating **outside their primary/legacy org**, these two diverge:

- Validation scopes lookups to the legacy FK org → objects in the active org are reported "not found" → request rejected with a 400 before the view body ever runs.
- The view's write path uses the active org and *would* have found them.

Single-org users (and users whose active org equals their legacy FK) were never affected, which is why this only reproduced for specific accounts.

### Root cause, confirmed against the dev DB
For the reported account `kartik.nvj@futureagi.com`:

| Item | Org | Org name |
|---|---|---|
| Agent definition (`df70ecee…`, voice agent) | `780a1c67…` | **futureagi - Anmol** (active org) |
| Scenario (`78627d90…`) | `780a1c67…` | **futureagi - Anmol** (active org) |
| `request.organization` (active, from header) | `780a1c67…` | **futureagi - Anmol** ✅ |
| `request.user.organization` (legacy FK) | `36ab6a86…` | **Future agi** ❌ |

The user is **Admin** of *futureagi - Anmol* and **Owner** of *Future agi*; their legacy FK still points at *Future agi*. The voice-sim entitlement (`has_voice_sim`) is allowed for the Anmol org and the OSS gate is inactive, so the validation bug was the sole blocker.

## Tests added

Three regression tests in `futureagi/simulate/tests/test_run_test_list_api.py`, one per validation surface the fix touches:

### `test_create_uses_active_org_not_legacy_user_fk`
Reproduces the multi-org condition against `POST /simulate/run-tests/create/` with `agent_definition_id` + `scenario_ids`. Exercises `CreateRunTestSerializer.validate_agent_definition_id` and `validate_scenario_ids`.

### `test_create_uses_active_org_for_eval_config_ids`
Same multi-org shape but the request also carries `eval_config_ids` referencing a `SimulateEvalConfig` scoped to a seed `RunTest` in the active org. Exercises `CreateRunTestSerializer.validate_eval_config_ids`.

### `test_prompt_simulation_create_uses_active_org_not_legacy_user_fk`
Same multi-org shape against `POST /simulate/prompt-templates/<id>/simulations/` with a valid `prompt_version_id` + `scenario_ids`. Exercises `CreatePromptSimulationSerializer.validate_prompt_template_id` and `validate_scenario_ids`.

All three follow the same pattern: agent definition / scenario / prompt template / eval config live in the active org (the `auth_client`'s workspace org); the user's legacy FK is repointed to a different, newly-created org to mimic Kartik (legacy FK = *Future agi*, active = *futureagi - Anmol*); the create endpoint is expected to return **HTTP 201** and the resulting `RunTest.organization_id` must match the active org. Together they cover all five patched validators.

Each test **fails on the pre-fix code** (serializer scoped by legacy FK → 400 "not found") and **passes after the fix** — verified locally by temporarily reverting the serializer.

The adjacent existing create tests in the same class continue to cover the single-org happy paths and remain green:
- `test_create_accepts_declared_agent_version_field` — create with an explicit `agent_version` binds correctly.
- `test_create_persists_request_workspace` — created run test is attached to the request workspace.
- `test_create_rejects_unknown_body_field` — strict input serializer rejects unknown fields.

## How to run the tests

From `futureagi/` (the Django backend root):

```bash
# All three new regression tests together
FI_SKIP_CH25_MIGRATION=1 bin/test --no-services simulate/tests/test_run_test_list_api.py \
  -k "test_create_uses_active_org_not_legacy_user_fk or test_create_uses_active_org_for_eval_config_ids or test_prompt_simulation_create_uses_active_org_not_legacy_user_fk"

# The regression tests plus the adjacent create-path tests
FI_SKIP_CH25_MIGRATION=1 bin/test --no-services simulate/tests/test_run_test_list_api.py \
  -k "test_create_uses_active_org_not_legacy_user_fk or test_create_uses_active_org_for_eval_config_ids or test_prompt_simulation_create_uses_active_org_not_legacy_user_fk or test_create_accepts_declared_agent_version_field or test_create_persists_request_workspace or test_create_rejects_unknown_body_field"

# The whole run-test API test file (24 tests)
FI_SKIP_CH25_MIGRATION=1 bin/test --no-services simulate/tests/test_run_test_list_api.py
```

`FI_SKIP_CH25_MIGRATION=1` sidesteps a CH25 schema apply issue on stale test containers; unrelated to this PR.

<img width="2182" height="940" alt="image" src="https://github.com/user-attachments/assets/514c3701-5942-4470-adfe-598fe95ba1ea" />


> These API tests require the postgres/redis/clickhouse/minio test services. `bin/test` starts them automatically; `--no-services` reuses already-running ones (faster). If clickhouse isn't up:
> `docker compose -f docker-compose.test.yml -p futureagi-test up -d test-clickhouse`

## FE Manual testing:

### Before:

<img width="2182" height="990" alt="image" src="https://github.com/user-attachments/assets/3bc5d498-3913-481a-9ce2-4863a753dbe0" />


### After:


https://github.com/user-attachments/assets/988d7696-2a00-4890-a5ca-356f1638ad96



## Out of scope (follow-up)

`get_request_organization` currently lives at `tracer/utils/workspace_scope.py:6-9` because that file also holds project-scoped helpers (`project_workspace_scope_q`, `project_queryset_for_request`) that ARE tracer-specific. The org resolver itself is domain-neutral and would fit better under a shared home (`accounts/utils.py` or a new `tfc/utils/request_scope.py`). Moving it now would touch 10+ existing importers across `tfc/`, `tracer/`, `model_hub/`, and this file, which is outside the scope of this bug fix. Tracked as a separate refactor so the move can land as one atomic sweep rather than mixed into this diff.

Closes TH-6191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
