### PR TITLE
fix(evals): use Iconify lucide:play for test-tab icon

### DIFF
--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1103,23 +1103,14 @@ const TestPlayground = React.forwardRef(
                 activeMainTab === "test" ? "primary.main" : "transparent",
             }}
           >
-            <Box
-              component="svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            <Iconify
+              icon="lucide:play"
+              width={14}
               sx={{
-                width: 14,
-                height: 14,
                 color:
                   activeMainTab === "test" ? "primary.main" : "text.secondary",
               }}
-            >
-              <polygon points="6 3 20 12 6 21 6 3" />
-            </Box>
+            />
             <Typography
               variant="body2"
               sx={{


### PR DESCRIPTION
### Why
Follow-up to the merged #1203. @cdileep23 left a review nit that the Test-tab play icon was a hand-inlined SVG, and `lucide:play` is already available via Iconify (as used in `RunPromptButton.jsx`). Since #1203 was merged before the nit could be applied, this small PR addresses it against `dev`.

### What
- `TestPlayground.jsx`: replaced the hand-inlined play `<Box component="svg">` with `<Iconify icon="lucide:play" width={14} sx={{ color: ... }} />`, matching the surrounding convention. Visually identical (outlined lucide play), fewer lines.

### Tests / verification
- `eslint` clean on the changed file (only pre-existing warnings).
- Pure icon swap — no behavior change; the active/inactive colour logic is preserved.

### Notes
Scoped to the single review nit; no other changes.