### PR TITLE
fix: run Python pre-commit hooks via husky, POSIX-ify pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,15 @@
 [ -f "$(git rev-parse --git-path MERGE_HEAD 2>/dev/null)" ] && exit 0
 
 npx --no-install lint-staged
+
+# lint-staged only covers frontend/src/**; run pre-commit (black/isort/mypy)
+# on staged Python files here instead of installing pre-commit's own git hook,
+# which conflicts with husky's core.hooksPath (see CONTRIBUTING.md).
+staged_py=$(git diff --cached --name-only --diff-filter=ACM -- 'futureagi/*.py' | sed 's|^futureagi/||')
+if [ -n "$staged_py" ]; then
+  if command -v pre-commit >/dev/null 2>&1; then
+    (cd futureagi && pre-commit run --files $staged_py)
+  else
+    echo "⚠️  pre-commit not found — skipping Python checks (pip install pre-commit)"
+  fi
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,16 +4,18 @@ echo "🔍 Validating branch name..."
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 
 # Skip validation for protected branches
-if [[ "$branch_name" == "main" || "$branch_name" == "develop" || "$branch_name" == "master" || "$branch_name" == "dev" ]]; then
+case "$branch_name" in
+  main|develop|master|dev)
     echo "✅ Protected branch — skipping validation"
     exit 0
-fi
+    ;;
+esac
 
 # Format: <type>/<ticket-id>-<description> or <type>/<description>
 # Types match Conventional Commits prefixes used in CONTRIBUTING.md.
-branch_regex="^(feat|fix|chore|docs|refactor|test|perf)\/[a-zA-Z0-9]+([a-zA-Z0-9\-]*[a-zA-Z0-9])?$"
+branch_regex="^(feat|fix|chore|docs|refactor|test|perf)/[a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?$"
 
-if [[ ! $branch_name =~ $branch_regex ]]; then
+if ! echo "$branch_name" | grep -Eq "$branch_regex"; then
     echo "❌ Invalid branch name: '$branch_name'"
     echo ""
     echo "Branch name must follow the pattern: <type>/<ticket-id>-<description>"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,17 @@ The backend will be at `http://localhost:8000`, the frontend at `http://localhos
 # From repo root — installs husky hooks and lint-staged tooling.
 yarn install
 
-# For Python hooks (black, isort, mypy, Django system checks):
-cd futureagi && make pre-commit-install
+# Python tooling used by the hooks below:
+pip install pre-commit
 ```
 
-On every commit, `lint-staged` auto-formats and lints the staged files:
+`yarn install` points `core.hooksPath` at husky's hooks, so don't also run
+`pre-commit install` — it detects `core.hooksPath` and refuses to install.
+Husky drives both toolchains: on every commit its `pre-commit` hook runs
+`lint-staged` for frontend files and `pre-commit run` for Python files:
 
-- `frontend/src/**` → ESLint + Prettier
-- `futureagi/**/*.py` → `black`, `isort`, `mypy` (via pre-commit)
+- `frontend/src/**` → ESLint + Prettier (via lint-staged)
+- `futureagi/**/*.py` → `black`, `isort`, `mypy` (via `pre-commit run`, staged files only)
 
 Branch names are validated on `git push`.
 


### PR DESCRIPTION
## Summary
Following CONTRIBUTING.md's documented setup (`yarn install` then `cd futureagi && make pre-commit-install`) fails outright, because `yarn install` sets `core.hooksPath` via husky and `pre-commit install` refuses to run once that's set. As a result, Python files never get `black`/`isort`/`mypy` on commit despite CONTRIBUTING.md's claim that they do — `.lintstagedrc.cjs` only has glob entries for `frontend/src/**`. Separately, `.husky/pre-push` uses bash `[[ ]]`/`=~` syntax, but husky invokes hooks via `sh`, so the branch-name validation silently no-ops (prints "valid" for every branch, including invalid ones).

This PR:
- Rewrites `.husky/pre-push`'s branch validation using POSIX `case`/`grep -E` instead of bash-only `[[ ]]`/`=~`.
- Wires Python linting into `.husky/pre-commit`: it now runs `pre-commit run --files <staged .py files>` from `futureagi/`, scoped to staged files, guarded by a `command -v pre-commit` check.
- Updates CONTRIBUTING.md's setup steps to drop the conflicting `make pre-commit-install` call and document that husky now drives both toolchains.

## Linked issues
Closes #1065

## Type of change
- [x] Bug fix

## How was this tested?
No test harness exists for husky hook scripts, so I verified manually:
```
$ sh .husky/pre-push
🔍 Validating branch name...
✅ Branch name 'fix/pre-commit-hooks-python-and-pre-push-shell' is valid
```
Also confirmed under `sh -c` that protected branches (`main`/`dev`/etc.) short-circuit correctly and that invalid branch names (e.g. `random-branch`) are now rejected — previously the bash-only regex silently passed everything under `sh`. Confirmed the new `staged_py` branch in `.husky/pre-commit` only invokes `pre-commit run` when staged `.py` files exist, and no-ops otherwise.

## Screenshots / recordings
N/A — dev tooling change, no UI impact.

## Checklist
- [x] PR description explains what and why
- [x] `make check-all`/`yarn check-all` — N/A, shell/doc-only change with no test suite to run
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA — will sign when the bot prompts