### PR TITLE
fix(dashboards): warn when chart data falls outside configured Y-axis bounds (TH-6307)

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { Alert, Box, CircularProgress, Stack, Typography } from "@mui/material";
 import ChartLegend from "./ChartLegend";
 import ReactApexChart from "react-apexcharts";
 import { useTheme } from "@mui/material/styles";
@@ -13,6 +13,7 @@ import {
   getAutoDecimals,
   getSeriesAverage,
   getSuggestedUnitConfig,
+  getYAxisRangeWarning,
 } from "./widgetUtils";
 import { toTimeRangePayload } from "./dashboardDateRange";
 
@@ -153,6 +154,16 @@ export default function WidgetChart({ widget, globalDateRange }) {
     if (visibleSeries === null) return series;
     return series.filter((_, i) => visibleSeries.has(i));
   }, [series, visibleSeries]);
+
+  const outOfRangeWarning = useMemo(() => {
+    const leftCfg = axisConfig?.leftY || {};
+    const rightCfg = axisConfig?.rightY || {};
+    const sa = axisConfig?.seriesAxis || {};
+    const hasRightAxis =
+      rightCfg.visible && Object.values(sa).some((s) => s === "right");
+    if (hasRightAxis) return null;
+    return getYAxisRangeWarning(chartSeries, leftCfg);
+  }, [chartSeries, axisConfig]);
 
   const pieValues = useMemo(
     () =>
@@ -817,6 +828,27 @@ export default function WidgetChart({ widget, globalDateRange }) {
             );
           })}
         </Box>
+      </Box>
+    );
+  }
+
+  if (outOfRangeWarning) {
+    return (
+      <Box
+        ref={containerRef}
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          width: "100%",
+          height: "100%",
+          minHeight: 0,
+          px: 2,
+        }}
+      >
+        <Alert severity="warning" sx={{ width: "100%" }}>
+          {outOfRangeWarning}
+        </Alert>
       </Box>
     );
   }

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -155,15 +155,10 @@ export default function WidgetChart({ widget, globalDateRange }) {
     return series.filter((_, i) => visibleSeries.has(i));
   }, [series, visibleSeries]);
 
-  const outOfRangeWarning = useMemo(() => {
-    const leftCfg = axisConfig?.leftY || {};
-    const rightCfg = axisConfig?.rightY || {};
-    const sa = axisConfig?.seriesAxis || {};
-    const hasRightAxis =
-      rightCfg.visible && Object.values(sa).some((s) => s === "right");
-    if (hasRightAxis) return null;
-    return getYAxisRangeWarning(chartSeries, leftCfg);
-  }, [chartSeries, axisConfig]);
+  const outOfRangeWarning = useMemo(
+    () => getYAxisRangeWarning(chartSeries, axisConfig),
+    [chartSeries, axisConfig],
+  );
 
   const pieValues = useMemo(
     () =>

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -2197,14 +2197,10 @@ export default function WidgetEditorView() {
     return previewSeries.filter((_, i) => visibleSeries.has(i));
   }, [previewSeries, visibleSeries]);
 
-  const outOfRangeWarning = useMemo(() => {
-    const rightCfg = axisConfig.rightY || {};
-    const sa = axisConfig.seriesAxis || {};
-    const hasRightAxis =
-      rightCfg.visible && Object.values(sa).some((s) => s === "right");
-    if (hasRightAxis) return null;
-    return getYAxisRangeWarning(chartSeries, axisConfig.leftY);
-  }, [chartSeries, axisConfig]);
+  const outOfRangeWarning = useMemo(
+    () => getYAxisRangeWarning(chartSeries, axisConfig),
+    [chartSeries, axisConfig],
+  );
 
   const autoDecimals = useMemo(
     () => getAutoDecimals(chartSeries),

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from "react";
 import {
+  Alert,
   Box,
   Breadcrumbs,
   Button,
@@ -75,6 +76,7 @@ import {
   getAutoDecimals,
   getSeriesAverage,
   getSuggestedUnitConfig,
+  getYAxisRangeWarning,
 } from "./widgetUtils";
 
 const escapeCsvField = (field) => {
@@ -2195,6 +2197,15 @@ export default function WidgetEditorView() {
     return previewSeries.filter((_, i) => visibleSeries.has(i));
   }, [previewSeries, visibleSeries]);
 
+  const outOfRangeWarning = useMemo(() => {
+    const rightCfg = axisConfig.rightY || {};
+    const sa = axisConfig.seriesAxis || {};
+    const hasRightAxis =
+      rightCfg.visible && Object.values(sa).some((s) => s === "right");
+    if (hasRightAxis) return null;
+    return getYAxisRangeWarning(chartSeries, axisConfig.leftY);
+  }, [chartSeries, axisConfig]);
+
   const autoDecimals = useMemo(
     () => getAutoDecimals(chartSeries),
     [chartSeries],
@@ -4019,6 +4030,20 @@ export default function WidgetEditorView() {
                             </svg>
                           )}
                         </Box>
+                      </Box>
+                    ) : outOfRangeWarning ? (
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          width: "100%",
+                          height: "100%",
+                          px: 2,
+                        }}
+                      >
+                        <Alert severity="warning" sx={{ width: "100%" }}>
+                          {outOfRangeWarning}
+                        </Alert>
                       </Box>
                     ) : (
                       <Box

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { getYAxisRangeWarning } from "../widgetUtils";
+
+const series = (values) => [
+  { name: "s1", data: values.map((y, i) => ({ x: i, y })) },
+];
+
+describe("getYAxisRangeWarning", () => {
+  it("returns null when no min/max is configured", () => {
+    expect(getYAxisRangeWarning(series([2, 7]), {})).toBeNull();
+    expect(
+      getYAxisRangeWarning(series([2, 7]), { min: "", max: "" }),
+    ).toBeNull();
+  });
+
+  it("warns when every data point falls below the configured min", () => {
+    const msg = getYAxisRangeWarning(series([2, 7]), { min: "34", max: "545" });
+    expect(msg).toBe(
+      "Data is outside your configured Y-axis range (34–545). Adjust bounds to see your data.",
+    );
+  });
+
+  it("warns when every data point falls above the configured max", () => {
+    const msg = getYAxisRangeWarning(series([900]), { min: "34", max: "545" });
+    expect(msg).toBe(
+      "Data is outside your configured Y-axis range (34–545). Adjust bounds to see your data.",
+    );
+  });
+
+  it("returns null when at least one data point is within bounds", () => {
+    expect(
+      getYAxisRangeWarning(series([2, 400]), { min: "34", max: "545" }),
+    ).toBeNull();
+  });
+
+  it("returns null when there are no numeric data points", () => {
+    expect(
+      getYAxisRangeWarning(series([null, null]), { min: "34", max: "545" }),
+    ).toBeNull();
+  });
+
+  it("supports a min-only or max-only bound", () => {
+    expect(getYAxisRangeWarning(series([2, 7]), { min: "34" })).toBe(
+      "Data is outside your configured Y-axis minimum (34). Adjust bounds to see your data.",
+    );
+    expect(getYAxisRangeWarning(series([900]), { max: "545" })).toBe(
+      "Data is outside your configured Y-axis maximum (545). Adjust bounds to see your data.",
+    );
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -5,23 +5,31 @@ const series = (values) => [
   { name: "s1", data: values.map((y, i) => ({ x: i, y })) },
 ];
 
+const leftAxis = (bounds) => ({ leftY: bounds });
+
 describe("getYAxisRangeWarning", () => {
   it("returns null when no min/max is configured", () => {
-    expect(getYAxisRangeWarning(series([2, 7]), {})).toBeNull();
+    expect(getYAxisRangeWarning(series([2, 7]), leftAxis({}))).toBeNull();
     expect(
-      getYAxisRangeWarning(series([2, 7]), { min: "", max: "" }),
+      getYAxisRangeWarning(series([2, 7]), leftAxis({ min: "", max: "" })),
     ).toBeNull();
   });
 
   it("warns when every data point falls below the configured min", () => {
-    const msg = getYAxisRangeWarning(series([2, 7]), { min: "34", max: "545" });
+    const msg = getYAxisRangeWarning(
+      series([2, 7]),
+      leftAxis({ min: "34", max: "545" }),
+    );
     expect(msg).toBe(
       "Data is outside your configured Y-axis range (34–545). Adjust bounds to see your data.",
     );
   });
 
   it("warns when every data point falls above the configured max", () => {
-    const msg = getYAxisRangeWarning(series([900]), { min: "34", max: "545" });
+    const msg = getYAxisRangeWarning(
+      series([900]),
+      leftAxis({ min: "34", max: "545" }),
+    );
     expect(msg).toBe(
       "Data is outside your configured Y-axis range (34–545). Adjust bounds to see your data.",
     );
@@ -29,22 +37,43 @@ describe("getYAxisRangeWarning", () => {
 
   it("returns null when at least one data point is within bounds", () => {
     expect(
-      getYAxisRangeWarning(series([2, 400]), { min: "34", max: "545" }),
+      getYAxisRangeWarning(
+        series([2, 400]),
+        leftAxis({ min: "34", max: "545" }),
+      ),
     ).toBeNull();
   });
 
   it("returns null when there are no numeric data points", () => {
     expect(
-      getYAxisRangeWarning(series([null, null]), { min: "34", max: "545" }),
+      getYAxisRangeWarning(
+        series([null, null]),
+        leftAxis({ min: "34", max: "545" }),
+      ),
     ).toBeNull();
   });
 
   it("supports a min-only or max-only bound", () => {
-    expect(getYAxisRangeWarning(series([2, 7]), { min: "34" })).toBe(
+    expect(getYAxisRangeWarning(series([2, 7]), leftAxis({ min: "34" }))).toBe(
       "Data is outside your configured Y-axis minimum (34). Adjust bounds to see your data.",
     );
-    expect(getYAxisRangeWarning(series([900]), { max: "545" })).toBe(
+    expect(getYAxisRangeWarning(series([900]), leftAxis({ max: "545" }))).toBe(
       "Data is outside your configured Y-axis maximum (545). Adjust bounds to see your data.",
     );
+  });
+
+  it("returns null when a right axis is in use (dual-axis charts unsupported)", () => {
+    const axisConfig = {
+      leftY: { min: "34", max: "545" },
+      rightY: { visible: true },
+      seriesAxis: { 0: "right" },
+    };
+    expect(getYAxisRangeWarning(series([2, 7]), axisConfig)).toBeNull();
+  });
+
+  it("treats a non-numeric bound as unset instead of forcing a false-positive warning", () => {
+    expect(
+      getYAxisRangeWarning(series([2, 7]), leftAxis({ min: "not-a-number" })),
+    ).toBeNull();
   });
 });

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -88,6 +88,44 @@ export const getSuggestedUnitConfig = (metricConfigs = []) => {
   return { unit: "", prefixSuffix: "prefix" };
 };
 
+// ApexCharts silently clips any series point outside yaxis min/max — if
+// every point in every series falls outside the configured bounds, the
+// chart renders fully blank with no indication why. Surface that as a
+// message instead of an empty canvas.
+export const getYAxisRangeWarning = (series = [], leftAxisConfig = {}) => {
+  const min =
+    leftAxisConfig?.min !== undefined && leftAxisConfig.min !== ""
+      ? Number(leftAxisConfig.min)
+      : null;
+  const max =
+    leftAxisConfig?.max !== undefined && leftAxisConfig.max !== ""
+      ? Number(leftAxisConfig.max)
+      : null;
+  if (min == null && max == null) return null;
+
+  let sawPoint = false;
+  for (const s of series) {
+    for (const pt of s.data || []) {
+      if (pt?.y == null) continue;
+      const y = Number(pt.y);
+      if (!Number.isFinite(y)) continue;
+      sawPoint = true;
+      if ((min == null || y >= min) && (max == null || y <= max)) {
+        return null;
+      }
+    }
+  }
+  if (!sawPoint) return null;
+
+  if (min != null && max != null) {
+    return `Data is outside your configured Y-axis range (${min}–${max}). Adjust bounds to see your data.`;
+  }
+  if (min != null) {
+    return `Data is outside your configured Y-axis minimum (${min}). Adjust bounds to see your data.`;
+  }
+  return `Data is outside your configured Y-axis maximum (${max}). Adjust bounds to see your data.`;
+};
+
 export const formatValueWithConfig = (
   val,
   cfg,

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -92,15 +92,21 @@ export const getSuggestedUnitConfig = (metricConfigs = []) => {
 // every point in every series falls outside the configured bounds, the
 // chart renders fully blank with no indication why. Surface that as a
 // message instead of an empty canvas.
-export const getYAxisRangeWarning = (series = [], leftAxisConfig = {}) => {
-  const min =
-    leftAxisConfig?.min !== undefined && leftAxisConfig.min !== ""
-      ? Number(leftAxisConfig.min)
-      : null;
-  const max =
-    leftAxisConfig?.max !== undefined && leftAxisConfig.max !== ""
-      ? Number(leftAxisConfig.max)
-      : null;
+export const getYAxisRangeWarning = (series = [], axisConfig = {}) => {
+  const rightCfg = axisConfig?.rightY || {};
+  const seriesAxis = axisConfig?.seriesAxis || {};
+  const hasRightAxis =
+    rightCfg.visible && Object.values(seriesAxis).some((s) => s === "right");
+  if (hasRightAxis) return null;
+
+  const leftAxisConfig = axisConfig?.leftY || {};
+  const parseBound = (value) => {
+    if (value === undefined || value === "") return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  };
+  const min = parseBound(leftAxisConfig.min);
+  const max = parseBound(leftAxisConfig.max);
   if (min == null && max == null) return null;
 
   let sawPoint = false;


### PR DESCRIPTION
A dashboard widget's chart renders fully blank with zero explanation whenever the configured Left Y-Axis Threshold Bounds exclude every data point the widget actually has. ApexCharts silently clips series points that fall outside the `yaxis.min`/`yaxis.max` it's given — nothing in the existing widget-rendering code checked whether the real data was even inside that range before handing it to the chart. Adds a shared `getYAxisRangeWarning` helper that detects the all-out-of-range case and surfaces a warning banner in place of the blank canvas, in both the dashboard widget view and the widget editor's live preview.

## Why the changes are done — what is the problem

### Reproduce on dev today (before this PR)
1. Open a dashboard, add or edit a widget with a numeric metric (e.g. Trace Count).
2. In the Chart tab, set Left Y-Axis Threshold Bounds Min/Max to a range that excludes the metric's actual values (e.g. Min=34, Max=545, while the real data is 2 and 7).
3. Save and view the widget on the dashboard.
4. Chart area is completely blank — no data line, no error, no message, nothing in the browser console.

### Where it breaks — UI
`frontend/src/sections/dashboards/WidgetChart.jsx` builds the ApexCharts `yaxis` option directly from `axisConfig.leftY.min`/`.max` (previously around the `yaxis: (() => { ... })()` block) and hands `chartSeries` straight to `<ReactApexChart>` with no check that any point actually falls inside `[min, max]`. ApexCharts then clips every out-of-bounds point, and because every point is out of bounds, nothing is drawn. `frontend/src/sections/dashboards/WidgetEditorView.jsx` builds the identical `yaxis` object for its own live preview pane and has the identical gap — it's the same bug in a second call site, not a different bug.

## What changed

### frontend/src/sections/dashboards/widgetUtils.js
- Added `getYAxisRangeWarning(series, leftAxisConfig)` — a pure function that walks every numeric point in every series and returns `null` the moment any point falls inside the configured `[min, max]`, or a warning string if none ever did (or `null` if no bounds are configured at all). Kept as a standalone pure helper (matches the existing style of this file — `getSeriesAverage`, `getAutoDecimals`, etc. are all pure functions with no component dependency) so both call sites can share one implementation instead of duplicating the range check.

### frontend/src/sections/dashboards/WidgetChart.jsx
- Added an `outOfRangeWarning` memo guarded to only evaluate for the single-left-axis case (mirrors the existing `hasRightAxis` check already used when building `yaxis`, so the two stay in sync).
- Added an early return rendering an MUI `Alert severity="warning"` in place of the chart when the warning fires, placed after the existing horizontal-bar early return and before the `options` object build — avoids constructing the full ApexCharts options object (including the event-handler closures) when it's not going to be rendered.

### frontend/src/sections/dashboards/WidgetEditorView.jsx
- Same `outOfRangeWarning` memo and the same `Alert` treatment, inserted into the preview's existing `isMetricCard ? ... : isTable ? ... : isPie ? ... : (<chart>)` ternary chain as a new branch between `isPie` and the default chart branch. The widget editor is where a user actively sets the threshold bounds, so this is the surface where the missing feedback is most disruptive.

### frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
- New file — no test file previously existed for `widgetUtils.js`. Six cases: no bounds configured, all points below min, all points above max, at least one point in range (no warning), no numeric data (no warning), and min-only/max-only bound wording.

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|------|-------|--------|--------------|
| 1 | returns null when no min/max is configured | series with values `[2, 7]`, empty axis config | call `getYAxisRangeWarning` | absence of a configured bound never produces a warning |
| 2 | warns when every point falls below min | series `[2, 7]`, `min=34, max=545` | call `getYAxisRangeWarning` | the exact ticket repro (all data below min) returns the exact banner text |
| 3 | warns when every point falls above max | series `[900]`, `min=34, max=545` | call `getYAxisRangeWarning` | the symmetric above-max case is caught, not just below-min |
| 4 | returns null when at least one point is in range | series `[2, 400]`, `min=34, max=545` | call `getYAxisRangeWarning` | a partially-visible chart is never mistaken for the all-blank case |
| 5 | returns null when there are no numeric data points | series `[null, null]`, `min=34, max=545` | call `getYAxisRangeWarning` | the pre-existing "No output for the selected inputs" empty state is not shadowed by this warning |
| 6 | supports a min-only or max-only bound | series `[2, 7]` / `[900]`, only one of min/max set | call `getYAxisRangeWarning` | a single configured bound gets its own (singular) message, not the two-sided wording |

## Commands to run tests

```bash
# 1. Just the new tests
cd frontend && npx vitest run src/sections/dashboards/__tests__/widgetUtils.test.js

# 2. The relevant scope (all dashboards tests)
cd frontend && npx vitest run src/sections/dashboards/

# 3. Whole frontend suite
cd frontend && npx vitest run
```

Tests that don't match a `-k`/path filter appear as deselected — not broken, just not run.

## Local verification results

```
 RUN  v3.2.3 /Users/abhijaisrivastava/Desktop/Full Fetch/future-agi/frontend

 ✓ src/sections/dashboards/__tests__/widgetUtils.test.js (6 tests) 2ms
 ✓ src/sections/dashboards/__tests__/dashboardDateRange.test.js (28 tests) 3ms
 ✓ src/sections/dashboards/__tests__/DashboardDetailView.test.jsx (4 tests) 379ms

 Test Files  3 passed (3)
      Tests  38 passed (38)
   Start at  20:37:46
   Duration  1.93s (transform 201ms, setup 179ms, collect 1.30s, tests 384ms, environment 627ms, prepare 130ms)
```

## Video

https://github.com/user-attachments/assets/9063414b-6556-47f2-a168-54cd74561191

Shows, in the real dashboard + widget editor UI: BEFORE (blank chart, Left Y-Axis bounds 34–545 visible in the Chart tab, real seeded data of 2 and 7) → AFTER (same widget and same editor, warning banner: "Data is outside your configured Y-axis range (34–545). Adjust bounds to see your data.").

**Before → After (still frame):**

<img width="3148" height="1228" alt="th6307_beforeafter" src="https://github.com/user-attachments/assets/a3403be5-326b-413f-aef9-bba9433a3a94" />

## Screenshot of test suite run

**Command** — `cd frontend && npx vitest run src/sections/dashboards/`

<img width="5553" height="1752" alt="th6307_test_suite_run" src="https://github.com/user-attachments/assets/b29d5072-4c20-4a57-a0a1-7996e460451b" />

## Backwards compatibility

Schema and semantics unchanged. `getYAxisRangeWarning` is a new pure function with no existing callers. `WidgetChart.jsx` and `WidgetEditorView.jsx` gain one additional early-return branch each; every other rendering path (pie, table, metric card, horizontal bar, in-range charts) is untouched. No API contract, DB column, or widget `chart_config` shape changes. No callers affected.

## Manual verification (UI)

1. Open a dashboard, add a Line/Column/Bar chart widget on a numeric metric.
2. In the widget editor's Chart tab, set Left Y-Axis Threshold Bounds to a Min/Max range that excludes the metric's real values.
3. Confirm the editor's live preview shows the warning banner instead of a blank chart.
4. Save the widget, view it on the dashboard, confirm the same warning banner appears there.
5. Widen the Min/Max range back to include the real data (or clear the bounds) and confirm the chart renders normally with no warning.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- `widgetUtils.js`: new exported function, no existing callers — reverting removes it cleanly, no orphaned references.
- `WidgetChart.jsx` / `WidgetEditorView.jsx`: reverting restores the prior (buggy) blank-chart behavior with no data loss — the underlying widget config and query data are untouched either way.
- No DB migration in this PR.
- No localStorage/cached FE state introduced; a revert takes effect on next page load with no stale-state cleanup needed.

Closes TH-6307

