### PR TITLE
fix(evals): stop link evals from treating e-mails and decimals as URLs

### DIFF
--- a/futureagi/model_hub/system_evals/function/contains_valid_link.yaml
+++ b/futureagi/model_hub/system_evals/function/contains_valid_link.yaml
@@ -23,7 +23,11 @@ config:
         import urllib.request
         text = kwargs.get("text", output or "")
         text = str(text)
-        pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
+        # Match scheme/www URLs and bare domains with an alphabetic TLD. The
+        # lookbehind stops matches from starting inside a word or right after
+        # "@", so e-mail addresses, decimals ("3.14") and abbreviations
+        # ("e.g.") are not treated as links.
+        pattern = r"(?<![@\w.])(?:https?://|www\.)?(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d+)?(?:[/?#]\S*)?"
         link_match = re.search(pattern, text)
         if not link_match:
             return {"score": 0.0, "reason": "No link found in output"}

--- a/futureagi/model_hub/system_evals/function/no_invalid_links.yaml
+++ b/futureagi/model_hub/system_evals/function/no_invalid_links.yaml
@@ -23,7 +23,11 @@ config:
         import urllib.request
         text = kwargs.get("text", output or "")
         text = str(text)
-        pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
+        # Match scheme/www URLs and bare domains with an alphabetic TLD. The
+        # lookbehind stops matches from starting inside a word or right after
+        # "@", so e-mail addresses, decimals ("3.14") and abbreviations
+        # ("e.g.") are not treated as links.
+        pattern = r"(?<![@\w.])(?:https?://|www\.)?(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d+)?(?:[/?#]\S*)?"
         links = re.findall(pattern, text)
         if not links:
             return {"score": 1.0, "reason": "No links found in output, so none are invalid"}

--- a/futureagi/model_hub/tests/test_system_eval_link_detection.py
+++ b/futureagi/model_hub/tests/test_system_eval_link_detection.py
@@ -1,0 +1,103 @@
+"""Link-detection system evals must not treat e-mail addresses or
+number/abbreviation tokens as URLs.
+
+The previous pattern's ``(?!.*@)`` guard only rejected match attempts that
+start before an ``@`` — ``re.search``/``re.findall`` simply retried after it
+and matched the e-mail's domain. ``\\S+\\.\\S+`` also matched decimals
+("3.14") and abbreviations ("e.g."), so ``no_invalid_links`` HEAD-requested
+``http://3.14`` and failed link-free outputs.
+"""
+
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+SYSTEM_EVALS_DIR = Path(__file__).resolve().parents[1] / "system_evals" / "function"
+
+
+def _load_evaluate(yaml_name):
+    definition = yaml.safe_load(
+        (SYSTEM_EVALS_DIR / yaml_name).read_text(encoding="utf-8")
+    )
+    namespace = {}
+    exec(definition["config"]["code"], namespace)  # noqa: S102 — repo-owned YAML
+    return namespace["evaluate"]
+
+
+def _response(status=200):
+    resp = mock.Mock()
+    resp.status = status
+    return resp
+
+
+class TestContainsValidLink:
+    def _evaluate(self, text, urlopen):
+        evaluate = _load_evaluate("contains_valid_link.yaml")
+        with mock.patch("urllib.request.urlopen", urlopen):
+            return evaluate(None, text, None, None)
+
+    def test_email_only_text_is_not_a_link(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate("Contact us at support@acme.io for help", urlopen)
+        assert result["score"] == 0.0
+        urlopen.assert_not_called()
+
+    def test_decimals_and_abbreviations_are_not_links(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate("Pi is roughly 3.14, e.g. in rough estimates", urlopen)
+        assert result["score"] == 0.0
+        urlopen.assert_not_called()
+
+    def test_scheme_url_is_detected_and_checked(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate("See https://futureagi.com/docs for details", urlopen)
+        assert result["score"] == 1.0
+        requested = urlopen.call_args.args[0].full_url
+        assert requested == "https://futureagi.com/docs"
+
+    def test_bare_domain_is_still_detected(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate("Visit futureagi.com to learn more", urlopen)
+        assert result["score"] == 1.0
+        requested = urlopen.call_args.args[0].full_url
+        assert requested == "http://futureagi.com"
+
+    def test_unreachable_link_fails(self):
+        urlopen = mock.Mock(side_effect=OSError("connection refused"))
+        result = self._evaluate("See https://dead.futureagi.com", urlopen)
+        assert result["score"] == 0.0
+        assert "unreachable" in result["reason"]
+
+
+class TestNoInvalidLinks:
+    def _evaluate(self, text, urlopen):
+        evaluate = _load_evaluate("no_invalid_links.yaml")
+        with mock.patch("urllib.request.urlopen", urlopen):
+            return evaluate(None, text, None, None)
+
+    def test_email_only_text_passes_without_network_calls(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate("Contact us at support@acme.io for help", urlopen)
+        assert result["score"] == 1.0
+        urlopen.assert_not_called()
+
+    def test_decimals_do_not_fail_linkless_text(self):
+        urlopen = mock.Mock(side_effect=OSError("no such host"))
+        result = self._evaluate("The value increased by 3.14 percent", urlopen)
+        assert result["score"] == 1.0
+        urlopen.assert_not_called()
+
+    def test_dead_link_still_fails(self):
+        urlopen = mock.Mock(side_effect=OSError("no such host"))
+        result = self._evaluate("Read https://dead.futureagi.com/page", urlopen)
+        assert result["score"] == 0.0
+        assert "invalid links" in result["reason"].lower()
+
+    def test_valid_links_pass(self):
+        urlopen = mock.Mock(return_value=_response())
+        result = self._evaluate(
+            "Docs at https://futureagi.com/docs and www.futureagi.com", urlopen
+        )
+        assert result["score"] == 1.0
+        assert urlopen.call_count == 2


### PR DESCRIPTION
## Summary

The production `contains_valid_link` and `no_invalid_links` system evals used the pattern `(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+`. The `(?!.*@)` e-mail guard is defeated by `re.search`/`re.findall` retrying past the `@` (so `support@acme.io` counted as a link and its domain got HEAD-requested), and `\S+\.\S+` matched decimals and abbreviations — `no_invalid_links` HEAD-requested `http://3.14` and failed link-free prose containing any number like "3.14" or token like "e.g.".

The new pattern matches scheme URLs, `www.` URLs, and bare domains with an alphabetic TLD (ports and paths included), anchored by a `(?<![@\w.])` lookbehind so a match can never start inside a word or right after `@`. Bare-domain detection (`futureagi.com`) is preserved. Per the guidance on #814, the fix targets the YAML-seeded production evals, not the legacy `functions.py` path.

## Linked issues

Closes #1342

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- New `futureagi/model_hub/tests/test_system_eval_link_detection.py` loads both YAMLs, execs their code blocks, and runs them with `urllib.request.urlopen` mocked (no network):
  - e-mail-only text → no link found, no HEAD request (both evals)
  - decimal/abbreviation text → no link found, `no_invalid_links` passes instead of HEAD-requesting `http://3.14`
  - scheme URL, `www.` URL, and bare-domain detection preserved (asserts the exact URL that gets HEAD-requested)
  - unreachable-link failure paths preserved
- Against the old pattern the 4 false-positive tests fail; the 5 behavior-preservation tests pass on both old and new code. 9/9 pass with the fix (`pytest model_hub/tests/test_system_eval_link_detection.py`).

## Screenshots / recordings (if UI)

N/A — eval logic fix.

## Checklist

- [x] My code follows the [style guide](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#contributor-license-agreement-cla)
