### PR TITLE
fix(api-contracts): accept multipart File bodies for array readOnly file fields [TH-6337]

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.js
+++ b/frontend/src/api/contracts/openapi-contract.js
@@ -273,10 +273,18 @@ function objectSchemaToZod(schema, options) {
 
   const shape = Object.fromEntries(
     keys.map((key) => {
-      if (options.requestBody && properties[key]?.readOnly) {
+      const property = properties[key];
+      // drf-yasg marks file uploads read-only on the property (single
+      // FileField) or on the array items (ListField of FileField); neither is
+      // client-sent, so accept anything and let multipart File bodies pass.
+      const isReadOnlyRequestField =
+        options.requestBody &&
+        (property?.readOnly ||
+          (property?.type === "array" && property?.items?.readOnly));
+      if (isReadOnlyRequestField) {
         return [key, z.any().optional()];
       }
-      let field = schemaToZod(properties[key], options);
+      let field = schemaToZod(property, options);
       if (!required.has(key)) field = field.optional();
       return [key, field];
     }),


### PR DESCRIPTION
## 🐛 Bug
In **dev**, attaching a PDF (or image/audio) to a prompt message via the **Add pdf/media** modal and clicking **Save** does nothing — silent no-op, modal stays open, no console error. (Surfaced while debugging the document-prompt run flow, TH-6264.)

## 🔍 Root cause
`/model-hub/upload-file/` has `runtimeRequestValidation: true`. Its `files` field is a `ListField(child=FileField())`, which drf-yasg renders as an `array` with `readOnly` on the **items**. The FE request-contract validator only skipped `readOnly` fields at the **property** level — not array items — so it validated the binary multipart `File` against `array<string>`, failed, and **blocked the request before it was sent**. Silent because the `ApiContractValidationError` has no `.result`, so the global `mutationCache.onError` toast (which only surfaces backend error envelopes) skips it. Prod unaffected (request contracts off in prod).

Single-file `FileField` uploads already worked (property-level `readOnly`, with an existing test at `openapi-contract.test.js:193`); only `ListField(FileField)` (multi-file) was unhandled — hence the first upload to hit it.

## 🔧 What changed
`src/api/contracts/openapi-contract.js` (`objectSchemaToZod`) — treat an `array` property whose items are `readOnly` the same as a `readOnly` property (→ `z.any().optional()`), so multipart `File`/`Blob` bodies pass.

```js
const isReadOnlyRequestField =
  options.requestBody &&
  (property?.readOnly ||
    (property?.type === "array" && property?.items?.readOnly));
```

No backend/serializer change (the serializer is already correct: `ListField(child=FileField())`), no regen. Fixes this endpoint and any other `ListField(FileField)` upload silently hitting the same wall.

## 🧪 Tests
Existing `openapi-contract.test.js` (23 tests) still pass — including the single-file multipart test. (A sibling assertion for the array shape can be added if wanted; verified manually for now.)

## ▶️ How to verify
1. Run this branch in dev. Develop → a dataset → **Run Prompt** column → a message → **Add pdf** → upload a PDF → **Save**.
2. Before: Save does nothing. After: the upload fires and the PDF embeds.
- Confirmed at the validator level: a real PDF `Blob` through `validateContractedRequestConfig("/model-hub/upload-file/")` now returns `ok: true` (was failing).

## 💻 Commands
```bash
# frontend/
yarn vitest run src/api/contracts/__tests__/openapi-contract.test.js
```

## 📹 Videos & Screenshots
https://github.com/user-attachments/assets/f2fdb8dc-847b-48e5-adb3-80a25e086832



## 🔗 Related
- **TH-6264** — the separate **backend** failure (run-time document download, "max retries exceeded"), assigned to backend.
