### PR TITLE
fix(simulate): make prompt version dropdown scrollable [TH-6268]

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
@@ -228,6 +228,7 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
                 setFormData((prev) => ({ ...prev, versionId: e.target.value }))
               }
               disabled={isLoadingVersions}
+              MenuProps={{ PaperProps: { sx: { maxHeight: 300 } } }}
             >
               {versions.map((version) => (
                 <MenuItem key={version.id} value={version.id}>


### PR DESCRIPTION
## Bug

**TH-6268** — In the Create Chat Simulation modal, the **Prompt Version** dropdown cannot be scrolled. With many versions the menu overflows the dialog and the lower entries are unreachable.

## Changes

- `workbench/createPrompt/Simulate/CreateSimulationModal.jsx`: add `MenuProps={{ PaperProps: { sx: { maxHeight: 300 } } }}` to the Prompt Version `<Select>`.

## Why

The Select had no `MenuProps`, so nothing capped the menu height. Capping the menu paper gives it an internal `overflowY: auto` scrollbar — the same pattern used by other Selects in the codebase (e.g. `CategoricalAnnotationSelectField`, `RuleStringInput`).

## Test scenarios

1. Open a prompt with many versions → Create Chat Simulation → open the Prompt Version dropdown → it caps at ~300px and scrolls through all versions.
2. Prompt with few versions → dropdown sizes to content, no change in behavior.

## How to reproduce (before fix)

Open Create Chat Simulation on a prompt with 10+ versions → open Prompt Version dropdown → list overflows the dialog and won't scroll.

## Commands

```
yarn lint
```

## Videos / screenshots

Scroll behavior verified live on the dev build (localhost:9002). Screenshot/recording to be attached.
