### PR TITLE
chore(test-runs): hide Github Actions beta CTA in run header

### DIFF
--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -185,7 +185,7 @@ const TestRunHeader = () => {
               simulationType={agentType}
             />
           </Suspense>
-          <CustomTooltip
+          {/* <CustomTooltip
             show
             title="In beta, send early access request"
             size="small"
@@ -231,7 +231,7 @@ const TestRunHeader = () => {
                 Github Actions
               </Button>
             </Box>
-          </CustomTooltip>
+          </CustomTooltip> */}
           <CustomTooltip
             show={
               isAgentDefinitionDeleted ||


### PR DESCRIPTION
## Summary

Hide the beta **"Github Actions"** CTA in the run-tests header until the feature is ready to surface.

## What changed

`frontend/src/sections/test/TestRuns/TestRunHeader.jsx` — commented out the `CustomTooltip` block ("In beta, send early access request") that wraps the Github Actions button.

## Type of change

- [x] Chore / minor UI

## Backout

Uncomment the block to restore the CTA.
