### PR TITLE
fix(evals): stop BLEU evals from zeroing out short hypotheses

### DIFF
--- a/futureagi/model_hub/system_evals/function/bleu_score.yaml
+++ b/futureagi/model_hub/system_evals/function/bleu_score.yaml
@@ -48,16 +48,21 @@ config:
                 clipped += min(count, ref_ngrams.get(ng, 0))
             return clipped, total
 
-        # Compute 1..4-gram precisions with +1 smoothing (Laplace) to avoid log(0).
-        weights = [0.25, 0.25, 0.25, 0.25]
+        # BLEU is only defined over the n-gram orders the hypothesis can
+        # form. Scoring fixed 1..4 orders zeroed out short answers: a
+        # single-word exact match scored ~2e-07 because orders 2-4 each
+        # contributed log(1e-9). Restrict to the available orders with
+        # renormalized weights, and smooth zero-overlap orders with a small
+        # epsilon mass (NLTK method-1 style) instead of inflating them.
+        max_n = min(4, len(hyp_tokens))
+        weights = [1.0 / max_n] * max_n
         log_precisions = []
-        for n in range(1, 5):
+        for n in range(1, max_n + 1):
             clipped, total = _modified_precision(ref_tokens, hyp_tokens, n)
-            if total == 0:
-                # No n-grams of this order in hypothesis.
-                precision = 1e-9
+            if clipped > 0:
+                precision = clipped / total
             else:
-                precision = (clipped + 1) / (total + 1)  # add-1 smoothing
+                precision = 0.1 / total  # epsilon smoothing, avoids log(0)
             log_precisions.append(math.log(precision))
 
         # Brevity penalty

--- a/futureagi/model_hub/system_evals/function/code_bleu.yaml
+++ b/futureagi/model_hub/system_evals/function/code_bleu.yaml
@@ -36,19 +36,21 @@ config:
             return {"score": 0.0, "reason": "Empty hypothesis"}
         def _ng(t, n):
             return [tuple(t[i:i+n]) for i in range(len(t)-n+1)]
+        # Only score the n-gram orders the hypothesis can form; fixed 1..4
+        # orders zeroed out short snippets (identical "return x" scored 0.30
+        # because orders 3-4 contributed log(1e-9) each). Zero-overlap orders
+        # get a small epsilon mass (NLTK method-1 style) instead.
+        max_n = min(4, len(ht))
         lp = []
-        for n in range(1, 5):
+        for n in range(1, max_n + 1):
             rn = Counter(_ng(rt, n))
             hn = Counter(_ng(ht, n))
             tot = sum(hn.values())
-            if tot == 0:
-                p = 1e-9
-            else:
-                cl = sum(min(hn[ng], rn.get(ng, 0)) for ng in hn)
-                p = (cl + 1) / (tot + 1)
+            cl = sum(min(hn[ng], rn.get(ng, 0)) for ng in hn)
+            p = cl / tot if cl > 0 else 0.1 / tot
             lp.append(math.log(p))
         bp = 1.0 if len(ht) >= len(rt) else math.exp(1 - len(rt)/max(len(ht), 1))
-        bleu = bp * math.exp(sum(0.25*l for l in lp))
+        bleu = bp * math.exp(sum(l / max_n for l in lp))
         kws = {"def","class","return","if","else","elif","for","while","try","except",
                "finally","with","import","from","as","in","not","and","or","is","None",
                "True","False","lambda","yield","async","await","function","const","let",

--- a/futureagi/model_hub/tests/test_system_eval_bleu_scores.py
+++ b/futureagi/model_hub/tests/test_system_eval_bleu_scores.py
@@ -1,0 +1,85 @@
+"""BLEU system evals must not zero out short hypotheses.
+
+The previous implementations always averaged over n-gram orders 1..4 and
+substituted ``1e-9`` for orders the hypothesis was too short to form, so an
+exact single-word match scored ``~2e-07`` (bleu_score) and an identical
+two-token snippet scored ``0.30`` (code_bleu) — every short answer failed the
+default 0.5 pass threshold even when byte-identical to the reference.
+"""
+
+from pathlib import Path
+
+import yaml
+
+SYSTEM_EVALS_DIR = Path(__file__).resolve().parents[1] / "system_evals" / "function"
+
+
+def _load_evaluate(yaml_name):
+    definition = yaml.safe_load(
+        (SYSTEM_EVALS_DIR / yaml_name).read_text(encoding="utf-8")
+    )
+    namespace = {}
+    exec(definition["config"]["code"], namespace)  # noqa: S102 — repo-owned YAML
+    return namespace["evaluate"]
+
+
+class TestBleuScore:
+    def _score(self, hypothesis, reference):
+        evaluate = _load_evaluate("bleu_score.yaml")
+        return evaluate(None, hypothesis, reference, None)["score"]
+
+    def test_exact_single_word_match_scores_one(self):
+        assert self._score("Paris", "Paris") == 1.0
+
+    def test_exact_short_sentence_scores_one(self):
+        assert self._score("the cat sat", "the cat sat") == 1.0
+
+    def test_exact_long_sentence_still_scores_one(self):
+        text = "the quick brown fox jumps over the lazy dog near the river bank"
+        assert self._score(text, text) == 1.0
+
+    def test_disjoint_single_word_fails_threshold(self):
+        assert self._score("London", "Paris") < 0.5
+
+    def test_disjoint_sentences_score_low(self):
+        score = self._score("dogs bark loudly at night", "the cat sat on the mat")
+        assert score < 0.5
+
+    def test_partial_overlap_scores_between_wrong_and_exact(self):
+        partial = self._score("the cat sat on a rug", "the cat sat on the mat")
+        wrong = self._score("dogs bark loudly at night", "the cat sat on the mat")
+        assert wrong < partial < 1.0
+
+    def test_brevity_penalty_still_applies(self):
+        truncated = self._score("the cat sat", "the cat sat on the mat")
+        assert truncated < 1.0
+        assert truncated > 0.0
+
+    def test_empty_hypothesis_scores_zero(self):
+        assert self._score("", "the cat sat") == 0.0
+
+
+class TestCodeBleu:
+    def _score(self, hypothesis, reference):
+        evaluate = _load_evaluate("code_bleu.yaml")
+        return evaluate(None, hypothesis, reference, None)["score"]
+
+    def test_identical_short_snippet_scores_one(self):
+        assert self._score("return x", "return x") == 1.0
+
+    def test_identical_single_keyword_scores_one(self):
+        assert self._score("return", "return") == 1.0
+
+    def test_identical_long_snippet_still_scores_one(self):
+        snippet = "def add(a, b): return a + b if a and b else None"
+        assert self._score(snippet, snippet) == 1.0
+
+    def test_disjoint_snippets_score_low(self):
+        score = self._score("SELECT * FROM users", "def add(a, b): return a + b")
+        assert score < 0.5
+
+    def test_keyword_component_still_contributes(self):
+        # Same keywords, different identifiers: keyword score is 1.0, BLEU
+        # partial — combined score must stay above the pure-BLEU component.
+        score = self._score("def sub(x, y): return x - y", "def add(a, b): return a + b")
+        assert 0.0 < score < 1.0


### PR DESCRIPTION
## Summary

`bleu_score` and `code_bleu` always averaged over n-gram orders 1..4 and substituted `1e-9` for orders the hypothesis was too short to form. Each missing order multiplied the geometric mean by `(1e-9)^0.25 ≈ 0.0056`, so an exact single-word match scored `~2e-07`, an identical three-word sentence `0.0056`, and an identical `return x` snippet `0.30` — every answer shorter than four tokens failed the default 0.5 pass threshold even when byte-identical to the reference. Short-answer QA is a primary use case for BLEU, so this silently failed a whole class of correct outputs.

Scoring is now restricted to the n-gram orders the hypothesis can form, with renormalized weights — the same approach the sibling `gleu_score.yaml` already uses. Zero-overlap orders get a small epsilon mass (NLTK method-1 style) instead of the previous add-1 inflation: keeping add-1 with renormalized orders would have let a completely wrong one-word answer (`"London"` vs `"Paris"`) score exactly 0.5 and pass. Exact matches now score 1.0 at every length, disjoint text stays well below the threshold, and the brevity penalty is unchanged.

## Linked issues

Closes #1345

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- New `futureagi/model_hub/tests/test_system_eval_bleu_scores.py` loads both YAMLs and execs their code blocks (no network/DB):
  - exact matches at 1, 2, 3, and 13 tokens → 1.0 (the short cases fail against the old implementation: `1.78e-07`, `0.0056`, `0.30`)
  - disjoint text and disjoint code → below the 0.5 threshold
  - partial overlap ordered strictly between disjoint and exact
  - brevity penalty still applies to truncated hypotheses
  - code_bleu keyword component still contributes
- 13/13 pass with the fix; against the previous implementation the 4 short exact-match tests fail and the 9 behavior-preservation tests pass, confirming no unintended behavior change for longer text.

## Screenshots / recordings (if UI)

N/A — eval logic fix.

## Checklist

- [x] My code follows the [style guide](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](https://github.com/future-agi/future-agi/blob/dev/CONTRIBUTING.md#contributor-license-agreement-cla)
