### PR TITLE
fix: add INTEGRATION_ENCRYPTION_KEY to root .env.example and fix invalid docker-compose default (#1059)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,16 @@ x-backend-env: &backend-env
   # Local-only defaults. deploy/docker-compose.production.yml re-binds these
   # with ${VAR:?error} guards so prod refuses to boot on the dev values.
   SECRET_KEY: ${SECRET_KEY:-local-dev-only-not-for-production-replace-me}
-  ENV_TYPE: ${ENV_TYPE:-development}
+  # 'local' (not 'development') so settings.py's _IS_LOCAL fallbacks (DEBUG,
+  # throwaway INTEGRATION_ENCRYPTION_KEY) activate for docker-compose installs.
+  ENV_TYPE: ${ENV_TYPE:-local}
   EE_LICENSE_KEY: ${EE_LICENSE_KEY:-}
   DJANGO_SETTINGS_MODULE: tfc.settings.settings
   FAST_STARTUP: ${FAST_STARTUP:-false}
   OTEL_ENABLED: ${OTEL_ENABLED:-false}
-  INTEGRATION_ENCRYPTION_KEY: ${INTEGRATION_ENCRYPTION_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}
+  # Empty -> settings.py auto-generates a throwaway dev key. Set in .env for
+  # persistence across restarts (generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+  INTEGRATION_ENCRYPTION_KEY: ${INTEGRATION_ENCRYPTION_KEY:-}
   FUTURE_AGI_VERSION: ${FUTURE_AGI_VERSION:-unknown}
   FUTURE_AGI_DEPLOYMENT_TYPE: ${FUTURE_AGI_DEPLOYMENT_TYPE:-docker}
   FUTURE_AGI_TELEMETRY_DISABLED: ${FUTURE_AGI_TELEMETRY_DISABLED:-false}


### PR DESCRIPTION

## Description

Two bugs affecting every fresh self-hosted install:

1. **Root `.env.example` missing `INTEGRATION_ENCRYPTION_KEY`** — users setting up via `docker compose up` had no documentation that this key was needed for integration credential encryption.

2. **docker-compose default was an invalid Fernet key** — the default `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=` is not a valid 32-byte Fernet key, but because it was non-empty, it **prevented** the settings.py auto-generation fallback (which only triggers when the env var is empty/absent). This meant encrypted integration credentials were silently lost on every container restart.

### Changes

| File | Change |
|------|--------|
| `.env.example` | Added `INTEGRATION_ENCRYPTION_KEY` with generation instructions |
| `docker-compose.yml` | Changed default from invalid key to empty (lets settings.py auto-generate) |
| `docker-compose.yml` | Changed `ENV_TYPE` default from `development` to `local` (matches settings.py default) |
| `docker-compose.dev.yml` | Same fixes as above |
| `settings.py` | Fallback now uses `_IS_LOCAL` (covers `test` env too, not just `local`) |
| `test.py` | Replaced invalid Fernet key with valid one |
| `simulate/tests/conftest.py` | Same fix |

### Related Issues
Fixes #1059
