### PR TITLE
feat: add JSONL dataset loading

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
@@ -4,14 +4,16 @@ from enum import Enum
 
 import structlog
 
-logger = structlog.get_logger(__name__)
 from agentic_eval.core_evals.fi_utils.evals_result import DataPoint
+
+logger = structlog.get_logger(__name__)
 
 
 class LoadFormat(Enum):
     """Supported load formats."""
 
     JSON = "json"
+    JSONL = "jsonl"
     DICT = "dict"
     FI = "fi"
 
@@ -44,6 +46,8 @@ class BaseLoader(ABC):
         """
         if format == LoadFormat.JSON.value:
             return self.load_json(**kwargs)
+        elif format == LoadFormat.JSONL.value:
+            return self.load_jsonl(**kwargs)
         elif format == LoadFormat.DICT.value:
             return self.load_dict(**kwargs)
         elif format == LoadFormat.FI.value:
@@ -66,6 +70,37 @@ class BaseLoader(ABC):
                 return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.error(f"Error loading JSON: {e}")
+            raise
+
+    def load_jsonl(self, filename: str) -> list[DataPoint]:
+        """
+        Loads and processes data from a JSON Lines file.
+
+        Blank lines are skipped. Each non-blank line must contain one JSON
+        object. Decode errors include the offending line number.
+
+        Raises:
+            FileNotFoundError: If the specified JSONL file is not found.
+            json.JSONDecodeError: If any non-blank line is not valid JSON.
+        """
+        try:
+            records = []
+            with open(filename) as f:
+                for line_number, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError as e:
+                        raise json.JSONDecodeError(
+                            f"{e.msg} on line {line_number}", e.doc, e.pos
+                        ) from e
+
+            self._raw_dataset = records
+            self.process()
+            return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.error(f"Error loading JSONL: {e}")
             raise
 
     def load_dict(self, data: list) -> list[DataPoint]:

--- a/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader_jsonl.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader_jsonl.py
@@ -1,0 +1,47 @@
+import json
+
+import pytest
+
+from agentic_eval.core_evals.fi_loaders.base_loader import BaseLoader, LoadFormat
+
+
+class _PassthroughLoader(BaseLoader):
+    def process(self):
+        self._processed_dataset = self._raw_dataset
+        return self._processed_dataset
+
+    def load_fi_inferences(self, data: dict):
+        self._raw_dataset = data
+        return self.process()
+
+
+def test_load_jsonl_skips_blank_lines_and_processes_records(tmp_path):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        '\n'.join(
+            [
+                json.dumps({"input": "first", "expected": "one"}),
+                "",
+                "   ",
+                json.dumps({"input": "second", "expected": "two"}),
+            ]
+        )
+    )
+
+    loader = _PassthroughLoader()
+
+    assert loader.load(LoadFormat.JSONL.value, filename=str(dataset)) == [
+        {"input": "first", "expected": "one"},
+        {"input": "second", "expected": "two"},
+    ]
+    assert loader.raw_dataset == loader.processed_dataset
+
+
+def test_load_jsonl_reports_invalid_line_number(tmp_path):
+    dataset = tmp_path / "bad.jsonl"
+    dataset.write_text('{"ok": true}\n{bad json}\n')
+
+    loader = _PassthroughLoader()
+
+    with pytest.raises(json.JSONDecodeError, match="line 2"):
+        loader.load_jsonl(str(dataset))


### PR DESCRIPTION
## Summary
- Add `LoadFormat.JSONL = "jsonl"` and route it through `BaseLoader.load()`.
- Add `BaseLoader.load_jsonl()` to parse one JSON object per non-blank line into `_raw_dataset` before calling `process()`.
- Include line-number context when a JSONL line fails to decode.
- Add focused tests for blank-line skipping and invalid-line reporting.

Fixes #1095.

## Verification
- `PYTHONPATH=$PWD/futureagi /tmp/future-agi-jsonl-test-venv/bin/python -m pytest futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader_jsonl.py -q` → 2 passed
- `ruff check futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader_jsonl.py` → all checks passed
- `git diff --check` → no whitespace errors

## Notes
I used a minimal local test venv for the targeted test because `uv run pytest ...` on my macOS x86_64 machine could not resolve `torch==2.11.0` for this platform. The changed code itself has no new dependency.
