### PR TITLE
fix(run-prompt): parse array/object/number output_format in new ModelHandler path

### DIFF
--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py
@@ -2088,3 +2088,96 @@ class TestEdgeCases:
 
         assert params_chirp["model"] == "vertex_ai/chirp"
         assert isinstance(params_chirp["voice"], dict)  # Dict voice for Chirp
+
+
+# =============================================================================
+# Unit Tests - ResponseFormatter output_format parsing
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResponseFormatterOutputFormat:
+    """format_llm_response must parse output_format into a structured value.
+
+    This is the real call path LLMHandler.execute_sync uses: litellm.completion
+    -> ResponseFormatter.format_llm_response(output_format=...). A caller asking
+    for "array" must get a list; if it gets the raw JSON string, downstream
+    consumers that type-check for list silently drop it (empty cells).
+    """
+
+    def _response(self, content):
+        from unittest.mock import Mock
+
+        mock = Mock()
+        mock.choices = [Mock()]
+        mock.choices[0].message = Mock()
+        mock.choices[0].message.content = content
+        mock.choices[0].message.tool_calls = None
+        mock.usage = Mock()
+        mock.usage.prompt_tokens = 10
+        mock.usage.completion_tokens = 20
+        mock.usage.total_tokens = 30
+        mock.model = "gpt-4o"
+        return mock
+
+    def _format(self, content, output_format):
+        from agentic_eval.core_evals.run_prompt.runprompt_handlers.utils.response_formatter import (  # noqa: E501
+            ResponseFormatter,
+        )
+
+        formatted, _ = ResponseFormatter.format_llm_response(
+            response=self._response(content),
+            model="gpt-4o",
+            start_time=time.time(),
+            output_format=output_format,
+        )
+        return formatted
+
+    def test_array_output_format_returns_list(self):
+        """A JSON-array response is parsed to a list, not left as a string.
+
+        Red before the fix: the placeholder returned the raw string, so this
+        asserts the exact regression that emptied every Extract Entity cell.
+        """
+        formatted = self._format('["Paris", "France"]', "array")
+        assert formatted == ["Paris", "France"]
+        assert isinstance(formatted, list)
+
+    def test_array_output_format_strips_code_fence(self):
+        """A fenced ```json array is unwrapped and parsed to a list."""
+        content = '```json\n["Paris", "France"]\n```'
+        formatted = self._format(content, "array")
+        assert formatted == ["Paris", "France"]
+
+    def test_array_output_format_parses_python_literal(self):
+        """Single-quoted array (Python literal, not valid JSON) still parses."""
+        formatted = self._format("['Paris', 'France']", "array")
+        assert formatted == ["Paris", "France"]
+
+    def test_array_output_format_empty_array(self):
+        """An empty array parses to an empty list, not a raw string."""
+        formatted = self._format("[]", "array")
+        assert formatted == []
+        assert isinstance(formatted, list)
+
+    def test_array_output_format_unparseable_falls_back_to_raw(self):
+        """Malformed array content degrades to the raw string, never raises."""
+        formatted = self._format("not an array at all", "array")
+        assert formatted == "not an array at all"
+
+    def test_object_output_format_returns_dict(self):
+        """A JSON-object response is parsed to a dict."""
+        formatted = self._format('{"city": "Paris"}', "object")
+        assert formatted == {"city": "Paris"}
+        assert isinstance(formatted, dict)
+
+    def test_number_output_format_returns_float(self):
+        """A numeric response is parsed to a float."""
+        formatted = self._format("42.5", "number")
+        assert formatted == 42.5
+        assert isinstance(formatted, float)
+
+    def test_string_output_format_passthrough_unchanged(self):
+        """The common string path is unchanged — raw content is returned."""
+        formatted = self._format("This is a plain answer.", "string")
+        assert formatted == "This is a plain answer."

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py
@@ -2097,13 +2097,7 @@ class TestEdgeCases:
 
 @pytest.mark.unit
 class TestResponseFormatterOutputFormat:
-    """format_llm_response must parse output_format into a structured value.
-
-    This is the real call path LLMHandler.execute_sync uses: litellm.completion
-    -> ResponseFormatter.format_llm_response(output_format=...). A caller asking
-    for "array" must get a list; if it gets the raw JSON string, downstream
-    consumers that type-check for list silently drop it (empty cells).
-    """
+    """format_llm_response parses output_format into a structured value."""
 
     def _response(self, content):
         from unittest.mock import Mock
@@ -2134,11 +2128,7 @@ class TestResponseFormatterOutputFormat:
         return formatted
 
     def test_array_output_format_returns_list(self):
-        """A JSON-array response is parsed to a list, not left as a string.
-
-        Red before the fix: the placeholder returned the raw string, so this
-        asserts the exact regression that emptied every Extract Entity cell.
-        """
+        """A JSON-array response is parsed to a list, not left as a string."""
         formatted = self._format('["Paris", "France"]', "array")
         assert formatted == ["Paris", "France"]
         assert isinstance(formatted, list)

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/response_formatter.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/response_formatter.py
@@ -22,13 +22,6 @@ from agentic_eval.core_evals.fi_utils.token_count_helper import calculate_total_
 
 logger = structlog.get_logger(__name__)
 
-# Output formats whose raw model text must be parsed into a structured value.
-# "string"/"text" (and anything else) pass through unchanged.
-ARRAY_OUTPUT_FORMAT = "array"
-OBJECT_OUTPUT_FORMAT = "object"
-NUMBER_OUTPUT_FORMAT = "number"
-
-
 @dataclass
 class UsageInfo:
     """
@@ -228,35 +221,16 @@ class ResponseFormatter:
 
     @staticmethod
     def _apply_output_format(response: Any, output_format: str) -> Any:
-        """
-        Parse the raw model text into the requested output format.
-
-        A caller asking for "array" must receive a ``list`` (not the raw JSON
-        text), "object" a ``dict``, and "number" a ``float``; consumers type-
-        check the result and silently drop anything of the wrong type. The
-        legacy handler path did this in ``RunPrompt.get_formatted_output()`` —
-        this restores the same contract for the new handler path.
-
-        Falls back to the raw content whenever the text cannot be parsed into
-        the requested shape, so a malformed model response degrades to a
-        passthrough instead of raising.
-
-        Args:
-            response: LiteLLM response object
-            output_format: Output format specification
-
-        Returns:
-            Parsed response value, or the raw content when it does not match
-        """
+        """Parse `output_format` to a list/dict/float, else return raw content."""
         content = response.choices[0].message.content
 
-        if output_format == ARRAY_OUTPUT_FORMAT:
+        if output_format == "array":
             parsed = ResponseFormatter._parse_structured(content)
             return parsed if isinstance(parsed, list) else content
-        if output_format == OBJECT_OUTPUT_FORMAT:
+        if output_format == "object":
             parsed = ResponseFormatter._parse_structured(content)
             return parsed if isinstance(parsed, dict) else content
-        if output_format == NUMBER_OUTPUT_FORMAT:
+        if output_format == "number":
             try:
                 return float(strip_code_fence(content))
             except (TypeError, ValueError):
@@ -281,6 +255,9 @@ class ResponseFormatter:
             try:
                 return ast.literal_eval(unfenced)
             except (ValueError, SyntaxError):
+                logger.warning(
+                    "response_format_parse_failed", preview=unfenced[:200]
+                )
                 return content
 
     @staticmethod

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/response_formatter.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/response_formatter.py
@@ -9,6 +9,7 @@ This module standardizes response formatting for LLM handlers:
 All formatters return consistent metadata and value_info structures.
 """
 
+import ast
 import json
 import time
 from dataclasses import dataclass
@@ -16,9 +17,16 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 
+from agentic_eval.core.utils.json_utils import strip_code_fence
 from agentic_eval.core_evals.fi_utils.token_count_helper import calculate_total_cost
 
 logger = structlog.get_logger(__name__)
+
+# Output formats whose raw model text must be parsed into a structured value.
+# "string"/"text" (and anything else) pass through unchanged.
+ARRAY_OUTPUT_FORMAT = "array"
+OBJECT_OUTPUT_FORMAT = "object"
+NUMBER_OUTPUT_FORMAT = "number"
 
 
 @dataclass
@@ -221,22 +229,59 @@ class ResponseFormatter:
     @staticmethod
     def _apply_output_format(response: Any, output_format: str) -> Any:
         """
-        Apply output format transformation to response.
+        Parse the raw model text into the requested output format.
 
-        Currently returns raw content - output format handling is done
-        at the handler level via get_formatted_output().
+        A caller asking for "array" must receive a ``list`` (not the raw JSON
+        text), "object" a ``dict``, and "number" a ``float``; consumers type-
+        check the result and silently drop anything of the wrong type. The
+        legacy handler path did this in ``RunPrompt.get_formatted_output()`` —
+        this restores the same contract for the new handler path.
+
+        Falls back to the raw content whenever the text cannot be parsed into
+        the requested shape, so a malformed model response degrades to a
+        passthrough instead of raising.
 
         Args:
             response: LiteLLM response object
             output_format: Output format specification
 
         Returns:
-            Formatted response content
+            Parsed response value, or the raw content when it does not match
         """
-        # Output format transformations are currently handled by
-        # RunPrompt.get_formatted_output() - this is a placeholder
-        # for future centralization
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+
+        if output_format == ARRAY_OUTPUT_FORMAT:
+            parsed = ResponseFormatter._parse_structured(content)
+            return parsed if isinstance(parsed, list) else content
+        if output_format == OBJECT_OUTPUT_FORMAT:
+            parsed = ResponseFormatter._parse_structured(content)
+            return parsed if isinstance(parsed, dict) else content
+        if output_format == NUMBER_OUTPUT_FORMAT:
+            try:
+                return float(strip_code_fence(content))
+            except (TypeError, ValueError):
+                return content
+        return content
+
+    @staticmethod
+    def _parse_structured(content: Any) -> Any:
+        """
+        Best-effort parse of model text into a Python object.
+
+        Unwraps a Markdown code fence some models emit, then tries JSON, then a
+        Python literal. Returns the raw content unchanged when neither parse
+        succeeds — the caller decides whether the resulting type is acceptable.
+        """
+        if not isinstance(content, str):
+            return content
+        unfenced = strip_code_fence(content)
+        try:
+            return json.loads(unfenced)
+        except (json.JSONDecodeError, ValueError):
+            try:
+                return ast.literal_eval(unfenced)
+            except (ValueError, SyntaxError):
+                return content
 
     @staticmethod
     def build_streaming_metadata(

--- a/futureagi/model_hub/tests/test_dynamic_columns.py
+++ b/futureagi/model_hub/tests/test_dynamic_columns.py
@@ -15,8 +15,9 @@ Endpoints covered:
 """
 
 import json
+import time
 import uuid
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from django.urls import reverse
@@ -39,6 +40,7 @@ from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.views.dynamic_columns import (
     AddApiColumnView,
     ExecutePythonCodeView,
+    ExtractEntitiesView,
     ExtractJsonColumnView,
 )
 from tfc.constants.roles import OrganizationRoles
@@ -488,6 +490,64 @@ class TestExtractEntitiesView(DynamicColumnsBaseTestCase):
         assert "new_column_id" in response.json()["result"]
         assert response.json()["result"]["new_column_name"] == "Person Names"
         mock_task.assert_called_once()
+
+    def test_extract_entities_populates_cell_from_array_response(self):
+        """A JSON-array LLM response yields a populated cell value, not None.
+
+        Drives ExtractEntitiesView._extract_entities through the real
+        ResponseFormatter (the live extract_async path). Red before the fix:
+        the formatter returned the raw JSON string, so the isinstance(list)
+        check failed and _extract_entities returned None -> every generated
+        cell was empty.
+        """
+        from agentic_eval.core_evals.run_prompt.litellm_response import RunPrompt
+        from agentic_eval.core_evals.run_prompt.runprompt_handlers.utils.response_formatter import (  # noqa: E501
+            ResponseFormatter,
+        )
+
+        _, columns, rows = self.create_test_dataset(num_columns=1, num_rows=1)
+        # _extract_entities runs per-thread in production and calls
+        # close_old_connections(); preload the relation chain so no lazy query
+        # fires after the connection is recycled.
+        cell = Cell.objects.select_related(
+            "column__dataset__organization", "column__dataset__workspace"
+        ).get(row=rows[0], column=columns[0])
+
+        def run_real_formatter(run_prompt_self, *args, **kwargs):
+            # The model emits a JSON array as text; let the REAL formatter parse
+            # it exactly as the LLM handler does on the live path.
+            mock_resp = Mock()
+            mock_resp.choices = [Mock()]
+            mock_resp.choices[0].message = Mock()
+            mock_resp.choices[0].message.content = '["Paris", "France"]'
+            mock_resp.choices[0].message.tool_calls = None
+            mock_resp.usage = Mock(
+                prompt_tokens=1, completion_tokens=1, total_tokens=2
+            )
+            mock_resp.model = "gpt-4o"
+            return ResponseFormatter.format_llm_response(
+                response=mock_resp,
+                model=run_prompt_self.model,
+                start_time=time.time(),
+                output_format=run_prompt_self.output_format,
+            )
+
+        # _extract_entities calls close_old_connections() for per-thread
+        # connection hygiene; in this single-thread test that would recycle the
+        # shared test connection, so neutralize it (not what we're asserting).
+        with (
+            patch.object(RunPrompt, "litellm_response", run_real_formatter),
+            patch("model_hub.views.dynamic_columns.close_old_connections"),
+        ):
+            value, value_infos = ExtractEntitiesView()._extract_entities(
+                cell=cell,
+                instruction="Extract the cities and countries",
+                model="gpt-4o",
+            )
+
+        assert value == json.dumps(["Paris", "France"])
+        assert value is not None
+        assert not (value_infos and "reason" in value_infos)
 
 
 # =============================================================================


### PR DESCRIPTION
The **Extract Entity** dynamic column created the output column but wrote an empty value into every generated cell. The column produced blanks for all rows, with no error surfaced. Root cause was not in the Extract Entity view at all — it was in the shared run-prompt response formatter, which had stopped parsing `output_format="array"` into a list after the new handler path became the default.

## Why the changes are done — what is the problem

`ExtractEntitiesView._extract_entities` asks the model for a JSON array of entities via `RunPrompt(..., output_format="array")`, then keeps the result **only if it is a `list`**:

```python
entities, value_infos = run_prompt.litellm_response()
if isinstance(entities, list):
    return json.dumps(entities), value_infos
elif isinstance(entities, dict) and "entities" in entities:
    return json.dumps(entities["entities"]), value_infos
else:
    return None, None          # <- fell through to here
```

### Reproduce on dev/main today (before this PR)

1. Open a dataset → **Add Column** → **Extract Entity**, configure and run.
2. The column is created, status COMPLETED, but every cell is blank.

### Where it breaks — BE

`RunPrompt.litellm_response()` now runs the new `ModelHandler` path (`USE_NEW_RUNPROMPT_HANDLERS = True`). That path formats the response through `ResponseFormatter._apply_output_format`, which was a placeholder:

```python
# returns raw content - output format handling is done at the handler level
return response.choices[0].message.content
```

So for `output_format="array"` it returned the raw **string** `'["Paris", "France"]'` instead of a `list`. `_extract_entities` then failed its `isinstance(list)` check, returned `None`, and the async writer stored `value=None` with a PASS status → empty cell, no error. Classification/other columns were unaffected because they use `output_format="string"`. The legacy path (`RunPrompt.get_formatted_output`) parsed array/object/number; the new path never did.

## What changed

### futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/response_formatter.py
- Implemented `_apply_output_format` to parse the model text into the requested shape: `array → list`, `object → dict`, `number → float`; `string`/anything else passes through unchanged (identical to before).
- Added `_parse_structured` — unwraps a Markdown code fence (reuses the existing `strip_code_fence` helper), then tries JSON, then a Python literal, falling back to the raw content so a malformed response degrades instead of raising.
- Added named constants (`ARRAY_/OBJECT_/NUMBER_OUTPUT_FORMAT`) instead of bare literals.

### futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py
- `TestResponseFormatterOutputFormat` — 8 tests driving the real formatter (`format_llm_response`, the same call `LLMHandler.execute_sync` makes) for array/object/number/string, code-fence, python-literal, empty-array, unparseable-fallback.

### futureagi/model_hub/tests/test_dynamic_columns.py
- `test_extract_entities_populates_cell_from_array_response` — drives `ExtractEntitiesView._extract_entities` through the real formatter and asserts the cell is populated (not `None`).

## Tests included — what each scenario covers

| Test | Asserts | Red if fix reverted |
|---|---|---|
| `test_array_output_format_returns_list` | array response → `list` | ✅ |
| `test_array_output_format_strips_code_fence` | ```` ```json ```` array unwrapped → `list` | ✅ |
| `test_array_output_format_parses_python_literal` | single-quoted array → `list` | ✅ |
| `test_array_output_format_empty_array` | `[]` → `[]` (not `"[]"`) | ✅ |
| `test_array_output_format_unparseable_falls_back_to_raw` | garbage → raw string, no raise | passthrough |
| `test_object_output_format_returns_dict` | object response → `dict` | ✅ |
| `test_number_output_format_returns_float` | numeric response → `float` | ✅ |
| `test_string_output_format_passthrough_unchanged` | string path unchanged | passthrough |
| `test_extract_entities_populates_cell_from_array_response` | cell value populated, not `None` | ✅ |

## Commands to run tests

```bash
cd futureagi && set -a && source .env.test && set +a
.venv/bin/pytest \
  agentic_eval/core_evals/run_prompt/runprompt_handlers/tests/test_handlers.py::TestResponseFormatterOutputFormat \
  model_hub/tests/test_dynamic_columns.py::TestExtractEntitiesView \
  -v
```

## Local verification results

- New tests: **9 passed** with the fix; **7 failed, 2 passed** with the fix reverted (RED→GREEN proven).
- Sibling suites green with the fix: `test_handlers.py` **69 passed**, `test_dynamic_columns.py` **60 passed, 4 skipped**.

## Before / After — cell value

![Before: cell empty (None) vs After: cell populated with entities](https://github.com/user-attachments/assets/6f4acea8-0d1b-49ac-a371-df326567f6ea)

## Video

![Behavioral tests RED then GREEN (animated)](https://github.com/user-attachments/assets/dae305b3-52fc-4ec1-a05e-422ddcda6576)

## Screenshot of test suite run

![Behavioral tests RED to GREEN — fix reverted 7 failed / fix applied 9 passed](https://github.com/user-attachments/assets/37c03973-4dbb-4bb9-bf82-7be614b89465)

## Backwards compatibility

Restores the pre-regression contract of the legacy `get_formatted_output` path. Consumers of a non-string `output_format` and how they are affected:

| Caller | output_format | Before (raw string) | After (parsed) |
|---|---|---|---|
| `ExtractEntitiesView._extract_entities` (dynamic_columns) | array | `None` → empty cell | list → populated cell |
| `_extract_entities` (develop_dataset legacy copy) | array | `None` → empty cell | list → populated cell |
| Conditional column `run_prompt` branch | user config | raw string | parsed value |
| All `output_format="string"` callers (classification, etc.) | string | unchanged | unchanged |

No caller depended on the raw-string behavior; `string` output is byte-for-byte unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Root-cause fix in the shared formatter, not a per-view bandaid
- [x] Behavioral tests on the real call path, red if reverted
- [x] Reuses existing `strip_code_fence`; named constants, no magic strings
- [x] `string` output path unchanged; malformed responses degrade, never raise
- [x] No proof media committed to the branch

## Backout / rollback

Revert this commit. `_apply_output_format` returns to the passthrough placeholder and Extract Entity cells go blank again; no schema/data migration involved.

Closes TH-6269
