### PR TITLE
fix(gateway): send backend-recognized granularity tokens in analytics charts

### DIFF
--- a/frontend/src/sections/gateway/analytics/ErrorAnalytics.jsx
+++ b/frontend/src/sections/gateway/analytics/ErrorAnalytics.jsx
@@ -21,6 +21,7 @@ import {
 import { useTheme } from "@mui/material/styles";
 import Chart from "react-apexcharts";
 import { useAnalyticsErrors } from "./hooks/useAnalyticsErrors";
+import { computeGranularity } from "../utils/analyticsHelpers";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -37,17 +38,6 @@ const TOP_N = 10;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function computeGranularity(start, end) {
-  if (!start || !end) return "1h";
-  const diffMs = new Date(end).getTime() - new Date(start).getTime();
-  const diffHours = diffMs / (1000 * 60 * 60);
-  if (diffHours <= 6) return "5m";
-  if (diffHours <= 24) return "15m";
-  if (diffHours <= 168) return "1h";
-  if (diffHours <= 720) return "6h";
-  return "1d";
-}
 
 function getChartColors(theme) {
   return [

--- a/frontend/src/sections/gateway/analytics/LatencyAnalytics.jsx
+++ b/frontend/src/sections/gateway/analytics/LatencyAnalytics.jsx
@@ -4,21 +4,11 @@ import { Box, Card, Grid, Typography, Skeleton } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import Chart from "react-apexcharts";
 import { useAnalyticsLatency } from "./hooks/useAnalyticsLatency";
+import { computeGranularity } from "../utils/analyticsHelpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function computeGranularity(start, end) {
-  if (!start || !end) return "1h";
-  const diffMs = new Date(end).getTime() - new Date(start).getTime();
-  const diffHours = diffMs / (1000 * 60 * 60);
-  if (diffHours <= 6) return "5m";
-  if (diffHours <= 24) return "15m";
-  if (diffHours <= 168) return "1h";
-  if (diffHours <= 720) return "6h";
-  return "1d";
-}
 
 function formatLatency(value) {
   if (value == null) return "--";

--- a/frontend/src/sections/gateway/analytics/UsageCharts.jsx
+++ b/frontend/src/sections/gateway/analytics/UsageCharts.jsx
@@ -13,6 +13,7 @@ import {
 import { useTheme } from "@mui/material/styles";
 import Chart from "react-apexcharts";
 import { useAnalyticsUsage } from "./hooks/useAnalyticsUsage";
+import { computeGranularity } from "../utils/analyticsHelpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -23,17 +24,6 @@ const GROUP_BY_OPTIONS = [
   { value: "model", label: "Model" },
   { value: "provider", label: "Provider" },
 ];
-
-function computeGranularity(start, end) {
-  if (!start || !end) return "1h";
-  const diffMs = new Date(end).getTime() - new Date(start).getTime();
-  const diffHours = diffMs / (1000 * 60 * 60);
-  if (diffHours <= 6) return "5m";
-  if (diffHours <= 24) return "15m";
-  if (diffHours <= 168) return "1h"; // 7 days
-  if (diffHours <= 720) return "6h"; // 30 days
-  return "1d";
-}
 
 // ---------------------------------------------------------------------------
 // Chart option builders

--- a/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
@@ -24,7 +24,7 @@ import { useApiKeyDetail, useRevokeApiKey } from "./hooks/useApiKeys";
 import EditKeyDialog from "./EditKeyDialog";
 import { useAnalyticsOverview } from "../analytics/hooks/useAnalyticsOverview";
 import { useAnalyticsUsage } from "../analytics/hooks/useAnalyticsUsage";
-import { val } from "../utils/analyticsHelpers";
+import { computeGranularity, val } from "../utils/analyticsHelpers";
 import { formatCost, formatDateTime as formatDate } from "../utils/formatters";
 
 const STATUS_COLORS = {
@@ -86,7 +86,15 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
   );
 
   const { data: usageData } = useAnalyticsUsage(
-    resolvedKeyId ? { ...analyticsParams, granularity: "1h" } : {},
+    resolvedKeyId
+      ? {
+          ...analyticsParams,
+          granularity: computeGranularity(
+            analyticsParams.start,
+            analyticsParams.end,
+          ),
+        }
+      : {},
     { enabled: Boolean(resolvedKeyId) },
   );
 

--- a/frontend/src/sections/gateway/utils/analyticsHelpers.js
+++ b/frontend/src/sections/gateway/utils/analyticsHelpers.js
@@ -25,3 +25,14 @@ export function trend(obj) {
     return obj.trend;
   return null;
 }
+
+/** Map a time range to a bucket granularity the analytics API accepts: the backend only recognizes "minute" | "hour" | "day" | "week" | "month" and silently coerces anything else to "hour". */
+export function computeGranularity(start, end) {
+  if (!start || !end) return "hour";
+  const diffMs = new Date(end).getTime() - new Date(start).getTime();
+  const diffHours = diffMs / (1000 * 60 * 60);
+  if (diffHours <= 6) return "minute";
+  if (diffHours <= 168) return "hour"; // up to 7 days
+  if (diffHours <= 720) return "day"; // up to 30 days
+  return "week";
+}

--- a/frontend/src/sections/gateway/utils/analyticsHelpers.js
+++ b/frontend/src/sections/gateway/utils/analyticsHelpers.js
@@ -33,6 +33,6 @@ export function computeGranularity(start, end) {
   const diffHours = diffMs / (1000 * 60 * 60);
   if (diffHours <= 6) return "minute";
   if (diffHours <= 168) return "hour"; // up to 7 days
-  if (diffHours <= 720) return "day"; // up to 30 days
+  if (diffHours <= 2160) return "day"; // up to 90 days
   return "week";
 }

--- a/frontend/src/sections/gateway/utils/analyticsHelpers.test.js
+++ b/frontend/src/sections/gateway/utils/analyticsHelpers.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { computeGranularity } from "./analyticsHelpers";
+
+// Must match TRUNC_MAP in futureagi/agentcc/services/analytics.py; the backend coerces any other token to "hour".
+const BACKEND_GRANULARITIES = ["minute", "hour", "day", "week", "month"];
+
+const range = (hours) => ({
+  start: new Date("2026-01-01T00:00:00Z").toISOString(),
+  end: new Date(
+    new Date("2026-01-01T00:00:00Z").getTime() + hours * 60 * 60 * 1000,
+  ).toISOString(),
+});
+
+describe("computeGranularity", () => {
+  it("returns 'hour' when the range is missing", () => {
+    expect(computeGranularity(null, null)).toBe("hour");
+    expect(computeGranularity("2026-01-01T00:00:00Z", null)).toBe("hour");
+  });
+
+  it("maps range length to the expected bucket size", () => {
+    const { start, end } = range(6);
+    expect(computeGranularity(start, end)).toBe("minute");
+    expect(computeGranularity(...Object.values(range(24)))).toBe("hour");
+    expect(computeGranularity(...Object.values(range(168)))).toBe("hour");
+    expect(computeGranularity(...Object.values(range(720)))).toBe("day");
+    expect(computeGranularity(...Object.values(range(2160)))).toBe("week");
+  });
+
+  it("only emits tokens the analytics backend accepts", () => {
+    [1, 6, 12, 24, 72, 168, 400, 720, 2160, 9000].forEach((hours) => {
+      const { start, end } = range(hours);
+      expect(BACKEND_GRANULARITIES).toContain(computeGranularity(start, end));
+    });
+  });
+});

--- a/frontend/src/sections/gateway/utils/analyticsHelpers.test.js
+++ b/frontend/src/sections/gateway/utils/analyticsHelpers.test.js
@@ -24,7 +24,8 @@ describe("computeGranularity", () => {
     expect(computeGranularity(...Object.values(range(24)))).toBe("hour");
     expect(computeGranularity(...Object.values(range(168)))).toBe("hour");
     expect(computeGranularity(...Object.values(range(720)))).toBe("day");
-    expect(computeGranularity(...Object.values(range(2160)))).toBe("week");
+    expect(computeGranularity(...Object.values(range(2160)))).toBe("day");
+    expect(computeGranularity(...Object.values(range(9000)))).toBe("week");
   });
 
   it("only emits tokens the analytics backend accepts", () => {


### PR DESCRIPTION
## Summary

The Gateway Analytics charts asked the API for bucket sizes like `5m`, `15m`, `1h`, `6h`, `1d`, but the backend only recognizes `minute`, `hour`, `day`, `week`, `month` and quietly falls back to `hour` for anything else. So every range renders hourly buckets: a 1H view shows two points instead of sixty, and the bucket density never changes when you switch ranges. This PR maps the requested granularity onto the backend's vocabulary so short ranges get real minute-level buckets, and fixes the same class of invalid token in KeyDetailDrawer.

To be upfront about scope, since @NVJKKartik's analysis on #945 addressed this territory: that analysis is right that granularity can't move the right-edge "sliver" on wide sparse ranges, since _fill_empty_buckets zero-fills the whole window at any unit. This PR doesn't claim otherwise and doesn't redistribute anything. What it fixes is narrower and, I think, uncontested: the frontend sends tokens the backend silently coerces, so bucket density is wrong on short ranges (the before/after in section 5 shows a 1H window with real traffic).

Thanks to @abhijaisrivastava15 for the writeup in #926: the token-mismatch diagnosis and the shared-helper plan are theirs.

## Linked issues

Related to #926 (fixes the token-coercion half; the wide-range sliver discussed there is data sparsity, per the analysis on #945)
Linear: N/A (external contribution)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

- `computeGranularity` now lives in `gateway/utils/analyticsHelpers.js` and returns tokens the backend accepts: ranges up to 6h get `minute`, up to 7d get `hour`, up to 30d get `day`, longer get `week`.
- The three private copies in `UsageCharts.jsx`, `ErrorAnalytics.jsx`, and `LatencyAnalytics.jsx` are deleted; all three import the shared helper, so the frontend and backend vocabularies can't drift apart again.
- `KeyDetailDrawer.jsx` sent the same class of invalid token (`"1h"`) for its per-key usage chart; it now uses the shared helper too.
- No API or backend change; the backend already zero-fills the full range for any accepted granularity.

---

## 2) Why the changes were done

- **Product/UX:** short ranges render almost no detail (a 1H view collapses to two hourly points), and switching the range preset never changes bucket density, which makes the charts feel broken even with plenty of gateway traffic.
- **Technical:** the root cause of that is a vocabulary mismatch, so the smallest correct fix is to speak the backend's tokens.
- **Architecture:** one shared helper instead of three copies, following the DRY direction the issue suggested.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/gateway/utils/analyticsHelpers.test.js`**: regression coverage for the granularity mapping

- `returns 'hour' when the range is missing`: the fallback for absent start/end.
- `maps range length to the expected bucket size`: each threshold boundary (6h, 24h, 7d, 30d, 90d).
- `only emits tokens the analytics backend accepts`: every emitted token must be in the backend's `TRUNC_MAP` set; the old `5m`/`15m`/`6h`/`1d` tokens all fail this, so it's the regression test for the bug itself.

> Run result: **58 passed** across the gateway suite (25 files); full `yarn test:run`: **2147 passed**; the only failing file is the pre-existing `scripts/api-journeys/preflight.test.mjs` infra check (see section 7). `vite build` succeeds. ESLint clean on touched files (0 errors, 0 warnings).

---

## 4) How to run / test

```bash
cd frontend
yarn install --frozen-lockfile

# The new helper test:
yarn test:run src/sections/gateway/utils/analyticsHelpers.test.js

# The full gateway suite:
yarn test:run src/sections/gateway
```

To see it in the UI: Gateway → Analytics → Overview, switch the time range between 6h / 24h / 7d / 30d and watch the network request's `granularity` param and the bucket density change.

---

## 5) Screenshots / recordings

### Test output

```
 Test Files  25 passed (25)
      Tests  58 passed (58)
```

(full `yarn test:run`: 2147 passed; the failures are pre-existing, see section 7)

### UI testing

Before/after from a local docker stack seeded with ~300 gateway requests over the trailing hour, Gateway → Analytics → Overview with the 1H range selected.

Before (dev): the charts request `granularity=5m`, the backend coerces it to hourly, and the whole hour renders as a smooth two-point hump.

![before](https://raw.githubusercontent.com/Zelys-DFKH/future-agi/assets-926/.github/pr-assets/before-926.png)

After (this branch): the charts request `granularity=minute`, so the same data renders as real per-minute buckets.

![after](https://raw.githubusercontent.com/Zelys-DFKH/future-agi/assets-926/.github/pr-assets/after-926.png)

The network logs during capture confirm the token change: `5m`/`15m` on dev, `minute`/`hour` on this branch.

---

## 6) Edge cases & considerations

- **Missing start or end:** helper returns `hour`, same behavior class as before (which returned `1h`).
- **Reversed range (start > end):** the negative diff maps to `minute`, still a token the backend accepts; the backend already swaps reversed ranges before bucketing.
- **Boundary values (exactly 6h/7d/30d):** covered by tests; each maps to the finer bucket.
- **Bucket counts stay bounded:** worst case is ~360 points (`minute` on a 6h range); a year on `week` is ~52 points.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `scripts/api-journeys/preflight.test.mjs`: assertion failures from the Docker/infra preflight check, identical on a clean `dev` checkout (verified by stashing this change and rerunning). Everything under `src/` passes.

---

## 8) Architectural / important decisions

- **Frontend-only fix:** teaching the backend to accept duration tokens (`5m`, `6h`) would widen a public API surface to preserve a frontend typo; mapping to the existing vocabulary is smaller and matches the fix outlined in the issue.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check`: N/A, no API surface change
- [x] Documentation: N/A, no user-facing docs affected
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (will sign when the bot prompts on this first PR)
- [x] PR title follows Conventional Commits
- [ ] Linear issue: N/A (external contribution)
