### PR TITLE
fix(prompt): block deprecated dall-e models from dropdown

### DIFF
--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_models.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_models.py
@@ -93,6 +93,14 @@ class LiteLLMModelManager:
             "standard/1024-x-1792/dall-e-3",
             "standard/1792-x-1024/dall-e-3",
             "standard/1024-x-1024/dall-e-3",
+            # Deprecated Azure dall-e variants
+            "azure/standard/1024-x-1024/dall-e-3",
+            "azure/hd/1024-x-1024/dall-e-3",
+            "azure/standard/1024-x-1792/dall-e-3",
+            "azure/standard/1792-x-1024/dall-e-3",
+            "azure/hd/1024-x-1792/dall-e-3",
+            "azure/hd/1792-x-1024/dall-e-3",
+            "azure/standard/1024-x-1024/dall-e-2",
             # Anthropic legacy models
             "claude-instant-1",
             "claude-2",

--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_models.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_models.py
@@ -2,13 +2,13 @@ import os
 
 import structlog
 
-logger = structlog.get_logger(__name__)
-from agentic_eval.core_evals.run_prompt.available_models import AVAILABLE_MODELS
-# (available_models always available)
-from model_hub.models.api_key import ApiKey
-from model_hub.models.custom_models import CustomAIModel
 from accounts.models.organization import Organization
 from accounts.models.workspace import Workspace
+from agentic_eval.core_evals.run_prompt.available_models import AVAILABLE_MODELS
+from model_hub.models.api_key import ApiKey
+from model_hub.models.custom_models import CustomAIModel
+
+logger = structlog.get_logger(__name__)
 
 
 class LiteLLMModelManager:
@@ -83,6 +83,16 @@ class LiteLLMModelManager:
             # "whisper-1",  # STT model - keep filtered
             # "tts-1",     # allow
             # "tts-1-hd",  # allow
+            # Deprecated OpenAI image generation models
+            "256-x-256/dall-e-2",
+            "512-x-512/dall-e-2",
+            "1024-x-1024/dall-e-2",
+            "hd/1024-x-1792/dall-e-3",
+            "hd/1792-x-1024/dall-e-3",
+            "hd/1024-x-1024/dall-e-3",
+            "standard/1024-x-1792/dall-e-3",
+            "standard/1792-x-1024/dall-e-3",
+            "standard/1024-x-1024/dall-e-3",
             # Anthropic legacy models
             "claude-instant-1",
             "claude-2",
@@ -163,14 +173,14 @@ class LiteLLMModelManager:
         except ApiKey.DoesNotExist:
             raise ValueError(
                 f"API key not configured for {provider}. Please add your API key in settings."
-            )
+            ) from None
         except ApiKey.MultipleObjectsReturned:
             # Fallback to first match if multiple keys exist (e.g., workspace not specified)
             api_key_entry = ApiKey.objects.filter(**query).first()
             if not api_key_entry:
                 raise ValueError(
                     f"API key not configured for {provider}. Please add your API key in settings."
-                )
+                ) from None
 
         if api_key_entry.key:
             return api_key_entry.actual_key
@@ -202,13 +212,13 @@ class LiteLLMModelManager:
         except CustomAIModel.MultipleObjectsReturned:
             raise ValueError(
                 f"Multiple custom models found for {model_name} for organization {organization_id} and workspace {workspace_id}"
-            )
+            ) from None
 
         except CustomAIModel.DoesNotExist:
             raise ValueError(
                 f"Model '{model_name}' is not available in the current model catalog. "
                 "It may be deprecated or retired. Please select a supported model from the latest available models list."
-            )
+            ) from None
 
     def get_model_by_provider(self, provider):
         model_name = []


### PR DESCRIPTION
## Summary

Blocks the **deprecated** dall-e-2 and dall-e-3 variants (both direct OpenAI and Azure-deployed) from the prompt workbench model dropdown. These specific models are no longer maintained, do not work in the text-model picker, and fail at runtime. Other image-generation models intentionally remain in the dropdown.

## Linked issues

Closes #<br>Linear:

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

---

## 1) What changes were done

**A. Block deprecated dall-e models in** `_remove_failed_models`

* Added 9 direct OpenAI dall-e 2/3 variant names to the `failed_models` set in `LiteLLMModelManager._remove_failed_models`
* Added 7 Azure-prefixed dall-e 2/3 variant names to the same set (these were missed in the initial pass)
* The user-facing effect: these deprecated models no longer appear in the prompt workbench model dropdown
* Also fixed pre-existing lint errors (E402 import ordering, B904 raise from None) to unblock the commit hook

---

## 2) Why the changes were done

* **Product/UX:** dall-e-2 and dall-e-3 are deprecated models that generate images, not text — they should not appear in the text-model dropdown where users might select them
* **Technical:** the existing `failed_models` blocklist is the standard pattern used across this file to hide deprecated models; this change follows the same approach

---

## 3) Tests written + scenarios each covers

No tests added. The change is purely additive to a blocklist set; verified the file parses cleanly.

---

## 4) How to run / test

### UI steps (manual)

1. Hard-refresh the prompt workbench page
2. Open the model dropdown
3. Verify no dall-e models (OpenAI or Azure) appear in the list

---

## 5) Screenshots / recordings

### Test output

N/A

### UI testing

https://github.com/user-attachments/assets/ecb6254b-8c36-4fed-b7dd-c9bf7516ccd3

---

## 6) Edge cases & considerations

* All 9 direct OpenAI dall-e variants are covered (2 sizes for dall-e-2, 3 sizes x 2 quality levels for dall-e-3)
* All 7 Azure-prefixed dall-e variants are covered (same variants with azure/ prefix)
* Non-deprecated image-generation models are unaffected and remain in the dropdown

---

## 7) Pre-existing issues (NOT introduced by this PR)

N/A

---

## 8) Architectural / important decisions

* Used the existing `failed_models` set pattern rather than adding a new filter, consistent with how all other deprecated models are handled

---

## Checklist

- [X] My code follows the [style guide](<../CONTRIBUTING.md#code-style>)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [X] No hardcoded secrets, URLs, or PII
- [X] I've signed the [CLA](<../CONTRIBUTING.md#contributor-license-agreement-cla>)
- [X] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status