### PR TITLE
fix: read lean span projection in annotation for-source to avoid ClickHouse OOM (TH-6252)

### DIFF
--- a/futureagi/model_hub/tests/test_per_queue_scoring_e2e.py
+++ b/futureagi/model_hub/tests/test_per_queue_scoring_e2e.py
@@ -588,6 +588,69 @@ class TestForSourceIsolation:
         assert str(span_queue.id) in returned
         assert str(session_queue.id) in returned
 
+    def test_default_queue_span_scope_uses_lean_projection(
+        self,
+        mocker,
+        auth_client,
+        organization,
+        workspace,
+        user,
+        observe_project,
+        observation_span,
+        star_label,
+    ):
+        """The default-queue span scope check must read only ``project_id`` via
+        ``scope_by_ids`` — reading the full span row (``list_by_ids``/``get``)
+        OOMs the shared ClickHouse cluster on fat voice spans (code 241). Guard
+        that the wide reads are never used on this path.
+        """
+        from unittest.mock import MagicMock
+
+        from tracer.services.clickhouse.v2.span_reader import SpanScope
+
+        # Default queue scoped to the span's project; the span is NOT an item of
+        # it, so it can only surface via the CH project scope check.
+        default_queue = _make_queue(
+            "Default Q",
+            organization,
+            workspace,
+            user,
+            observe_project,
+            is_default=True,
+        )
+        AnnotationQueueLabel.objects.create(queue=default_queue, label=star_label)
+
+        fake_reader = MagicMock()
+        fake_reader.__enter__.return_value = fake_reader
+        fake_reader.__exit__.return_value = False
+        fake_reader.scope_by_ids.return_value = {
+            observation_span.id: SpanScope(
+                project_id=str(observe_project.id), trace_id=None
+            )
+        }
+        # The wide reads must never be called on the for-source scope path.
+        fake_reader.list_by_ids.side_effect = AssertionError(
+            "for-source must not read full span rows (OOMs shared ClickHouse)"
+        )
+        fake_reader.get.side_effect = AssertionError(
+            "for-source must not read full span rows (OOMs shared ClickHouse)"
+        )
+        mocker.patch(
+            "tracer.services.clickhouse.v2.get_reader", return_value=fake_reader
+        )
+
+        sources = [
+            {"source_type": "observation_span", "source_id": observation_span.id}
+        ]
+        resp = auth_client.get(
+            f"{QUEUE_URL}for-source/", {"sources": json.dumps(sources)}
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        fake_reader.scope_by_ids.assert_called_once()
+        returned = {entry["queue"]["id"] for entry in resp.data["result"]}
+        # The lean scope check resolved the span's project → default surfaced.
+        assert str(default_queue.id) in returned
+
 
 # ---------------------------------------------------------------------------
 # 4. Auto-complete scoping

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -863,6 +863,55 @@ class TestForSourceEndpoint:
         assert "sourceType" in str(resp.data)
         assert "sourceId" in str(resp.data)
 
+    def test_span_scope_uses_lean_projection(
+        self, mocker, auth_client, observe_project, observation_span, star_label
+    ):
+        """The span-note org-scope check must read only project_id/trace_id via
+        ``scope_by_ids`` — reading the full span row (``reader.get``) OOMs the
+        shared ClickHouse cluster on fat voice spans (code 241). Guard that the
+        wide read is never used, and scores still return.
+        """
+        from unittest.mock import MagicMock
+
+        from tracer.services.clickhouse.v2.span_reader import SpanScope
+
+        auth_client.post(
+            SCORE_URL,
+            {
+                "source_type": "observation_span",
+                "source_id": observation_span.id,
+                "label_id": str(star_label.id),
+                "value": {"rating": 4},
+            },
+            format="json",
+        )
+
+        fake_reader = MagicMock()
+        fake_reader.__enter__.return_value = fake_reader
+        fake_reader.__exit__.return_value = False
+        fake_reader.scope_by_ids.return_value = {
+            observation_span.id: SpanScope(
+                project_id=str(observe_project.id), trace_id=None
+            )
+        }
+        fake_reader.get.side_effect = AssertionError(
+            "scores for-source must not read full span rows (OOMs shared ClickHouse)"
+        )
+        mocker.patch(
+            "tracer.services.clickhouse.v2.get_reader", return_value=fake_reader
+        )
+
+        resp = auth_client.get(
+            f"{SCORE_URL}for-source/",
+            {
+                "source_type": "observation_span",
+                "source_id": observation_span.id,
+            },
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        fake_reader.scope_by_ids.assert_called_once()
+        assert len(resp.data["result"]) == 1
+
 
 @pytest.mark.django_db
 class TestDeleteScore:

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -4408,9 +4408,14 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             # called `get_reader().get(sid)` inside both the project- and
             # agent-definition-scope branches for every queue × source
             # combination, producing N×M CH round-trips. Precompute the
-            # span lookup once with list_by_ids; the inner branches now
-            # consult an in-memory dict.
-            _ch_span_by_id: dict[str, object] = {}
+            # span lookup once; the inner branches now consult an in-memory dict.
+            #
+            # These branches only need each span's project_id (a scope check),
+            # so read the lean ``scope_by_ids`` projection — pulling the full
+            # span row here blows the shared ClickHouse memory limit (code 241)
+            # on fat voice spans whose ``attributes_extra`` carries a whole raw
+            # log.
+            _ch_scope_by_span: dict[str, object] = {}
             _span_source_ids = [
                 str(src["source_id"])
                 for src in sources
@@ -4420,8 +4425,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 from tracer.services.clickhouse.v2 import get_reader as _gr_bulk
 
                 with _gr_bulk() as _reader_bulk:
-                    for _s in _reader_bulk.list_by_ids(_span_source_ids):
-                        _ch_span_by_id[str(_s.id)] = _s
+                    _ch_scope_by_span = _reader_bulk.scope_by_ids(_span_source_ids)
 
             for dq in missing_defaults:
                 if dq.id in seen_queues:
@@ -4448,8 +4452,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                         elif st == "observation_span":
                             # Bulk-prefetched above; in-memory dict lookup
                             # (avoids N×M CH round-trips per codex P2).
-                            _sp = _ch_span_by_id.get(str(sid))
-                            exists = _sp is not None and _sp.project_id == str(
+                            _scope = _ch_scope_by_span.get(str(sid))
+                            exists = _scope is not None and _scope.project_id == str(
                                 dq.project_id
                             )
                         elif st == "trace_session":
@@ -4517,11 +4521,12 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                             # `project__observability_providers__agent_definition`
                             # isn't on the CH span row, so verify the project
                             # linkage via PG after the in-memory CH lookup.
-                            _sp = _ch_span_by_id.get(str(sid))
+                            _scope = _ch_scope_by_span.get(str(sid))
                             exists = (
-                                _sp is not None
+                                _scope is not None
+                                and _scope.project_id is not None
                                 and Project.objects.filter(
-                                    id=_sp.project_id,
+                                    id=_scope.project_id,
                                     observability_providers__agent_definition=dq.agent_definition_id,
                                 ).exists()
                             )

--- a/futureagi/model_hub/views/scores.py
+++ b/futureagi/model_hub/views/scores.py
@@ -764,19 +764,22 @@ class ScoreViewSet(viewsets.ModelViewSet):
             #     .values_list("trace_id", flat=True).first()
             # Org-tenant scope is verified by checking the span's project_id
             # against the requesting org via Project (the only side of the
-            # FK that's still in PG).
+            # FK that's still in PG). Read the lean ``scope_by_ids`` projection
+            # (project_id + trace_id only): pulling the full span row here blows
+            # the shared ClickHouse memory limit (code 241) on fat voice spans.
             with get_reader() as reader:
-                span = reader.get(str(source_id))
+                span_scope = reader.scope_by_ids([str(source_id)]).get(str(source_id))
             span_belongs_to_org = False
             trace_id = None
             if (
-                span is not None
+                span_scope is not None
+                and span_scope.project_id is not None
                 and Project.objects.filter(
-                    id=span.project_id, organization=request.organization
+                    id=span_scope.project_id, organization=request.organization
                 ).exists()
             ):
                 span_belongs_to_org = True
-                trace_id = span.trace_id or None
+                trace_id = span_scope.trace_id or None
 
             queue_note_filter = Q(queue_item__observation_span_id=source_id)
             if trace_id:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -120,6 +120,15 @@ class CHSpan:
         return self.id
 
 
+@dataclass(frozen=True)
+class SpanScope:
+    """Minimal span fields for org/project/trace scope checks — read WITHOUT the
+    wide JSON columns. See ``CHSpanReader.scope_by_ids``."""
+
+    project_id: str | None
+    trace_id: str | None
+
+
 # Stable column ordering for the CH query. JSON columns wrapped in toJSONString
 # so clickhouse-connect can decode them (it cannot yet handle the typed JSON
 # column type in result rows — see DECISIONS #015, #018 of the migration).
@@ -546,6 +555,41 @@ class CHSpanReader:
             parameters={"ids": tuple(span_ids)},
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
+
+    def scope_by_ids(self, span_ids: list[str]) -> dict[str, SpanScope]:
+        """Map ``span_id -> SpanScope(project_id, trace_id)``, reading ONLY those
+        two columns instead of the full span row.
+
+        The full-row reads (``get`` / ``list_by_ids``) pull the wide JSON
+        columns — ``attributes_extra`` / ``input`` / ``output`` / ``metadata`` /
+        ``attrs_string`` — which on a fat span (a voice root carrying its whole
+        raw log) blow the shared ClickHouse memory limit (code 241). The
+        annotation ``for-source`` scope checks only need each span's project
+        (and, for the scores panel, its trace), so read just those: a single
+        panel-open must not OOM the shared cluster. ``FINAL`` is kept —
+        project/trace are stable across versions and a two-column ``FINAL`` read
+        stays well under the limit.
+        """
+        if not span_ids:
+            return {}
+        rows = self._client.query(
+            "SELECT id, toString(project_id) AS project_id, "
+            "toString(trace_id) AS trace_id FROM spans FINAL "
+            "WHERE id IN %(ids)s AND is_deleted = 0",
+            parameters={"ids": tuple(span_ids)},
+        ).result_rows
+
+        def _norm(v: Any) -> str | None:
+            return (
+                None
+                if v in (None, "", "NULL", "00000000-0000-0000-0000-000000000000")
+                else str(v)
+            )
+
+        return {
+            str(sid): SpanScope(project_id=_norm(pid), trace_id=_norm(tid))
+            for sid, pid, tid in rows
+        }
 
     # ─── Aggregations across many traces ──────────────────────────────────────
     def aggregate_by_trace_ids(self, trace_ids: list[str]) -> dict[str, Any]:


### PR DESCRIPTION
## TH-6252 — added labels in annotate (tracing) but shows nothing

Reporter: @commitPirate (Nosang). Fixes [TH-6252](https://linear.app/future-agi/issue/TH-6252).

### The bug (root-caused on dev via Sentry + live repro)
Opening the **Annotate** panel on a span — or adding a label — shows nothing: the panel stays "No labels assigned… not part of any annotation queue." The read-back call `GET /model-hub/annotation-queues/for-source/` returns **500**.

The 500 is a **ClickHouse `OperationalError`, code 241 — `MEMORY_LIMIT_EXCEEDED`** (Sentry `CORE-BACKEND-11FR`):
```
DatabaseError: code 241 — (total) memory limit exceeded: would use 3.66 GiB, max 3.60 GiB
  while reading column attributes_extra ... from table futureagi.spans
  at annotation_queues.py for_source → CHSpanReader.list_by_ids(['39a6972b0fd4486e'])
```
ClickHouse is healthy — the **query** is the problem. The for-source paths read the *full* span row from `spans FINAL` (`list_by_ids` / `get`) just to resolve a span's `project_id` for a scope check. On a fat voice span — whose `attributes_extra` carries the whole raw conversation log — reading the wide columns under `FINAL` blows the shared CH server's ~3.6 GiB ceiling.

**Verified on dev** (span `39a6972b0fd4486e`):
| Read | Result |
|---|---|
| full row (`list_by_ids` / `get`) | OOM 241 |
| `_LEAN_SELECT_SQL` (stubs only the 3 heaviest JSON cols) | OOM 241 (still pulls input/output/metadata) |
| **`id, project_id, trace_id` only** | ✅ OK |

This is a regression from the CH25 migration: the old PG path read one column (`values_list("project_id")`); the CH swap reads the whole row.

### The fix
- New `CHSpanReader.scope_by_ids()` — reads **only `id, project_id, trace_id`** (no wide JSON columns), returning a typed `SpanScope`. Keeps `FINAL` (project/trace are stable across versions; a two-column `FINAL` read stays well under the limit).
- `annotation-queues.for_source` (default-queue span scope check) and `scores.for_source` (span-note org check) now use it — they only ever needed `project_id` (+`trace_id`). The full-row reads (`list_by_ids` / `get`) are **untouched** for callers that genuinely need span content (dataset/eval).

No migration, no API-contract change.

### Why not just bump CH memory / fail-open?
- A memory upgrade moves the cliff (unbounded `attributes_extra`, concurrent panel-opens) and doesn't touch the **1–7.5 s** latency these wide reads cause. Take it as a stop-the-bleed, but the query is the real bug.
- Catching the error and degrading still runs the pathological multi-GB query against shared CH and shows an empty panel — hides the problem instead of fixing it.

### Tests
`scope_by_ids` regression tests for both endpoints: the reader is mocked so the **wide reads raise** and only `scope_by_ids` returns data → assert 200 + `scope_by_ids` called. **Fail-on-revert verified**: swapping either call back to `list_by_ids` / `get` → 500. Full suites green (`test_scores_api`, `test_per_queue_scoring_e2e`: 60 passed).

### Follow-up
The same wide-read OOM risk exists for the other `list_by_ids` / `get` callers (`tracer/tasks/dataset.py`, `eval_tasks.py`, `views/dataset.py`) — those need span content, so the fix there is different (chunking / per-query memory). Tracked in **TH-6348** (assigned Chintan).
