### PR TITLE
refactor(simulate): full eval-resolver parity between initial-run and rerun paths

### DIFF
--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -4677,14 +4677,13 @@ class TestExecutor:
                 chain.from_iterable(scenario_column_order_qs)
             )
 
-            # Get agent_version with fallback to latest_version if not set on call_execution.
-            # Prefer test_execution.agent_definition (per-execution snapshot), fall back to
-            # run_test.agent_definition, matching the resolution order in xl.py.
+            # Get agent_version with fallback to latest_version if not set on call_execution
             agent_version = call_execution.agent_version
             if not agent_version:
-                agent_def = call_execution.test_execution.agent_definition
-                if not agent_def:
-                    agent_def = call_execution.test_execution.run_test.agent_definition
+                agent_def = (
+                    call_execution.test_execution.agent_definition
+                    or call_execution.test_execution.run_test.agent_definition
+                )
                 if agent_def:
                     agent_version = agent_def.latest_version
                     logger.debug(
@@ -4860,10 +4859,6 @@ class TestExecutor:
             # Get organization
             organization = call_execution.test_execution.run_test.organization
 
-            # Build call_context for data_injection support — gives agent-eval
-            # tools access to the full call payload (explore_trace etc.). Gated
-            # on the eval's data_injection.call_context flag because the payload
-            # includes PII (phone_number, recording_url).
             from common.utils.data_injection import is_enabled as _di_enabled
 
             _di_cfg = (
@@ -4879,23 +4874,15 @@ class TestExecutor:
                     "call_type": call_execution.call_type,
                     "simulation_call_type": call_execution.simulation_call_type,
                     "phone_number": call_execution.phone_number,
-                    "started_at": (
-                        str(call_execution.started_at) if call_execution.started_at else None
-                    ),
-                    "ended_at": (
-                        str(call_execution.ended_at) if call_execution.ended_at else None
-                    ),
+                    "started_at": str(call_execution.started_at) if call_execution.started_at else None,
+                    "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
                     "duration_seconds": call_execution.duration_seconds,
                     "recording_url": call_execution.recording_url,
                     "call_summary": call_execution.call_summary,
                     "ended_reason": call_execution.ended_reason,
                     "error_message": call_execution.error_message,
                     "message_count": call_execution.message_count,
-                    "overall_score": (
-                        float(call_execution.overall_score)
-                        if call_execution.overall_score is not None
-                        else None
-                    ),
+                    "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
                 }
 
             # Run the evaluation

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -110,7 +110,10 @@ except ImportError:
     ConversationMetricsCalculator = None
     PhoneNumberService = None
     decide_processing_skip = None
-from simulate.temporal.activities.xl import TRANSCRIPT_DOT_ALIASES
+from simulate.temporal.activities.xl import (
+    TRANSCRIPT_DOT_ALIASES,
+    _build_simulation_context_map,
+)
 from simulate.utils.eval_summary import derive_kpi_output_type
 from simulate.utils.processing_outcomes import (
     build_skipped_eval_output_payload,
@@ -4674,15 +4677,21 @@ class TestExecutor:
                 chain.from_iterable(scenario_column_order_qs)
             )
 
-            # Get agent_version with fallback to latest_version if not set on call_execution
+            # Get agent_version with fallback to latest_version if not set on call_execution.
+            # Prefer test_execution.agent_definition (per-execution snapshot), fall back to
+            # run_test.agent_definition, matching the resolution order in xl.py.
             agent_version = call_execution.agent_version
             if not agent_version:
-                agent_def = call_execution.test_execution.run_test.agent_definition
+                agent_def = call_execution.test_execution.agent_definition
+                if not agent_def:
+                    agent_def = call_execution.test_execution.run_test.agent_definition
                 if agent_def:
                     agent_version = agent_def.latest_version
                     logger.debug(
                         f"Using fallback agent_version (latest_version) for call_execution {call_execution.id}"
                     )
+
+            context_map = _build_simulation_context_map(call_execution, agent_version)
 
             logger.info(
                 f"Eval mapping validation for call_execution {call_execution.id}: "
@@ -4725,6 +4734,8 @@ class TestExecutor:
                             updated_mapping[key] = ""
                     else:
                         updated_mapping[key] = transcript_data.get(legacy_key, "")
+                elif value in context_map:
+                    updated_mapping[key] = context_map[value]
                 else:
                     if value == "agent_prompt":
                         if agent_version and agent_version.configuration_snapshot:
@@ -4849,6 +4860,44 @@ class TestExecutor:
             # Get organization
             organization = call_execution.test_execution.run_test.organization
 
+            # Build call_context for data_injection support — gives agent-eval
+            # tools access to the full call payload (explore_trace etc.). Gated
+            # on the eval's data_injection.call_context flag because the payload
+            # includes PII (phone_number, recording_url).
+            from common.utils.data_injection import is_enabled as _di_enabled
+
+            _di_cfg = (
+                (config or {}).get("run_config", {}).get("data_injection")
+                or (config or {}).get("data_injection")
+                or {}
+            )
+            _call_context = None
+            if _di_enabled(_di_cfg, "call_context"):
+                _call_context = {
+                    "id": str(call_execution.id),
+                    "status": call_execution.status,
+                    "call_type": call_execution.call_type,
+                    "simulation_call_type": call_execution.simulation_call_type,
+                    "phone_number": call_execution.phone_number,
+                    "started_at": (
+                        str(call_execution.started_at) if call_execution.started_at else None
+                    ),
+                    "ended_at": (
+                        str(call_execution.ended_at) if call_execution.ended_at else None
+                    ),
+                    "duration_seconds": call_execution.duration_seconds,
+                    "recording_url": call_execution.recording_url,
+                    "call_summary": call_execution.call_summary,
+                    "ended_reason": call_execution.ended_reason,
+                    "error_message": call_execution.error_message,
+                    "message_count": call_execution.message_count,
+                    "overall_score": (
+                        float(call_execution.overall_score)
+                        if call_execution.overall_score is not None
+                        else None
+                    ),
+                }
+
             # Run the evaluation
             logger.info(
                 f"Running evaluation {eval_config.id} for call {call_execution.id}"
@@ -4864,6 +4913,7 @@ class TestExecutor:
                 error_localizer=eval_config.error_localizer,
                 workspace=call_execution.test_execution.run_test.workspace,
                 source="simulate",
+                call_context=_call_context,
             )
 
             if isinstance(eval_result, str):
@@ -4917,6 +4967,9 @@ class TestExecutor:
                             f"Error triggering error localization for evaluation {eval_config.id}: {str(e)}"
                         )
 
+                eval_config.status = StatusType.COMPLETED.value
+                eval_config.save()
+
                 logger.info(f"Successfully completed evaluation {eval_config.id}")
             else:
                 logger.info(f"Evaluation {eval_config.id} returned no result")
@@ -4941,6 +4994,9 @@ class TestExecutor:
                 "status"
             ] = StatusType.FAILED.value
             call_execution.save(update_fields=["eval_outputs"])
+
+            eval_config.status = StatusType.FAILED.value
+            eval_config.save()
             raise
 
     def _aggregate_tool_columns_to_test_execution(self, test_execution):

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -110,6 +110,7 @@ except ImportError:
     ConversationMetricsCalculator = None
     PhoneNumberService = None
     decide_processing_skip = None
+from simulate.temporal.activities.xl import TRANSCRIPT_DOT_ALIASES
 from simulate.utils.eval_summary import derive_kpi_output_type
 from simulate.utils.processing_outcomes import (
     build_skipped_eval_output_payload,
@@ -4714,6 +4715,16 @@ class TestExecutor:
                     updated_mapping[key] = transcript_data["user_chat_transcript"]
                 elif value == "assistant_chat_transcript":
                     updated_mapping[key] = transcript_data["assistant_chat_transcript"]
+                elif value in TRANSCRIPT_DOT_ALIASES:
+                    legacy_key = TRANSCRIPT_DOT_ALIASES[value]
+                    if legacy_key == "agent_prompt":
+                        if agent_version and agent_version.configuration_snapshot:
+                            snapshot = agent_version.configuration_snapshot
+                            updated_mapping[key] = snapshot.get("description", "")
+                        else:
+                            updated_mapping[key] = ""
+                    else:
+                        updated_mapping[key] = transcript_data.get(legacy_key, "")
                 else:
                     if value == "agent_prompt":
                         if agent_version and agent_version.configuration_snapshot:

--- a/futureagi/simulate/tests/test_eval_config_contracts.py
+++ b/futureagi/simulate/tests/test_eval_config_contracts.py
@@ -97,23 +97,3 @@ def test_eval_config_update_rejects_unknown_root_fields():
 
     assert not serializer.is_valid()
     assert "testExecutionId" in serializer.errors
-
-
-def test_eval_resolvers_share_alias_and_context_builder():
-    from simulate.services.test_executor import (
-        TRANSCRIPT_DOT_ALIASES as EXECUTOR_ALIASES,
-    )
-    from simulate.services.test_executor import (
-        _build_simulation_context_map as executor_context_builder,
-    )
-    from simulate.temporal.activities.xl import (
-        TRANSCRIPT_DOT_ALIASES as XL_ALIASES,
-    )
-    from simulate.temporal.activities.xl import (
-        _build_simulation_context_map as xl_context_builder,
-    )
-
-    assert EXECUTOR_ALIASES is XL_ALIASES
-    assert executor_context_builder is xl_context_builder
-    assert "call.agent_prompt" in XL_ALIASES
-    assert "call.user_chat_transcript" in XL_ALIASES

--- a/futureagi/simulate/tests/test_eval_config_contracts.py
+++ b/futureagi/simulate/tests/test_eval_config_contracts.py
@@ -97,3 +97,24 @@ def test_eval_config_update_rejects_unknown_root_fields():
 
     assert not serializer.is_valid()
     assert "testExecutionId" in serializer.errors
+
+
+def test_transcript_dot_aliases_shared_between_resolvers():
+    """Both eval-resolver paths must resolve the same dot-form mapping values.
+
+    xl.py handles first-time evals inside the Temporal CallExecutionWorkflow;
+    test_executor.py handles rerun, add-and-run, update-mapping, and the
+    standalone chat-sim finalize path. When only one file learns a new
+    dot-form key, the other raises "Column mapping mismatch" at runtime.
+    """
+    from simulate.services.test_executor import (
+        TRANSCRIPT_DOT_ALIASES as EXECUTOR_ALIASES,
+    )
+    from simulate.temporal.activities.xl import (
+        TRANSCRIPT_DOT_ALIASES as XL_ALIASES,
+    )
+
+    assert EXECUTOR_ALIASES is XL_ALIASES
+    assert "call.agent_prompt" in XL_ALIASES
+    assert "call.user_chat_transcript" in XL_ALIASES
+    assert "call.assistant_chat_transcript" in XL_ALIASES

--- a/futureagi/simulate/tests/test_eval_config_contracts.py
+++ b/futureagi/simulate/tests/test_eval_config_contracts.py
@@ -110,11 +110,22 @@ def test_transcript_dot_aliases_shared_between_resolvers():
     from simulate.services.test_executor import (
         TRANSCRIPT_DOT_ALIASES as EXECUTOR_ALIASES,
     )
+    from simulate.services.test_executor import (
+        _build_simulation_context_map as executor_context_builder,
+    )
     from simulate.temporal.activities.xl import (
         TRANSCRIPT_DOT_ALIASES as XL_ALIASES,
+    )
+    from simulate.temporal.activities.xl import (
+        _build_simulation_context_map as xl_context_builder,
     )
 
     assert EXECUTOR_ALIASES is XL_ALIASES
     assert "call.agent_prompt" in XL_ALIASES
     assert "call.user_chat_transcript" in XL_ALIASES
     assert "call.assistant_chat_transcript" in XL_ALIASES
+
+    # The context-map builder is shared too, so keys like call.recording_url,
+    # call.summary, call.overall_score, and all agent.*/persona.*/scenario.*
+    # dot-form values resolve identically on both eval-runner paths.
+    assert executor_context_builder is xl_context_builder

--- a/futureagi/simulate/tests/test_eval_config_contracts.py
+++ b/futureagi/simulate/tests/test_eval_config_contracts.py
@@ -99,14 +99,7 @@ def test_eval_config_update_rejects_unknown_root_fields():
     assert "testExecutionId" in serializer.errors
 
 
-def test_transcript_dot_aliases_shared_between_resolvers():
-    """Both eval-resolver paths must resolve the same dot-form mapping values.
-
-    xl.py handles first-time evals inside the Temporal CallExecutionWorkflow;
-    test_executor.py handles rerun, add-and-run, update-mapping, and the
-    standalone chat-sim finalize path. When only one file learns a new
-    dot-form key, the other raises "Column mapping mismatch" at runtime.
-    """
+def test_eval_resolvers_share_alias_and_context_builder():
     from simulate.services.test_executor import (
         TRANSCRIPT_DOT_ALIASES as EXECUTOR_ALIASES,
     )
@@ -121,11 +114,6 @@ def test_transcript_dot_aliases_shared_between_resolvers():
     )
 
     assert EXECUTOR_ALIASES is XL_ALIASES
+    assert executor_context_builder is xl_context_builder
     assert "call.agent_prompt" in XL_ALIASES
     assert "call.user_chat_transcript" in XL_ALIASES
-    assert "call.assistant_chat_transcript" in XL_ALIASES
-
-    # The context-map builder is shared too, so keys like call.recording_url,
-    # call.summary, call.overall_score, and all agent.*/persona.*/scenario.*
-    # dot-form values resolve identically on both eval-runner paths.
-    assert executor_context_builder is xl_context_builder

--- a/futureagi/simulate/tests/test_eval_resolver_behavior.py
+++ b/futureagi/simulate/tests/test_eval_resolver_behavior.py
@@ -1,0 +1,394 @@
+"""End-to-end behavior tests for the eval-mapping resolver on the rerun /
+add-eval / update-mapping / chat-finalize path.
+
+Constructs a real Django model chain against Postgres (via bin/test
+docker-compose.test.yml), invokes
+`TestExecutor._run_single_simulate_evaluation` directly, and mocks
+`run_eval_func` at its import boundary so no LLM call is issued.
+Assertions read the `mappings` payload handed to the mock (proving the
+resolver produced the correct values) and the persisted
+`SimulateEvalConfig.status` (proving the model save happens).
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.models.evals_metric import EvalTemplate
+from simulate.models import AgentDefinition, Scenarios
+from simulate.models.agent_version import AgentVersion
+from simulate.models.eval_config import SimulateEvalConfig
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import CallExecution, TestExecution
+from simulate.services.test_executor import TestExecutor
+
+
+@pytest.fixture
+def agent_definition(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        contact_number="+15551230000",
+        inbound=True,
+        description="Test agent for resolver behavior",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def agent_version(db, agent_definition, organization, workspace):
+    return AgentVersion.objects.create(
+        agent_definition=agent_definition,
+        organization=organization,
+        workspace=workspace,
+        version_number=1,
+        version_name="v1",
+        configuration_snapshot={
+            "description": "You are a helpful agent.",
+            "assistant_id": "test-assistant-id",
+        },
+    )
+
+
+@pytest.fixture
+def simulator_agent(db, organization, workspace):
+    return SimulatorAgent.objects.create(
+        name="Test Simulator",
+        prompt="You are a test simulator agent.",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def dataset_for_scenario(db, organization, user, workspace):
+    dataset = Dataset.no_workspace_objects.create(
+        name="Test Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    col = Column.objects.create(
+        dataset=dataset,
+        name="situation",
+        data_type="text",
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(col.id)]
+    dataset.save()
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=col, row=row, value="row value")
+    return dataset
+
+
+@pytest.fixture
+def scenario(db, organization, workspace, dataset_for_scenario, agent_definition):
+    return Scenarios.objects.create(
+        name="Test Scenario",
+        description="Test scenario",
+        source="Test source",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset_for_scenario,
+        agent_definition=agent_definition,
+        status=StatusType.COMPLETED.value,
+    )
+
+
+@pytest.fixture
+def run_test(db, organization, workspace, agent_definition, scenario, simulator_agent):
+    rt = RunTest.objects.create(
+        name="Test Run",
+        description="Test run",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    rt.scenarios.add(scenario)
+    return rt
+
+
+@pytest.fixture
+def test_execution(
+    db, run_test, simulator_agent, agent_definition, agent_version, scenario
+):
+    return TestExecution.objects.create(
+        run_test=run_test,
+        status=TestExecution.ExecutionStatus.COMPLETED,
+        total_scenarios=1,
+        total_calls=1,
+        simulator_agent=simulator_agent,
+        agent_definition=agent_definition,
+        agent_version=agent_version,
+        scenario_ids=[str(scenario.id)],
+    )
+
+
+@pytest.fixture
+def call_execution(db, test_execution, scenario, agent_version):
+    return CallExecution.objects.create(
+        test_execution=test_execution,
+        scenario=scenario,
+        phone_number="+15551230000",
+        status=CallExecution.CallStatus.COMPLETED,
+        agent_version=agent_version,
+        recording_url="s3://bucket/rec.mp3",
+        stereo_recording_url="s3://bucket/stereo.mp3",
+        call_summary="Customer called about order 123.",
+        ended_reason="customer-ended-call",
+        duration_seconds=120,
+        overall_score=8,
+        simulation_call_type=CallExecution.SimulationCallType.VOICE,
+    )
+
+
+@pytest.fixture
+def eval_template(db, organization):
+    return EvalTemplate.objects.create(
+        name="Score Eval",
+        config={"prompt": "Score the interaction"},
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def transcript_data():
+    return {
+        "transcript": "Hello. Yes, order 123 shipped.",
+        "voice_recording": "s3://bucket/rec.mp3",
+        "assistant_recording": "s3://bucket/asst.mp3",
+        "customer_recording": "s3://bucket/cust.mp3",
+        "stereo_recording": "s3://bucket/stereo.mp3",
+        "user_chat_transcript": "",
+        "assistant_chat_transcript": "",
+    }
+
+
+def _make_eval(mapping, run_test, eval_template, config=None):
+    return SimulateEvalConfig.objects.create(
+        name=f"Eval {uuid.uuid4().hex[:6]}",
+        eval_template=eval_template,
+        run_test=run_test,
+        mapping=mapping,
+        config=config or {},
+    )
+
+
+def _run(eval_config, call_execution, transcript_data):
+    return TestExecutor()._run_single_simulate_evaluation(
+        eval_config, call_execution, transcript_data
+    )
+
+
+_SUCCESS_STUB = {"output": "8", "reason": "ok", "output_type": "score"}
+
+
+@pytest.mark.django_db
+@patch("simulate.services.test_executor.close_old_connections", lambda: None)
+class TestDotFormMappingResolution:
+    """The resolver on the rerun path must map every FE-emitted dot-form value
+    to the same runtime value the initial-run path (xl.py) maps it to.
+    """
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_transcript_resolves_to_transcript_data_value(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"conversation": "call.transcript"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["conversation"] == "Hello. Yes, order 123 shipped."
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_recording_url_resolves_to_call_execution_field(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"answer": "call.recording_url"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["answer"] == "s3://bucket/rec.mp3"
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_summary_resolves_to_call_summary_field(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"summary": "call.summary"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["summary"] == "Customer called about order 123."
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_agent_prompt_resolves_from_snapshot_description(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"system_prompt": "call.agent_prompt"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["system_prompt"] == "You are a helpful agent."
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_status_resolves_via_context_map(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"s": "call.status"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["s"] == CallExecution.CallStatus.COMPLETED.value
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_agent_dot_keys_resolve_via_context_map(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval(
+            {"name": "agent.name", "desc": "agent.description"},
+            run_test,
+            eval_template,
+        )
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["name"] == "Test Agent"
+        assert mappings["desc"] == "You are a helpful agent."
+
+
+@pytest.mark.django_db
+@patch("simulate.services.test_executor.close_old_connections", lambda: None)
+class TestLegacyUnderscoreCompatibility:
+    """Legacy underscore-form mapping values must keep resolving. Old
+    persisted eval configs from before the dot-form vocabulary must not
+    regress.
+    """
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_underscore_transcript_still_resolves(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"input": "transcript"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["input"] == "Hello. Yes, order 123 shipped."
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_underscore_agent_prompt_still_resolves_from_snapshot(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"sp": "agent_prompt"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        mappings = mock_run.call_args.kwargs["mappings"]
+        assert mappings["sp"] == "You are a helpful agent."
+
+
+@pytest.mark.django_db
+@patch("simulate.services.test_executor.close_old_connections", lambda: None)
+class TestEvalConfigStatusPersistence:
+    """`SimulateEvalConfig.status` must be persisted on both success and
+    failure so downstream selectors filtering on the model see the
+    resolved state.
+    """
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_status_completed_after_successful_run(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"x": "call.transcript"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        ec.refresh_from_db()
+        assert ec.status == StatusType.COMPLETED.value
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_status_failed_after_exception(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.side_effect = RuntimeError("boom")
+        ec = _make_eval({"x": "call.transcript"}, run_test, eval_template)
+
+        with pytest.raises(RuntimeError):
+            _run(ec, call_execution, transcript_data)
+
+        ec.refresh_from_db()
+        assert ec.status == StatusType.FAILED.value
+
+
+@pytest.mark.django_db
+@patch("simulate.services.test_executor.close_old_connections", lambda: None)
+class TestCallContextPropagation:
+    """`call_context` is passed to `run_eval_func` only when the eval
+    opts in via `config.data_injection.call_context`. Agent evals that
+    read the call payload through `explore_trace` depend on this.
+    """
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_context_is_none_when_data_injection_disabled(
+        self, mock_run, run_test, call_execution, transcript_data, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"x": "call.transcript"}, run_test, eval_template)
+
+        _run(ec, call_execution, transcript_data)
+
+        assert mock_run.call_args.kwargs["call_context"] is None
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_call_context_populated_when_data_injection_enabled(
+        self,
+        mock_run,
+        run_test,
+        call_execution,
+        transcript_data,
+        eval_template,
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval(
+            {"x": "call.transcript"},
+            run_test,
+            eval_template,
+            config={"data_injection": {"call_context": True}},
+        )
+
+        _run(ec, call_execution, transcript_data)
+
+        ctx = mock_run.call_args.kwargs["call_context"]
+        assert ctx is not None
+        assert ctx["id"] == str(call_execution.id)
+        assert ctx["recording_url"] == "s3://bucket/rec.mp3"
+        assert ctx["call_summary"] == "Customer called about order 123."
+        assert ctx["duration_seconds"] == 120
+        assert ctx["overall_score"] == 8.0


### PR DESCRIPTION
## Why

Users hitting the "Add Evals + Run New Evals" flow after a simulation completes see `Column mapping mismatch: Column 'call.<field>' is not available in the test scenario(s)` on every mapping that uses the current dot-form vocabulary. The initial-run resolver `simulate/temporal/activities/xl.py::_run_single_evaluation` understands the full vocabulary; the resolver used by every non-initial-run path, `simulate/services/test_executor.py::_run_single_simulate_evaluation`, understands only legacy underscore keys. Any dot-form value the current UI emits falls through to the mismatch branch and raises.

Broken paths through `_run_single_simulate_evaluation`:

- Add-eval + Run New Evals: `simulate/views/run_test.py:6965`
- Rerun eval-only: `RerunSimulateEvalsView`
- Update an existing eval mapping: `UpdateSimulateEvalView`
- Standalone chat-sim finalize: `simulate/services/chat_sim.py:693`

Reported symptoms: `call.agent_prompt` on chat sim; `call.recording_url` and `call.summary` on voice sim.

Both resolver functions are `@temporal_activity`-decorated at the outer task boundary, so even when the Temporal workflow dispatches the task it lands in `test_executor.py` code, not `xl.py` code. Parity between the two files is the correctness contract.

## What changed

| File | Change | Preserved |
|---|---|---|
| `simulate/services/test_executor.py` | Line 113: imports `TRANSCRIPT_DOT_ALIASES` and `_build_simulation_context_map` from `xl.py`. Line 4684: agent-version fallback reordered to prefer `test_execution.agent_definition` over `run_test.agent_definition`. Line 4693: builds `context_map` once per eval via the shared builder. Line 4726: `elif value in TRANSCRIPT_DOT_ALIASES:` branch. Line 4736: `elif value in context_map:` branch. Line 4903: passes `call_context=_call_context` to `run_eval_func`; `_call_context` is populated only when `config.data_injection.call_context` is enabled. Line 4957 (success) and line 4985 (failure): persist `eval_config.status` via `eval_config.save()`. | Existing legacy underscore branches (`transcript`, `voice_recording`, `agent_prompt`, ...) untouched. Scenario-column resolution via `scenario_column_order_list` untouched. Per-cell `Cell.objects.get` lookup untouched. Error-message shape untouched. Success `eval_outputs[eval_id]` shape untouched. |
| `simulate/tests/test_eval_config_contracts.py` | Adds `test_eval_resolvers_share_alias_and_context_builder`. Asserts both `TRANSCRIPT_DOT_ALIASES` and `_build_simulation_context_map` are the same shared references across the two resolver files, plus spot-checks that `call.agent_prompt` and `call.user_chat_transcript` are alias keys. | Existing six serializer contract tests untouched. |

## Behavior callouts

- `SimulateEvalConfig.status` on the model row now reflects `COMPLETED` or `FAILED` after every rerun / add-eval / update-mapping / chat-finalize path. Before this PR, only `eval_outputs` on `CallExecution` was updated; the config's own status field stayed at its prior value. Downstream selectors that filter on `SimulateEvalConfig.status` will now see the resolved state on these paths.
- `call_context` payload passed to `run_eval_func` on this path now matches the payload the initial-run path already passes (14 fields including `id`, `status`, `call_type`, `simulation_call_type`, `phone_number`, `started_at`, `ended_at`, `duration_seconds`, `recording_url`, `call_summary`, `ended_reason`, `error_message`, `message_count`, `overall_score`). Agent evals that opt in via `config.data_injection.call_context = true` now receive the full call payload on the rerun path.
- Cross-modality mappings (e.g. a chat sim mapping `call.voice_recording`) resolve to `""` because both transcript-data builders initialise the same seven keys with empty-string defaults. No `KeyError`, no `Column mapping mismatch`.

## Scope

| In | Out |
|---|---|
| Full dot-form vocabulary parity between `_run_single_evaluation` (xl.py) and `_run_single_simulate_evaluation` (test_executor.py). | Hoisting the resolver body into a single shared helper; deferred because the surrounding code differs and reconciling requires a separate refactor. |
| `data_injection.call_context` propagation on the rerun path. | Other `data_injection` flags beyond `call_context`; neither path uses them today. |
| `eval_config.status` model persistence on the rerun path. | Result-payload shape harmonisation between the two paths (`xl.py` omits `status` in `eval_outputs[eval_id]`); pre-existing, not introduced by this PR. |
| Agent-version fallback order alignment. | Cell-lookup batching optimisation (`xl.py` batches, `test_executor.py` per-cell); performance-only, pre-existing. |

## Test coverage

All behavior tests build the full Django model chain (`Organization` -> `Workspace` -> `AgentDefinition` -> `AgentVersion` -> `Scenario` -> `RunTest` -> `TestExecution` -> `CallExecution` -> `EvalTemplate` -> `SimulateEvalConfig`) in real Postgres, invoke `TestExecutor()._run_single_simulate_evaluation(...)` directly, and mock only `run_eval_func` at the LLM boundary. Assertions read the `mappings` payload handed to `run_eval_func` (proves the resolver produced the correct value) and the persisted `SimulateEvalConfig.status` (proves `.save()` fires).

| Test | What it pins |
|---|---|
| `TestDotFormMappingResolution::test_call_transcript_resolves_to_transcript_data_value` | `call.transcript` resolves to `transcript_data["transcript"]`. |
| `TestDotFormMappingResolution::test_call_recording_url_resolves_to_call_execution_field` | `call.recording_url` resolves to `CallExecution.recording_url`. |
| `TestDotFormMappingResolution::test_call_summary_resolves_to_call_summary_field` | `call.summary` resolves to `CallExecution.call_summary`. |
| `TestDotFormMappingResolution::test_call_agent_prompt_resolves_from_snapshot_description` | `call.agent_prompt` resolves to `agent_version.configuration_snapshot["description"]`. |
| `TestDotFormMappingResolution::test_call_status_resolves_via_context_map` | `call.status` resolves to `CallExecution.status`. |
| `TestDotFormMappingResolution::test_agent_dot_keys_resolve_via_context_map` | `agent.name` and `agent.description` resolve via the shared context_map builder. |
| `TestLegacyUnderscoreCompatibility::test_underscore_transcript_still_resolves` | Legacy `transcript` (no dot) still resolves. Regression guard on the untouched hardcoded branch. |
| `TestLegacyUnderscoreCompatibility::test_underscore_agent_prompt_still_resolves_from_snapshot` | Legacy `agent_prompt` (no dot) still resolves from the snapshot. |
| `TestEvalConfigStatusPersistence::test_status_completed_after_successful_run` | After a successful run, `SimulateEvalConfig.objects.get(id=...).status == COMPLETED`. |
| `TestEvalConfigStatusPersistence::test_status_failed_after_exception` | After `run_eval_func` raises, `SimulateEvalConfig.objects.get(id=...).status == FAILED`. |
| `TestCallContextPropagation::test_call_context_is_none_when_data_injection_disabled` | Default eval config passes `call_context=None` to `run_eval_func`. |
| `TestCallContextPropagation::test_call_context_populated_when_data_injection_enabled` | Eval with `config.data_injection.call_context=True` passes a `call_context` dict whose fields match the persisted `CallExecution` (`id`, `recording_url`, `call_summary`, `duration_seconds`, `overall_score`). |
| `test_eval_config_definition_accepts_canonical_payload` (existing) | `EvalConfigDefinitionSerializer` accepts the canonical dot-form mapping payload. |
| `test_eval_config_definition_rejects_unknown_root_fields` (existing) | Serializer rejects unknown root fields. |
| `test_eval_config_definition_rejects_filter_object_shape` (existing) | Serializer rejects `filters` as an object (must be a list). |
| `test_eval_config_definition_rejects_non_object_config` (existing) | Serializer rejects `config` as a non-object. |
| `test_eval_config_definition_rejects_camel_case_filter_contract` (existing) | Serializer rejects camelCase filter keys. |
| `test_eval_config_update_rejects_unknown_root_fields` (existing) | `EvalConfigUpdateRequestSerializer` rejects unknown root fields. |

## Test runbook

Unit + behavior suite (18 tests: 12 behavior + 6 serializer contract):

```
DJANGO_SETTINGS_MODULE=tfc.settings.test .venv/bin/pytest simulate/tests/test_eval_config_contracts.py simulate/tests/test_eval_resolver_behavior.py -v --no-cov
```

<img width="1632" height="1242" alt="image" src="https://github.com/user-attachments/assets/7e2594fc-9cff-4757-891e-cd4cbc88ba14" />

End-to-end on local:

1. Boot the local stack.
2. Recreate `backend` and `temporal-worker-dev` so the resolver picks up the code change.
3. Create a chat simulation with a `SimulateEvalConfig` whose mapping is `{"conversation": "call.transcript", "system_prompt": "call.agent_prompt"}` and trigger a run.
4. Open the call-details grid; confirm every call execution has the eval column populated with a numeric score and no `Column mapping mismatch` in the eval-output reason.
5. Create a voice simulation with a `SimulateEvalConfig` whose mapping includes `call.recording_url` and `call.summary` alongside `call.agent_prompt` and trigger a run.
6. Confirm the recording-url and summary values resolve to the persisted `CallExecution.recording_url` and `CallExecution.call_summary` values and the eval column populates.
7. On a completed run, open the "Add Evals" drawer; add a new eval with dot-form mappings and click "Run New Evals".
8. Confirm the new eval column populates for every existing call execution in the run.
9. Query `SimulateEvalConfig.objects.get(id=<new-eval-id>).status`; confirm the value is `COMPLETED` or `FAILED` (not the pre-existing default).

### Chat sim: Add Evals + Run New Evals

https://github.com/user-attachments/assets/ccc28e44-83fe-4901-af30-5dc32a42a93d

### Voice sim: Add Evals + Run New Evals

https://github.com/user-attachments/assets/11a841aa-d822-428f-a8b3-5e44660be639

## Architectural decisions

- Shared `TRANSCRIPT_DOT_ALIASES` and `_build_simulation_context_map` imports over duplicated definitions: single source of truth, and drift is caught at import time by the new test rather than at first request in prod.
- `eval_config.save()` explicit on both success and failure branches: matches the behavior in `xl.py`.
- `_call_context` builder inlined at the call site: matches the shape and gating in `xl.py`.
- Resolver-body hoist into a shared helper is deferred; it lands as part of a broader refactor.

## Linear

Fix TH-6201
Fix TH-6438



