### PR TITLE
Fix dataset summary column visibility, Last Run column, and + icon

### DIFF
--- a/frontend/src/components/filter-panel/FilterPanel.jsx
+++ b/frontend/src/components/filter-panel/FilterPanel.jsx
@@ -61,8 +61,14 @@ const ENUM_OPERATORS = [
   { value: "is_not", label: "Is not" },
 ];
 
-function getOperators(fieldType) {
-  return fieldType === "enum" ? ENUM_OPERATORS : STRING_OPERATORS;
+function getOperators(fieldDef) {
+  const fieldType = typeof fieldDef === "string" ? fieldDef : fieldDef?.type;
+  const base = fieldType === "enum" ? ENUM_OPERATORS : STRING_OPERATORS;
+  const allowed =
+    typeof fieldDef === "object" && Array.isArray(fieldDef?.operators)
+      ? fieldDef.operators
+      : null;
+  return allowed ? base.filter((op) => allowed.includes(op.value)) : base;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,7 +147,7 @@ function parseNaturalLanguage(query, filterFields, fieldMap) {
 // ---------------------------------------------------------------------------
 // EnumValuePicker — checkbox multi-select popover (matches trace filter design)
 // ---------------------------------------------------------------------------
-function EnumValuePicker({ choices, value = [], onChange }) {
+function EnumValuePicker({ choices, value = [], onChange, single = false }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [search, setSearch] = useState("");
 
@@ -153,11 +159,17 @@ function EnumValuePicker({ choices, value = [], onChange }) {
 
   const toggle = useCallback(
     (val) => {
+      if (single) {
+        onChange(value.includes(val) ? [] : [val]);
+        setAnchorEl(null);
+        setSearch("");
+        return;
+      }
       onChange(
         value.includes(val) ? value.filter((v) => v !== val) : [...value, val],
       );
     },
-    [value, onChange],
+    [value, onChange, single],
   );
 
   return (
@@ -257,7 +269,9 @@ function EnumValuePicker({ choices, value = [], onChange }) {
           <Typography
             sx={{ fontSize: 10, color: "text.disabled", mt: 0.5, px: 0.25 }}
           >
-            Select one or more values (multi-select)
+            {single
+              ? "Select a value"
+              : "Select one or more values (multi-select)"}
           </Typography>
         </Box>
         <Box
@@ -269,7 +283,7 @@ function EnumValuePicker({ choices, value = [], onChange }) {
           }}
         >
           {/* Select all matching */}
-          {search && filtered.length > 0 && (
+          {!single && search && filtered.length > 0 && (
             <Box
               onClick={() => {
                 const allFiltered = filtered.filter((o) => !value.includes(o));
@@ -379,9 +393,13 @@ function EnumValuePicker({ choices, value = [], onChange }) {
               >
                 <Iconify
                   icon={
-                    isSelected
-                      ? "mdi:checkbox-marked"
-                      : "mdi:checkbox-blank-outline"
+                    single
+                      ? isSelected
+                        ? "mdi:radiobox-marked"
+                        : "mdi:radiobox-blank"
+                      : isSelected
+                        ? "mdi:checkbox-marked"
+                        : "mdi:checkbox-blank-outline"
                   }
                   width={18}
                   sx={{
@@ -449,7 +467,7 @@ function FilterRow({
   onRemove,
 }) {
   const fieldDef = fieldMap[filter.field] || filterFields[0];
-  const operators = getOperators(fieldDef.type);
+  const operators = getOperators(fieldDef);
 
   return (
     <Stack direction="row" alignItems="center" gap={0.5}>
@@ -491,6 +509,7 @@ function FilterRow({
       {fieldDef.type === "enum" ? (
         <EnumValuePicker
           choices={fieldDef.choices || []}
+          single={fieldDef.single}
           value={
             Array.isArray(filter.value)
               ? filter.value
@@ -588,7 +607,7 @@ function QueryInput({
       }));
     if (phase === "operator") {
       const fd = fieldMap[partialField];
-      return getOperators(fd?.type || "string").map((o) => ({
+      return getOperators(fd || "string").map((o) => ({
         id: o.value,
         label: o.label,
         type: "operator",

--- a/frontend/src/components/run-tests/RunTestsContent.jsx
+++ b/frontend/src/components/run-tests/RunTestsContent.jsx
@@ -506,7 +506,7 @@ const RunTestsContent = ({
         ),
       },
       {
-        id: "lastRunAt",
+        id: "last_run_at",
         accessorKey: "last_run_at",
         header: "Last Run",
         size: 150,

--- a/frontend/src/sections/common/simulation/hooks/useCancelExecution.js
+++ b/frontend/src/sections/common/simulation/hooks/useCancelExecution.js
@@ -8,7 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 export const useCancelExecution = () => {
   return useMutation({
     mutationFn: (id) =>
-      axios.post(endpoints.testExecutions.cancelExecution(id)),
+      axios.post(endpoints.testExecutions.cancelExecution(id),{}),
   });
 };
 

--- a/frontend/src/sections/develop-detail/DataTab/DataMenuList/DataMenuList.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DataMenuList/DataMenuList.jsx
@@ -214,7 +214,7 @@ const DataMenuList = ({
         title="Add to Dataset"
         actionButton={
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <Icon icon="mdi:plus" width={18} height={18} color="white" />
+            <Icon icon="mdi:plus" width={18} height={18} color="inherit" />
             <Typography
               fontWeight={400}
               fontSize={14}

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
@@ -78,8 +78,8 @@ const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
 
   const updatedEvalsSummary = evalsSummary?.map((e) => {
     return {
-      originType: "evaluation",
       ...e,
+      origin_type: "evaluation",
     };
   });
   const columnLists = useMemo(() => {
@@ -158,11 +158,11 @@ const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
           <EvalCard
             setCurrentTab={setCurrentTabs}
             selectedColumns={appliedFilter
-              ?.filter((e) => e.originType !== "evaluation")
+              ?.filter((e) => e.origin_type !== "evaluation")
               ?.map((item) => item.id)}
             datasetId={datasetId}
             selectedEvals={appliedFilter
-              ?.filter((e) => e.originType === "evaluation")
+              ?.filter((e) => e.origin_type === "evaluation")
               ?.map((e) => e?.id)}
             datasetIndex={datasetIndex}
           />

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
@@ -32,21 +32,20 @@ const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
     { column_config_only: true },
   );
 
-  const allListItem = data?.columnConfig?.filter((item) => {
+  const allListItem = data?.column_config?.filter((item) => {
     if (currentTab === "evals") {
       return (
-        item.originType !== "evaluation" &&
-        item.originType !== "optimisation" &&
-        item.originType !== "optimisation_evaluation" &&
-        item.originType !== "evaluation_reason"
+        item.origin_type !== "evaluation" &&
+        item.origin_type !== "optimisation" &&
+        item.origin_type !== "optimisation_evaluation" &&
+        item.origin_type !== "evaluation_reason"
       );
     } else if (currentTab === "prompt") {
-      return item.originType === "run_prompt";
+      return item.origin_type === "run_prompt";
     } else {
       return false;
     }
   });
-
   const onFilterChange = (item) => {
     setAppliedFilter((pre) => {
       const newData = pre.some((temp) => temp.id === item.id)

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/FilterItems.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/FilterItems.jsx
@@ -62,10 +62,15 @@ const FilterItems = forwardRef(
 
     const filteredColumnList = useMemo(() => {
       const newData =
-        columnLists?.map((item) => ({
-          ...item,
-          type: columnType[item.originType || item.dataType],
-        })) || [];
+        columnLists?.map((item) => {
+          const originType = item.origin_type??item.originType ;
+          const dataType = item.data_type;
+          return {
+            ...item,
+            type: columnType[originType || dataType],
+          };
+        }) || [];
+  
       return newData?.filter((item) => {
         return filterItem.includes(item.type);
       });
@@ -85,15 +90,17 @@ const FilterItems = forwardRef(
     };
 
     const renderIcon = (col) => {
-      if (col.originType === "run_prompt") {
+      const originType = col.origin_type??col.originType;
+      const dataType = col.data_type;
+      if (originType === "run_prompt") {
         return (
-          <></>
-          // <SvgColor
-          //   src={`/assets/icons/action_buttons/ic_run_prompt.svg`}
-          //   sx={{ width: 20, height: 20, color: "info.main" }}
-          // />
+
+          <SvgColor
+            src={`/assets/icons/action_buttons/ic_run_prompt.svg`}
+            sx={{ width: 20, height: 20, color: "info.main" }}
+          />
         );
-      } else if (col.originType === "evaluation") {
+      } else if (originType === "evaluation") {
         return (
           <Iconify
             icon="material-symbols:check-circle-outline"
@@ -101,8 +108,8 @@ const FilterItems = forwardRef(
           />
         );
       } else if (
-        col.originType === "optimisation" ||
-        col.originType === "optimisation_evaluation"
+        originType === "optimisation" ||
+        originType === "optimisation_evaluation"
       ) {
         return (
           <SvgColor
@@ -110,32 +117,32 @@ const FilterItems = forwardRef(
             sx={{ width: 20, height: 20, color: "primary.main" }}
           />
         );
-      } else if (col.originType === "annotation_label") {
+      } else if (originType === "annotation_label") {
         return <Iconify icon="jam:write" sx={iconStyle} />;
-      } else if (col.dataType === "text") {
+      } else if (dataType === "text") {
         return <Iconify icon="material-symbols:notes" sx={iconStyle} />;
-      } else if (col.dataType === "array") {
+      } else if (dataType === "array") {
         return <Iconify icon="material-symbols:data-array" sx={iconStyle} />;
-      } else if (col.dataType === "integer") {
+      } else if (dataType === "integer") {
         return <Iconify icon="material-symbols:tag" sx={iconStyle} />;
-      } else if (col.dataType === "float") {
+      } else if (dataType === "float") {
         return <Iconify icon="tabler:decimal" sx={iconStyle} />;
-      } else if (col.dataType === "boolean") {
+      } else if (dataType === "boolean") {
         return (
           <Iconify icon="material-symbols:toggle-on-outline" sx={iconStyle} />
         );
-      } else if (col.dataType === "datetime") {
+      } else if (dataType === "datetime") {
         return <Iconify icon="tabler:calendar" sx={iconStyle} />;
-      } else if (col.dataType === "json") {
+      } else if (dataType === "json") {
         return <Iconify icon="material-symbols:data-object" sx={iconStyle} />;
-      } else if (col.dataType === "image") {
+      } else if (dataType === "image") {
         return (
           <SvgColor
             src={`/assets/icons/action_buttons/ic_image.svg`}
             sx={{ width: 20, height: 20, color: "text.secondary" }}
           />
         );
-      } else if (col.dataType === "audio") {
+      } else if (dataType === "audio") {
         return (
           <SvgColor
             src={`/assets/icons/action_buttons/ic_audio.svg`}

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/FilterItems.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/FilterItems.jsx
@@ -59,11 +59,10 @@ const FilterItems = forwardRef(
     );
 
     const id = useMemo(() => (open ? `eval-filter-popper` : undefined), [open]);
-
     const filteredColumnList = useMemo(() => {
       const newData =
         columnLists?.map((item) => {
-          const originType = item.origin_type??item.originType ;
+          const originType = item.origin_type;
           const dataType = item.data_type;
           return {
             ...item,
@@ -90,7 +89,7 @@ const FilterItems = forwardRef(
     };
 
     const renderIcon = (col) => {
-      const originType = col.origin_type??col.originType;
+      const originType = col.origin_type;
       const dataType = col.data_type;
       if (originType === "run_prompt") {
         return (

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -306,14 +306,16 @@ export const getPersonaDefaultValues = (editPersona) => {
             ? "true"
             : "false"
           : null,
-      finishedSpeakingSensitivity:
-        editPersona?.finishedSpeakingSensitivity !== null
-          ? parseInt(editPersona?.finishedSpeakingSensitivity?.[0])
-          : null,
-      interruptSensitivity:
-        editPersona?.interruptSensitivity !== null
-          ? parseInt(editPersona?.interruptSensitivity?.[0])
-          : null,
+      finishedSpeakingSensitivity: Number.isNaN(
+        parseInt(editPersona?.finishedSpeakingSensitivity?.[0]),
+      )
+        ? 1
+        : parseInt(editPersona?.finishedSpeakingSensitivity?.[0]),
+      interruptSensitivity: Number.isNaN(
+        parseInt(editPersona?.interruptSensitivity?.[0]),
+      )
+        ? 1
+        : parseInt(editPersona?.interruptSensitivity?.[0]),
       customProperties: Object.entries(editPersona?.metadata || {}).map(
         ([key, value]) => ({
           key,
@@ -347,8 +349,8 @@ export const getPersonaDefaultValues = (editPersona) => {
     language: [],
     conversationSpeed: [],
     backgroundSound: null,
-    finishedSpeakingSensitivity: null,
-    interruptSensitivity: null,
+    finishedSpeakingSensitivity: 1,
+    interruptSensitivity: 1,
     customProperties: [],
     additionalInstruction: null,
     multilingual: false,

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -280,6 +280,8 @@ export const chatOptionSettings = [
 export const getPersonaDefaultValues = (editPersona) => {
   logger.debug("editPersona", editPersona);
   if (editPersona) {
+    const fss = parseInt(editPersona?.finishedSpeakingSensitivity?.[0], 10);
+    const intr = parseInt(editPersona?.interruptSensitivity?.[0], 10);
     return {
       name: editPersona?.name,
       description: editPersona?.description,
@@ -306,16 +308,8 @@ export const getPersonaDefaultValues = (editPersona) => {
             ? "true"
             : "false"
           : null,
-      finishedSpeakingSensitivity: Number.isNaN(
-        parseInt(editPersona?.finishedSpeakingSensitivity?.[0]),
-      )
-        ? 1
-        : parseInt(editPersona?.finishedSpeakingSensitivity?.[0]),
-      interruptSensitivity: Number.isNaN(
-        parseInt(editPersona?.interruptSensitivity?.[0]),
-      )
-        ? 1
-        : parseInt(editPersona?.interruptSensitivity?.[0]),
+      finishedSpeakingSensitivity: Number.isNaN(fss) ? 1 : fss,
+      interruptSensitivity: Number.isNaN(intr) ? 1 : intr,
       customProperties: Object.entries(editPersona?.metadata || {}).map(
         ([key, value]) => ({
           key,

--- a/frontend/src/sections/persona/PersonaListView.jsx
+++ b/frontend/src/sections/persona/PersonaListView.jsx
@@ -446,6 +446,8 @@ const PersonaListView = ({
         label: "Category",
         type: "enum",
         choices: ["prebuilt", "custom"],
+        operators: ["is"],
+        single: true,
       });
     }
     if (!lockedSimulationType) {
@@ -458,6 +460,8 @@ const PersonaListView = ({
           [AGENT_TYPES.VOICE]: "Voice",
           [AGENT_TYPES.CHAT]: "Chat",
         },
+        operators: ["is"],
+        single: true,
       });
     }
     return fields;


### PR DESCRIPTION
## Summary

Fixes six UI bugs across the Develop, Test, and Persona sections, all small and self-contained:

- **Dataset Summary — no columns visible** (TH-6288): the Prompt/Columns filter rendered an empty list.
- **Run Tests — "Last Run" column shows "-"** (TH-6341).
- **Datasets — "+" icon invisible** on the *Add from Existing Dataset* button (TH-6286).
- **Persona — conversation sensitivity sliders stuck** (TH-6335): the +/- buttons did nothing until the slider was moved.
- **Persona — filter `is not` operator does nothing** (TH-6339): the exclusion operator and multi-select had no backend support and silently no-oped.
- **Cancel execution** POST sent no request body.

## Why / problem

Most of these are the same snake_case vs camelCase / uninitialized-value mismatch we keep hitting: the frontend read camelCase keys against snake_case payloads (or operated on a non-numeric value), so things resolved to `undefined`/`NaN`.

- **TH-6288**: the dataset `column_config` payload is snake_case (`origin_type`, `data_type`), but the Dataset Summary tab read `data?.columnConfig` and filtered on `item.originType`, and `FilterItems` mapped each column's category via `columnType[item.originType || item.dataType]`. Every column resolved to `type: undefined` and was filtered out → nothing rendered. Evaluation entries additionally arrive camelCase (`originType`), so the data is genuinely mixed.
- **TH-6341**: the "Last Run" column declared `id: "lastRunAt"` while the row data / `accessorKey` use `last_run_at`. The mismatched id meant `getValue()` resolved nothing → always "-".
- **TH-6286**: the plus icon used a hardcoded `color="white"`, invisible against the button background.
- **TH-6335**: the Persona conversation sliders (`finishedSpeakingSensitivity`, `interruptSensitivity`) defaulted to `null` on create and to `NaN` on edit (`parseInt` of a missing entry). `IncrementerButton` then computed `value + step` on a non-number → `NaN`, so the buttons stuck until the slider wrote a real number.
- **TH-6339**: the persona list filter exposed an `is not` operator and a multi-select value picker, but the personas endpoint only supports single-value inclusion filtering (`type=`, `simulation_type=`) and `handleFilterApply` already collapsed to the first value. So `is not` / extra selections were silently dropped — the filter looked like it did something but didn't.
- **Cancel execution**: the POST had no body; sending an empty object provides the JSON payload the endpoint expects.

## What changed

- `DatasetSummaryTab.jsx` — read `data?.column_config`; filter on `origin_type`.
- `FilterItems.jsx` — map column type and resolve row icons from `item.origin_type ?? item.originType` and `item.data_type ?? item.dataType` (handles the mixed casing); enable the previously commented-out `run_prompt` icon.
- `RunTestsContent.jsx` — align column `id` with `accessorKey` (`last_run_at`).
- `DataMenuList.jsx` — `color="white"` → `color="inherit"` on the + icon.
- `PersonaCreateEdit/common.js` — default `finishedSpeakingSensitivity` / `interruptSensitivity` to `1` on create, and fall back to `1` on edit when there is no valid saved value.
- `filter-panel/FilterPanel.jsx` — make operators configurable per field (`field.operators` allow-list) and add a `single` mode to the enum value picker (radio icons, replace-on-select, closes popover, hides multi-select affordances).
- `persona/PersonaListView.jsx` — restrict the Category and Agent Type filters to `operators: ["is"]` and `single: true`.
- `useCancelExecution.js` — pass `{}` body to the cancel-execution POST.

## Tests

- [ ] No automated tests added — UI-only changes.

## Commands

- [ ] `yarn eslint` on the changed files — clean (0 errors).

## Backwards compatibility

No API or contract changes. The `?? originType` / `?? dataType` fallbacks are additive and tolerate both payload shapes. The persona default serializes to `[1]` via the existing zod transform. The FilterPanel `operators`/`single` options are opt-in per field, so other FilterPanel consumers keep their existing multi-select + full operator set.

## Manual verification

- [ ] Dataset Summary → Columns/Prompt/Evaluation columns appear in the filter list; run-prompt and eval rows show their icons.
- [ ] Run Tests list → "Last Run" column shows the relative timestamp, not "-".
- [ ] Add from Existing Dataset button → the "+" icon is visible in light and dark themes.
- [ ] Persona create/edit → Finished-Speaking and Interrupt sensitivity show 1 by default and the +/- buttons work immediately (without touching the slider).
- [ ] Persona list filter → Category/Agent Type show only the `is` operator and a single-select (radio) value picker; applied filter sends a single value.
- [ ] Cancel a running execution → request succeeds.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Lint passes on changed files
- [x] Self-reviewed
- [ ] Manually verified in the UI

## Backout

Revert the commits on this branch; no data or migration impact.

## Linear

Closes TH-6288
Closes TH-6341
Closes TH-6286
Closes TH-6335
Closes TH-6339

- TH-6288 — Prompt and Column filter not showing columns (Dataset Summary)
- TH-6341 — "Last run" column showing "-"
- TH-6286 — UI Bug: "+" icon not visible on Add from Existing Dataset
- TH-6335 — Persona conversation sensitivity sliders can't be incremented/decremented
- TH-6339 — Persona filter `is not` operator is not working
- Follow-up (backend casing): TH-6362
