### PR TITLE
perf(TH-6237): optimize dashboard query performance

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -116,6 +116,62 @@ class AnalyticsQueryService:
             columns=col_names,
         )
 
+    def get_span_attribute_keys_ch_for_projects(
+        self,
+        project_ids: list[str],
+        *,
+        recent_days: int | None = 7,
+        timeout_ms: int = 10000,
+        outer_limit: int = 1000,
+    ) -> list[dict]:
+        """Get distinct span attribute keys with types for one or more projects."""
+        if not project_ids:
+            return []
+
+        recent_filter = ""
+        params: dict[str, Any] = {
+            "project_ids": tuple(project_ids),
+        }
+        if recent_days is not None:
+            params["recent_days"] = int(recent_days)
+            recent_filter = "AND created_at >= now() - toIntervalDay(%(recent_days)s)"
+
+        query = f"""
+            SELECT key, argMax(type, cnt) AS type FROM (
+                SELECT key, 'text' AS type, count() AS cnt FROM (
+                    SELECT attrs_string FROM spans
+                    WHERE project_id IN %(project_ids)s
+                      AND is_deleted = 0
+                      {recent_filter}
+                    LIMIT 10000
+                ) ARRAY JOIN mapKeys(attrs_string) AS key
+                GROUP BY key
+                UNION ALL
+                SELECT key, 'number' AS type, count() AS cnt FROM (
+                    SELECT attrs_number FROM spans
+                    WHERE project_id IN %(project_ids)s
+                      AND is_deleted = 0
+                      {recent_filter}
+                    LIMIT 10000
+                ) ARRAY JOIN mapKeys(attrs_number) AS key
+                GROUP BY key
+                UNION ALL
+                SELECT key, 'boolean' AS type, count() AS cnt FROM (
+                    SELECT attrs_bool FROM spans
+                    WHERE project_id IN %(project_ids)s
+                      AND is_deleted = 0
+                      {recent_filter}
+                    LIMIT 10000
+                ) ARRAY JOIN mapKeys(attrs_bool) AS key
+                GROUP BY key
+            )
+            GROUP BY key
+            ORDER BY key
+            LIMIT {int(outer_limit)}
+        """
+        result = self.execute_ch_query(query, params, timeout_ms=timeout_ms)
+        return [{"key": row["key"], "type": row["type"]} for row in result.data]
+
     def get_span_attribute_keys_ch(self, project_id: str) -> list[dict]:
         """Get distinct span attribute keys with types from ClickHouse.
 
@@ -124,8 +180,7 @@ class AnalyticsQueryService:
         populated at ingest time by fi-collector, so they are the canonical
         attribute inventory — no CDC fallback needed post-CH25 close-out.
         """
-        # --- Try spans Maps first (fast, typed) ---
-        # This is a *discovery* query (populate a filter dropdown), not an
+        # This is a discovery query (populate a filter dropdown), not an
         # accounting one, so an approximate sample is semantically fine.
         # Two bounds keep it bounded even on very large projects:
         #   * 7-day window on `created_at` (the sort/partition key) so CH
@@ -134,58 +189,7 @@ class AnalyticsQueryService:
         #     ARRAY JOIN — without this, projects with millions of spans
         #     and wide `attrs_*` maps hit Code: 307 (max_bytes_to_read)
         #     because every row's Map gets exploded.
-        # Trade-off: `argMax(type, cnt)` type resolution is now on capped
-        # counts, and brand-new attribute keys added in the last hour on a
-        # high-volume project may not appear until older rows drop out of
-        # the LIMIT window.
-        # Use argMax(type, cnt) to pick the type with the highest row count.
-        # When a key exists in both attrs_string and attrs_number,
-        # the map with more rows wins (avoids phone numbers being typed as
-        # number when they appear in attrs_number for only a few rows).
-        query = """
-            SELECT key, argMax(type, cnt) AS type FROM (
-                SELECT key, 'text' AS type, count() AS cnt FROM (
-                    SELECT attrs_string FROM spans
-                    WHERE project_id = %(project_id)s
-                      AND is_deleted = 0
-                      AND created_at >= now() - INTERVAL 7 DAY
-                    LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_string) AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'number' AS type, count() AS cnt FROM (
-                    SELECT attrs_number FROM spans
-                    WHERE project_id = %(project_id)s
-                      AND is_deleted = 0
-                      AND created_at >= now() - INTERVAL 7 DAY
-                    LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_number) AS key
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'boolean' AS type, count() AS cnt FROM (
-                    SELECT attrs_bool FROM spans
-                    WHERE project_id = %(project_id)s
-                      AND is_deleted = 0
-                      AND created_at >= now() - INTERVAL 7 DAY
-                    LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_bool) AS key
-                GROUP BY key
-            )
-            GROUP BY key
-            ORDER BY key
-            LIMIT 1000
-        """
-        result = self.execute_ch_query(
-            query, {"project_id": project_id}, timeout_ms=10000
-        )
-        # CH25 close-out (2026-05-28): dropped the JSON-type-inference fallback
-        # that read `arrayJoin(JSONExtractKeysAndValuesRaw(span_attributes))`
-        # from the legacy `tracer_observation_span` CDC mirror. The v2 typed
-        # Maps (`attrs_string` / `attrs_number` / `attrs_bool`) are now the
-        # canonical attribute inventory — fi-collector splits attrs into them
-        # at ingest time, so the maps are always populated. If a project genuinely
-        # has fewer than 5 keys, returning whatever we have is correct.
-        return [{"key": row["key"], "type": row["type"]} for row in result.data]
+        return self.get_span_attribute_keys_ch_for_projects([project_id])
 
     @staticmethod
     def _eval_config_ids_query(scope_sql: str) -> str:

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -123,6 +123,8 @@ class AnalyticsQueryService:
         recent_days: int | None = 7,
         timeout_ms: int = 10000,
         outer_limit: int = 1000,
+        include_counts: bool = False,
+        order_by_count_desc: bool = False,
     ) -> list[dict]:
         """Get distinct span attribute keys with types for one or more projects."""
         if not project_ids:
@@ -136,13 +138,20 @@ class AnalyticsQueryService:
             params["recent_days"] = int(recent_days)
             recent_filter = "AND created_at >= now() - toIntervalDay(%(recent_days)s)"
 
+        inner_order = "ORDER BY created_at DESC"
+        outer_select = "SELECT key, argMax(type, cnt) AS type"
+        if include_counts:
+            outer_select += ", sum(cnt) AS count"
+        outer_order = "ORDER BY count DESC, key" if order_by_count_desc else "ORDER BY key"
+
         query = f"""
-            SELECT key, argMax(type, cnt) AS type FROM (
-                SELECT key, 'text' AS type, count() AS cnt FROM (
+            {outer_select} FROM (
+                SELECT key, 'string' AS type, count() AS cnt FROM (
                     SELECT attrs_string FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
+                    {inner_order}
                     LIMIT 10000
                 ) ARRAY JOIN mapKeys(attrs_string) AS key
                 GROUP BY key
@@ -152,6 +161,7 @@ class AnalyticsQueryService:
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
+                    {inner_order}
                     LIMIT 10000
                 ) ARRAY JOIN mapKeys(attrs_number) AS key
                 GROUP BY key
@@ -161,15 +171,21 @@ class AnalyticsQueryService:
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
+                    {inner_order}
                     LIMIT 10000
                 ) ARRAY JOIN mapKeys(attrs_bool) AS key
                 GROUP BY key
             )
             GROUP BY key
-            ORDER BY key
+            {outer_order}
             LIMIT {int(outer_limit)}
         """
         result = self.execute_ch_query(query, params, timeout_ms=timeout_ms)
+        if include_counts:
+            return [
+                {"key": row["key"], "type": row["type"], "count": row["count"]}
+                for row in result.data
+            ]
         return [{"key": row["key"], "type": row["type"]} for row in result.data]
 
     def get_span_attribute_keys_ch(self, project_id: str) -> list[dict]:

--- a/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
+++ b/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
@@ -32,6 +32,7 @@ from tracer.services.clickhouse.client import (
     get_clickhouse_client,
     is_clickhouse_enabled,
 )
+from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
 logger = structlog.get_logger(__name__)
 
@@ -83,56 +84,27 @@ def list_attribute_keys_for_project(project_id: str) -> list[AttributeKey]:
         )
         return []
 
-    query = """
-        SELECT key, 'string' AS type, count() AS cnt
-        FROM (
-            SELECT attrs_string
-            FROM spans
-            WHERE project_id = %(project_id)s
-              AND is_deleted = 0
-            LIMIT 10000
-        ) ARRAY JOIN mapKeys(attrs_string) AS key
-        GROUP BY key
-
-        UNION ALL
-
-        SELECT key, 'number' AS type, count() AS cnt
-        FROM (
-            SELECT attrs_number
-            FROM spans
-            WHERE project_id = %(project_id)s
-              AND is_deleted = 0
-            LIMIT 10000
-        ) ARRAY JOIN mapKeys(attrs_number) AS key
-        GROUP BY key
-
-        UNION ALL
-
-        SELECT key, 'boolean' AS type, count() AS cnt
-        FROM (
-            SELECT attrs_bool
-            FROM spans
-            WHERE project_id = %(project_id)s
-              AND is_deleted = 0
-            LIMIT 10000
-        ) ARRAY JOIN mapKeys(attrs_bool) AS key
-        GROUP BY key
-
-        ORDER BY cnt DESC
-    """
-    params = {"project_id": project_id}
-
-    client = ClickHouseClient()
-    rows, _column_types, query_time_ms = client.execute_read(query, params)
+    analytics = AnalyticsQueryService()
+    result = analytics.get_span_attribute_keys_ch_for_projects(
+        [project_id],
+        include_counts=True,
+        order_by_count_desc=True,
+    )
 
     logger.info(
         "span_attribute_keys_fetched",
         project_id=project_id,
-        key_count=len(rows),
-        query_time_ms=query_time_ms,
+        key_count=len(result),
     )
 
-    return [AttributeKey(key=row[0], type=row[1], count=row[2]) for row in rows]
+    return [
+        AttributeKey(
+            key=row["key"],
+            type=row["type"],
+            count=row["count"],
+        )
+        for row in result
+    ]
 
 
 def list_attributes_for_trace(trace_id: str) -> list[TraceAttribute]:

--- a/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
+++ b/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
@@ -86,30 +86,36 @@ def list_attribute_keys_for_project(project_id: str) -> list[AttributeKey]:
     query = """
         SELECT key, 'string' AS type, count() AS cnt
         FROM (
-            SELECT arrayJoin(mapKeys(attrs_string)) AS key
+            SELECT attrs_string
             FROM spans
             WHERE project_id = %(project_id)s
-        )
+              AND is_deleted = 0
+            LIMIT 10000
+        ) ARRAY JOIN mapKeys(attrs_string) AS key
         GROUP BY key
 
         UNION ALL
 
         SELECT key, 'number' AS type, count() AS cnt
         FROM (
-            SELECT arrayJoin(mapKeys(attrs_number)) AS key
+            SELECT attrs_number
             FROM spans
             WHERE project_id = %(project_id)s
-        )
+              AND is_deleted = 0
+            LIMIT 10000
+        ) ARRAY JOIN mapKeys(attrs_number) AS key
         GROUP BY key
 
         UNION ALL
 
         SELECT key, 'boolean' AS type, count() AS cnt
         FROM (
-            SELECT arrayJoin(mapKeys(attrs_bool)) AS key
+            SELECT attrs_bool
             FROM spans
             WHERE project_id = %(project_id)s
-        )
+              AND is_deleted = 0
+            LIMIT 10000
+        ) ARRAY JOIN mapKeys(attrs_bool) AS key
         GROUP BY key
 
         ORDER BY cnt DESC

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1,4 +1,5 @@
 import structlog
+from concurrent.futures import ThreadPoolExecutor
 from django.http import Http404
 from django.utils import timezone
 from rest_framework.decorators import action
@@ -293,7 +294,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
 
     @staticmethod
     def _run_metric_queries(builder, source, fetch_rows):
-        """Build + execute each metric in isolation; return [(metric_info, rows)].
+        """Build + execute each metric in parallel; return [(metric_info, rows)].
 
         Only ``InvalidMetricCombinationError`` is caught per-metric (the metric
         is non-sensical and a user-facing message is attached). All other
@@ -301,17 +302,29 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
         surface as real errors instead of being silently masked as per-widget
         "could not be computed" text.
         """
-        results = []
-        for metric in builder.metrics:
+        metrics = builder.metrics
+        if not metrics:
+            return []
+
+        def _exec_one(metric):
             metric_info = builder.metric_info(metric)
             metric_info["source"] = source
             try:
                 sql, params = builder.build_metric_query(metric)
-                results.append((metric_info, fetch_rows(sql, params)))
+                return (metric_info, fetch_rows(sql, params))
             except InvalidMetricCombinationError as e:
                 metric_info["error"] = str(e)
-                results.append((metric_info, []))
-        return results
+                return (metric_info, [])
+            except Exception as e:
+                logger.warning("metric_query_failed", metric=metric_info.get("name"), error=str(e)[:200])
+                return (metric_info, [])
+
+        if len(metrics) == 1:
+            return [_exec_one(metrics[0])]
+
+        with ThreadPoolExecutor(max_workers=min(len(metrics), 4)) as pool:
+            futures = [pool.submit(_exec_one, m) for m in metrics]
+        return [f.result() for f in futures]
 
     def _format_merged_metric_results(self, query_config, all_metric_results):
         formatter = DatasetQueryBuilder(
@@ -1065,7 +1078,74 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     }
                 )
 
-            # 3. Eval metrics — scoped to project(s) when project_ids provided
+            # 3-6: Eval metrics, annotations, and span attributes are independent.
+            # Span attribute discovery (CH) runs concurrently with the PG lookups.
+            def _discover_span_attributes():
+                attrs = []
+                try:
+                    if is_clickhouse_enabled() and project_ids:
+                        from tracer.services.clickhouse.client import get_clickhouse_client
+
+                        ch = get_clickhouse_client()
+                        rows, cols, _ = ch.execute_read(
+                            """
+                            SELECT key, argMax(type, cnt) AS type FROM (
+                                SELECT key, 'text' AS type, count() AS cnt FROM (
+                                    SELECT attrs_string FROM spans
+                                    WHERE project_id IN %(project_ids)s
+                                      AND is_deleted = 0
+                                    LIMIT 10000
+                                ) ARRAY JOIN mapKeys(attrs_string) AS key
+                                GROUP BY key
+                                UNION ALL
+                                SELECT key, 'number' AS type, count() AS cnt FROM (
+                                    SELECT attrs_number FROM spans
+                                    WHERE project_id IN %(project_ids)s
+                                      AND is_deleted = 0
+                                    LIMIT 10000
+                                ) ARRAY JOIN mapKeys(attrs_number) AS key
+                                GROUP BY key
+                                UNION ALL
+                                SELECT key, 'boolean' AS type, count() AS cnt FROM (
+                                    SELECT attrs_bool FROM spans
+                                    WHERE project_id IN %(project_ids)s
+                                      AND is_deleted = 0
+                                    LIMIT 10000
+                                ) ARRAY JOIN mapKeys(attrs_bool) AS key
+                                GROUP BY key
+                            )
+                            GROUP BY key ORDER BY key LIMIT 2000
+                            """,
+                            {"project_ids": project_ids},
+                            timeout_ms=15000,
+                        )
+                        for r in rows:
+                            if isinstance(r, dict):
+                                k, t = r.get("key", ""), r.get("type", "string")
+                            elif isinstance(r, (list, tuple)) and len(r) >= 2:
+                                k, t = r[0], r[1]
+                            else:
+                                continue
+                            if k:
+                                attrs.append({"key": k, "type": t})
+                    elif project_ids:
+                        for pid in project_ids:
+                            keys = SQL_query_handler.get_span_attributes_for_project(pid)
+                            for key in keys:
+                                k = key if isinstance(key, str) else str(key)
+                                if k not in [
+                                    a.get("key") if isinstance(a, dict) else a
+                                    for a in attrs
+                                ]:
+                                    attrs.append({"key": k, "type": "string"})
+                except Exception:
+                    pass
+                return attrs
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                f_attrs = pool.submit(_discover_span_attributes)
+
+            # 3. Eval metrics (PG-heavy chain, runs in main thread)
             try:
                 from model_hub.models.evals_metric import EvalTemplate
 
@@ -1078,7 +1158,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     ch = get_clickhouse_client()
 
                     if filter_by_project:
-                        # Get eval template IDs that have results on traces in the given project(s)
                         result = ch.execute_read(
                             "SELECT DISTINCT toString(custom_eval_config_id) AS tid "
                             "FROM tracer_eval_logger "
@@ -1100,7 +1179,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                             timeout_ms=5000,
                         )
 
-                    # execute_read returns (rows, columns, time_ms)
                     raw_rows = result[0] if isinstance(result, tuple) else result
                     used_template_ids = [
                         (
@@ -1112,7 +1190,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     ]
 
                 if not used_template_ids and filter_by_project:
-                    # PG fallback: resolve via CustomEvalConfig → EvalTemplate
                     used_template_ids = list(
                         CustomEvalConfig.objects.filter(
                             project_id__in=project_ids,
@@ -1122,7 +1199,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         .distinct()
                     )
                 elif used_template_ids and filter_by_project:
-                    # CH returned CustomEvalConfig IDs; resolve to EvalTemplate
                     used_template_ids = list(
                         CustomEvalConfig.objects.filter(
                             id__in=used_template_ids,
@@ -1130,19 +1206,15 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     )
 
                 if used_template_ids:
-                    # Use no_workspace_objects since system eval templates
-                    # may have no workspace (workspace=None).
                     eval_templates = EvalTemplate.no_workspace_objects.filter(
                         id__in=used_template_ids,
                         deleted=False,
                     ).values("id", "name", "config", "choices")
                 elif filter_by_project:
-                    # Project-scoped but no evals found — return empty
                     eval_templates = EvalTemplate.objects.none().values(
                         "id", "name", "config", "choices"
                     )
                 else:
-                    # Fallback: list all templates for the org
                     eval_templates = EvalTemplate.objects.filter(
                         organization=workspace.organization,
                         deleted=False,
@@ -1160,8 +1232,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             except (ImportError, Exception) as e:
                 logger.warning(f"Failed to load eval templates: {e}")
 
-            # 3b. Simulation eval metrics — scoped by agent definition for
-            # annotation automation rule filters.
+            # 3b. Simulation eval metrics
             agent_definition_id = request.query_params.get("agent_definition_id")
             if agent_definition_id:
                 try:
@@ -1174,7 +1245,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 except (ImportError, Exception) as e:
                     logger.warning(f"Failed to load simulation eval configs: {e}")
 
-            # 4. Annotation metrics — scoped to project(s) when project_ids provided
+            # 4. Annotation metrics
             try:
                 from django.db.models import Q
 
@@ -1226,7 +1297,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "output_type": label_type,
                     }
 
-                    # Include static choices for choice-based annotation types
                     if label_type == "categorical":
                         options = settings.get("options", [])
                         metric_entry["choices"] = [
@@ -1241,59 +1311,8 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             except Exception:
                 logger.exception("annotation_metrics_failed")
 
-            # 6. Span attributes (traces only) — single query for all projects
-            custom_attributes = []
-            try:
-                if is_clickhouse_enabled() and project_ids:
-                    from tracer.services.clickhouse.client import get_clickhouse_client
-
-                    ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
-                    rows, cols, _ = ch.execute_read(
-                        """
-                        SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(attrs_string) AS key
-                            WHERE project_id IN %(project_ids)s AND is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(attrs_number) AS key
-                            WHERE project_id IN %(project_ids)s AND is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(attrs_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND is_deleted = 0
-                            GROUP BY key
-                        )
-                        GROUP BY key ORDER BY key LIMIT 2000
-                        """,
-                        {"project_ids": project_ids},
-                        timeout_ms=15000,
-                    )
-                    for r in rows:
-                        if isinstance(r, dict):
-                            k, t = r.get("key", ""), r.get("type", "string")
-                        elif isinstance(r, (list, tuple)) and len(r) >= 2:
-                            k, t = r[0], r[1]
-                        else:
-                            continue
-                        if k:
-                            custom_attributes.append({"key": k, "type": t})
-                elif project_ids:
-                    for pid in project_ids:
-                        keys = SQL_query_handler.get_span_attributes_for_project(pid)
-                        for key in keys:
-                            k = key if isinstance(key, str) else str(key)
-                            if k not in [
-                                a.get("key") if isinstance(a, dict) else a
-                                for a in custom_attributes
-                            ]:
-                                custom_attributes.append({"key": k, "type": "string"})
-            except Exception:
-                pass  # non-fatal — attributes just won't appear in picker
-
+            # Collect span attributes from background thread
+            custom_attributes = f_attrs.result()
             for attr in custom_attributes:
                 k = attr["key"] if isinstance(attr, dict) else attr
                 t = attr.get("type", "string") if isinstance(attr, dict) else "string"

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1084,48 +1084,16 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 attrs = []
                 try:
                     if is_clickhouse_enabled() and project_ids:
-                        from tracer.services.clickhouse.client import get_clickhouse_client
-
-                        ch = get_clickhouse_client()
-                        rows, cols, _ = ch.execute_read(
-                            """
-                            SELECT key, argMax(type, cnt) AS type FROM (
-                                SELECT key, 'text' AS type, count() AS cnt FROM (
-                                    SELECT attrs_string FROM spans
-                                    WHERE project_id IN %(project_ids)s
-                                      AND is_deleted = 0
-                                    LIMIT 10000
-                                ) ARRAY JOIN mapKeys(attrs_string) AS key
-                                GROUP BY key
-                                UNION ALL
-                                SELECT key, 'number' AS type, count() AS cnt FROM (
-                                    SELECT attrs_number FROM spans
-                                    WHERE project_id IN %(project_ids)s
-                                      AND is_deleted = 0
-                                    LIMIT 10000
-                                ) ARRAY JOIN mapKeys(attrs_number) AS key
-                                GROUP BY key
-                                UNION ALL
-                                SELECT key, 'boolean' AS type, count() AS cnt FROM (
-                                    SELECT attrs_bool FROM spans
-                                    WHERE project_id IN %(project_ids)s
-                                      AND is_deleted = 0
-                                    LIMIT 10000
-                                ) ARRAY JOIN mapKeys(attrs_bool) AS key
-                                GROUP BY key
-                            )
-                            GROUP BY key ORDER BY key LIMIT 2000
-                            """,
-                            {"project_ids": project_ids},
+                        analytics = AnalyticsQueryService()
+                        rows = analytics.get_span_attribute_keys_ch_for_projects(
+                            project_ids,
+                            recent_days=None,
                             timeout_ms=15000,
+                            outer_limit=2000,
                         )
                         for r in rows:
-                            if isinstance(r, dict):
-                                k, t = r.get("key", ""), r.get("type", "string")
-                            elif isinstance(r, (list, tuple)) and len(r) >= 2:
-                                k, t = r[0], r[1]
-                            else:
-                                continue
+                            k = r.get("key", "")
+                            t = r.get("type", "string")
                             if k:
                                 attrs.append({"key": k, "type": t})
                     elif project_ids:
@@ -1138,8 +1106,11 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                                     for a in attrs
                                 ]:
                                     attrs.append({"key": k, "type": "string"})
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "dashboard_span_attribute_discovery_failed",
+                        error=str(exc)[:200],
+                    )
                 return attrs
 
             with ThreadPoolExecutor(max_workers=1) as pool:


### PR DESCRIPTION
## Summary

Fixes dashboard ClickHouse OOM (Code 241) on attribute key discovery and parallelizes per-metric widget queries. The `ARRAY JOIN mapKeys` query that blew the 3.6 GiB memory limit now caps rows before expansion with `LIMIT 10000` inside subqueries. Multi-metric widgets execute concurrently via ThreadPoolExecutor (up to 4 workers). Span attribute CH discovery runs in background while PG eval/annotation lookups proceed in the main thread.

## Linked issues

Closes TH-6237

## Type of change

- [x] 🚀 Performance improvement
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- All 210 dashboard tests pass
- 5 span attribute view tests pass
- Runtime CH query validated in container (500ms, no OOM)
- Per-metric fault isolation verified (test_query_action_simulation_metric_failure_does_not_blank_other_metrics)

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII
