### PR TITLE
[TH-6505] Strip UI-only filter keys before sending list/graph filters

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
@@ -29,7 +29,7 @@ import { formatYAxisValue, getYAxisUnit, getLineSeriesName } from "./common";
 import SVGColor from "src/components/svg-color";
 import { useLLMTracingStoreShallow } from "../states";
 import { logger } from "src/utils/logger";
-import { FILTER_FOR_HAS_EVAL } from "../common";
+import { FILTER_FOR_HAS_EVAL, toBackendFilters } from "../common";
 
 const deltaObject = {
   hour: { hours: 1 },
@@ -174,7 +174,7 @@ const GraphSection = ({
     queryFn: () =>
       axios.post(endpoints.project.getTraceGraphData(), {
         interval: selectedInterval,
-        filters: combinedFilters,
+        filters: toBackendFilters(combinedFilters),
         property: "average",
         req_data_config: selectedGraphConfig,
         project_id: observeId,
@@ -202,7 +202,7 @@ const GraphSection = ({
     queryFn: () =>
       axios.post(endpoints.project.getSpanGraphData(), {
         interval: selectedInterval,
-        filters: combinedFilters,
+        filters: toBackendFilters(combinedFilters),
         property: "average",
         req_data_config: selectedGraphConfig,
         project_id: observeId,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx
@@ -40,7 +40,7 @@ import _ from "lodash";
 import GraphSkeleton from "./GraphSkeleton";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import { formatDate } from "src/utils/report-utils";
-import { FILTER_FOR_HAS_EVAL } from "../common";
+import { FILTER_FOR_HAS_EVAL, toBackendFilters } from "../common";
 
 // ---------------------------------------------------------------------------
 // Map dashboard category → graph API type
@@ -349,7 +349,7 @@ const PrimaryGraph = ({
     queryFn: () =>
       axios.post(apiEndpoint, {
         interval: selectedInterval,
-        filters: combinedFilters,
+        filters: toBackendFilters(combinedFilters),
         property: "average",
         req_data_config: {
           id: metricDef.id,

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -154,6 +154,7 @@ import {
   FILTER_FOR_ERRORS,
   FILTER_FOR_NON_ANNOTATED,
   FILTER_FOR_HAS_EVAL,
+  toBackendFilters,
 } from "./common";
 import {
   applySavedColumns,
@@ -4760,12 +4761,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 params={{
                   project_id: observeId,
                   remove_simulation_calls: excludeSimulationCalls,
-                  filters: JSON.stringify([
-                    ...primaryCombinedFilters,
-                    ...(extraFilters || []),
-                    ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
-                    ...(metricFilters || []),
-                  ]),
+                  filters: JSON.stringify(
+                    toBackendFilters([
+                      ...primaryCombinedFilters,
+                      ...(extraFilters || []),
+                      ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
+                      ...(metricFilters || []),
+                    ]),
+                  ),
                 }}
                 onRowClicked={handleRowClicked}
                 onConfigLoaded={handleSimulatorConfigLoaded}
@@ -4799,12 +4802,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 params={{
                   project_id: observeId,
                   remove_simulation_calls: excludeSimulationCalls,
-                  filters: JSON.stringify([
-                    ...compareCombinedFilters,
-                    ...(compareExtraFilters || []),
-                    ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
-                    ...(metricFilters || []),
-                  ]),
+                  filters: JSON.stringify(
+                    toBackendFilters([
+                      ...compareCombinedFilters,
+                      ...(compareExtraFilters || []),
+                      ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
+                      ...(metricFilters || []),
+                    ]),
+                  ),
                 }}
                 onRowClicked={handleRowClicked}
                 onConfigLoaded={handleSimulatorConfigLoaded}

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -24,6 +24,7 @@ import {
   mergeCellStyle,
   generateAnnotationColumnsForTracing,
   normalizeConfigKeys,
+  toBackendFilters,
 } from "./common";
 import CustomTraceRenderer from "./Renderers/CustomTraceRenderer";
 import CustomTraceHeaderRenderer from "./Renderers/CustomTraceHeaderRenderer";
@@ -403,12 +404,14 @@ const SpanGrid = React.forwardRef(
                 ...(observeId ? { project_id: observeId } : {}),
                 page_number: page,
                 page_size: ROWS_LIMIT,
-                filters: JSON.stringify([
-                  ...filters,
-                  ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
-                  ...(extraFilters || EMPTY_EXTRA_FILTERS),
-                  ...(metricFilters || []),
-                ]),
+                filters: JSON.stringify(
+                  toBackendFilters([
+                    ...filters,
+                    ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
+                    ...(extraFilters || EMPTY_EXTRA_FILTERS),
+                    ...(metricFilters || []),
+                  ]),
+                ),
               });
 
               // Use prefetched data if available, otherwise fetch

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -23,6 +23,7 @@ import {
   FILTER_FOR_HAS_EVAL,
   generateAnnotationColumnsForTracing,
   normalizeConfigKeys,
+  toBackendFilters,
 } from "./common";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { userTraceRowHeightMapping } from "../UsersView/common";
@@ -224,12 +225,14 @@ const TraceGrid = React.forwardRef(
                 ...(projectId ? { project_id: projectId } : {}),
                 page_number: page,
                 page_size: ROWS_LIMIT,
-                filters: JSON.stringify([
-                  ...filters,
-                  ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
-                  ...(extraFilters || EMPTY_EXTRA_FILTERS),
-                  ...(metricFilters || []),
-                ]),
+                filters: JSON.stringify(
+                  toBackendFilters([
+                    ...filters,
+                    ...(hasEvalFilter ? [FILTER_FOR_HAS_EVAL] : []),
+                    ...(extraFilters || EMPTY_EXTRA_FILTERS),
+                    ...(metricFilters || []),
+                  ]),
+                ),
                 ...(dateInterval && { interval: dateInterval }),
               });
 

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -897,6 +897,10 @@ export const FILTER_FOR_HAS_EVAL = {
   },
 };
 
+// Strip UI-only keys per UI_FILTER_ITEM_KEYS in src/api/contracts/filter-contract.js.
+export const toBackendFilters = (filters) =>
+  (filters || []).map(({ id, _meta, col_type, ...rest }) => rest);
+
 export const FILTER_FOR_ERRORS = {
   column_id: "status",
   filter_config: {

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -19,7 +19,10 @@ import { getSessionListColumnDef } from "./common";
 import { Events, trackEvent } from "src/utils/Mixpanel";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { userTraceRowHeightMapping } from "../UsersView/common";
-import { normalizeConfigKeys } from "src/sections/projects/LLMTracing/common";
+import {
+  normalizeConfigKeys,
+  toBackendFilters,
+} from "src/sections/projects/LLMTracing/common";
 import { useSessionsGridStoreShallow } from "./ReplaySessions/store";
 import { APP_CONSTANTS } from "src/utils/constants";
 
@@ -229,7 +232,7 @@ const SessionGrid = React.forwardRef(
                     direction: sort,
                   })),
                 ),
-                filters: JSON.stringify(filters),
+                filters: JSON.stringify(toBackendFilters(filters)),
                 ...(dateInterval && { interval: dateInterval }),
               });
 


### PR DESCRIPTION
**Ticket:** [TH-6505](https://linear.app/future-agi/issue/TH-6505/bugfix-fe-filter-row-keys-id-metacol-type-leak-into-list-traces) — Closes TH-6505

## What was the bug
Applying any filter in LLM Tracing (and Sessions / graphs) sent the raw UI filter-row objects on the wire. Those rows carry FE-only keys — the generated row `id` (e.g. `ds1ngez46`), `_meta`, and a top-level `col_type` — that are not part of the API filter contract. After the recent `trace_list.py` refactor tightened validation (`@validated_request(reject_unknown_fields=True)`), the list endpoints now **reject** these unknown keys instead of silently ignoring them, so `list_traces_of_session` (and the trace/span list calls) errored the moment a filter was applied.

## What changes have been done
- `frontend/src/sections/projects/LLMTracing/common.js` — new `toBackendFilters` helper: a non-throwing `.map` projection that drops the UI-only keys (`id`, `_meta`, top-level `col_type`) per `UI_FILTER_ITEM_KEYS` in `src/api/contracts/filter-contract.js`.
- `frontend/src/sections/projects/LLMTracing/TraceGrid.jsx` — wrap trace-list filters send.
- `frontend/src/sections/projects/LLMTracing/SpanGrid.jsx` — wrap span-list filters send.
- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx` — wrap call-logs filters send (primary + compare).
- `frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx` — wrap trace + span graph sends.
- `frontend/src/sections/projects/LLMTracing/GraphSection/PrimaryGraph.jsx` — wrap primary/compare graph send.
- `frontend/src/sections/projects/SessionsView/Session-grid.jsx` — wrap session-traces filters send.

## Why the changes
- `apiPath()` and the request interceptor only guard/register the URL — they do **not** strip body fields. The UI keys had always leaked; the backend used to ignore them, and the tightened validation now surfaces the long-standing leak as a hard error.
- The strip is a lightweight projection (not the strict `serializeFilterListForApi`) because these live arrays include heterogeneous internal filters (`FILTER_FOR_HAS_EVAL`, metric, error/date filters) that the strict serializer would throw on.
- It preserves everything the contract requires: the **nested** `filter_config.col_type` (required for system-metric filters — dropping it would 400 the list) and `display_name` / `source` / `output_type`.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Add a filter in LLM Tracing traces list | Request succeeds; `filters` payload has no `id`/`_meta`/top-level `col_type` |
| 2 | Add a filter in the Spans list | Request succeeds; UI keys stripped |
| 3 | Add a filter in a Session's traces (Sessions grid) | `list_traces_of_session` succeeds (the reported bug) |
| 4 | Add a system-metric filter | Nested `filter_config.col_type` preserved; list does not 400 |
| 5 | Apply filters with the graph shown (primary + compare) | Graphs render; payload is clean |
| 6 | Apply filters in compare mode (call-logs primary + compare) | Both sends succeed |
| 7 | Save a view with filters | Unchanged — save-view path only persists `{column_id, filter_config}` |

## How to reproduce (original bug)
1. Open LLM Tracing (or a Session's traces).
2. Add any filter row.
3. Observe the list request `filters` payload carries `id`/`col_type` and the request errors.

## Commands
```bash
cd frontend && yarn lint src/sections/projects/LLMTracing src/sections/projects/SessionsView
```

## Videos and screenshots

https://github.com/user-attachments/assets/550aa7e4-b20b-4abd-b06b-05a102f819e1

