### PR TITLE
fix(eval-task): lean materialize read (attributes_extra OOM) + mark task FAILED on workflow failure

### DIFF
--- a/futureagi/tfc/temporal/eval_tasks/tests/test_workflows.py
+++ b/futureagi/tfc/temporal/eval_tasks/tests/test_workflows.py
@@ -40,6 +40,15 @@ def _patch_noop_reconcile(monkeypatch):
     monkeypatch.setattr("tracer.services.eval_tasks.reconciler.reconcile", _noop)
 
 
+def _patch_failing_reconcile(monkeypatch):
+    """reconcile raises so the activity exhausts its retries and the run fails."""
+
+    def _boom(task):
+        raise RuntimeError("simulated reconcile failure")
+
+    monkeypatch.setattr("tracer.services.eval_tasks.reconciler.reconcile", _boom)
+
+
 def _patch_completing_run_entry(monkeypatch):
     def _complete(entry):
         EvalLogger.objects.filter(id=entry.id).update(
@@ -392,7 +401,29 @@ class TestHistoricalWorkflow:
         counts = await _status_counts(str(eval_task.id))
         assert counts["completed"] == 3  # the healthy entries still drained
         assert counts["running"] == 1  # the stranded one, left non-terminal
-        assert await _task_status(str(eval_task.id)) != EvalTaskStatus.COMPLETED
+        # Wrapper persists FAILED to the DB, not just the SA.
+        assert await _task_status(str(eval_task.id)) == EvalTaskStatus.FAILED
+
+    async def test_reconcile_failure_marks_task_failed(
+        self, workflow_environment, eval_task, monkeypatch
+    ):
+        """A failed activity (here reconcile) must leave the task FAILED, not
+        stuck ``running`` — it was flipped to running by _mark_running."""
+        from temporalio.client import WorkflowFailureError
+        from temporalio.common import RetryPolicy
+
+        import tfc.temporal.eval_tasks.workflows as wf
+
+        _patch_failing_reconcile(monkeypatch)
+        # One-shot so the reconcile activity exhausts its retries fast.
+        monkeypatch.setattr(wf, "CONTROL_RETRY_POLICY", RetryPolicy(maximum_attempts=1))
+
+        with pytest.raises(WorkflowFailureError):
+            await _run_historical(
+                workflow_environment, str(eval_task.id), batch_size=2, max_concurrent=4
+            )
+
+        assert await _task_status(str(eval_task.id)) == EvalTaskStatus.FAILED
 
     async def test_entry_passes_through_running_mid_drain(
         self, workflow_environment, eval_task, make_pending_entries, monkeypatch

--- a/futureagi/tfc/temporal/eval_tasks/workflows.py
+++ b/futureagi/tfc/temporal/eval_tasks/workflows.py
@@ -131,6 +131,14 @@ async def _mark_running(task_id: str) -> None:
     await _set_db_status(task_id, STATUS_RUNNING, expected_status=STATUS_PENDING)
 
 
+async def _fail_task(task_id: str) -> None:
+    """Persist FAILED to the DB row (the UI's source of truth) and the Temporal
+    Search Attribute. Forced (unguarded) — the run only reaches here on a genuine
+    error, since paused / deleted exit through the graceful state check."""
+    _set_status(STATUS_FAILED)
+    await _set_db_status(task_id, STATUS_FAILED)
+
+
 async def _reconcile(task_id: str) -> None:
     await workflow.execute_activity(
         "reconcile_eval_task_activity",
@@ -289,6 +297,16 @@ class HistoricalEvalTaskWorkflow(_ObservableEvalWorkflow):
 
     @workflow.run
     async def run(self, input: EvalTaskWorkflowInput) -> EvalTaskWorkflowOutput:
+        try:
+            return await self._run(input)
+        except Exception:
+            # Persist FAILED so a failed run doesn't stay stuck ``running``,
+            # then re-raise. continue_as_new / cancellation are BaseException,
+            # not caught here.
+            await _fail_task(input.task_id)
+            raise
+
+    async def _run(self, input: EvalTaskWorkflowInput) -> EvalTaskWorkflowOutput:
         self._phase = PHASE_MATERIALIZING
         await _apply_labels(input.task_id)
         _set_status(STATUS_RUNNING)
@@ -353,8 +371,8 @@ class HistoricalEvalTaskWorkflow(_ObservableEvalWorkflow):
             # run_entry and fail_eval_entry exhausted their retries. reap only
             # runs at first start (skipped across continue-as-new), so these
             # can't self-heal here; fail loudly rather than report COMPLETED
-            # over undrained work. A fresh workflow start reaps and re-drains.
-            _set_status(STATUS_FAILED)
+            # over undrained work (the wrapper persists FAILED). A fresh
+            # workflow start reaps and re-drains.
             raise ApplicationError(
                 f"eval task {input.task_id} drained but did not finalize",
                 non_retryable=True,
@@ -372,6 +390,14 @@ class ContinuousEvalTaskWorkflow(_ObservableEvalWorkflow):
 
     @workflow.run
     async def run(self, state: ContinuousDrainState) -> None:
+        try:
+            await self._run(state)
+        except Exception:
+            # Same fail-then-reraise as HistoricalEvalTaskWorkflow.run.
+            await _fail_task(state.task_id)
+            raise
+
+    async def _run(self, state: ContinuousDrainState) -> None:
         self._phase = PHASE_MATERIALIZING
         await _apply_labels(state.task_id)
         _set_status(STATUS_RUNNING)

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -678,6 +678,7 @@ class CHSpanReader:
         self,
         span_ids: list[str],
         *,
+        include_heavy: bool = True,
         project_id: str | None = None,
         org_id: str | None = None,
     ) -> list[CHSpan]:
@@ -686,9 +687,14 @@ class CHSpanReader:
         Result order is NOT preserved relative to the input list (CH orders
         by id for determinism). Callers that need a specific order should
         sort the result themselves.
+
+        With ``include_heavy=False`` the fat JSON columns (attributes_extra /
+        span_events / resource_attrs) come back as '' — opt out when only
+        id/scalar columns are needed.
         """
         if not span_ids:
             return []
+        select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
         where = ["id IN %(ids)s", "is_deleted = 0"]
         params: dict[str, Any] = {"ids": tuple(span_ids)}
         if project_id:
@@ -698,9 +704,7 @@ class CHSpanReader:
             where.append("org_id = %(oid)s")
             params["oid"] = str(org_id)
         rows = self._client.query(
-            f"SELECT {_SELECT_SQL} FROM spans FINAL "
-            f"WHERE {' AND '.join(where)} "
-            "ORDER BY id",
+            f"SELECT {select} FROM spans FINAL WHERE {' AND '.join(where)} ORDER BY id",
             parameters=params,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
@@ -757,10 +761,7 @@ class CHSpanReader:
             },
         ).result_rows
 
-        return {
-            str(row[0]): dict(zip(aliases, row, strict=False))
-            for row in rows
-        }
+        return {str(row[0]): dict(zip(aliases, row, strict=False)) for row in rows}
 
     # ─── Batch helpers for dataset child-tree export ─────────────────────────
 
@@ -2004,6 +2005,7 @@ class CHSpanReader:
         self,
         trace_ids: list[str],
         *,
+        include_heavy: bool = True,
         observation_type: str | None = None,
     ) -> dict[str, CHSpan]:
         """For each trace_id, return the root span (parent_span_id = '').
@@ -2018,9 +2020,14 @@ class CHSpanReader:
 
         Used by model_hub/services/bulk_selection.py for per-trace root
         lookups + annotation_queues.py default-queue resolution.
+
+        With ``include_heavy=False`` the fat JSON columns (attributes_extra /
+        span_events / resource_attrs) come back as '' — opt out when only
+        id/scalar columns are needed.
         """
         if not trace_ids:
             return {}
+        select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
         where = [
             "is_deleted = 0",
             "trace_id IN %(tids)s",
@@ -2033,7 +2040,7 @@ class CHSpanReader:
         # Single CH query; ORDER BY trace_id, start_time, id; then dedupe by
         # trace_id in Python keeping the first per trace_id (= earliest).
         rows = self._client.query(
-            f"SELECT {_SELECT_SQL} FROM spans FINAL "
+            f"SELECT {select} FROM spans FINAL "
             f"WHERE {' AND '.join(where)} "
             "ORDER BY trace_id, start_time, id",
             parameters=params,

--- a/futureagi/tracer/services/eval_tasks/entries.py
+++ b/futureagi/tracer/services/eval_tasks/entries.py
@@ -219,12 +219,16 @@ def _resolve_entry_fks(
     target_type. Rows that can't be shaped (missing span / rootless trace) are
     absent from the result and skipped by the caller."""
     if row_type in (RowType.SPANS, RowType.VOICE_CALLS):
-        spans = reader.list_by_ids(list(identities))
+        # Only id + trace_id are used, so skip the fat JSON columns.
+        spans = reader.list_by_ids(list(identities), include_heavy=False)
         return {
             s.id: {"observation_span_id": s.id, "trace_id": s.trace_id} for s in spans
         }
     if row_type == RowType.TRACES:
-        roots = reader.list_root_spans_by_trace_ids(list(identities))
+        # Only root.id is used below, so skip the fat JSON columns.
+        roots = reader.list_root_spans_by_trace_ids(
+            list(identities), include_heavy=False
+        )
         return {
             trace_id: {"observation_span_id": root.id, "trace_id": trace_id}
             for trace_id, root in roots.items()

--- a/futureagi/tracer/tests/test_eval_entries.py
+++ b/futureagi/tracer/tests/test_eval_entries.py
@@ -204,3 +204,67 @@ class TestSoftDeleteLive:
             ).count()
             == 4
         )
+
+
+class _RecordingReader:
+    """Wraps a real CHSpanReader, recording the ``include_heavy`` kwarg each
+    id-resolution method was called with while delegating everything else."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.calls: dict[str, object] = {}
+
+    def list_by_ids(self, *args, **kwargs):
+        self.calls["list_by_ids"] = kwargs.get("include_heavy")
+        return self._inner.list_by_ids(*args, **kwargs)
+
+    def list_root_spans_by_trace_ids(self, *args, **kwargs):
+        self.calls["list_root_spans_by_trace_ids"] = kwargs.get("include_heavy")
+        return self._inner.list_root_spans_by_trace_ids(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _spy_reader(monkeypatch):
+    from tracer.services.eval_tasks import entries as entries_mod
+
+    spy = _RecordingReader(entries_mod.get_reader())
+    monkeypatch.setattr(entries_mod, "get_reader", lambda: spy)
+    return spy
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestMaterializeLeanRead:
+    """Materialize only needs id/trace_id, so it must issue the lean read (no
+    attributes_extra) — hydrating the fat columns OOMs large tasks."""
+
+    def test_spans_materialize_requests_lean_read(
+        self, project, custom_eval_config, monkeypatch
+    ):
+        _make_spans(project, 3)
+        task = _task(project, evals=[custom_eval_config])
+        spy = _spy_reader(monkeypatch)
+        materialize_pending(task)
+        assert spy.calls.get("list_by_ids") is False
+        assert _live(task).count() == 3  # still materializes correctly
+
+    def test_traces_materialize_requests_lean_read(
+        self, project, custom_eval_config, monkeypatch
+    ):
+        trace = Trace.objects.create(project=project, name="tr-lean")
+        root = ObservationSpan.objects.create(
+            id=f"root-lean-{uuid.uuid4().hex[:8]}",
+            project=project,
+            trace=trace,
+            name="root",
+            observation_type="llm",
+            parent_span_id="",
+        )
+        _seed_past([root])
+        task = _task(project, row_type=RowType.TRACES, evals=[custom_eval_config])
+        spy = _spy_reader(monkeypatch)
+        materialize_pending(task)
+        assert spy.calls.get("list_root_spans_by_trace_ids") is False
+        assert _live(task).count() == 1  # still anchored + materialized


### PR DESCRIPTION
## Why

An eval task on the dev machine (`eval-task-0c496d8f-b54d-4dd9-84ba-a2d3a38bfa12`) failed, and two problems surfaced:

1. **The reconcile activity OOMed ClickHouse.** The `HistoricalEvalTaskWorkflow` failed with `Code: 241 … MEMORY_LIMIT_EXCEEDED … while reading column attributes_extra`. The materialize path hydrated full span rows including the wide JSON columns, even though it only needs `id`/`trace_id`.
2. **The failed workflow left the task stuck `running`.** In Temporal the workflow was `FAILED`, but the DB row (and the UI) still showed `running` — the failure was invisible, and the task looked alive.

## What

**Fix 1 — lean CH read in materialize (commit 1)**
- `_resolve_entry_fks` (the reconcile/materialize FK resolver) reads only `id` + `trace_id`, but called `list_by_ids` / `list_root_spans_by_trace_ids`, which hydrate the full `CHSpan` including `attributes_extra` / `span_events` / `resource_attrs`.
- Added `include_heavy: bool = True` to both readers. When `False`, they use the pre-existing `_LEAN_SELECT_SQL`, which stubs those three fat JSON columns to `''` while keeping the positional row shape (so `_row_to_chspan` / `CHSpan` are unchanged).
- `_resolve_entry_fks` now passes `include_heavy=False` on the spans and traces paths. Default `True` keeps every other caller unchanged.

**Fix 2 — mark task FAILED on workflow failure (commit 2)**
- Wrapped `HistoricalEvalTaskWorkflow.run` and `ContinuousEvalTaskWorkflow.run` in `try/except Exception`. On an unhandled error, `_fail_task` persists `FAILED` to the DB row (UI source of truth) **and** the search attribute, then re-raises so Temporal still records the failure.
- `continue_as_new` (`ContinueAsNewError`) and cancellation (`CancelledError`) are both `BaseException`, so `except Exception` never catches them — control flow is preserved.
- Also fixes the finalize-failure branch, which previously set only the search attribute, not the DB row.

## Tests

**New**
- `TestMaterializeLeanRead::test_spans_materialize_requests_lean_read` — spies the reader, asserts materialize calls `list_by_ids(include_heavy=False)` and still creates the entries.
- `TestMaterializeLeanRead::test_traces_materialize_requests_lean_read` — same for `list_root_spans_by_trace_ids` on the traces path.
- `TestHistoricalWorkflow::test_reconcile_failure_marks_task_failed` — a failing reconcile activity must leave the task `FAILED`, not stuck `running`.

**Existing (updated)**
- `TestHistoricalWorkflow::test_stranded_entry_fails_workflow_not_false_completed` — tightened the assertion from `!= COMPLETED` to `== FAILED`, since the wrapper now persists FAILED to the DB (not just the SA).

## Per-test scenarios

| Test | Scenario | Asserts |
|------|----------|---------|
| `test_spans_materialize_requests_lean_read` | 3 spans, run materialize with a recording reader | reader called with `include_heavy=False`; 3 entries created |
| `test_traces_materialize_requests_lean_read` | 1 trace with a root span | root reader called with `include_heavy=False`; 1 entry created |
| `test_reconcile_failure_marks_task_failed` | reconcile raises, retries exhausted | workflow raises `WorkflowFailureError`; task status == `FAILED` |
| `test_stranded_entry_fails_workflow_not_false_completed` | run_entry + fail both exhaust retries; entry stranded RUNNING | 3 completed, 1 running, task == `FAILED` |

## Commands

```bash
# lean-read (integration) tests — RAN LOCALLY
cd futureagi
uv run pytest tracer/tests/test_eval_entries.py::TestMaterializeLeanRead -v

# workflow (e2e) tests — run in CI (see note below)
uv run pytest tfc/temporal/eval_tasks/tests/test_workflows.py -p no:xdist
```

## Local test steps

1. `docker compose -f docker-compose.test.yml -p futureagi-test up -d`
2. From `futureagi/`, run the lean-read tests above (they use the test ClickHouse via `seed_ch_spans`).

## Terminal output (evidence)

Lean-read tests, run locally:

```
tracer/tests/test_eval_entries.py::TestMaterializeLeanRead::test_spans_materialize_requests_lean_read PASSED [ 50%]
tracer/tests/test_eval_entries.py::TestMaterializeLeanRead::test_traces_materialize_requests_lean_read PASSED [100%]
======================== 2 passed in 481.00s (0:08:00) =========================
```

> **Note on the workflow e2e tests:** the `start_local` Temporal e2e tests do not run in my local environment — they hang during server startup regardless of the change (I confirmed the *pristine, unmodified* `test_stranded_entry…` hangs identically). They are correct by construction (an `ActivityError` is a `temporalio.exceptions.FailureError`, which terminally fails the workflow execution rather than looping as a workflow-task failure) and are expected to run in CI. Flagging this explicitly rather than claiming a green run I didn't observe.

## Architectural rationale

- **Flag over a new method:** `list_by_ids` maps rows positionally onto `CHSpan` via `_row_to_chspan`, so a free-form column selector would break the return type for every caller. Reusing the existing `_LEAN_SELECT_SQL` (heavy columns stubbed, positions preserved) keeps `CHSpan` intact and matches the `include_heavy` convention already used by `roots_by_trace_ids`.
- **Fail in the workflow wrapper, not per-activity:** the DB write must be an activity (no Django in the Temporal sandbox), and centralizing it in one `try/except` around each `run` covers *every* failure path (reconcile, claim, drain, finalize) rather than sprinkling status writes at each call site.
