### PR TITLE
[TH-6474] Remove preview-only Test Evaluation button in create-simulation eval flow

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -415,7 +415,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         initialLoadDone.current = true;
       }
     }
-  }, [selectedVersionId, versions, isDirty, fullEval, normalizedFullEval, normalizedEvalData, isEditMode, evalData]);
+  }, [
+    selectedVersionId,
+    versions,
+    isDirty,
+    fullEval,
+    normalizedFullEval,
+    normalizedEvalData,
+    isEditMode,
+    evalData,
+  ]);
 
   // ── Populate from eval detail (same logic as EvalDetailPage) ──
   const initialLoadDone = useRef(false);
@@ -1963,6 +1972,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
         {source !== "composite" &&
           source !== "workbench" &&
+          source !== "create-simulate" &&
           (() => {
             const hasInstructions = !!(instructions || "").trim();
             const hasVariables =


### PR DESCRIPTION
**Ticket:** [TH-6474](https://linear.app/future-agi/issue/TH-6474/remove-test-eval-button-while-adding-evals-while-running-simulation) — Fixes TH-6474

## What was the bug
In the **Run Simulation** wizard → *Select Evaluations* step → *Add Evaluations*, the eval-config view showed a **"Test Evaluation"** button that was preview-only. Clicking it only surfaced the message *"Preview only — save the eval and run the simulation to test against real call data."* — it can't actually run, because the simulation hasn't run yet. A button that only tells you it does nothing shouldn't be there.

## What changes have been done
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` — added `source !== "create-simulate"` to the render guard around the "Test Evaluation" button, so it no longer renders in the create-simulation eval flow.

## Why the changes
- The "Test Evaluation" button is a **shared** control used by real flows (dataset / tracing / simulation / test / task / custom). Only the `create-simulate` source makes it a no-op — that source mounts `CreateSimulationPreviewMode`, whose `runTest` just emits the "Preview only" message.
- So instead of deleting the shared button, the fix excludes only `create-simulate` from its render guard. The **"Add Evaluation"** button and the blue *"Preview — the simulation hasn't run yet…"* info banner are untouched.
- `source === "create-simulate"` reaches this component only from the Run Simulation wizard (`CreateRunTestPage`), so no other page/flow is affected. The real Test Evaluation button everywhere else, and the separate "create a brand-new eval" tab (which uses a real test), are unchanged.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Run Simulation → Select Evaluations → Add Evaluations → configure an eval | No "Test Evaluation" button; only "Add Evaluation" shows |
| 2 | Add an eval from a **dataset / tracing / simulation / test** flow | Real "Test Evaluation" button still present and functional |
| 3 | "Create a brand-new eval" tab within the same wizard | Unchanged (uses a real test, not preview) |

## How to reproduce (original bug)
1. Go to **Simulate → Run Simulation** (`/dashboard/simulate/test`).
2. Complete *Add simulation details* and *Choose Scenario(s)*, reach **Select Evaluations**.
3. Click **Add Evaluations**, pick/configure an eval.
4. Bug: a **Test Evaluation** button appears; clicking it only shows *"Preview only — save the eval and run the simulation…"* — it never runs a real test.

## Videos and screenshots
📹 _Video uploading soon — before/after of the Add-Evaluations view with the preview-only Test Evaluation button removed._


https://github.com/user-attachments/assets/53fde7bf-6182-4988-823b-4012e1547eb3

