### PR TITLE
fix(frontend): fix mcp oauth consent field name mismatch

### DIFF
--- a/frontend/src/pages/mcp/OAuthConsent.jsx
+++ b/frontend/src/pages/mcp/OAuthConsent.jsx
@@ -62,7 +62,7 @@ export default function OAuthConsent() {
             const result = response.data.result;
             setConsentData(result);
             const initial = {};
-            (result.availableGroups || []).forEach((group) => {
+            (result.available_groups || []).forEach((group) => {
               initial[group.slug] = group.checked;
             });
             setSelectedGroups(initial);
@@ -119,7 +119,7 @@ export default function OAuthConsent() {
           setConsentData(result);
           // Initialize checkbox state from server response
           const initial = {};
-          (result.availableGroups || []).forEach((group) => {
+          (result.available_groups || []).forEach((group) => {
             initial[group.slug] = group.checked;
           });
           setSelectedGroups(initial);
@@ -178,7 +178,6 @@ export default function OAuthConsent() {
       }
 
       const redirectUrl =
-        response.data?.result?.redirectUrl ||
         response.data?.result?.redirect_url;
       if (response.data?.status && redirectUrl) {
         window.location.href = redirectUrl;
@@ -199,7 +198,7 @@ export default function OAuthConsent() {
 
   // Render
   const selectedCount = Object.values(selectedGroups).filter(Boolean).length;
-  const totalCount = consentData?.availableGroups?.length || 0;
+  const totalCount = consentData?.available_groups?.length || 0;
 
   return (
     <Box
@@ -266,7 +265,7 @@ export default function OAuthConsent() {
                 Authorize MCP Connection
               </Typography>
               <Typography variant="body2" color="text.secondary" align="center">
-                <strong>{consentData.clientName}</strong> wants to access your
+                 <strong>{consentData.client_name}</strong> wants to access your
                 Future AGI account
               </Typography>
             </>
@@ -299,7 +298,7 @@ export default function OAuthConsent() {
                 Permissions ({selectedCount} of {totalCount})
               </Typography>
               <Stack spacing={0}>
-                {(consentData.availableGroups || []).map((group) => (
+                {(consentData.available_groups || []).map((group) => (
                   <FormControlLabel
                     key={group.slug}
                     control={


### PR DESCRIPTION
## Summary

The MCP OAuth consent screen showed "Permissions (0 of 0)" with no tool groups listed and displayed "undefined" as the client name — both caused by camelCase vs snake_case key mismatches. The axios interceptor does not transform keys, so every camelCase lookup returned undefined.

All references updated to use the snake_case keys matching the API response.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Fix field names in OAuthConsent.jsx**

- `availableGroups` → `available_groups` (4 refs) — fixes 0-of-0 permissions, enables Authorize button
- `clientName` → `client_name` (1 ref) — fixes "undefined" client name on consent screen
- Removed dead `redirectUrl` fallback (backend only ever sends `redirect_url`)

## 2) Why the changes were done

- **Technical:** Backend serializers use snake_case; frontend axios config does not perform camelCase transformation, so camelCase reads are always undefined

## 3) Tests written + scenarios each covers

No tests added — pure field-name alignment fix.

## 4) How to run / test

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Navigate to `/mcp/authorize?request_id=...` or initiate MCP OAuth from an external client
3. Verify the client name is displayed (not "undefined")
4. Verify tool group permissions appear (not "0 of 0") and the Authorize button is enabled

---

## 5) Screenshots / recordings

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->
<img width="1794" height="1124" alt="SCR-20260630-kwzq" src="https://github.com/user-attachments/assets/25de1e50-ddec-4f81-84d3-b66f601bb874" />


## 6) Edge cases & considerations

- Both the new MCP SDK flow (`approve-info`) and legacy flow (`authorize`) return `available_groups` and `client_name` — both paths now read the correct keys
- The `selected_groups` field in POST requests was already correct (snake_case)

---

## 7) Pre-existing issues (NOT introduced by this PR)

N/A

---

## 8) Architectural / important decisions

- **Snake_case over camelCase:** Backend API consistently uses snake_case; the frontend does not run a transformation layer. Rather than add one (which would be a much larger change), we align reads to the actual response shape.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
