### PR TITLE
fix(eval-result): expose safe typed usage fields

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_utils/evals_result.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/evals_result.py
@@ -9,10 +9,12 @@ class OpenAiPromptMessage(TypedDict):
     role: str
     content: str
 
+
 class DataPoint(TypedDict, total=False):
     """Data point for a single inference."""
 
     response: str
+
 
 class EvalResultMetric(TypedDict):
     """
@@ -21,6 +23,41 @@ class EvalResultMetric(TypedDict):
 
     id: str
     value: float
+
+
+class _EvalResultCostRequired(TypedDict):
+    total_cost: float
+    prompt_cost: float
+    completion_cost: float
+
+
+class _EvalResultCostOptional(TypedDict, total=False):
+    pricing_source: str
+
+
+class EvalResultCost(_EvalResultCostRequired, _EvalResultCostOptional):
+    """
+    Represents the LLM evaluation cost breakdown.
+    """
+
+
+class _EvalResultTokenUsageRequired(TypedDict):
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+
+
+class _EvalResultTokenUsageOptional(TypedDict, total=False):
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+
+
+class EvalResultTokenUsage(
+    _EvalResultTokenUsageRequired, _EvalResultTokenUsageOptional
+):
+    """
+    Represents the LLM evaluation token usage breakdown.
+    """
 
 
 class DatapointFieldAnnotation(TypedDict):
@@ -34,11 +71,7 @@ class DatapointFieldAnnotation(TypedDict):
     annotation_note: str
 
 
-class EvalResult(TypedDict):
-    """
-    Represents the LLM evaluation result.
-    """
-
+class _EvalResultRequired(TypedDict):
     name: str
     display_name: str
     data: dict
@@ -49,6 +82,17 @@ class EvalResult(TypedDict):
     metadata: str | None
     metrics: list[EvalResultMetric]
     datapoint_field_annotations: list[DatapointFieldAnnotation] | None
+
+
+class _EvalResultOptional(TypedDict, total=False):
+    cost: EvalResultCost
+    token_usage: EvalResultTokenUsage
+
+
+class EvalResult(_EvalResultRequired, _EvalResultOptional):
+    """
+    Represents the LLM evaluation result.
+    """
 
 
 @dataclass

--- a/futureagi/evaluations/engine/formatting.py
+++ b/futureagi/evaluations/engine/formatting.py
@@ -144,7 +144,7 @@ def extract_raw_result(eval_result, eval_template):
 
     Returns:
         Dict with keys: data, failure, reason, runtime, model, metrics,
-                       metadata, output
+                       metadata, cost, token_usage, output
     """
     eval_results = getattr(eval_result, "eval_results", None) or []
     first = eval_results[0] if eval_results else {}
@@ -153,6 +153,8 @@ def extract_raw_result(eval_result, eval_template):
     if first is None:
         first = {}
     template_config = getattr(eval_template, "config", None) or {}
+    output = template_config.get("output", "score")
+
     return {
         "data": first.get("data"),
         "failure": first.get("failure"),
@@ -161,5 +163,7 @@ def extract_raw_result(eval_result, eval_template):
         "model": first.get("model"),
         "metrics": first.get("metrics"),
         "metadata": first.get("metadata"),
-        "output": template_config.get("output", "score"),
+        "cost": first.get("cost"),
+        "token_usage": first.get("token_usage"),
+        "output": output,
     }

--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -13,6 +13,7 @@ Callers handle their own:
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -26,6 +27,62 @@ from evaluations.engine.params import prepare_run_params
 from evaluations.engine.registry import get_eval_class
 
 logger = structlog.get_logger(__name__)
+
+
+_REQUIRED_COST_KEYS = {"total_cost", "prompt_cost", "completion_cost"}
+_REQUIRED_TOKEN_USAGE_KEYS = {
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+}
+_OPTIONAL_TOKEN_USAGE_KEYS = {
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+}
+
+
+def _valid_cost_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def _valid_token_count(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _sanitize_cost_payload(payload: Any) -> dict | None:
+    if not isinstance(payload, dict) or not _REQUIRED_COST_KEYS.issubset(
+        payload.keys()
+    ):
+        return None
+    if not all(_valid_cost_number(payload[key]) for key in _REQUIRED_COST_KEYS):
+        return None
+
+    sanitized = {key: payload[key] for key in _REQUIRED_COST_KEYS}
+    pricing_source = payload.get("pricing_source")
+    if isinstance(pricing_source, str):
+        sanitized["pricing_source"] = pricing_source
+    return sanitized
+
+
+def _sanitize_token_usage_payload(payload: Any) -> dict | None:
+    if not isinstance(payload, dict) or not _REQUIRED_TOKEN_USAGE_KEYS.issubset(
+        payload.keys()
+    ):
+        return None
+    if not all(_valid_token_count(payload[key]) for key in _REQUIRED_TOKEN_USAGE_KEYS):
+        return None
+
+    sanitized = {key: payload[key] for key in _REQUIRED_TOKEN_USAGE_KEYS}
+    for key in _OPTIONAL_TOKEN_USAGE_KEYS:
+        value = payload.get(key)
+        if _valid_token_count(value):
+            sanitized[key] = value
+    return sanitized
 
 
 @dataclass
@@ -68,8 +125,8 @@ class EvalResult:
     end_time: float | None = None
     duration: float | None = None
 
-    # Cost tracking (populated from the evaluator instance post-run so callers
-    # can emit billing events without having to hold the instance themselves).
+    # Cost tracking (prefer valid, complete response-level fields; fall back to
+    # evaluator instance fields for compatibility).
     cost: dict | None = None
     token_usage: dict | None = None
 
@@ -81,7 +138,10 @@ def run_eval(request: EvalRequest) -> EvalResult:
     This is the single point of truth for:
     resolve class → create instance → prepare params → run → format.
 
-    No result persistence. No cost tracking. Callers handle all side effects.
+    No result persistence or billing side effects. The returned EvalResult may
+    include valid, complete response-level cost/token_usage fields, and falls back to
+    evaluator instance fields for compatibility. Callers handle all other side
+    effects.
 
     Args:
         request: EvalRequest with template, inputs, and config
@@ -181,6 +241,17 @@ def run_eval(request: EvalRequest) -> EvalResult:
         duration=round(response["duration"], 3),
     )
 
+    response_cost = _sanitize_cost_payload(response.get("cost"))
+    response_token_usage = _sanitize_token_usage_payload(response.get("token_usage"))
+    cost: dict | None
+    token_usage: dict | None
+    if response_cost is not None and response_token_usage is not None:
+        cost = response_cost
+        token_usage = response_token_usage
+    else:
+        cost = getattr(eval_instance, "cost", None)
+        token_usage = getattr(eval_instance, "token_usage", None)
+
     return EvalResult(
         value=value,
         data=response.get("data"),
@@ -194,6 +265,6 @@ def run_eval(request: EvalRequest) -> EvalResult:
         start_time=start_time,
         end_time=end_time,
         duration=end_time - start_time,
-        cost=getattr(eval_instance, "cost", None),
-        token_usage=getattr(eval_instance, "token_usage", None),
+        cost=cost,
+        token_usage=token_usage,
     )

--- a/futureagi/evaluations/engine/tests/test_eval_result_cost_fields.py
+++ b/futureagi/evaluations/engine/tests/test_eval_result_cost_fields.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentic_eval.core_evals.fi_utils.evals_result import (
+    EvalResult,
+    EvalResultCost,
+    EvalResultTokenUsage,
+)
+from evaluations.engine.formatting import extract_raw_result
+from evaluations.engine.runner import EvalRequest, run_eval
+
+RESULT_COST = {
+    "total_cost": 0.03,
+    "prompt_cost": 0.01,
+    "completion_cost": 0.02,
+}
+RESULT_TOKEN_USAGE = {
+    "total_tokens": 30,
+    "prompt_tokens": 10,
+    "completion_tokens": 20,
+}
+INSTANCE_COST = {
+    "total_cost": 9.0,
+    "prompt_cost": 4.0,
+    "completion_cost": 5.0,
+}
+INSTANCE_TOKEN_USAGE = {
+    "total_tokens": 900,
+    "prompt_tokens": 400,
+    "completion_tokens": 500,
+}
+
+
+def _template(output="score"):
+    return SimpleNamespace(
+        name="unit_test_eval",
+        config={"eval_type_id": "UnitTestEval", "output": output},
+        choice_scores=None,
+        choices=[],
+        multi_choice=False,
+    )
+
+
+def _raw_result(*, cost_payload=RESULT_COST, token_usage_payload=RESULT_TOKEN_USAGE):
+    payload = {
+        "data": {"result": 0.7},
+        "failure": False,
+        "reason": "ok",
+        "runtime": 123,
+        "model": "unit-model",
+        "metrics": [{"id": "score", "value": 0.7}],
+        "metadata": {"source": "raw-result"},
+    }
+    if cost_payload is not None:
+        payload["cost"] = cost_payload
+    if token_usage_payload is not None:
+        payload["token_usage"] = token_usage_payload
+    return SimpleNamespace(eval_results=[payload])
+
+
+class _FakeEvalInstance:
+    cost = INSTANCE_COST
+    token_usage = INSTANCE_TOKEN_USAGE
+
+    def __init__(self, raw_result):
+        self.raw_result = raw_result
+
+    def run(self, **kwargs):
+        return self.raw_result
+
+
+def _patch_runner(monkeypatch, raw_result):
+    import evaluations.engine.runner as runner
+
+    monkeypatch.setattr(runner, "get_eval_class", lambda eval_type_id: object)
+    monkeypatch.setattr(
+        runner,
+        "create_eval_instance",
+        lambda **kwargs: (_FakeEvalInstance(raw_result), "criteria"),
+    )
+    import evaluations.engine.preprocessing as preprocessing
+
+    monkeypatch.setattr(preprocessing, "preprocess_inputs", lambda name, params: params)
+
+
+def test_eval_result_cost_fields_are_optional_and_shaped():
+    assert {"cost", "token_usage"}.issubset(EvalResult.__optional_keys__)
+    assert EvalResultCost.__required_keys__ == {
+        "total_cost",
+        "prompt_cost",
+        "completion_cost",
+    }
+    assert EvalResultCost.__optional_keys__ == {"pricing_source"}
+    assert EvalResultTokenUsage.__required_keys__ == {
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+    }
+    assert EvalResultTokenUsage.__optional_keys__ == {
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    }
+
+
+def test_extract_raw_result_preserves_cost_token_usage_from_nested_result():
+    raw = SimpleNamespace(eval_results=[[_raw_result().eval_results[0]]])
+
+    extracted = extract_raw_result(raw, _template())
+
+    assert extracted["metadata"] == {"source": "raw-result"}
+    assert extracted["cost"] == RESULT_COST
+    assert extracted["token_usage"] == RESULT_TOKEN_USAGE
+
+
+def test_extract_raw_result_empty_result_has_none_cost_token_usage():
+    extracted = extract_raw_result(SimpleNamespace(eval_results=[]), _template())
+
+    assert extracted["cost"] is None
+    assert extracted["token_usage"] is None
+
+
+@pytest.mark.parametrize("eval_results", [[None], [[None]]])
+def test_extract_raw_result_none_result_shapes_preserve_template_output(eval_results):
+    extracted = extract_raw_result(
+        SimpleNamespace(eval_results=eval_results),
+        _template(output="reason"),
+    )
+
+    assert extracted["cost"] is None
+    assert extracted["token_usage"] is None
+    assert extracted["output"] == "reason"
+
+
+def test_run_eval_prefers_result_cost_token_usage(monkeypatch):
+    _patch_runner(monkeypatch, _raw_result())
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.value == 0.7
+    assert result.cost == RESULT_COST
+    assert result.token_usage == RESULT_TOKEN_USAGE
+
+
+def test_run_eval_empty_response_cost_token_usage_falls_back_to_instance(monkeypatch):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(cost_payload={}, token_usage_payload={}),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+def test_run_eval_partial_response_cost_token_usage_falls_back_to_instance(monkeypatch):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(
+            cost_payload={"total_cost": 0.03, "prompt_cost": 0.01},
+            token_usage_payload={"total_tokens": 30, "prompt_tokens": 10},
+        ),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+@pytest.mark.parametrize(
+    ("cost_payload", "token_usage_payload"),
+    [
+        ({"total_cost": 0.03, "prompt_cost": 0.01}, RESULT_TOKEN_USAGE),
+        (RESULT_COST, {"total_tokens": 30, "prompt_tokens": 10}),
+        (None, RESULT_TOKEN_USAGE),
+        (RESULT_COST, None),
+    ],
+)
+def test_run_eval_incomplete_accounting_bundle_falls_back_to_instance(
+    monkeypatch, cost_payload, token_usage_payload
+):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(
+            cost_payload=cost_payload,
+            token_usage_payload=token_usage_payload,
+        ),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+def test_run_eval_complete_zero_response_cost_token_usage_is_accepted(monkeypatch):
+    zero_cost = {
+        "total_cost": 0.0,
+        "prompt_cost": 0.0,
+        "completion_cost": 0.0,
+    }
+    zero_token_usage = {
+        "total_tokens": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+    }
+    _patch_runner(
+        monkeypatch,
+        _raw_result(cost_payload=zero_cost, token_usage_payload=zero_token_usage),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == zero_cost
+    assert result.token_usage == zero_token_usage
+
+
+def test_run_eval_falls_back_to_instance_cost_token_usage(monkeypatch):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(cost_payload=None, token_usage_payload=None),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.value == 0.7
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+@pytest.mark.parametrize(
+    "cost_payload",
+    [
+        {"total_cost": True, "prompt_cost": 0.01, "completion_cost": 0.02},
+        {"total_cost": -0.01, "prompt_cost": 0.01, "completion_cost": 0.02},
+        {"total_cost": float("inf"), "prompt_cost": 0.01, "completion_cost": 0.02},
+        {"total_cost": float("nan"), "prompt_cost": 0.01, "completion_cost": 0.02},
+        {"total_cost": "0.03", "prompt_cost": 0.01, "completion_cost": 0.02},
+    ],
+)
+def test_run_eval_invalid_response_cost_falls_back_to_instance(
+    monkeypatch, cost_payload
+):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(cost_payload=cost_payload, token_usage_payload=RESULT_TOKEN_USAGE),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+@pytest.mark.parametrize(
+    "token_usage_payload",
+    [
+        {"total_tokens": True, "prompt_tokens": 10, "completion_tokens": 20},
+        {"total_tokens": -1, "prompt_tokens": 10, "completion_tokens": 20},
+        {"total_tokens": 30.5, "prompt_tokens": 10, "completion_tokens": 20},
+        {"total_tokens": "30", "prompt_tokens": 10, "completion_tokens": 20},
+    ],
+)
+def test_run_eval_invalid_response_token_usage_falls_back_to_instance(
+    monkeypatch, token_usage_payload
+):
+    _patch_runner(
+        monkeypatch,
+        _raw_result(cost_payload=RESULT_COST, token_usage_payload=token_usage_payload),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == INSTANCE_COST
+    assert result.token_usage == INSTANCE_TOKEN_USAGE
+
+
+def test_run_eval_valid_response_cost_token_usage_are_sanitized(monkeypatch):
+    cost_payload = {
+        "total_cost": 0.03,
+        "prompt_cost": 0.01,
+        "completion_cost": 0.02,
+        "pricing_source": "unit-prices",
+        "unknown_cost": 100,
+    }
+    token_usage_payload = {
+        "total_tokens": 30,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "cache_creation_input_tokens": 3,
+        "cache_read_input_tokens": 4,
+        "invalid_optional": 5,
+        "unknown_tokens": 99,
+    }
+    _patch_runner(
+        monkeypatch,
+        _raw_result(
+            cost_payload=cost_payload,
+            token_usage_payload=token_usage_payload,
+        ),
+    )
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=_template(),
+            inputs={"input": "value"},
+            skip_params_preparation=True,
+        )
+    )
+
+    assert result.cost == {
+        "total_cost": 0.03,
+        "prompt_cost": 0.01,
+        "completion_cost": 0.02,
+        "pricing_source": "unit-prices",
+    }
+    assert result.token_usage == {
+        "total_tokens": 30,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "cache_creation_input_tokens": 3,
+        "cache_read_input_tokens": 4,
+    }


### PR DESCRIPTION
## Summary

This PR closes the typed cost/token usage gap from #316 by declaring structured optional `cost` and `token_usage` fields on the agentic eval `EvalResult` contract and safely preserving valid complete response-level payloads through engine normalization. `run_eval()` now accepts response-level accounting only as an atomic sanitized bundle: both `cost` and `token_usage` must be valid and complete, otherwise both fields keep the existing evaluator-instance fallback. Based on prior maintainer guidance in #348, this intentionally does not change evaluator producer behavior.

## Linked issues

Closes #316
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Typed usage fields on eval results**

- Added shaped `EvalResultCost` and `EvalResultTokenUsage` `TypedDict`s.
- Declared `cost` and `token_usage` as optional fields on the raw agentic eval `EvalResult` contract.
- Used `total=False` optional mixins so the typed fields remain optional without depending on `NotRequired`.

**B. Preserve and validate usage payloads in the engine**

- `extract_raw_result()` now preserves `cost` and `token_usage` while normalizing evaluator output.
- `run_eval()` now uses response-level accounting only when both `cost` and `token_usage` are present, complete, and valid.
- Invalid, partial, empty, or one-sided response-level usage payloads fall back to the existing evaluator instance attributes for both accounting fields.
- Unknown response-level cost/token keys are stripped; valid optional `pricing_source` and cache token counters are preserved.

**C. Compatibility kept intentionally narrow**

- Existing evaluator metadata JSON output remains unchanged.
- Existing evaluators that only expose `eval_instance.cost` / `eval_instance.token_usage` keep working.
- No evaluator inheritance, LLM call behavior, HTTP API, or frontend contract is changed.
- This follows the maintainer feedback on closed PR #348: avoid `CustomPromptEvaluator` side effects and keep the #316 fix focused on typed, shaped fields.

---

## 2) Why the changes were done

- Consumers get a typed result contract for structured cost and token usage without parsing an opaque metadata blob.
- The engine can carry valid per-result usage payloads when present while preserving the existing evaluator-instance fallback path.
- The change stays at the result contract and normalization boundary instead of changing individual evaluator producers.

---

## 3) Tests written + scenarios each covers

**`futureagi/evaluations/engine/tests/test_eval_result_cost_fields.py`** — verifies typed result shapes, raw-result extraction, atomic safe payload validation, and runner fallback behavior.

- `test_eval_result_cost_fields_are_optional_and_shaped` — verifies `cost` and `token_usage` are optional on `EvalResult`, with required/optional nested keys shaped as expected.
- `test_extract_raw_result_preserves_cost_token_usage_from_nested_result` — verifies normalization preserves structured usage fields from nested raw results.
- `test_extract_raw_result_empty_result_has_none_cost_token_usage` — verifies missing raw results normalize usage fields to `None`.
- `test_extract_raw_result_none_result_shapes_preserve_template_output` — verifies pre-existing `None` result-shape compatibility while adding usage fields.
- `test_run_eval_prefers_result_cost_token_usage` — verifies valid complete response-level usage payloads win over evaluator instance attributes.
- `test_run_eval_empty_response_cost_token_usage_falls_back_to_instance` — verifies empty response payloads keep the compatibility fallback.
- `test_run_eval_partial_response_cost_token_usage_falls_back_to_instance` — verifies partial `cost` and partial `token_usage` payloads do not suppress valid instance usage fields.
- `test_run_eval_incomplete_accounting_bundle_falls_back_to_instance` — verifies one-sided valid accounting data is not mixed with instance fallback data.
- `test_run_eval_complete_zero_response_cost_token_usage_is_accepted` — verifies complete zero-valued usage payloads are treated as valid result-level data.
- `test_run_eval_falls_back_to_instance_cost_token_usage` — verifies omitted usage fields keep the existing instance fallback.
- `test_run_eval_invalid_response_cost_falls_back_to_instance` — verifies key-complete but invalid cost values fall back instead of poisoning billing data.
- `test_run_eval_invalid_response_token_usage_falls_back_to_instance` — verifies key-complete but invalid token values fall back instead of mixing accounting sources.
- `test_run_eval_valid_response_cost_token_usage_are_sanitized` — verifies optional valid fields are preserved and unknown keys are stripped.

> Run result: **24 passed** in the focused suite; **30 passed** across the focused suite plus adjacent formatting tests; **87 passed** across `evaluations/engine/tests`. `bin/test --no-services evaluations/engine/tests/test_eval_result_cost_fields.py -q` also passed with **24 passed**. `py_compile`, `uvx ruff check`, `uvx black --target-version py312 --check`, `.venv/bin/mypy --follow-imports=skip evaluations/engine/runner.py`, `git diff --check`, and `git diff --cached --check` passed.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
.venv/bin/python -m pytest evaluations/engine/tests/test_eval_result_cost_fields.py -q
.venv/bin/python -m pytest evaluations/engine/tests/test_eval_result_cost_fields.py evaluations/engine/tests/test_formatting_multi_choice.py -q
.venv/bin/python -m pytest evaluations/engine/tests -q
bin/test --no-services evaluations/engine/tests/test_eval_result_cost_fields.py -q
.venv/bin/python -m py_compile agentic_eval/core_evals/fi_utils/evals_result.py evaluations/engine/formatting.py evaluations/engine/runner.py evaluations/engine/tests/test_eval_result_cost_fields.py
uvx ruff check agentic_eval/core_evals/fi_utils/evals_result.py evaluations/engine/formatting.py evaluations/engine/runner.py evaluations/engine/tests/test_eval_result_cost_fields.py
uvx black --target-version py312 --check agentic_eval/core_evals/fi_utils/evals_result.py evaluations/engine/formatting.py evaluations/engine/runner.py evaluations/engine/tests/test_eval_result_cost_fields.py
.venv/bin/mypy --follow-imports=skip evaluations/engine/runner.py
```

### Frontend tests (if applicable)

Not applicable; this PR has no frontend changes.

### Contract verification (if API surface changed)

Not applicable; this PR does not change the HTTP API or frontend contracts.

### UI steps (manual)

Not applicable; this PR has no UI changes.

---

## 5) Screenshots / recordings

Not applicable; backend typing/result propagation change only.

---

## 6) Edge cases & considerations

- **Legacy evaluators:** evaluators that omit structured usage fields still use `eval_instance.cost` and `eval_instance.token_usage`.
- **Partial payloads:** incomplete response-level `cost` or `token_usage` dictionaries fall back to instance data instead of producing partial billing data.
- **Invalid keyed payloads:** key-complete payloads with booleans, negative values, non-finite cost values, strings, or wrong token-count types are rejected and fall back to instance data.
- **Mixed accounting sources:** response-level `cost` and `token_usage` are accepted only together after validation, so cost and token counts are not mixed across response and instance sources.
- **Zero values:** complete zero-valued usage payloads are accepted as valid result-level data.
- **Malformed raw results:** this PR does not introduce a new fail-closed malformed-output policy; malformed-output semantics should be handled in a separate behavior PR if needed.
- **Metadata compatibility:** existing metadata JSON remains unchanged and is not migrated in this PR.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Local pytest emits a non-fatal CH25 ClickHouse schema warning because ClickHouse is not running at `localhost:18123` in this environment. The warning did not fail collection or execution for the targeted suites.
- `ruff` and `black` are not installed in the local `.venv`; they were run successfully via `uvx` against the touched files.
- Full `bin/test` was not run; verification was scoped to the affected engine suites, targeted `bin/test --no-services`, syntax/lint/format/type checks, and diff checks.

---

## 8) Architectural / important decisions

- **Do not change evaluator producer behavior:** per-result fields are consumed when present, but this PR does not mutate `CustomPromptEvaluator` or other evaluator producers.
- **Require safe complete usage payloads:** response-level `cost` and `token_usage` must both include required keys with safe value shapes before they override instance-level fallback data.
- **Keep accounting provenance atomic:** if either side of the response-level accounting bundle is invalid or incomplete, both accounting fields fall back to the evaluator instance.
- **Avoid a malformed-output policy change:** changing how malformed evaluator results propagate through SDK/tracer callers would be a separate behavior PR.
- **Keep metadata unchanged:** removing or migrating the metadata JSON path would be a separate compatibility change.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
