### PR TITLE
fix(observe): parse graph timestamps as UTC so they render in local time (#1067)

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
@@ -31,6 +31,7 @@ import LeftControl from "./LeftControl";
 import Legend from "./Legend";
 import GraphSkeleton from "./GraphSkeleton";
 import { formatYAxisValue, getYAxisUnit, getLineSeriesName } from "./common";
+import { parseTimestampToMs } from "./timestampUtils";
 import SVGColor from "src/components/svg-color";
 import { useLLMTracingStoreShallow } from "../states";
 import { logger } from "src/utils/logger";
@@ -233,16 +234,14 @@ const GraphSection = ({
     const evalData = Array.isArray(apiGraphData?.data) ? apiGraphData.data : [];
 
     for (const item of evalData) {
-      if (item.timestamp != null) {
-        // Remove timezone suffix to normalize format
-        const normalizedTimestamp = item.timestamp.replace(/\+00:00$/, "");
+      const normalizedTimestamp = parseTimestampToMs(item.timestamp);
+      if (normalizedTimestamp == null) continue;
 
-        primaryData.push({ x: normalizedTimestamp, y: item.value ?? 0 });
-        trafficData.push({
-          x: normalizedTimestamp,
-          y: item.primary_traffic ?? 0,
-        });
-      }
+      primaryData.push({ x: normalizedTimestamp, y: item.value ?? 0 });
+      trafficData.push({
+        x: normalizedTimestamp,
+        y: item.primary_traffic ?? 0,
+      });
     }
 
     const lineSeriesName = getLineSeriesName(selectedGraphProperty);

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -38,6 +38,7 @@ import {
 } from "date-fns";
 import _ from "lodash";
 import GraphSkeleton from "./GraphSkeleton";
+import { parseTimestampToMs } from "./timestampUtils";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import { formatDate } from "src/utils/report-utils";
 import { FILTER_FOR_HAS_EVAL } from "../common";
@@ -375,10 +376,10 @@ const PrimaryGraph = ({
     const tData = [];
 
     for (const item of items) {
-      if (item.timestamp == null) continue;
-      const ts = item.timestamp.replace(/\+00:00$/, "");
-      mData.push({ x: new Date(ts).getTime(), y: item.value ?? 0 });
-      tData.push({ x: new Date(ts).getTime(), y: item.primary_traffic ?? 0 });
+      const ts = parseTimestampToMs(item.timestamp);
+      if (ts == null) continue;
+      mData.push({ x: ts, y: item.value ?? 0 });
+      tData.push({ x: ts, y: item.primary_traffic ?? 0 });
     }
 
     return { metricData: mData, trafficData: tData };

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/timestampUtils.js
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/timestampUtils.js
@@ -1,0 +1,22 @@
+import { isValid, parseISO } from "date-fns";
+
+/**
+ * Parse a trace timestamp into epoch milliseconds for chart plotting.
+ *
+ * Backend timestamps arrive as ISO-8601 strings with an explicit UTC
+ * offset (e.g. "2024-01-01T14:30:00+00:00"). Stripping the offset and
+ * feeding the bare string to `new Date()` makes it parse as local time,
+ * which shifts every point on the graph for non-UTC users. Parsing with
+ * `parseISO` preserves the offset so the value is a correct UTC instant;
+ * ApexCharts then renders it in the viewer's local timezone.
+ *
+ * Mirrors the parsing used by the trace list's TimestampCell.
+ *
+ * @param {string|number|Date|null|undefined} ts
+ * @returns {number|null} epoch ms, or null if the value is missing/invalid
+ */
+export function parseTimestampToMs(ts) {
+  if (ts == null) return null;
+  const date = typeof ts === "string" ? parseISO(ts) : new Date(ts);
+  return isValid(date) ? date.getTime() : null;
+}


### PR DESCRIPTION
## Summary

Fixes #1067 — the Observe graphs stripped the `+00:00` UTC suffix from trace timestamps with a regex before parsing, so `new Date()` interpreted them as **local** time instead of UTC. Every point on the graph was shifted by the viewer's UTC offset, disagreeing with the trace list's **Start Time** column (which parses correctly via `parseISO`).

## Changes

- New helper **`GraphSection/timestampUtils.js`** exporting `parseTimestampToMs(ts)`: returns `null` for null/undefined/invalid, otherwise `parseISO(ts).getTime()` (guarded by `isValid`), mirroring the parsing used by `TimestampCell.jsx`.
- **`PrimaryGraph.jsx`** and **`GraphSection.jsx`** — replace the `.replace(/\+00:00$/, "")` string-strip with `parseTimestampToMs`, pushing numeric epoch-ms `x` values. `GraphSection` previously pushed the raw stripped **string** as `x`; it now pushes numeric ms, which is the canonical input for its `type: "datetime"` axis.

Both graphs use ApexCharts `type: "datetime"` with `datetimeUTC: false`, so a correct UTC instant now renders in the viewer's local timezone.

## Acceptance criteria

- [x] A trace at 14:30 UTC shows as 20:00 for a UTC+5:30 user, matching the Start Time column.
- [x] A trace at 00:00 UTC shows as 08:00 for a UTC+8 user.
- [x] Null/undefined timestamps are still skipped without errors.
- [x] Both `PrimaryGraph` and `GraphSection` are updated consistently.

`TimestampCell.jsx` (already correct), `Sessions-view.jsx`, the `DateRangePill` filter, and backend timezone handling are untouched.

## Verification

Ran the helper directly to confirm behavior:

```
14:30 UTC          -> correct UTC instant (=== Date.UTC(2024,0,1,14,30,0))
old stripped value -> off by 300 min on a UTC-5 machine (reproduces the bug)
null / undefined / 'not-a-date' -> null (safely skipped)
numeric epoch ms   -> passthrough unchanged
```

`eslint` on all three files: 0 errors (only pre-existing warnings on untouched lines).

## Note for maintainers

There is an existing open PR for this issue, **#1168**, which inlines the same `parseISO` + `isValid` + `.getTime()` logic directly into both graph files. This PR is functionally equivalent but factors that logic into a single shared `parseTimestampToMs` helper so the two graphs can't drift and the UTC-parsing rule lives in one place (co-located with the graphs, matching `TimestampCell`'s pattern). If you'd rather keep it inlined, #1168 already covers it; offering this as the DRY alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
