### PR TITLE
fix: skip reviewer assignment for draft PRs

### DIFF
--- a/.github/scripts/reviewer-assigner.mjs
+++ b/.github/scripts/reviewer-assigner.mjs
@@ -150,6 +150,10 @@ async function assignForPr(prNumber) {
     log(`  state=${pr.state}, skipping`);
     return;
   }
+  if (pr.draft) {
+    log(`  draft PR, skipping`);
+    return;
+  }
   if ((pr.requested_reviewers?.length ?? 0) > 0 || (pr.requested_teams?.length ?? 0) > 0) {
     log(`  already has reviewers (${pr.requested_reviewers.map((r) => r.login).join(',')} + teams=${pr.requested_teams.length}), skipping`);
     return;

--- a/.github/workflows/reviewer-assigner.yml
+++ b/.github/workflows/reviewer-assigner.yml
@@ -18,7 +18,10 @@ on:
 
 jobs:
   assign:
-    if: github.repository == 'future-agi/future-agi' && github.event_name != 'schedule'
+    if: >-
+      github.repository == 'future-agi/future-agi' &&
+      github.event_name != 'schedule' &&
+      github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## What broke

The `reviewer-assigner` workflow fires on `pull_request: opened` events. GitHub fires `opened` for draft PRs too, and `assignForPr()` only checked `pr.state !== 'open'` — draft PRs have `state=open`, so they slipped through and got a reviewer assigned before the author was anywhere near ready for review.

This also sets off the downstream `/ossprattacher` flow (Linear ticket created for the assigned reviewer), making the problem visible to the whole team on a PR that hadn't left the author's desk yet.

## What changed

**`.github/workflows/reviewer-assigner.yml`**
- Added `github.event.pull_request.draft != true` to the `assign` job's `if` condition — kills the job at the YAML level for all draft `pull_request` events, zero compute wasted.

**`.github/scripts/reviewer-assigner.mjs`** (`assignForPr`, line ~151)
- Added `if (pr.draft) { log('draft PR, skipping'); return; }` right after the `state` check — covers the `workflow_dispatch` manual-PR-number path where `github.event.pull_request` isn't populated.

The `ping` and `summary` modes already had `if (pr.draft) continue` guards. This brings `assign` in line with them.

## Repro before this PR

1. Open a PR as draft on `future-agi/future-agi`
2. Watch `Reviewer Assigner` workflow fire, assign a reviewer within seconds
3. Reviewer gets a Linear ticket even though the PR isn't ready

## After this PR

Draft PRs are silently skipped. When the author clicks "Ready for review", the `ready_for_review` event fires (already in the trigger list), assignment runs normally.

## Tests / verification

No unit tests for this workflow script — the logic is a trivial guard. Verified manually against the API response shape: `gh pr view` returns `"isDraft": true` for drafts and `pr.draft` in the GitHub REST API response is `true`.