### PR TITLE
docs: add missing environment variables to root .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,24 +2,67 @@
 # Everything in this file is OPTIONAL. An empty .env runs the full stack on
 # safe local-only defaults. For production, see ./deploy/README.md.
 
-# Stack mode. Unset = light (~12 containers). `full` adds the PeerDB CDC
-# stack (~22 containers) so analytics views populate.
+# ── Stack mode ─────────────────────────────────────────────────────────────
+# Unset = light (~12 containers). `full` adds PeerDB CDC for analytics views.
 # COMPOSE_PROFILES=full
 
-# ClickHouse database for the v1 read path, the CH25 schema/read path, and the
-# fi-collector writer. CH25_DATABASE and FI_CH_DATABASE both cascade from this,
-# so overriding it here points all three at the same DB.
+# ── Database: ClickHouse (v1 read path + CH25 + fi-collector) ──────────────
+# CH25_DATABASE and FI_CH_DATABASE both cascade from CH_DATABASE, so
+# overriding it here points all three at the same DB.
 CH_DATABASE=default
+# CH25_DATABASE and FI_CH_DATABASE must be identical if overridden.
+CH25_DATABASE=default
+FI_CH_DATABASE=default
 
-# Each image has an independent version. Empty = use `:latest`. Pin per
-# service to lock a specific release.
+# ── Image versions ─────────────────────────────────────────────────────────
+# Empty = use `:latest`. Pin per service to lock a specific release.
 FUTURE_AGI_VERSION=
 FRONTEND_VERSION=
 AGENTCC_GATEWAY_VERSION=
 SERVING_VERSION=
 CODE_EXECUTOR_VERSION=
 
-# ---- BYO LLM provider keys ----
+# ── Django security & runtime ──────────────────────────────────────────────
+# SECRET_KEY — must be a unique, unpredictable value in production.
+#              Generate with: python -c "import secrets; print(secrets.token_urlsafe(50))"
+SECRET_KEY=
+# ENV_TYPE — environment classification: local, test, dev, staging, prod.
+#            Controls DEBUG mode, key generation, and other security defaults.
+ENV_TYPE=
+# FAST_STARTUP — skips non-essential startup checks (migrations always run).
+FAST_STARTUP=false
+# OTEL_ENABLED — enables OpenTelemetry tracing for the backend.
+OTEL_ENABLED=false
+
+# ── Database: PostgreSQL ───────────────────────────────────────────────────
+# Compose defaults these to `futureagi` when left empty.
+PG_USER=
+PG_PASSWORD=
+PG_DB=
+
+# ── Message broker: RabbitMQ ───────────────────────────────────────────────
+# Compose defaults these to `user`/`password` when left empty.
+RABBITMQ_USER=
+RABBITMQ_PASSWORD=
+
+# ── Object storage ─────────────────────────────────────────────────────────
+# STORAGE_BACKEND: minio (default), s3, or gcs.
+STORAGE_BACKEND=minio
+# For S3, set these:
+# S3_ENDPOINT_URL=https://s3.amazonaws.com
+# S3_ACCESS_KEY=your-access-key
+# S3_SECRET_KEY=your-secret-key
+# S3_BUCKET=your-bucket
+# For MinIO, only MINIO_URL needs overriding when accessing from outside localhost:
+# MINIO_URL=http://your-host:9005
+
+# ── Temporary API keys (change in production) ──────────────────────────────
+# AGENTCC_INTERNAL_API_KEY — shared secret between backend and agentcc-gateway
+# AGENTCC_ADMIN_TOKEN — admin auth for the gateway management API
+AGENTCC_INTERNAL_API_KEY=
+AGENTCC_ADMIN_TOKEN=
+
+# ── BYO LLM provider keys ──────────────────────────────────────────────────
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
@@ -29,24 +72,45 @@ AWS_REGION=
 # Perplexity (powers Sonar API + Agent API; see https://docs.perplexity.ai)
 PERPLEXITY_API_KEY=
 
-# ---- Optional integrations ----
+# ── Email (SMTP / Mailgun) ─────────────────────────────────────────────────
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 DEFAULT_FROM_EMAIL=
 SERVER_EMAIL=
-RECAPTCHA_SECRET_KEY=
 
-# Public URLs.
-# VITE_HOST_API   — backend URL the SPA calls (e.g. https://api.example.com).
-#                   Empty falls through to the SaaS hostname map and finally
-#                   http://localhost:8000 for local docker-compose.
-# FRONTEND_URL    — backend's view of the frontend, used in OAuth callbacks
-#                   and email links. Empty defers to the existing app config.
+# ── Integration credentials encryption ─────────────────────────────────────
+# Fernet key for encrypting external provider credentials.
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# If empty, a throwaway key is generated on every restart — encrypted data will be lost.
+INTEGRATION_ENCRYPTION_KEY=
+
+# ── reCAPTCHA ──────────────────────────────────────────────────────────────
+RECAPTCHA_SECRET_KEY=
+RECAPTCHA_ENABLED=false
+
+# ── CORS ───────────────────────────────────────────────────────────────────
+# Comma-separated list of origins allowed for cross-origin requests.
+# CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+
+# ── Public URLs ────────────────────────────────────────────────────────────
+# VITE_HOST_API — backend URL the SPA calls (e.g. https://api.example.com).
+#                 Empty falls through to http://localhost:8000 for local dev.
+# FRONTEND_URL — backend's view of the frontend, used in OAuth callbacks
+#                and email links.
 VITE_HOST_API=
 FRONTEND_URL=
 
-# reCAPTCHA — both must be set to enable.
-RECAPTCHA_ENABLED=false
+# ── Sentry (error tracking) ────────────────────────────────────────────────
+SENTRY_DSN=
+SENTRY_ENABLED=false
 
-# Future AGI Cloud (optional, leave blank for fully offline).
+# ── Future AGI Cloud (optional, leave blank for fully offline) ─────────────
 FUTURE_AGI_CLOUD_API_KEY=
+
+# ── Port overrides ─────────────────────────────────────────────────────────
+# Uncomment and change to use non-default ports.
+# FRONTEND_PORT=3000
+# BACKEND_PORT=8000
+# AGENTCC_GATEWAY_PORT=8090
+# PG_PORT=5432
+# REDIS_PORT=6379


### PR DESCRIPTION
## Description

Fixes #1910 — the root `.env.example` was missing ~30 commonly needed environment variables, leaving self-hosted users without documentation for important configuration.

### Changes

Added variables organized by section with inline documentation:

| Section | Variables Added |
|---------|----------------|
| Django security | `SECRET_KEY`, `ENV_TYPE`, `FAST_STARTUP`, `OTEL_ENABLED` |
| PostgreSQL | `PG_USER`, `PG_PASSWORD`, `PG_DB` |
| RabbitMQ | `RABBITMQ_USER`, `RABBITMQ_PASSWORD` |
| Object storage | `STORAGE_BACKEND`, S3 vars, `MINIO_URL` |
| Gateway auth | `AGENTCC_INTERNAL_API_KEY`, `AGENTCC_ADMIN_TOKEN` |
| CORS | `CORS_ALLOWED_ORIGINS` |
| Sentry | `SENTRY_DSN`, `SENTRY_ENABLED` |
| Port overrides | `FRONTEND_PORT`, `BACKEND_PORT`, etc. |

Each variable has a comment explaining its purpose and when it needs to be set. Production-critical vars include generation instructions.

### Related Issues
Closes #1910
