### PR TITLE
fix(annotations): show "All items" label in export-to-dataset dropdown

### DIFF
--- a/frontend/src/sections/annotations/queues/view/__tests__/export-to-dataset-dialog.test.jsx
+++ b/frontend/src/sections/annotations/queues/view/__tests__/export-to-dataset-dialog.test.jsx
@@ -334,6 +334,33 @@ describe("ExportToDatasetDialog", () => {
     ).not.toHaveProperty("data_type");
   });
 
+  it("keeps the label visible and submits status_filter when 'All items' is picked", async () => {
+    const user = userEvent.setup();
+    mocks.exportMutate.mockClear();
+    render(<ExportToDatasetDialog open onClose={() => {}} queueId="queue-1" />);
+
+    const itemsSelect = screen.getByRole("combobox", {
+      name: /items to export/i,
+    });
+    expect(itemsSelect).toHaveTextContent("Completed only");
+
+    await user.click(itemsSelect);
+    await user.click(screen.getByRole("option", { name: "All items" }));
+
+    // Regression: an empty-string value rendered the select blank.
+    expect(itemsSelect).toHaveTextContent("All items");
+
+    await user.type(screen.getByLabelText(/Dataset name/), "All items export");
+    await user.click(screen.getByRole("button", { name: "Export" }));
+
+    await waitFor(() =>
+      expect(mocks.exportMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ status_filter: "all" }),
+        expect.any(Object),
+      ),
+    );
+  });
+
   it("lets users choose an existing dataset without pasting a dataset id", async () => {
     const user = userEvent.setup();
     mocks.exportMutate.mockClear();

--- a/frontend/src/sections/annotations/queues/view/export-to-dataset-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/view/export-to-dataset-dialog.jsx
@@ -31,9 +31,12 @@ import {
   useGetDatasetColumns,
 } from "src/api/develop/develop-detail";
 
+// "all" (not "") is the sentinel for every status — an empty-string MenuItem
+// value makes MUI Select render blank (isFilled("") is false). The backend
+// normalizes "all" to "no status filter", same as an empty value.
 const STATUS_OPTIONS = [
   { value: "completed", label: "Completed only" },
-  { value: "", label: "All items" },
+  { value: "all", label: "All items" },
   { value: "pending", label: "Pending only" },
   { value: "in_progress", label: "In Progress only" },
 ];


### PR DESCRIPTION
## Summary

The annotation queue **Export to Dataset** drawer has an "Items to export" status dropdown. Selecting **"All items"** left the field rendering **blank** — the user couldn't tell what was selected. This fixes the dropdown so "All items" displays correctly, with no change to export behavior.

## Linked issues

Closes #
Linear: TH-6196

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. "Items to export" dropdown renders "All items"**

- The all-statuses option used an empty-string value (`{ value: "", label: "All items" }`). MUI's `Select` skips rendering a label when the value is empty (`isFilled("")` is `false`), so the field went blank on selection.
- Changed the sentinel to `"all"`. No backend change: `export_to_dataset` already runs `status_filter` through `_normalize_query_filter_value`, which maps **both `""` and `"all"`** to "no status filter" (export everything). The empty value was also producing an invalid empty React `key=""` on that `<MenuItem>`.

---

## 2) Why the changes were done

- **Product/UX:** users selecting "All items" saw a blank field and couldn't confirm their choice before exporting.
- **Technical:** fixing the root cause (empty-string-as-meaningful-value) rather than papering over it with `displayEmpty`. `"all"` is already a backend-supported sentinel, so it's a one-line, additive change with zero contract impact.

---

## 3) Tests written + scenarios each covers

**`export-to-dataset-dialog.test.jsx`** — export drawer behavior (jsdom + real MUI)

- `keeps the label visible and submits status_filter when 'All items' is picked` — selects "All items", asserts the field renders the **"All items"** label (not blank), and asserts the submitted payload carries `status_filter: "all"`. Verified to fail on the pre-fix code (field rendered an empty string).

> Run result: **10 passed** in this suite. ESLint clean on both files.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
nvm use 22
yarn test:run src/sections/annotations/queues/view/__tests__/export-to-dataset-dialog.test.jsx
```

### UI steps (manual)

1. Log in at **http://localhost:3031**.
2. Annotations → open any queue → **Export ▾ → Export to Dataset**.
3. Open the **Items to export** dropdown and choose **All items**.
4. Verify the field shows "All items" (before the fix it was blank).

---

## 5) Screenshots / recordings

Captured end-to-end on the real platform (annotation queue → Export to Dataset).

| Before (`value: ""`) | After (`value: "all"`) |
| --- | --- |
| Field blank after selecting "All items" | Field renders "All items" |
<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/bcf6e000-55e3-4665-acd0-e295750e9a63" />

<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/e6adee38-309b-4ec3-a3d2-9a3a37f03cef" />


---

## 6) Edge cases & considerations

- **Other statuses** (Completed / Pending / In Progress) are unaffected — non-empty values already rendered fine.
- **Wire contract:** backend treats `""` and `"all"` identically (both → no status filter), so existing clients sending `""` keep working.
