### PR TITLE
Add tool call loop detection module and related tests/documentation

### DIFF
--- a/futureagi/agentic_eval/metrics/test_tool_call_loop_repetition.py
+++ b/futureagi/agentic_eval/metrics/test_tool_call_loop_repetition.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for tool_call_loop_repetition.
+
+Run with:
+    pytest test_tool_call_loop_repetition.py -v
+"""
+
+import pytest
+
+from tool_call_loop_repetition import (
+    ToolCall,
+    ToolCallLoopDetector,
+    ToolCallLoopGuardrail,
+    evaluate_tool_call_loop_repetition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Healthy traces (should NOT flag a loop)
+# ---------------------------------------------------------------------------
+
+class TestHealthyTraces:
+    def test_empty_trace(self):
+        result = ToolCallLoopDetector().evaluate([])
+        assert result.loop_detected is False
+        assert result.score == 1.0
+
+    def test_single_call(self):
+        result = ToolCallLoopDetector().evaluate(
+            [ToolCall(name="search", arguments={"q": "hi"})]
+        )
+        assert result.loop_detected is False
+        assert result.passed is True
+
+    def test_distinct_sequential_calls(self):
+        calls = [
+            ToolCall(name="search", arguments={"q": "refund policy"}),
+            ToolCall(name="read_doc", arguments={"doc_id": "123"}),
+            ToolCall(name="summarize", arguments={"text": "..."}),
+            ToolCall(name="respond", arguments={"answer": "..."}),
+        ]
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is False
+        assert result.score == 1.0
+
+    def test_legitimate_pagination_not_flagged(self):
+        # Same tool, similar args, but results genuinely differ each time ->
+        # this is real progress (e.g. paging through search results), not a
+        # stuck loop, so it should NOT be flagged.
+        calls = [
+            ToolCall(name="list_items", arguments={"page": 1}, result="items 1-10, unique batch A"),
+            ToolCall(name="list_items", arguments={"page": 2}, result="items 11-20, unique batch B"),
+            ToolCall(name="list_items", arguments={"page": 3}, result="items 21-30, unique batch C"),
+        ]
+        result = ToolCallLoopDetector(near_duplicate_threshold=0.99).evaluate(calls)
+        assert result.loop_detected is False
+
+    def test_two_repeats_below_min_repeats_not_flagged(self):
+        # Only 2 repeats; default min_repeats=3, so this should be fine
+        # (agents legitimately retry once sometimes).
+        calls = [
+            ToolCall(name="fetch", arguments={"id": 1}),
+            ToolCall(name="fetch", arguments={"id": 1}),
+        ]
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is False
+
+    def test_ignored_keys_dont_cause_false_negative_masking(self):
+        # Arguments differ ONLY in an ignored (volatile) key across many
+        # calls -> should still be considered the same call and flagged.
+        calls = [
+            ToolCall(name="ping", arguments={"host": "api.example.com", "timestamp": t})
+            for t in range(5)
+        ]
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is True
+
+
+# ---------------------------------------------------------------------------
+# Exact repetition loops
+# ---------------------------------------------------------------------------
+
+class TestExactRepeatLoops:
+    def test_three_identical_calls_flagged(self):
+        calls = [
+            ToolCall(name="search_docs", arguments={"query": "refund policy"})
+            for _ in range(3)
+        ]
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is True
+        assert result.loop_type == "exact_repeat"
+        assert result.repeat_count == 3
+        assert result.passed is False
+
+    def test_more_repeats_lower_score(self):
+        few = [ToolCall(name="x", arguments={}) for _ in range(3)]
+        many = [ToolCall(name="x", arguments={}) for _ in range(8)]
+        few_result = ToolCallLoopDetector().evaluate(few)
+        many_result = ToolCallLoopDetector().evaluate(many)
+        assert many_result.score <= few_result.score
+
+    def test_loop_after_healthy_prefix(self):
+        calls = [
+            ToolCall(name="search", arguments={"q": "a"}),
+            ToolCall(name="read_doc", arguments={"doc_id": "1"}),
+        ] + [ToolCall(name="search", arguments={"q": "a"}) for _ in range(4)]
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is True
+        assert result.first_loop_start_index == 2
+
+    def test_custom_min_repeats_threshold(self):
+        calls = [ToolCall(name="x", arguments={}) for _ in range(2)]
+        strict = ToolCallLoopDetector(min_repeats=2).evaluate(calls)
+        default = ToolCallLoopDetector().evaluate(calls)  # min_repeats=3
+        assert strict.loop_detected is True
+        assert default.loop_detected is False
+
+
+# ---------------------------------------------------------------------------
+# Oscillation loops (A, B, A, B, ...)
+# ---------------------------------------------------------------------------
+
+class TestOscillationLoops:
+    def test_two_step_oscillation_flagged(self):
+        calls = []
+        for _ in range(4):
+            calls.append(ToolCall(name="search", arguments={"q": "refund"}))
+            calls.append(ToolCall(name="read_faq", arguments={"section": "billing"}))
+        result = ToolCallLoopDetector().evaluate(calls)
+        assert result.loop_detected is True
+        assert result.loop_type == "oscillation"
+        assert result.cycle_length == 2
+
+    def test_three_step_oscillation_flagged(self):
+        pattern = [
+            ToolCall(name="a", arguments={}),
+            ToolCall(name="b", arguments={}),
+            ToolCall(name="c", arguments={}),
+        ]
+        calls = pattern * 3
+        result = ToolCallLoopDetector(max_cycle_length=4).evaluate(calls)
+        assert result.loop_detected is True
+        assert result.cycle_length == 3
+        assert result.repeat_count == 3
+
+    def test_cycle_longer_than_max_cycle_length_not_flagged_as_oscillation(self):
+        pattern = [ToolCall(name=f"tool_{i}", arguments={}) for i in range(6)]
+        calls = pattern * 3
+        result = ToolCallLoopDetector(max_cycle_length=4, near_duplicate_threshold=1.0).evaluate(calls)
+        assert result.loop_type != "oscillation"
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate loops
+# ---------------------------------------------------------------------------
+
+class TestNearDuplicateLoops:
+    def test_slightly_reworded_repeated_query_flagged(self):
+        calls = [
+            ToolCall(name="search", arguments={"query": "refund policy for electronics"}),
+            ToolCall(name="search", arguments={"query": "refund policy electronics"}),
+            ToolCall(name="search", arguments={"query": "refund policy electronic items"}),
+        ]
+        result = ToolCallLoopDetector(near_duplicate_threshold=0.7).evaluate(calls)
+        assert result.loop_detected is True
+        assert result.loop_type == "near_duplicate"
+
+    def test_near_duplicate_with_diverging_results_not_flagged(self):
+        calls = [
+            ToolCall(
+                name="search",
+                arguments={"query": "refund policy a"},
+                result="Completely different result content number one about warranties",
+            ),
+            ToolCall(
+                name="search",
+                arguments={"query": "refund policy b"},
+                result="An entirely unrelated second result about shipping timelines",
+            ),
+            ToolCall(
+                name="search",
+                arguments={"query": "refund policy c"},
+                result="A third, again unrelated result about account settings",
+            ),
+        ]
+        result = ToolCallLoopDetector(near_duplicate_threshold=0.7).evaluate(calls)
+        assert result.loop_detected is False
+
+
+# ---------------------------------------------------------------------------
+# Functional wrapper (dict-based calling convention)
+# ---------------------------------------------------------------------------
+
+class TestFunctionalWrapper:
+    def test_dict_input_supported(self):
+        trace = [
+            {"name": "search", "arguments": {"q": "x"}},
+            {"name": "search", "arguments": {"q": "x"}},
+            {"name": "search", "arguments": {"q": "x"}},
+        ]
+        result = evaluate_tool_call_loop_repetition(trace)
+        assert result["loop_detected"] is True
+        assert result["loop_type"] == "exact_repeat"
+
+    def test_alternate_key_names_supported(self):
+        trace = [
+            {"tool_name": "search", "args": {"q": "x"}, "output": "same"},
+            {"tool_name": "search", "args": {"q": "x"}, "output": "same"},
+            {"tool_name": "search", "args": {"q": "x"}, "output": "same"},
+        ]
+        result = evaluate_tool_call_loop_repetition(trace)
+        assert result["loop_detected"] is True
+
+
+# ---------------------------------------------------------------------------
+# Streaming guardrail
+# ---------------------------------------------------------------------------
+
+class TestStreamingGuardrail:
+    def test_flags_as_soon_as_threshold_crossed(self):
+        guardrail = ToolCallLoopGuardrail(min_repeats=3)
+        results = []
+        for _ in range(5):
+            results.append(
+                guardrail.observe(ToolCall(name="ping", arguments={"host": "x"}))
+            )
+        # First two observations shouldn't trigger; from the 3rd onward they should.
+        assert results[0].loop_detected is False
+        assert results[1].loop_detected is False
+        assert results[2].loop_detected is True
+        assert results[3].loop_detected is True
+        assert results[4].loop_detected is True
+
+    def test_reset_clears_state(self):
+        guardrail = ToolCallLoopGuardrail(min_repeats=3)
+        for _ in range(3):
+            guardrail.observe(ToolCall(name="ping", arguments={}))
+        guardrail.reset()
+        result = guardrail.observe(ToolCall(name="ping", arguments={}))
+        assert result.loop_detected is False
+
+    def test_window_size_bounds_memory(self):
+        guardrail = ToolCallLoopGuardrail(window_size=5, min_repeats=3)
+        for i in range(20):
+            guardrail.observe(ToolCall(name=f"tool_{i}", arguments={}))
+        assert len(guardrail._buffer) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_min_repeats_must_be_at_least_two(self):
+        with pytest.raises(ValueError):
+            ToolCallLoopDetector(min_repeats=1)
+
+    def test_threshold_must_be_in_unit_range(self):
+        with pytest.raises(ValueError):
+            ToolCallLoopDetector(near_duplicate_threshold=1.5)

--- a/futureagi/agentic_eval/metrics/test_tool_call_loop_repetition.py
+++ b/futureagi/agentic_eval/metrics/test_tool_call_loop_repetition.py
@@ -7,7 +7,7 @@ Run with:
 
 import pytest
 
-from tool_call_loop_repetition import (
+from agentic_eval.metrics.tool_call_loop_repetition import (
     ToolCall,
     ToolCallLoopDetector,
     ToolCallLoopGuardrail,

--- a/futureagi/agentic_eval/metrics/tool_call_loop_repetition.py
+++ b/futureagi/agentic_eval/metrics/tool_call_loop_repetition.py
@@ -1,0 +1,497 @@
+"""
+tool_call_loop_repetition.py
+
+A local (no-LLM, no network call) evaluator + real-time guardrail that detects
+when an AI agent is stuck in a tool-call loop: repeating the same tool call,
+oscillating between a small cycle of calls, or issuing near-duplicate calls
+that differ only in cosmetic ways (timestamps, request ids, whitespace) while
+making no real progress.
+
+Why this metric exists
+-----------------------
+Agent loops are one of the most common and expensive agentic failure modes in
+production: an agent calls the same search/API/tool over and over, burns
+tokens and provider spend, and never reaches a terminal state. Existing local
+metrics in this project cover output quality (groundedness, hallucination,
+toxicity, PII, tone) and single-call tool-use correctness, but nothing
+currently inspects the *shape of the tool-call sequence itself* to catch
+non-terminating behavior. This module fills that gap.
+
+Design goals (matching this project's local-metric conventions)
+-----------------------------------------------------------------
+- Deterministic and dependency-free (stdlib only) so it can run in the
+  sub-10ms "local metrics" / guardrail tier, not the LLM-judge tier.
+- Usable two ways:
+    1. Post-hoc, over a full trace  -> ToolCallLoopDetector.evaluate(...)
+    2. Real-time / streaming, one call at a time -> ToolCallLoopGuardrail
+       (for wiring into the gateway / inline guardrail path).
+- Returns a score in [0, 1] where 1.0 = no loop detected ("safe", consistent
+  with how this project scores other guardrails such as toxicity, i.e.
+  higher = safer) plus a human-readable reason and structured diagnostics,
+  so it slots into the existing EvalResult-style contract.
+
+Integration notes (for the PR)
+-------------------------------
+This file is written to be dropped into the metrics package (e.g.
+`futureagi/agentic_eval/metrics/tool_call_loop_repetition.py`) and registered
+in the local metrics registry the same way `toxicity`, `pii_detection`, etc.
+are registered, so it becomes callable as:
+
+    from fi.evals import evaluate
+    result = evaluate("tool_call_loop_repetition", tool_calls=trace.tool_calls)
+
+The exact registry hook / base-metric class name will need to match whatever
+this repo actually calls it internally (I could not browse the private class
+hierarchy directly — see PR description). `ToolCallLoopDetector` below has no
+required base class, so it can be adapted to subclass the project's real
+`BaseMetric` / `BaseGuardrail` with minimal changes; the detection logic
+itself does not need to move.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolCall:
+    """A single tool/function call made by an agent during a run."""
+
+    name: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
+    result: Optional[Any] = None  # optional: the tool's return value/observation
+    index: Optional[int] = None  # optional: position in the full trace
+
+
+@dataclass
+class LoopEvalResult:
+    """Result contract, mirroring this project's local-metric EvalResult shape
+    (score, passed, reason) plus extra structured diagnostics useful for the
+    dashboard / trace inspector."""
+
+    score: float  # 1.0 = healthy, 0.0 = severe loop
+    passed: bool
+    reason: str
+    loop_detected: bool
+    loop_type: Optional[str] = None  # "exact_repeat" | "oscillation" | "near_duplicate"
+    cycle_length: Optional[int] = None
+    repeat_count: Optional[int] = None
+    first_loop_start_index: Optional[int] = None
+    involved_tools: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "score": self.score,
+            "passed": self.passed,
+            "reason": self.reason,
+            "loop_detected": self.loop_detected,
+            "loop_type": self.loop_type,
+            "cycle_length": self.cycle_length,
+            "repeat_count": self.repeat_count,
+            "first_loop_start_index": self.first_loop_start_index,
+            "involved_tools": self.involved_tools,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Normalization / similarity helpers
+# ---------------------------------------------------------------------------
+
+# Keys commonly used for nonces / timestamps / trace ids that should NOT count
+# as "the arguments changed" when comparing calls for repetition.
+_DEFAULT_IGNORED_ARG_KEYS = frozenset({
+    "timestamp", "ts", "request_id", "trace_id", "nonce", "idempotency_key",
+    "call_id", "id", "created_at",
+})
+
+
+def _normalize_arguments(
+    arguments: Dict[str, Any],
+    ignored_keys: frozenset,
+) -> str:
+    """Serialize arguments to a stable, comparable string, dropping
+    cosmetic/volatile keys and normalizing key order and whitespace."""
+    cleaned = {
+        k: v for k, v in (arguments or {}).items() if k not in ignored_keys
+    }
+    try:
+        return json.dumps(cleaned, sort_keys=True, default=str)
+    except TypeError:
+        # Fall back to a best-effort string representation for
+        # non-JSON-serializable arguments.
+        return str(sorted(cleaned.items(), key=lambda kv: str(kv[0])))
+
+
+def _signature(call: ToolCall, ignored_keys: frozenset) -> str:
+    """A comparable signature for a call: tool name + normalized arguments."""
+    return f"{call.name}::{_normalize_arguments(call.arguments, ignored_keys)}"
+
+
+def _similarity(a: str, b: str) -> float:
+    """Cheap, dependency-free string similarity in [0, 1]."""
+    if a == b:
+        return 1.0
+    return difflib.SequenceMatcher(a=a, b=b, autojunk=False).ratio()
+
+
+def _find_repeating_cycle(
+    signatures: Sequence[str],
+    max_cycle_length: int = 4,
+    min_repeats: int = 3,
+) -> Optional[Dict[str, int]]:
+    """Look at the *tail* of the signature sequence and check whether it is
+    made of a short repeating cycle (e.g. A,B,A,B,A,B or A,A,A,A).
+
+    Returns {"cycle_length": k, "repeat_count": n, "start_index": i} for the
+    longest qualifying repetition found, or None.
+    """
+    n = len(signatures)
+    best: Optional[Dict[str, int]] = None
+
+    for cycle_length in range(1, max_cycle_length + 1):
+        if cycle_length * min_repeats > n:
+            continue
+
+        # Compare every preceding chunk of this length against the final
+        # chunk in the sequence; count how many consecutive chunks (walking
+        # backwards from the end) are identical to it.
+        last_chunk = signatures[n - cycle_length:n]
+        repeats = 1
+        pos = n - cycle_length
+        while pos - cycle_length >= 0:
+            chunk = signatures[pos - cycle_length:pos]
+            if chunk == last_chunk:
+                repeats += 1
+                pos -= cycle_length
+            else:
+                break
+
+        if repeats >= min_repeats:
+            start_index = pos
+            candidate = {
+                "cycle_length": cycle_length,
+                "repeat_count": repeats,
+                "start_index": start_index,
+            }
+            # Prefer the result that covers more of the tail (repeats * cycle_length),
+            # and among ties prefer the smallest cycle (simplest explanation).
+            if best is None or (
+                candidate["repeat_count"] * candidate["cycle_length"]
+                > best["repeat_count"] * best["cycle_length"]
+            ):
+                best = candidate
+
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Core detector (post-hoc, full-trace evaluation)
+# ---------------------------------------------------------------------------
+
+class ToolCallLoopDetector:
+    """Detects non-terminating / repetitive tool-call behavior in an agent
+    trace.
+
+    Parameters
+    ----------
+    min_repeats:
+        Minimum number of consecutive cycle repetitions required before a
+        loop is flagged (default 3, e.g. A,A,A or A,B,A,B,A,B).
+    max_cycle_length:
+        Longest call-cycle to search for (default 4). Larger values catch
+        longer repeating patterns at extra compute cost; 3-4 covers the vast
+        majority of real agent loops (single-call retry loops and simple
+        two/three-step oscillations).
+    near_duplicate_threshold:
+        Similarity in [0, 1] above which two calls' arguments are treated as
+        "the same call" even if not byte-identical (default 0.92). Set to
+        1.0 to require exact matches only.
+    ignored_argument_keys:
+        Argument keys to ignore when comparing calls (timestamps, request
+        ids, etc). Defaults to a common set; pass your own frozenset to
+        override.
+    also_compare_results:
+        If True (default), and tool results are provided, identical/near
+        identical results across a repeated call further increase confidence
+        that no real progress is being made (vs. e.g. legitimate polling
+        where the result changes each time).
+    """
+
+    def __init__(
+        self,
+        min_repeats: int = 3,
+        max_cycle_length: int = 4,
+        near_duplicate_threshold: float = 0.92,
+        ignored_argument_keys: frozenset = _DEFAULT_IGNORED_ARG_KEYS,
+        also_compare_results: bool = True,
+    ) -> None:
+        if min_repeats < 2:
+            raise ValueError("min_repeats must be >= 2")
+        if not (0.0 <= near_duplicate_threshold <= 1.0):
+            raise ValueError("near_duplicate_threshold must be in [0, 1]")
+
+        self.min_repeats = min_repeats
+        self.max_cycle_length = max_cycle_length
+        self.near_duplicate_threshold = near_duplicate_threshold
+        self.ignored_argument_keys = ignored_argument_keys
+        self.also_compare_results = also_compare_results
+
+    def evaluate(self, tool_calls: Sequence[ToolCall]) -> LoopEvalResult:
+        if not tool_calls:
+            return LoopEvalResult(
+                score=1.0,
+                passed=True,
+                reason="No tool calls in trace; nothing to evaluate.",
+                loop_detected=False,
+            )
+
+        exact_signatures = [
+            _signature(c, self.ignored_argument_keys) for c in tool_calls
+        ]
+
+        # 1. Exact / cycle-based repetition (handles both "same call N times"
+        #    and "oscillation between 2-4 calls").
+        cycle = _find_repeating_cycle(
+            exact_signatures,
+            max_cycle_length=self.max_cycle_length,
+            min_repeats=self.min_repeats,
+        )
+
+        if cycle is not None:
+            start = cycle["start_index"]
+            involved = sorted({
+                tool_calls[i].name
+                for i in range(start, len(tool_calls))
+            })
+            loop_type = "exact_repeat" if cycle["cycle_length"] == 1 else "oscillation"
+
+            severity = self._severity(cycle["repeat_count"], cycle["cycle_length"])
+            score = round(max(0.0, 1.0 - severity), 4)
+
+            reason = self._describe(
+                loop_type=loop_type,
+                cycle_length=cycle["cycle_length"],
+                repeat_count=cycle["repeat_count"],
+                involved=involved,
+                start=start,
+            )
+
+            return LoopEvalResult(
+                score=score,
+                passed=score >= 0.5,
+                reason=reason,
+                loop_detected=True,
+                loop_type=loop_type,
+                cycle_length=cycle["cycle_length"],
+                repeat_count=cycle["repeat_count"],
+                first_loop_start_index=start,
+                involved_tools=involved,
+            )
+
+        # 2. Near-duplicate detection: catches loops where arguments drift
+        #    slightly each time (e.g. a retried search query with a trivial
+        #    rewording) but the agent is still not making real progress,
+        #    which the exact-match cycle search above would miss.
+        near_dup = self._find_near_duplicate_run(tool_calls, exact_signatures)
+        if near_dup is not None:
+            start, repeat_count, involved = near_dup
+            severity = self._severity(repeat_count, cycle_length=1)
+            score = round(max(0.0, 1.0 - severity * 0.85), 4)  # slightly less severe than exact
+            reason = self._describe(
+                loop_type="near_duplicate",
+                cycle_length=1,
+                repeat_count=repeat_count,
+                involved=involved,
+                start=start,
+            )
+            return LoopEvalResult(
+                score=score,
+                passed=score >= 0.5,
+                reason=reason,
+                loop_detected=True,
+                loop_type="near_duplicate",
+                cycle_length=1,
+                repeat_count=repeat_count,
+                first_loop_start_index=start,
+                involved_tools=involved,
+            )
+
+        return LoopEvalResult(
+            score=1.0,
+            passed=True,
+            reason="No repetitive or non-progressing tool-call pattern detected.",
+            loop_detected=False,
+        )
+
+    # -- helpers ------------------------------------------------------
+
+    def _find_near_duplicate_run(
+        self,
+        tool_calls: Sequence[ToolCall],
+        exact_signatures: Sequence[str],
+    ) -> Optional[tuple]:
+        """Scan for a contiguous run of same-tool calls whose arguments (and,
+        if available, results) are near-identical by fuzzy similarity, even
+        though they weren't byte-identical."""
+        n = len(tool_calls)
+        i = 0
+        while i < n:
+            j = i + 1
+            run = [i]
+            while j < n and tool_calls[j].name == tool_calls[i].name:
+                sim = _similarity(exact_signatures[i], exact_signatures[j])
+                if sim >= self.near_duplicate_threshold:
+                    if self.also_compare_results:
+                        r_i = str(tool_calls[i].result) if tool_calls[i].result is not None else ""
+                        r_j = str(tool_calls[j].result) if tool_calls[j].result is not None else ""
+                        if r_i or r_j:
+                            result_sim = _similarity(r_i, r_j)
+                            # If results genuinely diverge, treat this as
+                            # legitimate iterative work (e.g. pagination),
+                            # not a stuck loop.
+                            if result_sim < self.near_duplicate_threshold:
+                                break
+                    run.append(j)
+                    j += 1
+                else:
+                    break
+
+            if len(run) >= self.min_repeats:
+                involved = [tool_calls[i].name]
+                return run[0], len(run), involved
+
+            i = j if j > i + 1 else i + 1
+
+        return None
+
+    @staticmethod
+    def _severity(repeat_count: int, cycle_length: int) -> float:
+        """Map (repeat_count, cycle_length) to a severity in [0, 1].
+
+        More repeats -> more severe. Longer cycles are slightly less
+        alarming per-repeat than tight single-call loops, since they cover
+        more distinct behavior, but still ramp to full severity quickly.
+        """
+        # Baseline severity kicks in right at the configured min_repeats and
+        # saturates by ~2x that many repeats.
+        raw = (repeat_count - 1) / max(1, repeat_count)
+        cycle_discount = 1.0 if cycle_length == 1 else 0.85
+        return min(1.0, raw * cycle_discount * 1.15)
+
+    @staticmethod
+    def _describe(
+        loop_type: str,
+        cycle_length: int,
+        repeat_count: int,
+        involved: List[str],
+        start: int,
+    ) -> str:
+        tools_str = ", ".join(involved) if involved else "unknown tool(s)"
+        if loop_type == "exact_repeat":
+            return (
+                f"Detected {repeat_count} consecutive identical calls to "
+                f"'{tools_str}' starting at step {start}. The agent appears "
+                f"stuck repeating the same tool call without making progress."
+            )
+        if loop_type == "oscillation":
+            return (
+                f"Detected a repeating {cycle_length}-step call pattern "
+                f"({tools_str}) repeated {repeat_count} times starting at "
+                f"step {start}. The agent appears to be cycling between the "
+                f"same tool calls without reaching a new state."
+            )
+        return (
+            f"Detected {repeat_count} near-duplicate calls to '{tools_str}' "
+            f"starting at step {start} (similar arguments and results each "
+            f"time). The agent is likely stuck retrying without real progress."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming / real-time guardrail (for inline use in the gateway)
+# ---------------------------------------------------------------------------
+
+class ToolCallLoopGuardrail:
+    """Incremental variant of ToolCallLoopDetector for real-time / inline use
+    (e.g. the Agent Command Center gateway path), where you want to flag a
+    loop as soon as it happens rather than waiting for the full trace.
+
+    Usage:
+        guardrail = ToolCallLoopGuardrail(min_repeats=3)
+        for call in incoming_tool_calls:
+            result = guardrail.observe(call)
+            if result.loop_detected:
+                # block / intervene / surface a warning to the agent
+                ...
+    """
+
+    def __init__(self, window_size: int = 12, **detector_kwargs: Any) -> None:
+        self._detector = ToolCallLoopDetector(**detector_kwargs)
+        self._window_size = window_size
+        self._buffer: List[ToolCall] = []
+
+    def observe(self, call: ToolCall) -> LoopEvalResult:
+        self._buffer.append(call)
+        if len(self._buffer) > self._window_size:
+            self._buffer = self._buffer[-self._window_size:]
+        return self._detector.evaluate(self._buffer)
+
+    def reset(self) -> None:
+        self._buffer.clear()
+
+
+# ---------------------------------------------------------------------------
+# Functional entry point, matching this project's `evaluate("<metric>", ...)`
+# calling convention (see fi.evals.evaluate).
+# ---------------------------------------------------------------------------
+
+def evaluate_tool_call_loop_repetition(
+    tool_calls: Sequence[Dict[str, Any]] | Sequence[ToolCall],
+    **detector_kwargs: Any,
+) -> Dict[str, Any]:
+    """Functional wrapper so this metric can be called the same way other
+    local metrics in this project are called, e.g.:
+
+        from fi.evals import evaluate
+        result = evaluate(
+            "tool_call_loop_repetition",
+            tool_calls=[
+                {"name": "search", "arguments": {"q": "refund policy"}},
+                {"name": "search", "arguments": {"q": "refund policy"}},
+                {"name": "search", "arguments": {"q": "refund policy"}},
+            ],
+        )
+
+    Accepts either raw dicts (with "name"/"arguments"/"result" keys, as they
+    typically arrive off a trace/span) or ToolCall instances directly.
+    """
+    normalized: List[ToolCall] = [
+        c if isinstance(c, ToolCall) else ToolCall(
+            name=c.get("name") or c.get("tool_name") or "unknown_tool",
+            arguments=c.get("arguments") or c.get("args") or {},
+            result=c.get("result") or c.get("output"),
+            index=c.get("index"),
+        )
+        for c in tool_calls
+    ]
+    detector = ToolCallLoopDetector(**detector_kwargs)
+    return detector.evaluate(normalized).to_dict()
+
+
+if __name__ == "__main__":
+    # Minimal smoke test / usage demo.
+    looping_trace = [
+        ToolCall(name="search_docs", arguments={"query": "refund policy"}),
+        ToolCall(name="search_docs", arguments={"query": "refund policy"}),
+        ToolCall(name="search_docs", arguments={"query": "refund policy"}),
+        ToolCall(name="search_docs", arguments={"query": "refund policy"}),
+    ]
+    result = ToolCallLoopDetector().evaluate(looping_trace)
+    print(json.dumps(result.to_dict(), indent=2))

--- a/futureagi/docs/annotation-queues/evaluation/my-eval/Tool_Call_Loop_Repetition.md
+++ b/futureagi/docs/annotation-queues/evaluation/my-eval/Tool_Call_Loop_Repetition.md
@@ -1,0 +1,89 @@
+---
+title: Tool Call Loop Repetition
+description: Detects agents stuck repeating or oscillating between the same tool calls without making progress.
+category: Local Metrics / Guardrails
+tier: local
+latency: "< 10ms"
+requires_llm: false
+---
+
+# Tool Call Loop Repetition
+
+Detects when an agent is stuck in a non-terminating loop: calling the same
+tool over and over, oscillating between a small cycle of tool calls, or
+retrying near-duplicate calls that never really change state. This is one of
+the most common and expensive agentic failure modes in production — it burns
+tokens and API spend and leaves a workflow stuck — and it's a **local
+metric**: no LLM judge call is required, so it's safe to run inline as a
+guardrail as well as post-hoc over stored traces.
+
+## Why you'd use this
+
+- Catch runaway agent loops before they burn through your token/API budget.
+- Surface stuck workflows in the trace inspector so you know *where* an agent
+  got stuck, not just that the run took too long.
+- Wire it into the gateway as a real-time guardrail to interrupt a looping
+  agent mid-run instead of waiting for the full trace.
+
+## What it detects
+
+| Loop type | Example |
+|---|---|
+| `exact_repeat` | The same tool + same arguments called 3+ times in a row |
+| `oscillation` | A short cycle (e.g. `search → read_faq → search → read_faq`) repeating 3+ times |
+| `near_duplicate` | Same tool called repeatedly with only cosmetic argument differences (e.g. a slightly reworded query) and no meaningfully new result |
+
+It deliberately does **not** flag legitimate iterative patterns like
+pagination or polling, where arguments may look similar but the tool's
+*results* keep changing — that's treated as real progress, not a loop.
+
+## Usage
+
+```python
+from fi.evals import evaluate
+
+result = evaluate(
+    "tool_call_loop_repetition",
+    tool_calls=[
+        {"name": "search_docs", "arguments": {"query": "refund policy"}},
+        {"name": "search_docs", "arguments": {"query": "refund policy"}},
+        {"name": "search_docs", "arguments": {"query": "refund policy"}},
+    ],
+)
+
+print(result.score)   # 0.0-1.0, higher = healthier (no loop)
+print(result.passed)  # False once repeats cross the min_repeats threshold
+print(result.reason)  # human-readable explanation for the trace inspector
+```
+
+### Real-time guardrail (gateway / inline use)
+
+```python
+from fi.evals.guardrails import ToolCallLoopGuardrail
+
+guardrail = ToolCallLoopGuardrail(min_repeats=3)
+
+for call in agent_tool_calls:
+    result = guardrail.observe(call)
+    if result.loop_detected:
+        # interrupt the agent, surface a warning, or fall back to a human
+        break
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|---|---|---|
+| `min_repeats` | `3` | Minimum consecutive cycle repetitions before flagging a loop |
+| `max_cycle_length` | `4` | Longest call-cycle searched for (covers single-call retries through 4-step oscillations) |
+| `near_duplicate_threshold` | `0.92` | Similarity (0-1) above which two calls' arguments count as "the same call" |
+| `ignored_argument_keys` | timestamps, request/trace ids, nonces | Volatile keys ignored when comparing call arguments |
+| `also_compare_results` | `True` | If results genuinely diverge across similar calls, don't treat it as a stuck loop |
+
+## Score interpretation
+
+Score is in `[0, 1]`, where `1.0` means no repetitive pattern was found and
+lower scores indicate increasingly severe loops (more repeats / tighter
+cycles). `passed` defaults to `score >= 0.5`, matching the pass/fail
+convention used by this project's other guardrail-style metrics (e.g.
+toxicity).


### PR DESCRIPTION
## Add `tool_call_loop_repetition`: a local evaluator/guardrail for stuck agent loops

### What & why

Adds a new **local metric** (no LLM call, <10ms) that detects when an agent
is stuck repeating or oscillating between the same tool calls without making
progress — one of the most common and costly agentic failure modes in
production (runaway token/API spend, workflows that never terminate).

The current evaluator suite covers output quality (groundedness,
hallucination, toxicity, PII, tone) and single-call tool-use correctness, but
nothing inspects the *shape of the tool-call sequence itself*. This fills
that gap and fits the "local metrics" tier described in the docs (fast,
deterministic, guardrail-safe).

### What it catches

- **Exact repeats** — same tool + same args called 3+ times in a row
- **Oscillation** — a short cycle (e.g. `search → read_faq → search → read_faq`) repeating 3+ times
- **Near-duplicates** — same tool retried with only cosmetic argument drift (reworded query, changed nonce/timestamp) and no meaningfully different result

It's deliberately conservative about **false positives**: legitimate
iterative patterns like pagination or polling — where arguments look similar
but results genuinely differ each call — are not flagged.

### Two usage modes

1. Post-hoc, over a full trace: `ToolCallLoopDetector.evaluate(tool_calls)`
2. Real-time, one call at a time (for the gateway / inline guardrail path):
   `ToolCallLoopGuardrail.observe(call)`

Both return the same result shape (`score`, `passed`, `reason`, plus
structured diagnostics: `loop_type`, `cycle_length`, `repeat_count`,
`first_loop_start_index`, `involved_tools`) so it's easy to surface in the
trace inspector / dashboard.

### Files in this PR

- `tool_call_loop_repetition.py` — core detector + streaming guardrail + functional wrapper matching the `evaluate("<metric>", ...)` calling convention
- `test_tool_call_loop_repetition.py` — pytest suite (22 cases: healthy traces, exact repeats, oscillations, near-duplicates, streaming guardrail, input validation)
- `tool-call-loop-repetition.md` — docs page draft in the existing metrics-doc style

### Integration note for maintainers

I wrote this from the public README/docs and the `ai-evaluation` SDK's
public calling convention (`from fi.evals import evaluate`), since I didn't
have access to browse the private metrics-registry class hierarchy directly.
`ToolCallLoopDetector` has no required base class by design — it should be a
small change to subclass this repo's actual `BaseMetric`/guardrail base
class and register it in the local metrics registry the same way
`toxicity`/`pii_detection` are registered. Happy to adjust naming,
signatures, or file placement to match repo conventions — let me know in
review.

### Testing

All 22 test cases pass locally (`pytest test_tool_call_loop_repetition.py -v`).
No new dependencies — stdlib only (`json`, `difflib`, `dataclasses`).

### Checklist

- [ ] Matches this repo's actual `BaseMetric`/guardrail interface (please advise if it differs from the shape above)
- [ ] Registered in the local metrics registry
- [ ] Docs page wired into the sidebar (docs repo, separate PR if needed)
- [ ] CLA signed (bot will prompt on open)