### PR TITLE
[TH-6375] Keep current version selected after a run completes

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -175,7 +175,10 @@ const WorkbenchProvider = ({ children }) => {
       const newPre = [...pre];
       const newValue =
         typeof valueOrUpdater === "function"
-          ? { id: pre[index]?.id, prompts: valueOrUpdater(pre[index]?.prompts ?? []) }
+          ? {
+              id: pre[index]?.id,
+              prompts: valueOrUpdater(pre[index]?.prompts ?? []),
+            }
           : valueOrUpdater;
 
       newPre[index] = newValue;
@@ -554,18 +557,24 @@ const WorkbenchProvider = ({ children }) => {
       return;
     }
     setPromptName(data?.name);
-    setSelectedVersions([
-      {
-        isDraft: data?.is_draft,
-        version: data?.version,
-        lastSaved: data?.last_saved,
-        isDefault: data?.is_default,
-        labels: data?.labels || [],
-        originalTemplate: data?.original_template || id,
-        templateVersion: data?.template_version,
-        id: getRandomId(),
-      },
-    ]);
+    // Hydrate only when nothing is selected; a post-run refetch must not
+    // clobber the version the user is currently on.
+    setSelectedVersions((prev) =>
+      prev.length === 0
+        ? [
+            {
+              isDraft: data?.is_draft,
+              version: data?.version,
+              lastSaved: data?.last_saved,
+              isDefault: data?.is_default,
+              labels: data?.labels || [],
+              originalTemplate: data?.original_template || id,
+              templateVersion: data?.template_version,
+              id: getRandomId(),
+            },
+          ]
+        : prev,
+    );
     if (data?.is_draft) {
       setCurrentTab("Playground");
     }


### PR DESCRIPTION
**Ticket:** [TH-6375](https://linear.app/future-agi/issue/TH-6375/prompt-workbench-reverts-to-default-version-after-a-run-completes) — Fixes TH-6375

## What was the bug
In the Prompt Workbench, running a prompt while on a non-default version silently reverted the version badge to the **default** version once the run completed — while the editor kept the run's version. The badge and the shown prompt ended up out of sync.

## What changes have been done
- `frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx` — the `[data]` effect now hydrates `selectedVersions` **only when nothing is selected** (`prev.length === 0 ? [...] : prev`) instead of unconditionally overwriting it.

## Why the changes
- Running a prompt commits the draft and `saveAndRun` selects the new version (e.g. v6).
- Run completion invalidates `["prompt-latest-version"]`, which refetches `GET /prompt-templates/{id}/` = the template's **default** version (v4, since after commit no draft exists and `retrieve` returns draft-else-default).
- The `[data]` effect then re-ran and **unconditionally** reset the selection to that default, clobbering v6 → v4. The editor content wasn't reset (already `!…length`-guarded), so only the badge desynced.
- Guarding hydration to the empty-selection case preserves the version the user is actually on. All explicit flows (draft/commit/run/compare/restore) set the selection themselves, so the effect only needs to seed the initial load.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Edit → Run a non-default version | Badge stays on the run's version, in sync with the editor |
| 2 | Initial load / deep-link with a version | Badge hydrates to the correct version |
| 3 | `reset()` / new prompt | Selection re-hydrates correctly |
| 4 | Compare mode (2+ versions) | Unaffected (that query is disabled for length > 1) |
| 5 | Commit-as-default / restore | Badge behavior unchanged (driven by the action handlers, not this effect) |

## How to reproduce (original bug)
1. Open a prompt with a default version (e.g. v4).
2. Edit the prompt → it becomes a draft.
3. Click **Run Prompt** and wait for completion.
4. Bug: the badge flips back to v4 while the editor still shows the run's version.

## Videos and screenshots
https://github.com/user-attachments/assets/00574f62-66f5-4c37-8234-34969d1c75dd



## Notes for reviewers
- Verified end-to-end (runtime-logged): the flip is the `[data]` effect at completion; the guard preserves the selection on every refetch and doesn't affect compare / commit-as-default / restore (`is_default`/`labels` aren't even present in that retrieve response — those come from the action handlers).
- Out of scope (separate ticket): the run WebSocket (`/ws/prompt-stream/`) is falling back to HTTP polling — a different subsystem, not touched here.
