### PR TITLE
feat(tasks): add Duplicate action to Tasks detail page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+
+# Git worktrees
+.worktrees/

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -4,7 +4,7 @@ import { LoadingButton } from "@mui/lab";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
 import Iconify from "src/components/iconify";
@@ -30,6 +30,7 @@ const TAB_OPTIONS = [
 
 const TaskDetailPage = () => {
   const { taskId } = useParams();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [tab, setTab] = useState("details");
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -118,6 +119,23 @@ const TaskDetailPage = () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
       queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task renamed", { variant: "success" });
+    },
+  });
+
+  const { mutate: duplicateTask, isPending: isDuplicating } = useMutation({
+    mutationFn: () => axios.post(endpoints.project.duplicateEvalTask(taskId)),
+    onSuccess: (response) => {
+      const newTaskId = response?.data?.result?.id || response?.data?.id || response?.result?.id || response?.id;
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
+      enqueueSnackbar("Task duplicated successfully", { variant: "success" });
+      if (newTaskId) {
+        navigate(`/dashboard/tasks/${newTaskId}`);
+      }
+    },
+    onError: (err) => {
+      enqueueSnackbar(err?.response?.data?.result || "Failed to duplicate task", {
+        variant: "error",
+      });
     },
   });
 
@@ -227,6 +245,21 @@ const TaskDetailPage = () => {
           Resume
         </Button>
       )}
+      <LoadingButton
+        variant="outlined"
+        size="small"
+        loading={isDuplicating}
+        onClick={() => duplicateTask()}
+        startIcon={<Iconify icon="solar:copy-linear" width={14} />}
+        sx={{
+          textTransform: "none",
+          fontWeight: 500,
+          fontSize: "12px",
+          height: 30,
+        }}
+      >
+        Duplicate
+      </LoadingButton>
     </>
   );
 

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1114,6 +1114,8 @@ export const endpoints = {
       `/tracer/eval-task/pause_eval_task/?eval_task_id=${id}`,
     resumeEvalTask: (id) =>
       `/tracer/eval-task/unpause_eval_task/?eval_task_id=${id}`,
+    duplicateEvalTask: (id) =>
+      `/tracer/eval-task/duplicate_eval_task/?eval_task_id=${id}`,
     getAnnotationsForSpanId: () =>
       `/tracer/trace-annotation/get_annotation_values/`,
     getObservationSpanField: `/tracer/observation-span/get_observation_span_fields/`,

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1167,6 +1167,45 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             traceback.print_exc()
             return self._gm.bad_request(str(e))
 
+    @action(detail=False, methods=["post"])
+    def duplicate_eval_task(self, request, *args, **kwargs):
+        try:
+            eval_task_id = self.request.query_params.get("eval_task_id")
+            if not eval_task_id:
+                return self._gm.bad_request("Eval task ID is required")
+
+            try:
+                eval_task = EvalTask.objects.prefetch_related("evals").get(
+                    id=eval_task_id,
+                    project__organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                )
+            except EvalTask.DoesNotExist:
+                return self._gm.bad_request("Eval task not found")
+
+            # Duplicate the EvalTask
+            new_eval_task = EvalTask.objects.create(
+                project=eval_task.project,
+                name=f"Copy of {eval_task.name}" if eval_task.name else "Copy of Task",
+                filters=eval_task.filters.copy() if eval_task.filters else {},
+                sampling_rate=eval_task.sampling_rate,
+                spans_limit=eval_task.spans_limit,
+                run_type=eval_task.run_type,
+                status=EvalTaskStatus.PENDING,
+                evals_details=eval_task.evals_details.copy() if eval_task.evals_details else [],
+                row_type=eval_task.row_type,
+            )
+
+            # Copy Many-to-Many configurations
+            new_eval_task.evals.set(eval_task.evals.all())
+
+            serializer = self.get_serializer(new_eval_task)
+            return self._gm.success_response(serializer.data)
+
+        except Exception as e:
+            traceback.print_exc()
+            return self._gm.bad_request(str(e))
+
     @action(detail=False, methods=["get"])
     def list_eval_tasks_with_project_name(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
 Problem                                                                                     
    Users config/select evaluations, variables mapping, filters, etc., when defining a task. There 
  was no way to clone or duplicate an existing task configuration, forcing users to recreate it    
  from scratch.                                                                                    
                                                                                                   
  Solution                                                                                    
    1. **Backend**: Implemented `duplicate_eval_task` POST action on the `EvalTaskView`ViewSet in  
  eval_task.py to clone basic task fields and set the Many-to-Many `evals` configurations under a
  `PENDING` status.                                                                                
    2. **Frontend Endpoints**: Added the `duplicateEvalTask` helper in axios.js.             
    3. **Frontend UI**: Integrated a **Duplicate** loading button inside the `headerActions` of    
  TaskDetailPage.jsx that calls the endpoint and automatically redirects the user to the newly cloned
  task's detail page.                                                                              
                                                                                                   
 Verification                                                                                
    - Verified Django syntax is correct.                                                           
    - Verified React components compile and the path redirect matches the route                    
  (`/dashboard/tasks/:taskId`).