### PR TITLE
fix(simulate): verify masked API key at resolution time

### DIFF
--- a/futureagi/simulate/services/agent_definition.py
+++ b/futureagi/simulate/services/agent_definition.py
@@ -192,8 +192,12 @@ def resolve_api_key_for_version(version):
     return None
 
 
-def resolve_stored_api_key(*, organization, workspace=None, agent_id=None, assistant_id=None):
+def resolve_stored_api_key(*, organization, workspace=None, agent_id=None, assistant_id=None, masked_value=None):
     """Resolve the decrypted API key for a masked request, scoped to the caller's tenant.
+
+    When ``masked_value`` is provided, the stored key's masked form is compared
+    against it as a security check — a wrong masked prefix/suffix is rejected
+    even when the agent_id is valid.
 
     Returns the key, or None. Never crosses organization/workspace.
     """
@@ -213,4 +217,12 @@ def resolve_stored_api_key(*, organization, workspace=None, agent_id=None, assis
         return None
 
     version = agent.active_version or agent.latest_version
-    return resolve_api_key_for_version(version) or None
+    key = resolve_api_key_for_version(version) or None
+
+    if key and masked_value:
+        from agentcc.services.credential_manager import mask_key
+
+        if mask_key(key) != masked_value:
+            return None
+
+    return key

--- a/futureagi/simulate/tests/test_agent_definition_services.py
+++ b/futureagi/simulate/tests/test_agent_definition_services.py
@@ -14,6 +14,7 @@ from simulate.models.agent_definition import ProviderCredentials
 from simulate.services.agent_definition import (
     is_masked,
     resolve_api_key_for_version,
+    resolve_stored_api_key,
     sync_provider_credentials,
 )
 from simulate.services.types.agent_definition import ProviderCredentialsInput
@@ -255,3 +256,70 @@ class TestResolveApiKeyForVersion:
             api_key="sk-legacy-fallback-key",
         )
         assert resolve_api_key_for_version(agent_version) == "sk-legacy-fallback-key"
+
+
+class TestResolveStoredApiKey:
+    def test_returns_none_for_none_org(self):
+        assert resolve_stored_api_key(organization=None) is None
+
+    def test_returns_none_when_agent_not_found(self, organization):
+        assert resolve_stored_api_key(
+            organization=organization, agent_id="00000000-0000-0000-0000-000000000000"
+        ) is None
+
+    def test_returns_key_when_no_masked_value(self, organization, agent_definition):
+        version = agent_definition.create_version(
+            description="v1", commit_message="v1", status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        ProviderCredentials.objects.create(
+            agent_version=version,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-real-key-12345",
+        )
+        key = resolve_stored_api_key(
+            organization=organization, agent_id=str(agent_definition.id)
+        )
+        assert key == "sk-real-key-12345"
+
+    def test_returns_key_when_masked_value_matches(self, organization, agent_definition):
+        version = agent_definition.create_version(
+            description="v1", commit_message="v1", status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        ProviderCredentials.objects.create(
+            agent_version=version,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-real-key-12345",
+        )
+        key = resolve_stored_api_key(
+            organization=organization,
+            agent_id=str(agent_definition.id),
+            masked_value="sk-r...2345",
+        )
+        assert key == "sk-real-key-12345"
+
+    def test_returns_none_when_masked_value_mismatches(self, organization, agent_definition):
+        version = agent_definition.create_version(
+            description="v1", commit_message="v1", status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        ProviderCredentials.objects.create(
+            agent_version=version,
+            provider_type=ProviderCredentials.ProviderType.VAPI,
+            api_key="sk-real-key-12345",
+        )
+        key = resolve_stored_api_key(
+            organization=organization,
+            agent_id=str(agent_definition.id),
+            masked_value="sk-r...9999",
+        )
+        assert key is None
+
+    def test_returns_none_when_no_key_and_masked_value_provided(self, organization, agent_definition):
+        agent_definition.create_version(
+            description="v1", commit_message="v1", status=AgentVersion.StatusChoices.ACTIVE,
+        )
+        key = resolve_stored_api_key(
+            organization=organization,
+            agent_id=str(agent_definition.id),
+            masked_value="sk-r...2345",
+        )
+        assert key is None

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -533,6 +533,7 @@ class AgentDefinitionOperationsViewSet(BaseModelViewSetMixin, ModelViewSet):
                     workspace=getattr(request, "workspace", None),
                     agent_id=validated.get("agent_id"),
                     assistant_id=assistant_id,
+                    masked_value=api_key,
                 )
                 if not api_key:
                     msg = "Cannot sync with a masked API key. Please paste the actual key."

--- a/futureagi/tracer/views/observability_provider.py
+++ b/futureagi/tracer/views/observability_provider.py
@@ -201,6 +201,7 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
                     organization=get_request_organization(request),
                     workspace=getattr(request, "workspace", None),
                     agent_id=agent_id,
+                    masked_value=api_key,
                 )
                 if not api_key:
                     msg = "Could not resolve the api key. Please recheck the same"
@@ -241,6 +242,7 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
                     workspace=getattr(request, "workspace", None),
                     agent_id=agent_id,
                     assistant_id=assistant_id,
+                    masked_value=api_key,
                 )
                 if not api_key:
                     msg = "Could not resolve the api key. Please recheck the same"


### PR DESCRIPTION
## Summary

A masked API key like `"df97...a2da"` was accepted even when the stored key masked to `"df97...a2dd"` — the prefix/suffix mismatch went unchecked across three endpoints. This moves the comparison into the shared `resolve_stored_api_key` function so every masked-key verification path hits the same guard at resolution time.

## Linked issues

Closes #<br>Linear:

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Guard at resolution time —** `simulate/services/agent_definition.py`

* Added `masked_value` parameter to `resolve_stored_api_key`
* When provided, the stored key is masked with `mask_key()` and compared; mismatch returns `None`

**B. Caller updates**

* `fetch_assistant_from_provider` in `simulate/views/agent_definition.py` — passes `masked_value=api_key`
* `verify_api_key` and `verify_assistant_id` in `tracer/views/observability_provider.py` — passes `masked_value=api_key`

**C. Tests —** `simulate/tests/test_agent_definition_services.py`

* `TestResolveStoredApiKey` with 6 cases: no org, agent not found, no masked value, match, mismatch, no key with masked value

---

## 2) Why the changes were done

* **Technical:** The guard was missing entirely — the callers checked `is_masked()` and resolved the key, but never verified that the sent masked prefix/suffix matched the stored key's prefix/suffix. Adding the comparison to the shared resolver means all three paths are fixed at once.

---

## 3) Tests written + scenarios each covers

`test_agent_definition_services.py::TestResolveStoredApiKey` — 6 unit tests for `resolve_stored_api_key`

* `test_returns_none_for_none_org` — None org returns None
* `test_returns_none_when_agent_not_found` — unknown agent_id returns None
* `test_returns_key_when_no_masked_value` — backward compat: no masked_value returns the key
* `test_returns_key_when_masked_value_matches` — correct masked value returns the key
* `test_returns_none_when_masked_value_mismatches` — wrong masked value returns None
* `test_returns_none_when_no_key_and_masked_value_provided` — masked value with no stored key returns None

> Run result: **6 passed** across these suites. Syntax verified with `ast.parse`.

---

## 4) How to run / test

### Backend tests

Tests output: [https://pastes.io/pRH2Bxf9](<https://pastes.io/pRH2Bxf9>)

```bash
cd futureagi
bin/test simulate/tests/test_agent_definition_services.py -k "TestResolveStoredApiKey" -v
```

---

## 5) Screenshots / recordings

### Test output

https://github.com/user-attachments/assets/8971551d-209d-4e89-b4b3-120335db8837

---

## 6) Edge cases & considerations

* **Full (unmasked) keys are never compared**: all three callers only pass `masked_value` inside `if is_masked(api_key):` blocks
* `mask_key()` **on a short/surprising string**: `is_masked()` gates the block, so only keys already detected as masked reach the comparison
* **No key stored at all**: returns `None` before the mask comparison is reached

---

## 7) Pre-existing issues (NOT introduced by this PR)

* Tracer migration conflict (`0088_merge_20260702_1056` vs `0088_merge_20260703_0731`) prevents `--reuse-db` without `--no-migrations`
* Full test suite (19:53) yields 415 failures / 24 errors — all **pre-existing**, confirmed by root-cause analysis against our 4-file diff:
  * **ClickHouse** `DatabaseError`/`OperationalError` — test infrastructure connectivity, not API-key-path logic
  * `ee/tests/test_error_localizer.py` (14 failures) — `TypeError: cannot unpack non-iterable LocalizerResult` — return type change in unrelated module
  * **Entitlement enforcement** — `duplicate key value violates unique constraint` — DB test isolation / state
  * `ee.falcon_ai` — import-time `app_label` collection errors (known pre-existing)
  * **Tracer integration tests** (filter, eval_task, logs, voice, annotations) — validation errors against test fixtures, not API-key resolution
  * `simulate/tests/test_livekit_api.py` — error-message-string assertion mismatch, not API-key logic
  * Everything else — pre-existing fixture/environment mismatches, never touches `resolve_stored_api_key` or its callers

---

## 8) Architectural / important decisions

* **Guard in the shared function, not the callers:** `resolve_stored_api_key` is the one place every masked-key resolution routes through; putting the comparison there fixes it once for all endpoints rather than patching each caller individually.

---

## Checklist

- [X] My code follows the [style guide](<../CONTRIBUTING.md#code-style>)
- [X] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — *requires Postgres test DB*
- [ ] `yarn test:run` passes locally (frontend) — *N/A*
- [ ] `yarn contracts:check` passes if API surface changed — *N/A*
- [ ] I've updated the documentation where relevant — *N/A*
- [X] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](<../CONTRIBUTING.md#contributor-license-agreement-cla>)
- [X] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status