### PR TITLE
fix(annotations): collapse duplicate error toast on failed item assign

### DIFF
--- a/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
+++ b/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
@@ -918,11 +918,11 @@ describe("Annotation Queues API", () => {
       ).toEqual([{ id: "user-2", name: "Nikhil" }]);
     });
 
-    it("surfaces the backend's specific message so it matches the global toast", async () => {
+    it("surfaces the backend's specific message as the sole error toast", async () => {
       // Regression: the old onError showed a hardcoded "Failed to assign items"
-      // that differed from the backend message the global handler shows, so
-      // preventDuplicate could not collapse them and two toasts stacked. The
-      // mutation must now emit the same specific string for the dedup to work.
+      // beside the global handler's specific message, so two toasts stacked. The
+      // mutation now sets meta.errorHandled (global handler stays out) and its
+      // onError surfaces the backend's specific message as the single toast.
       enqueueSnackbar.mockClear();
       axios.post.mockRejectedValueOnce({
         result: "Only queue managers can manage queue item assignments.",

--- a/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
+++ b/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
@@ -917,6 +917,37 @@ describe("Annotation Queues API", () => {
           .result.item.assigned_users,
       ).toEqual([{ id: "user-2", name: "Nikhil" }]);
     });
+
+    it("surfaces the backend's specific message so it matches the global toast", async () => {
+      // Regression: the old onError showed a hardcoded "Failed to assign items"
+      // that differed from the backend message the global handler shows, so
+      // preventDuplicate could not collapse them and two toasts stacked. The
+      // mutation must now emit the same specific string for the dedup to work.
+      enqueueSnackbar.mockClear();
+      axios.post.mockRejectedValueOnce({
+        result: "Only queue managers can manage queue item assignments.",
+        statusCode: 403,
+      });
+
+      const { result } = renderHook(() => useAssignQueueItems(), {
+        wrapper: createQueryWrapper(),
+      });
+
+      result.current.mutate({
+        queueId: "queue-1",
+        itemIds: ["item-1"],
+        userIds: ["user-1"],
+        action: "set",
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(enqueueSnackbar).toHaveBeenCalledWith(
+        "Only queue managers can manage queue item assignments.",
+        { variant: "error" },
+      );
+    });
   });
 
   describe("useCompleteItem", () => {

--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -635,6 +635,8 @@ const patchAssignmentCacheValue = (value, variables) => {
 export const useAssignQueueItems = () => {
   const queryClient = useQueryClient();
   return useMutation({
+    // Own the error toast here so the global handler (app.jsx) doesn't also fire one.
+    meta: { errorHandled: true },
     mutationFn: ({ queueId, itemIds, userIds, action }) => {
       const normalizedUserIds = userIds ?? [];
       return axios.post(annotationQueueEndpoints.assignItems(queueId), {
@@ -708,12 +710,7 @@ export const useAssignQueueItems = () => {
       context?.previousDetails?.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
-      // Surface the backend's specific message. The global mutation-cache
-      // handler shows the same string, so matching it lets SnackbarProvider's
-      // preventDuplicate collapse them into one toast instead of stacking a
-      // separate generic "failed" one beside it.
-      const msg = extractErrorMessage(error, "Failed to assign items");
-      enqueueSnackbar(typeof msg === "string" ? msg : JSON.stringify(msg), {
+      enqueueSnackbar(extractErrorMessage(error, "Failed to assign items"), {
         variant: "error",
       });
     },

--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -701,14 +701,21 @@ export const useAssignQueueItems = () => {
         queryKey: annotationQueueKeys.progress(variables.queueId),
       });
     },
-    onError: (_error, _variables, context) => {
+    onError: (error, _variables, context) => {
       context?.previousQueueItems?.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
       context?.previousDetails?.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
-      enqueueSnackbar("Failed to assign items", { variant: "error" });
+      // Surface the backend's specific message. The global mutation-cache
+      // handler shows the same string, so matching it lets SnackbarProvider's
+      // preventDuplicate collapse them into one toast instead of stacking a
+      // separate generic "failed" one beside it.
+      const msg = extractErrorMessage(error, "Failed to assign items");
+      enqueueSnackbar(typeof msg === "string" ? msg : JSON.stringify(msg), {
+        variant: "error",
+      });
     },
   });
 };


### PR DESCRIPTION
## TH-6202 — "2 error messages, failed one is not a requirement"

Assigning queue items as a non-manager popped **two** error toasts: a generic **"Failed to assign items"** plus the backend's specific **"Only queue managers can manage queue item assignments."** The reporter wants only the meaningful one.

### Root cause
Two error layers fire on a failed mutation:
1. The mutation's own `onError` → `enqueueSnackbar(...)`
2. The global `MutationCache.onError` (`handleError` in `app.jsx`) → `enqueueSnackbar(extractErrorMessage(error.result))`

`SnackbarProvider` has `preventDuplicate`, so the two collapse into one **only when their strings match**. Every other mutation in `annotation-queues.js` surfaces the backend message via `extractErrorMessage(error, fallback)`, so it matches the global toast and dedups. The assign mutation was the odd one out — it showed a hardcoded generic string that *differed* from the backend's, so `preventDuplicate` couldn't collapse it and two toasts stacked.

### Fix
Switch the assign `onError` to the same `extractErrorMessage(error, "Failed to assign items")` pattern the rest of the file uses. Backend errors now match the global toast → one toast; errors with no backend message still fall back to the generic text.

### Tests
- Added a regression test asserting the mutation emits the **specific** backend string (`mockRejectedValueOnce({ result: "...", statusCode: 403 })`). Verified it **fails on pre-fix code** and passes on the fix.
- `eslint` clean; full `annotation-queues.test.js` suite green.

### Verified on the platform
Real app + real toasts; the assign request was intercepted to return the exact `403` envelope the backend sends a non-manager (no non-manager login available locally), since `preventDuplicate` dedup can only be observed in a browser. Before/after below:

| | Toasts |
|---|---|
| Before | 2 — "Failed to assign items" + "Only queue managers can manage queue item assignments." |
| After | 1 — "Only queue managers can manage queue item assignments." |


<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/ee6b705b-7dca-4f53-9f8e-479c35750801" />
<img width="1220" height="900" alt="image" src="https://github.com/user-attachments/assets/26e124bb-ee5b-4ad8-bbb6-5fce03dd184c" />


### Follow-up
Filed **TH-6360**: ~11 sibling mutations in this file share the same latent double-toast (manifests when the backend returns a differing specific message). Scoped out of this PR; recommend the same mechanical `extractErrorMessage` swap there, with the deeper "two error layers" abstraction as a separate question.
