### PR TITLE
feat(evals): align LLM-as-a-judge editor with agent layout and fix model logos

### DIFF
--- a/frontend/src/sections/evals/components/LLMPromptEditor.jsx
+++ b/frontend/src/sections/evals/components/LLMPromptEditor.jsx
@@ -13,6 +13,7 @@ import PropTypes from "prop-types";
 import React, { useCallback, useRef, useState } from "react";
 import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
+import { ShowComponent } from "src/components/show";
 import axios, { endpoints } from "src/utils/axios";
 import MessageEditor from "./MessageEditor";
 
@@ -155,8 +156,7 @@ const LLMPromptEditor = ({
         borderBottom: "1px solid",
         borderColor: "divider",
         borderRadius: "8px 8px 0 0",
-        backgroundColor: (theme) =>
-          theme.palette.mode === "dark" ? "#1a1a2e" : "#fafafe",
+        backgroundColor: "background.aiSurface",
       }}
     >
       {/* Row 1: Prompt + Reject/Accept */}
@@ -317,101 +317,100 @@ const LLMPromptEditor = ({
           mb: 0.5,
         }}
       >
-        <Typography variant="body2" fontWeight={600}>
-          Prompt Messages<span style={{ color: "#d32f2f" }}>*</span>
+        <Typography typography="s1" fontWeight={600}>
+          Prompt Messages
+          <Box component="span" sx={{ color: "error.main" }}>
+            *
+          </Box>
         </Typography>
 
-        {onTemplateFormatChange && (
-          <>
-            <Box
-              onClick={(e) => !disabled && setFormatAnchor(e.currentTarget)}
+        <ShowComponent condition={Boolean(onTemplateFormatChange)}>
+          <Box
+            onClick={(e) => !disabled && setFormatAnchor(e.currentTarget)}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.25,
+              py: 0.35,
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: "6px",
+              cursor: disabled ? "default" : "pointer",
+              "&:hover": disabled ? {} : { borderColor: "text.secondary" },
+            }}
+          >
+            <Typography
+              typography="s2"
               sx={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 0.75,
-                px: 1.25,
-                py: 0.35,
-                border: "1px solid",
-                borderColor: "divider",
-                borderRadius: "6px",
-                cursor: disabled ? "default" : "pointer",
-                "&:hover": disabled ? {} : { borderColor: "text.secondary" },
+                fontWeight: 600,
+                fontFamily: "monospace",
+                color: "text.secondary",
               }}
             >
-              <Typography
-                sx={{
-                  fontSize: "12px",
-                  fontWeight: 600,
-                  fontFamily: "monospace",
-                  color: "text.secondary",
+              {currentFormat.icon}
+            </Typography>
+            <Typography typography="s2">{currentFormat.label}</Typography>
+            <Iconify
+              icon={formatAnchor ? "mdi:chevron-up" : "mdi:chevron-down"}
+              width={14}
+              sx={{ color: "text.disabled" }}
+            />
+          </Box>
+          <Popover
+            open={Boolean(formatAnchor)}
+            anchorEl={formatAnchor}
+            onClose={() => setFormatAnchor(null)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            transformOrigin={{ vertical: "top", horizontal: "right" }}
+            slotProps={{
+              paper: { sx: { borderRadius: "8px", p: 0.5, minWidth: 220 } },
+            }}
+          >
+            {TEMPLATE_FORMATS.map((fmt) => (
+              <MenuItem
+                key={fmt.value}
+                selected={templateFormat === fmt.value}
+                onClick={() => {
+                  onTemplateFormatChange(fmt.value);
+                  setFormatAnchor(null);
                 }}
+                sx={{ borderRadius: "6px", py: 1, gap: 1.5 }}
               >
-                {currentFormat.icon}
-              </Typography>
-              <Typography variant="caption" sx={{ fontSize: "12px" }}>
-                {currentFormat.label}
-              </Typography>
-              <Iconify
-                icon={formatAnchor ? "mdi:chevron-up" : "mdi:chevron-down"}
-                width={14}
-                sx={{ color: "text.disabled" }}
-              />
-            </Box>
-            <Popover
-              open={Boolean(formatAnchor)}
-              anchorEl={formatAnchor}
-              onClose={() => setFormatAnchor(null)}
-              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-              transformOrigin={{ vertical: "top", horizontal: "right" }}
-              slotProps={{
-                paper: { sx: { borderRadius: "8px", p: 0.5, minWidth: 220 } },
-              }}
-            >
-              {TEMPLATE_FORMATS.map((fmt) => (
-                <MenuItem
-                  key={fmt.value}
-                  selected={templateFormat === fmt.value}
-                  onClick={() => {
-                    onTemplateFormatChange(fmt.value);
-                    setFormatAnchor(null);
+                <Typography
+                  sx={{
+                    fontSize: "14px",
+                    fontWeight: 700,
+                    fontFamily: "monospace",
+                    width: 40,
+                    textAlign: "center",
+                    color:
+                      templateFormat === fmt.value
+                        ? "primary.main"
+                        : "text.secondary",
                   }}
-                  sx={{ borderRadius: "6px", py: 1, gap: 1.5 }}
                 >
+                  {fmt.icon}
+                </Typography>
+                <Box>
                   <Typography
-                    sx={{
-                      fontSize: "14px",
-                      fontWeight: 700,
-                      fontFamily: "monospace",
-                      width: 40,
-                      textAlign: "center",
-                      color:
-                        templateFormat === fmt.value
-                          ? "primary.main"
-                          : "text.secondary",
-                    }}
+                    variant="body2"
+                    sx={{ fontSize: "13px", fontWeight: 600 }}
                   >
-                    {fmt.icon}
+                    {fmt.label}
                   </Typography>
-                  <Box>
-                    <Typography
-                      variant="body2"
-                      sx={{ fontSize: "13px", fontWeight: 600 }}
-                    >
-                      {fmt.label}
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ fontSize: "11px" }}
-                    >
-                      {fmt.description}
-                    </Typography>
-                  </Box>
-                </MenuItem>
-              ))}
-            </Popover>
-          </>
-        )}
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ fontSize: "11px" }}
+                  >
+                    {fmt.description}
+                  </Typography>
+                </Box>
+              </MenuItem>
+            ))}
+          </Popover>
+        </ShowComponent>
       </Box>
 
       <MessageEditor

--- a/frontend/src/sections/evals/components/LLMPromptEditor.jsx
+++ b/frontend/src/sections/evals/components/LLMPromptEditor.jsx
@@ -5,7 +5,8 @@ import {
   CircularProgress,
   IconButton,
   InputBase,
-  Tooltip,
+  MenuItem,
+  Popover,
   Typography,
 } from "@mui/material";
 import PropTypes from "prop-types";
@@ -15,11 +16,28 @@ import SvgColor from "src/components/svg-color";
 import axios, { endpoints } from "src/utils/axios";
 import MessageEditor from "./MessageEditor";
 
+const TEMPLATE_FORMATS = [
+  {
+    value: "mustache",
+    label: "Mustache",
+    icon: "{{x}}",
+    description: "{{variable}}",
+  },
+  {
+    value: "jinja",
+    label: "Jinja",
+    icon: "{% %}",
+    description: "{{ variable }}, {% if %}",
+  },
+];
+
 /**
  * LLM-As-A-Judge prompt editor with Falcon AI.
  *
- * Wraps MessageEditor with an AI bar that generates
- * or improves the full message chain (system + user + assistant).
+ * Wraps MessageEditor with an AI bar that generates or improves the full
+ * message chain (system + user + assistant). The header (label + template
+ * format) and the single bordered editor box mirror the agent
+ * InstructionEditor so both eval editors look visually identical.
  */
 const LLMPromptEditor = ({
   messages,
@@ -30,8 +48,6 @@ const LLMPromptEditor = ({
   datasetJsonSchemas = {},
   disabled = false,
   modelSelectorDisabled,
-  // Optional model selector — forwarded to MessageEditor's top bar so
-  // the model picker and template format picker share the same row.
   model,
   onModelChange,
 }) => {
@@ -40,6 +56,7 @@ const LLMPromptEditor = ({
   const [aiLoading, setAiLoading] = useState(false);
   const [hasResult, setHasResult] = useState(false);
   const [originalMessages, setOriginalMessages] = useState(null);
+  const [formatAnchor, setFormatAnchor] = useState(null);
   const followUpRef = useRef(null);
 
   const callAI = useCallback(
@@ -126,216 +143,290 @@ const LLMPromptEditor = ({
     setAiPrompt("");
   }, [hasResult, originalMessages, onMessagesChange]);
 
-  return (
-    <Box>
-      {/* ── Falcon AI bar ── */}
-      {aiOpen && (
-        <Box
-          sx={{
-            mb: 1,
-            borderRadius: "8px",
-            border: "1px solid",
-            borderColor: "divider",
-            backgroundColor: (theme) =>
-              theme.palette.mode === "dark" ? "#1a1a2e" : "#fafafe",
-          }}
-        >
-          {/* Row 1: Prompt + Reject/Accept */}
-          <Box sx={{ display: "flex", alignItems: "center", px: 1.5, py: 1 }}>
-            {aiLoading ? (
-              <Box
-                sx={{ display: "flex", alignItems: "center", gap: 1, flex: 1 }}
-              >
-                <CircularProgress size={14} />
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ fontSize: "13px" }}
-                >
-                  Generating messages...
-                </Typography>
-              </Box>
-            ) : !hasResult ? (
-              <>
-                <SvgColor
-                  src="/assets/icons/navbar/ic_falcon_ai.svg"
-                  sx={{
-                    width: 16,
-                    height: 16,
-                    color: "primary.main",
-                    mr: 1,
-                    flexShrink: 0,
-                  }}
-                />
-                <InputBase
-                  autoFocus
-                  fullWidth
-                  placeholder="Describe your eval — e.g. 'judge if chatbot responses are helpful and accurate'"
-                  value={aiPrompt}
-                  onChange={(e) => setAiPrompt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      handleSubmit(aiPrompt);
-                    }
-                    if (e.key === "Escape") handleClose();
-                  }}
-                  sx={{ fontSize: "13px" }}
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => handleSubmit(aiPrompt)}
-                  disabled={!aiPrompt.trim()}
-                  sx={{ p: 0.5 }}
-                >
-                  <Iconify
-                    icon="mdi:arrow-up-circle"
-                    width={20}
-                    sx={{
-                      color: aiPrompt.trim() ? "primary.main" : "text.disabled",
-                    }}
-                  />
-                </IconButton>
-              </>
-            ) : (
-              <Typography
-                variant="body2"
-                sx={{
-                  flex: 1,
-                  fontSize: "13px",
-                  color: "text.secondary",
-                  fontStyle: "italic",
-                }}
-              >
-                {aiPrompt}
-              </Typography>
-            )}
+  const currentFormat =
+    TEMPLATE_FORMATS.find((f) => f.value === templateFormat) ||
+    TEMPLATE_FORMATS[0];
 
-            <Box
+  // Falcon AI bar — rendered at the top of MessageEditor's bordered box
+  // (when open), matching the agent InstructionEditor's inline AI bar.
+  const aiBar = (
+    <Box
+      sx={{
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        borderRadius: "8px 8px 0 0",
+        backgroundColor: (theme) =>
+          theme.palette.mode === "dark" ? "#1a1a2e" : "#fafafe",
+      }}
+    >
+      {/* Row 1: Prompt + Reject/Accept */}
+      <Box sx={{ display: "flex", alignItems: "center", px: 1.5, py: 1 }}>
+        {aiLoading ? (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flex: 1 }}>
+            <CircularProgress size={14} />
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ fontSize: "13px" }}
+            >
+              Generating messages...
+            </Typography>
+          </Box>
+        ) : !hasResult ? (
+          <>
+            <SvgColor
+              src="/assets/icons/navbar/ic_falcon_ai.svg"
               sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-                ml: 1,
+                width: 16,
+                height: 16,
+                color: "primary.main",
+                mr: 1,
                 flexShrink: 0,
               }}
+            />
+            <InputBase
+              autoFocus
+              fullWidth
+              placeholder="Describe your eval — e.g. 'judge if chatbot responses are helpful and accurate'"
+              value={aiPrompt}
+              onChange={(e) => setAiPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit(aiPrompt);
+                }
+                if (e.key === "Escape") handleClose();
+              }}
+              sx={{ fontSize: "13px" }}
+            />
+            <IconButton
+              size="small"
+              onClick={() => handleSubmit(aiPrompt)}
+              disabled={!aiPrompt.trim()}
+              sx={{ p: 0.5 }}
             >
-              {hasResult && (
-                <>
-                  <Button
-                    size="small"
-                    onClick={handleReject}
-                    sx={{
-                      textTransform: "none",
-                      fontSize: "12px",
-                      color: "text.secondary",
-                      minWidth: 0,
-                      px: 1,
-                    }}
-                  >
-                    Reject
-                  </Button>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    onClick={handleAccept}
-                    sx={{
-                      textTransform: "none",
-                      fontSize: "12px",
-                      minWidth: 0,
-                      px: 1.5,
-                      fontWeight: 600,
-                    }}
-                  >
-                    Accept
-                  </Button>
-                </>
-              )}
-              <IconButton size="small" onClick={handleClose} sx={{ p: 0.25 }}>
-                <Iconify
-                  icon="mdi:close"
-                  width={16}
-                  sx={{ color: "text.disabled" }}
-                />
-              </IconButton>
-            </Box>
-          </Box>
-
-          {/* Row 2: Follow-up */}
-          {hasResult && (
-            <Box sx={{ px: 1.5, pb: 1, pt: 0.5 }}>
-              <InputBase
-                inputRef={followUpRef}
-                fullWidth
-                placeholder="Add a follow-up — e.g. 'add a user message with variable mapping'"
-                onKeyDown={(e) => {
-                  if (
-                    e.key === "Enter" &&
-                    !e.shiftKey &&
-                    e.target.value.trim()
-                  ) {
-                    e.preventDefault();
-                    handleSubmit(e.target.value);
-                    e.target.value = "";
-                  }
-                  if (e.key === "Escape") handleClose();
-                }}
+              <Iconify
+                icon="mdi:arrow-up-circle"
+                width={20}
                 sx={{
-                  fontSize: "13px",
-                  borderTop: "1px solid",
-                  borderColor: "divider",
-                  pt: 0.75,
+                  color: aiPrompt.trim() ? "primary.main" : "text.disabled",
                 }}
               />
-            </Box>
-          )}
-        </Box>
-      )}
+            </IconButton>
+          </>
+        ) : (
+          <Typography
+            variant="body2"
+            sx={{
+              flex: 1,
+              fontSize: "13px",
+              color: "text.secondary",
+              fontStyle: "italic",
+            }}
+          >
+            {aiPrompt}
+          </Typography>
+        )}
 
-      {/* ── Label + Falcon icon ── */}
-      {!aiOpen && (
         <Box
           sx={{
             display: "flex",
             alignItems: "center",
-            justifyContent: "space-between",
-            mb: 0.5,
+            gap: 0.5,
+            ml: 1,
+            flexShrink: 0,
           }}
         >
-          <Typography variant="body2" fontWeight={600}>
-            Prompt Messages<span style={{ color: "#d32f2f" }}>*</span>
-          </Typography>
-          <Tooltip title="Generate with Falcon AI" arrow placement="top">
-            <IconButton
-              size="small"
-              onClick={() => setAiOpen(true)}
-              disabled={disabled}
-              sx={{
-                width: 28,
-                height: 28,
-                "&:hover": { backgroundColor: "rgba(124,77,255,0.08)" },
-              }}
-            >
-              <SvgColor
-                src="/assets/icons/navbar/ic_falcon_ai.svg"
-                sx={{ width: 18, height: 18, color: "primary.main" }}
-              />
-            </IconButton>
-          </Tooltip>
+          {hasResult && (
+            <>
+              <Button
+                size="small"
+                onClick={handleReject}
+                sx={{
+                  textTransform: "none",
+                  fontSize: "12px",
+                  color: "text.secondary",
+                  minWidth: 0,
+                  px: 1,
+                }}
+              >
+                Reject
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={handleAccept}
+                sx={{
+                  textTransform: "none",
+                  fontSize: "12px",
+                  minWidth: 0,
+                  px: 1.5,
+                  fontWeight: 600,
+                }}
+              >
+                Accept
+              </Button>
+            </>
+          )}
+          <IconButton size="small" onClick={handleClose} sx={{ p: 0.25 }}>
+            <Iconify
+              icon="mdi:close"
+              width={16}
+              sx={{ color: "text.disabled" }}
+            />
+          </IconButton>
+        </Box>
+      </Box>
+
+      {/* Row 2: Follow-up */}
+      {hasResult && (
+        <Box sx={{ px: 1.5, pb: 1, pt: 0.5 }}>
+          <InputBase
+            inputRef={followUpRef}
+            fullWidth
+            placeholder="Add a follow-up — e.g. 'add a user message with variable mapping'"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && e.target.value.trim()) {
+                e.preventDefault();
+                handleSubmit(e.target.value);
+                e.target.value = "";
+              }
+              if (e.key === "Escape") handleClose();
+            }}
+            sx={{
+              fontSize: "13px",
+              borderTop: "1px solid",
+              borderColor: "divider",
+              pt: 0.75,
+            }}
+          />
         </Box>
       )}
+    </Box>
+  );
+
+  return (
+    <Box>
+      {/* ── Header row: label (left) + template format (right) — matches
+          the agent InstructionEditor header. ── */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 0.5,
+        }}
+      >
+        <Typography variant="body2" fontWeight={600}>
+          Prompt Messages<span style={{ color: "#d32f2f" }}>*</span>
+        </Typography>
+
+        {onTemplateFormatChange && (
+          <>
+            <Box
+              onClick={(e) => !disabled && setFormatAnchor(e.currentTarget)}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 1.25,
+                py: 0.35,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: "6px",
+                cursor: disabled ? "default" : "pointer",
+                "&:hover": disabled ? {} : { borderColor: "text.secondary" },
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: "12px",
+                  fontWeight: 600,
+                  fontFamily: "monospace",
+                  color: "text.secondary",
+                }}
+              >
+                {currentFormat.icon}
+              </Typography>
+              <Typography variant="caption" sx={{ fontSize: "12px" }}>
+                {currentFormat.label}
+              </Typography>
+              <Iconify
+                icon={formatAnchor ? "mdi:chevron-up" : "mdi:chevron-down"}
+                width={14}
+                sx={{ color: "text.disabled" }}
+              />
+            </Box>
+            <Popover
+              open={Boolean(formatAnchor)}
+              anchorEl={formatAnchor}
+              onClose={() => setFormatAnchor(null)}
+              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+              transformOrigin={{ vertical: "top", horizontal: "right" }}
+              slotProps={{
+                paper: { sx: { borderRadius: "8px", p: 0.5, minWidth: 220 } },
+              }}
+            >
+              {TEMPLATE_FORMATS.map((fmt) => (
+                <MenuItem
+                  key={fmt.value}
+                  selected={templateFormat === fmt.value}
+                  onClick={() => {
+                    onTemplateFormatChange(fmt.value);
+                    setFormatAnchor(null);
+                  }}
+                  sx={{ borderRadius: "6px", py: 1, gap: 1.5 }}
+                >
+                  <Typography
+                    sx={{
+                      fontSize: "14px",
+                      fontWeight: 700,
+                      fontFamily: "monospace",
+                      width: 40,
+                      textAlign: "center",
+                      color:
+                        templateFormat === fmt.value
+                          ? "primary.main"
+                          : "text.secondary",
+                    }}
+                  >
+                    {fmt.icon}
+                  </Typography>
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontSize: "13px", fontWeight: 600 }}
+                    >
+                      {fmt.label}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ fontSize: "11px" }}
+                    >
+                      {fmt.description}
+                    </Typography>
+                  </Box>
+                </MenuItem>
+              ))}
+            </Popover>
+          </>
+        )}
+      </Box>
 
       <MessageEditor
         messages={messages}
         onChange={onMessagesChange}
         templateFormat={templateFormat}
-        onTemplateFormatChange={onTemplateFormatChange}
         model={model}
         onModelChange={onModelChange}
         datasetColumns={datasetColumns}
         datasetJsonSchemas={datasetJsonSchemas}
         disabled={disabled}
         modelSelectorDisabled={modelSelectorDisabled}
+        aiBar={aiOpen ? aiBar : null}
+        onFalconClick={() => setAiOpen(true)}
+        aiOpen={aiOpen}
       />
     </Box>
   );

--- a/frontend/src/sections/evals/components/MessageEditor.jsx
+++ b/frontend/src/sections/evals/components/MessageEditor.jsx
@@ -4,11 +4,12 @@ import {
   IconButton,
   MenuItem,
   Select,
-  Typography,
+  Tooltip,
 } from "@mui/material";
 import PropTypes from "prop-types";
 import { useCallback, useMemo } from "react";
 import Iconify from "src/components/iconify";
+import SvgColor from "src/components/svg-color";
 import { extractJinjaVariables } from "src/utils/jinjaVariables";
 import MessageEditorBlock from "./MessageEditorBlock";
 import ModelSelector from "./ModelSelector";
@@ -17,21 +18,6 @@ const ROLES = [
   { value: "system", label: "System" },
   { value: "user", label: "User" },
   { value: "assistant", label: "Assistant" },
-];
-
-const TEMPLATE_FORMATS = [
-  {
-    value: "mustache",
-    label: "Mustache",
-    icon: "{{x}}",
-    description: "{{variable}}",
-  },
-  {
-    value: "jinja",
-    label: "Jinja",
-    icon: "{% %}",
-    description: "{{ variable }}, {% if %}",
-  },
 ];
 
 const JINJA_KEYWORDS = [
@@ -46,23 +32,33 @@ const JINJA_KEYWORDS = [
 
 /**
  * Multi-message prompt editor for LLM-As-A-Judge.
- * Uses the same PromptEditor (Quill) as the agent InstructionEditor
- * for consistent variable autocomplete and styling.
+ *
+ * Renders a single bordered box (Falcon AI bar at the top when open, the
+ * message cards joined by dividers, and a bottom bar with the model
+ * selector + Add message + Falcon AI trigger) so it looks visually
+ * identical to the agent InstructionEditor. The template-format picker
+ * and the "Prompt Messages" label live in the parent LLMPromptEditor's
+ * header row, mirroring the agent layout.
+ *
+ * Uses the same PromptEditor (Quill) as the agent InstructionEditor for
+ * consistent variable autocomplete and styling.
  */
 const MessageEditor = ({
   messages = [{ role: "system", content: "" }],
   onChange,
   templateFormat = "mustache",
-  onTemplateFormatChange,
   datasetColumns = [],
   datasetJsonSchemas = {},
   disabled = false,
   modelSelectorDisabled,
-  // Optional model selector — when provided, renders inline in the top
-  // bar alongside the template format picker so LLM-as-a-judge has the
-  // same top-bar layout as the agent InstructionEditor.
   model,
   onModelChange,
+  // Falcon AI: the parent renders the AI bar node (shown at the top of
+  // the box when open) and passes the trigger handler for the bottom-bar
+  // icon. aiOpen hides the trigger while the bar is open, matching agent.
+  aiBar,
+  onFalconClick,
+  aiOpen = false,
 }) => {
   // Build dropdown options for variable autocomplete (same logic as InstructionEditor)
   const dropdownOptions = useMemo(() => {
@@ -181,18 +177,124 @@ const MessageEditor = ({
         : "Enter message content...";
 
   return (
-    <Box>
-      {/* Top bar — model selector on the left, template format selector
-          on the right. Matches the top bar of InstructionEditor (agent
-          flow) so LLM-as-a-judge and agent editors look consistent. */}
-      {(onModelChange || onTemplateFormatChange) && (
+    <>
+      <Box
+        sx={{
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: "8px",
+          "&:focus-within": {
+            borderColor: disabled ? undefined : "primary.main",
+          },
+          ...(disabled && {
+            cursor: "not-allowed",
+            "& .ql-editor, & .ql-container, & .ql-toolbar": {
+              cursor: "not-allowed !important",
+            },
+          }),
+        }}
+      >
+        {/* ── Falcon AI bar (rendered at the top of the box when open) ── */}
+        {aiBar}
+
+        {/* ── Message cards — joined inside the single bordered box and
+          separated by dividers, mirroring the agent InstructionEditor's
+          single editor box. ── */}
+        <Box sx={{ display: "flex", flexDirection: "column" }}>
+          {messages.map((msg, i) => (
+            <Box
+              key={i}
+              sx={{
+                borderBottom: i < messages.length - 1 ? "1px solid" : "none",
+                borderColor: "divider",
+              }}
+            >
+              {/* Role header */}
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  px: 1.5,
+                  pt: 1,
+                  pb: 0.5,
+                }}
+              >
+                <Select
+                  size="small"
+                  value={msg.role}
+                  onChange={(e) => handleUpdateRole(i, e.target.value)}
+                  disabled={disabled}
+                  variant="standard"
+                  disableUnderline
+                  sx={{
+                    fontSize: "13px",
+                    fontWeight: 600,
+                    "& .MuiSelect-select": { py: 0, pr: "28px !important" },
+                    "& .MuiSelect-icon": { right: 0 },
+                  }}
+                >
+                  {ROLES.map((r) => (
+                    <MenuItem
+                      key={r.value}
+                      value={r.value}
+                      sx={{ fontSize: "13px" }}
+                    >
+                      {r.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+                  {messages.length > 1 && (
+                    <IconButton
+                      size="small"
+                      onClick={() => handleRemoveMessage(i)}
+                      disabled={disabled}
+                      sx={{ p: 0.25, opacity: 0.5, "&:hover": { opacity: 1 } }}
+                    >
+                      <Iconify icon="mdi:close" width={14} />
+                    </IconButton>
+                  )}
+                </Box>
+              </Box>
+
+              {/* Content — same PromptEditor as agent InstructionEditor */}
+              <MessageEditorBlock
+                content={msg.content}
+                onContentChange={(text) => handleUpdateContent(i, text)}
+                placeholder={i === 0 ? placeholder : "Enter message content..."}
+                minHeight={i === 0 ? 80 : 50}
+                dropdownOptions={dropdownOptions}
+                mentionEnabled={mentionEnabled}
+                mentionDenotationChars={denotationChars}
+                onMentionSelect={
+                  templateFormat === "jinja" ? handleMentionSelect : undefined
+                }
+                disabled={disabled}
+                templateFormat={templateFormat}
+                allVariablesValid={templateFormat !== "jinja"}
+                variableValidator={
+                  templateFormat === "jinja" ? variableValidator : undefined
+                }
+                jinjaMode={templateFormat === "jinja"}
+              />
+            </Box>
+          ))}
+        </Box>
+
+        {/* ── Bottom bar inside the box: model selector (left) + Add message
+          + Falcon AI trigger (right), separated by a top divider —
+          identical in spirit to the agent InstructionEditor's model bar. ── */}
         <Box
           sx={{
+            px: 1.5,
+            py: 1,
+            borderTop: "1px solid",
+            borderColor: "divider",
             display: "flex",
             alignItems: "center",
-            justifyContent: "space-between",
             gap: 1,
-            mb: 0.75,
           }}
         >
           {onModelChange ? (
@@ -208,174 +310,37 @@ const MessageEditor = ({
           ) : (
             <Box sx={{ flex: 1 }} />
           )}
-          {onTemplateFormatChange && (
-            <Select
-              size="small"
-              value={templateFormat}
-              onChange={(e) => onTemplateFormatChange?.(e.target.value)}
-              disabled={disabled}
-              variant="outlined"
-              sx={{
-                fontSize: "13px",
-                height: 30,
-                borderColor: "divider",
-                "& .MuiOutlinedInput-notchedOutline": {
-                  borderColor: "divider",
-                },
-              }}
-              renderValue={(val) => {
-                const fmt = TEMPLATE_FORMATS.find((f) => f.value === val);
-                return (
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                    <Typography
-                      sx={{
-                        fontSize: "12px",
-                        fontFamily: "monospace",
-                        fontWeight: 600,
-                      }}
-                    >
-                      {fmt?.icon}
-                    </Typography>
-                    <Typography sx={{ fontSize: "12px" }}>
-                      {fmt?.label}
-                    </Typography>
-                  </Box>
-                );
-              }}
-            >
-              {TEMPLATE_FORMATS.map((fmt) => (
-                <MenuItem
-                  key={fmt.value}
-                  value={fmt.value}
-                  sx={{ fontSize: "13px", gap: 1 }}
-                >
-                  <Typography
-                    sx={{
-                      fontSize: "12px",
-                      fontFamily: "monospace",
-                      fontWeight: 600,
-                      minWidth: 32,
-                    }}
-                  >
-                    {fmt.icon}
-                  </Typography>
-                  <Box>
-                    <Typography variant="body2" sx={{ fontSize: "13px" }}>
-                      {fmt.label}
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ fontSize: "11px" }}
-                    >
-                      {fmt.description}
-                    </Typography>
-                  </Box>
-                </MenuItem>
-              ))}
-            </Select>
-          )}
-        </Box>
-      )}
 
-      {/* Message cards */}
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 0 }}>
-        {messages.map((msg, i) => (
-          <Box
-            key={i}
-            sx={{
-              border: "1px solid",
-              borderColor: "divider",
-              borderRadius:
-                i === 0
-                  ? "8px 8px 0 0"
-                  : i === messages.length - 1
-                    ? "0 0 8px 8px"
-                    : 0,
-              borderTop: i > 0 ? "none" : undefined,
-              "&:focus-within": {
-                borderColor: "primary.main",
-                zIndex: 1,
-                position: "relative",
-              },
-            }}
-          >
-            {/* Role header */}
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                px: 1.5,
-                pt: 1,
-                pb: 0.5,
-              }}
-            >
-              <Select
+          {onFalconClick && !aiOpen && (
+            <Tooltip title="Generate with Falcon AI" arrow placement="top">
+              <IconButton
                 size="small"
-                value={msg.role}
-                onChange={(e) => handleUpdateRole(i, e.target.value)}
+                onClick={onFalconClick}
                 disabled={disabled}
-                variant="standard"
-                disableUnderline
                 sx={{
-                  fontSize: "13px",
-                  fontWeight: 600,
-                  "& .MuiSelect-select": { py: 0, pr: 2 },
+                  width: 32,
+                  height: 32,
+                  flexShrink: 0,
+                  "&:hover": {
+                    backgroundColor: (theme) =>
+                      theme.palette.mode === "dark"
+                        ? "rgba(124,77,255,0.12)"
+                        : "rgba(124,77,255,0.06)",
+                  },
                 }}
               >
-                {ROLES.map((r) => (
-                  <MenuItem
-                    key={r.value}
-                    value={r.value}
-                    sx={{ fontSize: "13px" }}
-                  >
-                    {r.label}
-                  </MenuItem>
-                ))}
-              </Select>
-
-              <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
-                {messages.length > 1 && (
-                  <IconButton
-                    size="small"
-                    onClick={() => handleRemoveMessage(i)}
-                    disabled={disabled}
-                    sx={{ p: 0.25, opacity: 0.5, "&:hover": { opacity: 1 } }}
-                  >
-                    <Iconify icon="mdi:close" width={14} />
-                  </IconButton>
-                )}
-              </Box>
-            </Box>
-
-            {/* Content — same PromptEditor as agent InstructionEditor */}
-            <MessageEditorBlock
-              content={msg.content}
-              onContentChange={(text) => handleUpdateContent(i, text)}
-              placeholder={i === 0 ? placeholder : "Enter message content..."}
-              minHeight={i === 0 ? 80 : 50}
-              dropdownOptions={dropdownOptions}
-              mentionEnabled={mentionEnabled}
-              mentionDenotationChars={denotationChars}
-              onMentionSelect={
-                templateFormat === "jinja" ? handleMentionSelect : undefined
-              }
-              disabled={disabled}
-              templateFormat={templateFormat}
-              allVariablesValid={templateFormat !== "jinja"}
-              variableValidator={
-                templateFormat === "jinja" ? variableValidator : undefined
-              }
-              jinjaMode={templateFormat === "jinja"}
-            />
-          </Box>
-        ))}
+                <SvgColor
+                  src="/assets/icons/navbar/ic_falcon_ai.svg"
+                  sx={{ width: 20, height: 20, color: "primary.main" }}
+                />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
       </Box>
 
-      {/* Bottom bar: + Message. Template format moved to the top bar
-          above for parity with the agent InstructionEditor. */}
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1 }}>
+      {/* ── Add message — sits outside the box, bottom-left. ── */}
+      <Box sx={{ mt: 1 }}>
         <Button
           size="small"
           variant="outlined"
@@ -393,7 +358,7 @@ const MessageEditor = ({
           Message
         </Button>
       </Box>
-    </Box>
+    </>
   );
 };
 
@@ -406,13 +371,15 @@ MessageEditor.propTypes = {
   ),
   onChange: PropTypes.func.isRequired,
   templateFormat: PropTypes.oneOf(["mustache", "jinja"]),
-  onTemplateFormatChange: PropTypes.func,
   model: PropTypes.string,
   onModelChange: PropTypes.func,
   datasetColumns: PropTypes.array,
   datasetJsonSchemas: PropTypes.object,
   disabled: PropTypes.bool,
   modelSelectorDisabled: PropTypes.bool,
+  aiBar: PropTypes.node,
+  onFalconClick: PropTypes.func,
+  aiOpen: PropTypes.bool,
 };
 
 export default MessageEditor;

--- a/frontend/src/sections/evals/components/MessageEditor.jsx
+++ b/frontend/src/sections/evals/components/MessageEditor.jsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import { useCallback, useMemo } from "react";
 import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
+import { ShowComponent } from "src/components/show";
 import { extractJinjaVariables } from "src/utils/jinjaVariables";
 import MessageEditorBlock from "./MessageEditorBlock";
 import ModelSelector from "./ModelSelector";
@@ -311,7 +312,7 @@ const MessageEditor = ({
             <Box sx={{ flex: 1 }} />
           )}
 
-          {onFalconClick && !aiOpen && (
+          <ShowComponent condition={onFalconClick && !aiOpen}>
             <Tooltip title="Generate with Falcon AI" arrow placement="top">
               <IconButton
                 size="small"
@@ -321,12 +322,7 @@ const MessageEditor = ({
                   width: 32,
                   height: 32,
                   flexShrink: 0,
-                  "&:hover": {
-                    backgroundColor: (theme) =>
-                      theme.palette.mode === "dark"
-                        ? "rgba(124,77,255,0.12)"
-                        : "rgba(124,77,255,0.06)",
-                  },
+                  "&:hover": { backgroundColor: "background.aiHover" },
                 }}
               >
                 <SvgColor
@@ -335,7 +331,7 @@ const MessageEditor = ({
                 />
               </IconButton>
             </Tooltip>
-          )}
+          </ShowComponent>
         </Box>
       </Box>
 

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -1197,9 +1197,8 @@ const ModelSelector = ({
                 Your Models
               </Typography>
               {apiModels.map((m) => {
-                // API is snake_case; read camelCase too in case the contract changes.
-                const available = (m.isAvailable ?? m.is_available) !== false;
-                const logoUrl = m.logoUrl || m.logo_url;
+                const available = m.is_available !== false;
+                const logoUrl = m.logo_url;
                 return (
                   <MenuItem
                     key={m.model_name}

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -26,6 +26,7 @@ import { useDebounce } from "src/hooks/use-debounce";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import { useNavigate } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
+import { getProviderLogoFilterSx } from "./modelLogo";
 
 // ---------------------------------------------------------------------------
 // Modes — how the evaluator runs
@@ -1196,17 +1197,9 @@ const ModelSelector = ({
                 Your Models
               </Typography>
               {apiModels.map((m) => {
-                // The models_list API returns snake_case `is_available`;
-                // read the camelCase form too in case the contract changes.
+                // API is snake_case; read camelCase too in case the contract changes.
                 const available = (m.isAvailable ?? m.is_available) !== false;
-                // The models_list API returns snake_case `logo_url`; keep
-                // reading the camelCase form too in case the contract changes.
                 const logoUrl = m.logoUrl || m.logo_url;
-                // OpenAI's logo is a solid-black PNG — invert it to white in
-                // dark mode so it stays visible on the dark menu background.
-                const isOpenAI = (m.providers || "")
-                  .toLowerCase()
-                  .includes("openai");
                 return (
                   <MenuItem
                     key={m.model_name}
@@ -1241,12 +1234,7 @@ const ModelSelector = ({
                           height: 18,
                           borderRadius: "4px",
                           flexShrink: 0,
-                          ...(isOpenAI && {
-                            filter: (theme) =>
-                              theme.palette.mode === "dark"
-                                ? "brightness(0) invert(1)"
-                                : "none",
-                          }),
+                          ...getProviderLogoFilterSx(m.providers),
                         }}
                       />
                     ) : (

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -1197,6 +1197,14 @@ const ModelSelector = ({
               </Typography>
               {apiModels.map((m) => {
                 const available = m.isAvailable !== false;
+                // The models_list API returns snake_case `logo_url`; keep
+                // reading the camelCase form too in case the contract changes.
+                const logoUrl = m.logoUrl || m.logo_url;
+                // OpenAI's logo is a solid-black PNG — invert it to white in
+                // dark mode so it stays visible on the dark menu background.
+                const isOpenAI = (m.providers || "")
+                  .toLowerCase()
+                  .includes("openai");
                 return (
                   <MenuItem
                     key={m.model_name}
@@ -1222,15 +1230,21 @@ const ModelSelector = ({
                       }),
                     }}
                   >
-                    {m.logoUrl ? (
+                    {logoUrl ? (
                       <Box
                         component="img"
-                        src={m.logoUrl}
+                        src={logoUrl}
                         sx={{
                           width: 18,
                           height: 18,
                           borderRadius: "4px",
                           flexShrink: 0,
+                          ...(isOpenAI && {
+                            filter: (theme) =>
+                              theme.palette.mode === "dark"
+                                ? "brightness(0) invert(1)"
+                                : "none",
+                          }),
                         }}
                       />
                     ) : (

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -1196,7 +1196,9 @@ const ModelSelector = ({
                 Your Models
               </Typography>
               {apiModels.map((m) => {
-                const available = m.isAvailable !== false;
+                // The models_list API returns snake_case `is_available`;
+                // read the camelCase form too in case the contract changes.
+                const available = (m.isAvailable ?? m.is_available) !== false;
                 // The models_list API returns snake_case `logo_url`; keep
                 // reading the camelCase form too in case the contract changes.
                 const logoUrl = m.logoUrl || m.logo_url;

--- a/frontend/src/sections/evals/components/__tests__/ModelSelector.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/ModelSelector.test.jsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ModelSelector from "../ModelSelector";
+
+const mockGet = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: (...args) => mockGet(...args) },
+  endpoints: {
+    develop: {
+      modelList: "/model-hub/api/models_list/",
+      eval: {
+        summaryTemplates: "/eval/summary-templates/",
+        summaryTemplate: (id) => `/eval/summary-templates/${id}/`,
+      },
+    },
+    falconAI: { connectors: "/falcon-ai/connectors/" },
+    knowledge: { list: "/knowledge/list/" },
+  },
+}));
+
+// KeysDrawer pulls in its own data fetching / drawer chrome that is
+// irrelevant to the model-logo behaviour under test.
+vi.mock("src/components/custom-model-dropdown/KeysDrawer", () => ({
+  default: () => null,
+}));
+
+const OPENAI_LOGO =
+  "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/openai-icon.png";
+
+function mockModelList(models) {
+  mockGet.mockImplementation((url) => {
+    if (url === "/model-hub/api/models_list/") {
+      return Promise.resolve({
+        data: { results: models, next: null, current_page: 1 },
+      });
+    }
+    // connectors + knowledge bases — empty is fine for these tests
+    return Promise.resolve({ data: { results: [] } });
+  });
+}
+
+function renderSelector(props = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ModelSelector model="" onModelChange={vi.fn()} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ModelSelector — BYOK model logos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the provider logo from the API's snake_case `logo_url` field", async () => {
+    mockModelList([
+      { model_name: "gpt-5.5", providers: "openai", logo_url: OPENAI_LOGO },
+    ]);
+    renderSelector();
+
+    // The model-list query is only enabled once the dropdown opens.
+    await userEvent.click(screen.getByText("Select model"));
+
+    expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
+    const logo = document.querySelector(`img[src="${OPENAI_LOGO}"]`);
+    expect(logo).toBeTruthy();
+  });
+
+  it("falls back to the cube icon (no <img>) when the model has no logo", async () => {
+    mockModelList([{ model_name: "local-model", providers: "custom" }]);
+    renderSelector();
+
+    await userEvent.click(screen.getByText("Select model"));
+
+    expect(await screen.findByText("local-model")).toBeInTheDocument();
+    // No raster logo should render — the component uses an Iconify <svg> cube.
+    expect(document.querySelector("img")).toBeNull();
+  });
+});

--- a/frontend/src/sections/evals/components/__tests__/ModelSelector.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/ModelSelector.test.jsx
@@ -79,4 +79,19 @@ describe("ModelSelector — BYOK model logos", () => {
     // No raster logo should render — the component uses an Iconify <svg> cube.
     expect(document.querySelector("img")).toBeNull();
   });
+
+  it("treats a model with snake_case `is_available: false` as unavailable (no selection on click)", async () => {
+    mockModelList([
+      { model_name: "gpt-5.5", providers: "openai", is_available: false },
+    ]);
+    const onModelChange = vi.fn();
+    renderSelector({ onModelChange });
+
+    await userEvent.click(screen.getByText("Select model"));
+    const row = await screen.findByText("gpt-5.5");
+
+    // Clicking an unavailable model opens the keys drawer instead of selecting it.
+    await userEvent.click(row);
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/sections/evals/components/modelLogo.js
+++ b/frontend/src/sections/evals/components/modelLogo.js
@@ -1,0 +1,15 @@
+// Providers whose logos ship as solid-black PNGs and disappear on the dark
+// menu background — they need inverting to white in dark mode.
+const DARK_INVERT_PROVIDERS = ["openai"];
+
+// Returns the sx `filter` for a model provider's logo. Unknown, missing, or
+// non-inverting providers get an empty object, so the logo renders untouched.
+export function getProviderLogoFilterSx(providers) {
+  const name = (providers ?? "").toString().toLowerCase();
+  const needsInvert = DARK_INVERT_PROVIDERS.some((p) => name.includes(p));
+  if (!needsInvert) return {};
+  return {
+    filter: (theme) =>
+      theme.palette.mode === "dark" ? "brightness(0) invert(1)" : "none",
+  };
+}

--- a/frontend/src/theme/palette.js
+++ b/frontend/src/theme/palette.js
@@ -331,6 +331,9 @@ export function palette(mode) {
       neutral: "#F8F8F8",
       subtle: "#F8F8F8",
       accent: grey[100],
+      // Falcon AI surfaces (inline AI bar background + AI-action hover)
+      aiSurface: "#fafafe",
+      aiHover: "rgba(124, 77, 255, 0.06)",
     },
     action: {
       ...base.action,
@@ -371,6 +374,9 @@ export function palette(mode) {
       neutral: darkSpace.asteroid,
       subtle: darkSpace.dust,
       accent: darkSpace.shadow,
+      // Falcon AI surfaces (inline AI bar background + AI-action hover)
+      aiSurface: "#1a1a2e",
+      aiHover: "rgba(124, 77, 255, 0.12)",
     },
     divider: darkBorder.default,
     action: {


### PR DESCRIPTION
## 1. Why the changes are made

In the **Create Evaluation** flow, the model-selection UI was inconsistent and had a few visual/visibility bugs:

- The model selector sat **above** the prompt in the **LLM-As-A-Judge** tab but **below** it in the **Agents** tab — inconsistent placement for the same control.
- The LLM-As-A-Judge editor box didn't visually match the Agents editor box (template-format picker, Falcon AI trigger, and model bar were laid out differently).
- The role dropdown (`System ▾`) had the chevron cramped against the label.
- BYOK ("Your Models") entries showed a generic cube icon instead of the real provider logos.
- The OpenAI logo (a solid-black PNG) was nearly invisible on the dark dropdown background.

The goal: make the LLM-As-A-Judge editor visually consistent with the Agents editor and fix the model-logo rendering.

## 2. What changes have been made

All changes are frontend-only, under `frontend/src/sections/evals/components/`:

- **`MessageEditor.jsx`** — restructured the LLM-As-A-Judge editor into a **single bordered box** matching the Agents `InstructionEditor`: Falcon AI bar at the top (when open), messages joined by dividers, and a bottom bar **inside the box** with the model selector (left) + Falcon AI icon (right). The model selector now sits **below** the prompt (consistent with the Agents tab). The role dropdown gets extra right padding (`28px`) so the label and chevron aren't cramped. The `+ Message` button was moved **outside the box, bottom-left**.
- **`LLMPromptEditor.jsx`** — header row now mirrors the Agents tab: `Prompt Messages*` label (left) + **template-format pill** (right). The Falcon AI bar is restyled to render inside the editor box and is passed down to `MessageEditor`.
- **`ModelSelector.jsx`** — fixed the provider-logo rendering. The model-list API (`/model-hub/api/models_list/`) returns each model's logo as snake_case **`logo_url`**, but the component read camelCase `m.logoUrl` (always `undefined`), so it always fell back to the cube icon. Now reads `m.logoUrl || m.logo_url`. Fixed the **same snake/camel mismatch for availability** — the API returns `is_available` but the component read `m.isAvailable` (always `undefined`), so every model was treated as available regardless of whether a key was configured; now reads `(m.isAvailable ?? m.is_available)`. Additionally, the OpenAI logo (solid-black PNG) is **inverted to white in dark mode only** so it stays visible on the dark menu background (scoped to OpenAI via the `providers` field; light mode keeps the original).

## 3. What all tests are being written (both new and old)

- **New:** `frontend/src/sections/evals/components/__tests__/ModelSelector.test.jsx` (3 tests). This component family had **no pre-existing tests**; this is the first test for it. The presentational/layout changes (box structure, control placement, spacing, dark-mode logo inversion) are verified manually (see §6/§7) since they aren't meaningfully assertable in jsdom.
- **Old:** No existing tests cover these components, so none needed updating. The full suite was run to confirm no regressions elsewhere.

## 4. What all test scenarios does each test cover

`ModelSelector.test.jsx`:
1. **Renders the provider logo from the API's snake_case `logo_url`** — mocks the model-list endpoint to return a model with `logo_url`, opens the dropdown, and asserts an `<img>` with that exact `src` renders (regression guard for the camelCase/snake_case bug).
2. **Falls back to the cube icon when the model has no logo** — mocks a model with no logo field and asserts no `<img>` renders (the cube is an Iconify `<svg>`).
3. **Treats `is_available: false` as unavailable** — mocks a model with snake_case `is_available: false`, clicks it, and asserts `onModelChange` is **not** called (clicking an unavailable model opens the keys drawer instead of selecting it).

## 5. Commands to run these tests

```bash
cd frontend

# Run just the new test
yarn test:run src/sections/evals/components/__tests__/ModelSelector.test.jsx

# Run the full suite (confirm no regressions)
yarn test:run

# Lint the changed files
yarn lint
```

## 6. Steps to test the specific PR changes on local/dev

```bash
# From the worktree/branch
cd frontend
cp .env.example .env   # if you don't already have a .env (set API base URL)
yarn install
yarn dev               # serves on http://localhost:3031
```

Then in the browser:
1. Go to **Evals → Create evaluation**.
2. **Agents tab**: note the model selector sits below the instruction box.
3. Switch to **LLM-As-A-Judge tab**: confirm the editor box now matches the Agents box — header has the template-format pill, the model selector is in the bottom bar inside the box with the Falcon AI icon on the right, and `+ Message` is below the box on the left.
4. Open the **model dropdown** → under "Your Models", confirm real provider logos render (not cubes), and the OpenAI logo is white/visible in dark mode (and the original in light mode).
5. Open the **role dropdown** (System ▾) and confirm comfortable spacing between the label and chevron.

## 7. Screenshots / videos

**Agents tab** — model selector below the instruction box (reference layout):

<img width="1506" height="935" alt="Create evaluation — Agents tab" src="https://github.com/user-attachments/assets/a145f0e4-de58-423e-99b9-6168f1e53f2b" />

**LLM-As-A-Judge tab** — now matches the Agents box: header with template-format pill, model selector in the bottom bar inside the box, `+ Message` below the box on the left:

<img width="1506" height="935" alt="Create evaluation — LLM-As-A-Judge tab" src="https://github.com/user-attachments/assets/6554f174-a69c-43c0-b887-04609bdda793" />

## 8. Why the specific architectural / important decisions were preferred

- **Defensive `m.logoUrl || m.logo_url`** rather than renaming one side: responses from this endpoint are not camelCased (the component already reads `m.model_name`/`m.providers` raw), and the codebase already uses this `camel ?? snake` defensive pattern elsewhere (e.g. `providerLogo ?? provider_logo`). Reading both is the lowest-risk fix and is resilient if the API contract later changes.
- **CSS filter (`brightness(0) invert(1)`) scoped to dark mode + OpenAI** rather than shipping a recolored asset or a backend change: the logo is a remote raster PNG, so it can't be recolored via `currentColor`. Inverting only in dark mode keeps the original (correct) black logo in light mode, and scoping by `providers` avoids washing out other providers' colored logos.
- **Kept the Falcon AI bar / `+ Message` behaviour intact** while restructuring layout: the change is purely presentational so functionality (multi-message editing, AI generation) is unchanged and low-risk.
- **Also fixed the `is_available` / `isAvailable` mismatch (frontend-only):** same root cause as the logo bug. Previously every model rendered as "available" regardless of whether a key was configured (because `m.isAvailable` was always `undefined`); now key-less models correctly render as unavailable and open the keys drawer on click. This is the intended product behaviour and required no backend change, so it's included here alongside the logo fix.
