### PR TITLE
fix(frontend): preserve Compare column selection across React Query refetches (fixes #1069)

### DIFF
--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/CompareDataRightSection.jsx
@@ -35,8 +35,18 @@ const CompareDataRightSection = ({
   const { diffMode, handleToggleDiffMode } = useDevelopDetailContext();
   const { role } = useAuthContext();
 
-  // Initialize all columns as selected when the component mounts or columns prop changes
+  // Initialize all columns as selected only on first load, i.e. while nothing is
+  // selected yet. React Query hands back a new `columns` array reference on every
+  // refetch even when the data is unchanged; the previous `[columns]` dependency
+  // fired this effect on those reference changes and reset every checkbox,
+  // silently discarding the user's deselections. Guarding on "nothing selected
+  // yet" preserves the user's choices while still initializing once the columns
+  // finish loading (which happens after mount, so a mount-only `[]` effect would
+  // never run).
   useEffect(() => {
+    if (selectedColumns.length > 0 || columns.length === 0) {
+      return;
+    }
     const temp = [];
     for (const col of columns) {
       temp.push(col?.id);
@@ -47,8 +57,7 @@ const CompareDataRightSection = ({
       }
     }
     setSelectedColumn(temp);
-    // setUnselectedColumns([]);
-  }, [columns]);
+  }, [columns, selectedColumns]);
 
   const handleColumnClick = () => {
     setColumnPopoverOpen(true);


### PR DESCRIPTION
## Problem

In the dataset Compare view, unchecking a column in the column selector is silently reverted whenever React Query refetches. `CompareDataRightSection`'s initialization effect depended on `[columns]`, and React Query returns a **new array reference** on every refetch (even when the data is identical), so the effect re-ran and reset every checkbox via `setSelectedColumn(temp)` — discarding the user's deselections.

Fixes #1069.

## Fix

Guard the initialization so it only runs while nothing is selected yet:

```js
useEffect(() => {
  if (selectedColumns.length > 0 || columns.length === 0) {
    return;
  }
  // ...build temp and setSelectedColumn(temp)
}, [columns, selectedColumns]);
```

- **Refetch with a selection present** → `selectedColumns.length > 0` → the effect no-ops → the user's selection is preserved.
- **Async loading still handled** → I intentionally kept the `[columns]` dependency rather than a mount-only `[]`: `columns` is empty at mount and only arrives later from React Query, so a `[]` effect would never initialize the selection. Keeping `[columns]` + the guard initializes exactly once (when columns first arrive) and then locks it in.

## Testing

Manual repro from the issue: open a dataset → enable Compare mode → open the column selector → uncheck a column → trigger a refetch. The deselection now persists instead of snapping back to all-checked.