### PR TITLE
fix(prompt-manager): folder-scoped search, deleted-folder cache, version dropdown [TH-6278, TH-6277, TH-6294]

### DIFF
--- a/frontend/src/sections/agent-playground/components/PromptNameRow.jsx
+++ b/frontend/src/sections/agent-playground/components/PromptNameRow.jsx
@@ -60,7 +60,7 @@ export default function PromptNameRow({ control }) {
       seen.add(selectedVersionDetail.id);
       options.push({
         value: selectedVersionDetail.id,
-        label: selectedVersionDetail.templateVersion?.toUpperCase(),
+        label: selectedVersionDetail.template_version?.toUpperCase(),
         isDraft: selectedVersionDetail.is_draft,
       });
     }
@@ -71,7 +71,7 @@ export default function PromptNameRow({ control }) {
         seen.add(v.id);
         options.push({
           value: v.id,
-          label: v.templateVersion?.toUpperCase(),
+          label: v.template_version?.toUpperCase(),
           isDraft: v.is_draft,
         });
       }

--- a/frontend/src/sections/agent-playground/utils/__tests__/promptVersionUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/promptVersionUtils.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { mapVersionToFormConfig } from "../promptVersionUtils";
+
+// A version object as returned by /model-hub/prompt-history-executions/ —
+// snake_case wire shape (the axios layer does not camelize responses).
+const apiVersion = {
+  id: "5673c644-e46d-443b-a346-64976b6387ad",
+  template_version: "v3",
+  is_draft: false,
+  prompt_config_snapshot: {
+    messages: [
+      { role: "system", content: [{ type: "text", text: "be terse" }] },
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ],
+    placeholders: [],
+    configuration: {
+      model: "gpt-4o",
+      model_detail: { model_name: "gpt-4o", providers: "openai" },
+      tools: [{ name: "search" }],
+      tool_choice: "auto",
+      temperature: 0.7,
+      max_tokens: 512,
+      top_p: 0.9,
+      frequency_penalty: 0.3,
+      presence_penalty: 0.1,
+      response_format: "text",
+      output_format: "json",
+    },
+  },
+};
+
+describe("mapVersionToFormConfig", () => {
+  it("reads snake_case configuration fields from prompt_config_snapshot", () => {
+    const cfg = mapVersionToFormConfig(apiVersion);
+
+    expect(cfg.modelConfig.model).toBe("gpt-4o");
+    expect(cfg.modelConfig.modelDetail).toEqual({
+      model_name: "gpt-4o",
+      providers: "openai",
+    });
+    expect(cfg.modelConfig.toolChoice).toBe("auto");
+    expect(cfg.modelConfig.tools).toEqual([{ name: "search" }]);
+    expect(cfg.modelConfig.responseFormat).toBe("text");
+    expect(cfg.outputFormat).toBe("json");
+  });
+
+  it("maps snake_case penalty/token params into the payload config", () => {
+    const { payload } = mapVersionToFormConfig(apiVersion);
+    const config = payload.promptConfig[0].configuration;
+
+    expect(config.temperature).toBe(0.7);
+    expect(config.maxTokens).toBe(512);
+    expect(config.topP).toBe(0.9);
+    expect(config.frequencyPenalty).toBe(0.3);
+    expect(config.presencePenalty).toBe(0.1);
+  });
+
+  it("preserves snapshot messages by role and content", () => {
+    const { messages } = mapVersionToFormConfig(apiVersion);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      role: "system",
+      content: [{ type: "text", text: "be terse" }],
+    });
+    expect(messages[1]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    });
+  });
+
+  it("does not silently return empty config for a snake_case payload (TH-6294)", () => {
+    // The bug read camelCase keys (promptConfigSnapshot/modelDetail/...), so the
+    // whole mapping came back empty. Guard that real fields now flow through.
+    const cfg = mapVersionToFormConfig(apiVersion);
+    expect(cfg.modelConfig.model).not.toBe("");
+    expect(cfg.modelConfig.modelDetail).not.toEqual({});
+  });
+
+  it("falls back to defaults when the snapshot is missing", () => {
+    const cfg = mapVersionToFormConfig({ id: "x", template_version: "v1" });
+
+    expect(cfg.modelConfig.model).toBe("");
+    expect(cfg.modelConfig.modelDetail).toEqual({});
+    expect(cfg.outputFormat).toBe("string");
+    // A system and a user message are always injected.
+    expect(cfg.messages.map((m) => m.role)).toEqual(["system", "user"]);
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
+++ b/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
@@ -12,14 +12,14 @@ import {
  * @returns {Object} Config compatible with getDefaultValues / setValue
  */
 export function mapVersionToFormConfig(version) {
-  const snapshot = version?.promptConfigSnapshot;
+  const snapshot = version?.prompt_config_snapshot;
   const cfg = snapshot?.configuration || {};
 
   return {
-    outputFormat: cfg.outputFormat || snapshot?.outputFormat || "string",
+    outputFormat: cfg.output_format || snapshot?.output_format || "string",
     modelConfig: {
       model: cfg.model || "",
-      modelDetail: cfg.modelDetail || {},
+      modelDetail: cfg.model_detail || {},
       toolChoice: cfg.tool_choice || "auto",
       tools: cfg.tools || [],
       responseFormat: normalizeResponseFormat(cfg.response_format),
@@ -54,8 +54,8 @@ export function mapVersionToFormConfig(version) {
             temperature: cfg.temperature,
             maxTokens: cfg.max_tokens,
             topP: cfg.top_p,
-            frequencyPenalty: cfg.frequencyPenalty,
-            presencePenalty: cfg.presencePenalty,
+            frequencyPenalty: cfg.frequency_penalty,
+            presencePenalty: cfg.presence_penalty,
             ...(cfg.reasoning && { reasoning: cfg.reasoning }),
           },
         },

--- a/frontend/src/sections/workbench-v2/components/CreateNewPrompt.jsx
+++ b/frontend/src/sections/workbench-v2/components/CreateNewPrompt.jsx
@@ -13,7 +13,7 @@ import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
 import { CREATE_PROMPT_OPTIONS } from "../common";
 import { useNavigate, useParams } from "react-router";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "notistack";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
@@ -79,6 +79,7 @@ export default function CreateNewPrompt({ open, onClose, isLoading }) {
   const theme = useTheme();
   const { folder } = useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [selectedOption, setSelectedOption] = useState(null);
   const { setSelectTemplateDrawerOpen, selectTemplateDrawerOpen } =
     usePromptStore();
@@ -90,6 +91,8 @@ export default function CreateNewPrompt({ open, onClose, isLoading }) {
       enqueueSnackbar("Prompt created successfully.", {
         variant: "success",
       });
+      queryClient.invalidateQueries({ queryKey: ["folder-items"] });
+      queryClient.invalidateQueries({ queryKey: ["prompt-templates"] });
       trackEvent(Events.promptCreateClicked, {
         [PropertyName.click]: true,
       });

--- a/frontend/src/sections/workbench-v2/components/DeleteItem.jsx
+++ b/frontend/src/sections/workbench-v2/components/DeleteItem.jsx
@@ -48,11 +48,9 @@ export const DeleteItem = ({
         queryClient.invalidateQueries({
           queryKey: ["prompt-folders"],
         });
-        if (folder === "all") {
-          queryClient.invalidateQueries({
-            queryKey: ["folder-items", folder],
-          });
-        }
+        queryClient.invalidateQueries({
+          queryKey: ["folder-items"],
+        });
       }
     },
   });

--- a/frontend/src/sections/workbench-v2/components/FolderListView.jsx
+++ b/frontend/src/sections/workbench-v2/components/FolderListView.jsx
@@ -45,18 +45,17 @@ export default function FolderListView({ sortConfig }) {
     ],
     queryFn: () => {
       const params = {
-        ...(folder !== "all" &&
-          !debouncedSearchQuery && { prompt_folder: folder }),
-        ...((folder === "all" || debouncedSearchQuery) && { send_all: true }),
         page,
         page_size: pageLimit,
         name: debouncedSearchQuery,
       };
 
-      if (folder === "all" || debouncedSearchQuery) {
+      if (folder === "all") {
+        params.send_all = true;
         params.sort_order = sortConfig?.direction;
         params.sort_by = sortConfig?.field;
       } else {
+        params.prompt_folder = folder;
         if (sortConfig?.field) {
           params.ordering = `${sortConfig?.direction === "desc" ? "-" : ""}${
             sortConfig.field


### PR DESCRIPTION
Bundles three related prompt-manager fixes.

## Bugs

- **TH-6294** — Prompt version dropdown is empty in the Agent Playground node form.
- **TH-6278** — Searching a prompt from inside a folder shows *all* prompts instead of filtering within that folder.
- **TH-6277** — Deleted prompt folders still appear in **All Prompts** and clicking the stale entry opens "template not found".

## Changes

- **TH-6294** (`agent-playground/components/PromptNameRow.jsx`, `utils/promptVersionUtils.js`): read the snake_case fields the API actually returns so the version dropdown populates (+ unit tests).
- **TH-6278** (`workbench-v2/components/FolderListView.jsx`): when inside a folder, always send `prompt_folder` (with `name`) instead of switching to `send_all` on search, so search stays scoped to the folder. The top-level "All Prompts" view still uses `send_all`.
- **TH-6277** (`workbench-v2/components/DeleteItem.jsx`): on folder delete, invalidate the `["folder-items"]` query prefix unconditionally (not only when already on All Prompts), so the deleted folder and its cascade-deleted prompts drop from every list.
- **Related fix found while testing** (`workbench-v2/components/CreateNewPrompt.jsx`): invalidate `["folder-items"]` / `["prompt-templates"]` after creating a prompt, so a prompt created inside a folder appears immediately.

## Why

The folder lists are cached with a global `staleTime: 30s` (`app.jsx`). Mutations (delete folder, create prompt) and the search query weren't keeping the cache / params in sync with the folder context, so within the 30s window the UI showed stale or unscoped data.

## Test scenarios

1. Inside a folder, search a prompt name → only that folder's matching prompts show. All Prompts search still searches everything.
2. Visit All Prompts, then within 30s open a folder and delete it → folder + its prompts disappear from All Prompts immediately; no "template not found".
3. Create a prompt inside a folder → it appears in the folder (and All Prompts) without a page refresh.
4. Agent Playground node form → prompt version dropdown is populated.

## How to reproduce (before fix)

- Open a folder, type in "Search in prompts" → other folders' prompts appear.
- Visit All Prompts, quickly open a folder, delete it → deleted folder still listed in All Prompts; clicking → "template not found".
- Create a prompt in a folder, go back within 30s → folder shows empty.

## Commands

```
yarn lint
yarn test:run
```

## Videos / screenshots

Folder-scoped search, folder-delete cache, and create-in-folder verified live on the dev build (localhost:9002). Screenshots/recording to be attached.
