### PR TITLE
Fix/user serializer ref name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+
+# Git worktrees
+.worktrees/

--- a/futureagi/model_hub/serializers/develop_annotations.py
+++ b/futureagi/model_hub/serializers/develop_annotations.py
@@ -281,6 +281,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["id", "email", "name", "organization_role", "is_active", "is_staff"]
+        ref_name = "ModelHubUserSerializer"
 
 
 class AnnotationProjectVersionMapperSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
  ## Problem                                                                                     
    Visiting the OpenAPI documentation endpoint (`/docs/?format=openapi`) throws a `500 Internal   
  Server Error` due to `SwaggerGenerationError: duplicate ref_name UserSerializer`.                
                                                                                                   
    ## Root Cause                                                                                  
    Both the accounts system user.py and the annotation schema develop_annotations.py define a      
  `UserSerializer` class. Django Rest Framework Spectacular (or Yasg) maps class names to OpenAPI  
  references, resulting in a namespace collision.                                                  
                                                                                                   
    ## Solution                                                                                    
    Added `ref_name = "ModelHubUserSerializer"` to the `Meta` class of the annotation              
  `UserSerializer` in develop_annotations.py to resolve the conflict.                                     
                                                                                                   
    ## Verification                                                                                
    Checked that the syntax is correct and the serialization schema name mapping resolved.