### PR TITLE
fix(scripts): add create-branch.sh referenced in BRANCH_NAMING_CONVENTION.md

### DIFF
--- a/BRANCH_NAMING_CONVENTION.md
+++ b/BRANCH_NAMING_CONVENTION.md
@@ -7,6 +7,7 @@ This document defines the branch naming conventions for this project to ensure c
 ## 📋 Branch Naming Rules
 
 ### Format
+
 ```
 <type>/<ticket-id>-<short-description>
 ```
@@ -17,22 +18,24 @@ This document defines the branch naming conventions for this project to ensure c
 
 Matches the Conventional Commits prefixes used in `CONTRIBUTING.md`.
 
-| Type | Description | Example |
-|------|-------------|---------|
-| `feat` | New features or enhancements | `feat/AUTH-123-user-login` |
-| `fix` | Bug fixes | `fix/BUG-456-login-error` |
-| `chore` | Maintenance tasks, build changes | `chore/BUILD-404-upgrade-deps` |
-| `docs` | Documentation updates | `docs/DOC-202-update-readme` |
+| Type       | Description                               | Example                           |
+| ---------- | ----------------------------------------- | --------------------------------- |
+| `feat`     | New features or enhancements              | `feat/AUTH-123-user-login`        |
+| `fix`      | Bug fixes                                 | `fix/BUG-456-login-error`         |
+| `chore`    | Maintenance tasks, build changes          | `chore/BUILD-404-upgrade-deps`    |
+| `docs`     | Documentation updates                     | `docs/DOC-202-update-readme`      |
 | `refactor` | Code refactoring without behavior changes | `refactor/TECH-101-cleanup-utils` |
-| `test` | Adding or updating tests | `test/TEST-303-add-unit-tests` |
-| `perf` | Performance improvements | `perf/PERF-500-optimize-query` |
+| `test`     | Adding or updating tests                  | `test/TEST-303-add-unit-tests`    |
+| `perf`     | Performance improvements                  | `perf/PERF-500-optimize-query`    |
 
 #### 2. **Ticket ID** (Optional but Recommended)
+
 - Use your project management system ticket ID
 - Examples: `JIRA-123`, `GH-456`, `TICKET-789`
 - If no ticket exists, use descriptive identifier
 
 #### 3. **Short Description** (Required)
+
 - Use kebab-case (lowercase with hyphens)
 - Keep it concise but descriptive
 - Maximum 50 characters recommended
@@ -89,9 +92,11 @@ feat/TICKET-123-implement-comprehensive-user-authentication-system-with-oauth-an
 ## 🚀 Branch Lifecycle
 
 ### Main Branch
+
 - `main` — production-ready code; PRs target this directly (see `CONTRIBUTING.md`).
 
 ### Workflow
+
 1. Branch from `main` using a valid `type/short-description` name.
 2. Make focused changes — keep the diff small.
 3. Open a PR against `main`.
@@ -100,23 +105,28 @@ feat/TICKET-123-implement-comprehensive-user-authentication-system-with-oauth-an
 ## 🛠️ Enforcement
 
 ### Local Validation
+
 - Pre-push Git hook validates branch names
 - Prevents pushing branches with invalid names
 
 ### CI/CD Integration
+
 - GitHub Actions validate branch names
 - Automated checks on all pushes
 
 ### GitHub Settings
+
 - Branch protection rules enforce naming
 - Required status checks for valid names
 
 ## 📝 Configuration
 
 ### IDE Integration
+
 Configure your IDE to suggest branch names:
 
 **VS Code Settings:**
+
 ```json
 {
   "git.branchPrefix": "feat/",
@@ -133,26 +143,31 @@ Configure your IDE to suggest branch names:
 ```
 
 ### Branch Creation Helper Script
+
 Use the provided script for easy branch creation:
+
 ```bash
 # Create a feat branch with ticket ID
-./frontend/scripts/create-branch.sh feat user-authentication AUTH-123
+./scripts/create-branch.sh feat user-authentication AUTH-123
 
 # Create a fix branch with ticket ID
-./frontend/scripts/create-branch.sh fix login-error BUG-456
+./scripts/create-branch.sh fix login-error BUG-456
 
 # Create a docs branch without ticket ID
-./frontend/scripts/create-branch.sh docs update-readme
+./scripts/create-branch.sh docs update-readme
 ```
 
 The script will:
+
 - ✅ Validate the branch type and description
 - ✅ Check if the branch already exists
 - ✅ Create and checkout the new branch
 - ✅ Provide next steps guidance
 
 ### Git Aliases
+
 Add to your `.gitconfig`:
+
 ```bash
 [alias]
   new-feat = "!f() { git checkout -b feat/$1; }; f"
@@ -161,6 +176,7 @@ Add to your `.gitconfig`:
 ```
 
 Usage:
+
 ```bash
 git new-feat TICKET-123-user-login
 git new-fix BUG-456-button-alignment
@@ -170,6 +186,7 @@ git new-chore UPDATE-333-upgrade-react
 ## 🎯 Best Practices
 
 ### DO:
+
 - ✅ Use descriptive names that explain the purpose
 - ✅ Include ticket/issue numbers when available
 - ✅ Keep descriptions concise but clear
@@ -177,6 +194,7 @@ git new-chore UPDATE-333-upgrade-react
 - ✅ Delete branches after merging
 
 ### DON'T:
+
 - ❌ Use personal identifiers in branch names
 - ❌ Create branches with generic names like "fix" or "update"
 - ❌ Use special characters or spaces
@@ -186,6 +204,7 @@ git new-chore UPDATE-333-upgrade-react
 ## 🔧 Troubleshooting
 
 ### Branch Name Rejected?
+
 ```bash
 # Check current branch name
 git branch --show-current
@@ -199,6 +218,7 @@ git push origin -u new-valid-name
 ```
 
 ### Common Issues
+
 1. **Spaces in names** → Use hyphens instead
 2. **Missing type prefix** → Add appropriate type/
 3. **Too long** → Shorten description
@@ -207,11 +227,13 @@ git push origin -u new-valid-name
 ## 📊 Validation Rules
 
 The following regex pattern validates branch names:
+
 ```regex
 ^(feat|fix|chore|docs|refactor|test|perf)\/[a-zA-Z0-9]+([a-zA-Z0-9\-]*[a-zA-Z0-9])?$
 ```
 
 ### Pattern Breakdown:
+
 - `^` - Start of string
 - `(feat|fix|chore|docs|refactor|test|perf)` - Valid types (Conventional Commits)
 - `\/` - Forward slash separator
@@ -244,4 +266,4 @@ Examples:
   ❌ myFeatureBranch           (no type prefix)
 ```
 
-For questions or suggestions, please create an issue or reach out to the development team. 
+For questions or suggestions, please create an issue or reach out to the development team.

--- a/scripts/create-branch.sh
+++ b/scripts/create-branch.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Branch creation helper script.
+# Creates a properly named branch following the project's naming convention.
+#
+# Usage:
+#   ./scripts/create-branch.sh <type> <description> [<ticket-id>]
+#
+# Examples:
+#   ./scripts/create-branch.sh feat user-authentication AUTH-123
+#   ./scripts/create-branch.sh fix login-error BUG-456
+#   ./scripts/create-branch.sh docs update-readme
+#
+# The script will:
+#   - Validate the branch type and description
+#   - Check if the branch already exists
+#   - Create and checkout the new branch
+#   - Provide next steps guidance
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Valid branch types (Conventional Commits prefixes) ────────────────────────
+VALID_TYPES="feat fix chore docs refactor test perf"
+
+# ── Regex from .husky/pre-push and BRANCH_NAMING_CONVENTION.md ───────────────
+BRANCH_REGEX="^(feat|fix|chore|docs|refactor|test|perf)\/[a-zA-Z0-9]+([a-zA-Z0-9\-]*[a-zA-Z0-9])?$"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+red()   { printf "\033[31m%s\033[0m\n" "$1"; }
+green() { printf "\033[32m%s\033[0m\n" "$1"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$1"; }
+
+usage() {
+    cat <<HELP
+Usage: ./scripts/create-branch.sh <type> <description> [<ticket-id>]
+
+Valid types: feat, fix, chore, docs, refactor, test, perf
+
+Examples:
+  ./scripts/create-branch.sh feat user-authentication AUTH-123
+  ./scripts/create-branch.sh fix login-error BUG-456
+  ./scripts/create-branch.sh docs update-readme
+HELP
+    exit 1
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+if [[ $# -lt 2 ]]; then
+    red "Error: Missing required arguments."
+    usage
+fi
+
+BRANCH_TYPE="$1"
+DESCRIPTION="$2"
+TICKET_ID="${3:-}"  # optional
+
+# ── Validate type ─────────────────────────────────────────────────────────────
+if ! echo "$VALID_TYPES" | grep -qw "$BRANCH_TYPE"; then
+    red "Error: Invalid branch type '${BRANCH_TYPE}'."
+    red "Valid types: feat, fix, chore, docs, refactor, test, perf"
+    exit 1
+fi
+
+# ── Build branch name ─────────────────────────────────────────────────────────
+if [[ -n "$TICKET_ID" ]]; then
+    BRANCH_NAME="${BRANCH_TYPE}/${TICKET_ID}-${DESCRIPTION}"
+else
+    BRANCH_NAME="${BRANCH_TYPE}/${DESCRIPTION}"
+fi
+
+# ── Validate full branch name against regex ───────────────────────────────────
+if [[ ! "$BRANCH_NAME" =~ $BRANCH_REGEX ]]; then
+    red "Error: Branch name '${BRANCH_NAME}' does not match naming convention."
+    red "Format: <type>/<ticket-id>-<description> or <type>/<description>"
+    red "Description must use kebab-case (lowercase letters, numbers, hyphens)."
+    exit 1
+fi
+
+# ── Check if branch already exists ────────────────────────────────────────────
+if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}" 2>/dev/null; then
+    red "Error: Branch '${BRANCH_NAME}' already exists locally."
+    echo "  Switch to it:  git checkout ${BRANCH_NAME}"
+    echo "  Or delete it:  git branch -D ${BRANCH_NAME}"
+    exit 1
+fi
+
+if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}" 2>/dev/null; then
+    yellow "Warning: Branch '${BRANCH_NAME}' exists on origin."
+    echo "  Track it:      git checkout ${BRANCH_NAME}"
+    echo "  Or delete it:  git push origin --delete ${BRANCH_NAME}"
+    exit 1
+fi
+
+# ── Create and checkout ──────────────────────────────────────────────────────
+git checkout -b "$BRANCH_NAME"
+
+green "Branch '${BRANCH_NAME}' created and checked out."
+
+echo ""
+echo "Next steps:"
+echo "  1. Make your changes"
+echo "  2. Commit:     git add . && git commit"
+echo "  3. Push:       git push origin -u ${BRANCH_NAME}"
+echo "  4. Open a PR against 'main'"
+echo ""
+echo "See BRANCH_NAMING_CONVENTION.md for full guidelines."


### PR DESCRIPTION
## What

`BRANCH_NAMING_CONVENTION.md` documents a branch creation helper script at `./scripts/create-branch.sh`, but the file did not exist. This PR adds the script so the documentation is self-consistent.

## Why

This is a minor completeness fix — it does **not** change any project behavior. The purpose is simply to avoid referencing a non-existent file, so contributors following the docs don't hit a "file not found" error.

Creating a branch manually (`git checkout -b feat/description`) works just as well; this script is purely a convenience wrapper.

## What the script does

- Validates the branch type against the same list used in `.husky/pre-push`
- Validates the full branch name against the same regex enforced by the pre-push hook
- Checks if the branch already exists (locally or on origin)
- Creates and checks out the new branch
- Prints next-step guidance

Follows the same style as existing scripts in `scripts/` (`#!/usr/bin/env bash`, `set -euo pipefail`, `ROOT_DIR` variable, `${VAR}` quoting).

Closes #1366
