### PR TITLE
refactor(evals): route error-localizer skip gate through shared pass_threshold resolver

### DIFF
--- a/futureagi/ai_tools/tools/evaluations/trigger_error_localization.py
+++ b/futureagi/ai_tools/tools/evaluations/trigger_error_localization.py
@@ -214,6 +214,7 @@ class TriggerErrorLocalizationTool(BaseTool):
             value=eval_result,
             mapping=mappings,
             eval_explanation=eval_explanation,
+            eval_config=config,
         )
         if not task:
             return ToolResult.error(

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -147,20 +147,7 @@ def resolve_pass_threshold(
     runtime_config: dict | None = None,
     resolved_version=None,
 ) -> float:
-    """Resolve pass_threshold using the engine's layered semantics.
-
-    Priority (highest to lowest):
-      1. runtime_config["run_config"]["pass_threshold"]  - per-binding picker override
-      2. runtime_config["pass_threshold"]                 - flat top-level (tracing / composite / SDK)
-      3. resolved_version.pass_threshold                  - pinned-version snapshot
-      4. eval_template.pass_threshold                     - template default
-      5. 0.5                                              - hard fallback
-
-    Single source of truth for pass_threshold resolution. Callers that
-    need the runtime-effective threshold (engine evaluators, error-
-    localizer triggers) all route through this function so semantics
-    stay identical across surfaces.
-    """
+    """Priority: runtime_config[run_config][pass_threshold] > runtime_config[pass_threshold] > resolved_version.pass_threshold > eval_template.pass_threshold > 0.5."""
     if isinstance(runtime_config, dict):
         run_config = runtime_config.get("run_config") or {}
         if isinstance(run_config, dict) and run_config.get("pass_threshold") is not None:
@@ -466,10 +453,6 @@ def create_eval_instance(
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
 
-    # Single source of truth for pass_threshold — collapses template default,
-    # version snapshot, and runtime_config picker override into one value.
-    # The `_RUNTIME_ALLOWED_KEYS` merge below re-applies the run_config picker
-    # override; identical value, no-op for pass_threshold specifically.
     config["pass_threshold"] = resolve_pass_threshold(
         eval_template, runtime_config, resolved_version
     )

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -453,9 +453,10 @@ def create_eval_instance(
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
 
-    config["pass_threshold"] = resolve_pass_threshold(
-        eval_template, runtime_config, resolved_version
-    )
+    if not eval_template.config.get("function_eval"):
+        config["pass_threshold"] = resolve_pass_threshold(
+            eval_template, runtime_config, resolved_version
+        )
 
     # Runtime override merge.
     #

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -142,6 +142,44 @@ def apply_version_overrides(config, resolved_version, criteria=None):
     return config, criteria
 
 
+def resolve_pass_threshold(
+    eval_template,
+    runtime_config: dict | None = None,
+    resolved_version=None,
+) -> float:
+    """Resolve pass_threshold using the engine's layered semantics.
+
+    Priority (highest to lowest):
+      1. runtime_config["run_config"]["pass_threshold"]  - per-binding picker override
+      2. runtime_config["pass_threshold"]                 - flat top-level (tracing / composite / SDK)
+      3. resolved_version.pass_threshold                  - pinned-version snapshot
+      4. eval_template.pass_threshold                     - template default
+      5. 0.5                                              - hard fallback
+
+    Single source of truth for pass_threshold resolution. Callers that
+    need the runtime-effective threshold (engine evaluators, error-
+    localizer triggers) all route through this function so semantics
+    stay identical across surfaces.
+    """
+    if isinstance(runtime_config, dict):
+        run_config = runtime_config.get("run_config") or {}
+        if isinstance(run_config, dict) and run_config.get("pass_threshold") is not None:
+            return float(run_config["pass_threshold"])
+        if runtime_config.get("pass_threshold") is not None:
+            return float(runtime_config["pass_threshold"])
+
+    if resolved_version is not None:
+        version_threshold = getattr(resolved_version, "pass_threshold", None)
+        if version_threshold is not None:
+            return float(version_threshold)
+
+    template_threshold = getattr(eval_template, "pass_threshold", None)
+    if template_threshold is not None:
+        return float(template_threshold)
+
+    return 0.5
+
+
 def _get_api_key(model, organization_id, workspace_id=None):
     """
     Get API key for the model via LiteLLMModelManager.
@@ -427,6 +465,14 @@ def create_eval_instance(
 
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
+
+    # Single source of truth for pass_threshold — collapses template default,
+    # version snapshot, and runtime_config picker override into one value.
+    # The `_RUNTIME_ALLOWED_KEYS` merge below re-applies the run_config picker
+    # override; identical value, no-op for pass_threshold specifically.
+    config["pass_threshold"] = resolve_pass_threshold(
+        eval_template, runtime_config, resolved_version
+    )
 
     # Runtime override merge.
     #

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -453,7 +453,7 @@ def create_eval_instance(
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
 
-    if not eval_template.config.get("function_eval"):
+    if not (eval_template.config or {}).get("function_eval"):
         config["pass_threshold"] = resolve_pass_threshold(
             eval_template, runtime_config, resolved_version
         )

--- a/futureagi/evaluations/engine/tests/test_resolve_pass_threshold.py
+++ b/futureagi/evaluations/engine/tests/test_resolve_pass_threshold.py
@@ -1,16 +1,4 @@
-"""Tests for `evaluations.engine.instance.resolve_pass_threshold`.
-
-Pins the layered resolution used by both the engine (for evaluator instantiation)
-and the error-localizer trigger sites (for EL Pass/Fail gating). Single source of
-truth for pass_threshold semantics.
-
-Priority (highest to lowest):
-  1. runtime_config["run_config"]["pass_threshold"]  - picker override
-  2. runtime_config["pass_threshold"]                 - flat top-level
-  3. resolved_version.pass_threshold                  - version snapshot
-  4. eval_template.pass_threshold                     - template default
-  5. 0.5                                              - hard fallback
-"""
+"""Layered resolution: run_config > flat top-level > version > template > 0.5."""
 
 from __future__ import annotations
 
@@ -31,25 +19,17 @@ def _version(**overrides):
     return SimpleNamespace(**defaults)
 
 
-# Layer 1 — run_config picker
-
-
 def test_run_config_pass_threshold_wins_over_everything():
     template = _template(pass_threshold=0.5)
     version = _version(pass_threshold=0.7)
     runtime_config = {"run_config": {"pass_threshold": 0.9}, "pass_threshold": 0.8}
-    assert (
-        resolve_pass_threshold(template, runtime_config, version) == 0.9
-    )
+    assert resolve_pass_threshold(template, runtime_config, version) == 0.9
 
 
 def test_run_config_zero_is_honoured():
     template = _template(pass_threshold=0.5)
     runtime_config = {"run_config": {"pass_threshold": 0}}
     assert resolve_pass_threshold(template, runtime_config) == 0.0
-
-
-# Layer 2 — flat top-level (tracing / composite / SDK)
 
 
 def test_flat_top_level_wins_over_version_and_template():
@@ -65,9 +45,6 @@ def test_flat_top_level_ignored_when_run_config_present():
     assert resolve_pass_threshold(template, runtime_config) == 0.9
 
 
-# Layer 3 — version
-
-
 def test_version_wins_over_template_when_no_runtime_override():
     template = _template(pass_threshold=0.5)
     version = _version(pass_threshold=0.7)
@@ -81,11 +58,8 @@ def test_version_none_falls_through_to_template():
 
 def test_version_without_pass_threshold_attribute_falls_through():
     template = _template(pass_threshold=0.5)
-    version = SimpleNamespace()  # no pass_threshold attr
+    version = SimpleNamespace()
     assert resolve_pass_threshold(template, None, version) == 0.5
-
-
-# Layer 4 — template default
 
 
 def test_template_default_when_no_runtime_no_version():
@@ -93,15 +67,9 @@ def test_template_default_when_no_runtime_no_version():
     assert resolve_pass_threshold(template, None) == 0.6
 
 
-# Layer 5 — hard fallback
-
-
 def test_hard_fallback_when_everything_missing():
     template = _template(pass_threshold=None)
     assert resolve_pass_threshold(template, None) == 0.5
-
-
-# Defensive input shapes
 
 
 def test_non_dict_runtime_config_ignored():

--- a/futureagi/evaluations/engine/tests/test_resolve_pass_threshold.py
+++ b/futureagi/evaluations/engine/tests/test_resolve_pass_threshold.py
@@ -1,0 +1,121 @@
+"""Tests for `evaluations.engine.instance.resolve_pass_threshold`.
+
+Pins the layered resolution used by both the engine (for evaluator instantiation)
+and the error-localizer trigger sites (for EL Pass/Fail gating). Single source of
+truth for pass_threshold semantics.
+
+Priority (highest to lowest):
+  1. runtime_config["run_config"]["pass_threshold"]  - picker override
+  2. runtime_config["pass_threshold"]                 - flat top-level
+  3. resolved_version.pass_threshold                  - version snapshot
+  4. eval_template.pass_threshold                     - template default
+  5. 0.5                                              - hard fallback
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from evaluations.engine.instance import resolve_pass_threshold
+
+
+def _template(**overrides):
+    defaults = {"pass_threshold": 0.5}
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _version(**overrides):
+    defaults = {"pass_threshold": 0.7}
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# Layer 1 — run_config picker
+
+
+def test_run_config_pass_threshold_wins_over_everything():
+    template = _template(pass_threshold=0.5)
+    version = _version(pass_threshold=0.7)
+    runtime_config = {"run_config": {"pass_threshold": 0.9}, "pass_threshold": 0.8}
+    assert (
+        resolve_pass_threshold(template, runtime_config, version) == 0.9
+    )
+
+
+def test_run_config_zero_is_honoured():
+    template = _template(pass_threshold=0.5)
+    runtime_config = {"run_config": {"pass_threshold": 0}}
+    assert resolve_pass_threshold(template, runtime_config) == 0.0
+
+
+# Layer 2 — flat top-level (tracing / composite / SDK)
+
+
+def test_flat_top_level_wins_over_version_and_template():
+    template = _template(pass_threshold=0.5)
+    version = _version(pass_threshold=0.7)
+    runtime_config = {"pass_threshold": 0.8}
+    assert resolve_pass_threshold(template, runtime_config, version) == 0.8
+
+
+def test_flat_top_level_ignored_when_run_config_present():
+    template = _template(pass_threshold=0.5)
+    runtime_config = {"run_config": {"pass_threshold": 0.9}, "pass_threshold": 0.8}
+    assert resolve_pass_threshold(template, runtime_config) == 0.9
+
+
+# Layer 3 — version
+
+
+def test_version_wins_over_template_when_no_runtime_override():
+    template = _template(pass_threshold=0.5)
+    version = _version(pass_threshold=0.7)
+    assert resolve_pass_threshold(template, None, version) == 0.7
+
+
+def test_version_none_falls_through_to_template():
+    template = _template(pass_threshold=0.5)
+    assert resolve_pass_threshold(template, None, None) == 0.5
+
+
+def test_version_without_pass_threshold_attribute_falls_through():
+    template = _template(pass_threshold=0.5)
+    version = SimpleNamespace()  # no pass_threshold attr
+    assert resolve_pass_threshold(template, None, version) == 0.5
+
+
+# Layer 4 — template default
+
+
+def test_template_default_when_no_runtime_no_version():
+    template = _template(pass_threshold=0.6)
+    assert resolve_pass_threshold(template, None) == 0.6
+
+
+# Layer 5 — hard fallback
+
+
+def test_hard_fallback_when_everything_missing():
+    template = _template(pass_threshold=None)
+    assert resolve_pass_threshold(template, None) == 0.5
+
+
+# Defensive input shapes
+
+
+def test_non_dict_runtime_config_ignored():
+    template = _template(pass_threshold=0.5)
+    assert resolve_pass_threshold(template, "not a dict") == 0.5
+
+
+def test_empty_run_config_dict_falls_through():
+    template = _template(pass_threshold=0.5)
+    runtime_config = {"run_config": {}}
+    assert resolve_pass_threshold(template, runtime_config) == 0.5
+
+
+def test_run_config_none_value_falls_through():
+    template = _template(pass_threshold=0.5)
+    runtime_config = {"run_config": {"pass_threshold": None}}
+    assert resolve_pass_threshold(template, runtime_config) == 0.5

--- a/futureagi/model_hub/services/error_localizer_service.py
+++ b/futureagi/model_hub/services/error_localizer_service.py
@@ -23,7 +23,9 @@ def error_localizer_enabled(eval_config: Any) -> bool:
 
 
 def should_run_error_localizer(
-    value: Any, eval_template: EvalTemplate | None
+    value: Any,
+    eval_template: EvalTemplate | None,
+    runtime_threshold: float | None = None,
 ) -> tuple[bool, str]:
     if eval_template is None:
         return (
@@ -50,8 +52,11 @@ def should_run_error_localizer(
 
     score = normalize_score(extracted, output_type, choice_scores)
 
-    threshold = getattr(eval_template, "pass_threshold", None)
-    threshold = float(threshold) if threshold is not None else 0.5
+    if runtime_threshold is not None:
+        threshold = float(runtime_threshold)
+    else:
+        template_threshold = getattr(eval_template, "pass_threshold", None)
+        threshold = float(template_threshold) if template_threshold is not None else 0.5
 
     decision = determine_pass_fail(score, threshold)
     if output_type == "pass_fail":

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -708,9 +708,16 @@ def trigger_error_localization_for_column(
     response: dict,
     cell: Cell,
     log_id: str | None = None,
+    eval_config: dict | None = None,
 ) -> None:
     """
     Helper function to create ErrorLocalizerTask records for cells.
+
+    `config` is the per-evaluator prepared config (used for input variables
+    and rule_prompt fallback). `eval_config` is the caller's runtime config
+    (typically ``UserEvalMetric.config``) so the pass_threshold resolver can
+    honour ``run_config`` overrides instead of the template default the
+    prepared config carries.
     """
     input_data_dict = {}
     required_keys = []
@@ -754,7 +761,7 @@ def trigger_error_localization_for_column(
         rule_prompt, input_data_dict, eval_result
     )
 
-    pass_threshold = resolve_pass_threshold(eval_template, config)
+    pass_threshold = resolve_pass_threshold(eval_template, eval_config)
 
     if task_exists:
         task = ErrorLocalizerTask.objects.get(source_id=cell.id)

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from typing import Any
 
 import structlog
 from django.db import close_old_connections
@@ -22,6 +23,7 @@ from analytics.utils import (
     get_mixpanel_properties,
     track_mixpanel_event,
 )
+from evaluations.engine.instance import resolve_pass_threshold
 from model_hub.models.choices import CellStatus, ModelChoices, SourceChoices, StatusType
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.error_localizer_model import (
@@ -29,7 +31,7 @@ from model_hub.models.error_localizer_model import (
     ErrorLocalizerStatus,
     ErrorLocalizerTask,
 )
-from model_hub.models.evals_metric import UserEvalMetric
+from model_hub.models.evals_metric import EvalTemplate, UserEvalMetric
 from model_hub.models.evaluation import Evaluation
 from model_hub.models.run_prompt import RunPrompter
 from model_hub.services.error_localizer_service import should_run_error_localizer
@@ -748,10 +750,12 @@ def trigger_error_localization_for_column(
         rule_prompt, input_data_dict, eval_result
     )
 
+    pass_threshold = resolve_pass_threshold(eval_template, config)
+
     if task_exists:
         task = ErrorLocalizerTask.objects.get(source_id=cell.id)
         metadata = task.metadata
-        metadata.update({"log_id": log_id})
+        metadata.update({"log_id": log_id, "pass_threshold": pass_threshold})
         task.eval_result = eval_result
         task.eval_explanation = response.get("reason", "")
         task.input_data = input_data_dict
@@ -776,7 +780,7 @@ def trigger_error_localization_for_column(
             rule_prompt=rule_prompt,
             organization=cell.dataset.organization,
             workspace=workspace,
-            metadata={"log_id": log_id},
+            metadata={"log_id": log_id, "pass_threshold": pass_threshold},
             status=initial_status,
             error_message=error_message,
         )
@@ -786,8 +790,14 @@ def trigger_error_localization_for_column(
 
 
 def trigger_error_localization_for_span(
-    eval_template, eval_logger, value, mapping, eval_explanation, log_id=None
-):
+    eval_template: EvalTemplate,
+    eval_logger: EvalLogger,
+    value: Any,
+    mapping: dict,
+    eval_explanation: str,
+    log_id: str | None = None,
+    eval_config: dict | None = None,
+) -> None:
     try:
         """
         Helper function to create ErrorLocalizerTask records for spans.
@@ -818,10 +828,14 @@ def trigger_error_localization_for_span(
             rule_prompt, input_data_dict, value
         )
 
+        pass_threshold = resolve_pass_threshold(eval_template, eval_config)
+
         if task_exists:
             task = ErrorLocalizerTask.objects.get(source_id=eval_logger.id)
             metadata = task.metadata
-            metadata.update({"log_id": str(log_id)})
+            metadata.update(
+                {"log_id": str(log_id), "pass_threshold": pass_threshold}
+            )
             task.eval_result = value
             task.eval_explanation = eval_explanation
             task.input_data = input_data_dict
@@ -845,7 +859,7 @@ def trigger_error_localization_for_span(
                 eval_explanation=eval_explanation,
                 rule_prompt=rule_prompt,
                 organization=eval_logger.observation_span.project.organization,
-                metadata={"log_id": log_id},
+                metadata={"log_id": log_id, "pass_threshold": pass_threshold},
                 workspace=workspace,
                 status=initial_status,
                 error_message=error_message,
@@ -903,6 +917,11 @@ def trigger_error_localization_for_standalone(evaluation: Evaluation):
             workspace=workspace,
             status=initial_status,
             error_message=error_message,
+            metadata={
+                "pass_threshold": resolve_pass_threshold(
+                    evaluation.eval_template, evaluation.eval_config
+                )
+            },
         )
 
         logger.info(
@@ -916,8 +935,13 @@ def trigger_error_localization_for_standalone(evaluation: Evaluation):
 
 
 def trigger_error_localization_for_playground(
-    eval_template, log, value, mapping, eval_explanation
-):
+    eval_template: EvalTemplate,
+    log: "APICallLog",
+    value: Any,
+    mapping: dict,
+    eval_explanation: str,
+    eval_config: dict | None = None,
+) -> None:
     try:
         """
         Helper function to create ErrorLocalizerTask records for playground.
@@ -943,6 +967,8 @@ def trigger_error_localization_for_playground(
             rule_prompt, input_data_dict, value
         )
 
+        pass_threshold = resolve_pass_threshold(eval_template, eval_config)
+
         try:
             task = ErrorLocalizerTask.objects.get(source_id=log.log_id)
             task.eval_result = value
@@ -953,6 +979,9 @@ def trigger_error_localization_for_playground(
             task.status = initial_status
             task.rule_prompt = rule_prompt
             task.error_message = error_message
+            metadata = task.metadata
+            metadata.update({"pass_threshold": pass_threshold})
+            task.metadata = metadata
         except ErrorLocalizerTask.DoesNotExist:
             task = ErrorLocalizerTask(
                 eval_template=eval_template,
@@ -968,6 +997,7 @@ def trigger_error_localization_for_playground(
                 workspace=workspace,
                 status=initial_status,
                 error_message=error_message,
+                metadata={"pass_threshold": pass_threshold},
             )
 
         task.save()
@@ -1056,6 +1086,9 @@ def trigger_error_localization_for_simulate(
                     "log_id": log_id,
                     "call_execution_id": str(call_execution.id),
                     "eval_config_id": str(eval_config.id),
+                    "pass_threshold": resolve_pass_threshold(
+                        eval_template, config
+                    ),
                 },
                 "status": initial_status,
                 "error_message": error_message,
@@ -1081,6 +1114,7 @@ def process_single_error_localization(task_id):
         should_run, reason = should_run_error_localizer(
             task.eval_result,
             task.eval_template,
+            runtime_threshold=(task.metadata or {}).get("pass_threshold"),
         )
         if not should_run:
             logger.info(

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from django.db import close_old_connections
@@ -47,6 +47,10 @@ from tfc.utils.distributed_state import evaluation_tracker
 from tfc.utils.error_codes import get_error_for_api_status
 from tracer.models.observation_span import EvalLogger
 from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
+if TYPE_CHECKING:
+    from simulate.models.eval_config import SimulateEvalConfig
+    from simulate.models.test_execution import CallExecution
 
 try:
     from ee.usage.models.usage import APICallLog
@@ -696,15 +700,15 @@ def _has_localized_segments(error_analysis: dict | list | None) -> bool:
 
 
 def trigger_error_localization_for_column(
-    eval_template,
-    config,
-    required_field,
-    mapping,
-    eval_result,
-    response,
-    cell,
-    log_id=None,
-):
+    eval_template: EvalTemplate,
+    config: dict,
+    required_field: list,
+    mapping: list,
+    eval_result: Any,
+    response: dict,
+    cell: Cell,
+    log_id: str | None = None,
+) -> None:
     """
     Helper function to create ErrorLocalizerTask records for cells.
     """
@@ -754,7 +758,7 @@ def trigger_error_localization_for_column(
 
     if task_exists:
         task = ErrorLocalizerTask.objects.get(source_id=cell.id)
-        metadata = task.metadata
+        metadata = task.metadata or {}
         metadata.update({"log_id": log_id, "pass_threshold": pass_threshold})
         task.eval_result = eval_result
         task.eval_explanation = response.get("reason", "")
@@ -832,7 +836,7 @@ def trigger_error_localization_for_span(
 
         if task_exists:
             task = ErrorLocalizerTask.objects.get(source_id=eval_logger.id)
-            metadata = task.metadata
+            metadata = task.metadata or {}
             metadata.update(
                 {"log_id": str(log_id), "pass_threshold": pass_threshold}
             )
@@ -979,7 +983,7 @@ def trigger_error_localization_for_playground(
             task.status = initial_status
             task.rule_prompt = rule_prompt
             task.error_message = error_message
-            metadata = task.metadata
+            metadata = task.metadata or {}
             metadata.update({"pass_threshold": pass_threshold})
             task.metadata = metadata
         except ErrorLocalizerTask.DoesNotExist:
@@ -1007,14 +1011,14 @@ def trigger_error_localization_for_playground(
 
 
 def trigger_error_localization_for_simulate(
-    eval_template,
-    call_execution,
-    eval_config,
-    value,
-    mapping,
-    eval_explanation,
-    log_id=None,
-):
+    eval_template: EvalTemplate,
+    call_execution: "CallExecution",
+    eval_config: "SimulateEvalConfig",
+    value: Any,
+    mapping: dict,
+    eval_explanation: str,
+    log_id: str | None = None,
+) -> None:
     try:
         """
         Helper function to create ErrorLocalizerTask records for simulate evaluations.

--- a/futureagi/model_hub/tests/test_error_localizer_service.py
+++ b/futureagi/model_hub/tests/test_error_localizer_service.py
@@ -158,6 +158,39 @@ class TestEarlyExits:
 
 
 # =========================================================================
+# Runtime threshold override — TH-6469
+# =========================================================================
+
+
+class TestRuntimeThresholdOverride:
+    def test_runtime_threshold_takes_precedence_over_template(self):
+        # Template default 0.5; user override 0.8; score 0.6 → EL must fire.
+        template = _template(
+            output_type_normalized="percentage", pass_threshold=0.5
+        )
+        run, reason = should_run_error_localizer(
+            0.6, template, runtime_threshold=0.8
+        )
+        assert run is True
+        assert "0.80" in reason
+
+    def test_runtime_threshold_flips_high_score_to_pass(self):
+        # Template default 0.5 would fire on 0.4; runtime 0.3 must skip.
+        template = _template(
+            output_type_normalized="percentage", pass_threshold=0.5
+        )
+        run, _ = should_run_error_localizer(0.4, template, runtime_threshold=0.3)
+        assert run is False
+
+    def test_runtime_threshold_none_falls_back_to_template(self):
+        template = _template(
+            output_type_normalized="percentage", pass_threshold=0.5
+        )
+        run, _ = should_run_error_localizer(0.2, template, runtime_threshold=None)
+        assert run is True
+
+
+# =========================================================================
 # The scorability helper, directly
 # =========================================================================
 

--- a/futureagi/model_hub/tests/test_error_localizer_service.py
+++ b/futureagi/model_hub/tests/test_error_localizer_service.py
@@ -158,13 +158,12 @@ class TestEarlyExits:
 
 
 # =========================================================================
-# Runtime threshold override — TH-6469
+# Runtime threshold override
 # =========================================================================
 
 
 class TestRuntimeThresholdOverride:
     def test_runtime_threshold_takes_precedence_over_template(self):
-        # Template default 0.5; user override 0.8; score 0.6 → EL must fire.
         template = _template(
             output_type_normalized="percentage", pass_threshold=0.5
         )
@@ -175,7 +174,6 @@ class TestRuntimeThresholdOverride:
         assert "0.80" in reason
 
     def test_runtime_threshold_flips_high_score_to_pass(self):
-        # Template default 0.5 would fire on 0.4; runtime 0.3 must skip.
         template = _template(
             output_type_normalized="percentage", pass_threshold=0.5
         )

--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -1519,7 +1519,11 @@ class TestTriggerMetadataSnapshot:
         mock_cell.objects.select_related.return_value.get.return_value = cell
         eval_template = MagicMock()
         eval_template.name = "some-template"
-        config = {"rule_prompt": "r", "run_config": {"pass_threshold": 0.9}}
+        # `config` is the per-evaluator prepared dict (holds template-stamped
+        # pass_threshold); `eval_config` is the caller's runtime config where
+        # the run_config override lives. The resolver must read the latter.
+        config = {"rule_prompt": "r", "pass_threshold": 0.5}
+        eval_config = {"run_config": {"pass_threshold": 0.9}}
 
         trigger_error_localization_for_column(
             eval_template=eval_template,
@@ -1530,9 +1534,10 @@ class TestTriggerMetadataSnapshot:
             response={"reason": ""},
             cell=cell,
             log_id="log-1",
+            eval_config=eval_config,
         )
 
-        mock_resolve.assert_called_once_with(eval_template, config)
+        mock_resolve.assert_called_once_with(eval_template, eval_config)
         construct_kwargs = mock_task.call_args.kwargs
         assert construct_kwargs["metadata"]["pass_threshold"] == self._SENTINEL
 

--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -1251,3 +1251,168 @@ class TestErrorLocalizerGateE2E:
         task.refresh_from_db()
         assert task.status == ErrorLocalizerStatus.SKIPPED
         assert "template" in task.error_message
+
+
+class TestTriggerMetadataSnapshot:
+    """Every EL trigger must snapshot resolve_pass_threshold onto task.metadata.
+
+    The worker reads task.metadata['pass_threshold'] as runtime_threshold; a
+    rename or drop here silently reverts EL to the template default.
+    """
+
+    _SENTINEL = 0.777
+
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizerTask")
+    @patch("model_hub.tasks.user_evaluation.resolve_pass_threshold")
+    def test_standalone_writes_pass_threshold(self, mock_resolve, mock_task):
+        from model_hub.tasks.user_evaluation import (
+            trigger_error_localization_for_standalone,
+        )
+
+        mock_resolve.return_value = self._SENTINEL
+        evaluation = MagicMock()
+        evaluation.eval_template.config = {"rule_prompt": "r"}
+        evaluation.input_data = {"q": "hi"}
+        evaluation.data = "Failed"
+        evaluation.reason = ""
+
+        trigger_error_localization_for_standalone(evaluation)
+
+        mock_resolve.assert_called_once_with(
+            evaluation.eval_template, evaluation.eval_config
+        )
+        create_kwargs = mock_task.objects.create.call_args.kwargs
+        assert create_kwargs["metadata"]["pass_threshold"] == self._SENTINEL
+
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizerTask")
+    @patch("model_hub.tasks.user_evaluation.resolve_pass_threshold")
+    def test_playground_writes_pass_threshold_on_create(
+        self, mock_resolve, mock_task
+    ):
+        from model_hub.models.error_localizer_model import ErrorLocalizerTask
+        from model_hub.tasks.user_evaluation import (
+            trigger_error_localization_for_playground,
+        )
+
+        mock_resolve.return_value = self._SENTINEL
+        mock_task.DoesNotExist = ErrorLocalizerTask.DoesNotExist
+        mock_task.objects.get.side_effect = ErrorLocalizerTask.DoesNotExist
+        eval_template = MagicMock()
+        eval_template.config = {"rule_prompt": "r"}
+        log = MagicMock()
+        eval_config = {"run_config": {"pass_threshold": 0.9}}
+
+        trigger_error_localization_for_playground(
+            eval_template=eval_template,
+            log=log,
+            value="Failed",
+            mapping={"q": "hi"},
+            eval_explanation="",
+            eval_config=eval_config,
+        )
+
+        mock_resolve.assert_called_once_with(eval_template, eval_config)
+        construct_kwargs = mock_task.call_args.kwargs
+        assert construct_kwargs["metadata"]["pass_threshold"] == self._SENTINEL
+
+    @patch("model_hub.tasks.user_evaluation.Workspace")
+    @patch("model_hub.tasks.user_evaluation.Cell")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizerTask")
+    @patch("model_hub.tasks.user_evaluation.resolve_pass_threshold")
+    def test_column_writes_pass_threshold_on_create(
+        self, mock_resolve, mock_task, mock_cell, _mock_workspace
+    ):
+        from model_hub.tasks.user_evaluation import (
+            trigger_error_localization_for_column,
+        )
+
+        mock_resolve.return_value = self._SENTINEL
+        mock_task.objects.filter.return_value.exists.return_value = False
+        cell = MagicMock()
+        mock_cell.objects.select_related.return_value.get.return_value = cell
+        eval_template = MagicMock()
+        eval_template.name = "some-template"
+        config = {"rule_prompt": "r", "run_config": {"pass_threshold": 0.9}}
+
+        trigger_error_localization_for_column(
+            eval_template=eval_template,
+            config=config,
+            required_field=["required_keys"],
+            mapping=[["q"], "hi"],
+            eval_result="Failed",
+            response={"reason": ""},
+            cell=cell,
+            log_id="log-1",
+        )
+
+        mock_resolve.assert_called_once_with(eval_template, config)
+        construct_kwargs = mock_task.call_args.kwargs
+        assert construct_kwargs["metadata"]["pass_threshold"] == self._SENTINEL
+
+    @patch("model_hub.tasks.user_evaluation.Workspace")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizerTask")
+    @patch("model_hub.tasks.user_evaluation.resolve_pass_threshold")
+    def test_span_writes_pass_threshold_on_create(
+        self, mock_resolve, mock_task, _mock_workspace
+    ):
+        from model_hub.models.error_localizer_model import ErrorLocalizerTask
+        from model_hub.tasks.user_evaluation import (
+            trigger_error_localization_for_span,
+        )
+
+        mock_resolve.return_value = self._SENTINEL
+        mock_task.objects.filter.return_value.exists.return_value = False
+        eval_template = MagicMock()
+        eval_template.config = {"rule_prompt": "r"}
+        eval_logger = MagicMock()
+        eval_config = {"run_config": {"pass_threshold": 0.9}}
+
+        trigger_error_localization_for_span(
+            eval_template=eval_template,
+            eval_logger=eval_logger,
+            value="Failed",
+            mapping={"q": "hi"},
+            eval_explanation="",
+            log_id="log-1",
+            eval_config=eval_config,
+        )
+
+        mock_resolve.assert_called_once_with(eval_template, eval_config)
+        construct_kwargs = mock_task.call_args.kwargs
+        assert construct_kwargs["metadata"]["pass_threshold"] == self._SENTINEL
+
+    @patch("model_hub.tasks.user_evaluation.Workspace")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizerTask")
+    @patch("model_hub.tasks.user_evaluation.resolve_pass_threshold")
+    def test_simulate_writes_pass_threshold(
+        self, mock_resolve, mock_task, _mock_workspace
+    ):
+        from model_hub.tasks.user_evaluation import (
+            trigger_error_localization_for_simulate,
+        )
+
+        mock_resolve.return_value = self._SENTINEL
+        mock_task.no_workspace_objects.update_or_create.return_value = (
+            MagicMock(),
+            True,
+        )
+        eval_template = MagicMock()
+        eval_template.config = {"rule_prompt": "r"}
+        call_execution = MagicMock()
+        eval_config = MagicMock()
+        eval_config.id = uuid.uuid4()
+        eval_config.config = {"run_config": {"pass_threshold": 0.9}}
+
+        trigger_error_localization_for_simulate(
+            eval_template=eval_template,
+            call_execution=call_execution,
+            eval_config=eval_config,
+            value="Failed",
+            mapping={"q": "hi"},
+            eval_explanation="",
+            log_id="log-1",
+        )
+
+        mock_resolve.assert_called_once_with(eval_template, eval_config.config)
+        update_kwargs = mock_task.no_workspace_objects.update_or_create.call_args.kwargs
+        assert update_kwargs["defaults"]["metadata"]["pass_threshold"] == self._SENTINEL

--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -695,7 +695,9 @@ class TestErrorLocalizerGateE2E:
         )
 
     @staticmethod
-    def _make_task(organization, workspace, template, *, eval_result):
+    def _make_task(
+        organization, workspace, template, *, eval_result, metadata=None, source=None
+    ):
         from model_hub.models.error_localizer_model import (
             ErrorLocalizerSource,
             ErrorLocalizerStatus,
@@ -704,7 +706,7 @@ class TestErrorLocalizerGateE2E:
 
         return ErrorLocalizerTask.objects.create(
             eval_template=template,
-            source=ErrorLocalizerSource.DATASET,
+            source=source or ErrorLocalizerSource.DATASET,
             source_id=uuid.uuid4(),
             input_data={"q": "hi"},
             input_keys=["q"],
@@ -715,6 +717,7 @@ class TestErrorLocalizerGateE2E:
             organization=organization,
             workspace=workspace,
             status=ErrorLocalizerStatus.PENDING,
+            metadata=metadata if metadata is not None else {},
         )
 
     @patch("model_hub.tasks.user_evaluation.close_old_connections")
@@ -1251,6 +1254,189 @@ class TestErrorLocalizerGateE2E:
         task.refresh_from_db()
         assert task.status == ErrorLocalizerStatus.SKIPPED
         assert "template" in task.error_message
+
+    @patch("model_hub.tasks.user_evaluation.close_old_connections")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizer")
+    @patch("model_hub.tasks.user_evaluation.log_and_deduct_cost_for_api_request")
+    def test_metadata_override_flips_gate_from_skip_to_run(
+        self, mock_log_cost, mock_localizer, _mock_close, organization, workspace
+    ):
+        """0.6 vs template=0.5 would skip; metadata override 0.8 forces run."""
+        from model_hub.models.error_localizer_model import (
+            ErrorLocalizerSource,
+            ErrorLocalizerStatus,
+        )
+        from model_hub.tasks.user_evaluation import process_single_error_localization
+        from tfc.constants.api_calls import APICallStatusChoices
+
+        template = self._make_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        task = self._make_task(
+            organization,
+            workspace,
+            template,
+            eval_result=0.6,
+            metadata={"pass_threshold": 0.8},
+            source=ErrorLocalizerSource.STANDALONE,
+        )
+
+        mock_api_log = MagicMock()
+        mock_api_log.status = APICallStatusChoices.PROCESSING.value
+        mock_log_cost.return_value = mock_api_log
+        mock_localizer.return_value.localize_errors.return_value = LocalizerResult(
+            analysis={"summary": "over-threshold-fail"}, selected_key="q",
+        )
+
+        process_single_error_localization._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status == ErrorLocalizerStatus.COMPLETED
+        mock_localizer.return_value.localize_errors.assert_called_once()
+
+    @patch("model_hub.tasks.user_evaluation.close_old_connections")
+    def test_metadata_override_flips_gate_from_run_to_skip(
+        self, _mock_close, organization, workspace
+    ):
+        """0.4 vs template=0.5 would run; metadata override 0.3 forces skip."""
+        from model_hub.models.error_localizer_model import ErrorLocalizerStatus
+        from model_hub.tasks.user_evaluation import process_single_error_localization
+
+        template = self._make_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        task = self._make_task(
+            organization,
+            workspace,
+            template,
+            eval_result=0.4,
+            metadata={"pass_threshold": 0.3},
+        )
+
+        process_single_error_localization._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status == ErrorLocalizerStatus.SKIPPED
+        assert "passed" in task.error_message.lower()
+        assert "0.30" in task.error_message
+
+    @patch("model_hub.tasks.user_evaluation.close_old_connections")
+    def test_metadata_threshold_zero_is_honoured_not_falsy_fallback(
+        self, _mock_close, organization, workspace
+    ):
+        """0.1 vs metadata=0 must skip; a truthy check would incorrectly fall back to template 0.5 and run."""
+        from model_hub.models.error_localizer_model import ErrorLocalizerStatus
+        from model_hub.tasks.user_evaluation import process_single_error_localization
+
+        template = self._make_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        task = self._make_task(
+            organization,
+            workspace,
+            template,
+            eval_result=0.1,
+            metadata={"pass_threshold": 0},
+        )
+
+        process_single_error_localization._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status == ErrorLocalizerStatus.SKIPPED
+        assert "0.00" in task.error_message
+
+    @patch("model_hub.tasks.user_evaluation.close_old_connections")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizer")
+    @patch("model_hub.tasks.user_evaluation.log_and_deduct_cost_for_api_request")
+    def test_missing_metadata_key_falls_back_to_template_threshold(
+        self, mock_log_cost, mock_localizer, _mock_close, organization, workspace
+    ):
+        """No pass_threshold in metadata; worker must fall back to template 0.5 and run 0.4 as failed."""
+        from model_hub.models.error_localizer_model import (
+            ErrorLocalizerSource,
+            ErrorLocalizerStatus,
+        )
+        from model_hub.tasks.user_evaluation import process_single_error_localization
+        from tfc.constants.api_calls import APICallStatusChoices
+
+        template = self._make_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        task = self._make_task(
+            organization,
+            workspace,
+            template,
+            eval_result=0.4,
+            metadata={"log_id": "some-log"},
+            source=ErrorLocalizerSource.STANDALONE,
+        )
+
+        mock_api_log = MagicMock()
+        mock_api_log.status = APICallStatusChoices.PROCESSING.value
+        mock_log_cost.return_value = mock_api_log
+        mock_localizer.return_value.localize_errors.return_value = LocalizerResult(
+            analysis={"summary": "under-template-fail"}, selected_key="q",
+        )
+
+        process_single_error_localization._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status == ErrorLocalizerStatus.COMPLETED
+        mock_localizer.return_value.localize_errors.assert_called_once()
+
+    @patch("model_hub.tasks.user_evaluation.close_old_connections")
+    @patch("model_hub.tasks.user_evaluation.ErrorLocalizer")
+    @patch("model_hub.tasks.user_evaluation.log_and_deduct_cost_for_api_request")
+    def test_explicit_null_metadata_falls_back_to_template_threshold(
+        self, mock_log_cost, mock_localizer, _mock_close, organization, workspace
+    ):
+        """metadata={'pass_threshold': None} must resolve to template default, not raise or short-circuit."""
+        from model_hub.models.error_localizer_model import (
+            ErrorLocalizerSource,
+            ErrorLocalizerStatus,
+        )
+        from model_hub.tasks.user_evaluation import process_single_error_localization
+        from tfc.constants.api_calls import APICallStatusChoices
+
+        template = self._make_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        task = self._make_task(
+            organization,
+            workspace,
+            template,
+            eval_result=0.4,
+            metadata={"pass_threshold": None},
+            source=ErrorLocalizerSource.STANDALONE,
+        )
+
+        mock_api_log = MagicMock()
+        mock_api_log.status = APICallStatusChoices.PROCESSING.value
+        mock_log_cost.return_value = mock_api_log
+        mock_localizer.return_value.localize_errors.return_value = LocalizerResult(
+            analysis={"summary": "null-override-fallback"}, selected_key="q",
+        )
+
+        process_single_error_localization._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status == ErrorLocalizerStatus.COMPLETED
+        mock_localizer.return_value.localize_errors.assert_called_once()
 
 
 class TestTriggerMetadataSnapshot:

--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -1165,12 +1165,13 @@ class TestErrorLocalizerGateE2E:
         mock_api_log.status = APICallStatusChoices.PROCESSING.value
         mock_log_cost.return_value = mock_api_log
 
-        mock_localizer.return_value.skip_reason = (
-            f"The input '{selected_key}' is of type '{expected_type}', "
-            f"which is not supported by error localization."
-        )
         mock_localizer.return_value.localize_errors.return_value = LocalizerResult(
-            analysis={}, selected_key=selected_key,
+            analysis={},
+            selected_key=selected_key,
+            skip_reason=(
+                f"The input '{selected_key}' is of type '{expected_type}', "
+                f"which is not supported by error localization."
+            ),
         )
 
         process_single_error_localization._original_func(str(task.id))

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1295,6 +1295,11 @@ class EvaluationRunner:
                     response=response,
                     cell=cell,
                     log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
+                    eval_config=(
+                        self.user_eval_metric.config
+                        if self.user_eval_metric
+                        else None
+                    ),
                 )
 
         except Exception as e:

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -516,6 +516,7 @@ def run_eval_func(
                 value=value,
                 mapping=mappings,
                 eval_explanation=response.get("reason"),
+                eval_config=config,
             )
 
         return output

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1773,6 +1773,7 @@ def _execute_evaluation(
                 eval_explanation=logger_kwargs.get("eval_explanation", ""),
                 value=value,
                 log_id=str(log_id),
+                eval_config=getattr(custom_eval_config, "config", None),
             )
 
         if type == EXPERIMENT:


### PR DESCRIPTION
## Why

Extends the error-localizer skip gate to honour per-binding runtime `pass_threshold` overrides from the FE picker. The gate currently resolves the threshold from the template default; this PR routes it through the same layered chain the engine uses when it instantiates the evaluator, so the gate and the evaluator see the same effective value on every surface that carries a `run_config` override.

## What changed

**Shared resolver on the engine.** New helper `resolve_pass_threshold(eval_template, runtime_config, resolved_version)` in `evaluations/engine/instance.py` with the layered priority chain:

```
runtime_config["run_config"]["pass_threshold"]   -> per-binding picker override
runtime_config["pass_threshold"]                  -> flat top-level (tracing / composite / SDK)
resolved_version.pass_threshold                   -> pinned-version snapshot
eval_template.pass_threshold                      -> template default
0.5                                               -> hard fallback
```

**Consumers:**

- **Engine.** `create_eval_instance` calls it after `apply_version_overrides`, so the evaluator instance is instantiated with the resolved value.
- **5 EL trigger sites.** Column / span / standalone / playground / simulate all call it and snapshot the resolved float onto `ErrorLocalizerTask.metadata["pass_threshold"]` at trigger time.
- **Dataset / Experiment surface wiring.** `EvaluationRunner._process_eval_result` (`model_hub/views/eval_runner.py`) now passes `self.user_eval_metric.config` as `eval_config` into the column trigger. The per-evaluator `config` dict is still handed through for input-variable and rule-prompt extraction, but the resolver reads `run_config.pass_threshold` off the raw UEM config where the FE picker persists overrides. Without this hand-off the resolver would only ever see the template-stamped value that `_prepare_eval_config` writes onto `config_error`.
- **EL worker.** `process_single_error_localization` passes `task.metadata["pass_threshold"]` as `runtime_threshold` to `should_run_error_localizer`; the gate honours it directly.

**Uniform trigger signatures.** Column, span, and playground triggers now accept `eval_config: dict | None` and resolve internally, matching the shape of the standalone / simulate triggers. All external callers (`tracer/utils/eval.py`, `views/utils/evals.py`, `ai_tools/tools/evaluations/trigger_error_localization.py`) pass through the config dict they already have in scope. Full type annotations added on the touched signatures.

## Per-file changes

| File | Change |
|---|---|
| `evaluations/engine/instance.py` | Add `resolve_pass_threshold` helper; invoke it inside `create_eval_instance` after version overrides so the evaluator instance sees the resolved value. |
| `model_hub/services/error_localizer_service.py` | `should_run_error_localizer` accepts optional `runtime_threshold`; template default kept as the fallback when the caller has no runtime value. |
| `model_hub/tasks/user_evaluation.py` | Column and span triggers gain `eval_config` param; each of the 5 triggers snapshots `resolve_pass_threshold(...)` onto `ErrorLocalizerTask.metadata`. Full type annotations on both touched signatures. |
| `model_hub/views/eval_runner.py` | `_process_eval_result` passes `self.user_eval_metric.config` as `eval_config` into the column trigger so the resolver sees the UEM run-config, not the template-stamped `config_error`. |
| `model_hub/views/utils/evals.py` | Playground caller forwards its runtime config as `eval_config` to the playground trigger. |
| `tracer/utils/eval.py` | Trace/observe caller forwards `custom_eval_config.config` as `eval_config` to the span trigger. |
| `ai_tools/tools/evaluations/trigger_error_localization.py` | Standalone caller forwards its runtime config as `eval_config` to the standalone trigger. |
| `evaluations/engine/tests/test_resolve_pass_threshold.py` | New. 12 tests: each priority layer independently, zero-value handling, defensive input shapes. |
| `model_hub/tests/test_error_localizer_service.py` | +3 tests: runtime threshold precedence, flip a high score to pass, `None` fallback. |
| `model_hub/tests/test_user_evaluation_tasks.py` | +10 tests: 5 E2E gate flips and 5 trigger metadata snapshots (see Test coverage). |

## Behaviour matrix

| Surface | Runtime override honoured |
|---|---|
| Dataset | Yes (via `uem.config["run_config"]`) |
| Experiment | Yes (same trigger as Dataset) |
| Tracing (span / trace / session) | Yes (via `custom_eval_config.config`) |
| Simulate | Yes (via `SimulateEvalConfig.config["run_config"]`) |
| Composite child | Yes when the child overlay writes `pass_threshold` at either the top level of the child config or under `run_config`; the resolver reads both shapes. |
| SDK / Standalone | Yes when caller writes to `evaluation.eval_config["run_config"]` or top level |
| Playground | Falls back to the template default. The Playground request body carries no `run_config` by design; the picker persists directly to the template and "Test Evaluation" runs against the saved template. |

## Snapshot semantic

The resolved threshold is captured on the `ErrorLocalizerTask` at trigger time. If the eval config's `pass_threshold` is edited between the source eval running and EL processing, the decision honours the value that was in effect when the source eval ran.

## No schema change

`ErrorLocalizerTask.metadata` already carries functional payload keys (`log_id`, `call_execution_id`, `eval_config_id`) used by worker code paths. `pass_threshold` joins the same pattern; no new column, no migration.

## Test coverage

**Resolver unit tests** (`evaluations/engine/tests/test_resolve_pass_threshold.py`, 12 tests): each priority layer independently, zero-value handling, and defensive input shapes (non-dict, empty sub-dict, `None` value inside `run_config`).

**Gate tests** (`model_hub/tests/test_error_localizer_service.py`, 3 tests): runtime threshold takes precedence over template, flips a high score to pass, `None` falls back cleanly.

**Trigger metadata snapshot tests** (`model_hub/tests/test_user_evaluation_tasks.py`, 5 tests): standalone / playground / column / span / simulate each assert the resolver is invoked with the right runtime dict and its return value lands in `ErrorLocalizerTask.metadata["pass_threshold"]`.

**E2E gate tests** (`model_hub/tests/test_user_evaluation_tasks.py`, 5 tests): metadata override flips the gate from skip to run and vice-versa, `0.0` is honoured over the template default (not treated as falsy), missing / explicit-null metadata keys fall back cleanly.

25 new tests added across three files.

## Local test runbook

```
DJANGO_SETTINGS_MODULE=tfc.settings.test .venv/bin/pytest \
  evaluations/engine/tests/test_resolve_pass_threshold.py \
  model_hub/tests/test_error_localizer_service.py \
  model_hub/tests/test_user_evaluation_tasks.py -v --no-cov
```

<img width="1626" height="920" alt="image" src="https://github.com/user-attachments/assets/69aa6a44-2937-4e65-ae77-117cd296491f" />


## Manual verification (dev)

1. On any dataset / trace / simulate binding, enable Error Localizer and set `pass_threshold = 0.8`.
2. Trigger an eval that produces a score of 0.6.
3. Verify EL fires (score 0.6 is below the runtime override of 0.8).

Repeat with `pass_threshold = 0.3` and a score of 0.4: verify EL skips (score above the override).

### Before:


https://github.com/user-attachments/assets/22b12d08-e367-404c-91ea-6a7b183325e3


### After:


https://github.com/user-attachments/assets/98d5570f-28f5-4e25-82b8-3bcbc7cdb725



## Linear

Fix TH-6469
