### PR TITLE
fix(evals): send empty body on set-default and restore version mutations (TH-6502)

### DIFF
--- a/frontend/src/sections/evals/hooks/useEvalVersions.js
+++ b/frontend/src/sections/evals/hooks/useEvalVersions.js
@@ -36,10 +36,6 @@ export function useSetDefaultVersion(templateId) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (versionId) => {
-      // The endpoint's request body is ModelHubEmptyRequest (an empty
-      // object schema). The FE openapi-contract request validator zod-parses
-      // the body against z.record(z.any()), which rejects `undefined`.
-      // Send `{}` so the parse succeeds and the request actually fires.
       const { data } = await axios.put(
         endpoints.develop.eval.setDefaultVersion(templateId, versionId),
         {},
@@ -61,8 +57,6 @@ export function useRestoreVersion(templateId) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (versionId) => {
-      // Contract body is ModelHubEmptyRequest, so send {}. The FE openapi
-      // request validator would reject `undefined` here.
       const { data } = await axios.post(
         endpoints.develop.eval.restoreVersion(templateId, versionId),
         {},

--- a/frontend/src/sections/evals/hooks/useEvalVersions.js
+++ b/frontend/src/sections/evals/hooks/useEvalVersions.js
@@ -36,8 +36,13 @@ export function useSetDefaultVersion(templateId) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (versionId) => {
+      // The endpoint's request body is ModelHubEmptyRequest (an empty
+      // object schema). The FE openapi-contract request validator zod-parses
+      // the body against z.record(z.any()), which rejects `undefined`.
+      // Send `{}` so the parse succeeds and the request actually fires.
       const { data } = await axios.put(
         endpoints.develop.eval.setDefaultVersion(templateId, versionId),
+        {},
       );
       return data?.result;
     },
@@ -56,8 +61,11 @@ export function useRestoreVersion(templateId) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (versionId) => {
+      // Contract body is ModelHubEmptyRequest, so send {}. The FE openapi
+      // request validator would reject `undefined` here.
       const { data } = await axios.post(
         endpoints.develop.eval.restoreVersion(templateId, versionId),
+        {},
       );
       return data?.result;
     },


### PR DESCRIPTION
## Summary

Clicking "Set as Default" or "Restore" on an eval template version in the Eval Playground fails silently on local dev builds with a red toast and no accompanying network call. Deployed dev works because the openapi request-contract validator only enforces in dev mode, so every reviewer testing these actions on their local box hits this wall.

`useSetDefaultVersion` and `useRestoreVersion` in `useEvalVersions.js` fire `axios.put(url)` and `axios.post(url)` with no body. Both endpoints declare `requestBody = ModelHubEmptyRequest` (an empty-properties object schema). `schemaToZod` compiles that to `z.record(z.any())`, which rejects `undefined`. In dev builds, `assertContractedRequestConfig` throws in the request interceptor before axios ever fires.

## Fix

Send `{}` on both mutations to match the declared contract shape.

## Scope

- `frontend/src/sections/evals/hooks/useEvalVersions.js`

## Why this matters beyond local dev

The FE was not sending the payload the contract says it should. If enforcement is ever flipped on in production, or the server adds strict body parsing on these empty-body endpoints, both actions would break for real users with the same silent failure.

## Test plan

- [ ] Local: open the Eval Playground, click "Set as Default" on a non-default version, expect the green toast and the row's Default badge to move.
- [ ] Local: click "Restore" on a prior version, expect the restore to succeed.
- [ ] DevTools Network tab shows the PUT / POST fires (was previously being blocked at the interceptor).

Fixes TH-6502.