### PR TITLE
feat: redesign dataset variable-mapping column picker for JSON/arrays

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -288,15 +288,24 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth, isLast }) {
 
 // Indented tree row. Parent rows carry a chevron to collapse/expand their
 // children (open by default) and show their direct-child count on the right.
-// Clicking the row selects the node's path; clicking the chevron only toggles.
-function TreeRow({ node, onSelect, selectedPath, depth = 0 }) {
+// Clicking the row selects the node's path (when it is a real column — leaves,
+// and prefixes that are themselves columns); the chevron only toggles.
+// `forceOpen` keeps rows expanded while a search is active so matches stay
+// visible regardless of the user's collapse state.
+function TreeRow({ node, onSelect, selectedPath, forceOpen = false }) {
   const hasKids = node.children.length > 0;
+  const selectable = node.isColumn ?? !hasKids;
   const [open, setOpen] = useState(true);
+  const effectiveOpen = forceOpen || open;
   const selected = !!selectedPath && selectedPath === node.path;
+  const toggle = (e) => {
+    e.stopPropagation();
+    setOpen((o) => !o);
+  };
   return (
     <>
       <Box
-        onClick={() => (hasKids ? setOpen((o) => !o) : onSelect(node.path))}
+        onClick={() => (selectable ? onSelect(node.path) : setOpen((o) => !o))}
         sx={{
           display: "flex",
           alignItems: "center",
@@ -314,9 +323,10 @@ function TreeRow({ node, onSelect, selectedPath, depth = 0 }) {
       >
         {hasKids ? (
           <Iconify
-            icon={open ? "mdi:chevron-down" : "mdi:chevron-right"}
+            icon={effectiveOpen ? "mdi:chevron-down" : "mdi:chevron-right"}
             width={16}
-            sx={{ color: "text.secondary", flexShrink: 0 }}
+            onClick={toggle}
+            sx={{ color: "text.secondary", flexShrink: 0, cursor: "pointer" }}
           />
         ) : (
           <Box sx={{ width: 16, flexShrink: 0 }} />
@@ -365,15 +375,17 @@ function TreeRow({ node, onSelect, selectedPath, depth = 0 }) {
           </Box>
         )}
       </Box>
-      {hasKids && open && (
-        <Box sx={{ ml: "15px", borderLeft: "1px solid", borderColor: "divider" }}>
+      {hasKids && effectiveOpen && (
+        <Box
+          sx={{ ml: "15px", borderLeft: "1px solid", borderColor: "divider" }}
+        >
           {node.children.map((child) => (
             <TreeRow
               key={child.id}
               node={child}
               onSelect={onSelect}
               selectedPath={selectedPath}
-              depth={depth + 1}
+              forceOpen={forceOpen}
             />
           ))}
         </Box>
@@ -556,7 +568,7 @@ function ColumnTreeSelect({
                       node={node}
                       onSelect={handleSelect}
                       selectedPath={value}
-                      depth={0}
+                      forceOpen={Boolean(search.trim())}
                     />
                   ))
                 ) : (

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -15,7 +15,6 @@ import {
   Typography,
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
-import { TreeView, TreeItem } from "@mui/lab";
 import PropTypes from "prop-types";
 import React, {
   useCallback,
@@ -335,32 +334,99 @@ function buildTree(columnNames) {
   return roots;
 }
 
-function renderTreeNode(node, onSelect) {
+// Indented tree row. Parent rows carry a chevron to collapse/expand their
+// children (open by default) and show their direct-child count on the right.
+// Clicking the row selects the node's path; clicking the chevron only toggles.
+function TreeRow({ node, onSelect, selectedPath, depth = 0 }) {
   const hasKids = node.children.length > 0;
+  const [open, setOpen] = useState(true);
+  const selected = !!selectedPath && selectedPath === node.path;
   return (
-    <TreeItem
-      key={node.id}
-      nodeId={node.id}
-      label={
+    <>
+      <Box
+        onClick={() => (hasKids ? setOpen((o) => !o) : onSelect(node.path))}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          pl: 0.75,
+          pr: 0.75,
+          py: 0.5,
+          cursor: "pointer",
+          borderRadius: "6px",
+          bgcolor: selected ? "action.selected" : "transparent",
+          "&:hover": {
+            bgcolor: selected ? "action.selected" : "action.hover",
+          },
+        }}
+      >
+        {hasKids ? (
+          <Iconify
+            icon={open ? "mdi:chevron-down" : "mdi:chevron-right"}
+            width={16}
+            sx={{ color: "text.secondary", flexShrink: 0 }}
+          />
+        ) : (
+          <Box sx={{ width: 16, flexShrink: 0 }} />
+        )}
         <Typography
+          noWrap
           sx={{
-            fontSize: "12px",
-            fontFamily: "monospace",
+            flex: 1,
+            minWidth: 0,
+            fontSize: "13px",
+            fontFamily: "Inter, sans-serif",
             fontWeight: hasKids ? 600 : 400,
-            color: hasKids ? "text.primary" : "text.secondary",
-            py: 0.15,
-          }}
-          onClick={(e) => {
-            e.stopPropagation();
-            onSelect(node.path);
+            color: "text.primary",
           }}
         >
           {node.label}
         </Typography>
-      }
-    >
-      {hasKids && node.children.map((child) => renderTreeNode(child, onSelect))}
-    </TreeItem>
+        {selected && (
+          <Iconify
+            icon="mdi:check"
+            width={15}
+            sx={{ color: "primary.main", flexShrink: 0 }}
+          />
+        )}
+        {hasKids && (
+          <Box
+            sx={{
+              flexShrink: 0,
+              minWidth: 20,
+              px: 0.75,
+              borderRadius: "10px",
+              bgcolor: "action.hover",
+              textAlign: "center",
+            }}
+          >
+            <Typography
+              sx={{
+                fontSize: "11px",
+                fontFamily: "Inter, sans-serif",
+                color: "text.secondary",
+                lineHeight: "18px",
+              }}
+            >
+              {node.children.length}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+      {hasKids && open && (
+        <Box sx={{ ml: "15px", borderLeft: "1px solid", borderColor: "divider" }}>
+          {node.children.map((child) => (
+            <TreeRow
+              key={child.id}
+              node={child}
+              onSelect={onSelect}
+              selectedPath={selectedPath}
+              depth={depth + 1}
+            />
+          ))}
+        </Box>
+      )}
+    </>
   );
 }
 
@@ -373,42 +439,31 @@ function ColumnTreeSelect({
   disabledTooltip = "",
 }) {
   const [open, setOpen] = useState(false);
-  const [typing, setTyping] = useState(false);
+  const [search, setSearch] = useState("");
   const anchorRef = useRef(null);
   const tree = useMemo(() => buildTree(columnNames), [columnNames]);
 
-  // Only filter when user is actively typing, not when re-opening with a selected value
+  // Filter by the dropdown search bar — substring match on the full path,
+  // keeping ancestors of any matching node so nested hits stay reachable.
   const filtered = useMemo(() => {
-    if (!typing || !value) return tree;
-    const q = value.toLowerCase();
+    const q = search.trim().toLowerCase();
+    if (!q) return tree;
     const filterNodes = (nodes) =>
       nodes
         .map((node) => {
-          if (node.path.toLowerCase().startsWith(q)) return node;
+          if (node.path.toLowerCase().includes(q)) return node;
           const kids = filterNodes(node.children);
           if (kids.length) return { ...node, children: kids };
           return null;
         })
         .filter(Boolean);
     return filterNodes(tree);
-  }, [tree, value, typing]);
-
-  // Collect all node IDs for default expansion
-  const allIds = useMemo(() => {
-    const ids = [];
-    const walk = (nodes) =>
-      nodes.forEach((n) => {
-        ids.push(n.id);
-        walk(n.children);
-      });
-    walk(filtered);
-    return ids;
-  }, [filtered]);
+  }, [tree, search]);
 
   const handleSelect = (path) => {
     onChange(path);
     setOpen(false);
-    setTyping(false);
+    setSearch("");
   };
 
   const textField = (
@@ -419,24 +474,18 @@ function ColumnTreeSelect({
       value={value}
       placeholder={disabled ? "Loading columns..." : "Select column"}
       disabled={disabled}
-      onFocus={() => {
-        if (disabled) return;
-        setOpen(true);
-      }}
-      onChange={(e) => {
-        if (disabled) return;
-        setTyping(true);
-        onChange(e.target.value);
-        if (!open) setOpen(true);
-      }}
-      autoComplete="off"
-      inputProps={{
-        autoComplete: "off",
-        autoCorrect: "off",
-        spellCheck: false,
+      onClick={() => {
+        if (!disabled) setOpen(true);
       }}
       InputProps={{
-        sx: { fontSize: "12px", fontFamily: "monospace", height: 30, py: 0 },
+        readOnly: true,
+        sx: {
+          fontSize: "13px",
+          fontFamily: "Inter, sans-serif",
+          height: 30,
+          py: 0,
+          cursor: disabled ? "default" : "pointer",
+        },
         endAdornment: (
           <InputAdornment position="end">
             {disabled ? (
@@ -446,9 +495,9 @@ function ColumnTreeSelect({
                 icon={open ? "mdi:chevron-up" : "mdi:chevron-down"}
                 width={16}
                 sx={{ color: "text.disabled", cursor: "pointer" }}
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   setOpen((p) => !p);
-                  setTyping(false);
                 }}
               />
             )}
@@ -479,7 +528,7 @@ function ColumnTreeSelect({
       ) : (
         textField
       )}
-      {!disabled && open && filtered.length > 0 && (
+      {!disabled && open && (
         <Popper
           open
           anchorEl={anchorRef.current}
@@ -491,42 +540,86 @@ function ColumnTreeSelect({
               // Don't close if clicking the input field itself
               if (anchorRef.current?.contains(e.target)) return;
               setOpen(false);
-              setTyping(false);
+              setSearch("");
             }}
           >
             <Paper
-              elevation={8}
+              elevation={0}
               sx={{
                 mt: 0.5,
                 borderRadius: "8px",
                 border: "1px solid",
                 borderColor: "divider",
+                boxShadow: (theme) => theme.customShadows.dropdown,
               }}
             >
-              <Box sx={{ maxHeight: 260, overflow: "auto", py: 0.5 }}>
-                <TreeView
-                  defaultExpanded={allIds}
-                  defaultCollapseIcon={
-                    <Iconify
-                      icon="mdi:chevron-down"
-                      width={14}
-                      sx={{ color: "text.disabled" }}
-                    />
-                  }
-                  defaultExpandIcon={
-                    <Iconify
-                      icon="mdi:chevron-right"
-                      width={14}
-                      sx={{ color: "text.disabled" }}
-                    />
-                  }
-                  sx={{
-                    "& .MuiTreeItem-content": { py: 0.1, borderRadius: "4px" },
-                    "& .MuiTreeItem-content:hover": { bgcolor: "action.hover" },
+              <Box sx={{ p: 0.75 }}>
+                <TextField
+                  size="small"
+                  fullWidth
+                  autoFocus
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search columns…"
+                  autoComplete="off"
+                  inputProps={{
+                    autoComplete: "off",
+                    autoCorrect: "off",
+                    spellCheck: false,
                   }}
-                >
-                  {filtered.map((node) => renderTreeNode(node, handleSelect))}
-                </TreeView>
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Iconify
+                          icon="eva:search-fill"
+                          width={16}
+                          sx={{ color: "text.disabled" }}
+                        />
+                      </InputAdornment>
+                    ),
+                    endAdornment: search ? (
+                      <InputAdornment position="end">
+                        <Iconify
+                          icon="mdi:close"
+                          width={15}
+                          sx={{ color: "text.disabled", cursor: "pointer" }}
+                          onClick={() => setSearch("")}
+                        />
+                      </InputAdornment>
+                    ) : null,
+                    sx: {
+                      fontSize: "13px",
+                      fontFamily: "Inter, sans-serif",
+                      height: 32,
+                      py: 0,
+                    },
+                  }}
+                />
+              </Box>
+              <Box sx={{ maxHeight: 260, overflow: "auto", pb: 0.5, px: 0.5 }}>
+                {filtered.length > 0 ? (
+                  filtered.map((node) => (
+                    <TreeRow
+                      key={node.id}
+                      node={node}
+                      onSelect={handleSelect}
+                      selectedPath={value}
+                      depth={0}
+                    />
+                  ))
+                ) : (
+                  <Typography
+                    sx={{
+                      fontSize: "12px",
+                      fontFamily: "Inter, sans-serif",
+                      color: "text.disabled",
+                      px: 1,
+                      py: 1,
+                    }}
+                  >
+                    No matching columns
+                  </Typography>
+                )}
               </Box>
             </Paper>
           </ClickAwayListener>

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -561,13 +561,9 @@ function ColumnTreeSelect({
                   ))
                 ) : (
                   <Typography
-                    sx={{
-                      fontSize: "12px",
-                      fontFamily: "Inter, sans-serif",
-                      color: "text.disabled",
-                      px: 1,
-                      py: 1,
-                    }}
+                    variant="caption"
+                    color="text.disabled"
+                    sx={{ display: "block", px: 1, py: 1 }}
                   >
                     No matching columns
                   </Typography>

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -34,6 +34,7 @@ import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
 import { unwrapCellValue } from "./datasetCellValue";
+import { buildTree } from "./columnTree";
 
 const DATASET_PAGE_SIZE = 25;
 
@@ -282,57 +283,8 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth, isLast }) {
 
 // ---------------------------------------------------------------------------
 // ColumnTreeSelect — dropdown with tree view for column + nested path selection
+// (buildTree lives in ./columnTree so its logic stays unit-testable in isolation)
 // ---------------------------------------------------------------------------
-function buildTree(columnNames) {
-  const roots = [];
-  const nodeMap = {}; // path → node
-
-  const getOrCreate = (path, label, parentList) => {
-    if (nodeMap[path]) return nodeMap[path];
-    const node = { id: path, label, path, children: [] };
-    nodeMap[path] = node;
-    parentList.push(node);
-    return node;
-  };
-
-  columnNames.forEach((fullPath) => {
-    // Split into segments: "col.a.b" → ["col","a","b"], "col[0].x" → ["col","[0]","x"]
-    const segments = [];
-    let current = "";
-    for (let i = 0; i < fullPath.length; i++) {
-      const ch = fullPath[i];
-      if (ch === ".") {
-        if (current) segments.push(current);
-        current = "";
-      } else if (ch === "[") {
-        if (current) segments.push(current);
-        current = "[";
-      } else if (ch === "]") {
-        current += "]";
-        segments.push(current);
-        current = "";
-      } else {
-        current += ch;
-      }
-    }
-    if (current) segments.push(current);
-
-    if (segments.length === 1) {
-      getOrCreate(fullPath, segments[0], roots);
-    } else {
-      // Walk segments, creating intermediate nodes
-      let parentList = roots;
-      let builtPath = "";
-      for (let i = 0; i < segments.length; i++) {
-        const sep = i === 0 ? "" : segments[i].startsWith("[") ? "" : ".";
-        builtPath += sep + segments[i];
-        const node = getOrCreate(builtPath, segments[i], parentList);
-        parentList = node.children;
-      }
-    }
-  });
-  return roots;
-}
 
 // Indented tree row. Parent rows carry a chevron to collapse/expand their
 // children (open by default) and show their direct-child count on the right.

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1104,7 +1104,7 @@ const TestPlayground = React.forwardRef(
             }}
           >
             <Iconify
-              icon="solar:play-bold"
+              icon="lucide:play"
               width={14}
               sx={{
                 color:

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1103,14 +1103,23 @@ const TestPlayground = React.forwardRef(
                 activeMainTab === "test" ? "primary.main" : "transparent",
             }}
           >
-            <Iconify
-              icon="lucide:play"
-              width={14}
+            <Box
+              component="svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
               sx={{
+                width: 14,
+                height: 14,
                 color:
                   activeMainTab === "test" ? "primary.main" : "text.secondary",
               }}
-            />
+            >
+              <polygon points="6 3 20 12 6 21 6 3" />
+            </Box>
             <Typography
               variant="body2"
               sx={{

--- a/frontend/src/sections/evals/components/columnTree.js
+++ b/frontend/src/sections/evals/components/columnTree.js
@@ -1,0 +1,57 @@
+// Pure helpers for the dataset variable-mapping column picker (ColumnTreeSelect).
+// Kept dependency-free so the tree-building logic is unit-testable without the
+// heavy DatasetTestMode component graph.
+
+// Parse flat column-path strings into the nested node tree the picker renders.
+// "col" → leaf; "col.a.b" → nested; "col[0].x" → array-indexed nested.
+// Each node is { id, label, path, children }; shared prefixes merge into one node.
+export function buildTree(columnNames) {
+  const roots = [];
+  const nodeMap = {}; // path → node
+
+  const getOrCreate = (path, label, parentList) => {
+    if (nodeMap[path]) return nodeMap[path];
+    const node = { id: path, label, path, children: [] };
+    nodeMap[path] = node;
+    parentList.push(node);
+    return node;
+  };
+
+  columnNames.forEach((fullPath) => {
+    // Split into segments: "col.a.b" → ["col","a","b"], "col[0].x" → ["col","[0]","x"]
+    const segments = [];
+    let current = "";
+    for (let i = 0; i < fullPath.length; i++) {
+      const ch = fullPath[i];
+      if (ch === ".") {
+        if (current) segments.push(current);
+        current = "";
+      } else if (ch === "[") {
+        if (current) segments.push(current);
+        current = "[";
+      } else if (ch === "]") {
+        current += "]";
+        segments.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    if (current) segments.push(current);
+
+    if (segments.length === 1) {
+      getOrCreate(fullPath, segments[0], roots);
+    } else {
+      // Walk segments, creating intermediate nodes
+      let parentList = roots;
+      let builtPath = "";
+      for (let i = 0; i < segments.length; i++) {
+        const sep = i === 0 ? "" : segments[i].startsWith("[") ? "" : ".";
+        builtPath += sep + segments[i];
+        const node = getOrCreate(builtPath, segments[i], parentList);
+        parentList = node.children;
+      }
+    }
+  });
+  return roots;
+}

--- a/frontend/src/sections/evals/components/columnTree.js
+++ b/frontend/src/sections/evals/components/columnTree.js
@@ -2,13 +2,15 @@
 
 // Parse flat column paths into a nested node tree; shared prefixes merge.
 // "col" → leaf; "col.a.b" → nested; "col[0].x" → array-indexed.
+// `isColumn` marks nodes whose path is an actual column (so a path that is both
+// a scalar and a prefix — e.g. "status" + "status.code" — stays selectable).
 export function buildTree(columnNames) {
   const roots = [];
   const nodeMap = {}; // path → node
 
   const getOrCreate = (path, label, parentList) => {
     if (nodeMap[path]) return nodeMap[path];
-    const node = { id: path, label, path, children: [] };
+    const node = { id: path, label, path, children: [], isColumn: false };
     nodeMap[path] = node;
     parentList.push(node);
     return node;
@@ -37,15 +39,16 @@ export function buildTree(columnNames) {
     if (current) segments.push(current);
 
     if (segments.length === 1) {
-      getOrCreate(fullPath, segments[0], roots);
+      getOrCreate(fullPath, segments[0], roots).isColumn = true;
     } else {
-      // Walk segments, creating intermediate nodes
+      // Walk segments, creating intermediate nodes; the terminal one is the column.
       let parentList = roots;
       let builtPath = "";
       for (let i = 0; i < segments.length; i++) {
         const sep = i === 0 ? "" : segments[i].startsWith("[") ? "" : ".";
         builtPath += sep + segments[i];
         const node = getOrCreate(builtPath, segments[i], parentList);
+        if (i === segments.length - 1) node.isColumn = true;
         parentList = node.children;
       }
     }

--- a/frontend/src/sections/evals/components/columnTree.js
+++ b/frontend/src/sections/evals/components/columnTree.js
@@ -1,10 +1,7 @@
-// Pure helpers for the dataset variable-mapping column picker (ColumnTreeSelect).
-// Kept dependency-free so the tree-building logic is unit-testable without the
-// heavy DatasetTestMode component graph.
+// Dependency-free helpers for the column picker (ColumnTreeSelect), kept unit-testable.
 
-// Parse flat column-path strings into the nested node tree the picker renders.
-// "col" → leaf; "col.a.b" → nested; "col[0].x" → array-indexed nested.
-// Each node is { id, label, path, children }; shared prefixes merge into one node.
+// Parse flat column paths into a nested node tree; shared prefixes merge.
+// "col" → leaf; "col.a.b" → nested; "col[0].x" → array-indexed.
 export function buildTree(columnNames) {
   const roots = [];
   const nodeMap = {}; // path → node

--- a/frontend/src/sections/evals/components/columnTree.test.js
+++ b/frontend/src/sections/evals/components/columnTree.test.js
@@ -68,4 +68,22 @@ describe("buildTree", () => {
     expect(tree[0].label).toBe("tags");
     expect(tree[0].children.map((c) => c.path)).toEqual(["tags[0]", "tags[1]"]);
   });
+
+  it("marks isColumn so a scalar that is also a prefix stays selectable", () => {
+    const tree = buildTree(["status", "status.code"]);
+    expect(tree).toHaveLength(1);
+    const status = tree[0];
+    // "status" is both a real column and a parent of "status.code".
+    expect(status.isColumn).toBe(true);
+    expect(status.children.map((c) => c.path)).toEqual(["status.code"]);
+    expect(status.children[0].isColumn).toBe(true);
+  });
+
+  it("does not mark pure prefix nodes as columns", () => {
+    const tree = buildTree(["a.b.c"]);
+    const a = tree[0];
+    expect(a.isColumn).toBe(false); // "a" is only a prefix, never its own column
+    expect(a.children[0].isColumn).toBe(false); // "a.b" likewise
+    expect(a.children[0].children[0].isColumn).toBe(true); // "a.b.c" is the column
+  });
 });

--- a/frontend/src/sections/evals/components/columnTree.test.js
+++ b/frontend/src/sections/evals/components/columnTree.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import { buildTree } from "./columnTree";
+
+// buildTree parses flat column-path strings ("col", "col.a.b", "col[0].x")
+// into the nested node tree that ColumnTreeSelect renders. Each node is
+// { id, label, path, children }.
+
+describe("buildTree", () => {
+  it("returns flat scalar columns as leaf roots with no children", () => {
+    const tree = buildTree(["prompt_tokens", "cost", "status"]);
+    expect(tree).toHaveLength(3);
+    expect(tree.map((n) => n.label)).toEqual([
+      "prompt_tokens",
+      "cost",
+      "status",
+    ]);
+    expect(tree.every((n) => n.children.length === 0)).toBe(true);
+    expect(tree[0]).toMatchObject({
+      id: "prompt_tokens",
+      label: "prompt_tokens",
+      path: "prompt_tokens",
+    });
+  });
+
+  it("nests dot paths and merges shared parents into one node", () => {
+    const tree = buildTree([
+      "status_message.name",
+      "status_message.operation_name.metadata.response_time_ms",
+    ]);
+    // One shared root: status_message
+    expect(tree).toHaveLength(1);
+    const root = tree[0];
+    expect(root.label).toBe("status_message");
+    expect(root.children.map((c) => c.label)).toEqual([
+      "name",
+      "operation_name",
+    ]);
+
+    // Deep leaf keeps the segment as label and the full dotted path as path
+    const operationName = root.children.find(
+      (c) => c.label === "operation_name",
+    );
+    const metadata = operationName.children[0];
+    expect(metadata.label).toBe("metadata");
+    const leaf = metadata.children[0];
+    expect(leaf).toMatchObject({
+      label: "response_time_ms",
+      path: "status_message.operation_name.metadata.response_time_ms",
+    });
+  });
+
+  it("parses array bracket segments without inserting a dot before '['", () => {
+    const tree = buildTree(["child_spans[0].name"]);
+    const root = tree[0];
+    expect(root.label).toBe("child_spans");
+    const index = root.children[0];
+    expect(index).toMatchObject({ label: "[0]", path: "child_spans[0]" });
+    expect(index.children[0]).toMatchObject({
+      label: "name",
+      path: "child_spans[0].name",
+    });
+  });
+
+  it("does not duplicate a parent shared across sibling array indices", () => {
+    const tree = buildTree(["tags[0]", "tags[1]"]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].label).toBe("tags");
+    expect(tree[0].children.map((c) => c.path)).toEqual(["tags[0]", "tags[1]"]);
+  });
+});


### PR DESCRIPTION
## 1. Why the changes are made
The dataset variable-mapping UI (Evals → Test Evaluation → **Dataset**) made it hard to map nested JSON/array fields and left fields unmapped (**TH-4665**). The column dropdown's search matched only from the column prefix, so deep fields like `status_message.operation_name.metadata.response_time_ms` were effectively unreachable; the tree opened fully expanded into an overwhelming wall; rows were monospace with no hierarchy cues; and in dark mode the popover blended into the page with dull leaf text. There was also an icon inconsistency in the Test Evaluation panel header.

## 2. What changes have been made
**Redesigned `ColumnTreeSelect` in `DatasetTestMode.jsx`:**
- Dedicated in-dropdown **search bar** with substring match on the full path (+ clear button) — fixes the prefix-only filter that hid nested fields.
- Custom **`TreeRow`** (replaces `@mui/lab` `TreeView`): open by default, with a per-parent **collapse/expand chevron**; clicking the row text *or* chevron toggles, clicking a **leaf** selects. Direct-child **count pill** per parent.
- **Inter font** (was monospace), **indent guide-lines**, **selected-row highlight** with a check, and the theme's `customShadows.dropdown` so the popover separates cleanly in **dark mode**; leaf text uses `text.primary` for readability.
- Extracted the pure path parser **`buildTree` into `./columnTree.js`** (no behaviour change) so it is unit-testable in isolation.

**Icon fix (`TestPlayground.jsx`):** Test Evaluation header used a filled `solar:play-bold` next to the outlined Versions icon → switched to outlined `lucide:play` matching its size and stroke.

Data model unchanged: mapping values remain `column.dotted.path` strings — **frontend-only, no API/contract change.**

## 3. Tests (new and existing)
- **New:** `src/sections/evals/components/columnTree.test.js` — 4 unit tests for `buildTree` (the column-path → tree parser, the core of the nested rendering).
- **Existing:** the current `vitest` suite is unaffected (no shared behaviour changed). `EvalPickerCreateNew.test.jsx`, which mocks `DatasetTestMode`, still passes.
- No component-render tests added: `ColumnTreeSelect`/`TreeRow` are internal presentational helpers, and the mapping output contract is unchanged; the interactive behaviour is covered by the manual scenarios in §6.

## 4. What scenarios each test covers
`columnTree.test.js` → `buildTree`:
1. **Flat scalar columns** → returned as leaf roots with no children (`prompt_tokens`, `cost`, `status`).
2. **Nested dot paths** → hierarchy built, shared parents merged into one node, leaf keeps the full dotted `path` (`status_message.operation_name.metadata.response_time_ms`).
3. **Array bracket segments** → parsed without a dot before `[` (`child_spans[0].name` → `child_spans` › `[0]` › `name`, paths `child_spans[0]`, `child_spans[0].name`).
4. **Shared parent across sibling indices** → `tags[0]` / `tags[1]` produce a single `tags` parent with two children (no duplicate parent).

## 5. Commands to run the tests
```bash
cd frontend
yarn install
# just the new test:
npx vitest run src/sections/evals/components/columnTree.test.js
# full suite:
yarn test:run
# lint:
yarn lint
```

## 6. Steps to test the changes on local/dev
1. `cd frontend && yarn install && yarn dev` → open `http://localhost:3031`.
2. **Evals** → open an eval (e.g. `customer_agent_task_completion`) → right **Test Evaluation** panel → **Dataset** tab.
3. Choose a dataset that has JSON columns (e.g. `exported-annotations`).
4. Open a **Select column** dropdown under **Variable Mapping** and verify:
   - Searching a nested field (e.g. `response_time`) surfaces the deep path.
   - Parents expand/collapse via the chevron **and** the row text; leaves select and populate the mapping.
   - Child-count pills and indent guide-lines render the hierarchy.
   - Repeat in **light and dark** theme (dropdown separation + readable leaf text).
5. Check the Test Evaluation / Versions header icons are consistent (both outlined, matching size/stroke).

## 7. Screenshots / videos

**Variable Mapping column picker (Test Evaluation → Dataset):**

<img width="794" height="616" alt="Variable Mapping column picker" src="https://github.com/user-attachments/assets/ad1fe107-cc47-4eea-b281-85aaf4ef763e" />

## 8. Key decisions (and why)
- **Kept the `mapping[var] = "col.path"` string model** → frontend-only, no backend coordination; avoids a contract change for a UI improvement.
- **Replaced `@mui/lab` `TreeView` with a custom `TreeRow`** → needed open-by-default + per-node collapse + count pills + guide-lines; fighting `TreeView`'s controlled/expanded API for all of that was more code and less predictable.
- **Extracted `buildTree` into a pure module** → importing `DatasetTestMode` in a test pulls a zustand store that reads `localStorage` at load time (why the existing test fully mocks the component); a dependency-free module makes the core logic unit-testable and is cleaner separation.
- **Used the theme's `customShadows.dropdown`** (not raw MUI elevation) → the default elevation shadow is invisible on the near-black dark page; the theme token gives a proper ring+shadow and matches the app's other dropdowns.
- **Array wildcard (`[*]`) left out of scope** → would require backend path resolution; current change exposes the concrete array indices present in the row.

Refs TH-4665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
