### PR TITLE
fix(prompt): use snake_case for media content block keys

### DIFF
--- a/frontend/src/components/PromptCards/ExpandedPrompt.jsx
+++ b/frontend/src/components/PromptCards/ExpandedPrompt.jsx
@@ -30,6 +30,7 @@ import {
   embedPdfs,
   handleRemoveImage,
   handleReplaceImage,
+  normalizeContentBlocks,
   placeEditBolt,
 } from "./common";
 import { getRandomId } from "src/utils/utils";
@@ -201,7 +202,7 @@ export default function ExpandedPrompt({
 
   const setBlocksFromPrompt = () => {
     if (mainEditorRef?.current) {
-      const blocks = prompt || [];
+      const blocks = normalizeContentBlocks(prompt) || [];
       const delta = { ops: [] };
 
       blocks.forEach((block) => {
@@ -211,8 +212,8 @@ export default function ExpandedPrompt({
             insert: {
               ImageBlot: {
                 url: block?.image_url?.url,
-                name: block?.image_url?.img_name || block?.image_url?.imgName,
-                size: block?.image_url?.img_size || block?.image_url?.imgSize,
+                name: block?.image_url?.img_name,
+                size: block?.image_url?.img_size,
                 setSelectedImage: setSelectedImageMain,
                 id: getRandomId(),
                 handleRemoveImage: handleRemoveImageMain,
@@ -228,12 +229,9 @@ export default function ExpandedPrompt({
             insert: {
               AudioBlot: {
                 url: block?.audio_url?.url,
-                name:
-                  block?.audio_url?.audio_name || block?.audio_url?.audioName,
-                size:
-                  block?.audio_url?.audio_size || block?.audio_url?.audioSize,
-                mimeType:
-                  block?.audio_url?.audio_type || block?.audio_url?.audioType,
+                name: block?.audio_url?.audio_name,
+                size: block?.audio_url?.audio_size,
+                mimeType: block?.audio_url?.audio_type,
                 id: getRandomId(),
                 handleRemoveAudio,
               },
@@ -244,8 +242,8 @@ export default function ExpandedPrompt({
             insert: {
               PdfBlot: {
                 url: block?.pdf_url?.url,
-                name: block?.pdf_url?.file_name || block?.pdf_url?.fileName,
-                size: block?.pdf_url?.pdf_size || block?.pdf_url?.pdfSize,
+                name: block?.pdf_url?.file_name,
+                size: block?.pdf_url?.pdf_size,
                 id: getRandomId(),
                 handleRemovePdf,
               },

--- a/frontend/src/components/PromptCards/ExpandedPrompt.jsx
+++ b/frontend/src/components/PromptCards/ExpandedPrompt.jsx
@@ -210,9 +210,9 @@ export default function ExpandedPrompt({
           delta.ops.push({
             insert: {
               ImageBlot: {
-                url: block?.imageUrl?.url,
-                name: block?.imageUrl?.imgName || block?.imageUrl?.img_name,
-                size: block?.imageUrl?.imgSize || block?.imageUrl?.img_size,
+                url: block?.image_url?.url,
+                name: block?.image_url?.img_name || block?.image_url?.imgName,
+                size: block?.image_url?.img_size || block?.image_url?.imgSize,
                 setSelectedImage: setSelectedImageMain,
                 id: getRandomId(),
                 handleRemoveImage: handleRemoveImageMain,
@@ -227,11 +227,13 @@ export default function ExpandedPrompt({
           delta.ops.push({
             insert: {
               AudioBlot: {
-                url: block?.audioUrl?.url,
-                name: block?.audioUrl?.audioName || block?.audioUrl?.audio_name,
-                size: block?.audioUrl?.audioSize || block?.audioUrl?.audio_size,
+                url: block?.audio_url?.url,
+                name:
+                  block?.audio_url?.audio_name || block?.audio_url?.audioName,
+                size:
+                  block?.audio_url?.audio_size || block?.audio_url?.audioSize,
                 mimeType:
-                  block?.audioUrl?.audioType || block?.audioUrl?.audio_type,
+                  block?.audio_url?.audio_type || block?.audio_url?.audioType,
                 id: getRandomId(),
                 handleRemoveAudio,
               },
@@ -241,9 +243,9 @@ export default function ExpandedPrompt({
           delta.ops.push({
             insert: {
               PdfBlot: {
-                url: block?.pdfUrl?.url,
-                name: block?.pdfUrl?.fileName || block?.pdfUrl?.file_name,
-                size: block?.pdfUrl?.pdfSize || block?.pdfUrl?.pdf_size,
+                url: block?.pdf_url?.url,
+                name: block?.pdf_url?.file_name || block?.pdf_url?.fileName,
+                size: block?.pdf_url?.pdf_size || block?.pdf_url?.pdfSize,
                 id: getRandomId(),
                 handleRemovePdf,
               },

--- a/frontend/src/components/PromptCards/PromptEditor.jsx
+++ b/frontend/src/components/PromptCards/PromptEditor.jsx
@@ -12,6 +12,7 @@ import { Box, useTheme } from "@mui/material";
 import {
   getBlocks,
   handleRemoveEditVariable,
+  normalizeContentBlocks,
   placeEditBolt,
   handleRemoveAllImages,
 } from "./common";
@@ -148,7 +149,7 @@ const PromptEditor = React.forwardRef(
     );
 
     const defaultValue = useMemo(() => {
-      const blocks = prompt || [];
+      const blocks = normalizeContentBlocks(prompt) || [];
       const delta = { ops: [] };
 
       blocks.forEach((block) => {
@@ -158,8 +159,8 @@ const PromptEditor = React.forwardRef(
             insert: {
               ImageBlot: {
                 url: block?.image_url?.url,
-                name: block?.image_url?.img_name || block?.image_url?.imgName,
-                size: block?.image_url?.img_size || block?.image_url?.imgSize,
+                name: block?.image_url?.img_name,
+                size: block?.image_url?.img_size,
                 setSelectedImage,
                 id: getRandomId(),
                 handleRemoveImage,
@@ -175,12 +176,9 @@ const PromptEditor = React.forwardRef(
             insert: {
               AudioBlot: {
                 url: block?.audio_url?.url,
-                name:
-                  block?.audio_url?.audio_name || block?.audio_url?.audioName,
-                size:
-                  block?.audio_url?.audio_size || block?.audio_url?.audioSize,
-                mimeType:
-                  block?.audio_url?.audio_type || block?.audio_url?.audioType,
+                name: block?.audio_url?.audio_name,
+                size: block?.audio_url?.audio_size,
+                mimeType: block?.audio_url?.audio_type,
                 id: getRandomId(),
                 handleRemoveAudio,
               },
@@ -191,8 +189,8 @@ const PromptEditor = React.forwardRef(
             insert: {
               PdfBlot: {
                 url: block?.pdf_url?.url,
-                name: block?.pdf_url?.file_name || block?.pdf_url?.fileName,
-                size: block?.pdf_url?.pdf_size || block?.pdf_url?.pdfSize,
+                name: block?.pdf_url?.file_name,
+                size: block?.pdf_url?.pdf_size,
                 id: getRandomId(),
                 handleRemovePdf,
               },

--- a/frontend/src/components/PromptCards/PromptEditor.jsx
+++ b/frontend/src/components/PromptCards/PromptEditor.jsx
@@ -157,9 +157,9 @@ const PromptEditor = React.forwardRef(
           delta.ops.push({
             insert: {
               ImageBlot: {
-                url: block?.imageUrl?.url,
-                name: block?.imageUrl?.imgName || block?.imageUrl?.img_name,
-                size: block?.imageUrl?.imgSize || block?.imageUrl?.img_size,
+                url: block?.image_url?.url,
+                name: block?.image_url?.img_name || block?.image_url?.imgName,
+                size: block?.image_url?.img_size || block?.image_url?.imgSize,
                 setSelectedImage,
                 id: getRandomId(),
                 handleRemoveImage,
@@ -174,11 +174,13 @@ const PromptEditor = React.forwardRef(
           delta.ops.push({
             insert: {
               AudioBlot: {
-                url: block?.audioUrl?.url,
-                name: block?.audioUrl?.audioName || block?.audioUrl?.audio_name,
-                size: block?.audioUrl?.audioSize || block?.audioUrl?.audio_size,
+                url: block?.audio_url?.url,
+                name:
+                  block?.audio_url?.audio_name || block?.audio_url?.audioName,
+                size:
+                  block?.audio_url?.audio_size || block?.audio_url?.audioSize,
                 mimeType:
-                  block?.audioUrl?.audioType || block?.audioUrl?.audio_type,
+                  block?.audio_url?.audio_type || block?.audio_url?.audioType,
                 id: getRandomId(),
                 handleRemoveAudio,
               },
@@ -188,9 +190,9 @@ const PromptEditor = React.forwardRef(
           delta.ops.push({
             insert: {
               PdfBlot: {
-                url: block?.pdfUrl?.url,
-                name: block?.pdfUrl?.fileName || block?.pdfUrl?.file_name,
-                size: block?.pdfUrl?.pdfSize || block?.pdfUrl?.pdf_size,
+                url: block?.pdf_url?.url,
+                name: block?.pdf_url?.file_name || block?.pdf_url?.fileName,
+                size: block?.pdf_url?.pdf_size || block?.pdf_url?.pdfSize,
                 id: getRandomId(),
                 handleRemovePdf,
               },

--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -497,6 +497,47 @@ export const embedPdfs = (pdfs, quill, location) => {
   }
 };
 
+const CAMEL_TO_SNAKE_OUTER = {
+  imageUrl: "image_url",
+  audioUrl: "audio_url",
+  pdfUrl: "pdf_url",
+};
+
+const CAMEL_TO_SNAKE_INNER = {
+  image_url: { imgName: "img_name", imgSize: "img_size" },
+  audio_url: {
+    audioName: "audio_name",
+    audioSize: "audio_size",
+    audioType: "audio_type",
+  },
+  pdf_url: { fileName: "file_name", pdfSize: "pdf_size" },
+};
+
+export function normalizeContentBlocks(blocks) {
+  if (!blocks) return blocks;
+  return blocks.map((block) => {
+    if (!block || typeof block !== "object") return block;
+    const fixedType = CAMEL_TO_SNAKE_OUTER[block.type] || block.type;
+    const result = { ...block, type: fixedType };
+    for (const [oldKey, newKey] of Object.entries(CAMEL_TO_SNAKE_OUTER)) {
+      if (block[oldKey] !== undefined && result[newKey] === undefined) {
+        result[newKey] = block[oldKey];
+        delete result[oldKey];
+      }
+    }
+    const innerMap = CAMEL_TO_SNAKE_INNER[fixedType];
+    if (innerMap && result[fixedType]) {
+      result[fixedType] = Object.fromEntries(
+        Object.entries(result[fixedType]).map(([k, v]) => [
+          innerMap[k] || k,
+          v,
+        ]),
+      );
+    }
+    return result;
+  });
+}
+
 export const getBlocks = (quill) => {
   const blocks = [];
   const delta = quill.getContents();
@@ -554,14 +595,23 @@ export const getBlocks = (quill) => {
     if (imageObject) {
       blocks.push({
         type: "image_url",
-        image_url: imageObject,
+        image_url: {
+          ...imageObject,
+          img_name: imageObject.imgName,
+          img_size: imageObject.imgSize,
+        },
       });
       imageObject = null;
     }
     if (audioObject) {
       blocks.push({
         type: "audio_url",
-        audio_url: audioObject,
+        audio_url: {
+          ...audioObject,
+          audio_name: audioObject.audioName,
+          audio_size: audioObject.audioSize,
+          audio_type: audioObject.audioType,
+        },
       });
       audioObject = null;
     }

--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -554,21 +554,21 @@ export const getBlocks = (quill) => {
     if (imageObject) {
       blocks.push({
         type: "image_url",
-        imageUrl: imageObject,
+        image_url: imageObject,
       });
       imageObject = null;
     }
     if (audioObject) {
       blocks.push({
         type: "audio_url",
-        audioUrl: audioObject,
+        audio_url: audioObject,
       });
       audioObject = null;
     }
     if (pdfObject) {
       blocks.push({
         type: "pdf_url",
-        pdfUrl: { ...pdfObject, file_name: pdfObject.pdf_name },
+        pdf_url: { ...pdfObject, file_name: pdfObject.pdf_name },
       });
       pdfObject = null;
     }

--- a/frontend/src/components/PromptCards/common.test.js
+++ b/frontend/src/components/PromptCards/common.test.js
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import { getBlocks, normalizeContentBlocks } from "./common";
+
+const mockQuill = (ops) => ({ getContents: () => ({ ops }) });
+
+describe("normalizeContentBlocks", () => {
+  it("converts old camelCase outer keys to snake_case", () => {
+    const old = [
+      {
+        type: "imageUrl",
+        imageUrl: { url: "https://img.com", imgName: "x", imgSize: 100 },
+      },
+      {
+        type: "audioUrl",
+        audioUrl: {
+          url: "https://aud.io",
+          audioName: "a",
+          audioSize: 200,
+          audioType: "mp3",
+        },
+      },
+      {
+        type: "pdfUrl",
+        pdfUrl: { url: "https://pdf.dev", fileName: "doc", pdfSize: 300 },
+      },
+    ];
+    const got = normalizeContentBlocks(old);
+    expect(got[0]).toEqual({
+      type: "image_url",
+      image_url: { url: "https://img.com", img_name: "x", img_size: 100 },
+    });
+    expect(got[1]).toEqual({
+      type: "audio_url",
+      audio_url: {
+        url: "https://aud.io",
+        audio_name: "a",
+        audio_size: 200,
+        audio_type: "mp3",
+      },
+    });
+    expect(got[2]).toEqual({
+      type: "pdf_url",
+      pdf_url: { url: "https://pdf.dev", file_name: "doc", pdf_size: 300 },
+    });
+  });
+
+  it("leaves already-snake_case blocks unchanged", () => {
+    const blocks = [
+      {
+        type: "image_url",
+        image_url: { url: "https://img.com", img_name: "x" },
+      },
+      { type: "text", text: "hello" },
+    ];
+    expect(normalizeContentBlocks(blocks)).toEqual(blocks);
+  });
+
+  it("returns null/undefined as-is", () => {
+    expect(normalizeContentBlocks(null)).toBeNull();
+    expect(normalizeContentBlocks(undefined)).toBeUndefined();
+  });
+});
+
+describe("getBlocks", () => {
+  it("returns text blocks from string inserts", () => {
+    const quill = mockQuill([{ insert: "Hello " }, { insert: "world" }]);
+    expect(getBlocks(quill)).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("returns image block with snake_case inner keys", () => {
+    const quill = mockQuill([
+      {
+        insert: {
+          ImageBlot: {
+            imageData: { url: "https://img.com", imgName: "x", imgSize: 100 },
+          },
+        },
+      },
+    ]);
+    expect(getBlocks(quill)).toEqual([
+      {
+        type: "image_url",
+        image_url: {
+          url: "https://img.com",
+          imgName: "x",
+          imgSize: 100,
+          img_name: "x",
+          img_size: 100,
+        },
+      },
+    ]);
+  });
+
+  it("returns audio block with snake_case inner keys", () => {
+    const quill = mockQuill([
+      {
+        insert: {
+          AudioBlot: {
+            audioData: {
+              url: "https://aud.io",
+              audioName: "a",
+              audioSize: 200,
+              audioType: "mp3",
+            },
+          },
+        },
+      },
+    ]);
+    expect(getBlocks(quill)).toEqual([
+      {
+        type: "audio_url",
+        audio_url: {
+          url: "https://aud.io",
+          audioName: "a",
+          audioSize: 200,
+          audioType: "mp3",
+          audio_name: "a",
+          audio_size: 200,
+          audio_type: "mp3",
+        },
+      },
+    ]);
+  });
+
+  it("returns pdf block with snake_case key and renamed field", () => {
+    const quill = mockQuill([
+      {
+        insert: {
+          PdfBlot: {
+            pdfData: { url: "https://pdf.dev", pdf_name: "doc", pdfSize: 300 },
+          },
+        },
+      },
+    ]);
+    expect(getBlocks(quill)).toEqual([
+      {
+        type: "pdf_url",
+        pdf_url: {
+          url: "https://pdf.dev",
+          pdf_name: "doc",
+          file_name: "doc",
+          pdfSize: 300,
+        },
+      },
+    ]);
+  });
+
+  it("separates text from surrounding media blocks", () => {
+    const quill = mockQuill([
+      { insert: "before" },
+      {
+        insert: {
+          ImageBlot: {
+            imageData: { url: "https://img.com", imgName: "x", imgSize: 100 },
+          },
+        },
+      },
+      { insert: "after" },
+    ]);
+    expect(getBlocks(quill)).toEqual([
+      { type: "text", text: "before" },
+      {
+        type: "image_url",
+        image_url: {
+          url: "https://img.com",
+          imgName: "x",
+          imgSize: 100,
+          img_name: "x",
+          img_size: 100,
+        },
+      },
+      { type: "text", text: "after" },
+    ]);
+  });
+
+  it("handles EditVariable inserts", () => {
+    const quill = mockQuill([
+      { insert: { EditVariable: { fromBlock: true } } },
+      { insert: { EditVariable: { fromBlock: false } } },
+    ]);
+    expect(getBlocks(quill)).toEqual([{ type: "text", text: "}" }]);
+  });
+
+  it("returns empty array for no ops", () => {
+    expect(getBlocks(mockQuill([]))).toEqual([]);
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/nodeFormSchemas.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/nodeFormSchemas.test.js
@@ -79,7 +79,7 @@ describe("getPromptNodeFormSchema", () => {
           content: [
             {
               type: "image_url",
-              imageUrl: { url: "https://example.com/img.png" },
+              image_url: { url: "https://example.com/img.png" },
             },
           ],
         },
@@ -98,7 +98,7 @@ describe("getPromptNodeFormSchema", () => {
           content: [
             {
               type: "pdf_url",
-              pdfUrl: { url: "https://example.com/doc.pdf" },
+              pdf_url: { url: "https://example.com/doc.pdf" },
             },
           ],
         },
@@ -117,7 +117,7 @@ describe("getPromptNodeFormSchema", () => {
           content: [
             {
               type: "audio_url",
-              audioUrl: { url: "https://example.com/audio.mp3" },
+              audio_url: { url: "https://example.com/audio.mp3" },
             },
           ],
         },

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/promptNodeFormUtils.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/promptNodeFormUtils.test.js
@@ -42,7 +42,7 @@ describe("extractVariablesFromContent", () => {
 
   it("ignores non-text blocks", () => {
     const content = [
-      { type: "image_url", imageUrl: { url: "{{not_a_var}}" } },
+      { type: "image_url", image_url: { url: "{{not_a_var}}" } },
       { type: "text", text: "{{real_var}}" },
     ];
     expect(extractVariablesFromContent(content)).toEqual(["real_var"]);

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -35,7 +35,7 @@ const getMessageValidationSchema = () =>
           } else if (item.type === "pdf_url") {
             return item.pdf_url?.url?.trim() !== "";
           } else if (item.type === "image_url") {
-            return item.image_url.url.trim().length > 0;
+            return item.image_url?.url?.trim()?.length > 0;
           }
           return false;
         });

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -31,11 +31,11 @@ const getMessageValidationSchema = () =>
           if (item.type === "text") {
             return item.text.trim().length > 0;
           } else if (item.type === "audio_url") {
-            return item.audioUrl?.url?.trim() !== "";
+            return item.audio_url?.url?.trim() !== "";
           } else if (item.type === "pdf_url") {
-            return item.pdfUrl?.url?.trim() !== "";
+            return item.pdf_url?.url?.trim() !== "";
           } else if (item.type === "image_url") {
-            return item.imageUrl.url.trim().length > 0;
+            return item.image_url.url.trim().length > 0;
           }
           return false;
         });

--- a/frontend/src/sections/agent-playground/utils/__tests__/workflowValidation.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/workflowValidation.test.js
@@ -176,7 +176,7 @@ describe("validateNodeForSave", () => {
           content: [
             {
               type: "image_url",
-              imageUrl: { url: "https://example.com/img.png" },
+              image_url: { url: "https://example.com/img.png" },
             },
           ],
         },
@@ -191,7 +191,10 @@ describe("validateNodeForSave", () => {
         {
           role: "user",
           content: [
-            { type: "pdf_url", pdfUrl: { url: "https://example.com/doc.pdf" } },
+            {
+              type: "pdf_url",
+              pdf_url: { url: "https://example.com/doc.pdf" },
+            },
           ],
         },
       ];
@@ -207,7 +210,7 @@ describe("validateNodeForSave", () => {
           content: [
             {
               type: "audio_url",
-              audioUrl: { url: "https://example.com/audio.mp3" },
+              audio_url: { url: "https://example.com/audio.mp3" },
             },
           ],
         },

--- a/frontend/src/sections/agent-playground/utils/workflowValidation.js
+++ b/frontend/src/sections/agent-playground/utils/workflowValidation.js
@@ -120,9 +120,11 @@ function hasValidUserContent(message) {
     return false;
   return message.content.some((item) => {
     if (item.type === "text") return item.text?.trim().length > 0;
-    if (item.type === "image_url") return item.imageUrl?.url?.trim().length > 0;
-    if (item.type === "pdf_url") return item.pdfUrl?.url?.trim().length > 0;
-    if (item.type === "audio_url") return item.audioUrl?.url?.trim().length > 0;
+    if (item.type === "image_url")
+      return item.image_url?.url?.trim().length > 0;
+    if (item.type === "pdf_url") return item.pdf_url?.url?.trim().length > 0;
+    if (item.type === "audio_url")
+      return item.audio_url?.url?.trim().length > 0;
     return false;
   });
 }

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -40,7 +40,7 @@ const getMessageValidationSchema = () =>
           } else if (item.type === "pdf_url") {
             return item.pdf_url?.url?.trim() !== "";
           } else if (item.type === "image_url") {
-            return item.image_url.url.trim().length > 0;
+            return item.image_url?.url?.trim()?.length > 0;
           }
           return false;
         });

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -36,11 +36,11 @@ const getMessageValidationSchema = () =>
           if (item.type === "text") {
             return item.text.trim().length > 0;
           } else if (item.type === "audio_url") {
-            return item.audioUrl?.url?.trim() !== "";
+            return item.audio_url?.url?.trim() !== "";
           } else if (item.type === "pdf_url") {
-            return item.pdfUrl?.url?.trim() !== "";
+            return item.pdf_url?.url?.trim() !== "";
           } else if (item.type === "image_url") {
-            return item.imageUrl.url.trim().length > 0;
+            return item.image_url.url.trim().length > 0;
           }
           return false;
         });

--- a/frontend/src/sections/develop-detail/Experiment/utils.js
+++ b/frontend/src/sections/develop-detail/Experiment/utils.js
@@ -144,26 +144,17 @@ const _replaceIdWithColumnName = (content, allColumns = []) => {
         };
       }
 
-      // Handle media content (image, pdf, audio) — keys are already snake_case
-      const mediaTypes = {
-        image_url: "image_url",
-        pdf_url: "pdf_url",
-        audio_url: "audio_url",
-      };
-
-      if (mediaTypes[part?.type] && part[mediaTypes[part?.type]]) {
-        const original = part?.[mediaTypes?.[part?.type]];
-        const converted = Object?.fromEntries(
-          Object.entries(original)?.map(([key, value]) => [
+      const MEDIA_TYPES = ["image_url", "pdf_url", "audio_url"];
+      if (MEDIA_TYPES.includes(part?.type) && part[part.type]) {
+        const original = part[part.type];
+        const converted = Object.fromEntries(
+          Object.entries(original).map(([key, value]) => [
             _.snakeCase(key),
             value,
           ]),
         );
 
-        return {
-          ...part,
-          [mediaTypes[part.type]]: converted,
-        };
+        return { ...part, [part.type]: converted };
       }
 
       return part;

--- a/frontend/src/sections/develop-detail/Experiment/utils.js
+++ b/frontend/src/sections/develop-detail/Experiment/utils.js
@@ -144,11 +144,11 @@ const _replaceIdWithColumnName = (content, allColumns = []) => {
         };
       }
 
-      // Handle media content (image, pdf, audio) with nested keys
+      // Handle media content (image, pdf, audio) — keys are already snake_case
       const mediaTypes = {
-        image_url: "imageUrl",
-        pdf_url: "pdfUrl",
-        audio_url: "audioUrl",
+        image_url: "image_url",
+        pdf_url: "pdf_url",
+        audio_url: "audio_url",
       };
 
       if (mediaTypes[part?.type] && part[mediaTypes[part?.type]]) {

--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
@@ -77,9 +77,9 @@ export const ReadOnlyPrompt = ({ title, prompt, allColumns = [] }) => {
             >
               <ImageEmbed
                 key={`image-${i}`}
-                name={prompt[i]?.imageUrl?.imgName}
-                url={prompt[i]?.imageUrl?.url}
-                size={prompt[i]?.imageUrl?.imgSize}
+                name={prompt[i]?.image_url?.img_name}
+                url={prompt[i]?.image_url?.url}
+                size={prompt[i]?.image_url?.img_size}
               />
             </Box>,
           );
@@ -91,9 +91,9 @@ export const ReadOnlyPrompt = ({ title, prompt, allColumns = [] }) => {
             >
               <PdfEmbed
                 key={`pdf-${i}`}
-                name={prompt[i]?.pdfUrl?.fileName}
-                url={prompt[i]?.pdfUrl?.url}
-                size={prompt[i]?.pdfUrl?.pdfSize}
+                name={prompt[i]?.pdf_url?.file_name}
+                url={prompt[i]?.pdf_url?.url}
+                size={prompt[i]?.pdf_url?.pdf_size}
               />
             </Box>,
           );
@@ -105,10 +105,10 @@ export const ReadOnlyPrompt = ({ title, prompt, allColumns = [] }) => {
             >
               <AudioEmbed
                 key={`audio-${i}`}
-                name={prompt[i]?.audioUrl?.audioName}
-                url={prompt[i]?.audioUrl?.url}
-                size={prompt[i]?.audioUrl?.audioSize}
-                mimeType={prompt[i]?.audioUrl?.audioType}
+                name={prompt[i]?.audio_url?.audio_name}
+                url={prompt[i]?.audio_url?.url}
+                size={prompt[i]?.audio_url?.audio_size}
+                mimeType={prompt[i]?.audio_url?.audio_type}
               />
             </Box>,
           );

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -67,26 +67,17 @@ export const transformDefaultData = (editConfigData, allColumns) => {
           };
         }
 
-        // Handle media content (image, pdf, audio) — keys are already snake_case
-        const mediaTypes = {
-          image_url: "image_url",
-          pdf_url: "pdf_url",
-          audio_url: "audio_url",
-        };
-
-        if (mediaTypes[part?.type] && part[mediaTypes[part?.type]]) {
-          const original = part?.[mediaTypes?.[part?.type]];
-          const converted = Object?.fromEntries(
-            Object.entries(original)?.map(([key, value]) => [
+        const MEDIA_TYPES = ["image_url", "pdf_url", "audio_url"];
+        if (MEDIA_TYPES.includes(part?.type) && part[part.type]) {
+          const original = part[part.type];
+          const converted = Object.fromEntries(
+            Object.entries(original).map(([key, value]) => [
               _.snakeCase(key),
               value,
             ]),
           );
 
-          return {
-            ...part,
-            [mediaTypes[part.type]]: converted,
-          };
+          return { ...part, [part.type]: converted };
         }
 
         return part;

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -67,11 +67,11 @@ export const transformDefaultData = (editConfigData, allColumns) => {
           };
         }
 
-        // Handle media content (image, pdf, audio) with nested keys
+        // Handle media content (image, pdf, audio) — keys are already snake_case
         const mediaTypes = {
-          image_url: "imageUrl",
-          pdf_url: "pdfUrl",
-          audio_url: "audioUrl",
+          image_url: "image_url",
+          pdf_url: "pdf_url",
+          audio_url: "audio_url",
         };
 
         if (mediaTypes[part?.type] && part[mediaTypes[part?.type]]) {
@@ -528,7 +528,7 @@ export const TextContent = z.object({
 
 export const ImageContent = z.object({
   type: z.literal("image_url"),
-  imageUrl: z.object({
+  image_url: z.object({
     img_name: z.string().optional(),
     url: z.string(),
     img_size: z.number().optional(),
@@ -537,7 +537,7 @@ export const ImageContent = z.object({
 
 export const PdfContent = z.object({
   type: z.literal("pdf_url"),
-  pdfUrl: z.object({
+  pdf_url: z.object({
     pdf_name: z.string().optional(),
     file_name: z.string().optional(),
     url: z.string(),
@@ -547,7 +547,7 @@ export const PdfContent = z.object({
 
 export const AudioContent = z.object({
   type: z.literal("audio_url"),
-  audioUrl: z.object({
+  audio_url: z.object({
     audio_name: z.string().optional(),
     url: z.string(),
     audio_size: z.number().optional(),
@@ -582,7 +582,9 @@ export const modelTypeByValueType = {
 };
 
 export const getOutputFormatFromCatalogType = (catalogType) =>
-  getOutputFormatForModelType(modelTypeByValueType[catalogType] ?? MODEL_TYPES.LLM);
+  getOutputFormatForModelType(
+    modelTypeByValueType[catalogType] ?? MODEL_TYPES.LLM,
+  );
 
 export const DUMMY_MODEL_PARAMS = [
   {

--- a/frontend/src/sections/develop-detail/RunPrompt/validation.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/validation.js
@@ -33,7 +33,7 @@ const MessageValidationSchema = z
         } else if (item.type === "pdf_url") {
           return item.pdf_url?.url?.trim() !== "";
         } else if (item.type === "image_url") {
-          return item.image_url.url.trim().length > 0;
+          return item.image_url?.url?.trim()?.length > 0;
         }
         return false;
       });

--- a/frontend/src/sections/develop-detail/RunPrompt/validation.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/validation.js
@@ -29,11 +29,11 @@ const MessageValidationSchema = z
         if (item.type === "text") {
           return item.text.trim().length > 0;
         } else if (item.type === "audio_url") {
-          return item.audioUrl?.url?.trim() !== "";
+          return item.audio_url?.url?.trim() !== "";
         } else if (item.type === "pdf_url") {
-          return item.pdfUrl?.url?.trim() !== "";
+          return item.pdf_url?.url?.trim() !== "";
         } else if (item.type === "image_url") {
-          return item.imageUrl.url.trim().length > 0;
+          return item.image_url.url.trim().length > 0;
         }
         return false;
       });

--- a/frontend/src/sections/prompt/NewPrompt/AddNewPrompt.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/AddNewPrompt.jsx
@@ -46,7 +46,7 @@ const transformToPayload = (
         // console.log(type,value);
         const isImage = type === "image_url";
         const typeOfInput = isImage ? "image_url" : "text";
-        const content = isImage ? object.imageUrl : object.text;
+        const content = isImage ? object.image_url : object.text;
         return {
           type: type,
           [typeOfInput]: content,

--- a/frontend/src/sections/prompt/PromptBox/InputPromptBoxV3.jsx
+++ b/frontend/src/sections/prompt/PromptBox/InputPromptBoxV3.jsx
@@ -264,7 +264,7 @@ const InputPromptBoxV3 = ({
         delta.ops.push({
           insert: {
             customImage: {
-              src: block.image_url.url,
+              src: block?.image_url?.url,
               alt: "Uploaded image",
               setSelectedImageId: setSelectedImageId,
               removeImageBlot: removeImageBlot,

--- a/frontend/src/sections/prompt/PromptBox/InputPromptBoxV3.jsx
+++ b/frontend/src/sections/prompt/PromptBox/InputPromptBoxV3.jsx
@@ -264,7 +264,7 @@ const InputPromptBoxV3 = ({
         delta.ops.push({
           insert: {
             customImage: {
-              src: block.imageUrl.url,
+              src: block.image_url.url,
               alt: "Uploaded image",
               setSelectedImageId: setSelectedImageId,
               removeImageBlot: removeImageBlot,

--- a/frontend/src/sections/prompt/prompt-context.js
+++ b/frontend/src/sections/prompt/prompt-context.js
@@ -12,7 +12,7 @@ import { getRandomId } from "src/utils/utils";
  * @property {"user" | "system" | "assistant"} promptConfigSnapshot.messages[].role
  * @property {Object[]} promptConfigSnapshot.messages[].content
  * @property {string} [promptConfigSnapshot.messages[].content[].text] - Optional
- * @property {{url: string}} [promptConfigSnapshot.messages[].content[].imageUrl] - Optional
+ * @property {{url: string}} [promptConfigSnapshot.messages[].content[].image_url] - Optional
  * @property {"text" | "image_url"} promptConfigSnapshot.messages[].content[].type
  * @property {Object} promptConfigSnapshot.configuration
  * @property {string} promptConfigSnapshot.configuration.model

--- a/frontend/src/sections/workbench/createPrompt/Playground/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Playground/common.js
@@ -62,13 +62,13 @@ export function isContentNotEmpty(contentArray) {
       return item.text.trim() !== "";
     }
     if (item.type === "image_url") {
-      return item.imageUrl?.url?.trim() !== "";
+      return item.image_url?.url?.trim() !== "";
     }
     if (item.type === "audio_url") {
-      return item.audioUrl?.url?.trim() !== "";
+      return item.audio_url?.url?.trim() !== "";
     }
     if (item.type === "pdf_url") {
-      return item.pdfUrl?.url?.trim() !== "";
+      return item.pdf_url?.url?.trim() !== "";
     }
     return false;
   });

--- a/futureagi/model_hub/serializers/run_prompt.py
+++ b/futureagi/model_hub/serializers/run_prompt.py
@@ -315,11 +315,14 @@ class PromptConfigSerializer(serializers.Serializer):
         if item_type == "text":
             return bool(item.get("text", "").strip())
         elif item_type == "image_url":
-            return bool(item.get("imageUrl", {}).get("url", "").strip())
+            outer = item.get("image_url") or item.get("imageUrl") or {}
+            return bool(outer.get("url", "").strip())
         elif item_type == "audio_url":
-            return bool(item.get("audioUrl", {}).get("url", "").strip())
+            outer = item.get("audio_url") or item.get("audioUrl") or {}
+            return bool(outer.get("url", "").strip())
         elif item_type == "pdf_url":
-            return bool(item.get("pdfUrl", {}).get("url", "").strip())
+            outer = item.get("pdf_url") or item.get("pdfUrl") or {}
+            return bool(outer.get("url", "").strip())
         return False
 
     def validate(self, attrs):


### PR DESCRIPTION
## Summary

Fixes prompt runs (workbench + simulations) failing with `KeyError('image_url')`, `ERROR_DOWNLOADING_IMAGE`, and `ERROR_DOWNLOADING_DOCUMENT` when messages contain attached images, PDFs, or audio. The frontend `getBlocks()` produced camelCase keys (`imageUrl`/`pdfUrl`/`audioUrl`) but the backend's `handle_media()` expected snake_case (`image_url`/`pdf_url`/`audio_url`), causing a `KeyError` on image (toast: 'image_url'), and `None` doc_url for PDFs (leading to download failure).

## Linked issues

Closes [TH-6264](https://linear.app/future-agi/issue/TH-6264/document-prompt-run-not-working)

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. CamelCase → snake_case migration for media content block keys**

* Frontend `getBlocks()` in `PromptCards/common.js` now outputs `image_url`, `pdf_url`, `audio_url` instead of `imageUrl`, `pdfUrl`, `audioUrl`
* Block renderers (`PromptEditor.jsx`, `ExpandedPrompt.jsx`) read snake_case with camelCase fallback for backward compatibility with existing saved prompts
* Zod validation schemas (`RunPrompt/common.js` — `ImageContent`, `PdfContent`, `AudioContent`) now expect snake_case outer keys
* Converter/mapper functions (`RunPrompt/common.js`, `Experiment/utils.js`) updated — media type map changed from camelCase target to identity
* All validation consumers updated: `RunPrompt/validation.js`, `Experiment/schema.js`, `agent-playground/nodeFormSchemas.js`, `agent-playground/workflowValidation.js`, `workbench/Playground/common.js`
* All display consumers updated: `RunPrompt/Modals/ImportPrompt.jsx`, `prompt/PromptBox/InputPromptBoxV3.jsx`, `prompt/NewPrompt/AddNewPrompt.jsx`
* JSDoc comment in `prompt/prompt-context.js` updated

**B. Test fixture updates**

* 3 test files updated with 7 fixture keys migrated from camelCase to snake_case
* All 94 affected tests pass (nodeFormSchemas 20, workflowValidation 56, promptNodeFormUtils 18)

**C. No backend changes**

* `handle_media()` in `prompt_template.py` already uses snake_case — no changes needed

---

## 2) Why the changes were done

* **Product/UX:** Users couldn't run prompts with attached images, PDFs, or audio in the prompt workbench — the prompt run would fail immediately with a toast error
* **Technical:** Key mismatch at the boundary between frontend producer (`getBlocks`) and backend consumer (`handle_media`). Both the `CONFIG_KEY_MAP` in `createPrompt/common.js` and the `RunPrompt/common.js` converter only handled inner object keys, leaving the outer block keys as camelCase
* **Architecture:** Chose snake_case everywhere (frontend + backend) over a normalization shim in the backend, since all consumers in the codebase follow the same `imageUrl`/etc. patterns and benefit from consistency

---

## 4) How to run / test

https://github.com/user-attachments/assets/eed0a494-2e5d-4b90-9e2a-eea5179e61f1

### Frontend tests

<img src="https://github.com/user-attachments/assets/dfc9ed4e-c85c-433c-99e6-35a40d1a06e9 " alt="SCR-20260701-joow" width="514" data-linear-height="386" />

```bash
cd frontend
yarn test:run
```

### UI steps (manual)

1. Open the prompt workbench, add a message
2. Attach an image or PDF via the upload button
3. Verify the media embed appears correctly in the editor
4. Set a model that supports vision/PDF input (e.g. GPT-4o)
5. Click Run — the prompt should execute successfully
6. Previously this would show "image_url" or "ERROR_DOWNLOADING_DOCUMENT: Max retries exceeded" as a toast error

---

## 6) Edge cases & considerations

* **Existing saved prompts with camelCase keys:** `PromptEditor` and `ExpandedPrompt` read both `image_url` and `imageUrl` (with snake_case preferred, camelCase as fallback) so old prompts still load and render correctly. On next save, they'll be written in snake_case
* **Prompt template run (workbench) vs dataset run-prompt:** Both flows call `handle_media()`. The dataset flow (`process_text_with_media`) already constructed snake_case dicts explicitly, so it was not affected
* **Audio handler:** The audio handler wraps everything in try/except and returns `None` on failure, so the KeyError was silently swallowed before the fix — audio uploads would just not work rather than visibly crash
* **No API contract change:** The OpenAPI schema does not validate inner content block structure, so no contract regeneration needed

---

## Checklist

- [X] My code follows the style guide
- [X] `yarn test:run` passes locally (frontend)
- [X] No hardcoded secrets, URLs, or PII
- [X] PR title follows Conventional Commits
- [X] Linear issue is linked