### PR TITLE
fix(dashboards): make list rows scannable

### DIFF
--- a/frontend/src/sections/dashboards/DashboardsListView.jsx
+++ b/frontend/src/sections/dashboards/DashboardsListView.jsx
@@ -34,9 +34,7 @@ import SvgColor from "src/components/svg-color";
 import EmptyLayout from "src/components/EmptyLayout/EmptyLayout";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import { useSnackbar } from "src/components/snackbar";
-import CustomTooltip from "src/components/tooltip/CustomTooltip";
-import { formatDistanceToNowStrict, format } from "date-fns";
-import useCanEditDashboard from "./hooks/useCanEditDashboard";
+import { fDate, fDateTime, fToNowStrict } from "src/utils/format-time";
 
 const AVATAR_COLORS = [
   "#7C4DFF",
@@ -48,6 +46,23 @@ const AVATAR_COLORS = [
   "#00BFA6",
   "#8C9EFF",
 ];
+
+const DASHBOARD_LIST_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px 32px";
+const DASHBOARD_LIST_CONTENT_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px)";
+
+const VISUALLY_HIDDEN_SX = {
+  border: 0,
+  clip: "rect(0 0 0 0)",
+  height: 1,
+  margin: -1,
+  overflow: "hidden",
+  padding: 0,
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: 1,
+};
 
 function getAvatarColor(name) {
   let hash = 0;
@@ -67,10 +82,43 @@ function getInitials(name) {
 function timeAgo(date) {
   if (!date) return "";
   try {
-    return formatDistanceToNowStrict(new Date(date), { addSuffix: true });
+    return fToNowStrict(date);
   } catch {
     return "";
   }
+}
+
+function getDashboardCreatorName(db) {
+  return db?.created_by?.name || "";
+}
+
+function getDashboardCreatorLabel(db) {
+  return getDashboardCreatorName(db) || "Unknown creator";
+}
+
+function formatDashboardListDate(date) {
+  if (!date) return "—";
+  try {
+    return fDate(date) || "—";
+  } catch {
+    return "—";
+  }
+}
+
+function formatDashboardTooltipDate(date) {
+  if (!date) return "";
+  try {
+    return fDateTime(date) || "";
+  } catch {
+    return "";
+  }
+}
+
+function formatDashboardWidgetCount(count) {
+  const numericCount = Number(count || 0);
+  const safeCount = Number.isFinite(numericCount) ? numericCount : 0;
+
+  return `${safeCount} widget${safeCount === 1 ? "" : "s"}`;
 }
 
 function getDashboardViewers(db) {
@@ -79,18 +127,32 @@ function getDashboardViewers(db) {
   const addUser = (u, time) => {
     if (!u || !u.email || seen.has(u.email)) return;
     seen.add(u.email);
-    users.push({ ...u, displayName: u.name || u.email, time });
+    users.push({ ...u, displayName: u.name || "Unknown user", time });
   };
   addUser(db.updated_by, db.updated_at);
   addUser(db.created_by, db.created_at);
   return users;
 }
 
-function ViewerAvatars({ db }) {
+function getDashboardPeopleSummary(db) {
+  const count = getDashboardViewers(db).length;
+  if (!count) return "No people";
+
+  return `${count} ${count === 1 ? "person" : "people"}`;
+}
+
+function ViewerAvatars({ db, dashboardName }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const viewers = getDashboardViewers(db);
-  if (!viewers.length) return null;
+  const creatorLabel = getDashboardCreatorLabel(db);
+  if (!viewers.length) {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        —
+      </Typography>
+    );
+  }
 
   const shown = viewers.slice(0, 3);
   const extra = viewers.length - 3;
@@ -139,12 +201,10 @@ function ViewerAvatars({ db }) {
                   height: 28,
                   fontSize: "11px",
                   fontWeight: 700,
-                  bgcolor: getAvatarColor(
-                    db.created_by.name || db.created_by.email,
-                  ),
+                  bgcolor: getAvatarColor(creatorLabel),
                 }}
               >
-                {getInitials(db.created_by.name || db.created_by.email)}
+                {getInitials(creatorLabel)}
               </Avatar>
               <Box>
                 <Typography
@@ -155,7 +215,7 @@ function ViewerAvatars({ db }) {
                     lineHeight: 1.3,
                   }}
                 >
-                  Created by {db.created_by.name || db.created_by.email}
+                  Created by {creatorLabel}
                 </Typography>
                 <Typography
                   variant="caption"
@@ -163,12 +223,7 @@ function ViewerAvatars({ db }) {
                     color: isDark ? "rgba(255,255,255,0.45)" : "text.secondary",
                   }}
                 >
-                  {db.created_at
-                    ? format(
-                        new Date(db.created_at),
-                        "MMM d, yyyy \u00b7 h:mm a",
-                      )
-                    : ""}
+                  {formatDashboardTooltipDate(db.created_at)}
                 </Typography>
               </Box>
             </Stack>
@@ -249,7 +304,7 @@ function ViewerAvatars({ db }) {
                   display: "block",
                 }}
               >
-                Last edited by {db.updated_by.name || db.updated_by.email}
+                Last edited by {db.updated_by.name || "Unknown user"}
               </Typography>
               <Typography
                 variant="caption"
@@ -257,21 +312,33 @@ function ViewerAvatars({ db }) {
                   color: isDark ? "rgba(255,255,255,0.5)" : "text.secondary",
                 }}
               >
-                {db.updated_at
-                  ? format(new Date(db.updated_at), "MMM d, yyyy \u00b7 h:mm a")
-                  : ""}
+                {formatDashboardTooltipDate(db.updated_at)}
               </Typography>
             </Box>
           )}
         </Box>
       }
     >
-      <Stack
-        direction="row"
-        alignItems="center"
-        gap={0.5}
+      <Box
+        component="button"
+        type="button"
+        aria-label={`People for ${dashboardName}: ${getDashboardPeopleSummary(
+          db,
+        )}`}
         onClick={(e) => e.stopPropagation()}
-        sx={{ cursor: "default" }}
+        sx={{
+          all: "unset",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          cursor: "default",
+          borderRadius: 1,
+          minWidth: 0,
+          "&:focus-visible": {
+            outline: (t) => `2px solid ${t.palette.primary.main}`,
+            outlineOffset: 2,
+          },
+        }}
       >
         <AvatarGroup
           max={3}
@@ -296,12 +363,13 @@ function ViewerAvatars({ db }) {
             + {extra}
           </Typography>
         )}
-      </Stack>
+      </Box>
     </Tooltip>
   );
 }
 
 ViewerAvatars.propTypes = {
+  dashboardName: PropTypes.string.isRequired,
   db: PropTypes.shape({
     created_by: PropTypes.shape({
       name: PropTypes.string,
@@ -339,10 +407,27 @@ export default function DashboardsListView() {
     dashboards.forEach((d) => {
       const u = d.created_by;
       if (u?.email && !map.has(u.email)) {
-        map.set(u.email, u.name || u.email);
+        const name = typeof u.name === "string" ? u.name.trim() : u.name;
+        map.set(u.email, name || null);
       }
     });
-    return Array.from(map, ([email, name]) => ({ email, name }));
+
+    const entries = Array.from(map, ([email, name]) => ({ email, name }));
+    const unnamedCount = entries.filter((creator) => !creator.name).length;
+    let unnamedIndex = 0;
+
+    return entries.map((creator) => {
+      if (creator.name) return creator;
+
+      unnamedIndex += 1;
+      return {
+        ...creator,
+        name:
+          unnamedCount > 1
+            ? `Unknown creator ${unnamedIndex}`
+            : "Unknown creator",
+      };
+    });
   }, [dashboards]);
 
   const filteredDashboards = useMemo(() => {
@@ -381,6 +466,26 @@ export default function DashboardsListView() {
     setDeleteTarget(db);
   };
 
+  const openDashboard = (dashboardId) => {
+    navigate(paths.dashboard.dashboards.detail(dashboardId));
+  };
+
+  const handleDashboardLinkClick = (event, dashboardId) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    openDashboard(dashboardId);
+  };
+
   const confirmDelete = () => {
     if (!deleteTarget) return;
     deleteMutation.mutate(deleteTarget.id, {
@@ -416,6 +521,7 @@ export default function DashboardsListView() {
         gap: theme.spacing(2),
         bgcolor: "background.paper",
         height: "100%",
+        minWidth: 0,
       }}
     >
       {/* Header */}
@@ -437,15 +543,27 @@ export default function DashboardsListView() {
       </Stack>
 
       {/* Search + Actions row */}
-      <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Stack direction="row" gap={1} alignItems="center">
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "stretch", sm: "center" }}
+        gap={1}
+        sx={{ minWidth: 0 }}
+      >
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          gap={1}
+          alignItems={{ xs: "stretch", sm: "center" }}
+          sx={{ minWidth: 0, flex: 1 }}
+        >
           <FormSearchField
             size="small"
             placeholder="Search"
             searchQuery={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             sx={{
-              minWidth: "250px",
+              minWidth: 0,
+              width: { xs: "100%", sm: "250px" },
               "& .MuiOutlinedInput-root": { height: "30px" },
             }}
           />
@@ -462,13 +580,15 @@ export default function DashboardsListView() {
               textTransform: "none",
               fontSize: "13px",
               whiteSpace: "nowrap",
+              width: { xs: "100%", sm: "auto" },
+              justifyContent: { xs: "space-between", sm: "center" },
             }}
           >
             {creatorFilter.length === 0
               ? "Created by anyone"
               : creatorFilter.length === 1
                 ? creators.find((c) => c.email === creatorFilter[0])?.name ||
-                  creatorFilter[0]
+                  "Unknown creator"
                 : `${creatorFilter.length} creators`}
           </Button>
           <Menu
@@ -527,7 +647,11 @@ export default function DashboardsListView() {
             })}
           </Menu>
         </Stack>
-        <Stack direction="row" gap={1}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          gap={1}
+          sx={{ width: { xs: "100%", sm: "auto" } }}
+        >
           <Button
             variant="outlined"
             size="small"
@@ -535,7 +659,7 @@ export default function DashboardsListView() {
               borderRadius: "4px",
               height: "30px",
               px: "4px",
-              width: "105px",
+              width: { xs: "100%", sm: "105px" },
             }}
             onClick={() => {
               window.open(
@@ -552,12 +676,19 @@ export default function DashboardsListView() {
               View Docs
             </Typography>
           </Button>
-          <CustomTooltip
-            show={!canCreate}
-            type=""
-            title="You don't have permission to create dashboards."
-            size="small"
-            arrow
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={
+              createMutation.isPending ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : (
+                <Iconify icon="mdi:plus" />
+              )
+            }
+            onClick={handleCreate}
+            disabled={createMutation.isPending}
+            sx={{ height: "38px", width: { xs: "100%", sm: "auto" } }}
           >
             <span>
               <Button
@@ -582,7 +713,7 @@ export default function DashboardsListView() {
       </Stack>
 
       {/* Dashboard list */}
-      <Box sx={{ flex: 1 }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
         {filteredDashboards.length === 0 ? (
           searchQuery ? (
             <Stack alignItems="center" gap={1} sx={{ py: 8 }}>
@@ -605,92 +736,289 @@ export default function DashboardsListView() {
             />
           )
         ) : (
-          <Stack spacing={1}>
-            {filteredDashboards.map((db) => (
-              <Stack
-                key={db.id}
-                direction="row"
-                alignItems="center"
-                onClick={() =>
-                  navigate(paths.dashboard.dashboards.detail(db.id))
-                }
-                sx={{
-                  px: 2,
-                  py: 1.25,
-                  cursor: "pointer",
-                  borderRadius: 1.5,
-                  border: (t) =>
-                    `1px solid ${
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.08)"
-                        : "rgba(0,0,0,0.08)"
-                    }`,
-                  transition: "all 0.15s",
-                  "&:hover": {
-                    bgcolor: (t) =>
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.04)"
-                        : "rgba(0,0,0,0.02)",
-                    borderColor: (t) =>
-                      t.palette.mode === "dark"
-                        ? "rgba(255,255,255,0.16)"
-                        : "rgba(0,0,0,0.16)",
-                    "& .row-actions": { opacity: 1 },
-                  },
-                }}
+          <Stack spacing={1} sx={{ minWidth: 0 }}>
+            <Box
+              sx={{
+                display: { xs: "none", md: "grid" },
+                gridTemplateColumns: DASHBOARD_LIST_COLUMNS,
+                columnGap: 1.5,
+                alignItems: "center",
+                px: 2,
+                color: "text.disabled",
+              }}
+            >
+              <Typography
+                variant="caption"
+                fontWeight={600}
+                sx={{ minWidth: 0 }}
               >
-                <Iconify
-                  icon="mdi:view-dashboard-outline"
-                  width={18}
-                  sx={{ color: "primary.main", mr: 1.5, flexShrink: 0 }}
-                />
+                Name
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Widgets
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Last updated
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                Created by
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                People
+              </Typography>
+              <Box />
+            </Box>
+            {filteredDashboards.map((db) => {
+              const creatorName = getDashboardCreatorName(db);
+              const creatorLabel = getDashboardCreatorLabel(db);
+              const dashboardDate = db.updated_at || db.created_at;
+              const dashboardDateText = formatDashboardListDate(dashboardDate);
+              const widgetCountText = formatDashboardWidgetCount(
+                db.widget_count,
+              );
+              const peopleSummary = getDashboardPeopleSummary(db);
+              const rowNameId = `dashboard-row-${db.id}-name`;
+              const rowDescriptionId = `dashboard-row-${db.id}-description`;
 
-                <Typography
-                  variant="body2"
-                  fontWeight={600}
-                  noWrap
-                  sx={{ flex: 1, mr: 2, minWidth: 0 }}
+              return (
+                <Box
+                  key={db.id}
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: {
+                      xs: "minmax(0, 1fr) 32px",
+                      md: DASHBOARD_LIST_COLUMNS,
+                    },
+                    columnGap: 1.5,
+                    rowGap: { xs: 1, md: 0 },
+                    alignItems: "center",
+                    px: 2,
+                    py: 1.25,
+                    borderRadius: 1.5,
+                    border: (t) =>
+                      `1px solid ${
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.08)"
+                          : "rgba(0,0,0,0.08)"
+                      }`,
+                    transition: "all 0.15s",
+                    "&:hover": {
+                      bgcolor: (t) =>
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.04)"
+                          : "rgba(0,0,0,0.02)",
+                      borderColor: (t) =>
+                        t.palette.mode === "dark"
+                          ? "rgba(255,255,255,0.16)"
+                          : "rgba(0,0,0,0.16)",
+                      "& .row-actions": { opacity: 1 },
+                    },
+                    "&:focus-within .row-actions": { opacity: 1 },
+                    "@media (hover: none)": {
+                      "& .row-actions": { opacity: 1 },
+                    },
+                  }}
                 >
-                  {db.name}
-                </Typography>
+                  <Box
+                    component="a"
+                    href={paths.dashboard.dashboards.detail(db.id)}
+                    aria-labelledby={rowNameId}
+                    aria-describedby={rowDescriptionId}
+                    onClick={(event) => handleDashboardLinkClick(event, db.id)}
+                    sx={{
+                      display: "grid",
+                      gridTemplateColumns: {
+                        xs: "minmax(0, 1fr)",
+                        md: DASHBOARD_LIST_CONTENT_COLUMNS,
+                      },
+                      columnGap: 1.5,
+                      rowGap: { xs: 0.75, md: 0 },
+                      alignItems: "center",
+                      color: "inherit",
+                      cursor: "pointer",
+                      minWidth: 0,
+                      gridColumn: { xs: "1 / 2", md: "1 / 5" },
+                      width: "100%",
+                      textAlign: "left",
+                      textDecoration: "none",
+                      borderRadius: 1,
+                      "&:focus-visible": {
+                        outline: (t) => `2px solid ${t.palette.primary.main}`,
+                        outlineOffset: 2,
+                      },
+                    }}
+                  >
+                    <Stack
+                      direction="row"
+                      alignItems={{ xs: "flex-start", md: "center" }}
+                      gap={1.5}
+                      sx={{ minWidth: 0 }}
+                    >
+                      <Iconify
+                        icon="mdi:view-dashboard-outline"
+                        width={18}
+                        sx={{ color: "primary.main", flexShrink: 0 }}
+                      />
 
-                <Typography
-                  variant="caption"
-                  color="text.disabled"
-                  sx={{ mr: 1.5, whiteSpace: "nowrap", flexShrink: 0 }}
-                >
-                  {db.widget_count || 0} widget
-                  {db.widget_count !== 1 ? "s" : ""}
-                </Typography>
+                      <Typography
+                        id={rowNameId}
+                        variant="body2"
+                        fontWeight={600}
+                        sx={{
+                          minWidth: 0,
+                          overflow: { xs: "visible", md: "hidden" },
+                          overflowWrap: "anywhere",
+                          textOverflow: { xs: "clip", md: "ellipsis" },
+                          whiteSpace: { xs: "normal", md: "nowrap" },
+                        }}
+                      >
+                        {db.name}
+                      </Typography>
+                    </Stack>
 
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mr: 2, whiteSpace: "nowrap", flexShrink: 0 }}
-                >
-                  {timeAgo(db.updated_at || db.created_at)}
-                </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.disabled"
+                      sx={{ whiteSpace: "nowrap" }}
+                    >
+                      <Box
+                        component="span"
+                        sx={{
+                          display: { xs: "inline", md: "none" },
+                          fontWeight: 600,
+                        }}
+                      >
+                        Widgets:{" "}
+                      </Box>
+                      {widgetCountText}
+                    </Typography>
 
-                <Box sx={{ mr: 1, flexShrink: 0 }}>
-                  <ViewerAvatars db={db} />
-                </Box>
+                    <Tooltip
+                      title={formatDashboardTooltipDate(dashboardDate)}
+                      arrow
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ whiteSpace: "nowrap" }}
+                      >
+                        <Box
+                          component="span"
+                          sx={{
+                            display: { xs: "inline", md: "none" },
+                            color: "text.disabled",
+                            fontWeight: 600,
+                          }}
+                        >
+                          Updated:{" "}
+                        </Box>
+                        {dashboardDateText}
+                      </Typography>
+                    </Tooltip>
 
-                {canDelete && (
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      gap={1}
+                      flexWrap={{ xs: "wrap", md: "nowrap" }}
+                      sx={{ minWidth: 0 }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.disabled"
+                        sx={{
+                          display: { xs: "inline", md: "none" },
+                          flexShrink: 0,
+                          fontWeight: 600,
+                        }}
+                      >
+                        Created by:
+                      </Typography>
+                      {creatorName && (
+                        <Avatar
+                          sx={{
+                            width: 26,
+                            height: 26,
+                            fontSize: "11px",
+                            fontWeight: 700,
+                            bgcolor: getAvatarColor(creatorName),
+                            flexShrink: 0,
+                          }}
+                        >
+                          {getInitials(creatorName)}
+                        </Avatar>
+                      )}
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        title={creatorName || undefined}
+                        sx={{
+                          minWidth: 0,
+                          overflow: { xs: "visible", md: "hidden" },
+                          overflowWrap: "anywhere",
+                          textOverflow: { xs: "clip", md: "ellipsis" },
+                          whiteSpace: { xs: "normal", md: "nowrap" },
+                        }}
+                      >
+                        {creatorLabel}
+                      </Typography>
+                    </Stack>
+
+                    <Box
+                      id={rowDescriptionId}
+                      component="span"
+                      sx={VISUALLY_HIDDEN_SX}
+                    >
+                      {`${widgetCountText}. Last updated ${dashboardDateText}. Created by ${creatorLabel}. ${peopleSummary}.`}
+                    </Box>
+                  </Box>
+
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    gap={1}
+                    flexWrap={{ xs: "wrap", md: "nowrap" }}
+                    sx={{
+                      minWidth: 0,
+                      gridColumn: { xs: "1 / 2", md: "5 / 6" },
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.disabled"
+                      sx={{
+                        display: { xs: "inline", md: "none" },
+                        flexShrink: 0,
+                        fontWeight: 600,
+                      }}
+                    >
+                      People:
+                    </Typography>
+                    <ViewerAvatars db={db} dashboardName={db.name} />
+                  </Stack>
+
                   <IconButton
                     className="row-actions"
                     size="small"
                     onClick={(e) => handleDelete(e, db)}
+                    aria-label={`Delete ${db.name}`}
                     sx={{
-                      opacity: 0,
+                      opacity: { xs: 1, md: 0 },
                       transition: "opacity 0.15s",
                       flexShrink: 0,
+                      width: 32,
+                      height: 32,
+                      justifySelf: "end",
+                      gridColumn: { xs: "2 / 3", md: "auto" },
+                      gridRow: { xs: "1 / 2", md: "auto" },
+                      "@media (hover: none)": { opacity: 1 },
                     }}
                   >
                     <Iconify icon="mdi:delete-outline" width={18} />
                   </IconButton>
-                )}
-              </Stack>
-            ))}
+                </Box>
+              );
+            })}
           </Stack>
         )}
       </Box>

--- a/frontend/src/sections/dashboards/DashboardsListView.jsx
+++ b/frontend/src/sections/dashboards/DashboardsListView.jsx
@@ -34,112 +34,26 @@ import SvgColor from "src/components/svg-color";
 import EmptyLayout from "src/components/EmptyLayout/EmptyLayout";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import { useSnackbar } from "src/components/snackbar";
-import { fDate, fDateTime, fToNowStrict } from "src/utils/format-time";
-
-const AVATAR_COLORS = [
-  "#7C4DFF",
-  "#FF6B6B",
-  "#5BE49B",
-  "#FFB547",
-  "#36B5FF",
-  "#FF85C0",
-  "#00BFA6",
-  "#8C9EFF",
-];
-
-const DASHBOARD_LIST_COLUMNS =
-  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px 32px";
-const DASHBOARD_LIST_CONTENT_COLUMNS =
-  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px)";
-
-const VISUALLY_HIDDEN_SX = {
-  border: 0,
-  clip: "rect(0 0 0 0)",
-  height: 1,
-  margin: -1,
-  overflow: "hidden",
-  padding: 0,
-  position: "absolute",
-  whiteSpace: "nowrap",
-  width: 1,
-};
-
-function getAvatarColor(name) {
-  let hash = 0;
-  for (let i = 0; i < (name || "").length; i++) {
-    hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
-}
-
-function getInitials(name) {
-  if (!name) return "?";
-  const parts = name.trim().split(/\s+/);
-  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-  return name.slice(0, 2).toUpperCase();
-}
-
-function timeAgo(date) {
-  if (!date) return "";
-  try {
-    return fToNowStrict(date);
-  } catch {
-    return "";
-  }
-}
-
-function getDashboardCreatorName(db) {
-  return db?.created_by?.name || "";
-}
-
-function getDashboardCreatorLabel(db) {
-  return getDashboardCreatorName(db) || "Unknown creator";
-}
-
-function formatDashboardListDate(date) {
-  if (!date) return "—";
-  try {
-    return fDate(date) || "—";
-  } catch {
-    return "—";
-  }
-}
-
-function formatDashboardTooltipDate(date) {
-  if (!date) return "";
-  try {
-    return fDateTime(date) || "";
-  } catch {
-    return "";
-  }
-}
-
-function formatDashboardWidgetCount(count) {
-  const numericCount = Number(count || 0);
-  const safeCount = Number.isFinite(numericCount) ? numericCount : 0;
-
-  return `${safeCount} widget${safeCount === 1 ? "" : "s"}`;
-}
-
-function getDashboardViewers(db) {
-  const users = [];
-  const seen = new Set();
-  const addUser = (u, time) => {
-    if (!u || !u.email || seen.has(u.email)) return;
-    seen.add(u.email);
-    users.push({ ...u, displayName: u.name || "Unknown user", time });
-  };
-  addUser(db.updated_by, db.updated_at);
-  addUser(db.created_by, db.created_at);
-  return users;
-}
-
-function getDashboardPeopleSummary(db) {
-  const count = getDashboardViewers(db).length;
-  if (!count) return "No people";
-
-  return `${count} ${count === 1 ? "person" : "people"}`;
-}
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import useCanEditDashboard from "./hooks/useCanEditDashboard";
+import {
+  DASHBOARD_LIST_COLUMNS,
+  DASHBOARD_LIST_CONTENT_COLUMNS,
+  VISUALLY_HIDDEN_SX,
+} from "./constants";
+import {
+  formatDashboardListDate,
+  formatDashboardTooltipDate,
+  formatDashboardWidgetCount,
+  getAvatarColor,
+  getDashboardCreatorLabel,
+  getDashboardCreatorName,
+  getDashboardPeopleSummary,
+  getDashboardViewers,
+  getInitials,
+  labelCreatorsWithStableUnknownIndex,
+  timeAgo,
+} from "./utils";
 
 function ViewerAvatars({ db, dashboardName }) {
   const theme = useTheme();
@@ -369,7 +283,7 @@ function ViewerAvatars({ db, dashboardName }) {
 }
 
 ViewerAvatars.propTypes = {
-  dashboardName: PropTypes.string.isRequired,
+  dashboardName: PropTypes.string,
   db: PropTypes.shape({
     created_by: PropTypes.shape({
       name: PropTypes.string,
@@ -413,21 +327,8 @@ export default function DashboardsListView() {
     });
 
     const entries = Array.from(map, ([email, name]) => ({ email, name }));
-    const unnamedCount = entries.filter((creator) => !creator.name).length;
-    let unnamedIndex = 0;
 
-    return entries.map((creator) => {
-      if (creator.name) return creator;
-
-      unnamedIndex += 1;
-      return {
-        ...creator,
-        name:
-          unnamedCount > 1
-            ? `Unknown creator ${unnamedIndex}`
-            : "Unknown creator",
-      };
-    });
+    return labelCreatorsWithStableUnknownIndex(entries);
   }, [dashboards]);
 
   const filteredDashboards = useMemo(() => {
@@ -676,19 +577,12 @@ export default function DashboardsListView() {
               View Docs
             </Typography>
           </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            startIcon={
-              createMutation.isPending ? (
-                <CircularProgress size={16} color="inherit" />
-              ) : (
-                <Iconify icon="mdi:plus" />
-              )
-            }
-            onClick={handleCreate}
-            disabled={createMutation.isPending}
-            sx={{ height: "38px", width: { xs: "100%", sm: "auto" } }}
+          <CustomTooltip
+            show={!canCreate}
+            type=""
+            title="You don't have permission to create dashboards."
+            size="small"
+            arrow
           >
             <span>
               <Button
@@ -744,6 +638,10 @@ export default function DashboardsListView() {
                 columnGap: 1.5,
                 alignItems: "center",
                 px: 2,
+                // Rows below carry a 1px border. With border-box sizing that
+                // border eats into their content width, so the header needs a
+                // border of the same width or its tracks sit ~1px off theirs.
+                border: "1px solid transparent",
                 color: "text.disabled",
               }}
             >
@@ -994,28 +892,33 @@ export default function DashboardsListView() {
                     >
                       People:
                     </Typography>
-                    <ViewerAvatars db={db} dashboardName={db.name} />
+                    <ViewerAvatars
+                      db={db}
+                      dashboardName={db.name || "this dashboard"}
+                    />
                   </Stack>
 
-                  <IconButton
-                    className="row-actions"
-                    size="small"
-                    onClick={(e) => handleDelete(e, db)}
-                    aria-label={`Delete ${db.name}`}
-                    sx={{
-                      opacity: { xs: 1, md: 0 },
-                      transition: "opacity 0.15s",
-                      flexShrink: 0,
-                      width: 32,
-                      height: 32,
-                      justifySelf: "end",
-                      gridColumn: { xs: "2 / 3", md: "auto" },
-                      gridRow: { xs: "1 / 2", md: "auto" },
-                      "@media (hover: none)": { opacity: 1 },
-                    }}
-                  >
-                    <Iconify icon="mdi:delete-outline" width={18} />
-                  </IconButton>
+                  {canDelete && (
+                    <IconButton
+                      className="row-actions"
+                      size="small"
+                      onClick={(e) => handleDelete(e, db)}
+                      aria-label={`Delete ${db.name}`}
+                      sx={{
+                        opacity: { xs: 1, md: 0 },
+                        transition: "opacity 0.15s",
+                        flexShrink: 0,
+                        width: 32,
+                        height: 32,
+                        justifySelf: "end",
+                        gridColumn: { xs: "2 / 3", md: "auto" },
+                        gridRow: { xs: "1 / 2", md: "auto" },
+                        "@media (hover: none)": { opacity: 1 },
+                      }}
+                    >
+                      <Iconify icon="mdi:delete-outline" width={18} />
+                    </IconButton>
+                  )}
                 </Box>
               );
             })}

--- a/frontend/src/sections/dashboards/DashboardsListView.jsx
+++ b/frontend/src/sections/dashboards/DashboardsListView.jsx
@@ -51,7 +51,7 @@ import {
   getDashboardPeopleSummary,
   getDashboardViewers,
   getInitials,
-  labelCreatorsWithStableUnknownIndex,
+  labelCreatorsWithStableUnknownIdentifier,
   timeAgo,
 } from "./utils";
 
@@ -60,6 +60,9 @@ function ViewerAvatars({ db, dashboardName }) {
   const isDark = theme.palette.mode === "dark";
   const viewers = getDashboardViewers(db);
   const creatorLabel = getDashboardCreatorLabel(db);
+  const updatedByLabel =
+    viewers.find((viewer) => viewer.email === db.updated_by?.email)
+      ?.displayName || "Unknown user";
   if (!viewers.length) {
     return (
       <Typography variant="caption" color="text.secondary">
@@ -165,15 +168,20 @@ function ViewerAvatars({ db, dashboardName }) {
             Recently Viewed By:
           </Typography>
           <Stack gap={1.5}>
-            {viewers.map((v, i) => (
-              <Stack key={i} direction="row" alignItems="center" gap={1.5}>
+            {viewers.map((v) => (
+              <Stack
+                key={v.email}
+                direction="row"
+                alignItems="center"
+                gap={1.5}
+              >
                 <Avatar
                   sx={{
                     width: 28,
                     height: 28,
                     fontSize: "11px",
                     fontWeight: 700,
-                    bgcolor: getAvatarColor(v.displayName),
+                    bgcolor: getAvatarColor(v.avatarKey),
                   }}
                 >
                   {getInitials(v.displayName)}
@@ -218,7 +226,7 @@ function ViewerAvatars({ db, dashboardName }) {
                   display: "block",
                 }}
               >
-                Last edited by {db.updated_by.name || "Unknown user"}
+                Last edited by {updatedByLabel}
               </Typography>
               <Typography
                 variant="caption"
@@ -248,6 +256,8 @@ function ViewerAvatars({ db, dashboardName }) {
           cursor: "default",
           borderRadius: 1,
           minWidth: 0,
+          position: "relative",
+          zIndex: 1,
           "&:focus-visible": {
             outline: (t) => `2px solid ${t.palette.primary.main}`,
             outlineOffset: 2,
@@ -266,8 +276,8 @@ function ViewerAvatars({ db, dashboardName }) {
             },
           }}
         >
-          {shown.map((v, i) => (
-            <Avatar key={i} sx={{ bgcolor: getAvatarColor(v.displayName) }}>
+          {shown.map((v) => (
+            <Avatar key={v.email} sx={{ bgcolor: getAvatarColor(v.avatarKey) }}>
               {getInitials(v.displayName)}
             </Avatar>
           ))}
@@ -313,7 +323,7 @@ export default function DashboardsListView() {
   const [newName, setNewName] = useState("");
   const [newDescription, setNewDescription] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
-  const [creatorFilter, setCreatorFilter] = useState([]);
+  const [selectedCreators, setSelectedCreators] = useState([]);
   const [creatorMenuAnchor, setCreatorMenuAnchor] = useState(null);
 
   const creators = useMemo(() => {
@@ -328,7 +338,7 @@ export default function DashboardsListView() {
 
     const entries = Array.from(map, ([email, name]) => ({ email, name }));
 
-    return labelCreatorsWithStableUnknownIndex(entries);
+    return labelCreatorsWithStableUnknownIdentifier(entries);
   }, [dashboards]);
 
   const filteredDashboards = useMemo(() => {
@@ -337,11 +347,15 @@ export default function DashboardsListView() {
       const q = searchQuery.toLowerCase();
       list = list.filter((d) => d.name?.toLowerCase().includes(q));
     }
-    if (creatorFilter.length > 0) {
-      list = list.filter((d) => creatorFilter.includes(d.created_by?.email));
+    if (selectedCreators.length > 0) {
+      list = list.filter((d) =>
+        selectedCreators.some(
+          (creator) => creator.email === d.created_by?.email,
+        ),
+      );
     }
     return list;
-  }, [dashboards, searchQuery, creatorFilter]);
+  }, [dashboards, searchQuery, selectedCreators]);
 
   const handleCreate = async () => {
     const name = newName.trim() || "Untitled";
@@ -470,14 +484,14 @@ export default function DashboardsListView() {
           />
           <Button
             size="small"
-            variant={creatorFilter.length > 0 ? "contained" : "outlined"}
+            variant={selectedCreators.length > 0 ? "contained" : "outlined"}
             onClick={(e) => setCreatorMenuAnchor(e.currentTarget)}
             startIcon={<Iconify icon="mdi:account-outline" width={18} />}
             endIcon={<Iconify icon="mdi:chevron-down" width={16} />}
             sx={{
               height: 38,
               borderColor: "divider",
-              color: creatorFilter.length > 0 ? undefined : "text.secondary",
+              color: selectedCreators.length > 0 ? undefined : "text.secondary",
               textTransform: "none",
               fontSize: "13px",
               whiteSpace: "nowrap",
@@ -485,12 +499,13 @@ export default function DashboardsListView() {
               justifyContent: { xs: "space-between", sm: "center" },
             }}
           >
-            {creatorFilter.length === 0
+            {selectedCreators.length === 0
               ? "Created by anyone"
-              : creatorFilter.length === 1
-                ? creators.find((c) => c.email === creatorFilter[0])?.name ||
-                  "Unknown creator"
-                : `${creatorFilter.length} creators`}
+              : selectedCreators.length === 1
+                ? creators.find(
+                    (creator) => creator.email === selectedCreators[0].email,
+                  )?.name || selectedCreators[0].name
+                : `${selectedCreators.length} creators`}
           </Button>
           <Menu
             anchorEl={creatorMenuAnchor}
@@ -502,10 +517,10 @@ export default function DashboardsListView() {
               },
             }}
           >
-            <MenuItem onClick={() => setCreatorFilter([])} sx={{ py: 0.5 }}>
+            <MenuItem onClick={() => setSelectedCreators([])} sx={{ py: 0.5 }}>
               <Checkbox
                 size="small"
-                checked={creatorFilter.length === 0}
+                checked={selectedCreators.length === 0}
                 sx={{ mr: 0.5 }}
               />
               <Stack direction="row" alignItems="center" gap={1}>
@@ -515,15 +530,17 @@ export default function DashboardsListView() {
             </MenuItem>
             <Divider />
             {creators.map((c) => {
-              const checked = creatorFilter.includes(c.email);
+              const checked = selectedCreators.some(
+                (creator) => creator.email === c.email,
+              );
               return (
                 <MenuItem
                   key={c.email}
                   onClick={() => {
-                    setCreatorFilter((prev) =>
+                    setSelectedCreators((prev) =>
                       checked
-                        ? prev.filter((e) => e !== c.email)
-                        : [...prev, c.email],
+                        ? prev.filter((creator) => creator.email !== c.email)
+                        : [...prev, { email: c.email, name: c.name }],
                     );
                   }}
                   sx={{ py: 0.5 }}
@@ -700,6 +717,9 @@ export default function DashboardsListView() {
                           : "rgba(0,0,0,0.08)"
                       }`,
                     transition: "all 0.15s",
+                    position: "relative",
+                    isolation: "isolate",
+                    cursor: "pointer",
                     "&:hover": {
                       bgcolor: (t) =>
                         t.palette.mode === "dark"
@@ -739,8 +759,18 @@ export default function DashboardsListView() {
                       width: "100%",
                       textAlign: "left",
                       textDecoration: "none",
-                      borderRadius: 1,
-                      "&:focus-visible": {
+                      borderRadius: "inherit",
+                      // Extend the real anchor across row padding, column gaps,
+                      // People, and the empty action track. The People and
+                      // Delete controls are raised above this overlay below.
+                      "&::after": {
+                        content: '""',
+                        position: "absolute",
+                        inset: 0,
+                        borderRadius: "inherit",
+                        zIndex: 0,
+                      },
+                      "&:focus-visible::after": {
                         outline: (t) => `2px solid ${t.palette.primary.main}`,
                         outlineOffset: 2,
                       },
@@ -798,7 +828,11 @@ export default function DashboardsListView() {
                       <Typography
                         variant="caption"
                         color="text.secondary"
-                        sx={{ whiteSpace: "nowrap" }}
+                        sx={{
+                          whiteSpace: "nowrap",
+                          position: "relative",
+                          zIndex: 1,
+                        }}
                       >
                         <Box
                           component="span"
@@ -856,6 +890,8 @@ export default function DashboardsListView() {
                           overflowWrap: "anywhere",
                           textOverflow: { xs: "clip", md: "ellipsis" },
                           whiteSpace: { xs: "normal", md: "nowrap" },
+                          position: "relative",
+                          zIndex: 1,
                         }}
                       >
                         {creatorLabel}
@@ -907,6 +943,8 @@ export default function DashboardsListView() {
                       sx={{
                         opacity: { xs: 1, md: 0 },
                         transition: "opacity 0.15s",
+                        position: "relative",
+                        zIndex: 1,
                         flexShrink: 0,
                         width: 32,
                         height: 32,

--- a/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  within,
+} from "src/utils/test-utils";
+import DashboardsListView from "../DashboardsListView";
+
+const h = vi.hoisted(() => ({
+  dashboards: [],
+  navigate: vi.fn(),
+  enqueueSnackbar: vi.fn(),
+  createDashboard: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  deleteDashboard: {
+    mutate: vi.fn(),
+    isPending: false,
+  },
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardList: () => ({
+    data: h.dashboards,
+    isLoading: false,
+  }),
+  useCreateDashboard: () => h.createDashboard,
+  useDeleteDashboard: () => h.deleteDashboard,
+}));
+
+vi.mock("react-router-dom", async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => h.navigate,
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: h.enqueueSnackbar }),
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon }) => <span aria-hidden="true" data-icon={icon} />,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src }) => <span aria-hidden="true" data-src={src} />,
+}));
+
+vi.mock("src/components/EmptyLayout/EmptyLayout", () => ({
+  default: ({ title, description }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+    </div>
+  ),
+}));
+
+vi.mock("src/components/FormSearchField/FormSearchField", () => ({
+  default: ({ placeholder, searchQuery, onChange }) => (
+    <input
+      aria-label={placeholder}
+      placeholder={placeholder}
+      value={searchQuery}
+      onChange={onChange}
+    />
+  ),
+}));
+
+const DASHBOARDS = [
+  {
+    id: "dash-1",
+    name: "Latency Overview",
+    widget_count: "1",
+    created_at: "2026-06-01T12:00:00.000Z",
+    updated_at: "2026-06-15T12:00:00.000Z",
+    created_by: {
+      name: "Alice Creator",
+      email: "alice@example.com",
+    },
+    updated_by: {
+      name: "Uma Updater",
+      email: "uma@example.com",
+    },
+  },
+  {
+    id: "dash-2",
+    name: "Fallback Owner Dashboard",
+    widget_count: "0",
+    created_at: "2026-05-20T12:00:00.000Z",
+    updated_at: null,
+    created_by: {
+      email: "owner@example.com",
+    },
+  },
+  {
+    id: "dash-3",
+    name: "No Metadata Dashboard",
+    widget_count: "2",
+    created_at: null,
+    updated_at: null,
+    created_by: null,
+  },
+];
+
+describe("DashboardsListView list metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.dashboards = DASHBOARDS;
+    h.createDashboard.isPending = false;
+    h.deleteDashboard.isPending = false;
+  });
+
+  it("renders column headers above non-empty dashboard rows", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Widgets")).toBeInTheDocument();
+    expect(screen.getByText("Last updated")).toBeInTheDocument();
+    expect(screen.getByText("Created by")).toBeInTheDocument();
+    expect(screen.getByText("People")).toBeInTheDocument();
+  });
+
+  it("renders shared calendar-date text instead of relative row timestamps", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("15 Jun 2026")).toBeInTheDocument();
+    expect(screen.getByText("20 May 2026")).toBeInTheDocument();
+    expect(screen.queryByText(/ago/i)).not.toBeInTheDocument();
+  });
+
+  it("renders creator names inline without exposing email fallbacks", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Alice Creator")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Unknown creator").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Created by anyone/i }));
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+  });
+
+  it("normalizes API-shaped widget counts and missing metadata", () => {
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("1 widget")).toBeInTheDocument();
+    expect(screen.getByText("0 widgets")).toBeInTheDocument();
+    expect(screen.getByText("2 widgets")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "No Metadata Dashboard" }),
+    ).toHaveAccessibleDescription(
+      /2 widgets\. Last updated —\. Created by Unknown creator\. No people\./,
+    );
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("falls back safely for invalid widget counts", () => {
+    h.dashboards = [
+      {
+        ...DASHBOARDS[2],
+        id: "dash-invalid",
+        name: "Invalid Count Dashboard",
+        widget_count: "not-a-number",
+      },
+    ];
+
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("0 widgets")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Invalid Count Dashboard" }),
+    ).toHaveAccessibleDescription(
+      /0 widgets\. Last updated —\. Created by Unknown creator\. No people\./,
+    );
+  });
+
+  it("does not render list column headers for the empty state", () => {
+    h.dashboards = [];
+
+    render(<DashboardsListView />);
+
+    expect(screen.getByText("Create your first dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Widgets")).not.toBeInTheDocument();
+    expect(screen.queryByText("Last updated")).not.toBeInTheDocument();
+    expect(screen.queryByText("Created by")).not.toBeInTheDocument();
+    expect(screen.queryByText("People")).not.toBeInTheDocument();
+  });
+
+  it("keeps headers hidden when search filters all dashboards out", () => {
+    render(<DashboardsListView />);
+
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: "does-not-exist" },
+    });
+
+    expect(
+      screen.getByText("No dashboards match your search"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Latency Overview")).not.toBeInTheDocument();
+  });
+
+  it("keeps row navigation on a semantic link with accessible metadata", () => {
+    render(<DashboardsListView />);
+
+    const latencyRow = screen.getByRole("link", {
+      name: "Latency Overview",
+    });
+
+    expect(latencyRow).toHaveAttribute("href", "/dashboard/dashboards/dash-1");
+    expect(latencyRow).toHaveAccessibleDescription(
+      /1 widget\. Last updated 15 Jun 2026\. Created by Alice Creator\. 2 people\./,
+    );
+
+    fireEvent.click(latencyRow);
+    expect(h.navigate).toHaveBeenCalledWith("/dashboard/dashboards/dash-1");
+
+    // jsdom attempts a real navigation for unhandled modified anchor clicks.
+    // The href is asserted above; remove it here to isolate the SPA handler.
+    latencyRow.removeAttribute("href");
+    h.navigate.mockClear();
+    fireEvent.click(latencyRow, { metaKey: true });
+    fireEvent.click(latencyRow, { ctrlKey: true });
+    fireEvent.click(latencyRow, { shiftKey: true });
+    expect(h.navigate).not.toHaveBeenCalled();
+  });
+
+  it("makes people metadata available as a focusable row action", () => {
+    render(<DashboardsListView />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "People for Latency Overview: 2 people",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps people tooltip fallbacks private when names are missing", async () => {
+    const user = userEvent.setup();
+    render(<DashboardsListView />);
+
+    await user.hover(
+      screen.getByRole("button", {
+        name: "People for Fallback Owner Dashboard: 1 person",
+      }),
+    );
+
+    expect(
+      await screen.findByText("Created by Unknown creator"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unknown user")).toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+  });
+
+  it("keeps selected creator filter private after dashboard data changes", () => {
+    const { rerender } = render(<DashboardsListView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Created by anyone/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Unknown creator/ }));
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    expect(
+      screen.getByRole("button", { name: "Unknown creator" }),
+    ).toBeInTheDocument();
+
+    h.dashboards = [DASHBOARDS[0]];
+    rerender(<DashboardsListView />);
+
+    expect(
+      screen.getByRole("button", { name: "Unknown creator" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+  });
+
+  it("disambiguates multiple unnamed creator filters without exposing emails", () => {
+    h.dashboards = [
+      DASHBOARDS[1],
+      {
+        ...DASHBOARDS[1],
+        id: "dash-4",
+        name: "Second Fallback Owner Dashboard",
+        created_by: {
+          email: "second-owner@example.com",
+        },
+      },
+    ];
+
+    render(<DashboardsListView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Created by anyone/i }));
+
+    expect(
+      screen.getByRole("menuitem", { name: /Unknown creator 1/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /Unknown creator 2/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("second-owner@example.com"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: /Unknown creator 2/ }),
+    );
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    expect(
+      screen.getByRole("button", { name: "Unknown creator 2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Second Fallback Owner Dashboard" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Fallback Owner Dashboard" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps delete as a separate action from row navigation", () => {
+    render(<DashboardsListView />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Latency Overview" }),
+    );
+
+    expect(h.navigate).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete Dashboard")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete "Latency Overview"? This action cannot be undone.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("confirms deletion for the selected dashboard without navigating", () => {
+    render(<DashboardsListView />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Delete Fallback Owner Dashboard",
+      }),
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Delete Dashboard" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    expect(h.navigate).not.toHaveBeenCalled();
+    expect(h.deleteDashboard.mutate).toHaveBeenCalledTimes(1);
+    expect(h.deleteDashboard.mutate).toHaveBeenCalledWith(
+      "dash-2",
+      expect.any(Object),
+    );
+  });
+});

--- a/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
@@ -161,6 +161,27 @@ describe("DashboardsListView list metadata", () => {
     expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
   });
 
+  it("renders whitespace-only creator names as Unknown creator", () => {
+    h.dashboards = [
+      {
+        ...DASHBOARDS[1],
+        id: "dash-whitespace-creator",
+        name: "Whitespace Creator Dashboard",
+        created_by: {
+          name: "   ",
+          email: "whitespace@example.com",
+        },
+      },
+    ];
+
+    render(<DashboardsListView />);
+
+    expect(screen.getAllByText("Unknown creator").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("link", { name: "Whitespace Creator Dashboard" }),
+    ).toHaveAccessibleDescription(/Created by Unknown creator\./);
+  });
+
   it("normalizes API-shaped widget counts and missing metadata", () => {
     render(<DashboardsListView />);
 
@@ -270,7 +291,7 @@ describe("DashboardsListView list metadata", () => {
     expect(
       await screen.findByText("Created by Unknown creator"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Unknown user")).toBeInTheDocument();
+    expect(screen.getAllByText("Unknown creator").length).toBeGreaterThan(0);
     expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
   });
 
@@ -281,17 +302,37 @@ describe("DashboardsListView list metadata", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: /Unknown creator/ }));
     fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
 
-    expect(
-      screen.getByRole("button", { name: "Unknown creator" }),
-    ).toBeInTheDocument();
+    const selectedLabel = screen.getByRole("button", {
+      name: /^Unknown creator [A-Z0-9]+$/,
+    }).textContent;
 
     h.dashboards = [DASHBOARDS[0]];
     rerender(<DashboardsListView />);
 
     expect(
-      screen.getByRole("button", { name: "Unknown creator" }),
+      screen.getByRole("button", { name: selectedLabel }),
     ).toBeInTheDocument();
     expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+  });
+
+  it("keeps the last known named creator label after a refetch removes them", () => {
+    const { rerender } = render(<DashboardsListView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Created by anyone/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Alice Creator/ }));
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+
+    expect(
+      screen.getByRole("button", { name: "Alice Creator" }),
+    ).toBeInTheDocument();
+
+    h.dashboards = [];
+    rerender(<DashboardsListView />);
+
+    expect(
+      screen.getByRole("button", { name: "Alice Creator" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Unknown creator")).not.toBeInTheDocument();
   });
 
   it("disambiguates multiple unnamed creator filters without exposing emails", () => {
@@ -311,24 +352,26 @@ describe("DashboardsListView list metadata", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Created by anyone/i }));
 
-    expect(
-      screen.getByRole("menuitem", { name: /Unknown creator 1/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /Unknown creator 2/ }),
-    ).toBeInTheDocument();
+    const anonymousCreatorItems = screen.getAllByRole("menuitem", {
+      name: /Unknown creator [A-Z0-9]+/,
+    });
+    expect(anonymousCreatorItems).toHaveLength(2);
+    expect(anonymousCreatorItems[0].textContent.trim()).not.toBe(
+      anonymousCreatorItems[1].textContent.trim(),
+    );
     expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
     expect(
       screen.queryByText("second-owner@example.com"),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole("menuitem", { name: /Unknown creator 2/ }),
-    );
+    const selectedLabel = within(anonymousCreatorItems[1]).getByText(
+      /^Unknown creator [A-Z0-9]+$/,
+    ).textContent;
+    fireEvent.click(anonymousCreatorItems[1]);
     fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
 
     expect(
-      screen.getByRole("button", { name: "Unknown creator 2" }),
+      screen.getByRole("button", { name: selectedLabel }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Second Fallback Owner Dashboard" }),

--- a/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx
@@ -20,6 +20,16 @@ const h = vi.hoisted(() => ({
     mutate: vi.fn(),
     isPending: false,
   },
+  permissions: {
+    canCreate: true,
+    canUpdate: true,
+    canDelete: true,
+    isReadOnly: false,
+  },
+}));
+
+vi.mock("../hooks/useCanEditDashboard", () => ({
+  default: () => h.permissions,
 }));
 
 vi.mock("src/hooks/useDashboards", () => ({
@@ -110,6 +120,12 @@ describe("DashboardsListView list metadata", () => {
     h.dashboards = DASHBOARDS;
     h.createDashboard.isPending = false;
     h.deleteDashboard.isPending = false;
+    h.permissions = {
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+      isReadOnly: false,
+    };
   });
 
   it("renders column headers above non-empty dashboard rows", () => {
@@ -356,5 +372,63 @@ describe("DashboardsListView list metadata", () => {
       "dash-2",
       expect.any(Object),
     );
+  });
+
+  it("hides every row delete action from users without delete permission", () => {
+    h.permissions = {
+      canCreate: true,
+      canUpdate: false,
+      canDelete: false,
+      isReadOnly: true,
+    };
+
+    render(<DashboardsListView />);
+
+    // The rows still render, but no row offers a delete affordance at all.
+    expect(
+      screen.getByRole("link", { name: /Latency Overview/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete Latency Overview" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete Fallback Owner Dashboard" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Delete / }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables dashboard creation for users without create permission", () => {
+    h.permissions = {
+      canCreate: false,
+      canUpdate: true,
+      canDelete: true,
+      isReadOnly: false,
+    };
+
+    render(<DashboardsListView />);
+
+    const createButton = screen.getByRole("button", {
+      name: /Create Dashboard/,
+    });
+
+    expect(createButton).toBeDisabled();
+
+    fireEvent.click(createButton);
+
+    expect(h.createDashboard.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("fires a single create action per click for permitted users", () => {
+    render(<DashboardsListView />);
+
+    const createButtons = screen.getAllByRole("button", {
+      name: /Create Dashboard/,
+    });
+
+    // A nested button would render the create control twice and double-fire
+    // handleCreate on a single click.
+    expect(createButtons).toHaveLength(1);
   });
 });

--- a/frontend/src/sections/dashboards/__tests__/utils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/utils.test.js
@@ -10,7 +10,7 @@ import {
   getDashboardPeopleSummary,
   getDashboardViewers,
   getInitials,
-  labelCreatorsWithStableUnknownIndex,
+  labelCreatorsWithStableUnknownIdentifier,
   timeAgo,
 } from "../utils";
 import { AVATAR_COLORS } from "../constants";
@@ -75,6 +75,16 @@ describe("creator naming", () => {
     );
   });
 
+  it("trims creator names and treats whitespace-only names as missing", () => {
+    expect(
+      getDashboardCreatorName({ created_by: { name: "  Alice Creator  " } }),
+    ).toBe("Alice Creator");
+    expect(getDashboardCreatorName({ created_by: { name: "   " } })).toBe("");
+    expect(getDashboardCreatorLabel({ created_by: { name: "   " } })).toBe(
+      "Unknown creator",
+    );
+  });
+
   it("never falls back to an email address", () => {
     const db = { created_by: { email: "owner@example.com" } };
 
@@ -92,50 +102,65 @@ describe("creator naming", () => {
   });
 });
 
-describe("labelCreatorsWithStableUnknownIndex", () => {
+describe("labelCreatorsWithStableUnknownIdentifier", () => {
   it("leaves named creators untouched", () => {
     const entries = [{ email: "a@example.com", name: "Alice" }];
 
-    expect(labelCreatorsWithStableUnknownIndex(entries)).toEqual(entries);
+    expect(labelCreatorsWithStableUnknownIdentifier(entries)).toEqual(entries);
   });
 
-  it("does not number a lone unnamed creator", () => {
-    const result = labelCreatorsWithStableUnknownIndex([
+  it("gives a lone unnamed creator a private stable identifier", () => {
+    const result = labelCreatorsWithStableUnknownIdentifier([
       { email: "a@example.com", name: "Alice" },
       { email: "z@example.com", name: "" },
     ]);
 
-    expect(result[1].name).toBe("Unknown creator");
+    expect(result[1].name).toMatch(/^Unknown creator [A-Z0-9]+$/);
+    expect(result[1].name).not.toContain("z@example.com");
   });
 
-  it("gives each unnamed creator a suffix that survives reordering", () => {
+  it("keeps anonymous labels stable across reordering, additions and removals", () => {
     const entries = [
       { email: "zoe@example.com", name: "" },
       { email: "amy@example.com", name: "" },
       { email: "named@example.com", name: "Named" },
     ];
 
-    const first = labelCreatorsWithStableUnknownIndex(entries);
+    const first = labelCreatorsWithStableUnknownIdentifier(entries);
     // Same people, different list order — as happens on any refetch or re-sort.
-    const reordered = labelCreatorsWithStableUnknownIndex([
+    const reordered = labelCreatorsWithStableUnknownIdentifier([
       entries[2],
       entries[1],
       entries[0],
     ]);
+    const added = labelCreatorsWithStableUnknownIdentifier([
+      { email: "aaron@example.com", name: "" },
+      ...entries,
+    ]);
+    const removed = labelCreatorsWithStableUnknownIdentifier([entries[0]]);
 
     const labelFor = (result, email) =>
       result.find((creator) => creator.email === email).name;
 
-    expect(labelFor(first, "amy@example.com")).toBe("Unknown creator 1");
-    expect(labelFor(first, "zoe@example.com")).toBe("Unknown creator 2");
-
-    // The label a given person gets must not depend on iteration order.
-    expect(labelFor(reordered, "amy@example.com")).toBe("Unknown creator 1");
-    expect(labelFor(reordered, "zoe@example.com")).toBe("Unknown creator 2");
+    expect(labelFor(first, "amy@example.com")).toBe(
+      labelFor(reordered, "amy@example.com"),
+    );
+    expect(labelFor(first, "zoe@example.com")).toBe(
+      labelFor(reordered, "zoe@example.com"),
+    );
+    expect(labelFor(first, "zoe@example.com")).toBe(
+      labelFor(added, "zoe@example.com"),
+    );
+    expect(labelFor(first, "zoe@example.com")).toBe(
+      labelFor(removed, "zoe@example.com"),
+    );
+    expect(labelFor(first, "amy@example.com")).not.toBe(
+      labelFor(first, "zoe@example.com"),
+    );
   });
 
   it("never leaks an email into an unnamed creator label", () => {
-    const result = labelCreatorsWithStableUnknownIndex([
+    const result = labelCreatorsWithStableUnknownIdentifier([
       { email: "a@example.com", name: "" },
       { email: "b@example.com", name: "" },
     ]);
@@ -156,14 +181,34 @@ describe("getDashboardViewers", () => {
     expect(viewers).toHaveLength(1);
   });
 
-  it("skips people with no email and labels missing names", () => {
+  it("skips people with no email and labels an anonymous creator consistently", () => {
     const viewers = getDashboardViewers({
       created_by: { email: "owner@example.com" },
       updated_by: { name: "No Email" },
     });
 
     expect(viewers).toHaveLength(1);
-    expect(viewers[0].displayName).toBe("Unknown user");
+    expect(viewers[0].displayName).toBe("Unknown creator");
+    expect(viewers[0].avatarKey).toBe("owner@example.com");
+  });
+
+  it("keeps distinct anonymous people visually distinct without exposing emails", () => {
+    const viewers = getDashboardViewers({
+      created_by: { email: "owner@example.com" },
+      updated_by: { email: "editor@example.com" },
+    });
+
+    expect(viewers.map((viewer) => viewer.displayName)).toEqual([
+      "Unknown user",
+      "Unknown creator",
+    ]);
+    expect(viewers[0].avatarKey).not.toBe(viewers[1].avatarKey);
+    expect(getAvatarColor(viewers[0].avatarKey)).not.toBe(
+      getAvatarColor(viewers[1].avatarKey),
+    );
+    viewers.forEach((viewer) => {
+      expect(viewer.displayName).not.toContain("@");
+    });
   });
 
   it("returns an empty list when nobody is attached", () => {

--- a/frontend/src/sections/dashboards/__tests__/utils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/utils.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  formatDashboardListDate,
+  formatDashboardTooltipDate,
+  formatDashboardWidgetCount,
+  getAvatarColor,
+  getDashboardCreatorLabel,
+  getDashboardCreatorName,
+  getDashboardPeopleSummary,
+  getDashboardViewers,
+  getInitials,
+  labelCreatorsWithStableUnknownIndex,
+  timeAgo,
+} from "../utils";
+import { AVATAR_COLORS } from "../constants";
+
+describe("formatDashboardWidgetCount", () => {
+  it("singularizes exactly one widget", () => {
+    expect(formatDashboardWidgetCount(1)).toBe("1 widget");
+    expect(formatDashboardWidgetCount("1")).toBe("1 widget");
+  });
+
+  it("pluralizes zero and many widgets", () => {
+    expect(formatDashboardWidgetCount(0)).toBe("0 widgets");
+    expect(formatDashboardWidgetCount(7)).toBe("7 widgets");
+  });
+
+  it("falls back to zero for missing or non-numeric counts", () => {
+    expect(formatDashboardWidgetCount(null)).toBe("0 widgets");
+    expect(formatDashboardWidgetCount(undefined)).toBe("0 widgets");
+    expect(formatDashboardWidgetCount("not-a-number")).toBe("0 widgets");
+    expect(formatDashboardWidgetCount(Infinity)).toBe("0 widgets");
+  });
+});
+
+describe("formatDashboardListDate", () => {
+  it("renders a calendar date, never relative text", () => {
+    expect(formatDashboardListDate("2026-06-15T12:00:00.000Z")).toBe(
+      "15 Jun 2026",
+    );
+  });
+
+  it("renders an em dash for missing or invalid dates", () => {
+    expect(formatDashboardListDate(null)).toBe("—");
+    expect(formatDashboardListDate(undefined)).toBe("—");
+    expect(formatDashboardListDate("")).toBe("—");
+  });
+});
+
+describe("formatDashboardTooltipDate", () => {
+  it("returns an empty string rather than a dash for missing dates", () => {
+    expect(formatDashboardTooltipDate(null)).toBe("");
+    expect(formatDashboardTooltipDate("")).toBe("");
+  });
+
+  it("includes time detail for a real date", () => {
+    expect(formatDashboardTooltipDate("2026-06-15T12:00:00.000Z")).toContain(
+      "2026",
+    );
+  });
+});
+
+describe("timeAgo", () => {
+  it("returns an empty string for missing dates", () => {
+    expect(timeAgo(null)).toBe("");
+    expect(timeAgo(undefined)).toBe("");
+  });
+});
+
+describe("creator naming", () => {
+  it("reads the creator name when present", () => {
+    expect(getDashboardCreatorName({ created_by: { name: "Alice" } })).toBe(
+      "Alice",
+    );
+  });
+
+  it("never falls back to an email address", () => {
+    const db = { created_by: { email: "owner@example.com" } };
+
+    expect(getDashboardCreatorName(db)).toBe("");
+    expect(getDashboardCreatorLabel(db)).toBe("Unknown creator");
+    expect(getDashboardCreatorLabel(db)).not.toContain("@");
+  });
+
+  it("handles a null or missing creator", () => {
+    expect(getDashboardCreatorLabel({ created_by: null })).toBe(
+      "Unknown creator",
+    );
+    expect(getDashboardCreatorLabel({})).toBe("Unknown creator");
+    expect(getDashboardCreatorLabel(undefined)).toBe("Unknown creator");
+  });
+});
+
+describe("labelCreatorsWithStableUnknownIndex", () => {
+  it("leaves named creators untouched", () => {
+    const entries = [{ email: "a@example.com", name: "Alice" }];
+
+    expect(labelCreatorsWithStableUnknownIndex(entries)).toEqual(entries);
+  });
+
+  it("does not number a lone unnamed creator", () => {
+    const result = labelCreatorsWithStableUnknownIndex([
+      { email: "a@example.com", name: "Alice" },
+      { email: "z@example.com", name: "" },
+    ]);
+
+    expect(result[1].name).toBe("Unknown creator");
+  });
+
+  it("gives each unnamed creator a suffix that survives reordering", () => {
+    const entries = [
+      { email: "zoe@example.com", name: "" },
+      { email: "amy@example.com", name: "" },
+      { email: "named@example.com", name: "Named" },
+    ];
+
+    const first = labelCreatorsWithStableUnknownIndex(entries);
+    // Same people, different list order — as happens on any refetch or re-sort.
+    const reordered = labelCreatorsWithStableUnknownIndex([
+      entries[2],
+      entries[1],
+      entries[0],
+    ]);
+
+    const labelFor = (result, email) =>
+      result.find((creator) => creator.email === email).name;
+
+    expect(labelFor(first, "amy@example.com")).toBe("Unknown creator 1");
+    expect(labelFor(first, "zoe@example.com")).toBe("Unknown creator 2");
+
+    // The label a given person gets must not depend on iteration order.
+    expect(labelFor(reordered, "amy@example.com")).toBe("Unknown creator 1");
+    expect(labelFor(reordered, "zoe@example.com")).toBe("Unknown creator 2");
+  });
+
+  it("never leaks an email into an unnamed creator label", () => {
+    const result = labelCreatorsWithStableUnknownIndex([
+      { email: "a@example.com", name: "" },
+      { email: "b@example.com", name: "" },
+    ]);
+
+    result.forEach((creator) => expect(creator.name).not.toContain("@"));
+  });
+});
+
+describe("getDashboardViewers", () => {
+  it("dedupes a person who both created and last updated the dashboard", () => {
+    const viewers = getDashboardViewers({
+      created_by: { name: "Alice", email: "alice@example.com" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_by: { name: "Alice", email: "alice@example.com" },
+      updated_at: "2026-06-01T00:00:00.000Z",
+    });
+
+    expect(viewers).toHaveLength(1);
+  });
+
+  it("skips people with no email and labels missing names", () => {
+    const viewers = getDashboardViewers({
+      created_by: { email: "owner@example.com" },
+      updated_by: { name: "No Email" },
+    });
+
+    expect(viewers).toHaveLength(1);
+    expect(viewers[0].displayName).toBe("Unknown user");
+  });
+
+  it("returns an empty list when nobody is attached", () => {
+    expect(getDashboardViewers({})).toEqual([]);
+  });
+});
+
+describe("getDashboardPeopleSummary", () => {
+  it("summarizes zero, one and many people", () => {
+    expect(getDashboardPeopleSummary({})).toBe("No people");
+    expect(
+      getDashboardPeopleSummary({
+        created_by: { name: "Alice", email: "alice@example.com" },
+      }),
+    ).toBe("1 person");
+    expect(
+      getDashboardPeopleSummary({
+        created_by: { name: "Alice", email: "alice@example.com" },
+        updated_by: { name: "Uma", email: "uma@example.com" },
+      }),
+    ).toBe("2 people");
+  });
+});
+
+describe("getInitials", () => {
+  it("uses the first letter of the first two words", () => {
+    expect(getInitials("Alice Creator")).toBe("AC");
+    expect(getInitials("  Alice   Creator  ")).toBe("AC");
+  });
+
+  it("uses the first two letters of a single word", () => {
+    expect(getInitials("Alice")).toBe("AL");
+  });
+
+  it("falls back to a question mark for missing names", () => {
+    expect(getInitials("")).toBe("?");
+    expect(getInitials(null)).toBe("?");
+    expect(getInitials(undefined)).toBe("?");
+  });
+});
+
+describe("getAvatarColor", () => {
+  it("always returns a color from the palette", () => {
+    ["Alice", "Bob", "", null, undefined].forEach((name) => {
+      expect(AVATAR_COLORS).toContain(getAvatarColor(name));
+    });
+  });
+
+  it("is stable for the same name", () => {
+    expect(getAvatarColor("Alice Creator")).toBe(
+      getAvatarColor("Alice Creator"),
+    );
+  });
+});

--- a/frontend/src/sections/dashboards/constants.js
+++ b/frontend/src/sections/dashboards/constants.js
@@ -49,3 +49,48 @@ export const DATE_CHIP_SX = {
   height: 28,
   borderRadius: "6px",
 };
+
+export const AVATAR_COLORS = [
+  "#7C4DFF",
+  "#FF6B6B",
+  "#5BE49B",
+  "#FFB547",
+  "#36B5FF",
+  "#FF85C0",
+  "#00BFA6",
+  "#8C9EFF",
+];
+
+/**
+ * Grid track definition for the dashboards list.
+ *
+ * The header row and every data row must render with the same tracks, so both
+ * read this single definition. `DASHBOARD_LIST_COLUMNS` includes the trailing
+ * 32px row-action track; `DASHBOARD_LIST_CONTENT_COLUMNS` covers the metadata
+ * columns only, for contexts that render without the action column.
+ */
+export const DASHBOARD_LIST_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px) 88px 32px";
+
+export const DASHBOARD_LIST_CONTENT_COLUMNS =
+  "minmax(220px, 1fr) 96px 112px minmax(160px, 220px)";
+
+/**
+ * Standard visually-hidden box.
+ *
+ * Values are explicit CSS strings on purpose: MUI's `sx` runs bare numbers
+ * through its sizing transform (any number <= 1 becomes a percentage) and its
+ * spacing transform (`margin: -1` becomes -8px), which would turn this into a
+ * full-size overlay rather than the intended 1px clip box.
+ */
+export const VISUALLY_HIDDEN_SX = {
+  border: 0,
+  clip: "rect(0 0 0 0)",
+  height: "1px",
+  margin: "-1px",
+  overflow: "hidden",
+  padding: 0,
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: "1px",
+};

--- a/frontend/src/sections/dashboards/utils.js
+++ b/frontend/src/sections/dashboards/utils.js
@@ -1,0 +1,112 @@
+import { fDate, fDateTime, fToNowStrict } from "src/utils/format-time";
+
+import { AVATAR_COLORS } from "./constants";
+
+export function getAvatarColor(name) {
+  let hash = 0;
+  for (let i = 0; i < (name || "").length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+export function getInitials(name) {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase();
+}
+
+export function timeAgo(date) {
+  if (!date) return "";
+  try {
+    return fToNowStrict(date);
+  } catch {
+    return "";
+  }
+}
+
+export function getDashboardCreatorName(db) {
+  return db?.created_by?.name || "";
+}
+
+export function getDashboardCreatorLabel(db) {
+  return getDashboardCreatorName(db) || "Unknown creator";
+}
+
+export function formatDashboardListDate(date) {
+  if (!date) return "—";
+  try {
+    return fDate(date) || "—";
+  } catch {
+    return "—";
+  }
+}
+
+export function formatDashboardTooltipDate(date) {
+  if (!date) return "";
+  try {
+    return fDateTime(date) || "";
+  } catch {
+    return "";
+  }
+}
+
+export function formatDashboardWidgetCount(count) {
+  const numericCount = Number(count || 0);
+  const safeCount = Number.isFinite(numericCount) ? numericCount : 0;
+
+  return `${safeCount} widget${safeCount === 1 ? "" : "s"}`;
+}
+
+export function getDashboardViewers(db) {
+  const users = [];
+  const seen = new Set();
+  const addUser = (u, time) => {
+    if (!u || !u.email || seen.has(u.email)) return;
+    seen.add(u.email);
+    users.push({ ...u, displayName: u.name || "Unknown user", time });
+  };
+  addUser(db.updated_by, db.updated_at);
+  addUser(db.created_by, db.created_at);
+  return users;
+}
+
+export function getDashboardPeopleSummary(db) {
+  const count = getDashboardViewers(db).length;
+  if (!count) return "No people";
+
+  return `${count} ${count === 1 ? "person" : "people"}`;
+}
+
+/**
+ * Label the creator filter entries, giving unnamed creators a stable suffix.
+ *
+ * The suffix is derived from the creator's position after sorting by email, not
+ * from list iteration order, so a given person keeps the same "Unknown creator
+ * N" label across refetches, renames and re-sorts. The filter stores `email`,
+ * so an order-dependent suffix would silently renumber the selected filter's
+ * label underneath the user.
+ */
+export function labelCreatorsWithStableUnknownIndex(entries) {
+  const unnamedEmails = entries
+    .filter((creator) => !creator.name)
+    .map((creator) => creator.email)
+    .sort();
+
+  const unnamedIndexByEmail = new Map(
+    unnamedEmails.map((email, index) => [email, index + 1]),
+  );
+
+  return entries.map((creator) => {
+    if (creator.name) return creator;
+
+    return {
+      ...creator,
+      name:
+        unnamedEmails.length > 1
+          ? `Unknown creator ${unnamedIndexByEmail.get(creator.email)}`
+          : "Unknown creator",
+    };
+  });
+}

--- a/frontend/src/sections/dashboards/utils.js
+++ b/frontend/src/sections/dashboards/utils.js
@@ -27,7 +27,8 @@ export function timeAgo(date) {
 }
 
 export function getDashboardCreatorName(db) {
-  return db?.created_by?.name || "";
+  const name = db?.created_by?.name;
+  return typeof name === "string" ? name.trim() : "";
 }
 
 export function getDashboardCreatorLabel(db) {
@@ -62,10 +63,20 @@ export function formatDashboardWidgetCount(count) {
 export function getDashboardViewers(db) {
   const users = [];
   const seen = new Set();
+  const creatorEmail = db?.created_by?.email;
   const addUser = (u, time) => {
     if (!u || !u.email || seen.has(u.email)) return;
     seen.add(u.email);
-    users.push({ ...u, displayName: u.name || "Unknown user", time });
+    const name = typeof u.name === "string" ? u.name.trim() : "";
+    users.push({
+      ...u,
+      displayName:
+        name || (u.email === creatorEmail ? "Unknown creator" : "Unknown user"),
+      // Keep anonymous people visually distinct without exposing their email.
+      // Named users retain the existing name-based colour assignment.
+      avatarKey: name || u.email,
+      time,
+    });
   };
   addUser(db.updated_by, db.updated_at);
   addUser(db.created_by, db.created_at);
@@ -79,34 +90,36 @@ export function getDashboardPeopleSummary(db) {
   return `${count} ${count === 1 ? "person" : "people"}`;
 }
 
+function getStablePrivateIdentifier(value) {
+  // FNV-1a gives us a compact deterministic identifier. Only the derived token
+  // is rendered, so the underlying email remains private.
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(-7).toUpperCase();
+}
+
 /**
- * Label the creator filter entries, giving unnamed creators a stable suffix.
+ * Label creator filter entries without exposing anonymous creators' emails.
  *
- * The suffix is derived from the creator's position after sorting by email, not
- * from list iteration order, so a given person keeps the same "Unknown creator
- * N" label across refetches, renames and re-sorts. The filter stores `email`,
- * so an order-dependent suffix would silently renumber the selected filter's
- * label underneath the user.
+ * Each anonymous label always includes an identifier derived from the creator's
+ * email. Unlike a rank within the current list, that identifier does not change
+ * when another creator is added or removed during a refetch.
  */
-export function labelCreatorsWithStableUnknownIndex(entries) {
-  const unnamedEmails = entries
-    .filter((creator) => !creator.name)
-    .map((creator) => creator.email)
-    .sort();
-
-  const unnamedIndexByEmail = new Map(
-    unnamedEmails.map((email, index) => [email, index + 1]),
-  );
-
+export function labelCreatorsWithStableUnknownIdentifier(entries) {
   return entries.map((creator) => {
-    if (creator.name) return creator;
+    const name =
+      typeof creator.name === "string" ? creator.name.trim() : creator.name;
+    if (name) return { ...creator, name };
 
     return {
       ...creator,
-      name:
-        unnamedEmails.length > 1
-          ? `Unknown creator ${unnamedIndexByEmail.get(creator.email)}`
-          : "Unknown creator",
+      name: `Unknown creator ${getStablePrivateIdentifier(
+        String(creator.email || ""),
+      )}`,
     };
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes the dashboard list scannability gap from #925 by making dashboard metadata visible without changing dashboard hooks or backend contracts. Non-empty dashboard lists now show aligned desktop headers plus per-row widget count, last-updated date, creator label, and people context so users can compare dashboards without opening each one or interpreting avatars by hover alone.

The final diff also keeps the interaction model safer and more accessible: the open-dashboard target is a semantic link with hidden metadata context, delete remains a separate sibling action, People metadata is keyboard-focusable, and missing creator names use a private `Unknown creator` fallback instead of rendering raw email addresses in the list, filter, or People tooltip UI.

## Linked issues

Closes #925

Linear: N/A — this is an open-source GitHub issue and I do not have a Linear issue for it.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Dashboard list metadata is visible and aligned**

- Adds a non-empty list header row: `Name`, `Widgets`, `Last updated`, `Created by`, and `People`.
- Reworks dashboard rows onto a shared desktop grid so names, widget counts, dates, creators, people, and actions scan consistently.
- Keeps small screens card-like with inline metadata labels (`Widgets`, `Updated`, `Created by`, `People`) instead of forcing the desktop header grid into a narrow row.
- Reduces dashboard-list-local small-screen overflow pressure from the search/actions row without changing the global dashboard shell layout.

**B. Dates and widget counts are defensive**

- Shows stable calendar dates in the row, e.g. `15 Jun 2026`, instead of relative text such as "last week".
- Routes dashboard list and tooltip date formatting through `src/utils/format-time` instead of local `date-fns` imports in the list component.
- Handles missing or malformed date values by showing `—`/empty tooltip text instead of throwing.
- Normalizes API-shaped widget counts such as string values (`"1"`, `"0"`) before pluralizing.

**C. Creator identity and people metadata are visible without exposing email fallbacks**

- Displays the creator name when present.
- Uses `Unknown creator` when the API only provides a single anonymous creator email; when multiple anonymous creators are present, filter labels become `Unknown creator 1`, `Unknown creator 2`, etc. so filtering remains distinguishable without exposing raw emails.
- Keeps existing viewer/avatar behavior but avoids using email as the visible viewer fallback.
- Makes the People avatar group keyboard-focusable with an accessible summary such as `People for Latency Overview: 2 people`.

**D. Existing interactions are preserved while avoiding nested controls**

- Keeps the same dashboard hooks, search/filter behavior, create flow, delete mutation, and route navigation.
- Gives the open-dashboard area semantic link behavior with an `href`, preserves click-driven SPA navigation, and leaves modified browser link clicks to the browser.
- Adds an accessible row description for screen readers containing widget count, last-updated date, creator label, and people summary.
- Keeps delete as a separate sibling `IconButton` so activating delete does not also trigger dashboard navigation.
- Keeps row actions discoverable on hover, keyboard focus, and no-hover/touch devices.

---

## 2) Why the changes were done

- **Product/UX:** The previous list required opening dashboards or interpreting avatars to understand creator/date/widget context, making dashboard comparison slow.
- **Privacy:** Missing creator names should not cause raw email addresses to appear in newly visible dashboard-list metadata.
- **Accessibility/reliability:** Semantic link rows, accessible metadata descriptions, and separate delete actions keep keyboard and screen-reader behavior predictable.
- **Architecture:** The fix stays inside `DashboardsListView` and does not change backend/API contracts, route contracts, or dashboard hook data shapes.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/dashboards/__tests__/DashboardsListView.test.jsx`** — focused regression coverage for issue #925.

- `renders column headers above non-empty dashboard rows` — verifies the new visible list headers.
- `renders shared calendar-date text instead of relative row timestamps` — verifies stable `dd MMM yyyy` row dates and guards against visible relative text.
- `renders creator names inline without exposing email fallbacks` — verifies creator labels and guards against raw email fallback exposure in rows/filter menu.
- `normalizes API-shaped widget counts and missing metadata` — covers string/zero widget counts plus null creator/date metadata and the row description fallback.
- `falls back safely for invalid widget counts` — guards malformed API values by rendering `0 widgets` without breaking row metadata.
- `does not render list column headers for the empty state` — keeps the empty layout clean.
- `keeps headers hidden when search filters all dashboards out` — prevents stale headers in the filtered-empty state.
- `keeps row navigation on a semantic link with accessible metadata` — verifies the row has a real `href`, preserves SPA click navigation, leaves modified link clicks out of the SPA handler, and exposes hidden metadata context.
- `makes people metadata available as a focusable row action` — verifies the People summary is keyboard-addressable.
- `keeps people tooltip fallbacks private when names are missing` — verifies tooltip creator/viewer fallbacks do not expose raw emails.
- `keeps selected creator filter private after dashboard data changes` — guards the stale-filter case where a selected email disappears from the current dashboard data.
- `disambiguates multiple unnamed creator filters without exposing emails` — keeps multiple anonymous creator filters distinguishable with private numbered labels.
- `keeps delete as a separate action from row navigation` — proves delete opens the confirmation flow without navigating.
- `confirms deletion for the selected dashboard without navigating` — verifies the confirm action calls the delete mutation with the selected dashboard ID.

Focused + adjacent dashboard run result: **54 passed** across `DashboardsListView.test.jsx`, `DashboardDetailView.test.jsx`, `dashboardDateRange.test.js`, and `widgetUtils.test.js`.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
npx -y yarn@1.22.22 test:run src/sections/dashboards/__tests__/DashboardsListView.test.jsx src/sections/dashboards/__tests__/DashboardDetailView.test.jsx src/sections/dashboards/__tests__/dashboardDateRange.test.js src/sections/dashboards/__tests__/widgetUtils.test.js
```

### Lint / format / type / build

```bash
cd frontend
npx -y prettier@3.4.2 --check src/sections/dashboards/DashboardsListView.jsx src/sections/dashboards/__tests__/DashboardsListView.test.jsx
npx -y eslint@8.57.1 src/sections/dashboards/DashboardsListView.jsx src/sections/dashboards/__tests__/DashboardsListView.test.jsx
npx -y yarn@1.22.22 type-check
npx -y yarn@1.22.22 build
```

Additional hygiene:

```bash
git diff --check
```

### UI steps (manual)

1. Open the dashboard list page.
2. Verify non-empty lists show headers for Name, Widgets, Last updated, Created by, and People.
3. Verify each row shows a stable date, widget count, creator label, and people metadata inline.
4. Verify missing creator names show `Unknown creator`, not a raw email address.
5. Verify the open-dashboard row link can be clicked, uses standard link keyboard behavior including Enter activation, and preserves browser affordances for modified link clicks.
6. Verify the People control can receive keyboard focus and exposes the people count.
7. Verify the delete action opens the existing confirmation flow without navigating.
8. Verify small-width layouts show inline metadata labels instead of the desktop header row.

---

## 5) Screenshots / recordings

I performed local Chrome headless smoke validation against the live Vite dashboard route with mocked auth/dashboard API responses at desktop (`1280×900`) and small-width (`390×844`) viewports. Screenshots were inspected locally and intentionally not committed as generated artifacts.

Observed during that smoke pass:

- Desktop row headers render with visible Name / Widgets / Last updated / Created by / People columns.
- Row metadata renders stable dates, creator labels, widget counts, and people avatars.
- Missing creator names render `Unknown creator` rather than raw email addresses.
- Small-width rows render inline metadata labels (`Widgets`, `Updated`, `Created by`, `People`).

Note: the existing dashboard shell keeps a fixed left navigation/min-width at very small browser widths; this PR does not broaden scope into global dashboard layout behavior.

---

## 6) Edge cases & considerations

- **Creator without name:** shows `Unknown creator` instead of raw email in list, filter, and People tooltip metadata; multiple unnamed creator filters use private numbered labels so users can still distinguish filter options.
- **Dashboard without update timestamp:** falls back to `created_at` for the visible list date.
- **Dashboard without creator/date metadata:** shows `Unknown creator`/`—` instead of throwing or rendering misleading text.
- **Widget count from API as a string/zero/invalid value:** normalizes before pluralizing and falls back to `0 widgets` for malformed values.
- **Empty list and filtered-empty list:** keep the empty-state layout and do not show table-style headers.
- **Small screens:** use inline metadata labels rather than forcing the desktop column grid into a narrow row.
- **Row actions:** delete is a sibling action, not nested inside the open-dashboard link.

---

## 7) Pre-existing issues (NOT introduced by this PR)

The focused and adjacent dashboard suites pass. A full frontend test run was also attempted on the earlier draft branch:

```bash
cd frontend && npx -y yarn@1.22.22 test:run
```

That full run failed with unrelated existing non-dashboard failures after reporting **241 passed test files** and **2102 passed tests**:

- `TypeError: localStorage.getItem is not a function` from `src/sections/develop-detail/states.jsx:177`, causing 25 untouched suites to fail during import.
- `src/sections/projects/UsersView/__tests__/UsersGrid.test.jsx` failed independently because its `getUsersList` spy was not called.

I confirmed these are unrelated to this dashboard diff by running representative failures individually:

```bash
cd frontend && npx -y yarn@1.22.22 test:run src/api/develop/__tests__/develop-detail.test.js
cd frontend && npx -y yarn@1.22.22 test:run src/sections/projects/UsersView/__tests__/UsersGrid.test.jsx
```

Both reproduce outside the changed dashboard files. The focused/adjacent dashboard tests were rerun after those failures and still passed.

Also note: this shell does not have a direct `yarn` binary on PATH, so Yarn 1 commands were invoked via `npx -y yarn@1.22.22`.

---

## 8) Architectural / important decisions

- **Keep the custom list instead of migrating to DataGrid:** issue #925 is a focused presentation/scannability bug; a DataGrid migration would broaden review scope and risk existing row/delete/navigation behavior.
- **Use shared date utilities:** `DashboardsListView` now relies on `src/utils/format-time` for list and tooltip date formatting instead of local `date-fns` imports.
- **Use semantic link rows:** the open-dashboard target has real link semantics and `href` support while preserving existing SPA click navigation for ordinary clicks and browser defaults for modified clicks.
- **Avoid nested interactive controls:** the open-dashboard link, People focus target, and delete button are siblings so keyboard/click behavior stays predictable.
- **No API or contract changes:** dashboard data shape, hooks, filters, mutations, and route paths remain unchanged.

---

## 9) Release note / changelog handling

Release note: Dashboard lists now show creator, updated date, widget count, and people metadata inline so dashboards are easier to scan and compare.

The repository does not contain an in-repo changelog file to edit; `CONTRIBUTING.md` says release notes live at futureagi.com/changelog.

---

## Notes for maintainers

This PR supersedes my earlier draft PR #1300 with a clean replacement branch after review follow-up. I avoided force-pushing the original branch and closed #1300 to avoid duplicate review noise.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend) — not run; frontend-only UI change
- [ ] `yarn test:run` passes locally (frontend) — full suite currently has unrelated non-dashboard failures documented above; focused/adjacent dashboard suites pass
- [ ] `yarn contracts:check` passes if API surface changed — not run; no API surface changed
- [x] I've updated the documentation where relevant — no docs page changed; release/changelog handling documented above
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — not verified in this local session
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status — no Linear issue available for this OSS GitHub issue

---

## Verified in the live UI

Brought the full stack up locally, seeded a handful of dashboards, and captured the dashboards list on `dev` vs this branch (same data both times).

![Before / after — the dashboards list is now scannable](https://raw.githubusercontent.com/DivyamTalwar/future-agi/pr-1301-media/00-before-after-composite.png)

**Before (`dev`):** each row crams the widget count, a relative "N days ago" timestamp, and an avatar-only creator against the right edge — with no column headers to scan by.

![Before — plain dashboards list](https://raw.githubusercontent.com/DivyamTalwar/future-agi/pr-1301-media/01-before-plain-list.png)

**After (this PR):** aligned **Name · Widgets · Last updated · Created by · People** columns, real dates (`16 Jul 2026`), and creator identity as an avatar + name — never a leaked email.

![After — scannable dashboards list](https://raw.githubusercontent.com/DivyamTalwar/future-agi/pr-1301-media/02-after-scannable-list.png)

Focused dashboard-list tests pass; branch is up to date with `dev` (0 behind).

