### PR TITLE
feat(evals): add JSONL source format to evaluation dataset loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+
+# Git worktrees
+.worktrees/

--- a/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
@@ -12,6 +12,7 @@ class LoadFormat(Enum):
     """Supported load formats."""
 
     JSON = "json"
+    JSONL = "jsonl"
     DICT = "dict"
     FI = "fi"
 
@@ -44,6 +45,8 @@ class BaseLoader(ABC):
         """
         if format == LoadFormat.JSON.value:
             return self.load_json(**kwargs)
+        elif format == LoadFormat.JSONL.value:
+            return self.load_jsonl(**kwargs)
         elif format == LoadFormat.DICT.value:
             return self.load_dict(**kwargs)
         elif format == LoadFormat.FI.value:
@@ -66,6 +69,22 @@ class BaseLoader(ABC):
                 return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.error(f"Error loading JSON: {e}")
+            raise
+
+    def load_jsonl(self, filename: str) -> list[DataPoint]:
+        """
+        Loads and processes data from a JSONL (JSON Lines) file.
+
+        Raises:
+            FileNotFoundError: If the specified JSONL file is not found.
+        """
+        try:
+            with open(filename) as f:
+                self._raw_dataset = [json.loads(line) for line in f if line.strip()]
+                self.process()
+                return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
+        except (FileNotFoundError, ValueError) as e:
+            logger.error(f"Error loading JSONL: {e}")
             raise
 
     def load_dict(self, data: list) -> list[DataPoint]:

--- a/futureagi/agentic_eval/core_evals/fi_utils/tests/test_loaders.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/tests/test_loaders.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+from agentic_eval.core_evals.fi_loaders.loader import Loader
+
+def test_jsonl_loader_happy_path(tmp_path):
+    # Create a temporary jsonl file
+    file_path = tmp_path / "test_dataset.jsonl"
+    
+    data = [
+        {"query": "What is AGI?", "response": "Artificial General Intelligence", "expected_response": "AGI"},
+        {"query": "Hello", "response": "Hi there", "expected_response": "Hello!"}
+    ]
+    
+    with open(file_path, "w") as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+            
+    # Initialize the loader
+    loader = Loader()
+    
+    # Load and process the jsonl file
+    result = loader.load("jsonl", filename=str(file_path))
+    
+    # Verify the results
+    assert len(result) == 2
+    
+    assert result[0]["query"] == "What is AGI?"
+    assert result[0]["response"] == "Artificial General Intelligence"
+    assert result[0]["expected_response"] == "AGI"
+    assert result[0]["context"] is None
+    
+    assert result[1]["query"] == "Hello"
+    assert result[1]["response"] == "Hi there"
+    assert result[1]["expected_response"] == "Hello!"
+    assert result[1]["context"] is None


### PR DESCRIPTION
 Problem                                                                                     
    The evaluation dataset loaders only supported three source formats (`json`, `dict`, `fi`),     
  lacking support for JSON Lines (`.jsonl`), which is the industry standard format for saving model
  evaluation outputs and inferences.                                                               
                                                                                                   
 Solution                                                                                    
    1. **Extend LoadFormat Enum**: Added `JSONL = "jsonl"` to `LoadFormat` in base_loader.py.      
    2. **Implement load_jsonl**: Added the `load_jsonl` method in base_loader.py to read lines,    
  parse JSON objects, and trigger dataset processing.                                              
    3. **Unit Tests**: Added a regression test suite in test_loaders.py to ensure correct parsing   
  and structure extraction.                                                                        
                                                                                                   
 Verification                                                                                
    Ran:                                                                                           
    `python3 -m pytest agentic_eval/core_evals/fi_utils/tests/test_loaders.py`                     
    Output: `1 passed`