### PR TITLE
fix: use python3 instead of python in host-side scripts

### DIFF
--- a/futureagi/agentic_eval/Makefile
+++ b/futureagi/agentic_eval/Makefile
@@ -28,40 +28,40 @@ help:
 # Test commands
 test:
 	@echo "🧪 Running all tests..."
-	python -m pytest tests/ -v
+	python3 -m pytest tests/ -v
 
 test-unit:
 	@echo "🔍 Running unit tests..."
-	python run_tests.py --unit --verbose
+	python3 run_tests.py --unit --verbose
 
 test-integration:
 	@echo "🔗 Running integration tests..."
-	python run_tests.py --integration --verbose
+	python3 run_tests.py --integration --verbose
 
 test-performance:
 	@echo "⚡ Running performance tests..."
-	python run_tests.py --performance --verbose
+	python3 run_tests.py --performance --verbose
 
 test-coverage:
 	@echo "📊 Running tests with coverage..."
-	python run_tests.py --coverage --verbose
+	python3 run_tests.py --coverage --verbose
 
 test-html:
 	@echo "📄 Generating HTML test report..."
-	python run_tests.py --html --verbose
+	python3 run_tests.py --html --verbose
 
 test-parallel:
 	@echo "🚀 Running tests in parallel..."
-	python run_tests.py --parallel --verbose
+	python3 run_tests.py --parallel --verbose
 
 test-fast:
 	@echo "⚡ Running fast tests..."
-	python run_tests.py --fast --verbose
+	python3 run_tests.py --fast --verbose
 
 # Specific test files
 test-serving:
 	@echo "🌐 Testing serving client..."
-	python -m pytest tests/test_serving_client.py -v
+	python3 -m pytest tests/test_serving_client.py -v
 
 # Setup commands
 install-test:
@@ -101,4 +101,4 @@ ci: lint test-coverage
 # Quick test for development
 quick:
 	@echo "⚡ Quick test run..."
-	python -m pytest tests/test_serving_client.py::TestModelServingClient::test_embed_text_string_input -v 
+	python3 -m pytest tests/test_serving_client.py::TestModelServingClient::test_embed_text_string_input -v 

--- a/futureagi/bin/test
+++ b/futureagi/bin/test
@@ -104,7 +104,7 @@ stop_services() {
 # Run migrations
 run_migrations() {
     echo -e "${YELLOW}Running migrations...${NC}"
-    python manage.py migrate --run-syncdb > /dev/null 2>&1
+    python3 manage.py migrate --run-syncdb > /dev/null 2>&1
 }
 
 # Run pytest

--- a/futureagi/bin/verify-team-setup.sh
+++ b/futureagi/bin/verify-team-setup.sh
@@ -145,7 +145,7 @@ if [ -f manage.py ]; then
     echo -e "${GREEN}✓${NC} manage.py found"
 
     # Try to run Django checks (may fail if DB not set up)
-    if python manage.py check --deploy > /dev/null 2>&1; then
+    if python3 manage.py check --deploy > /dev/null 2>&1; then
         echo -e "${GREEN}✓${NC} Django system check passed"
     else
         echo -e "${YELLOW}⚠${NC} Django system check has warnings (may be expected)"


### PR DESCRIPTION
What and why

bin/test, bin/verify-team-setup.sh, and agentic_eval/Makefile call bare python, which does not exist on a standard modern macOS setup (only python3 is on PATH). This breaks make test at the migrations step with Error 127, and would also break bin/verify-team-setup.sh and the agentic_eval test targets on any similar machine.

Simple fix, python to python3 in the three files, 12 lines total.

Found while investigating a broader macOS setup issue, see #1296. That issue covers two other problems (missing venv setup docs, and cuda-bindings having no macOS wheel) that are separate and larger in scope, raised there rather than folded into this PR.

Checks
Confirmed bash -n passes on both shell scripts (no syntax errors introduced)
Confirmed make -n test-unit in agentic_eval resolves to the corrected python3 command
Confirmed make test gets past the migrations step locally after this fix (still blocked further by the cuda-bindings issue in #1296, unrelated to this change)
No secrets, URLs, or hardcoded values touched