### PR TITLE
fix(experiment): default prompt model options editable + logo [TH-6357]

### DIFF
--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/ConfigureStepLLM.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/ConfigureStepLLM.jsx
@@ -22,7 +22,11 @@ import { PROMPT_CONFIG_TYPE, PROMPT_CONFIG_TYPES } from "../common";
 
 const transformPromptToFormSchema = (listPrompt) => {
   const modelArray = [
-    { id: getRandomId(), value: listPrompt?.model, ...listPrompt?.modelDetail },
+    {
+      id: getRandomId(),
+      value: listPrompt?.model,
+      ...listPrompt?.model_detail,
+    },
   ];
   return {
     _itemId: getRandomId(),


### PR DESCRIPTION
## Bug

**TH-6357** — In an experiment, the default (imported) prompt model shows a blank logo and its model options can't be edited (unless another model is added).

## Root cause

`ConfigureStepLLM.transformPromptToFormSchema` built the model entry by spreading `listPrompt?.modelDetail` (camelCase), but the prompt API returns this metadata under `model_detail` (snake_case). So `modelDetail` was `undefined` and the entry came out as just `{ id, value }` — no `providers`, no `logoUrl`. That:

- disabled the model-params query (it's gated on `selectedModel.providers`), so the options popover had no schema → "can't edit", and
- left the logo blank (the row reads `selectedModel.logoUrl`).

A model added via the dropdown worked because that path carries `providers`/`logoUrl` — hence "editable only after adding another model."

## Change

`ConfigureStepLLM.jsx` — spread `listPrompt?.model_detail` (snake_case) instead of `modelDetail`, so the entry carries `providers` + `logoUrl`.

## How verified

Confirmed against the live API and runtime logs: the prompt API returns `model_detail` (snake_case) populated (`providers: "openai"`, `logoUrl: "…openai-icon.png"`); the form entry was `{ id, value }` only with `providers/logoUrl` undefined → params query disabled + blank logo. After the change the entry carries `providers`/`logoUrl`.

## Test scenarios

1. Add an imported prompt to an experiment → the default model shows its logo and the Model options popover is editable (without adding a second model).
2. Add a second model → both remain editable (no regression).

## Commands

```
yarn lint
```

## Videos / screenshots

https://github.com/user-attachments/assets/fbf332b2-f326-4f80-9161-3c8970950de0

