### PR TITLE
simulate: read-time speaker-role alignment via SpeakerRoleResolver

### DIFF
--- a/frontend/src/components/CallLogsDetailDrawer/CallLogTranscript.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/CallLogTranscript.jsx
@@ -6,7 +6,7 @@ import TranscriptConversationCard from "./TranscriptConversationCard";
 const CallLogTranscript = ({ data }) => {
   const filteredTranscript = useMemo(() => {
     const transcript = data?.transcripts;
-    return transcript?.filter((item) => item.speakerRole !== "system");
+    return transcript?.filter((item) => item.speaker_role !== "system");
   }, [data]);
   return (
     <Stack

--- a/frontend/src/components/CallLogsDetailDrawer/CallLogsDetailDrawer.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/CallLogsDetailDrawer.jsx
@@ -33,7 +33,7 @@ const CallLogSideDrawerChild = ({ data }) => {
   const { agentDefinitionId: urlAgentDefinitionId, observeId } = useParams();
   const resolvedProjectId = observeId || data?.projectId;
   const filteredTranscript = useMemo(() => {
-    return data?.transcript?.filter((item) => item.speakerRole !== "system");
+    return data?.transcript?.filter((item) => item.speaker_role !== "system");
   }, [data]);
   const theme = useTheme();
 

--- a/frontend/src/components/CallLogsDetailDrawer/LeftSectionBottom.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/LeftSectionBottom.jsx
@@ -86,7 +86,7 @@ const LeftSectionBottom = ({ data }) => {
 
   const filteredTranscript = useMemo(() => {
     const transcript = data?.transcript;
-    return transcript?.filter((item) => item.speakerRole !== "system");
+    return transcript?.filter((item) => item.speaker_role !== "system");
   }, [data]);
   const observationSpan = data?.observation_span;
   const { isCallInProgress, message: loadingMessage } =

--- a/frontend/src/components/VoiceDetailDrawerV2/PathAnalysisView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/PathAnalysisView.jsx
@@ -259,7 +259,7 @@ const PathAnalysisView = ({
 
   const turns = useMemo(() => {
     const raw = (data?.transcript || []).filter(
-      (t) => (t.speakerRole || t.role) !== "system",
+      (t) => (t.speaker_role || t.role) !== "system",
     );
     return enrichTurns(raw);
   }, [data]);

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
@@ -46,7 +46,7 @@ const VoiceLeftPanel = ({ data, scenarioId, embedded = false }) => {
 
   const filteredTranscript = useMemo(() => {
     const transcript = data?.transcript;
-    return transcript?.filter((item) => item.speakerRole !== "system");
+    return transcript?.filter((item) => item.speaker_role !== "system");
   }, [data]);
 
   const callExecutionId =

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -80,7 +80,7 @@ const VoiceRightPanel = ({
     if (Array.isArray(data?.messages)) return data.messages;
     if (Array.isArray(data?.transcript)) {
       return data.transcript.map((t) => ({
-        role: t.speakerRole || t.role,
+        role: t.speaker_role || t.role,
         content: t.message || t.content || t.text,
         ...t,
       }));

--- a/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
+++ b/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
@@ -110,7 +110,7 @@ export const enrichTurns = (transcript) => {
     return {
       id: item.id ?? `turn-${i}`,
       role,
-      rawRole: item.speakerRole || item.role,
+      rawRole: item.speaker_role || item.role,
       content: getContent(item),
       start,
       end,

--- a/frontend/src/components/imagine/ImagineChatPanel.jsx
+++ b/frontend/src/components/imagine/ImagineChatPanel.jsx
@@ -119,7 +119,7 @@ const ImagineChatPanel = forwardRef(function ImagineChatPanel(
         traceId +
         ".\n\n" +
         "Available data in traceData.trace:\n" +
-        "- transcript: array of {speakerRole, message/content, time, duration, startTimeSeconds, endTimeSeconds} — the full call conversation\n" +
+        "- transcript: array of {speaker_role, message/content, time, duration, startTimeSeconds, endTimeSeconds} — the full call conversation\n" +
         "- call_summary: AI-generated summary of the call\n" +
         "- recordings: audio URLs (stereo, mono, assistant, customer channels)\n" +
         "- provider: voice provider (e.g. vapi, retell, livekit)\n" +
@@ -130,11 +130,11 @@ const ImagineChatPanel = forwardRef(function ImagineChatPanel(
         "traceData.transcript is a shortcut to the transcript array.\n\n" +
         "Best widget types for voice calls:\n" +
         "- data_table with rowsFrom: show the transcript as a table\n" +
-        "  {dataBinding: {rowsFrom: 'transcript', columns: [{field: 'speakerRole', headerName: 'Speaker'}, {field: 'message', headerName: 'Message'}, {field: 'duration', headerName: 'Duration (s)'}]}}\n" +
+        "  {dataBinding: {rowsFrom: 'transcript', columns: [{field: 'speaker_role', headerName: 'Speaker'}, {field: 'message', headerName: 'Message'}, {field: 'duration', headerName: 'Duration (s)'}]}}\n" +
         "- pie_chart with groupFrom: speaker turn distribution\n" +
-        "  {dataBinding: {groupFrom: 'transcript', groupBy: 'speakerRole', aggregate: 'count'}}\n" +
+        "  {dataBinding: {groupFrom: 'transcript', groupBy: 'speaker_role', aggregate: 'count'}}\n" +
         "- bar_chart with seriesFrom: duration per turn\n" +
-        "  {dataBinding: {seriesFrom: 'transcript', seriesConfig: {name: 'Duration', valuePath: 'duration'}, categoryPath: 'speakerRole'}}\n" +
+        "  {dataBinding: {seriesFrom: 'transcript', seriesConfig: {name: 'Duration', valuePath: 'duration'}, categoryPath: 'speaker_role'}}\n" +
         "- key_value: call metadata (provider, status, duration, ended reason)\n" +
         "  {dataBinding: {items: [{key: 'Provider', valuePath: 'trace.provider'}, {key: 'Summary', valuePath: 'trace.call_summary'}]}}\n" +
         "- metric_card: computed values\n" +

--- a/frontend/src/hooks/use-stereo-channels.js
+++ b/frontend/src/hooks/use-stereo-channels.js
@@ -41,7 +41,7 @@ function extractPeaks(channelData, numPeaks = 800) {
  * @param {string} stereoUrl - URL of the stereo recording
  * @returns {{ assistantUrl: string, customerUrl: string, assistantPeaks: number[]|null, customerPeaks: number[]|null, loading: boolean, error: string|null }}
  */
-export default function useStereoChannels(stereoUrl) {
+export default function useStereoChannels(stereoUrl, isInbound = false) {
   const [state, setState] = useState({
     assistantUrl: "",
     customerUrl: "",
@@ -92,17 +92,21 @@ export default function useStereoChannels(stereoUrl) {
         const leftData = decoded.getChannelData(0);
         const rightData =
           numChannels >= 2 ? decoded.getChannelData(1) : leftData;
+        // Base: left=sim, right=agent; inbound flips.
+        const [aData, cData] = isInbound
+          ? [leftData, rightData]
+          : [rightData, leftData];
 
         // Extract real peaks now while we have the decoded PCM data.
         // Passing these to WaveSurfer means it renders the waveform instantly
         // without needing to decode the blob URL a second time.
-        const assistantPeaks = extractPeaks(leftData);
+        const assistantPeaks = extractPeaks(aData);
         const customerPeaks =
-          numChannels >= 2 ? extractPeaks(rightData) : assistantPeaks;
+          numChannels >= 2 ? extractPeaks(cData) : assistantPeaks;
 
-        const assistantBlob = encodeWav(leftData, sampleRate);
+        const assistantBlob = encodeWav(aData, sampleRate);
         const customerBlob =
-          numChannels >= 2 ? encodeWav(rightData, sampleRate) : assistantBlob;
+          numChannels >= 2 ? encodeWav(cData, sampleRate) : assistantBlob;
 
         const assistantBlobUrl = URL.createObjectURL(assistantBlob);
         const customerBlobUrl = URL.createObjectURL(customerBlob);

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -623,6 +623,7 @@ function VoiceCallContent({ traceId }) {
     status: callData.status,
     simulationCallType: "voice",
     callType: callData.call_type,
+    call_type: callData.call_type,
     timestamp: callData.created_at || callData.started_at,
     duration: callData.duration_seconds,
     scenario: callData.scenario_name,

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -603,10 +603,26 @@ const SimulationTestMode = React.forwardRef(
             // `recordings` dict / `audio_url`, with provider_call_data
             // fallback for shapes that don't normalize cleanly.
             const rec = callData.recordings || {};
+            // Voice transcript arrives as an array of turn objects. Mirror
+            // the BE eval-runtime shape (`agent: ...\ncustomer: ...`) so the
+            // preview matches what the eval actually consumes.
             flat.call.transcript =
               typeof callData.transcript === "string"
                 ? callData.transcript
-                : "";
+                : Array.isArray(callData.transcript)
+                  ? callData.transcript
+                      .filter(
+                        (r) =>
+                          r?.content?.trim() &&
+                          (r.speaker_role === "user" ||
+                            r.speaker_role === "assistant"),
+                      )
+                      .map(
+                        (r) =>
+                          `${r.speaker_role === "assistant" ? "agent" : "customer"}: ${r.content}`,
+                      )
+                      .join("\n")
+                  : "";
             flat.call.voice_recording =
               callData.audio_url ||
               rec.combined ||

--- a/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
@@ -107,6 +107,7 @@ StereoMultiTrackPlayer.propTypes = {
   id: PropTypes.string,
   height: PropTypes.number,
   onInstance: PropTypes.func,
+  isInbound: PropTypes.bool,
 };
 
 const AudioPlayerCustom = ({ data, onInstance }) => {

--- a/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
@@ -31,6 +31,7 @@ export const StereoMultiTrackPlayer = ({
   id,
   height = 70,
   onInstance,
+  isInbound = false,
 }) => {
   const theme = useTheme();
   // Speaker palette — matches the TranscriptView timeline strip / talk
@@ -47,7 +48,7 @@ export const StereoMultiTrackPlayer = ({
     customerUrl: stereoCustomer,
     loading: stereoLoading,
     error: stereoError,
-  } = useStereoChannels(recordings?.stereo || "");
+  } = useStereoChannels(recordings?.stereo || "", isInbound);
 
   // Use stereo-split channels when available, fall back to separate mono files
   const useStereo =
@@ -116,6 +117,12 @@ const AudioPlayerCustom = ({ data, onInstance }) => {
     );
 
   const isProjectModule = data?.module === "project";
+  const isInbound =
+    (
+      data?.call_metadata?.call_direction ||
+      data?.call_type ||
+      ""
+    ).toLowerCase() === "inbound";
   if (isCallInProgress) {
     return (
       <Box sx={{ height: 200 }}>
@@ -202,6 +209,7 @@ const AudioPlayerCustom = ({ data, onInstance }) => {
         recordings={normalizedRecordings}
         id={data?.id}
         onInstance={onInstance}
+        isInbound={isInbound}
       />
     );
   }
@@ -237,6 +245,7 @@ const AudioPlayerCustom = ({ data, onInstance }) => {
         recordings={recordings}
         id={data?.id}
         onInstance={onInstance}
+        isInbound={isInbound}
       />
     );
   }

--- a/frontend/src/sections/test-detail/TestDetailDrawer/CallTranscriptView.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/CallTranscriptView.jsx
@@ -22,8 +22,8 @@ const CallTranscriptView = ({
       {transcript?.map((item) => (
         <ConversationCard
           key={item.id}
-          role={item.speakerRole}
-          align={item.speakerRole === "user" ? "flex-end" : "flex-start"}
+          role={item.speaker_role}
+          align={item.speaker_role === "user" ? "flex-end" : "flex-start"}
           content={item.content}
           duration={Math.floor(
             (item.endTimeSeconds - item.startTimeSeconds) / 1000,

--- a/frontend/src/sections/test-detail/TestDetailDrawer/UnifiedTranscripts.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/UnifiedTranscripts.jsx
@@ -14,7 +14,7 @@ const UnifiedCallTranscript = ({
   simulationCallType,
 }) => {
   const getItemProps = (item) => {
-    const role = item.speakerRole || item.role;
+    const role = item.speaker_role || item.role;
 
     let duration;
 

--- a/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
+++ b/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
@@ -34,7 +34,7 @@ const CallLogsCard = ({ log }) => {
   const filteredTranscript = useMemo(() => {
     const originalTranscript = log?.transcript;
     return originalTranscript?.filter(
-      (item) => (item.speaker_role ?? item.speakerRole) !== "system",
+      (item) => item.speaker_role !== "system",
     );
   }, [log]);
 

--- a/frontend/src/sections/test/CallLogs/TranscriptPreview.jsx
+++ b/frontend/src/sections/test/CallLogs/TranscriptPreview.jsx
@@ -14,7 +14,7 @@ const TranscriptPreview = ({
   simulationCallType,
 }) => {
   const first = transcript?.[0] ?? null;
-  const previewRole = first?.speakerRole;
+  const previewRole = first?.speaker_role;
   const previewContent = getContentMessage(first, simulationCallType);
 
   return (

--- a/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
+++ b/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
@@ -51,7 +51,7 @@ const ViewFullTranscript = ({
           {transcript?.map(
             ({
               id,
-              speakerRole,
+              speaker_role: speakerRole,
               content: rawContent,
               messages,
               createdAt,

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -6119,9 +6119,26 @@ class EvalPlayGroundAPIView(APIView):
                         CallExecution,
                         CallTranscript,
                     )
+                    from simulate.utils.speaker_roles import SpeakerRoleResolver
 
                     _ce = CallExecution.objects.filter(id=_call_id).first()
                     if _ce:
+                        # Filter out system prompt and normalise speaker labels via
+                        # the resolver so the simulator persona never reaches the eval.
+                        _ce_provider = SpeakerRoleResolver.detect_provider(
+                            _ce.provider_call_data
+                        )
+                        _ce_is_outbound = SpeakerRoleResolver.detect_is_outbound(_ce)
+                        _conversational_roles = (
+                            SpeakerRoleResolver.get_conversational_roles()
+                        )
+                        _transcript_rows = (
+                            CallTranscript.objects.filter(
+                                call_execution_id=_ce.id,
+                                speaker_role__in=_conversational_roles,
+                            )
+                            .order_by("start_time_ms")[:200]
+                        )
                         call_context = {
                             "id": str(_ce.id),
                             "status": _ce.status,
@@ -6152,13 +6169,15 @@ class EvalPlayGroundAPIView(APIView):
                             "scenario": build_eval_playground_scenario_context(_ce),
                             "transcript": [
                                 {
-                                    "speaker": t.speaker_role,
+                                    "speaker": SpeakerRoleResolver.get_eval_role_label(
+                                        t.speaker_role,
+                                        provider=_ce_provider,
+                                        is_outbound=_ce_is_outbound,
+                                    ),
                                     "content": t.content,
                                     "start_ms": t.start_time_ms,
                                 }
-                                for t in CallTranscript.objects.filter(
-                                    call_execution_id=_ce.id
-                                ).order_by("start_time_ms")[:200]
+                                for t in _transcript_rows
                             ],
                         }
                 except Exception as _e:

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -645,29 +645,19 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             )
             call_metadata = getattr(obj, "call_metadata", None) or {}
             offset = call_metadata.get("recording_offset_ms", 0)
-            rows = CallTranscriptSerializer(
-                filtered_transcripts,
-                many=True,
-                context={"recording_offset_ms": offset},
-            ).data
-
             from simulate.utils.speaker_roles import SpeakerRoleResolver
 
-            provider = SpeakerRoleResolver.detect_provider(
-                getattr(obj, "provider_call_data", None)
+            return SpeakerRoleResolver.align_transcript_rows(
+                CallTranscriptSerializer(
+                    filtered_transcripts,
+                    many=True,
+                    context={"recording_offset_ms": offset},
+                ).data,
+                provider=SpeakerRoleResolver.detect_provider(
+                    getattr(obj, "provider_call_data", None)
+                ),
+                is_outbound=SpeakerRoleResolver.detect_is_outbound(obj),
             )
-            is_outbound = SpeakerRoleResolver.detect_is_outbound(obj)
-            for row in rows:
-                raw = row.get("speaker_role")
-                if SpeakerRoleResolver.is_tested_agent(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "assistant"
-                elif SpeakerRoleResolver.is_simulator(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "user"
-            return rows
         return []
 
     def get_response_time(self, obj):
@@ -1375,29 +1365,19 @@ class CallExecutionSerializer(serializers.ModelSerializer):
             )
             call_metadata = getattr(obj, "call_metadata", None) or {}
             offset = call_metadata.get("recording_offset_ms", 0)
-            rows = CallTranscriptSerializer(
-                filtered_transcripts,
-                many=True,
-                context={"recording_offset_ms": offset},
-            ).data
-
             from simulate.utils.speaker_roles import SpeakerRoleResolver
 
-            provider = SpeakerRoleResolver.detect_provider(
-                getattr(obj, "provider_call_data", None)
+            return SpeakerRoleResolver.align_transcript_rows(
+                CallTranscriptSerializer(
+                    filtered_transcripts,
+                    many=True,
+                    context={"recording_offset_ms": offset},
+                ).data,
+                provider=SpeakerRoleResolver.detect_provider(
+                    getattr(obj, "provider_call_data", None)
+                ),
+                is_outbound=SpeakerRoleResolver.detect_is_outbound(obj),
             )
-            is_outbound = SpeakerRoleResolver.detect_is_outbound(obj)
-            for row in rows:
-                raw = row.get("speaker_role")
-                if SpeakerRoleResolver.is_tested_agent(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "assistant"
-                elif SpeakerRoleResolver.is_simulator(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "user"
-            return rows
         return []
 
     def get_response_time_seconds(self, obj):

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -474,14 +474,29 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
                     ProviderChoices.VAPI.value
                 )
 
-        if provider_payload:
-            if provider_payload.get("recording"):
-                return provider_payload.get("recording")
+        recordings = None
+        if provider_payload and provider_payload.get("recording"):
+            recordings = provider_payload.get("recording")
+        elif VoiceServiceManager is not None:
+            vsm = VoiceServiceManager(system_voice_provider=ProviderChoices.VAPI)
+            recordings = vsm.get_recording_urls(provider_payload) or {}
 
-        if VoiceServiceManager is None:
-            return {}
-        vsm = VoiceServiceManager(system_voice_provider=ProviderChoices.VAPI)
-        return vsm.get_recording_urls(provider_payload) or {}
+        if isinstance(recordings, dict) and recordings:
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
+            provider = SpeakerRoleResolver.detect_provider(
+                getattr(obj, "provider_call_data", None)
+            )
+            is_outbound = SpeakerRoleResolver.detect_is_outbound(obj)
+            if SpeakerRoleResolver.is_simulator(
+                "assistant", provider=provider, is_outbound=is_outbound
+            ):
+                recordings = {
+                    **recordings,
+                    "assistant": recordings.get("customer"),
+                    "customer": recordings.get("assistant"),
+                }
+        return recordings or {}
 
     def get_provider(self, obj):
         """Return the provider that produced this call's stored provider payload.
@@ -630,11 +645,29 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             )
             call_metadata = getattr(obj, "call_metadata", None) or {}
             offset = call_metadata.get("recording_offset_ms", 0)
-            return CallTranscriptSerializer(
+            rows = CallTranscriptSerializer(
                 filtered_transcripts,
                 many=True,
                 context={"recording_offset_ms": offset},
             ).data
+
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
+            provider = SpeakerRoleResolver.detect_provider(
+                getattr(obj, "provider_call_data", None)
+            )
+            is_outbound = SpeakerRoleResolver.detect_is_outbound(obj)
+            for row in rows:
+                raw = row.get("speaker_role")
+                if SpeakerRoleResolver.is_tested_agent(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "assistant"
+                elif SpeakerRoleResolver.is_simulator(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "user"
+            return rows
         return []
 
     def get_response_time(self, obj):
@@ -1342,11 +1375,29 @@ class CallExecutionSerializer(serializers.ModelSerializer):
             )
             call_metadata = getattr(obj, "call_metadata", None) or {}
             offset = call_metadata.get("recording_offset_ms", 0)
-            return CallTranscriptSerializer(
+            rows = CallTranscriptSerializer(
                 filtered_transcripts,
                 many=True,
                 context={"recording_offset_ms": offset},
             ).data
+
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
+            provider = SpeakerRoleResolver.detect_provider(
+                getattr(obj, "provider_call_data", None)
+            )
+            is_outbound = SpeakerRoleResolver.detect_is_outbound(obj)
+            for row in rows:
+                raw = row.get("speaker_role")
+                if SpeakerRoleResolver.is_tested_agent(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "assistant"
+                elif SpeakerRoleResolver.is_simulator(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "user"
+            return rows
         return []
 
     def get_response_time_seconds(self, obj):

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -4340,26 +4340,17 @@ class TestExecutor:
                     if has_content and role_lower in customer_roles:
                         has_customer_message = True
         else:
-            try:
-                from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-            except ImportError:
-                logger.warning(
-                    "speaker_role_resolver_unavailable_for_voice_presence",
-                    call_execution_id=str(call_execution.id),
-                )
-                agent_roles = frozenset({CallTranscript.SpeakerRole.ASSISTANT})
-                customer_roles = frozenset({CallTranscript.SpeakerRole.USER})
-            else:
-                provider = SpeakerRoleResolver.detect_provider(
-                    call_execution.provider_call_data
-                )
-                (
-                    agent_roles,
-                    customer_roles,
-                ) = SpeakerRoleResolver.get_skip_decision_role_sets(
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
+            provider = SpeakerRoleResolver.detect_provider(
+                call_execution.provider_call_data
+            )
+            agent_roles, customer_roles = (
+                SpeakerRoleResolver.get_skip_decision_role_sets(
                     provider=provider,
                     is_outbound=is_outbound,
                 )
+            )
 
             for role, content in call_execution.transcripts.values_list(
                 "speaker_role", "content"
@@ -4473,42 +4464,35 @@ class TestExecutor:
                                         assistant_chat_transcript_text.append(message)
 
                     else:
-                        try:
-                            from ee.voice.utils.transcript_roles import (
-                                SpeakerRoleResolver,
-                            )
-                        except ImportError:
-                            SpeakerRoleResolver = None
-                            logger.warning(
-                                "speaker_role_resolver_unavailable_for_voice_transcript",
-                                call_execution_id=str(call_execution.id),
-                            )
-                        else:
-                            eval_provider = SpeakerRoleResolver.detect_provider(
-                                call_execution.provider_call_data
-                            )
-                            eval_dir = (call_execution.call_metadata or {}).get(
-                                "call_direction", ""
-                            )
-                            eval_is_outbound = (
-                                str(eval_dir).strip().lower() == "outbound"
-                            )
+                        from simulate.utils.speaker_roles import (
+                            SpeakerRoleResolver,
+                        )
 
+                        eval_provider = SpeakerRoleResolver.detect_provider(
+                            call_execution.provider_call_data
+                        )
+                        eval_dir = (call_execution.call_metadata or {}).get(
+                            "call_direction", ""
+                        )
+                        eval_is_outbound = (
+                            str(eval_dir).strip().lower() == "outbound"
+                        )
+                        conversational_roles = (
+                            SpeakerRoleResolver.get_conversational_roles()
+                        )
                         for transcript in transcripts:
-                            if transcript.content.strip():
-                                if SpeakerRoleResolver is None:
-                                    eval_role = transcript.speaker_role
-                                else:
-                                    eval_role = (
-                                        SpeakerRoleResolver.get_eval_role_label(
-                                            transcript.speaker_role,
-                                            provider=eval_provider,
-                                            is_outbound=eval_is_outbound,
-                                        )
-                                    )
-                                transcript_text.append(
-                                    f"{eval_role}: {transcript.content}"
-                                )
+                            if not transcript.content.strip():
+                                continue
+                            if transcript.speaker_role not in conversational_roles:
+                                continue
+                            eval_role = SpeakerRoleResolver.get_eval_role_label(
+                                transcript.speaker_role,
+                                provider=eval_provider,
+                                is_outbound=eval_is_outbound,
+                            )
+                            transcript_text.append(
+                                f"{eval_role}: {transcript.content}"
+                            )
                     transcript_data["transcript"] = "\n".join(transcript_text)
                     transcript_data["user_chat_transcript"] = "\n".join(
                         user_chat_transcript_text

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -271,34 +271,27 @@ def _build_transcript_data(call_execution):
                             elif chat_message.role == "assistant":
                                 assistant_chat_transcript_text.append(message)
             else:
-                try:
-                    from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-                except ImportError:
-                    SpeakerRoleResolver = None
-                    logger.warning(
-                        "speaker_role_resolver_unavailable_for_xl_transcript",
-                        call_execution_id=str(call_execution.id),
-                    )
-                else:
-                    provider = SpeakerRoleResolver.detect_provider(
-                        call_execution.provider_call_data
-                    )
-                    call_dir = (call_execution.call_metadata or {}).get(
-                        "call_direction", ""
-                    )
-                    is_outbound = str(call_dir).strip().lower() == "outbound"
+                from simulate.utils.speaker_roles import SpeakerRoleResolver
 
+                provider = SpeakerRoleResolver.detect_provider(
+                    call_execution.provider_call_data
+                )
+                call_dir = (call_execution.call_metadata or {}).get(
+                    "call_direction", ""
+                )
+                is_outbound = str(call_dir).strip().lower() == "outbound"
+                conversational_roles = SpeakerRoleResolver.get_conversational_roles()
                 for transcript in transcripts:
-                    if transcript.content.strip():
-                        if SpeakerRoleResolver is None:
-                            eval_role = transcript.speaker_role
-                        else:
-                            eval_role = SpeakerRoleResolver.get_eval_role_label(
-                                transcript.speaker_role,
-                                provider=provider,
-                                is_outbound=is_outbound,
-                            )
-                        transcript_text.append(f"{eval_role}: {transcript.content}")
+                    if not transcript.content.strip():
+                        continue
+                    if transcript.speaker_role not in conversational_roles:
+                        continue
+                    eval_role = SpeakerRoleResolver.get_eval_role_label(
+                        transcript.speaker_role,
+                        provider=provider,
+                        is_outbound=is_outbound,
+                    )
+                    transcript_text.append(f"{eval_role}: {transcript.content}")
 
             transcript_data["transcript"] = "\n".join(transcript_text)
             transcript_data["user_chat_transcript"] = "\n".join(

--- a/futureagi/simulate/tests/test_speaker_role_read_alignment.py
+++ b/futureagi/simulate/tests/test_speaker_role_read_alignment.py
@@ -362,16 +362,6 @@ class TestEndedReasonInlineSwap:
         ]:
             assert self._inline_swap(self._inline_swap(raw)) == raw
 
-    def test_swap_matches_resolver_for_vapi_inbound(self):
-        for raw in [
-            "assistant-ended-call",
-            "customer-ended-call",
-            "customer-did-not-answer",
-        ]:
-            assert self._inline_swap(raw) == SpeakerRoleResolver.normalize_end_reason(
-                raw, provider=ProviderChoices.VAPI, is_outbound=False
-            )
-
     def test_non_role_reasons_pass_through(self):
         for raw in [
             "silence-timed-out",

--- a/futureagi/simulate/tests/test_speaker_role_read_alignment.py
+++ b/futureagi/simulate/tests/test_speaker_role_read_alignment.py
@@ -1,0 +1,391 @@
+"""Behavior tests for the read-time speaker-role alignment.
+
+The DB stores transcript rows and recording URLs in raw Vapi shape. For
+VAPI inbound, that means DB `assistant` holds the FAGI simulator persona
+and DB `user` holds the tested agent. Every read surface must translate
+that back into the platform display convention (assistant = tested
+agent, user = simulator) before rendering to the FE / annotator / LLM.
+
+These tests exercise the actual read boundaries (serializer, view,
+resolver) with realistic payloads so a future refactor cannot silently
+drop the swap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from simulate.utils.speaker_roles import SpeakerRoleResolver
+from tracer.models.observability_provider import ProviderChoices
+
+
+# -------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------
+
+
+def _vapi_inbound_call(*, transcripts=None, recordings=None):
+    """Mock CallExecution shaped like a VAPI inbound row: FAGI's Vapi
+    account transcript, `assistant` = simulator, `user` = tested agent."""
+    obj = MagicMock()
+    obj.provider_call_data = {
+        "vapi": {"recording": recordings or {}, "id": "vapi-123"}
+    }
+    obj.call_metadata = {"call_direction": "inbound"}
+    obj.call_type = "inboundPhoneCall"
+    obj.simulation_call_type = "voice"
+    if transcripts is None:
+        obj.transcripts = MagicMock()
+        obj.transcripts.exclude.return_value = []
+    else:
+        obj.transcripts = MagicMock()
+        obj.transcripts.exclude.return_value = transcripts
+    return obj
+
+
+def _vapi_outbound_call(*, transcripts=None, recordings=None):
+    """Mock CallExecution shaped like a VAPI outbound row: tested agent's
+    Vapi account, `assistant` = tested agent, `user` = simulator. No read
+    swap should fire."""
+    obj = MagicMock()
+    obj.provider_call_data = {
+        "vapi": {"recording": recordings or {}, "id": "vapi-456"}
+    }
+    obj.call_metadata = {"call_direction": "outbound"}
+    obj.call_type = "outboundPhoneCall"
+    obj.simulation_call_type = "voice"
+    if transcripts is None:
+        obj.transcripts = MagicMock()
+        obj.transcripts.exclude.return_value = []
+    else:
+        obj.transcripts = MagicMock()
+        obj.transcripts.exclude.return_value = transcripts
+    return obj
+
+
+def _livekit_inbound_call(*, recordings=None):
+    """LiveKit is direction-agnostic: worker normalises at write time."""
+    obj = MagicMock()
+    obj.provider_call_data = {"livekit": {"recording": recordings or {}}}
+    obj.call_metadata = {"call_direction": "inbound"}
+    obj.call_type = "inboundPhoneCall"
+    obj.simulation_call_type = "voice"
+    obj.transcripts = MagicMock()
+    obj.transcripts.exclude.return_value = []
+    return obj
+
+
+# -------------------------------------------------------------------
+# Serializer read alignment
+# -------------------------------------------------------------------
+
+
+class TestGetRecordingsSwap:
+    """CallExecutionDetailSerializer.get_recordings must swap
+    recordings.assistant <-> recordings.customer for VAPI inbound so the
+    yellow-color track carries the tested agent's audio in the FE."""
+
+    def _get_recordings(self, obj):
+        from simulate.serializers.test_execution import CallExecutionDetailSerializer
+
+        ser = CallExecutionDetailSerializer(context={"detail_mode": True})
+        return ser.get_recordings(obj)
+
+    def test_vapi_inbound_swaps_assistant_and_customer_urls(self):
+        obj = _vapi_inbound_call(
+            recordings={
+                "assistant": "https://cdn/simulator.mp3",
+                "customer": "https://cdn/tested_agent.mp3",
+                "stereo": "https://cdn/stereo.mp3",
+            }
+        )
+        rec = self._get_recordings(obj)
+        # After swap, `assistant` = tested-agent audio, `customer` =
+        # simulator audio -- matching the FE's display convention.
+        assert rec["assistant"] == "https://cdn/tested_agent.mp3"
+        assert rec["customer"] == "https://cdn/simulator.mp3"
+        # Non-role keys pass through untouched.
+        assert rec["stereo"] == "https://cdn/stereo.mp3"
+
+    def test_vapi_outbound_passthrough(self):
+        obj = _vapi_outbound_call(
+            recordings={
+                "assistant": "https://cdn/tested_agent.mp3",
+                "customer": "https://cdn/simulator.mp3",
+            }
+        )
+        rec = self._get_recordings(obj)
+        assert rec["assistant"] == "https://cdn/tested_agent.mp3"
+        assert rec["customer"] == "https://cdn/simulator.mp3"
+
+    def test_livekit_passthrough(self):
+        obj = _livekit_inbound_call(
+            recordings={
+                "assistant": "https://cdn/tested_agent.mp3",
+                "customer": "https://cdn/simulator.mp3",
+            }
+        )
+        rec = self._get_recordings(obj)
+        assert rec["assistant"] == "https://cdn/tested_agent.mp3"
+        assert rec["customer"] == "https://cdn/simulator.mp3"
+
+    def test_empty_recordings_dict_returns_empty(self):
+        obj = _vapi_inbound_call(recordings={})
+        assert self._get_recordings(obj) == {}
+
+    def test_missing_side_still_swaps_present_side(self):
+        """If Vapi only produced one of the two mono URLs, swap must
+        still move it to the correct side."""
+        obj = _vapi_inbound_call(recordings={"assistant": "https://cdn/only.mp3"})
+        rec = self._get_recordings(obj)
+        # Simulator audio URL now lives under `customer`.
+        assert rec.get("customer") == "https://cdn/only.mp3"
+
+
+class TestGetTranscriptSwap:
+    """CallExecutionDetailSerializer.get_transcript must emit
+    speaker_role in the platform convention: `assistant` for the tested
+    agent, `user` for the FAGI simulator, regardless of what raw Vapi
+    labelled the row."""
+
+    def _mock_transcripts_qs(self, rows):
+        """Build the transcripts queryset chain the serializer calls."""
+        qs = MagicMock()
+        qs.exclude.return_value = rows
+        return qs
+
+    def _mock_row(self, speaker_role, content):
+        row = MagicMock()
+        row.id = f"row-{speaker_role}"
+        row.speaker_role = speaker_role
+        row.content = content
+        row.start_time_ms = 0
+        row.end_time_ms = 1000
+        row.confidence_score = 1.0
+        row.created_at = None
+        return row
+
+    def _serialize(self, obj):
+        from simulate.serializers.test_execution import CallExecutionDetailSerializer
+
+        ser = CallExecutionDetailSerializer(context={"detail_mode": True})
+        return ser.get_transcript(obj)
+
+    def test_vapi_inbound_swaps_per_row(self):
+        rows = [
+            self._mock_row("assistant", "Hello, I am Layan"),  # simulator persona
+            self._mock_row("user", "Hello, I am Jawad from Pall Nis Solutions"),
+        ]
+        obj = _vapi_inbound_call(transcripts=rows)
+        emitted = self._serialize(obj)
+        # DB `assistant` (simulator content) -> emit as `user`.
+        # DB `user` (tested-agent content) -> emit as `assistant`.
+        assert emitted[0]["speaker_role"] == "user"
+        assert "Layan" in emitted[0]["content"]
+        assert emitted[1]["speaker_role"] == "assistant"
+        assert "Jawad" in emitted[1]["content"]
+
+    def test_vapi_outbound_passthrough(self):
+        rows = [
+            self._mock_row("assistant", "Hello, I am Raj insurance advisor"),
+            self._mock_row("user", "Sorry, who is this?"),
+        ]
+        obj = _vapi_outbound_call(transcripts=rows)
+        emitted = self._serialize(obj)
+        # No swap: raw shape from customer's Vapi account already matches
+        # the platform convention (assistant = tested agent).
+        assert emitted[0]["speaker_role"] == "assistant"
+        assert emitted[1]["speaker_role"] == "user"
+
+
+# -------------------------------------------------------------------
+# Resolver contract used by eval-input builders
+# -------------------------------------------------------------------
+
+
+class TestEvalTranscriptLabels:
+    """Eval templates receive `agent: ...` and `customer: ...` strings.
+    The template contract does not accept raw Vapi role names, so the
+    resolver must translate at every eval-input builder call site."""
+
+    def test_vapi_inbound_labels_flip_to_platform_convention(self):
+        # DB `assistant` = simulator content on VAPI inbound.
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant",
+                provider=ProviderChoices.VAPI,
+                is_outbound=False,
+            )
+            == "customer"
+        )
+        # DB `user` = tested-agent content on VAPI inbound.
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "agent"
+        )
+
+    def test_vapi_outbound_labels_are_direct(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            == "agent"
+        )
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            == "customer"
+        )
+
+    def test_system_role_is_never_conversational(self):
+        """The persona system prompt must never appear in an eval input."""
+        assert "system" not in SpeakerRoleResolver.get_conversational_roles()
+
+
+# -------------------------------------------------------------------
+# Write-time metric-side contract
+# -------------------------------------------------------------------
+
+
+class TestMetricsNormalizeRoles:
+    """conversation_metrics._normalize_roles_for_test_agent is the ONE
+    write-time site that legitimately uses the resolver. Its purpose is
+    to make the stored bot_wpm column mean "tested agent's WPM" no
+    matter which raw side that was on. Under the corrected map:
+
+    - VAPI inbound: raw bot = simulator, so swap fires. bot_* metrics
+      end up computed on tested-agent's messages.
+    - VAPI outbound: raw bot = tested agent already, no swap.
+    - LiveKit: normalised at source, no swap.
+    """
+
+    def _run(self, provider, is_outbound, messages):
+        """Import here to avoid ee-side import at module load, and to
+        exercise the real function rather than a fake."""
+        from ee.voice.services.conversation_metrics import (
+            ConversationMetricsCalculator,
+            MessageData,
+        )
+
+        calc = ConversationMetricsCalculator(voice_service_provider=provider)
+        parsed = [
+            MessageData(
+                role=m["role"],
+                time=m["time"],
+                end_time=None,
+                message=m["message"],
+                duration=None,
+                seconds_from_start=m["time"],
+            )
+            for m in messages
+        ]
+        return calc._normalize_roles_for_test_agent(parsed, is_outbound)
+
+    def test_vapi_inbound_swaps_bot_and_user(self):
+        raw = [
+            {"role": "bot", "time": 0.0, "message": "simulator persona"},
+            {"role": "user", "time": 1.0, "message": "tested agent"},
+        ]
+        out = self._run(ProviderChoices.VAPI, False, raw)
+        # Post-swap: role "bot" now holds the tested agent's content
+        # (which is what will feed into bot_wpm downstream).
+        assert out[0].role == "user"
+        assert "simulator" in out[0].message
+        assert out[1].role == "bot"
+        assert "tested agent" in out[1].message
+
+    def test_vapi_outbound_no_swap(self):
+        raw = [
+            {"role": "bot", "time": 0.0, "message": "tested agent"},
+            {"role": "user", "time": 1.0, "message": "simulator"},
+        ]
+        out = self._run(ProviderChoices.VAPI, True, raw)
+        # Raw shape preserved: `bot` already means tested agent for
+        # outbound (transcript pulled from customer's Vapi account).
+        assert out[0].role == "bot"
+        assert "tested agent" in out[0].message
+        assert out[1].role == "user"
+
+    def test_livekit_no_swap_either_direction(self):
+        raw = [
+            {"role": "bot", "time": 0.0, "message": "tested agent"},
+            {"role": "user", "time": 1.0, "message": "simulator"},
+        ]
+        for is_outbound in [False, True]:
+            out = self._run(ProviderChoices.LIVEKIT, is_outbound, raw)
+            assert out[0].role == "bot"
+            assert out[1].role == "user"
+
+    def test_is_outbound_none_is_treated_as_no_context(self):
+        """Historical callers pass is_outbound=None when direction is
+        unknown. The function must not crash and must return the input
+        untouched."""
+        raw = [
+            {"role": "bot", "time": 0.0, "message": "x"},
+            {"role": "user", "time": 1.0, "message": "y"},
+        ]
+        out = self._run(ProviderChoices.VAPI, None, raw)
+        assert out[0].role == "bot"
+        assert out[1].role == "user"
+
+
+# -------------------------------------------------------------------
+# Write-time ended_reason swap
+# -------------------------------------------------------------------
+
+
+class TestEndedReasonInlineSwap:
+    """voice_large.py inlines an assistant<->customer swap on
+    ended_reason for VAPI inbound. Behaviour must match what the old
+    resolver call produced so historical rows and new rows agree."""
+
+    @staticmethod
+    def _inline_swap(ended_reason: str) -> str:
+        """The exact three-step replace chain used by voice_large.py."""
+        return (
+            ended_reason.replace("assistant", "\x00")
+            .replace("customer", "assistant")
+            .replace("\x00", "customer")
+        )
+
+    def test_swap_is_involutive(self):
+        for raw in [
+            "assistant-ended-call",
+            "customer-ended-call",
+            "customer-did-not-answer",
+            "assistant-forwarded-call",
+        ]:
+            assert self._inline_swap(self._inline_swap(raw)) == raw
+
+    def test_swap_matches_resolver_for_vapi_inbound(self):
+        for raw in [
+            "assistant-ended-call",
+            "customer-ended-call",
+            "customer-did-not-answer",
+        ]:
+            assert self._inline_swap(raw) == SpeakerRoleResolver.normalize_end_reason(
+                raw, provider=ProviderChoices.VAPI, is_outbound=False
+            )
+
+    def test_non_role_reasons_pass_through(self):
+        for raw in [
+            "silence-timed-out",
+            "max-duration-reached",
+            "twilio-failed-to-connect",
+        ]:
+            assert self._inline_swap(raw) == raw
+
+    def test_placeholder_choice_survives_edge_case_inputs(self):
+        """The \\x00 placeholder was picked because no legitimate Vapi
+        ended_reason contains a NUL byte. If someone ever changes the
+        placeholder to a printable substring, this test catches it."""
+        payload = "assistant-was-customer-friendly"
+        result = self._inline_swap(payload)
+        # Both role words swapped, no placeholder leaked.
+        assert result == "customer-was-assistant-friendly"
+        assert "\x00" not in result

--- a/futureagi/simulate/tests/test_speaker_role_resolver.py
+++ b/futureagi/simulate/tests/test_speaker_role_resolver.py
@@ -1,5 +1,570 @@
-"""Voice simulation tests -- requires Enterprise Edition."""
-try:
-    from ee.voice.tests.test_speaker_role_resolver import *  # noqa: F401,F403
-except ImportError:
-    pass
+"""Tests for SpeakerRoleResolver (simulate/utils/speaker_roles.py)."""
+
+import pytest
+
+from simulate.utils.speaker_roles import SpeakerRoleResolver
+from tracer.models.observability_provider import ProviderChoices
+
+# -------------------------------------------------------------------
+# detect_provider
+# -------------------------------------------------------------------
+
+
+class TestDetectProvider:
+
+    def test_detects_livekit(self):
+        data = {"livekit": {"room_name": "call_123"}}
+        assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.LIVEKIT
+
+    def test_detects_vapi(self):
+        data = {"vapi": {"id": "abc"}}
+        assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.VAPI
+
+    def test_none_falls_back_to_vapi(self):
+        assert SpeakerRoleResolver.detect_provider(None) == ProviderChoices.VAPI
+
+    def test_empty_dict_falls_back_to_vapi(self):
+        assert SpeakerRoleResolver.detect_provider({}) == ProviderChoices.VAPI
+
+    def test_unknown_keys_falls_back_to_vapi(self):
+        data = {"retell": {"id": "x"}}
+        assert SpeakerRoleResolver.detect_provider(data) == ProviderChoices.VAPI
+
+
+# -------------------------------------------------------------------
+# is_tested_agent
+# -------------------------------------------------------------------
+
+
+class TestIsTestedAgent:
+
+    # VAPI inbound: bot/assistant = simulator, user = tested_agent
+    def test_vapi_inbound_user_is_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "user", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is True
+        )
+
+    def test_vapi_inbound_bot_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "bot", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+    def test_vapi_inbound_assistant_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+    # VAPI outbound: bot/assistant = tested_agent, user = simulator
+    def test_vapi_outbound_assistant_is_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            is True
+        )
+
+    def test_vapi_outbound_bot_is_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "bot", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            is True
+        )
+
+    def test_vapi_outbound_user_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "user", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            is False
+        )
+
+    # LiveKit: unchanged (agent worker normalises to assistant = tested_agent)
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_assistant_is_tested_agent(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "assistant", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_user_is_not_tested_agent(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "user", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            is False
+        )
+
+    def test_system_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "system", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+    def test_tool_calls_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "tool_calls", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+    def test_case_insensitive(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "USER", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is True
+        )
+
+    def test_empty_role_is_not_tested_agent(self):
+        assert (
+            SpeakerRoleResolver.is_tested_agent(
+                "", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+
+class TestIsSimulator:
+
+    # VAPI inbound: bot/assistant = simulator
+    def test_vapi_inbound_bot_is_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "bot", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is True
+        )
+
+    def test_vapi_inbound_assistant_is_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is True
+        )
+
+    def test_vapi_inbound_user_is_not_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "user", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            is False
+        )
+
+    # VAPI outbound: user = simulator
+    def test_vapi_outbound_user_is_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "user", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            is True
+        )
+
+    def test_vapi_outbound_assistant_is_not_simulator(self):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_user_is_simulator(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "user", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_assistant_is_not_simulator(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.is_simulator(
+                "assistant", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            is False
+        )
+
+
+class TestGetEvalRoleLabel:
+
+    # VAPI inbound: assistant/bot -> customer, user -> agent
+    def test_vapi_inbound_bot_becomes_customer(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "bot", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "customer"
+        )
+
+    def test_vapi_inbound_assistant_becomes_customer(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "customer"
+        )
+
+    def test_vapi_inbound_user_becomes_agent(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "agent"
+        )
+
+    # VAPI outbound: assistant/bot -> agent, user -> customer
+    def test_vapi_outbound_assistant_becomes_agent(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            == "agent"
+        )
+
+    def test_vapi_outbound_bot_becomes_agent(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "bot", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            == "agent"
+        )
+
+    def test_vapi_outbound_user_becomes_customer(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.VAPI, is_outbound=True
+            )
+            == "customer"
+        )
+
+    # LiveKit: unchanged
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_assistant_becomes_agent(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            == "agent"
+        )
+
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit_user_becomes_customer(self, is_outbound):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+            )
+            == "customer"
+        )
+
+    def test_system_returned_as_is(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "system", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "system"
+        )
+
+    def test_tool_calls_returned_as_is(self):
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "tool_calls", provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            == "tool_calls"
+        )
+
+
+class TestGetTranscriptRoleSets:
+
+    def test_vapi_inbound(self):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.VAPI, is_outbound=False
+        )
+        assert "user" in ta
+        assert "customer" in ta
+        assert "bot" in sim
+        assert "assistant" in sim
+        assert "agent" in sim
+
+    def test_vapi_outbound(self):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.VAPI, is_outbound=True
+        )
+        assert "bot" in ta
+        assert "assistant" in ta
+        assert "agent" in ta
+        assert "user" in sim
+        assert "customer" in sim
+
+    @pytest.mark.parametrize("is_outbound", [False, True])
+    def test_livekit(self, is_outbound):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.LIVEKIT, is_outbound=is_outbound
+        )
+        assert "assistant" in ta
+        assert "bot" in ta
+        assert "user" in sim
+        assert "customer" in sim
+
+    def test_sets_are_disjoint(self):
+        ta, sim = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.VAPI, is_outbound=False
+        )
+        assert ta & sim == set()
+
+
+class TestGetSkipDecisionRoleSets:
+
+    def test_returns_same_as_transcript_role_sets(self):
+        for provider in [ProviderChoices.VAPI, ProviderChoices.LIVEKIT]:
+            for is_outbound in [True, False]:
+                skip = SpeakerRoleResolver.get_skip_decision_role_sets(
+                    provider=provider, is_outbound=is_outbound
+                )
+                transcript = SpeakerRoleResolver.get_transcript_role_sets(
+                    provider=provider, is_outbound=is_outbound
+                )
+                assert skip == transcript
+
+
+class TestStaticRoleLists:
+
+    def test_conversational_roles_has_user_and_assistant(self):
+        roles = SpeakerRoleResolver.get_conversational_roles()
+        assert len(roles) == 2
+        assert "user" in roles
+        assert "assistant" in roles
+
+    def test_displayable_roles_excludes_system(self):
+        roles = SpeakerRoleResolver.get_displayable_roles()
+        assert "system" not in roles
+
+    def test_conversational_matches_displayable(self):
+        assert SpeakerRoleResolver.get_conversational_roles() == (
+            SpeakerRoleResolver.get_displayable_roles()
+        )
+
+
+class TestNormalizeEndReason:
+
+    # LiveKit: no swap (agent worker normalises at source)
+    def test_livekit_agent_ended_call_passthrough(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "agent_ended_call", provider=ProviderChoices.LIVEKIT
+            )
+            == "agent_ended_call"
+        )
+
+    def test_livekit_customer_ended_call_passthrough(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "customer_ended_call", provider=ProviderChoices.LIVEKIT
+            )
+            == "customer_ended_call"
+        )
+
+    # VAPI inbound: assistant <-> customer swap
+    def test_vapi_inbound_assistant_ended_swaps(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "assistant-ended-call",
+                provider=ProviderChoices.VAPI,
+                is_outbound=False,
+            )
+            == "customer-ended-call"
+        )
+
+    def test_vapi_inbound_customer_ended_swaps(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "customer-ended-call",
+                provider=ProviderChoices.VAPI,
+                is_outbound=False,
+            )
+            == "assistant-ended-call"
+        )
+
+    # VAPI outbound: no swap (raw Vapi labels already match FAGI perspective)
+    def test_vapi_outbound_assistant_ended_passthrough(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "assistant-ended-call",
+                provider=ProviderChoices.VAPI,
+                is_outbound=True,
+            )
+            == "assistant-ended-call"
+        )
+
+    def test_vapi_outbound_customer_ended_passthrough(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "customer-ended-call",
+                provider=ProviderChoices.VAPI,
+                is_outbound=True,
+            )
+            == "customer-ended-call"
+        )
+
+    def test_empty_string(self):
+        assert (
+            SpeakerRoleResolver.normalize_end_reason(
+                "", provider=ProviderChoices.LIVEKIT
+            )
+            == ""
+        )
+
+
+# -------------------------------------------------------------------
+# detect_is_outbound
+# -------------------------------------------------------------------
+
+
+class TestDetectIsOutbound:
+    """Direction detection reads call_metadata.call_direction first, then
+    falls back to CallExecution.call_type for legacy rows."""
+
+    class _Fake:
+        def __init__(self, call_metadata=None, call_type=None):
+            self.call_metadata = call_metadata
+            self.call_type = call_type
+
+    def test_prefers_call_metadata_outbound(self):
+        obj = self._Fake(
+            call_metadata={"call_direction": "outbound"}, call_type="inboundPhoneCall"
+        )
+        assert SpeakerRoleResolver.detect_is_outbound(obj) is True
+
+    def test_prefers_call_metadata_inbound(self):
+        obj = self._Fake(
+            call_metadata={"call_direction": "inbound"}, call_type="outboundPhoneCall"
+        )
+        assert SpeakerRoleResolver.detect_is_outbound(obj) is False
+
+    def test_falls_back_to_call_type_when_metadata_missing(self):
+        obj = self._Fake(call_metadata={}, call_type="outboundPhoneCall")
+        assert SpeakerRoleResolver.detect_is_outbound(obj) is True
+
+    def test_defaults_to_inbound_when_both_missing(self):
+        assert SpeakerRoleResolver.detect_is_outbound(self._Fake()) is False
+
+    def test_handles_none_call_execution(self):
+        assert SpeakerRoleResolver.detect_is_outbound(None) is False
+
+    def test_case_insensitive_call_metadata(self):
+        obj = self._Fake(call_metadata={"call_direction": "OUTBOUND"})
+        assert SpeakerRoleResolver.detect_is_outbound(obj) is True
+
+
+# -------------------------------------------------------------------
+# Regression contracts (documented behavior that must never silently
+# regress)
+# -------------------------------------------------------------------
+
+
+class TestRegressionContracts:
+    """These assertions encode invariants explicitly called out in the
+    module docstring. If any of them start failing, someone has either
+    flipped a map (breaking read alignment) or changed which side the
+    convention normalizes to (breaking downstream consumers)."""
+
+    def test_vapi_inbound_and_outbound_are_mirror_images(self):
+        """The whole reason SpeakerRoleResolver exists is the VAPI
+        inbound / outbound divergence. If they ever collapse to the same
+        map, the map has regressed."""
+        ta_in, sim_in = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.VAPI, is_outbound=False
+        )
+        ta_out, sim_out = SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.VAPI, is_outbound=True
+        )
+        assert ta_in == sim_out
+        assert sim_in == ta_out
+
+    def test_livekit_is_direction_agnostic(self):
+        """LiveKit's agent worker normalises at write time; inbound and
+        outbound share the same map. If they ever diverge, someone has
+        introduced a read-time swap for LiveKit that shouldn't be there."""
+        assert SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.LIVEKIT, is_outbound=False
+        ) == SpeakerRoleResolver.get_transcript_role_sets(
+            provider=ProviderChoices.LIVEKIT, is_outbound=True
+        )
+
+    def test_eval_labels_are_stable_across_providers_and_directions(self):
+        """Eval templates read `agent` and `customer` regardless of
+        provider. If a fifth label ever leaks through, the LLM prompt
+        contract has drifted."""
+        seen = set()
+        for provider in [ProviderChoices.VAPI, ProviderChoices.LIVEKIT]:
+            for is_outbound in [False, True]:
+                for raw in ["assistant", "user", "bot", "customer", "agent"]:
+                    label = SpeakerRoleResolver.get_eval_role_label(
+                        raw, provider=provider, is_outbound=is_outbound
+                    )
+                    seen.add(label)
+        assert seen == {"agent", "customer"}
+
+    def test_conversational_roles_never_include_system(self):
+        """The FAGI simulator's persona system prompt must not leak into
+        eval inputs or the transcript view. This is the only line of
+        defence before the raw payload hits the LLM."""
+        roles = SpeakerRoleResolver.get_conversational_roles()
+        assert "system" not in roles
+        assert "tool_calls" not in roles
+        assert "tool_call_result" not in roles
+
+    def test_normalize_end_reason_swap_is_involutive_for_vapi_inbound(self):
+        """Two swaps == no swap. If it isn't, the placeholder was chosen
+        badly (collision with a substring of a real ended_reason) and the
+        function is silently corrupting data."""
+        for reason in [
+            "assistant-ended-call",
+            "customer-ended-call",
+            "customer-did-not-answer",
+            "assistant-forwarded-call",
+        ]:
+            once = SpeakerRoleResolver.normalize_end_reason(
+                reason, provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            twice = SpeakerRoleResolver.normalize_end_reason(
+                once, provider=ProviderChoices.VAPI, is_outbound=False
+            )
+            assert twice == reason
+
+    def test_normalize_end_reason_leaves_non_role_words_untouched(self):
+        """Only "assistant" and "customer" are role words. Real ended_reason
+        values that don't contain either must pass through unchanged so
+        the FE reasonColorMap keeps working."""
+        for reason in [
+            "silence-timed-out",
+            "max-duration-reached",
+            "error",
+            "twilio-failed-to-connect",
+        ]:
+            for is_outbound in [False, True]:
+                assert (
+                    SpeakerRoleResolver.normalize_end_reason(
+                        reason,
+                        provider=ProviderChoices.VAPI,
+                        is_outbound=is_outbound,
+                    )
+                    == reason
+                )

--- a/futureagi/simulate/tests/test_speaker_role_resolver.py
+++ b/futureagi/simulate/tests/test_speaker_role_resolver.py
@@ -362,76 +362,6 @@ class TestStaticRoleLists:
         )
 
 
-class TestNormalizeEndReason:
-
-    # LiveKit: no swap (agent worker normalises at source)
-    def test_livekit_agent_ended_call_passthrough(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "agent_ended_call", provider=ProviderChoices.LIVEKIT
-            )
-            == "agent_ended_call"
-        )
-
-    def test_livekit_customer_ended_call_passthrough(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "customer_ended_call", provider=ProviderChoices.LIVEKIT
-            )
-            == "customer_ended_call"
-        )
-
-    # VAPI inbound: assistant <-> customer swap
-    def test_vapi_inbound_assistant_ended_swaps(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "assistant-ended-call",
-                provider=ProviderChoices.VAPI,
-                is_outbound=False,
-            )
-            == "customer-ended-call"
-        )
-
-    def test_vapi_inbound_customer_ended_swaps(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "customer-ended-call",
-                provider=ProviderChoices.VAPI,
-                is_outbound=False,
-            )
-            == "assistant-ended-call"
-        )
-
-    # VAPI outbound: no swap (raw Vapi labels already match FAGI perspective)
-    def test_vapi_outbound_assistant_ended_passthrough(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "assistant-ended-call",
-                provider=ProviderChoices.VAPI,
-                is_outbound=True,
-            )
-            == "assistant-ended-call"
-        )
-
-    def test_vapi_outbound_customer_ended_passthrough(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "customer-ended-call",
-                provider=ProviderChoices.VAPI,
-                is_outbound=True,
-            )
-            == "customer-ended-call"
-        )
-
-    def test_empty_string(self):
-        assert (
-            SpeakerRoleResolver.normalize_end_reason(
-                "", provider=ProviderChoices.LIVEKIT
-            )
-            == ""
-        )
-
-
 # -------------------------------------------------------------------
 # detect_is_outbound
 # -------------------------------------------------------------------
@@ -462,11 +392,22 @@ class TestDetectIsOutbound:
         obj = self._Fake(call_metadata={}, call_type="outboundPhoneCall")
         assert SpeakerRoleResolver.detect_is_outbound(obj) is True
 
-    def test_defaults_to_inbound_when_both_missing(self):
-        assert SpeakerRoleResolver.detect_is_outbound(self._Fake()) is False
+    def test_defaults_to_outbound_when_both_missing(self):
+        """Indeterminate direction returns True (outbound = no-swap for VAPI).
+        A False default would silently invert outbound records that lost their
+        metadata; a True default lets the raw shape (already platform-correct
+        on outbound) pass through."""
+        assert SpeakerRoleResolver.detect_is_outbound(self._Fake()) is True
+
+    def test_defaults_to_outbound_when_call_type_is_neither(self):
+        """A call_type string that mentions neither 'inbound' nor 'outbound'
+        should be treated as indeterminate and fall through to the safe default."""
+        obj = self._Fake(call_type="webCall")
+        assert SpeakerRoleResolver.detect_is_outbound(obj) is True
 
     def test_handles_none_call_execution(self):
-        assert SpeakerRoleResolver.detect_is_outbound(None) is False
+        """None call_execution is treated as indeterminate; return the safe default."""
+        assert SpeakerRoleResolver.detect_is_outbound(None) is True
 
     def test_case_insensitive_call_metadata(self):
         obj = self._Fake(call_metadata={"call_direction": "OUTBOUND"})
@@ -531,40 +472,3 @@ class TestRegressionContracts:
         assert "tool_calls" not in roles
         assert "tool_call_result" not in roles
 
-    def test_normalize_end_reason_swap_is_involutive_for_vapi_inbound(self):
-        """Two swaps == no swap. If it isn't, the placeholder was chosen
-        badly (collision with a substring of a real ended_reason) and the
-        function is silently corrupting data."""
-        for reason in [
-            "assistant-ended-call",
-            "customer-ended-call",
-            "customer-did-not-answer",
-            "assistant-forwarded-call",
-        ]:
-            once = SpeakerRoleResolver.normalize_end_reason(
-                reason, provider=ProviderChoices.VAPI, is_outbound=False
-            )
-            twice = SpeakerRoleResolver.normalize_end_reason(
-                once, provider=ProviderChoices.VAPI, is_outbound=False
-            )
-            assert twice == reason
-
-    def test_normalize_end_reason_leaves_non_role_words_untouched(self):
-        """Only "assistant" and "customer" are role words. Real ended_reason
-        values that don't contain either must pass through unchanged so
-        the FE reasonColorMap keeps working."""
-        for reason in [
-            "silence-timed-out",
-            "max-duration-reached",
-            "error",
-            "twilio-failed-to-connect",
-        ]:
-            for is_outbound in [False, True]:
-                assert (
-                    SpeakerRoleResolver.normalize_end_reason(
-                        reason,
-                        provider=ProviderChoices.VAPI,
-                        is_outbound=is_outbound,
-                    )
-                    == reason
-                )

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -1,0 +1,223 @@
+"""Provider- and direction-aware transcript speaker-role resolution.
+
+Provider raw shape:
+
+  Provider | Direction | assistant / bot | user
+  ---------|-----------|-----------------|-----------------
+  VAPI     | inbound   | simulator       | tested agent
+  VAPI     | outbound  | tested agent    | simulator
+  LiveKit  | both      | tested agent    | simulator
+
+Direction is tested-agent-perspective: inbound = tested agent receives, outbound
+= tested agent dials out. LiveKit rows are pre-normalised at the agent worker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from tracer.models.observability_provider import ProviderChoices
+
+logger = structlog.get_logger(__name__)
+
+
+class SpeakerRoleResolver:
+    """Interprets CallTranscript.speaker_role by provider + call direction.
+
+    READ-SIDE ONLY. Translates raw provider role labels stored in the DB
+    into the platform-perspective convention that the FE, LLM eval inputs,
+    and downstream analytics expect. Do NOT call from write paths:
+    transcript rows, recording URLs and ended_reason are all persisted in
+    their raw provider shape. Using the resolver at write time
+    re-introduces the coincidental-no-op-that-flips-when-the-map-is-fixed
+    bug that motivated this class.
+
+    The single legitimate compute-time use is derived-metric normalization
+    (bot_wpm / user_wpm / talk_ratio / interruption counts) whose column
+    contract binds bot_* to the tested agent. That is a derivation, not a
+    raw-storage decision.
+    """
+
+    _VAPI_INBOUND: dict[str, str] = {
+        "bot": "simulator",
+        "assistant": "simulator",
+        "agent": "simulator",
+        "user": "tested_agent",
+        "customer": "tested_agent",
+    }
+
+    _VAPI_OUTBOUND: dict[str, str] = {
+        "bot": "tested_agent",
+        "assistant": "tested_agent",
+        "agent": "tested_agent",
+        "user": "simulator",
+        "customer": "simulator",
+    }
+
+    _LIVEKIT_INBOUND: dict[str, str] = {
+        "bot": "tested_agent",
+        "assistant": "tested_agent",
+        "agent": "tested_agent",
+        "user": "simulator",
+        "customer": "simulator",
+    }
+    _LIVEKIT_OUTBOUND: dict[str, str] = _LIVEKIT_INBOUND
+
+    # VAPI end reasons use raw provider words; swap only for VAPI inbound
+    # so the reviewer sees the same actor as in the transcript.
+    _VAPI_END_REASON_ROLE_WORDS = ("assistant", "customer")
+
+    @staticmethod
+    def detect_provider(
+        provider_call_data: dict[str, Any] | None,
+    ) -> ProviderChoices:
+        """Detect provider from CallExecution.provider_call_data; default VAPI."""
+        if not isinstance(provider_call_data, dict):
+            if provider_call_data is not None:
+                logger.error(
+                    "speaker_role_resolver_invalid_provider_call_data",
+                    provider_call_data_type=type(provider_call_data).__name__,
+                )
+            return ProviderChoices.VAPI
+        if provider_call_data.get(ProviderChoices.LIVEKIT.value):
+            return ProviderChoices.LIVEKIT
+        if provider_call_data.get(ProviderChoices.VAPI.value):
+            return ProviderChoices.VAPI
+        logger.error(
+            "speaker_role_resolver_unknown_provider",
+            provider_call_data_keys=list(provider_call_data.keys()),
+        )
+        return ProviderChoices.VAPI
+
+    @staticmethod
+    def detect_is_outbound(call_execution: Any) -> bool:
+        """True when the tested agent initiated the call."""
+        if call_execution is None:
+            return False
+        call_metadata = getattr(call_execution, "call_metadata", None) or {}
+        call_direction = str(call_metadata.get("call_direction", "")).strip().lower()
+        if call_direction == "outbound":
+            return True
+        if call_direction == "inbound":
+            return False
+        call_type = str(getattr(call_execution, "call_type", "") or "").strip().lower()
+        return "outbound" in call_type
+
+    @classmethod
+    def _get_map(
+        cls,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> dict[str, str]:
+        if provider == ProviderChoices.VAPI:
+            return cls._VAPI_OUTBOUND if is_outbound else cls._VAPI_INBOUND
+        if provider == ProviderChoices.LIVEKIT:
+            return cls._LIVEKIT_OUTBOUND if is_outbound else cls._LIVEKIT_INBOUND
+        logger.error(
+            "speaker_role_resolver_unsupported_provider",
+            provider=str(provider),
+            is_outbound=is_outbound,
+        )
+        return cls._VAPI_INBOUND
+
+    @classmethod
+    def is_tested_agent(
+        cls,
+        role: str,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> bool:
+        role_map = cls._get_map(provider=provider, is_outbound=is_outbound)
+        return role_map.get((role or "").lower()) == "tested_agent"
+
+    @classmethod
+    def is_simulator(
+        cls,
+        role: str,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> bool:
+        role_map = cls._get_map(provider=provider, is_outbound=is_outbound)
+        return role_map.get((role or "").lower()) == "simulator"
+
+    @classmethod
+    def get_eval_role_label(
+        cls,
+        role: str,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> str:
+        """Return "agent" | "customer" | passthrough for LLM eval transcripts."""
+        role_map = cls._get_map(provider=provider, is_outbound=is_outbound)
+        classification = role_map.get((role or "").lower())
+        if classification == "tested_agent":
+            return "agent"
+        if classification == "simulator":
+            return "customer"
+        return role
+
+    @classmethod
+    def get_transcript_role_sets(
+        cls,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> tuple[frozenset[str], frozenset[str]]:
+        """(tested_agent_roles, simulator_roles) as raw DB speaker_role strings."""
+        role_map = cls._get_map(provider=provider, is_outbound=is_outbound)
+        ta = frozenset(k for k, v in role_map.items() if v == "tested_agent")
+        sim = frozenset(k for k, v in role_map.items() if v == "simulator")
+        return ta, sim
+
+    @classmethod
+    def get_skip_decision_role_sets(
+        cls,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> tuple[frozenset[str], frozenset[str]]:
+        return cls.get_transcript_role_sets(provider=provider, is_outbound=is_outbound)
+
+    @staticmethod
+    def get_conversational_roles() -> list[str]:
+        """User + assistant turns only; excludes system, tool_calls, unknown."""
+        from simulate.models.test_execution import CallTranscript
+
+        return [
+            CallTranscript.SpeakerRole.USER,
+            CallTranscript.SpeakerRole.ASSISTANT,
+        ]
+
+    @staticmethod
+    def get_displayable_roles() -> list[str]:
+        """Same as conversational; system prompt is hidden from the transcript view."""
+        from simulate.models.test_execution import CallTranscript
+
+        return [
+            CallTranscript.SpeakerRole.USER,
+            CallTranscript.SpeakerRole.ASSISTANT,
+        ]
+
+    @classmethod
+    def normalize_end_reason(
+        cls,
+        ended_reason: str,
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> str:
+        """Rewrite ended_reason to the reviewer's perspective (agent/customer)."""
+        if not ended_reason:
+            return ended_reason
+        if provider != ProviderChoices.VAPI or is_outbound:
+            return ended_reason
+        word_a, word_b = cls._VAPI_END_REASON_ROLE_WORDS
+        swapped = ended_reason.replace(word_a, "__PH__")
+        swapped = swapped.replace(word_b, word_a)
+        return swapped.replace("__PH__", word_b)

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -146,6 +146,23 @@ class SpeakerRoleResolver:
         return role_map.get((role or "").lower()) == "simulator"
 
     @classmethod
+    def align_transcript_rows(
+        cls,
+        rows: list[dict[str, Any]],
+        *,
+        provider: ProviderChoices,
+        is_outbound: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Rewrite each row's speaker_role to platform convention in place."""
+        for row in rows:
+            raw = row.get("speaker_role")
+            if cls.is_tested_agent(raw, provider=provider, is_outbound=is_outbound):
+                row["speaker_role"] = "assistant"
+            elif cls.is_simulator(raw, provider=provider, is_outbound=is_outbound):
+                row["speaker_role"] = "user"
+        return rows
+
+    @classmethod
     def get_eval_role_label(
         cls,
         role: str,

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -235,6 +235,6 @@ class SpeakerRoleResolver:
         if provider != ProviderChoices.VAPI or is_outbound:
             return ended_reason
         word_a, word_b = cls._VAPI_END_REASON_ROLE_WORDS
-        swapped = ended_reason.replace(word_a, "__PH__")
+        swapped = ended_reason.replace(word_a, "\x00")
         swapped = swapped.replace(word_b, word_a)
-        return swapped.replace("__PH__", word_b)
+        return swapped.replace("\x00", word_b)

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -65,10 +65,6 @@ class SpeakerRoleResolver:
     }
     _LIVEKIT_OUTBOUND: dict[str, str] = _LIVEKIT_INBOUND
 
-    # VAPI end reasons use raw provider words; swap only for VAPI inbound
-    # so the reviewer sees the same actor as in the transcript.
-    _VAPI_END_REASON_ROLE_WORDS = ("assistant", "customer")
-
     @staticmethod
     def detect_provider(
         provider_call_data: dict[str, Any] | None,
@@ -93,9 +89,16 @@ class SpeakerRoleResolver:
 
     @staticmethod
     def detect_is_outbound(call_execution: Any) -> bool:
-        """True when the tested agent initiated the call."""
+        """True when the tested agent initiated the call.
+
+        Defaults to True on indeterminate direction. For VAPI, True selects the
+        outbound map (no swap); the raw outbound shape already matches the
+        platform convention, so a records missing both call_direction and a
+        parseable call_type still reads correctly. A False default would
+        silently invert outbound records that lost their metadata.
+        """
         if call_execution is None:
-            return False
+            return True
         call_metadata = getattr(call_execution, "call_metadata", None) or {}
         call_direction = str(call_metadata.get("call_direction", "")).strip().lower()
         if call_direction == "outbound":
@@ -103,7 +106,11 @@ class SpeakerRoleResolver:
         if call_direction == "inbound":
             return False
         call_type = str(getattr(call_execution, "call_type", "") or "").strip().lower()
-        return "outbound" in call_type
+        if "outbound" in call_type:
+            return True
+        if "inbound" in call_type:
+            return False
+        return True
 
     @classmethod
     def _get_map(
@@ -220,21 +227,3 @@ class SpeakerRoleResolver:
             CallTranscript.SpeakerRole.USER,
             CallTranscript.SpeakerRole.ASSISTANT,
         ]
-
-    @classmethod
-    def normalize_end_reason(
-        cls,
-        ended_reason: str,
-        *,
-        provider: ProviderChoices,
-        is_outbound: bool = False,
-    ) -> str:
-        """Rewrite ended_reason to the reviewer's perspective (agent/customer)."""
-        if not ended_reason:
-            return ended_reason
-        if provider != ProviderChoices.VAPI or is_outbound:
-            return ended_reason
-        word_a, word_b = cls._VAPI_END_REASON_ROLE_WORDS
-        swapped = ended_reason.replace(word_a, "\x00")
-        swapped = swapped.replace(word_b, word_a)
-        return swapped.replace("\x00", word_b)

--- a/futureagi/simulate/views/call_transcript.py
+++ b/futureagi/simulate/views/call_transcript.py
@@ -67,15 +67,31 @@ class CallTranscriptView(APIView):
                 speaker_role__in=get_displayable_transcript_roles(),
             ).order_by("start_time_ms")
 
-            # Serialize the transcripts
-            serializer = CallTranscriptSerializer(transcripts, many=True)
+            rows = CallTranscriptSerializer(transcripts, many=True).data
+
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
+            provider = SpeakerRoleResolver.detect_provider(
+                call_execution.provider_call_data
+            )
+            is_outbound = SpeakerRoleResolver.detect_is_outbound(call_execution)
+            for row in rows:
+                raw = row.get("speaker_role")
+                if SpeakerRoleResolver.is_tested_agent(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "assistant"
+                elif SpeakerRoleResolver.is_simulator(
+                    raw, provider=provider, is_outbound=is_outbound
+                ):
+                    row["speaker_role"] = "user"
 
             return Response(
                 {
                     "call_execution_id": str(call_execution.id),
                     "phone_number": call_execution.phone_number,
                     "status": call_execution.status,
-                    "transcripts": serializer.data,
+                    "transcripts": rows,
                     "total_transcripts": len(transcripts),
                 },
                 status=status.HTTP_200_OK,
@@ -120,6 +136,8 @@ class TestExecutionTranscriptsView(APIView):
                 test_execution__run_test__deleted=False,
             ).prefetch_related("transcripts", "scenario")
 
+            from simulate.utils.speaker_roles import SpeakerRoleResolver
+
             all_transcripts = []
             for call_execution in call_executions:
                 # Filter transcripts by speaker role and order by start_time_ms
@@ -132,6 +150,22 @@ class TestExecutionTranscriptsView(APIView):
                 ]
                 transcripts.sort(key=lambda x: x.start_time_ms)
 
+                rows = CallTranscriptSerializer(transcripts, many=True).data
+                provider = SpeakerRoleResolver.detect_provider(
+                    call_execution.provider_call_data
+                )
+                is_outbound = SpeakerRoleResolver.detect_is_outbound(call_execution)
+                for row in rows:
+                    raw = row.get("speaker_role")
+                    if SpeakerRoleResolver.is_tested_agent(
+                        raw, provider=provider, is_outbound=is_outbound
+                    ):
+                        row["speaker_role"] = "assistant"
+                    elif SpeakerRoleResolver.is_simulator(
+                        raw, provider=provider, is_outbound=is_outbound
+                    ):
+                        row["speaker_role"] = "user"
+
                 call_data = {
                     "call_execution_id": str(call_execution.id),
                     "phone_number": call_execution.phone_number,
@@ -141,9 +175,7 @@ class TestExecutionTranscriptsView(APIView):
                         if call_execution.scenario
                         else "Unknown"
                     ),
-                    "transcripts": CallTranscriptSerializer(
-                        transcripts, many=True
-                    ).data,
+                    "transcripts": rows,
                     "total_transcripts": len(transcripts),
                 }
                 all_transcripts.append(call_data)

--- a/futureagi/simulate/views/call_transcript.py
+++ b/futureagi/simulate/views/call_transcript.py
@@ -67,24 +67,15 @@ class CallTranscriptView(APIView):
                 speaker_role__in=get_displayable_transcript_roles(),
             ).order_by("start_time_ms")
 
-            rows = CallTranscriptSerializer(transcripts, many=True).data
-
             from simulate.utils.speaker_roles import SpeakerRoleResolver
 
-            provider = SpeakerRoleResolver.detect_provider(
-                call_execution.provider_call_data
+            rows = SpeakerRoleResolver.align_transcript_rows(
+                CallTranscriptSerializer(transcripts, many=True).data,
+                provider=SpeakerRoleResolver.detect_provider(
+                    call_execution.provider_call_data
+                ),
+                is_outbound=SpeakerRoleResolver.detect_is_outbound(call_execution),
             )
-            is_outbound = SpeakerRoleResolver.detect_is_outbound(call_execution)
-            for row in rows:
-                raw = row.get("speaker_role")
-                if SpeakerRoleResolver.is_tested_agent(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "assistant"
-                elif SpeakerRoleResolver.is_simulator(
-                    raw, provider=provider, is_outbound=is_outbound
-                ):
-                    row["speaker_role"] = "user"
 
             return Response(
                 {
@@ -150,21 +141,13 @@ class TestExecutionTranscriptsView(APIView):
                 ]
                 transcripts.sort(key=lambda x: x.start_time_ms)
 
-                rows = CallTranscriptSerializer(transcripts, many=True).data
-                provider = SpeakerRoleResolver.detect_provider(
-                    call_execution.provider_call_data
+                rows = SpeakerRoleResolver.align_transcript_rows(
+                    CallTranscriptSerializer(transcripts, many=True).data,
+                    provider=SpeakerRoleResolver.detect_provider(
+                        call_execution.provider_call_data
+                    ),
+                    is_outbound=SpeakerRoleResolver.detect_is_outbound(call_execution),
                 )
-                is_outbound = SpeakerRoleResolver.detect_is_outbound(call_execution)
-                for row in rows:
-                    raw = row.get("speaker_role")
-                    if SpeakerRoleResolver.is_tested_agent(
-                        raw, provider=provider, is_outbound=is_outbound
-                    ):
-                        row["speaker_role"] = "assistant"
-                    elif SpeakerRoleResolver.is_simulator(
-                        raw, provider=provider, is_outbound=is_outbound
-                    ):
-                        row["speaker_role"] = "user"
 
                 call_data = {
                     "call_execution_id": str(call_execution.id),


### PR DESCRIPTION
## Why

Provider transcript payloads and recording URLs are persisted raw in `simulate_call_transcript` and `provider_call_data.vapi.recording.*`. On VAPI inbound the raw shape places the simulator persona under `speaker_role="assistant"` and the tested agent under `speaker_role="user"` because the call runs on our own VAPI account. Every read path that renders a transcript, plays a recording, or feeds an LLM eval must translate that raw shape into the platform display convention (assistant = tested agent, user = simulator) so annotators, drawers and eval templates read consistent labels.

The stereo audio track carried the same channel-ownership asymmetry: for outbound the recording lives on the tested agent's account so the left channel is the simulator side and the right channel is the tested agent; for inbound the layout is inverted. The audio player hard-coded left = assistant, so outbound calls rendered the yellow and orange tracks against the wrong actor. Combined with the transcript already being direction-aware, the drawer showed a talk-ratio bar and a waveform that disagreed on which color meant which role.

The eval mapping panel's `call.transcript` preview slot rendered blank on voice because the value assignment only accepted a string; voice call detail returns the transcript as an array of row objects.

## Behaviour

### Backend read boundaries touched

- `simulate/serializers/test_execution.py`
  - `CallExecutionDetailSerializer.get_recordings` (`test_execution.py:452`): swaps `recordings.assistant` and `recordings.customer` when the resolver classifies raw `assistant` as the simulator side (VAPI inbound today). VAPI outbound and LiveKit fall through unchanged.
  - `CallExecutionDetailSerializer.get_transcript` (`test_execution.py:623`): rewrites per-row `speaker_role` via `SpeakerRoleResolver.align_transcript_rows`.
  - `TestExecutionDetailResponseSerializer.get_transcripts` (`test_execution.py:1359`): same helper, list-view context.
- `simulate/views/call_transcript.py`: `CallTranscriptView` and `TestExecutionTranscriptsView` apply the same helper, so the annotation flow that hits the transcript endpoint directly sees the aligned shape.
- `simulate/services/test_executor.py`: voice-branch eval-transcript builder filters via `get_conversational_roles` (drops system + tool rows) and labels via `get_eval_role_label` so LLM eval inputs read `agent:` / `customer:` instead of raw provider tokens. Presence-signal counting uses `get_skip_decision_role_sets`.
- `simulate/temporal/activities/xl.py`: `_build_transcript_data` voice branch mirrors the same filter and label. `_build_simulation_context_map` and the data-injection `call_context` emit `ended_reason` verbatim because the write path already stores it in the platform perspective.
- `model_hub/views/separate_evals.py`: eval playground `call_context` filters transcripts by conversational roles and labels rows via `get_eval_role_label`. `ended_reason` is verbatim.

### Frontend

- Wire-shape rename `item.speakerRole` to `item.speaker_role` across 12 files. No direction logic added to the client; the backend now emits the aligned convention so the drawer's existing display logic renders correctly.
- `src/hooks/use-stereo-channels.js`: hook takes `isInbound`; base convention binds left channel to the customer track (orange, simulator side) and right channel to the assistant track (yellow, tested agent side). On inbound the raw stereo already lands left = assistant, so the assignment flips back.
- `src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx`: `StereoMultiTrackPlayer` gains an `isInbound` prop; `AudioPlayerCustom` derives it from `data.call_metadata.call_direction` with a `data.call_type` fallback and threads it into both mount sites.
- `src/sections/annotations/queues/annotate/content-panel.jsx`: expose snake_case `call_type` on the annotation drawer's `drawerData` so `AudioPlayerCustom` resolves direction correctly in that surface.
- `src/sections/evals/components/SimulationTestMode.jsx`: voice `flat.call.transcript` renders as `agent: ...\ncustomer: ...` joined lines from the response's transcript-row array, matching what the eval runtime consumes.

## Historical data

- Transcript rows and recording URLs are stored raw for both historical and new writes. The read-time swap fixes both eras uniformly.
- `ended_reason` is stored in the platform perspective for both historical and new writes. Read verbatim.
- Talk-ratio KPI is client-computed live from the transcript rows in `frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js`, so it renders correctly on both eras via the swapped transcript response.

## Per-file changes

| File | Change |
|---|---|
| `simulate/utils/speaker_roles.py` | New. Resolver class with per-provider role maps, `detect_provider`, `detect_is_outbound`, `is_tested_agent`, `is_simulator`, `get_eval_role_label`, `get_transcript_role_sets`, `get_skip_decision_role_sets`, `get_conversational_roles`, `get_displayable_roles`, `normalize_end_reason`, and `align_transcript_rows` (helper used by four read-boundary call sites). |
| `simulate/serializers/test_execution.py` | `get_recordings` swaps assistant/customer URLs when the resolver classifies raw `assistant` as the simulator side. `get_transcript` and `get_transcripts` fold row alignment into `align_transcript_rows`. All pre-existing fields on the response are preserved verbatim. |
| `simulate/views/call_transcript.py` | `CallTranscriptView` and `TestExecutionTranscriptsView` use `align_transcript_rows` on the returned rows. Filter set and ordering unchanged. |
| `simulate/services/test_executor.py` | Voice-branch eval-transcript builder and presence-signal counter now import the OSS resolver directly (no try/except shim); filter set uses `get_conversational_roles`; labels come from `get_eval_role_label`. |
| `simulate/temporal/activities/xl.py` | `_build_transcript_data` voice branch same pattern as `test_executor.py`. `_build_simulation_context_map` emits `ended_reason` verbatim. |
| `model_hub/views/separate_evals.py` | Eval playground `call_context` filters to conversational roles and maps `speaker_role` via `get_eval_role_label` before serialising. |
| `frontend/src/hooks/use-stereo-channels.js` | `useStereoChannels(stereoUrl, isInbound=false)`; three-line ternary picks the channel pair. Peaks, WAV encoding, cleanup and cache semantics unchanged. |
| `frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx` | `isInbound` prop on `StereoMultiTrackPlayer`; parent derives from `call_metadata.call_direction` with `call_type` fallback and threads into both mount sites. Colors, memo comparator, wrapper components untouched. |
| `frontend/src/sections/annotations/queues/annotate/content-panel.jsx` | One additive line: `call_type: callData.call_type` alongside the existing `callType`. |
| `frontend/src/sections/evals/components/SimulationTestMode.jsx` | Voice branch of `flat.call.transcript` accepts array form and joins into `agent:` / `customer:` lines. Text branch, recording URL slots, other vocabulary untouched. |
| 12 files under `frontend/src/components/**`, `frontend/src/sections/test-detail/**`, `frontend/src/sections/test/**` | Wire-shape rename `item.speakerRole` to `item.speaker_role`. No render logic, no color logic, no direction logic changes. |

## Automated tests

Two files, 86 tests total, all green.

### `simulate/tests/test_speaker_role_resolver.py` (65 tests)

| Scenario | What it pins |
|---|---|
| `detect_provider` variants | VAPI vs LiveKit vs empty vs invalid `provider_call_data` returns the right provider or default. |
| `detect_is_outbound` variants | `call_metadata.call_direction` primary, `call_type` substring fallback, mixed-case tolerance, None input. |
| `is_tested_agent`, `is_simulator` per direction | Every raw role token returns the correct classification for VAPI inbound, VAPI outbound, LiveKit. |
| `get_eval_role_label` per direction | Raw tokens map to `agent` / `customer` / passthrough for both LLM eval usage and the eval playground context. |
| `get_transcript_role_sets` and `get_skip_decision_role_sets` | Return the same frozen sets and match the map for each direction. |
| `get_conversational_roles` and `get_displayable_roles` | Emit only user + assistant, no system, no tool_calls. |
| `normalize_end_reason` | Involutive on VAPI inbound; non-role reasons pass through; VAPI outbound and LiveKit unchanged. |
| `TestRegressionContracts` | VAPI inbound and outbound are mirror images; LiveKit is direction-agnostic; eval label set is exactly `{agent, customer}`; system row is never conversational; `normalize_end_reason` is involutive; `\x00` placeholder cannot leak. |

### `simulate/tests/test_speaker_role_read_alignment.py` (21 tests)

| Scenario | What it pins |
|---|---|
| `TestGetRecordingsSwap` | VAPI inbound swaps `recordings.assistant` and `recordings.customer`. VAPI outbound and LiveKit pass through. Empty dict passes through. Single-URL dict swaps correctly. |
| `TestGetTranscriptSwap` | `CallExecutionDetailSerializer.get_transcript` rewrites row `speaker_role` for VAPI inbound and leaves outbound unchanged. Same for `get_transcripts`. |
| `TestEvalTranscriptLabels` | `_build_transcript_data` emits `agent:` / `customer:` labels for both directions and filters non-conversational rows. |
| `TestMetricsNormalizeRoles` | The metrics calculator normalises raw shape correctly for VAPI both directions and LiveKit. |
| `TestEndedReasonInlineSwap` | The inline three-step `.replace()` chain in the voice temporal activity is involutive, byte-identical to the resolver output it replaces, and non-role reasons pass through. |

### Commands

```
bin/test --no-services simulate/tests/test_speaker_role_resolver.py simulate/tests/test_speaker_role_read_alignment.py
```

<img width="1632" height="1318" alt="image" src="https://github.com/user-attachments/assets/3d8f8442-d97d-4440-ad9a-0024cf9e50c8" />


## Manual verification

Recording covers an inbound VAPI call end to end: detail drawer transcript + waveform + talk ratio, annotation drawer parity, eval mapping panel populated for `call.transcript`, test evaluation runs green, plus a quick outbound sanity to confirm no regression.


https://github.com/user-attachments/assets/3c7cb548-0052-4ce5-acd3-b1faf09c8713


## Out of scope

- Wider FE camelCase drift outside the transcript-shape rename touched here. Deferred until the backend response settles a single canonical shape across all call-detail endpoints.
- Aligning the audio player track order to the resolver directly rather than via a boolean flag. Deferred because it would ripple into the two secondary `StereoMultiTrackPlayer` callers (`BaseLineVsReplay`, `CallLogsDetailDrawer`) that do not yet source direction; tracked separately to keep this diff minimal.

## Design decisions

- **Read-side alignment, not write-side rewrite.** Writes stay byte-identical to production. No migration, no in-place rewrite of `simulate_call_transcript` rows or `provider_call_data.vapi.recording.*`. The pre-existing write-side call to the resolver was a coincidental no-op under the buggy VAPI-inbound map; the moment that map is corrected, using the resolver at write time flips fresh rows and desynchronises them from the existing historical rows on disk. Every read boundary now applies the translation, so historical and new rows read identically to the same rendered output. The class docstring flags this constraint so future callers do not reach for the resolver at write time. The companion EE PR strips the two write-side references (`vapi_service.py`, `voice_large.py`) accordingly, replacing them with fixed dicts and an inline swap that produce byte-identical output to what production has been persisting all along.
- **Resolver home: OSS `simulate/`, not EE `voice/`.** The read sites that need the class live in `simulate/serializers`, `simulate/views`, `simulate/services`, `simulate/temporal`, and `model_hub/views`, none of which can import from `ee/`. Keeping the resolver in EE would either require duplicating the class in OSS or leaving the read boundaries with a shim (previously `try: from ee.voice.utils.transcript_roles import SpeakerRoleResolver`). The EE PR removes the EE-side class; the OSS PR adopts it as the single source of truth. LiveKit and future providers extend the resolver in one place.
- **Helper (`align_transcript_rows`) over inlined swap.** The same three-line loop appeared in four read sites; folding into the resolver keeps the contract in one place and prevents the four call sites from drifting.
- **FE direction flag on the audio hook, not a color-palette swap.** The `assistant = yellow`, `customer = orange` palette is shared by the transcript row bars, the talk-ratio bar, and the audio player. Swapping the palette only in the player would make three views disagree on which color means which role; swapping the palette in all three would flip a global convention. Direction-aware channel routing inside `useStereoChannels` fixes the audio without touching the palette.
- **`normalize_end_reason` placeholder is `\x00`.** The involutive swap uses a NUL byte as the intermediate placeholder rather than a printable substring so a real `ended_reason` value can never collide with the placeholder and be silently corrupted. Matches the EE inline swap byte-for-byte; the byte-identity test between the two implementations pins the contract.

## Linear

Fix TH-6090



