### PR TITLE
fix(ch25): keep tracer_eval_logger out of the legacy CDC drop chain

### DIFF
--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -72,9 +72,11 @@ _LEGACY_CDC_CHAIN_NAMES = (
     "tracer_trace",
     "tracer_enduser",
     "trace_session",
-    "tracer_eval_logger",
     "eval_metrics_hourly",
 )
+# tracer_eval_logger is deliberately NOT retired with the chain: the eval-config
+# discovery reads still query it (CH25_EVAL_LOGGER_TABLE), so the boot apply keeps
+# creating it and the PeerDB CDC mirror keeps filling it.
 
 # The legacy v1 ``spans`` DDL in this module conflicts with the v2 spans
 # schema applied by ``tracer/services/clickhouse/v2/schema/002_spans_v2.sql``.
@@ -328,6 +330,8 @@ CREATE TABLE IF NOT EXISTS tracer_eval_logger (
     -- Work-item state (mirror of EvalLogger.status / config_hash)
     status LowCardinality(String) DEFAULT 'completed',
     config_hash Nullable(String),
+    skipped_reason Nullable(String),
+    attempts Int32 DEFAULT 0,
 
     -- Explanation / metadata
     eval_explanation Nullable(String),
@@ -1927,6 +1931,14 @@ POST_DDL_ALTERS: list[str] = [
     "status LowCardinality(String) DEFAULT 'completed'",
     "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
     "config_hash Nullable(String)",
+    # skipped_reason / attempts exist on the PG source (EvalLogger work-item
+    # columns) and are in the PeerDB normalize INSERT column list; without them
+    # the CH normalize fails with "No such column ..." and the mirror never
+    # drains.
+    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+    "skipped_reason Nullable(String)",
+    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+    "attempts Int32 DEFAULT 0",
     # Strip the legacy 365d TTL from the v1 hourly rollup tables. The CREATE
     # strings above no longer declare TTL, but existing prod clusters carry
     # the original TTL on the live tables — these ALTERs remove it.


### PR DESCRIPTION
## Why

On environments running the CH25 cutover (`CH25_DROP_LEGACY_CDC_CHAIN=true`), eval-reading endpoints — `list_traces_of_session` and others — were returning **HTTP 400**. Root cause: the ClickHouse table `tracer_eval_logger` was missing from the `futureagi` CH database, so the eval-config discovery query (`CH25_EVAL_LOGGER_TABLE` → `SELECT DISTINCT custom_eval_config_id FROM tracer_eval_logger …`) failed with **CH Code 60 "Unknown table"**, which the CH read path surfaces as a generic 400.

Why the table was missing: `tracer_eval_logger` was listed in `_LEGACY_CDC_CHAIN_NAMES`. At boot, `model_hub.apps._ensure_analytics_schema`:
1. **dropped** it via `get_legacy_chain_drop_statements()`, and
2. **excluded** it from recreation, because `get_all_schema_ddl()` filters out `excluded = set(_LEGACY_CDC_CHAIN_NAMES) | set(_V1_TO_V2_TABLES)`.

Net: dropped and never re-created. The subsequent `POST_DDL_ALTERS` then failed with `Code 60: Could not find table: tracer_eval_logger`, confirming the table's absence. `tracer_eval_logger` is **not** part of the fi-collector v2 path — it is still PeerDB-fed — so it must survive the legacy-chain drop.

## What

`futureagi/tracer/services/clickhouse/schema.py` only (+13 / −1):

1. **Remove `tracer_eval_logger` from `_LEGACY_CDC_CHAIN_NAMES`** (+ a comment explaining why it is exempt). The boot apply now keeps creating it and PeerDB CDC keeps filling it.
2. **Add `skipped_reason Nullable(String)` and `attempts Int32 DEFAULT 0`** to the `CDC_EVAL_LOGGER` `CREATE` and to `POST_DDL_ALTERS`. These columns exist on the PG source (`EvalLogger` work-item columns) and are in the PeerDB normalize `INSERT` column list; without them CH normalize fails with "No such column …" and the mirror never drains.

## Tests

**No new tests** — this is a schema/boot-hook change; correctness is verified end-to-end against a live stack (below), per the team convention of not adding dedicated tests for infra/schema changes.

**Existing test now passes:** `tracer/tests/test_clickhouse.py::TestClickHouse::test_legacy_chain_drop_covers_exactly_the_expected_set` already pins the expected drop set **without** `tracer_eval_logger` and asserts `"tracer_eval_logger" not in names`. That assertion is **currently failing on `dev`** (dev's `schema.py` still lists it). This change makes the code match the test.

### Per-test scenarios
- `test_legacy_chain_drop_covers_exactly_the_expected_set` — drop set must equal the exact 11-name set and exclude `tracer_eval_logger`. ✅ after this change.
- `test_legacy_chain_drop_statements_order_and_idempotency` — MV drops precede their source tables; every drop is `IF EXISTS`; each kind uses its matching `DROP` statement. ✅ (unaffected — order/kinds unchanged).

## Commands

Direct function-level verification (no DB needed — pure registry functions):

```bash
cd futureagi
python - <<'PY'
import os, importlib.util
os.environ.setdefault('CH25_DROP_LEGACY_CDC_CHAIN','true')
spec = importlib.util.spec_from_file_location('sch','tracer/services/clickhouse/schema.py')
m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
names = {n for n,_ in m.get_legacy_chain_drop_statements()}
assert 'tracer_eval_logger' not in names
active = {n for n,_ in m.get_all_schema_ddl()}
assert 'tracer_eval_logger' in active
create = [d for n,d in m.SCHEMA_DDL_STATEMENTS if n=='tracer_eval_logger'][0]
assert 'skipped_reason' in create and 'attempts' in create
assert any('skipped_reason' in a for a in m.POST_DDL_ALTERS)
assert any('attempts' in a for a in m.POST_DDL_ALTERS)
print("OK")
PY
```

Unit tests (full test env):
```bash
uv run pytest tracer/tests/test_clickhouse.py -k legacy_chain -q
```

## Local test steps
1. Bring up a stack with `CH25_DROP_LEGACY_CDC_CHAIN=true`.
2. Restart the backend so `_ensure_analytics_schema` runs.
3. Confirm the boot no longer logs `CH legacy DDL dropped: tracer_eval_logger` and no `Could not find table: tracer_eval_logger` post-DDL alter errors.
4. `EXISTS TABLE tracer_eval_logger` in the `futureagi` CH DB → 1, engine `ReplacingMergeTree`.
5. Hit `GET /tracer/trace/list_traces_of_session/…` → 200 (was 400).

## Terminal output (evidence, captured on a live CH25 stack)

Boot after the fix — table no longer dropped, no alter failures:
```
dropped tracer_eval_logger this boot?  -> 0
post-DDL alter "Could not find table"  -> 0
SHOW TABLES LIKE 'tracer_eval_logger'  -> tracer_eval_logger
engine                                 -> ReplacingMergeTree
```

Function-level assertions (this branch):
```
chain drop set: ['enduser_dict','eval_metrics_hourly','eval_metrics_hourly_mv',
 'span_metrics_hourly','span_metrics_hourly_mv','spans_mv','trace_session',
 'trace_session_dict','tracer_enduser','tracer_observation_span','tracer_trace']
ASSERT ok: tracer_eval_logger NOT in drop set
tracer_eval_logger in active DDL (created & kept): True
CREATE has skipped_reason: True | attempts: True
POST_DDL_ALTERS mention skipped_reason/attempts: True True
```

Data parity after re-seeding the table (PeerDB `RESYNC MIRROR`):
```
PG  tracer_eval_logger count : 332845
CH  tracer_eval_logger count : 332845   (exact parity)
distinct eval configs        : 3136     (was 0 / erroring)
list_traces_of_session        : 200
```

## Architectural rationale

The CH25 cutover retires the legacy PeerDB→CH normalize chain for span/trace/session tables because **fi-collector** becomes the sole writer for the v2 `spans`/`traces`/`trace_sessions` tables. `tracer_eval_logger` is different: there is no fi-collector v2 replacement for it — eval-config discovery reads still query it directly (`CH25_EVAL_LOGGER_TABLE`), and it is fed by its own PeerDB mirror. So it must be **created and kept** by the boot apply regardless of the drop-chain flag, not swept up with the retired chain. The added `skipped_reason`/`attempts` columns keep the CH table schema in sync with the PG source so PeerDB normalize doesn't stall on a missing column.
