### PR TITLE
fix: route queue status changes from the edit drawer through update-status (TH-6166)

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/create-queue-drawer.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/create-queue-drawer.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
+import CreateQueueDrawer from "../create-queue-drawer";
+
+// Auto-invoke onSuccess so the drawer's chained status update can fire.
+const mockCreateQueue = vi.fn((_payload, opts) => opts?.onSuccess?.());
+const mockUpdateQueue = vi.fn((_payload, opts) => opts?.onSuccess?.());
+const mockUpdateStatus = vi.fn((_payload, opts) => opts?.onSuccess?.());
+
+vi.mock("src/api/annotation-queues/annotation-queues", () => ({
+  useCreateAnnotationQueue: () => ({
+    mutate: mockCreateQueue,
+    isPending: false,
+  }),
+  useUpdateAnnotationQueue: () => ({
+    mutate: mockUpdateQueue,
+    isPending: false,
+  }),
+  useUpdateAnnotationQueueStatus: () => ({
+    mutate: mockUpdateStatus,
+    isPending: false,
+  }),
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+// Return a STABLE user object. The drawer's reset effect lists `user` in its
+// deps; a fresh object each render would re-run the effect → reset() → re-render
+// in an infinite loop (the real auth context is memoized, so it stays stable).
+vi.mock("src/auth/hooks", () => {
+  const user = { id: "user-1" };
+  return { useAuthContext: () => ({ user }) };
+});
+
+vi.mock("../components/label-picker", () => ({
+  default: () => <div data-testid="label-picker" />,
+}));
+
+vi.mock("../components/annotator-picker", () => ({
+  default: () => <div data-testid="annotator-picker" />,
+}));
+
+const ACTIVE_QUEUE = {
+  id: "queue-1",
+  name: "Hallucination QA",
+  description: "",
+  status: "active",
+  annotations_required: 1,
+  annotators: [],
+  labels: [],
+};
+
+describe("CreateQueueDrawer status update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a changed status through the dedicated update-status endpoint", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <CreateQueueDrawer open onClose={onClose} editQueue={ACTIVE_QUEUE} />,
+    );
+
+    // active -> paused is a valid transition; pick it from the Status select.
+    await user.click(screen.getByRole("combobox", { name: /status/i }));
+    await user.click(await screen.findByRole("option", { name: "Paused" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      // Status must NOT ride the general queue update (it's read-only there and
+      // is silently dropped — the bug). It goes through update-status instead.
+      expect(mockUpdateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "queue-1", status: "paused" }),
+        expect.any(Object),
+      );
+    });
+    expect(mockUpdateQueue).toHaveBeenCalledWith(
+      expect.not.objectContaining({ status: expect.anything() }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not call update-status when the status is unchanged", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateQueueDrawer open onClose={vi.fn()} editQueue={ACTIVE_QUEUE} />,
+    );
+
+    // Save without touching the Status select. A same-status transition is
+    // rejected by the state machine, so it must be skipped entirely.
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateQueue).toHaveBeenCalledOnce();
+    });
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not offer an unreachable status target (no transition leads to draft)", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateQueueDrawer open onClose={vi.fn()} editQueue={ACTIVE_QUEUE} />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: /status/i }));
+
+    expect(screen.getByRole("option", { name: "Paused" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Completed" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Draft" })).toBeNull();
+  });
+});

--- a/frontend/src/sections/annotations/queues/constants.js
+++ b/frontend/src/sections/annotations/queues/constants.js
@@ -45,6 +45,16 @@ export const queueViewerMembership = (queue) => {
 export const canViewerAddItemsToQueue = (queue) =>
   hasQueueRole(queueViewerMembership(queue), QUEUE_ROLES.MANAGER);
 
+// Allowed queue status transitions, mirroring the backend state machine
+// (VALID_STATUS_TRANSITIONS in model_hub/models/annotation_queues.py). The
+// update-status endpoint rejects anything not listed here, so the UI must only
+// offer reachable targets — nothing transitions *to* "draft", for instance.
+export const QUEUE_STATUS_TRANSITIONS = {
+  draft: ["active"],
+  active: ["paused", "completed"],
+  paused: ["active", "completed"],
+  completed: ["active", "paused"],
+};
 
 export const SOURCE_OPTIONS = [
   { value: "dataset_row", label: "Dataset Row" },

--- a/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
+++ b/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
@@ -24,10 +24,16 @@ import { useAuthContext } from "src/auth/hooks";
 import {
   useCreateAnnotationQueue,
   useUpdateAnnotationQueue,
+  useUpdateAnnotationQueueStatus,
 } from "src/api/annotation-queues/annotation-queues";
 import LabelPicker from "./components/label-picker";
 import AnnotatorPicker from "./components/annotator-picker";
-import { QUEUE_ROLES, isQueueAnnotatorRole, queueRoleList } from "./constants";
+import {
+  QUEUE_ROLES,
+  QUEUE_STATUS_TRANSITIONS,
+  isQueueAnnotatorRole,
+  queueRoleList,
+} from "./constants";
 
 const STATUS_OPTIONS = [
   { value: "draft", label: "Draft" },
@@ -121,8 +127,21 @@ export default function CreateQueueDrawer({
     useCreateAnnotationQueue();
   const { mutate: updateQueue, isPending: isUpdating } =
     useUpdateAnnotationQueue();
-  const isPending = isCreating || isUpdating;
+  const { mutate: updateStatus, isPending: isStatusUpdating } =
+    useUpdateAnnotationQueueStatus();
+  const isPending = isCreating || isUpdating || isStatusUpdating;
   const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Status lives behind its own state-machine endpoint, so only offer targets
+  // the backend will accept from the queue's current status (plus the current
+  // status itself, so the select can show where it stands). Offering an
+  // unreachable target like "draft" just produces a guaranteed error.
+  const currentStatus = editQueue?.status || "draft";
+  const statusOptions = STATUS_OPTIONS.filter(
+    (opt) =>
+      opt.value === currentStatus ||
+      (QUEUE_STATUS_TRANSITIONS[currentStatus] || []).includes(opt.value),
+  );
 
   const { control, handleSubmit, reset, setValue, watch, trigger } = useForm({
     defaultValues: DEFAULT_VALUES,
@@ -207,9 +226,29 @@ export default function CreateQueueDrawer({
     };
 
     if (isEdit) {
+      // `status` is read-only on the queue serializer; it only moves through the
+      // dedicated state-machine endpoint. Save settings first, then transition
+      // status separately (and only when it actually changed — a no-op
+      // same-status transition is rejected by the state machine).
+      const statusChanged = formData.status !== currentStatus;
       updateQueue(
-        { id: editQueue.id, ...payload, status: formData.status },
-        { onSuccess: () => onClose() },
+        { id: editQueue.id, ...payload },
+        {
+          onSuccess: () => {
+            if (!statusChanged) {
+              onClose();
+              return;
+            }
+            updateStatus(
+              { id: editQueue.id, status: formData.status },
+              {
+                onSuccess: () => onClose(),
+                // Keep the drawer open on failure so the user can pick a valid
+                // target; the status hook surfaces the backend reason.
+              },
+            );
+          },
+        },
       );
     } else {
       createQueue(payload, {
@@ -333,7 +372,7 @@ export default function CreateQueueDrawer({
                           "& .MuiOutlinedInput-root": { borderRadius: 0.5 },
                         }}
                       >
-                        {STATUS_OPTIONS.map((opt) => (
+                        {statusOptions.map((opt) => (
                           <MenuItem key={opt.value} value={opt.value}>
                             {opt.label}
                           </MenuItem>


### PR DESCRIPTION
## TH-6166 — queue status update from the drawer doesn't change

Reporter: @commitPirate (Nosang). Fixes [TH-6166](https://linear.app/future-agi/issue/TH-6166).

### The bug (verified frame-by-frame against the screen recording)
Editing a queue from the **Edit drawer**, changing **Status**, and hitting **Save changes** shows a green "Queue updated successfully" toast — but the status never changes.

Root cause: the drawer sent `status` inside the **general** queue-update PATCH (`useUpdateAnnotationQueue`). But `status` is in `read_only_fields` on `AnnotationQueueSerializer`, so DRF silently drops it and returns `200`. The recording's Network tab (Request Payload) literally shows `status: "paused"` going to `PATCH /annotation-queues/{id}/` and being ignored. The reported transition was **active → paused**, a valid one.

Status is meant to move **only** through the dedicated `update-status` action, which enforces the `VALID_STATUS_TRANSITIONS` state machine. The **settings tab already does this correctly** — the drawer was the one edit surface that bypassed the gate. (Confirmed via grep: only two `useUpdateAnnotationQueue` callers exist — this drawer and the settings tab.)

### The fix (frontend only — backend is correct by design)
- **`create-queue-drawer.jsx`** — route the status change through `useUpdateAnnotationQueueStatus`, mirroring the settings-tab pattern. Guarded by `statusChanged` (a no-op same-status transition is *rejected* by the state machine, so it must be skipped). Dropped the now-dead `status` from the general payload. On status-endpoint failure the drawer stays open so the user can correct the selection.
- **`constants.js`** — new shared `QUEUE_STATUS_TRANSITIONS` (mirrors backend `VALID_STATUS_TRANSITIONS`). The drawer constrains its Status options to `[current, ...validTargets]`, so it can't offer a guaranteed-failing target like **draft** (nothing transitions *to* draft). The table's `getStatusActions` is a deliberately-curated kebab subset and is left unchanged.

No backend change, no migration, no API-contract change.

### Tests
`create-queue-drawer.test.jsx` (3, vitest), all green:
1. A changed status routes through `update-status` and is **not** in the general payload — **fail-on-revert verified** (restoring the buggy `onSubmit` makes this fail).
2. An unchanged status skips `update-status` (the `active→active` 400 guard).
3. The drawer doesn't offer the unreachable "draft" target.

<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/11a36d67-6e71-46d1-b377-4e3198eb95d9" />
<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/e23b43e8-bb54-4ace-aa4b-5d45023c6934" />
<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/9fc7b322-1955-4c0b-b778-eaaa8c8fac4b" />
<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/69342752-82db-4dbd-9fb5-8e1e4c4ec2f0" />


