### PR TITLE
fix: normalize eval search text

### DIFF
--- a/frontend/src/sections/evals/CustomEvalDrawer/CustomEvalDrawer.jsx
+++ b/frontend/src/sections/evals/CustomEvalDrawer/CustomEvalDrawer.jsx
@@ -8,6 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 import EvalTypesSkeleton from "src/sections/develop-detail/Common/EvaluationType/EvalTypesSkeleton";
 import EvaluationTypeCard from "src/sections/develop-detail/Common/EvaluationTypeCard";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
+import { normalizeEvalSearchText } from "../utils/search";
 
 const categories = [
   { label: "Conversation", value: "CONVERSATION" },
@@ -26,13 +27,17 @@ const CustomEvalDrawer = ({ onClose, onOptionClick }) => {
   const theme = useTheme();
   const [searchText, setSearchText] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
+  const normalizedSearchText = useMemo(
+    () => normalizeEvalSearchText(searchText),
+    [searchText],
+  );
 
   const {
     data: evalList,
     isLoading: loadingEvalList,
     isFetching,
   } = useQuery({
-    queryKey: ["develop", "preset-eval-list"],
+    queryKey: ["develop", "preset-eval-list", normalizedSearchText],
     queryFn: () =>
       axios.get(
         endpoints.develop.eval.getEvalsList(
@@ -41,7 +46,7 @@ const CustomEvalDrawer = ({ onClose, onOptionClick }) => {
         {
           params: {
             eval_type: "preset",
-            search_text: searchText || "",
+            search_text: normalizedSearchText || "",
           },
         },
       ),
@@ -53,25 +58,25 @@ const CustomEvalDrawer = ({ onClose, onOptionClick }) => {
     if (selectedCategory === "all") {
       return evalList.filter(
         (each) =>
-          !searchText ||
-          each.name.toLowerCase().includes(searchText.toLowerCase()),
+          !normalizedSearchText ||
+          each.name.toLowerCase().includes(normalizedSearchText),
       );
     }
     return evalList.filter(
       (each) =>
         each.eval_template_tags.includes(selectedCategory) &&
-        (!searchText ||
-          each.name.toLowerCase().includes(searchText.toLowerCase())),
+        (!normalizedSearchText ||
+          each.name.toLowerCase().includes(normalizedSearchText)),
     );
-  }, [selectedCategory, evalList, searchText]);
+  }, [selectedCategory, evalList, normalizedSearchText]);
 
   const categoryCount = useMemo(() => {
     if (!evalList) return {};
     return evalList
       .filter(
         (each) =>
-          !searchText ||
-          each.name.toLowerCase().includes(searchText.toLowerCase()),
+          !normalizedSearchText ||
+          each.name.toLowerCase().includes(normalizedSearchText),
       )
       .reduce(
         (acc, each) => {
@@ -83,7 +88,7 @@ const CustomEvalDrawer = ({ onClose, onOptionClick }) => {
         },
         { all: 0 },
       );
-  }, [evalList, searchText]);
+  }, [evalList, normalizedSearchText]);
 
   const handleSearchChange = (event) => {
     const value = event.target.value;

--- a/frontend/src/sections/evals/utils/__tests__/search.test.js
+++ b/frontend/src/sections/evals/utils/__tests__/search.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEvalSearchText } from "../search";
+
+describe("normalizeEvalSearchText", () => {
+  it("normalizes human-readable eval names", () => {
+    expect(normalizeEvalSearchText(" Context   Adherence ")).toBe(
+      "context_adherence",
+    );
+  });
+
+  it("preserves underscore searches", () => {
+    expect(normalizeEvalSearchText("context_adherence")).toBe(
+      "context_adherence",
+    );
+  });
+
+  it("keeps empty search empty", () => {
+    expect(normalizeEvalSearchText("")).toBe("");
+  });
+});

--- a/frontend/src/sections/evals/utils/search.js
+++ b/frontend/src/sections/evals/utils/search.js
@@ -1,0 +1,5 @@
+export const normalizeEvalSearchText = (searchText) =>
+  String(searchText ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_");

--- a/futureagi/model_hub/tests/test_eval_list.py
+++ b/futureagi/model_hub/tests/test_eval_list.py
@@ -10,6 +10,7 @@ import pytest
 
 from model_hub.models.choices import OwnerChoices
 from model_hub.models.evals_metric import EvalTemplate
+from model_hub.utils.eval_search import normalize_eval_search_text
 from model_hub.utils.eval_list import (
     build_eval_list_queryset,
     derive_eval_type,
@@ -273,6 +274,16 @@ class TestEvalTemplateListAPI:
         items = response.data["result"]["items"]
         for item in items:
             assert "user_custom" in item["name"].lower()
+
+    def test_list_search_matches_human_readable_spaces(
+        self, auth_client, user_eval_template
+    ):
+        """Human-readable search text should match underscore-stored eval names."""
+        response = auth_client.post(self.url, {"search": "User Custom"}, format="json")
+        assert response.status_code == 200
+
+        item_names = {item["name"] for item in response.data["result"]["items"]}
+        assert "user_custom_eval" in item_names
 
     def test_list_owner_filter_user(
         self, auth_client, system_eval_template, user_eval_template
@@ -820,6 +831,17 @@ class TestEvalListOutputTypeFilter:
             filters={},
         )
         assert qs.count() >= 6
+
+
+class TestEvalSearchNormalization:
+    def test_normalizes_human_readable_eval_names(self):
+        assert normalize_eval_search_text(" Context   Adherence ") == "context_adherence"
+
+    def test_preserves_underscore_searches(self):
+        assert normalize_eval_search_text("context_adherence") == "context_adherence"
+
+    def test_empty_search_stays_empty(self):
+        assert normalize_eval_search_text("") == ""
 
 
 # =============================================================================

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -566,6 +566,29 @@ class TestGetEvalsListView:
         }
         assert names == {"visible-user-eval"}
 
+    def test_get_evals_list_search_matches_human_readable_spaces(
+        self, auth_client, dataset, organization, workspace
+    ):
+        """Picker search should match underscore-stored eval names."""
+        EvalTemplate.objects.create(
+            name="context_adherence",
+            organization=organization,
+            workspace=workspace,
+            owner="user",
+            visible_ui=True,
+            config={},
+            eval_tags=["TEXT"],
+        )
+
+        response = auth_client.get(
+            f"/model-hub/develops/{dataset.id}/get_evals_list/",
+            {"search_text": "Context Adherence"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        names = {item["name"] for item in response.data["result"]["evals"]}
+        assert "context_adherence" in names
+
     def test_get_evals_list_invalid_dataset(self, auth_client):
         """Test that invalid dataset_id returns error."""
         fake_dataset_id = uuid.uuid4()

--- a/futureagi/model_hub/utils/SQL_queries.py
+++ b/futureagi/model_hub/utils/SQL_queries.py
@@ -4,6 +4,7 @@ import pandas as pd
 from django.db import connection
 
 from accounts.models.workspace import Workspace
+from model_hub.utils.eval_search import normalize_eval_search_text
 from tracer.models.observation_span import EndUser
 
 # Shared SQL expression for calculating model costs
@@ -344,6 +345,7 @@ class SQLQueryHandler:
         )
         limit = limit if limit else 10
         offset = offset if offset else 0
+        search_name = normalize_eval_search_text(search_name) or None
         query = f"""
         WITH filtered_templates AS (
             SELECT *

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -20,6 +20,7 @@ from agentic_eval.core_evals.fi_evals.eval_type import (
 )
 from model_hub.models.choices import EvalOutputType, OwnerChoices
 from model_hub.types import EvalListFilters, ThirtyDayDataPoint
+from model_hub.utils.eval_search import normalize_eval_search_text
 from tfc.constants.api_calls import APICallStatusChoices
 
 if TYPE_CHECKING:
@@ -378,7 +379,9 @@ def build_eval_list_queryset(
 
     # Search by name
     if search:
-        qs = qs.filter(name__icontains=search.strip())
+        normalized_search = normalize_eval_search_text(search)
+        if normalized_search:
+            qs = qs.filter(name__icontains=normalized_search)
 
     # Advanced filters
     if filters:

--- a/futureagi/model_hub/utils/eval_search.py
+++ b/futureagi/model_hub/utils/eval_search.py
@@ -1,0 +1,5 @@
+import re
+
+
+def normalize_eval_search_text(search_text):
+    return re.sub(r"\s+", "_", str(search_text or "").strip().lower())

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -229,6 +229,7 @@ from model_hub.utils.eval_reasons import (
     MIN_ROWS_FOR_CRITICAL_ISSUES,
     get_explanation_summary,
 )
+from model_hub.utils.eval_search import normalize_eval_search_text
 from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 from model_hub.utils.evals import (
     FUNCTION_CONFIG_EVALS,
@@ -6613,7 +6614,9 @@ class GetEvalsListView(APIView):
     ):  # Changed from 'post' to 'get'
         try:
             # Get parameters from query params instead of request body
-            search_text = request.GET.get("search_text", "").strip()
+            search_text = normalize_eval_search_text(
+                request.GET.get("search_text", "")
+            )
             eval_categories = request.GET.get("eval_categories")
             eval_type = request.GET.get("eval_type")
             eval_tags = request.GET.getlist("eval_tags[]") or request.GET.getlist(
@@ -6633,7 +6636,7 @@ class GetEvalsListView(APIView):
                 "eval_tags": eval_tags,
                 "use_cases": use_cases,
             }
-            search_text = validated_data.get("search_text", "").strip()
+            search_text = validated_data.get("search_text", "")
             eval_categories = validated_data.get("eval_categories")
             eval_type = validated_data.get("eval_type")
             eval_tags = validated_data.get("eval_tags")

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -110,6 +110,7 @@ from model_hub.utils.eval_playground_call_context import (
     build_eval_playground_scenario_context,
 )
 from model_hub.utils.evals import prepare_user_eval_config
+from model_hub.utils.eval_search import normalize_eval_search_text
 from model_hub.utils.function_eval_params import (
     has_function_params_schema,
     normalize_eval_runtime_config,
@@ -1170,7 +1171,11 @@ class GetEvalTemplateNameView(APIView):
                 .order_by("name")
             )
             if search_text:
-                eval_templates = eval_templates.filter(name__icontains=search_text)
+                normalized_search_text = normalize_eval_search_text(search_text)
+                if normalized_search_text:
+                    eval_templates = eval_templates.filter(
+                        name__icontains=normalized_search_text
+                    )
             eval_template_names = [
                 {
                     "id": str(eval_template.id),


### PR DESCRIPTION
﻿Fixes #1070.

## Summary
- normalize eval search text so human-readable queries like `context adherence` match stored eval names like `context_adherence`
- apply the same normalization in the eval list API, eval picker endpoints, legacy SQL template search, and `CustomEvalDrawer`
- add backend and frontend regression coverage for space-to-underscore search normalization

## Validation
- `python -m py_compile futureagi\model_hub\utils\eval_search.py futureagi\model_hub\utils\eval_list.py futureagi\model_hub\views\separate_evals.py futureagi\model_hub\views\develop_dataset.py futureagi\model_hub\utils\SQL_queries.py futureagi\model_hub\tests\test_eval_list.py futureagi\model_hub\tests\test_evaluation_api.py`
- `python -c "..."` helper behavior check for `normalize_eval_search_text`
- `node -e "..."` helper behavior check for `normalizeEvalSearchText`
- `git diff --cached --check`

Not run locally:
- `python -m pytest model_hub/tests/test_eval_list.py model_hub/tests/test_evaluation_api.py -k "human_readable_spaces or EvalSearchNormalization" -q` (`pytest` is not installed in this local Python environment)
- `yarn test:run src/sections/evals/utils/__tests__/search.test.js` (`node_modules` / `vitest` are not installed locally)
