### PR TITLE
fix(frontend): optimization graph + table, agent contact number, scenario name prefill

### DIFF
--- a/frontend/src/pages/dashboard/agent-definitions/AgentDefinitions.jsx
+++ b/frontend/src/pages/dashboard/agent-definitions/AgentDefinitions.jsx
@@ -171,7 +171,7 @@ function AgentDefinitions() {
         ),
       },
       {
-        id: "contactNumber",
+        id: "contact_number",
         accessorKey: "contact_number",
         header: "Contact Number",
         size: 170,

--- a/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationResultGraph.jsx
+++ b/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationResultGraph.jsx
@@ -199,7 +199,7 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
                     width: 10,
                     height: 10,
                     borderRadius: "50%",
-                    backgroundColor: getUniqueColorPalette(index).tagForeground,
+                    backgroundColor: getUniqueColorPalette(index).tagBackground,
                   }}
                 />
                 <Typography typography="s1">{series.name}</Typography>
@@ -252,7 +252,7 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
               if (activeSeries !== null && idx !== activeSeries) {
                 return getUniqueColorPalette(idx).tagBackground;
               } else {
-                return getUniqueColorPalette(idx).tagForeground;
+                return getUniqueColorPalette(idx).tagBackground;
               }
             }),
             stroke: {
@@ -278,7 +278,7 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
                 show: true,
                 position: "back",
                 stroke: {
-                  color: getUniqueColorPalette(0).tagForeground,
+                  color: getUniqueColorPalette(0).tagBackground,
                   width: 1,
                   dashArray: 4,
                 },
@@ -329,8 +329,8 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
               onMarkerHover: (_, chartContext, { seriesIndex }) => {
                 if (seriesIndex !== undefined) {
                   const color =
-                    getUniqueColorPalette(seriesIndex)?.tagForeground ||
-                    getUniqueColorPalette(0).tagForeground;
+                    getUniqueColorPalette(seriesIndex)?.tagBackground ||
+                    getUniqueColorPalette(0).tagBackground;
                   const baseEl = chartContext.w.globals.dom.baseEl;
                   const crosshairLine = baseEl?.querySelector(
                     ".apexcharts-xcrosshairs line",
@@ -346,8 +346,8 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
               custom: ({ seriesIndex, dataPointIndex, w }) => {
                 if (seriesIndex !== undefined) {
                   const color =
-                    getUniqueColorPalette(seriesIndex)?.tagForeground ||
-                    getUniqueColorPalette(0).tagForeground;
+                    getUniqueColorPalette(seriesIndex)?.tagBackground ||
+                    getUniqueColorPalette(0).tagBackground;
                   const baseEl = w.globals.dom.baseEl;
                   const crosshairLine = baseEl?.querySelector(
                     ".apexcharts-xcrosshairs line",
@@ -364,8 +364,8 @@ const DatasetOptimizationResultGraph = ({ optimizationId }) => {
                 const seriesName = w.config.series[seriesIndex].name;
                 const value = w.globals.series[seriesIndex][dataPointIndex];
                 const color =
-                  getUniqueColorPalette(seriesIndex)?.tagForeground ??
-                  getUniqueColorPalette(0).tagForeground;
+                  getUniqueColorPalette(seriesIndex)?.tagBackground ??
+                  getUniqueColorPalette(0).tagBackground;
 
                 return getGraphTooltipComponent(
                   trialName,

--- a/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationResultGrid.jsx
+++ b/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationResultGrid.jsx
@@ -93,8 +93,8 @@ const DatasetOptimizationResultGrid = ({ optimizationId, onTrialClick }) => {
   });
 
   const columnDefs = useMemo(() => {
-    return getColumnConfig(optimizationData?.columnConfig);
-  }, [optimizationData?.columnConfig]);
+    return getColumnConfig(optimizationData?.column_config);
+  }, [optimizationData?.column_config]);
 
   const rowData = useMemo(() => {
     return optimizationData?.table ?? [];

--- a/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationTrialDetail.jsx
+++ b/frontend/src/sections/develop-detail/DatasetOptimization/DatasetOptimizationTrialDetail.jsx
@@ -155,8 +155,8 @@ const DatasetOptimizationTrialDetail = ({
 
   // Column definitions for trial items grid - using simulation's pattern
   const trialItemsColumnDefs = useMemo(() => {
-    return getTrialItemsColumnConfig(trialScenarios?.columnConfig);
-  }, [trialScenarios?.columnConfig]);
+    return getTrialItemsColumnConfig(trialScenarios?.column_config);
+  }, [trialScenarios?.column_config]);
 
   const defaultColDef = useMemo(
     () => ({

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -607,9 +607,9 @@ const CreateScenarioView = () => {
     if (defaultSelectedAgent) {
       applySourceChange({
         value: defaultSelectedAgent.id,
-        label: defaultSelectedAgent.agentName,
+        label: defaultSelectedAgent.agent_name,
         sourceType: SourceType.AGENT_DEFINITION,
-        agentType: defaultSelectedAgent.agentType,
+        agentType: defaultSelectedAgent.agent_type,
       });
     }
   }, [defaultAgentDefinitionId, agentDefinitions]);

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultGraph.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultGraph.jsx
@@ -149,7 +149,7 @@ const OptimizationResultGraph = ({ optimizationId }) => {
                   borderRadius: 0.5,
                   backgroundColor:
                     activeSeries === index
-                      ? getUniqueColorPalette(index).tagBackground
+                      ? getUniqueColorPalette(index).solid
                       : "transparent",
                   userSelect: "none",
                 }}
@@ -166,7 +166,7 @@ const OptimizationResultGraph = ({ optimizationId }) => {
                     width: 10,
                     height: 10,
                     borderRadius: "50%",
-                    backgroundColor: getUniqueColorPalette(index).tagForeground,
+                    backgroundColor: getUniqueColorPalette(index).tagBackground,
                   }}
                 />
                 <Typography typography="s1">{series.name}</Typography>
@@ -185,169 +185,175 @@ const OptimizationResultGraph = ({ optimizationId }) => {
             multiple
           />
         </Box>
-        <ReactApexChart
-          options={{
-            chart: {
-              id: "optimization-result-graph",
-              type: "line",
-              background: "transparent",
-              foreColor: isDark ? "#a1a1aa" : undefined,
-              toolbar: {
-                show: false,
-              },
-              zoom: {
-                enabled: false,
-              },
-              events: {
-                dataPointMouseEnter: (_, chartContext, config) => {
-                  updateCrosshairColor(chartContext, config.seriesIndex);
-                },
-                mouseMove: (_, chartContext, config) => {
-                  if (config.seriesIndex !== undefined) {
-                    updateCrosshairColor(chartContext, config.seriesIndex);
-                  }
-                },
-                mouseLeave: (_, chartContext) => {
-                  updateCrosshairColor(chartContext, undefined);
-                },
-              },
-            },
-            theme: {
-              mode: isDark ? "dark" : "light",
-            },
-            colors: seriesData.map((_, idx) => {
-              if (activeSeries !== null && idx !== activeSeries) {
-                return getUniqueColorPalette(idx).tagBackground;
-              } else {
-                return getUniqueColorPalette(idx).tagForeground;
-              }
-            }),
-            stroke: {
-              width: 2,
-              curve: "smooth",
-            },
-            markers: {
-              size: 0,
-            },
-            xaxis: {
-              categories: categories,
-              labels: {
-                style: {
-                  fontFamily: "IBM Plex Sans",
-                  fontWeight: 400,
-                  fontSize: "12px",
-                  lineHeight: "18px",
-                  letterSpacing: "0%",
-                  textAlign: "center",
-                },
-              },
-              crosshairs: {
-                show: true,
-                position: "back",
-                stroke: {
-                  color: getUniqueColorPalette(0).tagForeground,
-                  width: 1,
-                  dashArray: 4,
-                },
-              },
-            },
-            yaxis: {
-              title: {
-                text: "Evaluation Score",
-                style: {
-                  fontFamily: "IBM Plex Sans",
-                  fontWeight: 400,
-                  fontSize: "12px",
-                  lineHeight: "18px",
-                  letterSpacing: "0%",
-                },
-              },
-              min: 0,
-              max: 100,
-              tickAmount: 5,
-              labels: {
-                formatter: (value) => Math.round(value),
-              },
-            },
-            grid: {
-              borderColor: "var(--border-default)",
-              strokeDashArray: 4,
-              xaxis: {
-                lines: {
+    
+        {seriesData.length === 0 ? (
+          <Box sx={{ height: 260 }} />
+        ) : (
+          <ReactApexChart
+            options={{
+              chart: {
+                id: "optimization-result-graph",
+                type: "line",
+                background: "transparent",
+                foreColor: isDark ? "#a1a1aa" : undefined,
+                toolbar: {
                   show: false,
+                },
+                zoom: {
+                  enabled: false,
+                },
+                events: {
+                  dataPointMouseEnter: (_, chartContext, config) => {
+                    updateCrosshairColor(chartContext, config.seriesIndex);
+                  },
+                  mouseMove: (_, chartContext, config) => {
+                    if (config.seriesIndex !== undefined) {
+                      updateCrosshairColor(chartContext, config.seriesIndex);
+                    }
+                  },
+                  mouseLeave: (_, chartContext) => {
+                    updateCrosshairColor(chartContext, undefined);
+                  },
+                },
+              },
+              theme: {
+                mode: isDark ? "dark" : "light",
+              },
+              colors: seriesData.map((_, idx) => {
+                if (activeSeries !== null && idx !== activeSeries) {
+                  // Dim the non-selected lines to a light tint.
+                  return getUniqueColorPalette(idx).solid;
+                } else {
+                  return getUniqueColorPalette(idx).tagBackground;
+                }
+              }),
+              stroke: {
+                width: 2,
+                curve: "smooth",
+              },
+              markers: {
+                size: 0,
+              },
+              xaxis: {
+                categories: categories,
+                labels: {
+                  style: {
+                    fontFamily: "IBM Plex Sans",
+                    fontWeight: 400,
+                    fontSize: "12px",
+                    lineHeight: "18px",
+                    letterSpacing: "0%",
+                    textAlign: "center",
+                  },
+                },
+                crosshairs: {
+                  show: true,
+                  position: "back",
+                  stroke: {
+                    color: getUniqueColorPalette(0).tagBackground,
+                    width: 1,
+                    dashArray: 4,
+                  },
                 },
               },
               yaxis: {
-                lines: {
-                  show: true,
+                title: {
+                  text: "Evaluation Score",
+                  style: {
+                    fontFamily: "IBM Plex Sans",
+                    fontWeight: 400,
+                    fontSize: "12px",
+                    lineHeight: "18px",
+                    letterSpacing: "0%",
+                  },
+                },
+                min: 0,
+                max: 100,
+                tickAmount: 5,
+                labels: {
+                  formatter: (value) => Math.round(value),
                 },
               },
-            },
-            legend: {
-              show: false,
-            },
-            tooltip: {
-              theme: isDark ? "dark" : "light",
-              shared: false,
-              fillSeriesColor: true,
-              style: {
-                border: "none !important",
+              grid: {
+                borderColor: "var(--border-default)",
+                strokeDashArray: 4,
+                xaxis: {
+                  lines: {
+                    show: false,
+                  },
+                },
+                yaxis: {
+                  lines: {
+                    show: true,
+                  },
+                },
               },
-              onMarkerHover: (_, chartContext, { seriesIndex }) => {
-                if (seriesIndex !== undefined) {
-                  const color =
-                    getUniqueColorPalette(seriesIndex)?.tagForeground ||
-                    getUniqueColorPalette(0).tagForeground;
-                  const baseEl = chartContext.w.globals.dom.baseEl;
-                  const crosshairLine = baseEl?.querySelector(
-                    ".apexcharts-xcrosshairs line",
-                  );
-                  if (crosshairLine) {
-                    crosshairLine.setAttribute("stroke", color);
-                    crosshairLine.setAttribute("stroke-dasharray", "4");
-                    crosshairLine.style.stroke = color;
-                    crosshairLine.style.strokeDasharray = "4";
+              legend: {
+                show: false,
+              },
+              tooltip: {
+                theme: isDark ? "dark" : "light",
+                shared: false,
+                fillSeriesColor: true,
+                style: {
+                  border: "none !important",
+                },
+                onMarkerHover: (_, chartContext, { seriesIndex }) => {
+                  if (seriesIndex !== undefined) {
+                    const color =
+                      getUniqueColorPalette(seriesIndex)?.tagBackground ||
+                      getUniqueColorPalette(0).tagBackground;
+                    const baseEl = chartContext.w.globals.dom.baseEl;
+                    const crosshairLine = baseEl?.querySelector(
+                      ".apexcharts-xcrosshairs line",
+                    );
+                    if (crosshairLine) {
+                      crosshairLine.setAttribute("stroke", color);
+                      crosshairLine.setAttribute("stroke-dasharray", "4");
+                      crosshairLine.style.stroke = color;
+                      crosshairLine.style.strokeDasharray = "4";
+                    }
                   }
-                }
-              },
-              custom: ({ seriesIndex, dataPointIndex, w }) => {
-                // Update crosshair color when tooltip is shown
-                if (seriesIndex !== undefined) {
-                  const color =
-                    getUniqueColorPalette(seriesIndex)?.tagForeground ||
-                    getUniqueColorPalette(0).tagForeground;
-                  const baseEl = w.globals.dom.baseEl;
-                  const crosshairLine = baseEl?.querySelector(
-                    ".apexcharts-xcrosshairs line",
-                  );
-                  if (crosshairLine) {
-                    crosshairLine.setAttribute("stroke", color);
-                    crosshairLine.setAttribute("stroke-dasharray", "4");
-                    crosshairLine.style.stroke = color;
-                    crosshairLine.style.strokeDasharray = "4";
+                },
+                custom: ({ seriesIndex, dataPointIndex, w }) => {
+                  // Update crosshair color when tooltip is shown
+                  if (seriesIndex !== undefined) {
+                    const color =
+                      getUniqueColorPalette(seriesIndex)?.tagBackground ||
+                      getUniqueColorPalette(0).tagBackground;
+                    const baseEl = w.globals.dom.baseEl;
+                    const crosshairLine = baseEl?.querySelector(
+                      ".apexcharts-xcrosshairs line",
+                    );
+                    if (crosshairLine) {
+                      crosshairLine.setAttribute("stroke", color);
+                      crosshairLine.setAttribute("stroke-dasharray", "4");
+                      crosshairLine.style.stroke = color;
+                      crosshairLine.style.strokeDasharray = "4";
+                    }
                   }
-                }
 
-                const trialName = w.globals.categoryLabels[dataPointIndex];
-                const seriesName = w.config.series[seriesIndex].name;
-                const value = w.globals.series[seriesIndex][dataPointIndex];
-                const color =
-                  getUniqueColorPalette(seriesIndex)?.tagForeground ??
-                  getUniqueColorPalette(0).tagForeground;
+                  const trialName = w.globals.categoryLabels[dataPointIndex];
+                  const seriesName = w.config.series[seriesIndex].name;
+                  const value = w.globals.series[seriesIndex][dataPointIndex];
+                  const color =
+                    getUniqueColorPalette(seriesIndex)?.tagBackground ??
+                    getUniqueColorPalette(0).tagBackground;
 
-                return getGraphTooltipComponent(
-                  trialName,
-                  seriesName,
-                  value,
-                  color,
-                );
+                  return getGraphTooltipComponent(
+                    trialName,
+                    seriesName,
+                    value,
+                    color,
+                  );
+                },
               },
-            },
-          }}
-          series={seriesData}
-          type="line"
-          height={260}
-        />
+            }}
+            series={seriesData}
+            type="line"
+            height={260}
+          />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

A few independent frontend fixes (optimization results, agents table, scenario creation):

- **TH-6282** — Optimization Results: chart lines were invisible in light theme, and the trial table rendered empty.
- **TH-6330** — Agent Definitions: the Contact Number column always showed "-".
- **TH-6333** — Creating a scenario from an agent definition page didn't pre-fill the scenario name.

## What changed

- **OptimizationResultGraph.jsx / DatasetOptimizationResultGraph.jsx** (TH-6282) — lines, legend dots, crosshair, and tooltip accents used `ColorPairs.tagForeground` (`whiteScale[100]` = white), so lines were white-on-white in light theme. Use the vibrant `tagBackground` instead. (Fix-My-Agent graph also dims non-selected lines to the light `solid` tint on click and mounts the chart only once series exist.)
- **DatasetOptimizationResultGrid.jsx / DatasetOptimizationTrialDetail.jsx** (TH-6282) — read `column_config` (snake_case) from the API instead of `columnConfig`, so the trial table and trial-item grids populate.
- **AgentDefinitions.jsx** (TH-6330) — the Contact Number column `id` was `contactNumber` while the data field is `contact_number`, so the column didn't resolve and rendered "-". Align the column `id` with the snake_case accessorKey.
- **CreateScenarioView.jsx** (TH-6333) — the default-agent effect passed the agent's name/type as camelCase (`agentName`/`agentType`) while the API returns snake_case (`agent_name`/`agent_type`), so `sourceLabel` was `undefined` and the auto-name generator bailed. Read the snake_case fields so the source label resolves and the scenario name pre-fills (e.g. `MyAgent_2026-06-29v1`).

## Backwards compatibility

Frontend-only, no API/contract changes.

## Manual verification

- [ ] TH-6282: Completed optimization in light theme → chart lines visible; trial table populates; dark theme still fine.
- [ ] TH-6330: Agents table shows the provided contact number instead of "-".
- [ ] TH-6333: From an agent's detail page → Create scenario → name is pre-filled and the agent is pre-selected.

## Type of change

- [x] 🐛 Bug fix (non-breaking)

## Backout

Revert this PR's commits; no migrations.

## Linear

- Fixes TH-6282
- Fixes TH-6330
- Fixes TH-6333
