### PR TITLE
fix(dashboards): hide time filter bar on empty (0-widget) dashboards

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -668,7 +668,7 @@ export default function DashboardDetailView() {
 
   const [confirmDelete, setConfirmDelete] = useState(null);
   const lastConfirmDeleteRef = useRef(null);
-  
+
   if (confirmDelete) lastConfirmDeleteRef.current = confirmDelete;
   const confirmDeleteView = confirmDelete ?? lastConfirmDeleteRef.current;
 
@@ -692,6 +692,10 @@ export default function DashboardDetailView() {
   );
 
   const rows = useMemo(() => computeRows(widgets), [widgets]);
+
+  // The time filter only acts on widgets — hide the bar until one exists
+  // (an interactive-but-inert bar on an empty dashboard reads as broken).
+  const hasWidgets = widgets.length > 0;
 
   // --- Handlers ---
 
@@ -1104,74 +1108,80 @@ export default function DashboardDetailView() {
         </Stack>
       </Stack>
 
-      {/* ---- Global date filter bar ---- */}
-      <Stack
-        direction="row"
-        alignItems="center"
-        spacing={0.5}
-        sx={{
-          px: 3,
-          py: 1.5,
-          borderBottom: "1px solid",
-          borderColor: "divider",
-          flexWrap: "wrap",
-          gap: 0.5,
-        }}
-      >
-        <Chip
-          ref={customDateAnchorRef}
-          icon={
-            <Iconify
-              icon="mdi:calendar-outline"
-              width={15}
-              sx={{ color: "inherit !important" }}
+      {/* ---- Global date filter bar (hidden until the dashboard has widgets) ---- */}
+      {hasWidgets && (
+        <>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={0.5}
+            sx={{
+              px: 3,
+              py: 1.5,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+              flexWrap: "wrap",
+              gap: 0.5,
+            }}
+          >
+            <Chip
+              ref={customDateAnchorRef}
+              icon={
+                <Iconify
+                  icon="mdi:calendar-outline"
+                  width={15}
+                  sx={{ color: "inherit !important" }}
+                />
+              }
+              label={
+                datePreset === "custom" && customDateRange
+                  ? `${format(customDateRange[0], "MMM dd")} - ${format(customDateRange[1], "MMM dd")}`
+                  : "Custom"
+              }
+              size="small"
+              variant={datePreset === "custom" ? "filled" : "outlined"}
+              color={datePreset === "custom" ? "primary" : "default"}
+              onClick={() => setIsDatePickerOpen(true)}
+              sx={DATE_CHIP_SX}
             />
-          }
-          label={
-            datePreset === "custom" && customDateRange
-              ? `${format(customDateRange[0], "MMM dd")} - ${format(customDateRange[1], "MMM dd")}`
-              : "Custom"
-          }
-          size="small"
-          variant={datePreset === "custom" ? "filled" : "outlined"}
-          color={datePreset === "custom" ? "primary" : "default"}
-          onClick={() => setIsDatePickerOpen(true)}
-          sx={DATE_CHIP_SX}
-        />
-        {DATE_PRESETS.filter((p) => p.value !== "custom").map((preset) => (
-          <Chip
-            key={preset.value}
-            label={preset.label}
-            size="small"
-            variant={datePreset === preset.value ? "filled" : "outlined"}
-            color={datePreset === preset.value ? "primary" : "default"}
-            onClick={() =>
-              setDatePreset(datePreset === preset.value ? null : preset.value)
-            }
-            sx={DATE_CHIP_SX}
-          />
-        ))}
-        <Chip
-          label="Default"
-          size="small"
-          variant={!datePreset ? "filled" : "outlined"}
-          color={!datePreset ? "primary" : "default"}
-          onClick={() => setDatePreset(null)}
-          sx={DATE_CHIP_SX}
-        />
-      </Stack>
+            {DATE_PRESETS.filter((p) => p.value !== "custom").map((preset) => (
+              <Chip
+                key={preset.value}
+                label={preset.label}
+                size="small"
+                variant={datePreset === preset.value ? "filled" : "outlined"}
+                color={datePreset === preset.value ? "primary" : "default"}
+                onClick={() =>
+                  setDatePreset(
+                    datePreset === preset.value ? null : preset.value,
+                  )
+                }
+                sx={DATE_CHIP_SX}
+              />
+            ))}
+            <Chip
+              label="Default"
+              size="small"
+              variant={!datePreset ? "filled" : "outlined"}
+              color={!datePreset ? "primary" : "default"}
+              onClick={() => setDatePreset(null)}
+              sx={DATE_CHIP_SX}
+            />
+          </Stack>
 
-      <CustomDateRangePicker
-        open={isDatePickerOpen}
-        onClose={() => setIsDatePickerOpen(false)}
-        anchorEl={customDateAnchorRef.current}
-        setDateFilter={(filter) => {
-          if (filter && filter[0] && filter[1]) {
-            setCustomDateRange([new Date(filter[0]), new Date(filter[1])]);
-          }
-        }}
-        setDateOption={() => setDatePreset("custom")}
-      />
+          <CustomDateRangePicker
+            open={isDatePickerOpen}
+            onClose={() => setIsDatePickerOpen(false)}
+            anchorEl={customDateAnchorRef.current}
+            setDateFilter={(filter) => {
+              if (filter && filter[0] && filter[1]) {
+                setCustomDateRange([new Date(filter[0]), new Date(filter[1])]);
+              }
+            }}
+            setDateOption={() => setDatePreset("custom")}
+          />
+        </>
+      )}
 
       {/* ---- Dashboard title & description (inline editable) ---- */}
       <Box sx={{ px: 3, pt: 2 }}>
@@ -1211,7 +1221,7 @@ export default function DashboardDetailView() {
         ref={gridContainerRef}
         sx={{ px: 3, pt: 2, pb: 4, flex: 1, overflow: "visible" }}
       >
-        {widgets.length === 0 ? (
+        {!hasWidgets ? (
           <Box
             sx={{
               display: "flex",

--- a/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "src/utils/test-utils";
 import DashboardDetailView from "../DashboardDetailView";
+import { DATE_PRESETS } from "../constants";
 
-// Controlled mutation stubs (hoisted so the vi.mock factory can see them).
+// Controlled stubs (hoisted so the vi.mock factory can see them). `widgets` is
+// per-test controllable so we can drive both the empty and populated dashboard.
 const h = vi.hoisted(() => ({
   deleteWidget: { mutate: vi.fn(), isPending: false },
   deleteDashboard: { mutate: vi.fn(), isPending: false },
+  widgets: [{ id: "w-1", name: "Tokens", position: 0, width: 12 }],
 }));
 
 vi.mock("src/hooks/useDashboards", () => ({
@@ -13,7 +16,7 @@ vi.mock("src/hooks/useDashboards", () => ({
     data: {
       id: "dash-1",
       name: "My Dash",
-      widgets: [{ id: "w-1", name: "Tokens", position: 0, width: 12 }],
+      widgets: h.widgets,
     },
     isLoading: false,
   }),
@@ -51,6 +54,7 @@ describe("DashboardDetailView — delete confirmation", () => {
     vi.clearAllMocks();
     h.deleteWidget.isPending = false;
     h.deleteDashboard.isPending = false;
+    h.widgets = [{ id: "w-1", name: "Tokens", position: 0, width: 12 }];
   });
 
   it("widget delete: opens the keyed dialog with the widget's name", () => {
@@ -83,7 +87,9 @@ describe("DashboardDetailView — delete confirmation", () => {
   it("dashboard delete: deletes the dashboard by id, closing on settle", () => {
     render(<DashboardDetailView />);
     fireEvent.click(screen.getByRole("button", { name: /dashboard options/i }));
-    fireEvent.click(screen.getByRole("menuitem", { name: /delete dashboard/i }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: /delete dashboard/i }),
+    );
     expect(
       screen.getByText(/Are you sure you want to delete "My Dash"/),
     ).toBeInTheDocument();
@@ -93,5 +99,31 @@ describe("DashboardDetailView — delete confirmation", () => {
       expect.objectContaining({ onSettled: expect.any(Function) }),
     );
     expect(h.deleteWidget.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("DashboardDetailView — time filter bar visibility", () => {
+  // A chip label unique to the global time-filter bar, read from the real
+  // preset source (not hand-authored) so the assertion tracks what renders.
+  const presetLabel = DATE_PRESETS.find((p) => p.value === "30D").label;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides the time filter bar on an empty (0-widget) dashboard", () => {
+    h.widgets = [];
+    render(<DashboardDetailView />);
+    // The empty-state CTA is what should greet the user instead...
+    expect(screen.getByText(/no widgets yet/i)).toBeInTheDocument();
+    // ...and the interactive-but-inert time filter is not in the DOM.
+    expect(screen.queryByText(presetLabel)).not.toBeInTheDocument();
+  });
+
+  it("shows the time filter bar once the dashboard has a widget", () => {
+    h.widgets = [{ id: "w-1", name: "Tokens", position: 0, width: 12 }];
+    render(<DashboardDetailView />);
+    expect(screen.getByText(presetLabel)).toBeInTheDocument();
+    expect(screen.queryByText(/no widgets yet/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Newly created dashboards render the global time filter bar (Custom / 7D / 30D / …) above an empty canvas. The chips are fully interactive but have nothing to act on, so clicking a preset silently does nothing — which reads as a broken or still-loading UI to a new user. This gates the filter bar on whether the dashboard has any widgets, so it stays hidden until the first widget is added.

## Why the changes are done — what is the problem
- The date filter bar in `DashboardDetailView` was rendered **unconditionally**, independent of widget count.
- On a 0-widget dashboard the bar is present and clickable, but every preset is inert (there are no widgets to re-scope), so the interaction produces no visible effect — the exact "non-responding filters look like a loading failure" symptom in TH-6319.
- The grid below already had an empty-state branch (`widgets.length === 0` → "No widgets yet"); only the filter bar was missing the same gate.

## What changed
- **`frontend/src/sections/dashboards/DashboardDetailView.jsx`**
  - Added a single `hasWidgets` derivation (`widgets.length > 0`).
  - Gated the global date filter bar **and** its date-range picker behind `hasWidgets` — hidden when there are no widgets.
  - Reused that same `hasWidgets` for the existing empty-state branch (`{!hasWidgets ? …}`) so the bar's visibility and the empty state derive from one value and can't drift apart.
- **`frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx`**
  - Made the mocked widget list per-test controllable; folded two new behavioral tests into the existing sibling file (no new test file).

> The functional change is 13 lines (`git diff -w` = +13/−3); the larger file churn is whitespace only — the existing JSX block was indented one level to sit under the `hasWidgets` guard.

## Tests included — what each scenario covers
| Test | Asserts |
|---|---|
| hides the time filter bar on an empty (0-widget) dashboard | empty-state CTA renders **and** the `30D` preset chip is *not* in the DOM |
| shows the time filter bar once the dashboard has a widget | the `30D` preset chip *is* in the DOM; empty state not shown |

The preset label is imported from the real `DATE_PRESETS` constant, not hand-authored, so the assertion tracks what actually renders.

## Commands to run tests
```bash
cd frontend
npx vitest run src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
```

## Local verification results
- Targeted file: **6/6 passing** (4 pre-existing delete-confirmation tests + 2 new visibility tests).
- **Red-if-reverted proven**: removing the `hasWidgets` gate makes the empty-dashboard test fail (it finds the `30D` chip). See the RED→GREEN screenshot below.
- Full frontend suite: this change introduces **0 net-new failures**. The failures present on the run are pre-existing on `dev` (the changed files are byte-identical to `origin/dev`) and unrelated to dashboards.

## Video

![Walkthrough — dead filter bar → hidden on empty dashboard](https://github.com/user-attachments/assets/ea0f4757-334d-4e6b-b240-1ef8372b97ec)
Walkthrough GIF — on the buggy build, clicking `7D` then `30D` on the empty dashboard toggles the chip's selected state but the canvas stays "No widgets yet" (interactive-but-inert); on the fixed build the bar is gone. _(GIF to .)_

## Screenshot of test suite run
RED→GREEN — with the `hasWidgets` gate reverted the empty-dashboard test fails (finds the `30D` chip); with the fix applied all 6 pass. ![RED→GREEN test suite](https://github.com/user-attachments/assets/0591b226-5119-4ec7-a803-c12e17eded90)

## Backwards compatibility
- Dashboards **with** widgets are unchanged: `hasWidgets` is true → the bar renders exactly as before.
- No API, prop, or storage-shape changes. `widgets` is always an array (`dashboard?.widgets || []`), so `hasWidgets` cannot throw on a missing/loading dashboard; it defaults to hidden.

| State | Before | After |
|---|---|---|
| Dashboard with ≥1 widget | bar shown | bar shown (unchanged) |
| Empty (0-widget) dashboard | bar shown but inert | bar hidden |
| Dashboard still loading | loading spinner | loading spinner (unchanged) |

## Manual verification (UI)
<!-- PROOF: th-6319_beforeafter.png -->
- Created a fresh dashboard with no widgets → the filter bar no longer renders; only the "No widgets yet / Add your first widget" empty state shows. Added a widget → the bar reappears and works as before.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Root-cause fix in the module the ticket names
- [x] Behavioral test that goes red if the fix is reverted
- [x] One `hasWidgets` source of truth for the bar and the empty state
- [x] Matches this section's existing idiom (`{cond && ()}`)
- [x] Prettier + ESLint clean; no new lint errors
- [x] No proof media committed to the branch

## Backout / rollback
Revert this commit — the filter bar returns to rendering unconditionally. No migrations, no data changes.

---
**Design note:** the ticket allowed "hidden **or** disabled-with-tooltip." Hidden was chosen because the empty state already communicates the dashboard's status, it's the least-noise fix, and it defaults to the safe/hidden state — happy to switch to a disabled+tooltip variant if preferred.

Closes TH-6319



## Before / After

![Before / After — filter bar over empty canvas → gone](https://github.com/user-attachments/assets/0b613781-5787-4fb1-8f73-ce1bcd053aaf)

