### PR TITLE
revert(workbench): undo empty-label tag save flow from #895 [TH-5894]

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelSelectContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelSelectContent.jsx
@@ -49,11 +49,6 @@ const LabelSelectContent = ({
     return [];
   });
 
-  const originalLabelIds = new Set((selectedLabels ?? []).map((l) => l.id));
-  const hasChanges =
-    selectedLabelsList.length !== originalLabelIds.size ||
-    selectedLabelsList.some((l) => !originalLabelIds.has(l.id));
-
   const { mutate: assignLabel, isPending: isAssigning } = useMutation({
     mutationFn: (labelIds) =>
       axios.post(endpoints.develop.runPrompt.assignMultipleLabels, {
@@ -111,6 +106,11 @@ const LabelSelectContent = ({
   );
 
   const handleSave = useCallback(() => {
+    if (selectedLabelsList.length === 0) {
+      return enqueueSnackbar("Please select at least one label", {
+        variant: "warning",
+      });
+    }
     const labelIds = selectedLabelsList.map((label) => label.id);
     assignLabel(labelIds);
   }, [selectedLabelsList, assignLabel]);
@@ -257,7 +257,7 @@ const LabelSelectContent = ({
 
         <LoadingButton
           size="small"
-          disabled={!hasChanges}
+          disabled={selectedLabelsList?.length === 0}
           loading={isAssigning}
           color="primary"
           variant="contained"

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/__tests__/LabelSelectContent.test.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/__tests__/LabelSelectContent.test.jsx
@@ -10,7 +10,8 @@ vi.mock("src/utils/axios", () => ({
   endpoints: {
     develop: {
       runPrompt: {
-        assignMultipleLabels: "/model-hub/prompt-labels/assign-multiple-labels/",
+        assignMultipleLabels:
+          "/model-hub/prompt-labels/assign-multiple-labels/",
         createPromptLabel: "/model-hub/prompt-labels/",
       },
     },
@@ -73,27 +74,19 @@ describe("LabelSelectContent — Save button (TH-5894)", () => {
     expect(saveButton()).toBeDisabled();
   });
 
-  it("disables Save when the selection matches the original (no change)", () => {
+  it("enables Save whenever the selection is non-empty", () => {
     renderContent({ selectedLabels: [ALPHA] });
-    expect(saveButton()).toBeDisabled();
+    expect(saveButton()).toBeEnabled();
   });
 
-  it("enables Save and submits an empty list when the only tag is removed", async () => {
+  it("disables Save when the only tag is removed — empty selection cannot be submitted", () => {
     const { container } = renderContent({ selectedLabels: [ALPHA] });
-    expect(saveButton()).toBeDisabled();
+    expect(saveButton()).toBeEnabled();
 
     fireEvent.click(deleteIcons(container)[0]);
 
-    expect(saveButton()).toBeEnabled();
-
-    fireEvent.click(saveButton());
-
-    await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith(
-        "/model-hub/prompt-labels/assign-multiple-labels/",
-        { template_version_id: "version-1", label_ids: [] },
-      );
-    });
+    expect(saveButton()).toBeDisabled();
+    expect(mocks.post).not.toHaveBeenCalled();
   });
 
   it("submits the remaining ids when one of several tags is removed", async () => {


### PR DESCRIPTION
**Ticket:** [TH-5894](https://linear.app/future-agi/issue/TH-5894/when-i-add-a-single-tag-i-am-not-able-to-remove-the-tag-which-was) — reverts the empty-label flow shipped for it in #895

## What was the bug
Product direction reversed on allowing a prompt version to end up with zero tags. #895 made the tag selector's Save dirty-check-driven and let an empty selection submit `label_ids: []` to clear all tags — that flow needs to come out.

## What changes have been done
- `LabelSelectContent.jsx` — removed the `originalLabelIds`/`hasChanges` dirty-check; restored the original "Please select at least one label" guard in `handleSave`; Save button disabled on empty selection again (`selectedLabelsList?.length === 0`).
- `__tests__/LabelSelectContent.test.jsx` — rewrote the two dirty-check cases: non-empty selection enables Save; removing the only tag disables Save and fires no request. Kept the empty-initial-state and remove-one-of-several cases.

## Why the changes
This is a **manual semantic revert**, not `git revert 5ec2a4c489`: the component was redesigned since (#TH-6228, `LabelList`/`CreateTagInput`), so only the flow logic is unwound on today's code. Deliberately kept from #895: all dark-theme styling fixes (`hoverBackgroundColor` in `common.js`, dropdown/chip hover, `PromptActions` hover). Backend acceptance of empty `label_ids` (TH-5927) is untouched — the UI just never sends it anymore.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | No tags on version, none selected | Save disabled |
| 2 | Any non-empty selection | Save enabled |
| 3 | Remove the only tag | Save disabled, no request sent |
| 4 | Remove one of two tags | Save enabled, submits remaining id |
| 5 | Dark theme tag chips/dropdown hover | unchanged (#895 styling kept) |

## How to reproduce (behavior being removed)
1. Prompt workbench → version tag selector → version with one tag.
2. Remove the tag → previously Save enabled and submitted `label_ids: []`, clearing all tags. Now Save disables.

## Commands
```bash
cd frontend
yarn vitest run src/sections/workbench/createPrompt/VersionHistory/LabelDropdown
```

## Videos and screenshots

https://github.com/user-attachments/assets/fe725a99-fd79-4c9d-977f-38cad3abe049


