### PR TITLE
test(evals): pass skip_reason into LocalizerResult in post-selection skip tests

### DIFF
--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -1162,12 +1162,13 @@ class TestErrorLocalizerGateE2E:
         mock_api_log.status = APICallStatusChoices.PROCESSING.value
         mock_log_cost.return_value = mock_api_log
 
-        mock_localizer.return_value.skip_reason = (
-            f"The input '{selected_key}' is of type '{expected_type}', "
-            f"which is not supported by error localization."
-        )
         mock_localizer.return_value.localize_errors.return_value = LocalizerResult(
-            analysis={}, selected_key=selected_key,
+            analysis={},
+            selected_key=selected_key,
+            skip_reason=(
+                f"The input '{selected_key}' is of type '{expected_type}', "
+                f"which is not supported by error localization."
+            ),
         )
 
         process_single_error_localization._original_func(str(task.id))


### PR DESCRIPTION
## Summary

The 3 parametrized cases of `test_el_post_selection_skip_when_selected_type_unsupported` have been failing on `dev` since PR #765 landed. They set `mock_localizer.return_value.skip_reason = ...` on the ErrorLocalizer mock instance, but the worker reads `result.skip_reason` from the `LocalizerResult` returned by `localize_errors()` (`user_evaluation.py:1212`). The mock value never reached the code under test, so the task ended up with the generic "Error localization did not produce any results." message instead of the type-specific one the assertions were expecting.

`LocalizerResult` has a `skip_reason` field (see `ee/evals/localizer/error_localizer.py:42`); the fix is to pass the value in through the constructor.

## Scope

- `futureagi/model_hub/tests/test_user_evaluation_tasks.py` — move `skip_reason` from the ErrorLocalizer mock into the `LocalizerResult(...)` constructor for `test_el_post_selection_skip_when_selected_type_unsupported`.

## Test plan

```
DJANGO_SETTINGS_MODULE=tfc.settings.test .venv/bin/pytest \
  "model_hub/tests/test_user_evaluation_tasks.py::TestErrorLocalizerGateE2E::test_el_post_selection_skip_when_selected_type_unsupported" \
  -v --no-cov
```

All 3 parametrized cases pass locally.