### PR TITLE
fix(frontend): annotation queue UI fixes [TH-6267, TH-6231, TH-6204, TH-6188, TH-6192]

### DIFF
--- a/frontend/src/components/ColumnDropdown/ColumnDropdown.jsx
+++ b/frontend/src/components/ColumnDropdown/ColumnDropdown.jsx
@@ -209,7 +209,7 @@ const ColumnDropdown = ({
           position: "sticky",
           top: 0,
           zIndex: 2,
-          background: "background.paper",
+          backgroundColor: "background.paper",
           padding: (theme) => theme.spacing(1),
         }}
       >

--- a/frontend/src/components/ComplexFilter/common.js
+++ b/frontend/src/components/ComplexFilter/common.js
@@ -22,6 +22,7 @@ const RangeOperators = new Set(RANGE_FILTER_OPS);
 
 export const stripUiFilterKeys = (filters = []) =>
   (Array.isArray(filters) ? filters : []).map((filter) => {
+    if (!filter || typeof filter !== "object") return filter;
     const cleaned = { ...filter };
     delete cleaned._meta;
     delete cleaned.id;

--- a/frontend/src/sections/annotations/queues/annotate/label-input.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-input.jsx
@@ -520,6 +520,13 @@ function CategoricalInput({ settings, value, onChange, focused }) {
   const options = rawOptions.map(getOptionLabel).filter(Boolean);
   const isMulti = settings.multi_choice || false;
 
+  const keyHintFor = (i) => {
+    if (options.length > 10) return null;
+    if (i < 9) return i + 1;
+    if (i === 9 && options.length === 10) return 0;
+    return null;
+  };
+
   if (isMulti) {
     return (
       <Stack spacing={0.25}>
@@ -562,7 +569,7 @@ function CategoricalInput({ settings, value, onChange, focused }) {
               />
               <Typography variant="body2">{opt}</Typography>
             </Box>
-            {focused && i < 9 && <Kbd>{i + 1}</Kbd>}
+            {focused && keyHintFor(i) !== null && <Kbd>{keyHintFor(i)}</Kbd>}
           </Box>
         ))}
       </Stack>
@@ -606,7 +613,7 @@ function CategoricalInput({ settings, value, onChange, focused }) {
               />
               <Typography variant="body2">{opt}</Typography>
             </Box>
-            {focused && i < 9 && <Kbd>{i + 1}</Kbd>}
+            {focused && keyHintFor(i) !== null && <Kbd>{keyHintFor(i)}</Kbd>}
           </Box>
         );
       })}

--- a/frontend/src/sections/annotations/queues/annotate/label-input.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-input.jsx
@@ -338,57 +338,77 @@ function StarInput({ value, settings, onChange, focused }) {
   const current = value?.rating || 0;
 
   return (
-    <Stack direction="row" spacing={0.25} alignItems="center">
-      {Array.from({ length: max }, (_, i) => {
-        const starVal = i + 1;
-        const isActive = starVal <= current;
-        return (
-          <Box
-            key={starVal}
-            onClick={() =>
-              onChange({ rating: starVal === current ? 0 : starVal })
-            }
-            sx={{
-              position: "relative",
-              cursor: "pointer",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: 32,
-              height: 32,
-              borderRadius: 0.5,
-              transition: "all 0.1s",
-              bgcolor: isActive ? "rgba(239,68,68,0.1)" : "transparent",
-              "&:hover": {
-                bgcolor: "rgba(239,68,68,0.15)",
-              },
-            }}
-          >
-            <Iconify
-              icon={isActive ? "solar:star-bold" : "solar:star-line-duotone"}
-              width={20}
+    <Stack spacing={0.5}>
+      <Stack direction="row" spacing={0.25} alignItems="center">
+        {Array.from({ length: max }, (_, i) => {
+          const starVal = i + 1;
+          const isActive = starVal <= current;
+          return (
+            <Box
+              key={starVal}
+              onClick={() =>
+                onChange({ rating: starVal === current ? 0 : starVal })
+              }
               sx={{
-                color: isActive ? "#ef4444" : "text.disabled",
-                transition: "color 0.1s",
+                position: "relative",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 32,
+                height: 32,
+                borderRadius: 0.5,
+                transition: "all 0.1s",
+                bgcolor: isActive ? "rgba(239,68,68,0.1)" : "transparent",
+                "&:hover": {
+                  bgcolor: "rgba(239,68,68,0.15)",
+                },
               }}
-            />
-            {focused && (
-              <Box
+            >
+              <Iconify
+                icon={isActive ? "solar:star-bold" : "solar:star-line-duotone"}
+                width={20}
                 sx={{
-                  position: "absolute",
-                  bottom: -1,
-                  fontSize: 8,
-                  fontWeight: 700,
-                  color: "text.disabled",
-                  lineHeight: 1,
+                  color: isActive ? "#ef4444" : "text.disabled",
+                  transition: "color 0.1s",
                 }}
-              >
-                {starVal}
-              </Box>
-            )}
-          </Box>
-        );
-      })}
+              />
+              {focused && (
+                <Box
+                  sx={{
+                    position: "absolute",
+                    bottom: -1,
+                    fontSize: 8,
+                    fontWeight: 700,
+                    color: "text.disabled",
+                    lineHeight: 1,
+                  }}
+                >
+                  {starVal === 10 ? 0 : starVal}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Stack>
+      {focused && max >= 10 && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.5,
+            color: "text.secondary",
+          }}
+        >
+          <Typography variant="caption" sx={{ fontSize: 11 }}>
+            Press
+          </Typography>
+          <Kbd>0</Kbd>
+          <Typography variant="caption" sx={{ fontSize: 11 }}>
+            for 10
+          </Typography>
+        </Box>
+      )}
     </Stack>
   );
 }

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -638,41 +638,51 @@ const LabelPanel = forwardRef(function LabelPanel(
         return;
       }
 
-      if (num < 1 || num > 9) return;
-      e.preventDefault();
-
       if (ql.type === "thumbs_up_down") {
         if (num === 1) {
+          e.preventDefault();
           handleChange(labelId, {
             value: currentVal?.value === "up" ? null : "up",
           });
         } else if (num === 2) {
+          e.preventDefault();
           handleChange(labelId, {
             value: currentVal?.value === "down" ? null : "down",
           });
         }
-      } else if (ql.type === "categorical") {
+        return;
+      }
+
+      if (ql.type === "categorical") {
         const rawOptions = ql.settings?.options || [];
         const options = rawOptions
           .map((opt) =>
             typeof opt === "string" ? opt : opt?.label || opt?.value || "",
           )
           .filter(Boolean);
-        const optIndex = num - 1;
-        if (optIndex < options.length) {
-          const opt = options[optIndex];
-          const selected = currentVal?.selected || [];
-          const isMulti = ql.settings?.multi_choice || false;
-          if (isMulti) {
-            const next = selected.includes(opt)
-              ? selected.filter((v) => v !== opt)
-              : [...selected, opt];
-            handleChange(labelId, { selected: next });
-          } else {
-            handleChange(labelId, {
-              selected: selected[0] === opt ? [] : [opt],
-            });
-          }
+        // Number shortcuts are only offered for up to 10 options: digits 1-9
+        // select options 1-9 and "0" selects the 10th (same as the star
+        // "0 = 10" mapping). With more than 10 options the mapping is
+        // ambiguous, so number shortcuts are disabled entirely.
+        if (options.length > 10) return;
+        let optIndex = -1;
+        if (num >= 1 && num <= 9) optIndex = num - 1;
+        else if (num === 0 && options.length === 10) optIndex = 9;
+        if (optIndex < 0 || optIndex >= options.length) return;
+
+        e.preventDefault();
+        const opt = options[optIndex];
+        const selected = currentVal?.selected || [];
+        const isMulti = ql.settings?.multi_choice || false;
+        if (isMulti) {
+          const next = selected.includes(opt)
+            ? selected.filter((v) => v !== opt)
+            : [...selected, opt];
+          handleChange(labelId, { selected: next });
+        } else {
+          handleChange(labelId, {
+            selected: selected[0] === opt ? [] : [opt],
+          });
         }
       }
     };

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -618,52 +618,60 @@ const LabelPanel = forwardRef(function LabelPanel(
 
       // Number keys → dispatch to focused label
       const num = parseInt(e.key, 10);
-      if (num >= 1 && num <= 9 && labels.length > 0) {
-        const ql = labels[focusedIndex];
-        if (!ql) return;
-        const labelId = ql.label_id;
-        const currentVal = displayValues[labelId] ?? null;
+      if (Number.isNaN(num) || labels.length === 0) return;
 
-        e.preventDefault();
+      const ql = labels[focusedIndex];
+      if (!ql) return;
+      const labelId = ql.label_id;
+      const currentVal = displayValues[labelId] ?? null;
 
-        if (ql.type === "star") {
-          const max = ql.settings?.no_of_stars || 5;
-          if (num <= max) {
-            const current = currentVal?.rating || 0;
-            handleChange(labelId, { rating: num === current ? 0 : num });
-          }
-        } else if (ql.type === "thumbs_up_down") {
-          if (num === 1) {
+      if (ql.type === "star") {
+        const max = ql.settings?.no_of_stars || 5;
+        // A single keypress can't produce "10", so the "0" key maps to a
+        // rating of 10 (the max). Digits 1-9 map to themselves.
+        const rating = num === 0 ? 10 : num;
+        if (rating >= 1 && rating <= max) {
+          e.preventDefault();
+          const current = currentVal?.rating || 0;
+          handleChange(labelId, { rating: rating === current ? 0 : rating });
+        }
+        return;
+      }
+
+      if (num < 1 || num > 9) return;
+      e.preventDefault();
+
+      if (ql.type === "thumbs_up_down") {
+        if (num === 1) {
+          handleChange(labelId, {
+            value: currentVal?.value === "up" ? null : "up",
+          });
+        } else if (num === 2) {
+          handleChange(labelId, {
+            value: currentVal?.value === "down" ? null : "down",
+          });
+        }
+      } else if (ql.type === "categorical") {
+        const rawOptions = ql.settings?.options || [];
+        const options = rawOptions
+          .map((opt) =>
+            typeof opt === "string" ? opt : opt?.label || opt?.value || "",
+          )
+          .filter(Boolean);
+        const optIndex = num - 1;
+        if (optIndex < options.length) {
+          const opt = options[optIndex];
+          const selected = currentVal?.selected || [];
+          const isMulti = ql.settings?.multi_choice || false;
+          if (isMulti) {
+            const next = selected.includes(opt)
+              ? selected.filter((v) => v !== opt)
+              : [...selected, opt];
+            handleChange(labelId, { selected: next });
+          } else {
             handleChange(labelId, {
-              value: currentVal?.value === "up" ? null : "up",
+              selected: selected[0] === opt ? [] : [opt],
             });
-          } else if (num === 2) {
-            handleChange(labelId, {
-              value: currentVal?.value === "down" ? null : "down",
-            });
-          }
-        } else if (ql.type === "categorical") {
-          const rawOptions = ql.settings?.options || [];
-          const options = rawOptions
-            .map((opt) =>
-              typeof opt === "string" ? opt : opt?.label || opt?.value || "",
-            )
-            .filter(Boolean);
-          const optIndex = num - 1;
-          if (optIndex < options.length) {
-            const opt = options[optIndex];
-            const selected = currentVal?.selected || [];
-            const isMulti = ql.settings?.multi_choice || false;
-            if (isMulti) {
-              const next = selected.includes(opt)
-                ? selected.filter((v) => v !== opt)
-                : [...selected, opt];
-              handleChange(labelId, { selected: next });
-            } else {
-              handleChange(labelId, {
-                selected: selected[0] === opt ? [] : [opt],
-              });
-            }
           }
         }
       }

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -1954,7 +1954,7 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
             project_id: projectId,
             page_number: pageNumber,
             page_size: TRACE_ROWS_LIMIT,
-            filters: JSON.stringify(filtersRef.current || []),
+            filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
           };
           if (versionId) {
             apiParams.project_version_id = versionId;
@@ -2606,7 +2606,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             project_id: projectId,
             page_number: pageNumber,
             page_size: SPAN_ROWS_LIMIT,
-            filters: JSON.stringify(filtersRef.current || []),
+            filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
           };
           if (versionId) {
             apiParams.project_version_id = versionId;
@@ -3176,7 +3176,7 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
                     direction: sort,
                   })),
                 ),
-                filters: JSON.stringify(filtersRef.current || []),
+                filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
               },
             },
           );

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -1138,13 +1138,7 @@ export function buildReadOnlyColumnDefs(columnConfig) {
 // ---------------------------------------------------------------------------
 // Server-side datasource for dataset grid (read-only, with filters)
 // ---------------------------------------------------------------------------
-function createDataSource(
-  queryClient,
-  datasetId,
-  filtersRef,
-  searchRef,
-  setGridLoading,
-) {
+function createDataSource(queryClient, datasetId, filtersRef, searchRef) {
   return {
     getRows: async (params) => {
       const { request } = params;
@@ -1160,7 +1154,6 @@ function createDataSource(
       const search = searchRef.current || "";
 
       try {
-        setGridLoading?.(true);
         const queryOptions = getDatasetQueryOptions(
           datasetId,
           pageNumber,
@@ -1183,8 +1176,6 @@ function createDataSource(
         });
       } catch {
         params.fail();
-      } finally {
-        setGridLoading?.(false);
       }
     },
   };
@@ -1308,36 +1299,6 @@ SelectorEmptyState.propTypes = {
   loadingLabel: PropTypes.string,
 };
 
-function GridLoadingOverlay({ open, label = "Loading rows..." }) {
-  if (!open) return null;
-  return (
-    <Box
-      sx={{
-        position: "absolute",
-        inset: 0,
-        zIndex: 2,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        bgcolor: (theme) => alpha(theme.palette.background.paper, 0.72),
-        backdropFilter: "blur(1px)",
-      }}
-    >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-        <CircularProgress size={18} />
-        <Typography variant="body2" color="text.secondary">
-          {label}
-        </Typography>
-      </Box>
-    </Box>
-  );
-}
-
-GridLoadingOverlay.propTypes = {
-  open: PropTypes.bool,
-  label: PropTypes.string,
-};
-
 // ---------------------------------------------------------------------------
 // Dataset Row Selector – Same AG Grid as dataset view
 // ---------------------------------------------------------------------------
@@ -1350,7 +1311,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
   const [filters, setFiltersState] = useState([
     { ...DefaultFilter, id: getRandomId() },
   ]);
-  const [isGridLoading, setIsGridLoading] = useState(false);
   const gridRef = useRef(null);
   const agTheme = useAgThemeWith(DATASET_GRID_THEME_PARAMS);
   const queryClient = useQueryClient();
@@ -1421,7 +1381,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
           datasetId,
           filtersRef,
           searchRef,
-          setIsGridLoading,
         );
         params.api.setGridOption("serverSideDatasource", ds);
       }
@@ -1437,7 +1396,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
         datasetId,
         filtersRef,
         searchRef,
-        setIsGridLoading,
       );
       gridApi.setGridOption("serverSideDatasource", ds);
     }
@@ -1452,7 +1410,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
         datasetId,
         filtersRef,
         searchRef,
-        setIsGridLoading,
       );
       gridApi.setGridOption("serverSideDatasource", ds);
     },
@@ -1512,7 +1469,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
         datasetId,
         filtersRef,
         searchRef,
-        setIsGridLoading,
       );
       gridApi.setGridOption("serverSideDatasource", ds);
     }
@@ -1759,7 +1715,6 @@ export function DatasetRowSelector({ onSetSelection, onSelectAll }) {
             }}
           >
             <Box sx={{ flex: 1, position: "relative" }}>
-              <GridLoadingOverlay open={isGridLoading} />
               <AgGridReact
                 ref={gridRef}
                 rowHeight={100}
@@ -1825,7 +1780,6 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
   const [gridApi, setGridApi] = useState(null);
-  const [isGridLoading, setIsGridLoading] = useState(false);
   const gridRef = useRef(null);
   const filterButtonRef = useRef(null);
   const agTheme = useAgThemeWith(SELECTOR_GRID_THEME_PARAMS);
@@ -1959,7 +1913,6 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
           if (versionId) {
             apiParams.project_version_id = versionId;
           }
-          setIsGridLoading(true);
           const results = await axios.get(
             endpoints.project.getTracesForObserveProject(),
             { params: apiParams },
@@ -1984,8 +1937,6 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
           });
         } catch {
           params.fail();
-        } finally {
-          setIsGridLoading(false);
         }
       },
     }),
@@ -2451,7 +2402,6 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
             onSelectAll={commitFilterModeSelectAll}
           />
           <Box sx={{ flex: 1, position: "relative" }}>
-            <GridLoadingOverlay open={isGridLoading} />
             <AgGridReact
               ref={gridRef}
               className="clean-data-table"
@@ -2505,7 +2455,6 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
   const [gridApi, setGridApi] = useState(null);
-  const [isGridLoading, setIsGridLoading] = useState(false);
   const gridRef = useRef(null);
   const filterButtonRef = useRef(null);
   const agTheme = useAgThemeWith(SELECTOR_GRID_THEME_PARAMS);
@@ -2612,7 +2561,6 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             apiParams.project_version_id = versionId;
           }
 
-          setIsGridLoading(true);
           const results = await axios.get(
             endpoints.project.getSpansForObserveProject(),
             { params: apiParams },
@@ -2637,8 +2585,6 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
           });
         } catch {
           params.fail();
-        } finally {
-          setIsGridLoading(false);
         }
       },
     }),
@@ -3024,7 +2970,6 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             onSelectAll={commitFilterModeSelectAll}
           />
           <Box sx={{ flex: 1, position: "relative" }}>
-            <GridLoadingOverlay open={isGridLoading} />
             <AgGridReact
               ref={gridRef}
               className="clean-data-table"
@@ -3078,7 +3023,6 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
   const [gridApi, setGridApi] = useState(null);
-  const [isGridLoading, setIsGridLoading] = useState(false);
   const gridRef = useRef(null);
   const filterButtonRef = useRef(null);
   const agTheme = useAgThemeWith(SELECTOR_GRID_THEME_PARAMS);
@@ -3161,7 +3105,6 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
           const pageSize = request.endRow - request.startRow;
           const pageNumber = Math.floor(request.startRow / pageSize);
 
-          setIsGridLoading(true);
           const results = await axios.get(
             endpoints.project.projectSessionList(),
             {
@@ -3200,8 +3143,6 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
           });
         } catch {
           params.fail();
-        } finally {
-          setIsGridLoading(false);
         }
       },
     }),
@@ -3601,7 +3542,6 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
             onSelectAll={commitFilterModeSelectAll}
           />
           <Box sx={{ flex: 1, position: "relative" }}>
-            <GridLoadingOverlay open={isGridLoading} />
             <AgGridReact
               ref={gridRef}
               className="clean-data-table"
@@ -4200,7 +4140,6 @@ function SimulationSelector({ onSetSelection }) {
   const [testId, setTestId] = useState("");
   const [executionRunId, setExecutionRunId] = useState("");
   const [gridApi, setGridApi] = useState(null);
-  const [isGridLoading, setIsGridLoading] = useState(false);
   const [simulationColumnOrder, setSimulationColumnOrder] = useState([]);
   const [filters, setFilters] = useState([
     { ...simulationDefaultFilterBase, id: getRandomId() },
@@ -4269,7 +4208,6 @@ function SimulationSelector({ onSetSelection }) {
           const pageSize = request.endRow - request.startRow;
           const pageNumber = Math.floor(request.startRow / pageSize);
 
-          setIsGridLoading(true);
           const { data } = await queryClient.fetchQuery({
             queryKey: [
               "sim-call-executions",
@@ -4315,8 +4253,6 @@ function SimulationSelector({ onSetSelection }) {
           });
         } catch {
           params.fail();
-        } finally {
-          setIsGridLoading(false);
         }
       },
     }),
@@ -4704,7 +4640,6 @@ function SimulationSelector({ onSetSelection }) {
           }}
         >
           <Box sx={{ flex: 1, position: "relative" }}>
-            <GridLoadingOverlay open={isGridLoading} />
             <AgGridReact
               ref={gridRef}
               className="clean-data-table"

--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -497,9 +497,9 @@ function ActionsCellRenderer({ data, context }) {
             context?.onRemoveConfirm(data);
           }}
           sx={{
-            opacity: 0,
-            color: "text.disabled",
-            ".ag-row:hover &": { opacity: 1 },
+            opacity: 2,
+
+   
             "&:hover": { color: "error.main" },
           }}
         >

--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -497,9 +497,7 @@ function ActionsCellRenderer({ data, context }) {
             context?.onRemoveConfirm(data);
           }}
           sx={{
-            opacity: 2,
-
-   
+            opacity: 1,
             "&:hover": { color: "error.main" },
           }}
         >

--- a/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
+import { ConfirmDialog } from "src/components/custom-dialog";
 import { useEvaluationContext } from "./context/EvaluationContext";
 import { formatDistanceToNow } from "date-fns";
 import { canonicalEntries, canonicalValues } from "src/utils/utils";
@@ -754,6 +755,7 @@ const SavedEvalsList = ({
     setVisibleSection("config");
   };
   const [sel, setSel] = useState(new Set());
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const toggle = (item) =>
     setSel((p) => {
       const n = new Set(p);
@@ -766,6 +768,13 @@ const SavedEvalsList = ({
     );
   const selected = evals.filter((e) => sel.has(e.id));
   const hasSel = sel.size > 0;
+
+  const handleBulkDelete = async () => {
+    await Promise.all(selected.map((e) => onDeleteEvalClick?.(e)));
+    setConfirmBulkDelete(false);
+    setSel(new Set());
+    onClose?.();
+  };
 
   return (
     <Box
@@ -882,13 +891,7 @@ const SavedEvalsList = ({
                 variant="outlined"
                 color="error"
                 startIcon={<Iconify icon="mdi:trash-can-outline" width={14} />}
-                onClick={async () => {
-                  await Promise.all(
-                    selected.map((e) => onDeleteEvalClick?.(e)),
-                  );
-                  setSel(new Set());
-                  onClose?.();
-                }}
+                onClick={() => setConfirmBulkDelete(true)}
                 sx={{
                   textTransform: "none",
                   fontSize: "12px",
@@ -920,6 +923,26 @@ const SavedEvalsList = ({
           </Button>
         </Box>
       )}
+
+      <ConfirmDialog
+        open={confirmBulkDelete}
+        onClose={() => setConfirmBulkDelete(false)}
+        title="Delete evaluations"
+        content={`Delete ${sel.size} selected evaluation${
+          sel.size === 1 ? "" : "s"
+        } and their results? This action cannot be undone.`}
+        action={
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            onClick={handleBulkDelete}
+            sx={{ paddingX: "24px" }}
+          >
+            Delete
+          </Button>
+        }
+      />
     </Box>
   );
 };

--- a/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx
@@ -770,10 +770,13 @@ const SavedEvalsList = ({
   const hasSel = sel.size > 0;
 
   const handleBulkDelete = async () => {
-    await Promise.all(selected.map((e) => onDeleteEvalClick?.(e)));
-    setConfirmBulkDelete(false);
-    setSel(new Set());
-    onClose?.();
+    try {
+      await Promise.all(selected.map((e) => onDeleteEvalClick?.(e)));
+    } finally {
+      setConfirmBulkDelete(false);
+      setSel(new Set());
+      onClose?.();
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

Small, independent frontend fixes for destructive-action safety, dropdown/grid UI, and annotate keyboard shortcuts:

- **TH-6267** — Strip UI-only filter keys (`id`, `_meta`) before the add-items dialog calls the trace/span/session list endpoints, so adding a filter chip no longer 400s.
- **TH-6231** — Add a confirmation dialog before bulk-deleting evals (the "Delete" action on selected evals deleted immediately with no confirmation).
- **TH-6204** — Make the column-dropdown search header opaque (it was transparent, so the list bled through it).
- **TH-6188** — Remove the redundant custom grid loader in the add-items dialog (two loaders showed while data loaded — a custom overlay on top of AG Grid's native loading rows).
- **TH-6192** — Make the "10" key mapping work in the annotate flow for star ratings and categorical options.
- **TH-6327** — Stop hiding the remove (delete) button in the queue items table so it's always visible.

## Why the changes are done — what is the problem

- **TH-6267:** The add-items dialog sent the trace/span/session selector filters verbatim to the strict `list_*` endpoints, including UI-only bookkeeping keys (`id`, `_meta` — the latter re-added by `panelFilterToApi(..., { includeMeta: true })`). The backend filter-item serializer rejects unknown keys, so adding any user filter chip returned `400 validation_error` and the grid showed "error fetching…".
- **TH-6231:** The bulk **Delete** in the evaluations drawer ran `Promise.all(selected.map(onDeleteEvalClick))` on click — destructive, immediate, no confirmation and no chance to cancel.
- **TH-6204:** The column dropdown's sticky search header used `background: "background.paper"`. MUI's `sx` only resolves theme palette tokens for `bgcolor`/`backgroundColor`, not the `background` shorthand, so the header rendered transparent and column rows scrolled visibly underneath the search box.
- **TH-6188:** Each selector grid rendered a custom `GridLoadingOverlay` spinner (driven by an `isGridLoading` flag) on every server-side fetch — stacked on top of AG Grid's own loading rows, so users saw two loaders at once.
- **TH-6192:** The annotate number-key handler only accepted digits `1-9`, and a single keypress can't produce "10". So a 10-star rating (and a 10th categorical option) was unreachable by keyboard, while the UI still showed a "10" hint on the last star — over-promising a shortcut that did nothing.
- **TH-6327:** The remove action in the queue items table was hidden (`opacity: 0`) and only revealed on row hover, so it wasn't discoverable.

## What changed

- **`frontend/src/sections/annotations/queues/items/add-items-dialog.jsx`** —
  - TH-6267: Route the trace, span, and session selector filters through the shared `stripUiFilterKeys()` helper before serialization. Only `id` and `_meta` are dropped (shallow) — the required `filter_config.col_type` is preserved.
  - TH-6188: Remove the custom `GridLoadingOverlay` component and the `isGridLoading` state/setters across all five selectors (dataset, trace, span, session, simulation), and drop the `setGridLoading` plumbing from the shared `createDataSource`. AG Grid's native server-side loading rows still cover the fetch state.
- **`frontend/src/components/ComplexFilter/common.js`** — Harden `stripUiFilterKeys()` with a null/non-object guard so it is safe across all callers.
- **`frontend/src/sections/common/EvaluationDrawer/SavedEvalsList.jsx`** — The footer bulk Delete now opens a `ConfirmDialog` (count-aware, "cannot be undone") and runs the delete only on confirm; selection is cleared and the drawer closed afterwards. Per-row delete keeps its existing inline confirmation.
- **`frontend/src/components/ColumnDropdown/ColumnDropdown.jsx`** — Change the sticky search header from `background` to `backgroundColor: "background.paper"` so it stays opaque while the list scrolls.
- **`frontend/src/sections/annotations/queues/annotate/label-panel.jsx`** — TH-6192: The focused-label number-key handler now maps the `0` key to a rating of 10 for star labels. For categorical labels, digits 1-9 select options 1-9 and `0` selects the 10th — but only when there are at most 10 options; with more than 10 the mapping is ambiguous, so number shortcuts are disabled entirely for that label.
- **`frontend/src/sections/annotations/queues/annotate/label-input.jsx`** — TH-6192: Show `0` (not `10`) as the 10th star's key badge and add a "Press 0 for 10" hint when focused. Categorical option badges follow the same rule (1-9, `0` for the 10th, none when there are more than 10 options).
- **`frontend/src/sections/annotations/queues/items/queue-items-table.jsx`** — TH-6327: The row remove button is now always visible instead of `opacity: 0` + hover-reveal. Note: the "column needs a header" sub-item from TH-6327 is not yet addressed (the actions column still has an empty header).

## Tests

- [ ] No automated tests added (UI-only changes).

## Commands

- [ ] `yarn lint`

## Backwards compatibility

No API or contract changes. Frontend-only, fully backwards compatible. TH-6267 only removes UI-only keys from the request body (the keys the backend already rejects).

## Manual verification

- [ ] TH-6267: In the add-items dialog, pick traces/spans/sessions, add a filter chip — the list loads (no 400), and `col_type` filtering still works.
- [ ] TH-6231: Select multiple evals → click Delete → a confirmation dialog appears; Cancel aborts, Delete removes them and clears the selection.
- [ ] TH-6204: Open the column dropdown and scroll — rows no longer show through the search box (light + dark theme).
- [ ] TH-6188: Open the add-items dialog and load a dataset/trace/span/session/simulation grid — only one loader shows during fetch, not two.
- [ ] TH-6192: Focus a 10-star label → last badge reads `0` and a "Press 0 for 10" hint shows; `0` sets 10 stars. A 10-option categorical shows badges 1-9 then `0`; a >10-option categorical shows no badges and number keys do nothing.
- [ ] TH-6327: Open the queue items table — the remove button is visible without hovering the row.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the changes
- [x] Lint passes

## Backout / rollback

Revert this PR's commits — changes are isolated to frontend files with no migrations or contract changes.

## Linear

- Fixes TH-6267
- Fixes TH-6231
- Fixes TH-6204
- Fixes TH-6188
- Fixes TH-6192
- TH-6327 (delete-button visibility done; column-header sub-item still pending)
