### PR TITLE
fix(annotations): membership-based access for org-users endpoint (TH-6156)

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
@@ -28,7 +28,6 @@ import {
   useUpdateErrorFeedIssue,
 } from "src/api/errorFeed/error-feed";
 import { useOrgMembers } from "src/api/annotation-queues/annotation-queues";
-import { useAuthContext } from "src/auth/hooks";
 import { useOrganization } from "src/contexts/OrganizationContext";
 import openExternal from "../openExternal";
 import { useErrorFeedStore } from "../store";
@@ -832,12 +831,15 @@ export function LinearTeamPicker({ open, onClose, clusterId, traceId }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const { enqueueSnackbar } = useSnackbar();
-  const { user } = useAuthContext();
+  // Use the live active org (matches the X-Organization-Id header) instead of
+  // the cached user.organization.id, which can drift and 404 the request
+  // (TH-6156).
+  const { currentOrganizationId } = useOrganization();
   const {
     data: linearData,
     isLoading: teamsLoading,
     isError: teamsError,
-  } = useLinearTeams(user?.organization?.id, { enabled: open });
+  } = useLinearTeams(currentOrganizationId, { enabled: open });
   const createIssue = useCreateLinearIssue();
   const teams = linearData?.teams ?? [];
 
@@ -1086,12 +1088,14 @@ function Integrations({
   externalIssueId,
 }) {
   const navigate = useNavigate();
-  const { user } = useAuthContext();
+  // Live active org (matches the X-Organization-Id header) rather than the
+  // cached user.organization.id, which can drift and 404 the request (TH-6156).
+  const { currentOrganizationId } = useOrganization();
   const {
     data: linearData,
     isLoading: linearLoading,
     isError: linearError,
-  } = useLinearTeams(user?.organization?.id);
+  } = useLinearTeams(currentOrganizationId);
   const linearConnected = linearData?.connected === true;
   const [teamPickerOpen, setTeamPickerOpen] = useState(false);
 

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
@@ -29,6 +29,7 @@ import {
 } from "src/api/errorFeed/error-feed";
 import { useOrgMembers } from "src/api/annotation-queues/annotation-queues";
 import { useAuthContext } from "src/auth/hooks";
+import { useOrganization } from "src/contexts/OrganizationContext";
 import openExternal from "../openExternal";
 import { useErrorFeedStore } from "../store";
 import PropTypes from "prop-types";
@@ -1168,8 +1169,11 @@ export default function ErrorMetadataPanel({ error }) {
   const isDark = theme.palette.mode === "dark";
   const [severity, setSeverityLocal] = useState(error?.severity ?? "high");
   const [assignee, setAssigneeLocal] = useState(error?.assignees?.[0] ?? null);
-  const { user } = useAuthContext();
-  const { data: orgMembers = [] } = useOrgMembers(user?.organization?.id);
+  // Use the live active org (matches the X-Organization-Id header) instead of
+  // the cached user.organization.id, which can drift and 404 the members
+  // request (TH-6156).
+  const { currentOrganizationId } = useOrganization();
+  const { data: orgMembers = [] } = useOrgMembers(currentOrganizationId);
   const updateIssue = useUpdateErrorFeedIssue();
 
   const setSeverity = (val) => {

--- a/frontend/src/sections/annotations/queues/components/__tests__/annotator-picker.test.jsx
+++ b/frontend/src/sections/annotations/queues/components/__tests__/annotator-picker.test.jsx
@@ -3,9 +3,9 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, userEvent, within } from "src/utils/test-utils";
 import AnnotatorPicker from "../annotator-picker";
 
-vi.mock("src/auth/hooks", () => ({
-  useAuthContext: () => ({
-    user: { organization: { id: "org-1" } },
+vi.mock("src/contexts/OrganizationContext", () => ({
+  useOrganization: () => ({
+    currentOrganizationId: "org-1",
   }),
 }));
 

--- a/frontend/src/sections/annotations/queues/components/annotator-picker.jsx
+++ b/frontend/src/sections/annotations/queues/components/annotator-picker.jsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
-import { useAuthContext } from "src/auth/hooks";
+import { useOrganization } from "src/contexts/OrganizationContext";
 import { useOrgMembersInfinite } from "src/api/annotation-queues/annotation-queues";
 import { useDebounce } from "src/hooks/use-debounce";
 import { QUEUE_ROLES, ROLE_PRIORITY } from "../constants";
@@ -71,7 +71,12 @@ export default function AnnotatorPicker({
 }) {
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search.trim(), 300);
-  const { user } = useAuthContext();
+  // Use the live active org (sessionStorage-backed, same source as the
+  // X-Organization-Id header axios sends) rather than the cached
+  // user.organization.id, which can drift from the active context and made the
+  // members request 404 with "No users found for the specified organization."
+  // (TH-6156).
+  const { currentOrganizationId } = useOrganization();
   const scrollRef = useRef(null);
 
   const {
@@ -79,7 +84,7 @@ export default function AnnotatorPicker({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useOrgMembersInfinite(user?.organization?.id, debouncedSearch);
+  } = useOrgMembersInfinite(currentOrganizationId, debouncedSearch);
 
   const selectedMap = useMemo(
     () => new Map(value.map((a) => [a.userId, normalizeRoles(a)])),

--- a/futureagi/accounts/migrations/0023_create_missing_org_memberships.py
+++ b/futureagi/accounts/migrations/0023_create_missing_org_memberships.py
@@ -1,0 +1,137 @@
+"""
+Heals membership drift: active workspace members with *no* OrganizationMembership.
+
+0022 only *linked* WorkspaceMembership → an existing active OrganizationMembership;
+it never created the org membership when one was missing entirely. Those users
+(workspace access but no org-membership row) hit
+``UserViewSet._validate_requested_organization`` and got
+``"No users found for the specified organization."`` when opening the annotation
+queue annotator picker (TH-6156), and were invisible to other
+OrganizationMembership-dependent surfaces.
+
+This migration creates the minimal ``Viewer`` org membership for every active
+workspace member that lacks one, then re-runs the FK backfill so the new rows are
+linked.
+
+Fail-closed: only ``(user, organization)`` pairs with **no non-deleted** org
+membership are created. A pair whose only row is *inactive* (the user was
+deliberately removed from the org) is left untouched — we never resurrect a
+removed membership.
+
+Safety: non-atomic + id-batched; idempotent — re-running creates nothing because
+the pairs now have a non-deleted row.
+"""
+
+import uuid
+
+from django.db import migrations
+from django.utils import timezone
+
+_VIEWER_LEVEL = 1  # tfc.constants.levels.Level.VIEWER
+_VIEWER_ROLE = "Viewer"  # OrganizationRoles.MEMBER_VIEW_ONLY value
+_BATCH_SIZE = 2000
+
+# (user, org) pairs that have an active workspace membership but no non-deleted
+# org membership of any kind.
+_MISSING_PAIRS_SQL = """
+    SELECT DISTINCT wm.user_id, w.organization_id
+    FROM accounts_workspacemembership wm
+    JOIN accounts_workspace w ON w.id = wm.workspace_id
+    WHERE wm.is_active = true
+      AND wm.deleted = false
+      AND NOT EXISTS (
+          SELECT 1 FROM accounts_organization_membership om
+          WHERE om.user_id = wm.user_id
+            AND om.organization_id = w.organization_id
+            AND om.deleted = false
+      )
+"""
+
+# Mirrors 0022: link any NULL-FK active workspace membership to its active org
+# membership (now including the rows created above). psycopg3 binds the batch as
+# a Postgres array and matches with ``= ANY(...)``.
+_LINK_SQL = """
+    UPDATE accounts_workspacemembership wm
+    SET organization_membership_id = (
+        SELECT om.id
+        FROM accounts_organization_membership om
+        JOIN accounts_workspace w ON w.id = wm.workspace_id
+        WHERE om.user_id = wm.user_id
+          AND om.organization_id = w.organization_id
+          AND om.is_active = true
+        ORDER BY om.created_at DESC, om.id DESC
+        LIMIT 1
+    )
+    WHERE wm.id = ANY(%s::uuid[])
+      AND wm.organization_membership_id IS NULL
+"""
+
+
+def create_missing_org_memberships(apps, schema_editor):
+    OrganizationMembership = apps.get_model("accounts", "OrganizationMembership")
+    WorkspaceMembership = apps.get_model("accounts", "WorkspaceMembership")
+    connection = schema_editor.connection
+
+    with connection.cursor() as cursor:
+        cursor.execute(_MISSING_PAIRS_SQL)
+        pairs = cursor.fetchall()
+
+    now = timezone.now()
+    to_create = [
+        OrganizationMembership(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            organization_id=org_id,
+            role=_VIEWER_ROLE,
+            level=_VIEWER_LEVEL,
+            is_active=True,
+            deleted=False,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        for (user_id, org_id) in pairs
+    ]
+
+    created = 0
+    for start in range(0, len(to_create), _BATCH_SIZE):
+        batch = to_create[start : start + _BATCH_SIZE]
+        OrganizationMembership.objects.bulk_create(batch)
+        created += len(batch)
+
+    # Link freshly-created (and any other NULL-FK) active workspace memberships.
+    null_ids = list(
+        WorkspaceMembership.objects.filter(
+            organization_membership__isnull=True
+        ).values_list("id", flat=True)
+    )
+    linked = 0
+    for start in range(0, len(null_ids), _BATCH_SIZE):
+        batch = [str(pk) for pk in null_ids[start : start + _BATCH_SIZE]]
+        with connection.cursor() as cursor:
+            cursor.execute(_LINK_SQL, [batch])
+            linked += cursor.rowcount
+
+    if created or linked:
+        print(
+            f"\n  Created {created} Viewer OrganizationMembership rows; "
+            f"linked {linked} WorkspaceMembership FK rows"
+        )
+
+
+def noop(apps, schema_editor):
+    # Irreversible by design: auto-created rows are indistinguishable from
+    # legitimate Viewer memberships, so we never delete on reverse.
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("accounts", "0022_backfill_ws_org_membership_fk"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_missing_org_memberships, noop),
+    ]

--- a/futureagi/accounts/migrations/0023_create_missing_org_memberships.py
+++ b/futureagi/accounts/migrations/0023_create_missing_org_memberships.py
@@ -4,7 +4,7 @@ Heals membership drift: active workspace members with *no* OrganizationMembershi
 0022 only *linked* WorkspaceMembership → an existing active OrganizationMembership;
 it never created the org membership when one was missing entirely. Those users
 (workspace access but no org-membership row) hit
-``UserViewSet._validate_requested_organization`` and got
+``UserViewSet._resolve_org_access`` and got
 ``"No users found for the specified organization."`` when opening the annotation
 queue annotator picker (TH-6156), and were invisible to other
 OrganizationMembership-dependent surfaces.
@@ -31,14 +31,18 @@ _VIEWER_LEVEL = 1  # tfc.constants.levels.Level.VIEWER
 _VIEWER_ROLE = "Viewer"  # OrganizationRoles.MEMBER_VIEW_ONLY value
 _BATCH_SIZE = 2000
 
-# (user, org) pairs that have an active workspace membership but no non-deleted
-# org membership of any kind.
+# (user, org) pairs that have an active membership in a *live* workspace but no
+# non-deleted org membership of any kind. The workspace must itself be active and
+# not soft-deleted — a stale membership on a dead workspace must not mint a fresh
+# org Viewer membership (that would be an access expansion from stale data).
 _MISSING_PAIRS_SQL = """
     SELECT DISTINCT wm.user_id, w.organization_id
     FROM accounts_workspacemembership wm
     JOIN accounts_workspace w ON w.id = wm.workspace_id
     WHERE wm.is_active = true
       AND wm.deleted = false
+      AND w.is_active = true
+      AND w.deleted = false
       AND NOT EXISTS (
           SELECT 1 FROM accounts_organization_membership om
           WHERE om.user_id = wm.user_id

--- a/futureagi/accounts/services/workspace_membership.py
+++ b/futureagi/accounts/services/workspace_membership.py
@@ -37,6 +37,47 @@ def resolve_org_membership(user, organization):
     )
 
 
+def ensure_org_membership(user, organization, *, invited_by=None):
+    """Return an active ``OrganizationMembership``, creating a minimal one if absent.
+
+    Enforces the invariant "a workspace member belongs to the org" at the single
+    create path, healing the drift that left workspace members with no
+    ``OrganizationMembership`` row (TH-6156).
+
+    Fail-closed on removal: if a row already exists but is *inactive* (the user
+    was deliberately removed from the org), it is NOT resurrected — ``None`` is
+    returned and the caller leaves the FK NULL. New rows are created at the
+    minimal ``Viewer`` level, which grants org membership without global
+    workspace access (that requires ``>= ADMIN``).
+    """
+    if user is None or organization is None:
+        return None
+
+    existing = (
+        OrganizationMembership.no_workspace_objects.filter(
+            user=user, organization=organization
+        )
+        .order_by("-created_at", "-id")
+        .first()
+    )
+    if existing is not None:
+        # The (user, organization) unique constraint (deleted=False) guarantees
+        # at most one such row. Active → use it; inactive → respect the removal.
+        return existing if existing.is_active else None
+
+    from tfc.constants.levels import Level
+    from tfc.constants.roles import OrganizationRoles
+
+    return OrganizationMembership.no_workspace_objects.create(
+        user=user,
+        organization=organization,
+        role=OrganizationRoles.MEMBER_VIEW_ONLY,
+        level=Level.VIEWER,
+        invited_by=invited_by,
+        is_active=True,
+    )
+
+
 def create_workspace_membership(
     *,
     workspace,
@@ -60,12 +101,19 @@ def create_workspace_membership(
     # ``setdefault`` would evaluate ``resolve_org_membership`` unconditionally
     # (and fire a wasted query per call — N times inside bulk-invite loops).
     if "organization_membership" not in extra:
-        extra["organization_membership"] = resolve_org_membership(
-            user, workspace.organization
-        )
+        org_membership = resolve_org_membership(user, workspace.organization)
+        if org_membership is None:
+            # No active org membership — create the minimal one so a workspace
+            # member always belongs to the org (TH-6156). Returns None only when
+            # an inactive (deliberately removed) membership exists.
+            org_membership = ensure_org_membership(
+                user, workspace.organization, invited_by=invited_by
+            )
+        extra["organization_membership"] = org_membership
     if extra["organization_membership"] is None:
         # Visibility into the only path that can still produce a NULL FK (user
-        # without an active org membership) — distinct from the old silent drift.
+        # with a deactivated org membership we won't resurrect) — distinct from
+        # the old silent drift.
         logger.warning(
             "workspace_membership_created_without_org_fk",
             workspace_id=str(getattr(workspace, "id", "")),

--- a/futureagi/accounts/services/workspace_membership.py
+++ b/futureagi/accounts/services/workspace_membership.py
@@ -53,29 +53,27 @@ def ensure_org_membership(user, organization, *, invited_by=None):
     if user is None or organization is None:
         return None
 
-    existing = (
-        OrganizationMembership.no_workspace_objects.filter(
-            user=user, organization=organization
-        )
-        .order_by("-created_at", "-id")
-        .first()
-    )
-    if existing is not None:
-        # The (user, organization) unique constraint (deleted=False) guarantees
-        # at most one such row. Active → use it; inactive → respect the removal.
-        return existing if existing.is_active else None
-
     from tfc.constants.levels import Level
     from tfc.constants.roles import OrganizationRoles
 
-    return OrganizationMembership.no_workspace_objects.create(
+    # The (user, organization) unique constraint (WHERE deleted=False) guarantees
+    # at most one non-deleted row, so get_or_create resolves to exactly that row.
+    # get_or_create also closes the race where two concurrent invite flows both
+    # find no row: the loser's INSERT hits the unique constraint, Django catches
+    # the IntegrityError and re-fetches the winner's row instead of raising.
+    membership, _created = OrganizationMembership.no_workspace_objects.get_or_create(
         user=user,
         organization=organization,
-        role=OrganizationRoles.MEMBER_VIEW_ONLY,
-        level=Level.VIEWER,
-        invited_by=invited_by,
-        is_active=True,
+        defaults={
+            "role": OrganizationRoles.MEMBER_VIEW_ONLY,
+            "level": Level.VIEWER,
+            "invited_by": invited_by,
+            "is_active": True,
+        },
     )
+    # Active → use it; inactive → the user was deliberately removed from the org,
+    # so respect the removal (fail-closed) and leave the workspace FK NULL.
+    return membership if membership.is_active else None
 
 
 def create_workspace_membership(

--- a/futureagi/accounts/tests/test_workspace_member_fk.py
+++ b/futureagi/accounts/tests/test_workspace_member_fk.py
@@ -496,6 +496,30 @@ class TestEnsureOrgMembershipInvariant:
         member, om = _make_member(organization, "existing-active@futureagi.com")
         assert ensure_org_membership(member, organization).id == om.id
 
+    def test_ensure_org_membership_is_idempotent(self, organization):
+        """A second call resolves to the same row instead of racing to a second
+        INSERT (get_or_create closes the concurrent-create hole)."""
+        from accounts.services.workspace_membership import ensure_org_membership
+
+        set_workspace_context(organization=organization)
+        member = User.objects.create_user(
+            email="ensure-idem@futureagi.com",
+            password="pass123",
+            name="Ensure Idem",
+            organization=None,
+        )
+
+        first = ensure_org_membership(member, organization)
+        second = ensure_org_membership(member, organization)
+
+        assert first.id == second.id
+        assert (
+            OrganizationMembership.no_workspace_objects.filter(
+                user=member, organization=organization
+            ).count()
+            == 1
+        )
+
 
 @pytest.mark.django_db
 class TestCreateMissingOrgMembershipsMigration:
@@ -563,6 +587,42 @@ class TestCreateMissingOrgMembershipsMigration:
         )
         ws_mem.refresh_from_db()
         assert ws_mem.organization_membership_id is None
+
+    def test_does_not_create_for_member_of_dead_workspace(self, organization, user):
+        """A membership in a soft-deleted / deactivated workspace must not mint a
+        fresh org Viewer membership — that would expand access from stale
+        workspace data (TH-6156)."""
+        from accounts.models.workspace import Workspace
+
+        set_workspace_context(organization=organization)
+        dead_ws = Workspace.objects.create(
+            name="Dead WS Migration",
+            organization=organization,
+            is_active=True,
+            created_by=user,
+        )
+        member = User.objects.create_user(
+            email="dead-ws-drift@futureagi.com",
+            password="pass123",
+            name="Dead WS Drift",
+            organization=None,
+        )
+        WorkspaceMembership.objects.create(
+            workspace=dead_ws,
+            user=member,
+            role="workspace_member",
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+            organization_membership=None,
+        )
+        # Soft-delete the workspace after seeding the membership.
+        Workspace.objects.filter(pk=dead_ws.pk).update(deleted=True)
+
+        self._run()
+
+        assert not OrganizationMembership.no_workspace_objects.filter(
+            user=member, organization=organization
+        ).exists()
 
     def test_idempotent(self, organization, workspace):
         set_workspace_context(organization=organization)

--- a/futureagi/accounts/tests/test_workspace_member_fk.py
+++ b/futureagi/accounts/tests/test_workspace_member_fk.py
@@ -431,6 +431,168 @@ class TestGetOrCreateSitesSetOrgFK:
 
 
 @pytest.mark.django_db
+class TestEnsureOrgMembershipInvariant:
+    """TH-6156: a workspace member must belong to the org. The single create path
+    creates a minimal Viewer org membership when none exists, and never
+    resurrects a deliberately removed (inactive) one."""
+
+    def test_factory_creates_viewer_org_membership_when_absent(
+        self, organization, workspace
+    ):
+        from accounts.services.workspace_membership import create_workspace_membership
+
+        set_workspace_context(organization=organization)
+        member = User.objects.create_user(
+            email="no-org@futureagi.com",
+            password="pass123",
+            name="No Org",
+            organization=None,
+        )
+        assert not OrganizationMembership.no_workspace_objects.filter(
+            user=member, organization=organization
+        ).exists()
+
+        ws_mem = create_workspace_membership(
+            workspace=workspace,
+            user=member,
+            role="workspace_member",
+            level=Level.WORKSPACE_MEMBER,
+        )
+
+        om = OrganizationMembership.no_workspace_objects.get(
+            user=member, organization=organization, is_active=True
+        )
+        # Minimal access only — Viewer, not global-workspace (>= ADMIN).
+        assert om.level == Level.VIEWER
+        ws_mem.refresh_from_db()
+        assert ws_mem.organization_membership_id == om.id
+
+    def test_factory_does_not_resurrect_inactive_org_membership(
+        self, organization, workspace
+    ):
+        from accounts.services.workspace_membership import create_workspace_membership
+
+        member, om = _make_member(organization, "removed@futureagi.com")
+        # Deliberately removed from the org.
+        OrganizationMembership.objects.filter(pk=om.pk).update(is_active=False)
+
+        ws_mem = create_workspace_membership(
+            workspace=workspace,
+            user=member,
+            role="workspace_member",
+            level=Level.WORKSPACE_MEMBER,
+        )
+
+        # Fail-closed: no new active membership, FK stays NULL.
+        assert not OrganizationMembership.no_workspace_objects.filter(
+            user=member, organization=organization, is_active=True
+        ).exists()
+        ws_mem.refresh_from_db()
+        assert ws_mem.organization_membership_id is None
+
+    def test_ensure_org_membership_returns_existing_active(self, organization):
+        from accounts.services.workspace_membership import ensure_org_membership
+
+        member, om = _make_member(organization, "existing-active@futureagi.com")
+        assert ensure_org_membership(member, organization).id == om.id
+
+
+@pytest.mark.django_db
+class TestCreateMissingOrgMembershipsMigration:
+    """0023 creates the missing Viewer org membership for active workspace
+    members that have none, then links the FK — fail-closed for removed members,
+    and idempotent."""
+
+    def _run(self):
+        import importlib
+
+        from django.apps import apps as global_apps
+        from django.db import connection
+
+        migration = importlib.import_module(
+            "accounts.migrations.0023_create_missing_org_memberships"
+        )
+        shim = type("_SchemaEditorShim", (), {})()
+        shim.connection = connection
+        clear_workspace_context()
+        migration.create_missing_org_memberships(global_apps, shim)
+
+    def test_creates_viewer_membership_and_links_fk_for_drifted_member(
+        self, organization, workspace
+    ):
+        set_workspace_context(organization=organization)
+        member = User.objects.create_user(
+            email="drift-heal@futureagi.com",
+            password="pass123",
+            name="Drift Heal",
+            organization=None,
+        )
+        ws_mem = WorkspaceMembership.objects.create(
+            workspace=workspace,
+            user=member,
+            role="workspace_member",
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+            organization_membership=None,
+        )
+
+        self._run()
+
+        om = OrganizationMembership.no_workspace_objects.get(
+            user=member, organization=organization, is_active=True
+        )
+        assert om.level == Level.VIEWER
+        ws_mem.refresh_from_db()
+        assert ws_mem.organization_membership_id == om.id
+
+    def test_does_not_create_for_removed_member(self, organization, workspace):
+        member, om = _make_member(organization, "drift-removed@futureagi.com")
+        ws_mem = _add_to_workspace(workspace, member, om)
+        _null_the_fk(ws_mem)
+        OrganizationMembership.objects.filter(pk=om.pk).update(is_active=False)
+
+        self._run()
+
+        # A non-deleted (inactive) row exists -> NOT EXISTS excludes the pair ->
+        # no new row created, FK stays NULL.
+        assert (
+            OrganizationMembership.no_workspace_objects.filter(
+                user=member, organization=organization
+            ).count()
+            == 1
+        )
+        ws_mem.refresh_from_db()
+        assert ws_mem.organization_membership_id is None
+
+    def test_idempotent(self, organization, workspace):
+        set_workspace_context(organization=organization)
+        member = User.objects.create_user(
+            email="drift-idem@futureagi.com",
+            password="pass123",
+            name="Drift Idem",
+            organization=None,
+        )
+        WorkspaceMembership.objects.create(
+            workspace=workspace,
+            user=member,
+            role="workspace_member",
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+            organization_membership=None,
+        )
+
+        self._run()
+        self._run()
+
+        assert (
+            OrganizationMembership.no_workspace_objects.filter(
+                user=member, organization=organization, is_active=True
+            ).count()
+            == 1
+        )
+
+
+@pytest.mark.django_db
 class TestBackfillMigration:
     """Exercises the 0022 data migration that heals already-drifted NULL FKs.
 

--- a/futureagi/model_hub/tests/test_develop_annotations_api.py
+++ b/futureagi/model_hub/tests/test_develop_annotations_api.py
@@ -1293,6 +1293,182 @@ class TestUserViewSet:
         # Must not 404, and must return the requested org's members (user owns it).
         assert str(user.id) in ids
 
+    def test_removed_org_member_is_not_reauthorized_by_workspace_drift(
+        self, organization, workspace
+    ):
+        """A deliberately removed org member (inactive OrganizationMembership) is
+        rejected even if a stale active WorkspaceMembership lingers — the gate
+        fails closed and never lets workspace drift resurrect access (TH-6156)."""
+        from rest_framework.exceptions import NotFound
+
+        from accounts.models.organization_membership import OrganizationMembership
+        from accounts.models.workspace import WorkspaceMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        removed = User.objects.create_user(
+            email="removed-member@example.com",
+            password="testpassword123",
+            name="Removed Member",
+            organization=None,
+        )
+        # Inactive (removed) org membership + a still-active workspace row.
+        OrganizationMembership.no_workspace_objects.create(
+            user=removed,
+            organization=organization,
+            role=OrganizationRoles.MEMBER,
+            level=Level.MEMBER,
+            is_active=False,
+        )
+        WorkspaceMembership.no_workspace_objects.create(
+            user=removed,
+            workspace=workspace,
+            role=OrganizationRoles.WORKSPACE_MEMBER,
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+        )
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=workspace,
+            organization=organization,
+            user=removed,
+        )
+
+        with pytest.raises(NotFound):
+            list(view.get_queryset())
+
+    def test_membership_in_dead_workspace_does_not_pass_gate(self, organization, user):
+        """A workspace-only requester whose only membership is in a soft-deleted
+        (or deactivated) workspace is rejected — a dead workspace's stale
+        membership must not authorize (TH-6156)."""
+        from rest_framework.exceptions import NotFound
+
+        from accounts.models.workspace import Workspace, WorkspaceMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        dead_ws = Workspace.objects.create(
+            name="Dead WS",
+            organization=organization,
+            is_active=True,
+            created_by=user,
+        )
+        requester = User.objects.create_user(
+            email="dead-ws-requester@example.com",
+            password="testpassword123",
+            name="Dead WS Requester",
+            organization=None,
+        )
+        WorkspaceMembership.no_workspace_objects.create(
+            user=requester,
+            workspace=dead_ws,
+            role=OrganizationRoles.WORKSPACE_MEMBER,
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+        )
+        # Soft-delete the workspace after the membership exists.
+        Workspace.objects.filter(pk=dead_ws.pk).update(deleted=True)
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=None,
+            organization=organization,
+            user=requester,
+        )
+
+        with pytest.raises(NotFound):
+            list(view.get_queryset())
+
+    def test_workspace_only_requester_scoped_to_own_workspace_members(
+        self, organization, workspace, user
+    ):
+        """A workspace-only (drift) requester whose active workspace is a
+        different org is scoped to the members of the workspace(s) they belong to
+        — never the full org member list (TH-6156)."""
+        from accounts.models.organization_membership import OrganizationMembership
+        from accounts.models.workspace import WorkspaceMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        # Drift requester: workspace access in `workspace`, no org membership.
+        requester = User.objects.create_user(
+            email="drift-scoped-requester@example.com",
+            password="testpassword123",
+            name="Drift Scoped Requester",
+            organization=None,
+        )
+        WorkspaceMembership.no_workspace_objects.create(
+            user=requester,
+            workspace=workspace,
+            role=OrganizationRoles.WORKSPACE_MEMBER,
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+        )
+        # A peer sharing the same workspace — should be visible.
+        ws_peer = User.objects.create_user(
+            email="ws-peer@example.com",
+            password="testpassword123",
+            name="WS Peer",
+            organization=None,
+        )
+        WorkspaceMembership.no_workspace_objects.create(
+            user=ws_peer,
+            workspace=workspace,
+            role=OrganizationRoles.WORKSPACE_MEMBER,
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+        )
+        # An org member NOT in `workspace` — must NOT leak to a workspace-only
+        # requester.
+        org_only = User.objects.create_user(
+            email="org-only-member@example.com",
+            password="testpassword123",
+            name="Org Only Member",
+            organization=None,
+        )
+        OrganizationMembership.no_workspace_objects.create(
+            user=org_only,
+            organization=organization,
+            role=OrganizationRoles.MEMBER,
+            level=Level.MEMBER,
+            is_active=True,
+        )
+
+        # Active context is a *different* org, so the org-wide fallback branch is
+        # the one under test.
+        other_org = Organization.objects.create(name="Other Active Org 2")
+        other_ws = Workspace.objects.create(
+            name="Other Active WS 2",
+            organization=other_org,
+            is_active=True,
+            created_by=user,
+        )
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=other_ws,
+            organization=other_org,
+            user=requester,
+        )
+
+        ids = {
+            str(user_id) for user_id in view.get_queryset().values_list("id", flat=True)
+        }
+        assert str(requester.id) in ids
+        assert str(ws_peer.id) in ids
+        # The org-wide member list must NOT leak to a workspace-scoped requester.
+        assert str(org_only.id) not in ids
+
 
 # ==================== AnnotationSummaryView Tests ====================
 

--- a/futureagi/model_hub/tests/test_develop_annotations_api.py
+++ b/futureagi/model_hub/tests/test_develop_annotations_api.py
@@ -800,7 +800,10 @@ class TestAnnotationsViewSetActions:
             payload,
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_update_cells_rejects_legacy_label_values_alias(
         self, auth_client, annotation, row
@@ -1162,6 +1165,134 @@ class TestUserViewSet:
             str(user_id) for user_id in view.get_queryset().values_list("id", flat=True)
         }
 
+    def test_workspace_only_requester_without_org_membership_passes_gate(
+        self, organization, workspace
+    ):
+        """A workspace member with no OrganizationMembership can still list
+        annotators — the access gate accepts workspace-based access, matching the
+        member-listing it guards (TH-6156)."""
+        from accounts.models.workspace import WorkspaceMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        requester = User.objects.create_user(
+            email="ws-only-requester@example.com",
+            password="testpassword123",
+            name="WS Only Requester",
+            organization=None,
+        )
+        # Deliberate drift: workspace access but NO OrganizationMembership row.
+        WorkspaceMembership.no_workspace_objects.create(
+            user=requester,
+            workspace=workspace,
+            role=OrganizationRoles.WORKSPACE_MEMBER,
+            level=Level.WORKSPACE_MEMBER,
+            is_active=True,
+        )
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=workspace,
+            organization=organization,
+            user=requester,
+        )
+
+        # Must not raise NotFound, and the requester is a selectable annotator.
+        ids = {
+            str(user_id) for user_id in view.get_queryset().values_list("id", flat=True)
+        }
+        assert str(requester.id) in ids
+
+    def test_requesting_user_always_included_as_annotator(
+        self, organization, workspace
+    ):
+        """The requester is always selectable for their own queue, even when they
+        are neither a member of the active workspace nor an org admin — so an
+        empty workspace no longer surfaces the misleading 404 (TH-6156)."""
+        from accounts.models.organization_membership import OrganizationMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        requester = User.objects.create_user(
+            email="plain-org-member@example.com",
+            password="testpassword123",
+            name="Plain Org Member",
+            organization=None,
+        )
+        # Org Member (not admin) with no WorkspaceMembership in `workspace`:
+        # only self-inclusion can place them in the result.
+        OrganizationMembership.no_workspace_objects.create(
+            user=requester,
+            organization=organization,
+            role=OrganizationRoles.MEMBER,
+            level=Level.MEMBER,
+            is_active=True,
+        )
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=workspace,
+            organization=organization,
+            user=requester,
+        )
+
+        ids = {
+            str(user_id) for user_id in view.get_queryset().values_list("id", flat=True)
+        }
+        assert str(requester.id) in ids
+
+    def test_lists_members_when_a_different_org_is_active(
+        self, organization, workspace, user
+    ):
+        """The requested org may differ from the active org/workspace. A member
+        of the requested org still gets its member list instead of a 404 — the
+        exact failure from the annotator picker passing the queue's org while a
+        different org is the active context (TH-6156)."""
+        from accounts.models.organization_membership import OrganizationMembership
+        from model_hub.views.develop_annotations import UserViewSet
+        from tfc.constants.levels import Level
+        from tfc.constants.roles import OrganizationRoles
+
+        # `user` (fixture) is an Owner of `organization` with `workspace`.
+        # Create a SECOND org + workspace and make it the active request context.
+        other_org = Organization.objects.create(name="Other Active Org")
+        other_ws = Workspace.objects.create(
+            name="Other Active WS",
+            organization=other_org,
+            is_active=True,
+            created_by=user,
+        )
+        OrganizationMembership.no_workspace_objects.create(
+            user=user,
+            organization=other_org,
+            role=OrganizationRoles.OWNER,
+            level=Level.OWNER,
+            is_active=True,
+        )
+
+        view = UserViewSet()
+        view.kwargs = {"organization_id": str(organization.id)}
+        # Active context points at other_org/other_ws, but the URL asks for
+        # `organization` — the mismatch that used to raise 404.
+        view.request = SimpleNamespace(
+            query_params={},
+            workspace=other_ws,
+            organization=other_org,
+            user=user,
+        )
+
+        ids = {
+            str(user_id) for user_id in view.get_queryset().values_list("id", flat=True)
+        }
+        # Must not 404, and must return the requested org's members (user owns it).
+        assert str(user.id) in ids
+
 
 # ==================== AnnotationSummaryView Tests ====================
 
@@ -1183,9 +1314,7 @@ class TestAnnotationSummaryView:
 
         # Mock the summary service response
         mock_summary_service.return_value = {
-            "header_data": pd.DataFrame(
-                {"label_id": [], "type": [], "name": []}
-            ),
+            "header_data": pd.DataFrame({"label_id": [], "type": [], "name": []}),
             "metric_calc": pd.DataFrame(
                 {"label_id": [], "row_id": [], "user_id": [], "value": []}
             ),

--- a/futureagi/model_hub/views/develop_annotations.py
+++ b/futureagi/model_hub/views/develop_annotations.py
@@ -1732,24 +1732,32 @@ class UserViewSet(viewsets.ModelViewSet):
         )
 
     def _validate_requested_organization(self, organization_id):
-        request_organization = getattr(self.request, "organization", None)
-        if request_organization and str(request_organization.id) != str(
-            organization_id
-        ):
-            raise NotFound(detail="No users found for the specified organization.")
-
-        workspace = getattr(self.request, "workspace", None)
-        if workspace and str(workspace.organization_id) != str(organization_id):
-            raise NotFound(detail="No users found for the specified organization.")
-
+        # Authorization is membership-based: a user may list an organization's
+        # members iff they belong to that organization — via an active
+        # OrganizationMembership, or a WorkspaceMembership in one of its
+        # workspaces (membership drift leaves some workspace members without an
+        # org-membership row).
+        #
+        # We intentionally do NOT require the URL org to equal the request's
+        # *currently-active* org/workspace. That coupling 404s legitimate lookups
+        # for another org the user also belongs to (e.g. the annotation annotator
+        # picker passing the queue's org while a different org is active) without
+        # adding any access control — the membership check below already blocks
+        # foreign orgs, so the coupling was pure breakage (TH-6156).
         from accounts.models.organization_membership import OrganizationMembership
+        from accounts.models.workspace import WorkspaceMembership
 
-        has_membership = OrganizationMembership.no_workspace_objects.filter(
+        has_org_membership = OrganizationMembership.no_workspace_objects.filter(
             user=self.request.user,
             organization_id=organization_id,
             is_active=True,
         ).exists()
-        if not has_membership:
+        has_workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
+            user=self.request.user,
+            workspace__organization_id=organization_id,
+            is_active=True,
+        ).exists()
+        if not (has_org_membership or has_workspace_membership):
             raise NotFound(detail="No users found for the specified organization.")
 
     def get_queryset(self):
@@ -1761,9 +1769,13 @@ class UserViewSet(viewsets.ModelViewSet):
             self._validate_requested_organization(organization_id)
             is_active_param = self.request.query_params.get("is_active")
 
-            # Prefer workspace-level filtering when workspace context is available
+            # Prefer workspace-level filtering only when the active workspace
+            # actually belongs to the requested org. When a different org is
+            # active, request.workspace is from that other org — using it would
+            # return an empty/admin-only slice of the requested org, so fall back
+            # to the org-wide member list instead (TH-6156).
             workspace = getattr(self.request, "workspace", None)
-            if workspace:
+            if workspace and str(workspace.organization_id) == str(organization_id):
                 explicit_workspace_user_ids = WorkspaceMembership.objects.filter(
                     workspace=workspace,
                     workspace__organization_id=organization_id,
@@ -1790,9 +1802,13 @@ class UserViewSet(viewsets.ModelViewSet):
                 ).values_list("user_id", flat=True)
 
             user_ids = list(dict.fromkeys(user_ids))
-            if not user_ids:
-                self._gm.not_found(get_error_message("USER_NOT_FOUND_IN_ORG"))
-                raise NotFound(detail="No users found for the specified organization.")
+            # The requesting user passed the access gate above, so they are a
+            # valid annotator for their own queue — always keep them selectable.
+            # This also guarantees a non-empty list for brand-new/empty
+            # workspaces, where the old empty-list 404 surfaced as the misleading
+            # "No users found for the specified organization." error (TH-6156).
+            if self.request.user.id not in user_ids:
+                user_ids.append(self.request.user.id)
 
             queryset = User.objects.filter(id__in=user_ids)
             if is_active_param is not None:

--- a/futureagi/model_hub/views/develop_annotations.py
+++ b/futureagi/model_hub/views/develop_annotations.py
@@ -1731,34 +1731,51 @@ class UserViewSet(viewsets.ModelViewSet):
             detail="Organization user mutations are not supported on this route.",
         )
 
-    def _validate_requested_organization(self, organization_id):
-        # Authorization is membership-based: a user may list an organization's
-        # members iff they belong to that organization — via an active
-        # OrganizationMembership, or a WorkspaceMembership in one of its
-        # workspaces (membership drift leaves some workspace members without an
-        # org-membership row).
-        #
-        # We intentionally do NOT require the URL org to equal the request's
-        # *currently-active* org/workspace. That coupling 404s legitimate lookups
-        # for another org the user also belongs to (e.g. the annotation annotator
-        # picker passing the queue's org while a different org is active) without
-        # adding any access control — the membership check below already blocks
-        # foreign orgs, so the coupling was pure breakage (TH-6156).
+    def _resolve_org_access(self, organization_id):
+        """Authorize the requester and return their visibility scope.
+
+        Returns ``"org"`` when the user has org-wide visibility (an active
+        ``OrganizationMembership``) or ``"workspace"`` when access is granted
+        only through a ``WorkspaceMembership`` (membership drift: some workspace
+        members have no org-membership row). Raises ``NotFound`` (fail-closed)
+        when the user has no access.
+
+        We intentionally do NOT require the URL org to equal the request's
+        *currently-active* org/workspace. That coupling 404s legitimate lookups
+        for another org the user also belongs to (e.g. the annotation annotator
+        picker passing the queue's org while a different org is active) without
+        adding any access control — the membership check below already blocks
+        foreign orgs, so the coupling was pure breakage (TH-6156).
+        """
         from accounts.models.organization_membership import OrganizationMembership
         from accounts.models.workspace import WorkspaceMembership
 
-        has_org_membership = OrganizationMembership.no_workspace_objects.filter(
+        # The unique constraint (user, organization) WHERE deleted=False means at
+        # most one non-deleted row. An *inactive* row is a deliberate removal:
+        # fail closed and never let a lingering workspace row re-authorize the
+        # user (a removed member must not regain visibility via drift).
+        org_membership = OrganizationMembership.no_workspace_objects.filter(
             user=self.request.user,
             organization_id=organization_id,
-            is_active=True,
-        ).exists()
-        has_workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
+        ).first()
+        if org_membership is not None:
+            if org_membership.is_active:
+                return "org"
+            raise NotFound(detail="No users found for the specified organization.")
+
+        # No org-membership row at all → genuine drift. Grant workspace-scoped
+        # access only through a *live* workspace (a soft-deleted or deactivated
+        # workspace's stale membership must not authorize).
+        has_live_workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
             user=self.request.user,
             workspace__organization_id=organization_id,
+            workspace__deleted=False,
+            workspace__is_active=True,
             is_active=True,
         ).exists()
-        if not (has_org_membership or has_workspace_membership):
+        if not has_live_workspace_membership:
             raise NotFound(detail="No users found for the specified organization.")
+        return "workspace"
 
     def get_queryset(self):
         try:
@@ -1766,7 +1783,7 @@ class UserViewSet(viewsets.ModelViewSet):
             from accounts.models.workspace import WorkspaceMembership
 
             organization_id = self.kwargs["organization_id"]
-            self._validate_requested_organization(organization_id)
+            access_scope = self._resolve_org_access(organization_id)
             is_active_param = self.request.query_params.get("is_active")
 
             # Prefer workspace-level filtering only when the active workspace
@@ -1795,10 +1812,29 @@ class UserViewSet(viewsets.ModelViewSet):
                 user_ids = list(explicit_workspace_user_ids) + list(
                     auto_access_user_ids
                 )
-            else:
-                # Fallback to org membership
+            elif access_scope == "org":
+                # Org-wide visibility (active org membership) with no matching
+                # active workspace → the full org member list.
                 user_ids = OrganizationMembership.no_workspace_objects.filter(
                     organization_id=organization_id, is_active=True
+                ).values_list("user_id", flat=True)
+            else:
+                # Workspace-only (drift) requester whose active workspace is a
+                # different org. Fail closed against the org-wide list: scope to
+                # the members of the *live* workspaces the requester belongs to in
+                # this org, so drift access never leaks the whole org (TH-6156).
+                requester_workspace_ids = (
+                    WorkspaceMembership.no_workspace_objects.filter(
+                        user=self.request.user,
+                        workspace__organization_id=organization_id,
+                        workspace__deleted=False,
+                        workspace__is_active=True,
+                        is_active=True,
+                    ).values_list("workspace_id", flat=True)
+                )
+                user_ids = WorkspaceMembership.no_workspace_objects.filter(
+                    workspace_id__in=list(requester_workspace_ids),
+                    is_active=True,
                 ).values_list("user_id", flat=True)
 
             user_ids = list(dict.fromkeys(user_ids))


### PR DESCRIPTION
## Linear
Closes [TH-6156](https://linear.app/future-agi/issue/TH-6156) (also covers the same-endpoint TH-6180 "No members found" side pane).

---

## 1) Why the changes

Opening the **Create Annotation Queue** drawer (annotator picker) called `GET /model-hub/organizations/{org_id}/users/` and returned:

```json
{ "detail": "No users found for the specified organization." }
```

That one message was raised from **four indistinguishable branches** of `UserViewSet`, so the failure was undiagnosable from the response. Verified live on dev (as an Owner of two orgs): the real cause is the **access gate**, which required the URL org to equal the request's *currently-active* org **and** to have an `OrganizationMembership`. Neither is correct authorization:

- **Active-org coupling (the live failure):** the picker sends the queue's org (`user.organization.id`) in the URL while a *different* org is the active `X-Organization-Id`. The gate 404'd this even though the user is a full member of the requested org. This coupling added **no** access control — the membership check already blocks foreign orgs — it was pure breakage.
- **Org-only membership:** the listing logic already grants visibility by **workspace** membership, but the gate only accepted **org** membership. Workspace members whose `OrganizationMembership` row is missing ("drift") were wrongly rejected.
- **Empty list → 404:** a brand-new/empty workspace surfaced the *same* opaque 404 instead of an empty result.

The correct model (matching the Members page) is **membership-based**: you may list an org's members iff you belong to that org.

---

## 2) What changed

### Backend — `model_hub/views/develop_annotations.py`
- **`_validate_requested_organization` is now a pure membership check** — access granted iff the user has an active `OrganizationMembership` **OR** an active `WorkspaceMembership` in the requested org. Removed the active-org/active-workspace equality guards.
- **`get_queryset` workspace branch is org-guarded** — the active workspace is used only when it belongs to the requested org; otherwise it falls back to the **org-wide** member list (correct results when a different org is active).
- **Removed the empty-list 404** — the requesting user is always self-included as a selectable annotator for their own queue.

### Backend — data integrity (`accounts/services/workspace_membership.py`)
- **`ensure_org_membership()`** wired into the single workspace-membership create path: when a workspace member has no active org membership, create the **minimal `Viewer`** `OrganizationMembership` (no global workspace access). **Fail-closed:** an *inactive* (deliberately removed) membership is never resurrected — FK stays NULL and the existing drift warning fires. This stops new drift at the source and heals every org-membership-dependent surface (e.g. the Members-page Org Role chip), not just this endpoint.

### Backend — backfill migration (`accounts/migrations/0023_create_missing_org_memberships.py`)
- Heals **existing** drift: creates the missing `Viewer` membership for active workspace members that have none, then links the workspace-membership FKs. Idempotent, batched, non-atomic, fail-closed (skips users with an inactive row). `0022` only *linked* existing memberships; it never *created* missing ones — this closes that gap.

### Frontend
- `annotator-picker.jsx` and `ErrorMetadataPanel.jsx` now use the **live active org** (`currentOrganizationId` from `useOrganization()` — the same sessionStorage value axios sends as `X-Organization-Id`) instead of the cached `user.organization.id`, which could drift from the active context and cause the mismatch 404. This fixes the staleness at the source; the backend fix makes the endpoint robust regardless.

---

## 3) Tests added — scenarios each covers

### `model_hub/tests/test_develop_annotations_api.py::TestUserViewSet` (+3)
| Test | Scenario it pins |
|------|------------------|
| `test_workspace_only_requester_without_org_membership_passes_gate` | A user with a **WorkspaceMembership but no OrganizationMembership** (drift) passes the gate and is listed — the gate accepts workspace-based access. |
| `test_requesting_user_always_included_as_annotator` | A plain org **Member** (not admin) with no membership in the active workspace is still returned via **self-inclusion** — empty/edge workspaces no longer 404. |
| `test_lists_members_when_a_different_org_is_active` | **The exact live bug:** Owner of org A requests A's users while the active context is **org B** → returns A's members (not 404). 404'd before, passes now. |

### `accounts/tests/test_workspace_member_fk.py` (+6)
| Test | Scenario it pins |
|------|------------------|
| `TestEnsureOrgMembershipInvariant::test_factory_creates_viewer_org_membership_when_absent` | Create path creates a **Viewer** org membership when none exists, and links the FK. |
| `TestEnsureOrgMembershipInvariant::test_factory_does_not_resurrect_inactive_org_membership` | **Fail-closed:** an inactive (removed) membership is not reactivated; FK stays NULL. |
| `TestEnsureOrgMembershipInvariant::test_ensure_org_membership_returns_existing_active` | An existing active membership is reused, not duplicated. |
| `TestCreateMissingOrgMembershipsMigration::test_creates_viewer_membership_and_links_fk_for_drifted_member` | Migration 0023 creates the Viewer membership for a drifted active workspace member and links the FK. |
| `TestCreateMissingOrgMembershipsMigration::test_does_not_create_for_removed_member` | Migration skips users whose only row is inactive (no resurrection). |
| `TestCreateMissingOrgMembershipsMigration::test_idempotent` | Re-running the migration creates nothing new. |

### `frontend/.../annotator-picker.test.jsx`
- Updated the mock from `useAuthContext` → `useOrganization` to match the new live-active-org source; both existing picker tests still pass.

---

## 4) Affected existing tests — updated and passing

- **`TestUserViewSet`** (existing 15 + 3 new) → **18 passed**, incl. `test_list_users_rejects_cross_organization_path` (a non-member of the URL org is still **404'd** — cross-org isolation preserved).
- **`TestCreateWorkspaceMembershipFactory` / `TestBackfillMigration`** (existing) → still green under the new create-path behavior (the fail-closed inactive case is unchanged).
- **Full `accounts` app suite → 1192 passed** (confirms the shared create-path change is regression-free).
- **`model_hub/tests/test_develop_annotations_api.py` (full file) → 72 passed.**
- **Frontend `annotator-picker.test.jsx` → 2 passed.**
- `ruff` / `black` / `isort` clean on backend; ESLint **0 errors** on the changed FE files.

---

## Commands to run the tests

**Backend** (from `futureagi/`):
```bash
# New + affected endpoint tests (membership gate, self-inclusion, cross-active-org)
bin/test --no-services model_hub/tests/test_develop_annotations_api.py -k "TestUserViewSet"

# Whole endpoint test file
bin/test --no-services model_hub/tests/test_develop_annotations_api.py

# Data-integrity: create-path invariant + 0023 migration (+ existing FK/backfill tests)
bin/test --no-services accounts -k "TestEnsureOrgMembershipInvariant or TestCreateMissingOrgMembershipsMigration or TestCreateWorkspaceMembershipFactory or TestBackfillMigration"

# Full accounts app (regression check for the shared create path)
bin/test --no-services accounts
```

**Frontend** (from `frontend/`):
```bash
yarn test:run src/sections/annotations/queues/components/__tests__/annotator-picker.test.jsx
```

> On the first backend run, drop `--no-services` so the docker test services (postgres/redis/clickhouse/minio) start automatically; later runs can keep `--no-services` to skip them.


## 5) Command to run the script, and why it's needed

The healing **script is the data migration** `accounts/migrations/0023_create_missing_org_memberships.py`. It runs automatically with the normal migrate step on deploy:

```bash
# from futureagi/
python manage.py migrate accounts
# or target just this migration:
python manage.py migrate accounts 0023_create_missing_org_memberships
```

**Why it's needed:** the code fixes (gate + create-path invariant) only prevent *new* drift and make the endpoint tolerant. They do **not** retro-actively create the `OrganizationMembership` rows for accounts that **already** drifted. This migration backfills those existing rows (minimal `Viewer` membership) and links the workspace-membership FKs, so every org-membership-dependent surface (annotator picker, Members-page Org Role chip, etc.) is correct for current users — not just future ones. It is idempotent and fail-closed, so re-running is safe and it never resurrects deliberately-removed members.

---

## Type of change
- [x] 🐛 Bug fix (non-breaking)
- [x] 🧹 Chore / data-integrity (create-path invariant + backfill migration)

## Rollback
- View/service/FE changes revert cleanly. Migration `0023` reverse is a no-op by design (auto-created Viewer rows are indistinguishable from legitimate ones, so reverse never deletes).


---

## Running migration `0023` in dev & prod

The backfill is a standard Django data migration, so it runs **automatically** as part of the normal release migrate step. It is **non-atomic + id-batched** (never holds one long table lock), **idempotent** (safe to re-run — a second run creates nothing), and **fail-closed** (never resurrects a removed membership). Reverse is a no-op by design.

**Verified locally** against Postgres 16: seeded a drifted workspace member (active `WorkspaceMembership`, no `OrganizationMembership`), ran `manage.py migrate accounts 0023_create_missing_org_memberships` →
```
Applying accounts.0023_create_missing_org_memberships...
  Created 1 Viewer OrganizationMembership rows; linked 1 WorkspaceMembership FK rows
 OK
```
Post-run the user had an active `Viewer` org membership and the workspace FK was linked; re-running migrate was a clean `No migrations to apply.`

### Dev
```bash
# from the backend app dir (e.g. futureagi/), or exec into the dev backend pod/container
python manage.py showmigrations accounts          # expect: [ ] 0023_create_missing_org_memberships
python manage.py migrate accounts 0023_create_missing_org_memberships
# (or simply `python manage.py migrate` to apply all pending)
```
Preview without writing:
```bash
python manage.py migrate accounts --plan
```

### Prod
The deploy pipeline runs `python manage.py migrate` during release, which applies `0023` automatically — no separate step required. If running manually (exec into the backend pod/container):
```bash
python manage.py showmigrations accounts          # confirm 0023 is [ ] unapplied
python manage.py migrate accounts 0023_create_missing_org_memberships
python manage.py showmigrations accounts          # confirm it is now [X]
```
Notes:
- No downtime required; the batched, non-atomic design avoids long locks.
- Safe to re-run if a deploy is retried (idempotent).
- Take a routine DB snapshot beforehand per standard prod-migration policy.


##Videos and Screenshots

https://github.com/user-attachments/assets/5c1cd1a3-706d-4629-a764-4b3317aa5677

<img width="1512" height="982" alt="Screenshot 2026-07-01 at 10 41 16 PM" src="https://github.com/user-attachments/assets/a639dd8b-baa0-4dd6-a475-8c441c74abb4" />


