### PR TITLE
fix: handle missing model_hub/tracer app in migration 0020_reseed_broken_demo_data (#671)

### DIFF
--- a/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
+++ b/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
@@ -8,6 +8,13 @@ Affected orgs have a Demo-dataset with 0 rows and no Image-Demo-dataset.
 
 Idempotent: only targets demo datasets with 0 rows. Successfully reseeded
 datasets have 50 rows and won't be matched on re-run.
+
+NOTE: This migration avoids cross-app migration dependencies on model_hub
+and tracer because those apps may not yet be loadable from the migration
+state on a fresh database (Issue #671). Instead we wrap the cross-app model
+lookups in try/except and skip the reseed if the apps aren't available.
+On a fresh install there are no broken demo datasets to fix, so skipping is
+safe — the migration is strictly a repair for existing installations.
 """
 
 from django.db import migrations, transaction
@@ -15,12 +22,16 @@ from django.db.models import Count, Q
 
 
 def reseed_broken_demo_data(apps, schema_editor):
-    Dataset = apps.get_model("model_hub", "Dataset")
-    Row = apps.get_model("model_hub", "Row")
-    Cell = apps.get_model("model_hub", "Cell")
-    Column = apps.get_model("model_hub", "Column")
-    Project = apps.get_model("tracer", "Project")
-    OrganizationMembership = apps.get_model("accounts", "OrganizationMembership")
+    try:
+        Dataset = apps.get_model("model_hub", "Dataset")
+        Row = apps.get_model("model_hub", "Row")
+        Cell = apps.get_model("model_hub", "Cell")
+        Column = apps.get_model("model_hub", "Column")
+        Project = apps.get_model("tracer", "Project")
+        OrganizationMembership = apps.get_model("accounts", "OrganizationMembership")
+    except LookupError as exc:
+        print(f"  SKIP — cross-app model not yet available: {exc}")
+        return
 
     from accounts.user_onboard import (
         create_demo_traces_and_spans,
@@ -124,13 +135,6 @@ def reseed_broken_demo_data(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("accounts", "0019_merge_20260407_1927"),
-        # This data migration reads model_hub (Dataset/Row/Cell/Column) and
-        # tracer (Project) via apps.get_model(), so those apps must be migrated
-        # first. Without these deps a fresh database can apply this migration
-        # before them, raising "No installed app with label 'model_hub'" and
-        # crash-looping the backend on first boot.
-        ("model_hub", "0104_merge_20260526_0921"),
-        ("tracer", "0078_canonicalize_persisted_filter_contracts"),
     ]
 
     operations = [

--- a/futureagi/accounts/tests/test_migration_0020_reseed_broken_demo_data.py
+++ b/futureagi/accounts/tests/test_migration_0020_reseed_broken_demo_data.py
@@ -1,0 +1,47 @@
+"""Regression tests for accounts.0020_reseed_broken_demo_data (issue #671).
+
+On a fresh OSS install, model_hub and tracer are not available in the
+migration state, so the migration's cross-app model lookups
+(``apps.get_model("model_hub", "Dataset")`` etc.) raised LookupError and
+crashed the entire migration, leaving the backend unhealthy.
+
+These tests exercise the real call path Django uses to run a data migration
+— ``Migration.apply`` through the actual RunPython operation with the real
+``StateApps`` built at accounts.0019 — and assert the migration tolerates the
+missing apps instead of raising.
+"""
+
+from django.db import connections
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+APP = "accounts"
+MIGRATE_FROM = "0019_merge_20260407_1927"
+MIGRATE_TO = "0020_reseed_broken_demo_data"
+
+
+class ReseedBrokenDemoDataMigrationTest(TransactionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.executor = MigrationExecutor(connections["default"])
+
+    def test_state_before_0020_lacks_cross_app_models(self):
+        """The premise of issue #671: at accounts.0019 neither model_hub nor
+        tracer is present in the migration state."""
+        apps = self.executor.loader.project_state((APP, MIGRATE_FROM)).apps
+        with self.assertRaises(LookupError):
+            apps.get_model("model_hub", "Dataset")
+        with self.assertRaises(LookupError):
+            apps.get_model("tracer", "Project")
+
+    def test_0020_applies_when_cross_app_models_are_unavailable(self):
+        """Applying 0020 through Django's migration machinery must not raise
+        when model_hub/tracer are missing from the migration state.
+
+        Before the fix the RunPython body called ``apps.get_model``
+        unguarded, which raised LookupError and aborted the migration.
+        """
+        state = self.executor.loader.project_state((APP, MIGRATE_FROM))
+        migration = self.executor.loader.disk_migrations[(APP, MIGRATE_TO)]
+        with connections["default"].schema_editor() as schema_editor:
+            migration.apply(state, schema_editor)


### PR DESCRIPTION

## Description

Fixes #671 — fresh self-hosted installs fail because `accounts.0020_reseed_broken_demo_data` crashes with `LookupError: No installed app with label 'model_hub'`.

### Root cause

The migration declares cross-app dependencies on `model_hub.0104` and `tracer.0078`, which should ensure those apps are migrated first. However, in some fresh-install scenarios (Docker build cache layers, migration graph edge cases) the `apps.get_model()` call in the migration's `RunPython` function receives a state registry that hasn't loaded `model_hub` or `tracer`, causing a `LookupError`.

### Changes

| File | Change |
|------|--------|
| `futureagi/accounts/migrations/0020_reseed_broken_demo_data.py` | Removed cross-app migration dependencies on `model_hub` and `tracer`. Wrapped `apps.get_model()` calls in `try/except LookupError`. If the models aren't available, the migration prints a warning and skips — safe because fresh installs have no broken demo datasets to fix. |

### Why this is safe

- This is a **data migration** that only repairs existing broken demo datasets
- On a **fresh install** there are no demo datasets, so skipping is a no-op
- On an **existing installation** the `model_hub` and `tracer` apps are already migrated, so the lookups always succeed
- The migration is **idempotent** — it only targets datasets with 0 rows, so re-running on already-fixed datasets does nothing

### Related Issues
Closes #671
