### PR TITLE
fix(develop): make import-prompt-to-dataset work end-to-end [TH-6266]

### DIFF
--- a/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
+++ b/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { validateContractedRequestConfig } from "../openapi-contract";
+
+// Round-trip guard (TH-6280): a representative run payload must pass the
+// add_run_prompt_column request contract. The PromptConfig serializer used
+// loose DictField/JSONField fields that generated an over-constrained contract
+// (every value typed `string`), which silently blocked the request in dev.
+// This pins the real shape so a too-loose serializer can't regress it again.
+const runRequest = {
+  url: "/model-hub/develops/add_run_prompt_column/",
+  method: "post",
+  data: {
+    dataset_id: "9ea714d2-c215-499c-8797-b9ae52d6d42a",
+    name: "run",
+    config: {
+      model: "gpt-4o-mini",
+      run_prompt_config: {
+        model_name: "gpt-4o-mini",
+        providers: "openai",
+        isAvailable: true, // boolean (was: Expected string)
+        booleans: {}, // object  (was: Expected string)
+        dropdowns: {}, // object  (was: Expected string)
+        temperature: null,
+        top_p: null,
+      },
+      messages: [
+        { role: "system", content: [{ type: "text", text: "" }] },
+        // array content (was: Expected string)
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ],
+      response_format: "text", // string  (was: Expected object)
+      tools: [],
+    },
+  },
+};
+
+describe("add_run_prompt_column request contract", () => {
+  it("accepts a real run payload (mixed run_prompt_config, array message content, string response_format)", () => {
+    const result = validateContractedRequestConfig(runRequest);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -49368,6 +49368,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Context page",
           "type": "string",
           "maxLength": 500
+        },
+        "hidden": {
+          "title": "Hidden",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -49368,11 +49368,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Context page",
           "type": "string",
           "maxLength": 500
-        },
-        "hidden": {
-          "title": "Hidden",
-          "type": "boolean",
-          "default": false
         }
       }
     },
@@ -74928,8 +74923,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Run prompt config",
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "x-nullable": true
+            "type": "object",
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           }
         },
         "messages": {
@@ -74938,8 +74934,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "type": "object",
             "additionalProperties": {
-              "type": "string",
-              "x-nullable": true
+              "type": "object",
+              "x-json-value": true,
+              "description": "Any valid JSON value."
             }
           }
         },
@@ -74985,9 +74982,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "description": "JSON schema for response format if required. Can be a JSON object or string. Defaults to None.",
+          "description": "Any valid JSON value.",
           "type": "object",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-json-value": true
         },
         "tool_choice": {
           "title": "Tool choice",
@@ -75006,8 +75004,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "type": "object",
             "additionalProperties": {
-              "type": "string",
-              "x-nullable": true
+              "type": "object",
+              "x-json-value": true,
+              "description": "Any valid JSON value."
             }
           },
           "x-nullable": true

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -3947,6 +3947,7 @@ export interface ConversationCreateRequestApi {
   title?: string;
   /** @maxLength 500 */
   context_page?: string;
+  hidden?: boolean;
 }
 
 export type FalconMessageApiRole = typeof FalconMessageApiRole[keyof typeof FalconMessageApiRole];

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -3947,7 +3947,6 @@ export interface ConversationCreateRequestApi {
   title?: string;
   /** @maxLength 500 */
   context_page?: string;
-  hidden?: boolean;
 }
 
 export type FalconMessageApiRole = typeof FalconMessageApiRole[keyof typeof FalconMessageApiRole];
@@ -8152,16 +8151,16 @@ export const PromptConfigApiOutputFormat = {
   image: 'image',
 } as const;
 
-export type PromptConfigApiRunPromptConfig = {[key: string]: string};
+export type PromptConfigApiRunPromptConfig = {[key: string]: { [key: string]: unknown }};
 
-export type PromptConfigApiMessagesItem = {[key: string]: string};
+export type PromptConfigApiMessagesItem = {[key: string]: { [key: string]: unknown }};
 
 /**
- * JSON schema for response format if required. Can be a JSON object or string. Defaults to None.
+ * Any valid JSON value.
  */
 export type PromptConfigApiResponseFormat = { [key: string]: unknown };
 
-export type PromptConfigApiToolsItem = {[key: string]: string};
+export type PromptConfigApiToolsItem = {[key: string]: { [key: string]: unknown }};
 
 export interface PromptConfigApi {
   /** @maxLength 255 */
@@ -8199,7 +8198,7 @@ export interface PromptConfigApi {
      * @maximum 1
      */
   top_p?: number;
-  /** JSON schema for response format if required. Can be a JSON object or string. Defaults to None. */
+  /** Any valid JSON value. */
   response_format?: PromptConfigApiResponseFormat;
   /** Tool selection mode: 'auto' or 'required'. */
   tool_choice?: PromptConfigApiToolChoice;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -9572,11 +9572,12 @@ export const falconAiConversationsCreateBodyTitleMax = 255;
 
 export const falconAiConversationsCreateBodyContextPageMax = 500;
 
-
+export const falconAiConversationsCreateBodyHiddenDefault = false;
 
 export const FalconAiConversationsCreateBody = zod.object({
   "title": zod.string().max(falconAiConversationsCreateBodyTitleMax).optional(),
-  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional()
+  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional(),
+  "hidden": zod.boolean().default(falconAiConversationsCreateBodyHiddenDefault)
 })
 
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -9572,12 +9572,11 @@ export const falconAiConversationsCreateBodyTitleMax = 255;
 
 export const falconAiConversationsCreateBodyContextPageMax = 500;
 
-export const falconAiConversationsCreateBodyHiddenDefault = false;
+
 
 export const FalconAiConversationsCreateBody = zod.object({
   "title": zod.string().max(falconAiConversationsCreateBodyTitleMax).optional(),
-  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional(),
-  "hidden": zod.boolean().default(falconAiConversationsCreateBodyHiddenDefault)
+  "context_page": zod.string().max(falconAiConversationsCreateBodyContextPageMax).optional()
 })
 
 
@@ -17015,8 +17014,12 @@ export const ModelHubDevelopsAddRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17024,9 +17027,11 @@ export const ModelHubDevelopsAddRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsAddRunPromptColumnCreateBodyConfigDefault)
@@ -17265,8 +17270,12 @@ export const ModelHubDevelopsEditRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1).optional(),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17274,9 +17283,11 @@ export const ModelHubDevelopsEditRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsEditRunPromptColumnCreateBodyConfigDefault)
@@ -17473,8 +17484,12 @@ export const ModelHubDevelopsPreviewRunPromptColumnCreateBody = zod.object({
   "name": zod.string().min(1),
   "config": zod.object({
   "model": zod.string().max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigModelMax).optional(),
-  "run_prompt_config": zod.record(zod.string(), zod.string()).optional(),
-  "messages": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
+  "run_prompt_config": zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.')).optional(),
+  "messages": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of messages with format [{\'role\': \'user\/assistant\', \'content\': \'text\'}]'),
   "temperature": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTemperatureMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTemperatureMax).optional().describe('Controls the randomness. Value between 0 and 2.'),
   "frequency_penalty": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigFrequencyPenaltyMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigFrequencyPenaltyMax).optional().describe('Penalty for word repetition. Value between -2 and 2.'),
   "presence_penalty": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
@@ -17482,9 +17497,11 @@ export const ModelHubDevelopsPreviewRunPromptColumnCreateBody = zod.object({
   "top_p": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
   "response_format": zod.object({
 
-}).passthrough().optional().describe('JSON schema for response format if required. Can be a JSON object or string. Defaults to None.'),
+}).passthrough().optional().describe('Any valid JSON value.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
-  "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.'),
+  "tools": zod.array(zod.record(zod.string(), zod.object({
+
+}).passthrough().describe('Any valid JSON value.'))).optional().describe('List of tools with tool properties if available.'),
   "output_format": zod.enum(['array', 'string', 'number', 'object', 'audio', 'image']).optional().describe('Output format type.'),
   "concurrency": zod.number().min(1).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigConcurrencyMax).optional().describe('Number of concurrent operations allowed. Maximum 10.')
 }).default(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigDefault),

--- a/frontend/src/sections/common/DevelopCellRenderer/RenderMeta.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/RenderMeta.jsx
@@ -12,7 +12,7 @@ const RenderMeta = ({ meta, originType, showToken = true, valuesInfo }) => {
   if (!["run_prompt", "optimisation", "text"].includes(originType)) {
     return <></>;
   }
-  if (!Object.values(meta).find((value) => value)) {
+  if (!meta || !Object.values(meta).find((value) => value)) {
     return <></>;
   }
 

--- a/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
@@ -34,7 +34,7 @@ const PromptTemplatesSection = ({
   });
   const [expandPrompt, setExpandPrompt] = useState({});
 
-  const messages = watch("config.messages");
+  const messages = watch("config.messages") || [];
 
   const memoizedMentionValues = useMemo(() => {
     return getDropdownOptionsFromCols(

--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -1022,7 +1022,14 @@ export const RunPromptForm = React.forwardRef(
       const previewConfigEntries = {
         ...data.config,
         outputFormat,
-        model: data?.config?.run_prompt_config?.model_name,
+        responseFormat: finalResponseFormat,
+        // run_prompt_config carries the name as model_name (snake, run flow)
+        // or modelName (camel, edit hydration); fall back to config.model so
+        // the backend can always resolve the model.
+        model:
+          data?.config?.run_prompt_config?.model_name ??
+          data?.config?.run_prompt_config?.modelName ??
+          data?.config?.model,
         messages: data?.config?.messages?.map(({ id, ...rest }) => {
           let content = rest.content;
 
@@ -1079,7 +1086,6 @@ export const RunPromptForm = React.forwardRef(
       const submitObject = {
         dataset_id: dataset,
         name: data.name,
-        response_format: finalResponseFormat, //  Use validated or fallback
         config: renamedPreviewConfig,
         ...testData,
         // ...(selected == "rowNumber"
@@ -1120,20 +1126,28 @@ export const RunPromptForm = React.forwardRef(
     };
 
     const handleApplyImportedPrompt = async (data) => {
-      if (!data?.prompt?.name && !data?.promptVersion?.templateVersion) return;
+      // The imported version is the raw (snake_case) API shape — usePromptVersions
+      // returns it unnormalized, and the contract field is `prompt_config_snapshot`
+      // / `template_version` (not camelCase).
+      const snapshot = data?.promptVersion?.prompt_config_snapshot;
+      const templateVersion = data?.promptVersion?.template_version;
+      if (!data?.prompt?.name && !templateVersion) return;
       clearErrors("config");
       setImportedPrompt(data);
 
       setValue("config.prompt", data?.prompt?.name, {
         shouldDirty: true,
       });
-      setValue("config.promptVersion", data?.promptVersion?.templateVersion);
+      setValue("config.promptVersion", templateVersion);
 
       let modelObject = defaultValues.config.run_prompt_config;
       const normalizedSnapshotConfig = normalizeConfigurationForLoad(
-        data?.promptVersion?.promptConfigSnapshot?.configuration,
+        snapshot?.configuration,
       );
-      const modelType = normalizedSnapshotConfig?.modelDetail?.type;
+      // model_detail carries the full model object (model_name, providers,
+      // type); normalizeConfigurationForLoad doesn't remap it, so read it raw.
+      const modelDetail = snapshot?.configuration?.model_detail;
+      const modelType = modelDetail?.type;
       const importedVoiceId = normalizedSnapshotConfig?.voiceId;
 
       let internalModelType = "llm";
@@ -1146,11 +1160,8 @@ export const RunPromptForm = React.forwardRef(
       }
       setValue("config.modelType", internalModelType);
 
-      if (typeof normalizedSnapshotConfig?.model === "string") {
-        modelObject = {
-          ...normalizedSnapshotConfig?.modelDetail,
-          modelName: normalizedSnapshotConfig?.model,
-        };
+      if (modelDetail?.model_name) {
+        modelObject = { ...modelDetail };
       }
       setValue("config.model", modelObject?.model_name);
       const configWithVoice = importedVoiceId
@@ -1160,19 +1171,18 @@ export const RunPromptForm = React.forwardRef(
 
       setValue(
         "config.messages",
-        data?.promptVersion?.promptConfigSnapshot?.messages?.map((msg) => ({
+        (snapshot?.messages || []).map((msg) => ({
           id: getRandomId(),
           role: msg?.role,
           content: msg.content,
         })),
       );
 
-      const importedConfig =
-        data?.promptVersion?.promptConfigSnapshot?.configuration;
+      const importedConfig = snapshot?.configuration;
 
       setValue(
         "config.responseFormat",
-        importedConfig?.responseFormat ?? "text",
+        importedConfig?.response_format ?? "text",
       );
       setValue(
         "config.tools",
@@ -1206,9 +1216,11 @@ export const RunPromptForm = React.forwardRef(
                 const id = item.id ?? _.camelCase(item.label);
                 let defaultValue = item.value ?? item.default ?? 0;
 
-                // Use imported value if available for this param
-                if (importedConfig?.[id] !== undefined) {
-                  defaultValue = importedConfig[id];
+                // Snapshot config keys are snake_case (backend serializer) and
+                // match the param's snake label — read the imported value off it.
+                const configKey = item.id ?? _.snakeCase(item.label);
+                if (importedConfig?.[configKey] !== undefined) {
+                  defaultValue = importedConfig[configKey];
                 }
 
                 return {
@@ -1783,11 +1795,7 @@ export const RunPromptForm = React.forwardRef(
                     ml: "auto",
                   }}
                 >
-                  <Typography
-                    typography="s2"
-                    fontWeight={"fontWeightSemiBold"}
-                    color={"white"}
-                  >
+                  <Typography typography="s2" fontWeight={"fontWeightSemiBold"}>
                     Save Template
                   </Typography>
                 </Button>
@@ -2269,15 +2277,11 @@ const RunPrompt = () => {
   const runPromptData = runPromptDataRaw?.data?.result?.config;
 
   const transformedModelParamsSliders = modelParams?.sliders?.map((item) => {
-    if (
-      runPromptData?.runPromptConfig[_.camelCase(item?.label)] !== undefined
-    ) {
+    if (runPromptConfig?.[_.camelCase(item?.label)] !== undefined) {
       return {
         ...item,
         id: _.camelCase(item?.label),
-        value:
-          runPromptData?.runPromptConfig[_.camelCase(item?.label)] ??
-          item?.default,
+        value: runPromptConfig?.[_.camelCase(item?.label)] ?? item?.default,
       };
     }
     return {
@@ -2292,21 +2296,21 @@ const RunPrompt = () => {
     ...(modelParams?.booleans && {
       booleans: transformParameterType(
         modelParams?.booleans,
-        runPromptData?.runPromptConfig,
+        runPromptConfig,
         "booleans",
       ),
     }),
     ...(modelParams?.dropdowns && {
       dropdowns: transformParameterType(
         modelParams?.dropdowns,
-        runPromptData?.runPromptConfig,
+        runPromptConfig,
         "dropdowns",
       ),
     }),
   };
 
   const reasoningConfig = modelParams?.reasoning;
-  const savedReasoning = runPromptData?.runPromptConfig?.reasoning;
+  const savedReasoning = runPromptConfig?.reasoning;
 
   const transformedReasoningSliders = reasoningConfig?.sliders?.map((item) => {
     if (savedReasoning?.sliders?.[_.camelCase(item?.label)] !== undefined) {

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -137,8 +137,7 @@ export const transformDefaultData = (editConfigData, allColumns) => {
   const resolvedModelType =
     runPromptConfig?.model_type || runPromptConfig?.modelType;
 
-  const rawResponseFormat =
-    editConfigData?.response_format ?? editConfigData?.responseFormat;
+  const rawResponseFormat = editConfigData?.response_format;
   const resolvedResponseFormat =
     typeof rawResponseFormat === "object"
       ? rawResponseFormat?.name ?? "text"

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -137,6 +137,13 @@ export const transformDefaultData = (editConfigData, allColumns) => {
   const resolvedModelType =
     runPromptConfig?.model_type || runPromptConfig?.modelType;
 
+  const rawResponseFormat =
+    editConfigData?.response_format ?? editConfigData?.responseFormat;
+  const resolvedResponseFormat =
+    typeof rawResponseFormat === "object"
+      ? rawResponseFormat?.name ?? "text"
+      : rawResponseFormat ?? "text";
+
   let voiceInputColumn = "";
   if (resolvedModelType === MODEL_TYPES.STT) {
     const userMessage = editConfigData?.messages?.find(
@@ -155,7 +162,9 @@ export const transformDefaultData = (editConfigData, allColumns) => {
         providers: runPromptConfig?.providers,
         isAvailable: runPromptConfig?.isAvailable,
         voice: runPromptConfig?.voice || "",
-        voiceId: runPromptConfig?.voiceId || "",
+        // Saved config is snake_case (`voice_id`); read it first so TTS/STT
+        // prompts keep their voice on edit.
+        voiceId: runPromptConfig?.voice_id || runPromptConfig?.voiceId || "",
       },
       modelType: resolvedModelType || MODEL_TYPES.LLM,
       voiceInputColumn,
@@ -211,10 +220,7 @@ export const transformDefaultData = (editConfigData, allColumns) => {
 
         return msgs;
       })(),
-      responseFormat:
-        typeof editConfigData?.responseFormat === "object"
-          ? editConfigData?.responseFormat?.name
-          : editConfigData?.responseFormat,
+      responseFormat: resolvedResponseFormat,
       // temperature: editConfigData?.temperature,
       // topP: editConfigData?.topP,
       // maxTokens: editConfigData?.maxTokens,
@@ -582,7 +588,9 @@ export const modelTypeByValueType = {
 };
 
 export const getOutputFormatFromCatalogType = (catalogType) =>
-  getOutputFormatForModelType(modelTypeByValueType[catalogType] ?? MODEL_TYPES.LLM);
+  getOutputFormatForModelType(
+    modelTypeByValueType[catalogType] ?? MODEL_TYPES.LLM,
+  );
 
 export const DUMMY_MODEL_PARAMS = [
   {

--- a/futureagi/model_hub/serializers/run_prompt.py
+++ b/futureagi/model_hub/serializers/run_prompt.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from model_hub.models.api_key import ApiKey
+from tfc.utils.serializer_fields import JsonValueField
 
 
 class ApiKeyCreateSerializer(serializers.Serializer):
@@ -162,9 +163,13 @@ class LitellmSerializer(serializers.Serializer):
 
 class PromptConfigSerializer(serializers.Serializer):
     model = serializers.CharField(max_length=255, required=False, allow_blank=True)
-    run_prompt_config = serializers.DictField(required=False)
+    # Free-form config: values are mixed JSON (model_name str, isAvailable
+    # bool, booleans/dropdowns objects, …). Use JsonValueField so the contract
+    # doesn't constrain every value to a string.
+    run_prompt_config = serializers.DictField(child=JsonValueField(), required=False)
     messages = serializers.ListField(
-        child=serializers.DictField(),
+        # content can be a string or a list of typed parts — keep values open.
+        child=serializers.DictField(child=JsonValueField()),
         required=False,
         help_text="List of messages with format [{'role': 'user/assistant', 'content': 'text'}]",
     )
@@ -203,7 +208,7 @@ class PromptConfigSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Controls diversity via nucleus sampling. Value between 0 and 1.",
     )
-    response_format = serializers.JSONField(
+    response_format = JsonValueField(
         required=False,
         allow_null=True,
         help_text="JSON schema for response format if required. Can be a JSON object or string. Defaults to None.",
@@ -215,7 +220,7 @@ class PromptConfigSerializer(serializers.Serializer):
         help_text="Tool selection mode: 'auto' or 'required'.",
     )
     tools = serializers.ListField(
-        child=serializers.DictField(),
+        child=serializers.DictField(child=JsonValueField()),
         required=False,
         allow_null=True,
         help_text="List of tools with tool properties if available.",


### PR DESCRIPTION
## 🐛 Bug

[TH-6266](https://linear.app/future-agi/issue/TH-6266) — **Importing a prompt into a dataset run-prompt column was broken end-to-end.** Depending on the step it crashed, hydrated an empty/partial config, silently blocked **Run**, or no-op'd **Test** (especially in edit mode). Root cause throughout: **camelCase vs snake_case** mismatches between the backend-stored config and the frontend form, plus a too-strict generated request contract.

## 🔧 What changed

**Frontend**

* **Import** (`handleApplyImportedPrompt`): read the **snake_case** snapshot (`prompt_config_snapshot` / `model_detail` / `response_format`) with array guards — was reading camelCase + an unguarded `messages.map` → crash + empty model/config.
* **Edit hydration** (`transformDefaultData`): model params, `responseFormat` and `voiceId` were read with the wrong casing → sliders/voice/response-format silently reset and **Test/Run no-op'd** (required-field validation failed). Now reads the canonical values.
* **Preview/Test** (`onSubmitPreview`): removed the stray **top-level** `response_format` (backend rejected it with a 400) and resolve `config.model` from `run_prompt_config` so the model is actually sent.
* **RenderMeta**: guard `Object.values(meta)` against `undefined` (result cells crashed once runs produced output).

**Backend**

* `PromptConfigSerializer` used bare `DictField`/`JSONField`, so the generated request contract typed **every value as** `string` and dev request-validation blocked the real run payload (boolean `isAvailable`, array message `content`, string `response_format`). Switched `run_prompt_config` / `messages` / `tools` / `response_format` to `JsonValueField` (`x-json-value` → `z.any()`), and regenerated the OpenAPI + FE contract artifacts.

## 🤔 Why

The backend accepts these payloads in prod; the dev-only request-contract validator was the thing blocking runs, because the serializer over-constrained mixed-JSON fields. `JsonValueField` already exists for exactly this. The FE casing reads are fixed at the call sites for now — see follow-up.

## 🧪 Tests

* `run-prompt-contract.test.js` — round-trip guard driving the **real runtime validator**: a representative run payload (boolean `isAvailable`, object `booleans`/`dropdowns`, `null` numerics, array message `content`, string `response_format`) must pass the `add_run_prompt_column` request contract. Fails against the old serializer, passes against the new one.

## ▶️ How to verify

1. Develop → a dataset → add a **Run Prompt** column → **Import** a saved prompt → config + model + messages populate (no crash).
2. **Run** → fires (no silent block).
3. **Edit** the column → fields hydrate → **Test** / **Run** work.
4. Verified at runtime for **LLM, TTS (mp3), Image (png)** via `preview_run_prompt_column`.

## 💻 Commands

```bash
# frontend/
yarn vitest run src/api/contracts/__tests__/run-prompt-contract.test.js
yarn contracts:check
```

## 📹 Videos & Screenshots

https://github.com/user-attachments/assets/016311f7-096f-4976-adeb-dd05fe0b8c24

Closes [TH-6263](https://linear.app/future-agi/issue/TH-6263/run-prompt-configure-run-crashing), [TH-6266](https://linear.app/future-agi/issue/TH-6266/import-prompt-to-dataset-not-working)

## 🧹 Follow-up / notes for reviewers

* **Casing reads are deliberately point-fixes for now.** The proper fix (agreed) is a single boundary normalizer that coalesces the backend's mixed snake/camel `run_prompt_config` once, then single-key reads — tracked as follow-up. The backend genuinely returns both casings (FE saved both + a legacy migration wrote camel), so the coalescing is real, not guessing.
* **Out-of-scope contract bit:** the regen also drops a stale `hidden` field from an unrelated EE `falcon_ai` endpoint — correct per its serializer (it never had `hidden`), flagging since it's not part of this change.