### PR TITLE
fix(develop): import prompt to dataset reads snake_case snapshot [TH-6266]

### DIFF
--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -1120,20 +1120,28 @@ export const RunPromptForm = React.forwardRef(
     };
 
     const handleApplyImportedPrompt = async (data) => {
-      if (!data?.prompt?.name && !data?.promptVersion?.templateVersion) return;
+      // The imported version is the raw (snake_case) API shape — usePromptVersions
+      // returns it unnormalized, and the contract field is `prompt_config_snapshot`
+      // / `template_version` (not camelCase).
+      const snapshot = data?.promptVersion?.prompt_config_snapshot;
+      const templateVersion = data?.promptVersion?.template_version;
+      if (!data?.prompt?.name && !templateVersion) return;
       clearErrors("config");
       setImportedPrompt(data);
 
       setValue("config.prompt", data?.prompt?.name, {
         shouldDirty: true,
       });
-      setValue("config.promptVersion", data?.promptVersion?.templateVersion);
+      setValue("config.promptVersion", templateVersion);
 
       let modelObject = defaultValues.config.run_prompt_config;
       const normalizedSnapshotConfig = normalizeConfigurationForLoad(
-        data?.promptVersion?.promptConfigSnapshot?.configuration,
+        snapshot?.configuration,
       );
-      const modelType = normalizedSnapshotConfig?.modelDetail?.type;
+      // model_detail carries the full model object (model_name, providers,
+      // type); normalizeConfigurationForLoad doesn't remap it, so read it raw.
+      const modelDetail = snapshot?.configuration?.model_detail;
+      const modelType = modelDetail?.type;
       const importedVoiceId = normalizedSnapshotConfig?.voiceId;
 
       let internalModelType = "llm";
@@ -1146,11 +1154,8 @@ export const RunPromptForm = React.forwardRef(
       }
       setValue("config.modelType", internalModelType);
 
-      if (typeof normalizedSnapshotConfig?.model === "string") {
-        modelObject = {
-          ...normalizedSnapshotConfig?.modelDetail,
-          modelName: normalizedSnapshotConfig?.model,
-        };
+      if (modelDetail?.model_name) {
+        modelObject = { ...modelDetail };
       }
       setValue("config.model", modelObject?.model_name);
       const configWithVoice = importedVoiceId
@@ -1160,19 +1165,18 @@ export const RunPromptForm = React.forwardRef(
 
       setValue(
         "config.messages",
-        data?.promptVersion?.promptConfigSnapshot?.messages?.map((msg) => ({
+        (snapshot?.messages || []).map((msg) => ({
           id: getRandomId(),
           role: msg?.role,
           content: msg.content,
         })),
       );
 
-      const importedConfig =
-        data?.promptVersion?.promptConfigSnapshot?.configuration;
+      const importedConfig = snapshot?.configuration;
 
       setValue(
         "config.responseFormat",
-        importedConfig?.responseFormat ?? "text",
+        importedConfig?.response_format ?? "text",
       );
       setValue(
         "config.tools",
@@ -1206,9 +1210,11 @@ export const RunPromptForm = React.forwardRef(
                 const id = item.id ?? _.camelCase(item.label);
                 let defaultValue = item.value ?? item.default ?? 0;
 
-                // Use imported value if available for this param
-                if (importedConfig?.[id] !== undefined) {
-                  defaultValue = importedConfig[id];
+                // Snapshot config keys are snake_case (backend serializer) and
+                // match the param's snake label — read the imported value off it.
+                const configKey = item.id ?? _.snakeCase(item.label);
+                if (importedConfig?.[configKey] !== undefined) {
+                  defaultValue = importedConfig[configKey];
                 }
 
                 return {


### PR DESCRIPTION
## 🐛 Bug
Importing a prompt into a dataset (Develop → dataset → Import prompt → Add) **crashed the Run Prompt panel**: `TypeError: Cannot read properties of undefined (reading 'map')` at `PromptTemplatesSection.jsx:71` (`messages.map`). Even when it didn't crash, the **model, model params, and response format imported empty**.

## Root cause
`handleApplyImportedPrompt` read the imported version as **camelCase** (`promptConfigSnapshot`, `templateVersion`), but `usePromptVersions` returns the **raw snake_case** API shape (`prompt_config_snapshot`, `template_version`) — it isn't normalized. So:
- `promptConfigSnapshot?.messages?.map(...)` → `undefined` → `config.messages = undefined` → `messages.map()` crashes.
- `normalizeConfigurationForLoad` doesn't remap `model_detail`, so the model object was lost (empty dropdown).
- `responseFormat` (camel) read off the snake config → always defaulted to `"text"`.
- Model param sliders looked up `importedConfig[camelCaseId]` against snake keys (`max_tokens`, `top_p`, …) → never matched → defaulted.

Verified each via runtime logs against the real payload.

## 🔧 What changed (`RunPrompt/RunPrompt.jsx`, `handleApplyImportedPrompt`)
- Read the snapshot once as snake_case: `prompt_config_snapshot`, `template_version`.
- Build the model object from the raw `model_detail` (has `model_name`/`providers`/`type`).
- `config.messages` ← `snapshot?.messages || []` (guard the map → no crash).
- `response_format` read with the snake key.
- Imported slider values looked up by the snake config key (`item.id ?? _.snakeCase(item.label)`).

All reads are snake-direct (no `camel ?? snake` guessing) — backend payloads here are snake_case by contract.

## 🧪 Tests
Manual (browser, verified): import a prompt → no crash; messages, model (`gpt-4o-mini`), and params all populate; run fires.
(No unit test added — `handleApplyImportedPrompt` is tightly coupled to the form/query context.)

## ▶️ How to reproduce / verify
- Pre-fix: dataset → Import prompt → pick prompt+version → **Add** → page crashes.
- Post-fix: same flow → imports cleanly (messages/model/params/response-format) and Run works.

## ⚠️ Note (separate ticket)
Running the imported prompt in **dev** is blocked by an unrelated, pre-existing contract bug — the `PromptConfig` request contract mistypes fields the run payload legitimately sends (`message.content` array, `isAvailable` boolean, etc.), so dev `runtimeRequestValidation` throws before sending. Prod is unaffected. Tracked in **TH-6280** (backend serializer + regen). Not in scope here.
