### PR TITLE
Optimiser apply-the-fix (whole-agent via kit) + Agora RTC (stack 4/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+futureagi/agora*.dat

--- a/frontend/src/api/tests/testDetails.js
+++ b/frontend/src/api/tests/testDetails.js
@@ -19,6 +19,17 @@ export const useGetTestDetail = (testId, options = {}) => {
   });
 };
 
+export const useApplyTrialPrompt = (options = {}) => {
+  return useMutation({
+    mutationFn: async ({ optimizationId, trialId }) =>
+      axios.post(
+        endpoints.optimizeSimulate.applyTrial(optimizationId, trialId),
+        {},
+      ),
+    ...options,
+  });
+};
+
 export const useOptimizeTrialPrompts = ({ optimizationId, trialId }) => {
   return useQuery({
     queryKey: ["fix-my-agent-trail-prompts", optimizationId, trialId],

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -33,6 +33,21 @@ import { spin } from "../../../../animations/animations";
 import { pinCodeOptions } from "src/components/agent-definitions/helper";
 import { useAuthContext } from "src/auth/hooks";
 
+// Providers whose credential is two values joined by a colon (validated
+// backend-side the same way: api_key.partition(":")).
+const COMPOSITE_API_KEY_HINTS = {
+  twilio: {
+    placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:your_auth_token",
+    helper:
+      "Twilio: Account SID and Auth Token joined by a colon (SID:AUTH_TOKEN)",
+  },
+  agora: {
+    placeholder: "customer_key:customer_secret",
+    helper:
+      "Agora: RESTful API Customer Key and Secret joined by a colon (KEY:SECRET)",
+  },
+};
+
 export default function AgentVoiceForm() {
   const { orgLimit } = useAuthContext();
   const { control, setValue: setFormValue } = useFormContext();
@@ -399,7 +414,11 @@ export default function AgentVoiceForm() {
             control={control}
             fieldName="apiKey"
             label="Provider API Key"
-            placeholder="Enter your provider’s API key to authenticate the agent"
+            placeholder={
+              COMPOSITE_API_KEY_HINTS[selectedProvider]?.placeholder ||
+              "Enter your provider’s API key to authenticate the agent"
+            }
+            helperText={COMPOSITE_API_KEY_HINTS[selectedProvider]?.helper}
             required={observabilityEnabled || keysRequired}
             size="small"
             fullWidth

--- a/frontend/src/sections/test-detail/CreateEditOptimization/CreateEditOptimizationForm.jsx
+++ b/frontend/src/sections/test-detail/CreateEditOptimization/CreateEditOptimizationForm.jsx
@@ -1,6 +1,14 @@
-import { Box, Button, InputAdornment, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  FormControlLabel,
+  InputAdornment,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/material";
 import React, { useState } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import { FieldWrapper } from "./ShareComponents";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
@@ -120,6 +128,12 @@ const CreateEditOptimizationForm = ({ onClose, defaultValues, onSuccess }) => {
         }),
         ...(configuration.maxMetricCalls !== undefined && {
           max_metric_calls: configuration.maxMetricCalls,
+        }),
+        ...(configuration.searchSpace?.trim() && {
+          search_space: JSON.parse(configuration.searchSpace),
+        }),
+        ...(configuration.dryRun !== undefined && {
+          dry_run: configuration.dryRun,
         }),
       },
       test_execution_id: executionId,
@@ -404,6 +418,41 @@ const CreateEditOptimizationForm = ({ onClose, defaultValues, onSuccess }) => {
                 }}
                 fullWidth
               />
+            </ShowComponent>
+            <ShowComponent
+              condition={optimizerValue === OPTIMIZER_TYPE.AGENT_LEARNING_KIT}
+            >
+              <FieldWrapper helperText='Optional. JSON mapping agent config paths to candidate values to search beyond instructions, e.g. {"model": ["gpt-4o", "gpt-4o-mini"], "voice_id": ["..."]}'>
+                <FormTextFieldV2
+                  placeholder='{"model": ["gpt-4o", "gpt-4o-mini"]}'
+                  control={control}
+                  fieldName="configuration.searchSpace"
+                  label="Search space (whole-agent, JSON)"
+                  multiline
+                  minRows={3}
+                  maxRows={8}
+                  fullWidth
+                  size="small"
+                />
+              </FieldWrapper>
+              <FieldWrapper helperText="Score candidates without calling the live provider agent">
+                <Controller
+                  name="configuration.dryRun"
+                  control={control}
+                  render={({ field }) => (
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={!!field.value}
+                          onChange={(e) => field.onChange(e.target.checked)}
+                          size="small"
+                        />
+                      }
+                      label="Dry run"
+                    />
+                  )}
+                />
+              </FieldWrapper>
             </ShowComponent>
             <ShowComponent
               condition={optimizerValue === OPTIMIZER_TYPE.PROMPTWIZARD}

--- a/frontend/src/sections/test-detail/CreateEditOptimization/common.js
+++ b/frontend/src/sections/test-detail/CreateEditOptimization/common.js
@@ -129,11 +129,35 @@ const GEPAOptimizerSchema = z.object({
     .min(1, "Max metric calls must be at least 1"),
 });
 
-// Backend builds candidates from the agent's base prompt and applies its own
-// defaults (simulate/utils/agent_prompt_optimiser.py), so only the optional
-// task description is collected here.
+// Whole-agent optimization: the backend derives base_agent from the run's
+// agent definition; searchSpace (dot-path -> candidate values, JSON) widens
+// the search beyond instructions (e.g. {"model": [...], "voice_id": [...]}).
 const AgentLearningKitOptimizerSchema = z.object({
   taskDescription: z.string().optional(),
+  searchSpace: z
+    .string()
+    .optional()
+    .refine(
+      (value) => {
+        if (!value || !value.trim()) return true;
+        try {
+          const parsed = JSON.parse(value);
+          return (
+            parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed) &&
+            Object.values(parsed).every((v) => Array.isArray(v))
+          );
+        } catch {
+          return false;
+        }
+      },
+      {
+        message:
+          'Must be a JSON object mapping config paths to value lists, e.g. {"model": ["gpt-4o", "gpt-4o-mini"]}',
+      },
+    ),
+  dryRun: z.boolean().optional(),
 });
 
 export const createEditOptimizerSchema = z.discriminatedUnion("optimiserType", [
@@ -226,5 +250,7 @@ export const OptimizerConfigurationMapping = {
   },
   agent_learning_kit: {
     taskDescription: "",
+    searchSpace: "",
+    dryRun: false,
   },
 };

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/PrompDetails/PromptDetails.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/PrompDetails/PromptDetails.jsx
@@ -1,8 +1,30 @@
 import { Box } from "@mui/material";
+import { LoadingButton } from "@mui/lab";
 import PropTypes from "prop-types";
-import { useOptimizeTrialPrompts } from "src/api/tests/testDetails";
+import {
+  useApplyTrialPrompt,
+  useOptimizeTrialPrompts,
+} from "src/api/tests/testDetails";
+import { enqueueSnackbar } from "src/components/snackbar";
 import PromptDiffView from "./PromptDiffView";
 import PromptPanel from "./PromptPanel";
+
+// The apply endpoint picks the right edge per run and reports which one it
+// took: a new default PromptVersion (prompt-template runs), a live write to
+// the hosted provider agent, or a new active AgentVersion (self-hosted).
+const applySuccessMessage = (result) => {
+  if (result?.newPromptVersionId) {
+    return `Applied as prompt version ${result.templateVersion ?? ""}`.trim();
+  }
+  if (result?.target === "provider_agent") {
+    const fields = (result.appliedFields || []).join(", ");
+    return `Applied to the live ${result.provider} agent${fields ? ` (${fields})` : ""}`;
+  }
+  if (result?.target === "agent_version") {
+    return `Applied as agent version v${result.versionNumber} (${result.provider})`;
+  }
+  return "Fix applied";
+};
 
 const PromptDetails = ({ optimizationId, trialId, showDiff }) => {
   const { data: trailPromptData } = useOptimizeTrialPrompts({
@@ -10,22 +32,55 @@ const PromptDetails = ({ optimizationId, trialId, showDiff }) => {
     trialId,
   });
 
+  const { mutate: applyTrial, isPending: isApplying } = useApplyTrialPrompt({
+    onSuccess: (response) => {
+      enqueueSnackbar(applySuccessMessage(response?.data?.result), {
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      enqueueSnackbar(
+        error?.response?.data?.detail || "Failed to apply the fix",
+        { variant: "error" },
+      );
+    },
+  });
+
+  const applyButton = (
+    <Box sx={{ display: "flex", justifyContent: "flex-end", px: 2, pt: 1 }}>
+      <LoadingButton
+        size="small"
+        variant="contained"
+        loading={isApplying}
+        onClick={() => applyTrial({ optimizationId, trialId })}
+      >
+        Apply fix
+      </LoadingButton>
+    </Box>
+  );
+
   if (showDiff) {
     return (
-      <PromptDiffView
-        originalPrompt={trailPromptData?.basePrompt}
-        optimizedPrompt={trailPromptData?.trialPrompt}
-      />
+      <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        {applyButton}
+        <PromptDiffView
+          originalPrompt={trailPromptData?.basePrompt}
+          optimizedPrompt={trailPromptData?.trialPrompt}
+        />
+      </Box>
     );
   }
 
   return (
-    <Box sx={{ display: "flex", gap: 1, height: "100%" }}>
-      <Box sx={{ flex: 1 }}>
-        <PromptPanel
-          title="OPTIMIZED AGENT PROMPT"
-          prompt={trailPromptData?.trialPrompt}
-        />
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      {applyButton}
+      <Box sx={{ display: "flex", gap: 1, flex: 1, minHeight: 0 }}>
+        <Box sx={{ flex: 1 }}>
+          <PromptPanel
+            title="OPTIMIZED AGENT PROMPT"
+            prompt={trailPromptData?.trialPrompt}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1681,6 +1681,11 @@ export const endpoints = {
         { id: id, trial_id: trialId },
       ),
     getOptimizationRuns: () => apiPath("/simulate/api/agent-prompt-optimiser/"),
+    applyTrial: (id, trialId) =>
+      apiPath(
+        "/simulate/api/agent-prompt-optimiser/{id}/trial/{trial_id}/apply/",
+        { id: id, trial_id: trialId },
+      ),
   },
   workspaces: {
     list: apiPath("/accounts/workspace/list/"),

--- a/futureagi/.gitignore
+++ b/futureagi/.gitignore
@@ -57,3 +57,4 @@ playwright-report/
 *.out
 .DS_Store
 **/.DS_Store
+agora_cache.db

--- a/futureagi/docker-compose.branch.yml
+++ b/futureagi/docker-compose.branch.yml
@@ -25,6 +25,7 @@ x-livekit-env: &livekit-env
   # Agora RTC connector (web_agora): RTC tokens + ConvAI agent llm/tts defaults.
   AGORA_APP_ID: aa038cecadcc47e7b3e493cef42e7d49
   AGORA_APP_CERT: 1466bc6a58bf48759a7b2f3641b1758a
+  CARTESIA_API_KEY: sk_car_K7SEemFZgJwBhWwW2N9W78
   ELEVENLABS_API_KEY: sk_594e200cd46087427a7bc27e3852e78ba5e5c0f2eaf16ce5
 
 services:

--- a/futureagi/docker-compose.branch.yml
+++ b/futureagi/docker-compose.branch.yml
@@ -22,6 +22,10 @@ x-livekit-env: &livekit-env
   # worker's own BACKEND_URL env). Default is :8000 → pushes vanish; the lksip
   # containers run host-network, so the branch backend is host :8003.
   LIVEKIT_BACKEND_CALLBACK_URL: http://localhost:8003
+  # Agora RTC connector (web_agora): RTC tokens + ConvAI agent llm/tts defaults.
+  AGORA_APP_ID: aa038cecadcc47e7b3e493cef42e7d49
+  AGORA_APP_CERT: 1466bc6a58bf48759a7b2f3641b1758a
+  ELEVENLABS_API_KEY: sk_594e200cd46087427a7bc27e3852e78ba5e5c0f2eaf16ce5
 
 services:
   backend:

--- a/futureagi/docker-compose.branch.yml
+++ b/futureagi/docker-compose.branch.yml
@@ -1,0 +1,42 @@
+# TH-5642 local branch run: use the baked :dev image (deps) + mount THIS working
+# tree as source, so the running backend/worker execute the feat/multi-provider-registry
+# code WITHOUT a rebuild (base image v1.8.19_base isn't local). Compose `up` (no --build)
+# uses the existing :dev image because it's set here.
+# Voice E2E: point the voice stack at the LOCAL LiveKit+SIP containers (lksip-*,
+# host network → reachable from compose containers via host.docker.internal).
+x-livekit-env: &livekit-env
+  LIVEKIT_URL: ws://host.docker.internal:7880
+  LIVEKIT_API_KEY: APIe0919c953e2fa7b0
+  LIVEKIT_API_SECRET: qjPNcqBF+c4C7/mQUbiySYGCkH4ijiVlWI2mIjsCUTU=
+  # Voice executions are orchestrated by TestExecutionWorkflow (creates
+  # CallExecutions + launches ee CallExecutionWorkflow children). The legacy
+  # monitor-based pickup is commented out in tfc/temporal/schedules/simulate.py,
+  # so without this flag voice runs are created PENDING and never picked up.
+  TEMPORAL_TEST_EXECUTION_ENABLED: "true"
+  # The lksip agent worker pushes transcripts/metrics/call-end to the backend's
+  # internal livekit API (Authorization: Bearer <INTERNAL_API_SECRET>); must match
+  # the worker's INTERNAL_API_SECRET.
+  INTERNAL_API_SECRET: devsecret
+  # Callback URL the backend embeds in LiveKit agent-dispatch metadata; the
+  # lksip job process pushes transcripts/lifecycle THERE (it overrides the
+  # worker's own BACKEND_URL env). Default is :8000 → pushes vanish; the lksip
+  # containers run host-network, so the branch backend is host :8003.
+  LIVEKIT_BACKEND_CALLBACK_URL: http://localhost:8003
+
+services:
+  backend:
+    image: futureagi/future-agi:dev
+    pull_policy: never
+    platform: linux/arm64
+    volumes:
+      - ".:/app/backend"
+    environment:
+      <<: *livekit-env
+  temporal-worker-dev:
+    image: futureagi/future-agi:dev
+    pull_policy: never
+    platform: linux/arm64
+    volumes:
+      - ".:/app/backend"
+    environment:
+      <<: *livekit-env

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -209,9 +209,13 @@ _SPECS: tuple[ProviderSpec, ...] = (
         roles=frozenset({Role.AGENT_PLATFORM}),
         transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
         observability_key="bland", status=Status.PLANNED,
-        # Bland is outbound-first: outbound now wired via BlandOutboundDialer
-        # (/v1/calls). Inbound (receiving on a Bland number) is not wired yet.
-        supported_directions=_BOTH, implemented_directions=_OUT,
+        # Outbound wired via BlandOutboundDialer (/v1/calls). INBOUND: a Bland
+        # agent with an inbound number ($15/mo purchase or BYO-Twilio/SIP)
+        # answers any PSTN caller, so the provider-neutral SIP path (dial the
+        # agent's contact_number) reaches it with NO new code — capability
+        # research 2026-06-10 (TH-5683). Live verification still needs an
+        # account with a configured pathway + inbound number.
+        supported_directions=_BOTH, implemented_directions=_BOTH,
     ),
     # --- Non-agent-platform roles ---
     ProviderSpec(

--- a/futureagi/simulate/providers/registry.py
+++ b/futureagi/simulate/providers/registry.py
@@ -24,20 +24,20 @@ class Role(StrEnum):
     """A role a provider plays. Enum/component presence != tested-platform support."""
 
     AGENT_PLATFORM = "agent_platform"  # a customer agent we TEST (agent-under-test)
-    SYSTEM_ENGINE = "system_engine"    # infra that runs OUR simulated caller
-    TRANSPORT = "transport"            # how we reach the agent (SIP / WebRTC / PSTN)
-    STT = "stt"                        # simulator-side speech-to-text component
-    TTS = "tts"                        # simulator-side text-to-speech component
-    CHAT_ENGINE = "chat_engine"        # text-simulation engine
+    SYSTEM_ENGINE = "system_engine"  # infra that runs OUR simulated caller
+    TRANSPORT = "transport"  # how we reach the agent (SIP / WebRTC / PSTN)
+    STT = "stt"  # simulator-side speech-to-text component
+    TTS = "tts"  # simulator-side text-to-speech component
+    CHAT_ENGINE = "chat_engine"  # text-simulation engine
 
 
 class Transport(StrEnum):
     """How the simulator reaches the agent-under-test."""
 
     WEBRTC_BRIDGE = "webrtc_bridge"  # join via our LiveKit bridge connector (web_*)
-    SIP = "sip"                      # dial via our LiveKit SIP trunk (provider-neutral)
-    DIRECT_WS = "direct_ws"          # raw provider WebSocket, Vapi-style
-    AGORA_RTC = "agora_rtc"          # Agora's proprietary RTC (NOT LiveKit-compatible)
+    SIP = "sip"  # dial via our LiveKit SIP trunk (provider-neutral)
+    DIRECT_WS = "direct_ws"  # raw provider WebSocket, Vapi-style
+    AGORA_RTC = "agora_rtc"  # Agora's proprietary RTC (NOT LiveKit-compatible)
     NONE = "none"
 
 
@@ -45,18 +45,18 @@ class CredentialShape(StrEnum):
     """The credential field-group a provider needs (drives the agent-def form)."""
 
     API_KEY_ASSISTANT = "api_key_assistant"  # api_key + assistant/agent_id
-    LIVEKIT_SERVER = "livekit_server"        # url + api_key + api_secret + agent_name
-    AGENT_ID = "agent_id"                    # api_key + agent_id (ElevenLabs/Deepgram)
-    SIP_ONLY = "sip_only"                    # just a phone number
-    WEBSOCKET_URL = "websocket_url"          # custom ws endpoint
+    LIVEKIT_SERVER = "livekit_server"  # url + api_key + api_secret + agent_name
+    AGENT_ID = "agent_id"  # api_key + agent_id (ElevenLabs/Deepgram)
+    SIP_ONLY = "sip_only"  # just a phone number
+    WEBSOCKET_URL = "websocket_url"  # custom ws endpoint
     NONE = "none"
 
 
 class Status(StrEnum):
-    GA = "ga"                          # wired & working as a tested platform today
-    PLANNED = "planned"                # designed (DESIGN.md §5), not yet built
+    GA = "ga"  # wired & working as a tested platform today
+    PLANNED = "planned"  # designed (DESIGN.md §5), not yet built
     TRANSPORT_ONLY = "transport_only"  # never an agent platform (e.g. Twilio)
-    INTERNAL = "internal"              # our own engine, not a tested platform
+    INTERNAL = "internal"  # our own engine, not a tested platform
 
 
 class Direction(StrEnum):
@@ -67,7 +67,7 @@ class Direction(StrEnum):
     so we mirror rather than import; ``test_provider_registry`` pins the equality.
     """
 
-    INBOUND = "inbound"    # FutureAGI's simulator CALLS the agent (agent receives)
+    INBOUND = "inbound"  # FutureAGI's simulator CALLS the agent (agent receives)
     OUTBOUND = "outbound"  # the agent CALLS FutureAGI (our simulator answers)
 
 
@@ -79,13 +79,13 @@ _NONE: frozenset[Direction] = frozenset()
 
 @dataclass(frozen=True)
 class ProviderSpec:
-    key: str                              # canonical client-provider string
+    key: str  # canonical client-provider string
     label: str
     roles: frozenset[Role]
     transport: Transport = Transport.NONE
-    connector_key: str | None = None      # WebRTC bridge registry key (web_*), if any
+    connector_key: str | None = None  # WebRTC bridge registry key (web_*), if any
     credential_shape: CredentialShape = CredentialShape.NONE
-    chat: bool = False                    # has / will have a named chat engine
+    chat: bool = False  # has / will have a named chat engine
     observability_key: str | None = None  # maps to ProviderChoices value, if any
     status: Status = Status.PLANNED
     # Call directions the provider's API can do AND we can drive (capability).
@@ -114,65 +114,92 @@ class ProviderSpec:
 # Declarative registry — the ONLY place a provider is declared. See DESIGN.md §1/§5.
 _SPECS: tuple[ProviderSpec, ...] = (
     ProviderSpec(
-        "vapi", "Vapi",
+        "vapi",
+        "Vapi",
         roles=frozenset({Role.AGENT_PLATFORM, Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
-        transport=Transport.WEBRTC_BRIDGE, connector_key="web_vapi",
-        credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
-        observability_key="vapi", status=Status.GA,
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_vapi",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        chat=True,
+        observability_key="vapi",
+        status=Status.GA,
         # The only provider whose outbound (agent-dials-us) path is wired today.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     ProviderSpec(
-        "retell", "Retell",
+        "retell",
+        "Retell",
         roles=frozenset({Role.AGENT_PLATFORM, Role.CHAT_ENGINE}),
-        transport=Transport.WEBRTC_BRIDGE, connector_key="web_retell",
-        credential_shape=CredentialShape.API_KEY_ASSISTANT, chat=True,
-        observability_key="retell", status=Status.GA,
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_retell",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        chat=True,
+        observability_key="retell",
+        status=Status.GA,
         # Inbound via the web_retell bridge; outbound now wired via the
         # RetellOutboundDialer (/v2/create-phone-call). "implemented" = wired, not
         # yet live-verified e2e (a real outbound call needs a Retell number + stack).
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # The customer's own LiveKit agent (distinct from the SYSTEM 'livekit' engine).
     ProviderSpec(
-        "livekit_bridge", "LiveKit (agent)",
+        "livekit_bridge",
+        "LiveKit (agent)",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_livekit_bridge",
         credential_shape=CredentialShape.LIVEKIT_SERVER,
-        observability_key="livekit", status=Status.GA,
+        observability_key="livekit",
+        status=Status.GA,
         # WebRTC bridge has NO PSTN leg: we connect to the agent the same way in
         # both directions; the only difference is who speaks first, now handled by
         # first_message_mode for all transports. So outbound = inbound bridge +
         # agent-speaks-first → both wired.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # Provider-neutral catch-all: custom agents reached by phone (SIP) or websocket.
     ProviderSpec(
-        "others", "Others (custom / SIP)",
+        "others",
+        "Others (custom / SIP)",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.SIP, credential_shape=CredentialShape.WEBSOCKET_URL,
-        observability_key="others", status=Status.GA,
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.WEBSOCKET_URL,
+        observability_key="others",
+        status=Status.GA,
         # Plain-E.164 SIP works in both directions today.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # --- Planned tested platforms (DESIGN.md §5) ---
     ProviderSpec(
-        "elevenlabs", "ElevenLabs Conversational AI",
+        "elevenlabs",
+        "ElevenLabs Conversational AI",
         roles=frozenset({Role.AGENT_PLATFORM, Role.TTS}),
-        transport=Transport.DIRECT_WS, connector_key="web_elevenlabs",
-        credential_shape=CredentialShape.AGENT_ID, chat=True,
-        observability_key="eleven_labs", status=Status.PLANNED,
+        transport=Transport.DIRECT_WS,
+        connector_key="web_elevenlabs",
+        credential_shape=CredentialShape.AGENT_ID,
+        chat=True,
+        observability_key="eleven_labs",
+        status=Status.PLANNED,
         # Inbound via the connect()-only WS connector; outbound now wired via
         # ElevenLabsOutboundDialer (POST /v1/convai/twilio/outbound-call).
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     ProviderSpec(
-        "deepgram", "Deepgram Voice Agent",
+        "deepgram",
+        "Deepgram Voice Agent",
         roles=frozenset({Role.AGENT_PLATFORM, Role.STT}),
-        transport=Transport.DIRECT_WS, connector_key="web_deepgram",
+        transport=Transport.DIRECT_WS,
+        connector_key="web_deepgram",
         observability_key="deepgram",
-        credential_shape=CredentialShape.AGENT_ID, status=Status.PLANNED,
-        supported_directions=_BOTH, implemented_directions=_IN,
+        credential_shape=CredentialShape.AGENT_ID,
+        status=Status.PLANNED,
+        supported_directions=_BOTH,
+        implemented_directions=_IN,
     ),
     # Agora Conversational AI Engine exposes its agents over SIP/PSTN via an
     # Elastic SIP Trunk (import a number, assign to the agent for inbound/outbound)
@@ -182,66 +209,90 @@ _SPECS: tuple[ProviderSpec, ...] = (
     # SDK-gated (DESIGN.md §5.4). Modeling SIP as the primary transport matches the
     # only path achievable on our infra today.
     ProviderSpec(
-        "agora", "Agora Conversational AI",
+        "agora",
+        "Agora Conversational AI",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.SIP, observability_key="agora",
-        credential_shape=CredentialShape.API_KEY_ASSISTANT, status=Status.PLANNED,
-        # SIP/PSTN both directions per Agora's Elastic SIP Trunk. Outbound now wired via
-        # AgoraOutboundDialer (ConvAI telephony API; agent SIP-dials our pool number);
-        # inbound (we SIP-call an Agora number) is not wired yet — same shape as Bland.
-        supported_directions=_BOTH, implemented_directions=_OUT,
+        transport=Transport.SIP,
+        connector_key="web_agora",
+        observability_key="agora",
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        status=Status.PLANNED,
+        # Outbound wired via AgoraOutboundDialer (ConvAI telephony API). Inbound is
+        # now implemented PHONE-FREE via the native web_agora RTC connector
+        # (AgoraRTCConnector spawns the ConvAI agent into an RTC channel and the
+        # simulator joins the same channel — TH-5682).
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # Pipecat-on-LiveKit reuses the existing LiveKit bridge connector (DESIGN.md §5.5).
     ProviderSpec(
-        "pipecat", "Pipecat (LiveKit transport)",
+        "pipecat",
+        "Pipecat (LiveKit transport)",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.WEBRTC_BRIDGE, connector_key="web_livekit_bridge",
+        transport=Transport.WEBRTC_BRIDGE,
+        connector_key="web_livekit_bridge",
         observability_key="pipecat",
-        credential_shape=CredentialShape.LIVEKIT_SERVER, status=Status.PLANNED,
+        credential_shape=CredentialShape.LIVEKIT_SERVER,
+        status=Status.PLANNED,
         # Reuses the LiveKit bridge → same as livekit_bridge: outbound is just the
         # agent-speaks-first opener over the same bridge connection. Both wired.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # Bland.ai agents are reached via the provider-neutral SIP/phone path (no
     # WebRTC connector needed) — DESIGN.md §3/§6.
     ProviderSpec(
-        "bland", "Bland.ai",
+        "bland",
+        "Bland.ai",
         roles=frozenset({Role.AGENT_PLATFORM}),
-        transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
-        observability_key="bland", status=Status.PLANNED,
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        observability_key="bland",
+        status=Status.PLANNED,
         # Outbound wired via BlandOutboundDialer (/v1/calls). INBOUND: a Bland
         # agent with an inbound number ($15/mo purchase or BYO-Twilio/SIP)
         # answers any PSTN caller, so the provider-neutral SIP path (dial the
         # agent's contact_number) reaches it with NO new code — capability
         # research 2026-06-10 (TH-5683). Live verification still needs an
         # account with a configured pathway + inbound number.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     # --- Non-agent-platform roles ---
     ProviderSpec(
-        "twilio", "Twilio",
+        "twilio",
+        "Twilio",
         # Twilio is BOTH a carrier substrate AND a platform customers build agents on
         # (ConversationRelay / Media Streams / TwiML routed to their logic).
         roles=frozenset({Role.AGENT_PLATFORM, Role.TRANSPORT}),
-        transport=Transport.SIP, credential_shape=CredentialShape.API_KEY_ASSISTANT,
-        observability_key="twilio", status=Status.PLANNED,
+        transport=Transport.SIP,
+        credential_shape=CredentialShape.API_KEY_ASSISTANT,
+        observability_key="twilio",
+        status=Status.PLANNED,
         # Inbound = dial the Twilio number over our SIP path; outbound = the
         # TwilioOutboundDialer (Calls.json). Both wired.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     ProviderSpec(
-        "livekit", "LiveKit (system engine)",
+        "livekit",
+        "LiveKit (system engine)",
         roles=frozenset({Role.SYSTEM_ENGINE, Role.TRANSPORT}),
-        transport=Transport.SIP, observability_key="livekit", status=Status.INTERNAL,
+        transport=Transport.SIP,
+        observability_key="livekit",
+        status=Status.INTERNAL,
         # The system engine drives both directions of the simulated call.
-        supported_directions=_BOTH, implemented_directions=_BOTH,
+        supported_directions=_BOTH,
+        implemented_directions=_BOTH,
     ),
     ProviderSpec(
-        "futureagi", "FutureAGI (internal simulator)",
+        "futureagi",
+        "FutureAGI (internal simulator)",
         roles=frozenset({Role.SYSTEM_ENGINE, Role.CHAT_ENGINE}),
         status=Status.INTERNAL,
         # Internal chat engine — telephony direction not applicable.
-        supported_directions=_NONE, implemented_directions=_NONE,
+        supported_directions=_NONE,
+        implemented_directions=_NONE,
     ),
 )
 

--- a/futureagi/simulate/serializers/agent_prompt_optimiser.py
+++ b/futureagi/simulate/serializers/agent_prompt_optimiser.py
@@ -117,7 +117,7 @@ class AgentPromptOptimiserRunCreateSerializer(serializers.ModelSerializer):
                 workspace_id=workspace_id,
             )
         except ValueError as e:
-            raise serializers.ValidationError(str(e))
+            raise serializers.ValidationError(str(e)) from e
 
         validated_data["test_execution"] = test_execution
         validated_data["agent_optimiser"] = agent_optimiser
@@ -402,6 +402,56 @@ class AgentPromptOptimiserTrialPromptResultSerializer(
 class AgentPromptOptimiserTrialPromptResponseSerializer(serializers.Serializer):
     status = serializers.BooleanField(default=True)
     result = AgentPromptOptimiserTrialPromptResultSerializer()
+
+
+class AgentPromptOptimiserApplyTrialRequestSerializer(serializers.Serializer):
+    make_default = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text="Prompt-template runs only: make the new PromptVersion the default.",
+    )
+
+
+class AgentPromptOptimiserApplyTrialResultSerializer(serializers.Serializer):
+    """Union of the three apply targets (prompt_version | provider_agent | agent_version).
+
+    The view picks the edge per run; ``target`` discriminates which optional
+    fields are present (prompt-template runs omit ``target`` and return the
+    ``new_prompt_version_id`` group instead).
+    """
+
+    applied = serializers.BooleanField(read_only=True)
+    source_trial_id = serializers.UUIDField(read_only=True)
+    target = serializers.ChoiceField(
+        choices=["provider_agent", "agent_version"], read_only=True, required=False
+    )
+    provider = serializers.CharField(read_only=True, required=False)
+    # target=provider_agent
+    assistant_id = serializers.CharField(read_only=True, required=False)
+    applied_fields = serializers.ListField(
+        child=serializers.CharField(), read_only=True, required=False
+    )
+    skipped_fields = serializers.ListField(
+        child=serializers.CharField(), read_only=True, required=False
+    )
+    previous_prompt = serializers.CharField(
+        read_only=True, required=False, allow_null=True
+    )
+    previous_config = serializers.DictField(read_only=True, required=False)
+    # target=agent_version
+    reason = serializers.CharField(read_only=True, required=False)
+    new_agent_version_id = serializers.UUIDField(read_only=True, required=False)
+    version_number = serializers.IntegerField(read_only=True, required=False)
+    # prompt-template runs
+    new_prompt_version_id = serializers.UUIDField(read_only=True, required=False)
+    template_version = serializers.CharField(read_only=True, required=False)
+    original_template_id = serializers.UUIDField(read_only=True, required=False)
+    is_default = serializers.BooleanField(read_only=True, required=False)
+
+
+class AgentPromptOptimiserApplyTrialResponseSerializer(serializers.Serializer):
+    status = serializers.BooleanField(default=True)
+    result = AgentPromptOptimiserApplyTrialResultSerializer()
 
 
 class AgentPromptOptimiserTrialEvaluationRowSerializer(serializers.Serializer):

--- a/futureagi/simulate/services/agent_definition_apply.py
+++ b/futureagi/simulate/services/agent_definition_apply.py
@@ -1,0 +1,80 @@
+"""Apply an optimised config to a platform AgentDefinition (TH-5642).
+
+The platform-side apply edge. For agent-definition runs whose provider has NO
+writable hosted prompt — self-hosted code agents (LiveKit, Pipecat, Deepgram) and
+non-prompt provider configs (Twilio TwiML, Bland pathway) — there is no provider
+API to write to, but the platform still owns the AgentDefinition + its versioned
+config. "Directly apply the fix" there means persisting the winning config as a
+NEW, non-destructive AgentVersion (mirrors optimizer_apply's new-PromptVersion
+pattern): the optimisation is recorded and becomes the agent's active version,
+which the customer's own deployment / the next simulation adopts.
+
+This makes apply work for ALL providers: provider-hosted agents additionally get
+a live provider-API write (see provider_prompt_apply), everything else gets the
+platform-version write here. Neither path silently drops the fix.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Keys of the kit's whole-agent candidate config that map onto an AgentDefinition
+# version snapshot. (provider/assistant_id identity keys are deliberately ignored.)
+_CONFIG_TO_SNAPSHOT = {
+    "instructions": "system_prompt",
+    "model": "model",
+    "temperature": "temperature",
+    "first_message": "first_message",
+    "voice": "voice",
+}
+
+
+def apply_config_as_new_agent_version(agent_definition, config: dict[str, Any]):
+    """Persist ``config`` as a new active AgentVersion of ``agent_definition``.
+
+    Returns the created AgentVersion. The previous version is untouched; the new
+    one becomes the latest/active version carrying the optimised config in its
+    ``configuration_snapshot`` (plus the raw config under ``optimised_config``).
+    """
+    from simulate.models import AgentVersion
+
+    latest = (
+        AgentVersion.objects.filter(agent_definition=agent_definition)
+        .order_by("-version_number")
+        .first()
+    )
+    snapshot = copy.deepcopy(getattr(latest, "configuration_snapshot", None) or {})
+
+    applied_fields: list[str] = []
+    for cfg_key, snap_key in _CONFIG_TO_SNAPSHOT.items():
+        if config.get(cfg_key) not in (None, ""):
+            snapshot[snap_key] = config[cfg_key]
+            applied_fields.append(cfg_key)
+    # Keep the full winning config addressable for downstream adopt/inspect.
+    snapshot["optimised_config"] = {
+        k: v for k, v in config.items() if k not in ("type", "name")
+    }
+
+    new_version = AgentVersion.objects.create(
+        agent_definition=agent_definition,
+        organization_id=agent_definition.organization_id,
+        workspace_id=agent_definition.workspace_id,
+        status=AgentVersion.StatusChoices.ACTIVE
+        if hasattr(AgentVersion, "StatusChoices")
+        else "active",
+        configuration_snapshot=snapshot,
+        commit_message="Applied optimised config (TH-5642 agent-learning-kit)",
+    )
+    logger.info(
+        "agent_definition_config_applied",
+        agent_definition_id=str(agent_definition.id),
+        new_version_id=str(new_version.id),
+        version_number=new_version.version_number,
+        applied_fields=applied_fields,
+    )
+    return new_version, applied_fields

--- a/futureagi/simulate/services/agent_learning_bridge.py
+++ b/futureagi/simulate/services/agent_learning_bridge.py
@@ -346,11 +346,17 @@ def build_optimization_manifest_for_agent(
     threshold: float = 0.9,
     min_turns: int = 1,
     max_turns: int | None = None,
+    search_space: Mapping[str, Sequence[Any]] | None = None,
+    base_agent: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a kit optimization manifest. Pure (no I/O).
 
-    ``agent_candidates`` are the variants to search over; the kit scores each against
-    ``evaluation_config`` and surfaces the best.
+    ``agent_candidates`` are full agent configs to search over. ``search_space``
+    extends the search to ANY dot-path of the agent/manifest — model, voice
+    knobs, tools, memory — so the optimisation covers the WHOLE agent, not just
+    its prompt (e.g. ``{"agent.model": ["gpt-4o-mini", "gpt-4o"],
+    "agent.instructions": [...]}``). ``base_agent`` pins which config the
+    patches apply to (defaults to the first candidate).
     """
     if not name:
         raise ValueError("name is required")
@@ -365,6 +371,10 @@ def build_optimization_manifest_for_agent(
         threshold=threshold,
         min_turns=min_turns,
         max_turns=max_turns,
+        search_space={k: list(v) for k, v in search_space.items()}
+        if search_space
+        else None,
+        base_agent=dict(base_agent) if base_agent is not None else None,
     )
 
 
@@ -377,6 +387,8 @@ def optimize_and_apply_for_agent(
     threshold: float = 0.9,
     min_turns: int = 1,
     max_turns: int | None = None,
+    search_space: Mapping[str, Sequence[Any]] | None = None,
+    base_agent: Mapping[str, Any] | None = None,
     dry_run: bool = True,
 ) -> dict[str, Any]:
     """Run optimization over agent candidates via the kit and return the result.
@@ -394,6 +406,8 @@ def optimize_and_apply_for_agent(
         threshold=threshold,
         min_turns=min_turns,
         max_turns=max_turns,
+        search_space=search_space,
+        base_agent=base_agent,
     )
     opt = _optimize_module()
     return opt.optimize_manifest(manifest, dry_run=dry_run)

--- a/futureagi/simulate/services/outbound_dialer.py
+++ b/futureagi/simulate/services/outbound_dialer.py
@@ -242,25 +242,29 @@ class AgoraOutboundDialer(OutboundDialer):
             raise OutboundDialError(
                 "AGORA_APP_ID env var is required for Agora outbound calls"
             )
+        # Endpoint + body per the official agora-agents-python SDK (TH-5642
+        # capability research; the docs restructure 404s, the SDK pins the
+        # contract): POST .../projects/{appid}/call with `pipeline_id` (the
+        # ConvAI pipeline = the agent under test) and a `sip` object
+        # {to_number, from_number[, rtc_uid, rtc_token]}.
         url = os.getenv(
             "AGORA_OUTBOUND_CALL_URL",
-            f"{self.BASE_URL}/projects/{app_id}/sip/outbound",
+            f"{self.BASE_URL}/projects/{app_id}/call",
         )
-        # The agent + SIP gateway share a per-call RTC channel.
-        channel = (metadata or {}).get("channel") or f"sim-{to_phone_number}"
+        meta = metadata or {}
+        sip: dict = {
+            "to_number": to_phone_number,
+            "from_number": from_phone_number,
+        }
+        if meta.get("rtc_uid"):
+            sip["rtc_uid"] = meta["rtc_uid"]
+        if meta.get("rtc_token"):
+            sip["rtc_token"] = meta["rtc_token"]
         resp = requests.post(
             url,
             headers={"Content-Type": "application/json"},
             auth=(key, secret),
-            json={
-                "name": channel,
-                "sip": {
-                    "called_number": to_phone_number,
-                    "caller_id": from_phone_number,
-                },
-                "properties": {"channel": channel, "agent_id": assistant_id},
-                "metadata": metadata or {},
-            },
+            json={"pipeline_id": assistant_id, "sip": sip},
             timeout=REQUEST_TIMEOUT,
         )
         if resp.status_code >= 400:

--- a/futureagi/simulate/services/provider_prompt_apply.py
+++ b/futureagi/simulate/services/provider_prompt_apply.py
@@ -47,6 +47,12 @@ def _check(resp: requests.Response, what: str) -> dict[str, Any]:
         return {}
 
 
+# Normalized whole-agent config keys (the kit's agent-config vocabulary).
+# Writers map the subset their provider supports; unknown keys are reported
+# back as ``skipped_fields`` rather than silently dropped.
+CONFIG_FIELDS = ("instructions", "model", "temperature", "first_message", "voice")
+
+
 class ProviderPromptWriter:
     provider: str = ""
 
@@ -59,6 +65,14 @@ class ProviderPromptWriter:
         raise NotImplementedError
 
     def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        raise NotImplementedError
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        """Read the agent's current config in normalized CONFIG_FIELDS keys."""
+        raise NotImplementedError
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        """Write the normalized ``config`` subset; return the field names applied."""
         raise NotImplementedError
 
     def apply(self, assistant_id: str, prompt: str) -> dict[str, Any]:
@@ -76,6 +90,49 @@ class ProviderPromptWriter:
             "assistant_id": assistant_id,
             "applied": True,
             "previous_prompt": previous,
+        }
+
+    def apply_config(self, assistant_id: str, config: dict[str, Any]) -> dict[str, Any]:
+        """Write a WHOLE-agent config (kit ``best_config.agent``) and verify.
+
+        Only normalized CONFIG_FIELDS are written; provider-identity keys
+        (type/name/provider/assistant_id) and unknown keys are skipped and
+        reported. Read-back verifies every field the provider echoes back.
+        """
+        desired = {
+            k: config[k] for k in CONFIG_FIELDS if config.get(k) not in (None, "")
+        }
+        if not desired:
+            raise PromptApplyError(
+                "Candidate config has no applicable fields "
+                f"(supported: {', '.join(CONFIG_FIELDS)})."
+            )
+        previous = self.get_config(assistant_id)
+        applied_fields = self.set_config(assistant_id, desired)
+        current = self.get_config(assistant_id)
+        mismatched = [
+            f
+            for f in applied_fields
+            if f in current and current.get(f) != desired.get(f)
+        ]
+        if mismatched:
+            raise PromptApplyError(
+                f"{self.provider} read-back mismatch after config update on: "
+                f"{', '.join(mismatched)}"
+            )
+        skipped = sorted(
+            k
+            for k in config
+            if k not in applied_fields
+            and k not in ("type", "name", "provider", "assistant_id")
+        )
+        return {
+            "provider": self.provider,
+            "assistant_id": assistant_id,
+            "applied": True,
+            "applied_fields": applied_fields,
+            "skipped_fields": skipped,
+            "previous_config": previous,
         }
 
 
@@ -113,6 +170,64 @@ class ElevenLabsPromptWriter(ProviderPromptWriter):
             ),
             "ElevenLabs update-agent",
         )
+
+    def _get_conversation_config(self, assistant_id: str) -> dict[str, Any]:
+        data = _check(
+            requests.get(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs get-agent",
+        )
+        return data.get("conversation_config") or {}
+
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        cc = self._get_conversation_config(assistant_id)
+        agent = cc.get("agent") or {}
+        prompt = agent.get("prompt") or {}
+        return {
+            "instructions": str(prompt.get("prompt") or ""),
+            "model": prompt.get("llm"),
+            "temperature": prompt.get("temperature"),
+            "first_message": agent.get("first_message"),
+            "voice": (cc.get("tts") or {}).get("voice_id"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        prompt_patch: dict[str, Any] = {}
+        agent_patch: dict[str, Any] = {}
+        cc_patch: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            prompt_patch["prompt"] = str(config["instructions"])
+            applied.append("instructions")
+        if "model" in config:
+            prompt_patch["llm"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            prompt_patch["temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if "first_message" in config:
+            agent_patch["first_message"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            cc_patch["tts"] = {"voice_id": str(config["voice"])}
+            applied.append("voice")
+        if prompt_patch:
+            agent_patch["prompt"] = prompt_patch
+        if agent_patch:
+            cc_patch["agent"] = agent_patch
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                json={"conversation_config": cc_patch},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs update-agent",
+        )
+        return applied
 
 
 class VapiPromptWriter(ProviderPromptWriter):
@@ -174,6 +289,64 @@ class VapiPromptWriter(ProviderPromptWriter):
             "Vapi update-assistant",
         )
 
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        assistant = self._get_assistant(assistant_id)
+        model = assistant.get("model") or {}
+        return {
+            "instructions": self._system_content(model),
+            "model": model.get("model"),
+            "temperature": model.get("temperature"),
+            "first_message": assistant.get("firstMessage"),
+            "voice": (assistant.get("voice") or {}).get("voiceId"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        assistant = self._get_assistant(assistant_id)
+        # Vapi PATCH replaces whole sub-objects, so read-modify-write model/voice.
+        model = dict(assistant.get("model") or {})
+        body: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            messages = [
+                dict(m) for m in (model.get("messages") or []) if isinstance(m, dict)
+            ]
+            for msg in messages:
+                if msg.get("role") == "system":
+                    msg["content"] = str(config["instructions"])
+                    break
+            else:
+                messages.insert(
+                    0, {"role": "system", "content": str(config["instructions"])}
+                )
+            model["messages"] = messages
+            applied.append("instructions")
+        if "model" in config:
+            model["model"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            model["temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if applied:
+            body["model"] = model
+        if "first_message" in config:
+            body["firstMessage"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            voice = dict(assistant.get("voice") or {})
+            voice["voiceId"] = str(config["voice"])
+            body["voice"] = voice
+            applied.append("voice")
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                json=body,
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi update-assistant",
+        )
+        return applied
+
 
 class RetellPromptWriter(ProviderPromptWriter):
     """Agent prompt = ``general_prompt`` on the agent's Retell-LLM.
@@ -230,6 +403,72 @@ class RetellPromptWriter(ProviderPromptWriter):
             "Retell update-retell-llm",
         )
 
+    def get_config(self, assistant_id: str) -> dict[str, Any]:
+        agent = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-agent/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-agent",
+        )
+        llm = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-retell-llm",
+        )
+        return {
+            "instructions": str(llm.get("general_prompt") or ""),
+            "model": llm.get("model"),
+            "temperature": llm.get("model_temperature"),
+            "first_message": llm.get("begin_message"),
+            "voice": agent.get("voice_id"),
+        }
+
+    def set_config(self, assistant_id: str, config: dict[str, Any]) -> list[str]:
+        llm_patch: dict[str, Any] = {}
+        agent_patch: dict[str, Any] = {}
+        applied: list[str] = []
+        if "instructions" in config:
+            llm_patch["general_prompt"] = str(config["instructions"])
+            applied.append("instructions")
+        if "model" in config:
+            llm_patch["model"] = str(config["model"])
+            applied.append("model")
+        if "temperature" in config:
+            llm_patch["model_temperature"] = float(config["temperature"])
+            applied.append("temperature")
+        if "first_message" in config:
+            llm_patch["begin_message"] = str(config["first_message"])
+            applied.append("first_message")
+        if "voice" in config:
+            agent_patch["voice_id"] = str(config["voice"])
+            applied.append("voice")
+        if llm_patch:
+            _check(
+                requests.patch(
+                    f"{self.BASE_URL}/update-retell-llm/{self._llm_id(assistant_id)}",
+                    headers=self._headers(),
+                    json=llm_patch,
+                    timeout=REQUEST_TIMEOUT,
+                ),
+                "Retell update-retell-llm",
+            )
+        if agent_patch:
+            _check(
+                requests.patch(
+                    f"{self.BASE_URL}/update-agent/{assistant_id}",
+                    headers=self._headers(),
+                    json=agent_patch,
+                    timeout=REQUEST_TIMEOUT,
+                ),
+                "Retell update-agent",
+            )
+        return applied
+
 
 _UNSUPPORTED: dict[str, str] = {
     "bland": "Bland pathways are node graphs, not a single prompt; apply per-node "
@@ -255,14 +494,10 @@ PROVIDER_PROMPT_WRITERS: dict[str, type[ProviderPromptWriter]] = {
 }
 
 
-def apply_prompt_to_provider_agent(agent_definition, prompt: str) -> dict[str, Any]:
-    """Write ``prompt`` to the agent definition's provider-side agent.
-
-    Resolves credentials like the chat adapters do (encrypted ProviderCredentials
-    first, plain ``api_key`` field as fallback). Raises ``PromptApplyUnsupported``
-    with a per-provider reason when there is nothing writable, ``PromptApplyError``
-    on API failure or read-back mismatch.
-    """
+def _writer_for_agent_definition(
+    agent_definition,
+) -> tuple[ProviderPromptWriter, str]:
+    """Resolve (writer, assistant_id) for an agent definition or raise."""
     provider = (agent_definition.provider or "").strip().lower()
     assistant_id = (agent_definition.assistant_id or "").strip()
     if not provider:
@@ -284,11 +519,43 @@ def apply_prompt_to_provider_agent(agent_definition, prompt: str) -> dict[str, A
         raise PromptApplyError(
             f"No {provider} credentials on the agent definition to apply with."
         )
-    result = writer_cls(api_key=api_key).apply(assistant_id, prompt)
+    return writer_cls(api_key=api_key), assistant_id
+
+
+def apply_prompt_to_provider_agent(agent_definition, prompt: str) -> dict[str, Any]:
+    """Write ``prompt`` to the agent definition's provider-side agent.
+
+    Resolves credentials like the chat adapters do (encrypted ProviderCredentials
+    first, plain ``api_key`` field as fallback). Raises ``PromptApplyUnsupported``
+    with a per-provider reason when there is nothing writable, ``PromptApplyError``
+    on API failure or read-back mismatch.
+    """
+    writer, assistant_id = _writer_for_agent_definition(agent_definition)
+    result = writer.apply(assistant_id, prompt)
     logger.info(
         "provider_prompt_applied",
-        provider=provider,
+        provider=writer.provider,
         assistant_id=assistant_id,
         agent_definition_id=str(agent_definition.id),
+    )
+    return result
+
+
+def apply_config_to_provider_agent(
+    agent_definition, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Write a WHOLE-agent config (kit candidate / ``best_config.agent``) to the
+    provider-side agent — instructions, model, temperature, first message, voice —
+    with per-field read-back verification. The kit is the engine that produced the
+    config; this is the platform's apply edge.
+    """
+    writer, assistant_id = _writer_for_agent_definition(agent_definition)
+    result = writer.apply_config(assistant_id, config)
+    logger.info(
+        "provider_config_applied",
+        provider=writer.provider,
+        assistant_id=assistant_id,
+        agent_definition_id=str(agent_definition.id),
+        applied_fields=result.get("applied_fields"),
     )
     return result

--- a/futureagi/simulate/services/provider_prompt_apply.py
+++ b/futureagi/simulate/services/provider_prompt_apply.py
@@ -1,0 +1,294 @@
+"""Apply an optimised prompt to the customer's PROVIDER-SIDE agent (TH-5642).
+
+"Directly apply the fix" for agent-definition runs: unlike prompt-template runs
+(where the platform owns the prompt and applying = a new PromptVersion, see
+``optimizer_apply.py``), an AgentDefinition describes an agent hosted by a third
+party — its prompt lives on the provider. Applying there means writing through
+the provider's management API.
+
+Each writer follows the same contract:
+- read the agent's current prompt first (returned as ``previous_prompt`` so the
+  caller can surface an undo),
+- write the new prompt,
+- read it back and verify the write landed (no trust-the-200).
+
+Providers whose "agent" is not a single prompt (Bland pathways are node graphs;
+Twilio agents are the customer's own TwiML/app code; LiveKit/Pipecat agents are
+the customer's own deployment) raise ``PromptApplyUnsupported`` with the reason —
+callers turn that into a clear 400, never a silent skip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+REQUEST_TIMEOUT = 30
+
+
+class PromptApplyError(RuntimeError):
+    """A provider API call failed or the read-back didn't match."""
+
+
+class PromptApplyUnsupported(PromptApplyError):
+    """The provider has no single-prompt agent to write to."""
+
+
+def _check(resp: requests.Response, what: str) -> dict[str, Any]:
+    if resp.status_code >= 400:
+        raise PromptApplyError(f"{what} failed ({resp.status_code}): {resp.text[:500]}")
+    try:
+        return resp.json() or {}
+    except ValueError:
+        return {}
+
+
+class ProviderPromptWriter:
+    provider: str = ""
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError(f"{type(self).__name__} requires an api_key")
+        self._api_key = api_key
+
+    def get_prompt(self, assistant_id: str) -> str:
+        raise NotImplementedError
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        raise NotImplementedError
+
+    def apply(self, assistant_id: str, prompt: str) -> dict[str, Any]:
+        """Write ``prompt`` to the provider agent and verify by read-back."""
+        previous = self.get_prompt(assistant_id)
+        self.set_prompt(assistant_id, prompt)
+        current = self.get_prompt(assistant_id)
+        if current != prompt:
+            raise PromptApplyError(
+                f"{self.provider} read-back mismatch after update: "
+                f"expected the applied prompt, got {current[:200]!r}"
+            )
+        return {
+            "provider": self.provider,
+            "assistant_id": assistant_id,
+            "applied": True,
+            "previous_prompt": previous,
+        }
+
+
+class ElevenLabsPromptWriter(ProviderPromptWriter):
+    """ConvAI agent prompt at ``conversation_config.agent.prompt.prompt``."""
+
+    provider = "eleven_labs"
+    BASE_URL = "https://api.elevenlabs.io"
+
+    def _headers(self) -> dict[str, str]:
+        return {"xi-api-key": self._api_key, "Content-Type": "application/json"}
+
+    def get_prompt(self, assistant_id: str) -> str:
+        data = _check(
+            requests.get(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs get-agent",
+        )
+        return str(
+            ((data.get("conversation_config") or {}).get("agent") or {})
+            .get("prompt", {})
+            .get("prompt", "")
+        )
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/v1/convai/agents/{assistant_id}",
+                headers=self._headers(),
+                json={"conversation_config": {"agent": {"prompt": {"prompt": prompt}}}},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "ElevenLabs update-agent",
+        )
+
+
+class VapiPromptWriter(ProviderPromptWriter):
+    """Assistant prompt = the system message in ``model.messages``.
+
+    Vapi's PATCH replaces the whole ``model`` object, so read-modify-write.
+    """
+
+    provider = "vapi"
+    BASE_URL = "https://api.vapi.ai"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_assistant(self, assistant_id: str) -> dict[str, Any]:
+        return _check(
+            requests.get(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi get-assistant",
+        )
+
+    @staticmethod
+    def _system_content(model: dict[str, Any]) -> str:
+        for msg in model.get("messages") or []:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                return str(msg.get("content") or "")
+        return ""
+
+    def get_prompt(self, assistant_id: str) -> str:
+        return self._system_content(
+            self._get_assistant(assistant_id).get("model") or {}
+        )
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        model = dict(self._get_assistant(assistant_id).get("model") or {})
+        messages = [
+            dict(m) for m in (model.get("messages") or []) if isinstance(m, dict)
+        ]
+        for msg in messages:
+            if msg.get("role") == "system":
+                msg["content"] = prompt
+                break
+        else:
+            messages.insert(0, {"role": "system", "content": prompt})
+        model["messages"] = messages
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/assistant/{assistant_id}",
+                headers=self._headers(),
+                json={"model": model},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Vapi update-assistant",
+        )
+
+
+class RetellPromptWriter(ProviderPromptWriter):
+    """Agent prompt = ``general_prompt`` on the agent's Retell-LLM.
+
+    The agent references its LLM via ``response_engine.llm_id``; only
+    ``response_engine.type == "retell-llm"`` agents carry an editable prompt.
+    """
+
+    provider = "retell"
+    BASE_URL = "https://api.retellai.com"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _llm_id(self, assistant_id: str) -> str:
+        agent = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-agent/{assistant_id}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-agent",
+        )
+        engine = agent.get("response_engine") or {}
+        if engine.get("type") != "retell-llm" or not engine.get("llm_id"):
+            raise PromptApplyUnsupported(
+                "Retell agent does not use a retell-llm response engine; "
+                "its prompt is not editable via the Retell API."
+            )
+        return str(engine["llm_id"])
+
+    def get_prompt(self, assistant_id: str) -> str:
+        llm = _check(
+            requests.get(
+                f"{self.BASE_URL}/get-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell get-retell-llm",
+        )
+        return str(llm.get("general_prompt") or "")
+
+    def set_prompt(self, assistant_id: str, prompt: str) -> None:
+        _check(
+            requests.patch(
+                f"{self.BASE_URL}/update-retell-llm/{self._llm_id(assistant_id)}",
+                headers=self._headers(),
+                json={"general_prompt": prompt},
+                timeout=REQUEST_TIMEOUT,
+            ),
+            "Retell update-retell-llm",
+        )
+
+
+_UNSUPPORTED: dict[str, str] = {
+    "bland": "Bland pathways are node graphs, not a single prompt; apply per-node "
+    "via the Bland pathway editor/API.",
+    "twilio": "A Twilio agent is the customer's own TwiML application code; there "
+    "is no provider-side prompt to write.",
+    "livekit": "LiveKit agents are the customer's own deployment; the prompt lives "
+    "in their code.",
+    "livekit_bridge": "LiveKit agents are the customer's own deployment; the prompt "
+    "lives in their code.",
+    "pipecat": "Pipecat agents are the customer's own deployment; the prompt lives "
+    "in their code.",
+    "deepgram": "Deepgram Voice Agents are defined inline per-connection (Settings "
+    "message), not stored provider-side.",
+    "agora": "Agora ConvAI pipeline prompt updates need project access (TH-5682).",
+}
+
+PROVIDER_PROMPT_WRITERS: dict[str, type[ProviderPromptWriter]] = {
+    "vapi": VapiPromptWriter,
+    "retell": RetellPromptWriter,
+    "elevenlabs": ElevenLabsPromptWriter,
+    "eleven_labs": ElevenLabsPromptWriter,  # provider-string drift
+}
+
+
+def apply_prompt_to_provider_agent(agent_definition, prompt: str) -> dict[str, Any]:
+    """Write ``prompt`` to the agent definition's provider-side agent.
+
+    Resolves credentials like the chat adapters do (encrypted ProviderCredentials
+    first, plain ``api_key`` field as fallback). Raises ``PromptApplyUnsupported``
+    with a per-provider reason when there is nothing writable, ``PromptApplyError``
+    on API failure or read-back mismatch.
+    """
+    provider = (agent_definition.provider or "").strip().lower()
+    assistant_id = (agent_definition.assistant_id or "").strip()
+    if not provider:
+        raise PromptApplyUnsupported("Agent definition has no provider set.")
+    if provider in _UNSUPPORTED:
+        raise PromptApplyUnsupported(_UNSUPPORTED[provider])
+    writer_cls = PROVIDER_PROMPT_WRITERS.get(provider)
+    if writer_cls is None:
+        raise PromptApplyUnsupported(f"No prompt writer for provider {provider!r}.")
+    if not assistant_id:
+        raise PromptApplyUnsupported(
+            "Agent definition has no assistant_id to apply to."
+        )
+
+    from simulate.services.chat_agent_adapter_factory import _resolve_api_key
+
+    api_key = _resolve_api_key(agent_definition)
+    if not api_key:
+        raise PromptApplyError(
+            f"No {provider} credentials on the agent definition to apply with."
+        )
+    result = writer_cls(api_key=api_key).apply(assistant_id, prompt)
+    logger.info(
+        "provider_prompt_applied",
+        provider=provider,
+        assistant_id=assistant_id,
+        agent_definition_id=str(agent_definition.id),
+    )
+    return result

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import structlog
 from django.db import transaction
@@ -29,12 +29,11 @@ from simulate.services.test_executor import (
 from simulate.utils.chat_simulation import (
     _aggregate_chat_metrics,
     _calculate_tokens_from_messages,
-    _swap_user_assistant_roles,
 )
 from simulate.utils.websocket_notifications import notify_simulation_update
+from tfc.temporal.drop_in import temporal_activity
 
 logger = structlog.get_logger(__name__)
-from tfc.temporal.drop_in import temporal_activity
 
 
 @temporal_activity(
@@ -45,12 +44,12 @@ def store_chat_messages(
     call_execution_id: str,
     organization_id: str,
     workspace_id: str,
-    input_messages: List[Union[ChatMessage, dict]],
-    output_messages: List[Union[ChatMessage, dict]],
+    input_messages: list[ChatMessage | dict],
+    output_messages: list[ChatMessage | dict],
     chat_ended: bool,
     chat_session_id: str,
     create_timestamp: datetime,
-    metrics: Optional[dict[str, Optional[float | int]]] = None,
+    metrics: dict[str, float | int | None] | None = None,
 ):
     try:
         organization = Organization.objects.get(id=organization_id)
@@ -73,12 +72,12 @@ def store_chat_messages(
         # - input_messages (from agent via SDK) come as role="user" (SDK converts assistant->user)
         # - output_messages (from simulator) are role="user" (simulator is the customer)
         # So we extract ALL content, not filtering by role.
-        input_messages_content: List[str] = [
+        input_messages_content: list[str] = [
             (msg.content if hasattr(msg, "content") else msg.get("content", ""))
             for msg in input_messages
             if (msg.content if hasattr(msg, "content") else msg.get("content"))
         ]
-        output_messages_content: List[str] = [
+        output_messages_content: list[str] = [
             (msg.content if hasattr(msg, "content") else msg.get("content", ""))
             for msg in output_messages
             if (msg.content if hasattr(msg, "content") else msg.get("content"))
@@ -451,7 +450,7 @@ def monitor_chat_timeout_call_executions():
                 .values_list("id", flat=True)[:50]
             )
 
-            updated = CallExecution.objects.filter(id__in=ids).update(
+            CallExecution.objects.filter(id__in=ids).update(
                 status=CallExecution.CallStatus.FAILED,
                 completed_at=now,
                 updated_at=now,  # because .update() won't auto-update updated_at
@@ -481,17 +480,22 @@ def process_prompt_based_chat_simulations():
     """
     # Lazy import: simulate.services.chat_sim imports from this module (circular)
     from simulate.services.chat_agent_adapter_factory import server_side_chat_filter
-    from simulate.services.chat_sim import initiate_chat, run_prompt_based_conversation
 
     try:
         # Per-organisation concurrency limit.  Each org uses its own LLM API
         # keys, so there is no need for an application-wide cap.
         MAX_PER_ORG = int(os.getenv("PROMPT_SIM_MAX_CONCURRENT_PER_ORG", "10"))
 
-        # Atomically claim REGISTERED CallExecutions to prevent duplicates on retry
+        # Atomically claim REGISTERED CallExecutions to prevent duplicates on retry.
+        # of=("self",): the server_side_chat_filter OR spans the nullable
+        # agent_definition FK, which Django renders as a LEFT JOIN — a bare
+        # FOR UPDATE then raises NotSupportedError ("nullable side of an outer
+        # join"), the broad except below ate it, and the trigger silently
+        # returned 0 forever for agent-definition chat sims (TH-5642 bug #22).
+        # Lock only the CallExecution rows.
         with transaction.atomic():
             registered = list(
-                CallExecution.objects.select_for_update(skip_locked=True)
+                CallExecution.objects.select_for_update(of=("self",), skip_locked=True)
                 .filter(
                     server_side_chat_filter(),
                     status=CallExecution.CallStatus.REGISTERED,
@@ -591,7 +595,9 @@ def run_single_prompt_chat(call_execution_id: str):
             usage_check = check_usage(str(organization.id), BillingEventType.TEXT_CALL)
             if not usage_check.allowed:
                 call_execution.status = CallExecution.CallStatus.FAILED
-                call_execution.ended_reason = usage_check.reason or "Usage limit exceeded"
+                call_execution.ended_reason = (
+                    usage_check.reason or "Usage limit exceeded"
+                )
                 call_execution.save(update_fields=["status", "ended_reason"])
                 return False
 

--- a/futureagi/simulate/temporal/types/activities.py
+++ b/futureagi/simulate/temporal/types/activities.py
@@ -740,6 +740,12 @@ class InitiateCallInput:
     user_api_key: Optional[str] = None
     user_assistant_id: Optional[str] = None
     user_phone_number: Optional[str] = None  # User's phone to call from
+    # The user's agent provider (retell/bland/...) — selects the user-side outbound
+    # dialer instead of the Vapi default (TH-5642). None → Vapi engine path.
+    # NOTE: this is THE imported copy (call_execution_workflow and voice_large both
+    # import from simulate.temporal.types.activities); the duplicate in
+    # ee/voice/temporal/types/voice_activities.py mirrors it and must stay in sync.
+    user_provider: Optional[str] = None
 
     # WebRTC bridge connection type (None = SIP, "web_vapi", "web_retell")
     connection_type: Optional[str] = None

--- a/futureagi/simulate/tests/test_agent_definition_apply.py
+++ b/futureagi/simulate/tests/test_agent_definition_apply.py
@@ -1,0 +1,65 @@
+"""Platform-side apply: optimised config -> new AgentVersion (TH-5642)."""
+
+import pytest
+
+from simulate.services.agent_definition_apply import (
+    apply_config_as_new_agent_version,
+)
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+@pytest.fixture
+def agent_def(db):
+    from accounts.models import Organization
+    from simulate.models import AgentDefinition
+
+    org = Organization.objects.create(name="t5642-apply-org")
+    return AgentDefinition.objects.create(
+        agent_name="selfhosted-livekit",
+        agent_type="voice",
+        provider="livekit_bridge",
+        description="self-hosted agent under optimisation",
+        inbound=True,
+        organization=org,
+    )
+
+
+def test_apply_creates_new_active_version_with_config(agent_def):
+    from simulate.models import AgentVersion
+
+    # seed a v1
+    AgentVersion.objects.create(
+        agent_definition=agent_def,
+        organization_id=agent_def.organization_id,
+        status="active",
+        commit_message="v1",
+    )
+    cfg = {
+        "type": "llm",
+        "name": "winner",
+        "instructions": "Be concise and answer hours questions directly.",
+        "model": "gpt-4o",
+        "temperature": 0.2,
+    }
+    new_version, applied = apply_config_as_new_agent_version(agent_def, cfg)
+
+    assert set(applied) == {"instructions", "model", "temperature"}
+    # non-destructive: a brand new, higher version number
+    assert new_version.version_number >= 2
+    snap = new_version.configuration_snapshot
+    assert snap["system_prompt"] == cfg["instructions"]
+    assert snap["model"] == "gpt-4o"
+    assert snap["temperature"] == 0.2
+    # the whole winning config is retained, identity keys stripped
+    assert snap["optimised_config"]["instructions"] == cfg["instructions"]
+    assert "name" not in snap["optimised_config"]
+
+
+def test_apply_works_with_no_prior_version(agent_def):
+    new_version, applied = apply_config_as_new_agent_version(
+        agent_def, {"instructions": "x", "model": "gpt-4o-mini"}
+    )
+    assert new_version.version_number >= 1
+    assert new_version.configuration_snapshot["system_prompt"] == "x"
+    assert set(applied) == {"instructions", "model"}

--- a/futureagi/simulate/tests/test_outbound_dialer.py
+++ b/futureagi/simulate/tests/test_outbound_dialer.py
@@ -77,11 +77,14 @@ def test_agora_outbound_shape_basic_auth_and_agent_id(monkeypatch):
     )
     assert out == {"id": "agt_9"}
     call = fake.calls[0]
-    assert "app-123" in call["url"]               # app id in path
+    # Endpoint + body per the official agora-agents-python SDK (TH-5642
+    # capability research): POST .../projects/{appid}/call with pipeline_id +
+    # sip.{to_number, from_number}.
+    assert call["url"].endswith("/projects/app-123/call")
     assert call["auth"] == ("cust_key", "cust_secret")  # Basic auth, not header key
-    assert call["json"]["sip"]["called_number"] == "+15550000099"
-    assert call["json"]["sip"]["caller_id"] == "+15550000001"
-    assert call["json"]["properties"]["agent_id"] == "studio-agent-1"
+    assert call["json"]["pipeline_id"] == "studio-agent-1"
+    assert call["json"]["sip"]["to_number"] == "+15550000099"
+    assert call["json"]["sip"]["from_number"] == "+15550000001"
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/tests/test_provider_prompt_apply.py
+++ b/futureagi/simulate/tests/test_provider_prompt_apply.py
@@ -188,3 +188,171 @@ class TestDispatch:
             out = apply_prompt_to_provider_agent(self._agent_def("elevenlabs"), "p")
         assert out == {"applied": True}
         mock_apply.assert_called_once_with("a1", "p")
+
+
+class TestWholeAgentConfigApply:
+    """apply_config writes the WHOLE candidate config, not just the prompt."""
+
+    def test_elevenlabs_config_maps_all_fields(self):
+        state = {
+            "agent": {
+                "prompt": {"prompt": "old", "llm": "gpt-4o-mini", "temperature": 0.5},
+                "first_message": "Hi",
+            },
+            "tts": {"voice_id": "voice-old"},
+        }
+
+        def fake_get(url, **kw):
+            return _resp({"conversation_config": state})
+
+        def fake_patch(url, **kw):
+            cc = kw["json"]["conversation_config"]
+            agent = cc.get("agent") or {}
+            if "prompt" in agent:
+                state["agent"]["prompt"].update(agent["prompt"])
+            if "first_message" in agent:
+                state["agent"]["first_message"] = agent["first_message"]
+            if "tts" in cc:
+                state["tts"].update(cc["tts"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = ElevenLabsPromptWriter(api_key="k").apply_config(
+                "agent_1",
+                {
+                    "type": "llm",
+                    "name": "winner",
+                    "instructions": "new prompt",
+                    "model": "gpt-4o",
+                    "temperature": 0.2,
+                    "first_message": "Hello there",
+                    "voice": "voice-new",
+                },
+            )
+
+        assert out["applied"] is True
+        assert set(out["applied_fields"]) == {
+            "instructions",
+            "model",
+            "temperature",
+            "first_message",
+            "voice",
+        }
+        assert out["previous_config"]["instructions"] == "old"
+        assert state["agent"]["prompt"]["prompt"] == "new prompt"
+        assert state["agent"]["prompt"]["llm"] == "gpt-4o"
+        assert state["tts"]["voice_id"] == "voice-new"
+
+    def test_vapi_config_preserves_model_object(self):
+        state = {
+            "model": {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "system", "content": "old"}],
+            },
+            "firstMessage": "Hi",
+            "voice": {"provider": "11labs", "voiceId": "v-old"},
+        }
+
+        def fake_get(url, **kw):
+            return _resp(dict(state))
+
+        def fake_patch(url, **kw):
+            state.update(kw["json"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = VapiPromptWriter(api_key="k").apply_config(
+                "asst_1",
+                {"instructions": "new", "model": "gpt-4o", "voice": "v-new"},
+            )
+
+        assert set(out["applied_fields"]) == {"instructions", "model", "voice"}
+        assert state["model"]["provider"] == "openai"  # preserved on replace
+        assert state["model"]["model"] == "gpt-4o"
+        assert state["voice"] == {"provider": "11labs", "voiceId": "v-new"}
+
+    def test_retell_config_splits_llm_and_agent_patches(self):
+        state = {
+            "agent": {
+                "response_engine": {"type": "retell-llm", "llm_id": "llm_9"},
+                "voice_id": "v-old",
+            },
+            "llm": {"general_prompt": "old", "model": "gpt-4o-mini"},
+        }
+
+        def fake_get(url, **kw):
+            if "/get-agent/" in url:
+                return _resp(dict(state["agent"]))
+            return _resp(dict(state["llm"]))
+
+        def fake_patch(url, **kw):
+            if "/update-retell-llm/" in url:
+                state["llm"].update(kw["json"])
+            else:
+                assert url.endswith("/update-agent/agent_1")
+                state["agent"].update(kw["json"])
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = RetellPromptWriter(api_key="k").apply_config(
+                "agent_1",
+                {"instructions": "new", "model": "gpt-4o", "voice": "v-new"},
+            )
+
+        assert set(out["applied_fields"]) == {"instructions", "model", "voice"}
+        assert state["llm"]["general_prompt"] == "new"
+        assert state["llm"]["model"] == "gpt-4o"
+        assert state["agent"]["voice_id"] == "v-new"
+
+    def test_config_with_no_applicable_fields_errors(self):
+        with pytest.raises(PromptApplyError, match="no applicable fields"):
+            ElevenLabsPromptWriter(api_key="k").apply_config(
+                "agent_1", {"type": "llm", "name": "x"}
+            )
+
+    def test_config_readback_mismatch_raises(self):
+        def fake_get(url, **kw):
+            return _resp(
+                {"conversation_config": {"agent": {"prompt": {"prompt": "stale"}}}}
+            )
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch(
+                "simulate.services.provider_prompt_apply.requests.patch",
+                lambda url, **kw: _resp({}),
+            ),
+        ):
+            with pytest.raises(PromptApplyError, match="read-back mismatch"):
+                ElevenLabsPromptWriter(api_key="k").apply_config(
+                    "agent_1", {"instructions": "new"}
+                )
+
+    def test_dispatch_apply_config(self):
+        from simulate.services.provider_prompt_apply import (
+            apply_config_to_provider_agent,
+        )
+
+        agent_def = SimpleNamespace(
+            id="ad-1",
+            provider="elevenlabs",
+            assistant_id="a1",
+            api_key="key",
+            credentials=None,
+        )
+        with patch.object(
+            ElevenLabsPromptWriter, "apply_config", return_value={"applied": True}
+        ) as mock_apply:
+            out = apply_config_to_provider_agent(agent_def, {"instructions": "p"})
+        assert out == {"applied": True}
+        mock_apply.assert_called_once_with("a1", {"instructions": "p"})

--- a/futureagi/simulate/tests/test_provider_prompt_apply.py
+++ b/futureagi/simulate/tests/test_provider_prompt_apply.py
@@ -1,0 +1,190 @@
+"""Provider-side prompt apply — "directly apply the fix" for agent-definition runs (TH-5642)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from simulate.services.provider_prompt_apply import (
+    ElevenLabsPromptWriter,
+    PromptApplyError,
+    PromptApplyUnsupported,
+    RetellPromptWriter,
+    VapiPromptWriter,
+    apply_prompt_to_provider_agent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(json_data, status=200):
+    return SimpleNamespace(
+        status_code=status, json=lambda: json_data, text=str(json_data)
+    )
+
+
+class TestElevenLabsWriter:
+    def test_apply_reads_writes_and_verifies(self):
+        state = {"prompt": "old prompt"}
+
+        def fake_get(url, **kw):
+            return _resp(
+                {
+                    "conversation_config": {
+                        "agent": {"prompt": {"prompt": state["prompt"]}}
+                    }
+                }
+            )
+
+        def fake_patch(url, **kw):
+            state["prompt"] = kw["json"]["conversation_config"]["agent"]["prompt"][
+                "prompt"
+            ]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = ElevenLabsPromptWriter(api_key="xi-key").apply(
+                "agent_1", "new prompt"
+            )
+
+        assert out["applied"] is True
+        assert out["previous_prompt"] == "old prompt"
+        assert state["prompt"] == "new prompt"
+
+    def test_readback_mismatch_raises(self):
+        with (
+            patch(
+                "simulate.services.provider_prompt_apply.requests.get",
+                lambda url, **kw: _resp(
+                    {"conversation_config": {"agent": {"prompt": {"prompt": "stale"}}}}
+                ),
+            ),
+            patch(
+                "simulate.services.provider_prompt_apply.requests.patch",
+                lambda url, **kw: _resp({}),
+            ),
+        ):
+            with pytest.raises(PromptApplyError, match="read-back mismatch"):
+                ElevenLabsPromptWriter(api_key="xi-key").apply("agent_1", "new")
+
+
+class TestVapiWriter:
+    def test_apply_replaces_system_message_in_model(self):
+        state = {
+            "model": {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "messages": [{"role": "system", "content": "old"}],
+            }
+        }
+
+        def fake_get(url, **kw):
+            return _resp({"model": state["model"]})
+
+        def fake_patch(url, **kw):
+            state["model"] = kw["json"]["model"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = VapiPromptWriter(api_key="k").apply("asst_1", "new sys")
+
+        assert out["previous_prompt"] == "old"
+        assert state["model"]["messages"] == [{"role": "system", "content": "new sys"}]
+        # The rest of the model object must be preserved (Vapi PATCH replaces model).
+        assert state["model"]["provider"] == "openai"
+
+    def test_inserts_system_message_when_absent(self):
+        state = {"model": {"provider": "openai", "model": "gpt-4o", "messages": []}}
+
+        def fake_get(url, **kw):
+            return _resp({"model": state["model"]})
+
+        def fake_patch(url, **kw):
+            state["model"] = kw["json"]["model"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            VapiPromptWriter(api_key="k").apply("asst_1", "sys")
+
+        assert state["model"]["messages"][0] == {"role": "system", "content": "sys"}
+
+
+class TestRetellWriter:
+    def test_apply_goes_through_llm_id(self):
+        state = {"general_prompt": "old"}
+
+        def fake_get(url, **kw):
+            if "/get-agent/" in url:
+                return _resp(
+                    {"response_engine": {"type": "retell-llm", "llm_id": "llm_9"}}
+                )
+            assert url.endswith("/get-retell-llm/llm_9")
+            return _resp({"general_prompt": state["general_prompt"]})
+
+        def fake_patch(url, **kw):
+            assert url.endswith("/update-retell-llm/llm_9")
+            state["general_prompt"] = kw["json"]["general_prompt"]
+            return _resp({})
+
+        with (
+            patch("simulate.services.provider_prompt_apply.requests.get", fake_get),
+            patch("simulate.services.provider_prompt_apply.requests.patch", fake_patch),
+        ):
+            out = RetellPromptWriter(api_key="k").apply("agent_1", "new")
+
+        assert out["previous_prompt"] == "old"
+        assert state["general_prompt"] == "new"
+
+    def test_non_retell_llm_engine_unsupported(self):
+        with patch(
+            "simulate.services.provider_prompt_apply.requests.get",
+            lambda url, **kw: _resp({"response_engine": {"type": "conversation-flow"}}),
+        ):
+            with pytest.raises(PromptApplyUnsupported, match="retell-llm"):
+                RetellPromptWriter(api_key="k").get_prompt("agent_1")
+
+
+class TestDispatch:
+    def _agent_def(self, provider, assistant_id="a1", api_key="key"):
+        return SimpleNamespace(
+            id="ad-1",
+            provider=provider,
+            assistant_id=assistant_id,
+            api_key=api_key,
+            credentials=None,
+        )
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["bland", "twilio", "livekit", "pipecat", "deepgram", "agora"],
+    )
+    def test_unsupported_providers_raise_with_reason(self, provider):
+        with pytest.raises(PromptApplyUnsupported):
+            apply_prompt_to_provider_agent(self._agent_def(provider), "p")
+
+    def test_missing_assistant_id_unsupported(self):
+        with pytest.raises(PromptApplyUnsupported, match="assistant_id"):
+            apply_prompt_to_provider_agent(
+                self._agent_def("vapi", assistant_id=""), "p"
+            )
+
+    def test_missing_credentials_is_error(self):
+        with pytest.raises(PromptApplyError, match="credentials"):
+            apply_prompt_to_provider_agent(self._agent_def("vapi", api_key=""), "p")
+
+    def test_elevenlabs_alias_dispatches(self):
+        with patch.object(
+            ElevenLabsPromptWriter, "apply", return_value={"applied": True}
+        ) as mock_apply:
+            out = apply_prompt_to_provider_agent(self._agent_def("elevenlabs"), "p")
+        assert out == {"applied": True}
+        mock_apply.assert_called_once_with("a1", "p")

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -43,9 +43,18 @@ class TestRegistryShape:
     @pytest.mark.unit
     def test_expected_providers_present(self):
         for key in [
-            "vapi", "retell", "livekit_bridge", "others",
-            "elevenlabs", "deepgram", "agora", "pipecat", "bland",
-            "twilio", "livekit", "futureagi",
+            "vapi",
+            "retell",
+            "livekit_bridge",
+            "others",
+            "elevenlabs",
+            "deepgram",
+            "agora",
+            "pipecat",
+            "bland",
+            "twilio",
+            "livekit",
+            "futureagi",
         ]:
             assert get_spec(key) is not None, key
 
@@ -79,13 +88,14 @@ class TestTaxonomy:
         assert get_spec("deepgram").status is Status.PLANNED
 
     @pytest.mark.unit
-    def test_agora_rides_sip_path_like_bland_no_rtc_sdk(self):
-        # Agora Conversational AI exposes agents over SIP/PSTN (Elastic SIP Trunk),
-        # so it is reachable via the provider-neutral SIP path with NO Agora RTC SDK
-        # — modeled like Bland/Twilio, not via a (SDK-gated) web_agora connector.
+    def test_agora_sip_primary_with_rtc_connector(self):
+        # Agora keeps SIP as primary transport (Elastic SIP Trunk parity with
+        # Bland/Twilio) but ALSO carries the native web_agora RTC connector
+        # (AgoraRTCConnector, TH-5682) for phone-free sims — same dual-path
+        # idea as the other web_* providers.
         agora = get_spec("agora")
         assert agora.transport is Transport.SIP
-        assert agora.connector_key is None  # no WebRTC bridge connector needed
+        assert agora.connector_key == "web_agora"
         assert agora.is_agent_platform
         # Parity with the other SIP-reachable agent platform.
         assert get_spec("bland").transport is Transport.SIP
@@ -184,7 +194,9 @@ class TestDerivations:
         valid = set(ProviderChoices.values)
         for key in agent_platform_keys():
             obs = get_spec(key).observability_key
-            assert obs in valid, f"{key} observability_key {obs!r} not a ProviderChoices value"
+            assert obs in valid, (
+                f"{key} observability_key {obs!r} not a ProviderChoices value"
+            )
 
 
 class TestCallDirection:
@@ -209,18 +221,30 @@ class TestCallDirection:
         # (key, supported, implemented) — from the direction audit (TH-5642).
         expected = {
             "vapi": ({IN, OUT}, {IN, OUT}),
-            "retell": ({IN, OUT}, {IN, OUT}),     # outbound wired via RetellOutboundDialer
-            "livekit_bridge": ({IN, OUT}, {IN, OUT}),  # bridge: outbound = speaking-order
+            "retell": ({IN, OUT}, {IN, OUT}),  # outbound wired via RetellOutboundDialer
+            "livekit_bridge": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # bridge: outbound = speaking-order
             "others": ({IN, OUT}, {IN, OUT}),
-            "elevenlabs": ({IN, OUT}, {IN, OUT}),  # outbound via ElevenLabsOutboundDialer
-            "deepgram": ({IN, OUT}, {IN}),         # no native outbound (BYO-SIP only)
-            "agora": ({IN, OUT}, {OUT}),          # outbound wired via AgoraOutboundDialer (ConvAI telephony)
-            "pipecat": ({IN, OUT}, {IN, OUT}),     # reuses bridge → outbound = speaking-order
+            "elevenlabs": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # outbound via ElevenLabsOutboundDialer
+            "deepgram": ({IN, OUT}, {IN}),  # no native outbound (BYO-SIP only)
+            "agora": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # outbound: AgoraOutboundDialer; inbound: web_agora RTC connector (TH-5682)
+            "pipecat": (
+                {IN, OUT},
+                {IN, OUT},
+            ),  # reuses bridge → outbound = speaking-order
             # Inbound flipped 2026-06-10: a Bland inbound number answers any
             # PSTN caller, so the neutral SIP path reaches it (TH-5683).
             "bland": ({IN, OUT}, {IN, OUT}),
-            "twilio": ({IN, OUT}, {IN, OUT}),     # SIP inbound + TwilioOutboundDialer
-            "futureagi": (set(), set()),          # internal chat
+            "twilio": ({IN, OUT}, {IN, OUT}),  # SIP inbound + TwilioOutboundDialer
+            "futureagi": (set(), set()),  # internal chat
         }
         for key, (sup, impl) in expected.items():
             spec = get_spec(key)
@@ -257,9 +281,7 @@ class TestBridgeRegistryParity:
     def test_cross_check_against_real_connector_registry_if_importable(self):
         # Best-effort: the real bridge registry pulls livekit SDK deps that may be
         # absent in the backend venv — skip if it can't import.
-        connector = pytest.importorskip(
-            "ee.voice.services.livekit.bridge.connector"
-        )
+        connector = pytest.importorskip("ee.voice.services.livekit.bridge.connector")
         real_keys = set(connector.get_connector_registry().keys())
         ga_webrtc = {
             s.connector_key

--- a/futureagi/simulate/tests/test_provider_registry.py
+++ b/futureagi/simulate/tests/test_provider_registry.py
@@ -216,7 +216,9 @@ class TestCallDirection:
             "deepgram": ({IN, OUT}, {IN}),         # no native outbound (BYO-SIP only)
             "agora": ({IN, OUT}, {OUT}),          # outbound wired via AgoraOutboundDialer (ConvAI telephony)
             "pipecat": ({IN, OUT}, {IN, OUT}),     # reuses bridge → outbound = speaking-order
-            "bland": ({IN, OUT}, {OUT}),          # outbound-first; BlandOutboundDialer
+            # Inbound flipped 2026-06-10: a Bland inbound number answers any
+            # PSTN caller, so the neutral SIP path reaches it (TH-5683).
+            "bland": ({IN, OUT}, {IN, OUT}),
             "twilio": ({IN, OUT}, {IN, OUT}),     # SIP inbound + TwilioOutboundDialer
             "futureagi": (set(), set()),          # internal chat
         }

--- a/futureagi/simulate/tests/test_provider_verification.py
+++ b/futureagi/simulate/tests/test_provider_verification.py
@@ -13,7 +13,7 @@ def test_registry_matrix_covers_every_provider():
     assert providers == set(reg.agent_platform_keys())
     # chat-capable providers get a chat cell; voice providers get per-direction cells.
     by = {(c.provider, c.modality, c.direction) for c in report.cells}
-    assert ("vapi", "chat", None) in by          # vapi.chat = True
+    assert ("vapi", "chat", None) in by  # vapi.chat = True
     assert ("vapi", "voice", "inbound") in by
     assert ("vapi", "voice", "outbound") in by
     assert ("deepgram", "voice", "inbound") in by
@@ -24,13 +24,14 @@ def test_registry_matrix_covers_every_provider():
 
 
 @pytest.mark.unit
-def test_agora_outbound_wired_inbound_not():
-    # Agora outbound is now wired (AgoraOutboundDialer); inbound is not.
+def test_agora_both_directions_wired():
+    # Agora outbound via AgoraOutboundDialer (ConvAI telephony); inbound now
+    # implemented phone-free via the native web_agora RTC connector (TH-5682).
     report = pv.declared_matrix()
     agora = [c for c in report.cells if c.provider == "agora"]
     cells = {(c.modality, c.direction): c.status for c in agora}
     assert ("voice", "outbound") in cells and cells[("voice", "outbound")] == pv.OK
-    assert ("voice", "inbound") not in cells
+    assert ("voice", "inbound") in cells and cells[("voice", "inbound")] == pv.OK
     assert ("chat", None) not in cells  # no chat product
 
 
@@ -49,7 +50,8 @@ def test_credential_status_sip_only_needs_stack():
     # 'others' = websocket_url, not sip_only; sip_only providers report SKIPPED.
     # Verify the SIP-stack messaging path via a known sip_only shape if present.
     sip_providers = [
-        p for p in reg.agent_platform_keys()
+        p
+        for p in reg.agent_platform_keys()
         if str(getattr(reg.get_spec(p), "credential_shape", "")) == "sip_only"
     ]
     for p in sip_providers:

--- a/futureagi/simulate/tests/test_provider_verification.py
+++ b/futureagi/simulate/tests/test_provider_verification.py
@@ -18,8 +18,9 @@ def test_registry_matrix_covers_every_provider():
     assert ("vapi", "voice", "outbound") in by
     assert ("deepgram", "voice", "inbound") in by
     assert ("deepgram", "voice", "outbound") not in by  # deepgram inbound-only
-    assert ("bland", "voice", "outbound") in by         # bland outbound-only
-    assert ("bland", "voice", "inbound") not in by
+    assert ("bland", "voice", "outbound") in by
+    # Inbound implemented via the neutral SIP path (registry flip, TH-5683).
+    assert ("bland", "voice", "inbound") in by
 
 
 @pytest.mark.unit

--- a/futureagi/simulate/utils/agent_prompt_optimiser.py
+++ b/futureagi/simulate/utils/agent_prompt_optimiser.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 
 import structlog
 from django.conf import settings
@@ -6,8 +7,6 @@ from django.db.models import Avg
 from django.db.models.functions import Round
 
 from model_hub.utils.dataset_optimization import calculate_percentage_point_change
-
-logger = structlog.get_logger(__name__)
 from simulate.constants.agent_prompt_optimiser import (
     AGENT_PROMPT_OPTIMISER_RUN_STEPS,
     TRIAL_TABLE_BASE_COLUMNS,
@@ -27,6 +26,8 @@ from simulate.serializers.agent_prompt_optimiser import (
 )
 from simulate.utils.agent_optimiser import get_full_test_execution_data
 from simulate.utils.llm import get_api_key_for_model
+
+logger = structlog.get_logger(__name__)
 
 
 def fetch_agent_level_issues_from_run(optimiser_run: AgentOptimiserRun) -> list[dict]:
@@ -314,7 +315,10 @@ def _run_agent_learning_kit_optimisation(prompt_optimiser_run) -> None:
 
     config = prompt_optimiser_run.configuration or {}
     candidates = config.get("agent_candidates") or [
-        {"type": "llm", "instructions": _resolve_optimiser_base_prompt(prompt_optimiser_run)}
+        {
+            "type": "llm",
+            "instructions": _resolve_optimiser_base_prompt(prompt_optimiser_run),
+        }
     ]
     evaluation_config = config.get("evaluation_config") or {
         "metrics": [{"name": "task_completion"}]
@@ -334,9 +338,49 @@ def _run_agent_learning_kit_optimisation(prompt_optimiser_run) -> None:
     prompt_optimiser_run.result = result
     prompt_optimiser_run.status = AgentPromptOptimiserRun.Status.COMPLETED
     prompt_optimiser_run.save(update_fields=["result", "status", "updated_at"])
+    _store_kit_candidates_as_trials(prompt_optimiser_run, result, candidates)
     logger.info(
         f"Agent prompt optimiser run {prompt_optimiser_run.id} completed via agent-learning-kit."
     )
+
+
+def _store_kit_candidates_as_trials(prompt_optimiser_run, result, candidates) -> None:
+    """Persist the kit's candidate history as PromptTrial rows (TH-5642).
+
+    apply_trial ("directly apply the fix") is trial-based, so without rows a kit
+    run's winning prompt could never be applied. Each history entry carries the
+    candidate's full patch; an empty patch means the baseline candidate, whose
+    instructions come from the submitted candidate list.
+    """
+    history = (result or {}).get("optimization", {}).get("history") or []
+    if not history:
+        return
+    baseline_prompt = ""
+    for cand in candidates or []:
+        if isinstance(cand, Mapping) and cand.get("instructions"):
+            baseline_prompt = str(cand["instructions"])
+            break
+    best_id = (result.get("summary") or {}).get("best_candidate_id")
+    try:
+        for idx, entry in enumerate(history):
+            patch_agent = (entry.get("candidate_patch") or {}).get("agent") or {}
+            prompt = str(patch_agent.get("instructions") or "") or baseline_prompt
+            is_baseline = not (entry.get("candidate_patch") or {})
+            PromptTrial.objects.create(
+                agent_prompt_optimiser_run=prompt_optimiser_run,
+                trial_number=idx,
+                is_baseline=is_baseline,
+                prompt=prompt,
+                average_score=float(entry.get("score") or 0.0),
+                metadata={
+                    "candidate_id": entry.get("candidate_id"),
+                    "selected": entry.get("candidate_id") == best_id,
+                    "evaluation_score": entry.get("evaluation_score"),
+                    "source": "agent_learning_kit",
+                },
+            )
+    except Exception:  # trials are an apply convenience; never fail the run on them
+        logger.exception("failed to store kit candidates as PromptTrials")
 
 
 def run_agent_prompt_optimiser(prompt_optimiser_run_id: str) -> None:
@@ -362,7 +406,10 @@ def run_agent_prompt_optimiser(prompt_optimiser_run_id: str) -> None:
         from ee.agenthub.fix_your_agent.fix_your_agent import FixYourAgent
     except ImportError:
         if settings.DEBUG:
-            logger.warning("Could not import ee.agenthub.fix_your_agent.fix_your_agent", exc_info=True)
+            logger.warning(
+                "Could not import ee.agenthub.fix_your_agent.fix_your_agent",
+                exc_info=True,
+            )
         return
 
     optimiser_run = prompt_optimiser_run.agent_optimiser_run

--- a/futureagi/simulate/utils/agent_prompt_optimiser.py
+++ b/futureagi/simulate/utils/agent_prompt_optimiser.py
@@ -297,6 +297,32 @@ def _resolve_optimiser_base_prompt(prompt_optimiser_run) -> str:
     return "You are a helpful assistant."
 
 
+def _resolve_optimiser_base_agent(prompt_optimiser_run) -> dict:
+    """Build the WHOLE-agent base config from the run's agent definition (TH-5642).
+
+    The optimisation searches the full agent config (model, provider identity,
+    instructions, …), not just the prompt; this is the seed every search-space
+    patch applies to. Provider/assistant_id ride along so the winning config can
+    be applied back to the provider-side agent.
+    """
+    te = prompt_optimiser_run.test_execution
+    agent_def = getattr(te, "agent_definition", None) or getattr(
+        getattr(te, "run_test", None), "agent_definition", None
+    )
+    base: dict = {
+        "type": "llm",
+        "name": getattr(agent_def, "agent_name", None) or "agent-under-optimisation",
+        "model": (getattr(prompt_optimiser_run, "model", None) or "gpt-4o-mini"),
+        "instructions": _resolve_optimiser_base_prompt(prompt_optimiser_run),
+    }
+    if agent_def is not None:
+        if getattr(agent_def, "provider", None):
+            base["provider"] = str(agent_def.provider)
+        if getattr(agent_def, "assistant_id", None):
+            base["assistant_id"] = str(agent_def.assistant_id)
+    return base
+
+
 def _run_agent_learning_kit_optimisation(prompt_optimiser_run) -> None:
     """Drive a prompt-optimiser run through the agent-learning-kit bridge (TH-5642).
 
@@ -314,12 +340,14 @@ def _run_agent_learning_kit_optimisation(prompt_optimiser_run) -> None:
         return
 
     config = prompt_optimiser_run.configuration or {}
-    candidates = config.get("agent_candidates") or [
-        {
-            "type": "llm",
-            "instructions": _resolve_optimiser_base_prompt(prompt_optimiser_run),
-        }
-    ]
+    base_agent = config.get("base_agent") or _resolve_optimiser_base_agent(
+        prompt_optimiser_run
+    )
+    candidates = config.get("agent_candidates") or [base_agent]
+    # search_space extends the search over the WHOLE agent config via dot-paths
+    # (e.g. {"agent.model": [...], "agent.instructions": [...]}), so the kit
+    # optimises the agent, not just its prompt.
+    search_space = config.get("search_space") or None
     evaluation_config = config.get("evaluation_config") or {
         "metrics": [{"name": "task_completion"}]
     }
@@ -328,6 +356,8 @@ def _run_agent_learning_kit_optimisation(prompt_optimiser_run) -> None:
             name=str(prompt_optimiser_run.id),
             agent_candidates=candidates,
             evaluation_config=evaluation_config,
+            search_space=search_space,
+            base_agent=base_agent,
             dry_run=config.get("dry_run", True),
         )
     except Exception as e:  # surface on the run; don't crash the task
@@ -355,17 +385,21 @@ def _store_kit_candidates_as_trials(prompt_optimiser_run, result, candidates) ->
     history = (result or {}).get("optimization", {}).get("history") or []
     if not history:
         return
-    baseline_prompt = ""
+    baseline_agent: dict = {}
     for cand in candidates or []:
-        if isinstance(cand, Mapping) and cand.get("instructions"):
-            baseline_prompt = str(cand["instructions"])
+        if isinstance(cand, Mapping):
+            baseline_agent = dict(cand)
             break
+    baseline_prompt = str(baseline_agent.get("instructions") or "")
     best_id = (result.get("summary") or {}).get("best_candidate_id")
     try:
         for idx, entry in enumerate(history):
             patch_agent = (entry.get("candidate_patch") or {}).get("agent") or {}
             prompt = str(patch_agent.get("instructions") or "") or baseline_prompt
             is_baseline = not (entry.get("candidate_patch") or {})
+            # The WHOLE candidate config (baseline overlaid with this candidate's
+            # patch) — what apply pushes to the provider, beyond just the prompt.
+            candidate_config = {**baseline_agent, **patch_agent}
             PromptTrial.objects.create(
                 agent_prompt_optimiser_run=prompt_optimiser_run,
                 trial_number=idx,
@@ -376,6 +410,7 @@ def _store_kit_candidates_as_trials(prompt_optimiser_run, result, candidates) ->
                     "candidate_id": entry.get("candidate_id"),
                     "selected": entry.get("candidate_id") == best_id,
                     "evaluation_score": entry.get("evaluation_score"),
+                    "candidate_config": candidate_config,
                     "source": "agent_learning_kit",
                 },
             )

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -258,48 +258,57 @@ class CreateAgentDefinitionView(APIView):
             replay_session_id = validated.get("replay_session_id")
             observability_provider = None
 
-            _api_fetch_providers = [
+            # Resolve the client-provider string to its canonical observability
+            # key via the registry (elevenlabs -> eleven_labs,
+            # livekit_bridge -> livekit, ...). Unknown strings fall back to the
+            # raw value ("vapi"/"retell"/"others" are already canonical).
+            from simulate.providers import get_spec
+
+            _spec = get_spec(provider)
+            _obs_key = (_spec.observability_key if _spec else None) or provider
+
+            # 3rd-party observability is PULL-based: like Vapi, we fetch the
+            # call data from the provider's API on a schedule
+            # (tracer.services.observability_providers.ObservabilityService),
+            # so credentials are required. Pull is implemented for these
+            # canonical keys; the rest (livekit/pipecat/deepgram/agora) have
+            # nothing hosted to pull — their conversation-level observability
+            # comes from the simulation side (CallTranscript -> sim trace).
+            _pull_obs_keys = [
                 ProviderChoices.VAPI,
                 ProviderChoices.RETELL,
+                ProviderChoices.ELEVEN_LABS,
+                ProviderChoices.BLAND,
+                ProviderChoices.TWILIO,
                 ProviderChoices.OTHERS,
             ]
             if (
                 enable_observability
+                and _obs_key in _pull_obs_keys
                 and assistant_id != ""
                 and api_key != ""
-                and provider in _api_fetch_providers
             ):
-                # API-fetch observability (Vapi/Retell pull logs via their API):
-                # needs creds to fetch.
                 observability_provider = create_observability_provider(
                     enabled=True,
                     user_id=user_id,
                     organization=organization,
                     workspace=workspace,
                     project_name=project_name,
-                    provider=provider,
+                    provider=_obs_key,
                 )
-            elif enable_observability and provider not in _api_fetch_providers:
-                # Trace-AI / push-based voice observability (e.g. LiveKit,
-                # ElevenLabs): the customer's agent is instrumented with the
-                # traceai-* SDK and PUSHES spans, so we only need to wire the
-                # agent-def -> ObservabilityProvider -> Project link (no fetch
-                # creds required). The ProviderSpec registry maps the client
-                # provider string (e.g. "livekit_bridge") to its canonical
-                # observability provider ("livekit") (TH-5642).
-                from simulate.providers import get_spec
-
-                _spec = get_spec(provider)
-                _obs_key = _spec.observability_key if _spec else None
-                if _obs_key:
-                    observability_provider = create_observability_provider(
-                        enabled=True,
-                        user_id=user_id,
-                        organization=organization,
-                        workspace=workspace,
-                        project_name=project_name,
-                        provider=_obs_key,
-                    )
+            elif enable_observability and _obs_key not in _pull_obs_keys and _spec:
+                # No pull API exists: keep the agent-def -> ObservabilityProvider
+                # -> Project link so simulation-side traces land in the agent's
+                # project (no fetch creds needed; the scheduled fetcher skips
+                # these gracefully).
+                observability_provider = create_observability_provider(
+                    enabled=True,
+                    user_id=user_id,
+                    organization=organization,
+                    workspace=workspace,
+                    project_name=project_name,
+                    provider=_obs_key,
+                )
 
             # Create agent definition — livekit_* fields are NOT model
             # columns, they're routed to ProviderCredentials below.

--- a/futureagi/simulate/views/agent_prompt_optimiser.py
+++ b/futureagi/simulate/views/agent_prompt_optimiser.py
@@ -468,11 +468,22 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
                     )
                 from simulate.services.provider_prompt_apply import (
                     PromptApplyError,
+                    apply_config_to_provider_agent,
                     apply_prompt_to_provider_agent,
                 )
 
+                # Kit trials carry the WHOLE candidate config (model, voice,
+                # first message, ... — not just the prompt); apply all of it.
+                candidate_config = (trial.metadata or {}).get("candidate_config")
                 try:
-                    applied = apply_prompt_to_provider_agent(agent_def, trial.prompt)
+                    if candidate_config:
+                        applied = apply_config_to_provider_agent(
+                            agent_def, dict(candidate_config)
+                        )
+                    else:
+                        applied = apply_prompt_to_provider_agent(
+                            agent_def, trial.prompt
+                        )
                 except PromptApplyError as e:
                     return self._gm.bad_request(str(e))
                 return self._gm.success_response(
@@ -481,7 +492,10 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "target": "provider_agent",
                         "provider": applied["provider"],
                         "assistant_id": applied["assistant_id"],
-                        "previous_prompt": applied["previous_prompt"],
+                        "applied_fields": applied.get("applied_fields"),
+                        "skipped_fields": applied.get("skipped_fields"),
+                        "previous_prompt": applied.get("previous_prompt"),
+                        "previous_config": applied.get("previous_config"),
                         "source_trial_id": str(trial.id),
                     }
                 )

--- a/futureagi/simulate/views/agent_prompt_optimiser.py
+++ b/futureagi/simulate/views/agent_prompt_optimiser.py
@@ -468,6 +468,7 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
                     )
                 from simulate.services.provider_prompt_apply import (
                     PromptApplyError,
+                    PromptApplyUnsupported,
                     apply_config_to_provider_agent,
                     apply_prompt_to_provider_agent,
                 )
@@ -475,6 +476,11 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
                 # Kit trials carry the WHOLE candidate config (model, voice,
                 # first message, ... — not just the prompt); apply all of it.
                 candidate_config = (trial.metadata or {}).get("candidate_config")
+                config_for_apply = (
+                    dict(candidate_config)
+                    if candidate_config
+                    else {"instructions": trial.prompt}
+                )
                 try:
                     if candidate_config:
                         applied = apply_config_to_provider_agent(
@@ -484,21 +490,46 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
                         applied = apply_prompt_to_provider_agent(
                             agent_def, trial.prompt
                         )
+                    return self._gm.success_response(
+                        {
+                            "applied": True,
+                            "target": "provider_agent",
+                            "provider": applied["provider"],
+                            "assistant_id": applied["assistant_id"],
+                            "applied_fields": applied.get("applied_fields"),
+                            "skipped_fields": applied.get("skipped_fields"),
+                            "previous_prompt": applied.get("previous_prompt"),
+                            "previous_config": applied.get("previous_config"),
+                            "source_trial_id": str(trial.id),
+                        }
+                    )
+                except PromptApplyUnsupported as e:
+                    # No writable provider-hosted prompt (self-hosted LiveKit/
+                    # Pipecat/Deepgram, Twilio TwiML, Bland pathway, Agora-gated):
+                    # apply the fix platform-side as a new, non-destructive
+                    # AgentVersion instead of refusing. The fix is recorded and
+                    # becomes the active version the customer's deployment adopts.
+                    from simulate.services.agent_definition_apply import (
+                        apply_config_as_new_agent_version,
+                    )
+
+                    new_version, applied_fields = apply_config_as_new_agent_version(
+                        agent_def, config_for_apply
+                    )
+                    return self._gm.success_response(
+                        {
+                            "applied": True,
+                            "target": "agent_version",
+                            "provider": (agent_def.provider or "").lower(),
+                            "reason": str(e),
+                            "new_agent_version_id": str(new_version.id),
+                            "version_number": new_version.version_number,
+                            "applied_fields": applied_fields,
+                            "source_trial_id": str(trial.id),
+                        }
+                    )
                 except PromptApplyError as e:
                     return self._gm.bad_request(str(e))
-                return self._gm.success_response(
-                    {
-                        "applied": True,
-                        "target": "provider_agent",
-                        "provider": applied["provider"],
-                        "assistant_id": applied["assistant_id"],
-                        "applied_fields": applied.get("applied_fields"),
-                        "skipped_fields": applied.get("skipped_fields"),
-                        "previous_prompt": applied.get("previous_prompt"),
-                        "previous_config": applied.get("previous_config"),
-                        "source_trial_id": str(trial.id),
-                    }
-                )
 
             from simulate.services.optimizer_apply import (
                 apply_optimized_prompt_as_new_version,

--- a/futureagi/simulate/views/agent_prompt_optimiser.py
+++ b/futureagi/simulate/views/agent_prompt_optimiser.py
@@ -8,7 +8,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-logger = structlog.get_logger(__name__)
 from model_hub.utils.dataset_optimization import calculate_percentage_point_change
 from model_hub.utils.llm_providers import get_provider_logo_url
 from simulate.constants.agent_prompt_optimiser import (
@@ -49,6 +48,8 @@ from tfc.utils.base_viewset import BaseModelViewSetMixin
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.errors import format_validation_error
 from tfc.utils.general_methods import GeneralMethods
+
+logger = structlog.get_logger(__name__)
 
 # Human-readable labels and descriptions for optimizer configuration parameters
 OPTIMISER_PARAM_META = {
@@ -451,13 +452,38 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
             if not (trial.prompt or "").strip():
                 return self._gm.bad_request("Trial has no prompt to apply.")
 
-            base_version = getattr(
-                getattr(getattr(instance, "test_execution", None), "run_test", None),
-                "prompt_version", None,
+            run_test = getattr(
+                getattr(instance, "test_execution", None), "run_test", None
             )
+            base_version = getattr(run_test, "prompt_version", None)
             if base_version is None:
-                return self._gm.bad_request(
-                    "This optimiser run is not linked to a prompt version to apply to."
+                # Agent-definition runs: the prompt lives on the PROVIDER, so
+                # applying writes through the provider's management API
+                # (read -> write -> read-back verify).
+                agent_def = getattr(run_test, "agent_definition", None)
+                if agent_def is None:
+                    return self._gm.bad_request(
+                        "This optimiser run is not linked to a prompt version or "
+                        "agent definition to apply to."
+                    )
+                from simulate.services.provider_prompt_apply import (
+                    PromptApplyError,
+                    apply_prompt_to_provider_agent,
+                )
+
+                try:
+                    applied = apply_prompt_to_provider_agent(agent_def, trial.prompt)
+                except PromptApplyError as e:
+                    return self._gm.bad_request(str(e))
+                return self._gm.success_response(
+                    {
+                        "applied": True,
+                        "target": "provider_agent",
+                        "provider": applied["provider"],
+                        "assistant_id": applied["assistant_id"],
+                        "previous_prompt": applied["previous_prompt"],
+                        "source_trial_id": str(trial.id),
+                    }
                 )
 
             from simulate.services.optimizer_apply import (

--- a/futureagi/simulate/views/agent_prompt_optimiser.py
+++ b/futureagi/simulate/views/agent_prompt_optimiser.py
@@ -23,6 +23,8 @@ from simulate.models import (
 )
 from simulate.serializers.agent_prompt_optimiser import (
     OPTIMISER_REQUIRED_CONFIG_KEYS,
+    AgentPromptOptimiserApplyTrialRequestSerializer,
+    AgentPromptOptimiserApplyTrialResponseSerializer,
     AgentPromptOptimiserGraphResponseSerializer,
     AgentPromptOptimiserRunCreateSerializer,
     AgentPromptOptimiserRunDetailResponseSerializer,
@@ -428,6 +430,15 @@ class AgentPromptOptimiserRunViewSet(BaseModelViewSetMixin, ModelViewSet):
             logger.exception(f"Error retrieving trial prompt: {str(e)}")
             return self._gm.bad_request(get_error_message("FAILED_TO_FETCH_DATA"))
 
+    @swagger_auto_schema(
+        request_body=AgentPromptOptimiserApplyTrialRequestSerializer,
+        responses={
+            200: AgentPromptOptimiserApplyTrialResponseSerializer,
+            400: ApiTextErrorResponseSerializer,
+            404: ApiTextErrorResponseSerializer,
+            500: ApiTextErrorResponseSerializer,
+        },
+    )
     @action(
         detail=True,
         methods=["post"],

--- a/futureagi/tfc/temporal/agent_prompt_optimiser/activities.py
+++ b/futureagi/tfc/temporal/agent_prompt_optimiser/activities.py
@@ -214,9 +214,18 @@ async def setup_run_activity(input: dict[str, Any]) -> dict[str, Any]:
             execution_data = get_full_test_execution_data(test_execution_id)
 
             if execution_data is None:
-                raise ValueError(
-                    f"Test execution {test_execution_id} not found or has no data"
-                )
+                # The kit optimiser builds its inputs from the agent definition,
+                # not from per-call execution data — don't fail setup for it
+                # (e.g. a still-running execution with no completed calls yet).
+                if (
+                    optimiser_type
+                    == AgentPromptOptimiserRun.OptimiserType.AGENT_LEARNING_KIT
+                ):
+                    execution_data = {}
+                else:
+                    raise ValueError(
+                        f"Test execution {test_execution_id} not found or has no data"
+                    )
 
             # Pin scenario manifest deterministically
             scenario_manifest = _select_scenario_manifest(execution_data)

--- a/futureagi/tfc/temporal/agent_prompt_optimiser/activities.py
+++ b/futureagi/tfc/temporal/agent_prompt_optimiser/activities.py
@@ -11,12 +11,11 @@ Design notes:
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import structlog
 from asgiref.sync import sync_to_async
 from django.db import close_old_connections
-from django.db.models import Max
 from temporalio import activity
 
 # Activity-aware stub: invocations raise a Temporal non-retryable
@@ -49,7 +48,7 @@ def _safe_close_db():
         pass
 
 
-def _compute_total_trials(optimiser_type: str, config: Dict[str, Any]) -> int:
+def _compute_total_trials(optimiser_type: str, config: dict[str, Any]) -> int:
     """
     Calculate total trials based on optimizer type and configuration.
 
@@ -88,7 +87,7 @@ def _compute_total_trials(optimiser_type: str, config: Dict[str, Any]) -> int:
         # Subsequent rounds: start with beam_size prompts
         total = 0
         current_beam = 1  # Initial prompt
-        for round_num in range(num_rounds):
+        for _round_num in range(num_rounds):
             # Expansion: each prompt in beam generates new candidates
             expanded = current_beam * num_gradients * prompts_per_gradient
             # Candidate pool = current beam + expanded prompts
@@ -133,7 +132,7 @@ def _compute_total_trials(optimiser_type: str, config: Dict[str, Any]) -> int:
         return 0
 
 
-def _select_scenario_manifest(execution_data: dict) -> List[str]:
+def _select_scenario_manifest(execution_data: dict) -> list[str]:
     call_executions = execution_data.get("call_executions", [])
     total = len(call_executions)
     if total == 0:
@@ -181,7 +180,7 @@ def _calc_best_from_trials_by_id(run_id: str):
 
 
 @activity.defn
-async def setup_run_activity(input: Dict[str, Any]) -> Dict[str, Any]:
+async def setup_run_activity(input: dict[str, Any]) -> dict[str, Any]:
     """
     Mark run as RUNNING, pin scenario manifest, compute totals.
     Simplified without locks - workflows are guaranteed not to conflict.
@@ -198,7 +197,7 @@ async def setup_run_activity(input: Dict[str, Any]) -> Dict[str, Any]:
             try:
                 run = AgentPromptOptimiserRun.objects.get(id=run_id)
             except AgentPromptOptimiserRun.DoesNotExist:
-                raise ValueError(f"Run {run_id} does not exist")
+                raise ValueError(f"Run {run_id} does not exist") from None
 
             # Update status if not already running
             if run.status != AgentPromptOptimiserRun.Status.RUNNING:
@@ -263,7 +262,7 @@ async def setup_run_activity(input: Dict[str, Any]) -> Dict[str, Any]:
 
 
 @activity.defn
-async def run_optimization_activity(input: Dict[str, Any]) -> Dict[str, Any]:
+async def run_optimization_activity(input: dict[str, Any]) -> dict[str, Any]:
     """
     Run entire optimization in one activity. Resume from latest PromptTrial if exists.
     Uses callback to persist each trial immediately after completion.
@@ -280,7 +279,32 @@ async def run_optimization_activity(input: Dict[str, Any]) -> Dict[str, Any]:
             try:
                 run = AgentPromptOptimiserRun.objects.get(id=run_id)
             except AgentPromptOptimiserRun.DoesNotExist:
-                raise ValueError(f"Run {run_id} does not exist")
+                raise ValueError(f"Run {run_id} does not exist") from None
+
+            # TH-5642: the agent-learning-kit optimiser has no trial loop — it runs
+            # through the kit bridge in one shot. Without this branch the type fell
+            # into _compute_total_trials' unknown-type 0, silently completing the
+            # run as a no-op with a NULL result.
+            if (
+                run.optimiser_type
+                == AgentPromptOptimiserRun.OptimiserType.AGENT_LEARNING_KIT
+            ):
+                from simulate.utils.agent_prompt_optimiser import (
+                    _run_agent_learning_kit_optimisation,
+                )
+
+                _run_agent_learning_kit_optimisation(run)
+                run.refresh_from_db()
+                if run.status == AgentPromptOptimiserRun.Status.FAILED:
+                    raise ValueError(
+                        run.error_message or "agent-learning-kit optimisation failed"
+                    )
+                kit_summary = (run.result or {}).get("summary") or {}
+                return {
+                    "trials_run": 0,
+                    "best_score": kit_summary.get("best_score"),
+                    "best_prompt": None,
+                }
 
             # Check for existing trials (resume case)
             latest_trial = (
@@ -383,7 +407,7 @@ async def run_optimization_activity(input: Dict[str, Any]) -> Dict[str, Any]:
 
 
 @activity.defn
-async def finalize_run_activity(input: Dict[str, Any]) -> Dict[str, Any]:
+async def finalize_run_activity(input: dict[str, Any]) -> dict[str, Any]:
     """
     Mark run as completed/failed/canceled.
     Simplified without locks - workflows are guaranteed not to conflict.
@@ -405,7 +429,7 @@ async def finalize_run_activity(input: Dict[str, Any]) -> Dict[str, Any]:
             run = AgentPromptOptimiserRun.objects.get(id=run_id)
         except AgentPromptOptimiserRun.DoesNotExist:
             logger.error("Run does not exist in finalize", run_id=run_id)
-            raise ValueError(f"Run {run_id} does not exist")
+            raise ValueError(f"Run {run_id} does not exist") from None
 
         # Update status based on input
         if status == "completed":

--- a/futureagi/tfc/utils/api_contracts.py
+++ b/futureagi/tfc/utils/api_contracts.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import wraps
 from inspect import Parameter, signature
 
@@ -290,9 +291,12 @@ def validated_request(
             # strict_response_validation=True.
             swagger_options["runtime_response_validation"] = True
 
-        @swagger_auto_schema(**swagger_options)
-        @wraps(view_func)
-        def wrapper(*args, **kwargs):
+        def _run_request_validation(args, kwargs):
+            """Validate query/body per the declared serializers.
+
+            Mutates the request (validated_* attributes) and returns an early
+            error Response, or None when the handler should run.
+            """
             request = _request_from_call(args)
             request.validated_data = {}
             request.validated_query_data = {}
@@ -351,8 +355,10 @@ def validated_request(
                 request.validated_data = serializer.validated_data
                 request.validated_serializer = serializer
 
-            response = view_func(*args, **kwargs)
+            return None
 
+        def _run_response_validation(response):
+            """Check the response against the declared response contract."""
             if not responses or not isinstance(response, Response):
                 return response
 
@@ -381,6 +387,35 @@ def validated_request(
                 )
 
             return response
+
+        if asyncio.iscoroutinefunction(view_func):
+            # Async handlers (e.g. the internal LiveKit API views) need a
+            # coroutine-function wrapper: a sync wrapper erases the handler's
+            # async-ness, Django then treats the whole view as sync, never
+            # awaits AsyncAPIView.dispatch, and every request 500s with
+            # "returned an unawaited coroutine" (found by the first local
+            # voice-sim E2E run — the agent worker's transcript/lifecycle
+            # pushes all failed). Awaiting here also makes the response
+            # contract actually checked for async views.
+            @swagger_auto_schema(**swagger_options)
+            @wraps(view_func)
+            async def wrapper(*args, **kwargs):
+                early = _run_request_validation(args, kwargs)
+                if early is not None:
+                    return early
+                response = await view_func(*args, **kwargs)
+                return _run_response_validation(response)
+
+        else:
+
+            @swagger_auto_schema(**swagger_options)
+            @wraps(view_func)
+            def wrapper(*args, **kwargs):
+                early = _run_request_validation(args, kwargs)
+                if early is not None:
+                    return early
+                response = view_func(*args, **kwargs)
+                return _run_response_validation(response)
 
         return wrapper
 

--- a/futureagi/tracer/constants/external_endpoints.py
+++ b/futureagi/tracer/constants/external_endpoints.py
@@ -5,6 +5,9 @@ class ObservabilityRoutes(str, Enum):
     VAPI_CALL_URL = "https://api.vapi.ai/call"
     RETELL_LIST_CALLS_URL = "https://api.retellai.com/v2/list-calls"
     ELEVEN_LABS_CONVERSATIONS_URL = "https://api.elevenlabs.io/v1/convai/conversations"
+    BLAND_CALLS_URL = "https://api.bland.ai/v1/calls"
+    # {account_sid} interpolated at fetch time (Twilio's API is account-scoped).
+    TWILIO_CALLS_URL = "https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Calls.json"
 
     ## Assistant endpoints
     VAPI_ASSISTANT_URL = "https://api.vapi.ai/assistant"

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -6,8 +6,6 @@ import requests
 import structlog
 
 from tracer.constants.external_endpoints import ObservabilityRoutes
-
-logger = structlog.get_logger(__name__)
 from tracer.models.observability_provider import ObservabilityProvider, ProviderChoices
 from tracer.models.project import VoiceCallLogs
 
@@ -310,7 +308,11 @@ class ObservabilityService:
         if start_time:
             params["start_date"] = start_time.strftime("%Y-%m-%d")
         if end_time:
-            params["end_date"] = end_time.strftime("%Y-%m-%d")
+            # Bland's end_date is EXCLUSIVE at date granularity: end_date=today
+            # silently drops all of today's calls (live-confirmed), so every
+            # scheduled pull (end=now) would never fetch same-day calls. Send
+            # the day after.
+            params["end_date"] = (end_time + timedelta(days=1)).strftime("%Y-%m-%d")
 
         response = requests.get(
             ObservabilityRoutes.BLAND_CALLS_URL.value,
@@ -895,7 +897,9 @@ class ObservabilityService:
         """
         call_length = raw_log.get("call_length")
         duration_seconds = (
-            int(round(float(call_length) * 60)) if call_length not in (None, "") else None
+            int(round(float(call_length) * 60))
+            if call_length not in (None, "")
+            else None
         )
         transcripts = [
             {
@@ -920,7 +924,10 @@ class ObservabilityService:
             "cost_cents": float(price) * 100 if price not in (None, "") else None,
             "transcript": transcripts,
             "error_message": raw_log.get("error_message"),
-            "call_metadata": {"from": raw_log.get("from"), "summary": raw_log.get("summary")},
+            "call_metadata": {
+                "from": raw_log.get("from"),
+                "summary": raw_log.get("summary"),
+            },
         }
         return VoiceCallLogs(**processed_log).model_dump()
 

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -823,6 +823,12 @@ class ObservabilityService:
             processed = ObservabilityService._process_vapi_logs(raw_log)
         elif provider == ProviderChoices.RETELL:
             processed = ObservabilityService._process_retell_logs(raw_log)
+        elif provider == ProviderChoices.ELEVEN_LABS:
+            processed = ObservabilityService._process_eleven_labs_raw(raw_log)
+        elif provider == ProviderChoices.BLAND:
+            processed = ObservabilityService._process_bland_raw(raw_log)
+        elif provider == ProviderChoices.TWILIO:
+            processed = ObservabilityService._process_twilio_raw(raw_log)
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
 
@@ -835,3 +841,112 @@ class ObservabilityService:
                 processed["stereo_recording_url"] = stereo
 
         return processed
+
+    @staticmethod
+    def _process_eleven_labs_raw(raw_log: dict) -> dict:
+        """ElevenLabs ConvAI conversation raw_log -> VoiceCallLogs dump (TH-5642).
+
+        Pulled raw shape: ``conversation_id``, ``status``, ``metadata``
+        (``start_time_unix_secs``, ``call_duration_secs``, ``cost``),
+        ``transcript``: [{"role", "message", "time_in_call_secs"}].
+        """
+        metadata = raw_log.get("metadata") or {}
+        started_at = None
+        if start_unix := metadata.get("start_time_unix_secs"):
+            started_at = datetime.fromtimestamp(start_unix).isoformat()
+
+        transcripts = [
+            {
+                "id": str(uuid.uuid4()),
+                "role": msg.get("role"),
+                "content": msg.get("message"),
+                "time": (
+                    str(msg["time_in_call_secs"])
+                    if msg.get("time_in_call_secs") is not None
+                    else None
+                ),
+                "duration": None,
+            }
+            for msg in (raw_log.get("transcript") or [])
+            if isinstance(msg, dict) and msg.get("message")
+        ]
+        cost = metadata.get("cost")
+        processed_log = {
+            "id": None,
+            "call_id": raw_log.get("conversation_id"),
+            "phone_number": None,
+            "status": raw_log.get("status"),
+            "started_at": started_at,
+            "duration_seconds": metadata.get("call_duration_secs"),
+            "recording_url": None,
+            "cost_cents": cost if cost is not None else None,
+            "transcript": transcripts,
+            "call_metadata": {"agent_id": raw_log.get("agent_id")},
+        }
+        return VoiceCallLogs(**processed_log).model_dump()
+
+    @staticmethod
+    def _process_bland_raw(raw_log: dict) -> dict:
+        """Bland.ai call raw_log -> VoiceCallLogs dump (TH-5642).
+
+        Pulled raw shape: ``call_id``, ``started_at``/``created_at``,
+        ``call_length`` (MINUTES), ``price`` (USD), ``to``/``from``,
+        ``transcripts``: [{"user", "text"}], ``recording_url``, ``status``.
+        """
+        call_length = raw_log.get("call_length")
+        duration_seconds = (
+            int(round(float(call_length) * 60)) if call_length not in (None, "") else None
+        )
+        transcripts = [
+            {
+                "id": str(uuid.uuid4()),
+                "role": row.get("user"),
+                "content": row.get("text"),
+                "time": None,
+                "duration": None,
+            }
+            for row in (raw_log.get("transcripts") or [])
+            if isinstance(row, dict) and row.get("text")
+        ]
+        price = raw_log.get("price")
+        processed_log = {
+            "id": None,
+            "call_id": raw_log.get("call_id"),
+            "phone_number": raw_log.get("to"),
+            "status": raw_log.get("status"),
+            "started_at": raw_log.get("started_at") or raw_log.get("created_at"),
+            "duration_seconds": duration_seconds,
+            "recording_url": raw_log.get("recording_url"),
+            "cost_cents": float(price) * 100 if price not in (None, "") else None,
+            "transcript": transcripts,
+            "error_message": raw_log.get("error_message"),
+            "call_metadata": {"from": raw_log.get("from"), "summary": raw_log.get("summary")},
+        }
+        return VoiceCallLogs(**processed_log).model_dump()
+
+    @staticmethod
+    def _process_twilio_raw(raw_log: dict) -> dict:
+        """Twilio Call resource raw_log -> VoiceCallLogs dump (TH-5642).
+
+        Telephony metadata only — Twilio stores no transcript on the Call
+        resource (transcript-level data comes from sims or the fronting
+        agent platform).
+        """
+        duration = raw_log.get("duration")
+        price = raw_log.get("price")
+        processed_log = {
+            "id": None,
+            "call_id": raw_log.get("sid"),
+            "phone_number": raw_log.get("to"),
+            "status": raw_log.get("status"),
+            "started_at": raw_log.get("start_time"),
+            "duration_seconds": int(duration) if duration not in (None, "") else None,
+            "recording_url": None,
+            "cost_cents": abs(float(price)) * 100 if price not in (None, "") else None,
+            "transcript": [],
+            "call_metadata": {
+                "from": raw_log.get("from"),
+                "direction": raw_log.get("direction"),
+            },
+        }
+        return VoiceCallLogs(**processed_log).model_dump()

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -82,12 +82,31 @@ class ObservabilityService:
             return ObservabilityService._fetch_eleven_labs_logs(
                 provider, start_time, end_time
             )
-        elif provider.provider == ProviderChoices.LIVEKIT:
-            # LiveKit observability is PUSH-based: the customer's agent is
-            # instrumented with the traceai-livekit SDK and pushes spans
-            # directly to the project, so there is nothing to PULL here. Skip
-            # gracefully instead of raising (which would log a fetch failure
-            # every poll cycle for a LiveKit agent definition). (TH-5642)
+        elif provider.provider == ProviderChoices.BLAND:
+            return ObservabilityService._fetch_bland_logs(
+                provider, start_time, end_time
+            )
+        elif provider.provider == ProviderChoices.TWILIO:
+            return ObservabilityService._fetch_twilio_logs(
+                provider, start_time, end_time
+            )
+        elif provider.provider in (
+            ProviderChoices.LIVEKIT,
+            ProviderChoices.DEEPGRAM,
+            ProviderChoices.PIPECAT,
+            ProviderChoices.AGORA,
+        ):
+            # Nothing hosted to PULL for these providers (TH-5642):
+            # - LiveKit / Pipecat: the tested agent is the customer's own
+            #   deployment; neither provider cloud stores conversation history.
+            # - Deepgram: the Voice Agent API is a live WebSocket; Deepgram
+            #   retains no conversations to list.
+            # - Agora: the ConvAI history API needs a project we don't have
+            #   access to yet (TH-5682) — skip gracefully until it lands.
+            # Conversation-level observability for these comes from the
+            # simulation side (CallTranscript → sim trace emission). Returning
+            # [] avoids a NotImplementedError crash-loop in the scheduled
+            # fetch for every enabled agent definition on these providers.
             return []
         else:
             raise NotImplementedError(f"Provider {provider.provider} not implemented.")
@@ -269,6 +288,107 @@ class ObservabilityService:
         response = requests.get(detail_url, headers=headers, timeout=30)
         response.raise_for_status()
         return response.json()
+
+    @staticmethod
+    def _fetch_bland_logs(
+        provider: ObservabilityProvider,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ):
+        """Pulls Bland.ai calls: list ``GET /v1/calls`` then per-call details
+        (``GET /v1/calls/{id}``) which carry the ``transcripts`` rows (TH-5642).
+
+        Auth header is ``authorization: <api_key>`` (no Bearer prefix).
+        """
+        agent = ObservabilityService._get_agent_definition(provider)
+        api_key = ObservabilityService._validate_agent_api_key(agent, provider, "Bland")
+        if not api_key:
+            return []
+
+        headers = {"authorization": api_key}
+        params: dict = {"limit": 100, "ascending": False}
+        if start_time:
+            params["start_date"] = start_time.strftime("%Y-%m-%d")
+        if end_time:
+            params["end_date"] = end_time.strftime("%Y-%m-%d")
+
+        response = requests.get(
+            ObservabilityRoutes.BLAND_CALLS_URL.value,
+            headers=headers,
+            params=params,
+            timeout=30,
+        )
+        response.raise_for_status()
+        calls = response.json().get("calls", []) or []
+
+        detailed_logs = []
+        for call in calls:
+            call_id = call.get("call_id") or call.get("c_id")
+            if not call_id:
+                continue
+            detail_resp = requests.get(
+                f"{ObservabilityRoutes.BLAND_CALLS_URL.value}/{call_id}",
+                headers=headers,
+                timeout=30,
+            )
+            if detail_resp.status_code != 200:
+                logger.warning(
+                    "bland_call_detail_fetch_failed",
+                    provider_id=str(provider.id),
+                    call_id=call_id,
+                    status_code=detail_resp.status_code,
+                )
+                # Fall back to the listing row (metadata-only, no transcripts).
+                detailed_logs.append(call)
+                continue
+            detailed_logs.append(detail_resp.json())
+
+        return detailed_logs
+
+    @staticmethod
+    def _fetch_twilio_logs(
+        provider: ObservabilityProvider,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ):
+        """Pulls Twilio Call resources (telephony metadata; Twilio stores no
+        transcripts on the Call resource) — TH-5642.
+
+        Credentials: ``AgentDefinition.api_key`` holds ``"<AccountSid>:<AuthToken>"``
+        (Twilio's two-part credential in the single key field; basic auth).
+        """
+        agent = ObservabilityService._get_agent_definition(provider)
+        api_key = ObservabilityService._validate_agent_api_key(
+            agent, provider, "Twilio"
+        )
+        if not api_key:
+            return []
+        if ":" not in api_key:
+            logger.warning(
+                "twilio_api_key_format_invalid",
+                provider_id=str(provider.id),
+                message=(
+                    "Twilio observability needs api_key formatted as "
+                    "'<AccountSid>:<AuthToken>'. Skipping log fetch."
+                ),
+            )
+            return []
+
+        account_sid, auth_token = api_key.split(":", 1)
+        params: dict = {"PageSize": 100}
+        if start_time:
+            params["StartTime>"] = start_time.strftime("%Y-%m-%d")
+        if end_time:
+            params["StartTime<"] = end_time.strftime("%Y-%m-%d")
+
+        response = requests.get(
+            ObservabilityRoutes.TWILIO_CALLS_URL.value.format(account_sid=account_sid),
+            auth=(account_sid, auth_token),
+            params=params,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json().get("calls", []) or []
 
     @staticmethod
     def _fetch_eleven_labs_logs(

--- a/futureagi/tracer/tests/test_observability_livekit_skip.py
+++ b/futureagi/tracer/tests/test_observability_livekit_skip.py
@@ -21,8 +21,10 @@ def test_get_call_logs_skips_livekit_push_based():
 
 @pytest.mark.unit
 def test_get_call_logs_still_raises_for_unimplemented_provider():
-    # A provider with no fetch path and not marked push-based still raises, so we
-    # notice genuinely-unwired providers.
-    provider = SimpleNamespace(provider="agora")
+    # A provider with no fetch path and not in the deliberate no-pull set still
+    # raises, so we notice genuinely-unwired providers. (agora/deepgram/pipecat
+    # moved to the graceful no-pull set — pull is impossible or gated TH-5682 —
+    # covered in test_pull_observability_bland_twilio.py.)
+    provider = SimpleNamespace(provider="not-a-real-provider")
     with pytest.raises(NotImplementedError):
         ObservabilityService.get_call_logs(provider)

--- a/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
+++ b/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
@@ -1,0 +1,154 @@
+"""Pull-based observability for Bland + Twilio (TH-5642).
+
+Per product direction, 3rd-party observability is PULL-based (like Vapi: we
+fetch call data from the provider's API). These tests pin the two new
+normalizers, the fetcher dispatch (incl. the graceful no-pull providers), and
+the normalization registry wiring.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tracer.models.observability_provider import ProviderChoices
+from tracer.services.observability_providers import ObservabilityService
+from tracer.utils.bland import normalize_bland_data
+from tracer.utils.twilio_calls import normalize_twilio_data
+
+BLAND_CALL = {
+    "call_id": "bl-123",
+    "created_at": "2026-06-09T20:00:00Z",
+    "started_at": "2026-06-09T20:00:05Z",
+    "end_at": "2026-06-09T20:01:05Z",
+    "call_length": 1.0,  # minutes
+    "completed": True,
+    "status": "completed",
+    "to": "+15551230000",
+    "from": "+15559990000",
+    "price": 0.09,
+    "recording_url": None,
+    "transcripts": [
+        {"id": 1, "user": "assistant", "text": "Hello, how can I help?"},
+        {"id": 2, "user": "user", "text": "What are your opening hours?"},
+    ],
+}
+
+TWILIO_CALL = {
+    "sid": "CA0123",
+    "status": "completed",
+    "start_time": "Tue, 09 Jun 2026 20:00:00 +0000",
+    "end_time": "Tue, 09 Jun 2026 20:00:43 +0000",
+    "duration": "43",
+    "to": "+12175696753",
+    "from": "+15555550000",
+    "price": "-0.0085",
+    "direction": "outbound-api",
+}
+
+
+@pytest.mark.unit
+def test_normalize_bland_data_shape():
+    out = normalize_bland_data(BLAND_CALL)
+    assert out["id"] == "bl-123"
+    assert out["status"] == "ok"
+    assert out["cost"] == 0.09
+    assert out["start_time"] == datetime(2026, 6, 9, 20, 0, 5, tzinfo=UTC)
+    assert out["end_time"] == datetime(2026, 6, 9, 20, 1, 5, tzinfo=UTC)
+    # Transcript flattened to role/message pairs.
+    transcript = out["input"]["transcript"]
+    assert transcript[0] == {"role": "assistant", "message": "Hello, how can I help?"}
+    assert transcript[1]["role"] == "user"
+    # Common call fields present in span_attributes.
+    assert out["span_attributes"]["call.total_turns"] == 2
+    assert out["span_attributes"]["call.duration"] == 60
+    assert out["span_attributes"]["raw_log"] is BLAND_CALL
+
+
+@pytest.mark.unit
+def test_normalize_bland_call_length_is_minutes():
+    out = normalize_bland_data({**BLAND_CALL, "end_at": None, "call_length": 2.5})
+    assert out["span_attributes"]["call.duration"] == 150
+    # end derived from start + duration
+    assert (out["end_time"] - out["start_time"]).total_seconds() == 150
+
+
+@pytest.mark.unit
+def test_normalize_twilio_data_shape():
+    out = normalize_twilio_data(TWILIO_CALL)
+    assert out["id"] == "CA0123"
+    assert out["status"] == "ok"
+    assert out["cost"] == 0.0085  # magnitude of the negative charge
+    assert out["start_time"] == datetime(2026, 6, 9, 20, 0, 0, tzinfo=UTC)
+    assert out["input"] == {}  # Twilio stores no transcript on the Call resource
+    assert out["span_attributes"]["call.duration"] == 43
+    assert out["metadata"]["direction"] == "outbound-api"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", ["busy", "failed", "no-answer", "canceled"])
+def test_normalize_twilio_failure_statuses(status):
+    assert normalize_twilio_data({**TWILIO_CALL, "status": status})["status"] == "error"
+
+
+def _provider(provider_value, api_key="k", assistant_id="a"):
+    agent = SimpleNamespace(api_key=api_key, assistant_id=assistant_id)
+    return SimpleNamespace(
+        id="00000000-0000-0000-0000-000000000001",
+        provider=provider_value,
+        agent_definition=agent,
+    )
+
+
+@pytest.mark.unit
+def test_get_call_logs_dispatches_bland_and_twilio():
+    with patch.object(ObservabilityService, "_fetch_bland_logs", return_value=[1]) as b:
+        assert (
+            ObservabilityService.get_call_logs(_provider(ProviderChoices.BLAND)) == [1]
+        )
+        b.assert_called_once()
+    with patch.object(
+        ObservabilityService, "_fetch_twilio_logs", return_value=[2]
+    ) as t:
+        assert (
+            ObservabilityService.get_call_logs(_provider(ProviderChoices.TWILIO)) == [2]
+        )
+        t.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "provider_value",
+    [
+        ProviderChoices.LIVEKIT,
+        ProviderChoices.DEEPGRAM,
+        ProviderChoices.PIPECAT,
+        ProviderChoices.AGORA,
+    ],
+)
+def test_get_call_logs_no_pull_providers_return_empty(provider_value):
+    """Providers with nothing hosted to pull must skip gracefully — a raise
+    here crash-loops the scheduled fetch for every enabled agent definition."""
+    assert ObservabilityService.get_call_logs(_provider(provider_value)) == []
+
+
+@pytest.mark.unit
+def test_twilio_fetch_requires_sid_token_format():
+    """api_key must be '<AccountSid>:<AuthToken>'; anything else skips safely."""
+    assert (
+        ObservabilityService._fetch_twilio_logs(
+            _provider(ProviderChoices.TWILIO, api_key="just-a-token")
+        )
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_normalization_registry_includes_new_providers():
+    import tracer.utils.observability_provider as op_module
+    import inspect
+
+    src = inspect.getsource(op_module.process_and_store_logs)
+    for key in ('"bland"', '"twilio"'):
+        assert key in src, f"{key} missing from normalization_functions registry"

--- a/futureagi/tracer/utils/bland.py
+++ b/futureagi/tracer/utils/bland.py
@@ -1,0 +1,140 @@
+"""Bland.ai call-log normalization for pull-based observability (TH-5642).
+
+Mirrors tracer/utils/eleven_labs.py: the fetcher
+(``ObservabilityService._fetch_bland_logs``) lists calls from
+``GET https://api.bland.ai/v1/calls`` and enriches each with
+``GET /v1/calls/{call_id}`` (which carries ``transcripts``); this module
+flattens one such detailed call into the provider-agnostic log shape consumed
+by ``process_and_store_logs``.
+
+Bland call fields used (https://docs.bland.ai/api-v1/get/calls):
+``call_id``, ``created_at``, ``started_at``, ``end_at``, ``call_length``
+(minutes, float), ``status``/``completed``, ``to``, ``from``,
+``recording_url``, ``price`` (USD), ``error_message``, ``summary``,
+``transcripts``: [{"id", "user", "text", "created_at"}] where ``user`` is the
+speaker ("user" | "assistant" | "agent-action").
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from tracer.utils.otel import (
+    CallAttributes,
+    ConversationAttributes,
+    MessageAttributes,
+    SpanAttributes,
+)
+
+
+def normalize_bland_data(log: dict) -> dict:
+    """Normalizes a single detailed Bland call into the standard log shape."""
+    status_map = {"completed": "ok", "complete": "ok", "failed": "error", "error": "error"}
+    raw_status = (log.get("status") or "") if isinstance(log.get("status"), str) else ""
+    status = status_map.get(raw_status.lower(), "ok" if log.get("completed") else "unset")
+
+    eval_attributes = _extract_eval_attributes(log)
+    start_time, end_time = _extract_timestamps(log)
+    transcript = _transcript_messages(log)
+
+    price = log.get("price")
+    cost = float(price) if price not in (None, "") else None
+
+    return {
+        "id": log.get("call_id") or log.get("c_id"),
+        "start_time": start_time,
+        "end_time": end_time,
+        "cost": cost,
+        "status": status,
+        "input": {"transcript": transcript} if transcript else {},
+        "metadata": {
+            "to": log.get("to"),
+            "from": log.get("from"),
+            "recording_url": log.get("recording_url"),
+            "summary": log.get("summary"),
+            "error_message": log.get("error_message"),
+        },
+        "span_attributes": eval_attributes,
+        # Bland does not expose LLM token usage on the call object.
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+    }
+
+
+def _transcript_messages(log: dict) -> list[dict]:
+    """Bland ``transcripts`` rows → [{"role", "message"}] (speaker key is ``user``)."""
+    rows = log.get("transcripts")
+    if not (rows and isinstance(rows, list)):
+        return []
+    return [
+        {"role": row.get("user"), "message": row.get("text")}
+        for row in rows
+        if isinstance(row, dict) and row.get("text")
+    ]
+
+
+def _extract_eval_attributes(log: dict) -> dict:
+    eval_attributes = {
+        SpanAttributes.SPAN_KIND: "conversation",
+        "raw_log": log,
+    }
+    _extract_transcript(log, eval_attributes)
+    _extract_common_call_fields(log, eval_attributes)
+    return eval_attributes
+
+
+def _extract_transcript(log: dict, eval_attributes: dict):
+    for i, msg in enumerate(_transcript_messages(log)):
+        if msg.get("role"):
+            eval_attributes[
+                f"{ConversationAttributes.CONVERSATION_TRANSCRIPT}.{i}.{MessageAttributes.MESSAGE_ROLE}"
+            ] = msg["role"]
+        if msg.get("message"):
+            eval_attributes[
+                f"{ConversationAttributes.CONVERSATION_TRANSCRIPT}.{i}.{MessageAttributes.MESSAGE_CONTENT}"
+            ] = msg["message"]
+
+
+def _duration_seconds(log: dict) -> int | None:
+    """``call_length`` is in MINUTES (float) per Bland's API."""
+    call_length = log.get("call_length")
+    if call_length in (None, ""):
+        return None
+    try:
+        return int(round(float(call_length) * 60))
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_ts(value) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _extract_timestamps(log: dict) -> tuple:
+    start_time = _parse_ts(log.get("started_at")) or _parse_ts(log.get("created_at"))
+    end_time = _parse_ts(log.get("end_at"))
+    if start_time and not end_time:
+        duration = _duration_seconds(log)
+        if duration is not None:
+            end_time = start_time + timedelta(seconds=duration)
+    return start_time, end_time
+
+
+def _extract_common_call_fields(log: dict, eval_attributes: dict):
+    """Provider-agnostic call fields, mirroring the other normalizers."""
+    transcript = _transcript_messages(log)
+    eval_attributes[CallAttributes.TOTAL_TURNS] = sum(
+        1 for msg in transcript if msg.get("role") in ("user", "assistant")
+    )
+    eval_attributes[CallAttributes.DURATION] = _duration_seconds(log)
+    eval_attributes[CallAttributes.PARTICIPANT_PHONE_NUMBER] = log.get("to")
+    eval_attributes[CallAttributes.STATUS] = log.get("status")
+    # Bland does not provide per-message timing → no WPM / talk-ratio signals.
+    eval_attributes[CallAttributes.USER_WPM] = None
+    eval_attributes[CallAttributes.BOT_WPM] = None
+    eval_attributes[CallAttributes.TALK_RATIO] = None

--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -24,9 +24,11 @@ from tracer.tasks.recordings_rehost import (
     RECORDING_KEYS_BY_PROVIDER,
     rehost_external_recordings,
 )
+from tracer.utils.bland import normalize_bland_data
 from tracer.utils.eleven_labs import normalize_eleven_labs_data
 from tracer.utils.otel import ResourceLimitError, get_or_create_project
 from tracer.utils.retell import normalize_retell_data
+from tracer.utils.twilio_calls import normalize_twilio_data
 from tracer.utils.usage_emit import emit_span_ingestion_usage
 from tracer.utils.vapi import normalize_vapi_data
 
@@ -295,6 +297,8 @@ def process_and_store_logs(logs: list, provider: ObservabilityProvider):
         "vapi": normalize_vapi_data,
         "retell": normalize_retell_data,
         "eleven_labs": normalize_eleven_labs_data,
+        "bland": normalize_bland_data,
+        "twilio": normalize_twilio_data,
     }
 
     if provider.provider not in normalization_functions:

--- a/futureagi/tracer/utils/twilio_calls.py
+++ b/futureagi/tracer/utils/twilio_calls.py
@@ -1,0 +1,91 @@
+"""Twilio call-log normalization for pull-based observability (TH-5642).
+
+Twilio is transport-only in the provider taxonomy, but agents fronted by a
+Twilio number still leave a pullable telephony record:
+``GET /2010-04-01/Accounts/{sid}/Calls.json``. Those records carry call
+metadata (status, timing, numbers, price) but NO transcript — Twilio does not
+store conversation text on the Call resource. Transcript-level observability
+for Twilio-fronted agents comes from the simulation side (CallTranscript) or
+the fronting agent platform's own API.
+
+Twilio Call resource fields used
+(https://www.twilio.com/docs/voice/api/call-resource): ``sid``, ``status``
+(queued|ringing|in-progress|completed|busy|failed|no-answer|canceled),
+``start_time``/``end_time`` (RFC 2822), ``duration`` (seconds, str), ``to``,
+``from``, ``price`` (negative USD str), ``direction``.
+"""
+
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+from tracer.utils.otel import CallAttributes, SpanAttributes
+
+
+def normalize_twilio_data(log: dict) -> dict:
+    """Normalizes a single Twilio Call resource into the standard log shape."""
+    status_map = {
+        "completed": "ok",
+        "busy": "error",
+        "failed": "error",
+        "no-answer": "error",
+        "canceled": "error",
+    }
+    status = status_map.get((log.get("status") or "").lower(), "unset")
+
+    start_time = _parse_rfc2822(log.get("start_time"))
+    end_time = _parse_rfc2822(log.get("end_time"))
+
+    price = log.get("price")
+    # Twilio reports price as a negative charge (e.g. "-0.0085"); store magnitude.
+    cost = abs(float(price)) if price not in (None, "") else None
+
+    eval_attributes = {
+        SpanAttributes.SPAN_KIND: "conversation",
+        "raw_log": log,
+        CallAttributes.TOTAL_TURNS: 0,  # no transcript on the Call resource
+        CallAttributes.DURATION: _duration_seconds(log),
+        CallAttributes.PARTICIPANT_PHONE_NUMBER: log.get("to"),
+        CallAttributes.STATUS: log.get("status"),
+        CallAttributes.USER_WPM: None,
+        CallAttributes.BOT_WPM: None,
+        CallAttributes.TALK_RATIO: None,
+    }
+
+    return {
+        "id": log.get("sid"),
+        "start_time": start_time,
+        "end_time": end_time,
+        "cost": cost,
+        "status": status,
+        "input": {},  # no transcript available from Twilio
+        "metadata": {
+            "to": log.get("to"),
+            "from": log.get("from"),
+            "direction": log.get("direction"),
+            "answered_by": log.get("answered_by"),
+        },
+        "span_attributes": eval_attributes,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+    }
+
+
+def _duration_seconds(log: dict) -> int | None:
+    duration = log.get("duration")
+    if duration in (None, ""):
+        return None
+    try:
+        return int(duration)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_rfc2822(value) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return None


### PR DESCRIPTION
Stack **4/5** · base `stack/3-kit-bridge`. Optimiser "apply the fix": persist kit candidates as PromptTrials, apply to provider-side agents, whole-AGENT optimization + apply via the kit, apply-as-new-AgentVersion for self-hosted/non-writable providers, the apply-the-fix UI + whole-agent kit fields; plus Agora native RTC connector wiring and pull-based call-log/observability fixes. 19 commits.

---
**Stacked PR series (1→5).** Merge bottom-up: this PR's base is the previous stack branch; after it merges, retarget the next PR's base to `dev`. PRs 1–4 are conflict-free (no internal dev-merges); PR 5 carries dev-merge noise by design (the branch merged `dev` 4×) — review it via its own ~37 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)