### PR TITLE
fix(extract-json): use snake_case form fields matching backend contract (TH-6423)

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
@@ -25,9 +25,9 @@ import { isJsonColumn } from "./columnFilterUtils";
 
 const getDefaultValue = () => {
   return {
-    columnId: "",
-    jsonKey: "",
-    newColumnName: "",
+    column_id: "",
+    json_key: "",
+    new_column_name: "",
     concurrency: "",
   };
 };
@@ -42,9 +42,9 @@ export const ExtractJsonKeyChild = ({
 
   const { control, handleSubmit, reset } = useForm({
     defaultValues: {
-      columnId: "",
-      jsonKey: "",
-      newColumnName: "",
+      column_id: "",
+      json_key: "",
+      new_column_name: "",
       concurrency: "",
     },
     resolver: zodResolver(
@@ -127,20 +127,10 @@ export const ExtractJsonKeyChild = ({
     },
   });
 
-  const transformFormToApi = (formValues) => {
-    const { columnId, newColumnName, jsonKey, ...rest } = formValues;
-    return {
-      ...rest,
-      column_id: columnId,
-      new_column_name: newColumnName,
-      json_key: jsonKey,
-    };
-  };
-
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({
-        config: transformFormToApi(formValues),
+        config: formValues,
         operation_type: "extract_json",
       });
       return;
@@ -148,13 +138,13 @@ export const ExtractJsonKeyChild = ({
     if (onFormSubmit) {
       onFormSubmit({ ...formValues, type: "extract_json" });
     } else {
-      addColumn(transformFormToApi(formValues));
+      addColumn(formValues);
     }
   };
 
   const handlePreview = handleSubmit((formValues) => {
     if (!onFormSubmit) {
-      preview(transformFormToApi(formValues));
+      preview(formValues);
     }
   });
 
@@ -212,7 +202,7 @@ export const ExtractJsonKeyChild = ({
               size="small"
               placeholder="Enter column name"
               control={control}
-              fieldName="newColumnName"
+              fieldName="new_column_name"
             />
           )}
           <FormSearchSelectFieldControl
@@ -220,7 +210,7 @@ export const ExtractJsonKeyChild = ({
             label="Column"
             size="small"
             control={control}
-            fieldName="columnId"
+            fieldName="column_id"
             options={columnOptions}
             noOptions={"No suitable column"}
           />
@@ -228,7 +218,7 @@ export const ExtractJsonKeyChild = ({
             label="JSON Key"
             size="small"
             control={control}
-            fieldName="jsonKey"
+            fieldName="json_key"
             placeholder="Enter JSON Path of the key (to be extracted)"
           />
 

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx
@@ -41,12 +41,7 @@ export const ExtractJsonKeyChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
-    defaultValues: {
-      column_id: "",
-      json_key: "",
-      new_column_name: "",
-      concurrency: "",
-    },
+    defaultValues: getDefaultValue(),
     resolver: zodResolver(
       ExtractJsonKeyValidationSchema(!!onFormSubmit, !!editId),
     ),

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/validation.js
@@ -5,9 +5,9 @@ export const ExtractJsonKeyValidationSchema = (
   isEdit = false,
 ) => {
   return z.object({
-    columnId: z.string().min(1, "Column is required"),
-    jsonKey: z.string().min(1, "JSON Key is required"),
-    newColumnName:
+    column_id: z.string().min(1, "Column is required"),
+    json_key: z.string().min(1, "JSON Key is required"),
+    new_column_name:
       isConditionalNode || isEdit
         ? z.string().optional()
         : z.string().min(1, "New Column Name is required"),


### PR DESCRIPTION
## Summary

Extract-JSON-Key drawer's edit view was not populating the `Column`, `JSON Key`, or `Name` fields — only `Concurrency` (which matched by coincidence) rendered correctly.

**Root cause: casing mismatch.** Backend `GET /model-hub/columns/{column_id}/operation-config/` returns the column's `metadata` dict verbatim in snake_case:
```json
{
  "status": true,
  "result": {
    "column_id": "8485d5cf-…",
    "metadata": { "json_key": "id", "column_id": "642e5484-…", "concurrency": 2 }
  }
}
```
FE was reading `data.data.result.metadata` and calling `reset(initialData)` on a form whose fields were declared as `columnId`, `jsonKey`, `newColumnName` (camelCase). Snake-cased keys silently didn't match — form stayed on default (empty) values.

**Fix: rename the form fields to snake_case so they match the backend contract directly.** No transform, no normalization, no fallback — the form now speaks the same shape backend does end-to-end.

Sibling drawers (`Classification`, `ExtractEntities`, `AddColumnApiCall`) go the other way and route through `transformDynamicColumnConfig` to convert snake→camel on load and camel→snake on submit. Kept ExtractJsonKey out of that helper on purpose — its shape is flat + trivial (four scalar fields), so the conversion boilerplate was strictly overhead.

## Changes

`frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/ExtractJsonKey.jsx`
- `defaultValues` + `getDefaultValue()`: `columnId → column_id`, `jsonKey → json_key`, `newColumnName → new_column_name`. `concurrency` unchanged (already matched).
- `fieldName=` on the three `FormTextFieldV2` / `FormSearchSelectFieldControl` instances updated to match.
- Removed the `transformFormToApi(formValues)` snake-case-conversion helper — `onSubmit`, `updateColumn`, `preview`, and the `onFormSubmit` handoff to `ConditionalNodeV2` all send `formValues` directly.

`frontend/src/sections/develop-detail/AddColumn/ExtractJsonKey/validation.js`
- Zod schema keys renamed to match: `columnId → column_id`, `jsonKey → json_key`, `newColumnName → new_column_name`.

Net: **+15 / −25 lines** across two files.

## Linked Issues

Closes TH-6423

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement

## Test plan

- [ ] Open **Add Column → Extract JSON Key** on a dataset with a JSON-shaped column → all four fields blank (existing default behaviour).
- [ ] Fill in `Name`, `Column`, `JSON Key`, `Concurrency`, click **Create New Column** → new column created, POST body has snake_case keys, backend accepts.
- [ ] Click **Test** on a populated form → preview POST also carries snake_case keys, preview renders.
- [ ] Edit an existing extract-json column (drawer opens with `editId` set) → **Column dropdown, JSON Key text field, and Concurrency all pre-populate correctly from the persisted metadata** (regression this PR fixes). Update → PATCH goes through.
- [ ] Inside a **Conditional Node**, add an `extract_json` branch, save the conditional column, reopen → the extract_json sub-form now round-trips correctly.
- [ ] Existing 14 tests in `ExtractJsonKey/__tests__/columnFilter.test.js` pass unchanged.

## Backward compatibility note

Any conditional column already persisted in prod with an `extract_json` branch would have been stored with the *old* camelCase shape (`columnId`, `jsonKey`, `newColumnName`) inside its `branchNodeConfig.config`. Those legacy branches will not pre-populate on edit until the branch is re-saved once — same failure mode as the top-level bug, isolated to legacy conditional-node data. If that turns out to hit real customers, a one-off migration in the backend rewriting `branchNodeConfig.config` keys from camel → snake would resolve it; deferred until we see it in the wild.
