### PR TITLE
fix(mcp): validate empty tool arguments against schema

### DIFF
--- a/agentcc-gateway/internal/mcp/server.go
+++ b/agentcc-gateway/internal/mcp/server.go
@@ -1,7 +1,10 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -382,8 +385,16 @@ func (s *Server) handleToolsCall(w http.ResponseWriter, r *http.Request, msg *Me
 
 	// Validate arguments against input schema if available.
 	if len(regTool.Tool.InputSchema) > 0 {
-		if errMsg := validateArgsAgainstSchema(regTool.Tool.InputSchema, params.Arguments); errMsg != "" {
-			writeJSONRPCError(w, msg.ID, ErrCodeInvalidParams, errMsg)
+		if failure := validateArgsAgainstSchemaFailure(regTool.Tool.InputSchema, params.Arguments); failure != nil {
+			slog.Warn("mcp tool call rejected by input schema",
+				"tool", params.Name,
+				"server", regTool.Server,
+				"schema_hash", inputSchemaHash(regTool.Tool.InputSchema),
+				"violation_path", failure.path,
+				"reason", failure.message,
+				"args_preview", redactedArgsPreview(params.Arguments),
+			)
+			writeJSONRPCError(w, msg.ID, ErrCodeInvalidParams, failure.message)
 			return
 		}
 	}
@@ -801,19 +812,35 @@ func stringInSlice(s string, list []string) bool {
 // validateArgsAgainstSchema validates tool call arguments against a JSON Schema.
 // Checks required fields and basic type validation.
 func validateArgsAgainstSchema(schemaRaw json.RawMessage, args map[string]interface{}) string {
+	if failure := validateArgsAgainstSchemaFailure(schemaRaw, args); failure != nil {
+		return failure.message
+	}
+	return ""
+}
+
+type schemaValidationFailure struct {
+	message string
+	path    string
+}
+
+func validateArgsAgainstSchemaFailure(schemaRaw json.RawMessage, args map[string]interface{}) *schemaValidationFailure {
 	var schema struct {
-		Type       string                            `json:"type"`
-		Required   []string                          `json:"required"`
-		Properties map[string]map[string]interface{} `json:"properties"`
+		Type                 string                            `json:"type"`
+		Required             []string                          `json:"required"`
+		Properties           map[string]map[string]interface{} `json:"properties"`
+		AdditionalProperties interface{}                       `json:"additionalProperties"`
 	}
 	if err := json.Unmarshal(schemaRaw, &schema); err != nil {
-		return "" // Can't parse schema, skip validation
+		return nil // Can't parse schema, skip validation
 	}
 
 	// Check required fields.
 	for _, req := range schema.Required {
 		if _, ok := args[req]; !ok {
-			return fmt.Sprintf("missing required argument: %q", req)
+			return &schemaValidationFailure{
+				message: fmt.Sprintf("missing required argument: %q", req),
+				path:    "$." + req,
+			}
 		}
 	}
 
@@ -821,18 +848,70 @@ func validateArgsAgainstSchema(schemaRaw json.RawMessage, args map[string]interf
 	for name, val := range args {
 		prop, ok := schema.Properties[name]
 		if !ok {
-			continue // Extra args are allowed
+			if disallowAdditionalProperties(schema.AdditionalProperties) {
+				return &schemaValidationFailure{
+					message: fmt.Sprintf("unexpected argument: %q", name),
+					path:    "$." + name,
+				}
+			}
+			continue // Extra args are allowed unless additionalProperties is false.
 		}
 		expectedType, _ := prop["type"].(string)
 		if expectedType == "" {
 			continue
 		}
 		if !matchesJSONType(val, expectedType) {
-			return fmt.Sprintf("argument %q: expected type %q", name, expectedType)
+			return &schemaValidationFailure{
+				message: fmt.Sprintf("argument %q: expected type %q", name, expectedType),
+				path:    "$." + name,
+			}
 		}
 	}
 
-	return ""
+	return nil
+}
+
+func disallowAdditionalProperties(additionalProperties interface{}) bool {
+	allowed, ok := additionalProperties.(bool)
+	return ok && !allowed
+}
+
+func inputSchemaHash(schemaRaw json.RawMessage) string {
+	var compact bytes.Buffer
+	hashInput := []byte(schemaRaw)
+	if err := json.Compact(&compact, schemaRaw); err == nil {
+		hashInput = compact.Bytes()
+	}
+
+	sum := sha256.Sum256(hashInput)
+	return hex.EncodeToString(sum[:8])
+}
+
+func redactedArgsPreview(args map[string]interface{}) map[string]string {
+	preview := make(map[string]string, len(args))
+	for name, val := range args {
+		preview[name] = redactedValuePreview(val)
+	}
+	return preview
+}
+
+func redactedValuePreview(val interface{}) string {
+	switch v := val.(type) {
+	case nil:
+		return "null"
+	case string:
+		return fmt.Sprintf("string(len=%d)", len(v))
+	case bool:
+		return "boolean"
+	case float64, float32, int, int64, int32, uint, uint64, uint32:
+		return "number"
+	case []interface{}:
+		return fmt.Sprintf("array(len=%d)", len(v))
+	case map[string]interface{}:
+		return fmt.Sprintf("object(keys=%d)", len(v))
+	default:
+		return fmt.Sprintf("%T", val)
+	}
 }
 
 // matchesJSONType checks if a Go value matches a JSON Schema type.

--- a/agentcc-gateway/internal/mcp/server_test.go
+++ b/agentcc-gateway/internal/mcp/server_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -898,6 +900,198 @@ func TestSchemaValidation_MissingRequired(t *testing.T) {
 	}
 }
 
+func TestSchemaValidation_OmittedArgumentsStillChecksRequired(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	schema := `{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`
+	tools := []Tool{{Name: "action", InputSchema: json.RawMessage(schema)}}
+	s.Registry().RegisterServer("srv", tools)
+
+	upstreamCalled := false
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		var msg Message
+		json.NewDecoder(r.Body).Decode(&msg)
+		resp, _ := NewResponse(msg.ID, ToolCallResult{Content: []ContentPart{{Type: "text", Text: "ok"}}})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockUpstream.Close()
+
+	client := NewClient(ClientConfig{ServerID: "srv", URL: mockUpstream.URL, TransportType: "http"})
+	client.transport = NewHTTPTransport(mockUpstream.URL, AuthConfig{})
+	client.healthy.Store(true)
+	client.tools.Store(&tools)
+	s.clientsMu.Lock()
+	s.clients["srv"] = client
+	s.clientsMu.Unlock()
+
+	sessionID := initializeSession(t, s)
+
+	msg := &Message{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  MethodToolsCall,
+		Params:  json.RawMessage(`{"name":"srv_action"}`),
+	}
+
+	w := postMCP(t, s, msg, map[string]string{"MCP-Session-Id": sessionID})
+	resp := decodeResponse(t, w)
+	if resp.Error == nil {
+		t.Fatal("expected error for missing required field with omitted arguments")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Fatalf("expected code %d, got %d", ErrCodeInvalidParams, resp.Error.Code)
+	}
+	if upstreamCalled {
+		t.Fatal("expected schema validation to block before calling upstream")
+	}
+}
+
+func TestSchemaValidation_MultipleRequiredAndNoAdditionalProperties(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	schema := `{"type":"object","required":["query","limit"],"additionalProperties":false,"properties":{"query":{"type":"string"},"limit":{"type":"integer"}}}`
+	tools := []Tool{{Name: "action", InputSchema: json.RawMessage(schema)}}
+	s.Registry().RegisterServer("srv", tools)
+
+	upstreamCalls := 0
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		var msg Message
+		json.NewDecoder(r.Body).Decode(&msg)
+		resp, _ := NewResponse(msg.ID, ToolCallResult{Content: []ContentPart{{Type: "text", Text: "ok"}}})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockUpstream.Close()
+
+	client := NewClient(ClientConfig{ServerID: "srv", URL: mockUpstream.URL, TransportType: "http"})
+	client.transport = NewHTTPTransport(mockUpstream.URL, AuthConfig{})
+	client.healthy.Store(true)
+	client.tools.Store(&tools)
+	s.clientsMu.Lock()
+	s.clients["srv"] = client
+	s.clientsMu.Unlock()
+
+	sessionID := initializeSession(t, s)
+
+	tests := []struct {
+		name      string
+		arguments map[string]interface{}
+		want      string
+	}{
+		{
+			name:      "missing required",
+			arguments: map[string]interface{}{"query": "hello"},
+			want:      `missing required argument: "limit"`,
+		},
+		{
+			name:      "unknown field",
+			arguments: map[string]interface{}{"query": "hello", "limit": 5.0, "unexpected": "bad"},
+			want:      `unexpected argument: "unexpected"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := ToolCallParams{Name: "srv_action", Arguments: tc.arguments}
+			paramsData, _ := json.Marshal(params)
+			msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: MethodToolsCall, Params: paramsData}
+
+			w := postMCP(t, s, msg, map[string]string{"MCP-Session-Id": sessionID})
+			resp := decodeResponse(t, w)
+			if resp.Error == nil {
+				t.Fatal("expected schema validation error")
+			}
+			if resp.Error.Code != ErrCodeInvalidParams {
+				t.Fatalf("expected code %d, got %d", ErrCodeInvalidParams, resp.Error.Code)
+			}
+			if resp.Error.Message != tc.want {
+				t.Fatalf("expected message %q, got %q", tc.want, resp.Error.Message)
+			}
+		})
+	}
+
+	if upstreamCalls != 0 {
+		t.Fatalf("expected schema validation to block before calling upstream, got %d calls", upstreamCalls)
+	}
+}
+
+func TestSchemaValidation_RejectionLogRedactsArgsPreview(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	schema := `{"type":"object","required":["name","token"],"properties":{"name":{"type":"string"},"token":{"type":"string"}}}`
+	tools := []Tool{{Name: "action", InputSchema: json.RawMessage(schema)}}
+	s.Registry().RegisterServer("srv", tools)
+
+	upstreamCalled := false
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		var msg Message
+		json.NewDecoder(r.Body).Decode(&msg)
+		resp, _ := NewResponse(msg.ID, ToolCallResult{Content: []ContentPart{{Type: "text", Text: "ok"}}})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockUpstream.Close()
+
+	client := NewClient(ClientConfig{ServerID: "srv", URL: mockUpstream.URL, TransportType: "http"})
+	client.transport = NewHTTPTransport(mockUpstream.URL, AuthConfig{})
+	client.healthy.Store(true)
+	client.tools.Store(&tools)
+	s.clientsMu.Lock()
+	s.clients["srv"] = client
+	s.clientsMu.Unlock()
+
+	sessionID := initializeSession(t, s)
+
+	params := ToolCallParams{
+		Name: "srv_action",
+		Arguments: map[string]interface{}{
+			"name": "Alice",
+			"note": "super-secret-token",
+		},
+	}
+	paramsData, _ := json.Marshal(params)
+	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: MethodToolsCall, Params: paramsData}
+
+	w := postMCP(t, s, msg, map[string]string{"MCP-Session-Id": sessionID})
+	resp := decodeResponse(t, w)
+	if resp.Error == nil {
+		t.Fatal("expected schema validation error")
+	}
+	if upstreamCalled {
+		t.Fatal("expected schema validation to block before calling upstream")
+	}
+
+	logs := logBuf.String()
+	for _, want := range []string{
+		"mcp tool call rejected by input schema",
+		`"tool":"srv_action"`,
+		`"server":"srv"`,
+		`"schema_hash"`,
+		`"violation_path":"$.token"`,
+		`"args_preview"`,
+		`"note":"string(len=18)"`,
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected logs to contain %q, got %s", want, logs)
+		}
+	}
+	if strings.Contains(logs, "super-secret-token") {
+		t.Fatalf("expected logs to redact raw argument values, got %s", logs)
+	}
+}
+
 func TestSchemaValidation_WrongType(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Close()
@@ -1042,6 +1236,11 @@ func TestValidateArgsAgainstSchema_Unit(t *testing.T) {
 	// Integer as whole float should pass.
 	if msg := validateArgsAgainstSchema(schema, map[string]interface{}{"q": "hello", "limit": 5.0}); msg != "" {
 		t.Errorf("expected pass for 5.0 as integer, got: %s", msg)
+	}
+
+	strictSchema := json.RawMessage(`{"type":"object","required":["q","limit"],"additionalProperties":false,"properties":{"q":{"type":"string"},"limit":{"type":"integer"}}}`)
+	if msg := validateArgsAgainstSchema(strictSchema, map[string]interface{}{"q": "hello", "limit": 5.0, "extra": "bad"}); msg == "" {
+		t.Error("expected error for extra argument when additionalProperties is false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Always validate MCP tool call arguments when an input schema is present, including `arguments: {}` and omitted `arguments`.
- Reject unknown fields when a tool schema sets `additionalProperties: false`.
- Emit a structured schema-rejection log with tool/server, schema hash, violation path, reason, and a redacted argument preview.
- Add regression tests that verify invalid tool calls return `invalid_params` before the upstream tool is called.

## Fixes issue

Fixes #1242

## Tests

- `go test ./internal/mcp -run TestSchemaValidation_(MissingRequired|EmptyArgumentsStillChecksRequired|OmittedArgumentsStillChecksRequired|MultipleRequiredAndNoAdditionalProperties|RejectionLogRedactsArgsPreview|WrongType|ValidArgs)|TestValidateArgsAgainstSchema_Unit -count=1`
- `git diff --check`

Additional local check attempted:

- `go test ./internal/mcp -count=1` currently fails on Windows in `TestTestTool_Success` with `expected positive duration`; the focused schema validation tests above pass.