### PR TITLE
fix(system-evals): mark min/max as required on word_count_in_range and sentence_count (TH-6205)

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 14
+SYSTEM_EVALS_VERSION = 15
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/function/sentence_count.yaml
+++ b/futureagi/model_hub/system_evals/function/sentence_count.yaml
@@ -1,6 +1,6 @@
 eval_id: 153
 name: sentence_count
-description: Counts sentences in text and optionally validates against a min/max range. Useful for enforcing structural constraints
+description: Checks if the sentence count of text falls within a specified range. Useful for enforcing structural constraints
   on generated text.
 eval_tags:
 - Output Validation
@@ -20,18 +20,16 @@ config:
   function_params_schema:
     min_sentences:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 0
     max_sentences:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 1
   config_params_desc:
     text: The text to count sentences in
-    min_sentences: Minimum sentence count (inclusive). Leave empty for no lower bound.
-    max_sentences: Maximum sentence count (inclusive). Leave empty for no upper bound.
+    min_sentences: Minimum sentence count (inclusive).
+    max_sentences: Maximum sentence count (inclusive).
   code: |
     def evaluate(input, output, expected, context, **kwargs):
         import re
@@ -43,22 +41,10 @@ config:
             count = len([s for s in sentences if s.strip()])
         min_s = kwargs.get("min_sentences")
         max_s = kwargs.get("max_sentences")
-        if min_s is None and max_s is None:
-            return {"score": 0.0, "reason": "At least one of min_sentences or max_sentences must be provided"}
-        if min_s is not None:
-            min_s = int(min_s)
-        if max_s is not None:
-            max_s = int(max_s)
-        if min_s is not None and max_s is not None:
-            passed = min_s <= count <= max_s
-            reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
-        elif min_s is not None:
-            passed = count >= min_s
-            reason = f"Sentence count {count} >= {min_s}" if passed else f"Sentence count {count} < {min_s}"
-        elif max_s is not None:
-            passed = count <= max_s
-            reason = f"Sentence count {count} <= {max_s}" if passed else f"Sentence count {count} > {max_s}"
-        else:
-            passed = True
-            reason = f"Sentence count: {count}"
+        if min_s is None or max_s is None:
+            return {"score": 0.0, "reason": "Both min_sentences and max_sentences must be provided"}
+        min_s = int(min_s)
+        max_s = int(max_s)
+        passed = min_s <= count <= max_s
+        reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
         return {"score": 1.0 if passed else 0.0, "reason": reason}

--- a/futureagi/model_hub/system_evals/function/sentence_count.yaml
+++ b/futureagi/model_hub/system_evals/function/sentence_count.yaml
@@ -1,6 +1,6 @@
 eval_id: 153
 name: sentence_count
-description: Counts sentences in text and optionally validates against a min/max range. Useful for enforcing structural constraints
+description: Counts sentences in text and validates against a min/max range. Useful for enforcing structural constraints
   on generated text.
 eval_tags:
 - Output Validation

--- a/futureagi/model_hub/system_evals/function/sentence_count.yaml
+++ b/futureagi/model_hub/system_evals/function/sentence_count.yaml
@@ -20,18 +20,16 @@ config:
   function_params_schema:
     min_sentences:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 0
     max_sentences:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 1
   config_params_desc:
     text: The text to count sentences in
-    min_sentences: Minimum sentence count (inclusive). Leave empty for no lower bound.
-    max_sentences: Maximum sentence count (inclusive). Leave empty for no upper bound.
+    min_sentences: Minimum sentence count (inclusive).
+    max_sentences: Maximum sentence count (inclusive).
   code: |
     def evaluate(input, output, expected, context, **kwargs):
         import re
@@ -43,22 +41,10 @@ config:
             count = len([s for s in sentences if s.strip()])
         min_s = kwargs.get("min_sentences")
         max_s = kwargs.get("max_sentences")
-        if min_s is None and max_s is None:
-            return {"score": 0.0, "reason": "At least one of min_sentences or max_sentences must be provided"}
-        if min_s is not None:
-            min_s = int(min_s)
-        if max_s is not None:
-            max_s = int(max_s)
-        if min_s is not None and max_s is not None:
-            passed = min_s <= count <= max_s
-            reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
-        elif min_s is not None:
-            passed = count >= min_s
-            reason = f"Sentence count {count} >= {min_s}" if passed else f"Sentence count {count} < {min_s}"
-        elif max_s is not None:
-            passed = count <= max_s
-            reason = f"Sentence count {count} <= {max_s}" if passed else f"Sentence count {count} > {max_s}"
-        else:
-            passed = True
-            reason = f"Sentence count: {count}"
+        if min_s is None or max_s is None:
+            return {"score": 0.0, "reason": "Both min_sentences and max_sentences must be provided"}
+        min_s = int(min_s)
+        max_s = int(max_s)
+        passed = min_s <= count <= max_s
+        reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
         return {"score": 1.0 if passed else 0.0, "reason": reason}

--- a/futureagi/model_hub/system_evals/function/sentence_count.yaml
+++ b/futureagi/model_hub/system_evals/function/sentence_count.yaml
@@ -1,6 +1,6 @@
 eval_id: 153
 name: sentence_count
-description: Counts sentences in text and validates against a min/max range. Useful for enforcing structural constraints
+description: Counts sentences in text and optionally validates against a min/max range. Useful for enforcing structural constraints
   on generated text.
 eval_tags:
 - Output Validation
@@ -20,16 +20,18 @@ config:
   function_params_schema:
     min_sentences:
       type: integer
-      required: true
+      default: null
+      nullable: true
       minimum: 0
     max_sentences:
       type: integer
-      required: true
+      default: null
+      nullable: true
       minimum: 1
   config_params_desc:
     text: The text to count sentences in
-    min_sentences: Minimum sentence count (inclusive).
-    max_sentences: Maximum sentence count (inclusive).
+    min_sentences: Minimum sentence count (inclusive). Leave empty for no lower bound.
+    max_sentences: Maximum sentence count (inclusive). Leave empty for no upper bound.
   code: |
     def evaluate(input, output, expected, context, **kwargs):
         import re
@@ -41,10 +43,22 @@ config:
             count = len([s for s in sentences if s.strip()])
         min_s = kwargs.get("min_sentences")
         max_s = kwargs.get("max_sentences")
-        if min_s is None or max_s is None:
-            return {"score": 0.0, "reason": "Both min_sentences and max_sentences must be provided"}
-        min_s = int(min_s)
-        max_s = int(max_s)
-        passed = min_s <= count <= max_s
-        reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
+        if min_s is None and max_s is None:
+            return {"score": 0.0, "reason": "At least one of min_sentences or max_sentences must be provided"}
+        if min_s is not None:
+            min_s = int(min_s)
+        if max_s is not None:
+            max_s = int(max_s)
+        if min_s is not None and max_s is not None:
+            passed = min_s <= count <= max_s
+            reason = f"Sentence count {count} {'is' if passed else 'is not'} within [{min_s}, {max_s}]"
+        elif min_s is not None:
+            passed = count >= min_s
+            reason = f"Sentence count {count} >= {min_s}" if passed else f"Sentence count {count} < {min_s}"
+        elif max_s is not None:
+            passed = count <= max_s
+            reason = f"Sentence count {count} <= {max_s}" if passed else f"Sentence count {count} > {max_s}"
+        else:
+            passed = True
+            reason = f"Sentence count: {count}"
         return {"score": 1.0 if passed else 0.0, "reason": reason}

--- a/futureagi/model_hub/system_evals/function/word_count_in_range.yaml
+++ b/futureagi/model_hub/system_evals/function/word_count_in_range.yaml
@@ -20,18 +20,16 @@ config:
   function_params_schema:
     min_words:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 0
     max_words:
       type: integer
-      default: null
-      nullable: true
+      required: true
       minimum: 1
   config_params_desc:
     text: The text to check word count for
-    min_words: Minimum word count (inclusive). Leave empty for no lower bound.
-    max_words: Maximum word count (inclusive). Leave empty for no upper bound.
+    min_words: Minimum word count (inclusive).
+    max_words: Maximum word count (inclusive).
   code: |
     def evaluate(input, output, expected, context, **kwargs):
         text = str(kwargs.get("text", output or "")).strip()
@@ -39,22 +37,10 @@ config:
         count = len(words)
         min_w = kwargs.get("min_words")
         max_w = kwargs.get("max_words")
-        if min_w is None and max_w is None:
-            return {"score": 0.0, "reason": "At least one of min_words or max_words must be provided"}
-        if min_w is not None:
-            min_w = int(min_w)
-        if max_w is not None:
-            max_w = int(max_w)
-        if min_w is not None and max_w is not None:
-            passed = min_w <= count <= max_w
-            reason = f"Word count {count} {'is' if passed else 'is not'} within [{min_w}, {max_w}]"
-        elif min_w is not None:
-            passed = count >= min_w
-            reason = f"Word count {count} >= {min_w}" if passed else f"Word count {count} < {min_w}"
-        elif max_w is not None:
-            passed = count <= max_w
-            reason = f"Word count {count} <= {max_w}" if passed else f"Word count {count} > {max_w}"
-        else:
-            passed = True
-            reason = f"Word count: {count} (no constraints)"
+        if min_w is None or max_w is None:
+            return {"score": 0.0, "reason": "Both min_words and max_words must be provided"}
+        min_w = int(min_w)
+        max_w = int(max_w)
+        passed = min_w <= count <= max_w
+        reason = f"Word count {count} {'is' if passed else 'is not'} within [{min_w}, {max_w}]"
         return {"score": 1.0 if passed else 0.0, "reason": reason}


### PR DESCRIPTION
## Summary

Both `word_count_in_range` and `sentence_count` (CustomCodeEval system evals) declared their bounds as `nullable: true, default: null` in `function_params_schema`, so the UI accepted saves with both empty. At run time the yamls' own code returned `{"score": 0.0, "reason": "At least one of min/max must be provided"}` — the "failure" the ticket flags.

Fix: mark both bounds required. Same treatment on `sentence_count` since an eval declared `output_type_normalized: pass_fail` needs an actual criterion — "count with no bounds always passes" is a metric shoved into the eval framework, not a legitimate eval.

See [TH-6205](https://linear.app/futureagi/issue/TH-6205) for the fuller context.

## Changes

- `word_count_in_range.yaml` — `min_words` / `max_words` marked `required: true`, `nullable` / `default: null` dropped, runtime `code:` collapsed to the both-required happy path (dead one-sided branches removed).
- `sentence_count.yaml` — same treatment on `min_sentences` / `max_sentences`. Description rewritten from "optionally validates against a min/max range" (which documented a design mistake) to "checks if the sentence count of text falls within a specified range" (matching the `word_count_in_range` phrasing).
- `seed_system_evals.py` — `SYSTEM_EVALS_VERSION` bumped 14 → 15 so deployed instances re-seed automatically.

## How the fix works end-to-end

The existing generic validator at `model_hub/utils/function_eval_params.py:99-111` (`normalize_function_params`) reads `required` off each schema definition and raises `ValueError("{name} is required")` when a required param is `None`. No new BE code needed.

FE side already blocks the Edit / Save action inline when required params are empty (confirmed empirically).

## Demo


https://github.com/user-attachments/assets/63d7114e-d13a-46e6-aed0-64a105258053


## Test plan

- [x] Local: `docker exec backend python manage.py seed_system_evals --force`; verify `word_count_in_range` and `sentence_count` templates in DB have `required: true` on both bounds
- [x] FE: try to save a dataset with either eval and both min/max empty → save blocked with the required-field prompt
- [x] Run either eval with `min ≤ max` and a text sample → pass/fail scores as expected