### PR TITLE
fix(test): refresh KPI cards and analytics after deleting an eval (#1073)

### DIFF
--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -125,6 +125,22 @@ const TestEvaluationPage = ({
       queryClient.invalidateQueries({
         queryKey: ["test-runs-detail", testId],
       });
+      // Also refresh the KPI cards and Analytics tab, which are keyed
+      // separately and would otherwise show stale counts after a delete.
+      if (executionIds?.length) {
+        executionIds.forEach((id) => {
+          queryClient.invalidateQueries({
+            queryKey: ["test-execution-detail", "KPIS", id],
+          });
+        });
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: ["test-execution-detail", "KPIS"],
+        });
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["test-execution-analytics", testId],
+      });
       enqueueSnackbar("Eval deleted successfully", {
         variant: "success",
       });


### PR DESCRIPTION
## Summary

Fixes #1073 — deleting an eval from a test run only invalidated `["test-runs-detail", testId]`, so the **KPI cards** (`["test-execution-detail", "KPIS", executionId]`, 5-min `staleTime`) and the **Analytics tab** (`["test-execution-analytics", testId]`) kept showing stale data until a manual page refresh.

## Changes

- **`TestEvaluationPage.jsx`** — extend the `deleteEval` `onSuccess` handler to also invalidate:
  - `["test-execution-detail", "KPIS", id]` for each `id` in `executionIds`; or, when `executionIds` is null/empty (the all-runs context), the whole `["test-execution-detail", "KPIS"]` subtree via React Query's partial matching.
  - `["test-execution-analytics", testId]`.

The existing `["test-runs-detail", testId]` invalidation, the success toast, and the confirm-dialog close are all left intact. All variables used (`queryClient`, `executionIds`, `testId`, `enqueueSnackbar`, `setOpenConfirmDialog`) were already in scope — no new imports.

## Acceptance criteria

- [x] Deleting an eval from a test run with 2+ evals immediately updates the KPI cards and Analytics tab without a refresh.
- [x] The eval list still refreshes as before (no regression).
- [x] Success toast and dialog close still work.
- [x] Works correctly when `executionIds` is null (all-runs context) — invalidates the full KPI subtree.

Scope kept to `TestEvaluationPage.jsx`; `useKpis.js`, `AnalyticsDetails.jsx`, and the backend delete endpoint are untouched.

## Verification

- Query keys confirmed against their consumers: `useKpis.js` uses `["test-execution-detail", "KPIS", executionId]`; `AnalyticsDetails.jsx` uses `["test-execution-analytics", testId]` — both match the keys invalidated here.
- `eslint`: 0 errors (only a pre-existing unused-var warning on an untouched line).

## Note for maintainers

There is an existing open PR for this issue, **#1097**, which is behaviorally equivalent but extracts the logic into a new `eval_cache.js` module (with a unit test). This PR keeps the change inline in `TestEvaluationPage.jsx` per the issue's suggested scope, which keeps the diff to a single file. If you'd prefer the extracted-helper structure (easier to unit test), #1097 is the way; if you'd prefer the minimal inline change, this one is. Either is fine by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
