### PR TITLE
fix(annotations): open new V2 trace drawer in session annotation flow [TH-6345]

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -4,8 +4,6 @@ import { render, screen, waitFor, userEvent } from "src/utils/test-utils";
 import axios from "src/utils/axios";
 import ContentPanel from "../annotate/content-panel";
 
-const traceDetailDrawerMock = vi.hoisted(() => vi.fn());
-
 vi.mock("src/components/iconify", () => ({
   default: ({ icon, ...props }) => (
     <span data-testid="iconify" data-icon={icon} {...props} />
@@ -93,19 +91,6 @@ vi.mock("src/components/CallLogsDetailDrawer/RightSection", () => ({
   default: () => <div data-testid="call-right-section" />,
 }));
 
-vi.mock("src/components/traceDetailDrawer/trace-detail-drawer", () => ({
-  default: (props) => {
-    traceDetailDrawerMock(props);
-    return (
-      <div
-        data-testid="trace-detail-drawer"
-        data-trace-id={props.traceData?.trace_id || ""}
-        data-camel-trace-id={props.traceData?.traceId || ""}
-      />
-    );
-  },
-}));
-
 vi.mock("src/components/traceDetail/SpanTreeTimeline", () => ({
   default: () => <div data-testid="span-tree" />,
 }));
@@ -152,7 +137,6 @@ describe("Annotation queue ContentPanel", () => {
   const clipboardWriteText = vi.fn(() => Promise.resolve());
 
   beforeEach(() => {
-    traceDetailDrawerMock.mockClear();
     clipboardWriteText.mockClear();
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: clipboardWriteText },
@@ -292,8 +276,7 @@ describe("Annotation queue ContentPanel", () => {
     });
   });
 
-  it("opens session traces with the backend trace_id contract key", async () => {
-    const user = userEvent.setup();
+  it("renders session traces without the legacy trace detail drawer", async () => {
     axios.get.mockResolvedValueOnce({
       data: {
         result: {
@@ -328,22 +311,11 @@ describe("Annotation queue ContentPanel", () => {
       </QueryClientProvider>,
     );
 
-    await user.click(await screen.findByText("customer asks for help"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("trace-detail-drawer")).toHaveAttribute(
-        "data-trace-id",
-        "trace-123",
-      );
-    });
-    expect(screen.getByTestId("trace-detail-drawer")).toHaveAttribute(
-      "data-camel-trace-id",
-      "",
-    );
-    expect(traceDetailDrawerMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        traceData: expect.objectContaining({ trace_id: "trace-123" }),
-      }),
-    );
+    // Session traces render, and the legacy trace-detail-drawer is gone — the
+    // per-card "View Trace" button now opens TraceDetailDrawerV2 instead.
+    expect(
+      await screen.findByText("customer asks for help"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("trace-detail-drawer")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -33,8 +33,6 @@ import axios, { endpoints } from "src/utils/axios";
 import SessionHistory from "src/sections/projects/TracesDrawer/SessionHistory";
 import { useScrollEnd } from "src/hooks/use-scroll-end";
 import { canonicalKeys, formatMs } from "src/utils/utils";
-import TraceDetailDrawer from "src/components/traceDetailDrawer/trace-detail-drawer";
-import { SelectedNodeProvider } from "src/components/traceDetailDrawer/selectedNodeContext";
 import SpanTreeTimeline from "src/components/traceDetail/SpanTreeTimeline";
 import SpanDetailPane from "src/components/traceDetail/SpanDetailPane";
 import LeftPanelSplit from "src/components/traceDetail/TraceLeftPanel";
@@ -1612,7 +1610,6 @@ SimulationContent.propTypes = {
 // ---------------------------------------------------------------------------
 function SessionContent({ content }) {
   const sessionId = content?.session_id;
-  const [openTraceData, setOpenTraceData] = useState(null);
 
   const {
     data: tracePages,
@@ -1636,10 +1633,6 @@ function SessionContent({ content }) {
       fetchNextPage();
     }
   }, [isFetchingNextPage, isLoading]);
-
-  const handleTraceClick = useCallback((traceId) => {
-    setOpenTraceData({ trace_id: traceId });
-  }, []);
 
   const sessionMetadata = tracePages?.pages[0]?.data?.result?.session_metadata;
   const traceDetail =
@@ -1696,23 +1689,8 @@ function SessionContent({ content }) {
           loading={isLoading}
           isFetchingNextPage={isFetchingNextPage}
           activeSessionId={sessionId}
-          onTraceClick={handleTraceClick}
         />
       </Box>
-
-      {/* Trace detail side drawer */}
-      <SelectedNodeProvider>
-        <TraceDetailDrawer
-          open={Boolean(openTraceData)}
-          onClose={() => setOpenTraceData(null)}
-          traceData={openTraceData}
-          setTraceDetailDrawerOpen={null}
-          setSelectedTraceId={(newTraceId) =>
-            setOpenTraceData((prev) => ({ ...prev, trace_id: newTraceId }))
-          }
-          viewOptions={{ showAnnotation: true, showNavigation: false }}
-        />
-      </SelectedNodeProvider>
     </Stack>
   );
 }

--- a/frontend/src/sections/projects/SessionsView/TraceCardRightSection.jsx
+++ b/frontend/src/sections/projects/SessionsView/TraceCardRightSection.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router";
 import { Typography, Box, Button, Stack, Tabs, Tab } from "@mui/material";
 import TraceDetailDrawerV2 from "src/components/traceDetail/TraceDetailDrawerV2";
+import { useGetTraceDetail } from "src/api/project/trace-detail";
 import SvgColor from "src/components/svg-color";
 import { ShowComponent } from "src/components/show";
 import EvaluationsContent from "./EvaluationsContent";
@@ -47,6 +48,12 @@ const TraceCardRightSection = ({
   };
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+
+  const { data: traceDetail } = useGetTraceDetail(
+    isDrawerOpen ? traceId : null,
+  );
+  const projectId = observeId || traceDetail?.trace?.project;
 
   return (
     <Box
@@ -171,7 +178,10 @@ const TraceCardRightSection = ({
           size="small"
           fullWidth
           sx={{ borderRadius: "8px" }}
-          onClick={() => setIsDrawerOpen(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsDrawerOpen(true);
+          }}
           startIcon={
             <SvgColor
               src="/assets/icons/custom/eye.svg"
@@ -197,7 +207,7 @@ const TraceCardRightSection = ({
         traceId={traceId}
         open={isDrawerOpen}
         onClose={() => setIsDrawerOpen(false)}
-        projectId={observeId}
+        projectId={projectId}
         hasPrev={false}
         hasNext={false}
       />


### PR DESCRIPTION
## Summary

Fixes the session annotation flow so clicking **View Trace** opens the current `TraceDetailDrawerV2`, not the legacy trace drawer.

## Why / problem

In the annotate session-history, each trace card had two competing click targets:

- The **card body** opened the legacy `TraceDetailDrawer` (via `onTraceClick`).
- The **"View Trace" button** opened `TraceDetailDrawerV2`.

The button did **not** call `e.stopPropagation()`, so clicking it also bubbled up to the card handler and the old drawer surfaced on top. On top of that, the annotate route (`queues/:queueId/annotate`) has no `:observeId` param, so V2 was rendered with `projectId={undefined}` — which broke its saved-views request and produced the backend error seen in the ticket.

## What changed

- **`frontend/src/sections/projects/SessionsView/TraceCardRightSection.jsx`**
  - `View Trace` button now calls `e.stopPropagation()` so it only opens V2.
  - `projectId` falls back to the trace's own project (`traceDetail?.trace?.project`) when the route has no `:observeId`. It's fetched via `useGetTraceDetail` only while the drawer is open, and shares V2's own cached `trace-detail` query (no extra request).
- **`frontend/src/sections/annotations/queues/annotate/content-panel.jsx`**
  - Removed the legacy `TraceDetailDrawer` path from `SessionContent`: its import, the `SelectedNodeProvider` wrapper, the `openTraceData` state, `handleTraceClick`, and the `onTraceClick` prop.

Result: **View Trace** opens the new V2 drawer consistently in both the annotate flow and the traces drawer, with a valid `projectId`.

## Tests

- [ ] No automated tests added (UI-only wiring change).

## Commands

- [x] `yarn eslint` (both changed files clean)

## Backwards compatibility

Frontend-only. No API or contract changes. The other consumer of this card (`TracesDrawer`) already opened V2 and is unaffected (there `projectId` still resolves from `:observeId`).

## Manual verification

- [ ] Add a session to an annotation queue → open the session → click a trace's **View Trace**: the new V2 drawer opens (not the old drawer), and no backend error appears.
- [ ] In the regular traces drawer (observe flow), **View Trace** still opens V2 as before.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the project style
- [x] Self-reviewed the changes
- [x] Lint passes

## Backout / rollback

Revert this PR's commit — isolated to two frontend files, no migrations or contract changes.

## Linear

- Fixes TH-6345

## Note

The ticket mentions the flow also surfaced a backend error. That error was the saved-views request firing with an undefined `projectId`; supplying a valid `projectId` to V2 resolves it from the frontend. If a separate backend hardening is still wanted, it can be tracked independently.
