### PR TITLE
[TH-6375][TH-6161] Keep selected version after a run + complete poll output

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -175,7 +175,10 @@ const WorkbenchProvider = ({ children }) => {
       const newPre = [...pre];
       const newValue =
         typeof valueOrUpdater === "function"
-          ? { id: pre[index]?.id, prompts: valueOrUpdater(pre[index]?.prompts ?? []) }
+          ? {
+              id: pre[index]?.id,
+              prompts: valueOrUpdater(pre[index]?.prompts ?? []),
+            }
           : valueOrUpdater;
 
       newPre[index] = newValue;
@@ -496,9 +499,6 @@ const WorkbenchProvider = ({ children }) => {
             queryClient.invalidateQueries({
               queryKey: ["prompt-versions", id],
             });
-            queryClient.invalidateQueries({
-              queryKey: ["prompt-latest-version", id],
-            });
             break;
           }
           case "all_completed": {
@@ -507,9 +507,6 @@ const WorkbenchProvider = ({ children }) => {
             runningVersionIndexMapping.current[version] = null;
             queryClient.invalidateQueries({
               queryKey: ["prompt-versions", id],
-            });
-            queryClient.invalidateQueries({
-              queryKey: ["prompt-latest-version", id],
             });
             break;
           }
@@ -869,7 +866,9 @@ const WorkbenchProvider = ({ children }) => {
           lastPayload?.error_message ||
           lastPayload?.executions_result?.error_message;
 
-        if (outputs.length > 0) {
+        // Return only once the run has completed — the backend streams
+        // partial output while status is still "running".
+        if (status === "completed" && outputs.length > 0) {
           return lastPayload;
         }
 
@@ -897,9 +896,6 @@ const WorkbenchProvider = ({ children }) => {
       setLoadingStatusByIndex(index, false);
       queryClient.invalidateQueries({
         queryKey: ["prompt-versions", id],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["prompt-latest-version", id],
       });
     },
     [id, queryClient, setLoadingStatusByIndex, setResultsByIndex],


### PR DESCRIPTION
**Tickets:** [TH-6375](https://linear.app/future-agi/issue/TH-6375) — Fixes TH-6375 · [TH-6161](https://linear.app/future-agi/issue/TH-6161) — Fixes TH-6161

## What was the bug
In the Prompt Workbench: v5 is default → you edit it → a draft (v6) is created and selected → you **Run** it → once the run finishes, the workbench **reverted the selected version back to the default (v5)** while the editor kept v6's content. The **save toaster (TH-6161)** reported the wrong version for the same reason.

Separately, when the run used **HTTP polling** (socket unavailable), the output showed **truncated** and only became complete after a manual refresh.

## What changes have been done
`frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx`
- Removed the `["prompt-latest-version", id]` invalidation from the three **run-completion** paths — WS `completed`, WS `all_completed`, and the HTTP-poll `applyPromptRunStatus`. Kept the paired `["prompt-versions", id]` invalidation in each.
- Poll loop now returns only once `status === "completed" && outputs.length > 0` (was returning on the first partial chunk while `status === "running"`).

## Why the changes
- `["prompt-latest-version"]` is the default-version loader (`getPrompt`). Invalidating it on run completion refetched the **default** version, and a `useEffect([data])` unconditionally re-applied it to `selectedVersions` → reverted the selection (and the toaster's version). A run doesn't change the default and the new version is already selected client-side, so the refetch was unnecessary; the `["prompt-versions"]` list refresh (kept) still surfaces the new version in the dropdown/history.
- The poll returned on the first streamed partial output; gating on `completed` returns the final result.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Edit default → draft → Run | badge stays on the run's version |
| 2 | Save/auto-version a committed prompt | toaster reports the correct new version |
| 3 | Run via HTTP polling (socket down) | complete output renders, no refresh needed |
| 4 | New version after a run | appears in the version dropdown/history |
| 5 | Compare-mode run | unaffected (that query is disabled for 2+ versions) |

## How to reproduce (original bug)
1. Open a prompt where v5 is default → edit → a draft (v6) is created.
2. Run it → on completion the badge flips back to v5.
3. (Polling) output shows cut off mid-response until you refresh.

## Notes for reviewers
- Verified end-to-end with runtime logging (version stays on v6; poll returns the full 521-char output instead of a 124-char partial).
- Reviewed by an agent. Two known **out-of-scope** follow-ups (not regressions from this change): (a) exiting **compare mode** re-enables the same query and can reset the surviving selection — durable fix is guarding the `[data]` effect; (b) the **commit** path (`SaveAndCommit`, `PromptActions`) also invalidates `prompt-latest-version`, but a reset may be desired on commit — left untouched pending product intent.
- Supersedes #1196 (earlier TH-6375 attempt).


https://github.com/user-attachments/assets/9a4de0c3-4231-4162-8afb-c072cf4c16f8

