### PR TITLE
fix(model-hub): type PromptConfig run-config fields as JSON-value [TH-6280]

### DIFF
--- a/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
+++ b/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { validateContractedRequestConfig } from "../openapi-contract";
+
+// Round-trip guard (TH-6280): a representative run payload must pass the
+// add_run_prompt_column request contract. The PromptConfig serializer used
+// loose DictField/JSONField fields that generated an over-constrained contract
+// (every value typed `string`), which silently blocked the request in dev.
+// This pins the real shape so a too-loose serializer can't regress it again.
+const runRequest = {
+  url: "/model-hub/develops/add_run_prompt_column/",
+  method: "post",
+  data: {
+    dataset_id: "9ea714d2-c215-499c-8797-b9ae52d6d42a",
+    name: "run",
+    config: {
+      model: "gpt-4o-mini",
+      run_prompt_config: {
+        model_name: "gpt-4o-mini",
+        providers: "openai",
+        isAvailable: true, // boolean (was: Expected string)
+        booleans: {}, // object  (was: Expected string)
+        dropdowns: {}, // object  (was: Expected string)
+        temperature: null,
+        top_p: null,
+      },
+      messages: [
+        { role: "system", content: [{ type: "text", text: "" }] },
+        // array content (was: Expected string)
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ],
+      response_format: "text", // string  (was: Expected object)
+      tools: [],
+    },
+  },
+};
+
+describe("add_run_prompt_column request contract", () => {
+  it("accepts a real run payload (mixed run_prompt_config, array message content, string response_format)", () => {
+    const result = validateContractedRequestConfig(runRequest);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -49368,11 +49368,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Context page",
           "type": "string",
           "maxLength": 500
-        },
-        "hidden": {
-          "title": "Hidden",
-          "type": "boolean",
-          "default": false
         }
       }
     },
@@ -74928,8 +74923,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Run prompt config",
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "x-nullable": true
+            "type": "object",
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           }
         },
         "messages": {
@@ -74938,8 +74934,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "type": "object",
             "additionalProperties": {
-              "type": "string",
-              "x-nullable": true
+              "type": "object",
+              "x-json-value": true,
+              "description": "Any valid JSON value."
             }
           }
         },
@@ -74985,9 +74982,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "description": "JSON schema for response format if required. Can be a JSON object or string. Defaults to None.",
+          "description": "Any valid JSON value.",
           "type": "object",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-json-value": true
         },
         "tool_choice": {
           "title": "Tool choice",
@@ -75006,8 +75004,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "type": "object",
             "additionalProperties": {
-              "type": "string",
-              "x-nullable": true
+              "type": "object",
+              "x-json-value": true,
+              "description": "Any valid JSON value."
             }
           },
           "x-nullable": true

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -3947,7 +3947,6 @@ export interface ConversationCreateRequestApi {
   title?: string;
   /** @maxLength 500 */
   context_page?: string;
-  hidden?: boolean;
 }
 
 export type FalconMessageApiRole = typeof FalconMessageApiRole[keyof typeof FalconMessageApiRole];
@@ -8152,16 +8151,16 @@ export const PromptConfigApiOutputFormat = {
   image: 'image',
 } as const;
 
-export type PromptConfigApiRunPromptConfig = {[key: string]: string};
+export type PromptConfigApiRunPromptConfig = {[key: string]: { [key: string]: unknown }};
 
-export type PromptConfigApiMessagesItem = {[key: string]: string};
+export type PromptConfigApiMessagesItem = {[key: string]: { [key: string]: unknown }};
 
 /**
- * JSON schema for response format if required. Can be a JSON object or string. Defaults to None.
+ * Any valid JSON value.
  */
 export type PromptConfigApiResponseFormat = { [key: string]: unknown };
 
-export type PromptConfigApiToolsItem = {[key: string]: string};
+export type PromptConfigApiToolsItem = {[key: string]: { [key: string]: unknown }};
 
 export interface PromptConfigApi {
   /** @maxLength 255 */
@@ -8199,7 +8198,7 @@ export interface PromptConfigApi {
      * @maximum 1
      */
   top_p?: number;
-  /** JSON schema for response format if required. Can be a JSON object or string. Defaults to None. */
+  /** Any valid JSON value. */
   response_format?: PromptConfigApiResponseFormat;
   /** Tool selection mode: 'auto' or 'required'. */
   tool_choice?: PromptConfigApiToolChoice;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -9572,12 +9572,11 @@ export const falconAiConversationsCreateBodyTitleMax = 255;
 
 export const falconAiConversationsCreateBodyContextPageMax = 500;
 
-export const falconAiConversationsCreateBodyHiddenDefault = false;
+
 
 export const FalconAiConversationsCreateBody = zod.object({
   "title": zod.string().max(falconAiConversationsCreateBodyTitleMax).optional(),
-  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional(),
-  "hidden": zod.boolean().default(falconAiConversationsCreateBodyHiddenDefault)
+  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional()
 })
 
 
@@ -17015,8 +17014,12 @@ export const ModelHubDevelopsAddRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17024,9 +17027,11 @@ export const ModelHubDevelopsAddRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsAddRunPromptColumnCreateBodyConfigDefault)
@@ -17265,8 +17270,12 @@ export const ModelHubDevelopsEditRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1).optional(),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17274,9 +17283,11 @@ export const ModelHubDevelopsEditRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsEditRunPromptColumnCreateBodyConfigDefault)
@@ -17473,8 +17484,12 @@ export const ModelHubDevelopsPreviewRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17482,9 +17497,11 @@ export const ModelHubDevelopsPreviewRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigDefault),

--- a/futureagi/model_hub/serializers/run_prompt.py
+++ b/futureagi/model_hub/serializers/run_prompt.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from model_hub.models.api_key import ApiKey
+from tfc.utils.serializer_fields import JsonValueField
 
 
 class ApiKeyCreateSerializer(serializers.Serializer):
@@ -162,9 +163,13 @@ class LitellmSerializer(serializers.Serializer):
 
 class PromptConfigSerializer(serializers.Serializer):
     model = serializers.CharField(max_length=255, required=False, allow_blank=True)
-    run_prompt_config = serializers.DictField(required=False)
+    # Free-form config: values are mixed JSON (model_name str, isAvailable
+    # bool, booleans/dropdowns objects, …). Use JsonValueField so the contract
+    # doesn't constrain every value to a string.
+    run_prompt_config = serializers.DictField(child=JsonValueField(), required=False)
     messages = serializers.ListField(
-        child=serializers.DictField(),
+        # content can be a string or a list of typed parts — keep values open.
+        child=serializers.DictField(child=JsonValueField()),
         required=False,
         help_text="List of messages with format [{'role': 'user/assistant', 'content': 'text'}]",
     )
@@ -203,7 +208,7 @@ class PromptConfigSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Controls diversity via nucleus sampling. Value between 0 and 1.",
     )
-    response_format = serializers.JSONField(
+    response_format = JsonValueField(
         required=False,
         allow_null=True,
         help_text="JSON schema for response format if required. Can be a JSON object or string. Defaults to None.",
@@ -215,7 +220,7 @@ class PromptConfigSerializer(serializers.Serializer):
         help_text="Tool selection mode: 'auto' or 'required'.",
     )
     tools = serializers.ListField(
-        child=serializers.DictField(),
+        child=serializers.DictField(child=JsonValueField()),
         required=False,
         allow_null=True,
         help_text="List of tools with tool properties if available.",


### PR DESCRIPTION
## 🐛 Bug
Running a prompt on a dataset (and importing-then-running) **silently did nothing in dev** — the request never left the browser, surfacing only as a generic "Something went wrong". Production was unaffected.

## Root cause
`add_run_prompt_column` has `runtimeRequestValidation: true`, and its generated `PromptConfig` request contract was **wrong** — it mistyped fields the run payload legitimately sends:

| Field | Declared (serializer) | Generated contract | Reality |
|---|---|---|---|
| `run_prompt_config` | `DictField()` | `additionalProperties: { type: string }` | mixed values (`isAvailable` bool, `booleans`/`dropdowns` objects, …) |
| `messages` | `ListField(child=DictField())` | values typed `string` | `content` is an **array** of parts |
| `tools` | `ListField(child=DictField())` | values typed `string` | non-string nested values |
| `response_format` | `JSONField()` | `type: object` | accepts a **string** too |

A bare `DictField()` defaults its child to `CharField` (→ "every value is a string"); `JSONField` → `object`-only. So the dev-only client-side contract validator threw before sending — even though the **backend accepts the payload** (verified end-to-end).

## 🔧 What changed
`model_hub/serializers/run_prompt.py` — `PromptConfigSerializer` now uses the existing **`JsonValueField`** (emits `x-json-value` → the FE maps it to `z.any()`) for the four mixed-JSON fields, so the contract no longer over-constrains them. Regenerated `swagger.json` + the FE contract artifacts (`openapi-contract.generated.js`, `api.schemas.ts`, `api.zod.ts`).

This is the real fix — **no `VITE_API_CONTRACTS=off` hack**. Dev request validation now accepts the real run payload.

## 🧪 Tests
- **Round-trip guard** (`__tests__/run-prompt-contract.test.js`): asserts a representative run payload (boolean `isAvailable`, array message `content`, string `response_format`) **passes** the `add_run_prompt_column` request contract. This is the exact class of check that was missing — `contracts:check` verifies contract⟷serializer consistency, not type-correctness against a real payload.

## ✅ Verification
- `yarn contracts:check` passes (no drift; swagger diff is scoped to `PromptConfig`).
- Round-trip test green.
- Surfaced while fixing TH-6266 (import prompt → dataset); that FE fix is separate (#1119).

## 📝 Notes for reviewer
- This is a **backend serializer + regenerated contract** change — regen done via `scripts/generate-openapi-schema.sh` + `yarn contracts:generate` (EE present, 968 paths, no path drift).
- Affects **all** dataset runs in dev, not just imports.
