### PR TITLE
fix: use usedforsecurity=False for non-cryptographic MD5 hashes

### DIFF
--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -1066,7 +1066,9 @@ class DatasetExperimentsView(APIView):
                     else:
                         messages = epc.get_messages() or []
                         msg_str = json.dumps(messages, sort_keys=True, default=str)
-                        grp_id = hashlib.md5(msg_str.encode()).hexdigest()
+                        grp_id = hashlib.md5(
+                            msg_str.encode(), usedforsecurity=False
+                        ).hexdigest()
                         if grp_id in seen_inline_groups:
                             grp_name = seen_inline_groups[grp_id]
                         else:

--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -3294,7 +3294,8 @@ def _extract_intents_sync(
                     ensure_ascii=False,
                 )
                 cache_hash = hashlib.md5(
-                    (branches_json + agent_description).encode()
+                    (branches_json + agent_description).encode(),
+                    usedforsecurity=False,
                 ).hexdigest()
                 cache_key = f"intent_cache:{graph_id}:{cache_hash}"
 


### PR DESCRIPTION
## Summary
Two `hashlib.md5()` calls in this codebase build non-cryptographic keys — a dedup grouping key in `model_hub/views/experiments.py` and a Redis cache key in `tfc/temporal/simulate/activities.py`. Neither output is used for authentication, integrity checking, or anything else security-sensitive; they're just identifiers. Bandit still flags both as B324 (weak hash for security) because it can't see intent, only the function name. This PR adds `usedforsecurity=False` to both calls so the flag reflects reality and the code stays clean under FIPS-mode OpenSSL builds.

## Linked issues
No linked issue — found independently via a bandit scan of the backend, not filed as an issue first. Given CONTRIBUTING.md's guidance to open an issue for anything larger than a few hours of work, this felt small enough (2 lines, 2 files, no behavior change) to skip that step. Happy to file one retroactively if that's your preference for scan-driven fixes like this.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
Read both call sites directly to confirm the hashes feed a dedup key and a cache key, not anything security-sensitive. Verified `usedforsecurity=False` doesn't change the digest itself — same algorithm, same output, it only changes whether OpenSSL's FIPS mode will permit the call:

hashlib.md5(data).hexdigest()
'0fc21457046e523cf1cab140004c3be7'
hashlib.md5(data, usedforsecurity=False).hexdigest()
'0fc21457046e523cf1cab140004c3be7'

Confirmed the diff applies clean against current `main` and compiles. I didn't run `make check-all` — no local dev stack set up for this repo yet, flagging that honestly rather than claiming a pass I can't back up. Also tried running `black`/`isort` on the two changed files directly, but both tools reformat unrelated pre-existing code elsewhere in those files (this repo isn't fully Black-clean yet per its own stated mypy baseline policy), so I reverted that and left the diff to just the two intended lines rather than bundle in unrelated formatting changes.

## Screenshots / recordings (if UI)
N/A — no UI change.

## Checklist
- [ ] My code follows the style guide — matched existing indentation and the 88-char line limit by hand; didn't run `black`/`isort` for the reason noted above
- [ ] I've added tests — none added; there's no behavior change to test, only a metadata flag on an already-correct hash call
- [ ] `make check-all` passes locally — not run, see note above
- [ ] Documentation updated — not applicable, no user-facing change
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts on submission