### PR TITLE
fix(mcp): throttle OAuth token endpoint

### DIFF
--- a/futureagi/mcp_server/tests/test_oauth_token_throttling.py
+++ b/futureagi/mcp_server/tests/test_oauth_token_throttling.py
@@ -1,0 +1,200 @@
+"""Tests for MCP OAuth token endpoint throttling."""
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+from mcp_server.models.oauth_client import MCPOAuthClient
+from mcp_server.models.oauth_code import MCPOAuthCode
+from mcp_server.oauth_utils import hash_client_secret
+from tfc.middleware.workspace_context import set_workspace_context
+
+
+TOKEN_URL = "/mcp/oauth/token/"
+CLIENT_SECRET = "correct-secret"
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_throttle_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def oauth_client_app():
+    return MCPOAuthClient.objects.create(
+        client_id="test-oauth-client",
+        client_secret_hash=hash_client_secret(CLIENT_SECRET),
+        name="Test OAuth Client",
+        redirect_uris=["https://example.com/callback"],
+    )
+
+
+def _create_auth_code(user, workspace, client):
+    set_workspace_context(
+        workspace=workspace,
+        organization=user.organization,
+        user=user,
+    )
+    return MCPOAuthCode.objects.create(
+        code="valid-code",
+        client=client,
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+        redirect_uri="https://example.com/callback",
+        scope=["evaluations"],
+    )
+
+
+@override_settings(
+    MCP_OAUTH_TOKEN_IP_THROTTLE_RATE="2/min",
+    MCP_OAUTH_TOKEN_CLIENT_THROTTLE_RATE="100/min",
+)
+def test_authorization_code_attempts_are_throttled_by_ip(
+    api_client, oauth_client_app
+):
+    payload = {
+        "grant_type": "authorization_code",
+        "code": "bad-code",
+        "client_id": oauth_client_app.client_id,
+        "client_secret": "wrong-secret",
+        "redirect_uri": "https://example.com/callback",
+    }
+
+    first = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.10",
+    )
+    second = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.10",
+    )
+    third = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.10",
+    )
+
+    assert first.status_code == 401
+    assert second.status_code == 401
+    assert third.status_code == 429
+
+
+@override_settings(
+    MCP_OAUTH_TOKEN_IP_THROTTLE_RATE="100/min",
+    MCP_OAUTH_TOKEN_CLIENT_THROTTLE_RATE="2/min",
+)
+def test_refresh_token_attempts_are_throttled_by_client_id_across_ips(
+    api_client, oauth_client_app
+):
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": "bad-refresh-token",
+        "client_id": oauth_client_app.client_id,
+        "client_secret": "wrong-secret",
+    }
+
+    first = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.21",
+    )
+    second = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.22",
+    )
+    third = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.23",
+    )
+
+    assert first.status_code == 401
+    assert second.status_code == 401
+    assert third.status_code == 429
+
+
+@override_settings(
+    MCP_OAUTH_TOKEN_IP_THROTTLE_RATE="100/min",
+    MCP_OAUTH_TOKEN_CLIENT_THROTTLE_RATE="100/min",
+    MCP_OAUTH_TOKEN_INVALID_ATTEMPT_LIMIT=2,
+    MCP_OAUTH_TOKEN_INVALID_ATTEMPT_WINDOW_SECONDS=300,
+    MCP_OAUTH_TOKEN_INVALID_LOCKOUT_SECONDS=60,
+)
+def test_repeated_invalid_refresh_grants_trigger_lockout(
+    api_client, oauth_client_app
+):
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": "bad-refresh-token",
+        "client_id": oauth_client_app.client_id,
+        "client_secret": CLIENT_SECRET,
+    }
+
+    first = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.40",
+    )
+    second = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.40",
+    )
+    third = api_client.post(
+        TOKEN_URL,
+        payload,
+        format="json",
+        REMOTE_ADDR="203.0.113.40",
+    )
+
+    assert first.status_code == 400
+    assert first.data["error"] == "invalid_grant"
+    assert second.status_code == 400
+    assert second.data["error"] == "invalid_grant"
+    assert third.status_code == 429
+    assert third.data["error"] == "slow_down"
+    assert int(third["Retry-After"]) > 0
+
+
+@override_settings(
+    MCP_OAUTH_TOKEN_IP_THROTTLE_RATE="2/min",
+    MCP_OAUTH_TOKEN_CLIENT_THROTTLE_RATE="2/min",
+)
+def test_low_volume_authorization_code_exchange_is_allowed(
+    api_client, user, workspace, oauth_client_app
+):
+    auth_code = _create_auth_code(user, workspace, oauth_client_app)
+
+    response = api_client.post(
+        TOKEN_URL,
+        {
+            "grant_type": "authorization_code",
+            "code": auth_code.code,
+            "client_id": oauth_client_app.client_id,
+            "client_secret": CLIENT_SECRET,
+            "redirect_uri": auth_code.redirect_uri,
+        },
+        format="json",
+        REMOTE_ADDR="203.0.113.30",
+    )
+
+    assert response.status_code == 200
+    assert response.data["token_type"] == "Bearer"
+    assert response.data["access_token"]
+    assert response.data["refresh_token"]

--- a/futureagi/mcp_server/tests/test_oauth_token_throttling.py
+++ b/futureagi/mcp_server/tests/test_oauth_token_throttling.py
@@ -1,12 +1,19 @@
 """Tests for MCP OAuth token endpoint throttling."""
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
 import pytest
 from django.core.cache import cache
 from django.test import override_settings
+from rest_framework.test import APIRequestFactory
 
 from mcp_server.models.oauth_client import MCPOAuthClient
 from mcp_server.models.oauth_code import MCPOAuthCode
 from mcp_server.oauth_utils import hash_client_secret
+from mcp_server.throttles import _invalid_attempt_key, record_invalid_token_attempt
+import mcp_server.throttles as throttles
+from mcp_server.views.oauth import MCPOAuthTokenView
 from tfc.middleware.workspace_context import set_workspace_context
 
 
@@ -170,6 +177,53 @@ def test_repeated_invalid_refresh_grants_trigger_lockout(
     assert third.status_code == 429
     assert third.data["error"] == "slow_down"
     assert int(third["Retry-After"]) > 0
+
+
+@override_settings(
+    MCP_OAUTH_TOKEN_INVALID_ATTEMPT_LIMIT=2,
+    MCP_OAUTH_TOKEN_INVALID_ATTEMPT_WINDOW_SECONDS=300,
+    MCP_OAUTH_TOKEN_INVALID_LOCKOUT_SECONDS=60,
+)
+def test_concurrent_invalid_attempts_set_lockout(oauth_client_app, monkeypatch):
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": "bad-refresh-token",
+        "client_id": oauth_client_app.client_id,
+        "client_secret": CLIENT_SECRET,
+    }
+
+    raw_request = APIRequestFactory().post(
+        TOKEN_URL, payload, format="json", REMOTE_ADDR="203.0.113.41"
+    )
+    request = MCPOAuthTokenView().initialize_request(raw_request)
+    attempt_key = _invalid_attempt_key(request)
+    original_add = throttles.cache.add
+    original_get = throttles.cache.get
+    cache_barrier = Barrier(2)
+
+    def synchronized_add(key, *args, **kwargs):
+        if key == attempt_key:
+            cache_barrier.wait(timeout=5)
+        return original_add(key, *args, **kwargs)
+
+    def synchronized_get(key, *args, **kwargs):
+        if key == attempt_key:
+            cache_barrier.wait(timeout=5)
+        return original_get(key, *args, **kwargs)
+
+    monkeypatch.setattr(throttles.cache, "add", synchronized_add)
+    monkeypatch.setattr(throttles.cache, "get", synchronized_get)
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        results = list(
+            workers.map(
+                record_invalid_token_attempt,
+                [request, request],
+            )
+        )
+
+    assert sorted(result > 0 for result in results) == [False, True]
+    assert throttles.get_invalid_attempt_lockout_wait(request) > 0
 
 
 @override_settings(

--- a/futureagi/mcp_server/throttles.py
+++ b/futureagi/mcp_server/throttles.py
@@ -1,0 +1,132 @@
+"""Throttle helpers for MCP public authentication endpoints."""
+
+import hashlib
+import time
+
+from django.conf import settings
+from django.core.cache import cache
+from rest_framework.throttling import SimpleRateThrottle
+
+
+DEFAULT_OAUTH_TOKEN_IP_RATE = "30/min"
+DEFAULT_OAUTH_TOKEN_CLIENT_RATE = "10/min"
+DEFAULT_OAUTH_TOKEN_INVALID_ATTEMPT_LIMIT = 5
+DEFAULT_OAUTH_TOKEN_INVALID_ATTEMPT_WINDOW_SECONDS = 300
+DEFAULT_OAUTH_TOKEN_INVALID_LOCKOUT_SECONDS = 300
+
+
+def stable_hash(value: str, length: int | None = None) -> str:
+    """Return a deterministic hash for cache keys and non-secret log labels."""
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return digest[:length] if length else digest
+
+
+def request_data_value(request, key: str) -> str:
+    value = request.data.get(key, "")
+    return str(value).strip() if value is not None else ""
+
+
+def oauth_token_attempt_ident(request) -> str:
+    grant_type = request_data_value(request, "grant_type") or "unknown"
+    client_id = request_data_value(request, "client_id") or "unknown"
+    remote_addr = request.META.get("REMOTE_ADDR", "") or "unknown"
+    return stable_hash(f"{remote_addr}:{grant_type}:{client_id}")
+
+
+def _invalid_attempt_key(request) -> str:
+    return f"mcp_oauth_token_invalid:{oauth_token_attempt_ident(request)}"
+
+
+def _invalid_lockout_key(request) -> str:
+    return f"mcp_oauth_token_invalid_lock:{oauth_token_attempt_ident(request)}"
+
+
+def get_invalid_attempt_lockout_wait(request) -> int:
+    locked_until = cache.get(_invalid_lockout_key(request))
+    if not locked_until:
+        return 0
+
+    wait = int(locked_until - time.time()) + 1
+    return max(wait, 0)
+
+
+def record_invalid_token_attempt(request) -> int:
+    now = time.time()
+    limit = int(
+        getattr(
+            settings,
+            "MCP_OAUTH_TOKEN_INVALID_ATTEMPT_LIMIT",
+            DEFAULT_OAUTH_TOKEN_INVALID_ATTEMPT_LIMIT,
+        )
+    )
+    window_seconds = int(
+        getattr(
+            settings,
+            "MCP_OAUTH_TOKEN_INVALID_ATTEMPT_WINDOW_SECONDS",
+            DEFAULT_OAUTH_TOKEN_INVALID_ATTEMPT_WINDOW_SECONDS,
+        )
+    )
+    lockout_seconds = int(
+        getattr(
+            settings,
+            "MCP_OAUTH_TOKEN_INVALID_LOCKOUT_SECONDS",
+            DEFAULT_OAUTH_TOKEN_INVALID_LOCKOUT_SECONDS,
+        )
+    )
+
+    attempt_key = _invalid_attempt_key(request)
+    attempts = cache.get(attempt_key, []) or []
+    cutoff = now - window_seconds
+    attempts = [ts for ts in attempts if ts > cutoff]
+    attempts.append(now)
+    cache.set(attempt_key, attempts, timeout=window_seconds)
+
+    if len(attempts) < limit:
+        return 0
+
+    locked_until = now + lockout_seconds
+    cache.set(
+        _invalid_lockout_key(request),
+        locked_until,
+        timeout=lockout_seconds,
+    )
+    return lockout_seconds
+
+
+class MCPOAuthTokenIPThrottle(SimpleRateThrottle):
+    """Rate-limit token exchange attempts from the same remote address."""
+
+    scope = "mcp_oauth_token_ip"
+
+    def get_rate(self):
+        return getattr(
+            settings,
+            "MCP_OAUTH_TOKEN_IP_THROTTLE_RATE",
+            DEFAULT_OAUTH_TOKEN_IP_RATE,
+        )
+
+    def get_cache_key(self, request, view):
+        ident = stable_hash(self.get_ident(request))
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class MCPOAuthTokenClientThrottle(SimpleRateThrottle):
+    """Rate-limit token exchange attempts for the same client and grant type."""
+
+    scope = "mcp_oauth_token_client"
+
+    def get_rate(self):
+        return getattr(
+            settings,
+            "MCP_OAUTH_TOKEN_CLIENT_THROTTLE_RATE",
+            DEFAULT_OAUTH_TOKEN_CLIENT_RATE,
+        )
+
+    def get_cache_key(self, request, view):
+        client_id = request_data_value(request, "client_id")
+        if not client_id:
+            return None
+
+        grant_type = request_data_value(request, "grant_type") or "unknown"
+        ident = stable_hash(f"{grant_type}:{client_id}")
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/futureagi/mcp_server/throttles.py
+++ b/futureagi/mcp_server/throttles.py
@@ -51,7 +51,6 @@ def get_invalid_attempt_lockout_wait(request) -> int:
 
 
 def record_invalid_token_attempt(request) -> int:
-    now = time.time()
     limit = int(
         getattr(
             settings,
@@ -75,16 +74,20 @@ def record_invalid_token_attempt(request) -> int:
     )
 
     attempt_key = _invalid_attempt_key(request)
-    attempts = cache.get(attempt_key, []) or []
-    cutoff = now - window_seconds
-    attempts = [ts for ts in attempts if ts > cutoff]
-    attempts.append(now)
-    cache.set(attempt_key, attempts, timeout=window_seconds)
+    if cache.add(attempt_key, 1, timeout=window_seconds):
+        attempts = 1
+    else:
+        try:
+            attempts = cache.incr(attempt_key)
+        except ValueError:
+            # Recover if the window expired between add() and incr().
+            cache.set(attempt_key, 1, timeout=window_seconds)
+            attempts = 1
 
-    if len(attempts) < limit:
+    if attempts < limit:
         return 0
 
-    locked_until = now + lockout_seconds
+    locked_until = time.time() + lockout_seconds
     cache.set(
         _invalid_lockout_key(request),
         locked_until,

--- a/futureagi/mcp_server/views/oauth.py
+++ b/futureagi/mcp_server/views/oauth.py
@@ -31,6 +31,14 @@ from mcp_server.serializers.contracts import (
     MCPOAuthTokenResponseSerializer,
 )
 from tfc.utils.api_contracts import validated_request
+from mcp_server.throttles import (
+    MCPOAuthTokenClientThrottle,
+    MCPOAuthTokenIPThrottle,
+    get_invalid_attempt_lockout_wait,
+    record_invalid_token_attempt,
+    request_data_value,
+    stable_hash,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -250,10 +258,56 @@ class MCPOAuthConsentView(APIView):
 
 
 class MCPOAuthTokenView(APIView):
-    """POST /mcp/oauth/token/ — Exchange code or refresh token for access token."""
+    """POST /mcp/oauth/token/ - Exchange code or refresh token for access token."""
 
     authentication_classes = []
     permission_classes = [AllowAny]
+    throttle_classes = [MCPOAuthTokenIPThrottle, MCPOAuthTokenClientThrottle]
+
+    def _token_log_context(self, request):
+        client_id = request_data_value(request, "client_id")
+        remote_addr = request.META.get("REMOTE_ADDR", "")
+        return {
+            "grant_type": request_data_value(request, "grant_type") or "unknown",
+            "client_id_hash": (
+                stable_hash(client_id, length=16) if client_id else None
+            ),
+            "remote_addr_hash": (
+                stable_hash(remote_addr, length=16) if remote_addr else None
+            ),
+        }
+
+    def _log_token_warning(self, request, event_name, **kwargs):
+        logger.warning(event_name, **self._token_log_context(request), **kwargs)
+
+    def throttled(self, request, wait):
+        self._log_token_warning(
+            request,
+            "mcp_oauth_token_throttled",
+            retry_after_seconds=wait,
+        )
+        return super().throttled(request, wait)
+
+    def _invalid_token_response(
+        self,
+        request,
+        *,
+        error,
+        status,
+        reason,
+        error_description=None,
+    ):
+        lockout_seconds = record_invalid_token_attempt(request)
+        self._log_token_warning(
+            request,
+            "mcp_oauth_token_invalid_attempt",
+            reason=reason,
+            lockout_seconds=lockout_seconds or None,
+        )
+        body = {"error": error}
+        if error_description:
+            body["error_description"] = error_description
+        return Response(body, status=status)
 
     @validated_request(
         request_serializer=MCPOAuthTokenRequestSerializer,
@@ -265,8 +319,24 @@ class MCPOAuthTokenView(APIView):
         validation_error_response=_oauth_validation_error_response,
     )
     def post(self, request):
-        data = request.validated_data
-        grant_type = data.get("grant_type")
+        lockout_wait = get_invalid_attempt_lockout_wait(request)
+        if lockout_wait:
+            self._log_token_warning(
+                request,
+                "mcp_oauth_token_invalid_attempt_lockout",
+                retry_after_seconds=lockout_wait,
+            )
+            return Response(
+                {
+                    "error": "slow_down",
+                    "error_description": "Too many invalid token attempts",
+                },
+                status=429,
+                headers={"Retry-After": str(lockout_wait)},
+            )
+
+            data = request.validated_data
+            grant_type = data.get("grant_type")
 
         if grant_type == "authorization_code":
             return self._handle_authorization_code(data)
@@ -295,7 +365,12 @@ class MCPOAuthTokenView(APIView):
             return Response({"error": "invalid_client"}, status=401)
 
         if not verify_client_secret(client_secret, client.client_secret_hash):
-            return Response({"error": "invalid_client"}, status=401)
+            return self._invalid_token_response(
+                request,
+                error="invalid_client",
+                status=401,
+                reason="invalid_client_secret",
+            )
 
         # Validate authorization code
         try:
@@ -303,21 +378,29 @@ class MCPOAuthTokenView(APIView):
                 "user", "organization", "workspace"
             ).get(code=code, client=client, used=False)
         except MCPOAuthCode.DoesNotExist:
-            return Response({"error": "invalid_grant"}, status=400)
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
+                status=400,
+                reason="authorization_code_not_found",
+            )
 
         if auth_code.is_expired:
-            return Response(
-                {"error": "invalid_grant", "error_description": "Code expired"},
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
                 status=400,
+                reason="authorization_code_expired",
+                error_description="Code expired",
             )
 
         if redirect_uri and auth_code.redirect_uri != redirect_uri:
-            return Response(
-                {
-                    "error": "invalid_grant",
-                    "error_description": "Redirect URI mismatch",
-                },
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
                 status=400,
+                reason="redirect_uri_mismatch",
+                error_description="Redirect URI mismatch",
             )
 
         # Mark code as used
@@ -399,15 +482,30 @@ class MCPOAuthTokenView(APIView):
             return Response({"error": "invalid_client"}, status=401)
 
         if not verify_client_secret(client_secret, client.client_secret_hash):
-            return Response({"error": "invalid_client"}, status=401)
+            return self._invalid_token_response(
+                request,
+                error="invalid_client",
+                status=401,
+                reason="invalid_client_secret",
+            )
 
         # Decrypt and validate refresh token
         payload = decrypt_oauth_token(refresh_token)
         if not payload or payload.get("type") != "mcp_refresh":
-            return Response({"error": "invalid_grant"}, status=400)
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
+                status=400,
+                reason="invalid_refresh_token",
+            )
 
         if payload.get("client_id") != client_id:
-            return Response({"error": "invalid_grant"}, status=400)
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
+                status=400,
+                reason="refresh_token_client_mismatch",
+            )
 
         user_id = payload["user_id"]
         org_id = payload["org_id"]
@@ -420,7 +518,12 @@ class MCPOAuthTokenView(APIView):
                 deleted=False,
             )
         except MCPConnection.DoesNotExist:
-            return Response({"error": "invalid_grant"}, status=400)
+            return self._invalid_token_response(
+                request,
+                error="invalid_grant",
+                status=400,
+                reason="refresh_connection_not_found",
+            )
 
         # Get current scope from tool config
         try:


### PR DESCRIPTION
## Summary
- Add IP and client/grant throttles to the public MCP OAuth token endpoint.
- Count invalid attempts with an atomic shared-cache counter and bounded window.
- Lock out repeated invalid attempts with `429` and `Retry-After`.
- Keep credentials out of logs by using hashed client/IP labels.

## Flow

```mermaid
sequenceDiagram
    participant C as Client
    participant IP as IP throttle
    participant CG as Client/grant throttle
    participant O as OAuth endpoint
    participant S as Shared cache

    C->>IP: POST /mcp/oauth/token
    IP->>S: Atomic rate-window check
    alt IP limit exceeded
        S-->>IP: Limit reached
        IP-->>C: 429 + Retry-After
    else IP allowed
        IP->>CG: Continue request
        CG->>S: Atomic client/grant rate-window check
        alt Client/grant limit exceeded
            S-->>CG: Limit reached
            CG-->>C: 429 + Retry-After
        else Client/grant allowed
            CG->>O: Continue request
            O->>S: Read invalid-attempt lockout
            alt Lockout exists
                S-->>O: locked_until
                O-->>C: 429 + Retry-After
            else No lockout
                O->>S: Atomic add/increment attempt counter
                Note over S: Counter expires after the invalid-attempt window
                alt Counter reaches limit
                    S-->>O: count >= limit
                    O->>S: Set shared lockout until locked_until
                    O-->>C: 400/401 invalid grant
                else Counter below limit
                    S-->>O: count < limit
                    O-->>C: 400/401 invalid grant
                end
            end
        end
    end

    par Concurrent invalid requests
        C->>O: Worker A submits bad request
        O->>S: Atomic add/increment
    and
        C->>O: Worker B submits bad request
        O->>S: Atomic add/increment
    end
    S-->>O: One worker observes count >= limit
    O->>S: Set shared lockout
    O-->>C: Next request gets 429 + Retry-After
```

Fixes #1138

## Tests
- `python -m compileall -q futureagi/mcp_server/throttles.py futureagi/mcp_server/tests/test_oauth_token_throttling.py` passes.
- Focused pytest was started from `futureagi/.venv`; collection reached all 5 tests but local execution is blocked because the test database schema service at `localhost:18123` is unavailable.

AI use: GitHub Copilot was used to inspect the PR, make the atomic-counter regression and PR-description updates, and run validation.
E2E: Not run; this change is backend-only and has focused pytest coverage.