### PR TITLE
fix(observe): preserve timezone in graph timestamps

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -44,6 +44,8 @@ import {
 } from "src/hooks/useDashboards";
 import {
   format,
+  isValid,
+  parseISO,
   startOfToday,
   startOfTomorrow,
   startOfYesterday,
@@ -941,13 +943,18 @@ const PrimaryGraph = ({
 
     for (const item of items) {
       if (item.timestamp == null) continue;
-      const ts = item.timestamp.replace(/\+00:00$/, "");
+      const date =
+        typeof item.timestamp === "string"
+          ? parseISO(item.timestamp)
+          : new Date(item.timestamp);
+      if (!isValid(date)) continue;
+      const ts = date.getTime();
       mData.push({
-        x: new Date(ts).getTime(),
+        x: ts,
         y: item.value == null ? null : Number(item.value),
       });
       tData.push({
-        x: new Date(ts).getTime(),
+        x: ts,
         y: item.primary_traffic == null ? null : Number(item.primary_traffic),
       });
     }

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/PrimaryGraph.test.jsx
@@ -23,6 +23,8 @@ vi.mock("react-apexcharts", () => ({
       data-traffic-series-name={series?.[1]?.name}
       data-traffic-axis-series-name={options?.yaxis?.[1]?.seriesName}
       data-primary-first-y={series?.[0]?.data?.[0]?.y}
+      data-primary-first-x={series?.[0]?.data?.[0]?.x}
+      data-primary-point-count={series?.[0]?.data?.length}
     />
   ),
 }));
@@ -151,7 +153,47 @@ describe("PrimaryGraph", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+  });
+
+  it("preserves UTC timestamps and skips invalid graph points outside UTC", async () => {
+    vi.stubEnv("TZ", "Asia/Kolkata");
+    expect(new Date("2026-09-01T10:00:00").getTimezoneOffset()).toBe(-330);
+    axios.post.mockResolvedValue({
+      data: {
+        result: {
+          metric_name: "latency",
+          data: [
+            {
+              timestamp: "2026-09-01T10:00:00+00:00",
+              value: 12,
+              primary_traffic: 1,
+            },
+            {
+              timestamp: "not-a-timestamp",
+              value: 999,
+              primary_traffic: 999,
+            },
+          ],
+          query_complete: true,
+          query_status: "complete",
+          query_sampled: false,
+          query_completed_at: "2026-09-01T11:00:00+00:00",
+        },
+      },
+    });
+
+    renderWithQueryClient(
+      <PrimaryGraph observeIdOverride="project-override" />,
+    );
+
+    const chart = await screen.findByTestId("apex-chart");
+    expect(chart).toHaveAttribute(
+      "data-primary-first-x",
+      String(Date.parse("2026-09-01T10:00:00Z")),
+    );
+    expect(chart).toHaveAttribute("data-primary-point-count", "1");
   });
 
   it("uses observeIdOverride as the graph project id", async () => {

--- a/futureagi/tracer/services/clickhouse/query_builders/base.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/base.py
@@ -28,6 +28,15 @@ def _unix_microseconds(value: datetime) -> int:
     return delta.days * 86_400_000_000 + delta.seconds * 1_000_000 + delta.microseconds
 
 
+def _utc_isoformat(value: datetime) -> str:
+    """Serialize a ClickHouse timestamp with an explicit UTC offset."""
+
+    utc_value = (
+        value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+    )
+    return utc_value.isoformat()
+
+
 @dataclass(frozen=True)
 class BoundedDateTimeRange:
     """One finite base window plus conjunctive exclusions inside it."""
@@ -580,13 +589,14 @@ class BaseQueryBuilder(ABC):
     def _normalize_timestamp(ts: date | datetime, interval: str) -> datetime:
         """Normalize *ts* to the start of its time bucket.
 
-        Strips timezone info and truncates to the start of the given
-        interval bucket.
+        Converts aware values to UTC before truncation. Bucket keys stay
+        timezone-naive to match ClickHouse's UTC-naive ``DateTime`` values;
+        graph responses reattach the UTC offset when serialized.
         """
         if isinstance(ts, date) and not isinstance(ts, datetime):
             ts = datetime(ts.year, ts.month, ts.day)
         if ts.tzinfo:
-            ts = ts.replace(tzinfo=None)
+            ts = ts.astimezone(UTC).replace(tzinfo=None)
 
         interval = interval.lower()
         if interval == "minute":
@@ -616,7 +626,7 @@ class BaseQueryBuilder(ABC):
         interval = interval.lower()
         current = BaseQueryBuilder._normalize_timestamp(start_date, interval)
         if end_date.tzinfo:
-            end_date = end_date.replace(tzinfo=None)
+            end_date = end_date.astimezone(UTC).replace(tzinfo=None)
 
         while current <= end_date:
             yield current
@@ -682,7 +692,7 @@ class BaseQueryBuilder(ABC):
             if ts is None:
                 continue
             normalized = self._normalize_timestamp(ts, interval)
-            point = {"timestamp": normalized.isoformat()}
+            point = {"timestamp": _utc_isoformat(normalized)}
             for i, col in enumerate(columns[1:], start=1):
                 if isinstance(row, dict):
                     val = row.get(col, 0)
@@ -697,7 +707,7 @@ class BaseQueryBuilder(ABC):
             if ts in existing:
                 result.append(existing[ts])
             else:
-                zero_point: dict[str, Any] = {"timestamp": ts.isoformat()}
+                zero_point: dict[str, Any] = {"timestamp": _utc_isoformat(ts)}
                 for key in value_keys:
                     zero_point[key] = 0
                 result.append(zero_point)

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -2753,6 +2753,47 @@ class TestTimeSeriesQueryBuilder:
         assert result["output_tokens"] == result["completion_tokens"]
         assert result["total_tokens"] == result["tokens"]
 
+    def test_format_result_emits_explicit_utc_offsets(self):
+        """Graph timestamps preserve their instant on the response wire."""
+        from datetime import UTC, datetime, timedelta, timezone
+
+        from tracer.services.clickhouse.query_builders import TimeSeriesQueryBuilder
+
+        start = datetime(2026, 9, 1, 10, tzinfo=UTC)
+        builder = TimeSeriesQueryBuilder(
+            project_id="test-project-id",
+            filters=[],
+            interval="hour",
+            start_date=start,
+            end_date=start + timedelta(hours=1),
+        )
+        rows = [
+            {
+                "time_bucket": datetime(
+                    2026,
+                    9,
+                    1,
+                    15,
+                    30,
+                    tzinfo=timezone(timedelta(hours=5, minutes=30)),
+                ),
+                "avg_latency": 12,
+                "total_tokens": 0,
+                "avg_cost": 0,
+                "traffic_count": 1,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "error_rate": 0,
+            }
+        ]
+
+        result = builder.format_result(rows, columns=[])
+
+        assert result["latency"] == [
+            {"timestamp": "2026-09-01T10:00:00+00:00", "value": 12, "latency": 0},
+            {"timestamp": "2026-09-01T11:00:00+00:00", "value": 0, "latency": 0},
+        ]
+
     def test_format_result_preserves_values_from_dict_rows(self):
         """Dict-row path (returned by execute_ch_query) must round-trip values.
 


### PR DESCRIPTION
## Summary
- Fix the shared backend graph timestamp producer so aware buckets are converted to UTC before truncation and every emitted timestamp, including zero-filled buckets, carries an explicit `+00:00` offset.
- Keep the valid `PrimaryGraph` invalid-date guard while removing the unreachable `GraphSection` half of the original change.
- Add backend wire-contract coverage and an IST-pinned frontend behavioral regression that also proves invalid timestamps never reach ApexCharts.
- Rebase the PR onto the current `dev` branch.

Fixes #1067.

Supersedes #1329, which applies the same frontend-only parsing approach that the live-backend review disproved, targets `main` instead of `dev`, and does not include the requested behavioral regression.

## Reviewer evidence addressed
The original frontend-only change could not fix the bug because `/tracer/trace/get_graph_methods/` returned offset-less timestamps after `BaseQueryBuilder._normalize_timestamp()` discarded `tzinfo`. This revision fixes that shared backend path first. An aware `2026-09-01T15:30:00+05:30` bucket is now emitted as `2026-09-01T10:00:00+00:00`, and generated gap buckets use the same explicit-UTC contract.

The live frontend path continues to parse the offset-bearing value into the correct epoch and skips invalid dates. The unused `GraphSection` file is no longer changed.

## Verification
- Focused `PrimaryGraph.test.jsx` suite passed under Node 24 (29 cases), including the new `TZ=Asia/Kolkata` regression.
- Focused ESLint on `PrimaryGraph.jsx` and `PrimaryGraph.test.jsx`: passed.
- Isolated `TimeSeriesQueryBuilder.format_result` execution: preserved the instant and emitted explicit UTC offsets for source and zero-filled buckets.
- `python -m compileall` on the changed backend source/test: passed.
- Ruff on the changed backend source/test: passed.
- `git diff --check upstream/dev...HEAD`: passed.

## Local environment note
Docker Desktop was not running on this host, so the repository's Docker-backed pytest runner could not be executed locally. The backend pytest regression is included for CI/reviewer execution, and the same `TimeSeriesQueryBuilder.format_result` path was exercised directly in an isolated Python environment.