### PR TITLE
[TH-6429] Infinite scroll for Simulate prompt version dropdown

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
@@ -17,6 +17,7 @@ import {
   ListItemText,
   MenuItem,
   Select,
+  Skeleton,
   TextField,
   Tooltip,
   Typography,
@@ -76,9 +77,25 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
   );
 
   // Fetch prompt versions using existing hook
-  const { versions, isLoading: isLoadingVersions } = usePromptVersions(
-    open ? promptTemplateId : null,
-  );
+  const {
+    versions,
+    isLoading: isLoadingVersions,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = usePromptVersions(open ? promptTemplateId : null);
+
+  // Load the next page when the version dropdown is scrolled near the bottom.
+  const handleVersionMenuScroll = (e) => {
+    const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+    if (
+      scrollHeight - scrollTop - clientHeight < 50 &&
+      hasNextPage &&
+      !isFetchingNextPage
+    ) {
+      fetchNextPage();
+    }
+  };
 
   // Reset form when modal opens with auto-generated name
   useEffect(() => {
@@ -229,7 +246,12 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
                 setFormData((prev) => ({ ...prev, versionId: e.target.value }))
               }
               disabled={isLoadingVersions}
-              MenuProps={{ PaperProps: { sx: { maxHeight: 300 } } }}
+              MenuProps={{
+                PaperProps: {
+                  sx: { maxHeight: 300 },
+                  onScroll: handleVersionMenuScroll,
+                },
+              }}
             >
               {versions.map((version) => (
                 <MenuItem key={version.id} value={version.id}>
@@ -270,6 +292,12 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
                   </Box>
                 </MenuItem>
               ))}
+              {isFetchingNextPage &&
+                Array.from({ length: 2 }).map((_, index) => (
+                  <MenuItem key={`version-skeleton-${index}`} disabled>
+                    <Skeleton variant="text" width={60} />
+                  </MenuItem>
+                ))}
             </Select>
           </FormControl>
 


### PR DESCRIPTION
**Ticket:** [TH-6429](https://linear.app/future-agi/issue/TH-6429) — Closes TH-6429

## What was the bug
The prompt version dropdown in the **Create Simulation** modal was made scrollable in TH-6268 (PR #1162), but it only ever showed the **first page** of versions. Scrolling to the bottom didn't load more, so older versions were unreachable.

## What changes have been done
- `frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx`
  - Destructured `fetchNextPage` / `hasNextPage` / `isFetchingNextPage` from `usePromptVersions` (the hook already returns them).
  - Added `handleVersionMenuScroll` → calls `fetchNextPage()` when the menu is scrolled within 50px of the bottom, wired via `MenuProps.PaperProps.onScroll`.
  - Loading skeletons while `isFetchingNextPage`.

## Why the changes
`usePromptVersions` is an `useInfiniteQuery`, but this modal only consumed `{ versions, isLoading }` and the `<Select>` had no scroll-to-load handler — so only page 1 loaded. Infinite scroll was never wired on this dropdown (confirmed via git history); sibling version dropdowns (`VersionSelect`, `VersionHistoryDrawer`, etc.) already do this. Used `onScroll` on the menu Paper (not `useScrollEnd`) because a `<Select>`'s menu only mounts on open, so a ref-based effect wouldn't attach — same approach as `ModelSelector.jsx`.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open Create Simulation on a prompt with >1 page of versions | Scroll to bottom of the version dropdown loads the next page |
| 2 | Scroll while a page is loading | Skeleton rows shown; no duplicate fetches (guarded by `hasNextPage && !isFetchingNextPage`) |
| 3 | Prompt with a single page of versions | No extra fetch; behaves as before |

## How to reproduce (original bug)
1. Open a prompt that has many versions (more than one page).
2. Prompt → Simulate → Create Simulation → open the Prompt Version dropdown.
3. Scroll to the bottom — older versions never appear (only page 1 is loaded).

## Videos and screenshots

https://github.com/user-attachments/assets/9301865d-2f2b-4079-b4ce-dad2ffdd97ae

