### PR TITLE
fix: add case-insensitive tokenization to Jaccard and SorensenDice similarity (Fixes #653)

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -108,8 +108,8 @@ class JaccardSimilarity(Comparator):
         return self._jaccard_similarity(string1, string2)
 
     def _jaccard_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
         return len(str1_tokens.intersection(str2_tokens)) / len(str1_tokens.union(str2_tokens))
 
 class SorensenDiceSimilarity(Comparator):
@@ -117,6 +117,6 @@ class SorensenDiceSimilarity(Comparator):
         return self._sorensen_dice_similarity(string1, string2)
 
     def _sorensen_dice_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
         return 2 * len(str1_tokens.intersection(str2_tokens)) / (len(str1_tokens) + len(str2_tokens))


### PR DESCRIPTION
Fixes #653

## Problem
`JaccardSimilarity` and `SorensenDiceSimilarity` perform case-sensitive token comparison, so "Cat" and "cat" are treated as different tokens and won't match. This is inconsistent with `CosineSimilarity` which already lowercases input via `re.findall(r'\b\w+\b', string.lower())`.

## Root Cause
Both `_jaccard_similarity` and `_sorensen_dice_similarity` call `str.split()` directly without lowercasing first.

## Solution
Added `.lower()` before `.split()` in both methods to normalize input to lowercase, consistent with `CosineSimilarity._tokenize()`.

## Verification
```python
from agentic_eval.core_evals.fi_evals.grounded.similarity import JaccardSimilarity, SorensenDiceSimilarity

j = JaccardSimilarity()
assert j.compare("Cat", "cat") == 1.0  # was 0.0

s = SorensenDiceSimilarity()
assert s.compare("Cat", "cat") == 1.0  # was 0.0
```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-30 | Added .lower() to Jaccard and SorensenDice tokenization | rtmalikian |

### Files Changed
- futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py — Added `.lower()` before `.split()` in `_jaccard_similarity` and `_sorensen_dice_similarity`

### Verification
- Confirmed `JaccardSimilarity().compare("Cat", "cat")` returns 1.0
- Confirmed `SorensenDiceSimilarity().compare("Cat", "cat")` returns 1.0

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek v4 Pro** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
