### PR TITLE
fix(dashboards): show selected filter value names instead of a count [TH-4437]

### DIFF
--- a/frontend/src/components/filter-value-label/FilterValueLabel.jsx
+++ b/frontend/src/components/filter-value-label/FilterValueLabel.jsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Box, Skeleton, Stack, Typography } from "@mui/material";
+import CustomTooltip from "src/components/tooltip";
+import { pluralize } from "src/utils/utils";
+import { useResolvedFilterOptions } from "./useResolvedFilterOptions";
+
+export default function FilterValueLabel({
+  filter,
+  source,
+  variant = "body2",
+  innerRef,
+  onClick,
+}) {
+  const values = useMemo(
+    () => (Array.isArray(filter?.value) ? filter.value : []),
+    [filter?.value],
+  );
+  const { options, isLoading } = useResolvedFilterOptions(
+    filter,
+    source,
+    values.length > 0,
+  );
+
+  const labels = useMemo(() => {
+    const byValue = new Map(options.map((o) => [o.value, o.label ?? o.value]));
+    return values.map((v) => byValue.get(v) ?? v);
+  }, [options, values]);
+
+  const hasValue = values.length > 0;
+  const isResolving = hasValue && isLoading && options.length === 0;
+  const extra = Math.max(labels.length - 1, 0);
+  const entity = (filter?.name || "item").toLowerCase();
+  const entityLabel = pluralize(entity, extra);
+  const fontSize = variant === "caption" ? "12px" : "13px";
+  const showBadge = extra > 0 && !isResolving;
+
+  const content = (
+    <Stack
+      ref={innerRef}
+      onClick={onClick}
+      direction="row"
+      alignItems="center"
+      gap={0.5}
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        cursor: "pointer",
+        "&:hover .filter-value-name": { color: "primary.main" },
+      }}
+    >
+      {isResolving ? (
+        <Skeleton
+          variant="rounded"
+          width={96}
+          height={14}
+          sx={{ flexShrink: 0 }}
+        />
+      ) : (
+        <Typography
+          className="filter-value-name"
+          variant={variant}
+          noWrap
+          sx={{
+            fontSize,
+            color: hasValue ? "text.primary" : "text.disabled",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {hasValue ? labels[0] : "Select value..."}
+        </Typography>
+      )}
+      {showBadge && (
+        <Typography
+          component="span"
+          variant="s3"
+          fontWeight="fontWeightSemiBold"
+          sx={{
+            flexShrink: 0,
+            px: 0.625,
+            py: "1px",
+            borderRadius: "6px",
+            bgcolor: "action.selected",
+            color: "text.secondary",
+            whiteSpace: "nowrap",
+          }}
+        >
+          +{extra} {entityLabel}
+        </Typography>
+      )}
+    </Stack>
+  );
+
+  return (
+    <CustomTooltip
+      show={showBadge}
+      placement="top"
+      size="small"
+      arrow
+      title={
+        <Box
+          component="ul"
+          sx={{ m: 0, pl: 2, maxHeight: 240, overflowY: "auto" }}
+        >
+          {labels.map((l, idx) => (
+            <Box
+              component="li"
+              key={`${l}-${idx}`}
+              sx={{ fontSize: "12px", lineHeight: 1.6 }}
+            >
+              {l}
+            </Box>
+          ))}
+        </Box>
+      }
+    >
+      {content}
+    </CustomTooltip>
+  );
+}
+
+FilterValueLabel.propTypes = {
+  filter: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    outputType: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      ),
+    ]),
+    choices: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({
+          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+          label: PropTypes.string,
+        }),
+      ]),
+    ),
+  }),
+  source: PropTypes.string,
+  variant: PropTypes.string,
+  innerRef: PropTypes.func,
+  onClick: PropTypes.func,
+};

--- a/frontend/src/components/filter-value-label/FilterValueLabel.jsx
+++ b/frontend/src/components/filter-value-label/FilterValueLabel.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Box, Skeleton, Stack, Typography } from "@mui/material";
 import CustomTooltip from "src/components/tooltip";
+import { ShowComponent } from "src/components/show";
 import { pluralize } from "src/utils/utils";
 import { useResolvedFilterOptions } from "./useResolvedFilterOptions";
 
@@ -32,7 +33,7 @@ export default function FilterValueLabel({
   const extra = Math.max(labels.length - 1, 0);
   const entity = (filter?.name || "item").toLowerCase();
   const entityLabel = pluralize(entity, extra);
-  const fontSize = variant === "caption" ? "12px" : "13px";
+  const sizeVariant = variant === "caption" ? "s2" : "s2_1";
   const showBadge = extra > 0 && !isResolving;
 
   const content = (
@@ -59,10 +60,9 @@ export default function FilterValueLabel({
       ) : (
         <Typography
           className="filter-value-name"
-          variant={variant}
+          variant={sizeVariant}
           noWrap
           sx={{
-            fontSize,
             color: hasValue ? "text.primary" : "text.disabled",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -71,7 +71,7 @@ export default function FilterValueLabel({
           {hasValue ? labels[0] : "Select value..."}
         </Typography>
       )}
-      {showBadge && (
+      <ShowComponent condition={showBadge}>
         <Typography
           component="span"
           variant="s3"
@@ -80,7 +80,7 @@ export default function FilterValueLabel({
             flexShrink: 0,
             px: 0.625,
             py: "1px",
-            borderRadius: "6px",
+            borderRadius: 0.75,
             bgcolor: "action.selected",
             color: "text.secondary",
             whiteSpace: "nowrap",
@@ -88,7 +88,7 @@ export default function FilterValueLabel({
         >
           +{extra} {entityLabel}
         </Typography>
-      )}
+      </ShowComponent>
     </Stack>
   );
 
@@ -107,7 +107,7 @@ export default function FilterValueLabel({
             <Box
               component="li"
               key={`${l}-${idx}`}
-              sx={{ fontSize: "12px", lineHeight: 1.6 }}
+              sx={{ typography: "s2", lineHeight: 1.6 }}
             >
               {l}
             </Box>

--- a/frontend/src/components/filter-value-label/FilterValueLabel.test.jsx
+++ b/frontend/src/components/filter-value-label/FilterValueLabel.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import FilterValueLabel from "./FilterValueLabel";
+
+const DEFAULT_OPTIONS = [
+  { value: "p1", label: "Project Alpha" },
+  { value: "p2", label: "Project Beta" },
+  { value: "p3", label: "Project Gamma" },
+];
+
+// FilterValueLabel resolves ids -> names via useDashboardFilterValues; mock it
+// with a controllable result and drive behavior through the `filter` prop.
+const { mockState } = vi.hoisted(() => ({
+  mockState: { current: { data: [], isLoading: false } },
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardFilterValues: () => mockState.current,
+}));
+
+const baseFilter = { name: "Project", type: "system", id: "project_id" };
+const renderLabel = (filter, extra = {}) =>
+  render(<FilterValueLabel filter={filter} source="traces" {...extra} />);
+
+describe("FilterValueLabel", () => {
+  beforeEach(() => {
+    mockState.current = { data: DEFAULT_OPTIONS, isLoading: false };
+  });
+
+  it("shows the placeholder when nothing is selected", () => {
+    renderLabel({ ...baseFilter, value: [] });
+    expect(screen.getByText("Select value...")).toBeInTheDocument();
+  });
+
+  it("shows the option name and no badge when one is selected", () => {
+    renderLabel({ ...baseFilter, value: ["p1"] });
+    expect(screen.getByText("Project Alpha")).toBeInTheDocument();
+    expect(screen.queryByText(/^\+\d/)).not.toBeInTheDocument();
+  });
+
+  it("shows a singular badge for two selected", () => {
+    renderLabel({ ...baseFilter, value: ["p1", "p2"] });
+    expect(screen.getByText("Project Alpha")).toBeInTheDocument();
+    expect(screen.getByText("+1 project")).toBeInTheDocument();
+  });
+
+  it("shows a pluralized badge for several selected", () => {
+    renderLabel({ ...baseFilter, value: ["p1", "p2", "p3"] });
+    expect(screen.getByText("Project Alpha")).toBeInTheDocument();
+    expect(screen.getByText("+2 projects")).toBeInTheDocument();
+  });
+
+  it("pluralizes field names ending in s/y correctly", () => {
+    const { unmount } = renderLabel({
+      ...baseFilter,
+      name: "Status",
+      value: ["p1", "p2", "p3"],
+    });
+    expect(screen.getByText("+2 statuses")).toBeInTheDocument();
+    unmount();
+
+    renderLabel({ ...baseFilter, name: "Category", value: ["p1", "p2", "p3"] });
+    expect(screen.getByText("+2 categories")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw value when no label matches", () => {
+    renderLabel({ ...baseFilter, value: ["unknown-id"] });
+    expect(screen.getByText("unknown-id")).toBeInTheDocument();
+  });
+
+  it("shows a skeleton instead of raw ids while resolving", () => {
+    mockState.current = { data: [], isLoading: true };
+    const { container } = renderLabel({ ...baseFilter, value: ["p1", "p2"] });
+    expect(container.querySelector(".MuiSkeleton-root")).toBeInTheDocument();
+    expect(screen.queryByText("p1")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^\+\d/)).not.toBeInTheDocument();
+  });
+
+  it("calls onClick when the row is clicked", async () => {
+    const onClick = vi.fn();
+    renderLabel({ ...baseFilter, value: ["p1"] }, { onClick });
+    await userEvent.click(screen.getByText("Project Alpha"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("lists all selected names in the tooltip on hover", async () => {
+    renderLabel({ ...baseFilter, value: ["p1", "p2", "p3"] });
+    await userEvent.hover(screen.getByText("Project Alpha"));
+    expect(await screen.findByText("Project Beta")).toBeInTheDocument();
+    expect(await screen.findByText("Project Gamma")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/filter-value-label/index.js
+++ b/frontend/src/components/filter-value-label/index.js
@@ -1,0 +1,2 @@
+export { default } from "./FilterValueLabel";
+export { useResolvedFilterOptions } from "./useResolvedFilterOptions";

--- a/frontend/src/components/filter-value-label/useResolvedFilterOptions.js
+++ b/frontend/src/components/filter-value-label/useResolvedFilterOptions.js
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { useDashboardFilterValues } from "src/hooks/useDashboards";
+
+const getFilterBackendType = (filter) => {
+  const map = {
+    system: "system_metric",
+    eval_metric: "eval_metric",
+    annotation: "annotation_metric",
+    custom_attribute: "custom_attribute",
+    custom_column: "custom_column",
+  };
+  return map[filter?.type] || filter?.type || "system_metric";
+};
+
+export function useResolvedFilterOptions(filter, source, enabled = true) {
+  const backendType = getFilterBackendType(filter);
+  const evalOutputType = filter?.outputType?.toUpperCase() || "";
+  const isEvalWithStaticOptions =
+    backendType === "eval_metric" &&
+    (evalOutputType === "PASS_FAIL" || evalOutputType === "CHOICES");
+
+  const { data: fetchedOptions = [], isLoading } = useDashboardFilterValues({
+    metricName: filter?.id || "",
+    metricType: backendType,
+    projectIds: [],
+    source: source || "traces",
+    enabled: enabled && !isEvalWithStaticOptions,
+  });
+
+  const options = useMemo(() => {
+    if (isEvalWithStaticOptions) {
+      if (evalOutputType === "PASS_FAIL") {
+        return [
+          { value: "Passed", label: "Passed" },
+          { value: "Failed", label: "Failed" },
+        ];
+      }
+      if (evalOutputType === "CHOICES" && filter?.choices?.length) {
+        return filter.choices.map((c) => ({
+          value: typeof c === "string" ? c : c.value || c.label || String(c),
+          label: typeof c === "string" ? c : c.label || c.value || String(c),
+        }));
+      }
+    }
+    return fetchedOptions;
+  }, [
+    isEvalWithStaticOptions,
+    evalOutputType,
+    fetchedOptions,
+    filter?.choices,
+  ]);
+
+  return { options, isLoading };
+}

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -50,13 +50,15 @@ import {
   useDashboardMetrics,
   useDashboardMetricsPaginated,
   useDashboardQuery,
-  useDashboardFilterValues,
   useCreateWidget,
   useUpdateWidget,
   useDeleteWidget,
   useSimulationAgents,
 } from "src/hooks/useDashboards";
 import Iconify from "src/components/iconify";
+import FilterValueLabel, {
+  useResolvedFilterOptions,
+} from "src/components/filter-value-label";
 import { useSnackbar } from "src/components/snackbar";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import { format } from "date-fns";
@@ -881,56 +883,7 @@ function FilterValuePickerPopup({
     Array.isArray(filter?.value) ? [...filter.value] : [],
   );
 
-  const backendType = (() => {
-    const map = {
-      system: "system_metric",
-      eval_metric: "eval_metric",
-      annotation: "annotation_metric",
-      custom_attribute: "custom_attribute",
-      custom_column: "custom_column",
-    };
-    return map[filter?.type] || filter?.type || "system_metric";
-  })();
-
-  // For eval metrics with known output types, provide static options
-  const evalOutputType = filter?.outputType?.toUpperCase() || "";
-  const isEvalWithStaticOptions =
-    backendType === "eval_metric" &&
-    (evalOutputType === "PASS_FAIL" || evalOutputType === "CHOICES");
-
-  const { data: fetchedOptions = [], isLoading } = useDashboardFilterValues({
-    metricName: filter?.id || "",
-    metricType: backendType,
-    projectIds: [],
-    source: source || "traces",
-    enabled: !isEvalWithStaticOptions,
-  });
-
-  const options = useMemo(() => {
-    if (isEvalWithStaticOptions) {
-      if (evalOutputType === "PASS_FAIL") {
-        return [
-          { value: "Passed", label: "Passed" },
-          { value: "Failed", label: "Failed" },
-        ];
-      }
-      if (
-        (evalOutputType === "CHOICES" || evalOutputType === "CHOICE") &&
-        filter?.choices?.length
-      ) {
-        return filter.choices.map((c) => ({
-          value: typeof c === "string" ? c : c.value || c.label || String(c),
-          label: typeof c === "string" ? c : c.label || c.value || String(c),
-        }));
-      }
-    }
-    return fetchedOptions;
-  }, [
-    isEvalWithStaticOptions,
-    evalOutputType,
-    fetchedOptions,
-    filter?.choices,
-  ]);
+  const { options, isLoading } = useResolvedFilterOptions(filter, source);
 
   const filteredOptions = useMemo(() => {
     if (!search) return options;
@@ -4996,9 +4949,11 @@ export default function WidgetEditorView() {
                               </Select>
                             </FormControl>
                             {curMfOp?.noValue ? null : curMfOp?.multi ? (
-                              <Typography
+                              <FilterValueLabel
+                                filter={mf}
+                                source={mf.source || "traces"}
                                 variant="caption"
-                                ref={(el) => {
+                                innerRef={(el) => {
                                   mfValueRefs.current[`${i}_${fi}`] = el;
                                 }}
                                 onClick={(e) => {
@@ -5008,25 +4963,7 @@ export default function WidgetEditorView() {
                                     filterIdx: fi,
                                   });
                                 }}
-                                sx={{
-                                  flex: 1,
-                                  fontSize: "12px",
-                                  cursor: "pointer",
-                                  color:
-                                    Array.isArray(mf.value) &&
-                                    mf.value.length > 0
-                                      ? "text.primary"
-                                      : "text.disabled",
-                                  "&:hover": { color: "primary.main" },
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {Array.isArray(mf.value) && mf.value.length > 0
-                                  ? `${mf.value.length} selected`
-                                  : "Select value..."}
-                              </Typography>
+                              />
                             ) : curMfOp?.range ? (
                               <Stack
                                 direction="row"
@@ -5473,9 +5410,11 @@ export default function WidgetEditorView() {
                               </Select>
                             </FormControl>
                             {currentOp?.noValue ? null : currentOp?.multi ? (
-                              <Typography
+                              <FilterValueLabel
+                                filter={f}
+                                source={f.source || "traces"}
                                 variant="body2"
-                                ref={(el) => {
+                                innerRef={(el) => {
                                   filterValueRefs.current[i] = el;
                                 }}
                                 onClick={(e) => {
@@ -5483,24 +5422,7 @@ export default function WidgetEditorView() {
                                   setFilterValueIndex(i);
                                   setFilterValueSearch("");
                                 }}
-                                sx={{
-                                  flex: 1,
-                                  fontSize: "13px",
-                                  cursor: "pointer",
-                                  color:
-                                    Array.isArray(f.value) && f.value.length > 0
-                                      ? "text.primary"
-                                      : "text.disabled",
-                                  "&:hover": { color: "primary.main" },
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {Array.isArray(f.value) && f.value.length > 0
-                                  ? `${f.value.length} selected`
-                                  : "Select value..."}
-                              </Typography>
+                              />
                             ) : currentOp?.range ? (
                               <Stack
                                 direction="row"

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1362,3 +1362,10 @@ export const stripAttributePathPrefix = (key) =>
   String(key ?? "")
     .replace(/^observation_span\.\d+\.(?:span_attributes\.)?/, "")
     .replace(/(^|\.)span_attributes\./g, "$1");
+
+export const pluralize = (word, count) => {
+  if (count === 1) return word;
+  if (/[^aeiou]y$/i.test(word)) return word.replace(/y$/i, "ies");
+  if (/(s|x|z|ch|sh)$/i.test(word)) return `${word}es`;
+  return `${word}s`;
+};


### PR DESCRIPTION
## Bug

**TH-4437** — In a dashboard widget, the Project filter showed `11 selected` instead of the actual selected project name(s).

## Changes

- New reusable `src/components/filter-value-label/`:
  - `FilterValueLabel` — renders a filter's selected value as names: the option name when one is selected; the first name + a distinct `+N <field>` badge when several; the full list in a `CustomTooltip` on hover; a MUI `Skeleton` while the names resolve.
  - `useResolvedFilterOptions` — shared id→label resolver (static eval choices or fetched distinct values), used by both the row label and the value-picker popup.
- `WidgetEditorView.jsx` — extracted the above out of this file; replaced the two inline `${value.length} selected` displays (widget filter + per-metric filter) with `<FilterValueLabel>`; refactored the picker popup to use the shared hook.
- `utils.js` — added reusable `pluralize(word, count)`.
- Unit tests for `FilterValueLabel` (9 cases).

## Why

`value` was stored as ids only; names live in the fetched options (only the popover had them), so the row could only show a count. Resolving from the same options source makes the names correct after a fresh selection **and** on reload of a saved widget.

## UX

- 1 selected → project name.
- Several → `FirstName` + `+N projects` badge (proper pluralization: `+1 project`, `+2 projects`, `+2 statuses`).
- Hover → bulleted list of all selected names (CustomTooltip).
- While resolving → skeleton (no raw UUID flash).


## Test scenarios

1. Select 1 project → name shown, no badge.
2. Select several → first name + `+N projects` badge; hover lists all.
3. Reload a saved widget with a project filter → names still show (skeleton briefly, then names).
4. Per-metric filter → same behavior.
5. Eval choice filter (Passed/Failed) → shows the choice name.

## Commands

```
yarn lint
yarn test:run src/components/filter-value-label
```

## Videos / screenshots
Verified live on the dev build (localhost:9002), including the 40-item / long-name stress test.
<img width="334" height="505" alt="Screenshot 2026-06-30 at 1 18 31 PM" src="https://github.com/user-attachments/assets/6d55aa23-9eb2-4929-b91c-00f1621c9ceb" />
<img width="429" height="856" alt="Screenshot 2026-06-30 at 1 24 47 PM" src="https://github.com/user-attachments/assets/c50f0190-47f6-473b-b5cf-f0158530845d" />
