### PR TITLE
fix(accounts): persist pending OrganizationInvite on user invite

### DIFF
--- a/futureagi/accounts/tests/test_workspace_management.py
+++ b/futureagi/accounts/tests/test_workspace_management.py
@@ -255,7 +255,10 @@ class TestWorkspaceInviteAPIView:
             },
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_invite_user_unauthenticated(self, api_client, workspace):
         """Unauthenticated request fails."""
@@ -312,6 +315,56 @@ class TestWorkspaceInviteAPIView:
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invite_new_user_creates_pending_invite(
+        self, auth_client, api_client, workspace, monkeypatch
+    ):
+        """Inviting a brand-new user must persist a PENDING OrganizationInvite.
+
+        Regression: like the onboarding add-users flow, this endpoint created
+        the user + emailed a token but no invite row, so accept_invitation_mail
+        rejected the link as "expired or invalid".
+        """
+        from django.contrib.auth.tokens import default_token_generator
+        from django.utils.encoding import force_bytes
+        from django.utils.http import urlsafe_base64_encode
+
+        import accounts.views.workspace_management as wm
+        from accounts.models.organization_invite import (
+            InviteStatus,
+            OrganizationInvite,
+        )
+
+        monkeypatch.setattr(wm, "email_helper", lambda *a, **k: None)
+
+        email = "wsinvite@futureagi.com"
+        response = auth_client.post(
+            "/accounts/workspace/invite/",
+            {
+                "emails": [email],
+                "role": OrganizationRoles.WORKSPACE_MEMBER,
+                "workspace_ids": [str(workspace.id)],
+                "select_all": False,
+            },
+            format="json",
+        )
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+        )
+
+        new_member = User.objects.get(email=email)
+        invite = OrganizationInvite.objects.get(
+            target_email__iexact=email,
+            organization=new_member.organization,
+            status=InviteStatus.PENDING,
+        )
+        assert invite.workspace_access
+
+        uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
+        token = default_token_generator.make_token(new_member)
+        preview = api_client.get(f"/accounts/accept-invitation/{uidb64}/{token}/")
+        assert preview.status_code == status.HTTP_200_OK
 
 
 # =============================================================================
@@ -546,7 +599,10 @@ class TestResendInviteAPIView:
             {"user_id": str(inactive_user.id)},
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_resend_invite_unauthenticated(self, api_client):
         """Unauthenticated request fails."""
@@ -620,7 +676,10 @@ class TestDeleteUserAPIView:
             {"user_id": str(admin_user.id)},
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_delete_user_unauthenticated(self, api_client):
         """Unauthenticated request fails."""
@@ -705,7 +764,10 @@ class TestDeactivateUserAPIView:
             {"user_id": str(admin_user.id)},
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_deactivate_user_unauthenticated(self, api_client):
         """Unauthenticated request fails."""
@@ -792,7 +854,10 @@ class TestSwitchWorkspaceAPIView:
             format="json",
         )
         # Members do NOT have global workspace access — need explicit membership
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_switch_workspace_unauthenticated(self, api_client, workspace):
         """Unauthenticated request fails."""
@@ -846,12 +911,18 @@ class TestManageTeamViewGet:
     def test_list_team_as_admin_forbidden(self, admin_client):
         """Admin cannot list team (owner only)."""
         response = admin_client.get("/accounts/team/users/")
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_list_team_as_member_forbidden(self, member_client):
         """Member cannot list team."""
         response = member_client.get("/accounts/team/users/")
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_list_team_unauthenticated(self, api_client):
         """Unauthenticated request fails."""
@@ -961,7 +1032,10 @@ class TestManageTeamViewPost:
             },
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_add_team_member_as_member_forbidden(self, member_client, workspace):
         """Member cannot add team members."""
@@ -978,7 +1052,10 @@ class TestManageTeamViewPost:
             },
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_add_team_member_unauthenticated(self, api_client):
         """Unauthenticated request fails."""
@@ -1017,6 +1094,65 @@ class TestManageTeamViewPost:
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_add_team_member_creates_pending_invite(
+        self, auth_client, api_client, workspace, monkeypatch
+    ):
+        """Adding a member must persist a PENDING OrganizationInvite.
+
+        Regression: the onboarding add-users flow created the user but no
+        invite row, so accept_invitation_mail rejected the link and the UI
+        rendered "This invite link has expired or is invalid."
+        """
+        from django.contrib.auth.tokens import default_token_generator
+        from django.utils.encoding import force_bytes
+        from django.utils.http import urlsafe_base64_encode
+
+        import accounts.views.workspace_management as wm
+        from accounts.models.organization_invite import (
+            InviteStatus,
+            OrganizationInvite,
+        )
+
+        # Avoid real email delivery and ee billing deduction in tests.
+        monkeypatch.setattr(wm, "email_helper", lambda *a, **k: None)
+        monkeypatch.setattr(
+            wm, "log_and_deduct_cost_for_resource_request", None, raising=False
+        )
+
+        email = "pendinginvite@futureagi.com"
+        response = auth_client.post(
+            "/accounts/team/users/",
+            {
+                "members": [
+                    {
+                        "email": email,
+                        "name": "Pending Invite",
+                        "organization_role": OrganizationRoles.MEMBER,
+                    }
+                ]
+            },
+            format="json",
+        )
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+        )
+
+        new_member = User.objects.get(email=email)
+        invite = OrganizationInvite.objects.get(
+            target_email__iexact=email,
+            organization=new_member.organization,
+            status=InviteStatus.PENDING,
+        )
+        # workspace_access lets invite.accept() materialize memberships.
+        assert invite.workspace_access
+
+        # The invite link the email carries must now validate (GET preview).
+        uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
+        token = default_token_generator.make_token(new_member)
+        preview = api_client.get(f"/accounts/accept-invitation/{uidb64}/{token}/")
+        assert preview.status_code == status.HTTP_200_OK
 
     def test_update_org_name(self, auth_client, organization):
         """Owner can update organization display name."""
@@ -1070,12 +1206,18 @@ class TestManageTeamViewDelete:
     def test_delete_team_member_as_admin_forbidden(self, admin_client, member_user):
         """Admin cannot delete team members (owner only)."""
         response = admin_client.delete(f"/accounts/team/users/{member_user.id}/")
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_delete_team_member_as_member_forbidden(self, member_client, admin_user):
         """Member cannot delete team members."""
         response = member_client.delete(f"/accounts/team/users/{admin_user.id}/")
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_delete_team_member_unauthenticated(self, api_client, member_user):
         """Unauthenticated request fails."""

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -12,6 +12,7 @@ from django.utils.http import urlsafe_base64_encode
 from slack_sdk import WebhookClient
 
 from accounts.models.organization import Organization
+from accounts.models.organization_invite import InviteStatus, OrganizationInvite
 from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.user import OrgApiKey, User
 from accounts.serializers.user import UserSignupSerializer
@@ -24,6 +25,7 @@ from analytics.utils import (
 )
 from saml2_auth.models import SAMLMetadataModel
 from tfc.constants.email import FREE_EMAIL_DOMAINS
+from tfc.constants.levels import Level
 from tfc.settings.settings import ssl
 from tfc.utils.email import email_helper
 from tfc.utils.parse_errors import parse_serialized_errors
@@ -272,6 +274,36 @@ def first_signup(data, mode=None):
         raise Exception(str(error_messages))
 
 
+def persist_pending_org_invite(
+    organization, target_email, org_role, workspace_role, workspaces, invited_by
+):
+    """Create or refresh the PENDING OrganizationInvite for a newly invited user.
+
+    The accept-invite flow (accept_invitation_mail) rejects any link that has
+    no pending invite, and invite.accept() materializes the org + workspace
+    memberships from level/workspace_access. Without this row the invite email
+    link always renders as "expired or invalid".
+
+    Keyed on (organization, target_email, status=PENDING) to match the
+    unique_pending_invite_per_org_email constraint. org_role may be None for
+    workspace-only invites (falls back to Level.VIEWER).
+    """
+    org_level = Level.from_string(org_role) if org_role else Level.VIEWER
+    ws_level = Level.from_string(Level.normalize_ws_role(workspace_role))
+    OrganizationInvite.objects.update_or_create(
+        organization=organization,
+        target_email=target_email,
+        status=InviteStatus.PENDING,
+        defaults={
+            "level": org_level,
+            "workspace_access": [
+                {"workspace_id": str(w.id), "level": ws_level} for w in workspaces
+            ],
+            "invited_by": invited_by,
+        },
+    )
+
+
 def send_invite_email(email, organization, inviter):
     """Send invite email to the target user."""
     try:
@@ -472,7 +504,9 @@ def _run_post_registration(user_id, generated_password):
             send_slack_notification(user, updated=updated, err=err)
 
 
-def existing_member_access_will_change(existing_user, organization, org_level, workspace_access):
+def existing_member_access_will_change(
+    existing_user, organization, org_level, workspace_access
+):
     """Check if re-inviting an existing active member would actually grant new access."""
     from accounts.models.workspace import WorkspaceMembership
     from tfc.constants.levels import Level

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -66,7 +66,12 @@ from accounts.services.workspace_membership import (
     create_workspace_membership,
     resolve_org_membership,
 )
-from accounts.utils import generate_password, resolve_org, resolve_org_role
+from accounts.utils import (
+    generate_password,
+    persist_pending_org_invite,
+    resolve_org,
+    resolve_org_role,
+)
 from analytics.mixpanel_util import mixpanel_tracker
 from analytics.utils import (
     MixpanelEvents,
@@ -152,34 +157,6 @@ def clear_user_redis_cache(user_id):
     except Exception as e:
         logger.error(f"Error clearing Redis cache for user {user_id}: {str(e)}")
         return False
-
-
-def persist_pending_org_invite(
-    organization, target_email, org_role, workspace_role, workspaces, invited_by
-):
-    """Persist a PENDING OrganizationInvite for a newly invited user.
-
-    The accept-invite flow (accept_invitation_mail) rejects any link that has
-    no pending invite, and invite.accept() materializes the org + workspace
-    memberships from level/workspace_access. Without this row the invite email
-    link always renders as "expired or invalid".
-    """
-    from accounts.models.organization_invite import InviteStatus, OrganizationInvite
-
-    org_level = Level.from_string(org_role) if org_role else Level.VIEWER
-    ws_level = Level.from_string(Level.normalize_ws_role(workspace_role))
-    OrganizationInvite.objects.update_or_create(
-        organization=organization,
-        target_email=target_email,
-        status=InviteStatus.PENDING,
-        defaults={
-            "level": org_level,
-            "workspace_access": [
-                {"workspace_id": str(w.id), "level": ws_level} for w in workspaces
-            ],
-            "invited_by": invited_by,
-        },
-    )
 
 
 class WorkspaceListAPIView(APIView):

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -605,6 +605,42 @@ class WorkspaceInviteAPIView(APIView):
                                         invited_by=user,
                                     )
 
+                            # Persist a PENDING OrganizationInvite so the
+                            # accept-invite flow (accept_invitation_mail) can
+                            # validate the link and, on accept, materialize the
+                            # org + workspace memberships from level/
+                            # workspace_access. Without this row the invite email
+                            # link always renders as "expired or invalid".
+                            from accounts.models.organization_invite import (
+                                InviteStatus,
+                                OrganizationInvite,
+                            )
+
+                            org_level = (
+                                Level.from_string(org_role)
+                                if org_role
+                                else Level.VIEWER
+                            )
+                            ws_level = Level.from_string(
+                                Level.normalize_ws_role(workspace_role)
+                            )
+                            OrganizationInvite.objects.update_or_create(
+                                organization=organization,
+                                target_email=email,
+                                status=InviteStatus.PENDING,
+                                defaults={
+                                    "level": org_level,
+                                    "workspace_access": [
+                                        {
+                                            "workspace_id": str(w.id),
+                                            "level": ws_level,
+                                        }
+                                        for w in workspaces
+                                    ],
+                                    "invited_by": user,
+                                },
+                            )
+
                             # Send invitation email with credentials
                             # ssl_context = ssl.create_default_context()
                             uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
@@ -2239,6 +2275,39 @@ class ManageTeamView(APIView):
                             workspace,
                             workspace_role,
                             request.user,
+                        )
+
+                        # Persist a PENDING OrganizationInvite. The accept-invite
+                        # flow (accept_invitation_mail) rejects any link that has
+                        # no pending invite, and its accept() materializes the
+                        # org + workspace memberships from level/workspace_access.
+                        # Without this row the invite email link always renders as
+                        # "expired or invalid".
+                        from accounts.models.organization_invite import (
+                            InviteStatus,
+                            OrganizationInvite,
+                        )
+
+                        org_level = (
+                            Level.from_string(org_role) if org_role else Level.VIEWER
+                        )
+                        ws_level = Level.from_string(
+                            Level.normalize_ws_role(workspace_role)
+                        )
+                        OrganizationInvite.objects.update_or_create(
+                            organization=organization,
+                            target_email=member_data["email"],
+                            status=InviteStatus.PENDING,
+                            defaults={
+                                "level": org_level,
+                                "workspace_access": [
+                                    {
+                                        "workspace_id": str(workspace.id),
+                                        "level": ws_level,
+                                    }
+                                ],
+                                "invited_by": request.user,
+                            },
                         )
 
                         token = default_token_generator.make_token(new_member)

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -154,6 +154,34 @@ def clear_user_redis_cache(user_id):
         return False
 
 
+def persist_pending_org_invite(
+    organization, target_email, org_role, workspace_role, workspaces, invited_by
+):
+    """Persist a PENDING OrganizationInvite for a newly invited user.
+
+    The accept-invite flow (accept_invitation_mail) rejects any link that has
+    no pending invite, and invite.accept() materializes the org + workspace
+    memberships from level/workspace_access. Without this row the invite email
+    link always renders as "expired or invalid".
+    """
+    from accounts.models.organization_invite import InviteStatus, OrganizationInvite
+
+    org_level = Level.from_string(org_role) if org_role else Level.VIEWER
+    ws_level = Level.from_string(Level.normalize_ws_role(workspace_role))
+    OrganizationInvite.objects.update_or_create(
+        organization=organization,
+        target_email=target_email,
+        status=InviteStatus.PENDING,
+        defaults={
+            "level": org_level,
+            "workspace_access": [
+                {"workspace_id": str(w.id), "level": ws_level} for w in workspaces
+            ],
+            "invited_by": invited_by,
+        },
+    )
+
+
 class WorkspaceListAPIView(APIView):
     """API for getting paginated list of workspaces"""
 
@@ -605,40 +633,13 @@ class WorkspaceInviteAPIView(APIView):
                                         invited_by=user,
                                     )
 
-                            # Persist a PENDING OrganizationInvite so the
-                            # accept-invite flow (accept_invitation_mail) can
-                            # validate the link and, on accept, materialize the
-                            # org + workspace memberships from level/
-                            # workspace_access. Without this row the invite email
-                            # link always renders as "expired or invalid".
-                            from accounts.models.organization_invite import (
-                                InviteStatus,
-                                OrganizationInvite,
-                            )
-
-                            org_level = (
-                                Level.from_string(org_role)
-                                if org_role
-                                else Level.VIEWER
-                            )
-                            ws_level = Level.from_string(
-                                Level.normalize_ws_role(workspace_role)
-                            )
-                            OrganizationInvite.objects.update_or_create(
+                            persist_pending_org_invite(
                                 organization=organization,
                                 target_email=email,
-                                status=InviteStatus.PENDING,
-                                defaults={
-                                    "level": org_level,
-                                    "workspace_access": [
-                                        {
-                                            "workspace_id": str(w.id),
-                                            "level": ws_level,
-                                        }
-                                        for w in workspaces
-                                    ],
-                                    "invited_by": user,
-                                },
+                                org_role=org_role,
+                                workspace_role=workspace_role,
+                                workspaces=workspaces,
+                                invited_by=user,
                             )
 
                             # Send invitation email with credentials
@@ -2277,37 +2278,13 @@ class ManageTeamView(APIView):
                             request.user,
                         )
 
-                        # Persist a PENDING OrganizationInvite. The accept-invite
-                        # flow (accept_invitation_mail) rejects any link that has
-                        # no pending invite, and its accept() materializes the
-                        # org + workspace memberships from level/workspace_access.
-                        # Without this row the invite email link always renders as
-                        # "expired or invalid".
-                        from accounts.models.organization_invite import (
-                            InviteStatus,
-                            OrganizationInvite,
-                        )
-
-                        org_level = (
-                            Level.from_string(org_role) if org_role else Level.VIEWER
-                        )
-                        ws_level = Level.from_string(
-                            Level.normalize_ws_role(workspace_role)
-                        )
-                        OrganizationInvite.objects.update_or_create(
+                        persist_pending_org_invite(
                             organization=organization,
                             target_email=member_data["email"],
-                            status=InviteStatus.PENDING,
-                            defaults={
-                                "level": org_level,
-                                "workspace_access": [
-                                    {
-                                        "workspace_id": str(workspace.id),
-                                        "level": ws_level,
-                                    }
-                                ],
-                                "invited_by": request.user,
-                            },
+                            org_role=org_role,
+                            workspace_role=workspace_role,
+                            workspaces=[workspace],
+                            invited_by=request.user,
                         )
 
                         token = default_token_generator.make_token(new_member)


### PR DESCRIPTION
## 1) Why the changes

When onboarding/inviting a user, the API returns `200` and the invite email is sent, but clicking the link (or trying to log in with the emailed password) shows:

> **This invite link has expired or is invalid.**

**Root cause:** the accept-invitation endpoint (`accept_invitation_mail` in `accounts/views/signup.py`) — which the frontend calls on page load to validate the link — now *requires* a pending `OrganizationInvite` row:

```python
invite_exists = OrganizationInvite.objects.filter(
    target_email__iexact=user.email, organization=org, status=InviteStatus.PENDING,
).exists()
if not invite_exists:
    return _gm.bad_request("This invitation has been cancelled or expired.")  # -> 400 -> "expired or invalid"
```

But the two legacy invite paths created the `User` + `WorkspaceMembership` and emailed a token **without ever writing that `OrganizationInvite` row**. Only the newer RBAC invite endpoint wrote it. So every link from these paths failed validation 100% of the time. Confirmed on dev: the invited user existed (`is_active=False`) with **zero** `OrganizationInvite` and **zero** `OrganizationMembership` rows.

Secondary effect fixed by the same change: because no invite existed, acceptance fell back to `_activate_memberships()`, which only *activates existing* memberships — and there was no org membership to activate, so even a working link would have landed the user in `requires_org_setup`. Writing the invite with `level` + `workspace_access` lets `invite.accept()` materialize the org + workspace memberships properly.

## 2) What are the changes done

`futureagi/accounts/views/workspace_management.py` — both new-user invite paths now persist a `PENDING OrganizationInvite` (keyed on `(organization, target_email, status=PENDING)` via `update_or_create`, matching the `unique_pending_invite_per_org_email` constraint and the existing RBAC pattern):

- **`ManageTeamView.post`** (`POST /accounts/team/users/` — onboarding "add users", the reported endpoint). `workspace_access` = the single workspace the member is added to.
- **`WorkspaceInviteAPIView.post`** (`POST /accounts/workspace/invite/` — same latent bug). `workspace_access` = **all** target workspaces (supports `select_all`).

The invite is written **before** token generation and does not call `user.save()`, so the emailed token is never invalidated. `level` is derived from the org role (falls back to `Level.VIEWER` for workspace-only invites); `ws_level` from the workspace role.

## 3) Test suite added and scenarios each test covers

`futureagi/accounts/tests/test_workspace_management.py`:

- **`TestManageTeamViewPost::test_add_team_member_creates_pending_invite`** — invites a brand-new member via the real onboarding endpoint and asserts:
  1. a `PENDING OrganizationInvite` now exists for that email + org;
  2. it carries `workspace_access` (so `invite.accept()` can build memberships);
  3. the **accept-invitation GET preview** (`/accounts/accept-invitation/<uid>/<token>/`), called with the real uid+token exactly as the email link does, returns **200** — i.e. the link no longer reports "expired/invalid".

- **`TestWorkspaceInviteAPIView::test_invite_new_user_creates_pending_invite`** — same three assertions for the `POST /accounts/workspace/invite/` path (new user, single workspace, `select_all=False`).

Both tests stub `email_helper` (no real mail) and the first stubs the `ee` billing hook so it can't `429` in CI. They reproduce the exact UI failure path, so they fail on the pre-fix code and pass after.

## 4) Affected tests updated / old ones passing

No existing tests needed behavioral updates (the change is purely additive — it writes a row that previously didn't exist). The two new tests were auto-formatted by the repo's `black`/`isort` pre-commit hooks.

Affected suites run green:

```
bin/test --no-services accounts/tests/test_workspace_management.py \
                       accounts/tests/test_signup.py \
                       accounts/tests/test_e2e_resend_reactivate.py
=> 167 passed
```

This includes the existing invite-acceptance lifecycle e2e tests (`test_accept_invite_activates_org_membership`, `test_accept_invite_activates_workspace_membership`, `test_accepted_user_has_active_membership_for_login`, `test_invite_accept_remove_reactivate_lifecycle`), confirming the accept flow still behaves correctly with the new invite rows.

## Notes / out of scope

- **Members list visibility:** invited users intentionally appear in the Manage Team list only *after* they accept (the list filters `is_active=true`; invitees are inactive until acceptance). Confirmed correct — no change.
- **Already-stuck users on dev** created before this fix have no invite row and won't self-heal; they need a re-invite after deploy (or a manual backfill). Not addressed here.

##Videos

https://github.com/user-attachments/assets/dbe02c8d-d9c5-4eff-a80e-c05221bc00a7

https://github.com/user-attachments/assets/fd6b6458-3afb-4017-8701-25ed47607863

<img width="1512" height="982" alt="Screenshot 2026-06-30 at 6 34 37 PM" src="https://github.com/user-attachments/assets/02f9bb63-8c90-4721-9397-a8600eb79424" />



##linear
Fixes TH-6165
