### PR TITLE
[TH-6271][TH-6270] Fix simulation version auto-select, run values, and Last Run

### DIFF
--- a/frontend/src/components/run-tests/RunTestsContent.jsx
+++ b/frontend/src/components/run-tests/RunTestsContent.jsx
@@ -511,8 +511,8 @@ const RunTestsContent = ({
         header: "Last Run",
         size: 150,
         enableSorting: false,
-        cell: ({ getValue }) => {
-          const v = getValue();
+        cell: ({ row }) => {
+          const v = row.original.last_run_at;
           return (
             <Typography
               variant="body2"

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -17,6 +17,7 @@ import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import SvgColor from "src/components/svg-color";
 import axios, { endpoints } from "src/utils/axios";
+import { getVersionLabel } from "src/utils/utils";
 import { ShowComponent } from "src/components/show";
 import WorkflowBuilderOption from "./WorkflowBuilderOption";
 import ImportDatasetOption from "./ImportDatasetOption";
@@ -227,9 +228,7 @@ const CreateScenarioView = () => {
   const promptVersionOptions = useMemo(() => {
     const results = promptVersionsData?.results || promptVersionsData || [];
     return results.map((version) => {
-      const versionLabel = String(version.template_version).startsWith("v")
-        ? version.template_version
-        : `v${version.template_version}`;
+      const versionLabel = getVersionLabel(version.template_version);
       return {
         label: versionLabel,
         value: version.id,

--- a/frontend/src/sections/test/TestDetailHeader.jsx
+++ b/frontend/src/sections/test/TestDetailHeader.jsx
@@ -21,6 +21,7 @@ import { useNavigate, useParams } from "react-router";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
 import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
+import { getVersionLabel } from "src/utils/utils";
 import { resetState, useTestEvaluationStoreShallow } from "./states";
 import { useIsMutating } from "@tanstack/react-query";
 import { useTestRunsList } from "src/api/tests/testRuns";
@@ -448,7 +449,7 @@ const TestDetailHeader = () => {
                         testData?.prompt_version_detail?.template_version ??
                         testData?.promptVersionDetail?.templateVersion;
                       if (!tv) return "-";
-                      return String(tv).startsWith("v") ? tv : `v${tv}`;
+                      return getVersionLabel(tv);
                     })()
                   )}
                 </Button>

--- a/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
@@ -29,6 +29,7 @@ import { useParams } from "react-router";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "src/components/snackbar";
 import axios, { endpoints } from "src/utils/axios";
+import { getVersionLabel } from "src/utils/utils";
 import { format } from "date-fns";
 import { useGetScenarioList } from "src/api/scenarios/scenarios";
 import { AGENT_TYPES } from "src/sections/agents/constants";
@@ -232,11 +233,7 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
               {versions.map((version) => (
                 <MenuItem key={version.id} value={version.id}>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <span>
-                      {String(version.template_version).startsWith("v")
-                        ? version.template_version
-                        : `v${version.template_version}`}
-                    </span>
+                    <span>{getVersionLabel(version.template_version)}</span>
                     {version.is_default && (
                       <Typography
                         component="span"

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
@@ -5,15 +5,13 @@ import {
   CircularProgress,
   IconButton,
   InputAdornment,
-  MenuItem,
-  Select,
   Skeleton,
   TextField,
   Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 import React, {
   useCallback,
@@ -27,6 +25,7 @@ import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "src/components/snackbar";
 import axios, { endpoints } from "src/utils/axios";
 import { useSimulationDetailContext } from "./context/SimulationDetailContext";
+import VersionSelect from "./VersionSelect";
 import SimulationEvaluationDrawer from "./SimulationEvaluationDrawer";
 import SimulationExecutionsSelection from "./SimulationExecutionsSelection";
 import {
@@ -107,21 +106,6 @@ const SimulationDetailHeader = ({ onBack }) => {
     setSelectAll(false);
   }, [getGridApi, setToggledNodes, setSelectAll]);
 
-  // Fetch prompt versions filtered by current template
-  const { data: versionsData, isLoading: isLoadingVersions } = useQuery({
-    queryKey: ["prompt-versions-for-simulation-detail", promptTemplateId],
-    queryFn: async () => {
-      const res = await axios.get(
-        endpoints.develop.runPrompt.getPromptVersions(),
-        { params: { template_id: promptTemplateId } },
-      );
-      return res.data;
-    },
-    enabled: !!promptTemplateId,
-  });
-
-  const versions = versionsData?.results || [];
-
   const isInitializedRef = useRef(false);
   const isSyncingRef = useRef(false);
   const prevScenariosRef = useRef(null);
@@ -131,7 +115,7 @@ const SimulationDetailHeader = ({ onBack }) => {
   if (simulation && !isInitializedRef.current) {
     skipNextSyncRef.current = true;
     setSelectedVersion(
-      simulation.promptVersion || simulation.promptVersionDetail?.id || "",
+      simulation.prompt_version || simulation.prompt_version_detail?.id || "",
     );
     setSelectedScenarios(simulation.scenarios || []);
     prevScenariosRef.current = simulation.scenarios || [];
@@ -198,8 +182,7 @@ const SimulationDetailHeader = ({ onBack }) => {
     }
   }, [simulation, selectedScenarios, updateSimulation]);
 
-  const handleVersionChange = (event) => {
-    const newVersion = event.target.value;
+  const handleVersionChange = (newVersion) => {
     if (newVersion === "create-new") {
       window.open(
         `/dashboard/workbench/create/${promptTemplateId}?tab=Playground`,
@@ -230,13 +213,6 @@ const SimulationDetailHeader = ({ onBack }) => {
       );
     },
   });
-
-  const getVersionLabel = (version) => {
-    const v = String(version.template_version).startsWith("v")
-      ? version.template_version
-      : `v${version.template_version}`;
-    return v;
-  };
 
   if (isLoading) {
     return (
@@ -329,59 +305,13 @@ const SimulationDetailHeader = ({ onBack }) => {
                 >
                   Version:
                 </Typography>
-                <Select
+                <VersionSelect
+                  promptTemplateId={promptTemplateId}
                   value={selectedVersion}
                   onChange={handleVersionChange}
-                  disabled={isLoadingVersions || isUpdating}
-                  size="small"
-                  displayEmpty
-                  renderValue={(value) => {
-                    if (!value) return "Select";
-                    const version = versions.find((v) => v.id === value);
-                    return version ? getVersionLabel(version) : "Select";
-                  }}
-                  sx={{
-                    minWidth: 80,
-                    "& .MuiSelect-select": { py: 0.5, fontSize: "0.8rem" },
-                    "& .MuiOutlinedInput-notchedOutline": {
-                      borderColor: theme.palette.divider,
-                    },
-                  }}
-                >
-                  {versions.map((version) => (
-                    <MenuItem key={version.id} value={version.id}>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <span>{getVersionLabel(version)}</span>
-                        {version.is_default && (
-                          <Chip
-                            label="Default"
-                            size="small"
-                            sx={{ height: 16, fontSize: "0.55rem" }}
-                            color="primary"
-                          />
-                        )}
-                      </Box>
-                    </MenuItem>
-                  ))}
-                  <MenuItem
-                    value="create-new"
-                    sx={{
-                      borderTop: `1px solid ${theme.palette.divider}`,
-                      mt: 0.5,
-                    }}
-                  >
-                    <Box display="flex" alignItems="center" gap={0.5}>
-                      <Iconify
-                        icon="mdi:plus"
-                        width={16}
-                        sx={{ color: theme.palette.primary.main }}
-                      />
-                      <Typography variant="caption" color="primary">
-                        New Version
-                      </Typography>
-                    </Box>
-                  </MenuItem>
-                </Select>
+                  versionDetail={simulation?.prompt_version_detail}
+                  disabled={isUpdating}
+                />
               </Box>
 
               {/* Scenarios Button */}

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/VersionSelect.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/VersionSelect.jsx
@@ -6,11 +6,12 @@ import {
   Skeleton,
   Typography,
 } from "@mui/material";
-import { useInfiniteQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 import React, { useMemo, useRef, useState } from "react";
 import Iconify from "src/components/iconify";
-import axios, { endpoints } from "src/utils/axios";
+import { ShowComponent } from "src/components/show";
+import { usePromptVersions } from "src/api/develop/prompt";
+import { getVersionLabel } from "src/utils/utils";
 import { useScrollEnd } from "src/hooks/use-scroll-end";
 
 const VERSION_SHAPE = PropTypes.shape({
@@ -18,11 +19,6 @@ const VERSION_SHAPE = PropTypes.shape({
   template_version: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   is_default: PropTypes.bool,
 });
-
-const getVersionLabel = (version) =>
-  String(version?.template_version).startsWith("v")
-    ? version.template_version
-    : `v${version?.template_version}`;
 
 const VersionPopoverContent = ({
   versions,
@@ -48,24 +44,30 @@ const VersionPopoverContent = ({
             onClick={() => onSelect(version.id)}
           >
             <Box display="flex" alignItems="center" gap={0.5}>
-              <span>{getVersionLabel(version)}</span>
-              {version.is_default && (
+              <span>{getVersionLabel(version?.template_version)}</span>
+              <ShowComponent condition={version.is_default}>
                 <Chip
                   label="Default"
                   size="small"
-                  sx={{ height: 16, fontSize: "0.55rem" }}
+                  sx={{
+                    height: 16,
+                    "& .MuiChip-label": {
+                      fontSize: (theme) => theme.typography.s3.fontSize,
+                    },
+                  }}
                   color="primary"
                 />
-              )}
+              </ShowComponent>
             </Box>
           </MenuItem>
         ))}
-        {isFetchingNextPage &&
-          Array.from({ length: 2 }).map((_, index) => (
+        <ShowComponent condition={isFetchingNextPage}>
+          {Array.from({ length: 2 }).map((_, index) => (
             <MenuItem key={`version-skeleton-${index}`} disabled>
               <Skeleton variant="text" width={48} sx={{ fontSize: "0.8rem" }} />
             </MenuItem>
           ))}
+        </ShowComponent>
       </Box>
       <Box sx={{ borderTop: "1px solid", borderColor: "divider", p: 0.5 }}>
         <Box
@@ -113,20 +115,7 @@ const VersionSelect = ({
   const anchorRef = useRef(null);
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ["prompt-versions-for-simulation-detail", promptTemplateId],
-      queryFn: async ({ pageParam = 1 }) => {
-        const res = await axios.get(
-          endpoints.develop.runPrompt.getPromptVersions(),
-          { params: { template_id: promptTemplateId, page: pageParam } },
-        );
-        return res.data;
-      },
-      getNextPageParam: (lastPage) =>
-        lastPage?.next ? (lastPage?.current_page || 1) + 1 : undefined,
-      initialPageParam: 1,
-      enabled: !!promptTemplateId,
-    });
+    usePromptVersions(promptTemplateId);
 
   const versions = useMemo(
     () => data?.pages?.flatMap((page) => page?.results || []) || [],
@@ -136,8 +125,9 @@ const VersionSelect = ({
   const selectedLabel = useMemo(() => {
     if (!value) return "Select";
     const match = versions.find((v) => v.id === value);
-    if (match) return getVersionLabel(match);
-    if (versionDetail?.id === value) return getVersionLabel(versionDetail);
+    if (match) return getVersionLabel(match.template_version);
+    if (versionDetail?.id === value)
+      return getVersionLabel(versionDetail.template_version);
     return "Select";
   }, [value, versions, versionDetail]);
 
@@ -164,7 +154,7 @@ const VersionSelect = ({
           "&:hover": { borderColor: "text.disabled" },
         }}
       >
-        <Typography sx={{ fontSize: "0.8rem", color: "text.primary" }}>
+        <Typography variant="s2" sx={{ color: "text.primary" }}>
           {selectedLabel}
         </Typography>
         <Iconify

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/VersionSelect.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/VersionSelect.jsx
@@ -1,0 +1,221 @@
+import {
+  Box,
+  Chip,
+  MenuItem,
+  Popover,
+  Skeleton,
+  Typography,
+} from "@mui/material";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+import React, { useMemo, useRef, useState } from "react";
+import Iconify from "src/components/iconify";
+import axios, { endpoints } from "src/utils/axios";
+import { useScrollEnd } from "src/hooks/use-scroll-end";
+
+const VERSION_SHAPE = PropTypes.shape({
+  id: PropTypes.string,
+  template_version: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  is_default: PropTypes.bool,
+});
+
+const getVersionLabel = (version) =>
+  String(version?.template_version).startsWith("v")
+    ? version.template_version
+    : `v${version?.template_version}`;
+
+const VersionPopoverContent = ({
+  versions,
+  selectedVersion,
+  onSelect,
+  onCreateNew,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+}) => {
+  const scrollRef = useScrollEnd(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage]);
+
+  return (
+    <>
+      <Box ref={scrollRef} sx={{ p: 0.5, overflowY: "auto", flex: 1 }}>
+        {versions?.map((version) => (
+          <MenuItem
+            key={version.id}
+            selected={version.id === selectedVersion}
+            onClick={() => onSelect(version.id)}
+          >
+            <Box display="flex" alignItems="center" gap={0.5}>
+              <span>{getVersionLabel(version)}</span>
+              {version.is_default && (
+                <Chip
+                  label="Default"
+                  size="small"
+                  sx={{ height: 16, fontSize: "0.55rem" }}
+                  color="primary"
+                />
+              )}
+            </Box>
+          </MenuItem>
+        ))}
+        {isFetchingNextPage &&
+          Array.from({ length: 2 }).map((_, index) => (
+            <MenuItem key={`version-skeleton-${index}`} disabled>
+              <Skeleton variant="text" width={48} sx={{ fontSize: "0.8rem" }} />
+            </MenuItem>
+          ))}
+      </Box>
+      <Box sx={{ borderTop: "1px solid", borderColor: "divider", p: 0.5 }}>
+        <Box
+          onClick={onCreateNew}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.5,
+            color: "primary.main",
+            cursor: "pointer",
+            py: 0.5,
+            px: 1,
+            borderRadius: 0.5,
+            "&:hover": { bgcolor: "action.hover" },
+          }}
+        >
+          <Iconify icon="mdi:plus" width={16} sx={{ color: "primary.main" }} />
+          <Typography variant="caption" color="primary">
+            New Version
+          </Typography>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+VersionPopoverContent.propTypes = {
+  versions: PropTypes.arrayOf(VERSION_SHAPE).isRequired,
+  selectedVersion: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+  onCreateNew: PropTypes.func.isRequired,
+  fetchNextPage: PropTypes.func,
+  hasNextPage: PropTypes.bool,
+  isFetchingNextPage: PropTypes.bool,
+};
+
+const VersionSelect = ({
+  promptTemplateId,
+  value,
+  onChange,
+  versionDetail,
+  disabled,
+}) => {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["prompt-versions-for-simulation-detail", promptTemplateId],
+      queryFn: async ({ pageParam = 1 }) => {
+        const res = await axios.get(
+          endpoints.develop.runPrompt.getPromptVersions(),
+          { params: { template_id: promptTemplateId, page: pageParam } },
+        );
+        return res.data;
+      },
+      getNextPageParam: (lastPage) =>
+        lastPage?.next ? (lastPage?.current_page || 1) + 1 : undefined,
+      initialPageParam: 1,
+      enabled: !!promptTemplateId,
+    });
+
+  const versions = useMemo(
+    () => data?.pages?.flatMap((page) => page?.results || []) || [],
+    [data],
+  );
+
+  const selectedLabel = useMemo(() => {
+    if (!value) return "Select";
+    const match = versions.find((v) => v.id === value);
+    if (match) return getVersionLabel(match);
+    if (versionDetail?.id === value) return getVersionLabel(versionDetail);
+    return "Select";
+  }, [value, versions, versionDetail]);
+
+  const isDisabled = disabled || isLoading;
+
+  return (
+    <>
+      <Box
+        ref={anchorRef}
+        onClick={() => !isDisabled && setOpen(true)}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 0.5,
+          minWidth: 80,
+          px: 1,
+          py: 0.5,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 0.5,
+          cursor: isDisabled ? "default" : "pointer",
+          bgcolor: "background.paper",
+          "&:hover": { borderColor: "text.disabled" },
+        }}
+      >
+        <Typography sx={{ fontSize: "0.8rem", color: "text.primary" }}>
+          {selectedLabel}
+        </Typography>
+        <Iconify
+          icon="eva:chevron-down-fill"
+          width={16}
+          sx={{ color: "text.secondary", flexShrink: 0 }}
+        />
+      </Box>
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={() => setOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        PaperProps={{
+          sx: {
+            mt: 0.5,
+            minWidth: 140,
+            maxHeight: 320,
+            overflow: "hidden",
+            display: "flex",
+            flexDirection: "column",
+          },
+        }}
+      >
+        <VersionPopoverContent
+          versions={versions}
+          selectedVersion={value}
+          onSelect={(id) => {
+            onChange(id);
+            setOpen(false);
+          }}
+          onCreateNew={() => {
+            onChange("create-new");
+            setOpen(false);
+          }}
+          fetchNextPage={fetchNextPage}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      </Popover>
+    </>
+  );
+};
+
+VersionSelect.propTypes = {
+  promptTemplateId: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  versionDetail: VERSION_SHAPE,
+  disabled: PropTypes.bool,
+};
+
+export default VersionSelect;

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/common.js
@@ -11,7 +11,7 @@ export const getSimulationExecutionsColDef = () => {
     },
     {
       headerName: "Run Start Time",
-      field: "startTime",
+      field: "start_time",
       flex: 1,
       minWidth: 150,
       valueFormatter: (params) => {
@@ -23,7 +23,7 @@ export const getSimulationExecutionsColDef = () => {
       headerName: "Total Chats",
       flex: 1,
       minWidth: 100,
-      field: "totalChats",
+      field: "total_chats",
       valueFormatter: (params) => params.value ?? 0,
     },
     {
@@ -35,7 +35,7 @@ export const getSimulationExecutionsColDef = () => {
     },
     {
       headerName: "Total Turns",
-      field: "totalNumberOfFagiAgentTurns",
+      field: "total_number_of_fagi_agent_turns",
       flex: 1,
       minWidth: 100,
       valueFormatter: (params) => {
@@ -47,7 +47,7 @@ export const getSimulationExecutionsColDef = () => {
       headerName: "% Chats Completed",
       flex: 1,
       minWidth: 110,
-      field: "successRate",
+      field: "success_rate",
       valueFormatter: (params) => {
         if (params.value == null) return "-";
         return `${params.value}%`;

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1362,3 +1362,8 @@ export const stripAttributePathPrefix = (key) =>
   String(key ?? "")
     .replace(/^observation_span\.\d+\.(?:span_attributes\.)?/, "")
     .replace(/(^|\.)span_attributes\./g, "$1");
+
+export const getVersionLabel = (templateVersion) => {
+  const tv = String(templateVersion ?? "");
+  return tv.startsWith("v") ? tv : `v${tv}`;
+};


### PR DESCRIPTION
**Tickets:** [TH-6271](https://linear.app/future-agi/issue/TH-6271) — Fixes TH-6271 · [TH-6270](https://linear.app/future-agi/issue/TH-6270) — Fixes TH-6270

## What was the bug
In Prompt → Simulation, after a run completes:
- The **detail** view didn't auto-select the version (showed "Select") and several run columns showed `-`/`0` (Run Start Time, Total Chats, Total Turns, % Chats Completed) — even for completed runs. *(TH-6271)*
- The **runs list** showed `-` for **Last Run** on completed simulations. *(TH-6270)*

All were frontend snake/camel field mismatches; the backend data was correct (verified against live responses).

## What changes have been done
**Detail view (TH-6271)** — `Simulate/SimulationDetailView/`
- `SimulationDetailHeader.jsx` — read `prompt_version` / `prompt_version_detail` (snake) so the version auto-selects; delegates the dropdown to a new `VersionSelect`.
- `common.js` — fix the 4 run-grid column `field`s to snake_case: `start_time`, `total_chats`, `total_number_of_fagi_agent_turns`, `success_rate`.
- `VersionSelect.jsx` (new) — the version dropdown, paginated (`useInfiniteQuery`, `page`) with scroll-to-load (`useScrollEnd`) and a fixed "New Version" footer. Previously only the first 10 versions loaded and older pinned versions weren't shown/selectable.

**Runs list (TH-6270)** — `components/run-tests/RunTestsContent.jsx`
- Last Run column read via `getValue()`, which `DataTable` resolves as `field: col.id || col.accessorKey` → the camelCase `id: "lastRunAt"` won over the snake `accessorKey`, so it read a nonexistent key → `-`. Now reads `row.original.last_run_at` directly, like the other columns.

## Why the changes
The detail/list APIs return snake_case (`prompt_version`, `start_time`, `total_chats`, `last_run_at`, …) while the FE read camelCase or a divergent column `id`. Matching the actual field names fixes every case.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open a simulation pinned to an older version | Version auto-selects (e.g. v27), not "Select" |
| 2 | View a completed run in the detail grid | Run Start Time / Total Chats / Total Turns / % Chats Completed populate |
| 3 | Open the version dropdown, scroll | All versions page in; "New Version" stays pinned at the bottom |
| 4 | Runs list after a completed sim | Last Run shows a relative time (e.g. "5 days ago") |

## How to reproduce (original bug)
1. Prompt → Simulation → open a simulation whose version isn't in the latest 10 → version shows "Select".
2. Completed run rows show `-`/`0` in the detail grid.
3. In the runs list, a completed simulation shows `-` under Last Run.

## Notes for reviewers
- Verified end-to-end against live API responses (curls) for both the detail and list endpoints.
- **Agent / Evals "—" in the runs list are correct**, not part of this fix: prompt simulations have no agent (`agent_definition_detail: null`) and these sims had no evals configured (`evals_detail: []`). Those columns render correctly when data exists. If the product wants the Agent column to show something for prompt sims, that's a separate design change.



https://github.com/user-attachments/assets/23e6b89a-274d-4523-8f49-a0977bf6d08b


https://github.com/user-attachments/assets/4da63d5f-0696-4a0e-a9e1-9f9a42e3f6cc


