### PR TITLE
fix(ai-tools): scope knowledge base search by context

### DIFF
--- a/futureagi/ai_tools/tests/test_kb_search_tool.py
+++ b/futureagi/ai_tools/tests/test_kb_search_tool.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+from ai_tools.base import ToolContext
+from ai_tools.tools.web.kb_search import KBSearchInput, KBSearchTool
+from model_hub.models.develop_dataset import KnowledgeBaseFile
+
+
+class FakeEmbeddingManager:
+    last_kwargs = None
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+
+    def retrieve_rag_based_examples(self, **kwargs):
+        type(self).last_kwargs = kwargs
+        return [
+            {
+                "chunk_text": "retrieved content",
+                "score": 0.9,
+                "metadata": {"organization_id": "org-current"},
+            }
+        ]
+
+
+def make_context():
+    return ToolContext(
+        user=SimpleNamespace(id="user-1"),
+        organization=SimpleNamespace(id="org-current"),
+        workspace=SimpleNamespace(id="workspace-current"),
+    )
+
+
+def test_kb_search_scopes_retrieval_by_tool_context_org(monkeypatch):
+    context = make_context()
+    captured_get_kwargs = {}
+
+    def fake_get(**kwargs):
+        captured_get_kwargs.update(kwargs)
+        return SimpleNamespace(
+            id=kwargs["id"],
+            organization=kwargs["organization"],
+            workspace_id=context.workspace_id,
+        )
+
+    FakeEmbeddingManager.last_kwargs = None
+    FakeEmbeddingManager.instantiated = False
+    monkeypatch.setattr(KnowledgeBaseFile.objects, "get", fake_get)
+    monkeypatch.setattr(
+        "agentic_eval.core.embeddings.embedding_manager.EmbeddingManager",
+        FakeEmbeddingManager,
+    )
+
+    result = KBSearchTool().execute(
+        KBSearchInput(query="billing policy", kb_id="kb-current", top_k=3),
+        context,
+    )
+
+    assert not result.is_error
+    assert captured_get_kwargs == {
+        "id": "kb-current",
+        "organization": context.organization,
+        "deleted": False,
+    }
+    assert FakeEmbeddingManager.last_kwargs is not None
+    assert FakeEmbeddingManager.last_kwargs["filter_by"] == {
+        "organization_id": str(context.organization_id)
+    }
+    assert FakeEmbeddingManager.last_kwargs["top_k"] == 3
+
+
+def test_kb_search_rejects_kb_outside_current_context(monkeypatch):
+    def fake_get(**kwargs):
+        raise KnowledgeBaseFile.DoesNotExist
+
+    FakeEmbeddingManager.last_kwargs = None
+    FakeEmbeddingManager.instantiated = False
+    monkeypatch.setattr(KnowledgeBaseFile.objects, "get", fake_get)
+    monkeypatch.setattr(
+        "agentic_eval.core.embeddings.embedding_manager.EmbeddingManager",
+        FakeEmbeddingManager,
+    )
+
+    result = KBSearchTool().execute(
+        KBSearchInput(query="billing policy", kb_id="kb-other-org"),
+        make_context(),
+    )
+
+    assert result.is_error
+    assert result.error_code == "NOT_FOUND"
+    assert not FakeEmbeddingManager.instantiated
+    assert FakeEmbeddingManager.last_kwargs is None
+
+
+def test_kb_search_rejects_kb_from_another_workspace(monkeypatch):
+    def fake_get(**kwargs):
+        return SimpleNamespace(
+            id=kwargs["id"],
+            organization=kwargs["organization"],
+            workspace_id="workspace-other",
+        )
+
+    FakeEmbeddingManager.last_kwargs = None
+    FakeEmbeddingManager.instantiated = False
+    monkeypatch.setattr(KnowledgeBaseFile.objects, "get", fake_get)
+    monkeypatch.setattr(
+        "agentic_eval.core.embeddings.embedding_manager.EmbeddingManager",
+        FakeEmbeddingManager,
+    )
+
+    result = KBSearchTool().execute(
+        KBSearchInput(query="billing policy", kb_id="kb-other-workspace"),
+        make_context(),
+    )
+
+    assert result.is_error
+    assert result.error_code == "PERMISSION_DENIED"
+    assert not FakeEmbeddingManager.instantiated
+    assert FakeEmbeddingManager.last_kwargs is None

--- a/futureagi/ai_tools/tools/web/kb_search.py
+++ b/futureagi/ai_tools/tools/web/kb_search.py
@@ -46,15 +46,40 @@ class KBSearchTool(BaseTool):
     def execute(self, params: KBSearchInput, context: ToolContext) -> ToolResult:
         try:
             from agentic_eval.core.embeddings.embedding_manager import EmbeddingManager
+            from model_hub.models.develop_dataset import KnowledgeBaseFile
+
+            try:
+                # BaseTool.run sets workspace_context, so the default manager also
+                # applies workspace scoping for workspace-bound KBs.
+                kb = KnowledgeBaseFile.objects.get(
+                    id=params.kb_id,
+                    organization=context.organization,
+                    deleted=False,
+                )
+            except KnowledgeBaseFile.DoesNotExist:
+                return ToolResult.not_found("Knowledge base", params.kb_id)
+
+            context_workspace_id = getattr(
+                getattr(context, "workspace", None), "id", None
+            )
+            if (
+                getattr(kb, "workspace_id", None)
+                and context_workspace_id
+                and str(kb.workspace_id) != str(context_workspace_id)
+            ):
+                return ToolResult.permission_denied(
+                    "Knowledge base is not available in the current workspace."
+                )
 
             manager = EmbeddingManager()
-
+            filter_by = {"organization_id": str(context.organization_id)}
             results = manager.retrieve_rag_based_examples(
                 query=params.query,
                 table_name="syn",
                 eval_id=params.kb_id,
                 meta_data_col="chunk_text",
                 input_type="text",
+                filter_by=filter_by,
                 top_k=params.top_k,
                 threshold=0.25,
             )


### PR DESCRIPTION
## Summary

- Verify the requested knowledge base belongs to the current tool context before running vector retrieval.
- Reject knowledge bases from another workspace when a workspace-bound KB is returned.
- Scope the vector search with the current organization metadata filter.
- Add focused tests for allowed search, missing/out-of-context KBs, and workspace mismatch.

## Fixes issue

Fixes #1243

## Tests

- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 ./.venv/Scripts/python.exe -m pytest ai_tools/tests/test_kb_search_tool.py -q`
- `./.venv/Scripts/python.exe -m py_compile ai_tools/tools/web/kb_search.py ai_tools/tests/test_kb_search_tool.py`
