### PR TITLE
fix: render images and document modalities in eval and experiment drawers

### DIFF
--- a/frontend/src/sections/common/DocumentDatapointCard.test.jsx
+++ b/frontend/src/sections/common/DocumentDatapointCard.test.jsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import DocumentDatapointCard from "./DocumentDatapointCard";
+
+const column = { headerName: "Attachment" };
+
+describe("DocumentDatapointCard", () => {
+  it("renders the column header name", () => {
+    render(<DocumentDatapointCard value={{}} column={column} />);
+    expect(screen.getByText("Attachment")).toBeInTheDocument();
+  });
+
+  it("renders the file name and type from cell_value", () => {
+    render(
+      <DocumentDatapointCard
+        value={{ cell_value: "https://cdn.test/docs/report.pdf" }}
+        column={column}
+      />,
+    );
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when cell_value is missing", () => {
+    render(<DocumentDatapointCard value={{}} column={column} />);
+    expect(screen.getByText("No document added")).toBeInTheDocument();
+  });
+
+  it("does not read the camelCase cellValue key", () => {
+    render(
+      <DocumentDatapointCard
+        value={{ cellValue: "https://cdn.test/docs/ignored.pdf" }}
+        column={column}
+      />,
+    );
+    expect(screen.getByText("No document added")).toBeInTheDocument();
+    expect(screen.queryByText("ignored.pdf")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/common/ImagesDatapointCard.test.jsx
+++ b/frontend/src/sections/common/ImagesDatapointCard.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import ImagesDatapointCard from "./ImagesDatapointCard";
+
+const column = { headerName: "Screenshots" };
+
+describe("ImagesDatapointCard", () => {
+  it("renders the column header name", () => {
+    render(<ImagesDatapointCard value={{ cell_value: [] }} column={column} />);
+    expect(screen.getByText("Screenshots")).toBeInTheDocument();
+  });
+
+  it("renders one image per url from a JSON-string cell_value", () => {
+    const urls = ["https://cdn.test/a.png", "https://cdn.test/b.png"];
+    render(
+      <ImagesDatapointCard
+        value={{ cell_value: JSON.stringify(urls) }}
+        column={column}
+      />,
+    );
+    expect(screen.getByAltText("Image 1")).toHaveAttribute("src", urls[0]);
+    expect(screen.getByAltText("Image 2")).toHaveAttribute("src", urls[1]);
+  });
+
+  it("renders images when cell_value is already an array", () => {
+    const urls = ["https://cdn.test/only.png"];
+    render(
+      <ImagesDatapointCard value={{ cell_value: urls }} column={column} />,
+    );
+    expect(screen.getByAltText("Image 1")).toHaveAttribute("src", urls[0]);
+  });
+
+  it("shows the placeholder when cell_value is missing", () => {
+    render(<ImagesDatapointCard value={{}} column={column} />);
+    expect(screen.getByAltText("No images placeholder")).toBeInTheDocument();
+    expect(screen.queryByAltText("Image 1")).not.toBeInTheDocument();
+  });
+
+  it("does not read the camelCase cellValue key", () => {
+    render(
+      <ImagesDatapointCard
+        value={{ cellValue: ["https://cdn.test/ignored.png"] }}
+        column={column}
+      />,
+    );
+    expect(screen.getByAltText("No images placeholder")).toBeInTheDocument();
+    expect(screen.queryByAltText("Image 1")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
@@ -19,8 +19,6 @@ import axios, { endpoints } from "src/utils/axios";
 import { format } from "date-fns";
 import AudioDatapointCard from "src/components/custom-audio/AudioDatapointCard";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
-import ImagesDatapointCard from "src/sections/common/ImagesDatapointCard";
-import DocumentDatapointCard from "src/sections/common/DocumentDatapointCard";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import AddEvalsFeedbackDrawer from "./../EvalsFeedback/AddEvalsFeedbackDrawer";
@@ -203,15 +201,13 @@ const LogsDrawerChild = ({
           }}
         >
           {data?.required_keys?.map((item, index) => {
-            const value = { cell_value: data?.values?.[item] || "-" };
+            const value = { cellValue: data?.values?.[item] || "-" };
             const columm = {
               headerName: item,
               dataType: data?.input_data_types?.[item],
             };
             const isAudioColumn = columm["dataType"] === "audio";
             const isImageColumn = columm["dataType"] === "image";
-            const isImagesColumn = columm["dataType"] === "images";
-            const isDocumentColumn = columm["dataType"] === "document";
             if (isAudioColumn) {
               return (
                 <AudioPlaybackProvider key={index}>
@@ -221,18 +217,6 @@ const LogsDrawerChild = ({
             } else if (isImageColumn) {
               return (
                 <ImageDatapointCard key={index} value={value} column={columm} />
-              );
-            } else if (isImagesColumn) {
-              return (
-                <ImagesDatapointCard key={index} value={value} column={columm} />
-              );
-            } else if (isDocumentColumn) {
-              return (
-                <DocumentDatapointCard
-                  key={index}
-                  value={value}
-                  column={columm}
-                />
               );
             }
 

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
@@ -19,6 +19,8 @@ import axios, { endpoints } from "src/utils/axios";
 import { format } from "date-fns";
 import AudioDatapointCard from "src/components/custom-audio/AudioDatapointCard";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
+import ImagesDatapointCard from "src/sections/common/ImagesDatapointCard";
+import DocumentDatapointCard from "src/sections/common/DocumentDatapointCard";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import AddEvalsFeedbackDrawer from "./../EvalsFeedback/AddEvalsFeedbackDrawer";
@@ -201,13 +203,15 @@ const LogsDrawerChild = ({
           }}
         >
           {data?.required_keys?.map((item, index) => {
-            const value = { cellValue: data?.values?.[item] || "-" };
+            const value = { cell_value: data?.values?.[item] || "-" };
             const columm = {
               headerName: item,
               dataType: data?.input_data_types?.[item],
             };
             const isAudioColumn = columm["dataType"] === "audio";
             const isImageColumn = columm["dataType"] === "image";
+            const isImagesColumn = columm["dataType"] === "images";
+            const isDocumentColumn = columm["dataType"] === "document";
             if (isAudioColumn) {
               return (
                 <AudioPlaybackProvider key={index}>
@@ -217,6 +221,18 @@ const LogsDrawerChild = ({
             } else if (isImageColumn) {
               return (
                 <ImageDatapointCard key={index} value={value} column={columm} />
+              );
+            } else if (isImagesColumn) {
+              return (
+                <ImagesDatapointCard key={index} value={value} column={columm} />
+              );
+            } else if (isDocumentColumn) {
+              return (
+                <DocumentDatapointCard
+                  key={index}
+                  value={value}
+                  column={columm}
+                />
               );
             }
 

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
@@ -32,6 +32,8 @@ import SvgColor from "src/components/svg-color/svg-color";
 import NumericCell from "src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/NumericCell";
 import { OutputTypes } from "src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
+import ImagesDatapointCard from "src/sections/common/ImagesDatapointCard";
+import DocumentDatapointCard from "src/sections/common/DocumentDatapointCard";
 import AgentFlowRenderer from "./AgentFlowRenderer";
 import { useAddEvaluationFeebackStore } from "src/sections/develop-detail/states";
 import AddEvaluationFeeback from "src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback";
@@ -461,6 +463,24 @@ export default function ExperimentDetailDrawerContent({
     if (col?.data_type === "image") {
       return (
         <ImageDatapointCard
+          value={row?.[col.id]}
+          column={{ ...col, headerName: col?.name, status: col?.status }}
+        />
+      );
+    }
+
+    if (col?.data_type === "images") {
+      return (
+        <ImagesDatapointCard
+          value={row?.[col.id]}
+          column={{ ...col, headerName: col?.name, status: col?.status }}
+        />
+      );
+    }
+
+    if (col?.data_type === "document") {
+      return (
+        <DocumentDatapointCard
           value={row?.[col.id]}
           column={{ ...col, headerName: col?.name, status: col?.status }}
         />


### PR DESCRIPTION
## Summary

Render `images` (multi-image) and `document` datapoint modalities in the Evals log drawer and the Experiment detail drawer, alongside the existing audio/image cards.

## Why / problem

The eval log drawer (`LogsDrawer`) and experiment detail drawer only rendered `audio` and single `image` columns. Columns of type `images` (multiple) or `document` fell through to the default text renderer instead of showing the proper media card.

## What changed

- `frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx`
  - Import `ImagesDatapointCard` and `DocumentDatapointCard`.
  - Add `images` and `document` branches to the required-keys renderer.
- `frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx`
  - Import the same two cards.
  - Add `images` and `document` branches to the cell renderer.

## Tests

- [ ] Frontend lint passes (`yarn lint`)

## Backwards compatibility

Frontend-only, additive rendering branches. No API or schema changes.

## Manual verification

- [ ] Evals log drawer: an `image` column still renders (regression check — see reviewer notes)
- [ ] Evals log drawer: `images` and `document` columns render their media cards
- [ ] Experiment detail drawer: `images` and `document` columns render their media cards
- [ ] Non-media columns still render as before

## Type of change

- [x] Bug fix / feature (render additional modalities)

## Reviewer notes — needs resolution before merge

1. **`LogsDrawer.jsx` value key mismatch.** The value object was changed from `{ cellValue: ... }` to `{ cell_value: ... }`, but `ImageDatapointCard`, `ImagesDatapointCard`, and `DocumentDatapointCard` all read `value?.cellValue`. As written this breaks the existing image card and prevents the new cards from receiving data. Should stay `cellValue`.
2. **`ExperimentDetailDrawerContent.jsx` data-type key.** The new branches check `col?.data_type`, but every existing branch in this component uses `col?.dataType` (camelCase). The new branches likely never match; should be `col?.dataType === "images"` / `"document"`.

## Backout

Revert commit `ea95f7e2d`; no data or migration impact.

## Linear

N/A (no linked ticket)
