### PR TITLE
[TH-6200] Hide voice-only call fields from chat eval variable mapping

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -333,14 +333,10 @@ const CreateRunTestPage = ({ open, onClose }) => {
       // Call-level runtime vocabulary — resolved server-side at eval run time
       "call.transcript",
       "call.agent_prompt",
-      "call.summary",
       "call.ended_reason",
       "call.duration_seconds",
       "call.status",
       "call.overall_score",
-      "call.phone_number",
-      "call.recording_url",
-      "call.stereo_recording_url",
       // Modality-specific runtime vocabulary
       ...(isText
         ? ["call.user_chat_transcript", "call.assistant_chat_transcript"]
@@ -349,6 +345,11 @@ const CreateRunTestPage = ({ open, onClose }) => {
             "call.stereo_recording",
             "call.assistant_recording",
             "call.customer_recording",
+            // Only the voice pipeline populates these; chat resolves them to "".
+            "call.summary",
+            "call.phone_number",
+            "call.recording_url",
+            "call.stereo_recording_url",
           ]),
     ];
     return keys.map((key) => ({

--- a/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
+++ b/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
@@ -45,6 +45,11 @@ const VOICE_RUNTIME_LEAVES = [
   "assistant_recording",
   "customer_recording",
   "agent_prompt",
+  // Only the voice pipeline populates these; chat resolves them to "".
+  "summary",
+  "phone_number",
+  "recording_url",
+  "stereo_recording_url",
 ];
 const TEXT_RUNTIME_LEAVES = [
   "transcript",
@@ -53,14 +58,10 @@ const TEXT_RUNTIME_LEAVES = [
   "agent_prompt",
 ];
 const COMMON_RUNTIME_LEAVES = [
-  "summary",
   "ended_reason",
   "duration_seconds",
   "status",
   "overall_score",
-  "phone_number",
-  "recording_url",
-  "stereo_recording_url",
 ];
 
 const PRIORITY_PREFIXES = [


### PR DESCRIPTION
**Ticket:** [TH-6200](https://linear.app/future-agi/issue/TH-6200/does-not-display-correct-variables-when-configuring-evals) — Fixes TH-6200

## What was the bug
When configuring an eval for a **chat** simulation in the Run Simulation create flow, the pre-run "Preview — Variable Mapping" panel and its mapping dropdown offered voice-only fields — `call.phone_number`, `call.recording_url`, `call.stereo_recording_url` (and `call.summary`). Chat executions never populate these, so the backend resolves them to an empty string: binding an eval variable to one silently evaluates against `""` and produces misleading scores, with no error surfaced.

## What changes have been done
- `frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx` — moved `phone_number`, `recording_url`, `stereo_recording_url`, `summary` from `COMMON_RUNTIME_LEAVES` to `VOICE_RUNTIME_LEAVES`
- `frontend/src/components/run-tests/CreateRunTestPage.jsx` — moved the same four keys (`call.*` form) from the shared list in `syntheticEvalVocabulary` into the voice arm of the `isText` ternary

## Why the changes
- The pre-run vocabulary is hardcoded in these two places as `COMMON + (isText ? TEXT : VOICE)`. The four fields sat in the common bucket, so the chat branch could never exclude them.
- Verified against the backend: only the voice ingest writes `phone_number` / `recording_url` / `stereo_recording_url` / `call_summary`. The chat path writes `status`, `ended_reason`, `duration_seconds`, and `overall_score` (CSAT) — those stay common. Confirmed with Karthik Avinash (RCA author).
- No backend change and no migration concern: previously saved mappings with these keys still resolve exactly as before; the fix only stops offering them for chat going forward.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Create-flow eval config on a **chat** sim — preview table + mapping dropdown | No `call.phone_number`, `call.recording_url`, `call.stereo_recording_url`, `call.summary`; chat transcripts + lifecycle fields present |
| 2 | Create-flow eval config on a **voice** sim | Full voice vocabulary including the four moved fields |
| 3 | Chat sim — common fields | `call.status`, `call.ended_reason`, `call.duration_seconds`, `call.overall_score`, `call.transcript`, `call.user/assistant_chat_transcript`, `call.agent_prompt` all still offered |
| 4 | Existing saved eval mapping using a removed key | Still resolves at run time (backend unchanged); value shown via the dropdown's unknown-value fallback |

## How to reproduce (original bug)
1. Simulate → Run Simulation → create a simulation with a **chat** scenario
2. Proceed to the eval step and add/configure an eval
3. Open the variable-mapping dropdown or scan the preview table → voice-only `call.*` fields are listed

## Videos and screenshots

https://github.com/user-attachments/assets/5905a0bf-04ee-4833-80e2-4809b68f04b6

