### PR TITLE
fix(dashboards): invalidate dashboard list cache on widget mutations (TH-6320)

### DIFF
--- a/frontend/src/hooks/__tests__/useDashboards.test.js
+++ b/frontend/src/hooks/__tests__/useDashboards.test.js
@@ -1,0 +1,179 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: mocks,
+  endpoints: {
+    dashboard: {
+      list: "/tracer/dashboard/",
+      widgets: (dashboardId) => `/tracer/dashboard/${dashboardId}/widgets/`,
+      widgetDetail: (dashboardId, widgetId) =>
+        `/tracer/dashboard/${dashboardId}/widgets/${widgetId}/`,
+      widgetReorder: (dashboardId) =>
+        `/tracer/dashboard/${dashboardId}/widgets/reorder/`,
+      widgetDuplicate: (dashboardId, widgetId) =>
+        `/tracer/dashboard/${dashboardId}/widgets/${widgetId}/duplicate/`,
+    },
+  },
+}));
+
+import {
+  useCreateWidget,
+  useUpdateWidget,
+  useDeleteWidget,
+  useReorderWidgets,
+  useDuplicateWidget,
+} from "../useDashboards";
+
+const DASHBOARD_LIST_KEY = ["dashboards", "list"];
+const dashboardDetailKey = (id) => ["dashboards", "detail", id];
+
+function createQueryWrapper(queryClient) {
+  function QueryWrapper({ children }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  }
+  QueryWrapper.propTypes = { children: PropTypes.node };
+  return QueryWrapper;
+}
+
+describe("useDashboards widget mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invalidates both the dashboard list and detail caches after creating a widget", async () => {
+    mocks.post.mockResolvedValueOnce({ data: { result: { id: "widget-1" } } });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateWidget(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    result.current.mutate({ dashboardId: "dash-1", data: { type: "chart" } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: dashboardDetailKey("dash-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: DASHBOARD_LIST_KEY,
+    });
+  });
+
+  it("invalidates both the dashboard list and detail caches after updating a widget", async () => {
+    mocks.patch.mockResolvedValueOnce({ data: { result: {} } });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateWidget(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      dashboardId: "dash-1",
+      widgetId: "widget-1",
+      data: { title: "Renamed" },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: dashboardDetailKey("dash-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: DASHBOARD_LIST_KEY,
+    });
+  });
+
+  it("invalidates both the dashboard list and detail caches after deleting a widget", async () => {
+    mocks.delete.mockResolvedValueOnce({ data: { result: {} } });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteWidget(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    result.current.mutate({ dashboardId: "dash-1", widgetId: "widget-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: dashboardDetailKey("dash-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: DASHBOARD_LIST_KEY,
+    });
+  });
+
+  it("invalidates both the dashboard list and detail caches after reordering widgets", async () => {
+    mocks.post.mockResolvedValueOnce({ data: { result: {} } });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useReorderWidgets(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      dashboardId: "dash-1",
+      order: ["widget-2", "widget-1"],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: dashboardDetailKey("dash-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: DASHBOARD_LIST_KEY,
+    });
+  });
+
+  it("invalidates both the dashboard list and detail caches after duplicating a widget", async () => {
+    mocks.post.mockResolvedValueOnce({ data: { result: { id: "widget-2" } } });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDuplicateWidget(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    result.current.mutate({ dashboardId: "dash-1", widgetId: "widget-1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: dashboardDetailKey("dash-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: DASHBOARD_LIST_KEY,
+    });
+  });
+});

--- a/frontend/src/hooks/useDashboards.js
+++ b/frontend/src/hooks/useDashboards.js
@@ -165,6 +165,7 @@ export function useCreateWidget() {
       queryClient.invalidateQueries({
         queryKey: DASHBOARD_KEYS.detail(dashboardId),
       });
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() });
     },
   });
 }
@@ -181,6 +182,7 @@ export function useUpdateWidget() {
       queryClient.invalidateQueries({
         queryKey: DASHBOARD_KEYS.detail(dashboardId),
       });
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() });
     },
   });
 }
@@ -194,6 +196,7 @@ export function useDeleteWidget() {
       queryClient.invalidateQueries({
         queryKey: DASHBOARD_KEYS.detail(dashboardId),
       });
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() });
     },
   });
 }
@@ -207,6 +210,7 @@ export function useReorderWidgets() {
       queryClient.invalidateQueries({
         queryKey: DASHBOARD_KEYS.detail(dashboardId),
       });
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() });
     },
   });
 }
@@ -220,6 +224,7 @@ export function useDuplicateWidget() {
       queryClient.invalidateQueries({
         queryKey: DASHBOARD_KEYS.detail(dashboardId),
       });
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() });
     },
   });
 }


### PR DESCRIPTION
The dashboard list showed a stale "last modified" timestamp after a widget inside that dashboard was edited and saved — the backend correctly bumped `Dashboard.updated_at` on every widget mutation, but the frontend's dashboard-list React Query cache was never invalidated by those mutations, so it kept serving its stale cached value until the 30s `staleTime` window happened to lapse on its own. Fix adds the missing list-cache invalidation to all five widget mutation hooks, matching the pattern the dashboard-level mutation already used.

## Why the changes are done — what is the problem

### Reproduce on dev/main today (before this PR)

1. Open the Dashboards list (`/dashboard/dashboards`) and note a dashboard's "last modified" time (e.g. "51 seconds ago").
2. Open that dashboard, edit a widget (rename it, resize it, reorder it, duplicate it, or delete one), and let the change save.
3. Navigate back to the Dashboards list within ~30 seconds of the list's last fetch.
4. The card still shows the old relative time — it does not update to "just now" even though the widget was just edited.

### Where it breaks — BE

Nowhere — `DashboardWidgetViewSet` (`tracer/views/dashboard.py`) already re-saves the parent dashboard with `update_fields=["updated_by", "updated_at"]` on every widget `create`/`update`/`destroy`/`reorder`/`duplicate_widget` action, and `DashboardViewSet.list` + `DashboardSerializer` read that column directly. The stored data is correct at every point.

### Where it breaks — UI

`useCreateWidget`, `useUpdateWidget`, `useDeleteWidget`, `useReorderWidgets`, and `useDuplicateWidget` in `frontend/src/hooks/useDashboards.js` each call `queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.detail(dashboardId) })` in their `onSuccess`, but never touch `DASHBOARD_KEYS.list()`. `useDashboardList()` has no `staleTime` override, so it inherits the app-wide default of 30s (`app.jsx`). Within that window, remounting `DashboardsListView` serves the cached (now-stale) list data as-is — there is nothing to trigger a refetch, because the query was never marked invalid. `useUpdateDashboard` (renaming/editing the dashboard itself) already invalidates both `detail` and `list()`; the five widget-level mutations were simply missing the second call.

## What changed

### `frontend/src/hooks/useDashboards.js`

- Added `queryClient.invalidateQueries({ queryKey: DASHBOARD_KEYS.list() })` to the `onSuccess` handler of `useCreateWidget`, `useUpdateWidget`, `useDeleteWidget`, `useReorderWidgets`, and `useDuplicateWidget` — one line each, alongside the existing detail invalidation. This is the same call `useUpdateDashboard` already made; the widget hooks were the outliers, not the pattern.
- Fixed at the hook level, not per call-site, so every UI entry point that drives these mutations (rename, resize, reorder drag, duplicate, delete, and the full widget editor's Save) is covered uniformly — there's no remaining bypass path.

### `frontend/src/hooks/__tests__/useDashboards.test.js` (new)

- Five behavioral tests, one per mutation hook, each spying on `queryClient.invalidateQueries` and asserting it is called with both the detail key and `["dashboards", "list"]`. Mirrors the existing house pattern in `src/api/annotation-queues/__tests__/annotation-queues.test.js` (mocked `src/utils/axios`, real `QueryClient`, `vi.spyOn`).

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `invalidates both the dashboard list and detail caches after creating a widget` | Mocked `axios.post` resolves, fresh `QueryClient`, spy on `invalidateQueries` | `useCreateWidget().mutate({dashboardId, data})` | List cache is invalidated on widget create, not just detail — reverting the fix fails this. |
| 2 | `invalidates both the dashboard list and detail caches after updating a widget` | Same, `axios.patch` mocked | `useUpdateWidget().mutate({dashboardId, widgetId, data})` | Same contract for the most common path (edit + save). |
| 3 | `invalidates both the dashboard list and detail caches after deleting a widget` | Same, `axios.delete` mocked | `useDeleteWidget().mutate({dashboardId, widgetId})` | Deleting a widget also has to refresh the list's timestamp. |
| 4 | `invalidates both the dashboard list and detail caches after reordering widgets` | Same, `axios.post` mocked | `useReorderWidgets().mutate({dashboardId, order})` | Drag-reorder is a real edit and must be reflected too. |
| 5 | `invalidates both the dashboard list and detail caches after duplicating a widget` | Same, `axios.post` mocked | `useDuplicateWidget().mutate({dashboardId, widgetId})` | Duplicate creates a new widget row — list must refresh. |

## Commands to run tests

```bash
# Run only the new tests
cd frontend && npx vitest run src/hooks/__tests__/useDashboards.test.js

# Run the relevant scope (all dashboard hook + component tests)
cd frontend && npx vitest run src/hooks/__tests__/useDashboards.test.js src/sections/dashboards/__tests__

# Run the whole frontend suite
cd frontend && npx vitest run
```

## Local verification results

Reverting `frontend/src/hooks/useDashboards.js` to the pre-fix version and running the new test file fails on exactly the missing `list()` call (5 failed, e.g. `expected "invalidateQueries" to be called with... "list"` but received `"detail"` only). Restoring the fix:

```
 RUN  v3.2.3 /Users/abhijaisrivastava/Desktop/Full Fetch/future-agi/frontend

 ✓ src/hooks/__tests__/useDashboards.test.js (5 tests) 278ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  23:13:39
   Duration  1.03s (transform 37ms, setup 66ms, collect 114ms, tests 278ms, environment 232ms, prepare 53ms)
```

## Before / After — live UI

Before/after on the real dashboard UI — same dashboard, same warm React Query cache, same "Resize Width" edit, client-side navigation back to the list. BEFORE shows the timestamp frozen at "51 seconds ago" immediately after the edit on the pre-fix code; AFTER shows "0 seconds ago" on the same flow with the fix:

![live UI before/after](https://github.com/user-attachments/assets/3ac1dfac-caee-4994-8564-8237bf7ec7b3)

## Screenshot of test suite run

**Command** — `cd frontend && npx vitest run src/hooks/__tests__/useDashboards.test.js`

RED (pre-fix) → GREEN (fix) side-by-side:

![test run before/after](https://github.com/user-attachments/assets/b2343913-fdb3-4d60-94d1-b66be6e0ec06)

Screen-recorded video of the same terminal run:

https://github.com/user-attachments/assets/2011c1df-b4ca-47ea-ac33-aeedaa017042

## Backwards compatibility

Schema and semantics unchanged. No new query keys, no API contract change, no caller outside these five hooks is affected. The only behavioral change is that the dashboard list query now also refetches (in addition to the detail query) whenever a widget mutation succeeds — strictly additive, and matches the existing `useUpdateDashboard` behavior other consumers of the list already rely on.

## Manual verification (UI)

1. Open a dashboard from the Dashboards list, note its widget's current width.
2. From the widget's options menu, pick "Resize Width" and choose a different width.
3. Click "Dashboards" in the sidebar to return to the list.
4. The dashboard's "last modified" time now reads "just now" / a few seconds, instead of the time from before the edit.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- `frontend/src/hooks/useDashboards.js` — reverting removes the five added `invalidateQueries` calls; the app returns to prior (buggy) behavior with no data loss. Backend data is untouched either way since `Dashboard.updated_at` was already correct.
- `frontend/src/hooks/__tests__/useDashboards.test.js` — new file; reverting removes it cleanly, no orphaned references.
- No migration, no schema change, no localStorage/cached state that would break on revert.

Fixes TH-6320

