### PR TITLE
fix(gateway): count Anthropic prompt-cache tokens in usage and cost

### DIFF
--- a/agentcc-gateway/internal/anthropicfmt/format.go
+++ b/agentcc-gateway/internal/anthropicfmt/format.go
@@ -66,17 +66,21 @@ func ExtractTextFromResponse(respBody []byte) string {
 }
 
 // ExtractUsage extracts input and output token counts from an Anthropic response.
+// input_tokens excludes cached tokens, so cache creation/read are added back in.
 func ExtractUsage(respBody []byte) (inputTokens int, outputTokens int) {
 	var m struct {
 		Usage struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(respBody, &m); err != nil {
 		return 0, 0
 	}
-	return m.Usage.InputTokens, m.Usage.OutputTokens
+	inputTokens = m.Usage.InputTokens + m.Usage.CacheCreationInputTokens + m.Usage.CacheReadInputTokens
+	return inputTokens, m.Usage.OutputTokens
 }
 
 // ExtractModel extracts the model name from an Anthropic response body.

--- a/agentcc-gateway/internal/anthropicfmt/format_test.go
+++ b/agentcc-gateway/internal/anthropicfmt/format_test.go
@@ -1,0 +1,42 @@
+package anthropicfmt
+
+import "testing"
+
+func TestExtractUsage(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantInput  int
+		wantOutput int
+	}{
+		{
+			name:       "no caching",
+			body:       `{"usage":{"input_tokens":10,"output_tokens":5}}`,
+			wantInput:  10,
+			wantOutput: 5,
+		},
+		{
+			name:       "with prompt caching",
+			body:       `{"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":900,"output_tokens":5}}`,
+			wantInput:  1010,
+			wantOutput: 5,
+		},
+		{
+			name:       "malformed body",
+			body:       `not json`,
+			wantInput:  0,
+			wantOutput: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in, out := ExtractUsage([]byte(tt.body))
+			if in != tt.wantInput {
+				t.Errorf("inputTokens = %d, want %d", in, tt.wantInput)
+			}
+			if out != tt.wantOutput {
+				t.Errorf("outputTokens = %d, want %d", out, tt.wantOutput)
+			}
+		})
+	}
+}

--- a/agentcc-gateway/internal/models/response.go
+++ b/agentcc-gateway/internal/models/response.go
@@ -27,18 +27,20 @@ type Usage struct {
 	TotalTokens             int              `json:"total_tokens"`
 	PromptTokensDetails     *json.RawMessage `json:"prompt_tokens_details,omitempty"`
 	CompletionTokensDetails *json.RawMessage `json:"completion_tokens_details,omitempty"`
+	// Cached portion of PromptTokens; not serialized (wire form: prompt_tokens_details).
+	CachedPromptTokens int `json:"-"`
 }
 
 // StreamChunk represents a single SSE chunk in a streaming response.
 type StreamChunk struct {
-	ID                string               `json:"id"`
-	Object            string               `json:"object"`
-	Created           int64                `json:"created"`
-	Model             string               `json:"model"`
-	Choices           []StreamChoice       `json:"choices"`
-	Usage             *Usage               `json:"usage,omitempty"`
-	AgentccMetadata     *AgentccStreamMetadata `json:"agentcc_metadata,omitempty"`
-	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+	ID                string                 `json:"id"`
+	Object            string                 `json:"object"`
+	Created           int64                  `json:"created"`
+	Model             string                 `json:"model"`
+	Choices           []StreamChoice         `json:"choices"`
+	Usage             *Usage                 `json:"usage,omitempty"`
+	AgentccMetadata   *AgentccStreamMetadata `json:"agentcc_metadata,omitempty"`
+	SystemFingerprint string                 `json:"system_fingerprint,omitempty"`
 }
 
 type AgentccStreamMetadata struct {

--- a/agentcc-gateway/internal/plugins/cost/cost.go
+++ b/agentcc-gateway/internal/plugins/cost/cost.go
@@ -29,8 +29,8 @@ func New(enabled bool, modelDBGetter func() *modeldb.ModelDB, tenantStore *tenan
 	}
 }
 
-func (p *Plugin) Name() string           { return "cost" }
-func (p *Plugin) Priority() int          { return 500 }
+func (p *Plugin) Name() string               { return "cost" }
+func (p *Plugin) Priority() int              { return 500 }
 func (p *Plugin) ShouldSkipOnCacheHit() bool { return true } // No cost to calculate on cache hits.
 
 // ProcessRequest is a no-op for the cost plugin.
@@ -97,7 +97,14 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 		usage := rc.Response.Usage
 		cost, ok = db.CalculateCost(model, usage.PromptTokens, usage.CompletionTokens, opts)
 		if !ok && model == rc.ResolvedModel && rc.Model != "" {
-			cost, ok = db.CalculateCost(rc.Model, usage.PromptTokens, usage.CompletionTokens, opts)
+			model = rc.Model
+			cost, ok = db.CalculateCost(model, usage.PromptTokens, usage.CompletionTokens, opts)
+		}
+		// Re-price the cached portion at the cheaper cache-read rate.
+		if ok && !opts.Cached && usage.CachedPromptTokens > 0 {
+			full, _ := db.CalculateCost(model, usage.CachedPromptTokens, 0, modeldb.CostOptions{})
+			cached, _ := db.CalculateCost(model, usage.CachedPromptTokens, 0, modeldb.CostOptions{Cached: true})
+			cost += cached - full
 		}
 	}
 

--- a/agentcc-gateway/internal/plugins/cost/cost_test.go
+++ b/agentcc-gateway/internal/plugins/cost/cost_test.go
@@ -365,3 +365,21 @@ func TestProcessResponse_RerankNoCost(t *testing.T) {
 		t.Fatal("Metadata[cost] should not be set for rerank endpoint")
 	}
 }
+
+func TestProcessResponse_CachedPromptTokens(t *testing.T) {
+	t.Parallel()
+	p := testPlugin()
+	rc := newRC("gpt-4o-mini", 1000, 500)
+	rc.Response.Usage.CachedPromptTokens = 800
+
+	p.ProcessResponse(context.Background(), rc)
+
+	// 200 fresh @0.15/M + 800 cached @0.075/M + 500 out @0.60/M = 0.000390 (0.000450 without the discount).
+	costStr, ok := rc.Metadata["cost"]
+	if !ok {
+		t.Fatal("Metadata[cost] not set")
+	}
+	if costStr != "0.000390" {
+		t.Fatalf("Metadata[cost] = %q, want %q (cached tokens should be discounted)", costStr, "0.000390")
+	}
+}

--- a/agentcc-gateway/internal/providers/anthropic/stream.go
+++ b/agentcc-gateway/internal/providers/anthropic/stream.go
@@ -10,10 +10,12 @@ import (
 
 // streamState tracks accumulated state across stream events.
 type streamState struct {
-	messageID   string
-	model       string
-	inputTokens int
-	created     int64
+	messageID           string
+	model               string
+	inputTokens         int
+	cacheCreationTokens int
+	cacheReadTokens     int
+	created             int64
 
 	// toolCallIndex tracks the current tool call index for streaming tool calls.
 	// Each content_block_start of type "tool_use" increments this.
@@ -61,9 +63,9 @@ type messageDeltaData struct {
 }
 
 type contentBlockStartData struct {
-	Type  string `json:"type"`
-	ID    string `json:"id,omitempty"`
-	Name  string `json:"name,omitempty"`
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // parseSSELine parses a single SSE data line and returns a StreamChunk if one should be emitted.
@@ -113,6 +115,8 @@ func (s *streamState) handleMessageStart(event streamEvent) (*models.StreamChunk
 	s.messageID = msg.ID
 	s.model = msg.Model
 	s.inputTokens = msg.Usage.InputTokens
+	s.cacheCreationTokens = msg.Usage.CacheCreationInputTokens
+	s.cacheReadTokens = msg.Usage.CacheReadInputTokens
 
 	role := "assistant"
 	chunk := &models.StreamChunk{
@@ -271,10 +275,13 @@ func (s *streamState) handleMessageDelta(event streamEvent) (*models.StreamChunk
 
 	// Include usage if available.
 	if event.Usage != nil {
+		promptTokens := s.inputTokens + s.cacheCreationTokens + s.cacheReadTokens
 		chunk.Usage = &models.Usage{
-			PromptTokens:     s.inputTokens,
-			CompletionTokens: event.Usage.OutputTokens,
-			TotalTokens:      s.inputTokens + event.Usage.OutputTokens,
+			PromptTokens:        promptTokens,
+			CompletionTokens:    event.Usage.OutputTokens,
+			TotalTokens:         promptTokens + event.Usage.OutputTokens,
+			CachedPromptTokens:  s.cacheReadTokens,
+			PromptTokensDetails: promptTokenDetails(s.cacheReadTokens),
 		}
 	}
 

--- a/agentcc-gateway/internal/providers/anthropic/translate.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate.go
@@ -82,8 +82,29 @@ type anthropicResponse struct {
 }
 
 type anthropicUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// Anthropic's input_tokens excludes cached tokens, so add cache writes and reads back in.
+func (u anthropicUsage) promptTokens() int {
+	return u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+}
+
+func promptTokenDetails(cachedTokens int) *json.RawMessage {
+	if cachedTokens <= 0 {
+		return nil
+	}
+	b, err := json.Marshal(struct {
+		CachedTokens int `json:"cached_tokens"`
+	}{CachedTokens: cachedTokens})
+	if err != nil {
+		return nil
+	}
+	raw := json.RawMessage(b)
+	return &raw
 }
 
 type anthropicErrorResponse struct {
@@ -549,9 +570,11 @@ func translateResponse(resp *anthropicResponse) *models.ChatCompletionResponse {
 			},
 		},
 		Usage: &models.Usage{
-			PromptTokens:     resp.Usage.InputTokens,
-			CompletionTokens: resp.Usage.OutputTokens,
-			TotalTokens:      resp.Usage.InputTokens + resp.Usage.OutputTokens,
+			PromptTokens:        resp.Usage.promptTokens(),
+			CompletionTokens:    resp.Usage.OutputTokens,
+			TotalTokens:         resp.Usage.promptTokens() + resp.Usage.OutputTokens,
+			CachedPromptTokens:  resp.Usage.CacheReadInputTokens,
+			PromptTokensDetails: promptTokenDetails(resp.Usage.CacheReadInputTokens),
 		},
 	}
 }

--- a/agentcc-gateway/internal/providers/anthropic/translate_test.go
+++ b/agentcc-gateway/internal/providers/anthropic/translate_test.go
@@ -1613,3 +1613,71 @@ func TestMapStopReason(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateResponse_CacheTokens(t *testing.T) {
+	resp := &anthropicResponse{
+		ID:         "msg_cache",
+		Model:      "claude-3-5-sonnet",
+		Content:    []anthropicContentBlock{{Type: "text", Text: "hi"}},
+		StopReason: "end_turn",
+		Usage: anthropicUsage{
+			InputTokens:              10,
+			CacheCreationInputTokens: 100,
+			CacheReadInputTokens:     900,
+			OutputTokens:             5,
+		},
+	}
+
+	out := translateResponse(resp)
+
+	if out.Usage.PromptTokens != 1010 {
+		t.Errorf("prompt_tokens = %d, want 1010", out.Usage.PromptTokens)
+	}
+	if out.Usage.TotalTokens != 1015 {
+		t.Errorf("total_tokens = %d, want 1015", out.Usage.TotalTokens)
+	}
+	if out.Usage.CachedPromptTokens != 900 {
+		t.Errorf("cached_prompt_tokens = %d, want 900", out.Usage.CachedPromptTokens)
+	}
+	if out.Usage.PromptTokensDetails == nil {
+		t.Fatal("prompt_tokens_details should be set when there are cache reads")
+	}
+	var details struct {
+		CachedTokens int `json:"cached_tokens"`
+	}
+	if err := json.Unmarshal(*out.Usage.PromptTokensDetails, &details); err != nil {
+		t.Fatalf("unmarshal prompt_tokens_details: %v", err)
+	}
+	if details.CachedTokens != 900 {
+		t.Errorf("details.cached_tokens = %d, want 900", details.CachedTokens)
+	}
+}
+
+func TestStreamParse_CacheTokens(t *testing.T) {
+	state := &streamState{}
+	start := `{"type":"message_start","message":{"id":"msg_c","model":"claude-3","usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":900}}}`
+	if _, _, err := state.parseSSELine("message_start", start); err != nil {
+		t.Fatalf("message_start: %v", err)
+	}
+	if state.cacheReadTokens != 900 || state.cacheCreationTokens != 100 {
+		t.Fatalf("captured cache tokens read=%d create=%d, want 900/100", state.cacheReadTokens, state.cacheCreationTokens)
+	}
+
+	delta := `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`
+	chunk, _, err := state.parseSSELine("message_delta", delta)
+	if err != nil {
+		t.Fatalf("message_delta: %v", err)
+	}
+	if chunk.Usage == nil {
+		t.Fatal("usage should not be nil")
+	}
+	if chunk.Usage.PromptTokens != 1010 {
+		t.Errorf("prompt_tokens = %d, want 1010", chunk.Usage.PromptTokens)
+	}
+	if chunk.Usage.CachedPromptTokens != 900 {
+		t.Errorf("cached_prompt_tokens = %d, want 900", chunk.Usage.CachedPromptTokens)
+	}
+	if chunk.Usage.TotalTokens != 1015 {
+		t.Errorf("total_tokens = %d, want 1015", chunk.Usage.TotalTokens)
+	}
+}


### PR DESCRIPTION
Anthropic's `usage.input_tokens` excludes cached tokens, but the gateway read only
`input_tokens`/`output_tokens` so every Claude request using prompt caching
under-reported its prompt tokens, and the cost derived from them, by the cached
fraction (often > 80% for cached system prompts, RAG context, or agents). This counts
`cache_creation` + `cache_read` at both usage-extraction sites (the
`/v1/chat/completions` adapter, streaming + non-streaming, and the native
`/v1/messages` path), surfaces cache reads via `prompt_tokens_details.cached_tokens`,
and prices cache reads at the cache-read rate. Non-cached traffic and non-Anthropic
providers are unchanged.

> Operational note: corrected (higher) costs may trip budgets that were
> undercounting. Bedrock-Claude has the same gap - follow-up.

## Linked issues

None, not previously tracked.