### PR TITLE
fix(dataset): auto-detect extensionless image URLs and fix edit-to-Image errors (TH-6207)

### DIFF
--- a/futureagi/model_hub/models/choices.py
+++ b/futureagi/model_hub/models/choices.py
@@ -671,11 +671,16 @@ def is_image_url(url):
         if mime_type and mime_type.lower() in _get_image_mime_types():
             return True
 
-        # Check for common image URL patterns
+        # Check for common image URL patterns. Includes extensionless shapes
+        # used by image CDNs (e.g. Unsplash "/photo-<id>") so signed/query-keyed
+        # image URLs without a file extension are still detected.
         image_patterns = [
             "/image/",
+            "/images/",
             "/img/",
             "/photo/",
+            "/photos/",
+            "/photo-",
             "/picture/",
             "/media/",
             "image=",
@@ -684,6 +689,16 @@ def is_image_url(url):
             "picture=",
         ]
         if any(pattern in url_lower for pattern in image_patterns):
+            return True
+
+        # Well-known image-CDN hosts that serve extensionless image URLs.
+        image_hosts = [
+            "images.unsplash.com",
+            "res.cloudinary.com",
+            "i.imgur.com",
+            "pbs.twimg.com",
+        ]
+        if any(host in url_lower for host in image_hosts):
             return True
 
         return False

--- a/futureagi/model_hub/tests/test_datatype_conversion.py
+++ b/futureagi/model_hub/tests/test_datatype_conversion.py
@@ -438,28 +438,27 @@ class TestDatatypeConverter(APITestCase):
     # ============= IMAGE/AUDIO/DOCUMENT CONVERSION TESTS =============
 
     @patch("model_hub.views.develop_dataset.upload_image_to_s3")
-    @patch("model_hub.views.develop_dataset.validate_file_url")
-    def test_convert_to_image_success(self, mock_validate, mock_upload):
-        """Test image conversion uploads to S3"""
-        mock_validate.return_value = None  # Validation passes
+    def test_convert_to_image_success(self, mock_upload):
+        """Test image conversion uploads to S3 (no URL pre-validation)"""
         mock_upload.return_value = "https://s3.bucket/image.jpg"
         converter = DatatypeConverter(
             DataTypeChoices.IMAGE.value, dataset_id=str(self.dataset.id)
         )
-        cell = self._create_cell("https://example.com/image.jpg")
+        # Extensionless CDN URL: previously rejected by validate_file_url,
+        # now accepted since upload_image_to_s3 validates the content.
+        cell = self._create_cell(
+            "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=800"
+        )
 
         result = converter._convert_single_cell(cell)
 
         assert result.success is True
         assert result.new_value == "https://s3.bucket/image.jpg"
-        mock_validate.assert_called_once()
         mock_upload.assert_called_once()
 
     @patch("model_hub.views.develop_dataset.upload_image_to_s3")
-    @patch("model_hub.views.develop_dataset.validate_file_url")
-    def test_convert_to_image_upload_fails(self, mock_validate, mock_upload):
+    def test_convert_to_image_upload_fails(self, mock_upload):
         """Test image conversion handles upload failure"""
-        mock_validate.return_value = None  # Validation passes
         mock_upload.side_effect = Exception("Upload failed")
         converter = DatatypeConverter(
             DataTypeChoices.IMAGE.value, dataset_id=str(self.dataset.id)

--- a/futureagi/model_hub/tests/test_determine_data_type.py
+++ b/futureagi/model_hub/tests/test_determine_data_type.py
@@ -622,3 +622,29 @@ class TestImagesDataTypeDetection:
         result = determine_data_type(column)
         # Should not be IMAGES since not all values have comma-separated multiple images
         assert result != DataTypeChoices.IMAGES.value
+
+
+class TestExtensionlessImageUrlDetection:
+    """Regression tests for TH-6207: image URLs without a file extension."""
+
+    def test_unsplash_style_urls_detected_as_image(self):
+        """Extensionless Unsplash CDN URLs should be detected as IMAGE, not TEXT."""
+        column = pd.Series(
+            [
+                "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=800",
+                "https://images.unsplash.com/photo-1503376780353-7e6692767b70?w=800",
+            ]
+        )
+        result = determine_data_type(column)
+        assert result == DataTypeChoices.IMAGE.value
+
+    def test_extensionless_photo_path_detected_as_image(self):
+        """A generic host serving a '/photo-<id>' path should be detected as IMAGE."""
+        column = pd.Series(
+            [
+                "https://cdn.example.com/photo-abc123",
+                "https://cdn.example.com/photo-def456",
+            ]
+        )
+        result = determine_data_type(column)
+        assert result == DataTypeChoices.IMAGE.value

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -6016,12 +6016,15 @@ class DatatypeConverter:
                 except (json.JSONDecodeError, TypeError):
                     pass
 
-            # Always validate the URL, even if extracted from a JSON array
-            validate_file_url(str(image_value), "image")
-
             # Skip re-upload only if it's already in our S3 bucket
             if is_s3_url:
                 return image_value, {}
+
+            # No extension/HEAD pre-check here: upload_image_to_s3 downloads the
+            # URL and opens it with PIL, so it already rejects non-images. A strict
+            # validate_file_url pre-gate wrongly errors on valid extensionless /
+            # signed CDN image URLs, unlike the ingest path (upload_cell_media)
+            # which uploads without pre-validation.
 
             image_key = f"images/{self.dataset_id}/{uuid.uuid4()}"
             image_url = upload_image_to_s3(


### PR DESCRIPTION
## Summary

Fixes **[TH-6207](https://linear.app/future-agi/issue/TH-6207/image-modality-is-not-auto-detected-upon-uploading-a-jsoncsv-and-edit)** — two related backend bugs around image columns in datasets:

1. **Image modality is not auto-detected** when uploading a JSON/CSV whose column holds image URLs — the column is classified as `TEXT`.
2. **Editing a column type to "Image" fails** — every cell renders a red **"Error"** instead of the image.

Both root causes are in the backend; the frontend was faithfully rendering what the backend returned.

---

## Why the change is needed

### Bug 1 — auto-detection misses extensionless image URLs
Column-type inference (`determine_data_type` → `_classify_url_column` → `is_image_url`) only recognized an image URL if it **ended with a known image extension**, matched an extension-driven MIME guess, or contained one of a few narrow substrings (`/image/`, `/photo/`, …). Real-world CDN URLs have **no file extension** — e.g. Unsplash's `https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=800`. The pattern `/photo/` does not match `/photo-<id>`, so the whole column fell through to `TEXT`.

### Bug 2 — "edit to Image" forces every cell to ERROR
`DatatypeConverter._convert_cell_to_image` called `validate_file_url(url, "image")` **before** uploading. That validator:
- requires the URL (query stripped) to `endswith` a configured image extension, and
- performs a live `requests.head(url, timeout=5)` and rejects anything that isn't `2xx` with a `Content-Type: image/*`.

Extensionless / signed / auth-gated CDN URLs fail this gate and raise, so `perform_conversion` marks each cell `CellStatus.ERROR`, which the grid renders as red **"Error"**.

Crucially, this pre-check is **redundant**: `upload_image_to_s3` already downloads the URL and opens it with PIL (`Image.open`), raising `INVALID_IMAGE`/`INVALID_URL` for anything that isn't a real image. The working **ingest** path (`upload_cell_media`, used on initial file upload) uploads via the same helper with **no** `validate_file_url` gate — which is exactly why the same data ingests fine but errors on manual conversion.

---

## Exact changes

### `model_hub/models/choices.py` — `is_image_url()`
Broaden extensionless image-URL detection (kept pure / no network, preserving its thread-safe contract):
- Added URL path patterns: `/images/`, `/photos/`, `/photo-`.
- Added a short allow-list of well-known image-CDN hosts that serve extensionless images: `images.unsplash.com`, `res.cloudinary.com`, `i.imgur.com`, `pbs.twimg.com`.

### `model_hub/views/develop_dataset.py` — `DatatypeConverter._convert_cell_to_image()`
- **Removed** the `validate_file_url(str(image_value), "image")` pre-gate.
- Content validation is preserved by `upload_image_to_s3` (downloads + PIL-validates), aligning the conversion path with the working ingest path.
- `validate_file_url` import is retained — still used by the document and audio converters (unchanged, out of scope).

### Tests
- `model_hub/tests/test_datatype_conversion.py`: updated the two image-conversion tests to no longer patch `validate_file_url`; the success case now uses an extensionless Unsplash URL.
- `model_hub/tests/test_determine_data_type.py`: added `TestExtensionlessImageUrlDetection` with regression tests.

---

## Tests added / updated & scenarios covered

| Test | File | Scenario it covers |
|------|------|--------------------|
| `test_unsplash_style_urls_detected_as_image` | `test_determine_data_type.py` | A column of extensionless Unsplash CDN URLs (`images.unsplash.com/photo-<id>?w=800`) is detected as `IMAGE`, not `TEXT` — the exact repro from the ticket. Guards the host-allow-list + `/photo-` path pattern. |
| `test_extensionless_photo_path_detected_as_image` | `test_determine_data_type.py` | A generic (non-Unsplash) host serving a `/photo-<id>` path is detected as `IMAGE`. Guards the path-pattern branch independently of the host allow-list. |
| `test_convert_to_image_success` (updated) | `test_datatype_conversion.py` | Converting a cell to `IMAGE` succeeds for an **extensionless** URL that the old `validate_file_url` gate would have rejected; asserts the S3 URL is stored and `upload_image_to_s3` is called. No longer patches `validate_file_url`. |
| `test_convert_to_image_upload_fails` (updated) | `test_datatype_conversion.py` | When the S3 upload itself raises, the cell fails cleanly with `success=False` and a `"Failed to upload image"` error message (failure path still reported, not swallowed). |
| `test_convert_to_image_empty_value` (existing, re-run) | `test_datatype_conversion.py` | Empty cell values convert to `None` without hitting upload — confirms the empty-value short-circuit is unaffected. |

Existing `TestImagesDataTypeDetection` cases (comma-separated multi-image, mixed image/non-image, plain text with commas, query-param URLs) continue to pass, confirming no regression to `TEXT`/`IMAGES` classification.

---

## How to run the tests

```bash
cd future-agi-temp/futureagi

# New detection regression tests (no DB required)
bin/test --no-services unit -k "TestExtensionlessImageUrlDetection"

# Image-conversion tests (needs the docker test DB)
bin/test model_hub/tests/test_datatype_conversion.py -k "test_convert_to_image"

# Full affected suites
bin/test model_hub/tests/test_datatype_conversion.py model_hub/tests/test_determine_data_type.py
```

Result on this branch: **134 passed** across both suites.

> Note: if you hit a `last_timezone` NOT-NULL error on an existing local test DB, it's a stale reused schema — rebuild with `pytest --create-db …` (or drop the test DB volume). It is unrelated to this change.

---

## Linear ticket

Closes **[TH-6207](https://linear.app/future-agi/issue/TH-6207/image-modality-is-not-auto-detected-upon-uploading-a-jsoncsv-and-edit)** — *"Image modality is not auto detected upon uploading a json/csv & edit column type to Image is not working"* (parent: TH-6147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
