### PR TITLE
Sim observability: traces, eval attach, alerting + mock tool returns (stack 2/5)

### DIFF
--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
@@ -1382,6 +1382,10 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(chunk.model, dict(chunk.usage)),
             "response_time": end_time - start_time,
+            # Expose structured tool calls (additive) so callers like the simulation
+            # mock-tool loop can intercept them instead of parsing the appended
+            # tool_calls_str out of the content (TH-5642).
+            "tool_calls": tool_calls or [],
         }
 
         # Note: Thinking content is now streamed during the loop above, not appended here
@@ -1488,6 +1492,8 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(response.model, dict(response.usage)),
             "response_time": completion_time,  # Assuming a static time or calculated elsewhere
+            # Structured tool calls (additive) for the simulation mock-tool loop.
+            "tool_calls": [],
         }
 
         if self.tools and response.choices[0].message.tool_calls:
@@ -1503,6 +1509,7 @@ class RunPrompt:
                 }
                 for tool_call in response.choices[0].message.tool_calls
             ]
+            metadata["tool_calls"] = tool_calls_list
 
             # Convert to JSON string
             tool_calls_str = json.dumps(tool_calls_list)
@@ -3076,6 +3083,10 @@ class RunPrompt:
             },
             "cost": calculate_total_cost(chunk.model, dict(chunk.usage)),
             "response_time": end_time - start_time,
+            # Expose structured tool calls (additive) so callers like the simulation
+            # mock-tool loop can intercept them instead of parsing the appended
+            # tool_calls_str out of the content (TH-5642).
+            "tool_calls": tool_calls or [],
         }
 
         # Note: Thinking content is now streamed during the loop above, not appended here

--- a/futureagi/simulate/services/mock_tools.py
+++ b/futureagi/simulate/services/mock_tools.py
@@ -1,0 +1,96 @@
+"""Mock scenario-aligned tool returns for prompt-based simulation (TH-5642).
+
+Competitors (Cekura's headline auto-setup) let a scenario inject deterministic tool
+return values so the agent-under-test's tool-call paths are exercised without a live
+backend. The prompt-based agent (PromptBasedAgentAdapter) runs the LLM itself, so we
+can intercept its tool calls and feed back configured mocks instead of executing.
+
+This module is the pure core: a resolver (tool name + args -> mock result) and a
+tool loop that drives an injected LLM-call function. The integration (the adapter
+provides a real LLM call that surfaces tool_calls) sits on top — so the loop logic is
+fully unit-testable without an LLM.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+# A mock config maps a tool name to either a fixed result, or an args-keyed dict of
+# results: {"get_weather": "Sunny, 22C"} or {"get_weather": {"London": "Rainy"}}.
+MockToolReturns = dict[str, Any]
+
+_DEFAULT_RESULT = "ok"
+
+
+def resolve_mock_tool_return(
+    mock_returns: MockToolReturns | None, tool_name: str, arguments: Any
+) -> str:
+    """Resolve the mock result for a tool call. Falls back to a generic result so a
+    tool with no configured mock still completes the path deterministically."""
+    if not mock_returns or tool_name not in mock_returns:
+        return _DEFAULT_RESULT
+    spec = mock_returns[tool_name]
+    if isinstance(spec, dict):
+        # Args-keyed: match on a stringified arg value (first match) or "default".
+        args = arguments
+        if isinstance(arguments, str):
+            try:
+                args = json.loads(arguments)
+            except (ValueError, TypeError):
+                args = {}
+        if isinstance(args, dict):
+            for v in args.values():
+                if str(v) in spec:
+                    return _as_text(spec[str(v)])
+        if "default" in spec:
+            return _as_text(spec["default"])
+        return _DEFAULT_RESULT
+    return _as_text(spec)
+
+
+def _as_text(value: Any) -> str:
+    return value if isinstance(value, str) else json.dumps(value)
+
+
+def run_mock_tool_loop(
+    llm_call: Callable[[list[dict[str, Any]]], tuple[str, list[dict[str, Any]]]],
+    messages: list[dict[str, Any]],
+    mock_returns: MockToolReturns | None,
+    *,
+    max_iters: int = 5,
+) -> tuple[str, int]:
+    """Drive an agent's tool calls with mock returns until it produces final content.
+
+    ``llm_call(messages) -> (content, tool_calls)`` where tool_calls is a list of
+    ``{"id","function":{"name","arguments"}}`` (or empty). On each tool round we
+    append the assistant tool-call message + a ``tool`` result message per call
+    (resolved from ``mock_returns``) and re-call, up to ``max_iters``.
+
+    Returns ``(final_content, tool_rounds)``.
+    """
+    convo = list(messages)
+    rounds = 0
+    content = ""
+    for _ in range(max_iters):
+        content, tool_calls = llm_call(convo)
+        if not tool_calls:
+            return content, rounds
+        rounds += 1
+        convo = convo + [{"role": "assistant", "tool_calls": tool_calls}]
+        for tc in tool_calls:
+            fn = tc.get("function") or {}
+            result = resolve_mock_tool_return(
+                mock_returns, fn.get("name") or "", fn.get("arguments")
+            )
+            convo = convo + [
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.get("id") or "",
+                    "name": fn.get("name") or "",
+                    "content": result,
+                }
+            ]
+    # Hit the cap with tools still pending — return the last content.
+    return content, rounds

--- a/futureagi/simulate/services/prompt_based_agent_adapter.py
+++ b/futureagi/simulate/services/prompt_based_agent_adapter.py
@@ -417,6 +417,10 @@ def create_adapter_from_run_test(
         organization_id=organization_id,
         workspace_id=workspace_id,
         variable_values=variable_values,
+        # Scenario-aligned mock tool returns live in the run_test metadata (TH-5642).
+        mock_tool_returns=(getattr(run_test, "metadata", None) or {}).get(
+            "mock_tool_returns"
+        ),
     )
 
 
@@ -454,4 +458,8 @@ def create_adapter_from_scenario(
         organization_id=organization_id,
         workspace_id=workspace_id,
         variable_values=variable_values,
+        # Scenario-aligned mock tool returns live in the scenario metadata (TH-5642).
+        mock_tool_returns=(getattr(scenario, "metadata", None) or {}).get(
+            "mock_tool_returns"
+        ),
     )

--- a/futureagi/simulate/services/prompt_based_agent_adapter.py
+++ b/futureagi/simulate/services/prompt_based_agent_adapter.py
@@ -33,6 +33,7 @@ class PromptBasedAgentAdapter:
         organization_id: UUID,
         workspace_id: Optional[UUID] = None,
         variable_values: Optional[dict[str, Any]] = None,
+        mock_tool_returns: Optional[dict[str, Any]] = None,
     ):
         """
         Initialize the adapter with a prompt version.
@@ -42,11 +43,19 @@ class PromptBasedAgentAdapter:
             organization_id: The organization ID for API key lookup
             workspace_id: Optional workspace ID for API key lookup
             variable_values: Optional dict of variable values to inject into the prompt
+            mock_tool_returns: Optional scenario-aligned mock tool returns (TH-5642);
+                when set, the agent's tool calls are answered with these mocks so the
+                tool-call paths are exercised deterministically.
         """
         self.prompt_version = prompt_version
         self.organization_id = organization_id
         self.workspace_id = workspace_id
         self.variable_values = variable_values or {}
+        # Mock tool returns may arrive explicitly, via variable_values, or (set in
+        # _load_config) from the prompt config snapshot.
+        self.mock_tool_returns = (
+            mock_tool_returns or self.variable_values.get("mock_tool_returns") or {}
+        )
         self._load_config()
 
     def _load_config(self) -> None:
@@ -203,6 +212,29 @@ class PromptBasedAgentAdapter:
 
         return messages
 
+    def _call_llm(self, messages: list[dict[str, Any]]):
+        """One LLM completion via RunPrompt; returns ``(content, value_info)``.
+
+        ``value_info["metadata"]["tool_calls"]`` carries structured tool calls when
+        the agent invokes a tool (TH-5642), letting the mock-tool loop intercept.
+        """
+        run_prompt = RunPrompt(
+            model=self.model,
+            messages=messages,
+            organization_id=str(self.organization_id),
+            output_format=None,
+            temperature=self.temperature,
+            frequency_penalty=self.frequency_penalty,
+            presence_penalty=self.presence_penalty,
+            max_tokens=self.max_tokens,
+            top_p=self.top_p,
+            response_format=None,
+            tool_choice=self.tool_choice,
+            tools=self.tools,
+            workspace_id=str(self.workspace_id) if self.workspace_id else None,
+        )
+        return run_prompt.litellm_response()
+
     @retry(stop_max_attempt_number=3, wait_fixed=2000)
     def generate_response(
         self,
@@ -229,27 +261,30 @@ class PromptBasedAgentAdapter:
                 prompt_version_id=str(self.prompt_version.id),
             )
 
-            run_prompt = RunPrompt(
-                model=self.model,
-                messages=messages,
-                organization_id=str(self.organization_id),
-                output_format=None,
-                temperature=self.temperature,
-                frequency_penalty=self.frequency_penalty,
-                presence_penalty=self.presence_penalty,
-                max_tokens=self.max_tokens,
-                top_p=self.top_p,
-                response_format=None,
-                tool_choice=self.tool_choice,
-                tools=self.tools,
-                workspace_id=str(self.workspace_id) if self.workspace_id else None,
-            )
-
             start_time = time.perf_counter()
-            response_text, value_info = run_prompt.litellm_response()
-            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            last_info: dict[str, Any] = {}
 
-            content = response_text or ""
+            def _llm(msgs):
+                text, info = self._call_llm(msgs)
+                last_info.clear()
+                last_info.update(info or {})
+                tool_calls = (info.get("metadata") or {}).get("tool_calls") or []
+                return text, tool_calls
+
+            if self.mock_tool_returns:
+                # Drive the agent's tool calls with scenario-aligned mocks so the
+                # tool-call paths are exercised deterministically (TH-5642).
+                from simulate.services.mock_tools import run_mock_tool_loop
+
+                content, _rounds = run_mock_tool_loop(
+                    _llm, messages, self.mock_tool_returns
+                )
+            else:
+                response_text, last_info = self._call_llm(messages)
+                content = response_text or ""
+
+            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            value_info = last_info
             usage = value_info.get("metadata", {}).get("usage", {})
 
             result = {

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -20,11 +20,25 @@ hands each span to the tracer's existing ``create_single_otel_span`` write path.
 from __future__ import annotations
 
 import secrets
+import uuid
 from typing import Any
 
 import structlog
 
 logger = structlog.get_logger(__name__)
+
+# Fixed namespace so deterministic ids are stable across processes/retries.
+_SIM_TRACE_NS = uuid.UUID("9f1b6d2e-0c3a-4e7b-9a1d-5e2f7c8b4a10")
+
+
+def _det_trace_id(seed: str) -> str:
+    """Deterministic 128-bit (32 hex) trace id from a seed (e.g. the call id)."""
+    return uuid.uuid5(_SIM_TRACE_NS, f"trace:{seed}").hex
+
+
+def _det_span_id(seed: str, key: str) -> str:
+    """Deterministic 64-bit (16 hex) span id from a seed + a per-span key."""
+    return uuid.uuid5(_SIM_TRACE_NS, f"span:{seed}:{key}").hex[:16]
 
 # Attribute keys mirror tracer.utils.otel.SpanAttributes (FI/OpenInference). Kept
 # local so this module stays import-light + pure; test_sim_observability pins them
@@ -93,6 +107,7 @@ def build_sim_spans(
     model: str | None = None,
     metadata: dict[str, Any] | None = None,
     trace_id: str | None = None,
+    seed: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build the OTLP span dicts for one simulated conversation.
 
@@ -105,8 +120,10 @@ def build_sim_spans(
     Returns root AGENT span + one LLM span per assistant turn + TOOL spans, all
     sharing one trace_id, parented correctly.
     """
-    trace_id = trace_id or _trace_id()
-    root_id = _span_id()
+    # Deterministic ids from `seed` (the call id) make re-emits idempotent — a
+    # Temporal retry produces the SAME trace + span ids instead of a duplicate trace.
+    trace_id = trace_id or (_det_trace_id(seed) if seed else _trace_id())
+    root_id = _det_span_id(seed, "root") if seed else _span_id()
 
     user_turns = [t for t in turns if t.get("role") == "user"]
     agent_turns = [t for t in turns if t.get("role") == "assistant"]
@@ -140,7 +157,7 @@ def build_sim_spans(
             history.append(f"user: {content}")
             continue
         turn_no += 1
-        llm_id = _span_id()
+        llm_id = _det_span_id(seed, f"turn:{turn_no}") if seed else _span_id()
         attrs: dict[str, Any] = {
             INPUT_VALUE: "\n".join(history) or first_user,
             OUTPUT_VALUE: content,
@@ -167,11 +184,16 @@ def build_sim_spans(
                 latency=t.get("latency_ms"),
             )
         )
-        for tc in t.get("tool_calls") or []:
+        for tool_idx, tc in enumerate(t.get("tool_calls") or []):
+            tool_sid = (
+                _det_span_id(seed, f"turn:{turn_no}:tool:{tool_idx}")
+                if seed
+                else _span_id()
+            )
             spans.append(
                 _span(
                     name=tc.get("name") or "tool", kind=SPAN_KIND_TOOL,
-                    span_id=_span_id(), parent_span_id=llm_id, trace_id=trace_id,
+                    span_id=tool_sid, parent_span_id=llm_id, trace_id=trace_id,
                     attributes={
                         TOOL_NAME: tc.get("name") or "",
                         TOOL_CALL_ID: tc.get("id") or "",
@@ -312,6 +334,7 @@ def emit_sim_trace(
         session_id=session_id,
         agent_name=getattr(agent_def, "agent_name", "agent-under-test"),
         metadata={"call_execution_id": str(getattr(call_execution, "id", ""))},
+        seed=str(getattr(call_execution, "id", "")) or None,
     )
     emitted = 0
     for span in spans:

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -344,3 +344,30 @@ def emit_sim_trace(
         except Exception:  # pragma: no cover - one bad span must not lose the rest
             logger.exception("sim_trace_span_emit_failed", extra={"name": span.get("name")})
     return emitted
+
+
+def attach_sim_evals_to_trace(call_execution, eval_attributes: dict[str, Any]) -> int:
+    """Write eval results onto the sim trace's root span, AFTER evals run.
+
+    The trace is emitted at sim completion (before async evals finish), so this is
+    the second half: it finds the root span by its DETERMINISTIC id (same seed = the
+    call id) and merges the eval results into ``span_attributes``, making eval
+    verdicts filterable at span granularity in the trace UI. Idempotent. Returns the
+    number of root spans updated (0 if the trace wasn't emitted / no evals).
+    """
+    from tracer.models.observation_span import ObservationSpan
+
+    seed = str(getattr(call_execution, "id", ""))
+    if not seed or not eval_attributes:
+        return 0
+    root_span_id = _det_span_id(seed, "root")
+    updated = 0
+    for span in ObservationSpan.objects.filter(span_id=root_span_id):
+        attrs = dict(span.span_attributes or {})
+        attrs.update(eval_attributes)
+        span.span_attributes = attrs
+        span.save(update_fields=["span_attributes"])
+        updated += 1
+    if not updated:
+        logger.info("sim_eval_attach_no_root_span", call_execution_id=seed)
+    return updated

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -22,6 +22,10 @@ from __future__ import annotations
 import secrets
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 # Attribute keys mirror tracer.utils.otel.SpanAttributes (FI/OpenInference). Kept
 # local so this module stays import-light + pure; test_sim_observability pins them
 # against the real SpanAttributes so they can't drift.
@@ -180,3 +184,121 @@ def build_sim_spans(
         history.append(f"assistant: {content}")
 
     return spans
+
+
+# ---------------------------------------------------------------------------
+# Emit layer — resolves the project + reads the call's messages, then hands each
+# built span to the tracer's existing OTel write path. Lazy imports keep the
+# builder above pure/Django-free.
+# ---------------------------------------------------------------------------
+def _message_text(row) -> str:
+    """Extract plain text from a ChatMessageModel row (messages list or content)."""
+    msgs = getattr(row, "messages", None)
+    if isinstance(msgs, list) and msgs:
+        return " ".join(str(m) for m in msgs if m)
+    content = getattr(row, "content", None)
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("content"):
+                parts.append(str(item["content"]))
+        return " ".join(parts)
+    return str(content) if content else ""
+
+
+def _tool_calls_from_row(row) -> list[dict[str, Any]]:
+    content = getattr(row, "content", None)
+    out: list[dict[str, Any]] = []
+    if isinstance(content, list):
+        for item in content:
+            for tc in (item.get("tool_calls") or []) if isinstance(item, dict) else []:
+                fn = tc.get("function") or {}
+                out.append({
+                    "name": fn.get("name") or tc.get("name") or "",
+                    "arguments": fn.get("arguments") or tc.get("arguments") or "",
+                    "result": tc.get("result") or "",
+                    "id": tc.get("id") or "",
+                })
+    return out
+
+
+def _row_to_turn(row) -> dict[str, Any]:
+    role = "assistant" if str(getattr(row, "role", "")) == "assistant" else "user"
+    turn: dict[str, Any] = {"role": role, "content": _message_text(row)}
+    if role == "assistant":
+        if getattr(row, "tokens", None) is not None:
+            turn["output_tokens"] = row.tokens
+            turn["total_tokens"] = row.tokens
+        if getattr(row, "latency_ms", None) is not None:
+            turn["latency_ms"] = row.latency_ms
+        tcs = _tool_calls_from_row(row)
+        if tcs:
+            turn["tool_calls"] = tcs
+    return turn
+
+
+def emit_sim_trace(call_execution, *, user_id: str | None = None) -> int:
+    """Emit a trace (span tree) for a completed sim CallExecution.
+
+    Resolves the project from the agent definition's observability provider (falling
+    back to a per-org "Simulations" project), reads the persisted ChatMessage rows,
+    builds the span tree, and writes each span via the tracer's OTel ingest path so
+    the sim appears in the same trace/Session UI as production traces.
+
+    Returns the number of spans emitted.
+    """
+    from simulate.models.chat_message import ChatMessageModel
+    from tracer.utils.create_otel_span import create_single_otel_span
+
+    test_execution = getattr(call_execution, "test_execution", None)
+    run_test = getattr(test_execution, "run_test", None)
+    agent_def = getattr(test_execution, "agent_definition", None) or getattr(
+        run_test, "agent_definition", None
+    )
+    organization_id = str(
+        getattr(run_test, "organization_id", None)
+        or getattr(call_execution, "organization_id", "")
+        or ""
+    )
+    workspace_id = getattr(run_test, "workspace_id", None)
+    workspace_id = str(workspace_id) if workspace_id else None
+
+    # Project: the agent's observability project, else a per-org Simulations project.
+    obs = getattr(agent_def, "observability_provider", None)
+    project = getattr(obs, "project", None)
+    if project is not None:
+        project_name, project_type = project.name, project.trace_type
+    else:
+        project_name, project_type = "Simulations", "observe"
+
+    rows = list(
+        ChatMessageModel.objects.filter(call_execution=call_execution).order_by(
+            "created_at"
+        )
+    )
+    turns = [_row_to_turn(r) for r in rows]
+    session_id = next((str(r.session_id) for r in rows if getattr(r, "session_id", None)), None)
+
+    modality = (
+        "voice"
+        if str(getattr(call_execution, "simulation_call_type", "")) == "voice"
+        else "chat"
+    )
+
+    spans = build_sim_spans(
+        turns,
+        modality=modality,
+        project_name=project_name,
+        project_type=project_type,
+        session_id=session_id,
+        agent_name=getattr(agent_def, "agent_name", "agent-under-test"),
+        metadata={"call_execution_id": str(getattr(call_execution, "id", ""))},
+    )
+    emitted = 0
+    for span in spans:
+        try:
+            create_single_otel_span(span, organization_id, user_id, workspace_id)
+            emitted += 1
+        except Exception:  # pragma: no cover - one bad span must not lose the rest
+            logger.exception("sim_trace_span_emit_failed", extra={"name": span.get("name")})
+    return emitted

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -1,0 +1,182 @@
+"""Simulation observability — emit a trace of spans for a sim call (TH-5642).
+
+Competitor research (Cekura/Coval/Roark) shows production-grade observability of
+EVERY simulated conversation as a span tree in the trace/Session UI is table stakes.
+Voice sims already produce latency/recording observability; CHAT sims previously
+emitted only ChatMessage rows and never appeared as traces. This builds a UNIFIED
+span tree for BOTH modalities so chat + voice sims land in the same trace UI as
+production traces.
+
+Span tree (OpenInference/FI conventions):
+  AGENT  "<modality> simulation"            (root: the whole conversation)
+   └─ LLM  "<modality>.turn N"              (each agent-under-test turn)
+        └─ TOOL "<tool name>"               (each tool call in that turn)
+
+This module is Django-free and pure (build_sim_spans returns plain dicts) so it is
+trivially unit-tested; the thin emit layer (emit_sim_trace) resolves the project and
+hands each span to the tracer's existing ``create_single_otel_span`` write path.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+# Attribute keys mirror tracer.utils.otel.SpanAttributes (FI/OpenInference). Kept
+# local so this module stays import-light + pure; test_sim_observability pins them
+# against the real SpanAttributes so they can't drift.
+FI_SPAN_KIND = "gen_ai.span.kind"  # SpanAttributes.FI_SPAN_KIND (converter also reads fi./openinference.)
+INPUT_VALUE = "input.value"
+OUTPUT_VALUE = "output.value"
+SESSION_ID = "session.id"
+REQUEST_MODEL = "gen_ai.request.model"
+LLM_MODEL_NAME = "llm.model_name"
+USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+TOOL_NAME = "gen_ai.tool.name"
+TOOL_CALL_ID = "gen_ai.tool.call.id"
+TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments"
+TOOL_CALL_RESULT = "gen_ai.tool.call.result"
+METADATA = "metadata"
+
+# Voice-only: per-turn pipeline latency split (only emitted when present).
+VOICE_LATENCY_KEYS = {
+    "stt": "gen_ai.voice.latency.stt",
+    "llm": "gen_ai.voice.latency.llm",
+    "tts": "gen_ai.voice.latency.tts",
+    "ttfb": "gen_ai.voice.latency.ttfb",
+    "total": "gen_ai.voice.latency.total",
+}
+
+SPAN_KIND_AGENT = "AGENT"
+SPAN_KIND_LLM = "LLM"
+SPAN_KIND_TOOL = "TOOL"
+
+
+def _trace_id() -> str:
+    return secrets.token_hex(16)  # 32 hex chars (128-bit), OTLP trace id
+
+
+def _span_id() -> str:
+    return secrets.token_hex(8)  # 16 hex chars (64-bit), OTLP span id
+
+
+def _span(
+    *, name, kind, span_id, parent_span_id, trace_id, attributes,
+    project_name, project_type, latency=None,
+) -> dict[str, Any]:
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "latency": latency,
+        "project_name": project_name,
+        "project_type": project_type,
+        "attributes": {FI_SPAN_KIND: kind, **attributes},
+    }
+
+
+def build_sim_spans(
+    turns: list[dict[str, Any]],
+    *,
+    modality: str,                 # "chat" | "voice"
+    project_name: str,
+    project_type: str = "observe",
+    session_id: str | None = None,
+    agent_name: str = "agent-under-test",
+    model: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build the OTLP span dicts for one simulated conversation.
+
+    ``turns``: ordered ``[{"role": "user"|"assistant", "content": str,
+    "model"?: str, "input_tokens"?: int, "output_tokens"?: int,
+    "total_tokens"?: int, "latency_ms"?: int, "voice_latency"?: {...},
+    "tool_calls"?: [{"name","arguments","result","id"}]}]`` — user = simulated
+    customer, assistant = the agent-under-test.
+
+    Returns root AGENT span + one LLM span per assistant turn + TOOL spans, all
+    sharing one trace_id, parented correctly.
+    """
+    trace_id = trace_id or _trace_id()
+    root_id = _span_id()
+
+    user_turns = [t for t in turns if t.get("role") == "user"]
+    agent_turns = [t for t in turns if t.get("role") == "assistant"]
+    first_user = next((t.get("content", "") for t in user_turns), "")
+    last_agent = next((t.get("content", "") for t in reversed(agent_turns)), "")
+
+    base_attrs: dict[str, Any] = {INPUT_VALUE: first_user, OUTPUT_VALUE: last_agent}
+    if session_id:
+        base_attrs[SESSION_ID] = session_id
+    if metadata:
+        base_attrs[METADATA] = {**metadata, "simulation_modality": modality}
+    else:
+        base_attrs[METADATA] = {"simulation_modality": modality}
+
+    spans = [
+        _span(
+            name=f"{modality} simulation", kind=SPAN_KIND_AGENT, span_id=root_id,
+            parent_span_id=None, trace_id=trace_id, attributes=base_attrs,
+            project_name=project_name, project_type=project_type,
+        )
+    ]
+
+    # Walk turns in order; each assistant turn becomes an LLM span whose input is
+    # the conversation so far and whose output is the agent's reply.
+    history: list[str] = []
+    turn_no = 0
+    for t in turns:
+        role = t.get("role")
+        content = t.get("content", "")
+        if role != "assistant":
+            history.append(f"user: {content}")
+            continue
+        turn_no += 1
+        llm_id = _span_id()
+        attrs: dict[str, Any] = {
+            INPUT_VALUE: "\n".join(history) or first_user,
+            OUTPUT_VALUE: content,
+        }
+        turn_model = t.get("model") or model
+        if turn_model:
+            attrs[REQUEST_MODEL] = turn_model
+            attrs[LLM_MODEL_NAME] = turn_model
+        if t.get("input_tokens") is not None:
+            attrs[USAGE_INPUT_TOKENS] = t["input_tokens"]
+        if t.get("output_tokens") is not None:
+            attrs[USAGE_OUTPUT_TOKENS] = t["output_tokens"]
+        if t.get("total_tokens") is not None:
+            attrs[USAGE_TOTAL_TOKENS] = t["total_tokens"]
+        if modality == "voice" and isinstance(t.get("voice_latency"), dict):
+            for k, attr_key in VOICE_LATENCY_KEYS.items():
+                if t["voice_latency"].get(k) is not None:
+                    attrs[attr_key] = t["voice_latency"][k]
+        spans.append(
+            _span(
+                name=f"{modality}.turn {turn_no}", kind=SPAN_KIND_LLM, span_id=llm_id,
+                parent_span_id=root_id, trace_id=trace_id, attributes=attrs,
+                project_name=project_name, project_type=project_type,
+                latency=t.get("latency_ms"),
+            )
+        )
+        for tc in t.get("tool_calls") or []:
+            spans.append(
+                _span(
+                    name=tc.get("name") or "tool", kind=SPAN_KIND_TOOL,
+                    span_id=_span_id(), parent_span_id=llm_id, trace_id=trace_id,
+                    attributes={
+                        TOOL_NAME: tc.get("name") or "",
+                        TOOL_CALL_ID: tc.get("id") or "",
+                        TOOL_CALL_ARGUMENTS: tc.get("arguments") or "",
+                        TOOL_CALL_RESULT: tc.get("result") or "",
+                    },
+                    project_name=project_name, project_type=project_type,
+                )
+            )
+        history.append(f"assistant: {content}")
+
+    return spans

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -237,17 +237,25 @@ def _row_to_turn(row) -> dict[str, Any]:
     return turn
 
 
-def emit_sim_trace(call_execution, *, user_id: str | None = None) -> int:
+def emit_sim_trace(
+    call_execution,
+    *,
+    turns: list[dict[str, Any]] | None = None,
+    user_id: str | None = None,
+) -> int:
     """Emit a trace (span tree) for a completed sim CallExecution.
 
     Resolves the project from the agent definition's observability provider (falling
-    back to a per-org "Simulations" project), reads the persisted ChatMessage rows,
-    builds the span tree, and writes each span via the tracer's OTel ingest path so
-    the sim appears in the same trace/Session UI as production traces.
+    back to a per-org "Simulations" project), builds the span tree, and writes each
+    span via the tracer's OTel ingest path so the sim appears in the same
+    trace/Session UI as production traces.
+
+    ``turns``: pass a normalized ``[{"role","content",...}]`` conversation directly —
+    used by the VOICE completion hook, which stores its transcript outside
+    ChatMessageModel. When omitted (CHAT), the persisted ChatMessage rows are read.
 
     Returns the number of spans emitted.
     """
-    from simulate.models.chat_message import ChatMessageModel
     from tracer.utils.create_otel_span import create_single_otel_span
 
     test_execution = getattr(call_execution, "test_execution", None)
@@ -271,13 +279,24 @@ def emit_sim_trace(call_execution, *, user_id: str | None = None) -> int:
     else:
         project_name, project_type = "Simulations", "observe"
 
-    rows = list(
-        ChatMessageModel.objects.filter(call_execution=call_execution).order_by(
-            "created_at"
+    session_id = None
+    if turns is None:
+        # CHAT: read the persisted ChatMessage rows.
+        from simulate.models.chat_message import ChatMessageModel
+
+        rows = list(
+            ChatMessageModel.objects.filter(call_execution=call_execution).order_by(
+                "created_at"
+            )
         )
+        turns = [_row_to_turn(r) for r in rows]
+        session_id = next(
+            (str(r.session_id) for r in rows if getattr(r, "session_id", None)), None
+        )
+    session_id = session_id or str(
+        (getattr(call_execution, "call_metadata", None) or {}).get("chat_session_id")
+        or getattr(call_execution, "id", "")
     )
-    turns = [_row_to_turn(r) for r in rows]
-    session_id = next((str(r.session_id) for r in rows if getattr(r, "session_id", None)), None)
 
     modality = (
         "voice"

--- a/futureagi/simulate/services/sim_observability.py
+++ b/futureagi/simulate/services/sim_observability.py
@@ -131,6 +131,20 @@ def build_sim_spans(
     last_agent = next((t.get("content", "") for t in reversed(agent_turns)), "")
 
     base_attrs: dict[str, Any] = {INPUT_VALUE: first_user, OUTPUT_VALUE: last_agent}
+    # Conversation-level token rollup on the root span (the ingest converter computes
+    # per-LLM-span cost, but not the trace total) — so the trace shows total usage.
+    _ti = sum(int(t.get("input_tokens") or 0) for t in agent_turns)
+    _to = sum(int(t.get("output_tokens") or 0) for t in agent_turns)
+    _tt = sum(int(t.get("total_tokens") or 0) for t in agent_turns)
+    if _ti:
+        base_attrs[USAGE_INPUT_TOKENS] = _ti
+    if _to:
+        base_attrs[USAGE_OUTPUT_TOKENS] = _to
+    if _tt:
+        base_attrs[USAGE_TOTAL_TOKENS] = _tt
+    if model:
+        base_attrs[REQUEST_MODEL] = model
+        base_attrs[LLM_MODEL_NAME] = model
     if session_id:
         base_attrs[SESSION_ID] = session_id
     if metadata:

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -3462,6 +3462,30 @@ class TestExecutor:
                     "call_metadata",  # JSONFields that may be modified in-place
                 ]
                 call_execution.save(update_fields=fields_to_update)
+
+                # Attach eval results onto the sim trace's root span (deterministic
+                # id), so eval verdicts are filterable at span granularity in the
+                # trace UI alongside the conversation spans (TH-5642). Idempotent +
+                # best-effort: a no-op if the trace wasn't emitted.
+                try:
+                    from simulate.services.sim_observability import (
+                        attach_sim_evals_to_trace,
+                    )
+
+                    _eval_attrs = {}
+                    if call_execution.overall_score is not None:
+                        _eval_attrs["gen_ai.evaluation.overall_score"] = float(
+                            call_execution.overall_score
+                        )
+                    _cmd = call_execution.conversation_metrics_data or {}
+                    if isinstance(_cmd, dict) and _cmd:
+                        _eval_attrs["gen_ai.evaluation.conversation_metrics"] = _cmd
+                    if _eval_attrs:
+                        attach_sim_evals_to_trace(call_execution, _eval_attrs)
+                except Exception:
+                    logger.exception(
+                        f"sim_eval_attach_failed for {call_execution.id}"
+                    )
                 # Calculate call duration and deduct cost if call is completed and has recording
                 if (
                     call_execution.status == CallExecution.CallStatus.COMPLETED

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -242,6 +242,19 @@ def store_chat_messages(
 
             logger.info(f"CallExecution {call_execution.id} marked as COMPLETED")
 
+            # Emit the simulation trace (span tree) so this chat sim shows up in the
+            # trace/Session UI like a production trace (TH-5642 observability). A
+            # trace failure must never break the sim.
+            try:
+                from simulate.services.sim_observability import emit_sim_trace
+
+                emit_sim_trace(call_execution)
+            except Exception:
+                logger.exception(
+                    "sim_trace_emit_failed",
+                    call_execution_id=str(call_execution.id),
+                )
+
             # Trigger test execution monitoring to update TestExecution status
             monitor_test_execution_for_chat.apply_async(
                 args=(str(call_execution.test_execution_id),)

--- a/futureagi/simulate/tests/test_mock_tools.py
+++ b/futureagi/simulate/tests/test_mock_tools.py
@@ -1,0 +1,90 @@
+"""Unit tests for mock scenario-aligned tool returns (TH-5642).
+
+The tool loop drives an INJECTED llm_call, so the deterministic-tool-path logic is
+fully testable without an LLM.
+"""
+
+import pytest
+
+from simulate.services.mock_tools import (
+    resolve_mock_tool_return,
+    run_mock_tool_loop,
+)
+
+
+@pytest.mark.unit
+def test_resolve_fixed_result():
+    assert resolve_mock_tool_return({"get_weather": "Sunny"}, "get_weather", "{}") == "Sunny"
+
+
+@pytest.mark.unit
+def test_resolve_args_keyed_and_default():
+    spec = {"get_weather": {"London": "Rainy", "default": "Clear"}}
+    assert resolve_mock_tool_return(spec, "get_weather", '{"city": "London"}') == "Rainy"
+    assert resolve_mock_tool_return(spec, "get_weather", '{"city": "Paris"}') == "Clear"
+
+
+@pytest.mark.unit
+def test_resolve_unconfigured_tool_falls_back():
+    assert resolve_mock_tool_return({}, "anything", "{}") == "ok"
+    assert resolve_mock_tool_return(None, "anything", "{}") == "ok"
+
+
+@pytest.mark.unit
+def test_resolve_non_string_result_is_json():
+    # A list/number fixed result is JSON-encoded.
+    assert resolve_mock_tool_return({"t": [1, 2]}, "t", "{}") == "[1, 2]"
+    # A bare dict is args-keyed, so a JSON-OBJECT result uses the "default" key.
+    assert resolve_mock_tool_return({"t": {"default": {"x": 1}}}, "t", "{}") == '{"x": 1}'
+
+
+@pytest.mark.unit
+def test_loop_serves_mocks_and_continues():
+    # The fake agent calls a tool on turn 1, then produces content after seeing the
+    # mock result.
+    calls = []
+
+    def fake_llm(messages):
+        calls.append(list(messages))
+        # First call → a tool call; second call → final content.
+        if len(calls) == 1:
+            return "", [{"id": "c1", "function": {"name": "get_inventory",
+                                                  "arguments": '{"q": "scooter"}'}}]
+        return "We have 3 scooters in stock.", []
+
+    content, rounds = run_mock_tool_loop(
+        fake_llm,
+        [{"role": "user", "content": "do you have scooters?"}],
+        {"get_inventory": "3 in stock"},
+    )
+    assert content == "We have 3 scooters in stock."
+    assert rounds == 1
+    # The 2nd LLM call saw the appended assistant tool_call + tool result messages.
+    second = calls[1]
+    assert second[-1] == {
+        "role": "tool", "tool_call_id": "c1", "name": "get_inventory",
+        "content": "3 in stock",
+    }
+    assert second[-2]["role"] == "assistant" and second[-2]["tool_calls"]
+
+
+@pytest.mark.unit
+def test_loop_no_tools_returns_immediately():
+    content, rounds = run_mock_tool_loop(
+        lambda m: ("hello", []), [{"role": "user", "content": "hi"}], {}
+    )
+    assert content == "hello"
+    assert rounds == 0
+
+
+@pytest.mark.unit
+def test_loop_respects_max_iters():
+    # An agent that calls tools forever stops at max_iters.
+    def always_tool(messages):
+        return "still thinking", [{"id": "c", "function": {"name": "t", "arguments": "{}"}}]
+
+    content, rounds = run_mock_tool_loop(
+        always_tool, [{"role": "user", "content": "x"}], {"t": "r"}, max_iters=3
+    )
+    assert rounds == 3
+    assert content == "still thinking"

--- a/futureagi/simulate/tests/test_prompt_adapter_mock_tools.py
+++ b/futureagi/simulate/tests/test_prompt_adapter_mock_tools.py
@@ -69,6 +69,26 @@ def test_adapter_serves_mock_tool_then_returns_content(monkeypatch):
 
 
 @pytest.mark.unit
+def test_factory_passes_mock_tool_returns_from_metadata(monkeypatch):
+    import simulate.services.prompt_based_agent_adapter as mod
+
+    captured = {}
+
+    def fake_adapter(**kwargs):
+        captured.update(kwargs)
+        return "adapter"
+
+    monkeypatch.setattr(mod, "PromptBasedAgentAdapter", fake_adapter)
+
+    run_test = SimpleNamespace(
+        source_type="prompt", prompt_version=SimpleNamespace(id="pv"),
+        id="rt-1", metadata={"mock_tool_returns": {"get_x": "Y"}},
+    )
+    mod.create_adapter_from_run_test(run_test, organization_id="org")
+    assert captured["mock_tool_returns"] == {"get_x": "Y"}
+
+
+@pytest.mark.unit
 def test_adapter_without_mocks_is_single_call(monkeypatch):
     a = _adapter({})  # no mock tool returns → single LLM call, no loop
     calls = []

--- a/futureagi/simulate/tests/test_prompt_adapter_mock_tools.py
+++ b/futureagi/simulate/tests/test_prompt_adapter_mock_tools.py
@@ -1,0 +1,83 @@
+"""Integration test: PromptBasedAgentAdapter drives the mock-tool loop (TH-5642).
+
+Mocks _call_llm (so no RunPrompt/LLM/DB), verifying the adapter feeds the agent's
+tool calls back with scenario-aligned mocks and returns the final content.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from simulate.services.prompt_based_agent_adapter import PromptBasedAgentAdapter
+
+
+def _adapter(mock_tool_returns):
+    # Build without __init__/_load_config (which needs a real PromptVersion).
+    a = object.__new__(PromptBasedAgentAdapter)
+    a.model = "gpt-4o-mini"
+    a.tools = [{"type": "function", "function": {"name": "get_inventory"}}]
+    a.tool_choice = "auto"
+    a.temperature = 0.7
+    a.frequency_penalty = 0.0
+    a.presence_penalty = 0.0
+    a.max_tokens = 800
+    a.top_p = 1.0
+    a.base_messages = [{"role": "system", "content": "You are a store agent."}]
+    a.variable_values = {}
+    a.organization_id = "org-1"
+    a.workspace_id = None
+    a.prompt_version = SimpleNamespace(id="pv-1")
+    a.mock_tool_returns = mock_tool_returns
+    return a
+
+
+@pytest.mark.unit
+def test_adapter_serves_mock_tool_then_returns_content(monkeypatch):
+    a = _adapter({"get_inventory": "3 scooters in stock"})
+    calls = []
+
+    def fake_call_llm(messages):
+        calls.append(list(messages))
+        if len(calls) == 1:
+            # The agent calls a tool.
+            return "ignored-tool-json", {
+                "metadata": {
+                    "tool_calls": [
+                        {"id": "c1", "type": "function",
+                         "function": {"name": "get_inventory", "arguments": "{}"}}
+                    ],
+                    "usage": {},
+                }
+            }
+        # After seeing the mock result, it answers.
+        return "We have 3 scooters in stock.", {
+            "metadata": {"tool_calls": [], "usage": {"total_tokens": 20}},
+            "model": "gpt-4o-mini",
+        }
+
+    monkeypatch.setattr(a, "_call_llm", fake_call_llm)
+
+    result = a.generate_response([{"role": "user", "content": "any scooters?"}])
+
+    assert result["content"] == "We have 3 scooters in stock."
+    assert result["usage"]["total_tokens"] == 20
+    assert len(calls) == 2  # one tool round, then the final answer
+    # The second LLM call saw the assistant tool_call + the mock tool result.
+    second = calls[1]
+    assert any(m.get("role") == "tool" and m.get("content") == "3 scooters in stock"
+               for m in second)
+
+
+@pytest.mark.unit
+def test_adapter_without_mocks_is_single_call(monkeypatch):
+    a = _adapter({})  # no mock tool returns → single LLM call, no loop
+    calls = []
+
+    def fake_call_llm(messages):
+        calls.append(messages)
+        return "Hi, how can I help?", {"metadata": {"usage": {"total_tokens": 5}}}
+
+    monkeypatch.setattr(a, "_call_llm", fake_call_llm)
+    result = a.generate_response([{"role": "user", "content": "hello"}])
+    assert result["content"] == "Hi, how can I help?"
+    assert len(calls) == 1

--- a/futureagi/simulate/tests/test_sim_alerting.py
+++ b/futureagi/simulate/tests/test_sim_alerting.py
@@ -1,0 +1,98 @@
+"""DB test for simulation alerting metric reader (TH-5642).
+
+UserAlertMonitor gains SIM_EVAL_SCORE / SIM_FAILURE_RATE metric types that read
+CallExecution data (not CH traces), so users can alert on sim quality regressions /
+failure spikes (the Slack/email/webhook plumbing already exists). This pins the
+metric computation.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from django.utils import timezone
+
+from model_hub.models.choices import StatusType
+from simulate.models import AgentDefinition, CallExecution, RunTest, Scenarios
+from simulate.models.test_execution import TestExecution
+from tracer.models.monitor import MonitorMetricTypeChoices
+
+
+def _call(organization, workspace, *, overall_score=None, status=None):
+    ad = AgentDefinition.objects.create(
+        agent_name="Alert Agent", agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True, description="alert", organization=organization,
+        workspace=workspace, provider="vapi", languages=["en"],
+    )
+    scenario = Scenarios.objects.create(
+        name="Alert Scenario", description="a", source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET, organization=organization,
+        workspace=workspace, agent_definition=ad, status=StatusType.COMPLETED.value,
+    )
+    rt = RunTest.objects.create(
+        name="Alert Run", description="a", agent_definition=ad,
+        organization=organization, workspace=workspace,
+    )
+    te = TestExecution.objects.create(
+        run_test=rt, status=TestExecution.ExecutionStatus.COMPLETED,
+        total_scenarios=1, total_calls=1, agent_definition=ad,
+    )
+    return CallExecution.objects.create(
+        test_execution=te, scenario=scenario,
+        status=status or CallExecution.CallStatus.COMPLETED,
+        simulation_call_type=CallExecution.SimulationCallType.VOICE,
+        overall_score=overall_score,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_eval_score_avg(organization, workspace):
+    _call(organization, workspace, overall_score=0.8)
+    _call(organization, workspace, overall_score=0.4)
+    _call(organization, workspace, overall_score=None)  # excluded from the average
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_EVAL_SCORE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now - timedelta(hours=1), now + timedelta(hours=1))
+    assert value == pytest.approx(0.6)  # (0.8 + 0.4) / 2, None excluded
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_failure_rate(organization, workspace):
+    _call(organization, workspace, status=CallExecution.CallStatus.COMPLETED)
+    _call(organization, workspace, status=CallExecution.CallStatus.COMPLETED)
+    _call(organization, workspace, status=CallExecution.CallStatus.FAILED)
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_FAILURE_RATE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now - timedelta(hours=1), now + timedelta(hours=1))
+    assert value == pytest.approx(1 / 3)  # 1 failed of 3
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_sim_metric_window_excludes_out_of_range(organization, workspace):
+    _call(organization, workspace, overall_score=0.9)
+
+    from tracer.utils.monitor import _get_sim_metric_value
+
+    monitor = SimpleNamespace(
+        metric_type=MonitorMetricTypeChoices.SIM_EVAL_SCORE,
+        project=SimpleNamespace(organization_id=organization.id),
+    )
+    # A window in the future contains no calls → None.
+    now = timezone.now()
+    value = _get_sim_metric_value(monitor, now + timedelta(hours=1), now + timedelta(hours=2))
+    assert value is None

--- a/futureagi/simulate/tests/test_sim_observability.py
+++ b/futureagi/simulate/tests/test_sim_observability.py
@@ -113,6 +113,56 @@ def test_empty_conversation_yields_just_root():
 
 
 @pytest.mark.unit
+def test_attach_sim_evals_to_trace_merges_onto_root_span(monkeypatch):
+    from types import SimpleNamespace
+
+    import tracer.models.observation_span as osmod
+
+    class _FakeSpan:
+        def __init__(self):
+            self.span_attributes = {"gen_ai.span.kind": "AGENT"}
+            self.saved_fields = None
+
+        def save(self, update_fields=None):
+            self.saved_fields = update_fields
+
+    fake = _FakeSpan()
+
+    class _FakeObservationSpan:
+        class objects:  # noqa: N801
+            @staticmethod
+            def filter(**kwargs):
+                # Looked up by the deterministic root span id.
+                assert kwargs.get("span_id")
+                return [fake]
+
+    monkeypatch.setattr(osmod, "ObservationSpan", _FakeObservationSpan)
+
+    from simulate.services.sim_observability import attach_sim_evals_to_trace
+
+    n = attach_sim_evals_to_trace(
+        SimpleNamespace(id="call-1"),
+        {"gen_ai.evaluation.score": 0.8, "gen_ai.evaluation.passed": True},
+    )
+    assert n == 1
+    # Merged (existing kept) + eval results added; saved the field.
+    assert fake.span_attributes["gen_ai.span.kind"] == "AGENT"
+    assert fake.span_attributes["gen_ai.evaluation.score"] == 0.8
+    assert fake.span_attributes["gen_ai.evaluation.passed"] is True
+    assert fake.saved_fields == ["span_attributes"]
+
+
+@pytest.mark.unit
+def test_attach_sim_evals_noops_without_evals_or_id():
+    from types import SimpleNamespace
+
+    from simulate.services.sim_observability import attach_sim_evals_to_trace
+
+    assert attach_sim_evals_to_trace(SimpleNamespace(id="c1"), {}) == 0
+    assert attach_sim_evals_to_trace(SimpleNamespace(id=""), {"x": 1}) == 0
+
+
+@pytest.mark.unit
 def test_attribute_keys_match_tracer_spanattributes():
     # Drift guard: our local keys must equal the tracer's real SpanAttributes so
     # the ingest converter reads them correctly.

--- a/futureagi/simulate/tests/test_sim_observability.py
+++ b/futureagi/simulate/tests/test_sim_observability.py
@@ -1,0 +1,113 @@
+"""Unit tests for the unified sim-observability span builder (TH-5642).
+
+Pins the span tree (AGENT root → LLM per agent turn → TOOL per tool call) for both
+chat and voice, and that the attribute keys match the tracer's real SpanAttributes
+so emitted sim spans are valid for the ingest converter.
+"""
+
+import pytest
+
+from simulate.services import sim_observability as so
+from simulate.services.sim_observability import build_sim_spans
+
+CHAT_TURNS = [
+    {"role": "user", "content": "Hi, do you sell scooters?"},
+    {"role": "assistant", "content": "Yes! Which model?", "model": "gpt-4o-mini",
+     "input_tokens": 30, "output_tokens": 8, "total_tokens": 38,
+     "tool_calls": [{"name": "lookup_inventory", "arguments": "{\"q\":\"scooter\"}",
+                     "result": "[3 models]", "id": "call_1"}]},
+    {"role": "user", "content": "The cheapest one."},
+    {"role": "assistant", "content": "That's the X1 at $199.", "model": "gpt-4o-mini",
+     "input_tokens": 50, "output_tokens": 10, "total_tokens": 60},
+]
+
+
+@pytest.mark.unit
+def test_chat_span_tree_shape_and_parenting():
+    spans = build_sim_spans(CHAT_TURNS, modality="chat", project_name="proj",
+                            session_id="sess-1")
+    by_kind = {}
+    for s in spans:
+        by_kind.setdefault(s["attributes"][so.FI_SPAN_KIND], []).append(s)
+    assert len(by_kind["AGENT"]) == 1
+    assert len(by_kind["LLM"]) == 2     # one per assistant turn
+    assert len(by_kind["TOOL"]) == 1    # one tool call
+
+    root = by_kind["AGENT"][0]
+    assert root["parent_span_id"] is None
+    assert root["name"] == "chat simulation"
+    assert root["attributes"][so.INPUT_VALUE] == "Hi, do you sell scooters?"
+    assert root["attributes"][so.OUTPUT_VALUE] == "That's the X1 at $199."
+    assert root["attributes"][so.SESSION_ID] == "sess-1"
+
+    # All spans share one trace; LLM spans parent the root; TOOL parents its LLM.
+    trace_ids = {s["trace_id"] for s in spans}
+    assert len(trace_ids) == 1
+    for llm in by_kind["LLM"]:
+        assert llm["parent_span_id"] == root["span_id"]
+    tool = by_kind["TOOL"][0]
+    llm_ids = {s["span_id"] for s in by_kind["LLM"]}
+    assert tool["parent_span_id"] in llm_ids
+
+
+@pytest.mark.unit
+def test_llm_span_carries_io_tokens_model():
+    spans = build_sim_spans(CHAT_TURNS, modality="chat", project_name="proj")
+    llm = [s for s in spans if s["attributes"][so.FI_SPAN_KIND] == "LLM"][0]
+    a = llm["attributes"]
+    assert a[so.OUTPUT_VALUE] == "Yes! Which model?"
+    assert a[so.USAGE_INPUT_TOKENS] == 30
+    assert a[so.USAGE_TOTAL_TOKENS] == 38
+    assert a[so.REQUEST_MODEL] == "gpt-4o-mini"
+
+
+@pytest.mark.unit
+def test_tool_span_attributes():
+    spans = build_sim_spans(CHAT_TURNS, modality="chat", project_name="proj")
+    tool = [s for s in spans if s["attributes"][so.FI_SPAN_KIND] == "TOOL"][0]
+    a = tool["attributes"]
+    assert a[so.TOOL_NAME] == "lookup_inventory"
+    assert a[so.TOOL_CALL_ID] == "call_1"
+    assert "scooter" in a[so.TOOL_CALL_ARGUMENTS]
+    assert a[so.TOOL_CALL_RESULT] == "[3 models]"
+
+
+@pytest.mark.unit
+def test_voice_modality_emits_pipeline_latency():
+    voice_turns = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Hi there!", "model": "gpt-4o",
+         "voice_latency": {"stt": 120, "llm": 300, "tts": 80, "ttfb": 500, "total": 900}},
+    ]
+    spans = build_sim_spans(voice_turns, modality="voice", project_name="proj")
+    llm = [s for s in spans if s["attributes"][so.FI_SPAN_KIND] == "LLM"][0]
+    assert llm["name"] == "voice.turn 1"
+    assert llm["attributes"][so.VOICE_LATENCY_KEYS["ttfb"]] == 500
+    assert llm["attributes"][so.VOICE_LATENCY_KEYS["total"]] == 900
+    assert spans[0]["attributes"][so.METADATA]["simulation_modality"] == "voice"
+
+
+@pytest.mark.unit
+def test_empty_conversation_yields_just_root():
+    spans = build_sim_spans([], modality="chat", project_name="proj")
+    assert len(spans) == 1
+    assert spans[0]["attributes"][so.FI_SPAN_KIND] == "AGENT"
+
+
+@pytest.mark.unit
+def test_attribute_keys_match_tracer_spanattributes():
+    # Drift guard: our local keys must equal the tracer's real SpanAttributes so
+    # the ingest converter reads them correctly.
+    from tracer.utils.otel import SpanAttributes as SA
+
+    assert so.FI_SPAN_KIND == SA.FI_SPAN_KIND
+    assert so.INPUT_VALUE == SA.INPUT_VALUE
+    assert so.OUTPUT_VALUE == SA.OUTPUT_VALUE
+    assert so.SESSION_ID == SA.SESSION_ID
+    assert so.USAGE_INPUT_TOKENS == SA.USAGE_INPUT_TOKENS
+    assert so.USAGE_OUTPUT_TOKENS == SA.USAGE_OUTPUT_TOKENS
+    assert so.USAGE_TOTAL_TOKENS == SA.USAGE_TOTAL_TOKENS
+    assert so.TOOL_NAME == SA.TOOL_NAME
+    assert so.TOOL_CALL_ID == SA.TOOL_CALL_ID
+    assert so.TOOL_CALL_ARGUMENTS == SA.TOOL_CALL_ARGUMENTS
+    assert so.TOOL_CALL_RESULT == SA.TOOL_CALL_RESULT

--- a/futureagi/simulate/tests/test_sim_observability.py
+++ b/futureagi/simulate/tests/test_sim_observability.py
@@ -73,6 +73,18 @@ def test_tool_span_attributes():
 
 
 @pytest.mark.unit
+def test_root_span_carries_conversation_token_rollup():
+    # The root AGENT span sums the per-turn usage so the trace shows total cost.
+    spans = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p")
+    root = spans[0]
+    assert root["attributes"][so.FI_SPAN_KIND] == "AGENT"
+    # Two assistant turns: input 30+50=80, output 8+10=18, total 38+60=98.
+    assert root["attributes"][so.USAGE_INPUT_TOKENS] == 80
+    assert root["attributes"][so.USAGE_OUTPUT_TOKENS] == 18
+    assert root["attributes"][so.USAGE_TOTAL_TOKENS] == 98
+
+
+@pytest.mark.unit
 def test_voice_modality_emits_pipeline_latency():
     voice_turns = [
         {"role": "user", "content": "hello"},

--- a/futureagi/simulate/tests/test_sim_observability.py
+++ b/futureagi/simulate/tests/test_sim_observability.py
@@ -88,6 +88,24 @@ def test_voice_modality_emits_pipeline_latency():
 
 
 @pytest.mark.unit
+def test_seed_makes_ids_deterministic_and_idempotent():
+    # Same seed → same trace + span ids (so a Temporal retry re-emits the SAME
+    # trace instead of a duplicate). Different seed → different ids.
+    a = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p", seed="call-1")
+    b = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p", seed="call-1")
+    c = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p", seed="call-2")
+    assert [s["trace_id"] for s in a] == [s["trace_id"] for s in b]
+    assert [s["span_id"] for s in a] == [s["span_id"] for s in b]
+    assert a[0]["trace_id"] != c[0]["trace_id"]
+    # Ids are valid OTLP hex widths.
+    assert len(a[0]["trace_id"]) == 32 and len(a[0]["span_id"]) == 16
+    # Without a seed, ids are random (not equal across calls).
+    d = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p")
+    e = build_sim_spans(CHAT_TURNS, modality="chat", project_name="p")
+    assert d[0]["trace_id"] != e[0]["trace_id"]
+
+
+@pytest.mark.unit
 def test_empty_conversation_yields_just_root():
     spans = build_sim_spans([], modality="chat", project_name="proj")
     assert len(spans) == 1

--- a/futureagi/simulate/tests/test_sim_observability_emit.py
+++ b/futureagi/simulate/tests/test_sim_observability_emit.py
@@ -1,0 +1,89 @@
+"""DB test for the sim-observability emit layer (TH-5642).
+
+Verifies emit_sim_trace reads a CallExecution's ChatMessage rows, builds the span
+tree, and hands each span to the tracer OTel write path — i.e. the sim actually
+becomes a trace. The tracer write itself (create_single_otel_span) is mocked so the
+test pins OUR orchestration, not the tracer's ingest internals.
+"""
+
+import uuid
+
+import pytest
+
+from model_hub.models.choices import StatusType
+from simulate.models import AgentDefinition, CallExecution, RunTest, Scenarios
+from simulate.models.chat_message import ChatMessageModel
+from simulate.models.test_execution import TestExecution
+
+
+def _chat_call(organization, workspace):
+    ad = AgentDefinition.objects.create(
+        agent_name="Obs Test Agent", agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+        inbound=True, description="obs", organization=organization, workspace=workspace,
+        provider="retell", assistant_id="agent_1", languages=["en"],
+    )
+    scenario = Scenarios.objects.create(
+        name="Obs Scenario", description="obs", source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET, organization=organization,
+        workspace=workspace, agent_definition=ad, status=StatusType.COMPLETED.value,
+    )
+    rt = RunTest.objects.create(
+        name="Obs Run", description="obs", agent_definition=ad,
+        organization=organization, workspace=workspace,
+    )
+    te = TestExecution.objects.create(
+        run_test=rt, status=TestExecution.ExecutionStatus.COMPLETED,
+        total_scenarios=1, total_calls=1, agent_definition=ad,
+    )
+    return CallExecution.objects.create(
+        test_execution=te, scenario=scenario,
+        status=CallExecution.CallStatus.COMPLETED,
+        simulation_call_type=CallExecution.SimulationCallType.TEXT,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_emit_sim_trace_builds_and_emits_span_tree(organization, workspace, monkeypatch):
+    ce = _chat_call(organization, workspace)
+    # Two turns: simulator (user) opens, agent-under-test (assistant) replies.
+    ChatMessageModel.objects.create(
+        id=uuid.uuid4(), role="user", call_execution=ce,
+        messages=["Hi, do you sell scooters?"], content=[], session_id="sess-9",
+        organization=organization, workspace=workspace, tokens=10,
+    )
+    ChatMessageModel.objects.create(
+        id=uuid.uuid4(), role="assistant", call_execution=ce,
+        messages=["Yes! The X1 is $199."], content=[], session_id="sess-9",
+        organization=organization, workspace=workspace, tokens=8, latency_ms=420,
+    )
+
+    captured = []
+    import tracer.utils.create_otel_span as cos
+
+    monkeypatch.setattr(
+        cos, "create_single_otel_span",
+        lambda span, org, user, ws=None: captured.append((span, org, ws)),
+    )
+
+    from simulate.services.sim_observability import emit_sim_trace
+
+    emitted = emit_sim_trace(ce)
+
+    # Root AGENT span + one LLM span for the single assistant turn.
+    kinds = [s["attributes"]["gen_ai.span.kind"] for s, _, _ in captured]
+    assert emitted == 2
+    assert kinds.count("AGENT") == 1
+    assert kinds.count("LLM") == 1
+    # The org id was threaded; no observability project → falls back to "Simulations".
+    org_ids = {org for _, org, _ in captured}
+    assert org_ids == {str(organization.id)}
+    assert all(s["project_name"] == "Simulations" for s, _, _ in captured)
+    # The agent's reply is the LLM span output + the root output.
+    llm = next(s for s, _, _ in captured if s["attributes"]["gen_ai.span.kind"] == "LLM")
+    assert llm["attributes"]["output.value"] == "Yes! The X1 is $199."
+    assert llm["attributes"]["gen_ai.usage.output_tokens"] == 8
+    assert llm["latency"] == 420
+    # session.id lives on the root AGENT span (links the whole conversation).
+    root = next(s for s, _, _ in captured if s["attributes"]["gen_ai.span.kind"] == "AGENT")
+    assert root["attributes"]["session.id"] == "sess-9"

--- a/futureagi/simulate/tests/test_sim_observability_emit.py
+++ b/futureagi/simulate/tests/test_sim_observability_emit.py
@@ -87,3 +87,35 @@ def test_emit_sim_trace_builds_and_emits_span_tree(organization, workspace, monk
     # session.id lives on the root AGENT span (links the whole conversation).
     root = next(s for s, _, _ in captured if s["attributes"]["gen_ai.span.kind"] == "AGENT")
     assert root["attributes"]["session.id"] == "sess-9"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_emit_sim_trace_accepts_voice_turns(organization, workspace, monkeypatch):
+    # VOICE: the completion hook passes its normalized transcript directly (voice
+    # transcripts live outside ChatMessageModel).
+    ce = _chat_call(organization, workspace)
+    ce.simulation_call_type = CallExecution.SimulationCallType.VOICE
+    ce.save(update_fields=["simulation_call_type"])
+
+    voice_turns = [
+        {"role": "user", "content": "Is my appointment confirmed?"},
+        {"role": "assistant", "content": "Yes, you're confirmed for 3pm.",
+         "voice_latency": {"ttfb": 480, "total": 950}},
+    ]
+    captured = []
+    import tracer.utils.create_otel_span as cos
+
+    monkeypatch.setattr(
+        cos, "create_single_otel_span",
+        lambda span, org, user, ws=None: captured.append(span),
+    )
+
+    from simulate.services.sim_observability import emit_sim_trace
+
+    emitted = emit_sim_trace(ce, turns=voice_turns)
+    assert emitted == 2
+    root = next(s for s in captured if s["attributes"]["gen_ai.span.kind"] == "AGENT")
+    assert root["name"] == "voice simulation"
+    llm = next(s for s in captured if s["attributes"]["gen_ai.span.kind"] == "LLM")
+    assert llm["attributes"]["gen_ai.voice.latency.ttfb"] == 480

--- a/futureagi/tracer/models/monitor.py
+++ b/futureagi/tracer/models/monitor.py
@@ -50,6 +50,11 @@ class MonitorMetricTypeChoices(models.TextChoices):
     EVALUATION_METRICS = "evaluation_metrics", "Evaluation metrics"
     # RATE_LIMIT_ALERT = "rate_limit_alert", "Rate limit alert" # we don't have this data in the db yet, removed for now
 
+    # Simulation metrics (TH-5642) — read from CallExecution, not CH traces. Lets
+    # users alert on sim quality regressions / failure spikes like Cekura/Coval do.
+    SIM_EVAL_SCORE = "sim_eval_score", "Simulation eval score (avg)"
+    SIM_FAILURE_RATE = "sim_failure_rate", "Simulation failure rate"
+
 
 class ThresholdCalculationMethodChoices(models.TextChoices):
     """Choices for how threshold values are calculated or determined."""

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -239,8 +239,51 @@ def _process_monitor(monitor, now):
     _check_thresholds_and_alert(monitor, metric_value, time_window_start, now)
 
 
+_SIM_METRIC_TYPES = frozenset(
+    {
+        MonitorMetricTypeChoices.SIM_EVAL_SCORE,
+        MonitorMetricTypeChoices.SIM_FAILURE_RATE,
+    }
+)
+
+
+def _get_sim_metric_value(monitor, start_time, end_time):
+    """Compute a simulation metric over completed sims in the window for the
+    monitor's org (TH-5642). Sim data lives in CallExecution, not CH traces, so this
+    reads the ORM directly — lets users alert on sim quality regressions / failure
+    spikes the way Cekura/Coval do."""
+    from django.db.models import Avg, Count, Q
+
+    from simulate.models import CallExecution
+
+    org_id = getattr(monitor.project, "organization_id", None) or getattr(
+        monitor, "organization_id", None
+    )
+    if not org_id:
+        return None
+    qs = CallExecution.objects.filter(
+        test_execution__run_test__organization_id=org_id,
+        created_at__range=(start_time, end_time),
+    )
+    if monitor.metric_type == MonitorMetricTypeChoices.SIM_EVAL_SCORE:
+        return qs.exclude(overall_score__isnull=True).aggregate(
+            v=Avg("overall_score")
+        )["v"]
+    if monitor.metric_type == MonitorMetricTypeChoices.SIM_FAILURE_RATE:
+        agg = qs.aggregate(
+            total=Count("id"),
+            failed=Count("id", filter=Q(status=CallExecution.CallStatus.FAILED)),
+        )
+        return (agg["failed"] / agg["total"]) if agg["total"] else None
+    return None
+
+
 def _get_metric_value(monitor, start_time, end_time):
     """Calculates the value of the metric for the given time window."""
+
+    # Simulation metrics read CallExecution data, not CH traces (TH-5642).
+    if monitor.metric_type in _SIM_METRIC_TYPES:
+        return _get_sim_metric_value(monitor, start_time, end_time)
 
     # --- ClickHouse dispatch ---
     analytics = AnalyticsQueryService()


### PR DESCRIPTION
Stack **2/5** · base `stack/1-provider-registry`. Unified sim-observability span builder (chat+voice), sim traces in the trace UI, deterministic idempotent re-emit, eval-results attached to sim traces, sim eval-score/failure-rate monitors, conversation token/cost rollup, and scenario-aligned mock tool returns wired into the prompt agent. 10 commits.

---
**Stacked PR series (1→5).** Merge bottom-up: this PR's base is the previous stack branch; after it merges, retarget the next PR's base to `dev`. PRs 1–4 are conflict-free (no internal dev-merges); PR 5 carries dev-merge noise by design (the branch merged `dev` 4×) — review it via its own ~37 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)