### PR TITLE
fix(run-tests): auto-run voice simulation on create so the run is visible (TH-6479)

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -499,6 +499,14 @@ const CreateRunTestPage = ({ open, onClose }) => {
   // on slow devices don't cause multiple api calls happening
   // on slower devices
   const isMutatingRef = useRef(false);
+  const executeTestMutation = useMutation({
+    mutationFn: (testId) =>
+      axios.post(endpoints.runTests.runTest(testId), {
+        select_all: false,
+        scenario_ids: formData?.selectedScenarios || [],
+      }),
+  });
+
   const createTestMutation = useMutation({
     /**
      *
@@ -514,11 +522,22 @@ const CreateRunTestPage = ({ open, onClose }) => {
     onSettled: () => {
       isMutatingRef.current = false;
     },
-    onSuccess: (data) => {
-      enqueueSnackbar("Test created successfully!", { variant: "success" });
+    onSuccess: async (data) => {
+      if (formData?.agentType === AGENT_TYPES.VOICE) {
+        try {
+          await executeTestMutation.mutateAsync(data.id);
+          enqueueSnackbar("Simulation run started", { variant: "success" });
+        } catch (error) {
+          enqueueSnackbar("Test created, but the run could not be started.", {
+            variant: "error",
+          });
+        }
+      } else {
+        enqueueSnackbar("Test created successfully!", { variant: "success" });
+      }
+
       onClose();
       navigate(`/dashboard/simulate/test/${data.id}/runs`);
-      // Navigate to run tests list page
     },
   });
   const handleSubmit = async () => {


### PR DESCRIPTION
## Summary

After a **voice** simulation is created, automatically kick off one run instead of leaving the user to press "Run" on the runs page. Chat/text simulations are unchanged.

## Why / problem

Fixes TH-6479 — running a voice sim left the user on the runs page with **no simulated run visible**, because creation navigated to the runs list without starting an execution. For voice, the expected flow is "create → it starts running", so the run now appears immediately.

## What changed

`frontend/src/components/run-tests/CreateRunTestPage.jsx`:
- Added an `executeTestMutation` (`useMutation`) that POSTs to the existing run-test execute endpoint (`/simulate/run-tests/{id}/execute/`) with `{ select_all: false, scenario_ids }` — matching the pattern used in `TestRunHeader`.
- In `createTestMutation.onSuccess`, when `agentType === AGENT_TYPES.VOICE`, it awaits `executeTestMutation.mutateAsync(testId)` with all selected scenarios, then navigates to the runs page.
- **Chat/text**: unchanged — navigates only, no auto-run.
- **One toast per outcome**: "Simulation run started" (voice success), "Test created, but the run could not be started." (voice run failed — e.g. entitlement gate), or "Test created successfully!" (chat/text).

## Tests

Manual (no auto test for this flow):

- [ ] Create a **voice** simulation → one run auto-starts (visible/running on the runs page); single "Simulation run started" toast
- [ ] Auto-run uses the scenarios selected during creation
- [ ] Create a **chat/text** simulation → no run starts; "Test created successfully!"; lands on runs page as before
- [ ] Voice create where the org lacks the voice entitlement → test still created, "…run could not be started." toast, navigation still happens
- [ ] Exactly one run is created (no duplicates), and exactly one toast

## Commands

```
npx eslint src/components/run-tests/CreateRunTestPage.jsx
```

## Backwards compatibility

Additive, frontend-only. No API/schema change; reuses the existing execute endpoint. Non-voice behavior is identical to before.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lints clean (0 errors)
- [x] Single-file, minimal diff
- [x] Reuses existing execute endpoint / mutation pattern (no new API)

## Backout

Revert the single commit; create returns to navigate-only for all agent types.

## Linear

Closes TH-6479
