### PR TITLE
fix(evals): make groundedness score robust to empty and null sentences

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_metrics/groundedness.py
+++ b/futureagi/agentic_eval/core_evals/fi_metrics/groundedness.py
@@ -16,7 +16,6 @@ class GroundednessScore(ABC):
         """
         Computes the metric.
         """
-        total_sentences = len(sentences_with_evidence)
         unsupported_sentences: list[str] = [] # List of unsupported sentences
         supported_sentences: list[tuple[str, list[str]]] = [] # List of (sentence, evidences) pairs
         for sentence_with_evidence in sentences_with_evidence:
@@ -29,7 +28,16 @@ class GroundednessScore(ABC):
             else:
                 unsupported_sentences.append(sentence_str)
         num_supported_sentences = len(supported_sentences)
-        score = num_supported_sentences / total_sentences
+        # Score over the sentences that were actually classified. Skipped
+        # (sentence is None) entries were dropped above, so counting the raw
+        # input length would wrongly lower the score, and an empty input would
+        # divide by zero. A response with no evaluable sentences is treated as
+        # fully grounded (nothing is unsupported).
+        num_classified_sentences = num_supported_sentences + len(unsupported_sentences)
+        if num_classified_sentences == 0:
+            score = 1.0
+        else:
+            score = num_supported_sentences / num_classified_sentences
         precision = 4
         score = round(score, precision)
         return score, unsupported_sentences, supported_sentences

--- a/futureagi/agentic_eval/core_evals/fi_metrics/tests/test_groundedness.py
+++ b/futureagi/agentic_eval/core_evals/fi_metrics/tests/test_groundedness.py
@@ -1,0 +1,36 @@
+from agentic_eval.core_evals.fi_metrics.groundedness import GroundednessScore
+
+
+class TestGroundednessScore:
+    """Regression tests for GroundednessScore.compute edge cases."""
+
+    def test_empty_input_does_not_crash(self):
+        # No sentences to evaluate must not raise ZeroDivisionError.
+        score, unsupported, supported = GroundednessScore.compute([])
+        assert score == 1.0
+        assert unsupported == []
+        assert supported == []
+
+    def test_none_sentences_excluded_from_denominator(self):
+        # A malformed entry with sentence=None must not dilute the score: one
+        # supported sentence plus one None entry should score 1.0, not 0.5.
+        result = GroundednessScore.compute(
+            [
+                {
+                    "sentence": "The sky is blue.",
+                    "supporting_evidence": ["Sky appears blue."],
+                },
+                {"sentence": None, "supporting_evidence": []},
+            ]
+        )
+        assert result[0] == 1.0
+
+    def test_mixed_supported_and_unsupported_unchanged(self):
+        # Normal case is unchanged: one supported plus one unsupported = 0.5.
+        result = GroundednessScore.compute(
+            [
+                {"sentence": "a", "supporting_evidence": ["x"]},
+                {"sentence": "b", "supporting_evidence": []},
+            ]
+        )
+        assert result[0] == 0.5


### PR DESCRIPTION
While reading through the groundedness metric I hit two edge cases in `GroundednessScore.compute` (`agentic_eval/core_evals/fi_metrics/groundedness.py`). Both come from scoring against the raw input length instead of the sentences that were actually classified:

```python
total_sentences = len(sentences_with_evidence)
...
for sentence_with_evidence in sentences_with_evidence:
    sentence_str = sentence_with_evidence.get("sentence")
    ...
    if sentence_str is None:
        continue          # skipped, and never added to supported/unsupported
    ...
score = num_supported_sentences / total_sentences
```

**1. Empty input crashes.** If `sentences_with_evidence` is empty, `total_sentences` is 0 and the division raises `ZeroDivisionError`. Grounding an empty or very short response (nothing extractable) takes down the evaluator instead of returning a score.

**2. Null sentences silently lower the score.** An entry whose `sentence` is `None` is skipped during classification but still counted in `total_sentences`. So one supported sentence plus one malformed (`None`) entry scores `0.5` instead of `1.0` — a malformed entry drags down a fully grounded response.

```python
>>> GroundednessScore.compute([])
ZeroDivisionError: division by zero
>>> GroundednessScore.compute([
...     {"sentence": "a", "supporting_evidence": ["x"]},
...     {"sentence": None, "supporting_evidence": []},
... ])[0]
0.5   # expected 1.0
```

### Fix

Score over the sentences that were actually classified (`supported + unsupported`) rather than the raw input length, and treat a response with no evaluable sentences as fully grounded (nothing is unsupported). The normal path (all sentences present) is unchanged, since with no `None` entries the two counts are equal.

**Why `1.0` for the empty case:** the metric measures whether the response makes claims that lack support. An empty response makes no claims, so there is nothing unsupported to penalize. Returning `0.0` would report "said nothing" as "everything hallucinated", which punishes legitimately short output. Returning `None` would change the return contract for existing callers of `compute`. If a downstream gate needs to fail closed on empty responses, that is really a check on response emptiness, and it is clearer to enforce it explicitly upstream than to encode it in the groundedness score.

### Tests

Added `tests/test_groundedness.py` covering the empty input, the null-sentence case, and the unchanged mixed case. They fail on `main` (the first two) and pass with this change.
