### PR TITLE
fix(agentic_eval): warn on large input truncation; add truncation flag to metadata

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -172,6 +172,8 @@ class CustomPromptEvaluator(LLM):
             is_turing=self._is_turing,
             input_keys=list(kwargs.keys()),
         )
+        # Track if any input was truncated
+        truncation_warning_fields = []
 
         # Create template context from kwargs with context windowing for large values
         from .context_window import fit_to_context
@@ -183,11 +185,16 @@ class CustomPromptEvaluator(LLM):
             value = kwargs[key]
             # Apply context windowing for large values (traces, spans, JSON blobs)
             if isinstance(value, str) and len(value) > _MAX_CONTEXT_CHARS:
+                logger.warning("input_truncated", field=key, original_length=len(value), max_chars=_MAX_CONTEXT_CHARS)
+                truncation_warning_fields.append(key)
                 value = fit_to_context(value, max_total_chars=_MAX_CONTEXT_CHARS, label=key)
             elif isinstance(value, (dict, list)):
                 serialized = json.dumps(value, default=str)
                 if len(serialized) > _MAX_CONTEXT_CHARS:
+                    logger.warning("input_truncated", field=key, original_length=len(serialized), max_chars=_MAX_CONTEXT_CHARS)
+                    truncation_warning_fields.append(key)
                     value = fit_to_context(value, max_total_chars=_MAX_CONTEXT_CHARS, label=key)
+            
             template_context[key] = value
 
         # Render the rule prompt with the template context using Jinja2
@@ -494,6 +501,8 @@ class CustomPromptEvaluator(LLM):
             },
             "response_time": eval_runtime_ms,
             "explanation": chat_completion_response_json["explanation"],
+            "truncated": bool(truncation_warning_fields),
+            "truncated_fields": truncation_warning_fields,
             # "data": chat_history,
         })
 

--- a/futureagi/tests/test_custom_prompt_evaluator_truncation.py
+++ b/futureagi/tests/test_custom_prompt_evaluator_truncation.py
@@ -1,0 +1,26 @@
+import json
+import pytest
+from unittest.mock import patch
+from futureagi.agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import CustomPromptEvaluator
+
+
+def test_truncation_warning_on_large_input():
+    """Verify truncation warning is logged and flagged in metadata."""
+    evaluator = CustomPromptEvaluator(
+        rule_prompt="Evaluate: {{input}}",
+        model="gpt-4",
+    )
+    
+    large_input = "x" * 200001
+    
+    with patch.object(evaluator, 'call_llm') as mock_llm:
+        mock_llm.return_value = '{"result": "Pass", "explanation": "Test"}'
+        
+        result = evaluator._evaluate(
+            required_keys=["input"],
+            input=large_input
+        )
+        
+        metadata = json.loads(result["metadata"])
+        assert metadata["truncated"] == True
+        assert "input" in metadata["truncated_fields"]


### PR DESCRIPTION
## Summary
This PR adds truncation warning functionality to CustomPromptEvaluator to address silent input truncation. When input values exceed 200K characters, the evaluator now logs a warning and adds metadata flags so users can detect when their evaluations ran on truncated data instead of complete inputs.

## Linked issues
Closes #317

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?
- Verified logging output when input exceeds _MAX_CONTEXT_CHARS (200K)
- Confirmed truncation_warning_fields list populates correctly for both string and dict/list inputs
- Checked metadata JSON includes "truncated" (boolean) and "truncated_fields" (list) keys
- Validated serialization to JSON works correctly

## Changes made
- Added `truncation_warning_fields = []` tracker at start of _evaluate()
- Added `logger.warning()` calls when truncation occurs (with field name and original length)
- Added fields to truncation list when truncation happens
- Added `"truncated"` and `"truncated_fields"` to EvalResult metadata dict

## Checklist
- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII