### PR TITLE
fix(huggingface): upload imported PDF documents

### DIFF
--- a/futureagi/model_hub/tests/test_huggingface_api.py
+++ b/futureagi/model_hub/tests/test_huggingface_api.py
@@ -13,7 +13,6 @@ These tests verify the complete flow including:
 Run with: pytest model_hub/tests/test_huggingface_api.py -v
 """
 
-import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/futureagi/model_hub/tests/test_huggingface_document_import.py
+++ b/futureagi/model_hub/tests/test_huggingface_document_import.py
@@ -1,0 +1,220 @@
+import base64
+import json
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pdfplumber
+import pytest
+
+from model_hub.models.choices import CellStatus, DataTypeChoices
+
+MINIMAL_PDF_BYTES = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n"
+    b"<< /Type /Catalog /Pages 2 0 R >>\n"
+    b"endobj\n"
+    b"2 0 obj\n"
+    b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>\n"
+    b"endobj\n"
+    b"3 0 obj\n"
+    b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R "
+    b"/Resources << /Font << /F1 5 0 R >> >> >>\n"
+    b"endobj\n"
+    b"4 0 obj\n"
+    b"<< /Length 44 >>\n"
+    b"stream\n"
+    b"BT /F1 12 Tf 72 120 Td (Hello PDF) Tj ET\n"
+    b"endstream\n"
+    b"endobj\n"
+    b"5 0 obj\n"
+    b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\n"
+    b"endobj\n"
+    b"xref\n"
+    b"0 6\n"
+    b"0000000000 65535 f \n"
+    b"0000000009 00000 n \n"
+    b"0000000058 00000 n \n"
+    b"0000000115 00000 n \n"
+    b"0000000241 00000 n \n"
+    b"0000000335 00000 n \n"
+    b"trailer\n"
+    b"<< /Root 1 0 R /Size 6 >>\n"
+    b"startxref\n"
+    b"405\n"
+    b"%%EOF\n"
+)
+
+
+def test_pdf_feature_maps_to_document_data_type():
+    from model_hub.utils.utils import get_data_type_huggingface
+
+    assert (
+        get_data_type_huggingface({"name": "paper", "type": {"_type": "Pdf"}})
+        == DataTypeChoices.DOCUMENT.value
+    )
+    assert (
+        get_data_type_huggingface({"name": "paper", "type": {"dtype": "pdf"}})
+        == DataTypeChoices.DOCUMENT.value
+    )
+
+
+def test_document_path_dict_rejects_local_file_without_bytes(tmp_path):
+    from model_hub.views.utils.hugginface import (
+        _coerce_huggingface_document_for_upload,
+    )
+
+    pdf_path = tmp_path / "local-paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\nfrom disk")
+
+    with pytest.raises(ValueError, match="did not include document bytes"):
+        _coerce_huggingface_document_for_upload(
+            {"path": str(pdf_path)}, fallback_name="paper.pdf"
+        )
+
+
+def test_document_path_dict_allows_remote_urls():
+    from model_hub.views.utils.hugginface import (
+        _coerce_huggingface_document_for_upload,
+    )
+
+    upload_input, document_name = _coerce_huggingface_document_for_upload(
+        {"path": "https://example.com/local-paper.pdf"}, fallback_name="paper.pdf"
+    )
+
+    assert upload_input == "https://example.com/local-paper.pdf"
+    assert document_name == "local-paper.pdf"
+
+
+@patch("model_hub.views.utils.hugginface.upload_document_to_s3")
+@patch("model_hub.views.utils.hugginface.Cell.objects.create")
+@patch("model_hub.views.utils.hugginface.Dataset.objects.get")
+@patch("model_hub.views.utils.hugginface.Column.objects.get")
+@patch("model_hub.views.utils.hugginface.close_old_connections")
+def test_process_columns_uploads_decoded_pdf_object(
+    mock_close_connections,
+    mock_column_get,
+    mock_dataset_get,
+    mock_cell_create,
+    mock_upload_document,
+):
+    from model_hub.views.utils.hugginface import process_huggingface_columns
+
+    decoded_pdf = pdfplumber.open(BytesIO(MINIMAL_PDF_BYTES))
+    column = SimpleNamespace(id="column-id", name="paper", data_type="document")
+    dataset = SimpleNamespace(id="dataset-id", organization_id="org-id")
+    mock_column_get.return_value = column
+    mock_dataset_get.return_value = dataset
+    mock_upload_document.return_value = "https://cdn.example.com/decoded.pdf"
+
+    try:
+        process_huggingface_columns(
+            data_dict={"paper": [decoded_pdf]},
+            dataset_id="dataset-id",
+            column_id="column-id",
+            rows={"0": "row-id"},
+            index=0,
+        )
+    finally:
+        decoded_pdf.close()
+
+    mock_upload_document.assert_called_once()
+    upload_input = mock_upload_document.call_args.args[0]
+    assert upload_input.startswith("data:application/pdf;base64,")
+    assert base64.b64decode(upload_input.split(",", 1)[1]) == MINIMAL_PDF_BYTES
+
+    mock_cell_create.assert_called_once()
+    cell_kwargs = mock_cell_create.call_args.kwargs
+    assert cell_kwargs["value"] == "https://cdn.example.com/decoded.pdf"
+    assert cell_kwargs["status"] == CellStatus.PASS.value
+    assert json.loads(cell_kwargs["value_infos"]) == {
+        "document_url": "https://cdn.example.com/decoded.pdf",
+        "document_name": "paper.pdf",
+    }
+
+
+@patch("model_hub.views.utils.hugginface.upload_document_to_s3")
+@patch("model_hub.views.utils.hugginface.Cell.objects.create")
+@patch("model_hub.views.utils.hugginface.Dataset.objects.get")
+@patch("model_hub.views.utils.hugginface.Column.objects.get")
+@patch("model_hub.views.utils.hugginface.close_old_connections")
+def test_process_columns_uploads_document_bytes(
+    mock_close_connections,
+    mock_column_get,
+    mock_dataset_get,
+    mock_cell_create,
+    mock_upload_document,
+):
+    from model_hub.views.utils.hugginface import process_huggingface_columns
+
+    column = SimpleNamespace(id="column-id", name="paper", data_type="document")
+    dataset = SimpleNamespace(id="dataset-id", organization_id="org-id")
+    mock_column_get.return_value = column
+    mock_dataset_get.return_value = dataset
+    mock_upload_document.return_value = "https://cdn.example.com/paper.pdf"
+
+    pdf_bytes = b"%PDF-1.4\nexample"
+
+    process_huggingface_columns(
+        data_dict={"paper": [{"bytes": pdf_bytes, "path": "paper.pdf"}]},
+        dataset_id="dataset-id",
+        column_id="column-id",
+        rows={"0": "row-id"},
+        index=0,
+    )
+
+    mock_upload_document.assert_called_once()
+    upload_input = mock_upload_document.call_args.args[0]
+    assert upload_input.startswith("data:application/pdf;base64,")
+    assert base64.b64decode(upload_input.split(",", 1)[1]) == pdf_bytes
+    assert mock_upload_document.call_args.kwargs["object_key"].startswith(
+        "documents/dataset-id/"
+    )
+    assert mock_upload_document.call_args.kwargs["org_id"] == "org-id"
+
+    mock_cell_create.assert_called_once()
+    cell_kwargs = mock_cell_create.call_args.kwargs
+    assert cell_kwargs["dataset"] is dataset
+    assert cell_kwargs["column"] is column
+    assert cell_kwargs["row_id"] == "row-id"
+    assert cell_kwargs["value"] == "https://cdn.example.com/paper.pdf"
+    assert cell_kwargs["status"] == CellStatus.PASS.value
+    assert json.loads(cell_kwargs["value_infos"]) == {
+        "document_url": "https://cdn.example.com/paper.pdf",
+        "document_name": "paper.pdf",
+    }
+
+
+@patch("model_hub.views.utils.hugginface.upload_document_to_s3")
+@patch("model_hub.views.utils.hugginface.Cell.objects.create")
+@patch("model_hub.views.utils.hugginface.Dataset.objects.get")
+@patch("model_hub.views.utils.hugginface.Column.objects.get")
+@patch("model_hub.views.utils.hugginface.close_old_connections")
+def test_process_columns_marks_document_upload_errors(
+    mock_close_connections,
+    mock_column_get,
+    mock_dataset_get,
+    mock_cell_create,
+    mock_upload_document,
+):
+    from model_hub.views.utils.hugginface import process_huggingface_columns
+
+    column = SimpleNamespace(id="column-id", name="paper", data_type="document")
+    dataset = SimpleNamespace(id="dataset-id", organization_id="org-id")
+    mock_column_get.return_value = column
+    mock_dataset_get.return_value = dataset
+    mock_upload_document.side_effect = ValueError("invalid document")
+
+    process_huggingface_columns(
+        data_dict={"paper": [{"bytes": b"not a pdf", "path": "paper.pdf"}]},
+        dataset_id="dataset-id",
+        column_id="column-id",
+        rows={"0": "row-id"},
+        index=0,
+    )
+
+    mock_cell_create.assert_called_once()
+    cell_kwargs = mock_cell_create.call_args.kwargs
+    assert cell_kwargs["value"] == ""
+    assert cell_kwargs["status"] == CellStatus.ERROR.value
+    assert json.loads(cell_kwargs["value_infos"]) == {"reason": "invalid document"}

--- a/futureagi/model_hub/utils/utils.py
+++ b/futureagi/model_hub/utils/utils.py
@@ -21,6 +21,7 @@ from nltk.stem import WordNetLemmatizer
 logger = structlog.get_logger(__name__)
 
 from agentic_eval.core_evals.run_prompt.available_models import AVAILABLE_MODELS
+
 # (available_models always available)
 from model_hub.models.ai_model import AIModel
 from model_hub.models.api_key import ApiKey
@@ -730,6 +731,11 @@ def get_data_type_huggingface(column_info):
         "datetime": DataTypeChoices.DATETIME.value,
         "Image": DataTypeChoices.IMAGE.value,
         "Audio": DataTypeChoices.AUDIO.value,
+        "Pdf": DataTypeChoices.DOCUMENT.value,
+        "PDF": DataTypeChoices.DOCUMENT.value,
+        "pdf": DataTypeChoices.DOCUMENT.value,
+        "Document": DataTypeChoices.DOCUMENT.value,
+        "document": DataTypeChoices.DOCUMENT.value,
         "date32": DataTypeChoices.DATETIME.value,
         "date64": DataTypeChoices.DATETIME.value,
         "date": DataTypeChoices.DATETIME.value,

--- a/futureagi/model_hub/views/utils/hugginface.py
+++ b/futureagi/model_hub/views/utils/hugginface.py
@@ -1,9 +1,12 @@
+import base64
 import gc
 import json
+import mimetypes
 import os
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import urlparse
 
 import pandas as pd
 import requests
@@ -19,9 +22,93 @@ from tfc.settings.settings import (
     HUGGINGFACE_API_TOKEN,
 )
 from tfc.utils.error_codes import get_error_message
-from tfc.utils.storage import upload_audio_to_s3_duration, upload_image_to_s3
+from tfc.utils.storage import (
+    upload_audio_to_s3_duration,
+    upload_document_to_s3,
+    upload_image_to_s3,
+)
 
 _HUGGINGFACE_DATASET_INFO_TIMEOUT_SECONDS = 30
+
+
+def _guess_document_content_type(path):
+    content_type, _ = mimetypes.guess_type(str(path or ""))
+    return content_type or "application/pdf"
+
+
+def _document_bytes_to_data_uri(raw_bytes, path=None):
+    return (
+        f"data:{_guess_document_content_type(path)};base64,"
+        f"{base64.b64encode(bytes(raw_bytes)).decode('ascii')}"
+    )
+
+
+def _document_name_from_path(path, fallback="document"):
+    if not path:
+        return fallback
+    name = os.path.basename(str(path))
+    return name or fallback
+
+
+def _is_remote_document_path(path):
+    return urlparse(str(path)).scheme in ("http", "https")
+
+
+def _pdfplumber_document_to_bytes(value):
+    stream = getattr(value, "stream", None)
+    if stream and hasattr(stream, "read") and hasattr(stream, "seek"):
+        position = None
+        try:
+            position = stream.tell()
+        except Exception:
+            position = None
+
+        try:
+            stream.seek(0)
+            raw_bytes = stream.read()
+        finally:
+            if position is not None:
+                stream.seek(position)
+
+        if isinstance(raw_bytes, str):
+            return raw_bytes.encode()
+        return bytes(raw_bytes)
+
+    from datasets.features.pdf import pdf_to_bytes
+
+    return pdf_to_bytes(value)
+
+
+def _coerce_huggingface_document_for_upload(value, fallback_name):
+    if isinstance(value, dict):
+        path = value.get("path")
+        raw_bytes = value.get("bytes")
+        document_name = _document_name_from_path(path, fallback=fallback_name)
+        if raw_bytes is not None:
+            return _document_bytes_to_data_uri(raw_bytes, path), document_name
+        if path:
+            if _is_remote_document_path(path):
+                return str(path), document_name
+            raise ValueError(
+                "HuggingFace document payload did not include document bytes"
+            )
+        return value, document_name
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _document_bytes_to_data_uri(value), fallback_name
+
+    try:
+        if value.__class__.__module__.startswith("pdfplumber"):
+            return (
+                _document_bytes_to_data_uri(_pdfplumber_document_to_bytes(value)),
+                fallback_name,
+            )
+    except Exception as e:
+        logger.exception("huggingface: Error converting decoded PDF document")
+        raise ValueError("Unable to convert HuggingFace decoded PDF document") from e
+
+    document_name = _document_name_from_path(value, fallback=fallback_name)
+    return value, document_name
 
 
 def get_huggingface_dataset_info(dataset_path, organization_id):
@@ -115,6 +202,28 @@ def process_huggingface_columns(data_dict, dataset_id, column_id, rows, index):
             except Exception as e:
                 traceback.print_exc()
                 logger.exception(f"huggingface: Error uploading audio: {str(e)}")
+                cell_value = ""
+                cell_value_infos["reason"] = str(e)
+                cell_status = CellStatus.ERROR.value
+
+        elif column.data_type == DataTypeChoices.DOCUMENT.value:
+            try:
+                document_key = f"documents/{dataset.id}/{uuid.uuid4()}"
+                document_input, document_name = _coerce_huggingface_document_for_upload(
+                    value, fallback_name=f"{column.name}.pdf"
+                )
+                document_url = upload_document_to_s3(
+                    document_input,
+                    bucket_name=os.getenv("S3_FOR_DATA"),
+                    object_key=document_key,
+                    org_id=str(dataset.organization_id),
+                )
+                cell_value = document_url
+                cell_value_infos["document_url"] = document_url
+                cell_value_infos["document_name"] = document_name[:400]
+                cell_status = CellStatus.PASS.value
+            except Exception as e:
+                logger.exception(f"huggingface: Error uploading document: {str(e)}")
                 cell_value = ""
                 cell_value_infos["reason"] = str(e)
                 cell_status = CellStatus.ERROR.value


### PR DESCRIPTION
## Summary

HuggingFace dataset imports currently infer PDF/document features as non-document data and then store decoded PDF objects as raw string representations. This PR maps HuggingFace PDF/document feature metadata to the existing document column type and routes imported document values through the same S3 upload path used by other document ingestion flows.

The result is that imported PDF/document cells store the uploaded document URL plus document metadata instead of a raw object repr.

## Linked issues

Closes #930
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. HuggingFace document type inference**

- Map HuggingFace `Pdf`, `PDF`, `pdf`, `Document`, and `document` feature metadata to `DataTypeChoices.DOCUMENT`.
- Preserve the existing mappings for image, audio, primitive, array, and JSON feature types.

**B. Document upload during HuggingFace import**

- Add a document branch to `process_huggingface_columns` alongside the existing image/audio upload branches.
- Convert HuggingFace document payloads into uploadable inputs:
  - `{"bytes": ..., "path": ...}` dictionaries become document data URIs.
  - Remote URL path dictionaries are passed to the existing storage URL validator.
  - Local path-only dictionaries are rejected unless the payload also includes bytes, avoiding arbitrary local file reads.
  - Raw byte-like values become PDF data URIs.
  - Decoded `pdfplumber` PDF objects are read from their underlying stream, converted to PDF data URIs, and uploaded.
- Store the uploaded document URL as the cell value and record `document_url` / `document_name` in `value_infos`.
- Mark upload failures as `ERROR` cells with the failure reason, matching the existing media-import behavior.

**C. Regression coverage**

- Add focused unit coverage for PDF feature inference, local-file coercion, successful document upload, and document upload error handling.
- Remove an unused import from the existing HuggingFace API test module that surfaced during scoped linting.

---

## 2) Why the changes were done

- **Product/UX:** Imported HuggingFace PDF/document columns should behave like document cells users can open, not raw Python object strings.
- **Technical:** The fix reuses the existing `upload_document_to_s3` path instead of adding a second storage implementation.
- **Architecture:** The change stays inside the existing HuggingFace import boundary: feature typing remains in `model_hub/utils/utils.py`, and per-cell upload handling remains in `model_hub/views/utils/hugginface.py` next to image/audio handling.

---

## 3) Tests written + scenarios each covers

**`model_hub/tests/test_huggingface_document_import.py`** — regression coverage for HuggingFace document/PDF import handling.

- `test_pdf_feature_maps_to_document_data_type` — verifies HuggingFace PDF metadata maps to the document column type.
- `test_document_path_dict_rejects_local_file_without_bytes` — verifies local path-only dictionaries fail safely instead of reading arbitrary local files.
- `test_document_path_dict_allows_remote_urls` — verifies remote document URLs remain uploadable through the existing storage validator.
- `test_process_columns_uploads_decoded_pdf_object` — verifies decoded HuggingFace/pdfplumber PDF objects are converted to PDF data URIs, uploaded, and stored as document URLs.
- `test_process_columns_uploads_document_bytes` — verifies document bytes are uploaded through `upload_document_to_s3` and the resulting URL/metadata are stored on the cell.
- `test_process_columns_marks_document_upload_errors` — verifies upload failures produce an `ERROR` cell with the failure reason.

> Run result: **6 passed** in the focused suite. Scoped lint (ruff) + format (black) are clean for the touched files.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
.venv/bin/python -m pytest model_hub/tests/test_huggingface_document_import.py -q
bin/test --no-services model_hub/tests/test_huggingface_document_import.py -q
.venv/bin/python -m py_compile model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py
uvx ruff check --extend-ignore E402 model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py
uvx black --target-version py312 --check model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py
```

### Actual local results

- `cd futureagi && .venv/bin/python -m pytest model_hub/tests/test_huggingface_document_import.py -q` — **6 passed**. Nonfatal CH25 ClickHouse warning because local ClickHouse is not running on `localhost:18123`.
- `cd futureagi && bin/test --no-services model_hub/tests/test_huggingface_document_import.py -q` — **6 passed**. Same nonfatal CH25 warning.
- `cd futureagi && .venv/bin/python -m py_compile model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py` — **passed**.
- `cd futureagi && uvx ruff check --extend-ignore E402 model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py` — **passed**.
- `cd futureagi && uvx black --target-version py312 --check model_hub/views/utils/hugginface.py model_hub/utils/utils.py model_hub/tests/test_huggingface_document_import.py model_hub/tests/test_huggingface_api.py` — **passed**.
- `git diff --check` — **passed**.

### Not run / environment-limited checks

- `cd futureagi && .venv/bin/python -m pytest model_hub/tests/test_huggingface_api.py -q` — not usable in this local environment because PostgreSQL is not running at `127.0.0.1:15432`; collection reaches the DB-backed fixtures and fails before the relevant scenarios can run. The new regression tests avoid that service dependency and exercise the affected mapping/upload boundary directly.
- Full `bin/test` — not run locally for this focused backend fix.

### Frontend tests (if applicable)

Not applicable; this PR only changes backend import handling and backend tests.

### Contract verification (if API surface changed)

Not applicable; no API contract/schema shape changes.

### UI steps (manual)

Not run locally. The expected manual path is importing a HuggingFace dataset with a PDF/document feature and confirming the resulting cell value is an uploaded document URL rather than a raw object string.

---

## 5) Screenshots / recordings

### Test output

Not attached; exact command results are listed above.

### UI testing

Not applicable for this backend-only fix.

---

## 6) Edge cases & considerations

- **HF document dictionaries with bytes:** converted to data URIs before upload.
- **HF document dictionaries with local paths:** rejected unless bytes are present, so crafted datasets cannot make the importer read arbitrary server files.
- **HF document dictionaries with remote URLs:** passed through to the existing storage helper for URL validation/download.
- **Decoded PDF objects:** read from the `pdfplumber` stream and covered by a regression test using a real `pdfplumber.open(BytesIO(...))` object.
- **Upload failures:** stored as `ERROR` cells with a reason rather than silently storing invalid/raw values.
- **Image/audio import:** intentionally unchanged.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The DB-backed HuggingFace API test module requires local PostgreSQL at `127.0.0.1:15432`; that service is not running in my local environment.
- The test configuration emits a nonfatal CH25 ClickHouse schema warning when ClickHouse is not running on `localhost:18123`; the focused tests still pass.
- These touched modules have existing module-level import placement that trips E402 under a plain ruff invocation, so the scoped ruff command uses `--extend-ignore E402` and keeps this PR from reformatting unrelated module structure.

---

## 8) Architectural / important decisions

- **Reuse existing storage behavior:** Document imports now call `upload_document_to_s3` instead of introducing a new storage helper.
- **Keep the fix narrow:** This PR only changes HuggingFace feature typing/document cell processing and does not alter the broader dataset import pipeline.
- **Prefer unit regression coverage:** The new tests cover the mapping/upload boundary directly without requiring local PostgreSQL or object storage services.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [x] I've updated the documentation where relevant (not needed for this backend bug fix)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
