### PR TITLE
fix: dashboard & session UI bugfixes (TH-6258, TH-6311, TH-6318, TH-6308, TH-6245)

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -643,7 +643,7 @@ export default function DashboardDetailView() {
 
   // Global date filter — restore from URL so returning from widget editor
   // preserves the previously selected preset.
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [datePreset, setDatePreset] = useState(
     () => searchParams.get("timePreset") || null,
   );

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -29,7 +29,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { paths } from "src/routes/paths";
 import {
   useDashboardDetail,
@@ -641,8 +641,12 @@ export default function DashboardDetailView() {
   const duplicateWidget = useDuplicateWidget();
   const createWidget = useCreateWidget();
 
-  // Global date filter
-  const [datePreset, setDatePreset] = useState(null);
+  // Global date filter — restore from URL so returning from widget editor
+  // preserves the previously selected preset.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [datePreset, setDatePreset] = useState(
+    () => searchParams.get("timePreset") || null,
+  );
   const [customDateRange, setCustomDateRange] = useState(null); // [start, end]
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
   const customDateAnchorRef = useRef(null);

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -157,9 +157,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
   const pieValues = useMemo(
     () =>
       isPie
-        ? chartSeries.map((s) =>
-            s.data.reduce((sum, pt) => sum + (pt.y || 0), 0),
-          )
+        ? chartSeries.map((s) => getSeriesAverage(s.data) ?? 0)
         : [],
     [isPie, chartSeries],
   );
@@ -422,11 +420,16 @@ export default function WidgetChart({ widget, globalDateRange }) {
                         flexShrink: 0,
                       }}
                     />
-                    {s.name === "total"
-                      ? queryConfig?.metrics?.[0]?.display_name ||
-                        queryConfig?.metrics?.[0]?.name ||
-                        "Total"
-                      : s.name}
+                    {(() => {
+                      const label =
+                        s.name === "total"
+                          ? queryConfig?.metrics?.[0]?.display_name ||
+                            queryConfig?.metrics?.[0]?.name ||
+                            "Total"
+                          : s.name;
+                      const unit = leftAxisFormatConfig?.unit;
+                      return unit ? `${label} (${unit})` : label;
+                    })()}
                   </span>
                 </th>
               ))}
@@ -479,7 +482,6 @@ export default function WidgetChart({ widget, globalDateRange }) {
                         {val != null
                           ? formatValueWithConfig(val, leftAxisFormatConfig, {
                               fallbackDecimals: autoDecimals,
-                              includeUnit: false,
                             })
                           : "-"}
                       </td>
@@ -498,12 +500,9 @@ export default function WidgetChart({ widget, globalDateRange }) {
     const isDarkPie = theme.palette.mode === "dark";
     const txtColor = isDarkPie ? "#fff" : "#1a1a2e";
     const pieTotal = pieValues.reduce((a, b) => a + b, 0);
-    const fmtTotal =
-      pieTotal >= 1000000
-        ? `${(pieTotal / 1000000).toFixed(1)}M`
-        : pieTotal >= 1000
-          ? pieTotal.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-          : pieTotal.toFixed(0);
+    const fmtTotal = formatValueWithConfig(pieTotal, leftAxisFormatConfig, {
+      fallbackDecimals: autoDecimals,
+    });
     const pieOptions = {
       chart: {
         type: "donut",

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1138,15 +1138,18 @@ export default function WidgetEditorView() {
       {
         onSuccess: () => {
           enqueueSnackbar("Widget deleted", { variant: "success" });
-          navigate(paths.dashboard.dashboards.detail(dashboardId));
+          navigate(dashboardDetailUrl);
         },
         // Close once the request settles, not before it starts.
         onSettled: () => setConfirmDeleteOpen(false),
       },
     );
   };
+  const incomingTimePreset = searchParams.get("timePreset");
+  const dashboardDetailUrl = `${paths.dashboard.dashboards.detail(dashboardId)}${incomingTimePreset ? `?timePreset=${incomingTimePreset}` : ""}`;
+
   const [timePreset, setTimePreset] = useState(
-    searchParams.get("timePreset") || "30D",
+    incomingTimePreset || "30D",
   );
   const [granularity, setGranularity] = useState("day");
   const [chartType, setChartType] = useState("line");
@@ -2105,7 +2108,7 @@ export default function WidgetEditorView() {
       setSaveStatus("saved");
       clearTimeout(saveNavTimerRef.current);
       saveNavTimerRef.current = setTimeout(() => {
-        navigate(paths.dashboard.dashboards.detail(dashboardId));
+        navigate(dashboardDetailUrl);
         setSaveStatus("idle");
       }, SAVED_NAV_DELAY_MS);
     } catch {
@@ -2893,7 +2896,7 @@ export default function WidgetEditorView() {
               display: "block",
             }}
             onClick={() =>
-              navigate(paths.dashboard.dashboards.detail(dashboardId))
+              navigate(dashboardDetailUrl)
             }
           >
             {dashboard?.name || "Dashboard"}
@@ -3151,7 +3154,7 @@ export default function WidgetEditorView() {
 
         <Button
           onClick={() =>
-            navigate(paths.dashboard.dashboards.detail(dashboardId))
+            navigate(dashboardDetailUrl)
           }
           sx={{ color: "text.primary", fontWeight: 500 }}
         >

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1128,6 +1128,9 @@ export default function WidgetEditorView() {
   const [moreMenuAnchor, setMoreMenuAnchor] = useState(null);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
+  const incomingTimePreset = searchParams.get("timePreset");
+  const dashboardDetailUrl = `${paths.dashboard.dashboards.detail(dashboardId)}${incomingTimePreset ? `?timePreset=${incomingTimePreset}` : ""}`;
+
   const confirmDeleteWidget = () => {
     if (!isEditing) {
       setConfirmDeleteOpen(false);
@@ -1145,8 +1148,6 @@ export default function WidgetEditorView() {
       },
     );
   };
-  const incomingTimePreset = searchParams.get("timePreset");
-  const dashboardDetailUrl = `${paths.dashboard.dashboards.detail(dashboardId)}${incomingTimePreset ? `?timePreset=${incomingTimePreset}` : ""}`;
 
   const [timePreset, setTimePreset] = useState(
     incomingTimePreset || "30D",

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -57,6 +57,7 @@ const SessionGrid = React.forwardRef(
       onGridReady,
       pendingCustomColumnsRef,
       isOnSavedView = false,
+      userIdForUserMode,
     },
     gridApiRef,
   ) => {
@@ -491,6 +492,7 @@ const SessionGrid = React.forwardRef(
                 open={open}
                 onClose={handleDrawerClose}
                 rowData={currentRowData}
+                userIdForUserMode={userIdForUserMode}
               />
             ) : null}
           </Box>

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -516,6 +516,7 @@ SessionGrid.propTypes = {
   className: PropTypes.string,
   pendingCustomColumnsRef: PropTypes.object,
   isOnSavedView: PropTypes.bool,
+  userIdForUserMode: PropTypes.string,
 };
 
 export default SessionGrid;

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -1121,6 +1121,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           onGridReady={onGridReady}
           pendingCustomColumnsRef={pendingCustomColumnsRef}
           isOnSavedView={Boolean(activeViewConfig)}
+          userIdForUserMode={userIdForUserMode}
         />
       </Box>
 

--- a/frontend/src/sections/projects/SessionsView/TraceCardRightSection.jsx
+++ b/frontend/src/sections/projects/SessionsView/TraceCardRightSection.jsx
@@ -34,7 +34,7 @@ const TraceCardRightSection = ({
   // Ensure systemMetrics is valid
   const safeSystemMetrics = {
     total_latency_ms: formatMs(systemMetrics?.total_latency_ms) || "N/A",
-    // user_id: user?.id,
+    ...(systemMetrics?.user_id ? { user_id: systemMetrics.user_id } : {}),
     total_cost: systemMetrics?.total_cost || "N/A",
     total_token_count: systemMetrics?.total_tokens || "N/A",
     input_tokens: systemMetrics?.input_tokens || "N/A", //DUMMY

--- a/frontend/src/sections/projects/TracesDrawer/TracesDrawer.jsx
+++ b/frontend/src/sections/projects/TracesDrawer/TracesDrawer.jsx
@@ -456,6 +456,7 @@ TracesDrawer.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   rowData: PropTypes.object,
+  userIdForUserMode: PropTypes.string,
 };
 
 export default TracesDrawer;

--- a/frontend/src/sections/projects/TracesDrawer/TracesDrawer.jsx
+++ b/frontend/src/sections/projects/TracesDrawer/TracesDrawer.jsx
@@ -34,7 +34,7 @@ function a11yProps(index) {
   };
 }
 
-const TracesDrawer = ({ open, onClose, rowData }) => {
+const TracesDrawer = ({ open, onClose, rowData, userIdForUserMode }) => {
   const theme = useTheme();
   const { projectId, observeId } = useParams();
   const projectIdToUse = projectId || observeId;
@@ -53,10 +53,14 @@ const TracesDrawer = ({ open, onClose, rowData }) => {
     isFetchingNextPage,
     isFetching,
   } = useInfiniteQuery({
-    queryKey: ["traceSession", activeSessionId],
+    queryKey: ["traceSession", activeSessionId, userIdForUserMode],
     queryFn: ({ pageParam }) => {
       return axios.get(`${endpoints.project.traceSession}${activeSessionId}/`, {
-        params: { page_number: pageParam, page_size: 10 },
+        params: {
+          page_number: pageParam,
+          page_size: 10,
+          ...(userIdForUserMode ? { user_id: userIdForUserMode } : {}),
+        },
       });
     },
     getNextPageParam: (page, _, pageParams) => {
@@ -325,6 +329,39 @@ const TracesDrawer = ({ open, onClose, rowData }) => {
                     },
                   }}
                 />
+                {sessionMetadata?.user_id && (
+                  <Chip
+                    label={
+                      <Typography
+                        variant="s2"
+                        sx={{ color: "text.primary" }}
+                        fontWeight={"fontWeightRegular"}
+                      >
+                        User ID: {sessionMetadata.user_id}
+                      </Typography>
+                    }
+                    icon={<Iconify icon="mdi:account-outline" width={14} />}
+                    sx={{
+                      border: "1px solid",
+                      borderColor: "divider",
+                      backgroundColor: "background.default",
+                      color: "text.secondary",
+                      height: "25px",
+                      paddingX: 0.5,
+                      borderRadius: "8px",
+                      "& .MuiChip-icon": {
+                        color:
+                          theme.palette.mode === "light"
+                            ? "text.primary"
+                            : "text.secondary",
+                      },
+                      "&:hover": {
+                        backgroundColor: "background.paper",
+                        borderColor: "divider",
+                      },
+                    }}
+                  />
+                )}
               </>
             )}
           </Box>

--- a/futureagi/tracer/utils/session.py
+++ b/futureagi/tracer/utils/session.py
@@ -44,14 +44,21 @@ def _try_session_navigation_ch(
 
         user_id = query_data.get("user_id")
         if user_id:
-            # Add user filter to the navigation query. Anchor must match the
-            # exact line emitted by ``build_session_navigation_query``; keep
-            # in sync if that builder is changed.
-            nav_params["user_id"] = user_id
-            nav_query = nav_query.replace(
-                "AND trace_session_id IS NOT NULL",
-                "AND trace_session_id IS NOT NULL AND end_user_id = %(user_id)s",
+            from tracer.services.clickhouse.v2.end_user_dict_reader import (
+                resolve_end_user_ids_by_user_id,
             )
+
+            end_user_ids = resolve_end_user_ids_by_user_id(
+                user_id, project_id=project_id
+            )
+            if end_user_ids:
+                nav_params["end_user_ids"] = end_user_ids
+                nav_query = nav_query.replace(
+                    "AND trace_session_id IS NOT NULL",
+                    "AND trace_session_id IS NOT NULL AND end_user_id IN %(end_user_ids)s",
+                )
+            else:
+                return None
 
         nav_result = service.execute_ch_query(nav_query, nav_params)
 
@@ -64,9 +71,6 @@ def _try_session_navigation_ch(
         first_q, last_q, msg_params = builder.build_first_last_message_query(
             session_ids
         )
-        if user_id:
-            msg_params["user_id"] = user_id
-
         first_result = service.execute_ch_query(first_q, msg_params)
         last_result = service.execute_ch_query(last_q, msg_params)
 


### PR DESCRIPTION
## Summary

Fixes five UI bugs across dashboard widgets and session views:
- **TH-6258**: User ID was missing from session metadata — added `end_user_id` aggregation in the backend session detail query, resolved it to the human-readable `user_id` label, and display it as a chip in the session drawer header and in trace system_metrics.
- **TH-6311**: Pie chart displayed a sum (~12× inflated) instead of the average, and stripped the unit label — switched to average aggregation and added unit formatting to the center label.
- **TH-6318**: Table chart type showed bare numbers with units stripped from column headers and cell values — restored unit display in both.
- **TH-6308**: Dashboard-level time filter reset to "Default" after closing widget edit mode — preserved `timePreset` query param through all widget editor navigation paths.
- **TH-6245**: Session prev/next navigation in the users tab was not scoped to the current user — threaded `userIdForUserMode` from the user detail page through to the backend API, and fixed a type mismatch where the backend compared a UUID `end_user_id` column against a string `user_id` by resolving via `resolve_end_user_ids_by_user_id()` first.

## Linked issues

Closes TH-6258
Closes TH-6311
Closes TH-6318
Closes TH-6308
Closes TH-6245

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Verified pie chart shows correct average values with unit labels
- Verified table chart columns and cells include units (e.g., "ms")
- Verified dashboard time filter persists through widget editor open/close
- Verified session drawer shows User ID chip when available
- Verified session navigation arrows are disabled when user has only one session

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] No hardcoded secrets, URLs, or PII