### PR TITLE
[TH-6409] fix(model-hub): allow null values in run_prompt_config dict

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -75048,6 +75048,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "object",
           "additionalProperties": {
             "type": "object",
+            "x-nullable": true,
             "x-json-value": true,
             "description": "Any valid JSON value."
           }

--- a/futureagi/model_hub/serializers/run_prompt.py
+++ b/futureagi/model_hub/serializers/run_prompt.py
@@ -165,8 +165,12 @@ class PromptConfigSerializer(serializers.Serializer):
     model = serializers.CharField(max_length=255, required=False, allow_blank=True)
     # Free-form config: values are mixed JSON (model_name str, isAvailable
     # bool, booleans/dropdowns objects, …). Use JsonValueField so the contract
-    # doesn't constrain every value to a string.
-    run_prompt_config = serializers.DictField(child=JsonValueField(), required=False)
+    # doesn't constrain every value to a string. allow_null because the FE
+    # sends null for unset model params (temperature, top_p, …) meaning "use
+    # provider default" — JSONField's default allow_null=False would 400 them.
+    run_prompt_config = serializers.DictField(
+        child=JsonValueField(allow_null=True), required=False
+    )
     messages = serializers.ListField(
         # content can be a string or a list of typed parts — keep values open.
         child=serializers.DictField(child=JsonValueField()),

--- a/futureagi/model_hub/tests/test_run_prompt_api.py
+++ b/futureagi/model_hub/tests/test_run_prompt_api.py
@@ -354,6 +354,43 @@ class TestAddRunPromptColumnView:
             name="AI Response", dataset=dataset, deleted=False
         ).exists()
 
+    def test_add_run_prompt_column_accepts_null_model_params(
+        self, auth_client, dataset, input_column, valid_run_prompt_config
+    ):
+        """Null values inside run_prompt_config mean "use provider default"
+        and must not be rejected (TH-6409)."""
+        config = {
+            **valid_run_prompt_config,
+            "run_prompt_config": {
+                "model_name": "gpt-4o-mini",
+                "model_type": "llm",
+                "temperature": None,
+                "top_p": None,
+                "max_tokens": None,
+                "presence_penalty": None,
+                "frequency_penalty": None,
+            },
+        }
+        payload = {
+            "dataset_id": str(dataset.id),
+            "name": "AI Response Nulls",
+            "config": config,
+        }
+
+        with patch(
+            "model_hub.tasks.run_prompt.process_prompts_single.apply_async"
+        ):
+            response = auth_client.post(
+                "/model-hub/develops/add_run_prompt_column/",
+                payload,
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert Column.objects.filter(
+            name="AI Response Nulls", dataset=dataset, deleted=False
+        ).exists()
+
     def test_add_run_prompt_column_duplicate_name(
         self, auth_client, dataset, input_column, valid_run_prompt_config
     ):


### PR DESCRIPTION
**Ticket:** [TH-6409](https://linear.app/future-agi/issue/TH-6409/bugfix-run-prompt-config-rejects-null-model-params-this-field-may-not) — Fixes TH-6409

## What was the bug
`POST /model-hub/develops/add_run_prompt_column/` (and every other endpoint validating `config` through `PromptConfigSerializer`) returns 400 — `run_prompt_config.temperature: This field may not be null.` — when the run config carries null model params. The FE always sends `temperature/top_p/max_tokens/presence_penalty/frequency_penalty: null` for unset params, meaning "use provider default", so configuring a run-prompt column on dev is broken.

## What changes have been done
- `futureagi/model_hub/serializers/run_prompt.py` — `run_prompt_config` dict child: `JsonValueField()` → `JsonValueField(allow_null=True)`, with a WHY comment.
- `futureagi/model_hub/tests/test_run_prompt_api.py` — regression test posting the exact null-bearing payload; asserts 200 + column created.
- `api_contracts/openapi/swagger.json` + `frontend/src/api/contracts/openapi-contract.generated.js` — regenerated (one line each: `x-nullable: true` on the dict child).

## Why the changes
TH-6280 (shipped via #1142 on 02/07) typed the free-form dict as `DictField(child=JsonValueField())` to loosen the generated contract from string-only to `z.any()`. But `JsonValueField` extends DRF `JSONField`, whose default `allow_null=False` now rejects every null **value** in the dict — an accidental tightening. The FE contract (`z.any()`) accepts null, so requests passed the FE validator and died at the backend. Top-level `PromptConfigSerializer` params already declare `allow_null=True` with null = provider default; this restores the same semantics inside the dict.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | `add_run_prompt_column` with `run_prompt_config` nulls (temperature, top_p, max_tokens, penalties) | 200, column created (new regression test) |
| 2 | Same payload pre-fix | 400 `This field may not be null` (verified against stashed code) |
| 3 | Existing add/edit/preview run-prompt suites | unchanged, pass |
| 4 | `yarn contracts:check` | passes; swagger diff scoped to `x-nullable: true` on the dict child |

## How to reproduce (original bug)
1. On dev, Develop → dataset → add a Run Prompt column with default model params (leave temperature etc. unset).
2. FE sends `run_prompt_config` with nulls → request 400s with "This field may not be null."

## Commands
```bash
cd futureagi && uv run pytest model_hub/tests/test_run_prompt_api.py -k null_model_params
cd frontend && yarn contracts:check
```

## Videos and screenshots
```
model_hub backend test run — branch fix/th-6409-run-prompt-config-allow-null (PR #1252)

Full suite (bin/test app model_hub, fresh test services + full migration chain incl. CH25):
= 7 failed, 2622 passed, 27 skipped, 188 deselected, 7 xfailed, 1 xpassed in 255.87s (0:04:15) =

Targeted — run-prompt API tests (includes new TH-6409 regression test test_add_run_prompt_column_accepts_null_model_params):
model_hub/tests/test_run_prompt_api.py — 121 passed in 6.86s ✅

The 7 failures are PRE-EXISTING on dev (verified by rerunning the failing files on dev baseline — identical failures), all in unrelated e2e areas:
- test_user_evaluation_tasks.py::TestErrorLocalizerGateE2E (error-localizer skip-message assertions)
- test_voice_annotation_regressions_e2e.py (voice call detail 404 trace_id)
None touch the run-prompt serializer path changed in this PR.

```

https://github.com/user-attachments/assets/93fc4ef3-b244-47e0-bf94-0afdbf6f0a08

https://github.com/user-attachments/assets/b1a5a514-a3e7-4857-8bed-8ac769a58b52
