### PR TITLE
fix(observe): scope add-to-dataset fields by route project

### DIFF
--- a/frontend/src/components/traceDetailDrawer/addToDataset/add-dataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/add-dataset.jsx
@@ -13,6 +13,7 @@ import {
 import Iconify from "../../iconify";
 import PropTypes from "prop-types";
 import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
 import AddExistingDataset from "./AddExistingDataset";
 import AddNewDataset from "./AddNewDataset";
@@ -38,6 +39,10 @@ const AddDataset = ({
     useState("existing");
 
   const theme = useTheme();
+  const { observeId, projectId } = useParams();
+  // Observation fields are project-scoped; these route params name the active project
+  // across different Observe surfaces. Keep legacy callers on one unscoped bucket.
+  const observationFieldsScopeId = observeId || projectId || "unscoped";
 
   const { data: availableDatasets = [] } = useQuery({
     queryKey: ["datasets"],
@@ -50,7 +55,7 @@ const AddDataset = ({
   });
 
   const { data: observationFields = EMPTY_ARRAY } = useQuery({
-    queryKey: ["observationFields"],
+    queryKey: ["observationFields", observationFieldsScopeId],
     queryFn: () =>
       axios
         .get(endpoints.project.getObservationSpanField)

--- a/frontend/src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import axios, { endpoints } from "src/utils/axios";
+import AddDataset from "./add-dataset";
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: vi.fn(),
+  },
+  endpoints: {
+    develop: {
+      getDatasetList: () => "/develop/datasets/",
+    },
+    project: {
+      getObservationSpanField:
+        "/tracer/observation-span/get_observation_span_fields/",
+    },
+  },
+}));
+
+vi.mock("../../iconify", () => ({
+  default: ({ icon }) => <span data-testid="iconify">{icon}</span>,
+}));
+
+vi.mock("./AddExistingDataset", () => ({
+  default: ({ observationFields }) => (
+    <div data-testid="existing-fields">
+      {observationFields.map((field) => field.name).join(",")}
+    </div>
+  ),
+}));
+
+vi.mock("./AddNewDataset", () => ({
+  default: ({ observationFields }) => (
+    <div data-testid="new-fields">
+      {observationFields.map((field) => field.name).join(",")}
+    </div>
+  ),
+}));
+
+const theme = createTheme();
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+}
+
+function renderAddDataset(
+  route,
+  queryClient,
+  routePath = "/dashboard/observe/:observeId/llm-tracing",
+) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={[route]}>
+          <Routes>
+            <Route
+              path={routePath}
+              element={<AddDataset actionToDataset handleClose={vi.fn()} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AddDataset observation fields cache scope", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("fetches observation fields per observe project instead of reusing another project's cached fields", async () => {
+    const queryClient = createQueryClient();
+    const observationFieldResponses = [
+      [{ name: "input", type: "text" }],
+      [{ name: "output", type: "text" }],
+    ];
+    let observationFieldFetches = 0;
+
+    axios.get.mockImplementation((url) => {
+      if (url === endpoints.develop.getDatasetList()) {
+        return Promise.resolve({ data: { result: { datasets: [] } } });
+      }
+
+      if (url === endpoints.project.getObservationSpanField) {
+        const result = observationFieldResponses[observationFieldFetches] || [];
+        observationFieldFetches += 1;
+        return Promise.resolve({ data: { result } });
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const firstRender = renderAddDataset(
+      "/dashboard/observe/project-a/llm-tracing",
+      queryClient,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-fields")).toHaveTextContent("input"),
+    );
+    expect(screen.getByTestId("existing-fields")).not.toHaveTextContent(
+      "output",
+    );
+
+    firstRender.unmount();
+
+    renderAddDataset("/dashboard/observe/project-b/llm-tracing", queryClient);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-fields")).toHaveTextContent("output"),
+    );
+    expect(screen.getByTestId("existing-fields")).not.toHaveTextContent(
+      "input",
+    );
+    expect(observationFieldFetches).toBe(2);
+    expect(
+      queryClient.getQueryData(["observationFields", "project-a"]),
+    ).toEqual({ result: [{ name: "input", type: "text" }] });
+    expect(
+      queryClient.getQueryData(["observationFields", "project-b"]),
+    ).toEqual({ result: [{ name: "output", type: "text" }] });
+  });
+
+  it("uses the projectId route param when observeId is not present", async () => {
+    const queryClient = createQueryClient();
+    let observationFieldFetches = 0;
+
+    axios.get.mockImplementation((url) => {
+      if (url === endpoints.develop.getDatasetList()) {
+        return Promise.resolve({ data: { result: { datasets: [] } } });
+      }
+
+      if (url === endpoints.project.getObservationSpanField) {
+        observationFieldFetches += 1;
+        return Promise.resolve({
+          data: { result: [{ name: "status", type: "text" }] },
+        });
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAddDataset(
+      "/dashboard/projects/project-c/datasets",
+      queryClient,
+      "/dashboard/projects/:projectId/datasets",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-fields")).toHaveTextContent("status"),
+    );
+    expect(observationFieldFetches).toBe(1);
+    expect(
+      queryClient.getQueryData(["observationFields", "project-c"]),
+    ).toEqual({ result: [{ name: "status", type: "text" }] });
+  });
+
+  it("keeps a deterministic unscoped cache key when no project route param exists", async () => {
+    const queryClient = createQueryClient();
+    let observationFieldFetches = 0;
+
+    axios.get.mockImplementation((url) => {
+      if (url === endpoints.develop.getDatasetList()) {
+        return Promise.resolve({ data: { result: { datasets: [] } } });
+      }
+
+      if (url === endpoints.project.getObservationSpanField) {
+        observationFieldFetches += 1;
+        return Promise.resolve({
+          data: { result: [{ name: "model", type: "text" }] },
+        });
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    renderAddDataset(
+      "/legacy-dataset-drawer",
+      queryClient,
+      "/legacy-dataset-drawer",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-fields")).toHaveTextContent("model"),
+    );
+    expect(observationFieldFetches).toBe(1);
+    expect(queryClient.getQueryData(["observationFields", "unscoped"])).toEqual(
+      { result: [{ name: "model", type: "text" }] },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes stale observation-field reuse in the Add to dataset drawer by scoping the `observationFields` React Query cache key to the active route project identity.

The old key, `["observationFields"]`, could stay fresh while moving between Observe projects in the same tab. The drawer now uses `observeId || projectId || "unscoped"`, so Observe/project routes get separate field caches while legacy mounts without route params keep one deterministic unscoped bucket.

## Linked issues

Closes #1072
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Scope the observation-fields cache for the drawer**

- The Add to dataset drawer now includes the active route project identifier in the `observationFields` query key.
- `observeId` and `projectId` share the same project-scoped cache namespace because both route params identify the active project for the drawer.
- Callers without either route param still use `["observationFields", "unscoped"]`, preserving the old shared fallback behavior.

**B. Add component-level regression coverage**

- Added a Vitest regression suite for the Add to dataset drawer cache scope.
- The tests use one shared `QueryClient` with `staleTime: Infinity` to reproduce the stale-cache condition without a live backend.
- Axios and child drawer components are mocked so the suite focuses on cache-key behavior.

**C. Architecture / layering changes**

- No API, backend, storage, or contract changes.
- The fix stays inside the frontend drawer component and its test.

---

## 2) Why the changes were done

- **Product/UX:** Prevents the drawer from reusing another project's cached column fields, which could apply incorrect mappings when adding spans to a dataset.
- **Technical:** The root cause is a global React Query cache key for project-contextual data; adding the route project identity creates separate cache entries without changing the endpoint.
- **Architecture:** The existing unscoped behavior remains available for non-route callers, avoiding a broad drawer API change for this focused bug fix.

---

## 3) Tests written + scenarios each covers

**`frontend/src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx`** — component-level regression coverage for observation-field cache scoping.

- `fetches observation fields per observe project instead of reusing another project's cached fields` — renders project A and project B with one `QueryClient` and verifies separate field fetches/cache entries.
- `uses the projectId route param when observeId is not present` — verifies `projectId` is used as the cache scope when `observeId` is absent.
- `keeps a deterministic unscoped cache key when no project route param exists` — verifies legacy/no-param callers use `["observationFields", "unscoped"]`.

> Run result: **3 passed** in the targeted Vitest suite. Scoped Prettier and ESLint checks passed.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
npm run test:run -- src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx --reporter=verbose
npx prettier --check src/components/traceDetailDrawer/addToDataset/add-dataset.jsx src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx
npx eslint src/components/traceDetailDrawer/addToDataset/add-dataset.jsx src/components/traceDetailDrawer/addToDataset/add-dataset.test.jsx
npm run type-check
npm run lint
npm run build
```

### Contract verification (if API surface changed)

Not run; this PR does not change API surface, generated contracts, or backend endpoints.

### UI steps (manual)

1. Open Observe project A and open the Add to dataset drawer.
2. Confirm the drawer field list matches project A.
3. Navigate to Observe project B in the same browser session and open the drawer again.
4. Confirm project B gets its own field list instead of reusing project A's cached fields.

---

## 5) Screenshots / recordings

### Test output

Not attached. Targeted command output: 1 file / 3 tests passed.

### UI testing

Not attached. This is covered by the component-level regression described above; no user-facing copy or layout changed.

---

## 6) Edge cases & considerations

- `observeId`: separate Observe project routes use separate cache entries.
- `projectId`: project routes without `observeId` still get a project-scoped cache entry.
- No project route params: legacy/non-route callers continue using the deterministic `"unscoped"` bucket.
- No API change: the drawer still fetches `endpoints.project.getObservationSpanField` the same way.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `npm run lint` passes with existing repository warnings: 409 warnings, 0 errors.
- `npm run build` exits 0 and builds successfully, while emitting existing warnings for Sentry auth/source-map upload and large Rollup chunks.

---

## 8) Architectural / important decisions

- **Cache-key scoping instead of refactoring the drawer:** The bug is caused by a global React Query key, so scoping the key is the smallest complete fix.
- **Preserve the unscoped fallback:** Some callers may mount the drawer outside an Observe/project route; they keep the old shared cache bucket.
- **Keep tests at component level:** The regression only needs to prove React Query cache behavior, so mocked axios/child drawers provide a stable, focused test.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend) — equivalent command run with npm because yarn is unavailable in this environment
- [ ] `yarn contracts:check` passes if API surface changed — not applicable; no API surface changed
- [ ] I've updated the documentation where relevant — not applicable; no docs/user workflow changed
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — N/A
