### PR TITLE
fix(simulate): scope dataset-scenario source lookup to scenario.organization (TH-6210)

### DIFF
--- a/futureagi/simulate/tests/test_activities.py
+++ b/futureagi/simulate/tests/test_activities.py
@@ -683,3 +683,84 @@ class TestDatasetCopyLogic:
         ).count()
 
         assert final_cell_count == initial_cell_count + len(new_cells)
+
+
+@pytest.mark.integration
+class TestDatasetScenarioSourceOrgScope:
+    """Source-dataset lookup must be scoped to ``scenario.organization``.
+
+    In a Temporal worker the workspace-context thread-local is unset and
+    ``user.organization`` can differ from the scenario's org for multi-org
+    users; either previously silently 404'd the dataset.
+    """
+
+    def test_lookup_uses_scenario_org(
+        self, db, organization, workspace, source_dataset, user
+    ):
+        from accounts.models.organization import Organization
+        from simulate.models.simulator_agent import SimulatorAgent
+        from tfc.middleware.workspace_context import clear_workspace_context
+        from tfc.temporal.simulate.activities import (
+            _create_dataset_scenario_sync,
+        )
+
+        # user's primary org differs from the scenario's org.
+        user.organization = Organization.objects.create(name="primary-other-org")
+        user.save(update_fields=["organization"])
+
+        agent_def = AgentDefinition.objects.create(
+            agent_name="A",
+            agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+            contact_number="+1",
+            inbound=True,
+            description="A",
+            organization=organization,
+            workspace=workspace,
+            languages=["en"],
+        )
+        sim_agent = SimulatorAgent.objects.create(
+            name="sa", prompt="p", organization=organization, workspace=workspace,
+        )
+        scenario = Scenarios.objects.create(
+            name="s",
+            source="src",
+            scenario_type=Scenarios.ScenarioTypes.DATASET,
+            source_type="agent_definition",
+            organization=organization,
+            workspace=workspace,
+            simulator_agent=sim_agent,
+            agent_definition=agent_def,
+            status=StatusType.PROCESSING.value,
+        )
+
+        clear_workspace_context()  # mimic worker thread
+
+        captured = {}
+
+        def _capture_and_stop(model, *args, **kwargs):
+            captured["kwargs"] = kwargs
+            raise RuntimeError("stop_after_capture")
+
+        result = None
+        # close_old_connections() in the activity tears down the pytest test
+        # transaction; skip it under test.
+        with (
+            patch("django.shortcuts.get_object_or_404", side_effect=_capture_and_stop),
+            patch("django.db.close_old_connections"),
+        ):
+            result = _create_dataset_scenario_sync(
+                user_id=str(user.id),
+                scenario_id=str(scenario.id),
+                validated_data={
+                    "dataset_id": str(source_dataset.id),
+                    "source_type": "agent_definition",
+                },
+            )
+
+        assert "kwargs" in captured, (
+            f"source-dataset lookup never invoked; activity returned {result!r}"
+        )
+        assert captured["kwargs"].get("organization") == organization, (
+            "lookup must be scoped to scenario.organization, got "
+            f"{captured['kwargs'].get('organization')!r}"
+        )

--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -56,7 +56,6 @@ from model_hub.models.choices import (
 )
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from simulate.models import Scenarios
-from tfc.middleware.workspace_context import get_current_organization
 from tfc.temporal.simulate.types import (  # Scenario Generation; Scenario Creation; Graph Scenario Sub-Activity Types (v2+v3)
     AddScenarioColumnsInput,
     CategorizeAndValidateInput,
@@ -1294,12 +1293,13 @@ def _create_dataset_scenario_sync(
         except Exception:
             logger.warning("usage_precheck_failed", exc_info=True)
 
-        # Get the source dataset
+        # Scope by scenario.organization: the workspace-context thread-local is
+        # unset inside Temporal workers, and user.organization can differ from it.
         source_dataset = get_object_or_404(
             Dataset,
             id=validated_data["dataset_id"],
             deleted=False,
-            organization=get_current_organization() or user.organization,
+            organization=scenario.organization,
         )
 
         # Determine simulation mode


### PR DESCRIPTION
## Why

`_create_dataset_scenario_sync` scopes the source-dataset lookup to `get_current_organization() or user.organization`. In a Temporal worker, `WorkspaceContextMiddleware` never runs, so `get_current_organization()` is `None` (or stale from a pooled thread) and the fallback `user.organization` is the user's primary org. For a multi-org user that differs from the org the scenario was created in, the lookup 404s.

Sibling activities in the same module already use `scenario.organization` (`activities.py:1217, 2487, 2524, 2914, 2963`); this one was the outlier.

## What changed

| File | Change |
|---|---|
| `futureagi/tfc/temporal/simulate/activities.py` | `get_object_or_404(Dataset, ...)` call uses `organization=scenario.organization` instead of `organization=get_current_organization() or user.organization`. Unused `get_current_organization` import removed. |
| `futureagi/simulate/tests/test_activities.py` | New `TestDatasetScenarioSourceOrgScope` regression test. Real DB; sets `user.organization != scenario.organization`; asserts the activity's lookup is scoped to `scenario.organization`. |

## Tests

```
cd futureagi
FI_SKIP_CH25_SCHEMA_APPLY=1 bin/test --no-services \
  simulate/tests/test_activities.py::TestDatasetScenarioSourceOrgScope -v
```

<img width="1132" height="279" alt="image" src="https://github.com/user-attachments/assets/da4be5bd-cf03-4e37-a86f-c704708fe22a" />

## Local A/B

1. Workspace switcher -> **Create Organization** -> name it `OrgB`. The BE preserves `user.organization` on the existing user row (`accounts/views/organization_views.py:204` docstring).
2. Switch into OrgB. Upload `dataset_basic_12rows.json` as a dataset; create any voice agent.
3. Simulate -> Scenarios -> Create -> Dataset kind + Voice agent. Submit.

| Branch | `simulate_scenarios.status` | Time | Worker log |
|---|---|---|---|
| dev | `Failed` | ~3s | `Failed to create dataset scenario: No Dataset matches the given query.` |
| this PR | `Completed` | ~3 min | `Dataset scenario created successfully, dataset_id=<copied-dataset>` |

Dev branch (no fix), scenario lands in Failed:

<img width="1688" height="1069" alt="image" src="https://github.com/user-attachments/assets/c7d791d1-23c4-4d10-8b3a-5783b092f674" />

This PR, scenario completes with graph + 5 scenario columns populated:

<img width="1688" height="1072" alt="image" src="https://github.com/user-attachments/assets/c4c594e9-7cc0-4a60-ad39-1fc9c5fc0004" />

## Tenant isolation

`scenario.organization` is stamped from `_request_organization(request)` at view time (`simulate/views/scenarios.py:518`). `validated_data["dataset_id"]` is validated against the same `request.organization` (`simulate/serializers/requests/scenarios.py:333-338`). So scenario org and dataset org are equal by construction; the new lookup restricts strictly more than the old fallback chain.

## Linear

Closes TH-6210