### PR TITLE
[TH-6476] Fix Create-agent-scenarios popup illustrations in dark theme

### DIFF
--- a/frontend/src/sections/agents/CreateAgentScenarioHelp.jsx
+++ b/frontend/src/sections/agents/CreateAgentScenarioHelp.jsx
@@ -43,7 +43,7 @@ function HelpCard({ title, description, imageSrc }) {
             width: "90%",
             bottom: 0,
             right: 0,
-            bgcolor: "background.paper",
+            bgcolor: "common.white",
             borderRadius: 1,
             padding: theme.spacing(1.5, 0, 0, 1.5),
             "& img": {


### PR DESCRIPTION
**Ticket:** [TH-6476](https://linear.app/future-agi/issue/TH-6476/create-agent-scenarions-popup-in-dark-theme-needs-to-be-optimized) — Fixes TH-6476

## What was the bug
In dark theme, the **Create agent scenarios** help popup's first card illustration was unreadable — the "Select agent definition" form mockup (Scenario name / Choose agent definition / Select version) rendered as near-invisible dark text on a dark panel.

## What changes have been done
- `frontend/src/sections/agents/CreateAgentScenarioHelp.jsx` — the card illustration panel now uses `bgcolor: "common.white"` instead of `"background.paper"`.

## Why the changes
- The illustration assets (`/assets/agents/help/*.svg`) are light-theme app screenshots — e.g. `select-agent-def.svg` uses hardcoded `fill="#1A1A1A"` text on a transparent background.
- The panel behind them was `background.paper`, which resolves to a **dark** color in dark mode, so the dark-text SVG disappeared. The other two cards are raster screenshots carrying their own white background, so they looked fine — which also made the three panels visually inconsistent in dark mode.
- Pinning the panel to `common.white` keeps the light-theme illustrations readable in **both** themes. Light mode is unchanged (`background.paper` was already white there).

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open Create-agent-scenarios popup in **dark** theme | All three card illustrations are readable on white panels; card 1 form mockup legible |
| 2 | Open the same popup in **light** theme | No visual change from before (panels already white) |
| 3 | Toggle theme with popup open | Panels stay white; text stays readable in both |

## How to reproduce (original bug)
1. Switch the app to **dark** theme.
2. Go to **Simulate → Agent Definition →** open an agent definition.
3. Click **Create scenarios** to open the "Create agent scenarios" help popup.
4. Bug: the first card's illustration (form mockup) is near-invisible — dark text on a dark panel.

## Videos and screenshots
<img width="1865" height="1054" alt="Screenshot 2026-07-07 at 12 32 44 PM" src="https://github.com/user-attachments/assets/d4776228-0c83-4bee-ac27-5c0340c9079e" />
<img width="1881" height="1066" alt="Screenshot 2026-07-07 at 12 32 25 PM" src="https://github.com/user-attachments/assets/c43f91c7-6076-4d5b-9a52-da85cfe245f4" />
