### PR TITLE
fix: preserve column selection across React Query refetches in Compar…

### DIFF
--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
@@ -35,12 +35,7 @@ const CompareDataRightSection = ({
   const prevColumnKeyRef = useRef(null);
   const { diffMode, handleToggleDiffMode } = useDevelopDetailContext();
   const { role } = useAuthContext();
-  // Initialize all columns as selected on first mount, or when the
-  // actual set of columns changes (e.g. switching datasets). We compare
-  // a stable signature of column ids rather than the `columns` array
-  // reference, since React Query returns a new reference on every
-  // refetch even when the underlying data is unchanged — otherwise this
-  // would silently wipe out the user's deselections on every refetch.
+   
   useEffect(() => {
     const temp = [];
     for (const col of columns) {

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
@@ -32,10 +32,15 @@ const CompareDataRightSection = ({
   // const [selectedColumns, setSelectedColumns] = useState([]);
   const [unselectedColumns] = useState([]);
   const columnButtonRef = useRef(null);
+  const prevColumnKeyRef = useRef(null);
   const { diffMode, handleToggleDiffMode } = useDevelopDetailContext();
   const { role } = useAuthContext();
-
-  // Initialize all columns as selected when the component mounts or columns prop changes
+  // Initialize all columns as selected on first mount, or when the
+  // actual set of columns changes (e.g. switching datasets). We compare
+  // a stable signature of column ids rather than the `columns` array
+  // reference, since React Query returns a new reference on every
+  // refetch even when the underlying data is unchanged — otherwise this
+  // would silently wipe out the user's deselections on every refetch.
   useEffect(() => {
     const temp = [];
     for (const col of columns) {
@@ -46,10 +51,14 @@ const CompareDataRightSection = ({
         }
       }
     }
-    setSelectedColumn(temp);
-    // setUnselectedColumns([]);
-  }, [columns]);
 
+    const columnKey = temp.join(",");
+
+    if (columnKey !== prevColumnKeyRef.current) {
+      prevColumnKeyRef.current = columnKey;
+      setSelectedColumn(temp);
+    }
+  }, [columns]);
   const handleColumnClick = () => {
     setColumnPopoverOpen(true);
   };


### PR DESCRIPTION
## Summary
Fixes the Compare view's column selector resetting all checkboxes to checked on every background refetch. The `useEffect` in `CompareDataRightSection.jsx` was keyed on the `columns` array reference (`[columns]`), so any React Query refetch — even one returning identical data — produced a new array reference, re-triggered the effect, and silently overwrote the user's deselections. The fix compares a stable signature of column ids (joined string) instead of the array reference, so the effect only re-initializes selection when the underlying column set actually changes (e.g. switching datasets), not on every refetch.

## Linked issues
Closes #1069

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
Verified the corrected `useEffect` logic in isolation via browser console, simulating the exact sequence from the bug report against the new column-key-comparison logic:
1. **Mount** with columns `[context, answer, question]` → all selected: `['context', 'answer', 'question']`
2. **Uncheck `answer`** → selection becomes `['context', 'question']`
3. **Simulated refetch** (new array reference, identical column data, mimicking a React Query background refetch) → selection correctly remains `['context', 'question']` — `answer` stays deselected (this is the core regression test for the bug)
4. **Simulated dataset switch** (genuinely different columns: `[title, body]`) → selection correctly resets to all new columns: `['title', 'body']`

All four scenarios match the acceptance criteria from the issue.

Note: I was unable to fully exercise this in the live UI end-to-end, due to an unrelated pre-existing issue where the `CompareDataRightSection` toolbar (and thus the column-selector icon) does not mount under certain conditions in local dev (looks tied to `currentTab` timing relative to `isCompareDataset` becoming `true`). This appears to be a separate, pre-existing bug unrelated to this fix and is out of scope here — happy to file a follow-up issue if useful.

## Screenshots / recordings (if UI)
N/A — change is to internal `useEffect` dependency/comparison logic only; no visual changes. Logic verified via console testing as described above.

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)