### PR TITLE
Fix/users csv export filters

### DIFF
--- a/frontend/src/sections/projects/ObserveHeader.jsx
+++ b/frontend/src/sections/projects/ObserveHeader.jsx
@@ -59,6 +59,7 @@ const ObserveHeader = ({
   filterSpan,
   selectedTab,
   filterSession,
+  filterUsers,
   refreshData,
   resetFilters,
 }) => {
@@ -220,6 +221,9 @@ const ObserveHeader = ({
       } else if (selectedTab === "spans") {
         url = endpoints.project.getSpansForObserveExport;
         filters = filterSpan;
+      } else if (text === "Users") {
+        url = endpoints.project.getUsersForObserveExport;
+        filters = filterUsers || [];
       } else {
         // Default to trace export
         url = endpoints.project.getTraceForObserveExport;
@@ -240,6 +244,8 @@ const ObserveHeader = ({
       const fileSuffix =
         text === "Sessions"
           ? "sessions"
+          : text === "Users"
+          ? "users"
           : selectedTab === "trace"
             ? "traces"
             : selectedTab === "spans"
@@ -669,6 +675,7 @@ ObserveHeader.propTypes = {
   filterSpan: PropTypes.array,
   selectedTab: PropTypes.string,
   filterSession: PropTypes.array,
+  filterUsers: PropTypes.array,
   refreshData: PropTypes.func,
   resetFilters: PropTypes.func,
 };

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -314,6 +314,14 @@ const UsersView = ({
     useUsersStore.setState({ filters: finalFilters });
   }, [finalFilters]);
 
+  // Sync filterUsers into header config so CSV export uses active filters
+  useEffect(() => {
+    setHeaderConfig((prev) => ({
+      ...prev,
+      filterUsers: finalFilters,
+    }));
+  }, [finalFilters, setHeaderConfig]);
+
   // Saved-view api — populates a ref the parent UsersPageTabBar drives.
   const getConfig = useCallback(() => {
     const visibleColumns = (columns || []).reduce((acc, col) => {

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1069,6 +1069,7 @@ export const endpoints = {
     getSpansForObserveProject: () =>
       `/tracer/observation-span/list_spans_observe/`,
     getSpansForObserveExport: `/tracer/observation-span/get_spans_export_data/`,
+    getUsersForObserveExport: `/tracer/users/export/`,
     getTraceProperties: `/tracer/trace/get_properties/`,
     getTraceEvals: () => `/tracer/trace/get_eval_names/`,
     getTraceErrorAnalysis: (id) => `/tracer/trace-error-analysis/${id}/`,

--- a/futureagi/tracer/urls.py
+++ b/futureagi/tracer/urls.py
@@ -44,7 +44,12 @@ from tracer.views.project_version import ProjectVersionView
 from tracer.views.replay_session import ReplaySessionView
 from tracer.views.saved_view import SavedViewViewSet
 from tracer.views.shared_link import SharedLinkViewSet, resolve_shared_link
-from tracer.views.trace import GetUserCodeExampleView, TraceView, UsersView
+from tracer.views.trace import (
+    GetUserCodeExampleView,
+    TraceView,
+    UsersExportView,
+    UsersView,
+)
 from tracer.views.trace_session import TraceSessionView
 
 router = DefaultRouter()
@@ -97,6 +102,7 @@ urlpatterns = [
     path("shared/<str:token>/", resolve_shared_link, name="resolve-shared-link"),
     path("users/", UsersView.as_view(), name="users"),
     path("users/get_code_example/", GetUserCodeExampleView.as_view(), name="users"),
+    path("users/export/", UsersExportView.as_view(), name="users-export"),
     # Deprecated — replaced by /feed/ endpoints (TH-3816 Phase 5)
     # path(
     #     "trace-error-analysis/clusters/feed/",

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -1090,8 +1090,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # 'choice': 'never'}") when output_float/output_str_list are empty.
         # Keyed by (trace_id, config_id); only the most recent row per pair.
         _str_lookup_configs = [
-            c for c in eval_configs
-            if ((getattr(getattr(c, "eval_template", None), "config", None) or {}).get("output"))
+            c
+            for c in eval_configs
+            if (
+                (getattr(getattr(c, "eval_template", None), "config", None) or {}).get(
+                    "output"
+                )
+            )
             in (EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value)
         ]
         output_str_map: dict[tuple, "EvalLogger"] = {}
@@ -1218,11 +1223,18 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         else None
                     )
                     log = output_str_map.get((trace.id, config.id))
-                    if log and log.output_str and tpl_output in (
-                        EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value,
+                    if (
+                        log
+                        and log.output_str
+                        and tpl_output
+                        in (
+                            EvalOutputType.CHOICES.value,
+                            EvalOutputType.SCORE.value,
+                        )
                     ):
                         try:
                             import ast as _ast_mod
+
                             parsed = _ast_mod.literal_eval(log.output_str)
                         except (ValueError, SyntaxError):
                             parsed = None
@@ -1231,7 +1243,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                 choice = parsed.get("choice")
                                 if choice:
                                     metric_entry["output"] = [choice]
-                                    metric_entry["output_type"] = EvalOutputType.CHOICES.value
+                                    metric_entry["output_type"] = (
+                                        EvalOutputType.CHOICES.value
+                                    )
                                     # Mirror as top-level `score` so the
                                     # drawer's `e?.score ?? e?.output ?? e?.value`
                                     # lookup hits a string and renders verbatim
@@ -1246,7 +1260,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                     metric_entry["output"] = round(
                                         float(score_val) * 100, 2
                                     )
-                                    metric_entry["output_type"] = EvalOutputType.SCORE.value
+                                    metric_entry["output_type"] = (
+                                        EvalOutputType.SCORE.value
+                                    )
 
                 metrics[str(config.id)] = metric_entry
             if metrics:
@@ -3800,14 +3816,22 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 if log.output_str_list:
                     # Legacy categorical eval — pre-agent-evaluator path
                     metric_entry["output"] = log.output_str_list
-                elif output_type == EvalOutputType.PASS_FAIL.value and log.output_bool is not None:
+                elif (
+                    output_type == EvalOutputType.PASS_FAIL.value
+                    and log.output_bool is not None
+                ):
                     metric_entry["output"] = "Pass" if log.output_bool else "Fail"
                 elif log.output_float is not None:
                     # Score evals on the legacy storage path.
                     metric_entry["output"] = round(log.output_float * 100, 2)
-                elif output_type in (
-                    EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value,
-                ) and log.output_str:
+                elif (
+                    output_type
+                    in (
+                        EvalOutputType.CHOICES.value,
+                        EvalOutputType.SCORE.value,
+                    )
+                    and log.output_str
+                ):
                     # New agent-evaluator path: output_str holds a Python dict
                     # literal like "{'score': 0.0, 'choice': 'never'}". For
                     # choices evals, use `choice`; for score evals, use `score`.
@@ -3816,6 +3840,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     # verbatim without a frontend change.
                     try:
                         import ast as _ast_mod
+
                         parsed = _ast_mod.literal_eval(log.output_str)
                     except (ValueError, SyntaxError):
                         parsed = None
@@ -5902,6 +5927,36 @@ class UsersView(APIView):
         except Exception as e:
             logger.exception(f"ERROR {e}")
             return self._gm.bad_request(f"error fetching users: {str(e)}")
+
+    def get_users_export_data(self, request, *args, **kwargs):
+        """Export users filtered by project ID with active filters, no pagination."""
+        try:
+            request.query_params._mutable = True
+            request.query_params["page_size"] = "100000"
+            request.query_params["current_page_index"] = "0"
+            response = self.get(request, *args, **kwargs)
+            if response.status_code != 200:
+                return response
+            result = response.data.get("result", {}).get("table", [])
+            df = pd.DataFrame(result) if result else pd.DataFrame()
+            buffer = io.BytesIO()
+            df.to_csv(buffer, index=False, encoding="utf-8")
+            buffer.seek(0)
+            filename = "users.csv"
+            return FileResponse(
+                buffer, as_attachment=True, filename=filename, content_type="text/csv"
+            )
+        except Exception as e:
+            traceback.print_exc()
+            return self._gm.bad_request(f"Error exporting users: {str(e)}")
+
+
+class UsersExportView(APIView):
+    permission_classes = [IsAuthenticated]
+    _gm = GeneralMethods()
+
+    def get(self, request, *args, **kwargs):
+        return UsersView().get_users_export_data(request, *args, **kwargs)
 
 
 class GetUserCodeExampleView(APIView):


### PR DESCRIPTION
## Summary
Fix CSV export on the Users tab so it respects active filters. Previously, 
export ignored applied filters and downloaded the unfiltered full dataset. 
Added a dedicated backend export endpoint that reuses the existing UsersView 
query/filter logic, and wired the active filters through the frontend export 
flow.

## Linked issues
Closes #923

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Verified Python syntax via `ast.parse`
- Ran `yarn lint` — no new errors introduced (only pre-existing warnings)
- Manually traced filter flow: UsersView → ObserveHeader → axios endpoint → 
  new UsersExportView backend handler
- Confirmed backend view reuses the same query/filter logic as the existing 
  paginated Users list endpoint, so filters apply identically

## Screenshots / recordings (if UI)
<!-- Will add once able to run full local stack -->

## Checklist
- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA