### PR TITLE
fix(api): scope request resilience — flattened retry status, no global timeout

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -90,8 +90,17 @@ const queryClient = new QueryClient({
       gcTime: 5 * 60 * 1000,
       // Don't refetch when browser tab regains focus
       refetchOnWindowFocus: false,
-      // Retry once on failure
-      retry: 1,
+      // Retry network/timeout/5xx failures (survives an intermittently
+      // stalling backend) but not 4xx, which won't change on retry.
+      retry: (failureCount, error) => {
+        // The axios interceptor flattens rejections to { ...errData, statusCode }
+        // with no `.response`, so read the flattened statusCode (falling back to
+        // response.status for any error that bypassed the interceptor).
+        const status = error?.statusCode ?? error?.response?.status;
+        if (status && status >= 400 && status < 500) return false;
+        return failureCount < 2;
+      },
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
     },
   },
 });

--- a/frontend/src/auth/context/jwt/auth-provider.jsx
+++ b/frontend/src/auth/context/jwt/auth-provider.jsx
@@ -68,6 +68,26 @@ const reducer = (state, action) => {
 
 const STORAGE_KEY = "accessToken";
 
+// Boot the session even when the backend intermittently stalls: retry the
+// auth check on timeout / network / 5xx (a tight per-call timeout so it cycles
+// fast), but never on a real 401/403/user_not_found — those won't change.
+const fetchAuthMeWithRetry = async (accessToken, attempts = 3) => {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await axios.get(endpoints.auth.me, {
+        timeout: 15000,
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+    } catch (error) {
+      const status = error?.response?.status ?? error?.statusCode;
+      const isAuthError =
+        error?.code === "user_not_found" ||
+        (status >= 400 && status < 500);
+      if (isAuthError || attempt === attempts - 1) throw error;
+    }
+  }
+};
+
 export function AuthProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const queryClient = useQueryClient();
@@ -77,11 +97,7 @@ export function AuthProvider({ children }) {
       const accessToken = localStorage.getItem(STORAGE_KEY);
 
       if (accessToken) {
-        const response = await axios.get(endpoints.auth.me, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        });
+        const response = await fetchAuthMeWithRetry(accessToken);
 
         const user = response.data;
 

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -23,7 +23,14 @@ import { RESPONSE_CODES } from "./constants";
 
 // ----------------------------------------------------------------------
 //
-const axiosInstance = axios.create({ baseURL: HOST_API });
+const axiosInstance = axios.create({
+  baseURL: HOST_API,
+  // No global timeout: it would cap legitimately long-running calls (e.g. blob
+  // exports) on this shared instance. The one flow that hangs the app — the
+  // bootstrap auth check against a stalling backend — is scoped with its own
+  // per-call timeout in auth-provider (fetchAuthMeWithRetry). Individual calls
+  // that need a deadline can pass their own `timeout`.
+});
 
 const avoidRedirect = [
   "/auth/jwt/register",


### PR DESCRIPTION
## 1. Why
Split out of #1117 (feedback flow) at review request — these app-resilience changes are unrelated to the feedback work and carried its two hardest issues. This PR carries them on their own, with both blockers fixed.

Context (reviewer's "which flow was hanging?"): the only flow that hangs the app is the **bootstrap auth `/me` check** against a stalling dev backend. That is already scoped in `auth-provider` via `fetchAuthMeWithRetry` (15s per call, 3 attempts), so the global axios timeout was redundant for that motivation and only did harm (capping long exports).

## 2. What changed
- **`app.jsx`** — the React Query `retry` guard read `error.response.status`, but our axios interceptor rejects with a flattened `{ ...errData, statusCode }` (no `.response`). Status was always `undefined`, so the "don't retry 4xx" guard never fired and every failure (incl. 400/403/404) retried twice. Now reads the flattened `error.statusCode`, so 4xx correctly short-circuits.
- **`axios.js`** — removed the global `timeout: 30000`. On the shared instance it capped legitimately long calls (blob exports in ProjectDetailView / RequestExplorerSection / ExperimentBarDataRightSection / DevelopDataTab).
- **`auth-provider.jsx`** — retry the bootstrap auth `/me` check on timeout/network/5xx with a per-call 15s timeout (`fetchAuthMeWithRetry`).

## 3. Tests written (new & old)
- **New automated tests:** none — small, targeted resilience changes with no isolated unit to assert against (retry predicate + instance config).
- **Existing / regression:** repo vitest suite unaffected; ESLint clean on the three touched files.

## 4. Test scenarios covered (manual)
- A 4xx query failure no longer retries (previously retried twice).
- Network / timeout / 5xx still retries with backoff.
- Long blob-export requests are no longer aborted at 30s.
- App still boots (and doesn't hang) when the dev backend stalls the auth check.

## 5. Commands to run tests
```bash
cd frontend
yarn lint
yarn test:run
```

## 6. Steps to test on local/dev
1. `cd frontend && yarn dev`.
2. Trigger a 4xx (e.g. open a resource you don't have access to) → confirm the request is **not** retried (Network tab shows a single call, not three).
3. Start a long blob export (Project export / Request Explorer / Experiment bar / Develop data tab) that runs > 30s → confirm it completes instead of aborting at 30s.
4. Point the app at a slow/stalling backend and reload → confirm it still boots (auth check times out per-call and retries) rather than hanging on the splash.

## 7. Screenshots & videos
N/A — non-visual change (request retry / timeout behavior). Verifiable via the Network tab per the steps above.

## 8. Key decisions & rationale
- Read the **flattened `statusCode`** (falling back to `response.status`) rather than reshape the interceptor — least-risk, and matches how `app.jsx:66` already reads it.
- **Remove** the global timeout instead of exempting individual export calls — the only genuine hang (bootstrap auth) is already scoped in `auth-provider`, so a global default only risks capping unrelated long calls.
