### PR TITLE
[TH-6425] Show new prompt folder in All Prompts list instantly

### DIFF
--- a/frontend/src/sections/workbench-v2/components/AddFolder.jsx
+++ b/frontend/src/sections/workbench-v2/components/AddFolder.jsx
@@ -28,6 +28,9 @@ export default function AddFolder({ open, onClose }) {
       queryClient.invalidateQueries({
         queryKey: ["prompt-folders"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["folder-items", "all"],
+      });
       if (data.data?.result?.id) {
         navigate(`/dashboard/workbench/${data.data?.result?.id}`);
       }


### PR DESCRIPTION
**Ticket:** [TH-6425](https://linear.app/future-agi/issue/TH-6425) — Closes TH-6425

## What was the bug
Creating a new prompt folder updated the **left sidebar** folder tree instantly, but the folder did **not** appear in the **All Prompts** main list until a manual page refresh.

## What changes have been done
- `frontend/src/sections/workbench-v2/components/AddFolder.jsx` — after a folder is created, also invalidate the All Prompts list query (`["folder-items", "all"]`) in addition to the existing `["prompt-folders"]`.

## Why the changes
The two folder surfaces are backed by different React Query keys:
- Left sidebar (`FileSystem` in `PromptDirView`) → `["prompt-folders"]`
- All Prompts main list (`FolderListView`, `folder === "all"`) → `["folder-items", "all", …]` (from `prompt-executions?send_all=true`, which returns folders)

`AddFolder.onSuccess` only invalidated `["prompt-folders"]`, so the All Prompts list was never refreshed on create. Sibling mutations already do this — `CreateNewPrompt` and `DeleteItem` both invalidate `["folder-items"]`. The fix scopes the invalidation to the `"all"` list only (new folders are always top-level), so other folders' item lists aren't needlessly refetched.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Create a folder from All Prompts | New folder appears in the All Prompts list instantly (no refresh) |
| 2 | Left sidebar folder tree | Still updates instantly (unchanged) |
| 3 | Other folder views / my-templates | Not needlessly refetched (scoped to `"all"`) |

## How to reproduce (original bug)
1. Open Prompts → All Prompts.
2. Create a new folder.
3. Folder shows in the left sidebar but is missing from the All Prompts list until a manual refresh.

## Videos and screenshots

https://github.com/user-attachments/assets/c9c2dd22-de21-4632-9f97-8e743c7bb569

