### PR TITLE
feat(evals): add citation_quality evaluator

### DIFF
--- a/.github/scripts/reviewer-assigner.mjs
+++ b/.github/scripts/reviewer-assigner.mjs
@@ -150,6 +150,10 @@ async function assignForPr(prNumber) {
     log(`  state=${pr.state}, skipping`);
     return;
   }
+  if (pr.draft) {
+    log(`  draft PR, skipping`);
+    return;
+  }
   if ((pr.requested_reviewers?.length ?? 0) > 0 || (pr.requested_teams?.length ?? 0) > 0) {
     log(`  already has reviewers (${pr.requested_reviewers.map((r) => r.login).join(',')} + teams=${pr.requested_teams.length}), skipping`);
     return;

--- a/.github/workflows/reviewer-assigner.yml
+++ b/.github/workflows/reviewer-assigner.yml
@@ -18,7 +18,10 @@ on:
 
 jobs:
   assign:
-    if: github.repository == 'future-agi/future-agi' && github.event_name != 'schedule'
+    if: >-
+      github.repository == 'future-agi/future-agi' &&
+      github.event_name != 'schedule' &&
+      github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Good feature requests:
 
 1. Pick a [`good first issue`](https://github.com/future-agi/future-agi/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) (or open one)
 2. Comment that you're working on it so we don't double-up
-3. Branch from `main`: `git checkout -b fix/short-description`
+3. Branch from `dev`: `git checkout -b fix/short-description`
 4. Make your change — keep the diff small and focused
 5. Add tests (every bug fix needs a regression test)
 6. Make sure `make check-all` passes

--- a/agentcc-gateway/internal/auth/keystore.go
+++ b/agentcc-gateway/internal/auth/keystore.go
@@ -367,6 +367,27 @@ type SyncedKey struct {
 	Models    []string          `json:"models"`
 	Providers []string          `json:"providers"`
 	Metadata  map[string]string `json:"metadata"`
+	ExpiresAt *time.Time        `json:"expires_at"`
+}
+
+// syncedKeyToAPIKey is the single construction site for both sync paths, so a
+// field can't be wired into one and missed in the other.
+func syncedKeyToAPIKey(sk SyncedKey, id string) *APIKey {
+	return &APIKey{
+		ID:               id,
+		KeyHash:          sk.KeyHash,
+		Name:             sk.Name,
+		Owner:            sk.Owner,
+		Status:           "active",
+		KeyType:          "byok",
+		Source:           "sync",
+		AllowedModels:    sk.Models,
+		AllowedProviders: sk.Providers,
+		Metadata:         sk.Metadata,
+		ExpiresAt:        sk.ExpiresAt,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
 }
 
 // LoadFromHashes merges control-plane keys (identified by pre-computed hashes)
@@ -392,20 +413,7 @@ func (ks *KeyStore) LoadFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key
@@ -468,20 +476,7 @@ func (ks *KeyStore) SyncFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"sync"
@@ -426,6 +427,137 @@ func TestExpiresAt_FromConfig(t *testing.T) {
 	expected, _ := time.Parse(time.RFC3339, expiresStr)
 	if !k.ExpiresAt.Equal(expected) {
 		t.Errorf("expected ExpiresAt %v, got %v", expected, *k.ExpiresAt)
+	}
+}
+
+// ---------- Synced-key expiry (control-plane path) ----------
+
+func syncKeyStore() *KeyStore {
+	return NewKeyStore(authCfg())
+}
+
+// Decoding the wire payload is where the original bug lived (the field was
+// dropped); DRF emits RFC3339 with offset + fractional seconds.
+func TestSyncedKey_DecodesExpiresAt(t *testing.T) {
+	const payload = `{
+		"id": "ck_1",
+		"name": "contractor",
+		"key_hash": "abc123",
+		"expires_at": "2030-06-15T12:30:45.123456Z"
+	}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if sk.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to decode from the wire, got nil")
+	}
+	want, _ := time.Parse(time.RFC3339, "2030-06-15T12:30:45.123456Z")
+	if !sk.ExpiresAt.Equal(want) {
+		t.Errorf("expected ExpiresAt %v, got %v", want, *sk.ExpiresAt)
+	}
+
+	// Null expiry must decode to nil (never-expiring keys).
+	var nullSk SyncedKey
+	if err := json.Unmarshal([]byte(`{"key_hash":"h","expires_at":null}`), &nullSk); err != nil {
+		t.Fatalf("unmarshal null failed: %v", err)
+	}
+	if nullSk.ExpiresAt != nil {
+		t.Errorf("expected nil ExpiresAt for null wire value, got %v", *nullSk.ExpiresAt)
+	}
+}
+
+// Real wire payload with a past expiry, decoded then synced, must be rejected.
+func TestSyncedExpiredKey_DecodeToReject(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired"
+	payload := `{"id":"ck_exp","name":"c","key_hash":"` + HashKey(rawKey) +
+		`","expires_at":"2000-01-01T00:00:00Z"}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{sk})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key (decoded from wire) to be rejected")
+	}
+}
+
+func TestSyncFromHashes_ExpiredKeyRejected(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired-2"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_expired",
+		Name:      "contractor",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if k := ks.Get("ck_expired"); k == nil || k.ExpiresAt == nil {
+		t.Fatal("expected synced key to carry ExpiresAt")
+	}
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key to be rejected")
+	}
+}
+
+func TestSyncFromHashes_FutureExpiryAccepted(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-future"
+	future := time.Now().Add(1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_future",
+		Name:      "valid",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &future,
+	}})
+
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected synced key with future expiry to authenticate")
+	}
+}
+
+func TestSyncFromHashes_NilExpiryNeverExpires(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-noexpiry"
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:      "ck_noexpiry",
+		Name:    "perpetual",
+		KeyHash: HashKey(rawKey),
+		// ExpiresAt nil — must remain non-expiring.
+	}})
+
+	k := ks.Get("ck_noexpiry")
+	if k == nil || k.ExpiresAt != nil {
+		t.Fatal("expected nil ExpiresAt on synced key")
+	}
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected non-expiring synced key to authenticate")
+	}
+}
+
+func TestLoadFromHashes_PropagatesExpiry(t *testing.T) {
+	const rawKey = "sk-agentcc-loaded-expired"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.LoadFromHashes([]SyncedKey{{
+		ID:        "ck_loaded",
+		Name:      "loaded",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired key loaded via LoadFromHashes to be rejected")
 	}
 }
 

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -399,8 +399,8 @@ func TestKeyPrefix(t *testing.T) {
 
 	// Long key: len > 12, prefix is first 12 + "..."
 	long := keyPrefix("sk-agentcc-abcdef1234567890")
-	if long != "sk-agentcc-abc..." {
-		t.Errorf("expected long key prefix 'sk-agentcc-abc...', got '%s'", long)
+	if long != "sk-agentcc-a..." {
+		t.Errorf("expected long key prefix 'sk-agentcc-a...', got '%s'", long)
 	}
 }
 

--- a/frontend/src/api/project/project-detail.js
+++ b/frontend/src/api/project/project-detail.js
@@ -1,7 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 
-export const useGetProjectDetails = (projectId, enabled = true) => {
+export const useGetProjectDetails = (
+  projectId,
+  enabled = true,
+  keepPrevious = false,
+) => {
   return useQuery({
     queryKey: ["project-detail", projectId],
     queryFn: () =>
@@ -9,6 +13,10 @@ export const useGetProjectDetails = (projectId, enabled = true) => {
     select: (d) => d?.data?.result,
     enabled: enabled,
     staleTime: 1 * 60 * 1000, // 1 min stale time
+    // Opt-in: hold last value across refetch so `source` never flickers
+    // undefined. Off by default — callers whose projectId is user-switchable
+    // rely on undefined-while-fetching to gate project-kind resolution.
+    ...(keepPrevious ? { placeholderData: keepPreviousData } : {}),
   });
 };
 

--- a/frontend/src/components/observe-tabs/ObserveTabBar.jsx
+++ b/frontend/src/components/observe-tabs/ObserveTabBar.jsx
@@ -25,6 +25,7 @@ import {
 import { useTabStoreShallow } from "src/sections/projects/LLMTracing/tabStore";
 import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 
+import { useSearchParams } from "react-router-dom";
 import FixedTab from "./FixedTab";
 import CustomViewTab from "./CustomViewTab";
 import SaveViewPopover from "src/components/traceDetail/SaveViewDialog";
@@ -122,7 +123,8 @@ const ObserveTabBar = ({
   const [saveViewAnchor, setSaveViewAnchor] = useState(null);
   const [isSavingView, setIsSavingView] = useState(false);
   const { mutate: createSavedView } = useCreateSavedView(projectId);
-  const { getViewConfig, getTabType } = useObserveHeader();
+  const { getViewConfig } = useObserveHeader();
+  const [searchParams] = useSearchParams();
 
   // Derive tab_type for a new saved view. Priority:
   //  - on a saved view tab, inherit the view's tab_type.
@@ -133,14 +135,18 @@ const ObserveTabBar = ({
   const resolveTabType = useCallback(() => {
     if (activeTab === "users") return "users";
     if (activeTab === "sessions") return "sessions";
-    if (activeTab === "traces") return getTabType?.() ?? "traces";
+    if (activeTab === "traces" || activeTab === "spans") {
+      // URL is the source of truth; the old getTabType callback raced and
+      // mis-saved spans as traces.
+      return searchParams.get("selectedTab") === "spans" ? "spans" : "traces";
+    }
     if (activeTab?.startsWith("view-")) {
       const currentId = activeTab.replace("view-", "");
       const current = customViews.find((v) => v.id === currentId);
       return current?.tab_type ?? current?.tabType ?? "traces";
     }
     return "traces";
-  }, [activeTab, customViews, getTabType]);
+  }, [activeTab, customViews, searchParams]);
 
   const handleSaveViewConfirm = useCallback(
     (name) => {

--- a/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
@@ -18,8 +18,15 @@ const renderWithCtx = ({
   getViewConfig = () => ({}),
   getTabType = () => "traces",
   activeTab = "traces",
-} = {}) =>
-  render(
+  selectedTab,
+} = {}) => {
+  // resolveTabType reads selectedTab from the URL (not getTabType).
+  window.history.pushState(
+    {},
+    "Test page",
+    selectedTab ? `/?selectedTab=${selectedTab}` : "/",
+  );
+  return render(
     <ObserveHeaderContext.Provider
       value={{
         headerConfig: {},
@@ -39,6 +46,7 @@ const renderWithCtx = ({
       />
     </ObserveHeaderContext.Provider>,
   );
+};
 
 const clickCreateViewButton = () => {
   const btn = document.querySelector("[data-create-view-btn]");
@@ -94,16 +102,16 @@ describe("ObserveTabBar — resolveTabType", () => {
     mockSavedViewsList = [];
   });
 
-  it("uses getTabType() when activeTab is 'traces' (returns 'traces' for trace sub-tab)", async () => {
-    renderWithCtx({ getTabType: () => "traces", activeTab: "traces" });
+  it("saves tab_type 'traces' when selectedTab is not 'spans'", async () => {
+    renderWithCtx({ activeTab: "traces" });
     clickCreateViewButton();
     await typeAndSubmit("t");
     await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
     expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("traces");
   });
 
-  it("uses getTabType() when activeTab is 'traces' (returns 'spans' for span sub-tab)", async () => {
-    renderWithCtx({ getTabType: () => "spans", activeTab: "traces" });
+  it("saves tab_type 'spans' when selectedTab is 'spans' in the URL", async () => {
+    renderWithCtx({ activeTab: "spans", selectedTab: "spans" });
     clickCreateViewButton();
     await typeAndSubmit("s");
     await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -278,7 +278,6 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     const visMap = {};
     const orderIndex = new Map();
     const customCols = [];
-    let firstCustomIdx = -1;
     (columnVisibility || []).forEach((c, i) => {
       if (c.field) {
         visMap[c.field] = c.isVisible !== false;
@@ -286,20 +285,15 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       }
       if (c.groupBy === "Custom Columns") {
         customCols.push(c);
-        if (firstCustomIdx === -1) firstCustomIdx = i;
+        // colId key so customs sort into their own store position.
+        orderIndex.set(c.id, i);
       }
     });
 
-    const updated = callLogsColumnDefs
-      .map((col) => ({
-        ...col,
-        ...(col.field && col.field in visMap && { hide: !visMap[col.field] }),
-      }))
-      .sort((a, b) => {
-        const ai = orderIndex.get(a?.field) ?? Infinity;
-        const bi = orderIndex.get(b?.field) ?? Infinity;
-        return ai - bi;
-      });
+    const updated = callLogsColumnDefs.map((col) => ({
+      ...col,
+      ...(col.field && col.field in visMap && { hide: !visMap[col.field] }),
+    }));
 
     // Add column defs for custom columns not already in the grid
     const existingFields = new Set(callLogsColumnDefs.map((c) => c.field));
@@ -346,22 +340,14 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         },
       }));
 
-    // Movable group at the first custom's store position (marryChildren +
-    // groupId keep it draggable as a unit across rebuilds).
-    if (newCustomDefs.length > 0) {
-      const group = {
-        headerName: "Custom Columns",
-        groupId: "custom-columns",
-        marryChildren: true,
-        children: newCustomDefs,
-      };
-      let insertAt = updated.findIndex(
-        (col) => (orderIndex.get(col?.field) ?? Infinity) > firstCustomIdx,
-      );
-      if (insertAt === -1) insertAt = updated.length;
-      return [...updated.slice(0, insertAt), group, ...updated.slice(insertAt)];
-    }
-    return updated;
+    // Sort base + custom together so customs sit flat at their own positions.
+    const combined = [...updated, ...newCustomDefs];
+    combined.sort((a, b) => {
+      const ai = orderIndex.get(a?.field ?? a?.colId) ?? Infinity;
+      const bi = orderIndex.get(b?.field ?? b?.colId) ?? Infinity;
+      return ai - bi;
+    });
+    return combined;
   }, [callLogsColumnDefs, columnVisibility, isLoading]);
   useEffect(() => {
     return () => {

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -278,19 +278,22 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     const visMap = {};
     const orderIndex = new Map();
     const customCols = [];
+    let firstCustomIdx = -1;
     (columnVisibility || []).forEach((c, i) => {
       if (c.field) {
         visMap[c.field] = c.isVisible !== false;
         orderIndex.set(c.field, i);
       }
-      if (c.groupBy === "Custom Columns") customCols.push(c);
+      if (c.groupBy === "Custom Columns") {
+        customCols.push(c);
+        if (firstCustomIdx === -1) firstCustomIdx = i;
+      }
     });
 
     const updated = callLogsColumnDefs
       .map((col) => ({
         ...col,
-        ...(col.field &&
-          col.field in visMap && { hide: !visMap[col.field] }),
+        ...(col.field && col.field in visMap && { hide: !visMap[col.field] }),
       }))
       .sort((a, b) => {
         const ai = orderIndex.get(a?.field) ?? Infinity;
@@ -311,7 +314,9 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         flex: 0,
         minWidth: 120,
         hide: c.isVisible === false,
-        cellRenderer: isLoading ? CustomColLoadingSkeleton : CustomColCellRenderer,
+        cellRenderer: isLoading
+          ? CustomColLoadingSkeleton
+          : CustomColCellRenderer,
         valueGetter: (params) => {
           if (!params.data) return null;
           let value = params.data[c.id];
@@ -341,12 +346,20 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         },
       }));
 
-    // Group under a "Custom Columns" header for parity with the other grids.
+    // Movable group at the first custom's store position (marryChildren +
+    // groupId keep it draggable as a unit across rebuilds).
     if (newCustomDefs.length > 0) {
-      return [
-        ...updated,
-        { headerName: "Custom Columns", children: newCustomDefs },
-      ];
+      const group = {
+        headerName: "Custom Columns",
+        groupId: "custom-columns",
+        marryChildren: true,
+        children: newCustomDefs,
+      };
+      let insertAt = updated.findIndex(
+        (col) => (orderIndex.get(col?.field) ?? Infinity) > firstCustomIdx,
+      );
+      if (insertAt === -1) insertAt = updated.length;
+      return [...updated.slice(0, insertAt), group, ...updated.slice(insertAt)];
     }
     return updated;
   }, [callLogsColumnDefs, columnVisibility, isLoading]);
@@ -359,7 +372,15 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   // Propagate reorder to parent so the View columns dropdown stays in sync.
   const onColumnMoved = useCallback(
     (params) => {
-      if (!params?.finished || !params?.api || typeof onColumnsChange !== "function") return;
+      if (
+        !params?.finished ||
+        !params?.api ||
+        typeof onColumnsChange !== "function"
+      )
+        return;
+      // User drags only — a programmatic move would rebuild the shared trace
+      // `columns` from this grid's voice-only state and corrupt it.
+      if (params.source !== "uiColumnMoved") return;
       const newOrder = (params?.api?.getColumnState() ?? [])
         .map((s) => s.colId)
         .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
@@ -374,8 +395,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       const sameOrder =
         next.length === cols.length &&
         next.every(
-          (c, i) =>
-            (c?.field || c?.id) === (cols[i]?.field || cols[i]?.id),
+          (c, i) => (c?.field || c?.id) === (cols[i]?.field || cols[i]?.id),
         );
       if (!sameOrder) onColumnsChange(next);
     },

--- a/frontend/src/sections/gateway/utils/formatters.js
+++ b/frontend/src/sections/gateway/utils/formatters.js
@@ -16,9 +16,16 @@ export function formatCost(value) {
   if (value == null) return "$0.00";
   const num = Number(value);
   if (Number.isNaN(num)) return "$0.00";
-  if (num >= 1000) return `$${(num / 1000).toFixed(1)}K`;
-  if (num >= 1) return `$${num.toFixed(2)}`;
-  return `$${num.toFixed(4)}`;
+
+  const abs = Math.abs(num);
+
+  if (abs >= 1000) return `$${(num / 1000).toFixed(1)}K`;
+  if (abs >= 1) return `$${num.toFixed(2)}`;
+  if (abs >= 0.01) return `$${num.toFixed(4)}`;
+  if (abs >= 0.001) return `$${num.toFixed(5)}`;
+  if (abs > 0) return `$${num.toFixed(7).replace(/0+$/, "0")}`;
+
+  return "$0.00";
 }
 
 export function formatPercent(value, decimals = 1) {

--- a/frontend/src/sections/project/context/ObserveHeaderContext.js
+++ b/frontend/src/sections/project/context/ObserveHeaderContext.js
@@ -20,10 +20,6 @@ export const ObserveHeaderContext = createContext({
   // Pass null to unregister.
   registerGetViewConfig: () => {},
   getViewConfig: () => null,
-  // Returns the current tab_type ("traces" | "spans") so save-view UIs know
-  // what to persist as the view's tab_type. Registered by LLMTracingView.
-  registerGetTabType: () => {},
-  getTabType: () => "traces",
 });
 
 export const useObserveHeader = () => {

--- a/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
+++ b/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
@@ -28,15 +28,6 @@ const ObserveHeaderProvider = ({ children }) => {
     return typeof fn === "function" ? fn() : null;
   }, []);
 
-  const getTabTypeRef = useRef(null);
-  const registerGetTabType = useCallback((fn) => {
-    getTabTypeRef.current = typeof fn === "function" ? fn : null;
-  }, []);
-  const getTabType = useCallback(() => {
-    const fn = getTabTypeRef.current;
-    return typeof fn === "function" ? fn() : "traces";
-  }, []);
-
   return (
     <ObserveHeaderContext.Provider
       value={{
@@ -46,8 +37,6 @@ const ObserveHeaderProvider = ({ children }) => {
         setActiveViewConfig,
         registerGetViewConfig,
         getViewConfig,
-        registerGetTabType,
-        getTabType,
       }}
     >
       {children}

--- a/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
+++ b/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
@@ -41,36 +41,3 @@ describe("ObserveHeaderContext — getViewConfig register/read", () => {
     expect(second).toHaveBeenCalledTimes(1);
   });
 });
-
-describe("ObserveHeaderContext — getTabType register/read", () => {
-  it("getTabType returns 'traces' default when nothing is registered", () => {
-    const { result } = renderHook(() => useObserveHeader(), { wrapper });
-    expect(result.current.getTabType()).toBe("traces");
-  });
-
-  it("getTabType returns the registered callback's result", () => {
-    const { result } = renderHook(() => useObserveHeader(), { wrapper });
-    const fake = vi.fn(() => "spans");
-    act(() => result.current.registerGetTabType(fake));
-    expect(result.current.getTabType()).toBe("spans");
-    expect(fake).toHaveBeenCalledTimes(1);
-  });
-
-  it("getTabType reverts to default after unregister", () => {
-    const { result } = renderHook(() => useObserveHeader(), { wrapper });
-    act(() => result.current.registerGetTabType(() => "spans"));
-    act(() => result.current.registerGetTabType(null));
-    expect(result.current.getTabType()).toBe("traces");
-  });
-
-  it("latest registration wins when re-registered", () => {
-    const { result } = renderHook(() => useObserveHeader(), { wrapper });
-    const first = vi.fn(() => "traces");
-    const second = vi.fn(() => "spans");
-    act(() => result.current.registerGetTabType(first));
-    act(() => result.current.registerGetTabType(second));
-    expect(result.current.getTabType()).toBe("spans");
-    expect(first).not.toHaveBeenCalled();
-    expect(second).toHaveBeenCalledTimes(1);
-  });
-});

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -159,6 +159,8 @@ import {
 } from "./common";
 import {
   applySavedColumns,
+  restampColumns,
+  columnStateToHideMap,
   reorderColumns,
   isColumnVisibilityDirty,
   isColumnOrderDirty,
@@ -972,7 +974,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     activeViewConfig,
     setActiveViewConfig,
     registerGetViewConfig,
-    registerGetTabType,
   } = useObserveHeader();
 
   // keepPrevious: hold `source` across refetch so projectSource doesn't flicker
@@ -2123,11 +2124,21 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         .join("|");
       if (idSetKey !== appliedIdSetKeyRef.current) {
         appliedIdSetKeyRef.current = idSetKey;
-        const next = applySavedColumns(
-          columns,
-          pendingSavedColsRef.current,
-          userToggledColsRef.current,
-        );
+        // While hydrating, position late-merging columns per the saved order.
+        // Once hydrated the user owns the order — only restamp visibility, so a
+        // manual drag isn't reverted when the id-set changes (add/remove a
+        // custom column). userToggledColsRef guards visibility; this guards order.
+        const next = isHydratingView
+          ? applySavedColumns(
+              columns,
+              pendingSavedColsRef.current,
+              userToggledColsRef.current,
+            )
+          : restampColumns(
+              columns,
+              columnStateToHideMap(pendingSavedColsRef.current),
+              userToggledColsRef.current,
+            );
         if (next !== columns) setColumns(next);
       }
       // Hydration done once all the view's custom columns have merged in.
@@ -2426,12 +2437,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     registerGetViewConfig(buildViewConfig);
     return () => registerGetViewConfig(null);
   }, [registerGetViewConfig, buildViewConfig]);
-
-  useEffect(() => {
-    const getTabType = () => (selectedTab === "spans" ? "spans" : "traces");
-    registerGetTabType(getTabType);
-    return () => registerGetTabType(null);
-  }, [registerGetTabType, selectedTab]);
 
   // Bound to ObserveToolbar's Save view button.
   const handleSaveView = useCallback(() => {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -2082,13 +2082,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       // Re-apply only on id-set change, so a manual drag/toggle isn't reverted.
       const slotKey =
         selectedTab === "trace" ? "primary-trace" : "primary-spans";
-      const compareSlotKey =
-        selectedTab === "trace" ? "compare-trace" : "compare-spans";
-      const idsOf = (k) => (columns[k] || []).map((c) => c?.id);
-      const idSetKey = [
-        ...idsOf(slotKey),
-        ...(showCompare ? idsOf(compareSlotKey) : []),
-      ]
+      const idSetKey = (columns[slotKey] || [])
+        .map((c) => c?.id)
         .sort()
         .join("|");
       if (idSetKey !== appliedIdSetKeyRef.current) {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -962,7 +962,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     registerGetTabType,
   } = useObserveHeader();
 
-  const { data: projectDetail } = useGetProjectDetails(observeId, !isUserMode);
+  // keepPrevious: hold `source` across refetch so projectSource doesn't flicker
+  // undefined mid-switch (would drop the voice saved-view custom columns).
+  const { data: projectDetail } = useGetProjectDetails(
+    observeId,
+    !isUserMode,
+    true,
+  );
   // User mode: behave like an OBSERVE project so the many projectSource
   // checks stay on the happy path.
   const projectSource = isUserMode
@@ -1992,9 +1998,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Array.isArray guard: UsersView writes `filters` as an object, which
-    // can briefly leak during cross-tab transitions (route change is queued
-    // in startTransition while activeViewConfig updates synchronously).
+    // Array.isArray guard: UsersView writes `filters` as an object, which can
+    // briefly leak across a cross-tab switch before this config resolves.
     const rawFilters = activeViewConfig.filters;
     const nextFilters = (Array.isArray(rawFilters) ? rawFilters : []).map(
       (f) => ({
@@ -2616,10 +2621,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     columnKey,
   ]);
 
-  // Defer the visibility signal so it catches up with activeViewConfig
-  // (which updates inside startTransition). Without this, canSaveView briefly
-  // returns true on view-switch because filter state updates urgently while
-  // the baseline update trails by a render, which makes the button flicker.
+  // Defer the visibility signal so a view-switch doesn't briefly flip
+  // canSaveView true if the baseline trails the filter state by a render.
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
   const currentGridRef = useMemo(() => {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -607,6 +607,17 @@ const DEFAULT_DISPLAY_CONFIG = {
   customColumns: [],
 };
 
+// The view's tab slot from its columnState name column — selectedTab lags
+// activeViewConfig on a cross-type switch, so don't key off it.
+const slotKeyFromColumnState = (columnState, fallbackSlotKey) => {
+  const ids = (Array.isArray(columnState) ? columnState : []).map(
+    (c) => c?.colId,
+  );
+  if (ids.includes("span_name")) return "primary-spans";
+  if (ids.includes("trace_name")) return "primary-trace";
+  return fallbackSlotKey;
+};
+
 const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const isUserMode = mode === "user";
   const { role } = useAuthContext();
@@ -948,6 +959,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const pendingSavedColsRef = useRef(null);
   // Re-apply only fires on id-set change, so a manual drag/toggle isn't reverted.
   const appliedIdSetKeyRef = useRef(null);
+  // Suppress the Save-view dirty signal while a saved view is still hydrating.
+  const [isHydratingView, setIsHydratingView] = useState(false);
   // Canonical order per grid, to restore default when leaving a saved view.
   const canonicalTraceOrderRef = useRef(null);
   const canonicalSpanOrderRef = useRef(null);
@@ -1796,6 +1809,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       pendingColumnStateRef.current = null;
       pendingSavedColsRef.current = null;
       appliedIdSetKeyRef.current = null;
+      setIsHydratingView(false);
       userToggledColsRef.current = new Set();
       primaryTracePendingRef.current = [];
       compareTracePendingRef.current = [];
@@ -1899,8 +1913,18 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.hasEvalFilter !== undefined)
       setHasEvalFilter(display.hasEvalFilter);
 
-    // Strip existing customs so view → view doesn't show the union of both
-    // sets (which would also dirty-flag the Save view button).
+    // Route hydration by the view's own tab type (selectedTab lags on a
+    // cross-type switch and would mis-route customs into the wrong slot).
+    const savedColIds = (display.columnState || []).map((c) => c?.colId);
+    const viewTabType = savedColIds.includes("span_name")
+      ? "spans"
+      : savedColIds.includes("trace_name")
+        ? "trace"
+        : selectedTab;
+    if (selectedTab !== viewTabType) setSelectedTab(viewTabType);
+
+    // Strip customs from all slots + reset all pending refs so a prior view's
+    // queued customs can't drain into this view's slot.
     setColumns((prev) => {
       const next = {};
       Object.keys(prev).forEach((ck) => {
@@ -1910,12 +1934,15 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       });
       return next;
     });
+    primaryTracePendingRef.current = [];
+    compareTracePendingRef.current = [];
+    primarySpansPendingRef.current = [];
+    compareSpansPendingRef.current = [];
 
-    // Populate both primary and compare refs for the active tab type so a
-    // compare-mode toggle later hydrates correctly. Shallow-clone per slot
-    // so mutations don't write through into the saved-views query cache.
+    // Queue this view's customs into its own tab's refs (primary + compare for a
+    // later compare-mode toggle). Clone per slot so we don't mutate the cache.
     if (display.customColumns?.length > 0) {
-      if (selectedTab === "trace") {
+      if (viewTabType === "trace") {
         primaryTracePendingRef.current = display.customColumns.map((c) => ({
           ...c,
         }));
@@ -1963,6 +1990,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // by the next columnDefs rebuild); the [columns] effect re-applies for cols
     // that merge in later.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      setIsHydratingView(true);
       userToggledColsRef.current = new Set();
       setColumns((prev) =>
         applySavedColumns(
@@ -1975,7 +2003,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       appliedIdSetKeyRef.current = null;
 
       const activeApi =
-        selectedTab === "trace"
+        viewTabType === "trace"
           ? primaryTraceGridRef.current?.api
           : primarySpanGridRef.current?.api;
       if (activeApi?.applyColumnState) {
@@ -1991,7 +2019,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // dateFilter lives inside display because the backend serializer only
     // whitelists `display` for arbitrary sub-keys.
     if (display.dateFilter) {
-      if (selectedTab === "trace") {
+      if (viewTabType === "trace") {
         setPrimaryTraceDateFilter(display.dateFilter);
       } else {
         setPrimarySpanDateFilter(display.dateFilter);
@@ -2007,7 +2035,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         id: f.id || getRandomId(),
       }),
     );
-    if (selectedTab === "trace") {
+    if (viewTabType === "trace") {
       setPrimaryTraceFilters(nextFilters);
     } else {
       setPrimarySpanFilters(nextFilters);
@@ -2028,7 +2056,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       ...f,
       id: f.id || getRandomId(),
     }));
-    if (selectedTab === "trace") {
+    if (viewTabType === "trace") {
       setCompareTraceFilters(nextCompareFilters);
       if (activeViewConfig.compareDateFilter !== undefined) {
         setCompareTraceDateFilter(activeViewConfig.compareDateFilter);
@@ -2050,8 +2078,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     let attempts = 0;
     let timer = null;
     const tryApply = () => {
+      const slotKey = slotKeyFromColumnState(
+        pendingColumnStateRef.current,
+        selectedTab === "trace" ? "primary-trace" : "primary-spans",
+      );
       const api =
-        selectedTab === "trace"
+        slotKey === "primary-trace"
           ? primaryTraceGridRef.current?.api
           : primarySpanGridRef.current?.api;
       if (
@@ -2080,8 +2112,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   useEffect(() => {
     if (pendingSavedColsRef.current) {
       // Re-apply only on id-set change, so a manual drag/toggle isn't reverted.
-      const slotKey =
-        selectedTab === "trace" ? "primary-trace" : "primary-spans";
+      // Slot from the view's own columnState (not selectedTab, which lags).
+      const slotKey = slotKeyFromColumnState(
+        pendingSavedColsRef.current,
+        selectedTab === "trace" ? "primary-trace" : "primary-spans",
+      );
       const idSetKey = (columns[slotKey] || [])
         .map((c) => c?.id)
         .sort()
@@ -2095,10 +2130,28 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         );
         if (next !== columns) setColumns(next);
       }
+      // Hydration done once all the view's custom columns have merged in.
+      const savedCustomIds = Array.isArray(
+        activeViewConfig?.display?.customColumns,
+      )
+        ? activeViewConfig.display.customColumns.map((c) => c?.id)
+        : [];
+      const curCustomIds = new Set(
+        (columns[slotKey] || [])
+          .filter((c) => c?.groupBy === "Custom Columns")
+          .map((c) => c?.id),
+      );
+      if (savedCustomIds.every((id) => curCustomIds.has(id))) {
+        setIsHydratingView(false);
+      }
     }
     if (!pendingColumnStateRef.current) return;
+    const drainSlotKey = slotKeyFromColumnState(
+      pendingColumnStateRef.current,
+      selectedTab === "trace" ? "primary-trace" : "primary-spans",
+    );
     const api =
-      selectedTab === "trace"
+      drainSlotKey === "primary-trace"
         ? primaryTraceGridRef.current?.api
         : primarySpanGridRef.current?.api;
     if (!api?.applyColumnState) return;
@@ -2109,6 +2162,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     pendingColumnStateRef.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columns]);
+
+  // Fallback: release the gate even if a saved custom col never loads, so the
+  // Save-view button can't get stuck hidden (the merge check above clears sooner).
+  useEffect(() => {
+    if (!isHydratingView) return undefined;
+    const t = setTimeout(() => setIsHydratingView(false), 2500);
+    return () => clearTimeout(t);
+  }, [isHydratingView]);
 
   // ---------------------------------------------------------------------------
   // View persistence — auto-save display + reset/default
@@ -2281,13 +2342,24 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         ? primaryTraceGridRef.current?.api
         : primarySpanGridRef.current?.api;
     // Voice (CallLogsGrid) has no grid api here — derive columnState from the store.
-    const columnState =
+    const rawColumnState =
       projectSource === PROJECT_SOURCE.SIMULATOR
         ? (columns[columnKey] || []).map((c) => ({
             colId: c.id,
             hide: c.isVisible === false,
           }))
         : activeGridApi?.getColumnState?.() ?? undefined;
+    // Dedup colIds before persisting — the store-derived save path bypasses
+    // AG Grid's own colId uniqueness.
+    const seenColIds = new Set();
+    const columnState = Array.isArray(rawColumnState)
+      ? rawColumnState.filter((c) => {
+          if (c?.colId == null) return true;
+          if (seenColIds.has(c.colId)) return false;
+          seenColIds.add(c.colId);
+          return true;
+        })
+      : rawColumnState;
     const currentDisplay = {
       viewMode,
       cellHeight,
@@ -2521,20 +2593,35 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // save-as-new — we don't want Save view cluttering the toolbar there.
   const canSaveView = useMemo(() => {
     if (!activeViewConfig) return false;
+    // Still hydrating → transient mismatches aren't user edits.
+    if (isHydratingView) return false;
 
     const baselineDisplay = activeViewConfig.display || {};
     const baselineExtraFilters = activeViewConfig.extraFilters || [];
     const baselineDateOption = baselineDisplay.dateFilter?.dateOption ?? null;
     const baselineColumnFilters = activeViewConfig.filters || [];
 
+    // Compare against the view's own tab type (selectedTab can point at the
+    // other table mid cross-type switch and falsely flag dirty).
+    const savedColIds = Array.isArray(baselineDisplay.columnState)
+      ? baselineDisplay.columnState.map((c) => c?.colId)
+      : [];
+    const viewTabType = savedColIds.includes("span_name")
+      ? "spans"
+      : savedColIds.includes("trace_name")
+        ? "trace"
+        : selectedTab;
+    const viewSlotKey =
+      viewTabType === "spans" ? "primary-spans" : "primary-trace";
+
     if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
 
     const currentDate =
-      selectedTab === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
+      viewTabType === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
     if ((currentDate?.dateOption ?? null) !== baselineDateOption) return true;
 
     const columnFilters =
-      selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters;
+      viewTabType === "trace" ? primaryTraceFilters : primarySpanFilters;
     if (!filtersContentEqual(columnFilters, baselineColumnFilters)) return true;
 
     if (
@@ -2575,12 +2662,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
     // Did the user show/hide a regular column since the saved view?
     if (
-      isColumnVisibilityDirty(columns[columnKey], baselineDisplay.columnState)
+      isColumnVisibilityDirty(columns[viewSlotKey], baselineDisplay.columnState)
     ) {
       return true;
     }
     // Did the user reorder columns (or move the custom-columns group)?
-    if (isColumnOrderDirty(columns[columnKey], baselineDisplay.columnState)) {
+    if (isColumnOrderDirty(columns[viewSlotKey], baselineDisplay.columnState)) {
       return true;
     }
     // Custom columns: did the user add/remove a custom column since the
@@ -2588,7 +2675,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     const baselineCustom = Array.isArray(baselineDisplay.customColumns)
       ? baselineDisplay.customColumns
       : [];
-    const currentCustom = getCustomColumns() || [];
+    const currentCustom = (columns[viewSlotKey] || []).filter(
+      (c) => c?.groupBy === "Custom Columns",
+    );
     if (currentCustom.length !== baselineCustom.length) return true;
     if (currentCustom.length > 0) {
       const baselineIds = new Set(baselineCustom.map((c) => c?.id));
@@ -2611,9 +2700,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     showNonAnnotated,
     showCompare,
     hasEvalFilter,
-    getCustomColumns,
     columns,
-    columnKey,
+    isHydratingView,
   ]);
 
   // Defer the visibility signal so a view-switch doesn't briefly flip

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -158,9 +158,10 @@ import {
   FILTER_FOR_HAS_EVAL,
 } from "./common";
 import {
-  columnStateToHideMap,
-  restampColumns,
+  applySavedColumns,
+  reorderColumns,
   isColumnVisibilityDirty,
+  isColumnOrderDirty,
 } from "./savedViewColumns";
 import TracingControls from "./TracingControls";
 import ObserveToolbar from "./ObserveToolbar";
@@ -942,13 +943,15 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const columnConfigureRef = useRef();
   // Drained by onGridReady on the primary grid.
   const pendingColumnStateRef = useRef(null);
-  // applyColumnState alone can't persist hide across columnDefs rebuilds —
-  // getTraceListColumnDefs sets hide explicitly from col.isVisible, so we
-  // need to update col.isVisible in the columns state for hide to stick.
-  const pendingHideMapRef = useRef(null);
-  // Col ids the user manually showed/hid since the saved view loaded. The
-  // saved-view re-stamp skips these so a manual toggle isn't reverted. Reset
-  // on view change / exit.
+  // Saved columnState baked into `columns` because applyColumnState is clobbered
+  // when columnDefs rebuild from isVisible + array order.
+  const pendingSavedColsRef = useRef(null);
+  // Re-apply only fires on id-set change, so a manual drag/toggle isn't reverted.
+  const appliedIdSetKeyRef = useRef(null);
+  // Canonical order per grid, to restore default when leaving a saved view.
+  const canonicalTraceOrderRef = useRef(null);
+  const canonicalSpanOrderRef = useRef(null);
+  // Cols the user manually toggled; the saved-view re-stamp skips these.
   const userToggledColsRef = useRef(new Set());
 
   const {
@@ -1275,7 +1278,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             }
             return [...config, ...customCols, ...dedupedPending];
           };
-          return {
+          const drained = {
             ...prev,
             "primary-trace": drainPending(
               "primary-trace",
@@ -1286,6 +1289,15 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               compareTracePendingRef,
             ),
           };
+          // The drain resets to default order; re-apply the saved view's order
+          // (the [columns] id-set guard skips this — same id-set).
+          return pendingSavedColsRef.current
+            ? applySavedColumns(
+                drained,
+                pendingSavedColsRef.current,
+                userToggledColsRef.current,
+              )
+            : drained;
         });
       }
     },
@@ -1776,7 +1788,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
-      pendingHideMapRef.current = null;
+      pendingSavedColsRef.current = null;
+      appliedIdSetKeyRef.current = null;
       userToggledColsRef.current = new Set();
       primaryTracePendingRef.current = [];
       compareTracePendingRef.current = [];
@@ -1788,9 +1801,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setColumns((prev) => {
         const next = {};
         Object.keys(prev).forEach((ck) => {
-          next[ck] = (prev[ck] || [])
+          const stripped = (prev[ck] || [])
             .filter((c) => c.groupBy !== "Custom Columns")
             .map((c) => (c.isVisible ? c : { ...c, isVisible: true }));
+          // Restore default order (the saved view's order was baked into the slot).
+          const canonical = ck.includes("spans")
+            ? canonicalSpanOrderRef.current
+            : canonicalTraceOrderRef.current;
+          next[ck] = reorderColumns(stripped, canonical);
         });
         return next;
       });
@@ -1935,20 +1953,20 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       compareTracePendingRef.current = [];
     }
 
-    // Hide needs a parallel path: applyColumnState's hide doesn't survive
-    // the next columnDefs rebuild (getTraceListColumnDefs sets hide from
-    // col.isVisible, which wins over applied state). The [columns] drain
-    // effect below updates col.isVisible from this map.
+    // Bake visibility + order into `columns` (applyColumnState alone is clobbered
+    // by the next columnDefs rebuild); the [columns] effect re-applies for cols
+    // that merge in later.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-      const hideMap = columnStateToHideMap(display.columnState);
-      // New view → drop the previous view's manual-toggle exemptions.
       userToggledColsRef.current = new Set();
-      // Apply now (a view→view switch with identical cols has no drain), then
-      // queue the map for cols that merge in later.
       setColumns((prev) =>
-        restampColumns(prev, hideMap, userToggledColsRef.current),
+        applySavedColumns(
+          prev,
+          display.columnState,
+          userToggledColsRef.current,
+        ),
       );
-      pendingHideMapRef.current = hideMap;
+      pendingSavedColsRef.current = display.columnState;
+      appliedIdSetKeyRef.current = null;
 
       const activeApi =
         selectedTab === "trace"
@@ -2052,23 +2070,31 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     };
   }, [activeViewConfig, selectedTab]);
 
-  // Re-apply queued columnState + hideMap once `columns` updates. The
-  // retry effect above only fires on activeViewConfig/selectedTab change;
-  // if it ran before custom cols landed, AG Grid dropped their entries.
-  // The hideMap path is necessary because the next columnDefs rebuild
-  // overrides applyColumnState's hide flag from col.isVisible.
+  // Re-apply the saved view's visibility + order whenever cols merge in later
+  // (the load effect can run before they land, and AG Grid drops their entries).
   useEffect(() => {
-    if (pendingHideMapRef.current) {
-      // Stays armed for the view's lifetime: each columnDefs rebuild resets
-      // hide from col.isVisible, so we re-stamp on every columns change.
-      // User-toggled cols are skipped so a manual deselect isn't reverted.
-      setColumns((prev) =>
-        restampColumns(
-          prev,
-          pendingHideMapRef.current,
+    if (pendingSavedColsRef.current) {
+      // Re-apply only on id-set change, so a manual drag/toggle isn't reverted.
+      const slotKey =
+        selectedTab === "trace" ? "primary-trace" : "primary-spans";
+      const compareSlotKey =
+        selectedTab === "trace" ? "compare-trace" : "compare-spans";
+      const idsOf = (k) => (columns[k] || []).map((c) => c?.id);
+      const idSetKey = [
+        ...idsOf(slotKey),
+        ...(showCompare ? idsOf(compareSlotKey) : []),
+      ]
+        .sort()
+        .join("|");
+      if (idSetKey !== appliedIdSetKeyRef.current) {
+        appliedIdSetKeyRef.current = idSetKey;
+        const next = applySavedColumns(
+          columns,
+          pendingSavedColsRef.current,
           userToggledColsRef.current,
-        ),
-      );
+        );
+        if (next !== columns) setColumns(next);
+      }
     }
     if (!pendingColumnStateRef.current) return;
     const api =
@@ -2254,7 +2280,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       selectedTab === "trace"
         ? primaryTraceGridRef.current?.api
         : primarySpanGridRef.current?.api;
-    const columnState = activeGridApi?.getColumnState?.() ?? undefined;
+    // Voice (CallLogsGrid) has no grid api here — derive columnState from the store.
+    const columnState =
+      projectSource === PROJECT_SOURCE.SIMULATOR
+        ? (columns[columnKey] || []).map((c) => ({
+            colId: c.id,
+            hide: c.isVisible === false,
+          }))
+        : activeGridApi?.getColumnState?.() ?? undefined;
     const currentDisplay = {
       viewMode,
       cellHeight,
@@ -2312,6 +2345,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     compareSpansDateFilter,
     extraFilters,
     compareExtraFilters,
+    projectSource,
+    columns,
+    columnKey,
   ]);
 
   useEffect(() => {
@@ -2541,6 +2577,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (
       isColumnVisibilityDirty(columns[columnKey], baselineDisplay.columnState)
     ) {
+      return true;
+    }
+    // Did the user reorder columns (or move the custom-columns group)?
+    if (isColumnOrderDirty(columns[columnKey], baselineDisplay.columnState)) {
       return true;
     }
     // Custom columns: did the user add/remove a custom column since the
@@ -4385,6 +4425,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
                     pendingCustomColumnsRef={primaryTracePendingRef}
+                    canonicalOrderRef={canonicalTraceOrderRef}
                     showErrors={showErrors}
                     enabled={
                       [
@@ -4423,6 +4464,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
                     pendingCustomColumnsRef={compareTracePendingRef}
+                    canonicalOrderRef={canonicalTraceOrderRef}
                     projectId={observeId}
                     showErrors={showErrors}
                     enabled={
@@ -4482,6 +4524,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
                     pendingCustomColumnsRef={primarySpansPendingRef}
+                    canonicalOrderRef={canonicalSpanOrderRef}
                     setFilters={setPrimarySpanFilters}
                     setExtraFilters={setExtraFilters}
                     setFilterOpen={setIsPrimaryFilterOpen}
@@ -4516,6 +4559,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
                     pendingCustomColumnsRef={compareSpansPendingRef}
+                    canonicalOrderRef={canonicalSpanOrderRef}
                     filters={compareSpansValidatedFilters}
                     extraFilters={extraFilters}
                     ref={compareSpanGridRef}

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -483,6 +483,8 @@ const SpanGrid = React.forwardRef(
     const onColumnMoved = useCallback(
       (params) => {
         if (!params.finished) return;
+        // User drags only; programmatic moves would feed back into setColumns.
+        if (params.source !== "uiColumnMoved") return;
         const newOrder = params.api
           .getColumnState()
           .map((s) => s.colId)

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -43,15 +43,25 @@ import { useShallowToggleAnnotationsStore } from "../../agents/store";
 
 const ROWS_LIMIT = 100;
 
-// Normalize config object keys from snake_case to camelCase while preserving id values as snake_case
-const normalizeConfigKeys = (config) =>
-  config?.map((obj) => {
+// snake_case → camelCase keys (id preserved). Dedup by id: the spans config can
+// list a column twice → AG Grid would otherwise mint a phantom `<id>_1` column.
+const normalizeConfigKeys = (config) => {
+  if (!Array.isArray(config)) return config;
+  const seen = new Set();
+  const out = [];
+  for (const obj of config) {
     const result = {};
     for (const [key, value] of Object.entries(obj)) {
       result[key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())] = value;
     }
-    return result;
-  });
+    if (result.id != null) {
+      if (seen.has(result.id)) continue;
+      seen.add(result.id);
+    }
+    out.push(result);
+  }
+  return out;
+};
 
 const getSpanListColumnDefs = (col) => {
   const colId = col?.id;
@@ -278,7 +288,9 @@ const SpanGrid = React.forwardRef(
       const bottomRowObj = {};
 
       for (const eachCol of columns) {
-        if (eachCol?.groupBy) {
+        // Bucket each custom col alone so it stays flat in its store position
+        // (a shared bucket collapsed them together and oscillated the order).
+        if (eachCol?.groupBy && eachCol.groupBy !== "Custom Columns") {
           if (!grouping[eachCol?.groupBy]) {
             grouping[eachCol?.groupBy] = [eachCol];
           } else {
@@ -293,12 +305,23 @@ const SpanGrid = React.forwardRef(
         showMetricsIds,
       );
       delete grouping["Annotation Metrics"];
-      const columnDefsResult = Object.entries(grouping).map(([group, cols]) => {
-        if (!AllowedGroups.includes(group) && cols.length === 1) {
-          const c = cols[0];
-          bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
-          return getSpanListColumnDefs(c);
-        } else {
+      const columnDefsResult = Object.entries(grouping).flatMap(
+        ([group, cols]) => {
+          if (!AllowedGroups.includes(group) && cols.length === 1) {
+            const c = cols[0];
+            bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
+            const colDef = getSpanListColumnDefs(c);
+            // Custom col: flat, but keep its width/style.
+            if (c?.groupBy === "Custom Columns") {
+              return {
+                ...colDef,
+                minWidth: 200,
+                flex: 1,
+                cellStyle: mergeCellStyle(colDef, { paddingInline: 0 }),
+              };
+            }
+            return colDef;
+          }
           // marryChildren + groupId keep the group movable across rebuilds.
           return {
             headerName: group,
@@ -315,8 +338,8 @@ const SpanGrid = React.forwardRef(
               };
             }),
           };
-        }
-      });
+        },
+      );
       if (annotationColumns?.length > 0) {
         columnDefsResult.push(annotationColumns[0]);
       }

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -186,6 +186,7 @@ const SpanGrid = React.forwardRef(
       cellHeight,
       metricFilters,
       pendingCustomColumnsRef,
+      canonicalOrderRef,
       enabled = true,
     },
     gridRef,
@@ -298,8 +299,11 @@ const SpanGrid = React.forwardRef(
           bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
           return getSpanListColumnDefs(c);
         } else {
+          // marryChildren + groupId keep the group movable across rebuilds.
           return {
             headerName: group,
+            groupId: group,
+            marryChildren: true,
             children: cols.map((c) => {
               bottomRowObj[c?.id] = c?.average ? `Average ${c?.average}` : null;
               const colDef = getSpanListColumnDefs(c);
@@ -376,6 +380,9 @@ const SpanGrid = React.forwardRef(
               // Use ref to get latest columns for comparison without triggering dataSource recreation
               // Compare only non-custom columns to avoid unnecessary re-renders
               if (newCols) {
+                // Canonical order, to restore default when leaving a saved view.
+                if (canonicalOrderRef)
+                  canonicalOrderRef.current = newCols.map((c) => c.id);
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
@@ -407,7 +414,10 @@ const SpanGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -412,6 +412,8 @@ const TraceGrid = React.forwardRef(
     const onColumnMoved = useCallback(
       (params) => {
         if (!params.finished) return;
+        // User drags only; programmatic moves would feed back into setColumns.
+        if (params.source !== "uiColumnMoved") return;
 
         const newOrder = params.api
           .getColumnState()

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -353,30 +353,16 @@ const TraceGrid = React.forwardRef(
       const annotationCols = columns.filter(
         (c) => c?.groupBy === "Annotation Metrics",
       );
-      const customCols = columns.filter((c) => c?.groupBy === "Custom Columns");
-
-      // Custom columns as one movable group at the first custom's position
-      // (marryChildren + groupId keep it draggable across rebuilds).
+      // Custom columns flat (ungrouped), in store order.
       const columnDefsResult = [];
-      let customGroupEmitted = false;
       for (const c of columns) {
         if (c?.groupBy === "Annotation Metrics") continue;
+        bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
         if (c?.groupBy === "Custom Columns") {
-          if (customGroupEmitted) continue;
-          customGroupEmitted = true;
-          columnDefsResult.push({
-            headerName: "Custom Columns",
-            groupId: "custom-columns",
-            marryChildren: true,
-            children: customCols.map((cc) => {
-              bottomRowObj[cc?.id] = cc?.average ? `${cc?.average}` : null;
-              const colDef = getTraceListColumnDefs(cc);
-              return { ...colDef, minWidth: 200, flex: 1 };
-            }),
-          });
+          const colDef = getTraceListColumnDefs(c);
+          columnDefsResult.push({ ...colDef, minWidth: 200, flex: 1 });
           continue;
         }
-        bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
         columnDefsResult.push(getTraceListColumnDefs(c));
       }
 

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -64,6 +64,7 @@ const TraceGrid = React.forwardRef(
       hasEvalFilter,
       metricFilters,
       pendingCustomColumnsRef,
+      canonicalOrderRef,
       enabled = true,
       showErrors = false,
     },
@@ -220,6 +221,9 @@ const TraceGrid = React.forwardRef(
               // Use ref to get latest columns for comparison without triggering dataSource recreation
               // Compare only non-custom columns to avoid unnecessary re-renders
               if (newCols) {
+                // Canonical order, to restore default when leaving a saved view.
+                if (canonicalOrderRef)
+                  canonicalOrderRef.current = newCols.map((c) => c.id);
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
@@ -251,7 +255,10 @@ const TraceGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];
@@ -347,32 +354,30 @@ const TraceGrid = React.forwardRef(
         (c) => c?.groupBy === "Annotation Metrics",
       );
       const customCols = columns.filter((c) => c?.groupBy === "Custom Columns");
-      const otherCols = columns.filter(
-        (c) =>
-          c?.groupBy !== "Annotation Metrics" &&
-          c?.groupBy !== "Custom Columns",
-      );
 
-      // Build flat column defs for non-annotation, non-custom columns
-      const columnDefsResult = otherCols.map((c) => {
+      // Custom columns as one movable group at the first custom's position
+      // (marryChildren + groupId keep it draggable across rebuilds).
+      const columnDefsResult = [];
+      let customGroupEmitted = false;
+      for (const c of columns) {
+        if (c?.groupBy === "Annotation Metrics") continue;
+        if (c?.groupBy === "Custom Columns") {
+          if (customGroupEmitted) continue;
+          customGroupEmitted = true;
+          columnDefsResult.push({
+            headerName: "Custom Columns",
+            groupId: "custom-columns",
+            marryChildren: true,
+            children: customCols.map((cc) => {
+              bottomRowObj[cc?.id] = cc?.average ? `${cc?.average}` : null;
+              const colDef = getTraceListColumnDefs(cc);
+              return { ...colDef, minWidth: 200, flex: 1 };
+            }),
+          });
+          continue;
+        }
         bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
-        return getTraceListColumnDefs(c);
-      });
-
-      // Group custom columns under a "Custom Columns" header (TH-4151)
-      if (customCols.length > 0) {
-        columnDefsResult.push({
-          headerName: "Custom Columns",
-          children: customCols.map((c) => {
-            bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
-            const colDef = getTraceListColumnDefs(c);
-            return {
-              ...colDef,
-              minWidth: 200,
-              flex: 1,
-            };
-          }),
-        });
+        columnDefsResult.push(getTraceListColumnDefs(c));
       }
 
       // Add annotation columns as flat columns (not grouped)

--- a/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   columnStateToHideMap,
+  columnStateToOrder,
+  reorderColumns,
   restampColumns,
+  applySavedColumns,
   isColumnVisibilityDirty,
+  isColumnOrderDirty,
 } from "../savedViewColumns";
 
 describe("columnStateToHideMap", () => {
@@ -137,5 +141,141 @@ describe("isColumnVisibilityDirty", () => {
   it("is clean when there is no saved columnState", () => {
     const cols = [{ id: "a", isVisible: false }];
     expect(isColumnVisibilityDirty(cols, undefined)).toBe(false);
+  });
+});
+
+describe("columnStateToOrder", () => {
+  it("returns colIds in array order", () => {
+    expect(
+      columnStateToOrder([{ colId: "a" }, { colId: "b" }, { colId: "c" }]),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops falsy colIds and handles non-arrays", () => {
+    expect(columnStateToOrder([{ colId: "a" }, {}, null])).toEqual(["a"]);
+    expect(columnStateToOrder(undefined)).toEqual([]);
+  });
+});
+
+describe("reorderColumns — flat array", () => {
+  it("reorders to match the given order", () => {
+    expect(
+      reorderColumns(
+        [{ id: "a" }, { id: "b" }, { id: "c" }],
+        ["c", "a", "b"],
+      ).map((c) => c.id),
+    ).toEqual(["c", "a", "b"]);
+  });
+
+  it("trails ids absent from order, preserving their relative position", () => {
+    const arr = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+    expect(reorderColumns(arr, ["c", "a"]).map((c) => c.id)).toEqual([
+      "c",
+      "a",
+      "b",
+      "d",
+    ]);
+  });
+
+  it("returns the SAME reference when already in order (no-loop guard)", () => {
+    const arr = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(reorderColumns(arr, ["a", "b", "c"])).toBe(arr);
+  });
+
+  it("returns the input on an empty order or null columns", () => {
+    const arr = [{ id: "a" }];
+    expect(reorderColumns(arr, [])).toBe(arr);
+    expect(reorderColumns(null, ["a"])).toBe(null);
+  });
+
+  it("positions a custom-columns group by its id", () => {
+    const arr = [
+      { id: "a" },
+      { id: "custom1", groupBy: "Custom Columns" },
+      { id: "b" },
+    ];
+    expect(reorderColumns(arr, ["custom1", "a", "b"]).map((c) => c.id)).toEqual(
+      ["custom1", "a", "b"],
+    );
+  });
+});
+
+describe("reorderColumns — slot object", () => {
+  it("reorders every slot", () => {
+    const obj = {
+      "primary-trace": [{ id: "a" }, { id: "b" }],
+      "compare-trace": [{ id: "a" }, { id: "b" }],
+    };
+    const next = reorderColumns(obj, ["b", "a"]);
+    expect(next["primary-trace"].map((c) => c.id)).toEqual(["b", "a"]);
+    expect(next["compare-trace"].map((c) => c.id)).toEqual(["b", "a"]);
+  });
+
+  it("returns the SAME object reference when nothing changed", () => {
+    const obj = { "primary-trace": [{ id: "a" }, { id: "b" }] };
+    expect(reorderColumns(obj, ["a", "b"])).toBe(obj);
+  });
+
+  it("keeps an unchanged slot referentially stable", () => {
+    const slotA = [{ id: "a" }, { id: "b" }];
+    const slotB = [{ id: "x" }, { id: "y" }];
+    const obj = { a: slotA, b: slotB };
+    const next = reorderColumns(obj, ["b", "a"]);
+    expect(next.a).not.toBe(slotA);
+    expect(next.b).toBe(slotB);
+  });
+});
+
+describe("applySavedColumns", () => {
+  it("applies visibility AND order in one pass", () => {
+    const obj = {
+      "primary-trace": [
+        { id: "a", isVisible: true },
+        { id: "b", isVisible: true },
+        { id: "c", isVisible: true },
+      ],
+    };
+    const columnState = [
+      { colId: "c", hide: false },
+      { colId: "a", hide: true },
+      { colId: "b", hide: false },
+    ];
+    const next = applySavedColumns(obj, columnState);
+    expect(next["primary-trace"].map((c) => c.id)).toEqual(["c", "a", "b"]);
+    expect(next["primary-trace"].find((c) => c.id === "a").isVisible).toBe(
+      false,
+    );
+  });
+});
+
+describe("isColumnOrderDirty", () => {
+  const saved = [{ colId: "a" }, { colId: "b" }, { colId: "c" }];
+
+  it("is clean when the order matches (incl. drag-then-back end-state)", () => {
+    expect(
+      isColumnOrderDirty([{ id: "a" }, { id: "b" }, { id: "c" }], saved),
+    ).toBe(false);
+  });
+
+  it("is dirty when columns are reordered", () => {
+    expect(
+      isColumnOrderDirty([{ id: "b" }, { id: "a" }, { id: "c" }], saved),
+    ).toBe(true);
+  });
+
+  it("compares only the intersection (extra/missing cols don't dirty)", () => {
+    expect(
+      isColumnOrderDirty([{ id: "a" }, { id: "x" }, { id: "b" }], saved),
+    ).toBe(false);
+  });
+
+  it("is dirty when the intersection order differs despite extra cols", () => {
+    expect(
+      isColumnOrderDirty([{ id: "b" }, { id: "x" }, { id: "a" }], saved),
+    ).toBe(true);
+  });
+
+  it("is clean for a non-array columnState", () => {
+    expect(isColumnOrderDirty([{ id: "a" }], undefined)).toBe(false);
   });
 });

--- a/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
@@ -278,4 +278,45 @@ describe("isColumnOrderDirty", () => {
   it("is clean for a non-array columnState", () => {
     expect(isColumnOrderDirty([{ id: "a" }], undefined)).toBe(false);
   });
+
+  it("ignores hidden cols so a custom col saved between hidden cols clears on drag-back (TH-6119)", () => {
+    // Saved order wedges `cust` between two hidden columns — unreachable by drag.
+    const savedWithHidden = [
+      { colId: "a" },
+      { colId: "b" },
+      { colId: "hidden1" },
+      { colId: "hidden2" },
+      { colId: "cust" },
+      { colId: "c" },
+    ];
+    // `cust` at its visible-original spot; hidden1/2 hidden → visible order matches.
+    const current = [
+      { id: "a" },
+      { id: "b" },
+      { id: "cust" },
+      { id: "hidden1", isVisible: false },
+      { id: "hidden2", isVisible: false },
+      { id: "c" },
+    ];
+    expect(isColumnOrderDirty(current, savedWithHidden)).toBe(false);
+  });
+
+  it("is still dirty when a visible col is genuinely moved among visible cols", () => {
+    const savedWithHidden = [
+      { colId: "a" },
+      { colId: "b" },
+      { colId: "hidden1" },
+      { colId: "cust" },
+      { colId: "c" },
+    ];
+    // `cust` moved before `b` → visible order [a, cust, b, c] ≠ saved [a, b, cust, c].
+    const current = [
+      { id: "a" },
+      { id: "cust" },
+      { id: "b" },
+      { id: "hidden1", isVisible: false },
+      { id: "c" },
+    ];
+    expect(isColumnOrderDirty(current, savedWithHidden)).toBe(true);
+  });
 });

--- a/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
+++ b/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
@@ -102,12 +102,16 @@ export const isColumnVisibilityDirty = (slotColumns, columnState) => {
 };
 
 // True when the current column order diverges from the saved view's columnState
-// order. Compares only the cols present in both (added/removed cols are caught
-// by the visibility/custom-column checks).
+// order (intersection only). Compares VISIBLE columns only — the user can't
+// reorder hidden cols, so a col saved between hidden cols is unreachable by drag
+// and a full-order compare would stay dirty forever (TH-6119).
 export const isColumnOrderDirty = (slotColumns, columnState) => {
   if (!Array.isArray(columnState)) return false;
   const savedOrder = columnStateToOrder(columnState);
-  const currentIds = (slotColumns || []).map((c) => c?.id).filter(Boolean);
+  const currentIds = (slotColumns || [])
+    .filter((c) => c?.isVisible !== false)
+    .map((c) => c?.id)
+    .filter(Boolean);
   const currentSet = new Set(currentIds);
   const savedSet = new Set(savedOrder);
   const currentSeq = currentIds.filter((id) => savedSet.has(id));

--- a/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
+++ b/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
@@ -36,6 +36,54 @@ export const restampColumns = (
   return anyChanged ? next : columnsObj;
 };
 
+// Ordered colIds from a saved columnState (its array order is the column order).
+export const columnStateToOrder = (columnState) =>
+  (Array.isArray(columnState) ? columnState : [])
+    .map((entry) => entry && entry.colId)
+    .filter(Boolean);
+
+// Reorder columns to match `order` (colIds); absent ids trail in place. Accepts
+// a flat array or a slot-keyed object. Same-ref when unchanged so re-apply can't loop.
+export const reorderColumns = (columnsObj, order) => {
+  if (!columnsObj || !Array.isArray(order) || order.length === 0)
+    return columnsObj;
+  const rank = new Map(order.map((id, i) => [id, i]));
+  // Reorder one column array; returns the same reference when unchanged.
+  const reorderSlot = (slot) => {
+    const sorted = slot
+      .map((col, i) => ({ col, i }))
+      .sort((a, b) => {
+        const ra = rank.has(a.col?.id) ? rank.get(a.col.id) : Infinity;
+        const rb = rank.has(b.col?.id) ? rank.get(b.col.id) : Infinity;
+        return ra !== rb ? ra - rb : a.i - b.i;
+      })
+      .map((x) => x.col);
+    return sorted.some((col, i) => col !== slot[i]) ? sorted : slot;
+  };
+  if (Array.isArray(columnsObj)) return reorderSlot(columnsObj);
+  let anyChanged = false;
+  const next = {};
+  Object.keys(columnsObj).forEach((slotKey) => {
+    const slot = columnsObj[slotKey] || [];
+    const sorted = reorderSlot(slot);
+    next[slotKey] = sorted !== slot ? sorted : columnsObj[slotKey];
+    if (sorted !== slot) anyChanged = true;
+  });
+  return anyChanged ? next : columnsObj;
+};
+
+// Restamp visibility (skipping userToggled) + reorder to the saved order in one
+// pass; both derive from the same columnState. Same-ref when nothing changed.
+export const applySavedColumns = (
+  columnsObj,
+  columnState,
+  userToggled = new Set(),
+) =>
+  reorderColumns(
+    restampColumns(columnsObj, columnStateToHideMap(columnState), userToggled),
+    columnStateToOrder(columnState),
+  );
+
 // True when a current column's visibility diverges from the saved view's
 // columnState. Only compares cols the baseline knows about; ignores custom cols.
 export const isColumnVisibilityDirty = (slotColumns, columnState) => {
@@ -51,4 +99,18 @@ export const isColumnVisibilityDirty = (slotColumns, columnState) => {
       col.id in baselineVisible &&
       (col.isVisible !== false) !== baselineVisible[col.id],
   );
+};
+
+// True when the current column order diverges from the saved view's columnState
+// order. Compares only the cols present in both (added/removed cols are caught
+// by the visibility/custom-column checks).
+export const isColumnOrderDirty = (slotColumns, columnState) => {
+  if (!Array.isArray(columnState)) return false;
+  const savedOrder = columnStateToOrder(columnState);
+  const currentIds = (slotColumns || []).map((c) => c?.id).filter(Boolean);
+  const currentSet = new Set(currentIds);
+  const savedSet = new Set(savedOrder);
+  const currentSeq = currentIds.filter((id) => savedSet.has(id));
+  const savedSeq = savedOrder.filter((id) => currentSet.has(id));
+  return currentSeq.some((id, i) => id !== savedSeq[i]);
 };

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useEffect, useRef, startTransition } from "react";
+import React, { useMemo, useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Box, Paper, useTheme, CircularProgress, Alert } from "@mui/material";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
@@ -15,10 +15,7 @@ import {
 import { useTabStoreShallow } from "./LLMTracing/tabStore";
 import { useGetProjectDetails } from "src/api/project/project-detail";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  useGetSavedViews,
-  SAVED_VIEWS_KEY,
-} from "src/api/project/saved-views";
+import { useGetSavedViews, SAVED_VIEWS_KEY } from "src/api/project/saved-views";
 import ReplayDrawer from "./ReplayDrawer/ReplayDrawer";
 import {
   resetReplaySessionsStore,
@@ -169,15 +166,7 @@ const ObservePage = React.memo(() => {
         viewTabType = view?.tab_type ?? view?.tabType ?? "traces";
       }
 
-      // Apply effects (activeViewConfig → apply effect → many setters) aren't
-      // urgent for tab responsiveness. Defer via startTransition so the
-      // navigation and URL update feel snappy while the filter apply runs as
-      // a non-blocking transition.
-      startTransition(() => {
-        setActiveViewConfig(activeConfig);
-      });
-
-      // Navigate to the appropriate route
+      let navTo = null;
       if (tabKey.startsWith("view-")) {
         const isUsersView =
           viewTabType === "users" || viewTabType === "user_detail";
@@ -202,10 +191,7 @@ const ObservePage = React.memo(() => {
         } else if (isSessionsView) {
           // Sessions uses sessionFilter / sessionDateFilter URL keys.
           if (activeConfig?.filters) {
-            params.set(
-              "sessionFilter",
-              JSON.stringify(activeConfig.filters),
-            );
+            params.set("sessionFilter", JSON.stringify(activeConfig.filters));
           }
           if (activeConfig?.display?.dateFilter) {
             params.set(
@@ -255,9 +241,7 @@ const ObservePage = React.memo(() => {
           }
         }
 
-        navigate(`${basePath}?${params.toString()}`, {
-          replace: true,
-        });
+        navTo = `${basePath}?${params.toString()}`;
       } else {
         const config = TAB_TO_ROUTE[tabKey];
         if (config) {
@@ -265,9 +249,14 @@ const ObservePage = React.memo(() => {
           const params = new URLSearchParams();
           params.set("tab", tabKey);
           Object.entries(config.params).forEach(([k, v]) => params.set(k, v));
-          navigate(`${basePath}?${params.toString()}`, { replace: true });
+          navTo = `${basePath}?${params.toString()}`;
         }
       }
+
+      // Set config + navigate together so React batches them into one render — a
+      // deferred config set left the URL naming a view while config was null.
+      setActiveViewConfig(activeConfig);
+      if (navTo) navigate(navTo, { replace: true });
     },
     [observeId, navigate, queryClient, setActiveViewConfig],
   );

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -69,6 +69,7 @@ const SessionGrid = React.forwardRef(
       pendingCustomColumnsRef,
       canonicalOrderRef,
       isOnSavedView = false,
+      onUserReorder,
     },
     gridApiRef,
   ) => {
@@ -422,9 +423,12 @@ const SessionGrid = React.forwardRef(
         const changed =
           next.length !== columns.length ||
           next.some((c, i) => c.id !== columns[i]?.id);
-        if (changed) setColumns(next);
+        if (changed) {
+          onUserReorder?.();
+          setColumns(next);
+        }
       },
-      [columns, setColumns],
+      [columns, setColumns, onUserReorder],
     );
 
     const onRowClicked = (event) => {
@@ -522,6 +526,7 @@ SessionGrid.propTypes = {
   updateObj: PropTypes.objectOf(PropTypes.bool).isRequired,
   columns: PropTypes.array,
   setColumns: PropTypes.func,
+  onUserReorder: PropTypes.func,
   filters: PropTypes.array,
   onGridReady: PropTypes.func,
   projectId: PropTypes.string,

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -400,6 +400,8 @@ const SessionGrid = React.forwardRef(
     const onColumnMoved = useCallback(
       (params) => {
         if (!params.finished) return;
+        // User drags only; programmatic moves would loop with the order re-apply.
+        if (params.source !== "uiColumnMoved") return;
 
         const newOrder = params.api
           .getColumnState()

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -155,7 +155,9 @@ const SessionGrid = React.forwardRef(
       const bottomRowObj = {};
 
       for (const eachCol of columns) {
-        if (eachCol?.groupBy) {
+        // Bucket each custom col alone so it stays flat in its store position
+        // (a shared bucket collapsed them together and oscillated the order).
+        if (eachCol?.groupBy && eachCol.groupBy !== "Custom Columns") {
           if (!grouping[eachCol?.groupBy]) {
             grouping[eachCol?.groupBy] = [eachCol];
           } else {
@@ -166,12 +168,13 @@ const SessionGrid = React.forwardRef(
         }
       }
 
-      const columnDefsResult = Object.entries(grouping).map(([group, cols]) => {
-        if (cols.length === 1) {
-          const c = cols[0];
-          bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
-          return getSessionListColumnDef(c);
-        } else {
+      const columnDefsResult = Object.entries(grouping).flatMap(
+        ([group, cols]) => {
+          if (cols.length === 1) {
+            const c = cols[0];
+            bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
+            return getSessionListColumnDef(c);
+          }
           // marryChildren + groupId keep the group movable across rebuilds.
           return {
             headerName: group,
@@ -182,8 +185,8 @@ const SessionGrid = React.forwardRef(
               return getSessionListColumnDef(c);
             }),
           };
-        }
-      });
+        },
+      );
 
       return {
         columnDefs: columnDefsResult,

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -67,6 +67,7 @@ const SessionGrid = React.forwardRef(
       className,
       onGridReady,
       pendingCustomColumnsRef,
+      canonicalOrderRef,
       isOnSavedView = false,
     },
     gridApiRef,
@@ -171,8 +172,11 @@ const SessionGrid = React.forwardRef(
           bottomRowObj[c?.id] = c?.average ? `${c?.average}` : null;
           return getSessionListColumnDef(c);
         } else {
+          // marryChildren + groupId keep the group movable across rebuilds.
           return {
             headerName: group,
+            groupId: group,
+            marryChildren: true,
             children: cols.map((c) => {
               bottomRowObj[c?.id] = c?.average ? `Average ${c?.average}` : null;
               return getSessionListColumnDef(c);
@@ -244,6 +248,9 @@ const SessionGrid = React.forwardRef(
 
               // Merge: preserve custom columns that the backend doesn't know about
               if (newCols) {
+                // Canonical order, to restore default when leaving a saved view.
+                if (canonicalOrderRef)
+                  canonicalOrderRef.current = newCols.map((c) => c.id);
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
@@ -517,6 +524,7 @@ SessionGrid.propTypes = {
   onSelectionChanged: PropTypes.func,
   className: PropTypes.string,
   pendingCustomColumnsRef: PropTypes.object,
+  canonicalOrderRef: PropTypes.object,
   isOnSavedView: PropTypes.bool,
 };
 

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -407,8 +407,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     sessionColumns,
   ]);
 
-  // Deferred so the button doesn't flicker between filter state (urgent)
-  // and activeViewConfig (startTransition) settling.
+  // Deferred so the button doesn't flicker while filter state and the baseline
+  // config settle on a view-switch.
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
   // dateFilter lives inside `display` because the backend serializer only

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -185,7 +185,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     activeViewConfig,
     setActiveViewConfig,
     registerGetViewConfig,
-    registerGetTabType,
   } = useObserveHeader();
 
   // --- Filter & date state (reuse trace filter hook) ---
@@ -447,11 +446,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetViewConfig(null);
   }, [registerGetViewConfig, buildViewConfig]);
 
-  useEffect(() => {
-    registerGetTabType(() => "sessions");
-    return () => registerGetTabType(null);
-  }, [registerGetTabType]);
-
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
@@ -565,6 +559,9 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // (cols land/leave), so it survives the grid-fetch race a one-shot apply lost.
   const pendingSessionOrderRef = useRef(null);
   const appliedSessionIdSetRef = useRef(null);
+  // Set once the user manually drags a column; the saved-order re-apply then
+  // stops reordering, so an add/remove (id-set change) doesn't revert the drag.
+  const sessionUserReorderedRef = useRef(false);
   // Set when the apply effect fires before the grid mounts (hard refresh
   // into a saved view). Drained in onGridReady, otherwise the pending
   // custom-col ref is stranded.
@@ -593,6 +590,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       pendingColumnStateRef.current = null;
       pendingSessionOrderRef.current = null;
       appliedSessionIdSetRef.current = null;
+      sessionUserReorderedRef.current = false;
       pendingCustomColumnsRef.current = [];
       setSessionColumns((prev) =>
         reorderColumns(
@@ -692,6 +690,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       // land (applyColumnState alone is clobbered by the next columnDefs rebuild).
       pendingSessionOrderRef.current = columnStateToOrder(display.columnState);
       appliedSessionIdSetRef.current = null;
+      sessionUserReorderedRef.current = false;
       // Queue widths/sort when customs pending — AG Grid drops unknown colIds.
       if (savedCustomCols.length > 0) {
         pendingColumnStateRef.current = display.columnState;
@@ -923,9 +922,13 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       .join("|");
     if (idSetKey !== appliedSessionIdSetRef.current) {
       appliedSessionIdSetRef.current = idSetKey;
-      setSessionColumns((prev) =>
-        reorderColumns(prev, pendingSessionOrderRef.current),
-      );
+      // Skip the saved-order re-apply once the user has manually reordered, so
+      // an add/remove (id-set change) doesn't revert the drag.
+      if (!sessionUserReorderedRef.current) {
+        setSessionColumns((prev) =>
+          reorderColumns(prev, pendingSessionOrderRef.current),
+        );
+      }
     }
   }, [sessionColumns]);
 
@@ -1159,6 +1162,9 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         <SessionGrid
           columns={sessionColumns}
           setColumns={setSessionColumns}
+          onUserReorder={() => {
+            sessionUserReorderedRef.current = true;
+          }}
           ref={sessionGridApiRef}
           updateObj={updateObj}
           filters={finalFilters}

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -70,6 +70,11 @@ import axios, { endpoints } from "src/utils/axios";
 import ColumnConfigureDropDown from "src/sections/project-detail/ColumnDropdown/ColumnConfigureDropDown";
 import useProjectFilterField from "../UsersView/useProjectFilterField";
 import CustomColumnDialog from "../LLMTracing/CustomColumnDialog";
+import {
+  reorderColumns,
+  columnStateToOrder,
+  isColumnOrderDirty,
+} from "../LLMTracing/savedViewColumns";
 import { filtersContentEqual } from "../saved-view-utils";
 
 // ---------------------------------------------------------------------------
@@ -339,8 +344,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
 
     const baselineExtraFilters = activeViewConfig.extraFilters || [];
     const baselineDisplay = activeViewConfig.display || {};
-    const baselineDateOption =
-      baselineDisplay.dateFilter?.dateOption ?? null;
+    const baselineDateOption = baselineDisplay.dateFilter?.dateOption ?? null;
 
     if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
     if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
@@ -387,6 +391,10 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     if (currentCustomIds.length !== baselineCustomIds.length) return true;
     for (let i = 0; i < currentCustomIds.length; i += 1) {
       if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
+    }
+    // Did the user reorder columns (or move the custom-columns group)?
+    if (isColumnOrderDirty(sessionColumns, baselineDisplay.columnState)) {
+      return true;
     }
     return false;
   }, [
@@ -551,6 +559,12 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
 
   // Drained in the api-ready effect below once sessionGridApiRef populates.
   const pendingColumnStateRef = useRef(null);
+  // Canonical order, to restore default when leaving a saved view.
+  const canonicalOrderRef = useRef(null);
+  // Saved order; the [sessionColumns] effect re-applies it on each id-set change
+  // (cols land/leave), so it survives the grid-fetch race a one-shot apply lost.
+  const pendingSessionOrderRef = useRef(null);
+  const appliedSessionIdSetRef = useRef(null);
   // Set when the apply effect fires before the grid mounts (hard refresh
   // into a saved view). Drained in onGridReady, otherwise the pending
   // custom-col ref is stranded.
@@ -577,9 +591,14 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       }
       if (api?.resetColumnState) api.resetColumnState();
       pendingColumnStateRef.current = null;
+      pendingSessionOrderRef.current = null;
+      appliedSessionIdSetRef.current = null;
       pendingCustomColumnsRef.current = [];
       setSessionColumns((prev) =>
-        (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+        reorderColumns(
+          (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+          canonicalOrderRef.current,
+        ),
       );
       // Re-hydrate from localStorage — the mount hydrate is keyed on
       // displayStorageKey and won't re-fire on a same-project saved-view →
@@ -627,10 +646,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     // Push visibility into AG Grid directly when the api is available so
     // the display matches without waiting for re-render. Done before the
     // snapshot below so canSaveView's baseline matches the just-applied state.
-    if (
-      display.visibleColumns &&
-      typeof display.visibleColumns === "object"
-    ) {
+    if (display.visibleColumns && typeof display.visibleColumns === "object") {
       const next = { ...display.visibleColumns };
       setUpdateObj(next);
       const api = sessionGridApiRef.current?.api;
@@ -672,9 +688,11 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-      // Queue columnState when customs are pending — AG Grid silently drops
-      // applyColumnState entries for unknown colIds, so widths/order for
-      // custom cols would be lost otherwise. Drained when the customs land.
+      // Arm the saved order; the [sessionColumns] effect bakes it in once cols
+      // land (applyColumnState alone is clobbered by the next columnDefs rebuild).
+      pendingSessionOrderRef.current = columnStateToOrder(display.columnState);
+      appliedSessionIdSetRef.current = null;
+      // Queue widths/sort when customs pending — AG Grid drops unknown colIds.
       if (savedCustomCols.length > 0) {
         pendingColumnStateRef.current = display.columnState;
       } else {
@@ -893,6 +911,22 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       applyOrder: true,
     });
     pendingColumnStateRef.current = null;
+  }, [sessionColumns]);
+
+  // Bake the saved order into sessionColumns, re-applying only on id-set change
+  // (so a manual drag isn't reverted); applyColumnState alone is clobbered on rebuild.
+  useEffect(() => {
+    if (!pendingSessionOrderRef.current) return;
+    const idSetKey = (sessionColumns || [])
+      .map((c) => c?.id)
+      .sort()
+      .join("|");
+    if (idSetKey !== appliedSessionIdSetRef.current) {
+      appliedSessionIdSetRef.current = idSetKey;
+      setSessionColumns((prev) =>
+        reorderColumns(prev, pendingSessionOrderRef.current),
+      );
+    }
   }, [sessionColumns]);
 
   // --- Column config for display panel ---
@@ -1134,6 +1168,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           className={shouldDisable ? "ag-grid-disabled" : ""}
           onGridReady={onGridReady}
           pendingCustomColumnsRef={pendingCustomColumnsRef}
+          canonicalOrderRef={canonicalOrderRef}
           isOnSavedView={Boolean(activeViewConfig)}
         />
       </Box>

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Box, Divider, Paper, Typography, useTheme } from "@mui/material";
 import { Helmet } from "react-helmet-async";
 import { useNavigate, useParams } from "react-router";
@@ -70,6 +76,11 @@ const UserDetailPageBody = () => {
   useEffect(() => {
     if (!activeTab || !activeTab.startsWith("view-")) {
       lastHydratedTabRef.current = null;
+      // Sync subTab to userTab — the group dropdown navigates the URL directly,
+      // not via handleTabChange, so otherwise the view wouldn't switch.
+      if (activeTab === "sessions" || activeTab === "traces") {
+        if (activeTab !== subTab) setSubTab(activeTab);
+      }
       return;
     }
     if (lastHydratedTabRef.current === activeTab) return;

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
@@ -58,7 +58,7 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
 
   const queryClient = useQueryClient();
   const { getViewConfig, setActiveViewConfig } = useObserveHeader();
-  const [, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Pre-seed the URL-synced state keys for the target sub-tab from the saved
   // view's config. Lets useUrlState read correct values on mount / refresh so
@@ -72,10 +72,7 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
           const display = config.display || {};
           if (subTab === "sessions") {
             if (display.dateFilter) {
-              next.set(
-                "sessionDateFilter",
-                JSON.stringify(display.dateFilter),
-              );
+              next.set("sessionDateFilter", JSON.stringify(display.dateFilter));
             }
             if (display.cellHeight) {
               next.set("sessionCellHeight", JSON.stringify(display.cellHeight));
@@ -86,7 +83,9 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
                 JSON.stringify(display.showCompare),
               );
             }
-          } else if (subTab === "traces") {
+          } else if (subTab === "traces" || subTab === "spans") {
+            // Restore the trace/span grouping encoded in sub_tab.
+            next.set("selectedTab", subTab === "spans" ? "spans" : "trace");
             if (display.dateFilter) {
               next.set(
                 "primaryTraceDateFilter",
@@ -139,7 +138,11 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
     // transitions, e.g. handleClose at line ~230 calling
     // `onTabChange("sessions","sessions")` after deleting an active view.
     if (FIXED_TABS.some((t) => t.key === activeTab)) {
-      setSearchParams(new URLSearchParams({ userTab: activeTab }), {
+      // Preserve selectedTab (the trace/span grouping) — not a stale saved-view param.
+      const next = new URLSearchParams({ userTab: activeTab });
+      const selectedTab = searchParams.get("selectedTab");
+      if (selectedTab) next.set("selectedTab", selectedTab);
+      setSearchParams(next, {
         replace: true,
       });
       lastAppliedTabRef.current = activeTab;
@@ -160,7 +163,8 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
     const cachedResult = cached?.data?.result;
     const cachedList =
       cachedResult?.customViews ?? cachedResult?.custom_views ?? [];
-    const view = cachedList.find((v) => v.id === id) ??
+    const view =
+      cachedList.find((v) => v.id === id) ??
       customViews.find((v) => v.id === id);
     if (view?.config) {
       const subTab = view.config.sub_tab || view.config.subTab || "sessions";
@@ -177,6 +181,8 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
     // refetch will land and customViews will include the new view).
   }, [
     activeTab,
+    searchParams,
+    setSearchParams,
     setActiveViewConfig,
     onTabChange,
     customViews,
@@ -191,7 +197,12 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
       // be a custom view — in that case fall back to its underlying sub_tab.
       let targetSubTab = null;
       if (FIXED_TABS.some((t) => t.key === activeTab)) {
-        targetSubTab = activeTab;
+        // Encode the grouping in sub_tab — selectedTab isn't an allowed
+        // saved-view config key, so the backend would reject it.
+        targetSubTab =
+          activeTab === "traces" && searchParams.get("selectedTab") === "spans"
+            ? "spans"
+            : activeTab;
       } else {
         const id = activeTab?.startsWith?.("view-") ? activeTab.slice(5) : null;
         const view = id ? customViews.find((v) => v.id === id) : null;
@@ -220,7 +231,14 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
         },
       );
     },
-    [activeTab, customViews, createSavedView, getViewConfig, onTabChange],
+    [
+      activeTab,
+      searchParams,
+      customViews,
+      createSavedView,
+      getViewConfig,
+      onTabChange,
+    ],
   );
 
   const handleClose = useCallback(

--- a/frontend/src/sections/projects/UsersView/UsersGrid.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersGrid.jsx
@@ -443,6 +443,8 @@ const UsersGrid = React.memo(
     const onColumnMoved = useCallback(
       (params) => {
         if (!params.finished) return;
+        // User drags only; programmatic moves would feed back into setColumns.
+        if (params.source !== "uiColumnMoved") return;
 
         const newOrder = params.api
           .getColumnState()

--- a/frontend/src/sections/projects/UsersView/UsersGrid.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersGrid.jsx
@@ -159,29 +159,16 @@ const UsersGrid = React.memo(
         };
       };
 
-      const customCols = columns.filter((c) => c?.groupBy === "Custom Columns");
-
-      // Custom columns as one movable group at the first custom's position
-      // (marryChildren + groupId keep it draggable across rebuilds).
+      // Custom columns flat (ungrouped), in store order.
       const result = [];
-      let customGroupEmitted = false;
       for (const c of columns) {
         if (c?.groupBy === "Custom Columns") {
-          if (customGroupEmitted) continue;
-          customGroupEmitted = true;
+          const colDef = buildColDef(c);
           result.push({
-            headerName: "Custom Columns",
-            groupId: "custom-columns",
-            marryChildren: true,
-            children: customCols.map((cc) => {
-              const colDef = buildColDef(cc);
-              return {
-                ...colDef,
-                minWidth: 200,
-                flex: 1,
-                cellStyle: mergeCellStyle(colDef, { paddingInline: 0 }),
-              };
-            }),
+            ...colDef,
+            minWidth: 200,
+            flex: 1,
+            cellStyle: mergeCellStyle(colDef, { paddingInline: 0 }),
           });
           continue;
         }

--- a/frontend/src/sections/projects/UsersView/UsersGrid.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersGrid.jsx
@@ -160,24 +160,32 @@ const UsersGrid = React.memo(
       };
 
       const customCols = columns.filter((c) => c?.groupBy === "Custom Columns");
-      const otherCols = columns.filter((c) => c?.groupBy !== "Custom Columns");
 
-      const result = otherCols.map(buildColDef);
-
-      // Group custom columns under a "Custom Columns" header (TH-4151)
-      if (customCols.length > 0) {
-        result.push({
-          headerName: "Custom Columns",
-          children: customCols.map((c) => {
-            const colDef = buildColDef(c);
-            return {
-              ...colDef,
-              minWidth: 200,
-              flex: 1,
-              cellStyle: mergeCellStyle(colDef, { paddingInline: 0 }),
-            };
-          }),
-        });
+      // Custom columns as one movable group at the first custom's position
+      // (marryChildren + groupId keep it draggable across rebuilds).
+      const result = [];
+      let customGroupEmitted = false;
+      for (const c of columns) {
+        if (c?.groupBy === "Custom Columns") {
+          if (customGroupEmitted) continue;
+          customGroupEmitted = true;
+          result.push({
+            headerName: "Custom Columns",
+            groupId: "custom-columns",
+            marryChildren: true,
+            children: customCols.map((cc) => {
+              const colDef = buildColDef(cc);
+              return {
+                ...colDef,
+                minWidth: 200,
+                flex: 1,
+                cellStyle: mergeCellStyle(colDef, { paddingInline: 0 }),
+              };
+            }),
+          });
+          continue;
+        }
+        result.push(buildColDef(c));
       }
 
       return result;

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -207,7 +207,6 @@ const UsersView = ({
     activeViewConfig: activeViewConfigCtx,
     setActiveViewConfig,
     registerGetViewConfig,
-    registerGetTabType,
   } = useObserveHeader();
   // Prefer prop (set by UserList for /dashboard/users) over context
   // (set by ObservePage for the Users fixed tab).
@@ -771,11 +770,6 @@ const UsersView = ({
     registerGetViewConfig(getConfig);
     return () => registerGetViewConfig(null);
   }, [registerGetViewConfig, getConfig]);
-
-  useEffect(() => {
-    registerGetTabType(() => "users");
-    return () => registerGetTabType(null);
-  }, [registerGetTabType]);
 
   // Deps watch only activeViewConfig — applyConfig's identity changes with
   // columns, and it mutates columns, so keeping it in deps would loop.

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -361,6 +361,9 @@ const UsersView = ({
 
   // Drained when gridApi becomes available (saved view arrived before grid mount).
   const pendingColumnStateRef = useRef(null);
+  // Saved visibility queued when `columns` isn't loaded yet at load; the
+  // [columns] effect re-applies it once they land (else it never hydrates).
+  const pendingVisibilityRef = useRef(null);
   // Armed on switch-to-default; the [columns] effect resets order to the default.
   const pendingDefaultReorderRef = useRef(false);
 
@@ -533,8 +536,13 @@ const UsersView = ({
       if (savedCustomCols.length > 0) {
         addCustomColumns(savedCustomCols);
       }
-      if (display.visibleColumns && columns?.length) {
-        updateColumnVisibility(display.visibleColumns);
+      if (display.visibleColumns) {
+        if (columns?.length) {
+          updateColumnVisibility(display.visibleColumns);
+        } else {
+          // Grid columns not loaded yet — re-apply once they land.
+          pendingVisibilityRef.current = display.visibleColumns;
+        }
       }
       if (
         Array.isArray(display.columnState) &&
@@ -587,6 +595,11 @@ const UsersView = ({
   // available, or `columns` changing (custom cols just landed → AG Grid
   // columnDefs prop updated → safe to apply state for the custom colIds).
   useEffect(() => {
+    // Saved visibility queued before columns loaded — apply now they're here.
+    if (pendingVisibilityRef.current && columns?.length) {
+      updateColumnVisibility(pendingVisibilityRef.current);
+      pendingVisibilityRef.current = null;
+    }
     if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
       const order = columnStateToOrder(pendingColumnStateRef.current);
       gridApi.applyColumnState({
@@ -597,7 +610,7 @@ const UsersView = ({
       // Bake order into the array too (applyColumnState is clobbered on rebuild).
       setColumns(reorderColumns(columns, order));
     }
-  }, [gridApi, columns, setColumns]);
+  }, [gridApi, columns, setColumns, updateColumnVisibility]);
 
   // After switch-to-default, reset order to the config default (the view's order
   // was baked into the store); disarms at the fixpoint so manual drags persist.
@@ -626,6 +639,12 @@ const UsersView = ({
     const baselineDisplay = activeViewConfig.display || {};
     const baselineExtraFilters = baselineFilters.extraFilters || [];
     const baselineDateOption = baselineFilters.dateFilter?.dateOption ?? null;
+
+    // The `actions` column is an always-present UI column (not user data); its
+    // visibility/position must not count toward "modified" (TH-6119).
+    const comparableColumns = (columns || []).filter(
+      (c) => c?.id !== "actions",
+    );
 
     if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
     if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
@@ -660,7 +679,7 @@ const UsersView = ({
       baselineDisplay.visibleColumns &&
       typeof baselineDisplay.visibleColumns === "object"
     ) {
-      const currentVisibility = (columns || []).reduce((acc, col) => {
+      const currentVisibility = comparableColumns.reduce((acc, col) => {
         acc[col.id] = col.isVisible !== false;
         return acc;
       }, {});
@@ -692,7 +711,7 @@ const UsersView = ({
       if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
     }
     // Did the user reorder columns (or move the custom-columns group)?
-    if (isColumnOrderDirty(columns, baselineDisplay.columnState)) {
+    if (isColumnOrderDirty(comparableColumns, baselineDisplay.columnState)) {
       return true;
     }
     return false;

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -31,6 +31,11 @@ import ObserveToolbar from "../LLMTracing/ObserveToolbar";
 import FilterChips from "../LLMTracing/FilterChips";
 import CustomColumnDialog from "../LLMTracing/CustomColumnDialog";
 import { useLLMTracingFilters } from "../LLMTracing/useLLMTracingFilters";
+import {
+  reorderColumns,
+  columnStateToOrder,
+  isColumnOrderDirty,
+} from "../LLMTracing/savedViewColumns";
 import ColumnConfigureDropDown from "src/sections/project-detail/ColumnDropdown/ColumnConfigureDropDown";
 
 // Lazy-load graph
@@ -356,6 +361,8 @@ const UsersView = ({
 
   // Drained when gridApi becomes available (saved view arrived before grid mount).
   const pendingColumnStateRef = useRef(null);
+  // Armed on switch-to-default; the [columns] effect resets order to the default.
+  const pendingDefaultReorderRef = useRef(false);
 
   const displayStorageKey = `observe-users-display-${observeId}`;
 
@@ -377,7 +384,8 @@ const UsersView = ({
       skipNextSaveRef.current = true;
       const saved = JSON.parse(raw);
       if (saved.cellHeight) setCellHeight(saved.cellHeight);
-      if (typeof saved.showErrors === "boolean") setShowErrors(saved.showErrors);
+      if (typeof saved.showErrors === "boolean")
+        setShowErrors(saved.showErrors);
       if (typeof saved.showNonAnnotated === "boolean") {
         setShowNonAnnotated(saved.showNonAnnotated);
       }
@@ -528,7 +536,10 @@ const UsersView = ({
       if (display.visibleColumns && columns?.length) {
         updateColumnVisibility(display.visibleColumns);
       }
-      if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      if (
+        Array.isArray(display.columnState) &&
+        display.columnState.length > 0
+      ) {
         // Defer columnState when custom cols are being added — AG Grid's
         // columnDefs prop only flips next render, so applying this tick
         // would drop entries for the custom colIds. Drained by the
@@ -540,6 +551,10 @@ const UsersView = ({
             state: display.columnState,
             applyOrder: true,
           });
+          // Bake order into the array too (applyColumnState is clobbered on rebuild).
+          setColumns(
+            reorderColumns(columns, columnStateToOrder(display.columnState)),
+          );
         } else {
           pendingColumnStateRef.current = display.columnState;
         }
@@ -561,6 +576,7 @@ const UsersView = ({
       updateColumnVisibility,
       addCustomColumns,
       removeCustomColumns,
+      setColumns,
       columns,
       gridApi,
       displayStorageKey,
@@ -572,13 +588,26 @@ const UsersView = ({
   // columnDefs prop updated → safe to apply state for the custom colIds).
   useEffect(() => {
     if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
+      const order = columnStateToOrder(pendingColumnStateRef.current);
       gridApi.applyColumnState({
         state: pendingColumnStateRef.current,
         applyOrder: true,
       });
       pendingColumnStateRef.current = null;
+      // Bake order into the array too (applyColumnState is clobbered on rebuild).
+      setColumns(reorderColumns(columns, order));
     }
-  }, [gridApi, columns]);
+  }, [gridApi, columns, setColumns]);
+
+  // After switch-to-default, reset order to the config default (the view's order
+  // was baked into the store); disarms at the fixpoint so manual drags persist.
+  useEffect(() => {
+    if (!pendingDefaultReorderRef.current) return;
+    const canonical = (getUsersColumnConfig() || []).map((c) => c.field);
+    const next = reorderColumns(columns, canonical);
+    if (next !== columns) setColumns(next);
+    else pendingDefaultReorderRef.current = false;
+  }, [columns, setColumns]);
 
   // Keep the ref's handles in sync with the latest closures
   useEffect(() => {
@@ -596,8 +625,7 @@ const UsersView = ({
     const baselineFilters = activeViewConfig.filters || {};
     const baselineDisplay = activeViewConfig.display || {};
     const baselineExtraFilters = baselineFilters.extraFilters || [];
-    const baselineDateOption =
-      baselineFilters.dateFilter?.dateOption ?? null;
+    const baselineDateOption = baselineFilters.dateFilter?.dateOption ?? null;
 
     if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
     if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
@@ -663,6 +691,10 @@ const UsersView = ({
     for (let i = 0; i < currentCustomIds.length; i += 1) {
       if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
     }
+    // Did the user reorder columns (or move the custom-columns group)?
+    if (isColumnOrderDirty(columns, baselineDisplay.columnState)) {
+      return true;
+    }
     return false;
   }, [
     activeViewConfig,
@@ -683,9 +715,7 @@ const UsersView = ({
 
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    const key = isObservePath
-      ? params.get("tab")
-      : params.get("usersTab");
+    const key = isObservePath ? params.get("tab") : params.get("usersTab");
     return key?.startsWith("view-") ? key.slice(5) : null;
   }, [activeViewConfig, isObservePath]);
 
@@ -738,6 +768,7 @@ const UsersView = ({
       const wasOnSavedView = wasOnSavedViewRef.current;
       wasOnSavedViewRef.current = false;
       if (!wasOnSavedView) return;
+      pendingDefaultReorderRef.current = true;
       applyConfig(null);
       return;
     }

--- a/futureagi/agentcc/tests/test_api_key_bulk.py
+++ b/futureagi/agentcc/tests/test_api_key_bulk.py
@@ -1,0 +1,78 @@
+"""Bulk API-key sync endpoint: expires_at wire format and expired-key filtering."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from agentcc.models import AgentccAPIKey
+
+ADMIN_TOKEN = "agentcc-admin-secret"
+
+
+@pytest.fixture(autouse=True)
+def set_agentcc_admin_token():
+    with patch("agentcc.permissions.AGENTCC_ADMIN_TOKEN", ADMIN_TOKEN):
+        yield
+
+
+@pytest.fixture
+def admin_client():
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {ADMIN_TOKEN}")
+    return client
+
+
+def _make_key(organization, workspace, gateway_key_id, key_hash, expires_at):
+    return AgentccAPIKey.objects.create(
+        gateway_key_id=gateway_key_id,
+        name=gateway_key_id,
+        organization=organization,
+        workspace=workspace,
+        key_hash=key_hash,
+        status=AgentccAPIKey.ACTIVE,
+        expires_at=expires_at,
+    )
+
+
+class TestAPIKeyBulkExpiresAt:
+    def test_future_and_null_expiry_are_serialized_on_the_wire(
+        self, admin_client, organization, workspace
+    ):
+        future = timezone.now() + timedelta(days=7)
+        _make_key(organization, workspace, "gw-expiring", "a" * 64, future)
+        _make_key(organization, workspace, "gw-perpetual", "b" * 64, None)
+
+        response = admin_client.get("/agentcc/api-keys/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # Assert on the rendered JSON the gateway actually receives, not the
+        # pre-render Python datetime.
+        by_id = {item["id"]: item for item in response.json()["result"]}
+
+        # Future-expiry key: expires_at is an ISO 8601 string the gateway can
+        # parse as RFC3339 (DRF renders aware datetimes with a 'Z'/offset).
+        expiring = by_id["gw-expiring"]["expires_at"]
+        assert isinstance(expiring, str)
+        parsed = datetime.fromisoformat(expiring.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None  # must be timezone-aware
+
+        # Null expiry stays null (never-expiring keys).
+        assert by_id["gw-perpetual"]["expires_at"] is None
+
+    def test_expired_keys_are_not_shipped(
+        self, admin_client, organization, workspace
+    ):
+        past = timezone.now() - timedelta(days=1)
+        _make_key(organization, workspace, "gw-expired", "c" * 64, past)
+        _make_key(organization, workspace, "gw-live", "d" * 64, None)
+
+        ids = {item["id"] for item in admin_client.get(
+            "/agentcc/api-keys/bulk/"
+        ).json()["result"]}
+
+        assert "gw-expired" not in ids  # filtered at the query level
+        assert "gw-live" in ids

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -1,4 +1,6 @@
 import structlog
+from django.db.models import Q
+from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 
@@ -25,10 +27,13 @@ class APIKeyBulkView(APIView):
 
     def get(self, request):
         try:
+            # Don't ship already-expired keys, even to gateways that predate
+            # real-time expiry enforcement.
+            now = timezone.now()
             keys = AgentccAPIKey.no_workspace_objects.filter(
                 status=AgentccAPIKey.ACTIVE,
                 deleted=False,
-            )
+            ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
 
             result = []
             for key in keys:
@@ -43,6 +48,7 @@ class APIKeyBulkView(APIView):
                         "models": key.allowed_models or [],
                         "providers": key.allowed_providers or [],
                         "metadata": key.metadata or {},
+                        "expires_at": key.expires_at,
                     }
                 )
 

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -55,4 +55,4 @@ class APIKeyBulkView(APIView):
             return self._gm.success_response(result)
         except Exception as e:
             logger.exception("api_key_bulk_error", error=str(e))
-            return self._gm.bad_request(str(e))
+            return self._gm.internal_server_error_response("Internal server error")

--- a/futureagi/model_hub/system_evals/agent/citation_quality.yaml
+++ b/futureagi/model_hub/system_evals/agent/citation_quality.yaml
@@ -1,0 +1,120 @@
+eval_id: 203
+name: citation_quality
+description: Evaluates whether inline citations in the response correctly reference the corresponding source documents.
+criteria: "You are evaluating whether the inline citations in the response correctly\
+  \ reference the corresponding source documents provided in the context.\n\n## Criteria\n\
+  \n1. Citation accuracy: Each citation marker (e.g., [1], [Source A], footnotes)\
+  \ must reference the correct source document.\n   - Pass: Response states \"Python\
+  \ 3.12 was released in October 2023 [1]\" and context [1] confirms this fact.\n\
+  \   - Fail: Response states \"Python 3.12 was released in October 2023 [2]\" but\
+  \ context [2] discusses Java, not Python.\n\n2. Citation completeness: Key factual\
+  \ claims derived from the context should have citations attached.\n   - Pass: All\
+  \ major claims sourced from the context include citation markers.\n   - Fail: The\
+  \ response presents specific facts from the context but provides no citations for\
+  \ them.\n\n3. No fabricated citations: The response must not cite sources that do\
+  \ not exist in the provided context.\n   - Pass: All citation markers map to actual\
+  \ documents in the context.\n   - Fail: Response references \"[5]\" but only 3 context\
+  \ documents were provided.\n\n## Anti-bias Rules\n\n- If the response contains no\
+  \ inline citations at all, score based on whether citations were expected. A response\
+  \ to a simple factual question may not need citations — do not penalize. A response\
+  \ synthesizing multiple sources should cite them.\n- Common knowledge statements\
+  \ do not require citations even when context is provided.\n- Paraphrased content\
+  \ with correct citation is just as valid as direct quotes with citation.\n- A single\
+  \ incorrect citation among many correct ones should reduce the score proportionally,\
+  \ not zero it out.\n- Citation format variations ([1], [Source 1], (1), etc.) are\
+  \ all acceptable — evaluate correctness, not format.\n\n## Scoring\n\nScore 0.0\
+  \ if citations are systematically wrong: pointing to incorrect sources, fabricating\
+  \ non-existent references, or entirely absent when clearly needed. Score 0.5 if\
+  \ citations are partially correct: some map to the right sources but others are\
+  \ wrong or missing for key claims. Score 1.0 if all citations accurately reference\
+  \ the correct sources, key claims are properly cited, and no fabricated references\
+  \ exist.\n\n## Inputs\n\n<context>{{context}}</context>\n\n<input>{{input}}</input>\n\
+  \n<output>{{output}}</output>"
+eval_tags:
+- RAG
+- Retrieval Systems
+- Quality
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - context
+  - input
+  - output
+  output: score
+  eval_type_id: AgentEvaluator
+  config:
+    check_internet:
+      type: boolean
+      default: false
+  config_params_desc:
+    context: The source documents or chunks provided as context (numbered or labeled)
+    input: The user query or question
+    output: The generated response containing inline citations to evaluate
+  param_modalities:
+    context:
+    - TEXT
+    - PDF
+    - KNOWLEDGE_BASE
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+    input:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+    output:
+    - TEXT
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+  rule_prompt: "You are evaluating whether the inline citations in the response correctly\
+    \ reference the corresponding source documents provided in the context.\n\n##\
+    \ Criteria\n\n1. Citation accuracy: Each citation marker (e.g., [1], [Source A],\
+    \ footnotes) must reference the correct source document.\n   - Pass: Response\
+    \ states \"Python 3.12 was released in October 2023 [1]\" and context [1] confirms\
+    \ this fact.\n   - Fail: Response states \"Python 3.12 was released in October\
+    \ 2023 [2]\" but context [2] discusses Java, not Python.\n\n2. Citation completeness:\
+    \ Key factual claims derived from the context should have citations attached.\n\
+    \   - Pass: All major claims sourced from the context include citation markers.\n\
+    \   - Fail: The response presents specific facts from the context but provides\
+    \ no citations for them.\n\n3. No fabricated citations: The response must not cite\
+    \ sources that do not exist in the provided context.\n   - Pass: All citation\
+    \ markers map to actual documents in the context.\n   - Fail: Response references\
+    \ \"[5]\" but only 3 context documents were provided.\n\n## Anti-bias Rules\n\n\
+    - If the response contains no inline citations at all, score based on whether\
+    \ citations were expected. A response to a simple factual question may not need\
+    \ citations — do not penalize. A response synthesizing multiple sources should\
+    \ cite them.\n- Common knowledge statements do not require citations even when\
+    \ context is provided.\n- Paraphrased content with correct citation is just as\
+    \ valid as direct quotes with citation.\n- A single incorrect citation among many\
+    \ correct ones should reduce the score proportionally, not zero it out.\n- Citation\
+    \ format variations ([1], [Source 1], (1), etc.) are all acceptable — evaluate\
+    \ correctness, not format.\n\n## Scoring\n\nScore 0.0 if citations are systematically\
+    \ wrong: pointing to incorrect sources, fabricating non-existent references, or\
+    \ entirely absent when clearly needed. Score 0.5 if citations are partially correct:\
+    \ some map to the right sources but others are wrong or missing for key claims.\
+    \ Score 1.0 if all citations accurately reference the correct sources, key claims\
+    \ are properly cited, and no fabricated references exist.\n\n## Inputs\n\n<context>{{context}}</context>\n\
+    \n<input>{{input}}</input>\n\n<output>{{output}}</output>"

--- a/futureagi/model_hub/system_evals/tests/test_citation_quality_eval.py
+++ b/futureagi/model_hub/system_evals/tests/test_citation_quality_eval.py
@@ -1,0 +1,166 @@
+"""
+Tests for the citation_quality agent evaluator YAML.
+
+Verifies:
+- YAML schema (required fields, types)
+- Template variables match required_keys
+- eval_id uniqueness against known range
+- PDF modality support (context can be a document)
+- Tags, output type, and visibility
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+YAML_PATH = Path(__file__).resolve().parent.parent / "agent" / "citation_quality.yaml"
+
+
+@pytest.fixture(scope="module")
+def eval_def():
+    return yaml.safe_load(YAML_PATH.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_loads_without_error(eval_def):
+    assert eval_def is not None
+
+
+def test_required_top_level_fields(eval_def):
+    for field in ("eval_id", "name", "description", "criteria", "config"):
+        assert field in eval_def, f"Missing required field: {field}"
+
+
+def test_name_matches_filename(eval_def):
+    assert eval_def["name"] == "citation_quality"
+
+
+def test_output_type_is_percentage(eval_def):
+    assert eval_def["output_type_normalized"] == "percentage"
+
+
+def test_pass_threshold_in_range(eval_def):
+    threshold = eval_def["pass_threshold"]
+    assert 0.0 <= threshold <= 1.0
+
+
+def test_eval_type_is_agent_evaluator(eval_def):
+    assert eval_def["config"]["eval_type_id"] == "AgentEvaluator"
+
+
+# ---------------------------------------------------------------------------
+# required_keys vs. template variables
+# ---------------------------------------------------------------------------
+
+
+def test_required_keys_present_in_config(eval_def):
+    required_keys = eval_def["config"]["required_keys"]
+    assert "input" in required_keys
+    assert "output" in required_keys
+    assert "context" in required_keys
+
+
+def test_rule_prompt_contains_all_template_variables(eval_def):
+    rule_prompt = eval_def["config"]["rule_prompt"]
+    for key in eval_def["config"]["required_keys"]:
+        assert f"{{{{{key}}}}}" in rule_prompt, (
+            f"Template variable '{{{{{key}}}}}' missing from rule_prompt"
+        )
+
+
+def test_config_params_desc_covers_required_keys(eval_def):
+    params_desc = eval_def["config"]["config_params_desc"]
+    for key in eval_def["config"]["required_keys"]:
+        assert key in params_desc, f"config_params_desc missing key: {key}"
+
+
+def test_param_modalities_covers_required_keys(eval_def):
+    modalities = eval_def["config"]["param_modalities"]
+    for key in eval_def["config"]["required_keys"]:
+        assert key in modalities, f"param_modalities missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# PDF modality — context accepts document sources
+# ---------------------------------------------------------------------------
+
+
+def test_context_supports_pdf_modality(eval_def):
+    """Citation quality requires reading source docs — context must accept PDF."""
+    context_modalities = eval_def["config"]["param_modalities"]["context"]
+    assert "PDF" in context_modalities, "context must support PDF modality"
+
+
+def test_context_supports_knowledge_base_modality(eval_def):
+    context_modalities = eval_def["config"]["param_modalities"]["context"]
+    assert "KNOWLEDGE_BASE" in context_modalities
+
+
+# ---------------------------------------------------------------------------
+# eval_id uniqueness guard
+# ---------------------------------------------------------------------------
+
+
+def test_eval_id_is_within_expected_range(eval_def):
+    """eval_id 203 should not collide with existing agent evals (max was 200)."""
+    assert eval_def["eval_id"] == 203
+
+
+def test_no_other_agent_eval_uses_same_eval_id(eval_def):
+    agent_dir = YAML_PATH.parent
+    our_id = eval_def["eval_id"]
+    for path in agent_dir.glob("*.yaml"):
+        if path.name == "citation_quality.yaml":
+            continue
+        other = yaml.safe_load(path.read_text())
+        assert other.get("eval_id") != our_id, (
+            f"eval_id {our_id} collision with {path.name}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tags and visibility
+# ---------------------------------------------------------------------------
+
+
+def test_has_rag_tag(eval_def):
+    assert "RAG" in eval_def.get("eval_tags", [])
+
+
+def test_has_retrieval_systems_tag(eval_def):
+    assert "Retrieval Systems" in eval_def.get("eval_tags", [])
+
+
+def test_visible_in_ui(eval_def):
+    assert eval_def.get("visible_ui") is True
+
+
+def test_allow_copy_is_true(eval_def):
+    assert eval_def["permissions"]["allow_copy"] is True
+
+
+# ---------------------------------------------------------------------------
+# Criteria sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_criteria_covers_citation_accuracy(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "accuracy" in criteria or "correct" in criteria
+
+
+def test_criteria_covers_fabricated_citations(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "fabricat" in criteria or "non-existent" in criteria or "exist" in criteria
+
+
+def test_criteria_covers_completeness(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "complet" in criteria

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1287,6 +1287,13 @@ class DashboardQueryBuilder:
             f"{time_col} < %(end_date)s",
         ]
 
+        # spans is partitioned by toYYYYMM(created_at) but the window is
+        # filtered on start_time, so bound created_at too — otherwise no
+        # partitions prune and the scan covers all history. Lower bound only
+        # (created_at >= start_time always holds), so no in-window row drops.
+        if time_col != "created_at":
+            clauses.append("created_at >= %(start_date)s - INTERVAL 1 DAY")
+
         # Apply global + per-metric system_metric filters directly
         # For string-comparable system metrics, use toString() to avoid UUID parse errors
         _STRING_FILTER_COL = {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -743,6 +743,51 @@ class TestDashboardQueryBuilder:
         assert "toStartOfDay" in sql
         assert params["project_ids"] == sample_query_config["project_ids"]
 
+    def test_system_metric_query_prunes_partitions(self, sample_query_config):
+        """Spans-based queries must bound created_at (the partition key) so a
+        windowed query prunes old partitions instead of scanning all history."""
+        builder = DashboardQueryBuilder(sample_query_config)
+        sql, _, _ = builder.build_all_queries()[0]
+        # partition-prune bound on the partition key is present
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        # and the precise event-time window is still enforced (correctness)
+        assert "start_time >= %(start_date)s" in sql
+        assert "start_time < %(end_date)s" in sql
+
+    def test_breakdown_query_prunes_partitions(self):
+        """A latency average broken down by a custom span attribute must emit
+        the created_at partition-prune bound while preserving the start_time
+        window."""
+        config = {
+            "project_ids": [str(uuid.uuid4())],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [],
+            "breakdowns": [
+                {
+                    "name": "final_status",
+                    "type": "custom_attribute",
+                    "source": "traces",
+                    "display_name": "final_status",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        sql, _, _ = builder.build_all_queries()[0]
+        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time >= %(start_date)s" in sql
+        # the breakdown is still applied (real call path intact)
+        assert "breakdown_value" in sql
+
     def test_all_system_metrics(self):
         for metric_name in SYSTEM_METRICS:
             config = {

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1057,24 +1057,26 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     from tracer.services.clickhouse.client import get_clickhouse_client
 
                     ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
                     rows, cols, _ = ch.execute_read(
                         """
                         SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
+                            SELECT
+                                pair.1 AS key,
+                                pair.2 AS type,
+                                count() AS cnt
+                            FROM (
+                                SELECT span_attr_str, span_attr_num, span_attr_bool
+                                FROM spans
+                                WHERE project_id IN %(project_ids)s
+                                  AND _peerdb_is_deleted = 0
+                                LIMIT 100000
+                            )
+                            ARRAY JOIN arrayConcat(
+                                arrayMap(k -> (k, 'text'),    mapKeys(span_attr_str)),
+                                arrayMap(k -> (k, 'number'),  mapKeys(span_attr_num)),
+                                arrayMap(k -> (k, 'boolean'), mapKeys(span_attr_bool))
+                            ) AS pair
+                            GROUP BY pair.1, pair.2
                         )
                         GROUP BY key ORDER BY key LIMIT 2000
                         """,


### PR DESCRIPTION
## Summary

Adds a new LLM-as-Judge agent evaluator `citation_quality` that verifies whether inline citations in a response correctly reference the corresponding source documents.

Closes #1225

## Motivation

Existing evals check if context was *used*, but none verify whether explicit citation markers map to the *correct* sources.

| Existing Eval | What it checks | Gap |
|---------------|----------------|-----|
| `chunk_attribution` | Was this chunk used at all? | No per-citation accuracy |
| `chunk_utilization` | How much of the chunks were used? | No citation marker verification |
| `context_adherence` | Is the answer faithful to context? | No citation-level granularity |
| **`citation_quality` (this PR)** | Do inline citations reference correct sources? | — |

Real-world failure this catches:
```
Context: [1] "Python 3.12 released Oct 2023"  [2] "Java 21 released Sep 2023"
Response: "Python 3.12 was released in October 2023 [2]"  ← wrong citation
```

Critical for: enterprise RAG auditability, legal/medical/financial agents, any UX that surfaces citations to end users.

## Implementation

**File:** `futureagi/model_hub/system_evals/agent/citation_quality.yaml`  
**Type:** Agent (LLM-as-Judge) — YAML-only, reuses `CustomPromptEvaluator`  
**Inputs:** `context` (source docs), `input` (query), `output` (response with citations)  
**Output type:** `percentage` (0.0–1.0) | **eval_id:** 203

**Evaluation criteria:**
1. **Citation accuracy** — Each marker references the correct source
2. **Citation completeness** — Key claims sourced from context have citations
3. **No fabricated citations** — No references to non-existent sources

**Anti-bias rules:**
- Simple factual responses without citations are not penalized
- Common knowledge doesn't require citation
- Proportional scoring: one wrong citation ≠ zero score
- Format-agnostic: `[1]`, `[Source A]`, `(1)` all valid

## Tests

`futureagi/model_hub/system_evals/tests/test_citation_quality_eval.py` covers:
- YAML schema validation
- All 3 required keys in template variables
- PDF + KNOWLEDGE_BASE modality on `context` param
- eval_id 203 uniqueness
- Criteria text sanity (accuracy, completeness, fabrication)

## Checklist

- [x] YAML added: `futureagi/model_hub/system_evals/agent/citation_quality.yaml`
- [x] Tests added: `futureagi/model_hub/system_evals/tests/test_citation_quality_eval.py`
- [x] YAML schema + template vars validated locally
- [x] eval_id 203 — no collision (203 follows 202 from #1224)
- [ ] Seed via `python manage.py seed_system_evals`