### PR TITLE
fix: don't reserve queue items for the reviewer who sent them back (TH-6238)

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_advanced_api.py
+++ b/futureagi/model_hub/tests/test_annotation_advanced_api.py
@@ -218,6 +218,38 @@ class TestReservations:
         assert item.reserved_by == user
         assert item.reservation_expires_at is not None
 
+    def test_reviewer_reopening_reviewed_item_does_not_reserve(
+        self, auth_client, organization, workspace, user
+    ):
+        """After a reviewer requests changes, re-opening the item must not grab
+        the editing lock. The FE re-fetches annotate-detail with reserve=true
+        right after the review; if the reviewer takes the reservation it
+        survives the hand-back and strands the annotator who has to rework the
+        item until expiry (the review/reservation deadlock).
+        """
+        queue_id = _create_queue(auth_client, name="Res Review Q")
+        _, row = _create_dataset_row(organization, workspace)
+        item = _add_item(auth_client, queue_id, row)
+
+        # Item sent back for rework: the auth user (a queue manager => reviewer)
+        # is recorded as its reviewer.
+        item.status = "in_progress"
+        item.review_status = "rejected"
+        item.reviewed_by = user
+        item.reviewed_at = timezone.now()
+        item.save(
+            update_fields=["status", "review_status", "reviewed_by", "reviewed_at"]
+        )
+
+        resp = auth_client.get(
+            f"{QUEUE_URL}{queue_id}/items/{item.id}/annotate-detail/",
+            {"reserve": "true"},
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        item.refresh_from_db()
+        assert item.reserved_by is None
+        assert item.reservation_expires_at is None
+
     def test_release_reservation(self, auth_client, organization, workspace):
         queue_id = _create_queue(auth_client, name="Res Q2")
         _, row = _create_dataset_row(organization, workspace)

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -5818,8 +5818,18 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             if assignment_denial_reason:
                 return self._gm.forbidden_response(assignment_denial_reason)
 
-        # Reservation logic: opt-in via ?reserve=true query param
+        # Reservation logic: opt-in via ?reserve=true query param.
         reserve = _is_truthy(query_params.get("reserve"))
+        # The reservation is an editing lock for the user annotating their own
+        # draft. A reviewer/manager opening the review workspace, or re-opening
+        # an item that already carries a review decision (reviewed_by set — e.g.
+        # after request-changes), is acting as a reviewer, not the editor.
+        # Granting them the lock strands the annotator who must rework the item
+        # until the reservation expires. Don't reserve in those review contexts.
+        if reserve and (
+            is_review_detail or (is_reviewer and item.reviewed_by_id is not None)
+        ):
+            reserve = False
         if reserve:
             # Atomic reservation to prevent race condition
             updated = (


### PR DESCRIPTION
## TH-6238 — review ↔ reservation deadlock

**Linear:** [TH-6238](https://linear.app/future-agi/issue/TH-6238)

### Symptom (reporter)
> Nosang submitted [annotations], Kartik requested changes. Now the item shows **reserved by Kartik** — but Kartik can't make changes (it's Nosang's submission to review) and Nosang can't make changes (it's reserved for Kartik).

### Root cause
`annotate-detail?reserve=true` acquires a per-item **editing reservation** for *any* caller. The reservation is meant to serialise annotators editing the same item — but nothing stops a **reviewer** from taking it.

Flow that deadlocks:
1. Reviewer requests changes → `review_item` sets `review_status=rejected`, `reviewed_by=<reviewer>`, and **clears** the reservation.
2. The FE immediately re-fetches `annotate-detail?...&reserve=true` for the now-rejected item, and the **reviewer re-acquires the reservation**.
3. The item is now reserved by the reviewer (who has nothing left to edit), and the annotator who must rework it gets **409 `item_reserved`** until the reservation expires.

It self-heals after `reservation_timeout_minutes` (default **60 min**), so it's a 60-minute lockout, not a permanent deadlock — but it reads as a hard deadlock to the user.

### Confirmed on dev (read-only)
Stuck item `53e655b9` (queue `5752dafa`, the reporter's queue): `reserved_at = 07:59:33 > reviewed_at = 07:54:38`, both Kartik; `review_status=rejected`. Correlating `request_started`/`request_finished` by `request_id` for that window:

| time | code | user | annotator_id? |
|---|---|---|---|
| 07:59:33.581 | **200** | kartik (reviewer) | **no** |
| 07:59:05.855 | 200 | kartik (reviewer) | no |
| 07:58:33 / 07:59:50 | **409** | nosang (annotator) | — |

The call that set the **stuck** reservation carried **no `annotator_id`** — so the FE-view signal alone doesn't identify the culprit. The discriminating signal is that the acquirer is the item's **reviewer** (`reviewed_by` set).

### Fix
One guard in `annotate_detail`: refuse the reservation when the requester is acting as a reviewer — opening the review workspace (`is_review_detail`) **or** re-opening an item that already carries a review decision (`is_reviewer and reviewed_by is not None`). Annotators, and reviewers adding an annotation *before* any review decision, are unaffected.

### Why BE, not FE
The backend owns the lock; granting it to a reviewer who isn't editing is a backend correctness bug, and the fix closes the deadlock for every client. (The FE's own `!isReviewWorkspaceMode` gate misses this path because a rejected item is opened via `exclude_review_status`, not `view_mode=review`.)

### Tests
- New `test_reviewer_reopening_reviewed_item_does_not_reserve` reproduces the exact culprit path (reviewer re-opens a `reviewed_by`-set, rejected item with `reserve=true`, **no** annotator_id) → asserts the reservation is refused. **Fail-on-revert verified** (reverting the guard → reviewer reserves → test fails).
- Existing `test_annotate_detail_acquires_reservation` (annotator reserves their own fresh draft) and `test_reviewer_assigned_item_can_add_missing_annotation_during_review` (reviewer annotates *before* a decision, `reviewed_by=None`) stay green — the not-yet-reviewed reviewer-annotator case is preserved.
- Full sweep: **220 passed, 6 xfailed (pre-existing), 1 xpassed (pre-existing)** across `test_annotation_advanced_api.py` + `test_annotation_workflow_api.py`.

### Notes
- No migration, no API-contract change (no serializer fields touched).
- Out of scope: the general "annotator A reserves then abandons, annotator B waits up to 60 min" case is a separate reservation-takeover concern, not this deadlock.
