### PR TITLE
fix(tracer): skip ingestion rate limiting when EE RateLimiter unavailable

### DIFF
--- a/futureagi/tracer/services/grpc.py
+++ b/futureagi/tracer/services/grpc.py
@@ -65,11 +65,11 @@ class ObservationSpanService(generics.GenericService, TraceServiceServicer):
 
             # Ingestion rate limit check
             try:
-                try:
-                    from ee.usage.services.rate_limiter import RateLimiter
-                except ImportError:
-                    RateLimiter = None
+                from ee.usage.services.rate_limiter import RateLimiter
+            except ImportError:
+                RateLimiter = None
 
+            if RateLimiter is not None:
                 rl_result = await sync_to_async(RateLimiter.check)(
                     str(organization_id), "ingestion"
                 )
@@ -77,8 +77,6 @@ class ObservationSpanService(generics.GenericService, TraceServiceServicer):
                     await context.abort(
                         grpc.StatusCode.RESOURCE_EXHAUSTED, rl_result.reason
                     )
-            except ImportError:
-                pass
 
             request_bytes = request.SerializeToString()
 

--- a/futureagi/tracer/tests/test_grpc_otlp.py
+++ b/futureagi/tracer/tests/test_grpc_otlp.py
@@ -138,6 +138,38 @@ class TestObservationSpanServiceUnit:
 
         asyncio.run(run_test())
 
+    @patch("tracer.services.grpc.bulk_create_observation_span_task")
+    def test_export_skips_rate_limit_when_unavailable(self, mock_task):
+        """OSS builds without EE rate limiting should still ingest traces."""
+
+        async def run_test():
+            mock_task.apply_async.return_value = None
+
+            mock_org = MagicMock()
+            mock_org.id = "00000000-0000-0000-0000-000000000123"
+
+            mock_user = MagicMock()
+            mock_user.id = "00000000-0000-0000-0000-000000000456"
+            mock_user.organization = mock_org
+
+            mock_context = MagicMock()
+            mock_context.user = mock_user
+            mock_context.abort = AsyncMock()
+
+            service = ObservationSpanService()
+            request = create_test_otlp_request()
+
+            with patch("ee.usage.services.rate_limiter.RateLimiter", None), patch(
+                "tracer.services.grpc.payload_storage.store", return_value="payload-key"
+            ):
+                response = await service.Export(request, mock_context)
+
+            assert isinstance(response, ExportTraceServiceResponse)
+            mock_context.abort.assert_not_called()
+            assert mock_task.apply_async.called
+
+        asyncio.run(run_test())
+
     def test_export_no_organization(self):
         """Test Export fails when user has no organization."""
 

--- a/futureagi/tracer/views/otlp.py
+++ b/futureagi/tracer/views/otlp.py
@@ -111,11 +111,12 @@ class OTLPTraceView(APIView):
                 except ImportError:
                     RateLimiter = None
 
-                rl_result = RateLimiter.check(organization_id, "ingestion")
-                if not rl_result.allowed:
-                    response = self._error_response(request, rl_result.reason, 429)
-                    response["Retry-After"] = str(rl_result.retry_after)
-                    return response
+                if RateLimiter is not None:
+                    rl_result = RateLimiter.check(organization_id, "ingestion")
+                    if not rl_result.allowed:
+                        response = self._error_response(request, rl_result.reason, 429)
+                        response["Retry-After"] = str(rl_result.retry_after)
+                        return response
             except ImportError:
                 pass
 


### PR DESCRIPTION
## Summary

Both `tracer/services/grpc.py` and `tracer/views/otlp.py` fall back to `RateLimiter = None` when the EE-only `ee.usage.services.rate_limiter` module can't be imported, but then unconditionally call `RateLimiter.check(...)` anyway. In OSS builds (no `ee` module) this raises `AttributeError: 'NoneType' object has no attribute 'check'` on every trace export, breaking trace ingestion via both gRPC and HTTP/OTLP. 
## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. `tracer/services/grpc.py` (gRPC trace ingestion)**

- Guard the rate-limit check with `if RateLimiter is not None:` instead of relying on catching `ImportError` around the `.check()` call (which never fires, since the failure mode is `AttributeError` on `None`, not `ImportError`).

**B. `tracer/views/otlp.py` (HTTP/OTLP trace ingestion)**

- Same guard applied to the HTTP ingestion path.

**C. `tracer/tests/test_grpc_otlp.py`**

- Added `test_export_skips_rate_limit_when_unavailable`, which patches `RateLimiter` to `None` and asserts `Export` still succeeds (doesn't abort, still enqueues the ingestion task).

## 2) Why the changes were done

- **Technical:** Previously, when `RateLimiter` import fails (OSS builds without the `ee` submodule), `RateLimiter` is set to `None`, but the code still called `RateLimiter.check(...)` unguarded. That raises `AttributeError`, which is not caught by the surrounding `except ImportError`, so it propagates and breaks every trace export in OSS deployments.
- **Architecture:** No architectural change — this is a straight cherry-pick of the fix that already shipped on `dev` (commits `564962ce3` and `5dc85ad2c`), isolated from the unrelated deployment-telemetry feature those commits were bundled with.

## 3) Tests written + scenarios each covers

**`tracer/tests/test_grpc_otlp.py`** — gRPC trace export behavior when EE rate limiting is unavailable

- `test_export_skips_rate_limit_when_unavailable` — with `RateLimiter` patched to `None`, `Export` completes successfully, doesn't call `context.abort`, and still enqueues `bulk_create_observation_span_task`

This test (and both fixes) already passed CI on `dev` as part of #891.

## 6) Edge cases & considerations

- EE deployments (where `RateLimiter` imports successfully) are unaffected — the rate-limit check still runs exactly as before.
- Applies identically to both the gRPC and HTTP/OTLP ingestion paths, since both had the same latent bug.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective (carried over from `dev`)
- [x] No hardcoded secrets, URLs, or PII