### PR TITLE
feat(evals): add PerspectiveGap system evals

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 15
+SYSTEM_EVALS_VERSION = 16
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/function/perspective_gap_prompt_writing.yaml
+++ b/futureagi/model_hub/system_evals/function/perspective_gap_prompt_writing.yaml
@@ -1,0 +1,238 @@
+eval_id: 203
+name: perspective_gap_prompt_writing
+description: Scores PerspectiveGap free-form prompt-writing outputs for multi-agent orchestration. Checks whether each role-specific prompt includes the required information fragments and excludes irrelevant or distractor fragments.
+criteria: Measures strict prompt-writing accuracy using the PerspectiveGap benchmark scorer over role sections and fragment fingerprints.
+eval_tags:
+- Agents
+- Output Validation
+- Context Engineering
+- Benchmark
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - output
+  - fragments
+  - reference_need_sets
+  output: score
+  eval_type_id: CustomCodeEval
+  config: {}
+  function_params_schema:
+    include_threshold:
+      type: number
+      default: 0.7
+      minimum: 0
+      maximum: 1
+    exclude_threshold:
+      type: number
+      default: 0.3
+      minimum: 0
+      maximum: 1
+  config_params_desc:
+    output: 'Model prediction with one Markdown section per role, using headings such as # Planner and role-specific prompt text'
+    fragments: 'PerspectiveGap fragments list as JSON, where each item contains an id and text'
+    reference_need_sets: 'Gold role-to-fragment mapping as JSON object, matching the PerspectiveGap reference_need_sets field'
+    distractor_id: Optional fragment ID for the distractor item; leaks are counted separately when present
+    include_threshold: Fraction of a required fragment fingerprint that must appear in the role section to count as included
+    exclude_threshold: Fraction of an irrelevant fragment fingerprint that triggers an extra/leak detection
+  param_modalities:
+    output:
+    - TEXT
+    fragments:
+    - JSON
+    - TEXT
+    reference_need_sets:
+    - JSON
+    - TEXT
+    distractor_id:
+    - TEXT
+  code: |
+    import json
+    import re
+
+    NGRAM_ORDERS = (1, 2, 3)
+
+    def metric_values(strict_pass, tp, fp, fn, distractor_leak):
+        expected = tp + fn
+        predicted = tp + fp
+        return {
+            "strict_pass": float(strict_pass),
+            "net_match_score": max(0.0, (tp - fp - fn) / expected) if expected else 0.0,
+            "required_coverage": tp / expected if expected else 0.0,
+            "boundary_precision": tp / predicted if predicted else 0.0,
+            "distractor_leakage": float(distractor_leak),
+        }
+
+    def token_sequence(text):
+        return re.findall(r"[a-zA-Z0-9]+", str(text).lower())
+
+    def ngrams(tokens, orders=NGRAM_ORDERS):
+        result = set()
+        for order in orders:
+            if order <= 0 or order > len(tokens):
+                continue
+            for index in range(len(tokens) - order + 1):
+                result.add(" ".join(tokens[index:index + order]))
+        return result
+
+    def distinctive_ngrams(items):
+        grams = {
+            fragment_id: ngrams(token_sequence(text))
+            for fragment_id, text in items.items()
+        }
+        result = {}
+        for fragment_id, fragment_grams in grams.items():
+            others = set()
+            for other_id, other_grams in grams.items():
+                if other_id != fragment_id:
+                    others.update(other_grams)
+            result[fragment_id] = fragment_grams - others
+        return result
+
+    def split_role_sections(response):
+        sections = {}
+        pattern = re.compile(r"^# (.+?)\s*$", re.MULTILINE)
+        matches = list(pattern.finditer(response))
+        for index, match in enumerate(matches):
+            role = match.group(1)
+            start = match.end()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(response)
+            sections[role] = response[start:end].strip()
+        return sections
+
+    def detect_fraction(distinctive, section_grams):
+        if not distinctive:
+            return 0.0
+        return len(distinctive & section_grams) / len(distinctive)
+
+    def score_prompt_writing(
+        response,
+        fragments,
+        reference_need_sets,
+        distractor_id=None,
+        include_threshold=0.7,
+        exclude_threshold=0.3,
+    ):
+        sections = split_role_sections(response or "")
+        info_items = {
+            fragment["id"]: fragment["text"]
+            for fragment in fragments
+            if isinstance(fragment, dict) and "id" in fragment and "text" in fragment
+        }
+        distinctive = distinctive_ngrams(info_items)
+        role_name_tokens = set()
+        for role in reference_need_sets:
+            role_name_tokens.update(token_sequence(role))
+        filtered_distinctive = {}
+        for fragment_id, fragment_grams in distinctive.items():
+            kept = set()
+            for gram in fragment_grams:
+                if not all(token in role_name_tokens for token in gram.split(" ")):
+                    kept.add(gram)
+            filtered_distinctive[fragment_id] = kept
+        per_role = {}
+        overall_pass = True
+        distractor_ids = {distractor_id} if distractor_id else set()
+        for role, expected_list in reference_need_sets.items():
+            expected_ids = set(expected_list)
+            section_grams = ngrams(token_sequence(sections.get(role, "")))
+            fractions = {
+                fragment_id: round(detect_fraction(fragment_grams, section_grams), 3)
+                for fragment_id, fragment_grams in filtered_distinctive.items()
+            }
+            detected = {
+                fragment_id
+                for fragment_id in expected_ids
+                if fractions.get(fragment_id, 0.0) >= include_threshold
+            }
+            extra = {
+                fragment_id
+                for fragment_id, fraction in fractions.items()
+                if fraction >= exclude_threshold
+            } - expected_ids
+            missing = expected_ids - detected
+            role_pass = not missing and not extra
+            overall_pass = overall_pass and role_pass
+            per_role[role] = {
+                "pass": role_pass,
+                "expected": sorted(expected_ids),
+                "detected": sorted(detected),
+                "missing": sorted(missing),
+                "extra": sorted(extra),
+                "distractor_leak": sorted(extra & distractor_ids),
+                "fractions": fractions,
+            }
+        tp = sum(len(role_result["detected"]) for role_result in per_role.values())
+        fp = sum(len(role_result["extra"]) for role_result in per_role.values())
+        fn = sum(len(role_result["missing"]) for role_result in per_role.values())
+        distractor_leak = sum(
+            len(role_result["distractor_leak"])
+            for role_result in per_role.values()
+        )
+        counts = {
+            "tp": tp,
+            "fp": fp,
+            "fn": fn,
+            "distractor_leak": distractor_leak,
+        }
+        return {
+            "pass": overall_pass,
+            "metrics": metric_values(overall_pass, tp, fp, fn, distractor_leak),
+            "counts": counts,
+            "sections_found": sorted(sections),
+            "per_role": per_role,
+        }
+
+    def evaluate(input, output, expected, context, **kwargs):
+        raw = kwargs.get("output", output) or ""
+        text = str(raw)
+        parts = text.rsplit("</think>", 1)
+        response = parts[1].strip() if len(parts) == 2 else text.strip()
+        fragments = kwargs.get("fragments")
+        reference = kwargs.get("reference_need_sets")
+        for name, value in [("fragments", fragments), ("reference_need_sets", reference)]:
+            if value is None:
+                return {"score": 0.0, "reason": f"Missing required field: {name}"}
+        if isinstance(fragments, str):
+            try:
+                fragments = json.loads(fragments)
+            except (json.JSONDecodeError, ValueError) as error:
+                return {"score": 0.0, "reason": f"Cannot parse fragments: {error}"}
+        if isinstance(reference, str):
+            try:
+                reference = json.loads(reference)
+            except (json.JSONDecodeError, ValueError) as error:
+                return {"score": 0.0, "reason": f"Cannot parse reference_need_sets: {error}"}
+        distractor = kwargs.get("distractor_id")
+        try:
+            include_threshold = float(kwargs.get("include_threshold", 0.7))
+            exclude_threshold = float(kwargs.get("exclude_threshold", 0.3))
+        except (TypeError, ValueError):
+            include_threshold = 0.7
+            exclude_threshold = 0.3
+        result = score_prompt_writing(
+            response,
+            fragments,
+            reference,
+            distractor,
+            include_threshold=include_threshold,
+            exclude_threshold=exclude_threshold,
+        )
+        score = float(result.get("metrics", {}).get("strict_pass", 0.0))
+        metrics = result.get("metrics", {})
+        counts = result.get("counts", {})
+        status = "passed" if result.get("pass") else "failed"
+        reason = (
+            f"PerspectiveGap prompt writing {status}: "
+            f"strict_pass={metrics.get('strict_pass', 0.0):.1f}, "
+            f"net_match={metrics.get('net_match_score', 0.0):.3f}, "
+            f"coverage={metrics.get('required_coverage', 0.0):.3f}, "
+            f"precision={metrics.get('boundary_precision', 0.0):.3f}, "
+            f"leakage={metrics.get('distractor_leakage', 0.0):.1f}; "
+            f"counts={counts}"
+        )
+        return {"score": score, "reason": reason}

--- a/futureagi/model_hub/system_evals/function/perspective_gap_role_assignment.yaml
+++ b/futureagi/model_hub/system_evals/function/perspective_gap_role_assignment.yaml
@@ -1,0 +1,188 @@
+eval_id: 202
+name: perspective_gap_role_assignment
+description: Scores PerspectiveGap role-fragment assignment outputs for multi-agent orchestration. Checks whether each sub-agent role receives exactly the information fragments it needs while avoiding omissions, leakage, and distractors.
+criteria: Measures strict role-fragment assignment accuracy using the PerspectiveGap benchmark scorer.
+eval_tags:
+- Agents
+- Output Validation
+- Context Engineering
+- Benchmark
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: percentage
+pass_threshold: 0.5
+config:
+  required_keys:
+  - output
+  - reference_need_sets
+  output: score
+  eval_type_id: CustomCodeEval
+  config: {}
+  config_params_desc:
+    output: 'Model prediction as a JSON object mapping role names to lists of fragment IDs, e.g. {"Planner": ["F1", "F3"]}'
+    reference_need_sets: 'Gold role-to-fragment mapping as JSON object, matching the PerspectiveGap reference_need_sets field'
+    distractor_id: Optional fragment ID for the distractor item; leaks are counted separately when present
+  param_modalities:
+    output:
+    - TEXT
+    - JSON
+    reference_need_sets:
+    - JSON
+    - TEXT
+    distractor_id:
+    - TEXT
+  code: |
+    import json
+    import re
+
+    def metric_values(strict_pass, tp, fp, fn, distractor_leak):
+        expected = tp + fn
+        predicted = tp + fp
+        return {
+            "strict_pass": float(strict_pass),
+            "net_match_score": max(0.0, (tp - fp - fn) / expected) if expected else 0.0,
+            "required_coverage": tp / expected if expected else 0.0,
+            "boundary_precision": tp / predicted if predicted else 0.0,
+            "distractor_leakage": float(distractor_leak),
+        }
+
+    def parse_json_response(text):
+        if text is None:
+            raise ValueError("empty response")
+        text = text.strip()
+        fence = re.match(r"^```(?:json)?\s*\n(.*?)\n```\s*$", text, re.DOTALL)
+        if fence:
+            text = fence.group(1).strip()
+        return json.loads(text)
+
+    def parse_json_object_loose(text):
+        if text is None:
+            raise ValueError("empty response")
+        try:
+            parsed = parse_json_response(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not match:
+            raise ValueError("no JSON object")
+        parsed = json.loads(match.group(0))
+        if not isinstance(parsed, dict):
+            raise ValueError("response is not a JSON object")
+        return parsed
+
+    def score_role_assignment(response_text, reference_need_sets, distractor_id=None):
+        reference_event_count = sum(len(items) for items in reference_need_sets.values())
+        parse_fail_counts = {
+            "tp": 0,
+            "fp": 0,
+            "fn": reference_event_count,
+            "distractor_leak": 0,
+        }
+        strict_error = None
+        try:
+            strict_predicted = parse_json_response(response_text)
+            if not isinstance(strict_predicted, dict):
+                strict_error = "response is not a JSON object"
+        except (json.JSONDecodeError, ValueError) as error:
+            strict_predicted = None
+            strict_error = f"parse: {error}"
+        try:
+            boundary_predicted = parse_json_object_loose(response_text)
+        except (json.JSONDecodeError, ValueError) as error:
+            return {
+                "pass": False,
+                "metrics": metric_values(
+                    False,
+                    parse_fail_counts["tp"],
+                    parse_fail_counts["fp"],
+                    parse_fail_counts["fn"],
+                    parse_fail_counts["distractor_leak"],
+                ),
+                "counts": parse_fail_counts,
+                "error": strict_error or f"parse: {error}",
+            }
+        normalized = {
+            role: sorted({fragment_id for fragment_id in fragment_ids if isinstance(fragment_id, str)})
+            for role, fragment_ids in boundary_predicted.items()
+            if isinstance(fragment_ids, list)
+        }
+        strict_role_values_are_valid = (
+            isinstance(strict_predicted, dict)
+            and all(
+                isinstance(fragment_ids, list)
+                and all(isinstance(fragment_id, str) for fragment_id in fragment_ids)
+                for fragment_ids in strict_predicted.values()
+            )
+        )
+        per_role = {
+            role: set(normalized.get(role, [])) == set(expected)
+            for role, expected in reference_need_sets.items()
+        }
+        tp = 0
+        fp = 0
+        fn = 0
+        distractor_leak = 0
+        distractor_ids = {distractor_id} if distractor_id else set()
+        for role, expected_list in reference_need_sets.items():
+            expected = set(expected_list)
+            predicted_set = set(normalized.get(role, []))
+            extra = predicted_set - expected
+            tp += len(predicted_set & expected)
+            fp += len(extra)
+            fn += len(expected - predicted_set)
+            distractor_leak += len(extra & distractor_ids)
+        overall_pass = (
+            strict_error is None
+            and strict_role_values_are_valid
+            and set(strict_predicted.keys()) == set(reference_need_sets.keys())
+            and all(per_role.values())
+        )
+        counts = {
+            "tp": tp,
+            "fp": fp,
+            "fn": fn,
+            "distractor_leak": distractor_leak,
+        }
+        return {
+            "pass": overall_pass,
+            "metrics": metric_values(overall_pass, tp, fp, fn, distractor_leak),
+            "counts": counts,
+            "normalized": normalized,
+            "per_role": per_role,
+        }
+
+    def evaluate(input, output, expected, context, **kwargs):
+        raw = kwargs.get("output", output) or ""
+        text = str(raw)
+        parts = text.rsplit("</think>", 1)
+        response = parts[1].strip() if len(parts) == 2 else text.strip()
+        ref = kwargs.get("reference_need_sets")
+        if ref is None:
+            return {"score": 0.0, "reason": "Missing required field: reference_need_sets"}
+        if isinstance(ref, str):
+            try:
+                ref = json.loads(ref)
+            except (json.JSONDecodeError, ValueError) as error:
+                return {"score": 0.0, "reason": f"Cannot parse reference_need_sets: {error}"}
+        distractor = kwargs.get("distractor_id")
+        result = score_role_assignment(response, ref, distractor)
+        score = float(result.get("metrics", {}).get("strict_pass", 0.0))
+        if result.get("error"):
+            return {"score": score, "reason": result["error"]}
+        metrics = result.get("metrics", {})
+        counts = result.get("counts", {})
+        status = "passed" if result.get("pass") else "failed"
+        reason = (
+            f"PerspectiveGap role assignment {status}: "
+            f"strict_pass={metrics.get('strict_pass', 0.0):.1f}, "
+            f"net_match={metrics.get('net_match_score', 0.0):.3f}, "
+            f"coverage={metrics.get('required_coverage', 0.0):.3f}, "
+            f"precision={metrics.get('boundary_precision', 0.0):.3f}, "
+            f"leakage={metrics.get('distractor_leakage', 0.0):.1f}; "
+            f"counts={counts}"
+        )
+        return {"score": score, "reason": reason}

--- a/futureagi/model_hub/system_evals/tests/test_perspective_gap_evals.py
+++ b/futureagi/model_hub/system_evals/tests/test_perspective_gap_evals.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+SYSTEM_EVALS_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_eval_yaml(track: str, name: str):
+    return yaml.safe_load((SYSTEM_EVALS_DIR / track / f"{name}.yaml").read_text())
+
+
+def _extract_evaluate(yaml_spec):
+    code = yaml_spec["config"]["code"]
+    namespace = {}
+    exec(code, namespace)
+    return namespace["evaluate"]
+
+
+def _run_in_production_sandbox(yaml_spec, input_data, monkeypatch):
+    from agentic_eval.core_evals.fi_utils import sandbox
+
+    monkeypatch.setattr(sandbox, "_call_executor_service", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sandbox, "SAFE_MODULES", ["json", "re", "difflib"])
+    result = sandbox.execute_sandboxed_python(
+        yaml_spec["config"]["code"],
+        input_data,
+        timeout=10,
+    )
+    assert result["status"] == "success", result
+    return result["data"]
+
+
+def test_role_assignment_yaml_registered():
+    spec = _load_eval_yaml("function", "perspective_gap_role_assignment")
+    assert spec["eval_id"] == 202
+    assert spec["name"] == "perspective_gap_role_assignment"
+    assert spec["config"]["eval_type_id"] == "CustomCodeEval"
+    assert spec["config"]["required_keys"] == ["output", "reference_need_sets"]
+    assert "from perspective_gap" not in spec["config"]["code"]
+
+
+def test_prompt_writing_yaml_registered():
+    spec = _load_eval_yaml("function", "perspective_gap_prompt_writing")
+    assert spec["eval_id"] == 203
+    assert spec["name"] == "perspective_gap_prompt_writing"
+    assert spec["config"]["eval_type_id"] == "CustomCodeEval"
+    assert spec["config"]["required_keys"] == [
+        "output",
+        "fragments",
+        "reference_need_sets",
+    ]
+    assert (
+        spec["config"]["function_params_schema"]["include_threshold"]["default"] == 0.7
+    )
+    assert (
+        spec["config"]["function_params_schema"]["exclude_threshold"]["default"] == 0.3
+    )
+    assert "from perspective_gap" not in spec["config"]["code"]
+
+
+def test_eval_ids_are_unique():
+    eval_ids = []
+    for path in SYSTEM_EVALS_DIR.glob("*/*.yaml"):
+        spec = yaml.safe_load(path.read_text())
+        if spec and "eval_id" in spec:
+            eval_ids.append(spec["eval_id"])
+    assert len(eval_ids) == len(set(eval_ids))
+
+
+def test_role_assignment_exact_match_passes():
+    spec = _load_eval_yaml("function", "perspective_gap_role_assignment")
+    evaluate = _extract_evaluate(spec)
+    reference = {"Planner": ["F1", "F3"], "Reviewer": ["F2"]}
+
+    result = evaluate(
+        input=None,
+        output='ignored </think> {"Planner": ["F3", "F1"], "Reviewer": ["F2"]}',
+        expected=None,
+        context=None,
+        reference_need_sets=json.dumps(reference),
+        distractor_id="D1",
+    )
+
+    assert result["score"] == 1.0
+    assert "PerspectiveGap role assignment passed" in result["reason"]
+    assert (
+        "counts={'tp': 3, 'fp': 0, 'fn': 0, 'distractor_leak': 0}" in result["reason"]
+    )
+
+
+def test_role_assignment_extra_distractor_fails():
+    spec = _load_eval_yaml("function", "perspective_gap_role_assignment")
+    evaluate = _extract_evaluate(spec)
+
+    result = evaluate(
+        input=None,
+        output='{"Planner": ["F1", "D1"]}',
+        expected=None,
+        context=None,
+        reference_need_sets={"Planner": ["F1"]},
+        distractor_id="D1",
+    )
+
+    assert result["score"] == 0.0
+    assert "PerspectiveGap role assignment failed" in result["reason"]
+    assert "leakage=1.0" in result["reason"]
+
+
+def test_role_assignment_surfaces_parse_error():
+    spec = _load_eval_yaml("function", "perspective_gap_role_assignment")
+    evaluate = _extract_evaluate(spec)
+
+    result = evaluate(
+        input=None,
+        output="not json",
+        expected=None,
+        context=None,
+        reference_need_sets={"Planner": ["F1"]},
+    )
+
+    assert result["score"] == 0.0
+    assert result["reason"].startswith("parse:")
+
+
+def test_prompt_writing_exact_fragments_pass():
+    spec = _load_eval_yaml("function", "perspective_gap_prompt_writing")
+    evaluate = _extract_evaluate(spec)
+    fragments = [{"id": "F1", "text": "Use the verified benchmark evidence."}]
+
+    result = evaluate(
+        input=None,
+        output="</think> # Planner\nUse the verified benchmark evidence.",
+        expected=None,
+        context=None,
+        fragments=json.dumps(fragments),
+        reference_need_sets=json.dumps({"Planner": ["F1"]}),
+        distractor_id="D1",
+    )
+
+    assert result["score"] == 1.0
+    assert "PerspectiveGap prompt writing passed" in result["reason"]
+
+
+def test_prompt_writing_distractor_leak_fails():
+    spec = _load_eval_yaml("function", "perspective_gap_prompt_writing")
+    evaluate = _extract_evaluate(spec)
+    fragments = [
+        {"id": "F1", "text": "alpha planner evidence"},
+        {"id": "F2", "text": "beta reviewer evidence"},
+        {"id": "D1", "text": "gamma confidential distractor"},
+    ]
+    response = (
+        "# Planner\nalpha planner evidence gamma confidential distractor\n\n"
+        "# Reviewer\nbeta reviewer evidence"
+    )
+
+    result = evaluate(
+        input=None,
+        output=response,
+        expected=None,
+        context=None,
+        fragments=fragments,
+        reference_need_sets={"Planner": ["F1"], "Reviewer": ["F2"]},
+        distractor_id="D1",
+    )
+
+    assert result["score"] == 0.0
+    assert "PerspectiveGap prompt writing failed" in result["reason"]
+    assert "leakage=1.0" in result["reason"]
+
+
+def test_role_assignment_runs_in_production_sandbox(monkeypatch):
+    spec = _load_eval_yaml("function", "perspective_gap_role_assignment")
+    result = _run_in_production_sandbox(
+        spec,
+        {
+            "output": '{"Planner": ["F1"]}',
+            "reference_need_sets": {"Planner": ["F1"]},
+            "distractor_id": "D1",
+        },
+        monkeypatch,
+    )
+
+    assert result["result"] == 1.0
+    assert "PerspectiveGap role assignment passed" in result["reason"]
+
+
+def test_prompt_writing_runs_in_production_sandbox(monkeypatch):
+    spec = _load_eval_yaml("function", "perspective_gap_prompt_writing")
+    result = _run_in_production_sandbox(
+        spec,
+        {
+            "output": "# Planner\nUse the verified benchmark evidence.",
+            "fragments": [{"id": "F1", "text": "Use the verified benchmark evidence."}],
+            "reference_need_sets": {"Planner": ["F1"]},
+            "distractor_id": "D1",
+        },
+        monkeypatch,
+    )
+
+    assert result["result"] == 1.0
+    assert "PerspectiveGap prompt writing passed" in result["reason"]


### PR DESCRIPTION
## Summary

Adds two PerspectiveGap benchmark tasks as Future AGI system evals:

- `perspective_gap_role_assignment` (eval_id 202)
- `perspective_gap_prompt_writing` (eval_id 203)

Both are `CustomCodeEval` definitions with self-contained scoring code that runs inside Future AGI's production RestrictedPython sandbox. They no longer import an external package or expose an installation hint users cannot act on. The role-assignment scorer preserves the official scoring logic; prompt writing preserves the distinctive unigram/bigram/trigram fingerprint algorithm with deterministic sandbox-safe tokenization.

`SYSTEM_EVALS_VERSION` is bumped `15 → 16` so the startup seeder inserts the new evals on deploy.

## Linked issues

Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

```bash
pytest model_hub/system_evals/tests/test_perspective_gap_evals.py -q
# 10 passed

pytest agentic_eval/core_evals/fi_utils/tests/test_restricted_code_execution.py -q
# 30 passed

pytest model_hub/system_evals/tests/test_validators.py -q
# 56 passed
```

The focused suite executes both YAML bodies through `execute_sandboxed_python` with the production import whitelist, in addition to direct behavior tests and eval-ID uniqueness checks.

Scorer comparison against the official PerspectiveGap package at commit `9c6921b3337ff3e6a6a453f68d117a8c1663135e`:

- Role assignment: 220 saved model outputs, 0 pass/metric/count mismatches.
- Prompt writing: 220 saved model outputs, 0 strict-pass mismatches. Two already-failing outputs differ in a secondary false-positive count because the sandbox-safe tokenizer cannot load the official Qwen tokenizer; the user-visible strict score is unchanged.
- Labeled scorer validation: 716 role judgments, 0 decision mismatches; both scorers match 712/716 labels (99.44%).

Repository pre-commit hooks pass on all four changed files, and `git diff --check` is clean.

## Screenshots / recordings (if UI)

N/A — no frontend changes.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA (if required)
