### PR TITLE
fix(evals): read snake_case runtime overrides in dataset eval edit

### DIFF
--- a/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
+++ b/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
@@ -145,20 +145,36 @@ const EditEvaluation = ({
   }, [evalConfig]);
 
   const handleEvalAdded = async (cfg) => {
-    // Build run_config from EvalPickerConfigFull output
+    // Build run_config from EvalPickerConfigFull output. The picker emits
+    // snake_case keys (pass_threshold, agent_mode, ...); read snake first
+    // and keep camelCase as a defensive fallback for any legacy caller.
     const runConfig = {};
-    if (cfg.model) runConfig.model = cfg.model;
-    if (cfg.agentMode) runConfig.agent_mode = cfg.agentMode;
-    if (cfg.checkInternet !== undefined)
-      runConfig.check_internet = !!cfg.checkInternet;
-    if (cfg.summary) runConfig.summary = cfg.summary;
-    if (cfg.dataInjection) runConfig.data_injection = cfg.dataInjection;
-    if (cfg.knowledgeBases) runConfig.knowledge_bases = cfg.knowledgeBases;
-    if (cfg.tools) runConfig.tools = cfg.tools;
-    if (cfg.passThreshold !== undefined)
-      runConfig.pass_threshold = cfg.passThreshold;
-    if (cfg.choiceScores && Object.keys(cfg.choiceScores).length)
-      runConfig.choice_scores = cfg.choiceScores;
+    const model = cfg.model;
+    const agentMode = cfg.agent_mode ?? cfg.agentMode;
+    const checkInternet = cfg.check_internet ?? cfg.checkInternet;
+    const summary = cfg.summary;
+    const dataInjection = cfg.data_injection ?? cfg.dataInjection;
+    const knowledgeBases = cfg.knowledge_bases ?? cfg.knowledgeBases;
+    const tools = cfg.tools;
+    const passThreshold = cfg.pass_threshold ?? cfg.passThreshold;
+    const choiceScores = cfg.choice_scores ?? cfg.choiceScores;
+    const multiChoice = cfg.multi_choice ?? cfg.multiChoice;
+    const errorLocalizerEnabled =
+      cfg.error_localizer_enabled ?? cfg.errorLocalizerEnabled;
+
+    if (model) runConfig.model = model;
+    if (agentMode) runConfig.agent_mode = agentMode;
+    if (checkInternet !== undefined) runConfig.check_internet = !!checkInternet;
+    if (summary) runConfig.summary = summary;
+    if (dataInjection) runConfig.data_injection = dataInjection;
+    if (knowledgeBases) runConfig.knowledge_bases = knowledgeBases;
+    if (tools) runConfig.tools = tools;
+    if (passThreshold !== undefined) runConfig.pass_threshold = passThreshold;
+    if (choiceScores && Object.keys(choiceScores).length)
+      runConfig.choice_scores = choiceScores;
+    if (multiChoice !== undefined) runConfig.multi_choice = !!multiChoice;
+    if (errorLocalizerEnabled !== undefined)
+      runConfig.error_localizer_enabled = !!errorLocalizerEnabled;
 
     const payload = {
       run: false,


### PR DESCRIPTION
## Summary

`EditEvaluation.handleEvalAdded` was reading camelCase keys off the picker payload while `EvalPickerConfigFull.onSave` has always emitted the same keys in snake_case. Every runtime override was silently dropped: the payload's `config.run_config` shipped without `pass_threshold`, `agent_mode`, `check_internet`, `data_injection`, `knowledge_bases`, or `choice_scores`, `UserEvalMetric.config` got overwritten with a runtime-config-less shape, and the next open of the edit form fell back to the template default (0.5 for `pass_threshold`).

Version pinning still fired on every save because `run_config.summary` and `run_config.tools` do drift across opens — so each save created a new pinned version with the wrong content.

## Repro

1. On any dataset, open an eval binding for edit.
2. Change Pass Threshold to 0.8 (or any non-default).
3. Save.
4. Reopen the edit form. Slider returns to the template default, not 0.8.
5. `SELECT config FROM model_hub_userevalmetric WHERE id = ...` confirms `run_config.pass_threshold` was never persisted.

## Scope

`frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx` (`handleEvalAdded`):
- Read snake_case keys first (`cfg.pass_threshold`, `cfg.agent_mode`, `cfg.check_internet`, `cfg.data_injection`, `cfg.knowledge_bases`, `cfg.choice_scores`), keep camelCase as a defensive fallback for any legacy caller.
- Also propagate `multi_choice` and `error_localizer_enabled` through the same builder so they aren't quietly dropped either.

## Blame

Bug has been in the codebase since Chirag's Initial Commit (`ce5bb328b`, 2026-04-23). Both files were authored in the same commit with inconsistent snake/camel across the boundary. Verified with `git log -S "pass_threshold: passThreshold" -- EvalPickerConfigFull.jsx` → only Initial Commit; `git log -S "passThreshold: passThreshold"` → no results (camelCase version never existed).

## Test plan

- [ ] On dev, open a dataset eval binding, set pass_threshold to 0.8, save, reopen — slider persists to 0.8.
- [ ] Verify `UserEvalMetric.config['run_config']['pass_threshold']` is written to DB.
- [ ] Repeat for `agent_mode`, `check_internet`, `data_injection`, `knowledge_bases`, `choice_scores`, `multi_choice`, `error_localizer_enabled`.
- [ ] Confirm version-pinning still de-duplicates correctly when no changes are made between opens.