### PR TITLE
fix(ch): replicate legacy default-DB tables to Replicated engines (TH-6276)

### DIFF
--- a/futureagi/agentic_eval/core/database/ch_vector.py
+++ b/futureagi/agentic_eval/core/database/ch_vector.py
@@ -33,6 +33,55 @@ def get_clickhouse_cluster_name() -> str:
     return os.getenv("CH_CLUSTER_NAME") or "cluster"
 
 
+_MERGE_TREE_ENGINE_RE = re.compile(
+    r"^\s*(?P<family>[A-Za-z]*MergeTree)\s*(?:\((?P<args>.*)\))?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def build_replicated_engine(
+    base_engine: str,
+    table_name: str,
+    *,
+    clustered: bool,
+    database: str | None = None,
+    cluster: str | None = None,
+) -> tuple[str, str]:
+    """Return ``(engine_clause, on_cluster_clause)`` for a ``CREATE TABLE``.
+
+    On a multi-replica cluster a plain ``*MergeTree[(args)]`` engine is rewritten
+    to its ``Replicated*`` form, preserving the sub-family and any version/sign
+    argument: ``MergeTree`` -> ``ReplicatedMergeTree``,
+    ``ReplacingMergeTree(ts)`` -> ``ReplicatedReplacingMergeTree('<zk>', '{replica}', ts)``.
+    The Keeper path follows the deployment convention
+    ``/clickhouse/tables/{shard}/<database>/<table>`` so two tables with the same
+    short name in different databases never share a znode.
+
+    On single-node CH the base engine is returned unchanged with an empty
+    ``ON CLUSTER`` clause, so dev and single-replica deployments keep plain
+    engines. One engine-selection rule for every legacy ``default.*`` table;
+    ``ClickHouseVectorDB.create_table`` is built on the same helper.
+    """
+    if not clustered:
+        return base_engine, ""
+    match = _MERGE_TREE_ENGINE_RE.match(base_engine)
+    if not match:
+        raise ValueError(
+            f"build_replicated_engine: {base_engine!r} is not a recognised "
+            "*MergeTree engine, so no Replicated* form can be derived."
+        )
+    family = match.group("family")
+    inner = (match.group("args") or "").strip()
+    zk_database_segment = f"{database}/" if database else ""
+    zk_path = f"/clickhouse/tables/{{shard}}/{zk_database_segment}{table_name}"
+    engine_args = [f"'{zk_path}'", "'{replica}'"]
+    if inner:
+        engine_args.append(inner)
+    engine = f"Replicated{family}({', '.join(engine_args)})"
+    on_cluster = f" ON CLUSTER '{cluster or get_clickhouse_cluster_name()}'"
+    return engine, on_cluster
+
+
 def sanitize_sql_value(value: str) -> str:
     """
     Sanitize and escape a string value to make it safe for SQL queries.
@@ -118,7 +167,8 @@ class ClickHouseVectorDB:
     ):
         self.client = clickhouse_driver.Client(**get_clickhouse_client_kwargs())
 
-    def _is_clustered(self) -> bool:
+    @classmethod
+    def is_clustered(cls, client) -> bool:
         """True iff CH has a genuinely multi-replica cluster; fails safe to False.
 
         Checking `system.macros` for the `replica` macro was too lenient: a
@@ -129,18 +179,25 @@ class ClickHouseVectorDB:
         Using `system.clusters.replica_num` is the precise check: prod multi-
         replica clusters have rows with `replica_num > 1`; a single-node
         cluster only has `replica_num = 1`.
+
+        Classmethod taking any client with `.execute`, so callers that hold a
+        raw driver client (boot-time DDL, the LLM usage logger) share the same
+        per-process answer instead of each re-probing.
         """
-        if ClickHouseVectorDB._is_clustered_cached is not None:
-            return ClickHouseVectorDB._is_clustered_cached
+        if cls._is_clustered_cached is not None:
+            return cls._is_clustered_cached
         try:
-            rows = self.client.execute(
+            rows = client.execute(
                 "SELECT count() FROM system.clusters WHERE replica_num > 1"
             )
-            ClickHouseVectorDB._is_clustered_cached = bool(rows and rows[0][0])
+            cls._is_clustered_cached = bool(rows and rows[0][0])
         except Exception:
             logger.warning("ch_vector_cluster_detect_failed", exc_info=True)
-            ClickHouseVectorDB._is_clustered_cached = False
-        return ClickHouseVectorDB._is_clustered_cached
+            cls._is_clustered_cached = False
+        return cls._is_clustered_cached
+
+    def _is_clustered(self) -> bool:
+        return self.is_clustered(self.client)
 
     def drop_table(self,table_name: str) -> None:
         """
@@ -182,19 +239,13 @@ class ClickHouseVectorDB:
         clustered = self._is_clustered()
         cluster_name = cluster or get_clickhouse_cluster_name()
         qualified = f"{database}.{table_name}" if database else table_name
-        zk_database_segment = f"{database}/" if database else ""
-
-        if clustered:
-            engine = (
-                f"ReplicatedReplacingMergeTree("
-                f"'/clickhouse/tables/{{shard}}/{zk_database_segment}{table_name}', "
-                f"'{{replica}}'"
-                f")"
-            )
-            on_cluster = f" ON CLUSTER '{cluster_name}'"
-        else:
-            engine = "ReplacingMergeTree()"
-            on_cluster = ""
+        engine, on_cluster = build_replicated_engine(
+            "ReplacingMergeTree()",
+            table_name,
+            clustered=clustered,
+            database=database,
+            cluster=cluster_name,
+        )
 
         create_table_query = f"""
         CREATE TABLE IF NOT EXISTS {qualified}{on_cluster} (

--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -249,125 +249,18 @@ class ModelHubConfig(AppConfig):
         for vector_db in vector_dbs:
             db_client.create_table(vector_db)
 
+        from model_hub.services.legacy_ch_tables import (
+            ensure_events_table,
+            ensure_llm_logs_table,
+        )
         from tfc.utils.clickhouse import ClickHouseClientSingleton
 
         ch_instance = ClickHouseClientSingleton()
 
-        # Example: Check if table exists
-        result = ch_instance.execute("SHOW TABLES FROM default")
-        tables = [row[0] for row in result]
-
-        if "events" in tables:
-            # Check if original_uuid column exists
-            columns = ch_instance.execute("DESCRIBE TABLE events")
-            column_names = [col[0] for col in columns]
-
-            if "original_uuid" not in column_names:
-                # Add the original_uuid column
-                ch_instance.execute(
-                    """
-                    ALTER TABLE events
-                    ADD COLUMN IF NOT EXISTS original_uuid UUID DEFAULT UUID
-                    """
-                )
-
-        if "events" not in tables:
-            # Create the table with original_uuid included
-            ch_instance.execute(
-                """
-                CREATE TABLE IF NOT EXISTS events (
-                    UUID UUID,
-                    original_uuid UUID DEFAULT UUID,
-                    EventDate Date,
-                    EventDateTime DateTime,
-                    EventName String,
-                    EventType String,
-                    AIModel String DEFAULT '',
-                    OrgID String,
-                    PredictionID String DEFAULT '',
-                    ModelVersion String DEFAULT '',
-                    BatchID String DEFAULT '',
-                    Environment UInt8 DEFAULT 0,
-                    Properties Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Features Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    ActualLabel Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    PredictionLabel Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    EvalResults Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    ShapValues Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Tags Nested(
-                        Key String,
-                        Value String,
-                        DataType String
-                    ),
-                    Embedding Array(Float32) DEFAULT [],
-                    deleted UInt8 DEFAULT 0
-
-                ) ENGINE = MergeTree()
-                PARTITION BY toYYYYMM(EventDate)
-                ORDER BY (EventDate, EventName, OrgID, UUID);
-            """
-            )
-
-        if "llm_logs" not in tables:
-            ch_instance.execute(
-                """
-            CREATE TABLE IF NOT EXISTS llm_logs
-            (
-                `EventDateTime` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-                `EventDate` Date,
-                `TraceId` String CODEC(ZSTD(1)),
-                `SpanId` String CODEC(ZSTD(1)),
-                `SeverityText` LowCardinality(String) CODEC(ZSTD(1)),
-                `SeverityNumber` Int32 CODEC(ZSTD(1)),
-                `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
-                `LLMModelName` LowCardinality(String) CODEC(ZSTD(1)), -- Name of the LLM model used
-                `UserId` String CODEC(ZSTD(1)), -- User identifier
-                `SessionId` String CODEC(ZSTD(1)), -- Session identifier
-                `RequestBody` String CODEC(ZSTD(1)), -- Request sent to the LLM
-                `ResponseBody` String CODEC(ZSTD(1)), -- Response received from the LLM
-                `RequestTokens` Int32 CODEC(ZSTD(1)), -- Number of tokens in the request
-                `ResponseTokens` Int32 CODEC(ZSTD(1)), -- Number of tokens in the response
-                `ResponseTime` Float32 CODEC(ZSTD(1)), -- Time taken to get the response
-                `LogAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)), -- Additional log attributes
-                `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-                INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_llm_model_name LLMModelName TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_user_id UserId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_session_id SessionId TYPE bloom_filter(0.001) GRANULARITY 1,
-                INDEX idx_request_body RequestBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
-                INDEX idx_response_body ResponseBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
-            )
-            ENGINE = MergeTree
-            PARTITION BY EventDate
-            ORDER BY (LLMModelName, EventDateTime)
-            SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-
-            """
-            )
+        # Idempotent CREATE TABLE IF NOT EXISTS, replicated on a multi-replica
+        # cluster. Targets the connection's current database (CH_DATABASE).
+        ensure_events_table(ch_instance)
+        ensure_llm_logs_table(ch_instance)
 
 
 ##################################################

--- a/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
+++ b/futureagi/model_hub/management/commands/migrate_legacy_default_tables_to_replicated.py
@@ -1,0 +1,518 @@
+"""Copy the non-vector ClickHouse tables that live in a legacy non-replicated
+location (``cluster_centroids``, ``trace_input_embeddings``, ``error_embeddings``,
+``llm_logs``, ``events``) into a replicated target database.
+
+Sibling of ``migrate_legacy_vectors_to_replicated``: same shape (read every
+replica via ``clusterAllReplicas``, create the target with the replicated
+engine, poll per-replica parity), but each table here has its own schema and
+dedup key, so the copy is driven by a per-table spec instead of a fixed
+``WHERE id NOT IN`` clause.
+
+Dedup keys
+----------
+* ``trace_input_embeddings`` -> ``(project_id, trace_id)``
+* ``error_embeddings``       -> ``id``
+* ``cluster_centroids``      -> ``cluster_id``
+* ``llm_logs`` / ``events``  -> append-only logs with no unique key. The copy is
+  one-shot: it runs only when the target is confirmed empty on EVERY replica and
+  refuses otherwise, because a second pass would duplicate every row (no key to
+  dedup on).
+
+Safety invariants
+-----------------
+* Replica awareness: the target row count and parity checks require every
+  expected replica (``system.clusters``) to be present in the
+  ``clusterAllReplicas ... GROUP BY hostName()`` result. A replica that is
+  missing (still registering) or behind is treated as not-yet-converged, never
+  as "empty" or "done".
+* Name-aligned copy: rows are copied with an explicit shared column list, not
+  ``SELECT *``. A legacy source whose column order/set has drifted from the
+  canonical target schema is copied by column name (target-only columns fall
+  back to their DEFAULT); it never silently misaligns by position.
+* Failure propagation: a table that cannot reach per-replica parity fails the
+  whole command with a non-zero exit, so an exit-code-gated cutover cannot flip
+  before the replicated copies have converged.
+
+Idempotent for the keyed tables; one-shot (guarded) for the log tables. Run from
+a backend pod that connects to the production CH cluster.
+"""
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import structlog
+from django.core.management.base import BaseCommand, CommandError
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    get_clickhouse_cluster_name,
+)
+from model_hub.services.legacy_ch_tables import (
+    EVENTS_TABLE,
+    LLM_LOGS_TABLE,
+    ensure_events_table,
+    ensure_llm_logs_table,
+)
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    ERROR_EMBEDDINGS_TABLE,
+    TRACE_INPUTS_TABLE,
+    ensure_centroid_table,
+    ensure_error_embeddings_table,
+    ensure_trace_inputs_table,
+)
+
+logger = structlog.get_logger(__name__)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class _LegacyTable:
+    """How to recreate and back-fill one legacy ``default.*`` table.
+
+    ``dedup_columns`` is the comma-separated key used for the idempotent
+    ``NOT IN`` anti-join; ``None`` marks an append-only log with no unique key
+    (copied one-shot into a confirmed-empty target only). ``pass_vectordb`` says
+    whether the ensure helper takes a ``ClickHouseVectorDB`` (the clustering
+    tables) or a raw client (the model-hub log tables).
+    """
+
+    name: str
+    dedup_columns: str | None
+    _ensure: Callable
+    pass_vectordb: bool
+
+    def ensure_target(
+        self, db: ClickHouseVectorDB, target_db: str, cluster: str
+    ) -> None:
+        client_arg = db if self.pass_vectordb else db.client
+        self._ensure(client_arg, database=target_db, cluster=cluster)
+
+    @property
+    def is_keyed(self) -> bool:
+        return self.dedup_columns is not None
+
+
+_TABLES: dict[str, _LegacyTable] = {
+    t.name: t
+    for t in (
+        _LegacyTable(
+            TRACE_INPUTS_TABLE, "project_id, trace_id", ensure_trace_inputs_table, True
+        ),
+        _LegacyTable(ERROR_EMBEDDINGS_TABLE, "id", ensure_error_embeddings_table, True),
+        _LegacyTable(CENTROIDS_TABLE, "cluster_id", ensure_centroid_table, True),
+        _LegacyTable(LLM_LOGS_TABLE, None, ensure_llm_logs_table, False),
+        _LegacyTable(EVENTS_TABLE, None, ensure_events_table, False),
+    )
+}
+
+
+def _require_identifier(value: str, flag: str) -> str:
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise CommandError(
+            f"{flag} {value!r} is not a valid ClickHouse identifier. "
+            "Allowed: letters, digits, underscores; must not start with a digit."
+        )
+    return value
+
+
+class Command(BaseCommand):
+    help = (
+        "Migrate the legacy non-replicated default-database CH tables "
+        "(cluster_centroids, trace_input_embeddings, error_embeddings, "
+        "llm_logs, events) into a replicated target database."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source-database",
+            default=os.getenv("CH_DATABASE") or "default",
+        )
+        parser.add_argument("--target-database", default=None)
+        parser.add_argument(
+            "--tables",
+            default=",".join(_TABLES),
+            help=f"Comma-separated subset of {', '.join(_TABLES)}.",
+        )
+        parser.add_argument("--cluster", default=get_clickhouse_cluster_name())
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **opts):
+        source_db = _require_identifier(opts["source_database"], "--source-database")
+        target_db = _require_identifier(
+            opts["target_database"] or source_db, "--target-database"
+        )
+        cluster = _require_identifier(opts["cluster"], "--cluster")
+        dry_run = opts["dry_run"]
+        table_names = [t.strip() for t in opts["tables"].split(",") if t.strip()]
+
+        unknown = [t for t in table_names if t not in _TABLES]
+        if unknown:
+            raise CommandError(
+                f"--tables contains unknown entries {unknown}. "
+                f"Allowed: {', '.join(_TABLES)}."
+            )
+
+        if source_db == target_db:
+            raise CommandError(
+                f"--source-database and --target-database must differ ({source_db!r})."
+            )
+
+        db_client = ClickHouseVectorDB()
+        if not dry_run and not db_client._is_clustered():
+            raise CommandError(
+                "CH server is not a multi-replica cluster member "
+                "(no row in `system.clusters` with `replica_num > 1`). "
+                "Run from a backend pod that connects to the production CH cluster."
+            )
+
+        expected_replicas = 0 if dry_run else self._expected_replica_count(
+            db_client, cluster
+        )
+
+        if not dry_run:
+            db_client.client.execute(
+                f"CREATE DATABASE IF NOT EXISTS {target_db} ON CLUSTER '{cluster}'"
+            )
+
+        logger.info(
+            "migrate_legacy_default_tables_started",
+            source_database=source_db,
+            target_database=target_db,
+            tables=table_names,
+            cluster=cluster,
+            expected_replicas=expected_replicas,
+            dry_run=dry_run,
+        )
+
+        total_copied = 0
+        failures: list[str] = []
+        for name in table_names:
+            copied, ok = self._migrate_one_table(
+                db_client=db_client,
+                spec=_TABLES[name],
+                source_db=source_db,
+                target_db=target_db,
+                cluster=cluster,
+                expected_replicas=expected_replicas,
+                dry_run=dry_run,
+            )
+            total_copied += copied
+            if not ok:
+                failures.append(name)
+
+        logger.info(
+            "migrate_legacy_default_tables_complete",
+            tables=table_names,
+            total_rows_copied=total_copied,
+            failures=failures,
+            dry_run=dry_run,
+        )
+        if failures:
+            # Non-zero exit so an exit-code-gated cutover can't flip CH_DATABASE
+            # before every replicated copy has converged.
+            raise CommandError(
+                f"Migration did not fully converge for {failures}. "
+                f"Do NOT flip CH_DATABASE. Inspect per-table logs; re-run once "
+                f"lagging replicas catch up (keyed tables are idempotent)."
+            )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Tables processed: {table_names}. "
+                f"Total rows copied: {total_copied}."
+            )
+        )
+
+    def _migrate_one_table(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        spec: _LegacyTable,
+        source_db: str,
+        target_db: str,
+        cluster: str,
+        expected_replicas: int,
+        dry_run: bool,
+    ) -> tuple[int, bool]:
+        """Return ``(rows_copied, converged_ok)``."""
+        source_qualified = f"{source_db}.{spec.name}"
+        target_qualified = f"{target_db}.{spec.name}"
+
+        source_exists = db_client.client.execute(
+            "SELECT count() FROM system.tables "
+            "WHERE database = %(db)s AND name = %(t)s",
+            {"db": source_db, "t": spec.name},
+        )[0][0]
+
+        # uniqExact over the dedup key for keyed tables; row count for the
+        # append-only log tables.
+        count_expr = f"uniqExact({spec.dedup_columns})" if spec.is_keyed else "count()"
+
+        if dry_run:
+            if not source_exists:
+                self.stdout.write(
+                    f"  dry-run: source {source_qualified} missing; "
+                    f"would create empty target {target_qualified}"
+                )
+                return 0, True
+            source_count = db_client.client.execute(
+                f"SELECT {count_expr} FROM clusterAllReplicas("
+                f"'{cluster}', {source_qualified})"
+            )[0][0]
+            mode = "idempotent" if spec.is_keyed else "one-shot (target must be empty)"
+            self.stdout.write(
+                f"  dry-run: would copy {source_count} rows from "
+                f"{source_qualified} -> {target_qualified} [{mode}]"
+            )
+            return 0, True
+
+        spec.ensure_target(db_client, target_db, cluster)
+
+        if not source_exists:
+            logger.info(
+                "migrate_target_created_source_missing",
+                source=source_qualified,
+                target=target_qualified,
+            )
+            self.stdout.write(
+                f"  {spec.name}: target ready; source {source_qualified} "
+                f"missing, nothing to copy"
+            )
+            return 0, True
+
+        source_count = db_client.client.execute(
+            f"SELECT {count_expr} FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified})"
+        )[0][0]
+
+        before_counts = self._per_replica_counts(
+            db_client, target_db, spec.name, cluster
+        )
+
+        if not spec.is_keyed:
+            # Append-only log with no dedup key. Three outcomes, decided by the
+            # FULL replica set (a replica missing from the result, or holding a
+            # different count, is never treated as "empty" or "done"):
+            #   - empty on every replica            -> safe to copy
+            #   - already >= source on every replica -> already migrated, no-op ok
+            #   - anything else (partial / diverged) -> refuse; re-copy would
+            #     duplicate the keyless log, so this needs a manual TRUNCATE.
+            # (min() across replicas would let one empty/lagging replica wave the
+            # copy through and duplicate the whole log.)
+            complete = len(before_counts) == expected_replicas
+            empty_everywhere = complete and all(
+                c == 0 for c in before_counts.values()
+            )
+            already_done = (
+                complete
+                and source_count > 0
+                and all(c >= source_count for c in before_counts.values())
+            )
+            if already_done:
+                self.stdout.write(
+                    f"  {spec.name}: already populated and converged on all "
+                    f"{expected_replicas} replicas ({before_counts}); one-shot no-op."
+                )
+                return 0, True
+            if not empty_everywhere:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  {spec.name}: append-only table is not confirmed empty on "
+                        f"all {expected_replicas} replicas (per-replica {before_counts}); "
+                        f"refusing to stay non-duplicating. TRUNCATE TABLE "
+                        f"{target_qualified} ON CLUSTER '{cluster}' and re-run to force "
+                        f"a fresh copy once every replica is up."
+                    )
+                )
+                logger.warning(
+                    "migrate_oneshot_target_not_confirmed_empty",
+                    target=target_qualified,
+                    expected_replicas=expected_replicas,
+                    per_replica_counts=before_counts,
+                )
+                return 0, False
+
+        existing_target_count = min(before_counts.values(), default=0)
+
+        # Name-aligned copy: explicit shared column list, never SELECT *. Guards
+        # against a drifted legacy source (column order/set) silently misaligning
+        # by position; target-only columns fall back to their DEFAULT.
+        shared_cols, source_only = self._shared_columns(
+            db_client, source_db, target_db, spec.name
+        )
+        if not shared_cols:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  {spec.name}: no shared columns between {source_qualified} and "
+                    f"{target_qualified}; refusing to copy."
+                )
+            )
+            return 0, False
+        if source_only:
+            logger.warning(
+                "migrate_source_only_columns_dropped",
+                table=spec.name,
+                source_only_columns=source_only,
+            )
+        col_list = ", ".join(f"`{c}`" for c in shared_cols)
+
+        where = ""
+        if spec.is_keyed:
+            where = (
+                f" WHERE ({spec.dedup_columns}) NOT IN "
+                f"(SELECT {spec.dedup_columns} FROM {target_qualified})"
+            )
+
+        insert_started = time.monotonic()
+        db_client.client.execute(
+            f"INSERT INTO {target_qualified} ({col_list}) "
+            f"SELECT {col_list} FROM clusterAllReplicas("
+            f"'{cluster}', {source_qualified}){where}"
+        )
+        insert_elapsed = time.monotonic() - insert_started
+
+        per_replica_counts, converged = self._poll_replica_parity(
+            db_client=db_client,
+            target_db=target_db,
+            table=spec.name,
+            cluster=cluster,
+            expected=source_count,
+            expected_replicas=expected_replicas,
+        )
+        after_target_count = min(per_replica_counts.values(), default=0)
+        newly_copied = after_target_count - existing_target_count
+
+        logger.info(
+            "migrate_table_complete",
+            source=source_qualified,
+            target=target_qualified,
+            source_count=source_count,
+            target_count_before=existing_target_count,
+            per_replica_counts=per_replica_counts,
+            expected_replicas=expected_replicas,
+            newly_copied=newly_copied,
+            insert_elapsed_sec=round(insert_elapsed, 3),
+            converged=converged,
+        )
+        if not converged:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"  {spec.name}: NOT converged — per-replica {per_replica_counts}, "
+                    f"expected {source_count} on each of {expected_replicas} replicas."
+                )
+            )
+        else:
+            self.stdout.write(
+                f"  {spec.name}: copied {newly_copied} rows; "
+                f"per-replica counts {per_replica_counts}"
+            )
+        return newly_copied, converged
+
+    def _expected_replica_count(
+        self, db_client: ClickHouseVectorDB, cluster: str
+    ) -> int:
+        """Number of hosts the cluster spans — the number of per-replica rows a
+        complete ``_per_replica_counts`` result must contain before it is trusted
+        (an incomplete result means a replica is still registering or is down).
+        """
+        rows = db_client.client.execute(
+            "SELECT count() FROM system.clusters WHERE cluster = %(c)s",
+            {"c": cluster},
+        )
+        return rows[0][0] if rows else 0
+
+    def _shared_columns(
+        self,
+        db_client: ClickHouseVectorDB,
+        source_db: str,
+        target_db: str,
+        table: str,
+    ) -> tuple[list[str], list[str]]:
+        """Columns present in BOTH source and target, in target order, plus the
+        list of source-only columns (dropped by the copy)."""
+        def cols(db: str) -> list[str]:
+            return [
+                r[0]
+                for r in db_client.client.execute(
+                    "SELECT name FROM system.columns "
+                    "WHERE database = %(d)s AND table = %(t)s ORDER BY position",
+                    {"d": db, "t": table},
+                )
+            ]
+        src = cols(source_db)
+        tgt = cols(target_db)
+        src_set, tgt_set = set(src), set(tgt)
+        shared = [c for c in tgt if c in src_set]
+        source_only = [c for c in src if c not in tgt_set]
+        return shared, source_only
+
+    def _per_replica_counts(
+        self,
+        db_client: ClickHouseVectorDB,
+        database: str,
+        table: str,
+        cluster: str,
+    ) -> dict[str, int]:
+        """Per-replica row count via ``system.tables.total_rows``.
+
+        Read through ``clusterAllReplicas(system.tables)`` rather than
+        ``count() ... GROUP BY hostName()``: the latter yields NO group for a
+        replica where the table is empty, so a freshly-created (all-empty) target
+        would read as "zero replicas" and mislead both the one-shot guard and the
+        parity check. ``system.tables`` has one row per replica that holds the
+        table — including the empty ones — and omits a replica that is missing
+        the table entirely, which is exactly the signal we want.
+        """
+        rows = db_client.client.execute(
+            f"SELECT hostName(), total_rows FROM clusterAllReplicas("
+            f"'{cluster}', system.tables) "
+            f"WHERE database = %(d)s AND name = %(t)s",
+            {"d": database, "t": table},
+        )
+        return {host: int(cnt or 0) for host, cnt in rows}
+
+    def _poll_replica_parity(
+        self,
+        *,
+        db_client: ClickHouseVectorDB,
+        target_db: str,
+        table: str,
+        cluster: str,
+        expected: int,
+        expected_replicas: int,
+        max_wait_sec: float = 30.0,
+        poll_interval: float = 2.0,
+    ) -> tuple[dict[str, int], bool]:
+        """Poll until EVERY expected replica reports >= ``expected`` rows.
+
+        Returns ``(per_replica_counts, converged)``. Converged requires the full
+        set of replicas to be present AND each at/above the expected count — a
+        replica still registering (absent from the result) counts as not-yet.
+        """
+        deadline = time.monotonic() + max_wait_sec
+        counts: dict[str, int] = {}
+        while True:
+            counts = self._per_replica_counts(db_client, target_db, table, cluster)
+            converged = (
+                len(counts) >= expected_replicas
+                and bool(counts)
+                and all(c >= expected for c in counts.values())
+            )
+            if converged:
+                return counts, True
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "migrate_parity_wait_timed_out",
+                    target=f"{target_db}.{table}",
+                    expected=expected,
+                    expected_replicas=expected_replicas,
+                    per_replica_counts=counts,
+                    max_wait_sec=max_wait_sec,
+                )
+                return counts, False
+            time.sleep(poll_interval)

--- a/futureagi/model_hub/services/legacy_ch_tables.py
+++ b/futureagi/model_hub/services/legacy_ch_tables.py
@@ -1,0 +1,139 @@
+"""DDL for the legacy ``default``-database ClickHouse tables that the model-hub
+app boots: ``events`` (ML-monitoring) and ``llm_logs`` (LLM usage telemetry).
+
+Both were plain ``MergeTree`` created inline in ``apps.py``, so on a multi-replica
+cluster each row lived on whichever replica took the write and a single-replica
+read saw only its slice. They become ``ReplicatedMergeTree`` here — plain, not
+``Replacing``: both are append-only logs whose ORDER BY keys are not unique
+(``llm_logs`` orders by ``(LLMModelName, EventDateTime)``), so a ``Replacing``
+engine would silently collapse distinct rows.
+
+Centralised so the engine choice has one home and the default-to-replicated
+migration command can recreate the same schema in a target database.
+"""
+from __future__ import annotations
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    build_replicated_engine,
+)
+
+EVENTS_TABLE = "events"
+LLM_LOGS_TABLE = "llm_logs"
+
+
+def _qualified(table: str, database: str | None) -> str:
+    return f"{database}.{table}" if database else table
+
+
+def ensure_events_table(client, *, database: str | None = None, cluster: str | None = None) -> None:
+    """Create the ML-monitoring ``events`` table if absent (idempotent)."""
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree()",
+        EVENTS_TABLE,
+        clustered=ClickHouseVectorDB.is_clustered(client),
+        database=database,
+        cluster=cluster,
+    )
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(EVENTS_TABLE, database)}{on_cluster} (
+            UUID UUID,
+            original_uuid UUID DEFAULT UUID,
+            EventDate Date,
+            EventDateTime DateTime,
+            EventName String,
+            EventType String,
+            AIModel String DEFAULT '',
+            OrgID String,
+            PredictionID String DEFAULT '',
+            ModelVersion String DEFAULT '',
+            BatchID String DEFAULT '',
+            Environment UInt8 DEFAULT 0,
+            Properties Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Features Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            ActualLabel Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            PredictionLabel Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            EvalResults Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            ShapValues Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Tags Nested(
+                Key String,
+                Value String,
+                DataType String
+            ),
+            Embedding Array(Float32) DEFAULT [],
+            deleted UInt8 DEFAULT 0
+        ) ENGINE = {engine}
+        PARTITION BY toYYYYMM(EventDate)
+        ORDER BY (EventDate, EventName, OrgID, UUID)
+        """
+    )
+
+
+def ensure_llm_logs_table(client, *, database: str | None = None, cluster: str | None = None) -> None:
+    """Create the ``llm_logs`` usage-telemetry table if absent (idempotent)."""
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree",
+        LLM_LOGS_TABLE,
+        clustered=ClickHouseVectorDB.is_clustered(client),
+        database=database,
+        cluster=cluster,
+    )
+    client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(LLM_LOGS_TABLE, database)}{on_cluster}
+        (
+            `EventDateTime` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+            `EventDate` Date,
+            `TraceId` String CODEC(ZSTD(1)),
+            `SpanId` String CODEC(ZSTD(1)),
+            `SeverityText` LowCardinality(String) CODEC(ZSTD(1)),
+            `SeverityNumber` Int32 CODEC(ZSTD(1)),
+            `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
+            `LLMModelName` LowCardinality(String) CODEC(ZSTD(1)),
+            `UserId` String CODEC(ZSTD(1)),
+            `SessionId` String CODEC(ZSTD(1)),
+            `RequestBody` String CODEC(ZSTD(1)),
+            `ResponseBody` String CODEC(ZSTD(1)),
+            `RequestTokens` Int32 CODEC(ZSTD(1)),
+            `ResponseTokens` Int32 CODEC(ZSTD(1)),
+            `ResponseTime` Float32 CODEC(ZSTD(1)),
+            `LogAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+            `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+            INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_llm_model_name LLMModelName TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_user_id UserId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_session_id SessionId TYPE bloom_filter(0.001) GRANULARITY 1,
+            INDEX idx_request_body RequestBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+            INDEX idx_response_body ResponseBody TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+        )
+        ENGINE = {engine}
+        PARTITION BY EventDate
+        ORDER BY (LLMModelName, EventDateTime)
+        SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+        """
+    )

--- a/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
+++ b/futureagi/model_hub/tests/test_legacy_ch_tables_engine_selection.py
@@ -1,0 +1,198 @@
+"""Engine-selection tests for the legacy ``default.*`` ClickHouse tables.
+
+These five tables (``cluster_centroids``, ``trace_input_embeddings``,
+``error_embeddings``, ``llm_logs``, ``events``) are created by ad-hoc
+``ensure_*`` helpers rather than the managed v2 schema. Each helper must emit a
+``Replicated*`` engine ``ON CLUSTER`` on a multi-replica cluster and the plain
+engine on single-node CH — and must preserve its own sub-family: the centroid /
+trace-input tables stay ``Replacing`` (with their version column), while the
+append-only / soft-delete tables stay plain ``MergeTree``.
+
+No real CH: the client is mocked and the cluster-introspection result forced.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentic_eval.core.database.ch_vector import build_replicated_engine
+from model_hub.services.legacy_ch_tables import (
+    ensure_events_table,
+    ensure_llm_logs_table,
+)
+from tracer.services.clickhouse.clustering_tables import (
+    ensure_centroid_table,
+    ensure_error_embeddings_table,
+    ensure_trace_inputs_table,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_clustered_cache():
+    """`is_clustered` caches on the class; reset so each test forces its own."""
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    yield
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+
+
+# (ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col)
+_CASES = [
+    (
+        ensure_centroid_table,
+        True,
+        "cluster_centroids",
+        "ReplicatedReplacingMergeTree",
+        "ReplacingMergeTree(last_updated)",
+        "last_updated",
+    ),
+    (
+        ensure_trace_inputs_table,
+        True,
+        "trace_input_embeddings",
+        "ReplicatedReplacingMergeTree",
+        "ReplacingMergeTree(created_at)",
+        "created_at",
+    ),
+    (
+        ensure_error_embeddings_table,
+        True,
+        "error_embeddings",
+        "ReplicatedMergeTree",
+        "MergeTree()",
+        None,
+    ),
+    (
+        ensure_events_table,
+        False,
+        "events",
+        "ReplicatedMergeTree",
+        "MergeTree()",
+        None,
+    ),
+    (
+        ensure_llm_logs_table,
+        False,
+        "llm_logs",
+        "ReplicatedMergeTree",
+        "MergeTree",
+        None,
+    ),
+]
+
+_IDS = [c[2] for c in _CASES]
+
+
+def _run_ensure(ensure_fn, takes_vectordb, *, clustered, database=None) -> str:
+    """Invoke an ensure helper with a mocked client and return the CREATE SQL."""
+    client = MagicMock()
+    # The legacy helpers probe system.clusters through this same client.
+    client.execute.return_value = [[1 if clustered else 0]]
+
+    if takes_vectordb:
+        db = MagicMock()
+        db._is_clustered.return_value = clustered
+        db.client = client
+        ensure_fn(db, database=database)
+    else:
+        ensure_fn(client, database=database)
+
+    for call in reversed(client.execute.call_args_list):
+        if "CREATE TABLE" in call.args[0]:
+            return call.args[0]
+    raise AssertionError("no CREATE TABLE call captured")
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_clustered_emits_replicated_engine_on_cluster(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True)
+
+    assert f"ENGINE = {replicated_engine}(" in sql
+    assert "ON CLUSTER 'cluster'" in sql
+    assert f"'/clickhouse/tables/{{shard}}/{table}'" in sql
+    if version_col:
+        # Replacing sub-family keeps its version column as the trailing arg.
+        assert f"'{{replica}}', {version_col})" in sql
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_single_node_emits_plain_engine_no_on_cluster(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=False)
+
+    assert f"ENGINE = {plain_engine}" in sql
+    assert "ON CLUSTER" not in sql
+    assert "Replicated" not in sql
+
+
+@pytest.mark.parametrize(
+    "ensure_fn,takes_vectordb,table,replicated_engine,plain_engine,version_col",
+    _CASES,
+    ids=_IDS,
+)
+def test_database_qualifies_target_and_zk_path(
+    ensure_fn, takes_vectordb, table, replicated_engine, plain_engine, version_col
+):
+    sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True, database="futureagi")
+
+    assert f"CREATE TABLE IF NOT EXISTS futureagi.{table}" in sql
+    assert f"'/clickhouse/tables/{{shard}}/futureagi/{table}'" in sql
+
+
+def test_append_only_and_softdelete_tables_never_become_replacing():
+    """Regression guard: the ticket title says "ReplicatedReplacingMergeTree",
+    but forcing Replacing onto llm_logs/events (no unique ORDER BY key) or
+    error_embeddings (soft-delete, no version col) would silently drop rows.
+    """
+    for ensure_fn, takes_vectordb, table in (
+        (ensure_error_embeddings_table, True, "error_embeddings"),
+        (ensure_events_table, False, "events"),
+        (ensure_llm_logs_table, False, "llm_logs"),
+    ):
+        sql = _run_ensure(ensure_fn, takes_vectordb, clustered=True)
+        assert "ReplacingMergeTree" not in sql, table
+        assert "ENGINE = ReplicatedMergeTree(" in sql, table
+
+
+def test_build_replicated_engine_rejects_unknown_engine():
+    with pytest.raises(ValueError):
+        build_replicated_engine("TinyLog", "whatever", clustered=True)
+
+
+def test_build_replicated_engine_passthrough_when_single_node():
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(ts)", "t", clustered=False, database="futureagi"
+    )
+    assert engine == "ReplacingMergeTree(ts)"
+    assert on_cluster == ""
+
+
+def test_centroid_ddl_is_shared_across_all_three_clustering_modules():
+    """cluster_centroids had three identical DDL copies; they must now resolve
+    to the one shared helper so a schema edit can't drift between them.
+    """
+    from tracer.queries import error_clustering, eval_clustering, scan_clustering
+    from tracer.services.clickhouse import clustering_tables
+
+    assert (
+        scan_clustering.ensure_centroid_table
+        is eval_clustering.ensure_centroid_table
+        is clustering_tables.ensure_centroid_table
+    )
+    # error_clustering keeps a thin method wrapper, but it delegates to the
+    # same module function rather than carrying its own DDL string.
+    assert "clustering_tables" in error_clustering.ErrorClusteringDB.ensure_centroid_table.__code__.co_names

--- a/futureagi/model_hub/tests/test_migrate_legacy_default_tables_to_replicated.py
+++ b/futureagi/model_hub/tests/test_migrate_legacy_default_tables_to_replicated.py
@@ -1,0 +1,260 @@
+"""Behavioural tests for ``migrate_legacy_default_tables_to_replicated``.
+
+ClickHouseVectorDB is mocked; we assert on the SQL the command sends (name-
+aligned column list, per-table dedup clause, one-shot guard, CREATE DATABASE
+ordering, replica-aware parity) and on the conditions that must raise
+CommandError. No real CH — cross-replica convergence is covered by the live
+2-replica harness; here we pin the SQL and the safety branches.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+_CMD = "migrate_legacy_default_tables_to_replicated"
+_DOTTED = (
+    "model_hub.management.commands."
+    "migrate_legacy_default_tables_to_replicated.ClickHouseVectorDB"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_clustered_cache():
+    from agentic_eval.core.database import ch_vector
+
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+    yield
+    ch_vector.ClickHouseVectorDB._is_clustered_cached = None
+
+
+def _make_db_client(
+    *,
+    source_count: int = 10,
+    target: dict | None = None,
+    table_exists: bool = True,
+    clustered: bool = True,
+    replicas: tuple = ("ch-0", "ch-1", "ch-2"),
+    columns: tuple = ("id", "eval_id", "vector"),
+    insert_reaches: int | None = None,
+):
+    """ClickHouseVectorDB stand-in with scripted query returns.
+
+    ``target`` is an optional per-host row-count dict (defaults to all-zero).
+    ``insert_reaches`` overrides the per-host count an INSERT drives the target
+    to (defaults to source_count, i.e. it converges); set it below source_count
+    to simulate a replica that never catches up.
+    """
+    state = {h: ((target or {}).get(h, 0)) for h in replicas}
+    reach = source_count if insert_reaches is None else insert_reaches
+    db = MagicMock()
+    executed: list[str] = []
+
+    def ex(sql, params=None, settings=None):
+        executed.append(sql)
+        lc = sql.lower()
+        if "from system.tables" in lc:
+            return [(1 if table_exists else 0,)]
+        if "from system.columns" in lc:
+            return [(c,) for c in columns]
+        if "from system.clusters" in lc:  # _expected_replica_count
+            return [(len(replicas),)]
+        if "hostname()" in lc and "clusterallreplicas" in lc:
+            return [(h, c) for h, c in state.items()]
+        if lc.lstrip().startswith("insert into"):
+            for h in state:
+                state[h] = max(state[h], reach)
+            return []
+        if "clusterallreplicas" in lc:  # source count (uniqExact / count())
+            return [(source_count,)]
+        return []
+
+    db.client.execute.side_effect = ex
+    db._is_clustered = MagicMock(return_value=clustered)
+    return db, executed, state
+
+
+def _run(*tables, db_client=None, dry_run=False, target="futureagi", source="default"):
+    out, err = StringIO(), StringIO()
+    args = [
+        _CMD,
+        f"--source-database={source}",
+        f"--target-database={target}",
+        f"--tables={','.join(tables)}",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    with patch(_DOTTED, return_value=db_client):
+        call_command(*args, stdout=out, stderr=err)
+    return out.getvalue(), err.getvalue()
+
+
+def _inserts(executed):
+    return [s for s in executed if s.lower().lstrip().startswith("insert into")]
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+def test_refuses_when_source_equals_target():
+    with pytest.raises(CommandError, match="must differ"):
+        call_command(_CMD, "--source-database=default", "--target-database=default",
+                     "--tables=llm_logs", stdout=StringIO())
+
+
+def test_refuses_invalid_identifier():
+    with pytest.raises(CommandError, match="valid ClickHouse identifier"):
+        call_command(_CMD, "--source-database=default", "--target-database=bad-name",
+                     "--tables=llm_logs", stdout=StringIO())
+
+
+def test_refuses_unknown_table():
+    with pytest.raises(CommandError, match="unknown entries"):
+        call_command(_CMD, "--source-database=default", "--target-database=futureagi",
+                     "--tables=not_a_table", stdout=StringIO())
+
+
+def test_refuses_when_not_clustered():
+    db_client, _, _ = _make_db_client(clustered=False)
+    with pytest.raises(CommandError, match="replica"):
+        _run("llm_logs", db_client=db_client)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_issues_no_writes():
+    db_client, executed, _ = _make_db_client()
+    out, _ = _run("cluster_centroids", db_client=db_client, dry_run=True)
+    joined = " ".join(executed).lower()
+    assert "create database" not in joined
+    assert "insert into" not in joined
+    assert "create table" not in joined
+    assert "would copy" in out
+
+
+# ---------------------------------------------------------------------------
+# Real run — keyed tables
+# ---------------------------------------------------------------------------
+
+def test_creates_database_on_cluster_before_table_work():
+    db_client, executed, _ = _make_db_client()
+    _run("cluster_centroids", db_client=db_client)
+    create_db = next(i for i, s in enumerate(executed) if "create database" in s.lower())
+    first_insert = next(i for i, s in enumerate(executed)
+                        if s.lower().lstrip().startswith("insert into"))
+    assert "ON CLUSTER 'cluster'" in executed[create_db]
+    assert create_db < first_insert
+
+
+@pytest.mark.parametrize("table,expected_where", [
+    ("trace_input_embeddings",
+     "WHERE (project_id, trace_id) NOT IN "
+     "(SELECT project_id, trace_id FROM futureagi.trace_input_embeddings)"),
+    ("error_embeddings",
+     "WHERE (id) NOT IN (SELECT id FROM futureagi.error_embeddings)"),
+    ("cluster_centroids",
+     "WHERE (cluster_id) NOT IN (SELECT cluster_id FROM futureagi.cluster_centroids)"),
+])
+def test_keyed_table_backfill_uses_its_dedup_clause(table, expected_where):
+    db_client, executed, _ = _make_db_client()
+    _run(table, db_client=db_client)
+    ins = _inserts(executed)
+    assert len(ins) == 1
+    assert f"INSERT INTO futureagi.{table}" in ins[0]
+    assert "clusterAllReplicas('cluster', default." in ins[0]
+    assert expected_where in ins[0]
+
+
+def test_backfill_uses_explicit_column_list_not_select_star():
+    # Regression: positional SELECT * silently misaligns a drifted source.
+    db_client, executed, _ = _make_db_client(columns=("id", "eval_id", "vector"))
+    _run("error_embeddings", db_client=db_client)
+    ins = _inserts(executed)[0]
+    assert "SELECT *" not in ins
+    assert "INSERT INTO futureagi.error_embeddings (`id`, `eval_id`, `vector`)" in ins
+    assert "SELECT `id`, `eval_id`, `vector` FROM" in ins
+
+
+def test_keyed_table_idempotent_rerun_copies_zero():
+    db_client, _, _ = _make_db_client(
+        source_count=10, target={"ch-0": 10, "ch-1": 10, "ch-2": 10})
+    out, _ = _run("error_embeddings", db_client=db_client)
+    assert "copied 0 rows" in out
+
+
+# ---------------------------------------------------------------------------
+# Real run — append-only log tables (one-shot, no key)
+# ---------------------------------------------------------------------------
+
+def test_one_shot_inserts_without_where_when_empty_everywhere():
+    db_client, executed, _ = _make_db_client(source_count=95)  # target all 0
+    _run("llm_logs", db_client=db_client)
+    ins = _inserts(executed)
+    assert len(ins) == 1
+    assert "INSERT INTO futureagi.llm_logs" in ins[0]
+    assert "NOT IN" not in ins[0] and "WHERE" not in ins[0]
+
+
+def test_one_shot_no_op_when_already_converged():
+    # Re-run after a successful one-shot: target == source on every replica.
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 95, "ch-1": 95, "ch-2": 95})
+    out, _ = _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)
+    assert "one-shot no-op" in out
+
+
+def test_one_shot_REFUSES_when_a_single_replica_is_empty():
+    # THE critical bug: min() across replicas let one empty replica wave the
+    # copy through and duplicate the keyless log. Must now refuse + fail.
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 95, "ch-1": 95, "ch-2": 0})
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)  # never inserted -> no duplication
+
+
+def test_one_shot_refuses_on_partial_target():
+    db_client, executed, _ = _make_db_client(
+        source_count=95, target={"ch-0": 42, "ch-1": 42, "ch-2": 42})
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("llm_logs", db_client=db_client)
+    assert not _inserts(executed)
+
+
+def test_source_missing_creates_target_and_skips_copy():
+    db_client, executed, _ = _make_db_client(table_exists=False)
+    out, _ = _run("events", db_client=db_client)
+    assert not _inserts(executed)
+    assert "nothing to copy" in out
+
+
+# ---------------------------------------------------------------------------
+# Replica-aware parity + failure propagation
+# ---------------------------------------------------------------------------
+
+def test_parity_failure_raises_nonzero(monkeypatch):
+    # A replica that never reaches source_count must fail the whole command so
+    # an exit-code-gated CH_DATABASE flip cannot proceed.
+    import model_hub.management.commands.migrate_legacy_default_tables_to_replicated as m
+    monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+    clock = {"t": 0.0}
+    monkeypatch.setattr(m.time, "monotonic", lambda: clock.__setitem__("t", clock["t"] + 100) or clock["t"])
+    db_client, _, _ = _make_db_client(source_count=100, insert_reaches=1)  # never converges
+    with pytest.raises(CommandError, match="did not fully converge"):
+        _run("cluster_centroids", db_client=db_client)
+
+
+def test_multi_table_run_processes_each():
+    db_client, executed, _ = _make_db_client()
+    _run("trace_input_embeddings", "error_embeddings", "cluster_centroids",
+         db_client=db_client)
+    for table in ("trace_input_embeddings", "error_embeddings", "cluster_centroids"):
+        assert any(f"INSERT INTO futureagi.{table}" in s for s in executed)

--- a/futureagi/tracer/queries/error_clustering.py
+++ b/futureagi/tracer/queries/error_clustering.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     ErrorEmbeddingClusterer = _ee_stub("ErrorEmbeddingClusterer")
 from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
+from tracer.services.clickhouse import clustering_tables
 
 logger = structlog.get_logger(__name__)
 from tracer.models.project import Project
@@ -31,52 +32,21 @@ class ErrorClusteringDB:
 
     def __init__(self, euclidean_threshold: float = 0.6):
         self.euclidean_threshold = euclidean_threshold
-        self.table_name = "error_embeddings"
+        self.table_name = clustering_tables.ERROR_EMBEDDINGS_TABLE
 
     def ensure_centroid_table(self):
         """Ensure the cluster_centroids table exists in ClickHouse."""
-
         db = ClickHouseVectorDB()
         try:
-            # Array(...) can't sit inside Nullable; override server profiles
-            # that set data_type_default_nullable=1 so unmodified types aren't
-            # auto-wrapped.
-            query = """
-                CREATE TABLE IF NOT EXISTS cluster_centroids (
-                    cluster_id String,
-                    project_id UUID,
-                    centroid Array(Float32),
-                    member_count UInt32,
-                    family String,
-                    last_updated DateTime DEFAULT now(),
-                    PRIMARY KEY (cluster_id)
-                ) ENGINE = ReplacingMergeTree(last_updated)
-                ORDER BY (cluster_id)
-            """
-            db.client.execute(query, settings={"data_type_default_nullable": 0})
+            clustering_tables.ensure_centroid_table(db)
         finally:
             db.close()
 
     def ensure_error_embeddings_table(self):
         """Ensure the error_embeddings table exists in ClickHouse."""
-
         db = ClickHouseVectorDB()
         try:
-            # Use the standard ClickHouse vector table structure
-            query = f"""
-                CREATE TABLE IF NOT EXISTS {self.table_name} (
-                    id UUID,
-                    eval_id UUID,
-                    vector Array(Float32),
-                    metadata Nested (
-                        key String,
-                        value Nullable(String)
-                    ),
-                    deleted UInt8 DEFAULT 0
-                ) ENGINE = MergeTree()
-                ORDER BY (eval_id, id)
-            """
-            db.client.execute(query, settings={"data_type_default_nullable": 0})
+            clustering_tables.ensure_error_embeddings_table(db)
         finally:
             db.close()
 

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -27,11 +27,14 @@ from tracer.models.trace_error_analysis import (
     FeedIssueStatus,
     TraceErrorGroup,
 )
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    ensure_centroid_table,
+)
 from tracer.types.eval_cluster_types import ClusterableEvalResult, EvalClusterMeta
 
 logger = structlog.get_logger(__name__)
 
-CENTROIDS_TABLE = "cluster_centroids"  # shared with scanner — different family values
 COSINE_THRESHOLD = 0.45
 
 # Only cluster recent eval failures — old results aren't actionable and
@@ -230,27 +233,6 @@ def embed_texts(texts: List[str]) -> List[List[float]]:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_centroid_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the cluster_centroids table exists (shared with scanner)."""
-    # Array(...) can't sit inside Nullable; override server profiles that set
-    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {CENTROIDS_TABLE} (
-            cluster_id String,
-            project_id UUID,
-            centroid Array(Float32),
-            member_count UInt32,
-            family String,
-            last_updated DateTime DEFAULT now(),
-            PRIMARY KEY (cluster_id)
-        ) ENGINE = ReplacingMergeTree(last_updated)
-        ORDER BY (cluster_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
-
 def _eval_family(eval_name: str, target_type: str = "span") -> str:
     """Family key for eval centroids — keeps the three targets (and scanner)
     in separate centroid spaces.
@@ -288,7 +270,7 @@ def find_nearest_centroid(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
         family = _eval_family(eval_name, target_type)
         rows = db.client.execute(
@@ -468,7 +450,7 @@ def create_cluster(
     family = _eval_family(result.eval_name, result.target_type)
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         db.client.execute(
             f"""
             INSERT INTO {CENTROIDS_TABLE}

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -23,12 +23,17 @@ from tracer.models.trace_error_analysis import (
     TraceErrorGroup,
 )
 from tracer.models.trace_scan import TraceScanIssue, TraceScanResult
+from tracer.services.clickhouse.clustering_tables import (
+    CENTROIDS_TABLE,
+    TRACE_INPUTS_TABLE,
+    ensure_centroid_table,
+    ensure_trace_inputs_table,
+)
 from tracer.services.clickhouse.v2 import get_reader
 from tracer.types.scan_types import ClusterableIssue, TraceInputData
 
 logger = structlog.get_logger(__name__)
 
-CENTROIDS_TABLE = "cluster_centroids"
 COSINE_THRESHOLD = 0.45  # cosine distance: 0 = identical, 2 = opposite
 
 
@@ -108,27 +113,6 @@ def embed_texts(texts: List[str]) -> List[List[float]]:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_centroid_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the cluster_centroids table exists."""
-    # Array(...) can't sit inside Nullable; override server profiles that set
-    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {CENTROIDS_TABLE} (
-            cluster_id String,
-            project_id UUID,
-            centroid Array(Float32),
-            member_count UInt32,
-            family String,
-            last_updated DateTime DEFAULT now(),
-            PRIMARY KEY (cluster_id)
-        ) ENGINE = ReplacingMergeTree(last_updated)
-        ORDER BY (cluster_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
-
 def _update_centroid(
     current: List[float], new_vector: List[float], count: int
 ) -> List[float]:
@@ -151,7 +135,7 @@ def find_nearest_centroid(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
         rows = db.client.execute(
             f"""
@@ -243,7 +227,7 @@ def create_cluster(
     # Store centroid in ClickHouse
     db = ClickHouseVectorDB()
     try:
-        _ensure_centroid_table(db)
+        ensure_centroid_table(db)
         db.client.execute(
             f"""
             INSERT INTO {CENTROIDS_TABLE}
@@ -359,25 +343,6 @@ def assign_to_cluster(
 # Trace input embeddings (for success trace matching)
 # ---------------------------------------------------------------------------
 
-TRACE_INPUTS_TABLE = "trace_input_embeddings"
-
-
-def _ensure_trace_inputs_table(db: ClickHouseVectorDB) -> None:
-    """Ensure the trace_input_embeddings table exists."""
-    db.client.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {TRACE_INPUTS_TABLE} (
-            trace_id UUID,
-            project_id UUID,
-            embedding Array(Float32),
-            has_issues Bool,
-            created_at DateTime DEFAULT now()
-        ) ENGINE = ReplacingMergeTree(created_at)
-        ORDER BY (project_id, trace_id)
-        """,
-        settings={"data_type_default_nullable": 0},
-    )
-
 
 def get_trace_input_data(trace_ids: List[str], project_id: str) -> List[TraceInputData]:
     """
@@ -466,7 +431,7 @@ def store_trace_input_embeddings(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         rows = [
             {
                 "trace_id": inp.trace_id,
@@ -508,7 +473,7 @@ def find_success_trace_baseline(
     """
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         vector_str = "[" + ",".join(map(str, query_embedding)) + "]"
 
         exclude_clause = ""
@@ -577,7 +542,7 @@ def get_cluster_trace_embeddings(
 
     db = ClickHouseVectorDB()
     try:
-        _ensure_trace_inputs_table(db)
+        ensure_trace_inputs_table(db)
         ids_str = ",".join(f"'{tid}'" for tid in trace_ids)
         rows = db.client.execute(
             f"""

--- a/futureagi/tracer/services/clickhouse/clustering_tables.py
+++ b/futureagi/tracer/services/clickhouse/clustering_tables.py
@@ -1,0 +1,123 @@
+"""Shared DDL for the clustering ClickHouse tables that live outside the managed
+v2 schema (``cluster_centroids``, ``trace_input_embeddings``, ``error_embeddings``).
+
+These tables are created lazily by the scanner / error / eval clustering query
+paths. The DDL was duplicated across three query modules (``cluster_centroids``
+alone had three identical copies); it lives here once so the engine-selection
+rule and the column layout have a single source of truth, and so the
+default-to-replicated migration command can create the same tables in a target
+database without re-declaring their schema.
+
+Engine selection mirrors ``ClickHouseVectorDB.create_table`` via
+``build_replicated_engine``: a multi-replica cluster gets the ``Replicated*``
+form ``ON CLUSTER`` with a Keeper path; single-node CH keeps the plain engine.
+Each table preserves its own sub-family — the ``cluster_centroids`` /
+``trace_input_embeddings`` ``ReplacingMergeTree`` dedup and the
+``error_embeddings`` plain ``MergeTree`` (soft-delete via ``ALTER ... UPDATE``,
+no version column) are intentional and must not be flattened to one engine.
+"""
+from __future__ import annotations
+
+from agentic_eval.core.database.ch_vector import (
+    ClickHouseVectorDB,
+    build_replicated_engine,
+)
+
+CENTROIDS_TABLE = "cluster_centroids"
+TRACE_INPUTS_TABLE = "trace_input_embeddings"
+ERROR_EMBEDDINGS_TABLE = "error_embeddings"
+
+
+def _qualified(table: str, database: str | None) -> str:
+    return f"{database}.{table}" if database else table
+
+
+def ensure_centroid_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the shared ``cluster_centroids`` table (scanner + error + eval)."""
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(last_updated)",
+        CENTROIDS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    # Array(...) can't sit inside Nullable; override server profiles that set
+    # data_type_default_nullable=1 so unmodified types aren't auto-wrapped.
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(CENTROIDS_TABLE, database)}{on_cluster} (
+            cluster_id String,
+            project_id UUID,
+            centroid Array(Float32),
+            member_count UInt32,
+            family String,
+            last_updated DateTime DEFAULT now(),
+            PRIMARY KEY (cluster_id)
+        ) ENGINE = {engine}
+        ORDER BY (cluster_id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )
+
+
+def ensure_trace_inputs_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the ``trace_input_embeddings`` table (scanner success-trace KNN)."""
+    engine, on_cluster = build_replicated_engine(
+        "ReplacingMergeTree(created_at)",
+        TRACE_INPUTS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(TRACE_INPUTS_TABLE, database)}{on_cluster} (
+            trace_id UUID,
+            project_id UUID,
+            embedding Array(Float32),
+            has_issues Bool,
+            created_at DateTime DEFAULT now()
+        ) ENGINE = {engine}
+        ORDER BY (project_id, trace_id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )
+
+
+def ensure_error_embeddings_table(
+    db: ClickHouseVectorDB, *, database: str | None = None, cluster: str | None = None
+) -> None:
+    """Create the ``error_embeddings`` table (error-feed cluster embeddings).
+
+    Plain ``MergeTree`` -> ``ReplicatedMergeTree``: rows are soft-deleted with
+    ``ALTER ... UPDATE deleted = 1`` and read with ``deleted = 0``, so a
+    ``Replacing`` engine would change the dedup semantics. Mutations on a
+    ``ReplicatedMergeTree`` propagate through the replication log on their own.
+    """
+    engine, on_cluster = build_replicated_engine(
+        "MergeTree()",
+        ERROR_EMBEDDINGS_TABLE,
+        clustered=db._is_clustered(),
+        database=database,
+        cluster=cluster,
+    )
+    db.client.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_qualified(ERROR_EMBEDDINGS_TABLE, database)}{on_cluster} (
+            id UUID,
+            eval_id UUID,
+            vector Array(Float32),
+            metadata Nested (
+                key String,
+                value Nullable(String)
+            ),
+            deleted UInt8 DEFAULT 0
+        ) ENGINE = {engine}
+        ORDER BY (eval_id, id)
+        """,
+        settings={"data_type_default_nullable": 0},
+    )


### PR DESCRIPTION
## Why

The five non-vector ClickHouse tables in `default` — `cluster_centroids`, `trace_input_embeddings`, `error_embeddings`, `llm_logs`, `events` — were on plain `MergeTree` / `ReplacingMergeTree`. On the multi-replica US-prod cluster the non-replicated engine family doesn't coordinate writes across replicas, so each row lives on a single replica and any single-replica read silently returns only that replica's share of the data.

Sibling of **TH-5914** and **stacked on it** (base branch = `fix/th-5914-...`) because it reuses `_is_clustered()` / `get_clickhouse_cluster_name()`. This covers exactly the tables TH-5914 declared out of scope. Retarget to `dev` once #1078 merges.

## What changed

### `agentic_eval/core/database/ch_vector.py`
- `build_replicated_engine()` — one engine-selection rule that **preserves each table's sub-family**: `ReplacingMergeTree(col)` → `ReplicatedReplacingMergeTree(...'{replica}', col)`, plain `MergeTree` → `ReplicatedMergeTree` (never Replacing). ZK path `/clickhouse/tables/{shard}/{database}/{table}`, `ON CLUSTER` on a clustered node, base engine unchanged single-node.
- `create_table` rebuilt on the helper (output byte-identical — TH-5914's engine tests stay green); `_is_clustered` exposed as classmethod `is_clustered(client)` for raw-client callers.

### DDL centralised, replicated-aware, `database=`-qualifiable
- **`tracer/services/clickhouse/clustering_tables.py`** (new) — centroid / trace_inputs / error_embeddings DDL; **consolidates the 3 duplicate `cluster_centroids` copies** across scan/eval/error clustering into one.
- **`model_hub/services/legacy_ch_tables.py`** (new) — events / llm_logs DDL; `apps.py` boot now calls these (drops the buggy `SHOW TABLES FROM default` gate + the obsolete `original_uuid` self-heal ALTER).

### `migrate_legacy_default_tables_to_replicated` (new command)
Per-table spec with dedup key — `(project_id, trace_id)` / `id` / `cluster_id`; `llm_logs` + `events` are append-only one-shot (no key). Safety invariants:
- **Replica-count-aware** guard + parity via `system.tables.total_rows` over `clusterAllReplicas` (enumerates empty replicas too — a plain `count() GROUP BY hostName()` yields no group for an empty replica).
- **One-shot guard** refuses unless every replica is confirmed empty (a lagging/empty replica must never wave a keyless re-copy through → duplication).
- **Name-aligned column copy**, never positional `SELECT *` — a drifted legacy source is copied by column name; target-only columns fall back to `DEFAULT` (this also heals `events.original_uuid`).
- **Non-zero exit** unless every replica converges, so an exit-code-gated cutover can't flip early.

## Engine sub-family note
`llm_logs` / `events` / `error_embeddings` go to plain `ReplicatedMergeTree`, **not** `ReplicatedReplacingMergeTree` as the ticket title suggests — Replacing would silently collapse distinct rows on their non-unique ORDER BY keys (`llm_logs` orders by `(LLMModelName, EventDateTime)`) / change `error_embeddings`' soft-delete semantics.

## Tests
- **33 new unit cases** (engine selection per cluster shape for all 5 tables; migration guards, dedup clauses, one-shot refusal incl. the single-empty-replica regression, name-aligned column list, parity-failure raises).
- Verified end-to-end against a **real 2-replica ClickHouse + keeper cluster**: divergence-heal converges equal on both replicas, exact-value integrity, 50k-row volume, one-shot duplication guard, and `events` schema-drift + `original_uuid` heal.

## Out of scope
- Operator cutover runbook (per-region `CH_DATABASE` flip, one-shot copy→flip write-loss window, consumer coordination) lives in the Linear ticket.
- Dropping the legacy `default.*` tables after soak.

Closes TH-6276.