### PR TITLE
feat(evals): add trajectory_quality evaluator

### DIFF
--- a/futureagi/model_hub/system_evals/agent/trajectory_quality.yaml
+++ b/futureagi/model_hub/system_evals/agent/trajectory_quality.yaml
@@ -1,0 +1,129 @@
+eval_id: 204
+name: trajectory_quality
+description: Evaluates the quality of an agent's execution trajectory without requiring a reference answer. Assesses tool selection appropriateness, step efficiency, and inter-step data flow using LLM-as-judge.
+criteria: "You are evaluating the quality of an AI agent's execution trajectory: the\
+  \ sequence of tool calls, observations, and reasoning steps it took to answer the\
+  \ user's input.\n\nThe trajectory is provided as a JSON array where each step has:\
+  \ a role (assistant/tool), the action taken or tool called, and the result or observation.\n\
+  \n## Criteria\n\n1. Tool selection appropriateness: The tools selected at each step\
+  \ must be suitable for accomplishing the user's goal.\n   - Pass: Agent uses a search\
+  \ tool to retrieve information before summarizing it.\n   - Fail: Agent uses a write\
+  \ tool when the user only asked a read-only question.\n   - Pass: Agent selects\
+  \ the most direct tool available for the task.\n   - Fail: Agent uses a general\
+  \ tool when a more specific tool would be more appropriate.\n\n2. Step efficiency:\
+  \ The agent should accomplish the task without unnecessary redundancy.\n   - Pass:\
+  \ Each tool call contributes new information or progresses the task.\n   - Fail:\
+  \ The agent calls the same tool with the same arguments multiple times without a\
+  \ clear reason.\n   - Pass: Exploratory calls (to understand what data is available)\
+  \ are acceptable as first steps.\n   - Fail: The agent repeats failed attempts without\
+  \ changing its approach.\n\n3. Inter-step data flow: Each step should build logically\
+  \ on the results of previous steps.\n   - Pass: The agent uses the output from step\
+  \ N as input to step N+1.\n   - Fail: The agent ignores a tool's output and proceeds\
+  \ with a different assumption.\n   - Pass: When a step fails, the agent adapts its\
+  \ next step accordingly.\n   - Fail: The agent proceeds as if a failed step succeeded.\n\
+  \n## Anti-bias Rules\n\n- Multiple valid paths can exist for the same task: do NOT\
+  \ penalize a trajectory simply because it differs from what you would have done.\n\
+  - Exploratory tool calls (e.g., listing available options before selecting one)\
+  \ are NOT inefficient — they reflect good information-gathering behavior.\n- Error\
+  \ recovery with retries is acceptable; only penalize if the agent retries the identical\
+  \ failing call without any change.\n- Short trajectories are not automatically better\
+  \ than long ones if the task genuinely requires multiple steps.\n- Do not penalize\
+  \ the agent for tool calls that returned errors outside its control.\n\n## Scoring\n\
+  \nScore 0.0 if the trajectory is clearly misguided: wrong tools, circular loops,\
+  \ or ignoring step outputs entirely. Score 0.5 if the trajectory is partially sound:\
+  \ mostly appropriate tools and flow, but with notable inefficiency or a step that\
+  \ ignores prior results. Score 1.0 if the trajectory is well-structured: appropriate\
+  \ tools at each step, no unnecessary redundancy, and each step builds logically\
+  \ on the last.\n\n## Inputs\n\n<input>{{input}}</input>\n\n<trajectory>{{context}}</trajectory>\n\
+  \n<output>{{output}}</output>"
+eval_tags:
+- Agents
+- Quality
+- Trajectory
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - input
+  - context
+  - output
+  output: score
+  eval_type_id: AgentEvaluator
+  config:
+    check_internet:
+      type: boolean
+      default: false
+  config_params_desc:
+    input: The original user query or task the agent was given
+    context: >-
+      The agent's execution trajectory as a JSON array. Each element represents one
+      step: {"role": "assistant"|"tool", "action": "tool_name or reasoning", "result":
+      "observation or output"}
+    output: The agent's final response to the user
+  param_modalities:
+    input:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+    context:
+    - TEXT
+    - JSON
+    - LIST
+    - ARRAY
+    output:
+    - TEXT
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+  rule_prompt: "You are evaluating the quality of an AI agent's execution trajectory:\
+    \ the sequence of tool calls, observations, and reasoning steps it took to answer\
+    \ the user's input.\n\nThe trajectory is provided as a JSON array where each step\
+    \ has: a role (assistant/tool), the action taken or tool called, and the result\
+    \ or observation.\n\n## Criteria\n\n1. Tool selection appropriateness: The tools\
+    \ selected at each step must be suitable for accomplishing the user's goal.\n \
+    \  - Pass: Agent uses a search tool to retrieve information before summarizing\
+    \ it.\n   - Fail: Agent uses a write tool when the user only asked a read-only\
+    \ question.\n   - Pass: Agent selects the most direct tool available for the task.\n\
+    \   - Fail: Agent uses a general tool when a more specific tool would be more\
+    \ appropriate.\n\n2. Step efficiency: The agent should accomplish the task without\
+    \ unnecessary redundancy.\n   - Pass: Each tool call contributes new information\
+    \ or progresses the task.\n   - Fail: The agent calls the same tool with the same\
+    \ arguments multiple times without a clear reason.\n   - Pass: Exploratory calls\
+    \ (to understand what data is available) are acceptable as first steps.\n   -\
+    \ Fail: The agent repeats failed attempts without changing its approach.\n\n3.\
+    \ Inter-step data flow: Each step should build logically on the results of previous\
+    \ steps.\n   - Pass: The agent uses the output from step N as input to step N+1.\n\
+    \   - Fail: The agent ignores a tool's output and proceeds with a different assumption.\n\
+    \   - Pass: When a step fails, the agent adapts its next step accordingly.\n  \
+    \ - Fail: The agent proceeds as if a failed step succeeded.\n\n## Anti-bias Rules\n\
+    \n- Multiple valid paths can exist for the same task: do NOT penalize a trajectory\
+    \ simply because it differs from what you would have done.\n- Exploratory tool\
+    \ calls (e.g., listing available options before selecting one) are NOT inefficient\
+    \ — they reflect good information-gathering behavior.\n- Error recovery with retries\
+    \ is acceptable; only penalize if the agent retries the identical failing call\
+    \ without any change.\n- Short trajectories are not automatically better than\
+    \ long ones if the task genuinely requires multiple steps.\n- Do not penalize the\
+    \ agent for tool calls that returned errors outside its control.\n\n## Scoring\n\
+    \nScore 0.0 if the trajectory is clearly misguided: wrong tools, circular loops,\
+    \ or ignoring step outputs entirely. Score 0.5 if the trajectory is partially\
+    \ sound: mostly appropriate tools and flow, but with notable inefficiency or a\
+    \ step that ignores prior results. Score 1.0 if the trajectory is well-structured:\
+    \ appropriate tools at each step, no unnecessary redundancy, and each step builds\
+    \ logically on the last.\n\n## Inputs\n\n<input>{{input}}</input>\n\n<trajectory>{{context}}</trajectory>\n\
+    \n<output>{{output}}</output>"

--- a/futureagi/model_hub/system_evals/tests/test_trajectory_quality_eval.py
+++ b/futureagi/model_hub/system_evals/tests/test_trajectory_quality_eval.py
@@ -1,0 +1,216 @@
+"""
+Tests for the trajectory_quality agent evaluator YAML.
+
+This eval fills the gap between deterministic trajectory evals
+(trajectory_match, tool_call_accuracy, step_count) and LLM-based
+quality judgment. Unlike the deterministic evals, this does NOT require
+a reference/expected trajectory — it judges quality without ground truth.
+
+Verifies:
+- YAML schema (required fields, types)
+- Template variables match required_keys
+- eval_id uniqueness (no collision with function evals)
+- Criteria covers the three key dimensions
+- Context accepts JSON/LIST for trajectory input
+- eval_id is distinct from all existing function and agent evals
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+YAML_PATH = (
+    Path(__file__).resolve().parent.parent / "agent" / "trajectory_quality.yaml"
+)
+FUNCTION_DIR = Path(__file__).resolve().parent.parent / "function"
+AGENT_DIR = Path(__file__).resolve().parent.parent / "agent"
+
+
+@pytest.fixture(scope="module")
+def eval_def():
+    return yaml.safe_load(YAML_PATH.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_loads_without_error(eval_def):
+    assert eval_def is not None
+
+
+def test_required_top_level_fields(eval_def):
+    for field in ("eval_id", "name", "description", "criteria", "config"):
+        assert field in eval_def, f"Missing required field: {field}"
+
+
+def test_name_matches_filename(eval_def):
+    assert eval_def["name"] == "trajectory_quality"
+
+
+def test_output_type_is_percentage(eval_def):
+    assert eval_def["output_type_normalized"] == "percentage"
+
+
+def test_pass_threshold_in_range(eval_def):
+    threshold = eval_def["pass_threshold"]
+    assert 0.0 <= threshold <= 1.0
+
+
+def test_eval_type_is_agent_evaluator(eval_def):
+    assert eval_def["config"]["eval_type_id"] == "AgentEvaluator"
+
+
+# ---------------------------------------------------------------------------
+# required_keys vs. template variables
+# ---------------------------------------------------------------------------
+
+
+def test_required_keys_present(eval_def):
+    required_keys = eval_def["config"]["required_keys"]
+    assert "input" in required_keys
+    assert "context" in required_keys
+    assert "output" in required_keys
+
+
+def test_rule_prompt_contains_all_template_variables(eval_def):
+    rule_prompt = eval_def["config"]["rule_prompt"]
+    for key in eval_def["config"]["required_keys"]:
+        assert f"{{{{{key}}}}}" in rule_prompt, (
+            f"Template variable '{{{{{key}}}}}' missing from rule_prompt"
+        )
+
+
+def test_config_params_desc_covers_required_keys(eval_def):
+    params_desc = eval_def["config"]["config_params_desc"]
+    for key in eval_def["config"]["required_keys"]:
+        assert key in params_desc, f"config_params_desc missing key: {key}"
+
+
+def test_param_modalities_covers_required_keys(eval_def):
+    modalities = eval_def["config"]["param_modalities"]
+    for key in eval_def["config"]["required_keys"]:
+        assert key in modalities, f"param_modalities missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Trajectory input — context must accept JSON and LIST
+# ---------------------------------------------------------------------------
+
+
+def test_context_accepts_json_modality(eval_def):
+    """Trajectory is a JSON array — context must accept JSON."""
+    context_modalities = eval_def["config"]["param_modalities"]["context"]
+    assert "JSON" in context_modalities, "context must support JSON modality for trajectory arrays"
+
+
+def test_context_accepts_list_modality(eval_def):
+    context_modalities = eval_def["config"]["param_modalities"]["context"]
+    assert "LIST" in context_modalities
+
+
+def test_context_accepts_text_modality(eval_def):
+    """Trajectory can also be passed as a formatted text string."""
+    context_modalities = eval_def["config"]["param_modalities"]["context"]
+    assert "TEXT" in context_modalities
+
+
+# ---------------------------------------------------------------------------
+# eval_id uniqueness — must not collide with function OR agent evals
+# ---------------------------------------------------------------------------
+
+
+def test_eval_id_value(eval_def):
+    """eval_id 204 follows citation_quality (203) and answer_relevance (202)."""
+    assert eval_def["eval_id"] == 204
+
+
+def test_no_collision_with_agent_evals(eval_def):
+    our_id = eval_def["eval_id"]
+    for path in AGENT_DIR.glob("*.yaml"):
+        if path.name == "trajectory_quality.yaml":
+            continue
+        other = yaml.safe_load(path.read_text())
+        assert other.get("eval_id") != our_id, (
+            f"eval_id {our_id} collision with agent eval {path.name}"
+        )
+
+
+def test_no_collision_with_function_evals(eval_def):
+    our_id = eval_def["eval_id"]
+    for path in FUNCTION_DIR.glob("*.yaml"):
+        other = yaml.safe_load(path.read_text())
+        assert other.get("eval_id") != our_id, (
+            f"eval_id {our_id} collision with function eval {path.name}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Differentiation from deterministic trajectory evals
+# ---------------------------------------------------------------------------
+
+
+def test_is_agent_evaluator_not_custom_code(eval_def):
+    """Key differentiator: this is LLM-as-judge, not deterministic code."""
+    assert eval_def["config"]["eval_type_id"] == "AgentEvaluator"
+    # Deterministic evals use CustomCodeEval
+    assert eval_def["config"]["eval_type_id"] != "CustomCodeEval"
+
+
+def test_does_not_require_expected_key(eval_def):
+    """Unlike trajectory_match and tool_call_accuracy, this eval works without
+    a reference/expected trajectory — it judges quality without ground truth."""
+    required_keys = eval_def["config"]["required_keys"]
+    assert "expected" not in required_keys, (
+        "trajectory_quality must NOT require 'expected' — it judges without ground truth"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criteria content sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_criteria_covers_tool_selection(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "tool" in criteria and ("select" in criteria or "appropriate" in criteria)
+
+
+def test_criteria_covers_step_efficiency(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "efficien" in criteria or "redundan" in criteria or "unnecessary" in criteria
+
+
+def test_criteria_covers_data_flow(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "data flow" in criteria or "inter-step" in criteria or "builds" in criteria
+
+
+def test_criteria_has_anti_bias_rules(eval_def):
+    criteria = eval_def["criteria"].lower()
+    assert "anti-bias" in criteria or "multiple valid" in criteria
+
+
+# ---------------------------------------------------------------------------
+# Tags and visibility
+# ---------------------------------------------------------------------------
+
+
+def test_has_agents_tag(eval_def):
+    assert "Agents" in eval_def.get("eval_tags", [])
+
+
+def test_has_trajectory_tag(eval_def):
+    assert "Trajectory" in eval_def.get("eval_tags", [])
+
+
+def test_visible_in_ui(eval_def):
+    assert eval_def.get("visible_ui") is True
+
+
+def test_allow_copy_is_true(eval_def):
+    assert eval_def["permissions"]["allow_copy"] is True


### PR DESCRIPTION
## Summary

Adds `trajectory_quality`, the first LLM-as-Judge agent evaluator for execution trajectory quality — without requiring a reference trajectory.

Closes #1245

## Gap this fills

The existing trajectory evals are all deterministic and require a known-correct reference:

| Existing Eval | Type | Requires reference? |
|---------------|------|-------------------|
| `trajectory_match` | CustomCodeEval | ✅ Yes — string comparison |
| `tool_call_accuracy` | CustomCodeEval | ✅ Yes — expected tool calls |
| `step_count` | CustomCodeEval | ✅ Yes — expected count |
| **`trajectory_quality` (this PR)** | **AgentEvaluator** | **❌ No — works without ground truth** |

This matters for open-ended agentic tasks where multiple valid execution paths exist. `trajectory_match` would fail any path that differs from the reference, even if it's equally valid.

## Implementation

**File:** `futureagi/model_hub/system_evals/agent/trajectory_quality.yaml`
**Type:** Agent (LLM-as-Judge) — YAML-only, reuses `CustomPromptEvaluator`
**eval_id:** 204 | **Output:** `percentage` (0.0–1.0)

**Inputs:**
- `input` — the original user query
- `context` — the agent's trajectory as a JSON array (`[{"role": ..., "action": ..., "result": ...}]`)
- `output` — the agent's final response

**Criteria (3):**
1. **Tool selection appropriateness** — are the tools chosen suitable for the task?
2. **Step efficiency** — no unnecessary redundancy or repeated failing calls
3. **Inter-step data flow** — each step builds on the prior step's results

**Anti-bias rules:**
- Multiple valid paths are allowed — no penalty for differing from a "canonical" path
- Exploratory tool calls (listing options before selecting) are not penalized
- Error recovery with retries is accepted; only identical repeated failures are penalized

**Design reference:** Aligned with [langchain-ai/agentevals](https://github.com/langchain-ai/agentevals) `TRAJECTORY_ACCURACY_PROMPT` approach (logical sense, progression, efficiency), adapted to Future AGI's YAML eval pattern.

## Tests

`futureagi/model_hub/system_evals/tests/test_trajectory_quality_eval.py` — 20 tests:
- YAML schema validation
- All required keys in template variables
- Context accepts JSON/LIST/TEXT modalities (trajectory can be formatted text or JSON)
- eval_id 204 uniqueness across both agent AND function evals
- Key differentiator: asserts `expected` is NOT a required key
- Confirms `AgentEvaluator` type, not `CustomCodeEval`
- Criteria coverage (tool selection, efficiency, data flow, anti-bias)

## Checklist

- [x] YAML added: `futureagi/model_hub/system_evals/agent/trajectory_quality.yaml`
- [x] Tests added: `futureagi/model_hub/system_evals/tests/test_trajectory_quality_eval.py`
- [x] YAML schema + template vars validated locally
- [x] eval_id 204 — no collision across all agent + function evals
- [x] Differentiation from existing evals verified (opposite type: LLM vs deterministic, no reference required)
- [ ] Seed via `python manage.py seed_system_evals`