### PR TITLE
fix(prompt): make Metrics/Linked-Traces filters work (TH-6417)

### DIFF
--- a/frontend/src/components/ComplexFilter/ComplexFilter.jsx
+++ b/frontend/src/components/ComplexFilter/ComplexFilter.jsx
@@ -55,6 +55,7 @@ const ComplexFilter = ({
   setFilters,
   filterDefinition,
   onClose,
+  className,
 }) => {
   const addFilter = useCallback(() => {
     setFilters(() => [...filters, { ...defaultFilter, id: getRandomId() }]);
@@ -141,6 +142,7 @@ const ComplexFilter = ({
 
   return (
     <Box
+      className={className}
       sx={{
         display: "flex",
         flexDirection: "column",
@@ -159,6 +161,7 @@ const ComplexFilter = ({
         </Typography>
       </Box> */}
       <Box
+        className="cf-rows"
         sx={{
           border: "1px solid",
           borderRadius: "8px",
@@ -181,6 +184,7 @@ ComplexFilter.propTypes = {
   setFilters: PropTypes.func,
   filterDefinition: PropTypes.array,
   onClose: PropTypes.func,
+  className: PropTypes.string,
 };
 
 export default ComplexFilter;

--- a/frontend/src/components/ComplexFilter/FilterRow.jsx
+++ b/frontend/src/components/ComplexFilter/FilterRow.jsx
@@ -270,6 +270,7 @@ const FilterRow = ({
 
   return (
     <Box
+      className="cf-row"
       sx={{
         display: "flex",
         alignItems: "center",
@@ -277,6 +278,7 @@ const FilterRow = ({
       }}
     >
       <Box
+        className="cf-row__controls"
         sx={{
           display: "flex",
           alignItems: "center",
@@ -394,7 +396,7 @@ const FilterRow = ({
           />
         </IconButton>
       </Box>
-      <Box>
+      <Box className="cf-row__add">
         <ShowComponent condition={index === 0}>
           <Button
             onClick={addFilter}

--- a/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
@@ -45,7 +45,7 @@ const LinkedTracesContent = () => {
   const [showEmptyState, setShowEmptyState] = useState(false);
 
   const hasActiveFiltersOrSearch = useMemo(() => {
-    const hasFilters = filters?.some((f) => f.columnId !== "");
+    const hasFilters = filters?.some((f) => f.column_id);
     const hasSearch = debouncedSearchQuery?.length > 0;
     return hasFilters || hasSearch;
   }, [filters, debouncedSearchQuery]);
@@ -171,11 +171,11 @@ const LinkedTracesContent = () => {
         try {
           setIsLoading(true);
 
-          // If filter is name, change it to spanName
+          // The span-name column's id is "name" but the backend filter map keys it "span_name".
           const validFilters = filters?.reduce((acc, f) => {
-            if (f.columnId === "") return acc;
+            if (!f.column_id) return acc;
             acc.push(
-              f.columnId === "name" ? { ...f, columnId: "spanName" } : f,
+              f.column_id === "name" ? { ...f, column_id: "span_name" } : f,
             );
             return acc;
           }, []);

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
@@ -11,6 +11,24 @@ import { useWorkbenchMetrics } from "../context/WorkbenchMetricsContext";
 import { getRandomId } from "src/utils/utils";
 import { buildFilterDefinitions, defaultFilterBase } from "../common";
 import ComplexFilter from "src/components/ComplexFilter/ComplexFilter";
+import { RANGE_FILTER_OPS } from "src/api/contracts/filter-contract.generated";
+
+const RANGE_OPS = new Set(RANGE_FILTER_OPS);
+const isEmptyValue = (v) => v === "" || v === undefined || v === null;
+
+// A row is applyable only with a complete value: range ops need both bounds;
+// every other op keeps its value at index 0 (NumberValueSelector stores a
+// trailing "" slot), so validate value[0].
+const isFilterComplete = (f) => {
+  if (!f?.column_id) return false;
+  const { filter_op: op, filter_value: value } = f?.filter_config || {};
+  if (Array.isArray(value)) {
+    return RANGE_OPS.has(op)
+      ? value.length >= 2 && !isEmptyValue(value[0]) && !isEmptyValue(value[1])
+      : !isEmptyValue(value[0]);
+  }
+  return !isEmptyValue(value);
+};
 
 const MetricFilterDrawer = React.memo(() => {
   const {
@@ -83,27 +101,15 @@ const MetricFilterDrawer = React.memo(() => {
   }, [setIsFilterDrawerOpen]);
 
   const handleApplyFilters = useCallback(() => {
-    const isEmpty = (v) => v === "" || v === undefined || v === null;
-    const validFilters = tempFilters.filter((f) => {
-      const value = f?.filter_config?.filter_value;
-      return Array.isArray(value)
-        ? f?.column_id && value.length > 0 && !value.some(isEmpty)
-        : f?.column_id && !isEmpty(value);
-    });
-
+    const validFilters = tempFilters.filter(isFilterComplete);
     setFilters(validFilters.length ? validFilters : getDefaultFilter());
     handleClose();
   }, [tempFilters, setFilters, handleClose]);
 
-  const hasValidFilters = useMemo(() => {
-    return tempFilters.some((f) => {
-      const value = f?.filter_config?.filter_value;
-      return (
-        f?.column_id ||
-        (value !== "" && !(Array.isArray(value) && value.length === 0))
-      );
-    });
-  }, [tempFilters]);
+  const hasValidFilters = useMemo(
+    () => tempFilters.some(isFilterComplete),
+    [tempFilters],
+  );
 
   const handleCancel = useCallback(() => {
     handleClose();

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
@@ -10,7 +10,7 @@ import Iconify from "src/components/iconify";
 import { useWorkbenchMetrics } from "../context/WorkbenchMetricsContext";
 import { getRandomId } from "src/utils/utils";
 import { buildFilterDefinitions, defaultFilterBase } from "../common";
-import LLMFilterBox from "src/sections/projects/LLMTracing/LLMFilterBox";
+import ComplexFilter from "src/components/ComplexFilter/ComplexFilter";
 
 const MetricFilterDrawer = React.memo(() => {
   const {
@@ -47,42 +47,35 @@ const MetricFilterDrawer = React.memo(() => {
   }, [activeTab, setFilters]);
 
   useEffect(() => {
-    if (isFilterDrawerOpen) {
-      const normalizedFilters = filters.map((f) => {
-        const newFilter = { ...f };
+    if (!isFilterDrawerOpen) return;
 
-        // ✅ Normalize number filters into string arrays
-        if (newFilter.filterConfig?.filterType === "number") {
-          const value = newFilter.filterConfig.filterValue;
-
-          if (typeof value === "number") {
-            newFilter.filterConfig.filterValue = [String(value), ""];
-          } else if (Array.isArray(value)) {
-            newFilter.filterConfig.filterValue = value.map((v) =>
-              v === "" ? "" : String(v),
-            );
-          }
-        }
-
-        // ✅ Normalize date filters into array form for the drawer
-        if (newFilter.filterConfig?.filterType === "date") {
-          const value = newFilter.filterConfig.filterValue;
-
-          if (typeof value === "string") {
-            // single-value ops → wrap into array
-            newFilter.filterConfig.filterValue = [value, "0"];
-          } else if (Array.isArray(value)) {
-            // already array, just keep as is
-            newFilter.filterConfig.filterValue = value;
-          }
-        }
-
-        return newFilter;
+    // Quick filters are appended API-shaped (no `_meta.parentProperty`/`id`) and
+    // sit alongside the empty default draft. Drop empty drafts and rebuild the
+    // property link from `column_id` so each applied filter shows as a real,
+    // editable row instead of a blank "Select Option".
+    const hydrated = (filters || [])
+      .filter((f) => f?.column_id)
+      .map((f) => {
+        if (f._meta?.parentProperty && f.id) return f;
+        const def = filterDefs.find(
+          (d) => d.propertyId === f.column_id || d.propertyName === f.column_id,
+        );
+        return {
+          ...f,
+          id: f.id || getRandomId(),
+          _meta: {
+            ...f._meta,
+            parentProperty:
+              f._meta?.parentProperty ||
+              def?.propertyId ||
+              def?.propertyName ||
+              f.column_id,
+          },
+        };
       });
 
-      setTempFilters(normalizedFilters);
-      setTempFilterDefs(filterDefs);
-    }
+    setTempFilters(hydrated.length ? hydrated : getDefaultFilter());
+    setTempFilterDefs(filterDefs);
   }, [isFilterDrawerOpen, filters, filterDefs]);
 
   const handleClose = useCallback(() => {
@@ -90,74 +83,26 @@ const MetricFilterDrawer = React.memo(() => {
   }, [setIsFilterDrawerOpen]);
 
   const handleApplyFilters = useCallback(() => {
-    const validFilters = tempFilters
-      .filter(
-        (f) =>
-          f?.columnId ||
-          (f?.filterConfig?.filterValue !== "" &&
-            !(
-              Array.isArray(f.filterConfig.filterValue) &&
-              f.filterConfig.filterValue.length === 0
-            )),
-      )
-      .map((f) => {
-        const newFilter = { ...f };
-
-        const def =
-          filterDefs.find((d) => d.propertyId === f.columnId) ||
-          filterDefs
-            .find((d) => d.propertyName === "Evaluation Metrics")
-            ?.dependents.find((d) => d.propertyId === f.columnId);
-
-        if (def?.filterType?.type) {
-          if (def.filterType.type === "option") {
-            newFilter.filterConfig.filterType = "array";
-          } else if (
-            newFilter.filterConfig.filterType !== "array" &&
-            newFilter.filterConfig.filterType !== "option"
-          ) {
-            newFilter.filterConfig.filterType = def.filterType.type;
-          }
-        }
-
-        // 🔹 Normalize number filter values
-        if (newFilter.filterConfig.filterType === "number") {
-          const values = newFilter.filterConfig.filterValue;
-
-          if (Array.isArray(values)) {
-            const numericValues = values.filter((v) => v !== "").map(Number);
-
-            if (numericValues.length === 1) {
-              newFilter.filterConfig.filterValue = numericValues[0];
-            } else {
-              newFilter.filterConfig.filterValue = numericValues;
-            }
-          } else if (typeof values === "string" && values.trim() !== "") {
-            newFilter.filterConfig.filterValue = Number(values);
-          }
-        }
-
-        if (newFilter._meta?.parentProperty === "Evaluation Metrics") {
-          newFilter.col_type = "PROMPT_METRIC";
-        }
-
-        return newFilter;
-      });
+    const isEmpty = (v) => v === "" || v === undefined || v === null;
+    const validFilters = tempFilters.filter((f) => {
+      const value = f?.filter_config?.filter_value;
+      return Array.isArray(value)
+        ? f?.column_id && value.length > 0 && !value.some(isEmpty)
+        : f?.column_id && !isEmpty(value);
+    });
 
     setFilters(validFilters.length ? validFilters : getDefaultFilter());
     handleClose();
-  }, [tempFilters, setFilters, handleClose, filterDefs]);
+  }, [tempFilters, setFilters, handleClose]);
 
   const hasValidFilters = useMemo(() => {
-    return tempFilters.some(
-      (f) =>
-        f?.columnId ||
-        (f?.filterConfig?.filterValue !== "" &&
-          !(
-            Array.isArray(f.filterConfig.filterValue) &&
-            f.filterConfig.filterValue.length === 0
-          )),
-    );
+    return tempFilters.some((f) => {
+      const value = f?.filter_config?.filter_value;
+      return (
+        f?.column_id ||
+        (value !== "" && !(Array.isArray(value) && value.length === 0))
+      );
+    });
   }, [tempFilters]);
 
   const handleCancel = useCallback(() => {
@@ -169,13 +114,20 @@ const MetricFilterDrawer = React.memo(() => {
     handleClose();
   };
 
+  const handleAddFilter = useCallback(() => {
+    setTempFilters((prev) => [
+      ...(prev?.length ? prev : []),
+      { ...defaultFilterBase, id: getRandomId() },
+    ]);
+  }, []);
+
   const drawerStyles = useMemo(
     () => ({
       height: "100vh",
       position: "fixed",
       borderRadius: "0px !important",
       backgroundColor: "background.paper",
-      width: "36vw",
+      width: "clamp(560px, 46vw, 720px)",
       display: "flex",
       flexDirection: "column",
     }),
@@ -224,6 +176,47 @@ const MetricFilterDrawer = React.memo(() => {
       pr: 1, // Padding for scrollbar
       display: "flex",
       flexDirection: "column",
+      // Restyle ComplexFilter into stacked cards via its stable class hooks
+      // (className="cf-cards") rather than positional selectors.
+      "& .cf-cards .cf-rows": {
+        border: "none",
+        p: 0,
+        gap: 3,
+      },
+      "& .cf-cards .cf-row": {
+        position: "relative",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "10px",
+        px: 1.5,
+        pt: 2,
+        pb: 1.25,
+        flexWrap: "wrap",
+        rowGap: 1,
+      },
+      "& .cf-cards .cf-row:not(:first-of-type)::before": {
+        content: '"AND"',
+        position: "absolute",
+        top: "-18px",
+        left: "2px",
+        fontSize: "11px",
+        fontWeight: 600,
+        letterSpacing: "0.5px",
+        color: "text.disabled",
+      },
+      "& .cf-cards .cf-row__controls": {
+        flexWrap: "nowrap",
+        alignItems: "center",
+        gap: 1,
+        minWidth: 0,
+        "& > *": { minWidth: 0 },
+        "& > .MuiTypography-root": { flexShrink: 0, minWidth: "max-content" },
+        "& > :first-child": { flex: "1 1 auto", maxWidth: "240px" },
+        "& > :last-child": { flexShrink: 0 },
+      },
+      "& .cf-cards .cf-row__add": {
+        display: "none", // FilterRow's inline add — replaced by the button below
+      },
     }),
     [],
   );
@@ -253,14 +246,35 @@ const MetricFilterDrawer = React.memo(() => {
           <Typography variant="h6">Filters</Typography>
         </Box>
         <Box sx={scrollableContentStyles}>
-          <LLMFilterBox
+          <ComplexFilter
+            className="cf-cards"
             filters={tempFilters}
             setFilters={setTempFilters}
             filterDefinition={tempFilterDefs}
-            setFilterDefinition={setTempFilterDefs}
             defaultFilter={defaultFilterBase}
-            resetFiltersAndClose={resetFiltersAndClose}
+            onClose={resetFiltersAndClose}
           />
+          <Button
+            fullWidth
+            variant="outlined"
+            startIcon={<Iconify icon="ic:round-plus" />}
+            onClick={handleAddFilter}
+            sx={{
+              mt: 3,
+              py: 1,
+              borderStyle: "dashed",
+              borderColor: "divider",
+              color: "text.secondary",
+              textTransform: "none",
+              "&:hover": {
+                borderStyle: "dashed",
+                borderColor: "text.disabled",
+                backgroundColor: "action.hover",
+              },
+            }}
+          >
+            Add Filter
+          </Button>
         </Box>
         <Box sx={actionButtonStyles}>
           <Button

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricFilterDrawer/MetricFilterDrawer.jsx
@@ -30,6 +30,8 @@ const isFilterComplete = (f) => {
   return !isEmptyValue(value);
 };
 
+const isBlankDraft = (f) => !f?.column_id;
+
 const MetricFilterDrawer = React.memo(() => {
   const {
     isFilterDrawerOpen,
@@ -107,7 +109,9 @@ const MetricFilterDrawer = React.memo(() => {
   }, [tempFilters, setFilters, handleClose]);
 
   const hasValidFilters = useMemo(
-    () => tempFilters.some(isFilterComplete),
+    () =>
+      tempFilters.some(isFilterComplete) &&
+      tempFilters.every((f) => isBlankDraft(f) || isFilterComplete(f)),
     [tempFilters],
   );
 

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
@@ -37,7 +37,7 @@ const MetricsContent = () => {
   const { id } = useParams();
 
   const hasActiveFiltersOrSearch = useMemo(() => {
-    const hasFilters = filters?.some((f) => f.columnId !== "");
+    const hasFilters = filters?.some((f) => f.column_id);
     return hasFilters;
   }, [filters]);
 
@@ -161,7 +161,7 @@ const MetricsContent = () => {
       getRows: async (params) => {
         try {
           setIsLoading(true);
-          const validFilters = filters?.filter((f) => f.columnId !== "");
+          const validFilters = filters?.filter((f) => f.column_id);
           // --- API Request ---
           const response = await axios.get(
             endpoints.develop.runPrompt.getPromptMetrics(),

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricsHeaderSection.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricsHeaderSection.jsx
@@ -45,12 +45,13 @@ const MetricsHeaderSection = () => {
 
   const appliedFilterCount = useMemo(() => {
     if (!filters?.length) return 0;
-    return filters.filter(
-      (f) =>
-        f?.columnId ||
-        (f?.filterConfig?.filterValue !== "" &&
-          f?.filterConfig?.filterValue?.length !== 0),
-    ).length;
+    return filters.filter((f) => {
+      const value = f?.filter_config?.filter_value;
+      return (
+        f?.column_id ||
+        (value !== "" && !(Array.isArray(value) && value.length === 0))
+      );
+    }).length;
   }, [filters]);
 
   return (

--- a/frontend/src/sections/workbench/createPrompt/Metrics/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/common.js
@@ -8,7 +8,7 @@ import { RENDERER_CONFIG } from "src/sections/projects/LLMTracing/Renderers/comm
 import { NameCell } from "src/sections/projects/LLMTracing/Renderers";
 import IPOPCell from "src/sections/projects/LLMTracing/Renderers/IPOPCell";
 import IPOPTooltipComponent from "src/sections/projects/LLMTracing/Renderers/IPOPTooltipComponent";
-import { buildApiFilterFromPanelRow } from "src/api/contracts/filter-contract";
+import { serializeFilterListForApi } from "src/api/contracts/filter-contract";
 
 const LABEL_BG_COLORS = {
   [LABELS.PRODUCTION]: "green.o10",
@@ -94,11 +94,11 @@ export const getMetricsTabSx = (theme) => ({
 });
 
 export const defaultFilterBase = {
-  columnId: "",
-  filterConfig: {
-    filterType: "",
-    filterOp: "",
-    filterValue: "",
+  column_id: "",
+  filter_config: {
+    filter_type: "",
+    filter_op: "",
+    filter_value: "",
   },
 };
 
@@ -107,26 +107,23 @@ export const getDefaultFilter = () => [
 ];
 
 export const normalizeFilters = (filters = []) => {
-  return filters
-    .filter((filter) => {
-      // Filter out invalid filters
-      return (
-        filter.columnId &&
-        filter.filterConfig?.filterType &&
-        filter.filterConfig?.filterOp &&
-        filter.filterConfig?.filterValue !== undefined &&
-        filter.filterConfig?.filterValue !== null &&
-        filter.filterConfig?.filterValue !== ""
-      );
-    })
-    .map((filter) =>
-      buildApiFilterFromPanelRow({
-        field: filter.columnId,
-        fieldType: filter.filterConfig.filterType,
-        operator: filter.filterConfig.filterOp,
-        value: filter.filterConfig.filterValue,
-      }),
+  const ready = filters.filter((filter) => {
+    const value = filter?.filter_config?.filter_value;
+    return (
+      filter?.column_id &&
+      filter?.filter_config?.filter_type &&
+      filter?.filter_config?.filter_op &&
+      value !== undefined &&
+      value !== null &&
+      value !== "" &&
+      !(
+        Array.isArray(value) &&
+        value.filter((v) => v !== "" && v !== null && v !== undefined)
+          .length === 0
+      )
     );
+  });
+  return serializeFilterListForApi(ready);
 };
 
 // mapping col.name => filter type config
@@ -224,6 +221,7 @@ export const getMetricsListColumnDefs = (col) => {
     headerName: col.name,
     field: col.id,
     hide: !col?.is_visible,
+    context: { sourceColumn: col },
     cellStyle: (params) => {
       const value = params.value;
       if (isCellValueEmpty(value)) {


### PR DESCRIPTION
## Bug
Filters in the Prompt → **Metrics** and **Linked Traces** tabs did not work. The tabs sent filters in a camelCase shape that no longer matched the backend contract, so filter selections were silently ignored (grid returned unfiltered data), and switching to the shared filter drawer crashed on text/boolean rows.

Linear: TH-6417

## Changes
- Migrate the Metrics and Linked-Traces filter drawer to the canonical **snake_case** filter contract (`{ column_id, filter_config: { filter_type, filter_op, filter_value } }`) and reuse the shared **ComplexFilter** component (routes every type through the migrated, snake-aware value selectors).
- Add inert **class hooks** to ComplexFilter/FilterRow — `cf-cards` / `cf-rows` / `cf-row` / `cf-row__controls` / `cf-row__add` — so the drawer styles the stacked-card layout via stable classes instead of positional `> div > div > div` selectors. The classes carry no CSS in the shared component, so its other consumers are unaffected.
- Remap the span-name filter column id (`name` → `span_name`) to match the backend filter field map on the span endpoint.
- On Apply, drop filter rows whose value is incomplete (e.g. a `between` range with a blank bound like `[1, ""]`) so malformed filters are never persisted, counted, or sent.

## Why
The prompt tabs were still on the pre-migration camelCase filter shape while the backend/contract had moved to snake_case, so filters never applied. Reusing ComplexFilter (already on the snake_case contract) fixes it without a bespoke filter UI, and the class hooks make the drawer's card styling resilient to markup changes in the shared component.

## Test-case scenarios
- Metrics tab: filter each column (Versions, Label Name, Median Input/Output Tokens, No. of traces, Median Cost/Latency, First/Last Used) → grid filters correctly for every reachable operator.
- Linked Traces tab: filter Versions, Label Name, Span name, Trace Id, Span Id, Session Id → all apply and return the expected subset.
- Numeric range with one bound filled (e.g. Median Cost `between 1 and <blank>`) → row is dropped on Apply instead of sending a malformed range.
- Search box on Linked Traces matches span name / version as before.

## How to reproduce
1. Open a prompt → **Metrics** (and **Linked Traces**) tab.
2. Open the **Filters** drawer, add a filter on any column, set a value, **Apply**.
3. Before: the grid ignores the filter (unfiltered rows) / drawer crashes on text filters.
4. After: the grid returns the filtered rows.

## Commands
```bash
yarn lint      # clean on all changed files
```

## Videos / Screenshots

https://github.com/user-attachments/assets/5cf0fff2-ea03-4b8a-853f-e1e4b239a1e5

