### PR TITLE
chore(clickhouse): raise container limits to 4 CPU / 8G

### DIFF
--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -335,8 +335,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.0"
-          memory: 4G
+          cpus: "4.0"
+          memory: 8G
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 10s


### PR DESCRIPTION
## What
Raise the `clickhouse` service resource limits in `futureagi/docker-compose.yml`:
- **CPU:** `2.0` → `4.0`
- **Memory:** `4G` → `8G`

## Why
The 2 CPU / 4G caps are too tight. 22 days of `system.metric_log` history (preserved on the migrated dev-box disk) show ClickHouse is chronically starved:

| Signal | Observation |
|---|---|
| CPU throttling | **99.8%** of scheduler periods throttled (cgroup `cpu.stat`) |
| CPU sustained | daily avg climbed to **~1.7 cores** vs the 2-core cap (~84%) |
| Memory | pinned at the **3.6 GiB** internal ceiling (0.9×4G) every day for ~10 days |
| Memory (symptom) | server now OOMs (`MEMORY_LIMIT_EXCEEDED`) even aggregating its own system tables |
| Uncensored peaks | before the cap, real peaks of **~7 cores** and **~10 GiB** during heavy merges/queries |

## Sizing rationale
4 CPU / 8G is sized to the observed **~1.7-core / ~2.5 GiB** sustained working set plus burst headroom — not an arbitrary round-up. It remains **~25% CPU / ~13% RAM** of the `n2-standard-16` host, leaving ample room for the other co-located services.

## Rollout
Takes effect when the container is recreated (`docker compose up -d clickhouse`) — a few seconds of ClickHouse downtime. No data, schema, or config-file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)