### PR TITLE
fix(experiments): cell rendering + drawer evaluations / scores end to end (TH-6279)

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -93184,7 +93184,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "token_count": {
           "title": "Token count",
-          "type": "integer"
+          "type": "integer",
+          "x-nullable": true
         },
         "cost": {
           "title": "Cost",

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -55113,7 +55113,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "additionalProperties": {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/definitions/ExperimentRowDiffCell"
+              "$ref": "#/definitions/ExperimentRowCell"
             }
           }
         }
@@ -80771,7 +80771,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
-    "ExperimentRowDiffCell": {
+    "ExperimentRowCell": {
       "type": "object",
       "properties": {
         "cell_value": {
@@ -80786,7 +80786,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "status": {
           "title": "Status",
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/ExperimentRowCellMetadata"
         },
         "value_infos": {
           "title": "Value infos",
@@ -80858,7 +80862,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "table": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "#/definitions/ExperimentTableRow"
           }
         },
         "metadata": {
@@ -93170,6 +93174,33 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
+    "ExperimentRowCellMetadata": {
+      "type": "object",
+      "properties": {
+        "response_time_ms": {
+          "title": "Response time ms",
+          "type": "number",
+          "x-nullable": true
+        },
+        "token_count": {
+          "title": "Token count",
+          "type": "integer"
+        },
+        "cost": {
+          "title": "Cost",
+          "type": "object",
+          "x-nullable": true
+        },
+        "cell_metadata": {
+          "$ref": "#/definitions/ExperimentRowCellInnerMetadata"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string",
+          "x-nullable": true
+        }
+      }
+    },
     "ExperimentStatsColumnConfig": {
       "required": [
         "name"
@@ -93227,6 +93258,19 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "reruns": {
           "title": "Reruns",
           "type": "boolean"
+        }
+      }
+    },
+    "ExperimentTableRow": {
+      "required": [
+        "row_id"
+      ],
+      "type": "object",
+      "properties": {
+        "row_id": {
+          "title": "Row id",
+          "type": "string",
+          "format": "uuid"
         }
       }
     },
@@ -98215,6 +98259,26 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "total_tokens": {
           "title": "Total tokens",
           "type": "integer"
+        }
+      }
+    },
+    "ExperimentRowCellInnerMetadata": {
+      "type": "object",
+      "properties": {
+        "explanation": {
+          "title": "Explanation",
+          "type": "string",
+          "x-nullable": true
+        },
+        "error_analysis": {
+          "title": "Error analysis",
+          "type": "object",
+          "x-nullable": true
+        },
+        "selected_input_key": {
+          "title": "Selected input key",
+          "type": "string",
+          "x-nullable": true
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -8454,20 +8454,39 @@ export interface DatasetRowDiffRequestApi {
   compare_column_ids: string[];
 }
 
-export type ExperimentRowDiffCellApiCellValue = { [key: string]: unknown };
+export type ExperimentRowCellInnerMetadataApiErrorAnalysis = { [key: string]: unknown };
 
-export type ExperimentRowDiffCellApiCellDiffValue = { [key: string]: unknown };
-
-export type ExperimentRowDiffCellApiValueInfos = { [key: string]: unknown };
-
-export interface ExperimentRowDiffCellApi {
-  cell_value?: ExperimentRowDiffCellApiCellValue;
-  cell_diff_value?: ExperimentRowDiffCellApiCellDiffValue;
-  status?: string;
-  value_infos?: ExperimentRowDiffCellApiValueInfos;
+export interface ExperimentRowCellInnerMetadataApi {
+  explanation?: string;
+  error_analysis?: ExperimentRowCellInnerMetadataApiErrorAnalysis;
+  selected_input_key?: string;
 }
 
-export type ExperimentRowDiffResponseApiResult = {[key: string]: {[key: string]: ExperimentRowDiffCellApi}};
+export type ExperimentRowCellMetadataApiCost = { [key: string]: unknown };
+
+export interface ExperimentRowCellMetadataApi {
+  response_time_ms?: number;
+  token_count?: number;
+  cost?: ExperimentRowCellMetadataApiCost;
+  cell_metadata?: ExperimentRowCellInnerMetadataApi;
+  reason?: string;
+}
+
+export type ExperimentRowCellApiCellValue = { [key: string]: unknown };
+
+export type ExperimentRowCellApiCellDiffValue = { [key: string]: unknown };
+
+export type ExperimentRowCellApiValueInfos = { [key: string]: unknown };
+
+export interface ExperimentRowCellApi {
+  cell_value?: ExperimentRowCellApiCellValue;
+  cell_diff_value?: ExperimentRowCellApiCellDiffValue;
+  status?: string;
+  metadata?: ExperimentRowCellMetadataApi;
+  value_infos?: ExperimentRowCellApiValueInfos;
+}
+
+export type ExperimentRowDiffResponseApiResult = {[key: string]: {[key: string]: ExperimentRowCellApi}};
 
 export interface ExperimentRowDiffResponseApi {
   status: boolean;
@@ -10991,6 +11010,10 @@ export interface ExperimentTableRowsColumnConfigApi {
   is_final?: boolean;
 }
 
+export interface ExperimentTableRowApi {
+  row_id: string;
+}
+
 export type ExperimentTableRowsMetadataApiDescription = {[key: string]: string};
 
 export interface ExperimentTableRowsMetadataApi {
@@ -11002,11 +11025,9 @@ export interface ExperimentTableRowsMetadataApi {
   description?: ExperimentTableRowsMetadataApiDescription;
 }
 
-export type ExperimentTableRowsResultApiTableItem = { [key: string]: unknown };
-
 export interface ExperimentTableRowsResultApi {
   column_config: ExperimentTableRowsColumnConfigApi[];
-  table?: ExperimentTableRowsResultApiTableItem[];
+  table?: ExperimentTableRowApi[];
   metadata?: ExperimentTableRowsMetadataApi;
   output_format?: string;
   status?: string;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -17427,6 +17427,21 @@ export const ModelHubDevelopsGetRowDiffCreateResponse = zod.object({
 
 }).passthrough().optional(),
   "status": zod.string().optional(),
+  "metadata": zod.object({
+  "response_time_ms": zod.number().optional(),
+  "token_count": zod.number().optional(),
+  "cost": zod.object({
+
+}).passthrough().optional(),
+  "cell_metadata": zod.object({
+  "explanation": zod.string().optional(),
+  "error_analysis": zod.object({
+
+}).passthrough().optional(),
+  "selected_input_key": zod.string().optional()
+}).optional(),
+  "reason": zod.string().optional()
+}).optional(),
   "value_infos": zod.object({
 
 }).passthrough().optional()
@@ -20361,6 +20376,21 @@ export const ModelHubExperimentsV2RowDiffCreateResponse = zod.object({
 
 }).passthrough().optional(),
   "status": zod.string().optional(),
+  "metadata": zod.object({
+  "response_time_ms": zod.number().optional(),
+  "token_count": zod.number().optional(),
+  "cost": zod.object({
+
+}).passthrough().optional(),
+  "cell_metadata": zod.object({
+  "explanation": zod.string().optional(),
+  "error_analysis": zod.object({
+
+}).passthrough().optional(),
+  "selected_input_key": zod.string().optional()
+}).optional(),
+  "reason": zod.string().optional()
+}).optional(),
   "value_infos": zod.object({
 
 }).passthrough().optional()
@@ -20894,8 +20924,8 @@ export const ModelHubExperimentsV2RowsListResponse = zod.object({
   "is_final": zod.boolean().optional()
 })),
   "table": zod.array(zod.object({
-
-}).passthrough()).optional(),
+  "row_id": zod.string().uuid()
+})).optional(),
   "metadata": zod.object({
   "total_rows": zod.number().optional(),
   "dataset": zod.string().optional(),
@@ -20947,8 +20977,8 @@ export const ModelHubExperimentsV2RowsReadResponse = zod.object({
   "is_final": zod.boolean().optional()
 })),
   "table": zod.array(zod.object({
-
-}).passthrough()).optional(),
+  "row_id": zod.string().uuid()
+})).optional(),
   "metadata": zod.object({
   "total_rows": zod.number().optional(),
   "dataset": zod.string().optional(),
@@ -21061,8 +21091,8 @@ export const ModelHubExperimentsReadResponse = zod.object({
   "is_final": zod.boolean().optional()
 })),
   "table": zod.array(zod.object({
-
-}).passthrough()).optional(),
+  "row_id": zod.string().uuid()
+})).optional(),
   "metadata": zod.object({
   "total_rows": zod.number().optional(),
   "dataset": zod.string().optional(),

--- a/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
@@ -374,7 +374,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
         borderRadius={1}
         padding={1.5}
       >
-        <CellMarkdown spacing={0} text={data?.value_infos?.reason ?? data?.valueInfos?.reason} />
+        <CellMarkdown spacing={0} text={data?.value_infos?.reason} />
       </Box>
 
       <div style={{ borderBottom: "1px solid var(--border-light)" }} />
@@ -497,7 +497,7 @@ const SubmittedFeedback = ({ control, data }) => {
           {data?.name}
         </Typography>
         <Typography sx={{ fontSize: "12px" }}>
-          {data?.value_infos?.reason ?? data?.valueInfos?.reason}
+          {data?.value_infos?.reason}
         </Typography>
         <Typography sx={{ fontSize: "12px", fontWeight: "600" }}>
           1 row received your feedback.

--- a/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
@@ -374,7 +374,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
         borderRadius={1}
         padding={1.5}
       >
-        <CellMarkdown spacing={0} text={data?.valueInfos?.reason} />
+        <CellMarkdown spacing={0} text={data?.value_infos?.reason ?? data?.valueInfos?.reason} />
       </Box>
 
       <div style={{ borderBottom: "1px solid var(--border-light)" }} />
@@ -497,7 +497,7 @@ const SubmittedFeedback = ({ control, data }) => {
           {data?.name}
         </Typography>
         <Typography sx={{ fontSize: "12px" }}>
-          {data?.valueInfos?.reason}
+          {data?.value_infos?.reason ?? data?.valueInfos?.reason}
         </Typography>
         <Typography sx={{ fontSize: "12px", fontWeight: "600" }}>
           1 row received your feedback.

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
@@ -193,14 +193,14 @@ function ExperimentDataView() {
 
       // Use unique row ID instead of rowIndex
       prev.forEach((row) => {
-        const id = row.data?.rowId;
+        const id = row.data?.row_id ?? row.data?.rowId;
         if (id !== undefined) {
           mergedMap.set(id, row);
         }
       });
 
       newRows.forEach((row) => {
-        const id = row.data?.rowId;
+        const id = row.data?.row_id ?? row.data?.rowId;
         if (id !== undefined) {
           mergedMap.set(id, row);
         }
@@ -213,9 +213,15 @@ function ExperimentDataView() {
       }
 
       // Check if any rows actually changed
-      const prevMap = new Map(prev.map((row) => [row.data?.rowId, row]));
+      const prevMap = new Map(
+        prev.map((row) => [row.data?.row_id ?? row.data?.rowId, row]),
+      );
       const hasChanges = newRows.some(
-        (newRow) => !isEqual(prevMap.get(newRow.data?.rowId), newRow),
+        (newRow) =>
+          !isEqual(
+            prevMap.get(newRow.data?.row_id ?? newRow.data?.rowId),
+            newRow,
+          ),
       );
 
       return hasChanges ? mergedArray : prev;
@@ -732,8 +738,10 @@ function ExperimentDataView() {
         };
 
         // Avoid unnecessary state updates if the same row is clicked
+        const prevRowKey = expandRow?.row_id ?? expandRow?.rowId;
+        const newRowKey = newExpandRow.row_id ?? newExpandRow.rowId;
         if (
-          expandRow?.rowId !== newExpandRow.rowId ||
+          prevRowKey !== newRowKey ||
           expandRow?.index !== newExpandRow.index
         ) {
           setExpandRow(newExpandRow);
@@ -841,7 +849,7 @@ function ExperimentDataView() {
           setFetchingData(false);
         }
       },
-      getRowId: (data) => data.rowId,
+      getRowId: (data) => data.row_id ?? data.rowId,
     }),
     [experimentId, diffMode, setFetchingData, experimentSearch],
   );
@@ -982,7 +990,7 @@ function ExperimentDataView() {
             getMainMenuItems={menuList}
             debounceVerticalScrollbar={true}
             // postProcessPopup={postProcessPopup}
-            getRowId={({ data }) => data.rowId}
+            getRowId={({ data }) => data.row_id ?? data.rowId}
             theme={agTheme}
             onRowClicked={handleRowClick}
             suppressColumnMoveAnimation={true}

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
@@ -193,14 +193,14 @@ function ExperimentDataView() {
 
       // Use unique row ID instead of rowIndex
       prev.forEach((row) => {
-        const id = row.data?.row_id ?? row.data?.rowId;
+        const id = row.data?.row_id;
         if (id !== undefined) {
           mergedMap.set(id, row);
         }
       });
 
       newRows.forEach((row) => {
-        const id = row.data?.row_id ?? row.data?.rowId;
+        const id = row.data?.row_id;
         if (id !== undefined) {
           mergedMap.set(id, row);
         }
@@ -214,12 +214,12 @@ function ExperimentDataView() {
 
       // Check if any rows actually changed
       const prevMap = new Map(
-        prev.map((row) => [row.data?.row_id ?? row.data?.rowId, row]),
+        prev.map((row) => [row.data?.row_id, row]),
       );
       const hasChanges = newRows.some(
         (newRow) =>
           !isEqual(
-            prevMap.get(newRow.data?.row_id ?? newRow.data?.rowId),
+            prevMap.get(newRow.data?.row_id),
             newRow,
           ),
       );
@@ -738,8 +738,8 @@ function ExperimentDataView() {
         };
 
         // Avoid unnecessary state updates if the same row is clicked
-        const prevRowKey = expandRow?.row_id ?? expandRow?.rowId;
-        const newRowKey = newExpandRow.row_id ?? newExpandRow.rowId;
+        const prevRowKey = expandRow?.row_id;
+        const newRowKey = newExpandRow.row_id;
         if (
           prevRowKey !== newRowKey ||
           expandRow?.index !== newExpandRow.index
@@ -849,7 +849,6 @@ function ExperimentDataView() {
           setFetchingData(false);
         }
       },
-      getRowId: (data) => data.row_id ?? data.rowId,
     }),
     [experimentId, diffMode, setFetchingData, experimentSearch],
   );
@@ -990,7 +989,7 @@ function ExperimentDataView() {
             getMainMenuItems={menuList}
             debounceVerticalScrollbar={true}
             // postProcessPopup={postProcessPopup}
-            getRowId={({ data }) => data.row_id ?? data.rowId}
+            getRowId={({ data }) => data.row_id}
             theme={agTheme}
             onRowClicked={handleRowClick}
             suppressColumnMoveAnimation={true}

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
@@ -49,9 +49,9 @@ const SkeletonLoader = () => (
 export const StatusCellRenderer = (props) => {
   const theme = useTheme();
   const { value } = props;
-  const cellValue = value?.cell_value ?? value?.cellValue;
+  const cellValue = value?.cell_value;
   const status = value?.status;
-  const outputType = props?.data?.output_type ?? props?.data?.outputType;
+  const outputType = props?.data?.output_type;
 
   if (status === "running") return <SkeletonLoader />;
   if (status === "error") {
@@ -203,9 +203,8 @@ export default function ExperimentDetailDrawerContent({
     for (const [_, value] of Object.entries(grouping)) {
       if (value.length === 1) {
         const col = value?.[0];
-        const isBaseColumn = col?.is_base_column || col?.isBaseColumn;
-        const originType =
-          col?.origin_type || col?.originType || col?.group?.origin;
+        const isBaseColumn = col?.is_base_column;
+        const originType = col?.origin_type || col?.group?.origin;
         const isExperimentType =
           originType === "Experiment" || originType === "experiment";
 
@@ -319,13 +318,13 @@ export default function ExperimentDetailDrawerContent({
     const datasetEvaluations = {};
     const evaluations = columnConfig?.filter((i) => {
       // Only include evaluation columns, but exclude summary/reason columns
-      const originType = i?.origin_type ?? i?.originType;
+      const originType = i?.origin_type;
       return originType === "evaluation" && !i?.name?.includes("-reason");
     });
 
     if (evaluations && evaluations?.length > 0) {
       for (const item of evaluations) {
-        const dsId = item?.dataset_id ?? item?.datasetId;
+        const dsId = item?.dataset_id;
         if (datasetEvaluations[dsId]) {
           datasetEvaluations[dsId].push(item);
         } else {
@@ -345,7 +344,7 @@ export default function ExperimentDetailDrawerContent({
     if (datasetCols?.length > 0) {
       const diffTracker = {};
       for (const datasetCol of datasetCols) {
-        if (row?.[datasetCol?.id]?.cellDiffValue) {
+        if (row?.[datasetCol?.id]?.cell_diff_value) {
           diffTracker[datasetCol?.id] = showDiff;
         }
       }
@@ -455,11 +454,11 @@ export default function ExperimentDetailDrawerContent({
   }
 
   const renderDatapoint = (col, row) => {
-    if (col.dataType === "audio") {
+    if (col.data_type === "audio") {
       return <AudioDatapointCard value={row?.[col.id]} column={col} />;
     }
 
-    if (col?.dataType === "image") {
+    if (col?.data_type === "image") {
       return (
         <ImageDatapointCard
           value={row?.[col.id]}
@@ -469,12 +468,12 @@ export default function ExperimentDetailDrawerContent({
     }
 
     // Render agent flow for agent columns
-    if (col?.isAgent) {
-      // Use agentGroupedColumns if available, otherwise find them
+    if (col?.is_agent) {
+      // Use agentGroupedColumns (FE-derived alias set at line 226) if available, otherwise find them
       const groupedAgentColumns =
         col?.agentGroupedColumns ||
         datasetCols.filter(
-          (c) => c?.group?.id === col?.group?.id && c?.isAgent,
+          (c) => c?.group?.id === col?.group?.id && c?.is_agent,
         );
 
       if (groupedAgentColumns.length > 0) {
@@ -485,7 +484,7 @@ export default function ExperimentDetailDrawerContent({
           return {
             ...cellData,
             columnName: agentCol?.name,
-            isFinal: agentCol?.isFinal,
+            isFinal: agentCol?.is_final,
           };
         });
 
@@ -493,8 +492,8 @@ export default function ExperimentDetailDrawerContent({
           <AgentFlowRenderer
             outputs={outputs}
             showDiff={
-              row?.[col?.id]?.cellDiffValue ||
-              Array.isArray(row?.[col?.id]?.cellValue)
+              row?.[col?.id]?.cell_diff_value ||
+              Array.isArray(row?.[col?.id]?.cell_value)
             }
             onDiffClick={(tabValue) =>
               handleToggleDiffForSingleCol(col?.id, tabValue)
@@ -513,23 +512,23 @@ export default function ExperimentDetailDrawerContent({
       }
     }
 
-    // insert cellDiffValue key if diffTracker is true
-    // else for raw & markdown if it is still array convert it to string by taking default and added
+    // Reads come off the BE row shape (cell_value / cell_diff_value, snake_case);
+    // writes use the DatapointCard prop names (cellValue / cellDiffValue, camelCase).
     const value = {
       ...(row?.[col.id] || {}),
       ...(indColsDifTracker?.[col?.id] &&
-      Array.isArray(row?.[col.id]?.cellValue)
-        ? { cellDiffValue: row?.[col.id]?.cellValue }
+      Array.isArray(row?.[col.id]?.cell_value)
+        ? { cellDiffValue: row?.[col.id]?.cell_value }
         : {
-            cellValue: Array.isArray(row?.[col.id]?.cellValue)
-              ? row?.[col.id]?.cellValue
+            cellValue: Array.isArray(row?.[col.id]?.cell_value)
+              ? row?.[col.id]?.cell_value
                   .filter(
                     (item) =>
                       item.status === "default" || item.status === "added",
                   )
                   .map((item) => item.text)
                   .join(" ") // if array but not diff tab filter normal text from the array
-              : row?.[col?.id]?.cellValue,
+              : row?.[col?.id]?.cell_value,
           }),
     };
 
@@ -537,11 +536,11 @@ export default function ExperimentDetailDrawerContent({
       <DatapointCard
         value={value}
         showDiff={
-          row?.[col?.id]?.cellDiffValue ||
-          Array.isArray(row?.[col?.id]?.cellValue)
+          row?.[col?.id]?.cell_diff_value ||
+          Array.isArray(row?.[col?.id]?.cell_value)
         }
         column={{
-          dataType: col?.dataType,
+          dataType: col?.data_type,
           headerName: col?.name,
         }}
         onDiffClick={(tabValue) =>
@@ -956,7 +955,7 @@ export default function ExperimentDetailDrawerContent({
                         columnDefs={TabColumnDefs}
                         defaultColDef={defaultColDef}
                         rowData={
-                          evalsData?.[col?.dataset_id ?? col?.datasetId] ?? []
+                          evalsData?.[col?.dataset_id] ?? []
                         }
                         domLayout="normal"
                         suppressRowDrag={true}
@@ -1041,7 +1040,7 @@ export default function ExperimentDetailDrawerContent({
                       }}
                       key={index}
                     >
-                      <ShowComponent condition={!col?.isAgent}>
+                      <ShowComponent condition={!col?.is_agent}>
                         <Typography
                           variant="s1"
                           color={"text.primary"}
@@ -1113,7 +1112,7 @@ export default function ExperimentDetailDrawerContent({
               ...evalData,
               userEvalMetricId: evalData?.group?.id,
               sourceId: evalData?.id,
-              rowData: { row_id: row?.row_id ?? row?.rowId },
+              rowData: { row_id: row?.row_id },
             });
             setOpenDetailRow(null);
           }}

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
@@ -14,6 +14,7 @@ import { AgGridReact } from "ag-grid-react";
 import PropTypes from "prop-types";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import { useAgThemeWith } from "src/hooks/use-ag-theme";
 import ExperimentDescriptionCell from "./ExperimentDescriptionCell";
 import DatapointCard from "src/sections/common/DatapointCard";
@@ -23,8 +24,8 @@ import { LoadingButton } from "@mui/lab";
 import { getUniqueColorPalette, copyToClipboard } from "src/utils/utils";
 import { enqueueSnackbar } from "notistack";
 import {
-  getLabel,
   getStatusColor,
+  normalizeEvalResult,
 } from "src/sections/develop-detail/DataTab/common";
 import { ShowComponent } from "src/components/show/ShowComponent";
 import SvgColor from "src/components/svg-color/svg-color";
@@ -45,13 +46,12 @@ const SkeletonLoader = () => (
   />
 );
 
-// StatusCellRenderer that properly handles different data types like the dataset detail drawer
 export const StatusCellRenderer = (props) => {
   const theme = useTheme();
   const { value } = props;
-  let cellValue = value?.cellValue;
+  const cellValue = value?.cell_value ?? value?.cellValue;
   const status = value?.status;
-  const type = props?.data?.dataType;
+  const outputType = props?.data?.output_type ?? props?.data?.outputType;
 
   if (status === "running") return <SkeletonLoader />;
   if (status === "error") {
@@ -68,52 +68,68 @@ export const StatusCellRenderer = (props) => {
     );
   }
 
-  if (type === OutputTypes.NUMERIC) {
+  if (outputType === OutputTypes.NUMERIC) {
     return <NumericCell value={cellValue} sx={{ padding: "0 12px" }} />;
   }
 
-  if (cellValue?.startsWith("['") && cellValue?.endsWith("']")) {
-    cellValue = JSON.parse(cellValue.replace(/'/g, '"'));
-  }
-  if (
-    !cellValue ||
-    cellValue === "[]" ||
-    cellValue === undefined ||
-    cellValue === ""
-  )
-    return "-";
+  const result = normalizeEvalResult(cellValue, outputType);
+  if (result.kind === "empty") return "-";
 
+  const chipSx = (v) => ({
+    ...getStatusColor(v, theme),
+    transition: "none",
+    "&:hover": {
+      backgroundColor: getStatusColor(v, theme).backgroundColor,
+      boxShadow: "none",
+    },
+  });
+
+  if (result.kind === "score") {
+    const pct = result.score <= 1 ? result.score * 100 : result.score;
+    return (
+      <Chip
+        variant="soft"
+        label={`${Math.round(pct)}%`}
+        size="small"
+        sx={chipSx(result.score)}
+      />
+    );
+  }
+
+  if (result.kind === "passfail") {
+    return (
+      <Chip
+        variant="soft"
+        label={result.label}
+        size="small"
+        sx={chipSx(result.label)}
+      />
+    );
+  }
+
+  const first = result.items[0];
   return (
     <Box>
       <Chip
         variant="soft"
-        label={getLabel(cellValue)}
+        label={first}
         size="small"
-        sx={{
-          ...getStatusColor(cellValue, theme),
-          marginRight: "10px",
-          transition: "none",
-          "&:hover": {
-            backgroundColor: getStatusColor(cellValue, theme).backgroundColor, // Lock it to same color
-            boxShadow: "none",
-          },
-        }}
+        sx={{ ...chipSx(first), marginRight: "10px" }}
       />
-
-      {Array.isArray(cellValue) && cellValue.length > 1 && (
-        <Chip
-          variant="soft"
-          label={`+${cellValue.length - 1}`}
+      {result.items.length > 1 && (
+        <CustomTooltip
+          show
+          title={result.items.slice(1).join(", ")}
+          arrow
           size="small"
-          sx={{
-            ...getStatusColor(cellValue, theme),
-            transition: "none",
-            "&:hover": {
-              backgroundColor: getStatusColor(cellValue, theme).backgroundColor, // Lock it to same color
-              boxShadow: "none",
-            },
-          }}
-        />
+        >
+          <Chip
+            variant="soft"
+            label={`+${result.items.length - 1}`}
+            size="small"
+            sx={{ ...chipSx(first), cursor: "default" }}
+          />
+        </CustomTooltip>
       )}
     </Box>
   );
@@ -121,12 +137,13 @@ export const StatusCellRenderer = (props) => {
 
 StatusCellRenderer.propTypes = {
   value: PropTypes.shape({
+    cell_value: PropTypes.any,
     cellValue: PropTypes.any,
     status: PropTypes.string,
-    dataType: PropTypes.string,
   }),
   data: PropTypes.shape({
-    dataType: PropTypes.string,
+    output_type: PropTypes.string,
+    outputType: PropTypes.string,
   }),
 };
 
@@ -271,7 +288,7 @@ export default function ExperimentDetailDrawerContent({
     }
 
     return tabs;
-  }, [showDescription]);
+  }, [showDescription, row]);
   // Custom overlay for empty evaluation data
   const CustomNoRowsOverlay = () => (
     <Box
@@ -302,15 +319,17 @@ export default function ExperimentDetailDrawerContent({
     const datasetEvaluations = {};
     const evaluations = columnConfig?.filter((i) => {
       // Only include evaluation columns, but exclude summary/reason columns
-      return i?.originType === "evaluation" && !i?.name?.includes("-reason");
+      const originType = i?.origin_type ?? i?.originType;
+      return originType === "evaluation" && !i?.name?.includes("-reason");
     });
 
     if (evaluations && evaluations?.length > 0) {
       for (const item of evaluations) {
-        if (datasetEvaluations[item?.datasetId]) {
-          datasetEvaluations[item?.datasetId].push(item);
+        const dsId = item?.dataset_id ?? item?.datasetId;
+        if (datasetEvaluations[dsId]) {
+          datasetEvaluations[dsId].push(item);
         } else {
-          datasetEvaluations[item?.datasetId] = [item];
+          datasetEvaluations[dsId] = [item];
         }
       }
     }
@@ -936,7 +955,9 @@ export default function ExperimentDetailDrawerContent({
                         suppressContextMenu={true}
                         columnDefs={TabColumnDefs}
                         defaultColDef={defaultColDef}
-                        rowData={evalsData?.[col?.datasetId] ?? []}
+                        rowData={
+                          evalsData?.[col?.dataset_id ?? col?.datasetId] ?? []
+                        }
                         domLayout="normal"
                         suppressRowDrag={true}
                         noRowsOverlayComponent={CustomNoRowsOverlay}
@@ -1092,7 +1113,7 @@ export default function ExperimentDetailDrawerContent({
               ...evalData,
               userEvalMetricId: evalData?.group?.id,
               sourceId: evalData?.id,
-              rowData: { rowId: row?.rowId },
+              rowData: { row_id: row?.row_id ?? row?.rowId },
             });
             setOpenDetailRow(null);
           }}

--- a/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
@@ -33,18 +33,10 @@ const ViewDetailsModal = ({
   const theme = useTheme();
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  // Get the actual evaluation data from the row data
-  const evalData = data
-    ? {
-        ...data,
-        cellValue: data.cellValue,
-        dataType: data.dataType,
-        metadata: data.metadata,
-      }
-    : null;
+  const evalData = data;
   // Detect composite eval results from value_infos
   const compositeResult = useMemo(() => {
-    const vi = data?.value_infos ?? data?.valueInfos;
+    const vi = data?.value_infos;
     const parsed =
       typeof vi === "string"
         ? (() => {
@@ -79,11 +71,10 @@ const ViewDetailsModal = ({
     };
   }, [data]);
 
-  const cellValue = evalData?.cell_value ?? evalData?.cellValue;
-  const cellMetadata =
-    evalData?.metadata?.cell_metadata ?? evalData?.metadata?.cellMetadata;
-  const errorAnalysis =
-    cellMetadata?.error_analysis ?? cellMetadata?.errorAnalysis;
+  const cellValue = evalData?.cell_value;
+  const cellMetadata = evalData?.metadata?.cell_metadata;
+  const errorAnalysis = cellMetadata?.error_analysis;
+  const normalizedResult = normalizeEvalResult(cellValue);
   const input1 = Array.isArray(errorAnalysis?.input1)
     ? errorAnalysis.input1
     : errorAnalysis?.input1
@@ -181,8 +172,8 @@ const ViewDetailsModal = ({
               <Typography sx={{ color: "red.700", margin: "8px" }}>
                 error
               </Typography>
-            ) : normalizeEvalResult(cellValue).kind === "choices" ? (
-              normalizeEvalResult(cellValue).items.map((item, idx) => (
+            ) : normalizedResult.kind === "choices" ? (
+              normalizedResult.items.map((item, idx) => (
                 <Chip
                   key={idx}
                   variant="soft"
@@ -373,8 +364,7 @@ const ViewDetailsModal = ({
                       key={key}
                       value={valueArray}
                       column={
-                        cellMetadata?.selected_input_key ??
-                        cellMetadata?.selectedInputKey
+                        cellMetadata?.selected_input_key
                       }
                       datapoint={evalData}
                     />

--- a/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
@@ -18,6 +18,7 @@ import CompositeResultView from "src/sections/evals/components/CompositeResultVi
 import {
   getLabel,
   getStatusColor,
+  normalizeEvalResult,
 } from "src/sections/develop-detail/DataTab/common";
 
 const ViewDetailsModal = ({
@@ -78,7 +79,11 @@ const ViewDetailsModal = ({
     };
   }, [data]);
 
-  const errorAnalysis = evalData?.metadata?.cellMetadata?.errorAnalysis;
+  const cellValue = evalData?.cell_value ?? evalData?.cellValue;
+  const cellMetadata =
+    evalData?.metadata?.cell_metadata ?? evalData?.metadata?.cellMetadata;
+  const errorAnalysis =
+    cellMetadata?.error_analysis ?? cellMetadata?.errorAnalysis;
   const input1 = Array.isArray(errorAnalysis?.input1)
     ? errorAnalysis.input1
     : errorAnalysis?.input1
@@ -176,37 +181,34 @@ const ViewDetailsModal = ({
               <Typography sx={{ color: "red.700", margin: "8px" }}>
                 error
               </Typography>
-            ) : evalData?.cellValue?.startsWith("['") &&
-              evalData?.cellValue?.endsWith("']") ? (
-              JSON.parse(evalData.cellValue.replace(/'/g, '"')).map(
-                (item, idx) => (
-                  <Chip
-                    key={idx}
-                    variant="soft"
-                    label={item}
-                    size="small"
-                    sx={{
-                      margin: "5px",
-                      backgroundColor: "action.hover",
+            ) : normalizeEvalResult(cellValue).kind === "choices" ? (
+              normalizeEvalResult(cellValue).items.map((item, idx) => (
+                <Chip
+                  key={idx}
+                  variant="soft"
+                  label={item}
+                  size="small"
+                  sx={{
+                    margin: "5px",
+                    backgroundColor: "action.hover",
+                    color: "primary.main",
+                    fontWeight: "400",
+                    pointerEvents: "none",
+                    "&:hover": {
                       color: "primary.main",
-                      fontWeight: "400",
-                      pointerEvents: "none",
-                      "&:hover": {
-                        color: "primary.main",
-                        backgroundColor: "action.hover",
-                      },
-                    }}
-                  />
-                ),
-              )
+                      backgroundColor: "action.hover",
+                    },
+                  }}
+                />
+              ))
             ) : (
               <Chip
                 variant="soft"
-                label={getLabel(evalData?.cellValue)}
+                label={getLabel(cellValue)}
                 size="small"
                 sx={{
                   pointerEvents: "none",
-                  ...getStatusColor(evalData?.cellValue, theme),
+                  ...getStatusColor(cellValue, theme),
                 }}
               />
             )}
@@ -227,9 +229,9 @@ const ViewDetailsModal = ({
                 borderRadius: theme.spacing(1),
               }}
             >
-              {evalData?.metadata?.cellMetadata?.explanation ? (
+              {cellMetadata?.explanation ? (
                 <ul>
-                  <li>{evalData?.metadata?.cellMetadata?.explanation}</li>
+                  <li>{cellMetadata?.explanation}</li>
                 </ul>
               ) : (
                 <Box
@@ -281,7 +283,7 @@ const ViewDetailsModal = ({
               Possible Error
             </Typography>
 
-            {evalData?.cellValue === "error" ? (
+            {cellValue === "error" ? (
               <Box
                 sx={{
                   display: "flex",
@@ -371,7 +373,8 @@ const ViewDetailsModal = ({
                       key={key}
                       value={valueArray}
                       column={
-                        evalData?.metadata?.cellMetadata?.selectedInputKey
+                        cellMetadata?.selected_input_key ??
+                        cellMetadata?.selectedInputKey
                       }
                       datapoint={evalData}
                     />

--- a/frontend/src/sections/experiment-detail/ExperimentData/__tests__/experimentRowShape.test.js
+++ b/frontend/src/sections/experiment-detail/ExperimentData/__tests__/experimentRowShape.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEvalResult } from "src/sections/develop-detail/DataTab/common";
+
+// Captured shape of one row + cell on the experiment-rows endpoint. Matches
+// the contract typed by ExperimentTableRowSerializer + ExperimentRowCellSerializer
+// in futureagi/model_hub/serializers/experiment_contracts.py. The reads below
+// are the exact ones EvalDetailDrawerContent's StatusCellRenderer and
+// ViewDetailsModal perform; the test is a regression lock against a future
+// rename on either side of the contract.
+const EXPERIMENT_ROW_FIXTURE = {
+  row_id: "5c05bbe6-5399-4274-bbbf-7e0f2a1caff4",
+  "8b3e0d2f-1234-49aa-bf02-d4fbf08e9f55": {
+    cell_value: "{'score': 0.25, 'choices': ['Useless', 'Non-Toxic']}",
+    status: "completed",
+    metadata: {
+      response_time_ms: 412.0,
+      token_count: 837,
+      cost: { input: 0.0, output: 0.0 },
+      cell_metadata: {
+        explanation: "Output declines to advise on lisinopril dosage.",
+        error_analysis: { input1: ["short response"] },
+        selected_input_key: "output",
+      },
+      reason: "Output declines to advise on lisinopril dosage.",
+    },
+    value_infos: {
+      reason: "Output declines to advise on lisinopril dosage.",
+    },
+  },
+};
+
+describe("experiment-rows endpoint shape", () => {
+  it("StatusCellRenderer reads snake_case directly off the cell", () => {
+    const evalCellId = "8b3e0d2f-1234-49aa-bf02-d4fbf08e9f55";
+    const cell = EXPERIMENT_ROW_FIXTURE[evalCellId];
+
+    expect(cell.cell_value).toBe(
+      "{'score': 0.25, 'choices': ['Useless', 'Non-Toxic']}",
+    );
+    expect(cell.status).toBe("completed");
+    expect(cell).not.toHaveProperty("cellValue");
+  });
+
+  it("normalizeEvalResult classifies the BE-emitted cell_value into choices", () => {
+    const evalCellId = "8b3e0d2f-1234-49aa-bf02-d4fbf08e9f55";
+    const cell = EXPERIMENT_ROW_FIXTURE[evalCellId];
+    const result = normalizeEvalResult(cell.cell_value);
+
+    expect(result.kind).toBe("choices");
+    expect(result.items).toEqual(["Useless", "Non-Toxic"]);
+  });
+
+  it("ViewDetailsModal reads cell_metadata.explanation / error_analysis / selected_input_key", () => {
+    const evalCellId = "8b3e0d2f-1234-49aa-bf02-d4fbf08e9f55";
+    const cell = EXPERIMENT_ROW_FIXTURE[evalCellId];
+    const cellMetadata = cell.metadata?.cell_metadata;
+
+    expect(cellMetadata.explanation).toBe(
+      "Output declines to advise on lisinopril dosage.",
+    );
+    expect(cellMetadata.error_analysis).toEqual({ input1: ["short response"] });
+    expect(cellMetadata.selected_input_key).toBe("output");
+    expect(cellMetadata).not.toHaveProperty("errorAnalysis");
+    expect(cellMetadata).not.toHaveProperty("selectedInputKey");
+  });
+
+  it("ExperimentDataView getRowId reads row_id directly", () => {
+    expect(EXPERIMENT_ROW_FIXTURE.row_id).toBe(
+      "5c05bbe6-5399-4274-bbbf-7e0f2a1caff4",
+    );
+    expect(EXPERIMENT_ROW_FIXTURE).not.toHaveProperty("rowId");
+  });
+});

--- a/futureagi/model_hub/serializers/experiment_contracts.py
+++ b/futureagi/model_hub/serializers/experiment_contracts.py
@@ -56,9 +56,70 @@ class ExperimentTableRowsMetadataSerializer(serializers.Serializer):
     )
 
 
+class ExperimentRowCellInnerMetadataSerializer(serializers.Serializer):
+    """Inner eval metadata living at `cell.metadata.cell_metadata`.
+
+    Surfaces the fields the frontend reads from the eval pipeline: the
+    natural-language `explanation`, the error-localizer output, and the
+    selected input key. Other eval-specific fields pass through opaquely
+    via the dict's open shape.
+    """
+
+    explanation = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    error_analysis = serializers.JSONField(required=False, allow_null=True)
+    selected_input_key = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+
+
+class ExperimentRowCellMetadataSerializer(serializers.Serializer):
+    response_time_ms = serializers.FloatField(required=False, allow_null=True)
+    token_count = serializers.IntegerField(required=False)
+    cost = serializers.JSONField(required=False, allow_null=True)
+    cell_metadata = ExperimentRowCellInnerMetadataSerializer(required=False)
+    reason = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+
+
+class ExperimentRowCellSerializer(serializers.Serializer):
+    """Per-cell shape on the experiment rows endpoint.
+
+    A row is a dict keyed by column UUID with cell dicts as values, plus a
+    `row_id` string. The row is dynamic-keyed so the row itself is typed
+    only at `row_id`; this serializer carries the per-cell contract the
+    frontend reads (`cell_value`, `status`, `metadata.cell_metadata`,
+    `value_infos`).
+    """
+
+    cell_value = serializers.JSONField(required=False, allow_null=True)
+    cell_diff_value = serializers.JSONField(required=False, allow_null=True)
+    status = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    metadata = ExperimentRowCellMetadataSerializer(required=False)
+    value_infos = serializers.JSONField(required=False, allow_null=True)
+
+
+class ExperimentTableRowSerializer(serializers.Serializer):
+    """One row: a `row_id` plus dynamic per-column cell dicts.
+
+    The cell entries are keyed by runtime column UUIDs so they cannot be
+    declared statically. The cell shape is `ExperimentRowCellSerializer`;
+    consumers read `row[column_id]` as that shape.
+    """
+
+    row_id = serializers.UUIDField()
+
+
 class ExperimentTableRowsResultSerializer(serializers.Serializer):
     column_config = ExperimentTableRowsColumnConfigSerializer(many=True)
-    table = serializers.ListField(child=serializers.JSONField(), required=False)
+    table = serializers.ListField(
+        child=ExperimentTableRowSerializer(),
+        required=False,
+    )
     metadata = ExperimentTableRowsMetadataSerializer(required=False)
     output_format = serializers.CharField(required=False, allow_blank=True)
     status = serializers.CharField(required=False, allow_blank=True)
@@ -73,17 +134,10 @@ class ExperimentTableRowsResponseSerializer(serializers.Serializer):
     result = ExperimentTableRowsResultSerializer()
 
 
-class ExperimentRowDiffCellSerializer(serializers.Serializer):
-    cell_value = serializers.JSONField(required=False, allow_null=True)
-    cell_diff_value = serializers.JSONField(required=False, allow_null=True)
-    status = serializers.CharField(required=False, allow_blank=True)
-    value_infos = serializers.JSONField(required=False, allow_null=True)
-
-
 class ExperimentRowDiffResponseSerializer(serializers.Serializer):
     status = serializers.BooleanField()
     result = serializers.DictField(
-        child=serializers.DictField(child=ExperimentRowDiffCellSerializer())
+        child=serializers.DictField(child=ExperimentRowCellSerializer())
     )
 
 

--- a/futureagi/model_hub/serializers/experiment_contracts.py
+++ b/futureagi/model_hub/serializers/experiment_contracts.py
@@ -57,14 +57,6 @@ class ExperimentTableRowsMetadataSerializer(serializers.Serializer):
 
 
 class ExperimentRowCellInnerMetadataSerializer(serializers.Serializer):
-    """Inner eval metadata living at `cell.metadata.cell_metadata`.
-
-    Surfaces the fields the frontend reads from the eval pipeline: the
-    natural-language `explanation`, the error-localizer output, and the
-    selected input key. Other eval-specific fields pass through opaquely
-    via the dict's open shape.
-    """
-
     explanation = serializers.CharField(
         required=False, allow_blank=True, allow_null=True
     )
@@ -76,7 +68,7 @@ class ExperimentRowCellInnerMetadataSerializer(serializers.Serializer):
 
 class ExperimentRowCellMetadataSerializer(serializers.Serializer):
     response_time_ms = serializers.FloatField(required=False, allow_null=True)
-    token_count = serializers.IntegerField(required=False)
+    token_count = serializers.IntegerField(required=False, allow_null=True)
     cost = serializers.JSONField(required=False, allow_null=True)
     cell_metadata = ExperimentRowCellInnerMetadataSerializer(required=False)
     reason = serializers.CharField(
@@ -85,15 +77,6 @@ class ExperimentRowCellMetadataSerializer(serializers.Serializer):
 
 
 class ExperimentRowCellSerializer(serializers.Serializer):
-    """Per-cell shape on the experiment rows endpoint.
-
-    A row is a dict keyed by column UUID with cell dicts as values, plus a
-    `row_id` string. The row is dynamic-keyed so the row itself is typed
-    only at `row_id`; this serializer carries the per-cell contract the
-    frontend reads (`cell_value`, `status`, `metadata.cell_metadata`,
-    `value_infos`).
-    """
-
     cell_value = serializers.JSONField(required=False, allow_null=True)
     cell_diff_value = serializers.JSONField(required=False, allow_null=True)
     status = serializers.CharField(
@@ -103,14 +86,9 @@ class ExperimentRowCellSerializer(serializers.Serializer):
     value_infos = serializers.JSONField(required=False, allow_null=True)
 
 
+# Per-column cells are keyed by runtime column UUID and stay dynamic;
+# row_id is the only statically typed field on the row dict.
 class ExperimentTableRowSerializer(serializers.Serializer):
-    """One row: a `row_id` plus dynamic per-column cell dicts.
-
-    The cell entries are keyed by runtime column UUIDs so they cannot be
-    declared statically. The cell shape is `ExperimentRowCellSerializer`;
-    consumers read `row[column_id]` as that shape.
-    """
-
     row_id = serializers.UUIDField()
 
 


### PR DESCRIPTION
## Why

A chain of FE-only bugs in the experiment data view, all of the same camelCase vs snake_case drift class as TH-6281 (eval picker). The rows endpoint emits snake_case fields and the axios response interceptor preserves canonical keys without aliasing; the components were reading camelCase aliases that don't exist on the wire and falling into wrong rendering paths.

Six user-visible symptoms, all addressed in this PR:

1. **Every experiment cell renders the literal `ERR`.** AgGrid's serverSide row model can't distinguish rows when `getRowId` returns the same `undefined` for all of them, falls into the `SkeletonCellRenderer` "row failed to load" branch, and stamps the three-character literal `"ERR"` baked into the AgGrid bundle (`ag-grid-community/dist/ag-grid-community.min.noStyle.js`, paired with `ariaSkeletonCellLoadingFailed`). Two `getRowId` callbacks and five other camelCase `data.rowId` reads were the actual cause.
2. **Clicking a row shows "No Evaluations Applied" even when evals are attached.** The drawer's `evalsData` memo filtered `columnConfig` on `i?.originType` and grouped by `item?.datasetId`; BE emits `origin_type` / `dataset_id` so every column failed the filter and the grouping map stayed empty.
3. **Even after evals showed up, every Score column rendered `-`.** The drawer's `StatusCellRenderer` read `value?.cellValue` and the falsy guard returned `-`. BE emits `cell_value`.
4. **Prev / Next kept showing the first row's scores.** `TabColumnDefs` memoizes the Score column's `valueGetter`, which closes over `row`, but the deps array only listed `[showDescription]`. Stale closure.
5. **Multi-choice evals only showed one of the picked labels.** The eval cell is a Python-repr dict like `"{'score': 0.25, 'choices': ['Useless', 'Non-Toxic']}"`; the chip code only looked at the first label and the `+N` pill was gated on `Array.isArray(cellValue)` which never held for the dict form.
6. **View Detail modal shows "Unable to fetch explanation" even when the BE returned one.** `ViewDetailsModal` read `evalData?.metadata?.cellMetadata?.explanation`, plus `evalData?.cellValue` and `cellMetadata?.errorAnalysis` / `?.selectedInputKey`. BE emits `metadata.cell_metadata.{explanation,error_analysis,selected_input_key}` and `cell_value`. Every read fell to `undefined`, so the modal showed the empty fallback for Score, Explanation, and the error-localization section.

## What changed

Backend serializer adds the typed row + cell shape, codegen mirrors it, and the frontend reads the typed snake_case directly. Same pipeline pattern as PR #883.

**Backend** (`futureagi/model_hub/serializers/experiment_contracts.py`)

- `ExperimentRowCellInnerMetadataSerializer` declares the eval-pipeline fields the frontend reads off `metadata.cell_metadata`: `explanation`, `error_analysis`, `selected_input_key`.
- `ExperimentRowCellMetadataSerializer` wraps those plus the per-cell stats: `response_time_ms`, `token_count`, `cost`, `cell_metadata`, `reason`.
- `ExperimentRowCellSerializer` is the per-cell contract: `cell_value`, `cell_diff_value`, `status`, `metadata`, `value_infos`.
- `ExperimentTableRowSerializer` types `row_id`. Per-column cells stay dynamic-keyed by column UUID at runtime; the cell shape itself is typed via `ExperimentRowCellSerializer` and reachable from `ExperimentRowDiffResponseSerializer` (which now uses the canonical cell directly; the previous diff-cell subclass was redundant and is gone).
- `ExperimentTableRowsResultSerializer.table` is now `ListField(child=ExperimentTableRowSerializer())` instead of `ListField(child=JSONField())`.

**Regenerated artefacts** committed in the same diff: `api_contracts/openapi/swagger.json`, `frontend/src/api/contracts/openapi-contract.generated.js`, `frontend/src/generated/api-contracts/api.schemas.ts`, `frontend/src/generated/api-contracts/api.zod.ts`. `api.schemas.ts` now exposes `ExperimentRowCellApi`, `ExperimentTableRowApi`, `ExperimentRowCellMetadataApi`, `ExperimentRowCellInnerMetadataApi`.

**Frontend** drops every `?? camel` fallback and reads the typed snake_case directly.

| File | Change |
|---|---|
| `ExperimentDataView.jsx` | All seven `data.rowId` / `expandRow.rowId` reads now `data.row_id`. The dead `getRowId` on the AgGrid serverSide datasource is dropped (`IServerSideDatasource` ignores it; the live one is the grid prop). |
| `ExperimentDetailDrawerContent.jsx` | `StatusCellRenderer` reads `value?.cell_value` and `props?.data?.output_type` direct. The `evalsData` memo reads `i?.origin_type` / `item?.dataset_id` direct. The drawer lookup reads `col?.dataset_id`. The dataset-cell render path now reads `col.data_type` (audio/image dispatch) and `row?.[col.id]?.cell_value` / `cell_diff_value`. The agent-flow path reads `col?.is_agent` and `agentCol?.is_final`. |
| `ViewDetailsModal.jsx` | Reads `evalData?.cell_value`, `evalData?.metadata?.cell_metadata`, `cellMetadata?.error_analysis`, `cellMetadata?.selected_input_key`, `data?.value_infos` direct. `normalizeEvalResult(cellValue)` is hoisted into a single `const normalizedResult` near the top instead of being called twice. |
| `AddEvaluationFeeback.jsx` | `data?.value_infos?.reason` read direct at both the form and submitted-feedback sites. |
| `__tests__/experimentRowShape.test.js` | New. Fixture-backed test that captures a realistic row + cell payload mirroring `ExperimentRowCellSerializer` and asserts `StatusCellRenderer`, `ViewDetailsModal`, and `ExperimentDataView`'s `getRowId` reads all resolve correctly, plus camelCase aliases asserted absent. |

`yarn contracts:check` is green; `yarn vitest run` across `experiment-detail` and `develop-detail/DataTab` passes 23 tests.

`StatusCellRenderer` itself is otherwise unchanged from the previous push: it mirrors the canonical renderer in `develop-detail/DataTab/DatapointDrawerV2/StatusCellRenderer.jsx`, routes through `normalizeEvalResult(cellValue, outputType)` to classify each cell as `pass/fail` / `score` / `choices` / `empty`, narrows `NumericCell` to `output_type === "numeric"` only, and uses the `EvalsListView.jsx` overflow-tag pattern for the `+N` pill. `TabColumnDefs` memo deps add `row` to fix the Prev/Next stale closure.

## Architectural decisions

- **The serializer is the source of truth; the frontend reads the typed shape direct.** No `?? camel` fallbacks anywhere in the changed surfaces. The previous push hedged with snake-first / camel-fallback reads to limit blast radius; with the typed contract committed, the camel fallbacks were never on the wire and the reads collapse to the single canonical form.
- **`StatusCellRenderer` reuses `normalizeEvalResult` rather than re-deriving the eval-cell shape.** The previous renderer was a hand-rolled duplicate of the canonical one in `DatapointDrawerV2`. The duplicate had diverged: it keyed off `data_type` (storage shape) instead of `output_type` (eval semantic), it only handled the `NUMERIC` kind, and it didn't recognise pass/fail or hybrid `{score, choices}` cells. Mirroring the canonical version collapses the divergence and ensures both drawers stay in lockstep.
- **`NumericCell` branch is narrowed back to `output_type === "numeric"` only.** Score-typed evals fall through to the chip path so they render as a percentage with color interpolation, matching the canonical's contract.
- **The `+N` pill tooltip mirrors `EvalsListView.jsx`'s overflow-tag pattern**, not a fresh tooltip wrapper. Same `CustomTooltip` component, same `show / title / arrow / size` props.
- **Cells stay dynamic-keyed on the row dict.** Each row is `{row_id, <column_uuid>: cell, ...}` with runtime UUIDs as keys, so the row-level dict can't enumerate its cell entries in a static serializer. `ExperimentTableRowSerializer` types `row_id`; the cell shape is exposed via `ExperimentRowCellSerializer` and reached from the diff endpoint's response so codegen still picks it up.
- **Serializers are wired via `@swagger_auto_schema(responses=...)` for documentation only**, same as every other view in `experiments.py` and the same as #883. The view's dict-builders (`_process_eval_cell`, `_process_dataset_cell`) already emit the snake_case shape directly; the serializer documents that shape so codegen and `contracts:check` catch drift. Runtime response validation (rendering through the serializer on the way out) would need custom `to_representation` overrides because the row dict is dynamic-keyed; out of scope for this PR.

## How to test

1. Pull the branch.
2. Open any experiment that previously showed `ERR` on every cell. The table now renders the underlying cell values.
3. Click any row. The drawer opens and the Evaluation Metrics table lists the attached evals (`customer_agent_*`, `toxicity_*`, etc.) for each column, not the "No Evaluations Applied" overlay.
4. Verify the Score column on each row shows a chip with the actual eval label or percentage instead of `-`.
5. Click Prev / Next. The Score column updates per row.
6. On a multi-choice eval row, the first chip shows one label and a `+1` pill follows it. Hovering the `+1` pill reveals the remaining label(s).
7. Toggle "Show Descriptions" and click "View Detail" on any eval row. The modal renders the Score chip, the actual Explanation text, and (where applicable) the error-localization section, instead of "Unable to fetch explanation".

### Demo

[<video: end-to-end walkthrough of the experiment cell rendering, drawer evaluations, Prev / Next score refresh, and multi-choice +N hover>](https://github.com/user-attachments/assets/524916f2-0646-416e-85d6-4fa703965dfe)

## Linear

Closes TH-6279