### PR TITLE
fix: Configure Project sampling slider reads snake_case sampling_rate

### DIFF
--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -416,8 +416,8 @@ ConfigureProject.propTypes = {
 };
 
 function getSamplingRatePercent(projectDetail, module) {
-  if (typeof projectDetail?.samplingRate === "number") {
-    return projectDetail.samplingRate * 100;
+  if (typeof projectDetail?.sampling_rate === "number") {
+    return projectDetail.sampling_rate * 100;
   }
-  return module === "observe" ? 100 : undefined;
+  return module === "observe" ? 0 : undefined;
 }


### PR DESCRIPTION
## Summary

The **Sampling rate** slider in the Configure Project dialog (Observe module) always showed **100%**, regardless of the project's real value. The read was against the camelCase key `projectDetail.samplingRate`, but the API returns snake_case `sampling_rate` (the camelCase alias bridge was removed from the axios layer). The `typeof … === "number"` guard therefore always failed and fell through to a hardcoded `100` fallback — and hitting **Save** would persist `1.0`, silently forcing 100% sampling.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Configure Project — sampling rate slider reads the correct key**

- The slider now reflects the project's real stored `sampling_rate` instead of always displaying 100%.
- `getSamplingRatePercent` reads `projectDetail.sampling_rate` (snake_case, the shape the API actually returns) instead of `projectDetail.samplingRate` (camelCase, always `undefined`).
- The missing-value fallback for the Observe module changed from `100` → `0`, matching the backend default (`TraceScanConfig.sampling_rate` defaults to `0`) and removing the footgun where opening + saving the dialog silently wrote 100%.
- No API/serializer/model changes.

---

## 2) Why the changes were done

- **Product/UX:** Users saw a misleading 100% and could accidentally overwrite their configured sampling rate to 100% just by opening the dialog and saving.
- **Technical:** The global camelCase response-alias bridge was removed from `src/utils/axios.js`; responses are snake_case only. This call site was a missed migration point still reading the camelCase alias. Fix mirrors sibling call sites that already do `Number(data?.sampling_rate)`.

---

## 3) Tests written + scenarios each covers

No automated test added — `getSamplingRatePercent` is a private, non-exported helper in `ConfigureProject.jsx` and the change is a one-line key correction. ESLint passes clean on the changed file. Happy to export the helper and add a unit test alongside `common.test.js` if preferred.

---

## 4) How to run / test

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Open an **Observe** project → **Configure Project**.
3. Verify the **Sampling rate** slider shows the project's real stored value (e.g. 0% for a fresh project) instead of always 100%.

---

## 6) Edge cases & considerations

- **`sampling_rate` absent from response:** falls back to `0` (Observe) / `undefined` (Prototype) — Prototype has no sampling control, so `undefined` is intentional.
- **`sampling_rate === 0`:** `typeof 0 === "number"` is true, so it correctly renders `0%` rather than hitting the fallback.

---

## 8) Architectural / important decisions

- **Read snake_case directly rather than reintroducing a camelCase alias:** consistent with the repo-wide move to snake_case responses; avoids resurrecting the removed alias bridge.

---

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [x] `yarn contracts:check` passes if API surface changed (N/A — no API change)
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
