### PR TITLE
[TH-6481] Auto-populate Simulated runs row when a run completes

### DIFF
--- a/frontend/src/sections/common/simulation/constants/statusStyles.js
+++ b/frontend/src/sections/common/simulation/constants/statusStyles.js
@@ -49,4 +49,6 @@ export const statusStyles = {
 
 export const STOPPABLE_STATUSES = ["Evaluating", "Running", "Pending"];
 
+export const TERMINAL_STATUSES = ["Completed", "Failed", "Cancelled"];
+
 export default statusStyles;

--- a/frontend/src/sections/common/simulation/index.js
+++ b/frontend/src/sections/common/simulation/index.js
@@ -13,7 +13,11 @@ export { default as BaseStatusCellRenderer } from "./components/BaseStatusCellRe
 export { default as BaseSelectionActions } from "./components/BaseSelectionActions";
 
 // Constants
-export { statusStyles, STOPPABLE_STATUSES } from "./constants/statusStyles";
+export {
+  statusStyles,
+  STOPPABLE_STATUSES,
+  TERMINAL_STATUSES,
+} from "./constants/statusStyles";
 
 // Store factories
 export {

--- a/frontend/src/sections/test/TestRuns/TestRunsGrid.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunsGrid.jsx
@@ -18,12 +18,15 @@ import { SIMULATION_TYPE } from "src/components/run-tests/common";
 import {
   statusStyles,
   STOPPABLE_STATUSES,
+  TERMINAL_STATUSES,
   useCancelExecution,
 } from "src/sections/common/simulation";
 
 import { useTestDetailContext } from "../context/TestDetailContext";
 import { useTestRunsGridStore } from "../states";
 import { useTestRunsSearchStoreShallow } from "./states";
+
+const POLL_INTERVAL_MS = 5000;
 
 // ── Cell renderers ──
 
@@ -399,6 +402,15 @@ const TestRunsGrid = ({ agentType, simulationType }) => {
     select: (d) => d.data,
     keepPreviousData: true,
     enabled: !!testId,
+    // Poll while any run is still in progress so the row auto-populates on completion.
+    refetchInterval: (query) => {
+      const rows = query?.state?.data?.data?.results ?? [];
+      const anyInProgress = rows.some(
+        (row) => !TERMINAL_STATUSES.includes(row.status),
+      );
+      return anyInProgress ? POLL_INTERVAL_MS : false;
+    },
+    refetchIntervalInBackground: false,
   });
 
   const items = useMemo(() => data?.results ?? [], [data]);


### PR DESCRIPTION
**Ticket:** [TH-6481](https://linear.app/future-agi/issue/TH-6481/when-a-sim-run-is-completed-its-data-is-not-automatically-populated-in) — Fixes TH-6481

## What was the bug
On the **Simulated runs** list, a run kept showing `Run Status = Pending` and `Calls Attempted = 0` even after it had actually completed on the backend. The row only updated when the user opened the row and navigated back (which re-mounted the grid) or refreshed the page. It never auto-populated.

## What changes have been done
- `frontend/src/sections/test/TestRuns/TestRunsGrid.jsx` — added a `refetchInterval` (+ `refetchIntervalInBackground: false`) to the executions `useQuery`; polls every `POLL_INTERVAL_MS` (5s) while any visible row is non-terminal, and stops once all rows are terminal.
- `frontend/src/sections/common/simulation/constants/statusStyles.js` — added `TERMINAL_STATUSES = ["Completed", "Failed", "Cancelled"]`.
- `frontend/src/sections/common/simulation/index.js` — re-exported `TERMINAL_STATUSES` from the barrel.

## Why the changes
- Root cause: the list query had no polling, so nothing re-fetched while a run was in progress; the row's status/attempts/duration only refreshed on a grid re-mount.
- Poll predicate reads `query.state.data.data.results` — in React Query v5 `select` doesn't mutate cached data, so `query.state.data` is the raw axios response (→ `.data` body → `.results`).
- Uses a **terminal** set (negation) rather than an in-progress whitelist so `Cancelling` keeps polling until `Cancelled`, and any future non-terminal backend status keeps polling rather than silently stalling.
- 5s interval + `refetchIntervalInBackground: false` mirror the existing sibling pattern in `EvalsTasks/TaskListView.jsx`.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Start a run, stay on the Simulated runs list | Row auto-updates Pending/Running → Completed with attempts/duration within ~5s, no manual refresh |
| 2 | Run reaches a terminal status (Completed/Failed/Cancelled) | Polling stops — no further network requests for the list |
| 3 | Cancel a run (status → Cancelling) | List keeps polling until it settles on Cancelled |
| 4 | Switch browser tab while a run is in progress | `refetchIntervalInBackground: false` pauses polling on the hidden tab, resumes on focus |

## How to reproduce (original bug)
1. Go to **Simulate → Run Simulation →** a test **→ Simulated runs**.
2. Kick off a new simulation and stay on the list.
3. Wait for the run to finish on the backend.
4. Bug: the row stays at `Pending` / `Calls Attempted 0` / `Duration —`. It only corrects to `Completed` / `20` / `18s` after opening the row and clicking Back, or refreshing.

## Videos and screenshots

https://github.com/user-attachments/assets/e2f66fe0-7740-48e6-9229-393998cc898d


