### PR TITLE
fix(docker-compose): map agentcc-gateway host port to 8090 to match container

### DIFF
--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       context: ../agentcc-gateway
       dockerfile: Dockerfile
     ports:
-      - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
+      - "${AGENTCC_GATEWAY_PORT:-8090}:8090"
     volumes:
       - ../${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
       - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/Vertex_AI_Creds.json:ro


### PR DESCRIPTION
## Summary

Container-to-container callers (backend, xl-worker, etc.) reach the gateway via `agentcc-gateway:8090` from `AGENTCC_INTERNAL_URL`. Docker's internal DNS routes that directly to the container's port `8090`, **bypassing the host port mapping**. The prior mapping `"${AGENTCC_GATEWAY_PORT:-8090}:8080"` therefore only served host-side callers, and left internal traffic pointed at a port the gateway process was not bound to.

## Change

Map host `8090` to container `8090`. One line in `futureagi/docker-compose.yml`.

Pairs with the ee-side change that keeps the gateway's `config.yaml` `server.port` on `8090`. Together, the three surfaces (env var, host mapping, gateway listen port) all agree on `8090` — internal and external callers both land on the same listening socket.

## Verification

Locally: after applying both this and the paired ee change, the internal path (backend to `agentcc-gateway:8090`) accepts connections, and the host path (curl `localhost:8090`) also reaches the gateway. Before the fix, internal LLM calls from evals were failing with `httpx.ConnectError`.

## Test plan

- [x] `docker exec backend python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('agentcc-gateway',8090))"` succeeds
- [x] `curl -sI http://localhost:8090/v1/models` returns a gateway response (not `ConnectionRefused`)
- [x] Chat sim SDK run against local completes evals with real output scores (previously blocked by gateway connection failure)