### PR TITLE
[TH-6430] Agent playground: omit media on prompt import + fix run/execution response key mismatches

### DIFF
--- a/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
@@ -49,7 +49,7 @@ export default function ExecutionDetailView({ graphId, executionId }) {
 
     const newNodeStatuses = {};
     for (const node of executionData.nodes) {
-      const nodeExecution = node.nodeExecution || node.node_execution;
+      const nodeExecution = node.node_execution;
       const currentStatus = nodeExecution?.status?.toLowerCase();
       const nodeExecId = nodeExecution?.id;
       const prevNodeStatus = nodeStatusesRef.current[node.id];
@@ -82,18 +82,17 @@ export default function ExecutionDetailView({ graphId, executionId }) {
       setSelectedNodeId(null);
       return;
     }
-    // Find last node that has a nodeExecution (skip pending nodes)
-    const executedNodes = executionData.nodes.filter(
-      (n) => n.nodeExecution || n.node_execution,
-    );
+    // Find last node that has a node_execution (skip pending nodes)
+    const executedNodes = executionData.nodes.filter((n) => n.node_execution);
     if (executedNodes.length === 0) {
       setSelectedNodeId(null);
       return;
     }
     const lastNode = executedNodes[executedNodes.length - 1];
-    if (lastNode.subGraph?.nodes?.length) {
-      const executedInner = lastNode.subGraph.nodes.filter(
-        (n) => n.nodeExecution || n.node_execution,
+    const lastNodeSubGraph = lastNode.sub_graph;
+    if (lastNodeSubGraph?.nodes?.length) {
+      const executedInner = lastNodeSubGraph.nodes.filter(
+        (n) => n.node_execution,
       );
       if (executedInner.length > 0) {
         const lastInner = executedInner[executedInner.length - 1];

--- a/frontend/src/sections/agent-playground/Executions/Executions.jsx
+++ b/frontend/src/sections/agent-playground/Executions/Executions.jsx
@@ -24,8 +24,8 @@ export default function Executions() {
         (page.data?.result?.executions ?? []).map((e) => ({
           id: e.id,
           status: e.status?.toLowerCase(),
-          startedAt: e.startedAt,
-          completedAt: e.completedAt,
+          startedAt: e.started_at,
+          completedAt: e.completed_at,
         })),
       ),
     [data],

--- a/frontend/src/sections/agent-playground/hooks/__tests__/useWorkflowExecution.test.js
+++ b/frontend/src/sections/agent-playground/hooks/__tests__/useWorkflowExecution.test.js
@@ -63,7 +63,7 @@ describe("useWorkflowExecution", () => {
         rows: [{ cells: [{ value: "ok" }] }],
       });
       mockExecuteDataset.mockResolvedValue({
-        data: { result: { executionIds: ["exec-1"] } },
+        data: { result: { execution_ids: ["exec-1"] } },
       });
 
       const { result } = renderHook(() => useWorkflowExecution());
@@ -170,7 +170,7 @@ describe("useWorkflowExecution", () => {
         rows: [{ cells: [{ value: "ok" }] }],
       });
       mockExecuteDataset.mockResolvedValue({
-        data: { result: { executionIds: ["exec-1"] } },
+        data: { result: { execution_ids: ["exec-1"] } },
       });
 
       const { result } = renderHook(() => useWorkflowExecution());

--- a/frontend/src/sections/agent-playground/hooks/useExecutionSync.js
+++ b/frontend/src/sections/agent-playground/hooks/useExecutionSync.js
@@ -84,8 +84,9 @@ export default function useExecutionSync(graphId, executionId) {
       status === EXECUTION_STATUS.ERROR ||
       status === EXECUTION_STATUS.FAILED
     ) {
-      failRun(executionData.errorMessage || "Execution failed", executionData);
-      enqueueSnackbar(executionData.errorMessage || "Execution failed", {
+      const executionError = executionData.error_message || "Execution failed";
+      failRun(executionError, executionData);
+      enqueueSnackbar(executionError, {
         variant: "error",
       });
       queryClient.invalidateQueries({
@@ -110,14 +111,15 @@ export default function useExecutionSync(graphId, executionId) {
     const nodeStatesMap = {};
     const newNodeStatuses = {};
     for (const node of executionData.nodes) {
-      const currentStatus = node.nodeExecution?.status?.toLowerCase();
+      const nodeExecution = node.node_execution;
+      const currentStatus = nodeExecution?.status?.toLowerCase();
       const nodeState = mapApiStatusToNodeState(currentStatus);
       if (nodeState) {
         nodeStatesMap[node.id] = nodeState;
       }
 
       // Invalidate node detail query when node reaches terminal status
-      const nodeExecId = node.nodeExecution?.id;
+      const nodeExecId = nodeExecution?.id;
       const prevStatus = nodeStatusesRef.current[node.id];
       if (nodeExecId && currentStatus && currentStatus !== prevStatus) {
         const isTerminal =

--- a/frontend/src/sections/agent-playground/hooks/useWorkflowExecution.js
+++ b/frontend/src/sections/agent-playground/hooks/useWorkflowExecution.js
@@ -124,7 +124,7 @@ export default function useWorkflowExecution() {
     setIsInitiating(false);
     try {
       const res = await executeDataset({ graphId });
-      const executionIds = res.data?.result?.executionIds;
+      const executionIds = res.data?.result?.execution_ids;
       if (executionIds?.[0]) {
         startPolling(executionIds[0]);
       } else {

--- a/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
+++ b/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
@@ -4,6 +4,14 @@ import {
   extractResponseSchema,
 } from "../AgentBuilder/NodeDrawer/nodeFormUtils";
 
+// Agent builder has no attachment upload and can't surface media, so drop
+// non-text content items when importing a workbench prompt into a node.
+function toTextOnlyContent(content) {
+  if (!Array.isArray(content)) return content;
+  const textOnly = content.filter((block) => block?.type === "text");
+  return textOnly.length ? textOnly : [{ type: "text", text: "" }];
+}
+
 /**
  * Maps a version's promptConfigSnapshot into a form-compatible config shape.
  * Used when importing a prompt and when changing versions in the dropdown.
@@ -29,7 +37,7 @@ export function mapVersionToFormConfig(version) {
       const msgs = (snapshot?.messages || []).map((m) => ({
         id: getRandomId(),
         role: m.role,
-        content: m?.content,
+        content: toTextOnlyContent(m?.content),
       }));
       if (!msgs.some((m) => m.role === "system")) {
         msgs.unshift({


### PR DESCRIPTION
**Ticket:** [TH-6430](https://linear.app/future-agi/issue/TH-6430/bugfix-agent-playground-omit-media-on-prompt-import-fix-runexecution) — Fixes TH-6430

## What was the bug
Two related agent-playground bugs found while testing prompt import + workflow run:

1. **Importing a prompt with media fails.** The agent builder has no attachment upload, but importing a workbench prompt containing a media content item (`audio_url`/`image_url`/`pdf_url`) copied the media block verbatim into the node. Saving/creating the node then 400'd with `audio_url: Enter a valid URL`.
2. **Running a workflow silently broke** because the FE read camelCase keys off a response the backend emits in snake_case (there is no camelization layer — `useGetExecutionDetail` returns the raw `result`). Most visibly: execute returned 201 but the UI showed **"No execution IDs returned"**, and after that the run's node coloring never updated and the Output pane hung on skeletons.

## What changes have been done
- `utils/promptVersionUtils.js` — strip non-text content blocks when importing a prompt version into a node (single choke point for both the import popper and the version-switch dropdown); a media-only message falls back to one empty text block.
- `hooks/useWorkflowExecution.js` — `result.executionIds` → `result.execution_ids`.
- `hooks/useExecutionSync.js` — `node.nodeExecution` → `node.node_execution`; `executionData.errorMessage` → `executionData.error_message`.
- `Executions/ExecutionDetailView.jsx` — `node.nodeExecution` → `node.node_execution`; `lastNode.subGraph` → `lastNode.sub_graph`.
- `Executions/Executions.jsx` — source `e.startedAt`/`e.completedAt` from `e.started_at`/`e.completed_at`.

## Why the changes
- **Import omit:** the playground can't upload or render attachments, and its node serializer types media URLs as flat strings — so media has no place here; dropping it on import keeps text intact and the node valid.
- **Key mismatches:** every field was verified 1:1 against the backend (DRF serializers / execution-detail builder) — `execution_ids`, `node_execution`, `sub_graph`, `error_message`, `started_at`/`completed_at`. Reads now use the confirmed snake_case field directly (no camel/snake guessing). Frontend-only.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Import a prompt containing an audio/image/pdf attachment into an LLM node | Node imports with text preserved, media omitted; Save succeeds (no 400) |
| 2 | Import a plain text prompt | Unchanged — all text messages preserved |
| 3 | Run a workflow | Execute proceeds (no "No execution IDs returned"); polling starts |
| 4 | While a run is in progress | Nodes light up live; Output pane populates on completion |
| 5 | Open the Executions history sidebar | Each row shows its real start date (not "—") |
| 6 | A run that fails | Toast shows the real backend error message |
| 7 | Subgraph execution detail | Auto-selects the last executed inner node |

## How to reproduce (original bug)
1. In workbench, create/pick a prompt that has an audio (or image/pdf) attachment in a message.
2. Agent playground → add an LLM Prompt node → import that prompt → **400 `Enter a valid URL`**.
3. With any wired graph, click **Run Agent Workflow** → **"No execution IDs returned"**, Output pane stuck on skeletons, execution-list dates show "—".

## Commands
```bash
# frontend
yarn dev   # port 3031
```

## Videos and screenshots

https://github.com/user-attachments/assets/fc9feb15-c2e7-453c-a787-ec9efc05eb9f

