### PR TITLE
fix(security): scope KB vector search tool by organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ frontend/scripts/.artifacts/
 # bin/install timestamped logs
 install-*.log
 uninstall-*.log
+
+# Git worktrees
+.worktrees/

--- a/futureagi/ai_tools/tests/test_kb_search_tool.py
+++ b/futureagi/ai_tools/tests/test_kb_search_tool.py
@@ -1,0 +1,105 @@
+import uuid
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ai_tools.tests.conftest import run_tool
+from model_hub.models.kb import KnowledgeBase
+
+@pytest.fixture(scope="session")
+def django_db_setup():
+    """Override and disable database setup entirely since we mock all database calls."""
+    pass
+
+@pytest.fixture
+def tool_context():
+    """Override database-dependent tool_context fixture with a clean in-memory mock."""
+    from ai_tools.base import ToolContext
+    user = MagicMock()
+    org = MagicMock()
+    workspace = MagicMock()
+    
+    org.id = uuid.uuid4()
+    user.organization = org
+    
+    return ToolContext(user=user, organization=org, workspace=workspace)
+
+class TestKBSearchTool:
+    def test_kb_search_same_organization_success(self, tool_context):
+        kb_id = str(uuid.uuid4())
+        mock_kb = MagicMock(spec=KnowledgeBase)
+
+        mock_results = [{"chunk_text": "hello test chunk content", "score": 0.95}]
+
+        # Pre-import to ensure module is loaded in sys.modules
+        import agentic_eval.core.embeddings.embedding_manager
+
+        # Mock the KnowledgeBase.objects.get lookup and the EmbeddingManager retrieve method
+        with patch("model_hub.models.kb.KnowledgeBase.objects.get") as mock_get, \
+             patch("agentic_eval.core.embeddings.embedding_manager.EmbeddingManager.retrieve_rag_based_examples") as mock_retrieve:
+            
+            mock_get.return_value = mock_kb
+            mock_retrieve.return_value = mock_results
+
+            result = run_tool(
+                "search_knowledge_base",
+                {"query": "hello", "kb_id": kb_id, "top_k": 3},
+                tool_context
+            )
+
+            # Assertions
+            assert not result.is_error
+            assert "hello test chunk content" in result.content
+            
+            mock_get.assert_called_once_with(
+                id=kb_id,
+                organization_id=tool_context.organization.id,
+            )
+            mock_retrieve.assert_called_once_with(
+                query="hello",
+                table_name="syn",
+                eval_id=kb_id,
+                meta_data_col="chunk_text",
+                input_type="text",
+                top_k=3,
+                threshold=0.25,
+            )
+
+    def test_kb_search_different_organization_denied(self, tool_context):
+        kb_id = str(uuid.uuid4())
+
+        # Mock the KnowledgeBase.objects.get lookup to raise DoesNotExist
+        with patch("model_hub.models.kb.KnowledgeBase.objects.get") as mock_get:
+            mock_get.side_effect = KnowledgeBase.DoesNotExist
+
+            result = run_tool(
+                "search_knowledge_base",
+                {"query": "secret query", "kb_id": kb_id},
+                tool_context
+            )
+
+            # Should fail with KB_NOT_FOUND error
+            assert result.is_error
+            assert result.error_code == "KB_NOT_FOUND"
+            assert "not found or permission denied" in result.content
+            mock_get.assert_called_once_with(
+                id=kb_id,
+                organization_id=tool_context.organization.id,
+            )
+
+    def test_kb_search_invalid_uuid_fails(self, tool_context):
+        # Mock the KnowledgeBase.objects.get lookup to raise ValueError (for invalid UUID string)
+        with patch("model_hub.models.kb.KnowledgeBase.objects.get") as mock_get:
+            mock_get.side_effect = ValueError("invalid UUID")
+
+            result = run_tool(
+                "search_knowledge_base",
+                {"query": "query", "kb_id": "not-a-valid-uuid"},
+                tool_context
+            )
+
+            assert result.is_error
+            assert result.error_code == "KB_NOT_FOUND"
+            mock_get.assert_called_once_with(
+                id="not-a-valid-uuid",
+                organization_id=tool_context.organization.id,
+            )

--- a/futureagi/ai_tools/tools/web/kb_search.py
+++ b/futureagi/ai_tools/tools/web/kb_search.py
@@ -45,6 +45,19 @@ class KBSearchTool(BaseTool):
 
     def execute(self, params: KBSearchInput, context: ToolContext) -> ToolResult:
         try:
+            from model_hub.models.kb import KnowledgeBase
+
+            try:
+                KnowledgeBase.objects.get(
+                    id=params.kb_id,
+                    organization_id=context.organization_id,
+                )
+            except (KnowledgeBase.DoesNotExist, ValueError):
+                return ToolResult.error(
+                    f"Knowledge Base '{params.kb_id}' not found or permission denied.",
+                    error_code="KB_NOT_FOUND",
+                )
+
             from agentic_eval.core.embeddings.embedding_manager import EmbeddingManager
 
             manager = EmbeddingManager()


### PR DESCRIPTION
                                                                                                
  Problem                                                                                     
    The `search_knowledge_base` RAG retrieval tool did not check whether the requested Knowledge   
  Base ID (`kb_id`) belonged to the organization of the executing `ToolContext`. This allowed      
  cross-tenant access to private vector embeddings if an attacker guessed or knew a different      
  tenant's `kb_id`.                                                                                
                                                                                                   
 Solution                                                                                    
    1. **Scoping Verification**: Added a database ownership check in the `KBSearchTool.execute`    
  method in kb_search.py. It now queries `KnowledgeBase.objects.get` verifying both `id` and     
  `organization_id=context.organization_id`.                                                       
    2. **Graceful Error Handling**: If the Knowledge Base is not found or belongs to a different   
  organization, it returns a standard `ToolResult.error` with error code `KB_NOT_FOUND`.           
    3. **Unit Tests**: Implemented a comprehensive test suite in test_kb_search_tool.py validating
same-   
  organization success, cross-tenant denial, and invalid UUID inputs.                              
                                                                                                   
 Verification                                                                                
    Ran:                                                                                           
    `pytest ai_tools/tests/test_kb_search_tool.py`                                                 
    Output: `3 passed`               