### PR TITLE
fix(experiments): scope v2 experiment list by active org and workspace (TH-6427)

### DIFF
--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -5213,10 +5213,7 @@ class ExperimentListV2APIView(generics.ListAPIView):
 
     def get_queryset(self):
         return (
-            ExperimentsTable.objects.filter(
-                dataset__organization=self.request.user.organization,
-                deleted=False,
-            )
+            _scoped_experiment_queryset(self.request)
             .select_related("dataset")
             .prefetch_related("user_eval_template_ids")
             .annotate(


### PR DESCRIPTION
## Summary

Fixes created experiments (incl. TTS) not appearing in the experiment list until a page refresh, in multi-org / multi-workspace sessions. The experiment list API was scoping by the user's default org instead of the active org/workspace, so a newly created experiment was counted on the dataset but returned empty from the list.

## Why / problem

`ExperimentListV2APIView.get_queryset` filtered by `request.user.organization` — the user's **default/home** org, which does not change when the user switches orgs. Meanwhile `GetDatasetsView` (which renders the experiment count on the dataset) resolves the **active** org (`request.organization` → fallback `request.user.organization`).

So in a multi-org session where the active org ≠ default org:

- `GET /model-hub/develops/get-datasets/` → counted the experiment under the active org → dataset showed `number_of_experiments: 1`.
- `GET /model-hub/experiments/v2/list/?dataset_id=…` → filtered `dataset__organization = default_org`, but the experiment's dataset belongs to the active org → **empty list**.

It also skipped workspace scoping entirely. Refresh sometimes "fixed" it only because the active-org context happened to re-establish a match — the list was never reliably correct.

## What changed

Route `ExperimentListV2APIView.get_queryset` through the shared `_scoped_experiment_queryset(self.request)` helper (already used by every other experiment view), which scopes by:

- active organization (`request.organization` → fallback `request.user.organization`), **and**
- active workspace (`_request_workspace_filter`), **and**
- `deleted=False`

```diff
     def get_queryset(self):
         return (
-            ExperimentsTable.objects.filter(
-                dataset__organization=self.request.user.organization,
-                deleted=False,
-            )
+            _scoped_experiment_queryset(self.request)
             .select_related("dataset")
             .prefetch_related("user_eval_template_ids")
             .annotate(models_count=..., agents_count=...)
         )
```

One file: `futureagi/model_hub/views/experiments.py`.

## Tests

No behavior-changing test added in this PR (scoping helper is already covered indirectly); the change swaps to the shared, tested `_scoped_experiment_queryset` used across the experiment views. A dedicated per-org / per-workspace list test can follow up under `model_hub/tests/test_experiment_v2_api.py`.
![Uploading image.png…]()


## Commands

```
# scoped run (local env: install pytest into the backend venv, then)
pytest model_hub/tests/test_experiment_v2_api.py -v
```

## Backwards compatibility

Fully backward compatible. Single-org users are unaffected — the helper falls back to `request.user.organization` when there is no active-org context. No API shape, schema, or contract change.

## Manual verification

- [x] Multi-org session, active org ≠ default org: create a TTS experiment on a dataset in the active org → it appears immediately in `experiments/v2/list` for that dataset (previously empty until refresh).
- [x] Dataset `number_of_experiments` count and the experiment list agree.
- [x] Switch workspace within the org → list scopes to the active workspace.
- [x] Single-org user: no regression.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the existing scoping pattern (`_scoped_experiment_queryset`)
- [x] Self-reviewed; minimal diff
- [x] No new lint errors
- [ ] Tests added/updated (follow-up)

## Backout

Revert the single-file change; behavior returns to filtering by `request.user.organization`.

## Linear

Closes TH-6427
