### PR TITLE
fix(experiment): load edit config from snake_case v2 payload and fix column/eval-source mapping

### DIFF
--- a/frontend/src/components/VersionList/VersionList.jsx
+++ b/frontend/src/components/VersionList/VersionList.jsx
@@ -219,7 +219,7 @@ const VersionList = ({
                         fontWeight="fontWeightMedium"
                         color={"text.primary"}
                       >
-                        Version {v.versionNameDisplay}
+                        Version {v.version_name_display}
                       </Typography>
                       {v.isDraft && <DraftBadge>Draft</DraftBadge>}
                     </Box>
@@ -235,7 +235,7 @@ const VersionList = ({
                       fontWeight="fontWeightRegular"
                       color="text.primary"
                     >
-                      {v.commitMessage}
+                      {v.commit_message}
                     </Typography>
                   </Box>
                 }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1168,7 +1168,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                 {(source === "dataset" ||
                   source === "workbench" ||
                   source === "custom" ||
-                  source === "run-experiment" ||
+                  source === "experiment" ||
                   source === "run-optimization") && (
                   <DatasetTestMode
                     ref={sourceRef}

--- a/frontend/src/sections/develop-detail/Experiment/RunExperiment.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/RunExperiment.jsx
@@ -567,7 +567,8 @@ const RunExperiment = ({
     !!selectedExperiment,
   );
   const allColumns = useMemo(() => {
-    const cols = experimentColumns ?? datasetColumns;
+
+    const cols = experimentColumns?.length ? experimentColumns : datasetColumns;
     if (!cols) return cols;
     return cols.map((col) => ({
       ...col,
@@ -576,7 +577,6 @@ const RunExperiment = ({
       value: col?.name,
     }));
   }, [experimentColumns, datasetColumns]);
-
   const { data: experimentJsonSchemas = {} } = useGetExperimentJSONSchema(
     !!selectedExperiment,
     selectedExperiment,
@@ -746,7 +746,7 @@ const RunExperiment = ({
           ) : (
             <RunExperimentForm
               allColumns={allColumns?.filter((col) =>
-                ["run_prompt", "others"].includes(
+                ["run_prompt", "others",].includes(
                   col?.originType?.toLowerCase(),
                 ),
               )}

--- a/frontend/src/sections/develop-detail/Experiment/utils.js
+++ b/frontend/src/sections/develop-detail/Experiment/utils.js
@@ -181,46 +181,62 @@ const _replaceIdWithColumnName = (content, allColumns = []) => {
   return content;
 };
 
+const asArray = (value) => (Array.isArray(value) ? value : []);
+const normalizePromptConfigItem = (item = {}) => ({
+  ...item,
+  id: item.id,
+  promptId: item.prompt_id ?? null,
+  promptVersion: item.prompt_version ?? null,
+  promptName: item.prompt_name ?? null,
+  agentId: item.agent_id ?? null,
+  agentVersion: item.agent_version ?? null,
+  model: item.model,
+  modelParams: item.model_params ?? {},
+  modelConfig: item.model_config,
+  messages: item.messages,
+  configuration: item.configuration,
+  outputFormat: item.output_format,
+  voiceInputColumnId: item.voice_input_column_id ?? "",
+});
+
+/** @param {any} editConfigData */
 export const getExperimentDefaultValue = (
   editConfigData = {},
   _allColumns = [],
 ) => {
-  const columnId = editConfigData?.columnId || null;
+  const columnId = editConfigData?.column_id ?? null;
   const name = editConfigData?.name || "";
-  const rawPromptConfigs = Array.isArray(editConfigData?.promptConfigs)
-    ? editConfigData.promptConfigs
-    : Array.isArray(editConfigData?.promptConfig)
-      ? editConfigData.promptConfig
-      : [];
+  const normalizedPromptConfigs = asArray(editConfigData?.prompt_configs).map(
+    normalizePromptConfigItem,
+  );
+  const experimentType = editConfigData?.experiment_type || "llm";
   const outputFormat =
-    editConfigData?.outputFormat ||
-    rawPromptConfigs?.[0]?.outputFormat ||
+    editConfigData?.output_format ||
+    normalizedPromptConfigs?.[0]?.outputFormat ||
     "string";
-  const experimentType = editConfigData?.experimentType || "llm";
-  const userEvalMetrics =
-    editConfigData?.userEvalMetrics?.map((item) => ({
+  const userEvalMetrics = asArray(editConfigData?.user_eval_metrics).map(
+    (item) => ({
       ...item,
       actualEvalCreatedId: item.id,
-      evalId: item.evalId || item.id,
-    })) || [];
+      evalId: item.id,
+    }),
+  );
   // Transform prompt configs using existing function
   const promptConfigTransformed = reversePromptConfigTransform(
-    rawPromptConfigs,
+    normalizedPromptConfigs,
     experimentType,
   );
 
   // Transform agent configs to form format
-  const agentConfigs = Array.isArray(editConfigData?.agentConfigs)
-    ? editConfigData.agentConfigs.map((agent) => ({
-        _itemId: agent.id,
-        agentId: agent.agentId,
-        agentVersion: agent.agentVersion,
-        name: agent.agentName,
-        experimentType: "llm",
-        outputFormat: outputFormat || "string",
-        promptConfigId: agent?.id,
-      }))
-    : [];
+  const agentConfigs = asArray(editConfigData?.agent_configs).map((agent) => ({
+    _itemId: agent.id,
+    agentId: agent.agent_id,
+    agentVersion: agent.agent_version,
+    name: agent.agent_name ?? agent.name,
+    experimentType: "llm",
+    outputFormat: outputFormat || "string",
+    promptConfigId: agent?.id,
+  }));
 
   const promptConfig = [...(promptConfigTransformed || []), ...agentConfigs];
 

--- a/frontend/src/sections/develop-detail/Experiment/utils.js
+++ b/frontend/src/sections/develop-detail/Experiment/utils.js
@@ -199,7 +199,7 @@ const normalizePromptConfigItem = (item = {}) => ({
   voiceInputColumnId: item.voice_input_column_id ?? "",
 });
 
-/** @param {any} editConfigData */
+
 export const getExperimentDefaultValue = (
   editConfigData = {},
   _allColumns = [],


### PR DESCRIPTION
## Summary

The experiment **edit** flow and the version list were still reading the legacy camelCase fields, but the v2 API now returns everything in snake_case. As a result, opening an experiment to edit loaded blank/partial config, the version list showed empty version names and commit messages, and the eval picker's experiment source didn't match. This PR maps the UI to the snake_case v2 payload and fixes the related column/source mapping.

## Why the changes are done — what is the problem

### Reproduce on dev today (before this PR)

1. Open an existing experiment and click **Edit** → prompt/agent/eval config loads empty or partial (fields like model, messages, eval metrics missing).
2. Open the version list panel → "Version" label and commit message render blank.
3. Open the eval picker from the experiment run flow → the "experiment" source path is not recognized.

### Where it breaks — UI

- `Experiment/utils.js#getExperimentDefaultValue` read camelCase keys (`columnId`, `promptConfigs`, `userEvalMetrics`, `agentConfigs`, `experimentType`, `outputFormat`), but the v2 payload delivers `column_id`, `prompt_configs`, `user_eval_metrics`, `agent_configs`, `experiment_type`, `output_format`. The camelCase reads resolved to `undefined`, so the edit form defaulted to empty.
- `VersionList.jsx` read `v.versionNameDisplay` / `v.commitMessage`; the payload provides `version_name_display` / `commit_message`.
- `EvalPickerCreateNew.jsx` gated on `source === "run-experiment"`, but the source value is `"experiment"`.
- `RunExperiment.jsx` used `experimentColumns ?? datasetColumns`, so an empty (but non-null) `experimentColumns` array shadowed the dataset columns instead of falling back.

## What changed

### frontend/src/sections/develop-detail/Experiment/utils.js
- Rewrote `getExperimentDefaultValue` to read the snake_case v2 payload. Added `asArray` and `normalizePromptConfigItem` helpers that normalize each prompt-config item (`prompt_id`, `prompt_version`, `model_params`, `output_format`, `voice_input_column_id`, etc.) into the camelCase shape the form expects.
- Mapped `agent_configs` (`agent_id`, `agent_version`, `agent_name`) and `user_eval_metrics` to their form representations.

### frontend/src/sections/develop-detail/Experiment/RunExperiment.jsx
- `allColumns` now uses `experimentColumns?.length ? experimentColumns : datasetColumns` so an empty experiment-columns array correctly falls back to dataset columns.

### frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
- Matched the eval-picker source on `"experiment"` instead of the stale `"run-experiment"`.

### frontend/src/components/VersionList/VersionList.jsx
- Read `version_name_display` and `commit_message` from the v2 payload so the version label and commit message render.

## Tests included — what each scenario covers

Frontend-only change, no automated tests added. Manual test plan below.

- [ ] Edit an existing experiment → prompt config, model params, messages, agent configs, and eval metrics all pre-populate correctly.
- [ ] Version list panel → version name and commit message display for each version.
- [ ] Eval picker opened from the experiment run flow → the experiment source path renders the dataset test mode.
- [ ] Experiment with no experiment-specific columns → dataset columns are used as fallback.

## Commands to run tests

```bash
cd frontend
yarn lint
```

### Local verification results
- [ ] `yarn lint` passes on the changed files (no new errors).

## Video

_N/A_

## Screenshot of test suit run

_N/A_

## Backwards compatibility

Pure UI read-path change. No API/schema changes. The UI now reads the snake_case fields the v2 payload already returns; older camelCase-only responses would no longer populate these fields, but the v2 payload is the current contract.

## Manual verification (UI)

1. Open an experiment → **Edit** → confirm all config fields load.
2. Open the version list → confirm version names + commit messages show.
3. Trigger the eval picker from experiment run → confirm the experiment source works.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Docs
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Perf
- [ ] 🧪 Test-only

## Checklist

- [x] Code follows the project style guide
- [ ] Tests added (frontend-only; manual test plan provided)
- [x] No secrets / URLs / PII committed

## Backout / rollback

Revert this branch's two commits (`8cb6d6ba1`, `2fc024b1a`); no migrations or data changes involved.

## Linear

Closes TH-6432
Closes TH-6467
Closes TH-6426
