### PR TITLE
perf(eval-tasks): scope CH eval reads by project_id

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/eval_loader.py
+++ b/futureagi/tracer/services/clickhouse/v2/eval_loader.py
@@ -92,12 +92,17 @@ def _read_source() -> str:
 
 
 def get_observation_span(
-    span_id: str, *, select_related: tuple[str, ...] = ()
+    span_id: str, *, select_related: tuple[str, ...] = (), project_id: str | None = None
 ) -> ObservationSpan:
     """Return an ObservationSpan instance for the given id.
 
     Mirrors the surface area of `ObservationSpan.objects.select_related(*).get(id=...)`
     so the eval runner can swap call sites mechanically.
+
+    ``project_id`` (the eval config's project) scopes the CH read to one tenant.
+    ``spans`` is sorted by ``project_id`` first, so passing it lets ClickHouse
+    prune by the primary index instead of scanning every project's parts for the
+    span id — the difference between a whole-table read and a pruned one.
 
     Raises `ObservationSpan.DoesNotExist` (same as the Django path) when no
     such span — keeps downstream `except ObservationSpan.DoesNotExist` blocks
@@ -123,11 +128,14 @@ def get_observation_span(
 
     # ── v2 path: read span data from CH, construct partial Django model,
     # let FK descriptors lazy-load from PG on attribute access.
-    return _hybrid_load_from_ch(span_id, select_related)
+    return _hybrid_load_from_ch(span_id, select_related, project_id=project_id)
 
 
 def _hybrid_load_from_ch(
-    span_id: str, select_related: tuple[str, ...]
+    span_id: str,
+    select_related: tuple[str, ...],
+    *,
+    project_id: str | None = None,
 ) -> ObservationSpan:
     """Reads the span row from CH and returns a partially-hydrated Django
     ObservationSpan whose FK descriptors will lazy-load from PG on access.
@@ -140,7 +148,7 @@ def _hybrid_load_from_ch(
 
     try:
         reader = get_reader()
-        ch_row = reader.get(span_id)
+        ch_row = reader.get(span_id, project_id=project_id)
     except Exception as e:  # noqa: BLE001 — CH transient errors → fall back to PG
         logger.warning(
             "eval_span_ch_read_fallback_to_pg", span_id=span_id, err=repr(e)[:200]
@@ -161,12 +169,18 @@ def _hybrid_load_from_ch(
     return _construct_from_chspan(ch_row)
 
 
-def filter_observation_spans_by_trace(trace_id: str, deleted: bool = False):
+def filter_observation_spans_by_trace(
+    trace_id: str, deleted: bool = False, *, project_id: str | None = None
+):
     """v2 equivalent of `ObservationSpan.objects.filter(trace=trace, deleted=False)`.
 
     Returns a list of ObservationSpan instances (NOT a QuerySet). Eval-runner
     aggregate sites that iterate the result work unchanged; sites that chain
     additional `.filter()` calls need explicit porting.
+
+    ``project_id`` scopes the CH read so ClickHouse can prune ``spans`` by the
+    ``project_id`` sort-key prefix instead of scanning all projects for the
+    trace's spans.
     """
     from tracer.models.observation_span import ObservationSpan
 
@@ -178,7 +192,7 @@ def filter_observation_spans_by_trace(trace_id: str, deleted: bool = False):
         from tracer.services.clickhouse.v2 import get_reader
 
         reader = get_reader()
-        ch_rows = reader.list_by_trace(trace_id)
+        ch_rows = reader.list_by_trace(trace_id, project_id=project_id)
     except Exception as e:  # noqa: BLE001
         if _forced_clickhouse():
             raise
@@ -267,13 +281,18 @@ def get_trace(
     *,
     select_related: tuple[str, ...] = (),
     reader: CHSpanReader | None = None,
+    project_id: str | None = None,
 ) -> Trace:
     """Return a Trace instance for the id. CH mode hydrates it from the CH
     ``traces`` table (the same store the trace list endpoints read), so
     trace-level fields (input/output/tags/metadata/error) match the UI; PG mode
     keeps the Django path. Raises Trace.DoesNotExist when forced-CH and the
     trace isn't in ClickHouse. Pass ``reader`` to reuse an open CHSpanReader
-    across a loop of traces instead of opening (and leaking) one per call."""
+    across a loop of traces instead of opening (and leaking) one per call.
+
+    ``project_id`` scopes the CH read; ``traces`` is sorted ``(project_id, id)``
+    and has no bloom on ``id``, so without it a lone-id lookup scans every
+    project's parts — passing it enables the sort-key prefix prune."""
     import json as _json
 
     from tracer.models.trace import Trace
@@ -287,10 +306,10 @@ def get_trace(
 
     try:
         if reader is not None:
-            row = reader.get_trace_row(str(trace_id))
+            row = reader.get_trace_row(str(trace_id), project_id=project_id)
         else:
             with get_reader() as _reader:
-                row = _reader.get_trace_row(str(trace_id))
+                row = _reader.get_trace_row(str(trace_id), project_id=project_id)
     except Exception as e:  # noqa: BLE001 — CH transient errors → fall back to PG
         logger.warning(
             "eval_trace_ch_read_fallback", trace_id=str(trace_id), err=repr(e)[:200]

--- a/futureagi/tracer/services/eval_tasks/run_entry.py
+++ b/futureagi/tracer/services/eval_tasks/run_entry.py
@@ -104,6 +104,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                     "project__organization",
                     "project__workspace",
                 ),
+                project_id=config.project_id,
             )
             run_params = _process_mapping(config.mapping, span, template_id)
             result = _execute_evaluation(
@@ -125,6 +126,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                     "project__organization",
                     "project__workspace",
                 ),
+                project_id=config.project_id,
             )
             run_params = _process_trace_mapping(config.mapping, trace, template_id)
             _execute_evaluation_for_trace(

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2477,7 +2477,9 @@ def _find_anchor_span(trace: Trace):
     )
 
     if _read_source() == "clickhouse":
-        spans = filter_observation_spans_by_trace(str(trace.id))
+        spans = filter_observation_spans_by_trace(
+            str(trace.id), project_id=trace.project_id
+        )
         if not spans:
             return None
         spans.sort(
@@ -2643,7 +2645,9 @@ def _resolve_trace_path(trace: Trace, path: str):
 
         if _read_source() == "clickhouse":
             spans = sorted(
-                filter_observation_spans_by_trace(str(trace.id)),
+                filter_observation_spans_by_trace(
+                    str(trace.id), project_id=trace.project_id
+                ),
                 key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
             )
         else:
@@ -2716,7 +2720,11 @@ def _resolve_session_path(trace_session: TraceSession, path: str):
                 traces = []
                 for tid in _trace_ids:
                     try:
-                        traces.append(get_trace(str(tid), reader=reader))
+                        traces.append(
+                            get_trace(
+                                str(tid), reader=reader, project_id=_project_id
+                            )
+                        )
                     except Trace.DoesNotExist:
                         continue
 


### PR DESCRIPTION
## Why

Eval tasks were failing with ClickHouse **Code 241 (total memory limit exceeded)** — the forced-ClickHouse eval runner reads each target span/trace by id, and those reads were issued **without `project_id`**. Because `id` is the *trailing* column of the `spans` (`project_id, observation_type, service_name, toStartOfHour(start_time), trace_id, id`) and `traces` (`project_id, id`) sort keys, a lone-`id` lookup can't use the primary index — it scans every project's parts. Under the runner's fan-out (up to 10 concurrent reads/task), those whole-table scans drove CH over its 9 GiB cap and every eval was mis-reported as "not in ClickHouse."

The eval config's `project_id` is already in hand at every call site; it was simply not threaded into the reads.

## What

Thread `project_id` into the forced-CH eval reads (no new reader code — the reader methods already accept an optional `project_id`):

- `eval_loader.get_observation_span` / `_hybrid_load_from_ch` → `reader.get(span_id, project_id=…)`
- `eval_loader.get_trace` → `reader.get_trace_row(trace_id, project_id=…)`
- `eval_loader.filter_observation_spans_by_trace` → `reader.list_by_trace(trace_id, project_id=…)`
- Call sites pass it: `run_entry.py` SPAN/TRACE branches (`config.project_id`); `eval.py` `_find_anchor_span` / `_resolve_trace_path` (`trace.project_id`) and `_resolve_session_path` fan-out (`trace_session.project_id`).

`project_id` is an **optional** param (default `None`) everywhere, so any non-forced/PG path and any un-threaded caller keep their current behavior. **`FINAL` semantics are unchanged** — this only adds a prune predicate.

This is the low-risk first slice. Dropping `FINAL` via `argMax` dedup (the larger ~426× reduction) is a tracked follow-up on this branch.

## Tests

**New:** none in this commit — it's a pure predicate-threading change with no new read code (the `argMax` `*_for_eval` readers + their unit tests land in the follow-up slice).

**Existing (regression):** ran the eval read/mapping suites that exercise these call sites:
`test_eval_loader_ch_hydration.py`, `test_run_entry_ch_input.py`, `test_run_entry.py`, `test_session_path_resolver.py`, `test_process_mapping.py`, `test_feed_session_resolution.py`.

### Per-test scenarios
- `test_session_path_resolver` / `test_feed_session_resolution` — session→trace→span path resolution through the (now project-scoped) `list_by_trace` / `get_trace`. **Pass.**
- `test_run_entry` — end-to-end entry dispatch for span/trace/session. **Pass.**
- 6 failures are **pre-existing on `dev`**, confirmed by re-running with this change stashed: 5 are test-DB data pollution (`assert ObservationSpan.objects.count() == 0` → `2927`, leftover rows in the shared test DB) and 1 is a `NameError: name 'exc' is not defined` bug inside `test_process_mapping`. None involve this change.

## Commands

```bash
# in the worktree futureagi/ dir (.env.test.local auto-loaded; test stack up as futureagi-test)
uv run pytest tracer/tests/test_eval_loader_ch_hydration.py \
  tracer/tests/test_run_entry_ch_input.py tracer/tests/test_run_entry.py \
  tracer/tests/test_session_path_resolver.py tracer/tests/test_process_mapping.py \
  tracer/tests/test_feed_session_resolution.py -q

# pruning measured on the dev CH (no execution, no memory):
EXPLAIN ESTIMATE SELECT id FROM spans FINAL WHERE id='…';                    -- 152,495 rows
EXPLAIN ESTIMATE SELECT id FROM spans FINAL WHERE project_id='…' AND id='…'; --  46,350 rows
```

## Local test steps
1. Deploy this branch to dev.
2. Re-run an eval task whose spans span one project (e.g. the failing `1a875a5b…`).
3. Confirm evals complete instead of erroring "not in ClickHouse."
4. In `system.query_log`, confirm the per-span `spans FINAL WHERE project_id … AND id …` reads `read_rows` in the tens-of-thousands, not the whole table, and `memory_usage` is well under the cap.

## Terminal output (evidence)

`EXPLAIN ESTIMATE` on the dev CH `spans` table (193 parts / 152,495 rows / 89 partitions):

```
--- no project_id (FINAL) ---     futureagi  spans  193  152495  754
--- with project_id (FINAL) ---   futureagi  spans  147   46350  147
```

→ adding `project_id` alone cuts rows read per lookup from **152,495 → 46,350** (~3.3×), the difference between a whole-table scan and a pruned prefix scan.

## Architectural rationale

Both `spans` and `traces` are `ReplacingMergeTree`s sorted `project_id`-first with `id` trailing. ClickHouse's primary index is a prefix index — it can only prune when the leading sort columns are constrained. A `WHERE id = X` therefore forces a scan across all parts/partitions (spans falls back to the `id` bloom filter; `traces` has no `id` bloom at all → full scan). Constraining `project_id` (the sort leader) restores prefix pruning. Since the eval runner always has the tenant in hand, passing it is free correctness-preserving pruning — and the foundation the follow-up `FINAL`-drop builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
