### PR TITLE
fix(dashboards): make list rows scannable

### DIFF
--- a/frontend/src/sections/dashboards/DashboardsListView.jsx
+++ b/frontend/src/sections/dashboards/DashboardsListView.jsx
@@ -34,7 +34,7 @@ import SvgColor from "src/components/svg-color";
 import EmptyLayout from "src/components/EmptyLayout/EmptyLayout";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import { useSnackbar } from "src/components/snackbar";
-import { formatDistanceToNowStrict, format } from "date-fns";
+import { fDate, fDateTime, fToNowStrict } from "src/utils/format-time";
 
 const AVATAR_COLORS = [
   "#7C4DFF",
@@ -46,6 +46,9 @@ const AVATAR_COLORS = [
   "#00BFA6",
   "#8C9EFF",
 ];
+
+const DASHBOARD_LIST_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px 32px";
 
 function getAvatarColor(name) {
   let hash = 0;
@@ -65,10 +68,22 @@ function getInitials(name) {
 function timeAgo(date) {
   if (!date) return "";
   try {
-    return formatDistanceToNowStrict(new Date(date), { addSuffix: true });
+    return fToNowStrict(date);
   } catch {
     return "";
   }
+}
+
+function getDashboardCreatorName(db) {
+  return db?.created_by?.name || db?.created_by?.email || "";
+}
+
+function formatDashboardListDate(date) {
+  return fDate(date) || "—";
+}
+
+function formatDashboardTooltipDate(date) {
+  return fDateTime(date) || "";
 }
 
 function getDashboardViewers(db) {
@@ -161,12 +176,7 @@ function ViewerAvatars({ db }) {
                     color: isDark ? "rgba(255,255,255,0.45)" : "text.secondary",
                   }}
                 >
-                  {db.created_at
-                    ? format(
-                        new Date(db.created_at),
-                        "MMM d, yyyy \u00b7 h:mm a",
-                      )
-                    : ""}
+                  {formatDashboardTooltipDate(db.created_at)}
                 </Typography>
               </Box>
             </Stack>
@@ -255,9 +265,7 @@ function ViewerAvatars({ db }) {
                   color: isDark ? "rgba(255,255,255,0.5)" : "text.secondary",
                 }}
               >
-                {db.updated_at
-                  ? format(new Date(db.updated_at), "MMM d, yyyy \u00b7 h:mm a")
-                  : ""}
+                {formatDashboardTooltipDate(db.updated_at)}
               </Typography>
             </Box>
           )}
@@ -375,6 +383,17 @@ export default function DashboardsListView() {
   const handleDelete = (e, db) => {
     e.stopPropagation();
     setDeleteTarget(db);
+  };
+
+  const openDashboard = (dashboardId) => {
+    navigate(paths.dashboard.dashboards.detail(dashboardId));
+  };
+
+  const handleDashboardRowKeyDown = (event, dashboardId) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    openDashboard(dashboardId);
   };
 
   const confirmDelete = () => {
@@ -592,89 +611,202 @@ export default function DashboardsListView() {
           )
         ) : (
           <Stack spacing={1}>
-            {filteredDashboards.map((db) => (
-              <Stack
-                key={db.id}
-                direction="row"
-                alignItems="center"
-                onClick={() =>
-                  navigate(paths.dashboard.dashboards.detail(db.id))
-                }
-                sx={{
-                  px: 2,
-                  py: 1.25,
-                  cursor: "pointer",
-                  borderRadius: 1.5,
-                  border: (t) =>
-                    `1px solid ${
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.08)"
-                        : "rgba(0,0,0,0.08)"
-                    }`,
-                  transition: "all 0.15s",
-                  "&:hover": {
-                    bgcolor: (t) =>
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.04)"
-                        : "rgba(0,0,0,0.02)",
-                    borderColor: (t) =>
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.16)"
-                        : "rgba(0,0,0,0.16)",
-                    "& .row-actions": { opacity: 1 },
-                  },
-                }}
+            <Box
+              sx={{
+                display: { xs: "none", md: "grid" },
+                gridTemplateColumns: DASHBOARD_LIST_COLUMNS,
+                columnGap: 1.5,
+                alignItems: "center",
+                px: 2,
+                color: "text.disabled",
+              }}
+            >
+              <Typography
+                variant="caption"
+                fontWeight={600}
+                sx={{ minWidth: 0 }}
               >
-                <Iconify
-                  icon="mdi:view-dashboard-outline"
-                  width={18}
-                  sx={{ color: "primary.main", mr: 1.5, flexShrink: 0 }}
-                />
+                Name
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Widgets
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Last updated
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Created by
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Viewers
+              </Typography>
+              <Box />
+            </Box>
+            {filteredDashboards.map((db) => {
+              const creatorName = getDashboardCreatorName(db);
+              const dashboardDate = db.updated_at || db.created_at;
 
-                <Typography
-                  variant="body2"
-                  fontWeight={600}
-                  noWrap
-                  sx={{ flex: 1, mr: 2, minWidth: 0 }}
-                >
-                  {db.name}
-                </Typography>
-
-                <Typography
-                  variant="caption"
-                  color="text.disabled"
-                  sx={{ mr: 1.5, whiteSpace: "nowrap", flexShrink: 0 }}
-                >
-                  {db.widget_count || 0} widget
-                  {db.widget_count !== 1 ? "s" : ""}
-                </Typography>
-
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mr: 2, whiteSpace: "nowrap", flexShrink: 0 }}
-                >
-                  {timeAgo(db.updated_at || db.created_at)}
-                </Typography>
-
-                <Box sx={{ mr: 1, flexShrink: 0 }}>
-                  <ViewerAvatars db={db} />
-                </Box>
-
-                <IconButton
-                  className="row-actions"
-                  size="small"
-                  onClick={(e) => handleDelete(e, db)}
+              return (
+                <Box
+                  key={db.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => openDashboard(db.id)}
+                  onKeyDown={(event) => handleDashboardRowKeyDown(event, db.id)}
                   sx={{
-                    opacity: 0,
-                    transition: "opacity 0.15s",
-                    flexShrink: 0,
+                    display: "grid",
+                    gridTemplateColumns: {
+                      xs: "minmax(0, 1fr) 32px",
+                      md: DASHBOARD_LIST_COLUMNS,
+                    },
+                    columnGap: 1.5,
+                    rowGap: { xs: 1, md: 0 },
+                    alignItems: "center",
+                    px: 2,
+                    py: 1.25,
+                    cursor: "pointer",
+                    borderRadius: 1.5,
+                    border: (t) =>
+                      `1px solid ${
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.08)"
+                          : "rgba(0,0,0,0.08)"
+                      }`,
+                    transition: "all 0.15s",
+                    "&:hover": {
+                      bgcolor: (t) =>
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.04)"
+                          : "rgba(0,0,0,0.02)",
+                      borderColor: (t) =>
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.16)"
+                          : "rgba(0,0,0,0.16)",
+                      "& .row-actions": { opacity: 1 },
+                    },
+                    "&:focus-visible": {
+                      outline: (t) => `2px solid ${t.palette.primary.main}`,
+                      outlineOffset: 2,
+                    },
+                    "&:focus-within .row-actions": { opacity: 1 },
                   }}
                 >
-                  <Iconify icon="mdi:delete-outline" width={18} />
-                </IconButton>
-              </Stack>
-            ))}
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    gap={1.5}
+                    sx={{
+                      minWidth: 0,
+                      gridColumn: { xs: "1 / 2", md: "auto" },
+                    }}
+                  >
+                    <Iconify
+                      icon="mdi:view-dashboard-outline"
+                      width={18}
+                      sx={{ color: "primary.main", flexShrink: 0 }}
+                    />
+
+                    <Typography
+                      variant="body2"
+                      fontWeight={600}
+                      noWrap
+                      sx={{ minWidth: 0 }}
+                    >
+                      {db.name}
+                    </Typography>
+                  </Stack>
+
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    gap={1.5}
+                    useFlexGap
+                    flexWrap="wrap"
+                    sx={{
+                      minWidth: 0,
+                      gridColumn: { xs: "1 / -1", md: "auto" },
+                      display: { xs: "flex", md: "contents" },
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.disabled"
+                      sx={{ whiteSpace: "nowrap" }}
+                    >
+                      {db.widget_count || 0} widget
+                      {db.widget_count !== 1 ? "s" : ""}
+                    </Typography>
+
+                    <Tooltip
+                      title={formatDashboardTooltipDate(dashboardDate)}
+                      arrow
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ whiteSpace: "nowrap" }}
+                      >
+                        {formatDashboardListDate(dashboardDate)}
+                      </Typography>
+                    </Tooltip>
+
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      gap={1}
+                      sx={{ minWidth: 0 }}
+                    >
+                      {db.created_by && (
+                        <Avatar
+                          sx={{
+                            width: 26,
+                            height: 26,
+                            fontSize: "11px",
+                            fontWeight: 700,
+                            bgcolor: getAvatarColor(creatorName),
+                            flexShrink: 0,
+                          }}
+                        >
+                          {getInitials(creatorName)}
+                        </Avatar>
+                      )}
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        noWrap
+                        title={creatorName || undefined}
+                        sx={{ minWidth: 0 }}
+                      >
+                        {creatorName || "—"}
+                      </Typography>
+                    </Stack>
+
+                    <Box sx={{ minWidth: 0 }}>
+                      <ViewerAvatars db={db} />
+                    </Box>
+                  </Stack>
+
+                  <IconButton
+                    className="row-actions"
+                    size="small"
+                    onClick={(e) => handleDelete(e, db)}
+                    aria-label={`Delete ${db.name}`}
+                    sx={{
+                      opacity: { xs: 1, md: 0 },
+                      transition: "opacity 0.15s",
+                      flexShrink: 0,
+                      width: 32,
+                      height: 32,
+                      justifySelf: "end",
+                      gridColumn: { xs: "2 / 3", md: "auto" },
+                      gridRow: { xs: "1 / 2", md: "auto" },
+                    }}
+                  >
+                    <Iconify icon="mdi:delete-outline" width={18} />
+                  </IconButton>
+                </Box>
+              );
+            })}
           </Stack>
         )}
       </Box>

--- a/frontend/src/sections/dashboards/DashboardsListView.jsx
+++ b/frontend/src/sections/dashboards/DashboardsListView.jsx
@@ -49,6 +49,8 @@ const AVATAR_COLORS = [
 
 const DASHBOARD_LIST_COLUMNS =
   "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px 32px";
+const DASHBOARD_LIST_CONTENT_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px";
 
 function getAvatarColor(name) {
   let hash = 0;
@@ -79,11 +81,28 @@ function getDashboardCreatorName(db) {
 }
 
 function formatDashboardListDate(date) {
-  return fDate(date) || "—";
+  if (!date) return "—";
+  try {
+    return fDate(date) || "—";
+  } catch {
+    return "—";
+  }
 }
 
 function formatDashboardTooltipDate(date) {
-  return fDateTime(date) || "";
+  if (!date) return "";
+  try {
+    return fDateTime(date) || "";
+  } catch {
+    return "";
+  }
+}
+
+function formatDashboardWidgetCount(count) {
+  const numericCount = Number(count || 0);
+  const safeCount = Number.isFinite(numericCount) ? numericCount : 0;
+
+  return `${safeCount} widget${safeCount === 1 ? "" : "s"}`;
 }
 
 function getDashboardViewers(db) {
@@ -638,21 +657,20 @@ export default function DashboardsListView() {
                 Created by
               </Typography>
               <Typography variant="caption" fontWeight={600}>
-                Viewers
+                People
               </Typography>
               <Box />
             </Box>
             {filteredDashboards.map((db) => {
               const creatorName = getDashboardCreatorName(db);
               const dashboardDate = db.updated_at || db.created_at;
+              const widgetCountText = formatDashboardWidgetCount(
+                db.widget_count,
+              );
 
               return (
                 <Box
                   key={db.id}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => openDashboard(db.id)}
-                  onKeyDown={(event) => handleDashboardRowKeyDown(event, db.id)}
                   sx={{
                     display: "grid",
                     gridTemplateColumns: {
@@ -664,7 +682,6 @@ export default function DashboardsListView() {
                     alignItems: "center",
                     px: 2,
                     py: 1.25,
-                    cursor: "pointer",
                     borderRadius: 1.5,
                     border: (t) =>
                       `1px solid ${
@@ -684,57 +701,78 @@ export default function DashboardsListView() {
                           : "rgba(0,0,0,0.16)",
                       "& .row-actions": { opacity: 1 },
                     },
-                    "&:focus-visible": {
-                      outline: (t) => `2px solid ${t.palette.primary.main}`,
-                      outlineOffset: 2,
-                    },
                     "&:focus-within .row-actions": { opacity: 1 },
+                    "@media (hover: none)": {
+                      "& .row-actions": { opacity: 1 },
+                    },
                   }}
                 >
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    gap={1.5}
+                  <Box
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Open ${db.name}`}
+                    onClick={() => openDashboard(db.id)}
+                    onKeyDown={(event) =>
+                      handleDashboardRowKeyDown(event, db.id)
+                    }
                     sx={{
+                      display: "grid",
+                      gridTemplateColumns: {
+                        xs: "minmax(0, 1fr)",
+                        md: DASHBOARD_LIST_CONTENT_COLUMNS,
+                      },
+                      columnGap: 1.5,
+                      rowGap: { xs: 0.75, md: 0 },
+                      alignItems: "center",
+                      cursor: "pointer",
                       minWidth: 0,
-                      gridColumn: { xs: "1 / 2", md: "auto" },
+                      gridColumn: { xs: "1 / 2", md: "1 / 6" },
+                      width: "100%",
+                      textAlign: "left",
+                      borderRadius: 1,
+                      "&:focus-visible": {
+                        outline: (t) => `2px solid ${t.palette.primary.main}`,
+                        outlineOffset: 2,
+                      },
                     }}
                   >
-                    <Iconify
-                      icon="mdi:view-dashboard-outline"
-                      width={18}
-                      sx={{ color: "primary.main", flexShrink: 0 }}
-                    />
-
-                    <Typography
-                      variant="body2"
-                      fontWeight={600}
-                      noWrap
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      gap={1.5}
                       sx={{ minWidth: 0 }}
                     >
-                      {db.name}
-                    </Typography>
-                  </Stack>
+                      <Iconify
+                        icon="mdi:view-dashboard-outline"
+                        width={18}
+                        sx={{ color: "primary.main", flexShrink: 0 }}
+                      />
 
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    gap={1.5}
-                    useFlexGap
-                    flexWrap="wrap"
-                    sx={{
-                      minWidth: 0,
-                      gridColumn: { xs: "1 / -1", md: "auto" },
-                      display: { xs: "flex", md: "contents" },
-                    }}
-                  >
+                      <Typography
+                        variant="body2"
+                        fontWeight={600}
+                        noWrap
+                        sx={{ minWidth: 0 }}
+                      >
+                        {db.name}
+                      </Typography>
+                    </Stack>
+
                     <Typography
                       variant="caption"
                       color="text.disabled"
                       sx={{ whiteSpace: "nowrap" }}
                     >
-                      {db.widget_count || 0} widget
-                      {db.widget_count !== 1 ? "s" : ""}
+                      <Box
+                        component="span"
+                        sx={{
+                          display: { xs: "inline", md: "none" },
+                          fontWeight: 600,
+                        }}
+                      >
+                        Widgets:{" "}
+                      </Box>
+                      {widgetCountText}
                     </Typography>
 
                     <Tooltip
@@ -746,6 +784,16 @@ export default function DashboardsListView() {
                         color="text.secondary"
                         sx={{ whiteSpace: "nowrap" }}
                       >
+                        <Box
+                          component="span"
+                          sx={{
+                            display: { xs: "inline", md: "none" },
+                            color: "text.disabled",
+                            fontWeight: 600,
+                          }}
+                        >
+                          Updated:{" "}
+                        </Box>
                         {formatDashboardListDate(dashboardDate)}
                       </Typography>
                     </Tooltip>
@@ -756,6 +804,17 @@ export default function DashboardsListView() {
                       gap={1}
                       sx={{ minWidth: 0 }}
                     >
+                      <Typography
+                        variant="caption"
+                        color="text.disabled"
+                        sx={{
+                          display: { xs: "inline", md: "none" },
+                          flexShrink: 0,
+                          fontWeight: 600,
+                        }}
+                      >
+                        Created by:
+                      </Typography>
                       {db.created_by && (
                         <Avatar
                           sx={{
@@ -781,10 +840,26 @@ export default function DashboardsListView() {
                       </Typography>
                     </Stack>
 
-                    <Box sx={{ minWidth: 0 }}>
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      gap={1}
+                      sx={{ minWidth: 0 }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.disabled"
+                        sx={{
+                          display: { xs: "inline", md: "none" },
+                          flexShrink: 0,
+                          fontWeight: 600,
+                        }}
+                      >
+                        People:
+                      </Typography>
                       <ViewerAvatars db={db} />
-                    </Box>
-                  </Stack>
+                    </Stack>
+                  </Box>
 
                   <IconButton
                     className="row-actions"
@@ -800,6 +875,7 @@ export default function DashboardsListView() {
                       justifySelf: "end",
                       gridColumn: { xs: "2 / 3", md: "auto" },
                       gridRow: { xs: "1 / 2", md: "auto" },
+                      "@media (hover: none)": { opacity: 1 },
                     }}
                   >
                     <Iconify icon="mdi:delete-outline" width={18} />

--- a/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+import DashboardsListView from "../DashboardsListView";
+
+const h = vi.hoisted(() => ({
+  dashboards: [],
+  navigate: vi.fn(),
+  enqueueSnackbar: vi.fn(),
+  createDashboard: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  deleteDashboard: {
+    mutate: vi.fn(),
+    isPending: false,
+  },
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardList: () => ({
+    data: h.dashboards,
+    isLoading: false,
+  }),
+  useCreateDashboard: () => h.createDashboard,
+  useDeleteDashboard: () => h.deleteDashboard,
+}));
+
+vi.mock("react-router-dom", async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => h.navigate,
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: h.enqueueSnackbar }),
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon }) => <span aria-hidden="true" data-icon={icon} />,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src }) => <span aria-hidden="true" data-src={src} />,
+}));
+
+vi.mock("src/components/EmptyLayout/EmptyLayout", () => ({
+  default: ({ title, description }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+    </div>
+  ),
+}));
+
+vi.mock("src/components/FormSearchField/FormSearchField", () => ({
+  default: ({ placeholder, searchQuery, onChange }) => (
+    <input
+      aria-label={placeholder}
+      placeholder={placeholder}
+      value={searchQuery}
+      onChange={onChange}
+    />
+  ),
+}));
+
+const DASHBOARDS = [
+  {
+    id: "dash-1",
+    name: "Latency Overview",
+    widget_count: 1,
+    created_at: "2026-06-01T12:00:00.000Z",
+    updated_at: "2026-06-15T12:00:00.000Z",
+    created_by: {
+      name: "Alice Creator",
+      email: "alice@example.com",
+    },
+    updated_by: {
+      name: "Uma Updater",
+      email: "uma@example.com",
+    },
+  },
+  {
+    id: "dash-2",
+    name: "Fallback Owner Dashboard",
+    widget_count: 0,
+    created_at: "2026-05-20T12:00:00.000Z",
+    updated_at: null,
+    created_by: {
+      email: "owner@example.com",
+    },
+  },
+];
+
+describe("DashboardsListView list metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.dashboards = DASHBOARDS;
+    h.createDashboard.isPending = false;
+    h.deleteDashboard.isPending = false;
+  });
+
+  it("renders column headers above non-empty dashboard rows", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Widgets")).toBeInTheDocument();
+    expect(screen.getByText("Last updated")).toBeInTheDocument();
+    expect(screen.getByText("Created by")).toBeInTheDocument();
+    expect(screen.getByText("Viewers")).toBeInTheDocument();
+  });
+
+  it("renders shared calendar-date text instead of relative row timestamps", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("15 Jun 2026")).toBeInTheDocument();
+    expect(screen.getByText("20 May 2026")).toBeInTheDocument();
+    expect(screen.queryByText(/ago/i)).not.toBeInTheDocument();
+  });
+
+  it("renders each creator inline using name with email fallback", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Alice Creator")).toBeInTheDocument();
+    expect(screen.getByText("owner@example.com")).toBeInTheDocument();
+  });
+
+  it("does not render list column headers for the empty state", () => {
+    h.dashboards = [];
+
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Create your first dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Widgets")).not.toBeInTheDocument();
+    expect(screen.queryByText("Last updated")).not.toBeInTheDocument();
+    expect(screen.queryByText("Created by")).not.toBeInTheDocument();
+    expect(screen.queryByText("Viewers")).not.toBeInTheDocument();
+  });
+
+  it("keeps row navigation on click and keyboard activation", () => {
+    render(<DashboardsListView />);
+
+    const latencyRow = screen.getByRole("button", {
+      name: /Latency Overview 1 widget/i,
+    });
+
+    fireEvent.click(latencyRow);
+    expect(h.navigate).toHaveBeenCalledWith("/dashboard/dashboards/dash-1");
+
+    h.navigate.mockClear();
+    fireEvent.keyDown(latencyRow, { key: "Enter" });
+    expect(h.navigate).toHaveBeenCalledWith("/dashboard/dashboards/dash-1");
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
@@ -66,7 +66,7 @@ const DASHBOARDS = [
   {
     id: "dash-1",
     name: "Latency Overview",
-    widget_count: 1,
+    widget_count: "1",
     created_at: "2026-06-01T12:00:00.000Z",
     updated_at: "2026-06-15T12:00:00.000Z",
     created_by: {
@@ -81,12 +81,20 @@ const DASHBOARDS = [
   {
     id: "dash-2",
     name: "Fallback Owner Dashboard",
-    widget_count: 0,
+    widget_count: "0",
     created_at: "2026-05-20T12:00:00.000Z",
     updated_at: null,
     created_by: {
       email: "owner@example.com",
     },
+  },
+  {
+    id: "dash-3",
+    name: "No Metadata Dashboard",
+    widget_count: "2",
+    created_at: null,
+    updated_at: null,
+    created_by: null,
   },
 ];
 
@@ -105,7 +113,7 @@ describe("DashboardsListView list metadata", () => {
     expect(screen.getByText("Widgets")).toBeInTheDocument();
     expect(screen.getByText("Last updated")).toBeInTheDocument();
     expect(screen.getByText("Created by")).toBeInTheDocument();
-    expect(screen.getByText("Viewers")).toBeInTheDocument();
+    expect(screen.getByText("People")).toBeInTheDocument();
   });
 
   it("renders shared calendar-date text instead of relative row timestamps", () => {
@@ -123,6 +131,15 @@ describe("DashboardsListView list metadata", () => {
     expect(screen.getByText("owner@example.com")).toBeInTheDocument();
   });
 
+  it("normalizes API-shaped widget counts and missing metadata", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("1 widget")).toBeInTheDocument();
+    expect(screen.getByText("2 widgets")).toBeInTheDocument();
+    expect(screen.getByText("No Metadata Dashboard")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("does not render list column headers for the empty state", () => {
     h.dashboards = [];
 
@@ -133,14 +150,28 @@ describe("DashboardsListView list metadata", () => {
     expect(screen.queryByText("Widgets")).not.toBeInTheDocument();
     expect(screen.queryByText("Last updated")).not.toBeInTheDocument();
     expect(screen.queryByText("Created by")).not.toBeInTheDocument();
-    expect(screen.queryByText("Viewers")).not.toBeInTheDocument();
+    expect(screen.queryByText("People")).not.toBeInTheDocument();
+  });
+
+  it("keeps headers hidden when search filters all dashboards out", () => {
+    render(<DashboardsListView />);
+
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: "does-not-exist" },
+    });
+
+    expect(
+      screen.getByText("No dashboards match your search"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Latency Overview")).not.toBeInTheDocument();
   });
 
   it("keeps row navigation on click and keyboard activation", () => {
     render(<DashboardsListView />);
 
     const latencyRow = screen.getByRole("button", {
-      name: /Latency Overview 1 widget/i,
+      name: "Open Latency Overview",
     });
 
     fireEvent.click(latencyRow);
@@ -149,5 +180,25 @@ describe("DashboardsListView list metadata", () => {
     h.navigate.mockClear();
     fireEvent.keyDown(latencyRow, { key: "Enter" });
     expect(h.navigate).toHaveBeenCalledWith("/dashboard/dashboards/dash-1");
+
+    h.navigate.mockClear();
+    fireEvent.keyDown(latencyRow, { key: " " });
+    expect(h.navigate).toHaveBeenCalledWith("/dashboard/dashboards/dash-1");
+  });
+
+  it("keeps delete as a separate action from row navigation", () => {
+    render(<DashboardsListView />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Latency Overview" }),
+    );
+
+    expect(h.navigate).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete Dashboard")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete "Latency Overview"? This action cannot be undone.',
+      ),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the dashboard list scannability gap from #925 by making dashboard metadata visible without changing the dashboard data flow. Non-empty dashboard lists now show aligned desktop headers, stable calendar dates, inline creator identity, and a clearer `People` column so users can compare dashboards without hovering or guessing from avatars alone.

Review follow-up also separates the open-dashboard control from the delete action, restores small-screen metadata labels, and keeps row actions visible on touch devices.

## Linked issues

Closes #925
Linear: N/A — this is an open-source GitHub issue and I do not have a Linear issue for it.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Dashboard list metadata is visible and aligned**

- Adds a non-empty list header row: `Name`, `Widgets`, `Last updated`, `Created by`, and `People`.
- Reworks dashboard rows onto a shared desktop grid so names, widget counts, dates, creators, people, and actions scan consistently.
- Keeps small screens card-like with inline metadata labels (`Widgets`, `Updated`, `Created by`, `People`) instead of forcing the desktop header grid into a narrow viewport.

**B. Dates and widget counts are defensive**

- Shows stable calendar dates in the row, e.g. `15 Jun 2026`, instead of relative text such as "last week".
- Routes dashboard list and tooltip date formatting through `src/utils/format-time` instead of local `date-fns` imports in the list component.
- Handles missing or malformed date values by showing `—`/empty tooltip text instead of throwing.
- Normalizes API-shaped widget counts such as string values (`"1"`, `"0"`) before pluralizing.

**C. Creator identity and people metadata are shown inline**

- Displays the creator name when present.
- Falls back to creator email when the name is unavailable.
- Preserves the existing viewer/shared-user avatar tooltip behavior.

**D. Existing interactions are preserved while avoiding nested controls**

- Keeps the same dashboard hooks, search/filter behavior, create flow, delete mutation, and route navigation.
- Gives the open-dashboard area its own focusable `role="button"` target with click, Enter, and Space activation.
- Keeps delete as a separate sibling `IconButton` so activating delete does not also trigger dashboard navigation.
- Keeps row actions discoverable on hover, keyboard focus, and no-hover/touch devices.

---

## 2) Why the changes were done

- **Product/UX:** The previous list required hovering/avatar interpretation to understand creator/date context, which made dashboards hard to compare at a glance.
- **Technical:** A focused grid layout solves the reported scannability issue without migrating this bespoke list to a broader table/DataGrid abstraction.
- **Accessibility/reliability:** Separating the open target from delete avoids nested interactive controls while preserving keyboard activation and action isolation.
- **Architecture:** The fix stays inside `DashboardsListView` and does not change backend/API contracts, route contracts, or dashboard hook data shapes.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx`** — focused regression coverage for issue #925.

- `renders column headers above non-empty dashboard rows` — verifies the new visible list headers.
- `renders shared calendar-date text instead of relative row timestamps` — verifies stable `dd MMM yyyy` row dates and guards against visible relative text.
- `renders each creator inline using name with email fallback` — verifies both creator name and email fallback display.
- `normalizes API-shaped widget counts and missing metadata` — covers string widget counts plus null creator/date metadata.
- `does not render list column headers for the empty state` — keeps the empty layout clean.
- `keeps headers hidden when search filters all dashboards out` — prevents stale headers in the filtered-empty state.
- `keeps row navigation on click and keyboard activation` — guards click, Enter, and Space activation for the open-dashboard target.
- `keeps delete as a separate action from row navigation` — proves delete opens the confirmation flow without navigating.

> Focused run result: **8 passed** in `DashboardsListView.test.jsx`.
>
> Adjacent dashboard run result: **48 passed** across `DashboardsListView.test.jsx`, `DashboardDetailView.test.jsx`, `dashboardDateRange.test.js`, and `widgetUtils.test.js`.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
npx -y yarn@1.22.22 test:run src/sections/dashboards/__tests__/DashboardsListView.test.jsx

npx -y yarn@1.22.22 test:run \
  src/sections/dashboards/__tests__/DashboardsListView.test.jsx \
  src/sections/dashboards/__tests__/DashboardDetailView.test.jsx \
  src/sections/dashboards/__tests__/dashboardDateRange.test.js \
  src/sections/dashboards/__tests__/widgetUtils.test.js
```

### Lint / format / type / build

```bash
cd frontend
npx eslint src/sections/dashboards/DashboardsListView.jsx src/sections/dashboards/__tests__/DashboardsListView.test.jsx
npx prettier --check src/sections/dashboards/DashboardsListView.jsx src/sections/dashboards/__tests__/DashboardsListView.test.jsx
npx -y yarn@1.22.22 type-check
npx -y yarn@1.22.22 build
```

Additional hygiene:

```bash
git diff --check
```

### UI steps (manual)

1. Open the dashboard list page.
2. Verify non-empty lists show headers for Name, Widgets, Last updated, Created by, and People.
3. Verify each row shows a real date and creator name/email inline.
4. Verify the open-dashboard area can be clicked and focused, then opened with Enter/Space.
5. Verify the delete action opens the existing confirmation flow without navigating.
6. Verify small-width layouts show inline metadata labels instead of the desktop header row.

---

## 5) Screenshots / recordings

### UI testing

I performed local Chrome headless smoke validation against the live Vite dashboard route with mocked auth/dashboard API responses at desktop (`1280×900`) and small-width (`390×844`) viewports. Screenshots were inspected locally and intentionally not committed as generated artifacts.

Observed during that smoke pass:

- Desktop row headers render with visible Name / Widgets / Last updated / Created by / People columns.
- Row metadata renders stable dates, creator identity, widget counts, and people avatars.
- Small-width rows render inline metadata labels (`Widgets`, `Updated`, `Created by`, `People`).

---

## 6) Edge cases & considerations

- **Creator without name:** falls back to `created_by.email`.
- **Dashboard without update timestamp:** falls back to `created_at` for the visible list date.
- **Dashboard without creator/date metadata:** shows `—` instead of throwing or rendering misleading text.
- **Widget count from API as a string:** normalizes before pluralizing.
- **Empty list and filtered-empty list:** keep the empty-state layout and do not show table-style headers.
- **Small screens:** use inline metadata labels rather than forcing the desktop column grid into a narrow viewport.
- **Row actions:** delete is a sibling action, not nested inside the open-dashboard control.

---

## 7) Pre-existing issues (NOT introduced by this PR)

The focused and adjacent dashboard suites pass. A full frontend test run was also attempted:

```bash
cd frontend && npx -y yarn@1.22.22 test:run
```

That full run failed with unrelated existing non-dashboard failures after reporting **241 passed test files** and **2102 passed tests**:

- `TypeError: localStorage.getItem is not a function` from `src/sections/develop-detail/states.jsx:177`, causing 25 untouched suites to fail during import.
- `src/sections/projects/UsersView/__tests__/UsersGrid.test.jsx` failed independently because its `getUsersList` spy was not called.

I confirmed these are unrelated to this dashboard diff by running representative failures individually:

```bash
cd frontend && npx -y yarn@1.22.22 test:run src/api/develop/__tests__/develop-detail.test.js
cd frontend && npx -y yarn@1.22.22 test:run src/sections/projects/UsersView/__tests__/UsersGrid.test.jsx
```

Both reproduce outside the changed dashboard files. The focused dashboard test was rerun after the full-suite failure and still passed.

Also note: this shell does not have a direct `yarn` binary on PATH, so the same Yarn 1 commands were invoked via `npx -y yarn@1.22.22`.

---

## 8) Architectural / important decisions

- **Keep the custom list instead of migrating to DataGrid:** issue #925 is a focused presentation/scannability bug; a DataGrid migration would broaden review scope and risk existing row/delete/navigation behavior.
- **Use shared date utilities:** `DashboardsListView` now relies on `src/utils/format-time` for list and tooltip date formatting instead of local `date-fns` imports.
- **Avoid nested interactive controls:** the open-dashboard target and delete button are siblings so keyboard/click behavior stays predictable.
- **No API or contract changes:** dashboard data shape, hooks, filters, mutations, and route paths remain unchanged.

---

## 9) Release note / changelog handling

Release note: Dashboard lists now show creator, updated date, widget count, and people metadata inline so dashboards are easier to scan and compare.

The repository does not contain an in-repo changelog file to edit; `CONTRIBUTING.md` says release notes live at futureagi.com/changelog.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — not run; frontend-only UI change
- [ ] `yarn test:run` passes locally (frontend) — full suite currently has unrelated non-dashboard failures documented above; focused/adjacent dashboard suites pass
- [ ] `yarn contracts:check` passes if API surface changed — not run; no API surface changed
- [x] I've updated the documentation where relevant — no docs page changed; release/changelog handling documented above
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — not verified in this local session
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — no Linear issue available for this OSS GitHub issue
