### PR TITLE
fix(error-localizer): tolerate snake_case patch coords on image card (TH-6500)

### DIFF
--- a/frontend/src/sections/common/ErrorLocalizeCard.jsx
+++ b/frontend/src/sections/common/ErrorLocalizeCard.jsx
@@ -168,8 +168,11 @@ const ImageWithOverlay = ({ imageUrl, value, boxWidth, boxHeight }) => {
         const highlightAreas = [];
 
         value.forEach((item) => {
-          const { topLeft, bottomRight } = item.orgPatch.coordinates;
-          const weight = item.weight;
+          const coords = item?.orgPatch?.coordinates;
+          const topLeft = coords?.topLeft || coords?.top_left;
+          const bottomRight = coords?.bottomRight || coords?.bottom_right;
+          if (!topLeft || !bottomRight) return;
+          const weight = item.weight ?? item.rank;
           const opacity = 0.2; // Base opacity for highlights
           const color = getMarkColor(weight, false, opacity);
 
@@ -264,7 +267,10 @@ const ImageWithOverlay = ({ imageUrl, value, boxWidth, boxHeight }) => {
           const mouseY = e.clientY - canvasRect.top;
 
           value.forEach((item) => {
-            const { topLeft, bottomRight } = item.orgPatch.coordinates;
+            const coords = item?.orgPatch?.coordinates;
+            const topLeft = coords?.topLeft || coords?.top_left;
+            const bottomRight = coords?.bottomRight || coords?.bottom_right;
+            if (!topLeft || !bottomRight) return;
 
             if (isInsideRect(mouseX, mouseY, topLeft, bottomRight)) {
               handleMouseEnter(item.reason, mouseX, mouseY);
@@ -510,7 +516,7 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                                 ],
                                 i?.orgSen?.startIdx ?? i?.orgSen?.start_idx,
                                 i?.orgSen?.endIdx ?? i?.orgSen?.end_idx,
-                                i.weight,
+                                i.weight ?? i.rank,
                                 i,
                               )}
                             </Box>
@@ -543,7 +549,7 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                             >
                               <span
                                 style={{
-                                  backgroundColor: getMarkColor(item.weight),
+                                  backgroundColor: getMarkColor(item.weight ?? item.rank),
                                   display: "inline",
                                 }}
                               >


### PR DESCRIPTION
## Summary

Image Error Localizer output rendered the thumbnail but no overlay rectangles. The draw and hover paths destructured `item.orgPatch.coordinates` as `{ topLeft, bottomRight }` and read `item.weight`, but the backend emits `top_left` / `bottom_right` and `rank`. Every patch resolved to `undefined`, `isInsideRect` never fired, and no rectangles were drawn.

This PR teaches the image card to accept either casing on the coordinates, guards the destructure, and falls back to `rank` when `weight` is missing. The same fallback is applied to the text side of the same card so ranked sentence colouring keeps working when the payload only carries `rank`.

Mirrors the audio Error Localizer fix in `audioHelper.js` (TH-6471).

## Scope

- `frontend/src/sections/common/ErrorLocalizeCard.jsx`
  - `ImageWithOverlay` draw loop: accept camel or snake on `topLeft` / `bottomRight`, guard for missing coordinates, fall back `weight ?? rank`.
  - `ImageWithOverlay` hover hit-test: same coordinate + guard fix.
  - Text render: `i.weight ?? i.rank` when rendering sentence marks.
  - Text mark background colour: `getMarkColor(item.weight ?? item.rank)`.

Backend canonicalisation (image patch output emitting snake_case) is a separate follow-up.

## Repro

Repro dataset: https://dev.futureagi.com/dashboard/develop/3a05940d-46a1-4558-b7cc-1d58753c133e?tab=data — every image EL cell previously showed the image with no overlay boxes.

## Test plan

- [ ] Load the repro dataset on dev, open any image EL cell, verify bounding boxes render on top of the image and colour by rank.
- [ ] Hover a bounding box and verify the tooltip / reason surfaces.
- [ ] Load any text EL cell and verify sentence marks still colour correctly.

Fixes TH-6500. Related TH-6471.