### PR TITLE
[TH-6380] Add permission tooltip on disabled Run Prompt button

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
@@ -151,6 +151,9 @@ const PromptActions = () => {
   const noModelIndex = modelConfig?.findIndex((m) => !m?.model);
 
   const buttonTooltip = useMemo(() => {
+    if (!RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]) {
+      return "You don't have permission to run prompts.";
+    }
     if (isAddingDraft) {
       return "Creating new version...";
     }
@@ -170,6 +173,7 @@ const PromptActions = () => {
     isVariablesDefined,
     noModelIndex,
     isAddingDraft,
+    userRole,
     // areAllPlaceholdersPresent,
   ]);
 
@@ -685,66 +689,68 @@ const PromptActions = () => {
               title={buttonTooltip || ""}
               arrow
             >
-              <ShowComponent condition={isGenerating}>
-                <StopGeneratingButton
-                  disabled={loadingPrompt}
-                  onClick={onStopGenerating}
-                  loading={isStoppingGenerating}
-                >
-                  <Typography variant="s1" fontWeight={"fontWeightMedium"}>
-                    Stop Generating
-                  </Typography>
-                </StopGeneratingButton>
-              </ShowComponent>
-              <ShowComponent condition={!isGenerating}>
-                <RunPromptButton
-                  disabled={
-                    loadingPrompt ||
-                    currentTab === "Evaluation" ||
-                    currentTab === "Metrics" ||
-                    !RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]
-                  }
-                  onClick={() => {
-                    if (buttonTooltip) {
-                      if (noModelIndex !== -1) {
-                        setOpenSelectModel(noModelIndex);
-                        trackEvent(Events.promptSelectModelClicked, {
-                          [PropertyName.promptId]: id,
-                          [PropertyName.type]: "system",
-                          [PropertyName.version]: selectedVersions?.map(
-                            (item) => item?.version,
-                          ),
-                        });
-                      } else if (!isVariablesDefined) {
-                        setVariableDrawerOpen(true);
+              <span style={{ display: "inline-flex" }}>
+                <ShowComponent condition={isGenerating}>
+                  <StopGeneratingButton
+                    disabled={loadingPrompt}
+                    onClick={onStopGenerating}
+                    loading={isStoppingGenerating}
+                  >
+                    <Typography variant="s1" fontWeight={"fontWeightMedium"}>
+                      Stop Generating
+                    </Typography>
+                  </StopGeneratingButton>
+                </ShowComponent>
+                <ShowComponent condition={!isGenerating}>
+                  <RunPromptButton
+                    disabled={
+                      loadingPrompt ||
+                      currentTab === "Evaluation" ||
+                      currentTab === "Metrics" ||
+                      !RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]
+                    }
+                    onClick={() => {
+                      if (buttonTooltip) {
+                        if (noModelIndex !== -1) {
+                          setOpenSelectModel(noModelIndex);
+                          trackEvent(Events.promptSelectModelClicked, {
+                            [PropertyName.promptId]: id,
+                            [PropertyName.type]: "system",
+                            [PropertyName.version]: selectedVersions?.map(
+                              (item) => item?.version,
+                            ),
+                          });
+                        } else if (!isVariablesDefined) {
+                          setVariableDrawerOpen(true);
+                        }
+                        return;
                       }
-                      return;
-                    }
-                    trackEvent(Events.promptRunPromptClicked, {
-                      [PropertyName.promptId]: id,
-                      [PropertyName.type]: "overall",
-                      [PropertyName.version]: selectedVersions?.map(
-                        (item) => item?.version,
-                      ),
-                    });
-                    if (
-                      !checkIfAudioModelHasAudioContent(modelConfig, prompts)
-                    ) {
-                      enqueueSnackbar(
-                        "Audio input is missing. Please add audio before running the prompt.",
-                        { variant: "error" },
-                      );
-                      return;
-                    }
-                    saveAndRun();
-                  }}
-                >
-                  {" "}
-                  <Typography variant="s1" fontWeight={"fontWeightMedium"}>
-                    Run Prompt
-                  </Typography>
-                </RunPromptButton>
-              </ShowComponent>
+                      trackEvent(Events.promptRunPromptClicked, {
+                        [PropertyName.promptId]: id,
+                        [PropertyName.type]: "overall",
+                        [PropertyName.version]: selectedVersions?.map(
+                          (item) => item?.version,
+                        ),
+                      });
+                      if (
+                        !checkIfAudioModelHasAudioContent(modelConfig, prompts)
+                      ) {
+                        enqueueSnackbar(
+                          "Audio input is missing. Please add audio before running the prompt.",
+                          { variant: "error" },
+                        );
+                        return;
+                      }
+                      saveAndRun();
+                    }}
+                  >
+                    {" "}
+                    <Typography variant="s1" fontWeight={"fontWeightMedium"}>
+                      Run Prompt
+                    </Typography>
+                  </RunPromptButton>
+                </ShowComponent>
+              </span>
             </CustomTooltip>
           </ShowComponent>
         </Box>


### PR DESCRIPTION
**Ticket:** [TH-6380](https://linear.app/future-agi/issue/TH-6380/viewer-can-trigger-prompt-run-before-access-denial-appears) — Closes TH-6380

## What was the bug
A Viewer (read-only role) sees the **Run Prompt** button in the prompt workbench rendered disabled, but with no indication of *why* it's disabled — there's no tooltip explaining the lack of permission. (The original race — clicking Run and only then getting a belated no-access notification — is already resolved by the button being disabled; this PR adds the missing explanation, per Vel's feedback on the ticket.)

## What changes have been done
- `frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx`
  - Added the RBAC case as the highest-priority reason in the `buttonTooltip` memo: when the user lacks `PROMPTS.UPDATE`, it returns `"You don't have permission to run prompts."` (`userRole` added to deps).
  - Wrapped the button branches in a single `<span style={{ display: "inline-flex" }}>` inside the existing `CustomTooltip`, so the tooltip surfaces over the disabled button.

## Why the changes
- The Run button was already disabled for Viewers via `!RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]`, but `buttonTooltip` only covered actionable hints (no model / empty prompt / undefined variables) — never the permission case — so viewers got no feedback. Reusing the same permission expression keeps the disabled state and the tooltip in sync (one source of truth).
- MUI does not fire a `Tooltip` over a `disabled` button (disabled DOM elements emit no hover events). The `<span>` wrapper is the standard fix — same pattern already used in `EvalCreatePage.jsx`.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Viewer hovers the greyed Run Prompt button | Tooltip: "You don't have permission to run prompts." |
| 2 | Member/Admin/Owner hovers Run Prompt | No permission tooltip; existing hints ("Select a model", "Please define all variables") intact |
| 3 | Editor runs a prompt normally | Run flow unchanged (permission check is false, falls through) |
| 4 | Mid-generation | Stop Generating button unchanged |

## How to reproduce (original bug)
1. Log in as a Viewer (read-only role).
2. Open a prompt in the workbench.
3. Observe the Run Prompt button is disabled with no tooltip explaining why.

## Videos and screenshots
https://github.com/user-attachments/assets/fa9d4c95-c34f-4bfe-9064-4c2bf5731ff8
