### PR TITLE
fix: replace em-dash with hyphen in install.ps1 for Windows PS 5.1 compat (Fixes #1124)

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Future AGI — self-hosted installer for Windows / PowerShell.
+  Future AGI - self-hosted installer for Windows / PowerShell.
 
 .DESCRIPTION
   PowerShell counterpart of bin/install. Sets up .env (with rotated
@@ -51,7 +51,7 @@ function Append-Log {
 }
 
 Append-Log @(
-  "# Future AGI install log — $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))",
+  "# Future AGI install log - $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))",
   "# host: $(hostname), ps: $($PSVersionTable.PSVersion)",
   ""
 )


### PR DESCRIPTION
Fixes #1124

## Problem
The UTF-8 em-dash character (`—`) in `bin/install.ps1` causes syntax errors on Windows PowerShell 5.1. PowerShell 5.1 falls back to CP1252 encoding when no BOM is present, and the em-dash byte sequence `0x94` is interpreted as a closing curly double-quote, terminating the string literal early.

## Root Cause
Two em-dash characters in the script:
1. Line 3: Comment in the synopsis block
2. Line 54: String literal in `Append-Log` call

## Solution
Replaced both em-dash characters with standard ASCII hyphens (`-`). This is the most robust fix — keeping the script strictly ASCII-safe avoids encoding issues across all PowerShell versions without requiring UTF-8 BOM.

## Verification
- `git diff` shows exactly 2 replacements (em-dash → hyphen)
- No other functional changes

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-30 | Replace em-dash with hyphen in install.ps1 (Fixes #1124) | rtmalikian |

### Files Changed
- `bin/install.ps1` — Replaced 2 em-dash characters with ASCII hyphens

### Verification
- Both em-dash instances confirmed replaced; script is now ASCII-safe

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek v4 Pro** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
