### PR TITLE
fix(hooks): spawn lint-staged tools via node so commits work on Windows

### DIFF
--- a/scripts/lint-staged-frontend.mjs
+++ b/scripts/lint-staged-frontend.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -66,15 +66,29 @@ const prettierFiles = uniqueFiles.filter((file) =>
   prettierExtensions.has(path.extname(file)),
 );
 
+// Resolve a package's bin script and run it with the current Node binary.
+// The .bin shims cannot be used here: on Windows they are .cmd files, which
+// Node refuses to spawn without a shell (the extensionless POSIX shim is not
+// executable there at all).
+const resolveBin = (pkg, binName = pkg) => {
+  const pkgDir = path.join(frontendDir, "node_modules", pkg);
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  if (!existsSync(pkgJsonPath)) return null;
+  const { bin } = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+  const relative = typeof bin === "string" ? bin : bin?.[binName];
+  if (!relative) return null;
+  return path.join(pkgDir, relative);
+};
+
 const run = (bin, args) => {
-  const command = path.join(frontendDir, "node_modules", ".bin", bin);
-  if (!existsSync(command)) {
+  const script = resolveBin(bin);
+  if (!script || !existsSync(script)) {
     console.error(
       `Missing ${bin}. Run "yarn --cwd frontend install" before committing.`,
     );
     process.exit(1);
   }
-  const result = spawnSync(command, args, {
+  const result = spawnSync(process.execPath, [script, ...args], {
     cwd: frontendDir,
     stdio: "inherit",
   });

--- a/scripts/lint-staged-root-format.mjs
+++ b/scripts/lint-staged-root-format.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -8,15 +8,25 @@ const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
-const prettier = path.join(
+// Resolve prettier's bin script so it can run with the current Node binary.
+// The .bin shim cannot be used here: on Windows it is a .cmd file, which
+// Node refuses to spawn without a shell (the extensionless POSIX shim is not
+// executable there at all).
+const prettierPkgDir = path.join(
   rootDir,
   "frontend",
   "node_modules",
-  ".bin",
   "prettier",
 );
+const prettier = (() => {
+  const pkgJsonPath = path.join(prettierPkgDir, "package.json");
+  if (!existsSync(pkgJsonPath)) return null;
+  const { bin } = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+  const relative = typeof bin === "string" ? bin : bin?.prettier;
+  return relative ? path.join(prettierPkgDir, relative) : null;
+})();
 
-if (!existsSync(prettier)) {
+if (!prettier || !existsSync(prettier)) {
   console.error('Missing prettier. Run "yarn --cwd frontend install" first.');
   process.exit(1);
 }
@@ -43,9 +53,13 @@ const files = process.argv
 const uniqueFiles = [...new Set(files)];
 if (uniqueFiles.length === 0) process.exit(0);
 
-const result = spawnSync(prettier, ["--write", ...uniqueFiles], {
-  cwd: rootDir,
-  stdio: "inherit",
-});
+const result = spawnSync(
+  process.execPath,
+  [prettier, "--write", ...uniqueFiles],
+  {
+    cwd: rootDir,
+    stdio: "inherit",
+  },
+);
 
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

On Windows, every commit touching a frontend or root-level file died in the pre-commit hook with `Task failed to spawn: node scripts/lint-staged-frontend.mjs`, forcing Windows contributors to `--no-verify` (and therefore to skip formatting/linting entirely). The scripts spawned the extensionless POSIX shims in `frontend/node_modules/.bin`, which aren't executable on Windows — and the `.cmd` counterparts can't be spawned without a shell either, since Node's CVE-2024-27980 hardening rejects `.cmd`/`.bat` spawns.

Both scripts now resolve the tool's real bin script from its `package.json` (`eslint/bin/eslint.js`, `prettier/bin/prettier.cjs`) and run it with `process.execPath`. This is platform-independent, avoids `shell: true` (no argument-quoting pitfalls, no DEP0190 deprecation on Node ≥ 24), keeps the helpful "run yarn install first" error, and preserves exit-code propagation so lint errors still block the commit. Behavior on macOS/Linux is unchanged — the same JS entrypoints the shims pointed at are executed, just without the shim indirection.

## Linked issues

Closes #1340

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

On Windows 11 / Node 24 (where the hook previously always failed):

- `node scripts/lint-staged-frontend.mjs frontend/src/utils/utils.js` — eslint --fix + prettier --write run, exit 0.
- Failure path: a staged file with a parse error exits 1 (`Parsing error: Unexpected token`), so bad code still blocks the commit; eslint warnings still exit 0, matching current POSIX behavior.
- `node scripts/lint-staged-root-format.mjs <root md file>` — prettier runs, exit 0.
- End-to-end: this PR's own commit was made **with the hook enabled** — lint-staged ran the fixed scripts against the staged `.mjs` files (prettier reformatted one of them during the commit).
- POSIX behavior is preserved by construction: the resolved bin script is exactly what the `.bin` shim executed before.

## Screenshots / recordings (if UI)

N/A — tooling fix.

## Checklist

- [x] My code follows the [style guide](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (manual verification above — these hook scripts have no test harness today)
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#contributor-license-agreement-cla)
