### PR TITLE
fix: enable gateway auth/logging/control-plane in example config

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -250,22 +250,26 @@ providers:
 
 # Virtual API key authentication.
 # When enabled, all requests must include Authorization: Bearer sk-agentcc-xxx
-# Setting AGENTCC_INTERNAL_API_KEY in the environment turns this on automatically
-# and registers that key. Running with no key and no auth block leaves the
+# and the backend UI's "Gateway" page can create/manage keys via /-/keys
+# (which is only registered when enabled: true).
+# Setting AGENTCC_INTERNAL_API_KEY in the environment also auto-enables this
+# and registers that key; running with no key and no auth block leaves the
 # gateway open — only do that on a trusted, non-public network.
-# auth:
-#   enabled: true
-#   keys:
-#     - name: "dev-key"
-#       key: "sk-agentcc-dev-key-for-testing"
-#       owner: "dev-team"
-#       models:
-#         - gpt-4o
-#         - gpt-4o-mini
-#     - name: "prod-key"
-#       key: "sk-agentcc-prod-key-unrestricted"
-#       owner: "production"
-#       # no models = unrestricted access to all models
+# Static keys below are optional — the backend creates keys dynamically via
+# the admin-token-protected /-/keys endpoints, so none are listed by default.
+auth:
+  enabled: true
+  # keys:
+  #   - name: "dev-key"
+  #     key: "sk-agentcc-dev-key-for-testing"
+  #     owner: "dev-team"
+  #     models:
+  #       - gpt-4o
+  #       - gpt-4o-mini
+  #   - name: "prod-key"
+  #     key: "sk-agentcc-prod-key-unrestricted"
+  #     owner: "production"
+  #     # no models = unrestricted access to all models
 
 # Load balancing across multiple providers for the same model.
 # routing:
@@ -357,11 +361,11 @@ providers:
 
 logging:
   level: info
-  # request_logging:
-  #   enabled: true              # Log every request (default: true)
-  #   include_bodies: false      # Include full request/response bodies (default: false)
-  #   buffer_size: 4096          # Async buffer size (default: 4096)
-  #   workers: 2                 # Number of log worker goroutines (default: 2)
+  request_logging:
+    enabled: true              # Log every request (default: true)
+    include_bodies: false      # Include full request/response bodies (default: false)
+    buffer_size: 4096          # Async buffer size (default: 4096)
+    workers: 2                 # Number of log worker goroutines (default: 2)
 
 # guardrails:
 #   enabled: true
@@ -586,13 +590,15 @@ logging:
 #     default_ttl: 300                 # seconds
 #     max_size: 1048576                # 1MB per entry
 
-# Pull config (keys, budgets, RBAC) from a Django control plane.
-# control_plane:
-#   url: "http://localhost:8000"
-#   admin_token: "${CONTROL_PLANE_ADMIN_TOKEN}"
-#   webhook_secret: "${CONTROL_PLANE_WEBHOOK_SECRET}"
-#   sync_on_startup: true
-#   sync_interval: 5m                  # 0 = disabled
+# Pull config (keys, budgets, RBAC) from a Django control plane. Also starts
+# the log flusher that ships gateway request logs to the dashboard — without
+# a url configured here, request logs never leave the gateway.
+control_plane:
+  url: "http://backend:80"
+  admin_token: "${AGENTCC_ADMIN_TOKEN}"
+  webhook_secret: "${AGENTCC_WEBHOOK_SECRET}"
+  sync_on_startup: true
+  sync_interval: 5m                  # 0 = disabled
 
 # OpenAI-compatible Assistants API proxy.
 # assistants:

--- a/agentcc-gateway/internal/config/config_test.go
+++ b/agentcc-gateway/internal/config/config_test.go
@@ -228,3 +228,24 @@ func TestLoadFromEnvDoesNotClobberExplicitInternalKey(t *testing.T) {
 		t.Fatalf("got %d entries for the key, want 1 (env seed must not duplicate an explicit config key)", n)
 	}
 }
+
+// TestExampleConfigEnablesSelfHostedFeatures guards against config.example.yaml
+// regressing to a state where self-hosted installs silently lose: API key
+// management (auth.enabled gates the /-/keys routes) and the log flusher /
+// dashboard request logs (control_plane.url gates the flusher's startup).
+func TestExampleConfigEnablesSelfHostedFeatures(t *testing.T) {
+	cfg, err := Load("../../config.example.yaml")
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	if !cfg.Auth.Enabled {
+		t.Error("auth.enabled = false, want true (required for /-/keys UI key management)")
+	}
+	if cfg.ControlPlane.URL == "" {
+		t.Error("control_plane.url is empty, want a value (required to start the log flusher)")
+	}
+	if !cfg.Logging.RequestLogging.Enabled {
+		t.Error("logging.request_logging.enabled = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
On a fresh self-hosted install, gateway request logs never reach `/dashboard/gateway/logs` and API key management via the UI is broken (404 on `/-/keys`). `agentcc-gateway/config.example.yaml` — the config mounted by default (see `docker-compose.yml`'s `AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml` fallback) — ships with `auth`, `control_plane`, and `logging.request_logging` entirely commented out:

- `auth.enabled` gates whether `internal/server/server.go` constructs a `keyStore` and registers the `/-/keys` routes at all (`internal/server/server.go:72`, `:528`). Disabled by default → routes never exist → 404.
- `control_plane.url` gates whether the log flusher starts (`cmd/agentcc/main.go:550`, "Start log flusher if control plane URL is configured"). Empty by default → flusher never runs → gateway request logs never leave the process.

I checked `.env.example` and `AGENTCC_WEBHOOK_SECRET` is already present there (looks like it was fixed separately) — so this PR only needed to touch the gateway's example config.

## Linked issues
Closes #1060

## Type of change
- [x] Bug fix

## How was this tested?
```
$ cd agentcc-gateway && go build ./...
$ go test ./internal/config/... -v
=== RUN   TestExampleConfigEnablesSelfHostedFeatures
--- PASS: TestExampleConfigEnablesSelfHostedFeatures (0.00s)
... (all other config tests pass)
```
Added `TestExampleConfigEnablesSelfHostedFeatures`, which loads the actual shipped `config.example.yaml` and asserts `auth.Enabled`, `ControlPlane.URL`, and `Logging.RequestLogging.Enabled` — a regression test that fails if these sections get re-commented.

Also confirmed with `python3 -c "import yaml; yaml.safe_load(...)"` that the edited YAML is still valid, and ran the broader `internal/server` test suite — 3 pre-existing failures there (`TestUnknownModel`, `TestChatCompletion_TimeoutMetadataHeader`, `TestProviderPrefixRouting`) are present on unmodified `main` too and unrelated to this change.

## Screenshots / recordings
N/A — config-only change, no UI.

## Checklist
- [x] PR description explains what and why
- [x] Tests added (`TestExampleConfigEnablesSelfHostedFeatures`)
- [x] `go build ./...` and `go test ./internal/config/...` pass
- [x] No hardcoded secrets, URLs, or PII — `admin_token`/`webhook_secret` still use `${VAR}` interpolation
- [ ] CLA — will sign when the bot prompts