### PR TITLE
fix(simulate): assistant_id verify + scenario auto-select contract drift (TH-6206, TH-6329, TH-6334)

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -73845,6 +73845,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Api key",
           "type": "string",
           "x-nullable": true
+        },
+        "agent_id": {
+          "title": "Agent id",
+          "type": "string",
+          "x-nullable": true
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -19513,6 +19513,7 @@ export interface VerifyAssistantIdRequestApi {
   provider: VerifyAssistantIdRequestApiProvider;
   assistant_id?: string;
   api_key?: string;
+  agent_id?: string;
 }
 
 export type ObservationSpanApiObservationType = typeof ObservationSpanApiObservationType[keyof typeof ObservationSpanApiObservationType];

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -36880,7 +36880,8 @@ export const TracerObservabilityProviderVerifyApiKeyResponse = zod.object({
 export const TracerObservabilityProviderVerifyAssistantIdBody = zod.object({
   "provider": zod.enum(['vapi', 'retell']),
   "assistant_id": zod.string().optional(),
-  "api_key": zod.string().optional()
+  "api_key": zod.string().optional(),
+  "agent_id": zod.string().optional()
 })
 
 export const tracerObservabilityProviderVerifyAssistantIdResponseStatusDefault = true;

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -324,6 +324,7 @@ export const createAgentDefinitionSchema = (options) => {
                   provider: data.provider,
                   api_key: data.apiKey,
                   assistant_id: data.assistantId,
+                  ...(agentDefinitionId && { agent_id: agentDefinitionId }),
                 });
               } catch (error) {
                 ctx.addIssue({

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -612,7 +612,7 @@ const CreateScenarioView = () => {
         agentType: defaultSelectedAgent.agent_type,
       });
     }
-  }, [defaultAgentDefinitionId, agentDefinitions]);
+  }, [defaultAgentDefinitionId, agentDefinitions, selectedAgent]);
 
   return (
     <Box

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -607,9 +607,9 @@ const CreateScenarioView = () => {
     if (defaultSelectedAgent) {
       applySourceChange({
         value: defaultSelectedAgent.id,
-        label: defaultSelectedAgent.agentName,
+        label: defaultSelectedAgent.agent_name,
         sourceType: SourceType.AGENT_DEFINITION,
-        agentType: defaultSelectedAgent.agentType,
+        agentType: defaultSelectedAgent.agent_type,
       });
     }
   }, [defaultAgentDefinitionId, agentDefinitions]);

--- a/futureagi/tracer/serializers/observability_provider.py
+++ b/futureagi/tracer/serializers/observability_provider.py
@@ -65,6 +65,7 @@ class VerifyAssistantIdRequestSerializer(serializers.Serializer):
         required=False, allow_blank=True, allow_null=True
     )
     api_key = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    agent_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
 
 class VerifyResponseSerializer(serializers.Serializer):

--- a/futureagi/tracer/views/observability_provider.py
+++ b/futureagi/tracer/views/observability_provider.py
@@ -234,10 +234,12 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
             assistant_id = request.data.get("assistant_id")
             api_key = request.data.get("api_key")
             provider = request.data.get("provider")
+            agent_id = request.data.get("agent_id")
             if is_masked(api_key):
                 api_key = resolve_stored_api_key(
                     organization=get_request_organization(request),
                     workspace=getattr(request, "workspace", None),
+                    agent_id=agent_id,
                     assistant_id=assistant_id,
                 )
                 if not api_key:


### PR DESCRIPTION
## Why

Three simulation bugs reported on the agent definition and scenario surface that all turn out to be silent contract drifts between FE and BE, not behaviour changes. Bundled into one PR because the diff is six lines across four files.

### TH-6206 / TH-6329: "Invalid assistant ID" on create-new-version and edit-agent save

Repro: open an existing voice agent (Vapi or Retell), hit Create new version or change any field and save. The form runs its async zod validator on `assistantId` and the server responds with `Could not resolve the api key`, so the FE renders `Invalid assistant ID` and the submit button stays disabled.

Why: the edit and new-version forms pre-fill `apiKey` with the masked value the agent definition serializer returns (`get_masked_api_key`). When the validator POSTs that masked key to `/tracer/observability-provider/verify_assistant_id/`, the view detects the mask and tries to look up the real key via `resolve_stored_api_key`. That helper requires `agent_id` to scope the lookup, but the view never extracted `agent_id` from the request body and never forwarded it, so resolution returns `None`. The sibling `verify_api_key` path already plumbs `agent_id` through the same pipeline; bring `verify_assistant_id` in line.

Note on the BYO-key audit done while in here: across `verify_api_key`, `verify_assistant_id`, `create-agent`, `edit-agent`, and `create-version` we now confirm the user-submitted `api_key` is the only one ever forwarded to Vapi/Retell. Masked requests resolve from tenant-scoped `ProviderCredentials` (org + workspace + agent_id), never from settings or env. No backend-default key path remains.

#### Test Videos:

In Linear:
- https://linear.app/future-agi/issue/TH-6329/assistant-id-is-correct-yet-getting-the-error#comment-626eadce
- https://linear.app/future-agi/issue/TH-6206/unable-to-create-new-version#comment-938211bf

### TH-6334: "Add persona" button disabled even though an agent is selected

Repro: open `Create scenario` with a `defaultAgentDefinitionId` in scope (deep link or post-create redirect). The agent appears selected in the dropdown, but PersonaSection's "Add persona" stays disabled with the "Please select an Agent Definition" tooltip; re-picking the same option from the dropdown unsticks it.

Why: the auto-select effect read `defaultSelectedAgent.agentName` and `defaultSelectedAgent.agentType`. The agent-definitions API serializes those as `agent_name` and `agent_type`, so both reads return `undefined`. `setValue("agentType", undefined)` leaves the watched value falsy and PersonaSection's `disabled={!agentType}` keeps the button locked. The dropdown path mapped the snake_case fields correctly via `combinedSourceOptions`; that is why re-picking worked.

#### Testing Video

- Added in Linear: https://linear.app/future-agi/issue/TH-6334/agent-is-selected-still-while-adding-persona-button-is-disabled#comment-6f81e87e

## What changed

| File | Change |
|---|---|
| `frontend/src/sections/agents/helper.jsx` | Forward `agent_id` to `verify_assistant_id` when `agentDefinitionId` is in scope, matching the sibling `verify_api_key` call. |
| `futureagi/tracer/serializers/observability_provider.py` | Declare `agent_id` on `VerifyAssistantIdRequestSerializer` so the contract advertises the field the view already needs. |
| `futureagi/tracer/views/observability_provider.py` | Extract `agent_id` from the request and forward it to `resolve_stored_api_key`. |
| `frontend/src/sections/scenarios/CreateScenarioView.jsx` | Read `agent_name` / `agent_type` from the API response on the auto-select path, dropping the camelCase reads that always returned undefined. |

Net diff: +6 / -2 across 4 source files. Generated contract snapshots (`swagger.json`, FE `openapi-contract.generated.js`, `api.schemas.ts`, `api.zod.ts`) advertise the new `agent_id` field.

## How to test

**TH-6206 / TH-6329**
1. Open an existing voice agent backed by Vapi or Retell.
2. Click `Create new version`. The drawer should not show `Invalid assistant ID`; the `Create version v2` button should be enabled once a commit message is entered.
3. From `Edit agent`, change a non-key field (e.g., description) and save. The save should succeed without `assistant id is not correct`.

**TH-6334**
1. Land on `Create scenario` via a route that pre-selects an agent (e.g., from agent detail view).
2. The agent should be reflected in the source dropdown and the `Add persona` button should be enabled immediately, without re-picking.

## Out of scope

* Wider zod-validator hygiene around masked-key handling on other forms.
* The `_get_required_fields_and_mappings` shape rework tracked separately.
