### PR TITLE
fix(develop): allow reconfiguring a conditional dynamic column after a failed run (TH-6272)

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
@@ -49,7 +49,7 @@ export const _transformDynamicColumnConfig = (type, config, allColumns) => {
 export const getConditionalNodeDefaultValues = (initialData, allColumns) => {
   if (initialData) {
     return {
-      newColumnName: initialData.newColumnName,
+      newColumnName: initialData.new_column_name,
       config: initialData.config?.map((con) => ({
         branchType: con.branch_type,
         condition: replaceColumnIdWithName(con.condition ?? "", allColumns),

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
@@ -51,11 +51,11 @@ export const getConditionalNodeDefaultValues = (initialData, allColumns) => {
     return {
       newColumnName: initialData.newColumnName,
       config: initialData.config?.map((con) => ({
-        ...con,
+        branchType: con.branch_type,
         condition: replaceColumnIdWithName(con.condition ?? "", allColumns),
         branchNodeConfig: {
-          type: con.branchNodeConfig?.type ?? "",
-          config: con.branchNodeConfig?.config ?? null,
+          type: con.branch_node_config?.type ?? "",
+          config: con.branch_node_config?.config ?? null,
         },
       })),
     };

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js
@@ -52,10 +52,10 @@ export const getConditionalNodeDefaultValues = (initialData, allColumns) => {
       newColumnName: initialData.newColumnName,
       config: initialData.config?.map((con) => ({
         ...con,
-        condition: replaceColumnIdWithName(con.condition, allColumns),
+        condition: replaceColumnIdWithName(con.condition ?? "", allColumns),
         branchNodeConfig: {
-          type: con.branchNodeConfig.type,
-          config: con.branchNodeConfig.config,
+          type: con.branchNodeConfig?.type ?? "",
+          config: con.branchNodeConfig?.config ?? null,
         },
       })),
     };

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
@@ -20,6 +20,7 @@ describe("getConditionalNodeDefaultValues", () => {
 
     const result = getConditionalNodeDefaultValues(saved, allColumns);
 
+    expect(result.newColumnName).toBe("verdict");
     expect(result.config[0].branchType).toBe("if");
     expect(result.config[0].condition).toBe("{{input}} == 'yes'");
     expect(result.config[0].branchNodeConfig).toEqual({

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { getConditionalNodeDefaultValues } from "./common";
+
+const allColumns = [{ headerName: "input", field: "col_input" }];
+
+describe("getConditionalNodeDefaultValues", () => {
+  it("maps a well-formed saved config into edit-form defaults", () => {
+    const saved = {
+      newColumnName: "verdict",
+      config: [
+        {
+          branchType: "if",
+          condition: "{{col_input}} == 'yes'",
+          branchNodeConfig: { type: "run_prompt", config: { prompt: "hi" } },
+        },
+      ],
+    };
+
+    const result = getConditionalNodeDefaultValues(saved, allColumns);
+
+    expect(result.newColumnName).toBe("verdict");
+    expect(result.config[0].condition).toBe("{{input}} == 'yes'");
+    expect(result.config[0].branchNodeConfig).toEqual({
+      type: "run_prompt",
+      config: { prompt: "hi" },
+    });
+  });
+
+  it("loads a partial post-failure config without throwing", () => {
+    const partial = {
+      newColumnName: "verdict",
+      config: [
+        { branchType: "if", condition: null, branchNodeConfig: undefined },
+        {
+          branchType: "else",
+          condition: null,
+          branchNodeConfig: { type: "run_prompt" },
+        },
+      ],
+    };
+
+    const result = getConditionalNodeDefaultValues(partial, allColumns);
+
+    expect(result.config[0].condition).toBe("");
+    expect(result.config[0].branchNodeConfig).toEqual({
+      type: "",
+      config: null,
+    });
+    expect(result.config[1].condition).toBe("");
+    expect(result.config[1].branchNodeConfig).toEqual({
+      type: "run_prompt",
+      config: null,
+    });
+  });
+});

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js
@@ -3,22 +3,24 @@ import { getConditionalNodeDefaultValues } from "./common";
 
 const allColumns = [{ headerName: "input", field: "col_input" }];
 
+// Saved metadata is snake_case (the shape transformFormToApi writes): branch_type,
+// branch_node_config. The transform must read those keys and rebuild camelCase form values.
 describe("getConditionalNodeDefaultValues", () => {
-  it("maps a well-formed saved config into edit-form defaults", () => {
+  it("round-trips a saved run_prompt config into edit-form defaults", () => {
     const saved = {
-      newColumnName: "verdict",
+      new_column_name: "verdict",
       config: [
         {
-          branchType: "if",
+          branch_type: "if",
           condition: "{{col_input}} == 'yes'",
-          branchNodeConfig: { type: "run_prompt", config: { prompt: "hi" } },
+          branch_node_config: { type: "run_prompt", config: { prompt: "hi" } },
         },
       ],
     };
 
     const result = getConditionalNodeDefaultValues(saved, allColumns);
 
-    expect(result.newColumnName).toBe("verdict");
+    expect(result.config[0].branchType).toBe("if");
     expect(result.config[0].condition).toBe("{{input}} == 'yes'");
     expect(result.config[0].branchNodeConfig).toEqual({
       type: "run_prompt",
@@ -28,13 +30,12 @@ describe("getConditionalNodeDefaultValues", () => {
 
   it("loads a partial post-failure config without throwing", () => {
     const partial = {
-      newColumnName: "verdict",
       config: [
-        { branchType: "if", condition: null, branchNodeConfig: undefined },
+        { branch_type: "if", condition: null, branch_node_config: undefined },
         {
-          branchType: "else",
+          branch_type: "else",
           condition: null,
-          branchNodeConfig: { type: "run_prompt" },
+          branch_node_config: { type: "run_prompt" },
         },
       ],
     };
@@ -46,7 +47,7 @@ describe("getConditionalNodeDefaultValues", () => {
       type: "",
       config: null,
     });
-    expect(result.config[1].condition).toBe("");
+    expect(result.config[1].branchType).toBe("else");
     expect(result.config[1].branchNodeConfig).toEqual({
       type: "run_prompt",
       config: null,


### PR DESCRIPTION
A Conditional-node dynamic column could not be reconfigured after its run: opening **Configure Dynamic Column** showed the drawer with **every branch loaded empty** — the saved condition, branch type, and node config were gone — so the column could never be edited to match what was actually saved.

The root cause is a **key-casing mismatch** between what the writer saves and what the edit-form transform reads. `transformFormToApi` persists each branch in **snake_case** (`branch_type`, `branch_node_config`), but the saved-config → edit-form transform `getConditionalNodeDefaultValues` read those fields in **camelCase** (`con.branchType`, `con.branchNodeConfig`). Every camelCase read was therefore `undefined`, so each branch mapped to empty defaults regardless of what was saved. The fix maps the real snake keys the writer produces, so the saved config round-trips back into the drawer.

## Why the changes are done — what is the problem

### Reproduce on dev/main today (before this PR)

1. Open a dataset.
2. Add a dynamic column using the **Conditional** node; give a branch a real condition, branch type, and node config.
3. Let the run succeed so the column has real data.
4. Open the column's header menu and click **Configure Dynamic Column**.
5. The drawer opens, but the saved branch is **blank** — condition empty, branch type unset, node config gone. The saved configuration cannot be recovered or edited.

### Where it breaks — UI

`getConditionalNodeDefaultValues` in `frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js` maps a **saved** conditional config into the edit-form defaults. Saved metadata is snake_case (that is the exact shape `transformFormToApi` writes), but the transform read camelCase:

```js
// before — camelCase reads against snake_case saved data => always undefined
branchType: con.branchType,
branchNodeConfig: {
  type: con.branchNodeConfig?.type,
  config: con.branchNodeConfig?.config,
},
...con,   // raw snake keys also rode along into the form values
```

Because the saved object only has `branch_type` / `branch_node_config`, `con.branchType` and `con.branchNodeConfig` are `undefined`, so every branch initialized empty. The trailing `...con` spread then leaked the raw snake keys straight through the form and back out via `transformFormToApi`.

## What changed

### frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.js

- Read the **real snake keys** the writer produces, and drop the `...con` spread so raw snake keys no longer ride into form values:

```js
config: initialData.config?.map((con) => ({
  branchType: con.branch_type,
  condition: replaceColumnIdWithName(con.condition ?? "", allColumns),
  branchNodeConfig: {
    type: con.branch_node_config?.type ?? "",
    config: con.branch_node_config?.config ?? null,
  },
})),
```

- Snake keys are read first (that is what the writer emits today). The saved condition, branch type, and node config now load back into the drawer exactly as saved.

## Tests included — what each scenario covers

### frontend/src/sections/develop-detail/AddColumn/ConditionalNode/common.test.js

- Both fixtures were rewritten in the **snake shape** `transformFormToApi` actually saves (`branch_type` / `branch_node_config`) — the previous fixtures used a camelCase shape no writer in the codebase produces, so the old happy-path test pinned against data that could not exist.
- The test now asserts that a saved `run_prompt` config **round-trips into the form defaults** — it fails on the old code (branches load empty) and passes on the fix. Suite is green at head (2/2).

## Proof — organic end-to-end flow

Organic flow through the real UI: create a conditional dynamic column → let the run **succeed** so the cells have real data → reopen **Configure Dynamic Column** → the saved condition, branch type, and node config load back into the drawer.

https://github.com/user-attachments/assets/1305a5e7-b4cb-4513-8611-5988e7741c20


