### PR TITLE
fix(observe): readable disabled colors + non-selectable mapped columns in add-to-dataset [TH-6325]

### DIFF
--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
@@ -436,6 +436,7 @@ const AddExistingDataset = ({
                           ).map((col, i) => ({
                             label: col?.name,
                             value: col,
+                            disabled: isMenuItemDisabled(col, item),
                             component: (
                               <MenuItem
                                 key={i}
@@ -446,7 +447,7 @@ const AddExistingDataset = ({
                                   alignItems: "center",
                                   color: theme.palette.text.primary,
                                   "&.Mui-disabled": {
-                                    color: theme.palette.divider,
+                                    color: theme.palette.text.disabled,
                                   },
                                 }}
                               >
@@ -650,7 +651,7 @@ const AddExistingDataset = ({
             fontWeight: 600,
             "&.Mui-disabled": {
               bgcolor: theme.palette.divider,
-              color: theme.palette.background.paper,
+              color: theme.palette.text.disabled,
             },
           }}
         >

--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
@@ -477,11 +477,17 @@ const AddExistingDataset = ({
                             value: "add_column",
                             alwaysVisible: true,
                             component: (
-                              <MenuItem key="add_column">
-                                <Box sx={{ color: "primary.main" }}>
-                                  + Add Column
-                                </Box>
-                              </MenuItem>
+                              <Box
+                                key="add_column"
+                                sx={{
+                                  color: "primary.main",
+                                  width: "100%",
+                                  px: 2,
+                                  py: 0.75,
+                                }}
+                              >
+                                + Add Column
+                              </Box>
                             ),
                           },
                         ]}


### PR DESCRIPTION
## 🐛 Bug
In the trace drawer's **Add to dataset → existing dataset** column picker, already-mapped (and type-incompatible) columns rendered with **unreadable text**, the disabled **Add to dataset** button text was nearly invisible, and already-mapped columns were **still selectable**.

## 🔍 Root cause
Disabled states used border/background tokens as *text* colors, and the disabled flag wasn't applied at the option level:
- Dropdown disabled option: `color: theme.palette.divider` (a hairline border color) → invisible text.
- Disabled "Add to dataset" button: `color: theme.palette.background.paper` (the page bg) → dark-on-dark, near-invisible.
- The column option only set `disabled` on the inner `MenuItem` (cosmetic in this custom `FormSearchSelectFieldState`); the **option object** had no `disabled`, so `FormSelectMenus` never blocked the click.

## 🔧 What changed
`AddExistingDataset.jsx`:
- Dropdown disabled-option text: `divider` → **`text.disabled`** (muted but legible).
- Disabled "Add to dataset" button text: `background.paper` → **`text.disabled`**.
- Set **option-level `disabled`** (`isMenuItemDisabled(col, item)`) so already-mapped / type-incompatible columns can't be selected.

## 🤔 Why
`text.disabled` is the proper token for "disabled but readable" text. The option-level `disabled` is what `FormSelectMenus` actually reads to block selection — the inner-MenuItem flag alone is purely visual here.

## ▶️ How to verify
1. A span/trace → **Add to dataset** → existing dataset.
2. Open a **Column** dropdown: already-mapped columns (and incompatible types) are now **legible** and **not clickable**.
3. With nothing mappable yet, the disabled **Add to dataset** button text is readable.

## 💻 Commands
```bash
# frontend/
yarn lint src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
```

## 📹 Videos & Screenshots
<img width="501" height="1009" alt="Screenshot 2026-06-29 at 5 50 17 PM" src="https://github.com/user-attachments/assets/3a6a431a-6132-4112-8b45-4f3207aa09ac" />
<img width="535" height="1013" alt="Screenshot 2026-06-29 at 5 49 59 PM" src="https://github.com/user-attachments/assets/e5c81dca-38d8-4814-a511-02d378c5bac3" />

