### PR TITLE
[TH-6422] Compare mode: populate variables + preserve remaining version on removal

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -131,6 +131,8 @@ const WorkbenchProvider = ({ children }) => {
   const stoppedIds = useRef([]);
   const runningVersionIndexMapping = useRef({});
   const activeSocketsRef = useRef({});
+  // Skip the next getPrompt(latest) load when collapsing compare -> single.
+  const skipLatestLoadOnce = useRef(false);
   const promptStreamUrl = usePromptStreamUrl();
 
   // Close all active sockets on unmount to prevent leaks
@@ -550,6 +552,11 @@ const WorkbenchProvider = ({ children }) => {
     if (!data) {
       return;
     }
+    // Collapse already selected the remaining version; don't let latest overwrite it.
+    if (skipLatestLoadOnce.current) {
+      skipLatestLoadOnce.current = false;
+      return;
+    }
     setPromptName(data?.name);
     setSelectedVersions([
       {
@@ -698,6 +705,7 @@ const WorkbenchProvider = ({ children }) => {
     const newModelConfigs = [];
     const newPlaceholders = [];
     const newPlaceholdersData = {};
+    const newVariableData = {};
 
     compareVersionData.data.forEach((version, _idx) => {
       newVersions.push({
@@ -718,6 +726,15 @@ const WorkbenchProvider = ({ children }) => {
 
       if (version?.placeholders) {
         Object.assign(newPlaceholdersData, version?.placeholders);
+      }
+
+      // Populate the shared variable panel; base (first) version wins on conflicts.
+      if (version?.variable_names) {
+        for (const [key, value] of Object.entries(version.variable_names)) {
+          if (!(key in newVariableData)) {
+            newVariableData[key] = value;
+          }
+        }
       }
 
       newModelConfigs.push({
@@ -756,6 +773,7 @@ const WorkbenchProvider = ({ children }) => {
     setResults(newResults);
     setPlaceholders(newPlaceholders);
     setPlaceholderData(newPlaceholdersData);
+    setVariableData(newVariableData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareVersionData]);
 
@@ -1430,6 +1448,10 @@ const WorkbenchProvider = ({ children }) => {
     setSelectedVersions((pre) => {
       const newPre = [...pre];
       newPre.splice(index, 1);
+      // Collapsing to one version re-enables getPrompt(latest); skip that load.
+      if (newPre.length === 1) {
+        skipLatestLoadOnce.current = true;
+      }
       return newPre;
     });
     setPrompts((pre) => {


### PR DESCRIPTION
**Ticket:** [TH-6422](https://linear.app/future-agi/issue/TH-6422) — Closes TH-6422

## What was the bug
Two related bugs in the prompt workbench **compare mode**:
1. **Variables not populated** — on loading/refreshing compare mode, the shared variable panel was empty even though each compared version carries `variable_names`.
2. **Removing a version loaded the latest draft** — with `[V1, V2]` in compare and a `V3` draft present, removing `V1` should collapse to single mode on `V2`, but `V3` (latest draft) loaded instead.

## What changes have been done
- `frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx`
  - Compare-restore effect now merges each version's `variable_names` (base/first version wins on key conflicts) and calls `setVariableData`.
  - Added a one-shot `skipLatestLoadOnce` ref, set when `removeFromCompare` collapses to a single version; the `getPrompt(latest)` data effect consumes it once and skips the load.

## Why the changes
- **Bug 1:** the compare-restore effect rebuilt prompts/config/placeholders/results but never called `setVariableData` — single-mode load (`:622`) and version-restore (`:1277`) both set it; only compare omitted it. Backend already returns `variable_names` per version (`PromptHistoryExecutionSerializer`), so this is frontend-only.
- **Bug 2:** `removeFromCompare` correctly splices to `[V2]`, but dropping to length 1 re-enables the `getPrompt(latest)` query (`enabled: selectedVersions.length <= 1`), whose effect unconditionally overwrote the selection with the latest version. The ref suppresses exactly that one load; single-mode refresh is untouched (ref is `false` on mount).

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open compare with 2 versions using `{{VAR}}`, reload | Variable panel repopulates with values |
| 2 | Compare `[V1, V2]` + a `V3` draft exists → remove `V1` | Collapses to single mode showing **V2** (its prompt/model/variables), not V3 |
| 3 | Remove `V1` from `[V1, V2, V3]` (stays in compare) | Remaining versions intact; no latest-load |
| 4 | Single-mode page refresh | Unchanged (loads latest as before) |

## How to reproduce (original bug)
1. Open a prompt, add a compare version so two versions are shown; ensure a variable like `{{VARIABLE_ONE}}` is used.
2. Reload → variable panel is empty (Bug 1).
3. With a newer draft version present, remove one of the two compared versions → the latest draft loads instead of the remaining version (Bug 2).

## Videos and screenshots

https://github.com/user-attachments/assets/52b7ad93-d22d-47b0-b968-94938353e181
https://github.com/user-attachments/assets/8db8be7e-6d44-4d4d-9cff-e7888b8fb899

