### PR TITLE
fix(simulation): refresh correct grid from eval drawer and drop stale eval columns (TH-6415)

### DIFF
--- a/frontend/src/sections/test-detail/TestRunDetailGrid.jsx
+++ b/frontend/src/sections/test-detail/TestRunDetailGrid.jsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { AgGridReact } from "ag-grid-react";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
+  getColumnDefsSignature,
   getSelectedCallExecutionIdsFilter,
   getTestRunDetailColumnQuery,
   getTestRunDetailGridColumnDefs,
@@ -204,7 +205,10 @@ const TestRunDetailGrid = () => {
             const newColDefs = getTestRunDetailGridColumnDefs(
               data?.column_order,
             );
-            if (currentColumnDef.length !== newColDefs?.length) {
+            if (
+              getColumnDefsSignature(currentColumnDef) !==
+              getColumnDefsSignature(newColDefs)
+            ) {
               setColumnDef(applyReasonColumnVisibility(newColDefs));
             }
 
@@ -337,7 +341,10 @@ const TestRunDetailGrid = () => {
 
         const currentColumnDef = useTestDetailStore.getState().columnDef;
         const newColDefs = getTestRunDetailGridColumnDefs(columns);
-        if (newColDefs.length !== currentColumnDef?.length) {
+        if (
+          getColumnDefsSignature(newColDefs) !==
+          getColumnDefsSignature(currentColumnDef)
+        ) {
           // If the columns have changed, update the query data no need to use transaction
           logger.debug("columns have changed, updating query data", {
             columns,

--- a/frontend/src/sections/test-detail/__tests__/getColumnDefsSignature.test.js
+++ b/frontend/src/sections/test-detail/__tests__/getColumnDefsSignature.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getColumnDefsSignature } from "../common";
+
+// Mirrors the real shape from getTestRunDetailGridColumnDefs: an "Evaluation"
+// group whose children are per-eval column defs (createColumnDef -> id: c.id,
+// createReasonColumnDef -> id: `${c.id}_reason`).
+const evalGroup = (childIds) => ({
+  id: "evaluation",
+  children: childIds.map((id) => ({ id, field: id })),
+});
+
+describe("getColumnDefsSignature (TH-6415 stale-column fix)", () => {
+  it("returns '' for empty/undefined input", () => {
+    expect(getColumnDefsSignature()).toBe("");
+    expect(getColumnDefsSignature([])).toBe("");
+  });
+
+  it("changes when one eval child is removed from a group (the exact bug)", () => {
+    // The old top-level length check saw [1 group] before and after and treated
+    // them as equal; the recursive signature descends into children and differs.
+    const twoEvals = [evalGroup(["eval_a", "eval_b"])];
+    const oneEval = [evalGroup(["eval_a"])];
+
+    expect(getColumnDefsSignature(twoEvals)).not.toBe(
+      getColumnDefsSignature(oneEval),
+    );
+  });
+
+  it("is stable across re-derivation: structurally equal defs share a signature", () => {
+    // Freshly-built defs (new object refs, same ids) must match stored ones so
+    // applyReasonColumnVisibility does not trigger a spurious column reset.
+    const stored = [evalGroup(["eval_a", "eval_b"])];
+    const freshlyDerived = [evalGroup(["eval_a", "eval_b"])];
+
+    expect(getColumnDefsSignature(freshlyDerived)).toBe(
+      getColumnDefsSignature(stored),
+    );
+  });
+
+  it("ignores `hide` so toggling reason-column visibility does not reset columns", () => {
+    const visible = [
+      { id: "eval_a", field: "eval_a", hide: false },
+      { id: "eval_a_reason", field: "eval_a_reason", hide: false },
+    ];
+    const reasonHidden = [
+      { id: "eval_a", field: "eval_a", hide: false },
+      { id: "eval_a_reason", field: "eval_a_reason", hide: true },
+    ];
+
+    expect(getColumnDefsSignature(reasonHidden)).toBe(
+      getColumnDefsSignature(visible),
+    );
+  });
+
+  it("is order-sensitive so a reordered group is detected as a change", () => {
+    const original = [evalGroup(["eval_a", "eval_b"])];
+    const reordered = [evalGroup(["eval_b", "eval_a"])];
+
+    expect(getColumnDefsSignature(reordered)).not.toBe(
+      getColumnDefsSignature(original),
+    );
+  });
+
+  it("falls back to `field` when a leaf has no id", () => {
+    expect(getColumnDefsSignature([{ field: "call_execution_id" }])).toBe(
+      "call_execution_id",
+    );
+  });
+});

--- a/frontend/src/sections/test-detail/common.js
+++ b/frontend/src/sections/test-detail/common.js
@@ -400,6 +400,15 @@ export const getTestRunDetailGridColumnDefs = (columnOrder) => {
   return config;
 };
 
+export const getColumnDefsSignature = (colDefs = []) =>
+  colDefs
+    .map((colDef) =>
+      colDef?.children
+        ? `${colDef.id}:[${getColumnDefsSignature(colDef.children)}]`
+        : String(colDef?.id ?? colDef?.field ?? ""),
+    )
+    .join(",");
+
 export const getTestRunDetailColumnQuery = (
   executionId,
   pageNumber,

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -64,6 +64,8 @@ const TestEvaluationPage = ({
 
   const { refreshTestRunGrid } = useTestDetailContext();
 
+  const refreshOpeningGrid = onSuccessOfAdditionOfEvals ?? refreshTestRunGrid;
+
   const selectedCount = useTestRunsSelectedCount();
 
   const [openUpdateKeysDialog, setOpenUpdateKeysDialog] = useState(false);
@@ -126,11 +128,7 @@ const TestEvaluationPage = ({
       queryClient.invalidateQueries({
         queryKey: ["test-execution-detail", "KPIS"],
       });
-      if (executionIds) {
-        onSuccessOfAdditionOfEvals?.();
-      } else {
-        refreshTestRunGrid?.();
-      }
+      refreshOpeningGrid?.();
       enqueueSnackbar("Eval deleted successfully", {
         variant: "success",
       });
@@ -148,12 +146,10 @@ const TestEvaluationPage = ({
     onSuccess: () => {
       setOpenConfirmRunEvaluations(false);
       onClose();
-      if (executionIds) {
-        onSuccessOfAdditionOfEvals?.();
-      } else {
+      if (!executionIds) {
         clearSelection();
-        refreshTestRunGrid?.();
       }
+      refreshOpeningGrid?.();
 
       enqueueSnackbar("Evals run successfully", {
         variant: "success",


### PR DESCRIPTION
## Summary
Fixes two related bugs in the shared evaluation drawer used by the test-executions grid and the test-execution-detail (call rows) grid: the drawer refreshed the wrong grid after an action, and a deleted eval's column stayed visible on the detail grid.

## Why / problem
- The drawer is shared by two pages, each with its own grid. It decided which grid to refresh from the presence of `executionIds`, which only worked by coincidence (on the detail page the `test/` context resolved to a no-op default). Fragile and easy to break.
- On the call-execution detail grid, deleting an eval config left its column showing even though the backend no longer sends that column config. Eval columns are nested as `children` of the "Evaluation Metrics" group, so removing one eval (with others remaining) does not change the top-level column count — and the refresh guard only compared top-level `length`, so it skipped re-deriving the columns.

## What changed
- `TestEvaluationPage.jsx`: route the post-action refresh through the callback supplied by the drawer that opened it (`refreshOpeningGrid = onSuccessOfAdditionOfEvals ?? refreshTestRunGrid`) instead of branching on `executionIds`. `executionIds` now only feeds the run payload / UI gating.
- `common.js`: add `getColumnDefsSignature`, a recursive signature over column `id`s (including nested group children).
- `TestRunDetailGrid.jsx`: replace both length-only column guards with the signature comparison so add/remove of an eval re-derives the grid columns.

## Tests
No new automated tests; change is UI/grid-refresh behavior. Verified manually (below).

## Commands
- `npx eslint <changed files>` — no new errors/warnings.

## Backwards compatibility
Fully backwards compatible. Signature is built from column `id`s only (not visibility/`hide` state), so scrolling and reason-column expand/collapse do not trigger extra column resets or update loops.

## Manual verification
- [ ] Delete one eval (others present) from the execution-detail drawer → its column disappears from the calls grid
- [ ] Delete the last eval → the whole "Evaluation Metrics" group disappears
- [ ] Run evals from the detail drawer → new eval columns appear
- [ ] Scroll / expand a reason column → no column flicker or reset
- [ ] Delete/run evals on the test-executions page → that grid still refreshes

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows project style
- [x] Lints cleanly (no new warnings)
- [x] Self-reviewed

## Backout
Revert this PR's commit; no migrations or data changes involved.

## Linear
Closes TH-6415
Closes TH-6208

