### PR TITLE
fix(observe): widen Tokens column so the leading value isn't clipped [TH-6338]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -51,7 +51,10 @@ const getSpanListColumnDefs = (col) => {
     headerName: col.name,
     ...(isCustomColumn
       ? { colId: col.id, minWidth: 180, flex: 1 }
-      : { field: col.id }),
+      : {
+          field: col.id,
+          ...(colId === "total_tokens" ? { minWidth: 240 } : {}),
+        }),
     hide: !col?.isVisible,
     context: { sourceColumn: col },
     // Custom columns use valueGetter to handle dot-notation attribute keys

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -509,7 +509,7 @@ const COLUMN_SIZE_MAP = {
   status: { minWidth: 130, maxWidth: 160, flex: 0 },
   latency: { minWidth: 100, maxWidth: 140, flex: 0 },
   latency_ms: { minWidth: 100, maxWidth: 140, flex: 0 },
-  total_tokens: { minWidth: 200, flex: 1 },
+  total_tokens: { minWidth: 240, flex: 1 },
   prompt_tokens: { minWidth: 100, maxWidth: 130, flex: 0 },
   completion_tokens: { minWidth: 100, maxWidth: 130, flex: 0 },
   total_cost: { minWidth: 130, flex: 0 },


### PR DESCRIPTION
## 🐛 Bug
[TH-6338](https://linear.app/future-agi/issue/TH-6338) — In the Observe trace/span tables, the **Tokens** column clipped the **left edge** of the value (e.g. `3.03k ↓ …` showed as `.03k ↓ …`), so the leading token count was hidden.

## 🔍 Root cause
`TokenCell` lays its breakdown out **right-aligned** (`justifyContent: flex-end`) with `whiteSpace: nowrap`. At the column's minimum width the content was wider than the column, so the right-anchored row overflowed on the **left** and the grid clipped it — hiding the leading value. The Tokens column floor (`minWidth: 200`) wasn't enough for the longer breakdowns.

## 🔧 What changed
Widen the Tokens column floor to **240px** in both grids (they use the same `TokenCell`):
- **Trace grid** — `COLUMN_SIZE_MAP.total_tokens` `minWidth 200 → 240` (`common.js`).
- **Span grid** — `getSpanListColumnDefs` adds `minWidth: 240` for `total_tokens` (it had no width override) (`SpanGrid.jsx`).

## 🤔 Why
Values are abbreviated via `fShortenNumber` (`k`/`M`), so the breakdown string is length-bounded; 240px fits the realistic worst case (`9.99M ↓ 9.99M ↑ (Σ 9.99M) ⓘ`). On the trace grid the column also has `flex: 1`, so it grows past 240 when there's room — the floor only matters in narrow/drawer views (where the clip was seen). Scoped to the Tokens column only; no other columns shift.

## ▶️ How to verify
Observe → open the trace list and the span list (narrow/drawer width) → the leading token value is fully visible (no left clip).

## 💻 Commands
```bash
yarn lint src/sections/projects/LLMTracing/common.js src/sections/projects/LLMTracing/SpanGrid.jsx
```

## 📹 Videos & Screenshots
<img width="465" height="693" alt="Screenshot 2026-06-29 at 6 46 22 PM" src="https://github.com/user-attachments/assets/1a8645a4-ff76-4255-a33c-745abd623607" />
