### PR TITLE
chore(clickhouse): raise memory limit 8G → 12G

### DIFF
--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -336,7 +336,7 @@ services:
       resources:
         limits:
           cpus: "4.0"
-          memory: 8G
+          memory: 12G
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 10s


### PR DESCRIPTION
## What
Raise the `clickhouse` service memory limit in `futureagi/docker-compose.yml`: **8G → 12G**. CPU unchanged at **4.0**.

## Why — follow-up to #1255
After the 2c/4g → 4c/8g right-size, monitoring showed the **8G cap (≈7.2 GiB effective**, at the default `max_server_memory_usage_to_ram_ratio` of 0.9) is too tight for heavy read queries — they fail with `MEMORY_LIMIT_EXCEEDED` (code 241).

Last 3h on the dev box:

| Query | 241 failures | Peak mem before kill |
|---|---|---|
| `spans … FINAL` (trace fetch) | **301** | ~6.7 GiB |
| peerdb CDC insert → `_peerdb_raw_mirror_usage_apicalllog` | **107** | ~3.1 GiB |

These queries need **>7.2 GiB** and get killed at the ceiling. (This predates #1255 — it was *worse* at the old 4G — but 8G doesn't fully clear it.)

## Sizing
- **CPU stays at 4.0** — measured steady-state demand is ~2.5 cores, so 4 is correctly sized. No change.
- **Memory → 12G** (≈10.8 GiB effective) clears the failing queries with margin.
- **Fits the host:** `future-dev` is now `n2-standard-8` (8 vCPU / 32 GiB). CH 12 + other services ~10 = **~22 GiB**, leaving ~10 GiB for page cache.

## Rollout
Applying a compose limits change requires **recreating** the container — a plain restart keeps the old cgroup cap:
```bash
docker compose up -d --force-recreate --no-deps clickhouse
```
A few seconds of ClickHouse downtime; no data or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)