### PR TITLE
fix(prompt): stop full page reload when enlarging media in Run Prompt (TH-6447)

### DIFF
--- a/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
@@ -74,6 +74,7 @@ const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
         <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
           <ShowComponent condition={Boolean(onDelete)}>
             <button
+              type="button"
               onClick={onDelete}
               style={{
                 background: "none",

--- a/frontend/src/components/PromptCards/EmbedComponents/ImageEmbed.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/ImageEmbed.jsx
@@ -93,7 +93,7 @@ const ImageEmbed = ({
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
         <ShowComponent condition={Boolean(onMagnify)}>
-          <button onClick={onMagnify} style={iconButtonStyle}>
+          <button type="button" onClick={onMagnify} style={iconButtonStyle}>
             <img
               src="/assets/icons/components/ic_magnify.svg"
               alt="magnify"
@@ -104,7 +104,7 @@ const ImageEmbed = ({
           </button>
         </ShowComponent>
         <ShowComponent condition={Boolean(onReplace)}>
-          <button onClick={onReplace} style={iconButtonStyle}>
+          <button type="button" onClick={onReplace} style={iconButtonStyle}>
             <img
               src="/assets/icons/components/ic_replace.svg"
               alt="replace"
@@ -115,7 +115,7 @@ const ImageEmbed = ({
           </button>
         </ShowComponent>
         <ShowComponent condition={Boolean(onDelete)}>
-          <button onClick={onDelete} style={iconButtonStyle}>
+          <button type="button" onClick={onDelete} style={iconButtonStyle}>
             <img
               src="/assets/icons/ic_delete.svg"
               alt="delete"

--- a/frontend/src/components/PromptCards/EmbedComponents/PdfEmbed.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/PdfEmbed.jsx
@@ -69,6 +69,7 @@ const PdfEmbed = ({ isEmbed, id, size, onDelete, name }) => {
         <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
           <ShowComponent condition={Boolean(onDelete)}>
             <button
+              type="button"
               onClick={onDelete}
               style={{
                 background: "none",


### PR DESCRIPTION
**Ticket:** [TH-6447](https://linear.app/future-agi/issue/TH-6447/enlarging-attached-media-in-run-prompt-reloads-the-whole-page) — Closes TH-6447

## What was the bug
In the Run Prompt panel (develop / dataset), clicking the **magnify** icon to enlarge an attached image triggered a **full browser page reload** every time — the whole app re-bootstrapped and all panel init calls (`get_evals_list`, `model_parameters`, `retrieve_run_prompt_options`, `provider-status`, `model_voices`, `response_schema`, …) re-fired. The same happened for the **replace/delete** icons, and for **delete** on audio/pdf attachments.

> The red `track/` `engage/` `groups/` requests seen alongside are just PostHog analytics blocked by the browser's tracking protection — unrelated to this bug.

## What changes have been done
Added `type="button"` to the 5 media-embed icon buttons:
- `ImageEmbed.jsx` — magnify, replace, delete
- `AudioEmbed.jsx` — delete
- `PdfEmbed.jsx` — delete

## Why the changes (root cause)
Those `<button>` elements had **no `type` attribute**, so they defaulted to `type="submit"`. They render inside the Run Prompt `<form>` (`RunPrompt.jsx`), which has **no `onSubmit` handler** — so clicking one performed a native GET form submission = full page reload. It's a pre-existing latent defect that only surfaces once media is present in the panel (the only time such a button exists to click). `type="button"` is a no-op outside a form and, inside one, only prevents the accidental implicit submit — every real submit (Run/Update/Import/Upload) has its own explicit trigger, so nothing else is affected.

## Test cases — what scenario each one covers
- **Image → magnify:** opens the View Image modal, **no page reload**, no re-fired init calls.
- **Image → replace / delete:** perform their action, no reload.
- **Audio → delete / PDF → delete:** remove the attachment, no reload.
- **Regression — real submits still work:** Run/Update in Run Prompt, Import in Import Prompt, Upload in the media modal all still submit via their explicit handlers.

## How to reproduce (the original bug)
1. Open Run Prompt on a dataset with an image attached to the User prompt.
2. Click the magnify icon to enlarge the media.
3. Observe: page reloads; Network tab shows the full app bootstrap + re-fired init calls.

## Commands
_None — no build/config changes; standard `yarn dev`._

## Videos and screenshots
https://github.com/user-attachments/assets/6e51f0d6-f80e-4ca3-8b16-d01ac3e7e9c9
