### PR TITLE
fix(feedback): canonicalize embed row_dict on dataset + experiment submit-action (TH-6347, stacked on TH-5462)

### DIFF
--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -11297,6 +11297,8 @@ class FeedbackViewSet(viewsets.ModelViewSet):
                 column_id = str(cell.column.id)
                 if column_id != str(eval_column.id):
                     row_dict[column_id] = cell.value
+                    if cell.column.name:
+                        row_dict[cell.column.name] = cell.value
 
             # Add feedback information
             row_dict["feedback_comment"] = feedback.explanation

--- a/futureagi/model_hub/views/experiment_feedback_v2.py
+++ b/futureagi/model_hub/views/experiment_feedback_v2.py
@@ -424,6 +424,8 @@ class ExperimentFeedbackSubmitV2View(APIView):
                 column_id = str(cell.column.id)
                 if column_id != str(eval_column.id):
                     row_dict[column_id] = cell.value
+                    if cell.column.name:
+                        row_dict[cell.column.name] = cell.value
 
             row_dict["feedback_comment"] = feedback.explanation
             row_dict["feedback_value"] = feedback.value


### PR DESCRIPTION
## Why

Stacked on PR #820 (TH-5462). PR #820 fixes the annotation auto-embed and observe-span feedback paths. This PR closes the same class of silent embed no-op on the two remaining write paths it does not touch:

* `FeedbackViewSet.submit_action_type` (dataset feedback) at `model_hub/views/develop_dataset.py:11296`.
* `ExperimentFeedbackSubmitV2View` (experiment feedback) at `model_hub/views/experiment_feedback_v2.py:423`.

Both build `row_dict` keyed only by column UUIDs, then call `parallel_process_metadata(..., inputs_formater=required_field)` where `required_field` comes from `_get_required_fields_and_mappings(user_eval_metric)`. When the eval template's mapping carries logical column names as the lookup key (rather than the source column UUID), `data_formatter`'s `if inp not in row_dict: continue` skips every input and the function returns `([], [])`. The view still returns 200; the embed never lands in ClickHouse.

## What changed

| File | Change |
|---|---|
| `futureagi/model_hub/views/develop_dataset.py` | When building `row_dict` in `submit_action_type`, also key by `cell.column.name` so logical-name lookups resolve. |
| `futureagi/model_hub/views/experiment_feedback_v2.py` | Same dual-keying on the experiment submit path. |

Net diff: +4 / -0 across 2 files. Additive only, no behavioural shift on the existing UUID-keyed lookup.

## Sequencing

* Base: `feat/TH-5462-feedback-fewshot-unify` (PR #820's head).
* Land order: merge #820 first, then rebase this onto `dev` and merge.
* When #820 merges into `dev`, GitHub will retarget this PR's base automatically and the diff shrinks to the 4 lines.

## How to test

1. Pick an existing eval whose template mapping uses logical column names (not column UUIDs).
2. Submit feedback on a dataset row through `Add feedback` -> Re-tune; verify a row lands in CH `futureagi.feedbacks` keyed by the eval template id with `feedback_value`, `feedback_comment`, and the embedded `index_column` text.
3. Repeat for an experiment row through the experiment feedback drawer.

## Out of scope

* The annotation and observe-span write paths -> covered by PR #820.
* FE drift on feedback drawers and the `EvalFeedbackTab` column ids -> covered by PR #1140.
* `_get_required_fields_and_mappings` shape rework (variable named `col_ids` but holding logical names in some templates) -> separate follow-up.
