### PR TITLE
fix(agentic_eval): correct Jaro-Winkler similarity scoring

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -79,6 +79,10 @@ class JaroWincklerSimilarity(Comparator):
         if len1 == 0 or len2 == 0:
             return 0.0
         max_dist = (max(len(str1), len(str2)) // 2) - 1
+        if max_dist < 0:
+            # Short strings (length <= 2) yield a negative match window, which
+            # skips every comparison and returns 0.0 even for identical inputs.
+            max_dist = 0
         match = 0
         hash_str1 = [0] * len(str1)
         hash_str2 = [0] * len(str2)
@@ -98,8 +102,12 @@ class JaroWincklerSimilarity(Comparator):
                 while hash_str2[point] == 0:
                     point += 1
                 if str1[i] != str2[point]:
-                    point += 1
                     t += 1
+                # Always advance past the matched position in str2. Previously
+                # `point` advanced only on a mismatch, so matched positions were
+                # re-compared, over-counting transpositions and deflating every
+                # score (identical strings scored < 1.0).
+                point += 1
         t //= 2
         return (match / len1 + match / len2 + (match - t) / match) / 3.0
 

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_similarity.py
@@ -1,0 +1,76 @@
+"""
+Tests for the string-similarity comparators in
+``agentic_eval.core_evals.fi_evals.grounded.similarity``.
+
+These focus on ``JaroWincklerSimilarity``, which previously produced
+mathematically incorrect scores:
+
+- Identical strings did not score 1.0 (e.g. "hello"/"hello" -> 0.9333),
+  because the transposition pointer only advanced on a character mismatch,
+  re-comparing already-matched positions and over-counting transpositions.
+- Short identical strings scored 0.0 (e.g. "a"/"a"), because a negative
+  match window skipped every comparison.
+
+The corrected implementation matches the reference Jaro computation in
+``fi_evals.function.functions.calculate_jaro_winkler_similarity`` (the Jaro
+component, i.e. without the Winkler prefix bonus).
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.grounded.similarity import (
+    JaroWincklerSimilarity,
+)
+
+
+@pytest.fixture
+def comparator():
+    return JaroWincklerSimilarity()
+
+
+class TestJaroWincklerSimilarityIdentical:
+    """Identical strings must score exactly 1.0 (the regression this fixes)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["a", "ab", "abcd", "hello", "MARTHA", "a longer sentence here"],
+    )
+    def test_identical_strings_score_one(self, comparator, value):
+        assert comparator.compare(value, value) == pytest.approx(1.0)
+
+
+class TestJaroWincklerSimilarityKnownValues:
+    """Canonical Jaro values (no Winkler prefix bonus)."""
+
+    @pytest.mark.parametrize(
+        "a, b, expected",
+        [
+            ("MARTHA", "MARHTA", 0.944444),  # textbook Jaro example
+            ("DIXON", "DICKSONX", 0.766667),
+            ("CRATE", "TRACE", 0.733333),
+        ],
+    )
+    def test_known_pairs(self, comparator, a, b, expected):
+        assert comparator.compare(a, b) == pytest.approx(expected, abs=1e-4)
+
+
+class TestJaroWincklerSimilarityEdgeCases:
+    def test_no_common_characters_scores_zero(self, comparator):
+        assert comparator.compare("abc", "xyz") == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("a, b", [("", "x"), ("x", ""), ("", "")])
+    def test_empty_string_scores_zero(self, comparator, a, b):
+        assert comparator.compare(a, b) == pytest.approx(0.0)
+
+    def test_score_is_symmetric(self, comparator):
+        assert comparator.compare("MARTHA", "MARHTA") == pytest.approx(
+            comparator.compare("MARHTA", "MARTHA")
+        )
+
+    @pytest.mark.parametrize(
+        "a, b",
+        [("MARTHA", "MARHTA"), ("DIXON", "DICKSONX"), ("hello", "world")],
+    )
+    def test_score_within_unit_interval(self, comparator, a, b):
+        score = comparator.compare(a, b)
+        assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## What

`JaroWincklerSimilarity` (`agentic_eval/core_evals/fi_evals/grounded/similarity.py`) returns mathematically incorrect similarity scores. Two concrete defects:

1. **Transposition over-counting** — the alignment pointer advanced only on a character *mismatch*, so already-matched positions were re-compared. This over-counts transpositions and deflates every score, so **identical strings never score 1.0**.
2. **Negative match window for short strings** — `max_dist = max(len) // 2 - 1` goes negative for strings of length ≤ 2, skipping all comparisons, so even `"a"` vs `"a"` scores `0.0`.

## Impact

`JaroWincklerSimilarity` backs `GroundedEvaluator` / `AnswerSimilarity` when the `jarowincklersimilarity` comparator is selected (`grounded_evaluator.py:62`). Deflated scores mean correct model outputs are wrongly flagged as failures — e.g. with a high `failure_threshold`, *identical* text is marked a failure.

## Reproduction

```python
from agentic_eval.core_evals.fi_evals.grounded.similarity import JaroWincklerSimilarity
c = JaroWincklerSimilarity()
c.compare("hello", "hello")    # 0.9333  -> should be 1.0
c.compare("a", "a")            # 0.0     -> should be 1.0
c.compare("MARTHA", "MARHTA")  # 0.8889  -> should be 0.9444 (textbook Jaro)
```

## Fix

Two surgical changes that make the Jaro computation match this repo's own reference implementation, `functions.calculate_jaro_winkler_similarity` (which already advances the pointer unconditionally and guards a negative window):

- advance the transposition pointer unconditionally after each matched position;
- clamp the match window at 0 for short strings.

After the fix: `hello/hello → 1.0`, `a/a → 1.0`, `MARTHA/MARHTA → 0.9444`, `DIXON/DICKSONX → 0.7667`.

## Tests

Adds `grounded/tests/test_similarity.py` covering identical strings (the regression), canonical Jaro values, no-match, empty, symmetry, and unit-interval bounds. The identical-string cases fail on the pre-fix code and pass after.

## Note

`JaroWincklerSimilarity` is named "Winckler" but computes plain Jaro (no prefix bonus), unlike `calculate_jaro_winkler_similarity`. I kept this PR to the unambiguous correctness fix; happy to align the two (add the Winkler prefix bonus and/or de-duplicate against the reference) in a follow-up if you'd prefer a single shared implementation.
