### PR TITLE
fix(simulation): annotate last_run_at and prefetch evals in prompt simulation list

### DIFF
--- a/futureagi/simulate/views/prompt_simulation.py
+++ b/futureagi/simulate/views/prompt_simulation.py
@@ -7,6 +7,7 @@ that use prompts as the agent source instead of SDK-based agent definitions.
 
 import structlog
 from django.db import transaction
+from django.db.models import Max
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
@@ -98,7 +99,10 @@ class PromptSimulationListCreateView(APIView):
                     organization=user_organization,
                     deleted=False,
                 )
-                .prefetch_related("scenarios")
+                .prefetch_related("scenarios", "simulate_eval_configs")
+                # ponytail: last_run_at is not a column, annotated here like
+                # run_test.py:363 does it
+                .annotate(last_run_at=Max("executions__created_at"))
                 .order_by("-created_at")
             )
 


### PR DESCRIPTION
## Summary

Fixes the Simulation tab showing `-` for Last Run and Evals columns in the Prompt Simulation list. The backend query was missing the `last_run_at` annotation and `simulate_eval_configs` prefetch that the regular agent-definition simulation view already applied.

## Linked issues

Closes TH-6270

## Type of change

- [x] 🐛 Bug fix

---

## 1) What changes were done

**A. Prompt simulation list query (prompt_simulation.py)**

- Added `.annotate(last_run_at=Max("executions__created_at"))` — matches the existing pattern at `run_test.py:363`. The `RunTestSerializer.last_run_at` field is a plain `DateTimeField` that expects this annotation; without it the value is always `None`.
- Added `"simulate_eval_configs"` to `.prefetch_related()` — avoids N+1 queries when the serializer reads eval configs via `source="simulate_eval_configs"`.

**B. No frontend changes**

- The frontend `RunTestsContent.jsx` already reads `last_run_at` and `evals_detail` correctly. The data just wasn't being populated by the backend.

---

## 2) Why the changes were done

- **Product/UX:** Users creating prompt simulations saw `-` in the Last Run and Evals columns even after successful execution — the data existed in the database but wasn't reaching the API response
- **Technical:** One-line annotation + one extra prefetch string. Same pattern already used by the regular simulation list view

---

## 4) How to run / test

### UI steps

1. Open a prompt template with existing simulations
2. Navigate to the Simulation tab
3. After a simulation completes, Last Run and Evals columns should show real values instead of `-`

---

## 7) Edge cases & considerations

- **Simulation with no executions:** `Max("executions__created_at")` returns `None` when there are no executions — the serializer's `default=None` handles this, showing `-`
- **Simulation with no eval configs:** Prefetch returns empty list — serializer produces `[]`, frontend handles empty evals gracefully