### PR TITLE
fix(gateway): avoid duplicate metadata aliases

### DIFF
--- a/frontend/src/sections/gateway/components/GatewayMetadata.jsx
+++ b/frontend/src/sections/gateway/components/GatewayMetadata.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import {
+  getGatewayMetadataEntries,
+  stringifyGatewayMetadata,
+  stringifyGatewayMetadataValue,
+} from "../utils/metadataDisplay";
+
+export function GatewayMetadataJson({ metadata }) {
+  return React.useMemo(() => stringifyGatewayMetadata(metadata), [metadata]);
+}
+
+GatewayMetadataJson.propTypes = {
+  metadata: PropTypes.any,
+};
+
+export function GatewayMetadataTable({ metadata }) {
+  const entries = React.useMemo(
+    () => getGatewayMetadataEntries(metadata),
+    [metadata],
+  );
+
+  if (entries.length === 0) {
+    return (
+      <Stack alignItems="center" py={4}>
+        <Typography variant="body2" color="text.secondary">
+          No metadata
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 600 }}>Key</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Value</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entries.map(([key, value]) => (
+            <TableRow key={key}>
+              <TableCell>{key}</TableCell>
+              <TableCell sx={{ wordBreak: "break-all" }}>
+                {stringifyGatewayMetadataValue(value)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+GatewayMetadataTable.propTypes = {
+  metadata: PropTypes.object,
+};

--- a/frontend/src/sections/gateway/components/GatewayMetadata.test.jsx
+++ b/frontend/src/sections/gateway/components/GatewayMetadata.test.jsx
@@ -1,0 +1,180 @@
+import React from "react";
+import { render, screen } from "src/utils/test-utils";
+import { markGeneratedCamelAlias } from "src/utils/responseAliasMetadata";
+import { describe, expect, it } from "vitest";
+import { GatewayMetadataJson, GatewayMetadataTable } from "./GatewayMetadata";
+import {
+  hasGatewayMetadata,
+  normalizeGatewayMetadata,
+  normalizeGatewayMetadataField,
+  normalizeGatewayMetadataResponse,
+  stringifyGatewayMetadata,
+} from "../utils/metadataDisplay";
+
+const withGeneratedAliases = (obj) => {
+  const out = { ...obj };
+  Object.keys(obj).forEach((key) => {
+    if (key.includes("_")) {
+      const camel = key.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
+      if (camel !== key && !(camel in out)) {
+        out[camel] = obj[key];
+        markGeneratedCamelAlias(out, camel);
+      }
+    }
+  });
+  return out;
+};
+
+describe("GatewayMetadata Unit", () => {
+  it("renders metadata tables without generated alias rows", () => {
+    const metadata = withGeneratedAliases({ user_id: "abc" });
+    metadata.nested = withGeneratedAliases({ inner_key: 1 });
+
+    render(<GatewayMetadataTable metadata={metadata} />);
+
+    expect(metadata.userId).toBe("abc");
+    expect(metadata.nested.innerKey).toBe(1);
+    expect(Object.keys(metadata)).toContain("userId");
+    expect(Object.keys(metadata.nested)).toContain("innerKey");
+    expect(screen.getByText("user_id")).toBeInTheDocument();
+    expect(screen.getByText("abc")).toBeInTheDocument();
+    expect(screen.queryByText("userId")).not.toBeInTheDocument();
+    expect(screen.getByText("nested")).toBeInTheDocument();
+    expect(screen.getByText('{"inner_key":1}')).toBeInTheDocument();
+    expect(screen.queryByText(/innerKey/)).not.toBeInTheDocument();
+  });
+
+  it("keeps real camelCase metadata when the snake_case sibling differs", () => {
+    render(
+      <GatewayMetadataTable
+        metadata={{
+          user_id: "snake-value",
+          userId: "camel-value",
+          nested: {
+            inner_key: 1,
+            innerKey: 2,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("user_id")).toBeInTheDocument();
+    expect(screen.getByText("snake-value")).toBeInTheDocument();
+    expect(screen.getByText("userId")).toBeInTheDocument();
+    expect(screen.getByText("camel-value")).toBeInTheDocument();
+    expect(
+      screen.getByText('{"inner_key":1,"innerKey":2}'),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps real camelCase metadata when same-valued siblings are user-defined", () => {
+    render(
+      <GatewayMetadataTable
+        metadata={{
+          user_id: "same-value",
+          userId: "same-value",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("user_id")).toBeInTheDocument();
+    expect(screen.getByText("userId")).toBeInTheDocument();
+    expect(screen.getAllByText("same-value")).toHaveLength(2);
+  });
+
+  it("keeps real object-valued camelCase metadata without generated provenance", () => {
+    render(
+      <GatewayMetadataTable
+        metadata={{
+          object_key: { a: 1 },
+          objectKey: { a: 1 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("object_key")).toBeInTheDocument();
+    expect(screen.getByText("objectKey")).toBeInTheDocument();
+    expect(screen.getAllByText('{"a":1}')).toHaveLength(2);
+  });
+
+  it("renders JSON metadata with generated aliases hidden and __proto__ preserved as data", () => {
+    const metadata = JSON.parse(
+      '{"__proto__":{"polluted":true},"safe_key":1,"nested":{"inner_key":2}}',
+    );
+    metadata.safeKey = metadata.safe_key;
+    metadata.nested.innerKey = metadata.nested.inner_key;
+    markGeneratedCamelAlias(metadata, "safeKey");
+    markGeneratedCamelAlias(metadata.nested, "innerKey");
+
+    render(<GatewayMetadataJson metadata={metadata} />);
+
+    const json = stringifyGatewayMetadata(metadata);
+    expect(
+      Object.prototype.hasOwnProperty.call(Object.prototype, "polluted"),
+    ).toBe(false);
+    expect(json).toContain('"__proto__"');
+    expect(json).toContain('"safe_key"');
+    expect(json).not.toContain('"safeKey"');
+    expect(json).not.toContain('"innerKey"');
+    expect(screen.getByText(/"safe_key": 1/)).toBeInTheDocument();
+  });
+
+  it("treats canonical metadata and non-null scalars as present", () => {
+    expect(hasGatewayMetadata({ user_id: 1, userId: 1 })).toBe(true);
+    expect(hasGatewayMetadata("plain-text")).toBe(true);
+    expect(stringifyGatewayMetadata("plain-text")).toBe('"plain-text"');
+    expect(hasGatewayMetadata(undefined)).toBe(false);
+    expect(hasGatewayMetadata(null)).toBe(false);
+    expect(hasGatewayMetadata({})).toBe(false);
+    render(<GatewayMetadataTable metadata={undefined} />);
+    expect(screen.getByText("No metadata")).toBeInTheDocument();
+  });
+
+  it("normalizes generated aliases recursively without dropping real camelCase keys", () => {
+    const metadata = withGeneratedAliases({
+      user_id: "abc",
+      userId: "real-user-field",
+      items: [withGeneratedAliases({ request_id: "req-1" })],
+    });
+
+    const normalized = normalizeGatewayMetadata(metadata);
+
+    expect(Object.keys(normalized)).toEqual(["user_id", "userId", "items"]);
+    expect(Object.keys(normalized.items[0])).toEqual(["request_id"]);
+    expect(normalized.userId).toBe("real-user-field");
+    expect(normalized.items[0].requestId).toBeUndefined();
+  });
+
+  it("normalizes gateway detail records before they are cached", () => {
+    const record = {
+      id: "log-1",
+      metadata: withGeneratedAliases({ user_id: "abc" }),
+    };
+
+    const normalized = normalizeGatewayMetadataField(record);
+
+    expect(record.metadata.userId).toBe("abc");
+    expect(normalized).not.toBe(record);
+    expect(Object.keys(normalized.metadata)).toEqual(["user_id"]);
+    expect(normalized.metadata.userId).toBeUndefined();
+    expect({ ...normalized.metadata }.userId).toBeUndefined();
+  });
+
+  it("normalizes enveloped gateway detail responses before they are cached", () => {
+    const response = {
+      status: "ok",
+      result: {
+        id: "log-1",
+        metadata: withGeneratedAliases({ request_id: "req-1" }),
+      },
+    };
+
+    const normalized = normalizeGatewayMetadataResponse(response);
+
+    expect(response.result.metadata.requestId).toBe("req-1");
+    expect(normalized).not.toBe(response);
+    expect(normalized.result).not.toBe(response.result);
+    expect(Object.keys(normalized.result.metadata)).toEqual(["request_id"]);
+    expect(normalized.result.metadata.requestId).toBeUndefined();
+  });
+});

--- a/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
@@ -22,6 +22,8 @@ import { useTheme } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
 import { useApiKeyDetail, useRevokeApiKey } from "./hooks/useApiKeys";
 import EditKeyDialog from "./EditKeyDialog";
+import { GatewayMetadataJson } from "../components/GatewayMetadata";
+import { hasGatewayMetadata } from "../utils/metadataDisplay";
 import { useAnalyticsOverview } from "../analytics/hooks/useAnalyticsOverview";
 import { useAnalyticsUsage } from "../analytics/hooks/useAnalyticsUsage";
 import { val } from "../utils/analyticsHelpers";
@@ -282,7 +284,7 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
             </Box>
 
             {/* Metadata */}
-            {keyData.metadata && Object.keys(keyData.metadata).length > 0 && (
+            {hasGatewayMetadata(keyData.metadata) && (
               <Box>
                 <Typography variant="subtitle2" mb={1}>
                   Metadata
@@ -298,7 +300,7 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
                     overflowX: "auto",
                   }}
                 >
-                  {JSON.stringify(keyData.metadata, null, 2)}
+                  <GatewayMetadataJson metadata={keyData.metadata} />
                 </Box>
               </Box>
             )}

--- a/frontend/src/sections/gateway/keys/hooks/useApiKeys.js
+++ b/frontend/src/sections/gateway/keys/hooks/useApiKeys.js
@@ -5,6 +5,7 @@ import {
   keepPreviousData,
 } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
+import { normalizeGatewayMetadataField } from "../../utils/metadataDisplay";
 
 const QUERY_KEY = "agentcc-api-keys";
 
@@ -45,7 +46,7 @@ export function useApiKeyDetail(keyId) {
     queryKey: [QUERY_KEY, "detail", keyId],
     queryFn: async () => {
       const { data } = await axios.get(endpoints.gateway.apiKeyDetail(keyId));
-      return normalizeApiKey(data.result);
+      return normalizeGatewayMetadataField(data.result);
     },
     enabled: Boolean(keyId),
     staleTime: 15000,

--- a/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
@@ -28,6 +28,7 @@ import {
 import Iconify from "src/components/iconify";
 import useRequestDetail from "./hooks/useRequestDetail";
 import FeedbackWidget from "../guardrails/FeedbackWidget";
+import { GatewayMetadataTable } from "../components/GatewayMetadata";
 import { formatCost } from "../utils/formatters";
 
 // ---------------------------------------------------------------------------
@@ -321,42 +322,7 @@ function ResponseTab({ log }) {
 MetadataTab.propTypes = { log: PropTypes.object.isRequired };
 
 function MetadataTab({ log }) {
-  const entries = Object.entries(log.metadata || {});
-
-  if (entries.length === 0) {
-    return (
-      <Stack alignItems="center" py={4}>
-        <Typography variant="body2" color="text.secondary">
-          No metadata
-        </Typography>
-      </Stack>
-    );
-  }
-
-  return (
-    <Box p={2}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ fontWeight: 600 }}>Key</TableCell>
-            <TableCell sx={{ fontWeight: 600 }}>Value</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {entries.map(([key, value]) => (
-            <TableRow key={key}>
-              <TableCell>{key}</TableCell>
-              <TableCell sx={{ wordBreak: "break-all" }}>
-                {typeof value === "object"
-                  ? JSON.stringify(value)
-                  : String(value)}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </Box>
-  );
+  return <GatewayMetadataTable metadata={log.metadata} />;
 }
 
 GuardrailsTab.propTypes = { log: PropTypes.object.isRequired };

--- a/frontend/src/sections/gateway/logs/hooks/useRequestDetail.js
+++ b/frontend/src/sections/gateway/logs/hooks/useRequestDetail.js
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axiosInstance, { endpoints } from "src/utils/axios";
+import { normalizeGatewayMetadataResponse } from "../../utils/metadataDisplay";
 
 /**
  * Fetches the full detail for a single request log entry.
@@ -14,7 +15,7 @@ export default function useRequestDetail(logId) {
       const res = await axiosInstance.get(
         endpoints.gateway.requestLogDetail(logId),
       );
-      return res.data;
+      return normalizeGatewayMetadataResponse(res.data);
     },
     enabled: Boolean(logId),
   });

--- a/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
@@ -21,6 +21,8 @@ import {
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 import { useSessionDetail, useSessionRequests } from "./hooks/useSessions";
+import { GatewayMetadataJson } from "../components/GatewayMetadata";
+import { hasGatewayMetadata } from "../utils/metadataDisplay";
 import {
   formatDateTime as formatDate,
   formatCost,
@@ -136,7 +138,7 @@ const SessionDetailDrawer = ({ sessionId, open, onClose }) => {
               </Card>
             </Stack>
 
-            {session.metadata && Object.keys(session.metadata).length > 0 && (
+            {hasGatewayMetadata(session.metadata) && (
               <Box mb={3}>
                 <Typography variant="subtitle2" mb={1}>
                   Metadata
@@ -151,7 +153,7 @@ const SessionDetailDrawer = ({ sessionId, open, onClose }) => {
                       whiteSpace: "pre-wrap",
                     }}
                   >
-                    {JSON.stringify(session.metadata, null, 2)}
+                    <GatewayMetadataJson metadata={session.metadata} />
                   </Typography>
                 </Card>
               </Box>

--- a/frontend/src/sections/gateway/sessions/hooks/useSessions.js
+++ b/frontend/src/sections/gateway/sessions/hooks/useSessions.js
@@ -5,6 +5,7 @@ import {
   keepPreviousData,
 } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
+import { normalizeGatewayMetadataField } from "../../utils/metadataDisplay";
 
 const SESSION_KEY = "agentcc-sessions";
 
@@ -27,7 +28,7 @@ export function useSessionDetail(id) {
     queryKey: [SESSION_KEY, "detail", id],
     queryFn: async () => {
       const { data } = await axios.get(endpoints.gateway.sessions.detail(id));
-      return data.result;
+      return normalizeGatewayMetadataField(data.result);
     },
     enabled: Boolean(id),
     staleTime: 15000,

--- a/frontend/src/sections/gateway/utils/metadataDisplay.js
+++ b/frontend/src/sections/gateway/utils/metadataDisplay.js
@@ -1,0 +1,79 @@
+import { isGeneratedCamelAlias } from "src/utils/responseAliasMetadata";
+
+const isObject = (value) => Boolean(value && typeof value === "object");
+
+export const normalizeGatewayMetadata = (metadata, seen = new WeakMap()) => {
+  if (!isObject(metadata)) return metadata;
+
+  if (seen.has(metadata)) return seen.get(metadata);
+
+  if (Array.isArray(metadata)) {
+    const result = [];
+    seen.set(metadata, result);
+    metadata.forEach((item, index) => {
+      result[index] = normalizeGatewayMetadata(item, seen);
+    });
+    return result;
+  }
+
+  const result = Object.create(null);
+  seen.set(metadata, result);
+  Object.entries(metadata).forEach(([key, value]) => {
+    if (isGeneratedCamelAlias(metadata, key)) return;
+    Object.defineProperty(result, key, {
+      value: normalizeGatewayMetadata(value, seen),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  });
+  return result;
+};
+
+export const normalizeGatewayMetadataField = (record) => {
+  if (!record || typeof record !== "object" || !("metadata" in record)) {
+    return record;
+  }
+
+  return {
+    ...record,
+    metadata: normalizeGatewayMetadata(record.metadata),
+  };
+};
+
+export const normalizeGatewayMetadataResponse = (response) => {
+  const normalized = normalizeGatewayMetadataField(response);
+  if (!normalized?.result || typeof normalized.result !== "object") {
+    return normalized;
+  }
+
+  return {
+    ...normalized,
+    result: normalizeGatewayMetadataField(normalized.result),
+  };
+};
+
+export const getGatewayMetadataEntries = (metadata) => {
+  const normalized = normalizeGatewayMetadata(metadata);
+  return isObject(normalized) ? Object.entries(normalized) : [];
+};
+
+export const hasGatewayMetadata = (metadata) =>
+  metadata !== null &&
+  metadata !== undefined &&
+  (!isObject(metadata) || getGatewayMetadataEntries(metadata).length > 0);
+
+export const stringifyGatewayMetadata = (metadata, space = 2) => {
+  const normalized =
+    metadata === null || metadata === undefined
+      ? {}
+      : normalizeGatewayMetadata(metadata);
+  const json = JSON.stringify(normalized, null, space);
+  return json === undefined ? String(normalized) : json;
+};
+
+export const stringifyGatewayMetadataValue = (value) => {
+  const normalized = normalizeGatewayMetadata(value);
+  const json = isObject(normalized) ? JSON.stringify(normalized) : undefined;
+  return json === undefined ? String(normalized) : json;
+};

--- a/frontend/src/utils/__tests__/axios.test.js
+++ b/frontend/src/utils/__tests__/axios.test.js
@@ -5,50 +5,11 @@ vi.mock("../Mixpanel", () => ({
 }));
 
 import axiosInstance from "../axios";
+import { canonicalKeys } from "../canonicalKeys";
+import { isGeneratedCamelAlias } from "../responseAliasMetadata";
 
-describe("axios response shape", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.restoreAllMocks();
-  });
-
-  it("keeps request bodies immutable and lets contract validation catch drift", () => {
-    const fulfilled = axiosInstance.interceptors.request.handlers.find(
-      (handler) => handler.fulfilled,
-    )?.fulfilled;
-
-    const body = {
-      query_config: {
-        time_range: { preset: "7D" },
-        metrics: [{ name: "Latency", type: "system_metric" }],
-      },
-      queryConfig: {
-        timeRange: { preset: "7D" },
-        metrics: [{ name: "Latency", type: "system_metric" }],
-      },
-    };
-    const config = {
-      url: "/tracer/dashboard/7f9d0f16-9d42-48b6-9bb8-44cdb1a9c0ab/widgets/preview/",
-      method: "post",
-      data: body,
-    };
-
-    expect(() => fulfilled(config)).toThrowError(
-      "request body contract validation failed",
-    );
-    expect(config.data).toEqual({
-      query_config: {
-        time_range: { preset: "7D" },
-        metrics: [{ name: "Latency", type: "system_metric" }],
-      },
-      queryConfig: {
-        timeRange: { preset: "7D" },
-        metrics: [{ name: "Latency", type: "system_metric" }],
-      },
-    });
-  });
-
-  it("preserves canonical response keys without adding camelCase aliases", () => {
+describe("axios response shape Unit", () => {
+  it("adds camelCase aliases while canonicalKeys still hides duplicates", () => {
     const fulfilled = axiosInstance.interceptors.response.handlers.find(
       (handler) => handler.fulfilled,
     )?.fulfilled;
@@ -73,6 +34,53 @@ describe("axios response shape", () => {
     expect(Object.keys(result.data.span_attributes)).toEqual([
       "gen_ai.usage.total_tokens",
     ]);
+    expect(isGeneratedCamelAlias(result.data, "createdAt")).toBe(false);
+  });
+
+  it("marks generated metadata aliases while preserving enumerable compatibility", () => {
+    const fulfilled = axiosInstance.interceptors.response.handlers.find(
+      (handler) => handler.fulfilled,
+    )?.fulfilled;
+
+    const response = {
+      data: {
+        metadata: {
+          generated_key: "generated",
+          explicit_key: "same-value",
+          explicitKey: "same-value",
+          events: [{ request_id: "req-1" }],
+        },
+      },
+    };
+
+    const result = fulfilled(response);
+
+    expect(result.data.metadata.generatedKey).toBe("generated");
+    expect(result.data.metadata.events[0].requestId).toBe("req-1");
+    expect(Object.keys(result.data.metadata)).toEqual([
+      "generated_key",
+      "explicit_key",
+      "explicitKey",
+      "events",
+      "generatedKey",
+    ]);
+    expect(Object.keys(result.data.metadata.events[0])).toEqual([
+      "request_id",
+      "requestId",
+    ]);
+    expect(JSON.stringify(result.data.metadata)).toContain("generatedKey");
+    expect(JSON.stringify(result.data.metadata)).toContain("requestId");
+    expect({ ...result.data.metadata }.generatedKey).toBe("generated");
+
+    expect(isGeneratedCamelAlias(result.data.metadata, "generatedKey")).toBe(
+      true,
+    );
+    expect(isGeneratedCamelAlias(result.data.metadata, "explicitKey")).toBe(
+      false,
+    );
+    expect(
+      isGeneratedCamelAlias(result.data.metadata.events[0], "requestId"),
+    ).toBe(true);
   });
 
   it("warns by default when documented error responses drift from the generated contract", async () => {

--- a/frontend/src/utils/__tests__/canonicalKeys.test.js
+++ b/frontend/src/utils/__tests__/canonicalKeys.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { canonicalKeys, canonicalEntries, canonicalValues } from "../utils";
+import {
+  canonicalKeys,
+  canonicalEntries,
+  canonicalValues,
+} from "../canonicalKeys";
+import { canonicalKeys as legacyCanonicalKeys } from "../utils";
 
 // Helper that simulates a legacy object containing both canonical keys and
 // old alias keys so iteration sees both.
@@ -16,7 +21,7 @@ const withAliases = (obj) => {
   return out;
 };
 
-describe("canonicalKeys / canonicalEntries / canonicalValues", () => {
+describe("canonicalKeys / canonicalEntries / canonicalValues Unit", () => {
   it("returns only snake_case keys when both forms exist", () => {
     const obj = withAliases({ user_id: 1, total_rows: 10 });
     // Sanity check: the aliased object has doubled keys
@@ -27,6 +32,12 @@ describe("canonicalKeys / canonicalEntries / canonicalValues", () => {
       "totalRows",
     ]);
     expect(canonicalKeys(obj).sort()).toEqual(["total_rows", "user_id"]);
+  });
+
+  it("preserves the legacy utils export path", () => {
+    expect(legacyCanonicalKeys(withAliases({ user_id: 1 }))).toEqual([
+      "user_id",
+    ]);
   });
 
   it("keeps genuine camelCase keys that have no snake_case twin", () => {
@@ -92,5 +103,67 @@ describe("canonicalKeys / canonicalEntries / canonicalValues", () => {
     const obj = withAliases({ tone_17_apr_2026: { neutral: 10 } });
     expect(Object.keys(obj)).toContain("tone17Apr2026");
     expect(canonicalKeys(obj)).toEqual(["tone_17_apr_2026"]);
+  });
+
+  it("preserves the legacy contract by hiding camelCase twins by key", () => {
+    const metadata = {
+      user_id: "snake-value",
+      userId: "camel-value",
+      nested: {
+        inner_key: 1,
+        innerKey: 2,
+      },
+      events: [
+        {
+          request_id: "snake-request",
+          requestId: "camel-request",
+        },
+      ],
+    };
+
+    expect(canonicalKeys(metadata).sort()).toEqual([
+      "events",
+      "nested",
+      "user_id",
+    ]);
+    expect(canonicalKeys(metadata.nested)).toEqual(["inner_key"]);
+    expect(canonicalKeys(metadata.events[0])).toEqual(["request_id"]);
+  });
+
+  it("preserves __proto__ data while filtering generated aliases", () => {
+    const metadata = JSON.parse(
+      '{"__proto__":{"polluted":true},"safe_key":1,"safeKey":1,"nested":{"__proto__":{"nested":true},"inner_key":2,"innerKey":2}}',
+    );
+
+    const entries = canonicalEntries(metadata);
+    const nestedEntries = canonicalEntries(metadata.nested);
+
+    expect(Object.prototype.polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(metadata, "__proto__")).toBe(
+      true,
+    );
+    expect(entries.map(([key]) => key)).toEqual([
+      "__proto__",
+      "safe_key",
+      "nested",
+    ]);
+    expect(nestedEntries.map(([key]) => key)).toEqual([
+      "__proto__",
+      "inner_key",
+    ]);
+    expect(
+      entries.some(([key, value]) => key === "__proto__" && value.polluted),
+    ).toBe(true);
+    expect(
+      nestedEntries.some(([key, value]) => key === "__proto__" && value.nested),
+    ).toBe(true);
+  });
+
+  it("drops serialized object and array aliases by key at the current level", () => {
+    const metadata = JSON.parse(
+      '{"object_key":{"a":1},"objectKey":{"a":1},"array_key":[{"b":2}],"arrayKey":[{"b":2}]}',
+    );
+
+    expect(canonicalKeys(metadata)).toEqual(["object_key", "array_key"]);
   });
 });

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -20,10 +20,147 @@ import {
 import { resetUser } from "./Mixpanel";
 import logger from "./logger";
 import { RESPONSE_CODES } from "./constants";
+import { markGeneratedCamelAlias } from "./responseAliasMetadata";
 
 // ----------------------------------------------------------------------
 //
 const axiosInstance = axios.create({ baseURL: HOST_API });
+
+// ----------------------------------------------------------------------
+// Compatibility bridge: backend responses are now snake_case, but a lot of
+// existing UI code still reads camelCase keys (`columnConfig`, `rowId`,
+// `totalRows`, etc.). Add camelCase aliases on responses so those flows keep
+// working while new dynamic-field lists can use canonicalKeys/canonicalEntries
+// to avoid showing both forms.
+// ----------------------------------------------------------------------
+const SNAKE_TO_CAMEL_RE = /_([a-z0-9])/g;
+
+function snakeToCamelKey(key) {
+  return key.replace(SNAKE_TO_CAMEL_RE, (_, c) => c.toUpperCase());
+}
+
+const USER_KEYED_MAP_FIELDS = new Set([
+  "variable_names",
+  "mapping",
+  "placeholders",
+  "params",
+  "headers",
+  "choice_scores",
+  "attributes",
+  "span_attributes",
+  "trace_attributes",
+  "session_attributes",
+  "call_attributes",
+  "voice_call_attributes",
+]);
+
+function buildAliasTable(obj) {
+  const table = {};
+  const keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    if (!key.includes("_")) continue;
+    const camel = snakeToCamelKey(key);
+    if (camel !== key && !(camel in obj)) {
+      table[camel] = key;
+    }
+  }
+  return table;
+}
+
+function isSpecialObject(obj) {
+  return (
+    obj instanceof Date ||
+    obj instanceof RegExp ||
+    (typeof FormData !== "undefined" && obj instanceof FormData) ||
+    (typeof Blob !== "undefined" && obj instanceof Blob) ||
+    (typeof File !== "undefined" && obj instanceof File)
+  );
+}
+
+function addCamelAliases(obj, seen, markGeneratedAliases = false) {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (seen.has(obj)) return obj;
+  seen.add(obj);
+
+  if (isSpecialObject(obj)) return obj;
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i += 1) {
+      addCamelAliases(obj[i], seen, markGeneratedAliases);
+    }
+    return obj;
+  }
+
+  const originalKeys = Object.keys(obj);
+  for (let i = 0; i < originalKeys.length; i += 1) {
+    const key = originalKeys[i];
+    if (USER_KEYED_MAP_FIELDS.has(key)) continue;
+    const value = obj[key];
+    if (value !== null && typeof value === "object") {
+      addCamelAliases(value, seen, markGeneratedAliases || key === "metadata");
+    }
+  }
+
+  // Keep aliases enumerable because many legacy call sites spread API objects
+  // before reading camelCase keys. Inside user-owned metadata subtrees, also
+  // mark generated aliases so gateway renderers can hide phantom fields without
+  // changing response object enumerability for existing consumers.
+  const aliases = buildAliasTable(obj);
+  Object.keys(aliases).forEach((camel) => {
+    const snake = aliases[camel];
+    try {
+      obj[camel] = obj[snake];
+      if (markGeneratedAliases) markGeneratedCamelAlias(obj, camel);
+    } catch {
+      // Ignore read-only / frozen objects.
+    }
+  });
+
+  return obj;
+}
+
+function stripCamelAliases(obj, seen) {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (seen.has(obj)) return obj;
+  seen.add(obj);
+
+  if (isSpecialObject(obj)) return obj;
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i += 1) {
+      stripCamelAliases(obj[i], seen);
+    }
+    return obj;
+  }
+
+  const keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    const value = obj[key];
+    if (value !== null && typeof value === "object") {
+      stripCamelAliases(value, seen);
+    }
+    if (/[A-Z]/.test(key) && !key.includes("_")) {
+      const snakeKey = key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+      if (
+        snakeKey !== key &&
+        Object.prototype.hasOwnProperty.call(obj, snakeKey) &&
+        obj[snakeKey] === obj[key]
+      ) {
+        try {
+          delete obj[key];
+        } catch {
+          // Ignore non-configurable objects.
+        }
+      }
+    }
+  }
+
+  return obj;
+}
 
 const avoidRedirect = [
   "/auth/jwt/register",

--- a/frontend/src/utils/canonicalKeys.js
+++ b/frontend/src/utils/canonicalKeys.js
@@ -1,0 +1,42 @@
+// API response objects can contain both a snake_case key and a camelCase alias
+// for the same value. Those aliases are plain enumerable own-properties, so
+// `Object.keys(obj)` returns both keys and dynamic UI lists can render
+// duplicate fields.
+//
+// These helpers only de-dupe an object that already has both keys. They do
+// not add aliases or mutate response payloads. Filtering is key-shape-only;
+// it does not verify value equality or generated-alias provenance, so do not
+// use it for user-owned metadata where real camelCase siblings must remain.
+const SNAKE_TO_CAMEL_ALIAS_RE = /_([a-z0-9])/g;
+
+// Forward-mapping is robust to digit separators
+// (e.g. `tone_17_apr_2026` -> `tone17Apr2026`), which a reverse regex on
+// camelCase cannot recover.
+const buildAliasSet = (obj) => {
+  const aliases = new Set();
+  const keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i += 1) {
+    const k = keys[i];
+    if (!k.includes("_")) continue;
+    const alias = k.replace(SNAKE_TO_CAMEL_ALIAS_RE, (_, c) => c.toUpperCase());
+    if (alias !== k) aliases.add(alias);
+  }
+  return aliases;
+};
+
+export const canonicalKeys = (obj) => {
+  if (!obj || typeof obj !== "object") return [];
+  const aliases = buildAliasSet(obj);
+  return Object.keys(obj).filter((key) => !aliases.has(key));
+};
+
+export const canonicalEntries = (obj) => {
+  if (!obj || typeof obj !== "object") return [];
+  const aliases = buildAliasSet(obj);
+  return Object.entries(obj).filter(([key]) => !aliases.has(key));
+};
+
+export const canonicalValues = (obj) => {
+  if (!obj || typeof obj !== "object") return [];
+  return canonicalKeys(obj).map((key) => obj[key]);
+};

--- a/frontend/src/utils/responseAliasMetadata.js
+++ b/frontend/src/utils/responseAliasMetadata.js
@@ -1,0 +1,31 @@
+// Generated-alias provenance is live-object metadata only. The Axios bridge
+// attaches it only for user-owned metadata subtrees that need display-time
+// filtering. It is intentionally non-enumerable and does not survive JSON
+// serialization, structured clones, or object spread; render/cache boundaries
+// should normalize before copying.
+const GENERATED_CAMEL_ALIAS_KEYS = Symbol("generatedCamelAliasKeys");
+
+export function markGeneratedCamelAlias(obj, aliasKey) {
+  if (!obj || typeof obj !== "object") return;
+
+  try {
+    let aliases = obj[GENERATED_CAMEL_ALIAS_KEYS];
+    if (!aliases) {
+      aliases = new Set();
+      Object.defineProperty(obj, GENERATED_CAMEL_ALIAS_KEYS, {
+        value: aliases,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      });
+    }
+    aliases.add(aliasKey);
+  } catch {
+    // Ignore read-only / frozen objects; the alias itself is best-effort too.
+  }
+}
+
+export function isGeneratedCamelAlias(obj, key) {
+  if (!obj || typeof obj !== "object") return false;
+  return Boolean(obj[GENERATED_CAMEL_ALIAS_KEYS]?.has(key));
+}

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -4,6 +4,11 @@ import { palette } from "src/theme/palette";
 
 import { extractJinjaVariables } from "./jinjaVariables";
 import { logger } from "./logger";
+export {
+  canonicalKeys,
+  canonicalEntries,
+  canonicalValues,
+} from "./canonicalKeys";
 
 export const colorPalette = [
   { bgColor: "#ECE8FF", textColor: "#846EFF", graphBgColor: "#D7D0FF" },
@@ -811,50 +816,24 @@ export function mergeRefs(...refs) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// canonicalKeys / canonicalEntries / canonicalValues
-//
-// Some client-side objects can contain both a snake_case key and a camelCase
-// key for the same value, especially data built outside generated contracts
-// (for example imported JSON, local cache, or developer tooling payloads).
-// Those duplicate keys are plain enumerable own-properties, so `Object.keys`
-// returns both and dynamic UI lists can render duplicate fields.
-//
-// These helpers only de-dupe an object that already has both keys. They do
-// not add aliases or mutate response payloads.
-// ---------------------------------------------------------------------------
-const SNAKE_TO_CAMEL_ALIAS_RE = /_([a-z0-9])/g;
-
-// Forward-mapping is robust to digit separators
-// (e.g. `tone_17_apr_2026` -> `tone17Apr2026`), which a reverse regex on
-// camelCase cannot recover.
-const buildAliasSet = (obj) => {
-  const aliases = new Set();
-  const keys = Object.keys(obj);
-  for (let i = 0; i < keys.length; i += 1) {
-    const k = keys[i];
-    if (!k.includes("_")) continue;
-    const alias = k.replace(SNAKE_TO_CAMEL_ALIAS_RE, (_, c) => c.toUpperCase());
-    if (alias !== k) aliases.add(alias);
+export const objectCamelToSnake = (obj) => {
+  if (obj === null || obj === undefined) {
+    return obj;
   }
-  return aliases;
-};
 
-export const canonicalKeys = (obj) => {
-  if (!obj || typeof obj !== "object") return [];
-  const aliases = buildAliasSet(obj);
-  return Object.keys(obj).filter((key) => !aliases.has(key));
-};
+  if (Array.isArray(obj)) {
+    return obj.map((item) => objectCamelToSnake(item));
+  }
 
-export const canonicalEntries = (obj) => {
-  if (!obj || typeof obj !== "object") return [];
-  const aliases = buildAliasSet(obj);
-  return Object.entries(obj).filter(([key]) => !aliases.has(key));
-};
+  if (typeof obj !== "object") {
+    return obj;
+  }
 
-export const canonicalValues = (obj) => {
-  if (!obj || typeof obj !== "object") return [];
-  return canonicalKeys(obj).map((key) => obj[key]);
+  return Object.keys(obj).reduce((acc, key) => {
+    const snakeKey = camelToSnakeCase(key);
+    acc[snakeKey] = objectCamelToSnake(obj[key]);
+    return acc;
+  }, {});
 };
 
 // Converts object keys from snake_case to camelCase


### PR DESCRIPTION
## Summary

This PR fixes the gateway metadata drawers so generated camelCase compatibility aliases no longer render as duplicate user metadata.

The Axios response compatibility bridge still keeps generated camelCase aliases enumerable and directly addressable for existing consumers. Within `metadata` subtrees, it now also tags generated aliases with non-enumerable provenance metadata. Gateway detail fetches normalize direct and enveloped `metadata` fields before caching, and the shared gateway metadata presenter normalizes again at render time. That normalization recursively removes only aliases tagged as generated while preserving real user-provided camelCase metadata fields, including same-valued and object-valued camelCase siblings.

## Linked issues

Closes #907

## Type of change

- [x] 🐛 Bug fix (gateway metadata rendering only; raw Axios alias enumerability remains compatible)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Commands run from `frontend/` unless noted otherwise:

- `npx -y yarn@1.22.22 test:run src/utils/__tests__/axios.test.js src/utils/__tests__/canonicalKeys.test.js src/sections/gateway/components/GatewayMetadata.test.jsx` — passed, 25 tests
- `npx -y yarn@1.22.22 test:unit src/utils/__tests__/axios.test.js src/utils/__tests__/canonicalKeys.test.js src/sections/gateway/components/GatewayMetadata.test.jsx` — passed, 25 tests; confirms the new tests are exercised by the repo's `test:unit` name filter
- `npx -y yarn@1.22.22 eslint --quiet --no-cache --max-warnings=0 src/utils/axios.js src/utils/utils.js src/utils/canonicalKeys.js src/utils/responseAliasMetadata.js src/utils/__tests__/axios.test.js src/utils/__tests__/canonicalKeys.test.js src/sections/gateway/utils/metadataDisplay.js src/sections/gateway/components/GatewayMetadata.jsx src/sections/gateway/components/GatewayMetadata.test.jsx src/sections/gateway/logs/hooks/useRequestDetail.js src/sections/gateway/sessions/hooks/useSessions.js src/sections/gateway/keys/hooks/useApiKeys.js src/sections/gateway/logs/RequestDetailDrawer.jsx src/sections/gateway/sessions/SessionDetailDrawer.jsx src/sections/gateway/keys/KeyDetailDrawer.jsx` — passed
- `npx -y prettier@3.3.3 --check src/utils/axios.js src/utils/utils.js src/utils/canonicalKeys.js src/utils/responseAliasMetadata.js src/utils/__tests__/axios.test.js src/utils/__tests__/canonicalKeys.test.js src/sections/gateway/utils/metadataDisplay.js src/sections/gateway/components/GatewayMetadata.jsx src/sections/gateway/components/GatewayMetadata.test.jsx src/sections/gateway/logs/hooks/useRequestDetail.js src/sections/gateway/sessions/hooks/useSessions.js src/sections/gateway/keys/hooks/useApiKeys.js src/sections/gateway/logs/RequestDetailDrawer.jsx src/sections/gateway/sessions/SessionDetailDrawer.jsx src/sections/gateway/keys/KeyDetailDrawer.jsx` — passed after formatting touched files only
- `npx -y yarn@1.22.22 type-check` — passed/no-op (`No tsconfig.json found, skipping type check`)
- `node --input-type=module -e "const keys = await import('./src/utils/canonicalKeys.js'); const aliases = await import('./src/utils/responseAliasMetadata.js'); const obj = {user_id: 1}; obj.userId = 1; aliases.markGeneratedCamelAlias(obj, 'userId'); console.log(keys.canonicalKeys(obj).join(','), aliases.isGeneratedCamelAlias(obj, 'userId'));"` — passed; output `user_id true`
- `npx -y yarn@1.22.22 build` — passed; emitted existing repo-wide lint/chunk warnings plus Sentry auth-token/source-map noise, but exited 0
- `npx -y -p node@20.17.0 -p yarn@1.22.22 yarn check-all` — passed under Node 20.17, matching `frontend/.nvmrc` and the frontend CI workflow. ESLint completed with 0 errors and 439 existing warnings, type-check was the existing no-op, and Vitest passed 134 test files / 1453 tests.
- `git diff --check` — passed from repo root

## Suggested changelog entry

Gateway metadata drawers now hide generated camelCase compatibility aliases in request logs, sessions, and API-key details while preserving real user-defined camelCase metadata fields.

## Screenshots / recordings (if UI)

Not included. This is a metadata rendering bug fix covered by deterministic Axios/provenance tests plus focused shared metadata presenter tests; I did not run a live gateway instance to capture drawer screenshots.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally under the repo-supported Node 20.17 runtime
- [x] I've updated the documentation where relevant (release-note text is suggested above; the changelog is maintained outside this repo)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

## Notes for maintainers

I intentionally did **not** add `metadata` to `USER_KEYED_MAP_FIELDS`; the issue notes that some system metadata elsewhere still relies on camelCase aliases. I also intentionally avoided changing raw Axios `metadata` alias enumerability globally or attaching generated-alias provenance outside metadata subtrees. Existing response consumers can still read, spread, and serialize generated aliases as before.

The gateway-specific fix happens at the detail-data/rendering boundary: generated metadata-subtree aliases are tagged when Axios creates them, then gateway metadata normalization removes only tagged aliases before those fields are cached/rendered. This keeps real user-owned camelCase metadata visible, including same-valued siblings that key-shape-only canonicalization would otherwise drop.
