### PR TITLE
Multi-provider sim: ProviderSpec registry + adapters + outbound dialers (stack 1/5)

### DIFF
--- a/futureagi/scripts/verify_providers_live.py
+++ b/futureagi/scripts/verify_providers_live.py
@@ -1,0 +1,219 @@
+"""Live provider verification (TH-5642) — run with keys passed via env.
+
+Drives the REAL RetellChatAgentAdapter against the live Retell API, and verifies
+the Deepgram + ElevenLabs WebSocket handshakes against the exact payload shapes
+our connectors send. Keys are read from env; nothing is printed unmasked.
+
+Usage:
+  RETELL_API_KEY=... DEEPGRAM_API_KEY=... ELEVENLABS_API_KEY=... \
+    .venv/bin/python scripts/verify_providers_live.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import aiohttp
+import requests
+
+RETELL_BASE = "https://api.retellai.com"
+DG_WS = "wss://agent.deepgram.com/v1/agent/converse"
+EL_LIST = "https://api.elevenlabs.io/v1/convai/agents"
+EL_SIGNED = "https://api.elevenlabs.io/v1/convai/conversation/get-signed-url"
+
+
+def mask(s: str) -> str:
+    if not s:
+        return "<empty>"
+    return f"{s[:6]}…{s[-4:]} (len {len(s)})"
+
+
+def hr(title: str) -> None:
+    print(f"\n{'=' * 8} {title} {'=' * 8}")
+
+
+# --------------------------------------------------------------------------
+# Retell — drive the REAL adapter end to end.
+# --------------------------------------------------------------------------
+def verify_retell() -> None:
+    hr("RETELL chat adapter (real code, live API)")
+    key = os.environ.get("RETELL_API_KEY", "")
+    if not key:
+        print("SKIP: RETELL_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+    # 1) Find a usable agent (prefer an explicit RETELL_TEST_AGENT_ID).
+    agent_id = os.environ.get("RETELL_TEST_AGENT_ID", "")
+    if not agent_id:
+        r = requests.get(f"{RETELL_BASE}/list-agents", headers=headers, timeout=30)
+        print(f"list-agents -> {r.status_code}")
+        if r.status_code >= 400:
+            print(f"FAIL list-agents: {r.text[:300]}")
+            return
+        agents = r.json() or []
+        print(f"found {len(agents)} agents")
+        if not agents:
+            print("FAIL: no agents in this Retell account to drive")
+            return
+        # Show shape of the first agent (keys only) to understand chat-capability.
+        a0 = agents[0]
+        print(f"agent[0] keys: {sorted(a0.keys())}")
+        agent_id = a0.get("agent_id") or a0.get("agent_id_")
+    print(f"using agent_id: {agent_id}")
+
+    # 2) Drive the REAL adapter.
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+
+    adapter = RetellChatAgentAdapter(agent_id=agent_id, api_key=key)
+    try:
+        # Turn 1: agent speaks first (begin_message from /create-chat).
+        t1 = adapter.generate_response([])
+        print(f"TURN1 (no user msg): content={t1['content']!r} ended={t1['chat_ended']}")
+        print(f"  chat_id cached: {adapter._chat_id}")
+        # Turn 2: send a user message, expect an agent reply.
+        t2 = adapter.generate_response(
+            [{"role": "user", "content": "Hi, what can you help me with?"}]
+        )
+        print(f"TURN2 content={t2['content']!r:.200} ended={t2['chat_ended']}")
+        print(f"  sent_user_turns={adapter._sent_user_turns}")
+        # Verdict on the parser assumptions.
+        ok = bool(adapter._chat_id) and (t2["content"] or t1["content"])
+        print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+              f"adapter created chat + parsed an agent reply via real API")
+    except Exception as e:
+        print(f"FAIL driving adapter: {type(e).__name__}: {e}")
+    finally:
+        try:
+            adapter.end()
+            print("end() called (best-effort cleanup)")
+        except Exception as e:
+            print(f"end() error: {e}")
+
+
+# --------------------------------------------------------------------------
+# Deepgram — verify the Voice Agent WS handshake with our exact Settings.
+# --------------------------------------------------------------------------
+async def verify_deepgram() -> None:
+    hr("DEEPGRAM Voice Agent WS handshake")
+    key = os.environ.get("DEEPGRAM_API_KEY", "")
+    if not key:
+        print("SKIP: DEEPGRAM_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    settings = {
+        "type": "Settings",
+        "audio": {
+            "input": {"encoding": "linear16", "sample_rate": 16000},
+            "output": {"encoding": "linear16", "sample_rate": 16000, "container": "none"},
+        },
+        "agent": {
+            "language": "en",
+            "listen": {"provider": {"type": "deepgram", "model": "nova-3"}},
+            "think": {"provider": {"type": "open_ai", "model": "gpt-4o-mini"}},
+            "speak": {"provider": {"type": "deepgram", "model": "aura-2-thalia-en"}},
+        },
+    }
+    try:
+        async with aiohttp.ClientSession() as s:
+            async with s.ws_connect(
+                DG_WS, headers={"Authorization": f"Token {key}"}, timeout=20
+            ) as ws:
+                print("WS connected (auth header accepted)")
+                await ws.send_json(settings)
+                got = []
+                for _ in range(6):
+                    try:
+                        msg = await asyncio.wait_for(ws.receive(), timeout=8)
+                    except asyncio.TimeoutError:
+                        break
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        ev = json.loads(msg.data)
+                        got.append(ev.get("type"))
+                        if ev.get("type") in ("Welcome", "SettingsApplied"):
+                            pass
+                        if ev.get("type") == "Error":
+                            print(f"  Error event: {msg.data[:300]}")
+                            break
+                    elif msg.type == aiohttp.WSMsgType.BINARY:
+                        got.append("BINARY")
+                    elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                        break
+                print(f"control frames received: {got}")
+                ok = "SettingsApplied" in got or "Welcome" in got
+                print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+                      f"handshake {'accepted our Settings' if ok else 'inconclusive'}")
+    except Exception as e:
+        print(f"FAIL: {type(e).__name__}: {e}")
+
+
+# --------------------------------------------------------------------------
+# ElevenLabs — verify signed-url + ConvAI WS handshake.
+# --------------------------------------------------------------------------
+async def verify_elevenlabs() -> None:
+    hr("ELEVENLABS ConvAI signed-url + WS handshake")
+    key = os.environ.get("ELEVENLABS_API_KEY", "")
+    if not key:
+        print("SKIP: ELEVENLABS_API_KEY not set")
+        return
+    print(f"key: {mask(key)}")
+    try:
+        async with aiohttp.ClientSession() as s:
+            # 1) list agents
+            async with s.get(EL_LIST, headers={"xi-api-key": key}, timeout=20) as r:
+                print(f"list agents -> {r.status}")
+                body = await r.json()
+            agents = body.get("agents") if isinstance(body, dict) else body
+            agent_id = os.environ.get("ELEVENLABS_TEST_AGENT_ID", "")
+            if not agent_id and agents:
+                agent_id = agents[0].get("agent_id")
+            print(f"agents found: {len(agents) if agents else 0}; using {agent_id}")
+            if not agent_id:
+                print("PARTIAL: auth worked (listed agents) but none to handshake")
+                return
+            # 2) signed url
+            async with s.get(
+                EL_SIGNED, params={"agent_id": agent_id},
+                headers={"xi-api-key": key}, timeout=20,
+            ) as r:
+                print(f"get-signed-url -> {r.status}")
+                sj = await r.json()
+            signed = sj.get("signed_url")
+            if not signed:
+                print(f"PARTIAL: no signed_url ({sj})")
+                return
+            print("signed_url obtained")
+            # 3) WS handshake
+            async with s.ws_connect(signed, timeout=20) as ws:
+                print("WS connected")
+                got = []
+                for _ in range(4):
+                    try:
+                        msg = await asyncio.wait_for(ws.receive(), timeout=8)
+                    except asyncio.TimeoutError:
+                        break
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        got.append(json.loads(msg.data).get("type"))
+                    elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                        break
+                print(f"frames received: {got}")
+                ok = any(g for g in got)
+                print(f"VERDICT: {'PASS' if ok else 'PARTIAL'} — "
+                      f"{'protocol frames received' if ok else 'no frames'}")
+    except Exception as e:
+        print(f"FAIL: {type(e).__name__}: {e}")
+
+
+async def main() -> None:
+    verify_retell()
+    await verify_deepgram()
+    await verify_elevenlabs()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/futureagi/simulate/providers/__init__.py
+++ b/futureagi/simulate/providers/__init__.py
@@ -1,0 +1,32 @@
+"""Simulation provider registry (TH-5642) — the ProviderSpec single source of truth.
+
+See internal-docs/multi-provider-simulation/DESIGN.md.
+"""
+
+from simulate.providers.registry import (
+    PROVIDER_REGISTRY,
+    CredentialShape,
+    ProviderSpec,
+    Role,
+    Status,
+    Transport,
+    agent_platform_keys,
+    connector_key_for,
+    get_spec,
+    is_agent_platform,
+    provider_choices,
+)
+
+__all__ = [
+    "PROVIDER_REGISTRY",
+    "CredentialShape",
+    "ProviderSpec",
+    "Role",
+    "Status",
+    "Transport",
+    "agent_platform_keys",
+    "connector_key_for",
+    "get_spec",
+    "is_agent_platform",
+    "provider_choices",
+]

--- a/futureagi/simulate/providers/__init__.py
+++ b/futureagi/simulate/providers/__init__.py
@@ -6,6 +6,7 @@ See internal-docs/multi-provider-simulation/DESIGN.md.
 from simulate.providers.registry import (
     PROVIDER_REGISTRY,
     CredentialShape,
+    Direction,
     ProviderSpec,
     Role,
     Status,
@@ -13,13 +14,17 @@ from simulate.providers.registry import (
     agent_platform_keys,
     connector_key_for,
     get_spec,
+    implemented_directions_for,
+    implements_direction,
     is_agent_platform,
     provider_choices,
+    supports_direction,
 )
 
 __all__ = [
     "PROVIDER_REGISTRY",
     "CredentialShape",
+    "Direction",
     "ProviderSpec",
     "Role",
     "Status",
@@ -27,6 +32,9 @@ __all__ = [
     "agent_platform_keys",
     "connector_key_for",
     "get_spec",
+    "implemented_directions_for",
+    "implements_direction",
     "is_agent_platform",
     "provider_choices",
+    "supports_direction",
 ]

--- a/futureagi/simulate/providers/direction.py
+++ b/futureagi/simulate/providers/direction.py
@@ -1,0 +1,84 @@
+"""Call-direction resolution + guards (TH-5642).
+
+Fixes the audit's silent direction bugs at the point direction is decided:
+- a typo'd ``call_direction`` (e.g. "outbond") previously became INBOUND silently;
+- an OUTBOUND test on a provider that hasn't WIRED outbound silently ran the
+  simulator-initiated INBOUND path (a green result that tested the wrong direction).
+
+Both now fail LOUDLY. This module is Django-free (it only touches the pure
+ProviderSpec registry) so the Temporal voice activities can import it.
+"""
+
+from __future__ import annotations
+
+from simulate.providers.registry import (
+    Direction,
+    get_spec,
+    implements_direction,
+)
+
+
+class UnsupportedCallDirectionError(ValueError):
+    """A call_direction is malformed, or not wired for the chosen provider."""
+
+
+def resolve_call_direction(
+    call_direction: str | None,
+    provider: str | None = None,
+    *,
+    enforce_implemented: bool = True,
+) -> Direction:
+    """Resolve a ``call_direction`` string to a :class:`Direction`, failing loudly.
+
+    - missing / None / "" → INBOUND (preserves the historical default: the common
+      case where direction is simply not specified is an inbound test);
+    - "inbound" / "outbound" (any case) → that Direction;
+    - any other non-empty value → raise (catches typos that previously became
+      INBOUND silently);
+    - if ``provider`` is a known agent platform that does NOT implement the resolved
+      direction (and ``enforce_implemented``) → raise, instead of silently running
+      the inbound path. Unknown / free-form providers skip this check so custom
+      integrations are not broken.
+    """
+    raw = (call_direction or "").strip().lower()
+    if raw == "":
+        direction = Direction.INBOUND
+    elif raw == Direction.INBOUND.value:
+        direction = Direction.INBOUND
+    elif raw == Direction.OUTBOUND.value:
+        direction = Direction.OUTBOUND
+    else:
+        raise UnsupportedCallDirectionError(
+            f"Unknown call_direction {call_direction!r} "
+            f"(expected 'inbound' or 'outbound')"
+        )
+
+    if enforce_implemented and provider:
+        spec = get_spec(provider)
+        if (
+            spec is not None
+            and spec.is_agent_platform
+            and not implements_direction(provider, direction)
+        ):
+            raise UnsupportedCallDirectionError(
+                f"Provider {provider!r} does not yet implement {direction.value} "
+                f"calls (supported={sorted(d.value for d in spec.supported_directions)}, "
+                f"implemented={sorted(d.value for d in spec.implemented_directions)}). "
+                f"Refusing to silently run the inbound path."
+            )
+    return direction
+
+
+def resolve_is_outbound(
+    call_direction: str | None,
+    provider: str | None = None,
+    *,
+    enforce_implemented: bool = True,
+) -> bool:
+    """Boolean form of :func:`resolve_call_direction` (True iff OUTBOUND)."""
+    return (
+        resolve_call_direction(
+            call_direction, provider, enforce_implemented=enforce_implemented
+        )
+        is Direction.OUTBOUND
+    )

--- a/futureagi/simulate/providers/direction.py
+++ b/futureagi/simulate/providers/direction.py
@@ -22,6 +22,26 @@ class UnsupportedCallDirectionError(ValueError):
     """A call_direction is malformed, or not wired for the chosen provider."""
 
 
+# Who speaks first, from the SIMULATOR's perspective (LiveKit first_message_mode).
+FIRST_MESSAGE_MODE_SPEAKS_FIRST = "assistant-speaks-first"
+FIRST_MESSAGE_MODE_WAITS = "assistant-waits-for-user"
+
+
+def first_message_mode_for(is_outbound: bool) -> str:
+    """The simulator's speaking order for a call direction.
+
+    Inbound (FutureAGI calls the agent → agent receives) → the simulator (our
+    caller) speaks first. Outbound (the agent calls us) → the simulator waits; the
+    agent speaks first. Previously this was set ONLY inside the LiveKit-bridge
+    branch, so DIRECT_WS (ElevenLabs/Deepgram) and SIP providers silently produced a
+    simulator-speaks-first transcript on outbound (audit gap). This resolver is
+    applied to every transport.
+    """
+    return (
+        FIRST_MESSAGE_MODE_WAITS if is_outbound else FIRST_MESSAGE_MODE_SPEAKS_FIRST
+    )
+
+
 def resolve_call_direction(
     call_direction: str | None,
     provider: str | None = None,

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -1,0 +1,202 @@
+"""ProviderSpec — the single source of truth for simulation providers (TH-5642).
+
+Design: internal-docs/multi-provider-simulation/DESIGN.md §4.
+
+A "provider" is never one thing: it plays one or more of five *non-interchangeable*
+roles. Today the same provider string must be registered independently in ~8
+non-centralised places (ProviderChoices, SupportedProviders, ProviderCredentials,
+serializer choices, the ``f"web_{provider}"`` interpolation, SpeakerRole maps, the
+frontend list…), which is the source of the historical "silent Vapi" string-drift
+bugs. This module declares each provider ONCE so those surfaces can derive from it.
+
+This module is intentionally dependency-free (pure dataclasses/enums, no Django
+imports) so it is importable in isolation and trivially testable. Call sites adopt
+it incrementally; nothing is rewired by simply adding this file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Role(StrEnum):
+    """A role a provider plays. Enum/component presence != tested-platform support."""
+
+    AGENT_PLATFORM = "agent_platform"  # a customer agent we TEST (agent-under-test)
+    SYSTEM_ENGINE = "system_engine"    # infra that runs OUR simulated caller
+    TRANSPORT = "transport"            # how we reach the agent (SIP / WebRTC / PSTN)
+    STT = "stt"                        # simulator-side speech-to-text component
+    TTS = "tts"                        # simulator-side text-to-speech component
+    CHAT_ENGINE = "chat_engine"        # text-simulation engine
+
+
+class Transport(StrEnum):
+    """How the simulator reaches the agent-under-test."""
+
+    WEBRTC_BRIDGE = "webrtc_bridge"  # join via our LiveKit bridge connector (web_*)
+    SIP = "sip"                      # dial via our LiveKit SIP trunk (provider-neutral)
+    DIRECT_WS = "direct_ws"          # raw provider WebSocket, Vapi-style
+    AGORA_RTC = "agora_rtc"          # Agora's proprietary RTC (NOT LiveKit-compatible)
+    NONE = "none"
+
+
+class CredentialShape(StrEnum):
+    """The credential field-group a provider needs (drives the agent-def form)."""
+
+    API_KEY_ASSISTANT = "api_key_assistant"  # api_key + assistant/agent_id
+    LIVEKIT_SERVER = "livekit_server"        # url + api_key + api_secret + agent_name
+    AGENT_ID = "agent_id"                    # api_key + agent_id (ElevenLabs/Deepgram)
+    SIP_ONLY = "sip_only"                    # just a phone number
+    WEBSOCKET_URL = "websocket_url"          # custom ws endpoint
+    NONE = "none"
+
+
+class Status(StrEnum):
+    GA = "ga"                          # wired & working as a tested platform today
+    PLANNED = "planned"                # designed (DESIGN.md §5), not yet built
+    TRANSPORT_ONLY = "transport_only"  # never an agent platform (e.g. Twilio)
+    INTERNAL = "internal"              # our own engine, not a tested platform
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    key: str                              # canonical client-provider string
+    label: str
+    roles: frozenset[Role]
+    transport: Transport = Transport.NONE
+    connector_key: str | None = None      # WebRTC bridge registry key (web_*), if any
+    credential_shape: CredentialShape = CredentialShape.NONE
+    chat: bool = False                    # has / will have a named chat engine
+    observability_key: str | None = None  # maps to ProviderChoices value, if any
+    status: Status = Status.PLANNED
+
+    @property
+    def is_agent_platform(self) -> bool:
+        return Role.AGENT_PLATFORM in self.roles
+
+    @property
+    def is_ga(self) -> bool:
+        return self.status in (Status.GA, Status.TRANSPORT_ONLY, Status.INTERNAL)
+
+
+# Declarative registry — the ONLY place a provider is declared. See DESIGN.md §1/§5.
+_SPECS: tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        "vapi", "Vapi",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
+        transport=Transport.WEBRTC_BRIDGE, connector_key="web_vapi",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
+        observability_key="vapi", status=Status.GA,
+    ),
+    ProviderSpec(
+        "retell", "Retell",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.WEBRTC_BRIDGE, connector_key="web_retell",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        observability_key="retell", status=Status.GA,
+    ),
+    # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).
+    ProviderSpec(
+        "livekit_bridge", "LiveKit (agent)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
+        credential_shape=CredentialShape.LIVEKIT_SERVER,
+        observability_key="livekit", status=Status.GA,
+    ),
+    # Provider-neutral catch-all: custom agents reached by phone (SIP) or websocket.
+    ProviderSpec(
+        "others", "Others (custom / SIP)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.SIP, credential_shape=CredentialShape.WEBSOCKET_URL,
+        observability_key="others", status=Status.GA,
+    ),
+    # --- Planned tested platforms (DESIGN.md §5) ---
+    ProviderSpec(
+        "elevenlabs", "ElevenLabs Conversational AI",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.TTS}),
+        transport=Transport.DIRECT_WS, connector_key="web_elevenlabs",
+        credential_shape=CredentialShape.AGENT_ID, chat=True,
+        observability_key="eleven_labs", status=Status.PLANNED,
+    ),
+    ProviderSpec(
+        "deepgram", "Deepgram Voice Agent",
+        roles=frozenset({Role.AGENT_PLATFORM, Role.STT}),
+        transport=Transport.DIRECT_WS, connector_key="web_deepgram",
+        credential_shape=CredentialShape.AGENT_ID, status=Status.PLANNED,
+    ),
+    ProviderSpec(
+        "agora", "Agora Conversational AI",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.AGORA_RTC, connector_key="web_agora",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT, status=Status.PLANNED,
+    ),
+    # Pipecat-on-LiveKit reuses the existing LiveKit bridge connector (DESIGN.md §5.5).
+    ProviderSpec(
+        "pipecat", "Pipecat (LiveKit transport)",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
+        credential_shape=CredentialShape.LIVEKIT_SERVER, status=Status.PLANNED,
+    ),
+    # --- Non-agent-platform roles ---
+    ProviderSpec(
+        "twilio", "Twilio",
+        roles=frozenset({Role.TRANSPORT}),
+        transport=Transport.SIP, credential_shape=CredentialShape.SIP_ONLY,
+        status=Status.TRANSPORT_ONLY,
+    ),
+    ProviderSpec(
+        "livekit", "LiveKit (system engine)",
+        roles=frozenset({Role.SYSTEM_ENGINE, Role.TRANSPORT}),
+        transport=Transport.SIP, observability_key="livekit", status=Status.INTERNAL,
+    ),
+    ProviderSpec(
+        "futureagi", "FutureAGI (internal simulator)",
+        roles=frozenset({Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
+        status=Status.INTERNAL,
+    ),
+)
+
+PROVIDER_REGISTRY: dict[str, ProviderSpec] = {s.key: s for s in _SPECS}
+
+
+def get_spec(key: str | None) -> ProviderSpec | None:
+    """Return the ProviderSpec for a client-provider string, or None."""
+    return PROVIDER_REGISTRY.get(key or "")
+
+
+def connector_key_for(key: str | None) -> str | None:
+    """The WebRTC-bridge connector key (web_*) for a provider, or None (→ SIP).
+
+    Replaces the fragile ``f"web_{client_provider}"`` interpolation — a lookup,
+    not string math, so a typo can't silently become an unknown connection_type.
+    """
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return spec.connector_key if spec else None
+
+
+def is_agent_platform(key: str | None) -> bool:
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and spec.is_agent_platform)
+
+
+def agent_platform_keys(*, include_planned: bool = True) -> list[str]:
+    """Provider keys that can be an agent-under-test."""
+    return [
+        s.key
+        for s in _SPECS
+        if s.is_agent_platform and (include_planned or s.is_ga)
+    ]
+
+
+def provider_choices(*, include_planned: bool = False) -> list[tuple[str, str]]:
+    """Django ``choices=`` for AgentDefinition.provider, derived from the registry.
+
+    Defaults to GA agent platforms so the free-form CharField can be constrained
+    without rejecting in-flight definitions (DESIGN.md §4.1, §7 Q2).
+    """
+    return [
+        (s.key, s.label)
+        for s in _SPECS
+        if s.is_agent_platform and (include_planned or s.is_ga)
+    ]

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -140,7 +140,11 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER,
         observability_key="livekit", status=Status.GA,
-        supported_directions=_BOTH, implemented_directions=_IN,
+        # WebRTC bridge has NO PSTN leg: we connect to the agent the same way in
+        # both directions; the only difference is who speaks first, now handled by
+        # first_message_mode for all transports. So outbound = inbound bridge +
+        # agent-speaks-first → both wired.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     # Provider-neutral catch-all: custom agents reached by phone (SIP) or websocket.
     ProviderSpec(
@@ -190,8 +194,9 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER, status=Status.PLANNED,
-        # Same bridge as livekit_bridge → inbound only until an answer path exists.
-        supported_directions=_BOTH, implemented_directions=_IN,
+        # Reuses the LiveKit bridge → same as livekit_bridge: outbound is just the
+        # agent-speaks-first opener over the same bridge connection. Both wired.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     # Bland.ai agents are reached via the provider-neutral SIP/phone path (no
     # WebRTC connector needed) — DESIGN.md §3/§6.

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -91,9 +91,9 @@ _SPECS: tuple[ProviderSpec, ...] = (
     ),
     ProviderSpec(
         "retell", "Retell",
-        roles=frozenset({Role.AGENT_PLATFORM}),
+        roles=frozenset({Role.AGENT_PLATFORM, Role.CHAT_ENGINE}),
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_retell",
-        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
         observability_key="retell", status=Status.GA,
     ),
     # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -59,6 +59,23 @@ class Status(StrEnum):
     INTERNAL = "internal"              # our own engine, not a tested platform
 
 
+class Direction(StrEnum):
+    """A telephony call direction (from the agent-under-test's call perspective).
+
+    Mirrors ``simulate.semantics.CallType`` (inbound/outbound) by VALUE — the
+    registry is intentionally Django-free, and CallType lives behind a Django import,
+    so we mirror rather than import; ``test_provider_registry`` pins the equality.
+    """
+
+    INBOUND = "inbound"    # FutureAGI's simulator CALLS the agent (agent receives)
+    OUTBOUND = "outbound"  # the agent CALLS FutureAGI (our simulator answers)
+
+
+_BOTH = frozenset({Direction.INBOUND, Direction.OUTBOUND})
+_IN = frozenset({Direction.INBOUND})
+_NONE: frozenset[Direction] = frozenset()
+
+
 @dataclass(frozen=True)
 class ProviderSpec:
     key: str                              # canonical client-provider string
@@ -70,6 +87,13 @@ class ProviderSpec:
     chat: bool = False                    # has / will have a named chat engine
     observability_key: str | None = None  # maps to ProviderChoices value, if any
     status: Status = Status.PLANNED
+    # Call directions the provider's API can do AND we can drive (capability).
+    supported_directions: frozenset[Direction] = _IN
+    # Subset of supported_directions actually WIRED in our orchestration today.
+    # Kept separate from `supported` (mirrors Status's planned-vs-GA intent): the
+    # orchestration must FAIL LOUDLY if a direction is requested that's supported but
+    # not yet implemented, instead of silently defaulting to inbound (audit gap).
+    implemented_directions: frozenset[Direction] = _NONE
 
     @property
     def is_agent_platform(self) -> bool:
@@ -78,6 +102,12 @@ class ProviderSpec:
     @property
     def is_ga(self) -> bool:
         return self.status in (Status.GA, Status.TRANSPORT_ONLY, Status.INTERNAL)
+
+    def supports(self, direction: Direction) -> bool:
+        return direction in self.supported_directions
+
+    def implements(self, direction: Direction) -> bool:
+        return direction in self.implemented_directions
 
 
 # Declarative registry — the ONLY place a provider is declared. See DESIGN.md §1/§5.
@@ -88,6 +118,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_vapi",
         credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
         observability_key="vapi", status=Status.GA,
+        # The only provider whose outbound (agent-dials-us) path is wired today.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     ProviderSpec(
         "retell", "Retell",
@@ -95,6 +127,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_retell",
         credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
         observability_key="retell", status=Status.GA,
+        # Retell supports both; only inbound (we dial the agent) is wired today.
+        supported_directions=_BOTH, implemented_directions=_IN,
     ),
     # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).
     ProviderSpec(
@@ -103,6 +137,7 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER,
         observability_key="livekit", status=Status.GA,
+        supported_directions=_BOTH, implemented_directions=_IN,
     ),
     # Provider-neutral catch-all: custom agents reached by phone (SIP) or websocket.
     ProviderSpec(
@@ -110,6 +145,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.SIP, credential_shape=CredentialShape.WEBSOCKET_URL,
         observability_key="others", status=Status.GA,
+        # Plain-E.164 SIP works in both directions today.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     # --- Planned tested platforms (DESIGN.md §5) ---
     ProviderSpec(
@@ -118,12 +155,16 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.DIRECT_WS, connector_key="web_elevenlabs",
         credential_shape=CredentialShape.AGENT_ID, chat=True,
         observability_key="eleven_labs", status=Status.PLANNED,
+        # Connector is connect()-only (simulator-initiated) → inbound wired; outbound
+        # would need a BYO-telephony/SIP leg (supported by API, not yet built).
+        supported_directions=_BOTH, implemented_directions=_IN,
     ),
     ProviderSpec(
         "deepgram", "Deepgram Voice Agent",
         roles=frozenset({Role.AGENT_PLATFORM, Role.STT}),
         transport=Transport.DIRECT_WS, connector_key="web_deepgram",
         credential_shape=CredentialShape.AGENT_ID, status=Status.PLANNED,
+        supported_directions=_BOTH, implemented_directions=_IN,
     ),
     # Agora Conversational AI Engine exposes its agents over SIP/PSTN via an
     # Elastic SIP Trunk (import a number, assign to the agent for inbound/outbound)
@@ -137,6 +178,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.SIP,
         credential_shape=CredentialShape.API_KEY_ASSISTANT, status=Status.PLANNED,
+        # SIP/PSTN both directions per Agora's Elastic SIP Trunk; nothing wired yet.
+        supported_directions=_BOTH, implemented_directions=_NONE,
     ),
     # Pipecat-on-LiveKit reuses the existing LiveKit bridge connector (DESIGN.md §5.5).
     ProviderSpec(
@@ -144,6 +187,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER, status=Status.PLANNED,
+        # Same bridge as livekit_bridge → inbound only until an answer path exists.
+        supported_directions=_BOTH, implemented_directions=_IN,
     ),
     # Bland.ai agents are reached via the provider-neutral SIP/phone path (no
     # WebRTC connector needed) — DESIGN.md §3/§6.
@@ -152,6 +197,8 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
         status=Status.PLANNED,
+        # Bland send-call (outbound) + inbound numbers, both via SIP; nothing wired.
+        supported_directions=_BOTH, implemented_directions=_NONE,
     ),
     # --- Non-agent-platform roles ---
     ProviderSpec(
@@ -159,16 +206,22 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.TRANSPORT}),
         transport=Transport.SIP, credential_shape=CredentialShape.SIP_ONLY,
         status=Status.TRANSPORT_ONLY,
+        # Carrier substrate, never directionally simulated as an agent.
+        supported_directions=_NONE, implemented_directions=_NONE,
     ),
     ProviderSpec(
         "livekit", "LiveKit (system engine)",
         roles=frozenset({Role.SYSTEM_ENGINE, Role.TRANSPORT}),
         transport=Transport.SIP, observability_key="livekit", status=Status.INTERNAL,
+        # The system engine drives both directions of the simulated call.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     ProviderSpec(
         "futureagi", "FutureAGI (internal simulator)",
         roles=frozenset({Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
         status=Status.INTERNAL,
+        # Internal chat engine — telephony direction not applicable.
+        supported_directions=_NONE, implemented_directions=_NONE,
     ),
 )
 
@@ -195,23 +248,54 @@ def is_agent_platform(key: str | None) -> bool:
     return bool(spec and spec.is_agent_platform)
 
 
-def agent_platform_keys(*, include_planned: bool = True) -> list[str]:
-    """Provider keys that can be an agent-under-test."""
+def supports_direction(key: str | None, direction: Direction) -> bool:
+    """True if the provider's API can do this direction AND we can drive it."""
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and direction in spec.supported_directions)
+
+
+def implements_direction(key: str | None, direction: Direction) -> bool:
+    """True if this direction is actually WIRED for the provider today.
+
+    Dispatch should check this (not just ``supports_direction``) and fail loudly
+    when a supported-but-unimplemented direction is requested, rather than silently
+    running the inbound path (audit: the ``is_outbound=False`` default bug).
+    """
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return bool(spec and direction in spec.implemented_directions)
+
+
+def implemented_directions_for(key: str | None) -> frozenset[Direction]:
+    spec = PROVIDER_REGISTRY.get(key or "")
+    return spec.implemented_directions if spec else _NONE
+
+
+def agent_platform_keys(
+    *, include_planned: bool = True, direction: Direction | None = None
+) -> list[str]:
+    """Provider keys that can be an agent-under-test, optionally for a direction."""
     return [
         s.key
         for s in _SPECS
-        if s.is_agent_platform and (include_planned or s.is_ga)
+        if s.is_agent_platform
+        and (include_planned or s.is_ga)
+        and (direction is None or direction in s.supported_directions)
     ]
 
 
-def provider_choices(*, include_planned: bool = False) -> list[tuple[str, str]]:
+def provider_choices(
+    *, include_planned: bool = False, direction: Direction | None = None
+) -> list[tuple[str, str]]:
     """Django ``choices=`` for AgentDefinition.provider, derived from the registry.
 
     Defaults to GA agent platforms so the free-form CharField can be constrained
-    without rejecting in-flight definitions (DESIGN.md §4.1, §7 Q2).
+    without rejecting in-flight definitions (DESIGN.md §4.1, §7 Q2). Pass
+    ``direction`` to constrain the per-provider inbound/outbound toggle in the form.
     """
     return [
         (s.key, s.label)
         for s in _SPECS
-        if s.is_agent_platform and (include_planned or s.is_ga)
+        if s.is_agent_platform
+        and (include_planned or s.is_ga)
+        and (direction is None or direction in s.supported_directions)
     ]

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -73,6 +73,7 @@ class Direction(StrEnum):
 
 _BOTH = frozenset({Direction.INBOUND, Direction.OUTBOUND})
 _IN = frozenset({Direction.INBOUND})
+_OUT = frozenset({Direction.OUTBOUND})
 _NONE: frozenset[Direction] = frozenset()
 
 
@@ -127,8 +128,10 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_retell",
         credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
         observability_key="retell", status=Status.GA,
-        # Retell supports both; only inbound (we dial the agent) is wired today.
-        supported_directions=_BOTH, implemented_directions=_IN,
+        # Inbound via the web_retell bridge; outbound now wired via the
+        # RetellOutboundDialer (/v2/create-phone-call). "implemented" = wired, not
+        # yet live-verified e2e (a real outbound call needs a Retell number + stack).
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).
     ProviderSpec(
@@ -197,8 +200,9 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
         status=Status.PLANNED,
-        # Bland send-call (outbound) + inbound numbers, both via SIP; nothing wired.
-        supported_directions=_BOTH, implemented_directions=_NONE,
+        # Bland is outbound-first: outbound now wired via BlandOutboundDialer
+        # (/v1/calls). Inbound (receiving on a Bland number) is not wired yet.
+        supported_directions=_BOTH, implemented_directions=_OUT,
     ),
     # --- Non-agent-platform roles ---
     ProviderSpec(

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -125,10 +125,17 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.DIRECT_WS, connector_key="web_deepgram",
         credential_shape=CredentialShape.AGENT_ID, status=Status.PLANNED,
     ),
+    # Agora Conversational AI Engine exposes its agents over SIP/PSTN via an
+    # Elastic SIP Trunk (import a number, assign to the agent for inbound/outbound)
+    # — so we reach it through the SAME provider-neutral SIP path as Bland/Twilio,
+    # with NO Agora RTC SDK. Native Agora-RTC (Transport.AGORA_RTC, the unbuilt
+    # web_agora connector) is only the optional WebRTC alternative and stays
+    # SDK-gated (DESIGN.md §5.4). Modeling SIP as the primary transport matches the
+    # only path achievable on our infra today.
     ProviderSpec(
         "agora", "Agora Conversational AI",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.AGORA_RTC, connector_key="web_agora",
+        transport=Transport.SIP,
         credential_shape=CredentialShape.API_KEY_ASSISTANT, status=Status.PLANNED,
     ),
     # Pipecat-on-LiveKit reuses the existing LiveKit bridge connector (DESIGN.md §5.5).

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -138,6 +138,14 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER, status=Status.PLANNED,
     ),
+    # Bland.ai agents are reached via the provider-neutral SIP/phone path (no
+    # WebRTC connector needed) — DESIGN.md §3/§6.
+    ProviderSpec(
+        "bland", "Bland.ai",
+        roles=frozenset({Role.AGENT_PLATFORM}),
+        transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        status=Status.PLANNED,
+    ),
     # --- Non-agent-platform roles ---
     ProviderSpec(
         "twilio", "Twilio",

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -212,11 +212,14 @@ _SPECS: tuple[ProviderSpec, ...] = (
     # --- Non-agent-platform roles ---
     ProviderSpec(
         "twilio", "Twilio",
-        roles=frozenset({Role.TRANSPORT}),
-        transport=Transport.SIP, credential_shape=CredentialShape.SIP_ONLY,
-        status=Status.TRANSPORT_ONLY,
-        # Carrier substrate, never directionally simulated as an agent.
-        supported_directions=_NONE, implemented_directions=_NONE,
+        # Twilio is BOTH a carrier substrate AND a platform customers build agents on
+        # (ConversationRelay / Media Streams / TwiML routed to their logic).
+        roles=frozenset({Role.AGENT_PLATFORM, Role.TRANSPORT}),
+        transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        status=Status.PLANNED,
+        # Inbound = dial the Twilio number over our SIP path; outbound = the
+        # TwilioOutboundDialer (Calls.json). Both wired.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     ProviderSpec(
         "livekit", "LiveKit (system engine)",

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -158,9 +158,9 @@ _SPECS: tuple[ProviderSpec, ...] = (
         transport=Transport.DIRECT_WS, connector_key="web_elevenlabs",
         credential_shape=CredentialShape.AGENT_ID, chat=True,
         observability_key="eleven_labs", status=Status.PLANNED,
-        # Connector is connect()-only (simulator-initiated) → inbound wired; outbound
-        # would need a BYO-telephony/SIP leg (supported by API, not yet built).
-        supported_directions=_BOTH, implemented_directions=_IN,
+        # Inbound via the connect()-only WS connector; outbound now wired via
+        # ElevenLabsOutboundDialer (POST /v1/convai/twilio/outbound-call).
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     ProviderSpec(
         "deepgram", "Deepgram Voice Agent",

--- a/futureagi/simulate/serializers/response/agent_version.py
+++ b/futureagi/simulate/serializers/response/agent_version.py
@@ -3,6 +3,34 @@ from rest_framework import serializers
 from agentcc.services.credential_manager import mask_key
 from simulate.models import AgentVersion
 
+# Provider-secret fields that may live in an AgentVersion.configuration_snapshot
+# and must never be returned to API clients in cleartext (they mirror the
+# credentials encrypted in ProviderCredentials). "Keys" get a partial mask
+# (first/last 4) so the UI can show *which* credential is set; the raw secret is
+# fully hidden. Keep in sync with the snapshot schema.
+_SNAPSHOT_MASKED_KEYS = ("api_key", "livekit_api_key")
+_SNAPSHOT_HIDDEN_SECRETS = ("livekit_api_secret",)
+
+
+def mask_snapshot_secrets(snapshot):
+    """Return a shallow copy of an agent configuration_snapshot with every
+    provider secret masked.
+
+    Safe on any input: a non-dict is returned unchanged. Use this everywhere a
+    configuration_snapshot is embedded in an API response so plaintext provider
+    secrets never reach clients, logs, or browser history.
+    """
+    if not isinstance(snapshot, dict):
+        return snapshot
+    masked = dict(snapshot)
+    for field in _SNAPSHOT_MASKED_KEYS:
+        if masked.get(field):
+            masked[field] = mask_key(masked[field])
+    for field in _SNAPSHOT_HIDDEN_SECRETS:
+        if masked.get(field):
+            masked[field] = "********"
+    return masked
+
 
 class AgentVersionResponseSerializer(serializers.ModelSerializer):
     """
@@ -49,11 +77,10 @@ class AgentVersionResponseSerializer(serializers.ModelSerializer):
             for key in ["organization", "knowledge_base", "workspace", "id"]:
                 if key in snapshot and snapshot[key] is not None:
                     snapshot[key] = str(snapshot[key])
-            # Mask sensitive secret so frontend knows it's set but can't read it
-            if "api_key" in snapshot and snapshot["api_key"]:
-                snapshot["api_key"] = mask_key(snapshot["api_key"])
-            if "livekit_api_secret" in snapshot and snapshot["livekit_api_secret"]:
-                snapshot["livekit_api_secret"] = "********"
+            # Mask every provider secret so the frontend knows a credential is
+            # set but can't read it. livekit_api_key was previously left in
+            # cleartext — mask_snapshot_secrets closes that gap.
+            snapshot = mask_snapshot_secrets(snapshot)
         data["configuration_snapshot"] = snapshot
         return data
 

--- a/futureagi/simulate/serializers/run_test.py
+++ b/futureagi/simulate/serializers/run_test.py
@@ -171,6 +171,10 @@ class RunTestSerializer(serializers.ModelSerializer):
         # re-serializing the same queryset a third time.
         data["evals"] = data.get("evals_detail", [])
         try:
+            from simulate.serializers.response.agent_version import (
+                mask_snapshot_secrets,
+            )
+
             # Only set agent_version for agent_definition source type.
             # Check for soft-deleted agent definition first: FK traversal bypasses
             # BaseModelManager's deleted=False filter, so we check explicitly.
@@ -190,7 +194,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                     data["agent_version"] = {
                         "id": instance.agent_version.id,
                         "name": instance.agent_version.version_name,
-                        "configuration_snapshot": snapshot,
+                        "configuration_snapshot": mask_snapshot_secrets(snapshot),
                     }
                 else:
                     # Try to use prefetched versions first to avoid N+1.
@@ -218,7 +222,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                         data["agent_version"] = {
                             "id": latest_version.id,
                             "name": latest_version.version_name,
-                            "configuration_snapshot": snapshot,
+                            "configuration_snapshot": mask_snapshot_secrets(snapshot),
                         }
         except Exception as e:
             logger.exception(

--- a/futureagi/simulate/services/chat_agent_adapter_factory.py
+++ b/futureagi/simulate/services/chat_agent_adapter_factory.py
@@ -1,0 +1,94 @@
+"""Selects the agent-under-test driver for a chat simulation (TH-5642).
+
+Product decision (2026-06-05): for an external **hosted** chat agent (e.g. Retell)
+the PLATFORM drives the conversation server-side via a provider adapter; SDK-push
+stays the path for providers that support it (e.g. LiveKit, whose agent runs the
+customer's own code). Dispatch is gated on **provider + assistant_id** so an SDK
+agent — which has no external hosted assistant_id — is never double-driven.
+
+Both adapters honour the same ``generate_response(conversation_history) -> {...}``
+contract as :class:`PromptBasedAgentAdapter`, so ``run_prompt_based_conversation``
+drives any of them unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import structlog
+
+from simulate.models.agent_definition import AgentDefinition
+from simulate.models.run_test import RunTest
+from simulate.services.prompt_based_agent_adapter import create_adapter_from_run_test
+from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+
+logger = structlog.get_logger(__name__)
+
+# Providers whose chat agent-under-test the platform drives SERVER-SIDE (hosted,
+# reached by API via assistant_id). provider key -> adapter builder(agent_id, api_key).
+EXTERNAL_HOSTED_CHAT_ADAPTERS = {
+    "retell": RetellChatAgentAdapter,
+}
+
+
+def _resolve_api_key(agent_definition: AgentDefinition) -> str:
+    """Prefer the encrypted ProviderCredentials, fall back to the plain field."""
+    creds = getattr(agent_definition, "credentials", None)
+    if creds is not None:
+        try:
+            key = creds.get_api_key()
+            if key:
+                return key
+        except Exception as e:  # pragma: no cover - defensive; never block on creds
+            logger.warning("chat_adapter_cred_resolve_failed", error=str(e))
+    return agent_definition.api_key or ""
+
+
+def is_external_hosted_chat(agent_definition: AgentDefinition | None) -> bool:
+    """True iff this is a TEXT agent on an external hosted chat provider we can
+    drive server-side (provider known + assistant_id present)."""
+    if agent_definition is None:
+        return False
+    return bool(
+        agent_definition.agent_type == AgentDefinition.AgentTypeChoices.TEXT
+        and (agent_definition.provider or "") in EXTERNAL_HOSTED_CHAT_ADAPTERS
+        and (agent_definition.assistant_id or "").strip()
+    )
+
+
+def create_chat_agent_adapter(
+    run_test: RunTest,
+    organization_id: UUID,
+    workspace_id: UUID | None = None,
+    variable_values: dict[str, Any] | None = None,
+):
+    """Return the agent-under-test driver for a chat sim, or ``None`` for SDK-push.
+
+    - ``source_type == prompt`` → :class:`PromptBasedAgentAdapter` (unchanged).
+    - ``agent_definition`` + external hosted chat provider + assistant_id → the
+      provider adapter (platform drives server-side).
+    - otherwise (SDK-driven agents) → ``None``; the caller keeps the SDK-push path.
+    """
+    if run_test.source_type == RunTest.SourceTypes.PROMPT:
+        return create_adapter_from_run_test(
+            run_test, organization_id, workspace_id, variable_values
+        )
+
+    agent_definition = run_test.agent_definition
+    if is_external_hosted_chat(agent_definition):
+        builder = EXTERNAL_HOSTED_CHAT_ADAPTERS[agent_definition.provider]
+        adapter = builder(
+            agent_id=agent_definition.assistant_id,
+            api_key=_resolve_api_key(agent_definition),
+        )
+        logger.info(
+            "chat_agent_adapter_server_side",
+            provider=agent_definition.provider,
+            agent_definition_id=str(agent_definition.id),
+        )
+        return adapter
+
+    # SDK-driven agent (e.g. LiveKit / custom): the customer's SDK pushes turns
+    # to send_message_to_chat; the platform does not drive it server-side.
+    return None

--- a/futureagi/simulate/services/chat_agent_adapter_factory.py
+++ b/futureagi/simulate/services/chat_agent_adapter_factory.py
@@ -21,6 +21,9 @@ from django.db.models import Q
 
 from simulate.models.agent_definition import AgentDefinition
 from simulate.models.run_test import RunTest
+from simulate.services.elevenlabs_chat_agent_adapter import (
+    ElevenLabsChatAgentAdapter,
+)
 from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
 
 # NOTE: ``create_adapter_from_run_test`` (prompt path) is imported lazily inside
@@ -34,6 +37,9 @@ logger = structlog.get_logger(__name__)
 # reached by API via assistant_id). provider key -> adapter builder(agent_id, api_key).
 EXTERNAL_HOSTED_CHAT_ADAPTERS = {
     "retell": RetellChatAgentAdapter,
+    # Both provider-string spellings exist in the wild (registry vs ProviderChoices).
+    "elevenlabs": ElevenLabsChatAgentAdapter,
+    "eleven_labs": ElevenLabsChatAgentAdapter,
 }
 
 # Provider keys the platform drives server-side — used by the trigger query to

--- a/futureagi/simulate/services/chat_agent_adapter_factory.py
+++ b/futureagi/simulate/services/chat_agent_adapter_factory.py
@@ -25,6 +25,7 @@ from simulate.services.elevenlabs_chat_agent_adapter import (
     ElevenLabsChatAgentAdapter,
 )
 from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+from simulate.services.vapi_chat_agent_adapter import VapiChatAgentAdapter
 
 # NOTE: ``create_adapter_from_run_test`` (prompt path) is imported lazily inside
 # create_chat_agent_adapter() — it transitively pulls in litellm/gateway clients,
@@ -37,6 +38,7 @@ logger = structlog.get_logger(__name__)
 # reached by API via assistant_id). provider key -> adapter builder(agent_id, api_key).
 EXTERNAL_HOSTED_CHAT_ADAPTERS = {
     "retell": RetellChatAgentAdapter,
+    "vapi": VapiChatAgentAdapter,
     # Both provider-string spellings exist in the wild (registry vs ProviderChoices).
     "elevenlabs": ElevenLabsChatAgentAdapter,
     "eleven_labs": ElevenLabsChatAgentAdapter,

--- a/futureagi/simulate/services/chat_agent_adapter_factory.py
+++ b/futureagi/simulate/services/chat_agent_adapter_factory.py
@@ -17,11 +17,16 @@ from typing import Any
 from uuid import UUID
 
 import structlog
+from django.db.models import Q
 
 from simulate.models.agent_definition import AgentDefinition
 from simulate.models.run_test import RunTest
-from simulate.services.prompt_based_agent_adapter import create_adapter_from_run_test
 from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+
+# NOTE: ``create_adapter_from_run_test`` (prompt path) is imported lazily inside
+# create_chat_agent_adapter() — it transitively pulls in litellm/gateway clients,
+# which must NOT load just because the trigger query wants EXTERNAL_HOSTED_CHAT_
+# PROVIDERS. Keeping this module light keeps the routing filter cheap to import.
 
 logger = structlog.get_logger(__name__)
 
@@ -30,6 +35,10 @@ logger = structlog.get_logger(__name__)
 EXTERNAL_HOSTED_CHAT_ADAPTERS = {
     "retell": RetellChatAgentAdapter,
 }
+
+# Provider keys the platform drives server-side — used by the trigger query to
+# route these agent_definition TEXT sims into run_single_prompt_chat.
+EXTERNAL_HOSTED_CHAT_PROVIDERS: tuple[str, ...] = tuple(EXTERNAL_HOSTED_CHAT_ADAPTERS)
 
 
 def _resolve_api_key(agent_definition: AgentDefinition) -> str:
@@ -43,6 +52,26 @@ def _resolve_api_key(agent_definition: AgentDefinition) -> str:
         except Exception as e:  # pragma: no cover - defensive; never block on creds
             logger.warning("chat_adapter_cred_resolve_failed", error=str(e))
     return agent_definition.api_key or ""
+
+
+def server_side_chat_filter() -> Q:
+    """CallExecution filter for chats the platform drives SERVER-SIDE (TH-5642).
+
+    Prompt-based sims, plus agent_definition TEXT sims whose agent-under-test is an
+    external HOSTED chat provider (e.g. Retell) reachable by assistant_id. SDK-driven
+    agents (no hosted provider/assistant_id) are excluded so they stay on SDK-push and
+    are never double-driven. Lives here (not in the heavy tasks module) so it stays
+    cheap to import. Mirrors :func:`is_external_hosted_chat` at the query level.
+    """
+    rt = "test_execution__run_test"
+    ad = f"{rt}__agent_definition"
+    return Q(**{f"{rt}__source_type": RunTest.SourceTypes.PROMPT}) | (
+        Q(**{f"{rt}__source_type": RunTest.SourceTypes.AGENT_DEFINITION})
+        & Q(**{f"{ad}__agent_type": AgentDefinition.AgentTypeChoices.TEXT})
+        & Q(**{f"{ad}__provider__in": EXTERNAL_HOSTED_CHAT_PROVIDERS})
+        & ~Q(**{f"{ad}__assistant_id__isnull": True})
+        & ~Q(**{f"{ad}__assistant_id__exact": ""})
+    )
 
 
 def is_external_hosted_chat(agent_definition: AgentDefinition | None) -> bool:
@@ -71,6 +100,11 @@ def create_chat_agent_adapter(
     - otherwise (SDK-driven agents) → ``None``; the caller keeps the SDK-push path.
     """
     if run_test.source_type == RunTest.SourceTypes.PROMPT:
+        # Lazy: pulls in litellm/gateway — only needed on the prompt path.
+        from simulate.services.prompt_based_agent_adapter import (
+            create_adapter_from_run_test,
+        )
+
         return create_adapter_from_run_test(
             run_test, organization_id, workspace_id, variable_values
         )

--- a/futureagi/simulate/services/chat_sim.py
+++ b/futureagi/simulate/services/chat_sim.py
@@ -322,26 +322,34 @@ def run_prompt_based_conversation(
         True if conversation completed successfully, False otherwise
     """
     from simulate.pydantic_schemas.chat import ChatMessage, ChatRole
-    from simulate.services.prompt_based_agent_adapter import (
-        create_adapter_from_run_test,
+    from simulate.services.chat_agent_adapter_factory import (
+        create_chat_agent_adapter,
     )
 
     try:
         run_test = call_execution.test_execution.run_test
 
-        # Create the prompt-based agent adapter
-        # Get variable values from scenario row data if available
+        # Resolve the agent-under-test driver (prompt template, or an external
+        # hosted chat provider the platform drives server-side — TH-5642).
+        # Get variable values from scenario row data if available.
         variable_values = {}
         if call_execution.call_metadata:
             row_data = call_execution.call_metadata.get("row_data", {})
             variable_values.update(row_data)
 
-        adapter = create_adapter_from_run_test(
+        adapter = create_chat_agent_adapter(
             run_test,
             organization_id=organization.id,
             workspace_id=workspace.id if workspace else None,
             variable_values=variable_values,
         )
+        if adapter is None:
+            # SDK-push agent (e.g. LiveKit/custom) — driven by the customer's SDK,
+            # not server-side. This server-side loop must never be triggered for it.
+            raise ValueError(
+                "run_prompt_based_conversation invoked for an SDK-push agent "
+                f"(run_test={run_test.id}); routing should keep it on SDK-push."
+            )
 
         # Build conversation history from existing messages
         conversation_history = []

--- a/futureagi/simulate/services/elevenlabs_chat_agent_adapter.py
+++ b/futureagi/simulate/services/elevenlabs_chat_agent_adapter.py
@@ -1,0 +1,197 @@
+"""ElevenLabsChatAgentAdapter — drive a real ElevenLabs ConvAI agent in TEXT mode.
+
+The chat analogue for ElevenLabs (TH-5642). Unlike Retell (stateless REST per turn),
+ElevenLabs ConvAI has no turn-by-turn REST chat endpoint — its text path is the
+stateful ConvAI WebSocket. This adapter holds one WS open for the conversation and
+bridges it to the synchronous ``generate_response(conversation_history) -> {...}``
+contract (same shape as PromptBasedAgentAdapter) via an owned event loop.
+
+ConvAI WebSocket (https://elevenlabs.io/docs/agents-platform/api-reference/...):
+- URL: signed (private agents) or ``wss://api.elevenlabs.io/v1/convai/conversation?agent_id=...``
+- Send text:  ``{"type": "user_message", "text": "..."}``
+- Receive:    ``{"type": "agent_response", "agent_response_event": {"agent_response": "..."}}``
+- Keepalive:  ``{"type": "ping", "ping_event": {"event_id": N}}`` -> ``{"type": "pong", "event_id": N}``
+- ``conversation_initiation_metadata`` / ``user_transcript`` / ``audio`` / ``interruption``
+  are control/voice frames — handled internally, not returned.
+
+The agent speaks first: on connect we read its opening ``agent_response`` (the
+agent's ``first_message``) and surface it as turn 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+ELEVENLABS_WS_URL = "wss://api.elevenlabs.io/v1/convai/conversation"
+ELEVENLABS_SIGNED_URL = "https://api.elevenlabs.io/v1/convai/conversation/get-signed-url"
+_RECV_TIMEOUT = 30.0
+# Short read for the opening greeting: many ConvAI agents have no first_message and
+# wait for the user, so we must not block a full turn-timeout on turn 1 (verified
+# live 2026-06-05: a no-greeting agent otherwise stalls ~30s before the first user
+# turn can be sent).
+_GREETING_TIMEOUT = 4.0
+_MAX_FRAMES_PER_TURN = 200
+
+
+class ElevenLabsChatAgentError(RuntimeError):
+    """Raised on ElevenLabs ConvAI protocol/transport errors."""
+
+
+class ElevenLabsChatAgentAdapter:
+    """Drives a customer's ElevenLabs ConvAI agent as the text agent-under-test."""
+
+    def __init__(self, agent_id: str, api_key: str, *, ws_url: str = ELEVENLABS_WS_URL):
+        if not agent_id:
+            raise ValueError("ElevenLabsChatAgentAdapter requires an agent_id")
+        self.agent_id = agent_id
+        self._api_key = api_key
+        self._ws_url = ws_url
+
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+        self._session = None
+        self._ws = None
+        self._connected = False
+        self._greeting: str = ""
+        self._sent_user_turns = 0
+
+    # ------------------------------------------------------------------
+    # sync <-> async bridge
+    # ------------------------------------------------------------------
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        if self._event_loop is None:
+            self._event_loop = asyncio.new_event_loop()
+        return self._event_loop
+
+    @staticmethod
+    def _user_turns(conversation_history: list[dict[str, Any]]) -> list[str]:
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    # ------------------------------------------------------------------
+    # WebSocket
+    # ------------------------------------------------------------------
+    async def _resolve_ws_url(self) -> str:
+        if not self._api_key:
+            return f"{self._ws_url}?agent_id={self.agent_id}"
+        async with self._session.get(
+            ELEVENLABS_SIGNED_URL,
+            params={"agent_id": self.agent_id},
+            headers={"xi-api-key": self._api_key},
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise ElevenLabsChatAgentError(
+                    f"ElevenLabs signed-url failed ({resp.status}): {body}"
+                )
+            data = await resp.json()
+        signed = data.get("signed_url")
+        if not signed:
+            raise ElevenLabsChatAgentError(f"No signed_url in response: {data}")
+        return signed
+
+    async def _connect(self) -> None:
+        import aiohttp
+
+        self._session = aiohttp.ClientSession()
+        url = await self._resolve_ws_url()
+        self._ws = await self._session.ws_connect(url)
+        self._connected = True
+        # Agent MAY speak first — capture its opening agent_response if it comes
+        # quickly; agents without a first_message just wait for the user (no stall).
+        self._greeting = await self._read_agent_text(timeout=_GREETING_TIMEOUT)
+        logger.info("elevenlabs_chat_connected", agent_id=self.agent_id)
+
+    async def _read_agent_text(self, timeout: float = _RECV_TIMEOUT) -> str:
+        """Read frames until an agent_response; answer pings; skip audio/control."""
+        import aiohttp
+
+        for _ in range(_MAX_FRAMES_PER_TURN):
+            try:
+                msg = await asyncio.wait_for(self._ws.receive(), timeout=timeout)
+            except TimeoutError:
+                return ""
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                import json
+
+                try:
+                    event = json.loads(msg.data)
+                except (ValueError, TypeError):
+                    continue
+                etype = event.get("type")
+                if etype == "agent_response":
+                    return str(
+                        (event.get("agent_response_event") or {}).get("agent_response")
+                        or ""
+                    )
+                if etype == "ping":
+                    event_id = (event.get("ping_event") or {}).get("event_id")
+                    await self._ws.send_json({"type": "pong", "event_id": event_id})
+                # conversation_initiation_metadata / user_transcript / audio /
+                # interruption: ignore.
+            elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+        return ""
+
+    async def _generate_async(self, conversation_history: list[dict[str, Any]]) -> str:
+        if not self._connected:
+            await self._connect()
+
+        user_turns = self._user_turns(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+        if not new_turns:
+            # Turn 1: the agent's opening message.
+            return self._greeting
+
+        await self._ws.send_json({"type": "user_message", "text": new_turns[-1]})
+        self._sent_user_turns = len(user_turns)
+        return await self._read_agent_text()
+
+    # ------------------------------------------------------------------
+    # agent-under-test contract
+    # ------------------------------------------------------------------
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        start = time.perf_counter()
+        content = self._loop().run_until_complete(
+            self._generate_async(conversation_history)
+        )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"elevenlabs:{self.agent_id}",
+            "latency_ms": latency_ms,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": False,
+        }
+
+    def end(self) -> None:
+        if self._event_loop is None:
+            return
+        try:
+            self._event_loop.run_until_complete(self._close())
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning("elevenlabs_chat_end_failed", error=str(e))
+        finally:
+            self._event_loop.close()
+            self._event_loop = None
+
+    async def _close(self) -> None:
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._connected = False

--- a/futureagi/simulate/services/optimizer_apply.py
+++ b/futureagi/simulate/services/optimizer_apply.py
@@ -1,0 +1,93 @@
+"""Apply an optimised prompt trial as a new PromptVersion (TH-5642).
+
+Product decision (2026-06-05): "directly apply the fix" = create a NEW prompt
+version the user confirms via the apply request — non-destructive, the baseline
+row is never overwritten or deleted.
+
+The new version clones the base PromptVersion with its system prompt replaced by
+the trial's optimised prompt inside ``prompt_config_snapshot`` (what the runtime
+adapter reads), takes the next ``template_version`` ("vN"), and — since the POST is
+the user's confirmation — becomes the active default for the template.
+"""
+
+from __future__ import annotations
+
+import copy
+from uuid import uuid4
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def _replace_system_message(messages: list, optimized_prompt: str) -> list:
+    """Deep-copy ``messages`` with the first system message's content set to the
+    optimised prompt (prepending one if none exists)."""
+    messages = copy.deepcopy(messages) if messages else []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "system":
+            msg["content"] = optimized_prompt
+            return messages
+    messages.insert(0, {"role": "system", "content": optimized_prompt})
+    return messages
+
+
+def snapshot_with_prompt(snapshot, optimized_prompt):
+    """Return a deep-copied prompt_config_snapshot with its system prompt replaced.
+
+    The snapshot is a list ``[{"messages": [...], "configuration": {...}}]`` (the
+    shape PromptBasedAgentAdapter reads); we only rewrite the system message.
+    """
+    snapshot = copy.deepcopy(snapshot)
+    cfg = snapshot[0] if isinstance(snapshot, list) and snapshot else snapshot
+    if isinstance(cfg, dict):
+        cfg["messages"] = _replace_system_message(cfg.get("messages", []), optimized_prompt)
+    return snapshot
+
+
+def apply_optimized_prompt_as_new_version(
+    base_version, optimized_prompt: str, *, make_default: bool = True
+):
+    """Clone ``base_version`` into a new PromptVersion carrying ``optimized_prompt``.
+
+    Args:
+        base_version: the PromptVersion the optimiser ran against (the baseline).
+        optimized_prompt: the winning trial's prompt text.
+        make_default: make the new version the template's active default (the apply
+            request is the user's confirmation that it should go live).
+
+    Returns:
+        The newly-created PromptVersion. The base row is untouched.
+    """
+    from model_hub.models.run_prompt import PromptVersion
+    from model_hub.services.prompt_service import get_next_version_number
+
+    # Fresh load so we never mutate the caller's instance / the base row in place.
+    base = PromptVersion.objects.get(pk=base_version.pk)
+
+    new_snapshot = snapshot_with_prompt(base.prompt_config_snapshot, optimized_prompt)
+    org_id = base.original_template.organization_id if base.original_template_id else None
+    next_number = get_next_version_number(base.original_template_id, org_id)
+
+    # Clone: detach the PK so save() inserts a new row, copying every scalar field;
+    # reset run-specific outputs so the new version starts clean.
+    base.pk = None
+    base.id = uuid4()
+    base._state.adding = True
+    base.prompt_config_snapshot = new_snapshot
+    base.template_version = f"v{next_number}"
+    base.is_default = make_default
+    base.is_draft = False
+    base.output = []
+    base.evaluation_results = {}
+    base.commit_message = "Applied optimised prompt (TH-5642)"
+    base.save()
+
+    logger.info(
+        "optimizer_prompt_applied_as_new_version",
+        new_version_id=str(base.id),
+        template_version=base.template_version,
+        original_template_id=str(base.original_template_id),
+        is_default=make_default,
+    )
+    return base

--- a/futureagi/simulate/services/outbound_dialer.py
+++ b/futureagi/simulate/services/outbound_dialer.py
@@ -119,11 +119,47 @@ class BlandOutboundDialer(OutboundDialer):
         return self._require_id(data.get("call_id"), data)
 
 
+class ElevenLabsOutboundDialer(OutboundDialer):
+    """ElevenLabs ConvAI outbound via ``POST /v1/convai/twilio/outbound-call``.
+
+    ElevenLabs places outbound calls through its Twilio integration, so
+    ``from_phone_number`` here carries the agent's registered
+    ``agent_phone_number_id`` (not a raw E.164 number). Auth is ``xi-api-key``.
+    """
+
+    provider = "elevenlabs"
+    BASE_URL = "https://api.elevenlabs.io"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        resp = requests.post(
+            f"{self.BASE_URL}/v1/convai/twilio/outbound-call",
+            headers={"xi-api-key": self._api_key, "Content-Type": "application/json"},
+            json={
+                "agent_id": assistant_id,
+                "agent_phone_number_id": from_phone_number,
+                "to_number": to_phone_number,
+                "conversation_initiation_client_data": {"metadata": metadata or {}},
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"ElevenLabs outbound-call failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        # The call id is conversation_id (fall back to Twilio's callSid).
+        return self._require_id(data.get("conversation_id") or data.get("callSid"), data)
+
+
 # provider key -> dialer class. Vapi keeps its existing engine path (it's already
 # wired); these add the previously-missing non-Vapi user-side dialers.
 OUTBOUND_DIALERS: dict[str, type[OutboundDialer]] = {
     "retell": RetellOutboundDialer,
     "bland": BlandOutboundDialer,
+    "elevenlabs": ElevenLabsOutboundDialer,
+    "eleven_labs": ElevenLabsOutboundDialer,  # provider-string drift
 }
 
 

--- a/futureagi/simulate/services/outbound_dialer.py
+++ b/futureagi/simulate/services/outbound_dialer.py
@@ -1,0 +1,138 @@
+"""Per-provider user-side outbound dialers (TH-5642).
+
+OUTBOUND simulation = the customer's agent CALLS our pool number and our simulator
+answers. The system-side answer leg (LiveKit SIP inbound trunk + dispatch) is
+provider-agnostic; the only per-provider piece is TRIGGERING the customer's agent to
+place the call. That was hard-wired to Vapi (voice_large.py: "currently always
+VAPI"), so a Retell/Bland user agent was silently dialed through the Vapi API.
+
+This module provides a dialer registry keyed by the user's provider, each a thin
+REST client returning ``{"id": <provider_call_id>}`` to match the existing
+``engine.create_outbound_call`` contract. Raw REST (no ee dependency) and
+unit-tested against the documented provider shapes; placing a real outbound call
+costs money and dials a live number, so these are not live-exercised here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class OutboundDialError(RuntimeError):
+    """Raised when a provider's outbound-call API errors or returns no call id."""
+
+
+class OutboundDialer:
+    """Triggers the customer's agent to place an outbound call to ``to_phone_number``."""
+
+    provider: str = ""
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError(f"{type(self).__name__} requires an api_key")
+        self._api_key = api_key
+
+    def create_outbound_call(
+        self,
+        *,
+        assistant_id: str,
+        from_phone_number: str,
+        to_phone_number: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _require_id(call_id: Any, payload: Any) -> dict[str, Any]:
+        if not call_id:
+            raise OutboundDialError(f"No call id returned by provider: {payload}")
+        return {"id": call_id}
+
+
+class RetellOutboundDialer(OutboundDialer):
+    """Retell outbound via ``POST /v2/create-phone-call`` (Bearer auth)."""
+
+    provider = "retell"
+    BASE_URL = "https://api.retellai.com"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        resp = requests.post(
+            f"{self.BASE_URL}/v2/create-phone-call",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "from_number": from_phone_number,
+                "to_number": to_phone_number,
+                "override_agent_id": assistant_id,
+                "metadata": metadata or {},
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Retell create-phone-call failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("call_id"), data)
+
+
+class BlandOutboundDialer(OutboundDialer):
+    """Bland.ai outbound via ``POST /v1/calls`` (raw api_key auth, pathway = agent)."""
+
+    provider = "bland"
+    BASE_URL = "https://api.bland.ai"
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        # Bland identifies the customer's agent by pathway_id; from_number is optional.
+        body: dict[str, Any] = {
+            "phone_number": to_phone_number,
+            "pathway_id": assistant_id,
+            "metadata": metadata or {},
+        }
+        if from_phone_number:
+            body["from"] = from_phone_number
+        resp = requests.post(
+            f"{self.BASE_URL}/v1/calls",
+            headers={"Authorization": self._api_key, "Content-Type": "application/json"},
+            json=body,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Bland /v1/calls failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("call_id"), data)
+
+
+# provider key -> dialer class. Vapi keeps its existing engine path (it's already
+# wired); these add the previously-missing non-Vapi user-side dialers.
+OUTBOUND_DIALERS: dict[str, type[OutboundDialer]] = {
+    "retell": RetellOutboundDialer,
+    "bland": BlandOutboundDialer,
+}
+
+
+def get_outbound_dialer(provider: str | None, api_key: str) -> OutboundDialer | None:
+    """Return a dialer for the user's provider, or None to fall back to the existing
+    (Vapi) engine path. Lets the orchestration replace the Vapi hard-wire with a
+    registry lookup without breaking the Vapi flow."""
+    cls = OUTBOUND_DIALERS.get((provider or "").strip().lower())
+    if cls is None:
+        return None
+    key = api_key or os.getenv(f"{(provider or '').upper()}_API_KEY", "")
+    return cls(api_key=key)

--- a/futureagi/simulate/services/outbound_dialer.py
+++ b/futureagi/simulate/services/outbound_dialer.py
@@ -153,6 +153,52 @@ class ElevenLabsOutboundDialer(OutboundDialer):
         return self._require_id(data.get("conversation_id") or data.get("callSid"), data)
 
 
+class TwilioOutboundDialer(OutboundDialer):
+    """Twilio outbound via ``POST /2010-04-01/Accounts/{sid}/Calls.json``.
+
+    A Twilio "agent" is a number whose call is driven by the customer's TwiML app
+    (ConversationRelay / Media Streams / a TwiML URL), so ``assistant_id`` carries
+    either that TwiML **URL** (used as ``Url``) or an **ApplicationSid** (used as
+    ``ApplicationSid``). Twilio uses HTTP Basic auth and FORM bodies, so the api_key
+    is ``"AccountSid:AuthToken"``.
+    """
+
+    provider = "twilio"
+    BASE_URL = "https://api.twilio.com"
+
+    def _account_sid_and_token(self) -> tuple[str, str]:
+        sid, _, token = self._api_key.partition(":")
+        if not sid or not token:
+            raise ValueError(
+                "TwilioOutboundDialer api_key must be 'AccountSid:AuthToken'"
+            )
+        return sid, token
+
+    def create_outbound_call(
+        self, *, assistant_id, from_phone_number, to_phone_number, metadata=None
+    ):
+        sid, token = self._account_sid_and_token()
+        form: dict[str, Any] = {"To": to_phone_number, "From": from_phone_number}
+        # TwiML URL vs ApplicationSid: a URL drives the call's behaviour; an
+        # ApplicationSid points at the customer's pre-configured TwiML app/agent.
+        if str(assistant_id).startswith(("http://", "https://")):
+            form["Url"] = assistant_id
+        else:
+            form["ApplicationSid"] = assistant_id
+        resp = requests.post(
+            f"{self.BASE_URL}/2010-04-01/Accounts/{sid}/Calls.json",
+            data=form,
+            auth=(sid, token),
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise OutboundDialError(
+                f"Twilio Calls.json failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json() or {}
+        return self._require_id(data.get("sid"), data)
+
+
 # provider key -> dialer class. Vapi keeps its existing engine path (it's already
 # wired); these add the previously-missing non-Vapi user-side dialers.
 OUTBOUND_DIALERS: dict[str, type[OutboundDialer]] = {
@@ -160,6 +206,7 @@ OUTBOUND_DIALERS: dict[str, type[OutboundDialer]] = {
     "bland": BlandOutboundDialer,
     "elevenlabs": ElevenLabsOutboundDialer,
     "eleven_labs": ElevenLabsOutboundDialer,  # provider-string drift
+    "twilio": TwilioOutboundDialer,
 }
 
 

--- a/futureagi/simulate/services/retell_chat_agent_adapter.py
+++ b/futureagi/simulate/services/retell_chat_agent_adapter.py
@@ -1,0 +1,253 @@
+"""RetellChatAgentAdapter — drive a real Retell *chat* agent as the agent-under-test.
+
+This is the chat analogue of the WebRTC bridge connectors (TH-5642): where the
+voice path tests a customer's Retell *voice* agent by joining it over LiveKit, the
+chat path tests a customer's Retell *chat* agent by driving its text conversation
+server-side.
+
+It deliberately mirrors the ``generate_response(conversation_history) -> {...}``
+contract of :class:`PromptBasedAgentAdapter` so it can be slotted into the same
+``run_prompt_based_conversation`` loop — the simulated customer (a
+``ChatServiceBlueprint`` engine) plays the user, and this adapter plays the agent.
+
+Retell Chat API (https://docs.retellai.com/api-references/create-chat,
+/create-chat-completion):
+- ``POST /create-chat``            ``{"agent_id": ...}`` -> ``{"chat_id", "message_with_tool_calls":[...], ...}``
+- ``POST /create-chat-completion`` ``{"chat_id", "content": <latest user turn>}`` -> ``{"messages":[{"role":"agent","content":...}], ...}``
+- ``PATCH /end-chat/{chat_id}``     ends the chat.
+
+Two protocol facts this adapter is built around (both confirmable only with a live
+Retell agent — see ``WIRING & LIVE-VERIFICATION`` below):
+1. **Retell holds conversation state server-side.** The chat is created ONCE
+   (lazily, on first turn) and ``chat_id`` cached; each completion sends only the
+   *newest* simulated-customer turn as ``content``. We never replay history — that
+   would double-send.
+2. **On turn 1 the agent speaks first.** ``/create-chat`` may return the agent's
+   ``begin_message`` in ``message_with_tool_calls``; we surface that as the first
+   response. If absent, we return empty content (the sim loop treats empty as a
+   natural end) rather than fabricating a turn.
+
+WIRING & LIVE-VERIFICATION (intentionally deferred — DESIGN.md §5):
+- No factory reads an agent-definition field here: chat agents-under-test are today
+  either prompt-templates (``source_type="prompt"``) or SDK-pushed
+  (``source_type="agent_definition"``). Hosting an *external* chat agent
+  server-side needs a new source_type + a schema field carrying ``agent_id``; that
+  product decision is out of scope for this unit (same gate as Deepgram).
+- The exact ``/create-chat-completion`` response envelope (``messages`` vs
+  ``message_with_tool_calls``) and whether token usage is returned can only be
+  pinned against a real Retell agent. The parser below accepts both message keys
+  defensively; usage defaults to zeros when Retell omits it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+RETELL_BASE_URL = "https://api.retellai.com"
+RETELL_AGENT_ROLE = "agent"  # Retell labels assistant turns "agent" in chat
+RETELL_REQUEST_TIMEOUT = 30
+
+
+class RetellChatAgentError(RuntimeError):
+    """Raised when the Retell Chat API returns an error or unexpected payload."""
+
+
+class RetellChatAgentAdapter:
+    """Drives a customer's Retell chat agent as the agent-under-test.
+
+    Implements the same ``generate_response`` contract as
+    :class:`PromptBasedAgentAdapter`; see module docstring for the protocol.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        api_key: str,
+        *,
+        base_url: str = RETELL_BASE_URL,
+        timeout: int = RETELL_REQUEST_TIMEOUT,
+    ):
+        """Initialize the adapter.
+
+        Args:
+            agent_id: The customer's Retell chat-agent id (agent-under-test).
+            api_key: Retell API key (Bearer).
+            base_url: Override for the Retell API base (tests / self-host).
+            timeout: Per-request timeout in seconds.
+        """
+        if not agent_id:
+            raise ValueError("RetellChatAgentAdapter requires an agent_id")
+        if not api_key:
+            raise ValueError("RetellChatAgentAdapter requires an api_key")
+        self.agent_id = agent_id
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+        # Server-side conversation state.
+        self._chat_id: str | None = None
+        # How many of the conversation_history "user" turns we have already
+        # forwarded to Retell — guards against re-sending the same turn.
+        self._sent_user_turns = 0
+        self._chat_ended = False
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        if resp.status_code >= 400:
+            raise RetellChatAgentError(
+                f"Retell {path} failed ({resp.status_code}): {resp.text}"
+            )
+        try:
+            return resp.json() or {}
+        except ValueError as e:
+            raise RetellChatAgentError(
+                f"Retell {path} returned non-JSON body: {resp.text}"
+            ) from e
+
+    # ------------------------------------------------------------------
+    # Protocol helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _latest_user_content(conversation_history: list[dict[str, Any]]) -> list[str]:
+        """Return the user (simulated-customer) turn contents, in order.
+
+        From the agent-under-test's perspective the simulated customer is the
+        "user"; "assistant" entries are the agent's own prior turns (which Retell
+        already tracks server-side, so we never resend them).
+        """
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    def _extract_agent_text(self, payload: dict[str, Any]) -> str:
+        """Pull the agent's reply text out of a Retell chat payload.
+
+        Accepts either ``messages`` (create-chat-completion) or
+        ``message_with_tool_calls`` (create-chat / get-chat); both are lists of
+        ``{"role", "content"}``. Only ``agent`` role messages are returned.
+        """
+        messages = payload.get("messages")
+        if messages is None:
+            messages = payload.get("message_with_tool_calls") or []
+        parts = [
+            str(m.get("content") or "")
+            for m in messages
+            if m.get("role") == RETELL_AGENT_ROLE and m.get("content")
+        ]
+        return "\n".join(p for p in parts if p)
+
+    @staticmethod
+    def _is_ended(payload: dict[str, Any]) -> bool:
+        return str(payload.get("chat_status") or "").lower() == "ended"
+
+    def _ensure_chat(self) -> dict[str, Any]:
+        """Create the Retell chat once and cache the chat_id; return the payload."""
+        if self._chat_id is not None:
+            return {}
+        payload = self._post("/create-chat", {"agent_id": self.agent_id})
+        chat_id = payload.get("chat_id")
+        if not chat_id:
+            raise RetellChatAgentError(
+                f"Retell /create-chat returned no chat_id: {payload}"
+            )
+        self._chat_id = chat_id
+        logger.info("retell_chat_agent_created", chat_id=chat_id, agent_id=self.agent_id)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Agent-under-test contract (mirrors PromptBasedAgentAdapter)
+    # ------------------------------------------------------------------
+
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Generate the Retell agent's next turn for the given conversation.
+
+        Args:
+            conversation_history: ``[{"role": "user"|"assistant", "content": ...}]``
+                from the agent-under-test's perspective (user = simulated customer).
+            additional_context: Unused; kept for contract parity.
+
+        Returns:
+            ``{"content", "role", "finish_reason", "model", "latency_ms", "usage",
+            "chat_ended"}`` — same shape PromptBasedAgentAdapter returns.
+        """
+        start = time.perf_counter()
+        create_payload = self._ensure_chat()
+
+        user_turns = self._latest_user_content(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+
+        if not new_turns:
+            # Turn 1 (agent speaks first): surface the begin_message from
+            # /create-chat if the agent has one; otherwise empty (loop ends).
+            content = self._extract_agent_text(create_payload)
+            ended = self._is_ended(create_payload)
+        else:
+            # Send only the newest customer turn; Retell holds the rest.
+            content_to_send = new_turns[-1]
+            completion = self._post(
+                "/create-chat-completion",
+                {"chat_id": self._chat_id, "content": content_to_send},
+            )
+            self._sent_user_turns = len(user_turns)
+            content = self._extract_agent_text(completion)
+            ended = self._is_ended(completion)
+
+        self._chat_ended = ended
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        logger.info(
+            "retell_chat_agent_turn",
+            chat_id=self._chat_id,
+            has_content=bool(content),
+            chat_ended=ended,
+        )
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"retell:{self.agent_id}",
+            "latency_ms": latency_ms,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": ended,
+        }
+
+    def end(self) -> None:
+        """Best-effort end of the Retell chat (idempotent)."""
+        if not self._chat_id:
+            return
+        try:
+            requests.patch(
+                f"{self._base_url}/end-chat/{self._chat_id}",
+                headers=self._headers,
+                timeout=self._timeout,
+            )
+        except requests.RequestException as e:  # pragma: no cover - best effort
+            logger.warning("retell_chat_agent_end_failed", error=str(e))

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -3644,36 +3644,47 @@ class TestExecutor:
                     f"Successfully deducted cost for chat call {call_execution.id}"
                 )
 
-                # Dual-write: emit usage event for text sim
+                # Dual-write: emit usage event for text sim. This is the SINGLE
+                # canonical TEXT_CALL emit — it is reached on every chat terminal
+                # path (interactive endCall, prompt-chat endCall via
+                # store_chat_messages, and prompt-chat max-turns via
+                # finalize_chat_execution). Do NOT emit TEXT_CALL anywhere else
+                # for the same source_id, or the call is double-billed.
                 try:
-                    try:
-                        from ee.usage.schemas.event_types import BillingEventType
-                    except ImportError:
-                        BillingEventType = None
-                    try:
-                        from ee.usage.schemas.events import UsageEvent
-                    except ImportError:
-                        UsageEvent = None
-                    try:
-                        from ee.usage.services.emitter import emit
-                    except ImportError:
-                        emit = None
+                    from ee.usage.schemas.event_types import BillingEventType
+                    from ee.usage.schemas.events import UsageEvent
+                    from ee.usage.services.emitter import emit
+                except ImportError:
+                    BillingEventType = UsageEvent = emit = None
 
-                    emit(
-                        UsageEvent(
-                            org_id=str(organization.id),
-                            event_type=BillingEventType.TEXT_CALL,
-                            amount=total_tokens,
-                            properties={
-                                "source": "simulate",
-                                "source_id": str(call_execution.id),
-                                "turns": no_of_fagi_agent_turns,
-                                "total_tokens": total_tokens,
-                            },
+                if emit and UsageEvent and BillingEventType:
+                    try:
+                        emit(
+                            UsageEvent(
+                                org_id=str(organization.id),
+                                event_type=BillingEventType.TEXT_CALL,
+                                # Floor at 1 so a token-tracking miss still bills a
+                                # non-zero TEXT_CALL (mirrors the voice
+                                # max(1, duration_minutes) floor) — never silent $0.
+                                amount=max(1, total_tokens),
+                                properties={
+                                    "source": "simulate",
+                                    "source_id": str(call_execution.id),
+                                    "turns": no_of_fagi_agent_turns,
+                                    "total_tokens": total_tokens,
+                                },
+                            )
                         )
+                    except Exception:
+                        logger.exception(
+                            "chat_usage_emit_failed",
+                            call_execution_id=str(call_execution.id),
+                        )
+                else:
+                    logger.error(
+                        "chat_usage_emit_unavailable",
+                        call_execution_id=str(call_execution.id),
                     )
-                except Exception:
-                    pass
 
                 return
 

--- a/futureagi/simulate/services/vapi_chat_agent_adapter.py
+++ b/futureagi/simulate/services/vapi_chat_agent_adapter.py
@@ -1,0 +1,151 @@
+"""VapiChatAgentAdapter — drive a real Vapi assistant in chat (text) mode (TH-5642).
+
+The chat analogue for Vapi. Like Retell, Vapi exposes a turn-by-turn REST chat API
+(the same endpoints the platform's VapiService already uses for the simulator side),
+so this mirrors RetellChatAgentAdapter: a chat session is created once, then each
+turn POSTs the latest user message and returns the assistant's reply.
+
+Vapi chat API (https://docs.vapi.ai, mirrored from ee VapiService):
+- ``POST {base}/session``  ``{"assistantId": ..., "name": ...}`` -> ``{"id": <session_id>}``
+- ``POST {base}/chat/``    ``{"input": [{"role":"user","content":...}], "sessionId": ...}``
+                           -> ``{"output": [{"role":"assistant","content":...}], ...}``
+- An ``endCall`` tool call in ``output`` signals the assistant ended the chat.
+
+Built from the proven VapiService request shapes; raw REST (no ee dependency) so the
+routing factory stays light to import. Not live-verified (no Vapi key in this env) —
+unit-tested against the documented shapes; flagged for a live run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+VAPI_DEFAULT_BASE_URL = "https://api.vapi.ai"
+VAPI_REQUEST_TIMEOUT = 30
+
+
+class VapiChatAgentError(RuntimeError):
+    """Raised on Vapi chat API errors / unexpected payloads."""
+
+
+class VapiChatAgentAdapter:
+    """Drives a customer's Vapi assistant as the text agent-under-test."""
+
+    def __init__(self, agent_id: str, api_key: str, *, base_url: str | None = None):
+        if not agent_id:
+            raise ValueError("VapiChatAgentAdapter requires an agent_id (assistantId)")
+        if not api_key:
+            raise ValueError("VapiChatAgentAdapter requires an api_key")
+        self.assistant_id = agent_id
+        self._api_key = api_key
+        self._base_url = (
+            base_url or os.getenv("VAPI_API_BASE_URL") or VAPI_DEFAULT_BASE_URL
+        ).rstrip("/")
+        self._session_id: str | None = None
+        self._sent_user_turns = 0
+        self._chat_ended = False
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = requests.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            headers=self._headers,
+            timeout=VAPI_REQUEST_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise VapiChatAgentError(
+                f"Vapi {path} failed ({resp.status_code}): {resp.text}"
+            )
+        try:
+            return resp.json() or {}
+        except ValueError as e:
+            raise VapiChatAgentError(
+                f"Vapi {path} returned non-JSON body: {resp.text}"
+            ) from e
+
+    @staticmethod
+    def _latest_user_content(conversation_history: list[dict[str, Any]]) -> list[str]:
+        return [
+            str(m.get("content") or "")
+            for m in conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+
+    @staticmethod
+    def _extract_assistant_text(output: list[dict[str, Any]]) -> str:
+        return "\n".join(
+            str(m.get("content") or "")
+            for m in output
+            if m.get("role") == "assistant" and m.get("content")
+        )
+
+    @staticmethod
+    def _ended(output: list[dict[str, Any]]) -> bool:
+        for m in output:
+            for tc in m.get("tool_calls") or []:
+                if (tc.get("function") or {}).get("name") == "endCall":
+                    return True
+        return False
+
+    def _ensure_session(self) -> None:
+        if self._session_id is not None:
+            return
+        payload = self._post(
+            "/session", {"assistantId": self.assistant_id, "name": "FI simulation chat"}
+        )
+        session_id = payload.get("id")
+        if not session_id:
+            raise VapiChatAgentError(f"Vapi /session returned no id: {payload}")
+        self._session_id = session_id
+        logger.info("vapi_chat_session_created", session_id=session_id)
+
+    def generate_response(
+        self,
+        conversation_history: list[dict[str, Any]],
+        additional_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        start = time.perf_counter()
+        self._ensure_session()
+
+        user_turns = self._latest_user_content(conversation_history)
+        new_turns = user_turns[self._sent_user_turns :]
+        if not new_turns:
+            # Vapi assistants respond to user input; no separate begin message here.
+            content, ended = "", False
+        else:
+            result = self._post(
+                "/chat/",
+                {
+                    "input": [{"role": "user", "content": new_turns[-1]}],
+                    "sessionId": self._session_id,
+                },
+            )
+            self._sent_user_turns = len(user_turns)
+            output = result.get("output") or []
+            content = self._extract_assistant_text(output)
+            ended = self._ended(output)
+
+        self._chat_ended = ended
+        return {
+            "content": content,
+            "role": "assistant",
+            "finish_reason": "stop",
+            "model": f"vapi:{self.assistant_id}",
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "chat_ended": ended,
+        }

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -456,16 +456,18 @@ def monitor_chat_timeout_call_executions():
 )
 def process_prompt_based_chat_simulations():
     """
-    Process REGISTERED CallExecutions for prompt-based simulations.
+    Process REGISTERED CallExecutions for server-side chat simulations.
 
     This activity picks up CallExecutions that:
     - Have status REGISTERED
     - Are TEXT type simulations
-    - Belong to prompt-based RunTests (source_type="prompt")
+    - Are driven server-side: prompt-based RunTests, OR agent_definition TEXT
+      RunTests on an external hosted chat provider (see _server_side_chat_filter).
 
     For each CallExecution, it initiates the chat and runs the full conversation.
     """
     # Lazy import: simulate.services.chat_sim imports from this module (circular)
+    from simulate.services.chat_agent_adapter_factory import server_side_chat_filter
     from simulate.services.chat_sim import initiate_chat, run_prompt_based_conversation
 
     try:
@@ -478,9 +480,9 @@ def process_prompt_based_chat_simulations():
             registered = list(
                 CallExecution.objects.select_for_update(skip_locked=True)
                 .filter(
+                    server_side_chat_filter(),
                     status=CallExecution.CallStatus.REGISTERED,
                     simulation_call_type=CallExecution.SimulationCallType.TEXT,
-                    test_execution__run_test__source_type=RunTest.SourceTypes.PROMPT,
                 )
                 .select_related("test_execution__run_test")
                 .order_by("created_at")[:50]
@@ -493,9 +495,9 @@ def process_prompt_based_chat_simulations():
             org_ids = {ce.test_execution.run_test.organization_id for ce in registered}
             org_ongoing = dict(
                 CallExecution.objects.filter(
+                    server_side_chat_filter(),
                     status=CallExecution.CallStatus.ONGOING,
                     simulation_call_type=CallExecution.SimulationCallType.TEXT,
-                    test_execution__run_test__source_type=RunTest.SourceTypes.PROMPT,
                     test_execution__run_test__organization_id__in=org_ids,
                 )
                 .values_list("test_execution__run_test__organization_id")

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -600,41 +600,12 @@ def run_single_prompt_chat(call_execution_id: str):
             max_turns=10,
         )
 
-        try:
-            call_execution.refresh_from_db()
-            from django.db.models import Sum
-
-            from simulate.models import ChatMessageModel
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-
-            total_tokens = (
-                ChatMessageModel.objects.filter(
-                    call_execution=call_execution
-                ).aggregate(total=Sum("tokens"))["total"]
-                or 0
-            )
-
-            emit(
-                UsageEvent(
-                    org_id=str(organization.id),
-                    event_type=BillingEventType.TEXT_CALL,
-                    amount=total_tokens,
-                    properties={
-                        "source": "simulate_prompt_chat",
-                        "source_id": str(call_execution.id),
-                        "total_tokens": total_tokens,
-                    },
-                )
-            )
-        except Exception:
-            pass  # Metering failure must not break the action
+        # Billing is emitted exactly once by the canonical path
+        # (TestExecutor._deduct_call_cost), which runs on BOTH terminal exits of
+        # run_prompt_based_conversation: the endCall exit (via
+        # store_chat_messages(chat_ended=True)) and the max-turns/empty exit (via
+        # finalize_chat_execution()). Emitting a second TEXT_CALL UsageEvent here
+        # for the same source_id double-billed every prompt-based chat — removed.
 
         logger.info(
             "prompt_chat_simulation_completed",

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -210,10 +210,13 @@ def _build_voice_settings(
         return {}
     from tracer.models.observability_provider import ProviderChoices
 
+    from simulate.utils.voice_provider import resolve_system_voice_provider
+
     # Voice_id format is determined by the system voice provider (the
     # infrastructure hosting the simulator assistant), not by the user's
-    # agent provider.
-    system_provider = os.getenv("SYSTEM_VOICE_PROVIDER", ProviderChoices.LIVEKIT)
+    # agent provider. Always a ProviderChoices enum via the single source of
+    # truth — no more string/enum drift.
+    system_provider = resolve_system_voice_provider()
 
     # Select voice name based on persona attributes (rule-based scoring)
     selected_voice_name = select_voice_id(persona_data, provider=system_provider)
@@ -231,7 +234,7 @@ def _build_voice_settings(
     # VAPI uses 11Labs voice names directly (e.g. "marissa", "phillip"),
     # so no resolution is needed. LiveKit uses Cartesia UUIDs, resolved
     # via the voice catalog adapter.
-    if system_provider == ProviderChoices.VAPI or system_provider == "vapi":
+    if system_provider == ProviderChoices.VAPI:
         provider_voice_id = selected_voice_name
     else:
         provider_voice_id = resolve_voice_id(

--- a/futureagi/simulate/tests/test_agent_definition_new_providers.py
+++ b/futureagi/simulate/tests/test_agent_definition_new_providers.py
@@ -1,0 +1,94 @@
+"""Agent-definition support for the multi-provider roster (TH-5642).
+
+Proves — as a regression guard, not an assertion — that the existing
+AgentDefinition model + AgentDefinitionSerializer are already provider-agnostic:
+an agent definition can be CREATED (validated + saved) for each new provider
+(Deepgram / Agora / Bland / ElevenLabs voice, Retell chat) with no schema change.
+The model's `provider` is a free-form CharField and `validate()` rejects no
+provider — it only special-cases LiveKit and requires *some* way to reach the
+agent (contact_number for SIP, or api_key+assistant_id for the web bridge).
+
+If a future change reintroduces a hard provider allow-list on the write path
+(the historical bug the ProviderSpec registry exists to prevent), these tests
+fail — which is the point.
+"""
+
+import pytest
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from simulate.models import AgentDefinition
+from simulate.serializers.agent_definition import AgentDefinitionSerializer
+
+
+@pytest.fixture
+def mock_request(user):
+    request = APIRequestFactory().post("/simulate/agent-definitions/")
+    drf_request = Request(request)
+    drf_request._user = user
+    drf_request._request.user = user
+    return drf_request
+
+
+def _base(provider, agent_type, **extra):
+    data = {
+        "agent_name": f"{provider} test agent",
+        "agent_type": agent_type,
+        "inbound": True,
+        "description": f"Agent-under-test on {provider}",
+        "provider": provider,
+        "languages": ["en"],
+    }
+    data.update(extra)
+    return data
+
+
+# (provider, agent_type, reach-creds) — each new provider with a realistic way to
+# be reached: SIP providers via contact_number, web-bridge providers via api_key+id.
+NEW_PROVIDER_CASES = [
+    ("deepgram", AgentDefinition.AgentTypeChoices.VOICE,
+     {"api_key": "dg-key", "assistant_id": "dg-agent-1"}),
+    ("elevenlabs", AgentDefinition.AgentTypeChoices.VOICE,
+     {"api_key": "el-key", "assistant_id": "el-agent-1"}),
+    ("agora", AgentDefinition.AgentTypeChoices.VOICE,
+     {"contact_number": "+14155550101"}),
+    ("bland", AgentDefinition.AgentTypeChoices.VOICE,
+     {"contact_number": "+14155550102"}),
+    ("retell", AgentDefinition.AgentTypeChoices.TEXT,
+     {"api_key": "rt-key", "assistant_id": "agent_chat_1"}),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+@pytest.mark.parametrize("provider,agent_type,creds", NEW_PROVIDER_CASES)
+def test_agent_definition_creatable_for_new_provider(
+    provider, agent_type, creds, organization, workspace, mock_request
+):
+    data = _base(provider, agent_type, **creds)
+    serializer = AgentDefinitionSerializer(
+        data=data, context={"request": mock_request}
+    )
+    # The object-level validate() is exactly what would reject an unknown
+    # provider — assert it does NOT.
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["provider"] == provider
+
+    instance = serializer.save(organization=organization, workspace=workspace)
+    assert instance.pk is not None
+    assert instance.provider == provider
+    assert instance.agent_type == agent_type
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_voice_agent_requires_a_provider(organization, workspace, mock_request):
+    # The only provider constraint on voice agents is "present" — not membership
+    # in a hard-coded allow-list.
+    data = _base("", AgentDefinition.AgentTypeChoices.VOICE,
+                 contact_number="+14155550103")
+    serializer = AgentDefinitionSerializer(
+        data=data, context={"request": mock_request}
+    )
+    assert not serializer.is_valid()
+    assert "provider" in serializer.errors

--- a/futureagi/simulate/tests/test_call_direction_resolver.py
+++ b/futureagi/simulate/tests/test_call_direction_resolver.py
@@ -44,12 +44,12 @@ def test_typo_raises_instead_of_silent_inbound():
 
 @pytest.mark.unit
 def test_unimplemented_outbound_raises_for_known_provider():
-    # Retell supports outbound but hasn't wired it → loud refusal, not a silent
-    # inbound run.
+    # Deepgram supports outbound but hasn't wired it → loud refusal, not a silent
+    # inbound run. (Retell/Vapi DO wire outbound via the dialer registry.)
     with pytest.raises(UnsupportedCallDirectionError):
-        resolve_call_direction("outbound", "retell")
-    # Inbound is implemented for retell → fine.
-    assert resolve_call_direction("inbound", "retell") is Direction.INBOUND
+        resolve_call_direction("outbound", "deepgram")
+    # Inbound is implemented for deepgram → fine.
+    assert resolve_call_direction("inbound", "deepgram") is Direction.INBOUND
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/tests/test_call_direction_resolver.py
+++ b/futureagi/simulate/tests/test_call_direction_resolver.py
@@ -7,7 +7,10 @@ an outbound request on a provider that hasn't wired outbound.
 import pytest
 
 from simulate.providers.direction import (
+    FIRST_MESSAGE_MODE_SPEAKS_FIRST,
+    FIRST_MESSAGE_MODE_WAITS,
     UnsupportedCallDirectionError,
+    first_message_mode_for,
     resolve_call_direction,
     resolve_is_outbound,
 )
@@ -60,6 +63,17 @@ def test_vapi_outbound_is_allowed():
 def test_unknown_provider_skips_implemented_check():
     # Custom / free-form providers are not in the registry → don't break them.
     assert resolve_call_direction("outbound", "my_custom_provider") is Direction.OUTBOUND
+
+
+@pytest.mark.unit
+def test_first_message_mode_is_direction_keyed():
+    # Outbound (agent calls us) → simulator waits; inbound → simulator speaks first.
+    assert first_message_mode_for(True) == FIRST_MESSAGE_MODE_WAITS
+    assert first_message_mode_for(False) == FIRST_MESSAGE_MODE_SPEAKS_FIRST
+    # Matches the existing LiveKit-bridge values so lifting it to all transports is
+    # behaviour-preserving for the bridge.
+    assert FIRST_MESSAGE_MODE_WAITS == "assistant-waits-for-user"
+    assert FIRST_MESSAGE_MODE_SPEAKS_FIRST == "assistant-speaks-first"
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/tests/test_call_direction_resolver.py
+++ b/futureagi/simulate/tests/test_call_direction_resolver.py
@@ -1,0 +1,71 @@
+"""Unit tests for the call-direction resolver (TH-5642).
+
+Pins that the audit's silent direction bugs now fail loudly: typo'd direction and
+an outbound request on a provider that hasn't wired outbound.
+"""
+
+import pytest
+
+from simulate.providers.direction import (
+    UnsupportedCallDirectionError,
+    resolve_call_direction,
+    resolve_is_outbound,
+)
+from simulate.providers.registry import Direction
+
+
+@pytest.mark.unit
+def test_missing_defaults_to_inbound():
+    # Preserves the historical default for the common unspecified case.
+    assert resolve_call_direction(None) is Direction.INBOUND
+    assert resolve_call_direction("") is Direction.INBOUND
+    assert resolve_call_direction("   ") is Direction.INBOUND
+
+
+@pytest.mark.unit
+def test_explicit_values_case_insensitive():
+    assert resolve_call_direction("inbound") is Direction.INBOUND
+    assert resolve_call_direction("OUTBOUND") is Direction.OUTBOUND
+    assert resolve_is_outbound("outbound") is True
+    assert resolve_is_outbound("inbound") is False
+
+
+@pytest.mark.unit
+def test_typo_raises_instead_of_silent_inbound():
+    # The exact bug: "outbond" previously became is_outbound=False (inbound) silently.
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_call_direction("outbond")
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_is_outbound("oubound")
+
+
+@pytest.mark.unit
+def test_unimplemented_outbound_raises_for_known_provider():
+    # Retell supports outbound but hasn't wired it → loud refusal, not a silent
+    # inbound run.
+    with pytest.raises(UnsupportedCallDirectionError):
+        resolve_call_direction("outbound", "retell")
+    # Inbound is implemented for retell → fine.
+    assert resolve_call_direction("inbound", "retell") is Direction.INBOUND
+
+
+@pytest.mark.unit
+def test_vapi_outbound_is_allowed():
+    # Vapi is the one provider with outbound wired.
+    assert resolve_call_direction("outbound", "vapi") is Direction.OUTBOUND
+    assert resolve_is_outbound("outbound", "vapi") is True
+
+
+@pytest.mark.unit
+def test_unknown_provider_skips_implemented_check():
+    # Custom / free-form providers are not in the registry → don't break them.
+    assert resolve_call_direction("outbound", "my_custom_provider") is Direction.OUTBOUND
+
+
+@pytest.mark.unit
+def test_enforce_implemented_can_be_disabled():
+    # For callers that only want normalisation/typo-catching, not the wiring gate.
+    assert (
+        resolve_call_direction("outbound", "retell", enforce_implemented=False)
+        is Direction.OUTBOUND
+    )

--- a/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
+++ b/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
@@ -13,7 +13,6 @@ import pytest
 
 from simulate.models.agent_definition import AgentDefinition
 from simulate.models.run_test import RunTest
-from simulate.services import chat_agent_adapter_factory as mod
 from simulate.services.chat_agent_adapter_factory import (
     create_chat_agent_adapter,
     is_external_hosted_chat,
@@ -48,7 +47,10 @@ def test_prompt_source_delegates_to_prompt_adapter(monkeypatch):
         called["args"] = (run_test, org, ws, vals)
         return sentinel
 
-    monkeypatch.setattr(mod, "create_adapter_from_run_test", fake_create)
+    # Patched at the source module — the factory imports it lazily inside the call.
+    import simulate.services.prompt_based_agent_adapter as pba
+
+    monkeypatch.setattr(pba, "create_adapter_from_run_test", fake_create)
     rt = _run_test(RunTest.SourceTypes.PROMPT)
     out = create_chat_agent_adapter(rt, "org-1", "ws-1", {"v": 1})
     assert out is sentinel

--- a/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
+++ b/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
@@ -1,0 +1,115 @@
+"""Unit tests for the chat agent-under-test factory (TH-5642).
+
+Pins the product-decided routing gate (2026-06-05):
+- external HOSTED chat provider (Retell) + assistant_id -> platform drives
+  server-side via RetellChatAgentAdapter;
+- SDK-capable providers (e.g. LiveKit) or a missing assistant_id -> None, i.e.
+  the SDK-push path is preserved (never double-driven).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from simulate.models.agent_definition import AgentDefinition
+from simulate.models.run_test import RunTest
+from simulate.services import chat_agent_adapter_factory as mod
+from simulate.services.chat_agent_adapter_factory import (
+    create_chat_agent_adapter,
+    is_external_hosted_chat,
+)
+from simulate.services.retell_chat_agent_adapter import RetellChatAgentAdapter
+
+TEXT = AgentDefinition.AgentTypeChoices.TEXT
+VOICE = AgentDefinition.AgentTypeChoices.VOICE
+
+
+def _ad(provider, agent_type=TEXT, assistant_id="agent_chat_1", api_key="k", credentials=None):
+    return SimpleNamespace(
+        id="ad-1",
+        provider=provider,
+        agent_type=agent_type,
+        assistant_id=assistant_id,
+        api_key=api_key,
+        credentials=credentials,
+    )
+
+
+def _run_test(source_type, agent_definition=None):
+    return SimpleNamespace(source_type=source_type, agent_definition=agent_definition)
+
+
+@pytest.mark.unit
+def test_prompt_source_delegates_to_prompt_adapter(monkeypatch):
+    sentinel = object()
+    called = {}
+
+    def fake_create(run_test, org, ws, vals):
+        called["args"] = (run_test, org, ws, vals)
+        return sentinel
+
+    monkeypatch.setattr(mod, "create_adapter_from_run_test", fake_create)
+    rt = _run_test(RunTest.SourceTypes.PROMPT)
+    out = create_chat_agent_adapter(rt, "org-1", "ws-1", {"v": 1})
+    assert out is sentinel
+    assert called["args"] == (rt, "org-1", "ws-1", {"v": 1})
+
+
+@pytest.mark.unit
+def test_retell_hosted_chat_drives_server_side():
+    rt = _run_test(RunTest.SourceTypes.AGENT_DEFINITION, _ad("retell"))
+    adapter = create_chat_agent_adapter(rt, "org-1")
+    assert isinstance(adapter, RetellChatAgentAdapter)
+    assert adapter.agent_id == "agent_chat_1"
+    assert adapter._api_key == "k"
+
+
+@pytest.mark.unit
+def test_livekit_text_agent_stays_sdk_push():
+    # LiveKit chat agents run the customer's own code -> SDK-push, not server-side.
+    rt = _run_test(RunTest.SourceTypes.AGENT_DEFINITION, _ad("livekit"))
+    assert create_chat_agent_adapter(rt, "org-1") is None
+
+
+@pytest.mark.unit
+def test_missing_assistant_id_stays_sdk_push():
+    rt = _run_test(RunTest.SourceTypes.AGENT_DEFINITION, _ad("retell", assistant_id=""))
+    assert create_chat_agent_adapter(rt, "org-1") is None
+
+
+@pytest.mark.unit
+def test_voice_agent_is_not_hosted_chat():
+    rt = _run_test(RunTest.SourceTypes.AGENT_DEFINITION, _ad("retell", agent_type=VOICE))
+    assert create_chat_agent_adapter(rt, "org-1") is None
+
+
+@pytest.mark.unit
+def test_is_external_hosted_chat_predicate():
+    assert is_external_hosted_chat(_ad("retell"))
+    assert not is_external_hosted_chat(_ad("retell", agent_type=VOICE))
+    assert not is_external_hosted_chat(_ad("retell", assistant_id=""))
+    assert not is_external_hosted_chat(_ad("livekit"))
+    assert not is_external_hosted_chat(_ad("vapi"))  # voice bridge, not hosted chat here
+    assert not is_external_hosted_chat(None)
+
+
+@pytest.mark.unit
+def test_api_key_prefers_encrypted_credentials():
+    creds = SimpleNamespace(get_api_key=lambda: "decrypted-secret")
+    rt = _run_test(
+        RunTest.SourceTypes.AGENT_DEFINITION,
+        _ad("retell", api_key="plain-fallback", credentials=creds),
+    )
+    adapter = create_chat_agent_adapter(rt, "org-1")
+    assert adapter._api_key == "decrypted-secret"
+
+
+@pytest.mark.unit
+def test_api_key_falls_back_to_plain_field_when_creds_blank():
+    creds = SimpleNamespace(get_api_key=lambda: "")
+    rt = _run_test(
+        RunTest.SourceTypes.AGENT_DEFINITION,
+        _ad("retell", api_key="plain-fallback", credentials=creds),
+    )
+    adapter = create_chat_agent_adapter(rt, "org-1")
+    assert adapter._api_key == "plain-fallback"

--- a/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
+++ b/futureagi/simulate/tests/test_chat_agent_adapter_factory.py
@@ -91,7 +91,8 @@ def test_is_external_hosted_chat_predicate():
     assert not is_external_hosted_chat(_ad("retell", agent_type=VOICE))
     assert not is_external_hosted_chat(_ad("retell", assistant_id=""))
     assert not is_external_hosted_chat(_ad("livekit"))
-    assert not is_external_hosted_chat(_ad("vapi"))  # voice bridge, not hosted chat here
+    assert is_external_hosted_chat(_ad("vapi"))  # vapi now has a hosted chat adapter
+    assert not is_external_hosted_chat(_ad("deepgram"))  # voice-only, no hosted chat
     assert not is_external_hosted_chat(None)
 
 

--- a/futureagi/simulate/tests/test_e2e_prompt_simulation.py
+++ b/futureagi/simulate/tests/test_e2e_prompt_simulation.py
@@ -1375,6 +1375,107 @@ class E2EPromptSimulationTestCase(TestCase):
         self.assertGreaterEqual(result_data.get("count", 0), 2)
         print(f"✓ Scenario pagination: 1 item per page, total >= 2")
 
+    # =========================================================================
+    # FLOW 16: Billing — exactly one TEXT_CALL emit (A9 double-bill regression)
+    # =========================================================================
+
+    def _make_text_call_execution(self, token_counts):
+        """Create a TEXT CallExecution with one ChatMessageModel per token count.
+
+        Roles alternate user/assistant starting with user, so the number of
+        user-role rows (the billed "turns") is deterministic.
+        """
+        from simulate.models.chat_message import ChatMessageModel
+
+        simulation = RunTest.objects.create(
+            name=f"A9 Billing Sim {uuid.uuid4()}",
+            source_type="prompt",
+            prompt_template=self.prompt_template,
+            prompt_version=self.prompt_version,
+            organization=self.org,
+            workspace=self.workspace,
+        )
+        test_execution = TestExecution.objects.create(
+            run_test=simulation, status="pending"
+        )
+        call_execution = CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=self.scenario,
+            status=CallExecution.CallStatus.ANALYZING,
+            simulation_call_type=CallExecution.SimulationCallType.TEXT,
+        )
+        for i, tok in enumerate(token_counts):
+            ChatMessageModel.objects.create(
+                call_execution=call_execution,
+                organization=self.org,
+                workspace=self.workspace,
+                role=(
+                    ChatMessageModel.RoleChoices.USER
+                    if i % 2 == 0
+                    else ChatMessageModel.RoleChoices.ASSISTANT
+                ),
+                content=[{"role": "user", "content": "hi"}],
+                tokens=tok,
+            )
+        return call_execution
+
+    def test_flow16a_deduct_call_cost_emits_single_floored_text_call(self):
+        """A9: the canonical _deduct_call_cost emits exactly ONE TEXT_CALL event."""
+        from ee.usage.schemas.event_types import BillingEventType
+        from simulate.services.test_executor import TestExecutor
+
+        call_execution = self._make_text_call_execution([100, 50])  # total 150
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ):
+            TestExecutor._deduct_call_cost(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        event = mock_emit.call_args.args[0]
+        self.assertEqual(event.event_type, BillingEventType.TEXT_CALL)
+        self.assertEqual(event.amount, 150)
+        print("✓ A9: canonical emit fires exactly once, amount=150")
+
+    def test_flow16b_zero_token_text_call_floored_to_one(self):
+        """A9: a token-tracking miss (0 tokens) still bills a non-zero TEXT_CALL."""
+        from simulate.services.test_executor import TestExecutor
+
+        call_execution = self._make_text_call_execution([0, 0])  # total 0
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ):
+            TestExecutor._deduct_call_cost(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        self.assertEqual(mock_emit.call_args.args[0].amount, 1)  # floored, never $0
+        print("✓ A9: 0-token chat floored to amount=1 (never silent $0)")
+
+    def test_flow16c_finalize_max_turns_emits_single_text_call(self):
+        """A9: the max-turns exit (finalize_chat_execution) bills exactly once.
+
+        Guards against the inverse bug: deleting the redundant task-level emit
+        must NOT zero-bill max-turns chats — finalize_chat_execution covers them
+        via the same canonical _deduct_call_cost.
+        """
+        from simulate.services.chat_sim import finalize_chat_execution
+
+        call_execution = self._make_text_call_execution([10, 20])  # total 30
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ), patch("simulate.services.chat_sim.notify_simulation_update"), patch(
+            "simulate.services.test_executor._run_simulate_evaluations_task"
+        ), patch(
+            "simulate.utils.chat_simulation._aggregate_chat_metrics"
+        ):
+            finalize_chat_execution(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        self.assertEqual(mock_emit.call_args.args[0].amount, 30)
+        print("✓ A9: max-turns finalize emits exactly one TEXT_CALL (no zero-bill)")
+
 
 def run_comprehensive_e2e_test():
     """

--- a/futureagi/simulate/tests/test_elevenlabs_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_elevenlabs_chat_agent_adapter.py
@@ -1,0 +1,102 @@
+"""Unit tests for ElevenLabsChatAgentAdapter (TH-5642).
+
+Exercises the ConvAI text WS protocol with a fake WebSocket (no network): send a
+``user_message``, read the ``agent_response``, answer pings, ignore audio/control.
+The sync ``generate_response`` drives the adapter's owned event loop.
+"""
+
+import json
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+
+from simulate.services.chat_agent_adapter_factory import EXTERNAL_HOSTED_CHAT_ADAPTERS
+from simulate.services.elevenlabs_chat_agent_adapter import (
+    ElevenLabsChatAgentAdapter,
+)
+
+
+class _FakeWS:
+    def __init__(self, incoming=()):
+        self._incoming = list(incoming)
+        self.sent = []
+        self.closed = False
+
+    async def send_json(self, obj):
+        self.sent.append(obj)
+
+    async def receive(self):
+        if self._incoming:
+            mtype, data = self._incoming.pop(0)
+            return SimpleNamespace(type=mtype, data=data)
+        return SimpleNamespace(type=aiohttp.WSMsgType.CLOSED, data=None)
+
+    async def close(self):
+        self.closed = True
+
+
+def _agent_response(text):
+    return (aiohttp.WSMsgType.TEXT, json.dumps(
+        {"type": "agent_response", "agent_response_event": {"agent_response": text}}))
+
+
+def _connected(ws):
+    a = ElevenLabsChatAgentAdapter(agent_id="agent_x", api_key="k")
+    a._ws = ws
+    a._connected = True  # skip the real _connect()
+    return a
+
+
+@pytest.mark.unit
+def test_registered_for_both_provider_spellings():
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["elevenlabs"] is ElevenLabsChatAgentAdapter
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["eleven_labs"] is ElevenLabsChatAgentAdapter
+
+
+@pytest.mark.unit
+def test_requires_agent_id():
+    with pytest.raises(ValueError):
+        ElevenLabsChatAgentAdapter(agent_id="", api_key="k")
+
+
+@pytest.mark.unit
+def test_sends_user_text_and_returns_agent_response():
+    ws = _FakeWS([_agent_response("Hello, how can I help?")])
+    a = _connected(ws)
+    out = a.generate_response([{"role": "user", "content": "hi there"}])
+    assert out["content"] == "Hello, how can I help?"
+    assert out["role"] == "assistant"
+    # The latest user turn was sent as a ConvAI user_message text frame.
+    assert {"type": "user_message", "text": "hi there"} in ws.sent
+
+
+@pytest.mark.unit
+def test_answers_ping_then_reads_agent_response():
+    ws = _FakeWS([
+        (aiohttp.WSMsgType.TEXT, json.dumps({"type": "ping", "ping_event": {"event_id": 7}})),
+        (aiohttp.WSMsgType.TEXT, json.dumps({"type": "user_transcript",
+                                             "user_transcription_event": {"user_transcript": "hi"}})),
+        _agent_response("Answer after ping"),
+    ])
+    a = _connected(ws)
+    out = a.generate_response([{"role": "user", "content": "q"}])
+    assert out["content"] == "Answer after ping"
+    assert {"type": "pong", "event_id": 7} in ws.sent
+
+
+@pytest.mark.unit
+def test_only_latest_turn_sent_no_replay():
+    ws = _FakeWS([_agent_response("R1"), _agent_response("R2")])
+    a = _connected(ws)
+    a.generate_response([{"role": "user", "content": "first"}])
+    a.generate_response([
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "R1"},
+        {"role": "user", "content": "second"},
+    ])
+    user_msgs = [m for m in ws.sent if m.get("type") == "user_message"]
+    assert user_msgs == [
+        {"type": "user_message", "text": "first"},
+        {"type": "user_message", "text": "second"},
+    ]

--- a/futureagi/simulate/tests/test_optimizer_apply.py
+++ b/futureagi/simulate/tests/test_optimizer_apply.py
@@ -1,0 +1,114 @@
+"""DB tests for applying an optimised prompt as a new PromptVersion (TH-5642).
+
+Verifies the product-decided "new version + confirm" apply: a NEW PromptVersion is
+created carrying the optimised system prompt, takes the next template_version, goes
+live as the default, and the baseline row is left intact.
+"""
+
+import pytest
+
+from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+from simulate.services.optimizer_apply import (
+    apply_optimized_prompt_as_new_version,
+    snapshot_with_prompt,
+)
+
+BASE_SNAPSHOT = [
+    {
+        "messages": [
+            {"role": "system", "content": "BASE SYSTEM PROMPT"},
+            {"role": "user", "content": "{{question}}"},
+        ],
+        "configuration": {"model": "gpt-4o-mini", "temperature": 0.7},
+    }
+]
+
+
+@pytest.mark.unit
+def test_snapshot_with_prompt_replaces_only_system_message():
+    out = snapshot_with_prompt(BASE_SNAPSHOT, "NEW PROMPT")
+    msgs = out[0]["messages"]
+    assert msgs[0] == {"role": "system", "content": "NEW PROMPT"}
+    assert msgs[1] == {"role": "user", "content": "{{question}}"}  # untouched
+    # configuration preserved
+    assert out[0]["configuration"]["model"] == "gpt-4o-mini"
+    # original snapshot object not mutated
+    assert BASE_SNAPSHOT[0]["messages"][0]["content"] == "BASE SYSTEM PROMPT"
+
+
+@pytest.mark.unit
+def test_snapshot_prepends_system_message_when_absent():
+    snap = [{"messages": [{"role": "user", "content": "hi"}], "configuration": {}}]
+    out = snapshot_with_prompt(snap, "SYS")
+    assert out[0]["messages"][0] == {"role": "system", "content": "SYS"}
+    assert out[0]["messages"][1]["role"] == "user"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_apply_creates_new_default_version_non_destructively(organization, workspace):
+    template = PromptTemplate.objects.create(
+        name="Optimiser Apply Prompt", organization=organization, workspace=workspace,
+    )
+    base = PromptVersion.objects.create(
+        original_template=template,
+        template_version="v1",
+        is_default=True,
+        commit_message="Initial",
+        prompt_config_snapshot=BASE_SNAPSHOT,
+    )
+
+    new_version = apply_optimized_prompt_as_new_version(base, "OPTIMISED SYSTEM PROMPT")
+
+    # A distinct new row.
+    assert new_version.id != base.id
+    assert new_version.original_template_id == template.id
+    assert new_version.template_version == "v2"
+    # Carries the optimised system prompt in the snapshot the adapter reads.
+    assert new_version.prompt_config_snapshot[0]["messages"][0] == {
+        "role": "system", "content": "OPTIMISED SYSTEM PROMPT",
+    }
+    # The rest of the config is preserved from the base.
+    assert new_version.prompt_config_snapshot[0]["messages"][1]["content"] == "{{question}}"
+    # The apply request is the confirmation -> the new version is live.
+    assert new_version.is_default is True
+
+    # Non-destructive: the base row still exists, its prompt is unchanged, and it is
+    # no longer the default (superseded by the new version).
+    base.refresh_from_db()
+    assert base.prompt_config_snapshot[0]["messages"][0]["content"] == "BASE SYSTEM PROMPT"
+    assert base.is_default is False
+    assert PromptVersion.objects.filter(original_template=template).count() == 2
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_apply_can_skip_default(organization, workspace):
+    template = PromptTemplate.objects.create(
+        name="Optimiser Apply NoDefault", organization=organization, workspace=workspace,
+    )
+    base = PromptVersion.objects.create(
+        original_template=template, template_version="v1", is_default=True,
+        prompt_config_snapshot=BASE_SNAPSHOT,
+    )
+    new_version = apply_optimized_prompt_as_new_version(
+        base, "OPT", make_default=False
+    )
+    assert new_version.is_default is False
+    base.refresh_from_db()
+    assert base.is_default is True  # base stays default when we don't promote
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_apply_does_not_overwrite_when_no_system_message(organization, workspace):
+    template = PromptTemplate.objects.create(
+        name="Optimiser Apply NoSys", organization=organization, workspace=workspace,
+    )
+    base = PromptVersion.objects.create(
+        original_template=template, template_version="v1",
+        prompt_config_snapshot=[{"messages": [{"role": "user", "content": "hi"}], "configuration": {}}],
+    )
+    new_version = apply_optimized_prompt_as_new_version(base, "INJECTED SYS")
+    msgs = new_version.prompt_config_snapshot[0]["messages"]
+    assert msgs[0] == {"role": "system", "content": "INJECTED SYS"}

--- a/futureagi/simulate/tests/test_outbound_dialer.py
+++ b/futureagi/simulate/tests/test_outbound_dialer.py
@@ -1,0 +1,119 @@
+"""Unit tests for the per-provider outbound dialers (TH-5642).
+
+Mocked REST (no network; placing a real call costs money + dials a live number).
+Pins the documented Retell/Bland outbound-call request shapes and the registry that
+replaces the Vapi-hardcoded user-side dialer.
+"""
+
+import json
+
+import pytest
+
+from simulate.services import outbound_dialer as mod
+from simulate.services.outbound_dialer import (
+    OUTBOUND_DIALERS,
+    BlandOutboundDialer,
+    OutboundDialError,
+    RetellOutboundDialer,
+    get_outbound_dialer,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    def __init__(self, resp):
+        self._resp = resp
+        self.calls = []
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.calls.append({"url": url, "headers": headers, "json": json})
+        return self._resp
+
+
+@pytest.mark.unit
+def test_registry_has_non_vapi_dialers():
+    assert OUTBOUND_DIALERS["retell"] is RetellOutboundDialer
+    assert OUTBOUND_DIALERS["bland"] is BlandOutboundDialer
+
+
+@pytest.mark.unit
+def test_get_outbound_dialer_falls_back_for_vapi():
+    # Vapi keeps its existing engine path → no dialer here (None = fall back).
+    assert get_outbound_dialer("vapi", "k") is None
+    assert get_outbound_dialer("unknown", "k") is None
+    assert isinstance(get_outbound_dialer("retell", "k"), RetellOutboundDialer)
+
+
+@pytest.mark.unit
+def test_requires_api_key():
+    with pytest.raises(ValueError):
+        RetellOutboundDialer(api_key="")
+
+
+@pytest.mark.unit
+def test_retell_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"call_id": "call_123", "agent_id": "agent_x"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = RetellOutboundDialer(api_key="rt-key")
+    out = dialer.create_outbound_call(
+        assistant_id="agent_x", from_phone_number="+15551110000",
+        to_phone_number="+15552220000", metadata={"call_id": "abc"},
+    )
+    assert out == {"id": "call_123"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v2/create-phone-call")
+    assert call["headers"]["Authorization"] == "Bearer rt-key"
+    assert call["json"] == {
+        "from_number": "+15551110000",
+        "to_number": "+15552220000",
+        "override_agent_id": "agent_x",
+        "metadata": {"call_id": "abc"},
+    }
+
+
+@pytest.mark.unit
+def test_bland_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"status": "success", "call_id": "bland_1"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = BlandOutboundDialer(api_key="bl-key")
+    out = dialer.create_outbound_call(
+        assistant_id="pathway_1", from_phone_number="+15551110000",
+        to_phone_number="+15552220000",
+    )
+    assert out == {"id": "bland_1"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v1/calls")
+    # Bland uses the raw key as Authorization (no Bearer).
+    assert call["headers"]["Authorization"] == "bl-key"
+    assert call["json"]["phone_number"] == "+15552220000"
+    assert call["json"]["pathway_id"] == "pathway_1"
+    assert call["json"]["from"] == "+15551110000"
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"error": "bad number"}, status_code=422))
+    monkeypatch.setattr(mod, "requests", fake)
+    with pytest.raises(OutboundDialError):
+        RetellOutboundDialer(api_key="k").create_outbound_call(
+            assistant_id="a", from_phone_number="+1", to_phone_number="+1"
+        )
+
+
+@pytest.mark.unit
+def test_missing_call_id_raises(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"status": "queued"}))  # no call_id
+    monkeypatch.setattr(mod, "requests", fake)
+    with pytest.raises(OutboundDialError):
+        BlandOutboundDialer(api_key="k").create_outbound_call(
+            assistant_id="p", from_phone_number="", to_phone_number="+1"
+        )

--- a/futureagi/simulate/tests/test_outbound_dialer.py
+++ b/futureagi/simulate/tests/test_outbound_dialer.py
@@ -13,6 +13,7 @@ from simulate.services import outbound_dialer as mod
 from simulate.services.outbound_dialer import (
     OUTBOUND_DIALERS,
     BlandOutboundDialer,
+    ElevenLabsOutboundDialer,
     OutboundDialError,
     RetellOutboundDialer,
     get_outbound_dialer,
@@ -97,6 +98,34 @@ def test_bland_outbound_request_shape(monkeypatch):
     assert call["json"]["phone_number"] == "+15552220000"
     assert call["json"]["pathway_id"] == "pathway_1"
     assert call["json"]["from"] == "+15551110000"
+
+
+@pytest.mark.unit
+def test_elevenlabs_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp(
+        {"success": True, "conversation_id": "conv_9", "callSid": "CA123"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    dialer = ElevenLabsOutboundDialer(api_key="xi-key")
+    out = dialer.create_outbound_call(
+        assistant_id="agent_el", from_phone_number="phnum_id_1",
+        to_phone_number="+15552220000",
+    )
+    # call id = conversation_id.
+    assert out == {"id": "conv_9"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/v1/convai/twilio/outbound-call")
+    # ElevenLabs uses xi-api-key, and from_phone_number carries the phone_number_id.
+    assert call["headers"]["xi-api-key"] == "xi-key"
+    assert call["json"]["agent_id"] == "agent_el"
+    assert call["json"]["agent_phone_number_id"] == "phnum_id_1"
+    assert call["json"]["to_number"] == "+15552220000"
+
+
+@pytest.mark.unit
+def test_elevenlabs_registered_for_both_spellings():
+    assert OUTBOUND_DIALERS["elevenlabs"] is ElevenLabsOutboundDialer
+    assert OUTBOUND_DIALERS["eleven_labs"] is ElevenLabsOutboundDialer
+    assert isinstance(get_outbound_dialer("eleven_labs", "k"), ElevenLabsOutboundDialer)
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/tests/test_outbound_dialer.py
+++ b/futureagi/simulate/tests/test_outbound_dialer.py
@@ -16,6 +16,7 @@ from simulate.services.outbound_dialer import (
     ElevenLabsOutboundDialer,
     OutboundDialError,
     RetellOutboundDialer,
+    TwilioOutboundDialer,
     get_outbound_dialer,
 )
 
@@ -35,8 +36,10 @@ class _FakeRequests:
         self._resp = resp
         self.calls = []
 
-    def post(self, url, headers=None, json=None, timeout=None):
-        self.calls.append({"url": url, "headers": headers, "json": json})
+    def post(self, url, headers=None, json=None, data=None, auth=None, timeout=None):
+        self.calls.append(
+            {"url": url, "headers": headers, "json": json, "data": data, "auth": auth}
+        )
         return self._resp
 
 
@@ -126,6 +129,45 @@ def test_elevenlabs_registered_for_both_spellings():
     assert OUTBOUND_DIALERS["elevenlabs"] is ElevenLabsOutboundDialer
     assert OUTBOUND_DIALERS["eleven_labs"] is ElevenLabsOutboundDialer
     assert isinstance(get_outbound_dialer("eleven_labs", "k"), ElevenLabsOutboundDialer)
+
+
+@pytest.mark.unit
+def test_twilio_outbound_request_shape(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"sid": "CA999", "status": "queued"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    # api_key carries "AccountSid:AuthToken"; assistant_id is a TwiML URL here.
+    dialer = TwilioOutboundDialer(api_key="ACsid:tok")
+    out = dialer.create_outbound_call(
+        assistant_id="https://example.com/twiml",
+        from_phone_number="+15551110000", to_phone_number="+15552220000",
+    )
+    assert out == {"id": "CA999"}
+    call = fake.calls[0]
+    assert call["url"].endswith("/2010-04-01/Accounts/ACsid/Calls.json")
+    assert call["auth"] == ("ACsid", "tok")  # HTTP Basic
+    assert call["data"]["To"] == "+15552220000"
+    assert call["data"]["From"] == "+15551110000"
+    assert call["data"]["Url"] == "https://example.com/twiml"  # URL → Url
+
+
+@pytest.mark.unit
+def test_twilio_application_sid_when_not_a_url(monkeypatch):
+    fake = _FakeRequests(_FakeResp({"sid": "CA1"}))
+    monkeypatch.setattr(mod, "requests", fake)
+    TwilioOutboundDialer(api_key="ACsid:tok").create_outbound_call(
+        assistant_id="AP123app", from_phone_number="+1", to_phone_number="+1",
+    )
+    # Non-URL assistant_id → ApplicationSid, not Url.
+    assert fake.calls[0]["data"]["ApplicationSid"] == "AP123app"
+    assert "Url" not in fake.calls[0]["data"]
+
+
+@pytest.mark.unit
+def test_twilio_requires_sid_and_token():
+    with pytest.raises(ValueError):
+        TwilioOutboundDialer(api_key="just-one-value").create_outbound_call(
+            assistant_id="x", from_phone_number="+1", to_phone_number="+1"
+        )
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -1,0 +1,151 @@
+"""Tests for the ProviderSpec SSOT registry (TH-5642, DESIGN.md §4).
+
+The registry is the single place a provider is declared; these tests pin the
+taxonomy (roles are not interchangeable) and that derived values stay in sync
+with the real connector registry / ProviderChoices.
+"""
+
+import pytest
+
+from simulate.providers import (
+    PROVIDER_REGISTRY,
+    Role,
+    Status,
+    Transport,
+    agent_platform_keys,
+    connector_key_for,
+    get_spec,
+    is_agent_platform,
+    provider_choices,
+)
+
+# The bridge connector keys that exist TODAY (ee/voice/.../bridge/connector.py).
+CURRENT_BRIDGE_KEYS = {"web_vapi", "web_retell", "web_livekit_bridge"}
+
+
+class TestRegistryShape:
+    @pytest.mark.unit
+    def test_registry_keyed_by_canonical_key(self):
+        for key, spec in PROVIDER_REGISTRY.items():
+            assert spec.key == key
+
+    @pytest.mark.unit
+    def test_specs_are_frozen(self):
+        import dataclasses
+
+        spec = get_spec("vapi")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            spec.key = "mutated"  # frozen dataclass
+
+    @pytest.mark.unit
+    def test_expected_providers_present(self):
+        for key in [
+            "vapi", "retell", "livekit_bridge", "others",
+            "elevenlabs", "deepgram", "agora", "pipecat",
+            "twilio", "livekit", "futureagi",
+        ]:
+            assert get_spec(key) is not None, key
+
+
+class TestTaxonomy:
+    @pytest.mark.unit
+    def test_twilio_is_transport_not_agent_platform(self):
+        spec = get_spec("twilio")
+        assert Role.TRANSPORT in spec.roles
+        assert not spec.is_agent_platform
+        assert spec.status is Status.TRANSPORT_ONLY
+
+    @pytest.mark.unit
+    def test_system_livekit_distinct_from_livekit_bridge(self):
+        # 'livekit' = our SYSTEM engine; 'livekit_bridge' = the customer's agent.
+        system = get_spec("livekit")
+        bridge = get_spec("livekit_bridge")
+        assert Role.SYSTEM_ENGINE in system.roles
+        assert not system.is_agent_platform
+        assert bridge.is_agent_platform
+        assert bridge.connector_key == "web_livekit_bridge"
+
+    @pytest.mark.unit
+    def test_component_presence_is_not_platform_support(self):
+        # ElevenLabs/Deepgram are STT/TTS components but only PLANNED as platforms.
+        assert Role.TTS in get_spec("elevenlabs").roles
+        assert Role.STT in get_spec("deepgram").roles
+        assert get_spec("elevenlabs").status is Status.PLANNED
+        assert get_spec("deepgram").status is Status.PLANNED
+
+    @pytest.mark.unit
+    def test_pipecat_reuses_livekit_bridge_connector(self):
+        assert get_spec("pipecat").connector_key == "web_livekit_bridge"
+        assert get_spec("pipecat").transport is Transport.WEBRTC_BRIDGE
+
+
+class TestDerivations:
+    @pytest.mark.unit
+    def test_connector_key_for_replaces_string_interpolation(self):
+        assert connector_key_for("vapi") == "web_vapi"
+        assert connector_key_for("retell") == "web_retell"
+        assert connector_key_for("livekit_bridge") == "web_livekit_bridge"
+        # SIP-only / unknown → None (routes to SIP, not an unknown connection_type)
+        assert connector_key_for("others") is None
+        assert connector_key_for("twilio") is None
+        assert connector_key_for("nonsense") is None
+        assert connector_key_for(None) is None
+
+    @pytest.mark.unit
+    def test_ga_webrtc_connector_keys_match_current_bridge_registry(self):
+        ga_webrtc = {
+            s.connector_key
+            for s in PROVIDER_REGISTRY.values()
+            if s.is_ga and s.transport is Transport.WEBRTC_BRIDGE and s.connector_key
+        }
+        assert ga_webrtc == CURRENT_BRIDGE_KEYS
+
+    @pytest.mark.unit
+    def test_agent_platform_keys(self):
+        ga = set(agent_platform_keys(include_planned=False))
+        assert ga == {"vapi", "retell", "livekit_bridge", "others"}
+        allp = set(agent_platform_keys(include_planned=True))
+        assert {"elevenlabs", "deepgram", "agora", "pipecat"} <= allp
+        # transport-only / system engines are never agent platforms
+        assert "twilio" not in allp
+        assert "livekit" not in allp
+        assert "futureagi" not in allp
+
+    @pytest.mark.unit
+    def test_provider_choices_ga_only_by_default(self):
+        ga = dict(provider_choices())
+        assert set(ga) == {"vapi", "retell", "livekit_bridge", "others"}
+        withp = dict(provider_choices(include_planned=True))
+        assert "elevenlabs" in withp and "pipecat" in withp
+
+    @pytest.mark.unit
+    def test_is_agent_platform(self):
+        assert is_agent_platform("retell")
+        assert not is_agent_platform("twilio")
+        assert not is_agent_platform("unknown")
+
+    @pytest.mark.unit
+    def test_observability_keys_are_valid_provider_choices(self):
+        from tracer.models.observability_provider import ProviderChoices
+
+        valid = {c.value for c in ProviderChoices}
+        for spec in PROVIDER_REGISTRY.values():
+            if spec.observability_key is not None:
+                assert spec.observability_key in valid, spec.key
+
+
+class TestBridgeRegistryParity:
+    @pytest.mark.unit
+    def test_cross_check_against_real_connector_registry_if_importable(self):
+        # Best-effort: the real bridge registry pulls livekit SDK deps that may be
+        # absent in the backend venv — skip if it can't import.
+        connector = pytest.importorskip(
+            "ee.voice.services.livekit.bridge.connector"
+        )
+        real_keys = set(connector.get_connector_registry().keys())
+        ga_webrtc = {
+            s.connector_key
+            for s in PROVIDER_REGISTRY.values()
+            if s.is_ga and s.transport is Transport.WEBRTC_BRIDGE and s.connector_key
+        }
+        assert ga_webrtc <= real_keys

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -41,7 +41,7 @@ class TestRegistryShape:
     def test_expected_providers_present(self):
         for key in [
             "vapi", "retell", "livekit_bridge", "others",
-            "elevenlabs", "deepgram", "agora", "pipecat",
+            "elevenlabs", "deepgram", "agora", "pipecat", "bland",
             "twilio", "livekit", "futureagi",
         ]:
             assert get_spec(key) is not None, key
@@ -117,7 +117,7 @@ class TestDerivations:
         ga = set(agent_platform_keys(include_planned=False))
         assert ga == {"vapi", "retell", "livekit_bridge", "others"}
         allp = set(agent_platform_keys(include_planned=True))
-        assert {"elevenlabs", "deepgram", "agora", "pipecat"} <= allp
+        assert {"elevenlabs", "deepgram", "agora", "pipecat", "bland"} <= allp
         # transport-only / system engines are never agent platforms
         assert "twilio" not in allp
         assert "livekit" not in allp

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -52,11 +52,13 @@ class TestRegistryShape:
 
 class TestTaxonomy:
     @pytest.mark.unit
-    def test_twilio_is_transport_not_agent_platform(self):
+    def test_twilio_is_both_transport_and_agent_platform(self):
+        # Twilio is a carrier substrate AND a platform customers build agents on
+        # (ConversationRelay/TwiML) — testable inbound (SIP) + outbound (Calls.json).
         spec = get_spec("twilio")
         assert Role.TRANSPORT in spec.roles
-        assert not spec.is_agent_platform
-        assert spec.status is Status.TRANSPORT_ONLY
+        assert spec.is_agent_platform
+        assert spec.supported_directions and spec.implemented_directions
 
     @pytest.mark.unit
     def test_system_livekit_distinct_from_livekit_bridge(self):
@@ -132,9 +134,8 @@ class TestDerivations:
         ga = set(agent_platform_keys(include_planned=False))
         assert ga == {"vapi", "retell", "livekit_bridge", "others"}
         allp = set(agent_platform_keys(include_planned=True))
-        assert {"elevenlabs", "deepgram", "agora", "pipecat", "bland"} <= allp
-        # transport-only / system engines are never agent platforms
-        assert "twilio" not in allp
+        assert {"elevenlabs", "deepgram", "agora", "pipecat", "bland", "twilio"} <= allp
+        # system engines are never agent platforms (twilio now is, via ConvRelay)
         assert "livekit" not in allp
         assert "futureagi" not in allp
 
@@ -148,7 +149,7 @@ class TestDerivations:
     @pytest.mark.unit
     def test_is_agent_platform(self):
         assert is_agent_platform("retell")
-        assert not is_agent_platform("twilio")
+        assert is_agent_platform("twilio")  # now an agent platform (ConvRelay/TwiML)
         assert not is_agent_platform("unknown")
 
     @pytest.mark.unit
@@ -204,7 +205,7 @@ class TestCallDirection:
             "agora": ({IN, OUT}, set()),
             "pipecat": ({IN, OUT}, {IN, OUT}),     # reuses bridge → outbound = speaking-order
             "bland": ({IN, OUT}, {OUT}),          # outbound-first; BlandOutboundDialer
-            "twilio": (set(), set()),             # transport-only, direction n/a
+            "twilio": ({IN, OUT}, {IN, OUT}),     # SIP inbound + TwilioOutboundDialer
             "futureagi": (set(), set()),          # internal chat
         }
         for key, (sup, impl) in expected.items():
@@ -222,17 +223,17 @@ class TestCallDirection:
         # Vapi and Retell: outbound both supported and wired (dialer registry).
         assert implements_direction("vapi", Direction.OUTBOUND)
         assert implements_direction("retell", Direction.OUTBOUND)
-        # Unknown provider / transport-only.
+        # Twilio is now an agent platform (both directions); only unknown is empty.
         assert not supports_direction("nonsense", Direction.INBOUND)
-        assert not supports_direction("twilio", Direction.INBOUND)
+        assert supports_direction("twilio", Direction.INBOUND)
 
     @pytest.mark.unit
     def test_direction_filtered_selectors(self):
         # Every GA agent platform supports both directions, so a direction filter on
         # GA choices doesn't drop any — but it MUST exclude transport/internal rows.
         out_keys = set(agent_platform_keys(direction=Direction.OUTBOUND))
-        assert {"vapi", "retell", "livekit_bridge", "others"} <= out_keys
-        assert "twilio" not in out_keys and "futureagi" not in out_keys
+        assert {"vapi", "retell", "livekit_bridge", "others", "twilio"} <= out_keys
+        assert "futureagi" not in out_keys  # system engine, never an agent platform
         ga_out = dict(provider_choices(direction=Direction.OUTBOUND))
         assert set(ga_out) == {"vapi", "retell", "livekit_bridge", "others"}
 

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -78,6 +78,18 @@ class TestTaxonomy:
         assert get_spec("pipecat").connector_key == "web_livekit_bridge"
         assert get_spec("pipecat").transport is Transport.WEBRTC_BRIDGE
 
+    @pytest.mark.unit
+    def test_livekit_bridge_credentials_path_predicate(self):
+        # voice_small.py routes any provider whose connector IS the LiveKit
+        # bridge through the bridge-credentials path. This pins exactly which
+        # providers that is (Phase 1 wires Pipecat onto it).
+        bridge_path = {
+            s.key
+            for s in PROVIDER_REGISTRY.values()
+            if s.connector_key == "web_livekit_bridge"
+        }
+        assert bridge_path == {"livekit_bridge", "pipecat"}
+
 
 class TestDerivations:
     @pytest.mark.unit

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -197,12 +197,12 @@ class TestCallDirection:
         expected = {
             "vapi": ({IN, OUT}, {IN, OUT}),
             "retell": ({IN, OUT}, {IN, OUT}),     # outbound wired via RetellOutboundDialer
-            "livekit_bridge": ({IN, OUT}, {IN}),
+            "livekit_bridge": ({IN, OUT}, {IN, OUT}),  # bridge: outbound = speaking-order
             "others": ({IN, OUT}, {IN, OUT}),
             "elevenlabs": ({IN, OUT}, {IN, OUT}),  # outbound via ElevenLabsOutboundDialer
             "deepgram": ({IN, OUT}, {IN}),         # no native outbound (BYO-SIP only)
             "agora": ({IN, OUT}, set()),
-            "pipecat": ({IN, OUT}, {IN}),
+            "pipecat": ({IN, OUT}, {IN, OUT}),     # reuses bridge → outbound = speaking-order
             "bland": ({IN, OUT}, {OUT}),          # outbound-first; BlandOutboundDialer
             "twilio": (set(), set()),             # transport-only, direction n/a
             "futureagi": (set(), set()),          # internal chat

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -199,8 +199,8 @@ class TestCallDirection:
             "retell": ({IN, OUT}, {IN, OUT}),     # outbound wired via RetellOutboundDialer
             "livekit_bridge": ({IN, OUT}, {IN}),
             "others": ({IN, OUT}, {IN, OUT}),
-            "elevenlabs": ({IN, OUT}, {IN}),
-            "deepgram": ({IN, OUT}, {IN}),
+            "elevenlabs": ({IN, OUT}, {IN, OUT}),  # outbound via ElevenLabsOutboundDialer
+            "deepgram": ({IN, OUT}, {IN}),         # no native outbound (BYO-SIP only)
             "agora": ({IN, OUT}, set()),
             "pipecat": ({IN, OUT}, {IN}),
             "bland": ({IN, OUT}, {OUT}),          # outbound-first; BlandOutboundDialer

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -145,6 +145,19 @@ class TestDerivations:
             if spec.observability_key is not None:
                 assert spec.observability_key in valid, spec.key
 
+    @pytest.mark.unit
+    def test_observability_key_mapping_for_voice_obs_wiring(self):
+        # The agent-def observability wiring (views/agent_definition.py) maps the
+        # client provider string to its canonical ObservabilityProvider via
+        # these keys (TH-5642 step 1). livekit_bridge -> livekit is the crux.
+        assert get_spec("livekit_bridge").observability_key == "livekit"
+        assert get_spec("elevenlabs").observability_key == "eleven_labs"
+        assert get_spec("vapi").observability_key == "vapi"
+        assert get_spec("retell").observability_key == "retell"
+        # Providers without a push/API observability path are skipped (None).
+        assert get_spec("pipecat").observability_key is None
+        assert get_spec("deepgram").observability_key is None
+
 
 class TestBridgeRegistryParity:
     @pytest.mark.unit

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -74,6 +74,18 @@ class TestTaxonomy:
         assert get_spec("deepgram").status is Status.PLANNED
 
     @pytest.mark.unit
+    def test_agora_rides_sip_path_like_bland_no_rtc_sdk(self):
+        # Agora Conversational AI exposes agents over SIP/PSTN (Elastic SIP Trunk),
+        # so it is reachable via the provider-neutral SIP path with NO Agora RTC SDK
+        # — modeled like Bland/Twilio, not via a (SDK-gated) web_agora connector.
+        agora = get_spec("agora")
+        assert agora.transport is Transport.SIP
+        assert agora.connector_key is None  # no WebRTC bridge connector needed
+        assert agora.is_agent_platform
+        # Parity with the other SIP-reachable agent platform.
+        assert get_spec("bland").transport is Transport.SIP
+
+    @pytest.mark.unit
     def test_pipecat_reuses_livekit_bridge_connector(self):
         assert get_spec("pipecat").connector_key == "web_livekit_bridge"
         assert get_spec("pipecat").transport is Transport.WEBRTC_BRIDGE

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -9,14 +9,17 @@ import pytest
 
 from simulate.providers import (
     PROVIDER_REGISTRY,
+    Direction,
     Role,
     Status,
     Transport,
     agent_platform_keys,
     connector_key_for,
     get_spec,
+    implements_direction,
     is_agent_platform,
     provider_choices,
+    supports_direction,
 )
 
 # The bridge connector keys that exist TODAY (ee/voice/.../bridge/connector.py).
@@ -169,6 +172,68 @@ class TestDerivations:
         # Providers without a push/API observability path are skipped (None).
         assert get_spec("pipecat").observability_key is None
         assert get_spec("deepgram").observability_key is None
+
+
+class TestCallDirection:
+    @pytest.mark.unit
+    def test_direction_values_mirror_calltype(self):
+        # The registry mirrors semantics.CallType by value (it can't import the
+        # Django-bound enum). Pin the equality so they can't drift.
+        from simulate.semantics import CallType
+
+        assert Direction.INBOUND.value == CallType.INBOUND.value
+        assert Direction.OUTBOUND.value == CallType.OUTBOUND.value
+
+    @pytest.mark.unit
+    def test_implemented_is_subset_of_supported(self):
+        # You can never implement a direction the provider can't support.
+        for spec in PROVIDER_REGISTRY.values():
+            assert spec.implemented_directions <= spec.supported_directions, spec.key
+
+    @pytest.mark.unit
+    def test_per_provider_direction_capability_matches_audit(self):
+        IN, OUT = Direction.INBOUND, Direction.OUTBOUND
+        # (key, supported, implemented) — from the direction audit (TH-5642).
+        expected = {
+            "vapi": ({IN, OUT}, {IN, OUT}),       # only fully-wired outbound provider
+            "retell": ({IN, OUT}, {IN}),
+            "livekit_bridge": ({IN, OUT}, {IN}),
+            "others": ({IN, OUT}, {IN, OUT}),
+            "elevenlabs": ({IN, OUT}, {IN}),
+            "deepgram": ({IN, OUT}, {IN}),
+            "agora": ({IN, OUT}, set()),
+            "pipecat": ({IN, OUT}, {IN}),
+            "bland": ({IN, OUT}, set()),
+            "twilio": (set(), set()),             # transport-only, direction n/a
+            "futureagi": (set(), set()),          # internal chat
+        }
+        for key, (sup, impl) in expected.items():
+            spec = get_spec(key)
+            assert set(spec.supported_directions) == sup, f"{key} supported"
+            assert set(spec.implemented_directions) == impl, f"{key} implemented"
+
+    @pytest.mark.unit
+    def test_supports_and_implements_helpers(self):
+        # Retell supports outbound but has not wired it — the distinction that lets
+        # dispatch fail loudly instead of silently running inbound.
+        assert supports_direction("retell", Direction.OUTBOUND)
+        assert not implements_direction("retell", Direction.OUTBOUND)
+        assert implements_direction("retell", Direction.INBOUND)
+        # Vapi: both supported and implemented.
+        assert implements_direction("vapi", Direction.OUTBOUND)
+        # Unknown provider / transport-only.
+        assert not supports_direction("nonsense", Direction.INBOUND)
+        assert not supports_direction("twilio", Direction.INBOUND)
+
+    @pytest.mark.unit
+    def test_direction_filtered_selectors(self):
+        # Every GA agent platform supports both directions, so a direction filter on
+        # GA choices doesn't drop any — but it MUST exclude transport/internal rows.
+        out_keys = set(agent_platform_keys(direction=Direction.OUTBOUND))
+        assert {"vapi", "retell", "livekit_bridge", "others"} <= out_keys
+        assert "twilio" not in out_keys and "futureagi" not in out_keys
+        ga_out = dict(provider_choices(direction=Direction.OUTBOUND))
+        assert set(ga_out) == {"vapi", "retell", "livekit_bridge", "others"}
 
 
 class TestBridgeRegistryParity:

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -195,15 +195,15 @@ class TestCallDirection:
         IN, OUT = Direction.INBOUND, Direction.OUTBOUND
         # (key, supported, implemented) — from the direction audit (TH-5642).
         expected = {
-            "vapi": ({IN, OUT}, {IN, OUT}),       # only fully-wired outbound provider
-            "retell": ({IN, OUT}, {IN}),
+            "vapi": ({IN, OUT}, {IN, OUT}),
+            "retell": ({IN, OUT}, {IN, OUT}),     # outbound wired via RetellOutboundDialer
             "livekit_bridge": ({IN, OUT}, {IN}),
             "others": ({IN, OUT}, {IN, OUT}),
             "elevenlabs": ({IN, OUT}, {IN}),
             "deepgram": ({IN, OUT}, {IN}),
             "agora": ({IN, OUT}, set()),
             "pipecat": ({IN, OUT}, {IN}),
-            "bland": ({IN, OUT}, set()),
+            "bland": ({IN, OUT}, {OUT}),          # outbound-first; BlandOutboundDialer
             "twilio": (set(), set()),             # transport-only, direction n/a
             "futureagi": (set(), set()),          # internal chat
         }
@@ -214,13 +214,14 @@ class TestCallDirection:
 
     @pytest.mark.unit
     def test_supports_and_implements_helpers(self):
-        # Retell supports outbound but has not wired it — the distinction that lets
+        # Deepgram supports outbound but has not wired it — the distinction that lets
         # dispatch fail loudly instead of silently running inbound.
-        assert supports_direction("retell", Direction.OUTBOUND)
-        assert not implements_direction("retell", Direction.OUTBOUND)
-        assert implements_direction("retell", Direction.INBOUND)
-        # Vapi: both supported and implemented.
+        assert supports_direction("deepgram", Direction.OUTBOUND)
+        assert not implements_direction("deepgram", Direction.OUTBOUND)
+        assert implements_direction("deepgram", Direction.INBOUND)
+        # Vapi and Retell: outbound both supported and wired (dialer registry).
         assert implements_direction("vapi", Direction.OUTBOUND)
+        assert implements_direction("retell", Direction.OUTBOUND)
         # Unknown provider / transport-only.
         assert not supports_direction("nonsense", Direction.INBOUND)
         assert not supports_direction("twilio", Direction.INBOUND)

--- a/futureagi/simulate/tests/test_retell_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_retell_chat_agent_adapter.py
@@ -1,0 +1,212 @@
+"""Unit tests for RetellChatAgentAdapter (TH-5642 — chat agent-under-test).
+
+Exercises the Retell Chat API handling with a fake ``requests`` (no network),
+pinning the two protocol facts that are easy to get backwards:
+- the chat is created ONCE and ``chat_id`` reused (Retell holds state server-side);
+- each completion sends only the *newest* simulated-customer turn (no replay).
+"""
+
+import json
+
+import pytest
+
+from simulate.services import retell_chat_agent_adapter as mod
+from simulate.services.retell_chat_agent_adapter import (
+    RetellChatAgentAdapter,
+    RetellChatAgentError,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeRequests:
+    """Records POST/PATCH calls and replays queued responses by path."""
+
+    def __init__(self, responses):
+        # responses: dict[path_suffix -> list[_FakeResp]] (FIFO per path)
+        self._responses = {k: list(v) for k, v in responses.items()}
+        self.posts = []  # list[(url, json_payload)]
+        self.patches = []
+        self.RequestException = Exception
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.posts.append((url, json))
+        for suffix, queue in self._responses.items():
+            if url.endswith(suffix) and queue:
+                return queue.pop(0)
+        raise AssertionError(f"no fake response queued for POST {url}")
+
+    def patch(self, url, headers=None, timeout=None):
+        self.patches.append(url)
+        return _FakeResp({}, 200)
+
+
+def _adapter(monkeypatch, responses):
+    fake = _FakeRequests(responses)
+    monkeypatch.setattr(mod, "requests", fake)
+    adapter = RetellChatAgentAdapter(agent_id="agent_x", api_key="key_x")
+    return adapter, fake
+
+
+@pytest.mark.unit
+def test_requires_agent_id_and_api_key():
+    with pytest.raises(ValueError):
+        RetellChatAgentAdapter(agent_id="", api_key="k")
+    with pytest.raises(ValueError):
+        RetellChatAgentAdapter(agent_id="a", api_key="")
+
+
+@pytest.mark.unit
+def test_turn1_returns_begin_message_from_create_chat(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [
+                _FakeResp(
+                    {
+                        "chat_id": "Chat_1",
+                        "chat_status": "ongoing",
+                        "message_with_tool_calls": [
+                            {"role": "agent", "content": "Hello, how can I help?"}
+                        ],
+                    }
+                )
+            ],
+        },
+    )
+    # No user turn yet -> the agent speaks first (begin message).
+    result = adapter.generate_response([])
+    assert result["content"] == "Hello, how can I help?"
+    assert result["chat_ended"] is False
+    # create-chat called exactly once; no completion yet.
+    assert [u for u, _ in fake.posts] == ["https://api.retellai.com/create-chat"]
+
+
+@pytest.mark.unit
+def test_chat_created_once_and_only_latest_turn_sent(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [
+                _FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})
+            ],
+            "/create-chat-completion": [
+                _FakeResp({"messages": [{"role": "agent", "content": "Reply A"}]}),
+                _FakeResp({"messages": [{"role": "agent", "content": "Reply B"}]}),
+            ],
+        },
+    )
+
+    # First customer turn.
+    r1 = adapter.generate_response([{"role": "user", "content": "first"}])
+    # Second customer turn arrives; history now holds both + the agent's reply.
+    r2 = adapter.generate_response(
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "Reply A"},
+            {"role": "user", "content": "second"},
+        ]
+    )
+
+    assert r1["content"] == "Reply A"
+    assert r2["content"] == "Reply B"
+
+    # /create-chat hit exactly once (state is server-side).
+    create_calls = [u for u, _ in fake.posts if u.endswith("/create-chat")]
+    assert len(create_calls) == 1
+
+    # Each completion sent ONLY the newest turn, with the cached chat_id — no replay.
+    completion_payloads = [p for u, p in fake.posts if u.endswith("/create-chat-completion")]
+    assert completion_payloads == [
+        {"chat_id": "Chat_1", "content": "first"},
+        {"chat_id": "Chat_1", "content": "second"},
+    ]
+
+
+@pytest.mark.unit
+def test_chat_ended_detected_from_status(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})],
+            "/create-chat-completion": [
+                _FakeResp(
+                    {
+                        "chat_status": "ended",
+                        "messages": [{"role": "agent", "content": "Goodbye!"}],
+                    }
+                )
+            ],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "bye"}])
+    assert result["content"] == "Goodbye!"
+    assert result["chat_ended"] is True
+
+
+@pytest.mark.unit
+def test_only_agent_role_messages_are_returned(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})],
+            "/create-chat-completion": [
+                _FakeResp(
+                    {
+                        "messages": [
+                            {"role": "user", "content": "echoed user turn"},
+                            {"role": "agent", "content": "the answer"},
+                        ]
+                    }
+                )
+            ],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "q"}])
+    # The echoed user turn is dropped; only the agent text comes back.
+    assert result["content"] == "the answer"
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"error": "bad key"}, status_code=401)]},
+    )
+    with pytest.raises(RetellChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.unit
+def test_missing_chat_id_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"chat_status": "ongoing"})]},
+    )
+    with pytest.raises(RetellChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.unit
+def test_end_is_idempotent_and_best_effort(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {"/create-chat": [_FakeResp({"chat_id": "Chat_1", "message_with_tool_calls": []})]},
+    )
+    # No chat yet -> end() is a no-op (no PATCH).
+    adapter.end()
+    assert fake.patches == []
+    # After a turn, end() PATCHes the cached chat_id.
+    adapter.generate_response([])
+    adapter.end()
+    assert fake.patches == ["https://api.retellai.com/end-chat/Chat_1"]

--- a/futureagi/simulate/tests/test_server_side_chat_routing.py
+++ b/futureagi/simulate/tests/test_server_side_chat_routing.py
@@ -1,0 +1,95 @@
+"""DB test for the server-side chat routing gate (TH-5642).
+
+Proves `_server_side_chat_filter()` selects exactly the CallExecutions the platform
+should drive server-side — prompt sims + agent_definition TEXT sims on an external
+HOSTED chat provider (Retell) with an assistant_id — and excludes SDK-driven agents
+(LiveKit), missing assistant_id, and voice agents, so SDK-push is never double-driven.
+"""
+
+import pytest
+
+from model_hub.models.choices import StatusType
+from simulate.models import AgentDefinition, CallExecution, RunTest, Scenarios
+from simulate.models.test_execution import TestExecution
+
+TEXT = AgentDefinition.AgentTypeChoices.TEXT
+VOICE = AgentDefinition.AgentTypeChoices.VOICE
+
+
+def _mk_call(organization, workspace, *, source_type, provider, agent_type=TEXT,
+             assistant_id="agent_1", label=""):
+    ad = AgentDefinition.objects.create(
+        agent_name=f"AUT {label}",
+        agent_type=agent_type,
+        inbound=True,
+        description="routing test agent",
+        organization=organization,
+        workspace=workspace,
+        provider=provider,
+        assistant_id=assistant_id,
+        languages=["en"],
+    )
+    scenario = Scenarios.objects.create(
+        name=f"Scenario {label}",
+        description="routing test scenario",
+        source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        agent_definition=ad,
+        status=StatusType.COMPLETED.value,
+    )
+    rt = RunTest.objects.create(
+        name=f"Run {label}",
+        description="routing test run",
+        agent_definition=ad,
+        organization=organization,
+        workspace=workspace,
+        source_type=source_type,
+    )
+    te = TestExecution.objects.create(
+        run_test=rt,
+        status=TestExecution.ExecutionStatus.RUNNING,
+        total_scenarios=1,
+        total_calls=1,
+        agent_definition=ad,
+    )
+    return CallExecution.objects.create(
+        test_execution=te,
+        scenario=scenario,
+        status=CallExecution.CallStatus.REGISTERED,
+        simulation_call_type=CallExecution.SimulationCallType.TEXT,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_server_side_filter_selects_only_hosted_and_prompt(organization, workspace):
+    from simulate.services.chat_agent_adapter_factory import server_side_chat_filter
+
+    prompt = _mk_call(organization, workspace,
+                      source_type=RunTest.SourceTypes.PROMPT, provider="vapi", label="prompt")
+    retell_hosted = _mk_call(organization, workspace,
+                             source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+                             provider="retell", label="retell")
+    livekit_sdk = _mk_call(organization, workspace,
+                           source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+                           provider="livekit", label="livekit")
+    retell_no_id = _mk_call(organization, workspace,
+                            source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+                            provider="retell", assistant_id="", label="retell-no-id")
+    retell_voice = _mk_call(organization, workspace,
+                            source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+                            provider="retell", agent_type=VOICE, label="retell-voice")
+
+    selected = set(
+        CallExecution.objects.filter(server_side_chat_filter()).values_list("id", flat=True)
+    )
+
+    # Server-side: prompt sims + hosted Retell TEXT with an assistant_id.
+    assert prompt.id in selected
+    assert retell_hosted.id in selected
+    # SDK-push / not-hosted: excluded (never double-driven).
+    assert livekit_sdk.id not in selected
+    assert retell_no_id.id not in selected
+    assert retell_voice.id not in selected

--- a/futureagi/simulate/tests/test_snapshot_secret_masking.py
+++ b/futureagi/simulate/tests/test_snapshot_secret_masking.py
@@ -1,0 +1,63 @@
+"""A5b: provider secrets must never leave an API response in cleartext.
+
+`mask_snapshot_secrets` is the single masking choke point used by both the
+agent-version response serializer and the run_test serializer (which previously
+embedded the raw configuration_snapshot verbatim, leaking customer api_key /
+livekit_api_key / livekit_api_secret).
+"""
+
+import pytest
+
+from simulate.serializers.response.agent_version import mask_snapshot_secrets
+
+PLAINTEXT_SECRET = "supersecretvalue1234567890"
+
+
+class TestMaskSnapshotSecrets:
+    @pytest.mark.unit
+    def test_masks_all_three_secret_fields(self):
+        raw = {
+            "api_key": "sk-vapi-1234567890abcdef",
+            "livekit_api_key": "APIabcdef123456",
+            "livekit_api_secret": PLAINTEXT_SECRET,
+            "provider": "livekit",
+            "livekit_url": "wss://example.livekit.cloud",
+        }
+        masked = mask_snapshot_secrets(raw)
+
+        # Input dict is not mutated (callers reuse the snapshot).
+        assert raw["api_key"] == "sk-vapi-1234567890abcdef"
+        assert raw["livekit_api_secret"] == PLAINTEXT_SECRET
+
+        # No secret field is returned in cleartext.
+        assert masked["api_key"] != raw["api_key"]
+        assert masked["livekit_api_key"] != raw["livekit_api_key"]
+        assert masked["livekit_api_secret"] == "********"
+
+        # Non-secret fields are preserved unchanged.
+        assert masked["provider"] == "livekit"
+        assert masked["livekit_url"] == "wss://example.livekit.cloud"
+
+        # The raw secret value appears nowhere in the masked output.
+        assert PLAINTEXT_SECRET not in masked.values()
+
+    @pytest.mark.unit
+    def test_livekit_api_key_is_masked(self):
+        # Regression for the specific gap: livekit_api_key used to pass through.
+        masked = mask_snapshot_secrets({"livekit_api_key": "APIverylongkey123"})
+        assert masked["livekit_api_key"] != "APIverylongkey123"
+        assert "verylongkey" not in masked["livekit_api_key"]
+
+    @pytest.mark.unit
+    def test_non_dict_returned_unchanged(self):
+        assert mask_snapshot_secrets(None) is None
+        assert mask_snapshot_secrets("not-a-dict") == "not-a-dict"
+
+    @pytest.mark.unit
+    def test_empty_or_missing_secrets_are_not_masked_to_noise(self):
+        masked = mask_snapshot_secrets(
+            {"api_key": "", "livekit_api_key": None, "provider": "vapi"}
+        )
+        assert masked["api_key"] == ""
+        assert masked["livekit_api_key"] is None
+        assert masked["provider"] == "vapi"

--- a/futureagi/simulate/tests/test_temporal_activities.py
+++ b/futureagi/simulate/tests/test_temporal_activities.py
@@ -905,6 +905,46 @@ class TestFetchAndPersistCallResultActivity:
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
+    async def test_real_extract_costs_from_livekit_usage_persists_real_cost(
+        self, call_execution
+    ):
+        """Real DB CallExecution + REAL extract_costs (real litellm pricing) →
+        non-zero cost. Proves the $0-billing fix end-to-end on the backend,
+        given the usage dict the (SDK-verified) agent worker emits. No mock of
+        the cost path."""
+        from asgiref.sync import sync_to_async
+
+        from ee.voice.services.livekit.service import LivekitService
+
+        call_execution.provider_call_data = {
+            "livekit": {
+                "usage": {
+                    "stt": {"duration": 120.0},
+                    "llm": {"prompt_tokens": 2000, "completion_tokens": 1000},
+                    "tts": {"characters": 5000},
+                    "models": {
+                        "stt": "nova-3",
+                        "llm": "gpt-4o-mini",
+                        "tts": "sonic-2",
+                    },
+                }
+            }
+        }
+        call_execution.duration_seconds = 120.0
+        await sync_to_async(call_execution.save)()
+
+        costs = await LivekitService().extract_costs(str(call_execution.id))
+
+        # Real, non-zero cost components (the $0 bug would make these all 0).
+        assert costs.total > 0
+        assert costs.llm > 0  # real litellm gpt-4o-mini registry pricing
+        assert costs.stt > 0
+        assert costs.tts > 0
+        # Cents conversion, exactly as voice_large persists it.
+        assert int(round(costs.total * 100)) > 0
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
     async def test_fetch_and_persist_call_result_updates_call_execution(
         self, call_execution
     ):

--- a/futureagi/simulate/tests/test_vapi_chat_agent_adapter.py
+++ b/futureagi/simulate/tests/test_vapi_chat_agent_adapter.py
@@ -1,0 +1,115 @@
+"""Unit tests for VapiChatAgentAdapter (TH-5642).
+
+Drives the Vapi chat REST shapes with a fake ``requests`` (no network): create the
+session once, then POST the latest user turn and read the assistant output. Mirrors
+the proven VapiService request shapes.
+"""
+
+import json
+
+import pytest
+
+from simulate.services import vapi_chat_agent_adapter as mod
+from simulate.services.chat_agent_adapter_factory import EXTERNAL_HOSTED_CHAT_ADAPTERS
+from simulate.services.vapi_chat_agent_adapter import (
+    VapiChatAgentAdapter,
+    VapiChatAgentError,
+)
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequests:
+    def __init__(self, responses):
+        self._responses = {k: list(v) for k, v in responses.items()}
+        self.posts = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.posts.append((url, json))
+        for suffix, queue in self._responses.items():
+            if url.endswith(suffix) and queue:
+                return queue.pop(0)
+        raise AssertionError(f"no fake response for POST {url}")
+
+
+def _adapter(monkeypatch, responses):
+    fake = _FakeRequests(responses)
+    monkeypatch.setattr(mod, "requests", fake)
+    return VapiChatAgentAdapter(agent_id="assistant_x", api_key="k"), fake
+
+
+@pytest.mark.unit
+def test_registered_in_factory():
+    assert EXTERNAL_HOSTED_CHAT_ADAPTERS["vapi"] is VapiChatAgentAdapter
+
+
+@pytest.mark.unit
+def test_requires_agent_id_and_key():
+    with pytest.raises(ValueError):
+        VapiChatAgentAdapter(agent_id="", api_key="k")
+    with pytest.raises(ValueError):
+        VapiChatAgentAdapter(agent_id="a", api_key="")
+
+
+@pytest.mark.unit
+def test_session_created_once_and_only_latest_turn_sent(monkeypatch):
+    adapter, fake = _adapter(
+        monkeypatch,
+        {
+            "/session": [_FakeResp({"id": "sess_1"})],
+            "/chat/": [
+                _FakeResp({"output": [{"role": "assistant", "content": "Reply A"}]}),
+                _FakeResp({"output": [{"role": "assistant", "content": "Reply B"}]}),
+            ],
+        },
+    )
+    r1 = adapter.generate_response([{"role": "user", "content": "first"}])
+    r2 = adapter.generate_response([
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "Reply A"},
+        {"role": "user", "content": "second"},
+    ])
+    assert r1["content"] == "Reply A"
+    assert r2["content"] == "Reply B"
+    # /session hit exactly once.
+    assert len([u for u, _ in fake.posts if u.endswith("/session")]) == 1
+    # Each /chat/ sent only the newest turn with the cached sessionId.
+    chat_payloads = [p for u, p in fake.posts if u.endswith("/chat/")]
+    assert chat_payloads == [
+        {"input": [{"role": "user", "content": "first"}], "sessionId": "sess_1"},
+        {"input": [{"role": "user", "content": "second"}], "sessionId": "sess_1"},
+    ]
+
+
+@pytest.mark.unit
+def test_endcall_tool_marks_chat_ended(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        {
+            "/session": [_FakeResp({"id": "sess_1"})],
+            "/chat/": [_FakeResp({"output": [
+                {"role": "assistant", "content": "Bye",
+                 "tool_calls": [{"function": {"name": "endCall"}}]},
+            ]})],
+        },
+    )
+    result = adapter.generate_response([{"role": "user", "content": "bye"}])
+    assert result["content"] == "Bye"
+    assert result["chat_ended"] is True
+
+
+@pytest.mark.unit
+def test_http_error_raises(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch, {"/session": [_FakeResp({"error": "bad"}, status_code=401)]}
+    )
+    with pytest.raises(VapiChatAgentError):
+        adapter.generate_response([{"role": "user", "content": "hi"}])

--- a/futureagi/simulate/tests/test_voice_provider_resolver.py
+++ b/futureagi/simulate/tests/test_voice_provider_resolver.py
@@ -1,0 +1,122 @@
+"""Unit tests for the canonical system-voice-provider resolver.
+
+The resolver is the single source of truth for selecting the simulator-side
+voice provider. These tests pin its precedence rules, its enum return
+contract, and its normalisation/validation behaviour.
+"""
+
+import pytest
+
+from simulate.utils.voice_provider import (
+    DEFAULT_SYSTEM_VOICE_PROVIDER,
+    SYSTEM_VOICE_PROVIDER_ENV_VAR,
+    resolve_system_voice_provider,
+)
+from tracer.models.observability_provider import ProviderChoices
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Ensure no ambient SYSTEM_VOICE_PROVIDER leaks across cases."""
+    monkeypatch.delenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, raising=False)
+
+
+class TestDefault:
+    @pytest.mark.unit
+    def test_default_is_livekit(self):
+        assert DEFAULT_SYSTEM_VOICE_PROVIDER is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_no_override_no_env_returns_livekit(self):
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_always_returns_enum(self):
+        assert isinstance(resolve_system_voice_provider(), ProviderChoices)
+        assert isinstance(resolve_system_voice_provider("vapi"), ProviderChoices)
+
+
+class TestEnvPrecedence:
+    @pytest.mark.unit
+    def test_env_pins_provider(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider() is ProviderChoices.VAPI
+
+    @pytest.mark.unit
+    def test_env_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "LiveKit")
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_empty_env_falls_through_to_default(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "")
+        assert resolve_system_voice_provider() is ProviderChoices.LIVEKIT
+
+
+class TestOverridePrecedence:
+    @pytest.mark.unit
+    def test_override_beats_env(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider("livekit") is ProviderChoices.LIVEKIT
+
+    @pytest.mark.unit
+    def test_override_string(self):
+        assert resolve_system_voice_provider("vapi") is ProviderChoices.VAPI
+
+    @pytest.mark.unit
+    def test_override_enum_passthrough(self):
+        assert (
+            resolve_system_voice_provider(ProviderChoices.VAPI)
+            is ProviderChoices.VAPI
+        )
+
+    @pytest.mark.unit
+    def test_none_and_empty_override_fall_through(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "vapi")
+        assert resolve_system_voice_provider(None) is ProviderChoices.VAPI
+        assert resolve_system_voice_provider("") is ProviderChoices.VAPI
+
+
+class TestValidation:
+    @pytest.mark.unit
+    def test_unknown_override_raises(self):
+        with pytest.raises(ValueError, match="Unknown system voice provider"):
+            resolve_system_voice_provider("klingon")
+
+    @pytest.mark.unit
+    def test_unknown_env_raises(self, monkeypatch):
+        monkeypatch.setenv(SYSTEM_VOICE_PROVIDER_ENV_VAR, "nope")
+        with pytest.raises(ValueError, match="Unknown system voice provider"):
+            resolve_system_voice_provider()
+
+
+class TestEngineWiring:
+    """Pin P0's end-to-end intent at the VoiceServiceManager wiring level.
+
+    These assert the two roles the resolver feeds (the ``voice_large.py``
+    fetch-engine branch): the *system* path (resolver default) must build a
+    LiveKit engine, while the *client-fetch* path (customer api_key, no
+    explicit provider) must keep building a Vapi engine. This is the only
+    genuine behaviour flip in P0; the resolver unit tests alone don't cover it.
+    """
+
+    def _vsm(self):
+        return pytest.importorskip(
+            "ee.voice.services.voice_service_manager"
+        ).VoiceServiceManager
+
+    @pytest.mark.unit
+    def test_system_path_resolver_default_builds_livekit_engine(self):
+        VoiceServiceManager = self._vsm()
+        vsm = VoiceServiceManager(
+            system_voice_provider=resolve_system_voice_provider()
+        )
+        assert type(vsm.engine).__name__ == "LivekitService"
+
+    @pytest.mark.unit
+    def test_client_fetch_path_defaults_to_vapi_engine(self):
+        VoiceServiceManager = self._vsm()
+        # Customer-account fetch: api_key, no explicit provider. Must stay Vapi
+        # (the engine exposes Vapi-only SDK methods the fetch path calls).
+        vsm = VoiceServiceManager(api_key="customer-key")
+        assert type(vsm.engine).__name__ == "VapiService"

--- a/futureagi/simulate/utils/voice_provider.py
+++ b/futureagi/simulate/utils/voice_provider.py
@@ -1,0 +1,102 @@
+"""Single source of truth for selecting the **system** voice provider.
+
+There are two distinct provider notions in the simulation stack, and they must
+never be conflated:
+
+* **System provider** — the infrastructure FutureAGI runs the *simulator*
+  persona on (LiveKit or Vapi). This module resolves it. It is the lever for
+  the Vapi→LiveKit migration: LiveKit is the default; Vapi stays registered and
+  pluggable behind it.
+* **Client provider** — the customer's *own* agent account
+  (``AgentDefinition.provider``). It reflects whatever the user configured and
+  is resolved separately; do **not** route it through this module.
+
+Every code path that needs to know which engine the ``VoiceServiceManager``
+should run MUST call :func:`resolve_system_voice_provider`. Do not read
+``SYSTEM_VOICE_PROVIDER`` directly and do not hard-code a provider — doing so
+reintroduces the string/enum drift this module exists to remove.
+
+Resolution precedence (highest first):
+
+1. an explicit ``override`` (a per-test / per-project pin),
+2. the ``SYSTEM_VOICE_PROVIDER`` environment variable,
+3. :data:`DEFAULT_SYSTEM_VOICE_PROVIDER` (LiveKit).
+
+The function always returns a :class:`ProviderChoices` enum, normalising any
+string input, so callers can rely on a single comparable type.
+"""
+
+from __future__ import annotations
+
+import os
+
+from tracer.models.observability_provider import ProviderChoices
+
+__all__ = [
+    "DEFAULT_SYSTEM_VOICE_PROVIDER",
+    "SYSTEM_VOICE_PROVIDER_ENV_VAR",
+    "resolve_system_voice_provider",
+]
+
+#: The simulator runs on LiveKit unless explicitly overridden. This is the
+#: migration default — Vapi remains registered in ``ENGINE_REGISTRY`` and
+#: selectable via an override or the environment variable.
+DEFAULT_SYSTEM_VOICE_PROVIDER: ProviderChoices = ProviderChoices.LIVEKIT
+
+#: Environment variable that pins the system provider when no explicit override
+#: is supplied. Accepts any ``ProviderChoices`` value (e.g. ``"vapi"``).
+SYSTEM_VOICE_PROVIDER_ENV_VAR: str = "SYSTEM_VOICE_PROVIDER"
+
+
+def _coerce_provider(value: ProviderChoices | str) -> ProviderChoices:
+    """Coerce a provider value to a :class:`ProviderChoices` enum.
+
+    Args:
+        value: an existing enum member or a provider string (case-insensitive).
+
+    Returns:
+        The matching :class:`ProviderChoices` member.
+
+    Raises:
+        ValueError: if ``value`` does not name a recognised provider.
+    """
+    if isinstance(value, ProviderChoices):
+        return value
+    try:
+        return ProviderChoices(str(value).strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(choice.value for choice in ProviderChoices)
+        raise ValueError(
+            f"Unknown system voice provider {value!r}; expected one of: {valid}."
+        ) from exc
+
+
+def resolve_system_voice_provider(
+    override: ProviderChoices | str | None = None,
+) -> ProviderChoices:
+    """Resolve the system (simulator-side) voice provider.
+
+    See the module docstring for the precedence rules. Always returns a
+    :class:`ProviderChoices` enum so callers never have to defend against a
+    raw string vs. enum.
+
+    Args:
+        override: an explicit per-call provider pin. Takes priority over the
+            environment variable and the default. ``None`` or an empty string
+            falls through to the environment, then the default.
+
+    Returns:
+        The resolved :class:`ProviderChoices` enum.
+
+    Raises:
+        ValueError: if ``override`` or the ``SYSTEM_VOICE_PROVIDER`` environment
+            variable names an unknown provider.
+    """
+    if override is not None and override != "":
+        return _coerce_provider(override)
+
+    env_value = os.getenv(SYSTEM_VOICE_PROVIDER_ENV_VAR)
+    if env_value:
+        return _coerce_provider(env_value)
+
+    return DEFAULT_SYSTEM_VOICE_PROVIDER

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -258,17 +258,19 @@ class CreateAgentDefinitionView(APIView):
             replay_session_id = validated.get("replay_session_id")
             observability_provider = None
 
+            _api_fetch_providers = [
+                ProviderChoices.VAPI,
+                ProviderChoices.RETELL,
+                ProviderChoices.OTHERS,
+            ]
             if (
                 enable_observability
                 and assistant_id != ""
                 and api_key != ""
-                and provider
-                in [
-                    ProviderChoices.VAPI,
-                    ProviderChoices.RETELL,
-                    ProviderChoices.OTHERS,
-                ]
+                and provider in _api_fetch_providers
             ):
+                # API-fetch observability (Vapi/Retell pull logs via their API):
+                # needs creds to fetch.
                 observability_provider = create_observability_provider(
                     enabled=True,
                     user_id=user_id,
@@ -277,6 +279,27 @@ class CreateAgentDefinitionView(APIView):
                     project_name=project_name,
                     provider=provider,
                 )
+            elif enable_observability and provider not in _api_fetch_providers:
+                # Trace-AI / push-based voice observability (e.g. LiveKit,
+                # ElevenLabs): the customer's agent is instrumented with the
+                # traceai-* SDK and PUSHES spans, so we only need to wire the
+                # agent-def -> ObservabilityProvider -> Project link (no fetch
+                # creds required). The ProviderSpec registry maps the client
+                # provider string (e.g. "livekit_bridge") to its canonical
+                # observability provider ("livekit") (TH-5642).
+                from simulate.providers import get_spec
+
+                _spec = get_spec(provider)
+                _obs_key = _spec.observability_key if _spec else None
+                if _obs_key:
+                    observability_provider = create_observability_provider(
+                        enabled=True,
+                        user_id=user_id,
+                        organization=organization,
+                        workspace=workspace,
+                        project_name=project_name,
+                        provider=_obs_key,
+                    )
 
             # Create agent definition — livekit_* fields are NOT model
             # columns, they're routed to ProviderCredentials below.

--- a/futureagi/simulate/views/agent_prompt_optimiser.py
+++ b/futureagi/simulate/views/agent_prompt_optimiser.py
@@ -427,6 +427,64 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
             logger.exception(f"Error retrieving trial prompt: {str(e)}")
             return self._gm.bad_request(get_error_message("FAILED_TO_FETCH_DATA"))
 
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path=r"trial/(?P<trial_id>[^/.]+)/apply",
+    )
+    def apply_trial(self, request, trial_id=None, *args, **kwargs):
+        """Apply an optimised trial as a NEW PromptVersion (TH-5642).
+
+        "Directly apply the fix" = create a new, non-destructive version carrying
+        the trial's optimised prompt; the POST is the user's confirmation, so the
+        new version goes live as the template's default. The baseline is untouched.
+
+        URL: POST /agent-prompt-optimiser/{id}/trial/{trial_id}/apply/
+        Body (optional): {"make_default": bool}  (default true)
+        """
+        try:
+            instance = self.get_object()
+            trial = instance.trials.get(id=trial_id)
+
+            if trial.is_baseline:
+                return self._gm.bad_request("Cannot apply the baseline trial.")
+            if not (trial.prompt or "").strip():
+                return self._gm.bad_request("Trial has no prompt to apply.")
+
+            base_version = getattr(
+                getattr(getattr(instance, "test_execution", None), "run_test", None),
+                "prompt_version", None,
+            )
+            if base_version is None:
+                return self._gm.bad_request(
+                    "This optimiser run is not linked to a prompt version to apply to."
+                )
+
+            from simulate.services.optimizer_apply import (
+                apply_optimized_prompt_as_new_version,
+            )
+
+            make_default = bool(request.data.get("make_default", True))
+            new_version = apply_optimized_prompt_as_new_version(
+                base_version, trial.prompt, make_default=make_default
+            )
+
+            return self._gm.success_response(
+                {
+                    "applied": True,
+                    "new_prompt_version_id": str(new_version.id),
+                    "template_version": new_version.template_version,
+                    "original_template_id": str(new_version.original_template_id),
+                    "is_default": new_version.is_default,
+                    "source_trial_id": str(trial.id),
+                }
+            )
+        except PromptTrial.DoesNotExist:
+            return self._gm.bad_request(get_error_message("PROMPT_TRIAL_NOT_FOUND"))
+        except Exception as e:
+            logger.exception(f"Error applying trial prompt: {str(e)}")
+            return self._gm.bad_request(get_error_message("FAILED_TO_FETCH_DATA"))
+
     @swagger_auto_schema(
         responses={
             200: AgentPromptOptimiserTrialEvaluationsResponseSerializer,

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -3266,23 +3266,30 @@ class CallExecutionDetailView(APIView):
             # collapsed raw_log tree. `include_call_logs=False` skips the
             # blocking GET against `artifact.logUrl`; CallExecutionLogsView
             # handles that asynchronously via the ingest task.
+            # Flatten the provider payload through its own engine so this
+            # shared view stays provider-agnostic (no direct import of a
+            # specific provider's flattener). Vapi emits flat OTEL keys;
+            # other engines fall back to a raw_log tree via the blueprint
+            # default.
             pcd = call_execution.provider_call_data or {}
-            vapi_data = pcd.get("vapi") if isinstance(pcd.get("vapi"), dict) else None
-            if vapi_data:
-                from tracer.utils.vapi import _extract_eval_attributes
+            provider = next((p for p in pcd if isinstance(pcd[p], dict)), None)
+            if provider:
+                from ee.voice.services.voice_service_manager import (
+                    VoiceServiceManager,
+                )
+                from tracer.models.observability_provider import ProviderChoices
 
-                response_data["attributes"] = _extract_eval_attributes(
-                    vapi_data, include_call_logs=False
-                )
-            else:
-                # Fallback for other providers (retell etc.): ship the raw
-                # payload under `raw_log` so the Attributes tab at least
-                # renders the full object tree.
-                provider_data = next(
-                    (v for v in pcd.values() if isinstance(v, dict)), None
-                )
-                if provider_data:
-                    response_data["attributes"] = {"raw_log": provider_data}
+                try:
+                    engine = VoiceServiceManager(
+                        system_voice_provider=ProviderChoices(provider)
+                    ).engine
+                    response_data["attributes"] = engine.extract_attributes(
+                        pcd[provider], include_call_logs=False
+                    )
+                except ValueError:
+                    # Provider string not in the engine registry (e.g. retell)
+                    # — ship the raw payload so the tab still renders.
+                    response_data["attributes"] = {"raw_log": pcd[provider]}
 
             return Response(response_data, status=status.HTTP_200_OK)
 
@@ -3497,6 +3504,12 @@ class CallExecutionLogsView(APIView):
             pcd = call_execution.provider_call_data or {}
             vapi = pcd.get("vapi") or {}
             provider_log_url = (vapi.get("artifact") or {}).get("logUrl")
+            # LiveKit has no artifact log file — iter_call_logs reads
+            # transcripts from the DB keyed by call_execution id, so the
+            # "log url" for LiveKit is the id itself. Without this the Logs tab
+            # never triggers ingestion for LiveKit calls.
+            if not provider_log_url and "livekit" in pcd:
+                provider_log_url = str(call_execution.id)
             log_url = call_execution.customer_log_url or provider_log_url
             has_ingestion_summary = bool(call_execution.customer_logs_summary)
             should_start_ingestion = (
@@ -6010,9 +6023,13 @@ def _create_rerun_call_execution(call_execution):
     }
 
     # phone_number_id is only used by VAPI; LiveKit's prepare_call
-    # ignores CreateCallExecution.phone_number_id entirely.
-    system_provider = os.getenv("SYSTEM_VOICE_PROVIDER", "livekit")
-    if system_provider == "livekit":
+    # ignores CreateCallExecution.phone_number_id entirely. The system
+    # provider comes from the single source of truth (defaults to LiveKit).
+    from simulate.utils.voice_provider import resolve_system_voice_provider
+    from tracer.models.observability_provider import ProviderChoices
+
+    system_provider = resolve_system_voice_provider()
+    if system_provider == ProviderChoices.LIVEKIT:
         phone_number_id = ""
     elif phone_number and phone_number.startswith("+91"):
         phone_number_id = VAPI_INDIAN_PHONE_NUMBER_ID or os.getenv(

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -590,6 +590,13 @@ LIVEKIT_API_SECRET = os.getenv("LIVEKIT_API_SECRET", "")
 # agent-definition API or globally via this env var.
 DEFAULT_LIVEKIT_MAX_CONCURRENCY = int(os.getenv("DEFAULT_LIVEKIT_MAX_CONCURRENCY", "2"))
 
+# Post-call summary generation for providers that don't supply one (LiveKit).
+# Off by default so it never adds LLM cost until explicitly enabled.
+LIVEKIT_CALL_SUMMARY_ENABLED = (
+    os.getenv("LIVEKIT_CALL_SUMMARY_ENABLED", "false").lower() == "true"
+)
+LIVEKIT_CALL_SUMMARY_MODEL = os.getenv("LIVEKIT_CALL_SUMMARY_MODEL", "gpt-4o-mini")
+
 # Third-party provider URLs for WebRTC bridge connectors
 VAPI_API_URL = os.getenv("VAPI_API_URL", "https://api.vapi.ai/call")
 RETELL_API_URL = os.getenv(

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -82,6 +82,13 @@ class ObservabilityService:
             return ObservabilityService._fetch_eleven_labs_logs(
                 provider, start_time, end_time
             )
+        elif provider.provider == ProviderChoices.LIVEKIT:
+            # LiveKit observability is PUSH-based: the customer's agent is
+            # instrumented with the traceai-livekit SDK and pushes spans
+            # directly to the project, so there is nothing to PULL here. Skip
+            # gracefully instead of raising (which would log a fetch failure
+            # every poll cycle for a LiveKit agent definition). (TH-5642)
+            return []
         else:
             raise NotImplementedError(f"Provider {provider.provider} not implemented.")
 

--- a/futureagi/tracer/tests/test_observability_livekit_skip.py
+++ b/futureagi/tracer/tests/test_observability_livekit_skip.py
@@ -1,0 +1,28 @@
+"""Voice observability fetcher must skip push-based providers (TH-5642 step 1).
+
+LiveKit agents are instrumented with traceai-livekit and PUSH spans, so the
+log-fetcher has nothing to pull and must skip gracefully (return []) rather than
+raising NotImplementedError every poll cycle.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tracer.models.observability_provider import ProviderChoices
+from tracer.services.observability_providers import ObservabilityService
+
+
+@pytest.mark.unit
+def test_get_call_logs_skips_livekit_push_based():
+    provider = SimpleNamespace(provider=ProviderChoices.LIVEKIT)
+    assert ObservabilityService.get_call_logs(provider) == []
+
+
+@pytest.mark.unit
+def test_get_call_logs_still_raises_for_unimplemented_provider():
+    # A provider with no fetch path and not marked push-based still raises, so we
+    # notice genuinely-unwired providers.
+    provider = SimpleNamespace(provider="agora")
+    with pytest.raises(NotImplementedError):
+        ObservabilityService.get_call_logs(provider)


### PR DESCRIPTION
Stack **1/5** · base `dev`. The multi-provider foundation (TH-5642 Phase 0–1): a single ProviderSpec SSOT registry, hosted chat-agent adapters (Retell, ElevenLabs, Vapi), per-provider outbound dialers (Retell, Bland, ElevenLabs, Twilio), LiveKit/Pipecat bridge transports, direction-aware speaking order, and the canonical system-voice-provider resolver. 24 commits.

---
**Stacked PR series (1→5).** Merge bottom-up: this PR's base is the previous stack branch; after it merges, retarget the next PR's base to `dev`. PRs 1–4 are conflict-free (no internal dev-merges); PR 5 carries dev-merge noise by design (the branch merged `dev` 4×) — review it via its own ~37 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)