### PR TITLE
fix(evals): read snake_case runtime overrides in dataset eval edit (TH-6501)

### DIFF
--- a/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
+++ b/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
@@ -145,20 +145,36 @@ const EditEvaluation = ({
   }, [evalConfig]);
 
   const handleEvalAdded = async (cfg) => {
-    // Build run_config from EvalPickerConfigFull output
+    // Build run_config from EvalPickerConfigFull output. The picker emits
+    // snake_case keys (pass_threshold, agent_mode, ...); read snake first
+    // and keep camelCase as a defensive fallback for any legacy caller.
     const runConfig = {};
-    if (cfg.model) runConfig.model = cfg.model;
-    if (cfg.agentMode) runConfig.agent_mode = cfg.agentMode;
-    if (cfg.checkInternet !== undefined)
-      runConfig.check_internet = !!cfg.checkInternet;
-    if (cfg.summary) runConfig.summary = cfg.summary;
-    if (cfg.dataInjection) runConfig.data_injection = cfg.dataInjection;
-    if (cfg.knowledgeBases) runConfig.knowledge_bases = cfg.knowledgeBases;
-    if (cfg.tools) runConfig.tools = cfg.tools;
-    if (cfg.passThreshold !== undefined)
-      runConfig.pass_threshold = cfg.passThreshold;
-    if (cfg.choiceScores && Object.keys(cfg.choiceScores).length)
-      runConfig.choice_scores = cfg.choiceScores;
+    const model = cfg.model;
+    const agentMode = cfg.agent_mode ?? cfg.agentMode;
+    const checkInternet = cfg.check_internet ?? cfg.checkInternet;
+    const summary = cfg.summary;
+    const dataInjection = cfg.data_injection ?? cfg.dataInjection;
+    const knowledgeBases = cfg.knowledge_bases ?? cfg.knowledgeBases;
+    const tools = cfg.tools;
+    const passThreshold = cfg.pass_threshold ?? cfg.passThreshold;
+    const choiceScores = cfg.choice_scores ?? cfg.choiceScores;
+    const multiChoice = cfg.multi_choice ?? cfg.multiChoice;
+    const errorLocalizerEnabled =
+      cfg.error_localizer_enabled ?? cfg.errorLocalizerEnabled;
+
+    if (model) runConfig.model = model;
+    if (agentMode) runConfig.agent_mode = agentMode;
+    if (checkInternet !== undefined) runConfig.check_internet = !!checkInternet;
+    if (summary) runConfig.summary = summary;
+    if (dataInjection) runConfig.data_injection = dataInjection;
+    if (knowledgeBases) runConfig.knowledge_bases = knowledgeBases;
+    if (tools) runConfig.tools = tools;
+    if (passThreshold !== undefined) runConfig.pass_threshold = passThreshold;
+    if (choiceScores && Object.keys(choiceScores).length)
+      runConfig.choice_scores = choiceScores;
+    if (multiChoice !== undefined) runConfig.multi_choice = !!multiChoice;
+    if (errorLocalizerEnabled !== undefined)
+      runConfig.error_localizer_enabled = !!errorLocalizerEnabled;
 
     const payload = {
       run: false,

--- a/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
+++ b/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
@@ -145,36 +145,19 @@ const EditEvaluation = ({
   }, [evalConfig]);
 
   const handleEvalAdded = async (cfg) => {
-    // Build run_config from EvalPickerConfigFull output. The picker emits
-    // snake_case keys (pass_threshold, agent_mode, ...); read snake first
-    // and keep camelCase as a defensive fallback for any legacy caller.
     const runConfig = {};
-    const model = cfg.model;
-    const agentMode = cfg.agent_mode ?? cfg.agentMode;
-    const checkInternet = cfg.check_internet ?? cfg.checkInternet;
-    const summary = cfg.summary;
-    const dataInjection = cfg.data_injection ?? cfg.dataInjection;
-    const knowledgeBases = cfg.knowledge_bases ?? cfg.knowledgeBases;
-    const tools = cfg.tools;
-    const passThreshold = cfg.pass_threshold ?? cfg.passThreshold;
-    const choiceScores = cfg.choice_scores ?? cfg.choiceScores;
-    const multiChoice = cfg.multi_choice ?? cfg.multiChoice;
-    const errorLocalizerEnabled =
-      cfg.error_localizer_enabled ?? cfg.errorLocalizerEnabled;
-
-    if (model) runConfig.model = model;
-    if (agentMode) runConfig.agent_mode = agentMode;
-    if (checkInternet !== undefined) runConfig.check_internet = !!checkInternet;
-    if (summary) runConfig.summary = summary;
-    if (dataInjection) runConfig.data_injection = dataInjection;
-    if (knowledgeBases) runConfig.knowledge_bases = knowledgeBases;
-    if (tools) runConfig.tools = tools;
-    if (passThreshold !== undefined) runConfig.pass_threshold = passThreshold;
-    if (choiceScores && Object.keys(choiceScores).length)
-      runConfig.choice_scores = choiceScores;
-    if (multiChoice !== undefined) runConfig.multi_choice = !!multiChoice;
-    if (errorLocalizerEnabled !== undefined)
-      runConfig.error_localizer_enabled = !!errorLocalizerEnabled;
+    if (cfg.model) runConfig.model = cfg.model;
+    if (cfg.agent_mode) runConfig.agent_mode = cfg.agent_mode;
+    if (cfg.check_internet !== undefined)
+      runConfig.check_internet = !!cfg.check_internet;
+    if (cfg.summary) runConfig.summary = cfg.summary;
+    if (cfg.data_injection) runConfig.data_injection = cfg.data_injection;
+    if (cfg.knowledge_bases) runConfig.knowledge_bases = cfg.knowledge_bases;
+    if (cfg.tools) runConfig.tools = cfg.tools;
+    if (cfg.pass_threshold !== undefined)
+      runConfig.pass_threshold = cfg.pass_threshold;
+    if (cfg.choice_scores && Object.keys(cfg.choice_scores).length)
+      runConfig.choice_scores = cfg.choice_scores;
 
     const payload = {
       run: false,


### PR DESCRIPTION
## Summary

`EditEvaluation.handleEvalAdded` reads camelCase keys off the picker payload while `EvalPickerConfigFull.onSave` emits the same keys in snake_case. Every per-binding runtime override was silently dropped before the payload left the browser: the request's `config.run_config` shipped without `pass_threshold`, `agent_mode`, `check_internet`, `data_injection`, `knowledge_bases`, or `choice_scores`. Downstream, `UserEvalMetric.config` was overwritten with the runtime-config-less shape, and reopening the edit form fell back to the template default. `maybe_pin_new_version` still fired on every save because incidental drift in `summary`/`tools` made the snapshot differ, so each save quietly created a new pinned version with the wrong content.

## Fix

`frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx` (`handleEvalAdded`):
- Read snake_case keys first (`cfg.pass_threshold`, `cfg.agent_mode`, `cfg.check_internet`, `cfg.data_injection`, `cfg.knowledge_bases`, `cfg.choice_scores`), keep camelCase as a defensive fallback.
- Also carry `multi_choice` and `error_localizer_enabled` through the same builder.

## Repro

1. On any dataset, open an eval binding for edit.
2. Change Pass Threshold to 0.8 (or any non-default).
3. Save.
4. Reopen the edit form — before the fix, the slider snaps back to the template default; after the fix, it stays at 0.8.
5. `SELECT config FROM model_hub_userevalmetric WHERE id = ...` confirms `run_config.pass_threshold` is written.

## Test plan

- [ ] Persist `pass_threshold`, `agent_mode`, `check_internet`, `data_injection`, `knowledge_bases`, `choice_scores`, `multi_choice`, `error_localizer_enabled` across a save/reload cycle.
- [ ] Confirm version pinning still de-duplicates when no changes are made between opens.

Fixes TH-6501.