### PR TITLE
fix: correct indentation bugs in async prompt runners

### DIFF
--- a/futureagi/model_hub/tests/test_async_prompt_runners.py
+++ b/futureagi/model_hub/tests/test_async_prompt_runners.py
@@ -1,0 +1,151 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from tfc.constants.api_calls import APICallStatusChoices
+
+
+def _sync_to_async(func):
+    async def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class _UsageEvent:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _install_usage_modules(monkeypatch, emitted):
+    modules = {
+        "ee": types.ModuleType("ee"),
+        "ee.usage": types.ModuleType("ee.usage"),
+        "ee.usage.schemas": types.ModuleType("ee.usage.schemas"),
+        "ee.usage.services": types.ModuleType("ee.usage.services"),
+        "ee.usage.utils": types.ModuleType("ee.usage.utils"),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    event_types = types.ModuleType("ee.usage.schemas.event_types")
+    event_types.BillingEventType = SimpleNamespace(
+        AI_PROMPT_CREATION="ai_prompt_creation",
+        AI_PROMPT_IMPROVEMENT="ai_prompt_improvement",
+    )
+    monkeypatch.setitem(sys.modules, "ee.usage.schemas.event_types", event_types)
+
+    events = types.ModuleType("ee.usage.schemas.events")
+    events.UsageEvent = _UsageEvent
+    monkeypatch.setitem(sys.modules, "ee.usage.schemas.events", events)
+
+    config = types.ModuleType("ee.usage.services.config")
+    config.BillingConfig = SimpleNamespace(
+        get=lambda: SimpleNamespace(calculate_ai_credits=lambda cost: cost * 100)
+    )
+    monkeypatch.setitem(sys.modules, "ee.usage.services.config", config)
+
+    emitter = types.ModuleType("ee.usage.services.emitter")
+    emitter.emit = emitted.append
+    monkeypatch.setitem(sys.modules, "ee.usage.services.emitter", emitter)
+
+    properties = types.ModuleType("ee.usage.utils.event_properties")
+    properties.llm_usage_properties = lambda generator: {"model": "fake-model"}
+    monkeypatch.setitem(sys.modules, "ee.usage.utils.event_properties", properties)
+
+
+@pytest.mark.asyncio
+async def test_improve_prompt_insufficient_credits_returns_before_generator(
+    monkeypatch,
+):
+    from model_hub.utils import async_improve_prompt_runner as runner
+
+    class FakePromptGenerator:
+        called = False
+
+        async def _improve_prompt_async(self, **kwargs):
+            FakePromptGenerator.called = True
+
+    class FakeWsManager:
+        def __init__(self):
+            self.errors = []
+
+        async def send_improve_prompt_error_message(self, **kwargs):
+            self.errors.append(kwargs)
+
+    monkeypatch.setattr(runner, "database_sync_to_async", _sync_to_async)
+    monkeypatch.setattr(runner, "close_old_connections", lambda: None)
+    monkeypatch.setattr(runner.Organization.objects, "get", lambda id: object())
+    monkeypatch.setattr(runner, "PromptGenerator", FakePromptGenerator)
+    monkeypatch.setattr(runner, "count_text_tokens", lambda text: len(text))
+    monkeypatch.setattr(runner, "log_and_deduct_cost_for_api_request", lambda *args, **kwargs: None)
+
+    ws_manager = FakeWsManager()
+
+    await runner.improve_prompt_async(
+        original_prompt="Original prompt",
+        improvement_suggestions="Make it clearer",
+        examples=[],
+        improve_id="improve-1",
+        organization_id="org-1",
+        user_id="user-1",
+        uid="uid-1",
+        workspace=object(),
+        ws_manager=ws_manager,
+    )
+
+    assert ws_manager.errors == [
+        {"improve_id": "improve-1", "error": "Insufficient credits"}
+    ]
+    assert FakePromptGenerator.called is False
+
+
+@pytest.mark.asyncio
+async def test_generate_prompt_emits_usage_event_after_success(monkeypatch):
+    from model_hub.utils import async_generate_prompt_runner as runner
+
+    emitted = []
+    _install_usage_modules(monkeypatch, emitted)
+
+    class FakePromptGenerator:
+        def __init__(self):
+            self.llm = SimpleNamespace(cost={"total_cost": 1.25})
+
+        async def _generate_prompt_async(self, **kwargs):
+            return None
+
+    monkeypatch.setattr(runner, "database_sync_to_async", _sync_to_async)
+    monkeypatch.setattr(runner, "close_old_connections", lambda: None)
+    monkeypatch.setattr(runner.Organization.objects, "get", lambda id: object())
+    monkeypatch.setattr(runner, "PromptGenerator", FakePromptGenerator)
+    monkeypatch.setattr(runner, "count_text_tokens", lambda text: len(text))
+    monkeypatch.setattr(
+        runner,
+        "log_and_deduct_cost_for_api_request",
+        lambda *args, **kwargs: SimpleNamespace(
+            status=APICallStatusChoices.PROCESSING.value
+        ),
+    )
+
+    await runner.generate_prompt_async(
+        description="Generate a concise support prompt",
+        generation_id="generation-1",
+        organization_id="org-1",
+        user_id="user-1",
+        uid="uid-1",
+        workspace=object(),
+        ws_manager=SimpleNamespace(),
+    )
+
+    assert len(emitted) == 1
+    assert emitted[0].org_id == "org-1"
+    assert emitted[0].event_type == "ai_prompt_creation"
+    assert emitted[0].amount == 125
+    assert emitted[0].properties == {
+        "source": "run_prompt_gen",
+        "source_id": "generation-1",
+        "raw_cost_usd": "1.25",
+        "model": "fake-model",
+    }

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -132,21 +132,19 @@ async def generate_prompt_async(
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
                 emit(
-                UsageEvent(
-                    org_id=str(organization_id),
-                    event_type=BillingEventType.AI_PROMPT_CREATION,
-                    amount=credits,
-                    properties={
-                        "source": "run_prompt_gen",
-                        "source_id": str(generation_id),
-                        "raw_cost_usd": str(actual_cost),
-                        **llm_usage_properties(prompt_generator),
-                    },
+                    UsageEvent(
+                        org_id=str(organization_id),
+                        event_type=BillingEventType.AI_PROMPT_CREATION,
+                        amount=credits,
+                        properties={
+                            "source": "run_prompt_gen",
+                            "source_id": str(generation_id),
+                            "raw_cost_usd": str(actual_cost),
+                            **llm_usage_properties(prompt_generator),
+                        },
+                    )
                 )
-            )
         except Exception:
             pass
 

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -90,8 +90,8 @@ async def improve_prompt_async(
                 await ws_manager.send_improve_prompt_error_message(
                     improve_id=improve_id,
                     error="Insufficient credits",
-            )
-            return
+                )
+                return
 
         # Run the improve_prompt process with WebSocket manager
         # Use async version when ws_manager is provided (WebSocket context)
@@ -140,21 +140,19 @@ async def improve_prompt_async(
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
                 emit(
-                UsageEvent(
-                    org_id=str(organization_id),
-                    event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,
-                    amount=credits,
-                    properties={
-                        "source": "run_prompt_improve",
-                        "source_id": str(improve_id),
-                        "raw_cost_usd": str(actual_cost),
-                        **llm_usage_properties(prompt_generator),
-                    },
+                    UsageEvent(
+                        org_id=str(organization_id),
+                        event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,
+                        amount=credits,
+                        properties={
+                            "source": "run_prompt_improve",
+                            "source_id": str(improve_id),
+                            "raw_cost_usd": str(actual_cost),
+                            **llm_usage_properties(prompt_generator),
+                        },
+                    )
                 )
-            )
         except Exception:
             pass
 

--- a/futureagi/model_hub/utils/async_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_prompt_runner.py
@@ -160,14 +160,14 @@ async def run_template_async(
                         if emit is not None and UsageEvent is not None:
                             emit(
                                 UsageEvent(
-                                org_id=str(organization.id),
-                                event_type=APICallTypeChoices.PROMPT_BENCH.value,
-                                properties={
-                                    "source": "run_prompt_gen",
-                                    "source_id": str(template.id),
-                                },
+                                    org_id=str(organization.id),
+                                    event_type=APICallTypeChoices.PROMPT_BENCH.value,
+                                    properties={
+                                        "source": "run_prompt_gen",
+                                        "source_id": str(template.id),
+                                    },
+                                )
                             )
-                        )
                     except Exception:
                         pass  # Metering failure must not break the action
 


### PR DESCRIPTION
- async_improve_prompt_runner: return statement was outside the insufficient-credits guard, causing improve-prompt to always exit early regardless of credit balance
- async_generate_prompt_runner: emit() call closing paren was misaligned, placing the call outside the null-check guard
- async_prompt_runner: UsageEvent args were misindented inside emit()

All three files had the same copy-paste origin error.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
