### PR TITLE
fix(evals): add scroll to eval log explanation panel (#1071)

### DIFF
--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
@@ -53,6 +53,7 @@ const LogDrawerRight = ({
       <Box
         sx={{
           flex: 1,
+          display: "flex",
           flexDirection: "column",
           gap: "15px",
           overflowY: "auto",
@@ -131,6 +132,8 @@ const LogDrawerRight = ({
               border: `1px solid ${alpha(theme.palette.text.disabled, 0.2)}`,
               padding: "16px",
               borderRadius: "4px",
+              maxHeight: "300px",
+              overflowY: "auto",
             }}
           >
             <Typography fontWeight={400} fontSize={14} color="text.primary">

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsDrawer.jsx
@@ -182,7 +182,7 @@ const LogsDrawerChild = ({
         <Divider orientation="horizontal" />
       </Box>
       <Box display={"flex"} gap="16px" height="calc(100% - 80px)">
-        <Box sx={{ width: "100%" }}>
+        <Box sx={{ width: "100%", height: "100%" }}>
           <LogDrawerRight
             output={data?.output}
             error={data?.error_details || {}}


### PR DESCRIPTION
## Summary

Fixes #1071 — the **Explanation** section in the eval log drawer's right panel had no scroll, so long LLM-generated explanations were clipped and unreachable, unlike the sibling **Possible Error** section which already scrolls.

## Changes

- **`LogDrawerRight.jsx`**
  - Add `display: "flex"` to the outer scroll container so its existing `flex: 1` + `overflowY: "auto"` actually take effect (it previously had only `flexDirection: "column"`, so the scroll never engaged).
  - Cap the Explanation content box at `maxHeight: "300px"` with `overflowY: "auto"` so long text scrolls **within the box** rather than pushing/clipping the drawer.
- **`LogsDrawer.jsx`**
  - Add `height: "100%"` to the `LogDrawerRight` wrapper `Box` so the height chain resolves down and the flex scroll container is actually bounded.

## Acceptance criteria

- [x] Long explanation (>~300px) shows a vertical scrollbar and is fully reachable.
- [x] Scrolling inside the Explanation box doesn't scroll the outer drawer.
- [x] Short explanations render without an empty scroll area (`maxHeight` is a cap, not a min).
- [x] The **Possible Error** section is unaffected.
- [x] Null/empty explanations still show "Unable to fetch Explanation" without breaking layout.

Scope was kept to `LogDrawerRight.jsx` and `LogsDrawer.jsx` only; `CellRenderingData.jsx`, `LogDrawer.jsx`, and backend explanation generation are untouched.

## Verification

- `eslint` on both files: 0 errors (only a pre-existing `react-hooks/exhaustive-deps` warning on an untouched `useMemo`).
- Structural review of the height chain: root `Box` has `height:100%` → wrapper now propagates it → scroll container `flex:1` + `overflowY:auto` engage; Explanation box scrolls independently at its 300px cap.

## Note for maintainers

There is an existing open PR for this issue, **#1158**, which takes a much broader approach (it also edits `EvalsTabView.jsx`, `DatapointDrawerV2.jsx`, `EvalResultDisplay.jsx`, `FormattedReason.jsx`, `EvalSection.jsx`, and adds a test file). For `LogDrawerRight.jsx`, #1158 only adds the `maxHeight`/`overflowY` cap on the Explanation box — it does **not** add `display:flex` to the outer container or the `height:100%` fix in `LogsDrawer.jsx`, so the underlying height-resolution chain remains unaddressed there.

This PR is deliberately narrow: it fixes the actual height chain and stays within the two files named in the issue. Happy to defer to #1158, combine, or have this taken as the focused alternative — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
