### PR TITLE
[TH-6359] Guard undefined config.messages in Run Prompt template section

### DIFF
--- a/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
@@ -34,7 +34,7 @@ const PromptTemplatesSection = ({
   });
   const [expandPrompt, setExpandPrompt] = useState({});
 
-  const messages = watch("config.messages");
+  const messages = watch("config.messages") || [];
 
   const memoizedMentionValues = useMemo(() => {
     return getDropdownOptionsFromCols(


### PR DESCRIPTION
**Ticket:** [TH-6359](https://linear.app/future-agi/issue/TH-6359/creating-an-optimizer-run-crashes-the-frontend) — Fixes TH-6359

> ⚠️ **Stacked on #1142** (`fix/th-6266-import-run-prompt`). Review against that base — the import-casing fix lives there; this PR only adds the one-line crash guard on top.

## What was the bug
Opening the Run Prompt drawer in **create mode** (e.g. via the optimizer's empty-state **"Run Prompt"** button — test case 27.1) crashed the whole frontend with `Cannot read properties of undefined (reading 'map')` in `PromptTemplatesSection`.

## What changes have been done
- `frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx` — default the watched messages to an empty array: `const messages = watch("config.messages") || [];`

## Why the changes
- `config.messages` is owned by `useFieldArray`. In RHF v7 a field array's value is **not mirrored into `_formValues` until it's mutated**, so `watch("config.messages")` returns `undefined` on the drawer's first render (while `fields` already holds the 2 default messages).
- The default model type is `llm`, so the LLM-gated `PromptTemplatesSection` renders on that first pass and the bare `messages.map(...)` at line 71 throws.
- Every other read in the component is already defensive (`messages?.[idx]?.role`) or renders from `fields`; only this line was unguarded. Defaulting to `[]` closes the pre-materialization window with no behavior change.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Optimizer → empty-state "Run Prompt" → drawer opens (LLM default) | No crash; prompt template renders |
| 2 | Dataset → "Run Prompt" create drawer | No crash on open |
| 3 | Import a saved prompt into the drawer | Model / roles / message content populate (via #1142 base) |
| 4 | Edit an existing Run Prompt column | Messages hydrate and render as before |

## How to reproduce (original bug)
1. Open a dataset → start an optimizer run flow.
2. Click the empty-state **"Run Prompt"** button (opens the drawer in create mode, model type = LLM).
3. Frontend crashes at `PromptTemplatesSection.jsx:71`.

## Videos and screenshots

https://github.com/user-attachments/assets/3d2cd143-21c5-4a44-ad2f-d64bf369016c
https://github.com/user-attachments/assets/e471abd3-8400-40ec-8e87-0e9ab9e9e5d2


