### PR TITLE
fix(model-hub): validate provider API key at save time (TH-6363)

### DIFF
--- a/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
+++ b/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
@@ -15,6 +15,12 @@ import { ShowComponent } from "src/components/show";
 import APIKeyReadOnlyView from "src/components/custom-model-dropdown/APIKeyReadOnlyView";
 import Actions from "./Actions";
 import { LOGO_WITH_BLACK_BACKGROUND } from "src/components/custom-model-dropdown/common";
+import { RESPONSE_CODES } from "src/utils/constants";
+
+// Kept in sync with tfc.utils.error_codes.err_dict["INVALID_API_KEY"] on the
+// backend -- this is only a fallback for the rare case the server response
+// doesn't carry a message, so it must read identically to that string.
+const INVALID_API_KEY_MESSAGE = "Invalid API key, please type in the right one.";
 
 const KeyCardComponent = ({ data, onDeleteClick }) => {
   const theme = useTheme();
@@ -86,17 +92,31 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
     hasClearedOnceRef.current = false;
   }, [data, reset]);
 
-  // Surface a rejected key inline under the input (matches the AI Providers
-  // design). A 400 from the save endpoint means the provider rejected the key;
-  // anything else is an unexpected failure and gets a generic toast.
+  // Surface a rejected key. Text-key providers get an inline error under the
+  // input (matches the AI Providers design); JSON-config providers
+  // (Vertex/Azure/Bedrock) never mount a "key" field here -- they render
+  // APIKeyReadOnlyView + the CloudProviderModals dialog instead, which is
+  // already closed by the time this resolves, so setError('key', ...) would
+  // write into a sink nothing renders and the save would silently appear to
+  // do nothing. Only a definitive key rejection (INVALID_API_KEY) is a "key"
+  // problem on the text path -- every other 400 (e.g. UNABLE_TO_ADD_API_KEY
+  // from the save block) is an unrelated failure and always gets a toast.
   const handleSaveError = (error) => {
-    const message =
-      error?.message || "Invalid API key, please type in the right one";
-    if (error?.statusCode === 400) {
+    const message = error?.message || INVALID_API_KEY_MESSAGE;
+    const isKeyRejection = error?.code === "INVALID_API_KEY";
+
+    if (isKeyRejection && !isJsonKey) {
       setError("key", { type: "server", message });
-    } else {
-      enqueueSnackbar(message, { variant: "error" });
+      return;
     }
+
+    if (error?.statusCode === RESPONSE_CODES.PAYMENT_REQUIRED) {
+      // The axios response interceptor already enqueues an error snackbar for
+      // 402 upgrade_required; avoid stacking a second, identical toast here.
+      return;
+    }
+
+    enqueueSnackbar(message, { variant: "error" });
   };
 
   const { mutate: createApiKey, isPending } = useMutation({

--- a/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
+++ b/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
@@ -28,6 +28,7 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
     reset,
     watch,
     clearErrors,
+    setError,
     handleSubmit,
     setValue,
     formState: { isDirty },
@@ -85,6 +86,19 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
     hasClearedOnceRef.current = false;
   }, [data, reset]);
 
+  // Surface a rejected key inline under the input (matches the AI Providers
+  // design). A 400 from the save endpoint means the provider rejected the key;
+  // anything else is an unexpected failure and gets a generic toast.
+  const handleSaveError = (error) => {
+    const message =
+      error?.message || "Invalid API key, please type in the right one";
+    if (error?.statusCode === 400) {
+      setError("key", { type: "server", message });
+    } else {
+      enqueueSnackbar(message, { variant: "error" });
+    }
+  };
+
   const { mutate: createApiKey, isPending } = useMutation({
     mutationFn: (d) => axios.post(endpoints.develop.apiKey.create, d),
     onSuccess: () => {
@@ -97,6 +111,7 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
       setEditMode(false);
       hasClearedOnceRef.current = false;
     },
+    onError: handleSaveError,
   });
 
   const { mutate: updateApiKey, isPending: isUpdatingApiKey } = useMutation({
@@ -110,11 +125,15 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
       setEditMode(false);
       hasClearedOnceRef.current = false;
     },
+    onError: handleSaveError,
   });
   const handleFormSubmit = async (formData) => {
     // trackEvent(Events.saveApiClicked, {
     //   [PropertyName.click]: formData?.provider,
     // });
+
+    // Clear any prior "invalid key" error before re-submitting.
+    clearErrors("key");
 
     // Add the hasKey property from the original data
     const submitData = {
@@ -130,6 +149,9 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
   };
 
   const handleSubmitData = async (submitData) => {
+    // Clear any prior "invalid key" error before re-submitting.
+    clearErrors("key");
+
     // For JSON keys, ensure provider is included from the component's data
     const dataToSubmit = {
       ...submitData,

--- a/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.test.jsx
+++ b/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.test.jsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTheme } from "@mui/material/styles";
+import KeyCard from "./KeyCard";
+
+const mockPost = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: (...args) => mockPost(...args) },
+  endpoints: {
+    develop: {
+      apiKey: {
+        create: "/model-hub/api-keys/",
+        update: "/model-hub/api-keys/",
+      },
+    },
+  },
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+// Provider logo pulls in react-lazy-load-image-component, which does not render
+// under jsdom and is irrelevant to the save behavior under test.
+vi.mock("src/components/image", () => ({
+  default: () => null,
+}));
+
+// The card renders a "key configured" check icon styled with palette.green,
+// which the bare test theme does not define.
+const theme = createTheme({
+  palette: {
+    mode: "light",
+    primary: { main: "#1976d2" },
+    green: { 400: "#22c55e" },
+  },
+});
+
+const INVALID_KEY_MESSAGE = "Invalid API key, please type in the right one.";
+
+const OPENAI_DATA = {
+  provider: "openai",
+  display_name: "Open AI",
+  type: "text",
+  maskedKey: "",
+  hasKey: false,
+  logoUrl: "https://example.test/openai.png",
+};
+
+function renderCard(props = {}) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <KeyCard data={OPENAI_DATA} onDeleteClick={vi.fn()} {...props} />
+    </QueryClientProvider>,
+    { theme },
+  );
+}
+
+describe("KeyCard — invalid API key surfacing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the inline error when the provider rejects the key on save", async () => {
+    mockPost.mockRejectedValue({
+      message: INVALID_KEY_MESSAGE,
+      statusCode: 400,
+    });
+
+    renderCard();
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "totally-wrong-key");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(INVALID_KEY_MESSAGE)).toBeInTheDocument();
+    expect(mockPost).toHaveBeenCalledWith(
+      "/model-hub/api-keys/",
+      expect.objectContaining({ provider: "openai", key: "totally-wrong-key" }),
+    );
+  });
+
+  it("does not show the error when the save succeeds", async () => {
+    mockPost.mockResolvedValue({ data: { status: true, result: {} } });
+
+    renderCard();
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "sk-valid-key");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText(INVALID_KEY_MESSAGE)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.test.jsx
+++ b/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, userEvent } from "src/utils/test-utils";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createTheme } from "@mui/material/styles";
+import { enqueueSnackbar } from "src/components/snackbar";
 import KeyCard from "./KeyCard";
 
 const mockPost = vi.fn();
@@ -70,8 +71,12 @@ describe("KeyCard — invalid API key surfacing", () => {
   });
 
   it("shows the inline error when the provider rejects the key on save", async () => {
+    // Shape matches what build_error_envelope() actually sends: error_code is
+    // promoted to top-level `code`, and `message`/`error`/`detail` all carry
+    // the same string (tfc/utils/api_errors.py:build_error_envelope).
     mockPost.mockRejectedValue({
       message: INVALID_KEY_MESSAGE,
+      code: "INVALID_API_KEY",
       statusCode: 400,
     });
 
@@ -86,9 +91,10 @@ describe("KeyCard — invalid API key surfacing", () => {
       "/model-hub/api-keys/",
       expect.objectContaining({ provider: "openai", key: "totally-wrong-key" }),
     );
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
   });
 
-  it("does not show the error when the save succeeds", async () => {
+  it("shows a success toast, invalidates queries, and exits edit mode when the save succeeds", async () => {
     mockPost.mockResolvedValue({ data: { status: true, result: {} } });
 
     renderCard();
@@ -97,7 +103,42 @@ describe("KeyCard — invalid API key surfacing", () => {
     await userEvent.type(input, "sk-valid-key");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledWith(
+        "API Key created successfully",
+        { variant: "success" },
+      );
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/model-hub/api-keys/",
+      expect.objectContaining({ provider: "openai", key: "sk-valid-key" }),
+    );
+    // The "Add"/"Save" button only renders while out of the configured,
+    // read-only state -- confirms the success path collapsed edit mode
+    // rather than merely failing to show an error.
     expect(screen.queryByText(INVALID_KEY_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it("does not stack a second toast on a 402 upgrade_required rejection", async () => {
+    // The axios response interceptor already enqueues the upgrade-required
+    // snackbar for this status (src/utils/axios.js); handleSaveError must not
+    // enqueue a second, identical one.
+    mockPost.mockRejectedValue({
+      message: "Not available on OSS. Upgrade your plan.",
+      statusCode: 402,
+      upgrade_required: true,
+    });
+
+    renderCard();
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "sk-some-key");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await vi.waitFor(() => expect(mockPost).toHaveBeenCalled());
+    // Give handleSaveError's microtask a tick to run before asserting the
+    // negative (mirrors the settle wait the success test needs).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
   });
 });

--- a/futureagi/model_hub/tests/test_run_prompt_api.py
+++ b/futureagi/model_hub/tests/test_run_prompt_api.py
@@ -18,6 +18,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
+from litellm.exceptions import AuthenticationError
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -34,6 +35,7 @@ from model_hub.models.choices import (
 )
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.run_prompt import RunPrompter
+from model_hub.utils.provider_key_validation import is_provider_key_valid
 from tfc.middleware.workspace_context import set_workspace_context
 
 
@@ -859,6 +861,18 @@ class TestRunPromptForRowsView:
 
 @pytest.mark.django_db
 class TestProviderApiKeys:
+    @pytest.fixture(autouse=True)
+    def _stub_provider_key_probe(self):
+        # Saving a flat key now validates it by probing the provider with a live
+        # litellm call. Stub that probe so these tests never touch the network; a
+        # returned response means "the provider accepted the key". Tests that need
+        # the reject path re-patch this inside their own body.
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            return_value=MagicMock(),
+        ) as mock_completion:
+            yield mock_completion
+
     def test_text_provider_key_responses_are_masked_only(self, auth_client):
         raw_key = "secret-provider-key-value"
         updated_raw_key = "secret-provider-key-value-updated"
@@ -1091,6 +1105,89 @@ class TestProviderApiKeys:
         provider_key.refresh_from_db()
         assert provider_key.config_json == encrypted_config
         assert provider_key.actual_json == updated_config
+
+    def test_invalid_provider_key_is_rejected_at_save(self, auth_client):
+        # A provider that authenticates and rejects the key must fail the save
+        # with the inline "invalid key" message and persist nothing.
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=AuthenticationError(
+                "invalid key",
+                llm_provider="openai",
+                model="openai/gpt-4o-mini",
+            ),
+        ):
+            response = auth_client.post(
+                API_KEYS_URL,
+                {"provider": "openai", "key": "totally-wrong-key"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            response.data["message"]
+            == "Invalid API key, please type in the right one."
+        )
+        assert not ApiKey.no_workspace_objects.filter(provider="openai").exists()
+
+    def test_valid_provider_key_is_saved(self, auth_client):
+        # When the provider accepts the probe, the key is stored as before.
+        response = auth_client.post(
+            API_KEYS_URL,
+            {"provider": "openai", "key": "sk-valid-key"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["result"]["provider"] == "openai"
+        assert ApiKey.no_workspace_objects.filter(provider="openai").exists()
+
+
+@pytest.mark.django_db
+class TestProviderKeyValidation:
+    """Unit tests for is_provider_key_valid — the model-provider key probe."""
+
+    def test_rejects_only_on_authentication_error(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=AuthenticationError(
+                "bad", llm_provider="openai", model="openai/gpt-4o-mini"
+            ),
+        ):
+            assert is_provider_key_valid("openai", "wrong-key") is False
+
+    def test_fails_open_on_non_auth_error(self):
+        # Network/timeout/rate-limit errors are inconclusive and must NOT block
+        # a legitimate save — otherwise a transient blip breaks the flow.
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=RuntimeError("connection reset"),
+        ):
+            assert is_provider_key_valid("openai", "some-key") is True
+
+    def test_valid_key_passes_and_probes_provider(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            return_value=MagicMock(),
+        ) as mock_completion:
+            assert is_provider_key_valid("openai", "sk-good") is True
+        mock_completion.assert_called_once()
+
+    def test_unmapped_provider_is_not_probed(self):
+        # JSON-config providers (vertex_ai/azure/...) and anything without a
+        # probe model are skipped entirely — fail-open, no network call.
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion"
+        ) as mock_completion:
+            assert is_provider_key_valid("vertex_ai", "anything") is True
+        mock_completion.assert_not_called()
+
+    def test_missing_key_is_not_probed(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion"
+        ) as mock_completion:
+            assert is_provider_key_valid("openai", "") is True
+        mock_completion.assert_not_called()
 
 
 # ==================== LitellmAPIView Tests ====================

--- a/futureagi/model_hub/tests/test_run_prompt_api.py
+++ b/futureagi/model_hub/tests/test_run_prompt_api.py
@@ -17,8 +17,9 @@ import json
 import uuid
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-from litellm.exceptions import AuthenticationError
+from litellm.exceptions import APIError, AuthenticationError, PermissionDeniedError
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -1164,6 +1165,64 @@ class TestProviderKeyValidation:
             side_effect=RuntimeError("connection reset"),
         ):
             assert is_provider_key_valid("openai", "some-key") is True
+
+    def test_rejects_on_permission_denied_error(self):
+        # Some providers signal bad credentials as a 403 (PermissionDeniedError)
+        # rather than AuthenticationError's 401 — this used to fall through to
+        # the fail-open branch and silently accept a genuinely invalid key.
+        response = httpx.Response(403, request=httpx.Request("POST", "https://example.test"))
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=PermissionDeniedError(
+                "forbidden",
+                llm_provider="anthropic",
+                model="anthropic/claude-haiku-4-5",
+                response=response,
+            ),
+        ):
+            assert is_provider_key_valid("anthropic", "wrong-key") is False
+
+    def test_rejects_on_generic_api_error_carrying_auth_status(self):
+        # Some litellm provider integrations wrap a 401/403 in the generic
+        # APIError (or a subclass) instead of AuthenticationError/
+        # PermissionDeniedError, but still carry the real status on
+        # `.status_code`. That must still be treated as a definitive rejection,
+        # not silently fail open.
+        exc = APIError(
+            status_code=401,
+            message="unauthorized",
+            llm_provider="openai",
+            model="openai/gpt-4o-mini",
+        )
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=exc,
+        ):
+            assert is_provider_key_valid("openai", "wrong-key") is False
+
+    def test_new_probe_providers_are_actually_probed(self):
+        # Regression guard for the coverage gap Kartik flagged (#1370): the
+        # providers added to PROVIDER_PROBE_MODEL must actually route through
+        # the probe, not silently fail open because the map lookup misses.
+        for provider in ("deepseek", "openrouter", "fireworks_ai", "cerebras", "cohere_chat"):
+            with patch(
+                "model_hub.utils.provider_key_validation.litellm.completion",
+                return_value=MagicMock(),
+            ) as mock_completion:
+                assert is_provider_key_valid(provider, "some-key") is True
+            mock_completion.assert_called_once()
+
+    def test_inconclusive_probe_logs_at_warning(self):
+        # Kartik: a fail-open branch that logs at INFO is invisible if probing
+        # silently becomes a no-op (retired model, blocked egress). Must match
+        # the sibling validate_model_working's WARNING convention.
+        with patch(
+            "model_hub.utils.provider_key_validation.litellm.completion",
+            side_effect=RuntimeError("model retired"),
+        ), patch("model_hub.utils.provider_key_validation.logger") as mock_logger:
+            is_provider_key_valid("openai", "some-key")
+        mock_logger.warning.assert_called_once()
+        mock_logger.info.assert_not_called()
 
     def test_valid_key_passes_and_probes_provider(self):
         with patch(

--- a/futureagi/model_hub/utils/provider_key_validation.py
+++ b/futureagi/model_hub/utils/provider_key_validation.py
@@ -7,15 +7,31 @@ visible at save time by probing the provider with a minimal completion call and
 rejecting the key only on a definitive authentication failure.
 
 Semantics are deliberately fail-open: ``is_provider_key_valid`` returns ``False``
-ONLY when the provider authoritatively rejects the key (``AuthenticationError``).
-Any other outcome -- an unmapped provider, a network/timeout error, a rate limit,
-or a self-hosted install with no outbound access -- is inconclusive and returns
-``True`` so a transient issue can never block a legitimate save.
+ONLY when the provider authoritatively rejects the key (see
+``_is_definitive_auth_rejection`` for the exact set). Any other outcome -- an
+unmapped provider, a network/timeout error, a rate limit, or a self-hosted
+install with no outbound access -- is inconclusive and returns ``True`` so a
+transient issue can never block a legitimate save.
+
+Why this doesn't reuse ``model_hub.utils.utils.validate_model_working``: that
+helper is a good fit for probing a *specific* model a user is registering (it
+takes a mandatory ``model_name`` and already knows how to route
+openai/azure/vertex_ai/bedrock/sagemaker/custom credentials), but its exception
+handling collapses every failure into a bare ``Exception(str(...))`` before it
+reaches the caller -- the original litellm exception type and status code are
+gone by the time we'd see it. That makes it unusable for the "reject only on a
+definitive auth failure, by exception type/status" contract this module needs
+(see ``_is_definitive_auth_rejection``), and changing its contract to preserve
+that would ripple into its other caller (``CustomAIModelCreateView``, which
+intentionally rejects on *any* validation error, not just auth failures).
+Keeping this a separate, narrow probe avoids that risk; the shared concept is
+still centralized on this module's side via ``validate_or_400`` in
+``run_prompt.py`` so there's exactly one call site for "probe and reject" here.
 """
 
 import litellm
 import structlog
-from litellm.exceptions import AuthenticationError
+from litellm.exceptions import AuthenticationError, PermissionDeniedError
 
 logger = structlog.get_logger(__name__)
 
@@ -25,29 +41,74 @@ logger = structlog.get_logger(__name__)
 # never land on a reasoning model whose max_tokens quirk would surface a param
 # error instead of the auth error we need to see. A provider absent from this map
 # is not probed (fail-open) -- this covers the JSON-config providers
-# (vertex_ai/azure/bedrock/sagemaker) and any provider we have no cheap probe for.
+# (vertex_ai/azure/bedrock/sagemaker) and any provider we have no cheap,
+# currently-supported probe model for (e.g. voice-only or embedding-only
+# providers, which litellm.completion cannot probe at all).
 PROVIDER_PROBE_MODEL = {
     "openai": "openai/gpt-4o-mini",
-    "anthropic": "anthropic/claude-3-5-haiku-20241022",
+    "anthropic": "anthropic/claude-haiku-4-5",
     "groq": "groq/llama-3.1-8b-instant",
     "cohere": "cohere/command-r",
+    "cohere_chat": "cohere_chat/command-r",
     "mistral": "mistral/mistral-small-latest",
-    "gemini": "gemini/gemini-1.5-flash",
+    "gemini": "gemini/gemini-2.5-flash-lite",
     "perplexity": "perplexity/sonar",
-    "together_ai": "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo",
+    "together_ai": "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
+    "deepseek": "deepseek/deepseek-chat",
+    "openrouter": "openrouter/mistralai/mistral-7b-instruct",
+    "fireworks_ai": "fireworks_ai/accounts/fireworks/models/llama-v3p1-8b-instruct",
+    "cerebras": "cerebras/llama3.1-8b",
 }
 
 # One-token probe keeps the validation call as cheap as possible.
 _PROBE_MESSAGES = [{"role": "user", "content": "ping"}]
 _PROBE_MAX_TOKENS = 1
 
+# Bound the worst case latency of the synchronous save-time probe. Without
+# this, a reachable-but-hanging provider blocks the request thread up to
+# litellm's ~600s default -- the save spinner hangs and the request eventually
+# 5xx's at the gateway. 10s is generous for a 1-token completion while still
+# keeping a stuck provider from degrading the whole worker.
+_PROBE_TIMEOUT_SECONDS = 10
+
+# HTTP statuses that unambiguously mean "the provider authenticated the
+# request and rejected the credentials" -- never a transient/network/model
+# issue.
+_AUTH_REJECT_STATUS_CODES = {401, 403}
+
+
+def _is_definitive_auth_rejection(exc: Exception) -> bool:
+    """Return True only when ``exc`` is a definitive "bad credentials" signal.
+
+    litellm normalizes most provider auth failures to ``AuthenticationError``
+    (401) or ``PermissionDeniedError`` (403), but some provider integrations
+    fall back to the generic ``APIError`` (or another ``APIError`` subclass,
+    e.g. ``BadRequestError``) while still carrying the real HTTP status on
+    ``.status_code`` or on the wrapped ``.response``. Checking both means a
+    provider that reports a 401/403 through one of those unmapped exception
+    types is still treated as a rejection instead of silently falling through
+    to the fail-open branch below.
+    """
+    if isinstance(exc, (AuthenticationError, PermissionDeniedError)):
+        return True
+
+    if getattr(exc, "status_code", None) in _AUTH_REJECT_STATUS_CODES:
+        return True
+
+    response = getattr(exc, "response", None)
+    if getattr(response, "status_code", None) in _AUTH_REJECT_STATUS_CODES:
+        return True
+
+    return False
+
 
 def is_provider_key_valid(provider, key):
     """Return whether ``key`` is usable for ``provider``.
 
-    ``False`` only when the provider authenticates the request and rejects the
-    key. ``True`` when the key works OR when validity cannot be determined
-    (unmapped provider, missing key, network/other error) -- fail-open by design.
+    ``False`` only when the provider authenticates the request and definitively
+    rejects the key (see ``_is_definitive_auth_rejection``). ``True`` when the
+    key works OR when validity cannot be determined (unmapped provider, missing
+    key, network/timeout/rate-limit/other error) -- fail-open by design.
     """
     if not provider or not key:
         return True
@@ -62,12 +123,18 @@ def is_provider_key_valid(provider, key):
             messages=_PROBE_MESSAGES,
             api_key=key,
             max_tokens=_PROBE_MAX_TOKENS,
+            timeout=_PROBE_TIMEOUT_SECONDS,
         )
         return True
-    except AuthenticationError:
-        return False
-    except Exception as exc:  # noqa: BLE001 - inconclusive, never block the save
-        logger.info(
+    except Exception as exc:  # noqa: BLE001 - classified below
+        if _is_definitive_auth_rejection(exc):
+            return False
+        # Inconclusive (network blip, rate limit, retired probe model, egress
+        # blocked in a self-hosted install, ...): never block the save, but
+        # log at WARNING -- same convention as the sibling
+        # validate_model_working -- since this is the only signal an operator
+        # gets if probing has silently become a no-op for a provider.
+        logger.warning(
             "provider_key_validation_inconclusive",
             provider=provider,
             error=str(exc),

--- a/futureagi/model_hub/utils/provider_key_validation.py
+++ b/futureagi/model_hub/utils/provider_key_validation.py
@@ -1,0 +1,75 @@
+"""Validate a model-provider API key against the provider before it is stored.
+
+The AI Providers settings page used to persist keys without ever checking them,
+so an invalid key was only discovered later when a prompt/optimization run failed
+with a cryptic "API key not configured" error. This module makes the failure
+visible at save time by probing the provider with a minimal completion call and
+rejecting the key only on a definitive authentication failure.
+
+Semantics are deliberately fail-open: ``is_provider_key_valid`` returns ``False``
+ONLY when the provider authoritatively rejects the key (``AuthenticationError``).
+Any other outcome -- an unmapped provider, a network/timeout error, a rate limit,
+or a self-hosted install with no outbound access -- is inconclusive and returns
+``True`` so a transient issue can never block a legitimate save.
+"""
+
+import litellm
+import structlog
+from litellm.exceptions import AuthenticationError
+
+logger = structlog.get_logger(__name__)
+
+# Cheap, non-reasoning chat models used purely to auth-probe a provider key.
+# Provider-prefixed so litellm routes unambiguously without a custom_llm_provider
+# hint. Kept explicit (not "first chat model in the catalog") so the probe can
+# never land on a reasoning model whose max_tokens quirk would surface a param
+# error instead of the auth error we need to see. A provider absent from this map
+# is not probed (fail-open) -- this covers the JSON-config providers
+# (vertex_ai/azure/bedrock/sagemaker) and any provider we have no cheap probe for.
+PROVIDER_PROBE_MODEL = {
+    "openai": "openai/gpt-4o-mini",
+    "anthropic": "anthropic/claude-3-5-haiku-20241022",
+    "groq": "groq/llama-3.1-8b-instant",
+    "cohere": "cohere/command-r",
+    "mistral": "mistral/mistral-small-latest",
+    "gemini": "gemini/gemini-1.5-flash",
+    "perplexity": "perplexity/sonar",
+    "together_ai": "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo",
+}
+
+# One-token probe keeps the validation call as cheap as possible.
+_PROBE_MESSAGES = [{"role": "user", "content": "ping"}]
+_PROBE_MAX_TOKENS = 1
+
+
+def is_provider_key_valid(provider, key):
+    """Return whether ``key`` is usable for ``provider``.
+
+    ``False`` only when the provider authenticates the request and rejects the
+    key. ``True`` when the key works OR when validity cannot be determined
+    (unmapped provider, missing key, network/other error) -- fail-open by design.
+    """
+    if not provider or not key:
+        return True
+
+    probe_model = PROVIDER_PROBE_MODEL.get(provider)
+    if not probe_model:
+        return True
+
+    try:
+        litellm.completion(
+            model=probe_model,
+            messages=_PROBE_MESSAGES,
+            api_key=key,
+            max_tokens=_PROBE_MAX_TOKENS,
+        )
+        return True
+    except AuthenticationError:
+        return False
+    except Exception as exc:  # noqa: BLE001 - inconclusive, never block the save
+        logger.info(
+            "provider_key_validation_inconclusive",
+            provider=provider,
+            error=str(exc),
+        )
+        return True

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -219,6 +219,23 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
             context["workspace"] = workspace
         return context
 
+    def _validate_or_400(self, provider, key):
+        """Reject ``key`` with a structured 400 if the provider rejects it.
+
+        Shared by create() and _update_provider_key() so the probe-and-reject
+        semantics (message, error code, timeout, when-to-skip) live in exactly
+        one place instead of being copy-pasted at both call sites. Returns a
+        Response to short-circuit the caller on rejection, or None to continue.
+        """
+        if not key or is_provider_key_valid(provider, key):
+            return None
+        return self._gm.bad_request(
+            {
+                "error": get_error_message("INVALID_API_KEY"),
+                "error_code": "INVALID_API_KEY",
+            }
+        )
+
     def _normalize_provider_key_payload(self, data, instance=None):
         payload = data.copy() if hasattr(data, "copy") else dict(data)
         provider = payload.get("provider") or getattr(instance, "provider", None)
@@ -274,9 +291,11 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         if serializer.is_valid():
             validated_data = serializer.validated_data
 
-            key = validated_data.get("key")
-            if key and not is_provider_key_valid(validated_data.get("provider"), key):
-                return self._gm.bad_request(get_error_message("INVALID_API_KEY"))
+            rejection = self._validate_or_400(
+                validated_data.get("provider"), validated_data.get("key")
+            )
+            if rejection is not None:
+                return rejection
 
             # First try to get existing API key
             try:
@@ -336,10 +355,10 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(instance, data=payload, partial=partial)
         serializer.is_valid(raise_exception=True)
 
-        key = serializer.validated_data.get("key")
         provider = serializer.validated_data.get("provider") or instance.provider
-        if key and not is_provider_key_valid(provider, key):
-            return self._gm.bad_request(get_error_message("INVALID_API_KEY"))
+        rejection = self._validate_or_400(provider, serializer.validated_data.get("key"))
+        if rejection is not None:
+            return rejection
 
         self.perform_update(serializer)
         return Response(serializer.data)

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -80,6 +80,7 @@ from model_hub.services.column_service import (
 from model_hub.utils.model_provider_update import (
     one_time_model_providers_update,
 )
+from model_hub.utils.provider_key_validation import is_provider_key_valid
 from model_hub.utils.utils import (
     get_model_mode,
     remove_empty_text_from_messages,
@@ -273,6 +274,10 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         if serializer.is_valid():
             validated_data = serializer.validated_data
 
+            key = validated_data.get("key")
+            if key and not is_provider_key_valid(validated_data.get("provider"), key):
+                return self._gm.bad_request(get_error_message("INVALID_API_KEY"))
+
             # First try to get existing API key
             try:
                 config_json = validated_data.get("config_json")
@@ -330,6 +335,12 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         payload = self._normalize_provider_key_payload(request.data, instance=instance)
         serializer = self.get_serializer(instance, data=payload, partial=partial)
         serializer.is_valid(raise_exception=True)
+
+        key = serializer.validated_data.get("key")
+        provider = serializer.validated_data.get("provider") or instance.provider
+        if key and not is_provider_key_valid(provider, key):
+            return self._gm.bad_request(get_error_message("INVALID_API_KEY"))
+
         self.perform_update(serializer)
         return Response(serializer.data)
 

--- a/futureagi/tfc/utils/error_codes.py
+++ b/futureagi/tfc/utils/error_codes.py
@@ -779,6 +779,7 @@ err_dict = {
     "PROJECT_ID_REQUIRED": ["Project ID is required."],
     "UNABLE_TO_GET_NEXT_VERSION": ["Unable to get next version."],
     "UNABLE_TO_ADD_API_KEY": ["Unable to add api key."],
+    "INVALID_API_KEY": ["Invalid API key, please type in the right one."],
     "MODEL_VALIDATION_FAILED": [
         "Failed to validate model. Please enter correct details."
     ],


### PR DESCRIPTION
## Summary

Adds an invalid-API-key validation flow on **Settings → AI Providers**. When a user enters a provider API key and clicks **Save**, the key is now validated against the provider before it is stored. An invalid key is rejected at save time with an inline error — *"Invalid API key, please type in the right one."* — instead of being silently persisted.

## Why / where it breaks today

Provider keys are persisted by `ApiKeyViewSet` with **no validation** — the save path only reshapes JSON config and checks the provider is a known enum. An invalid key is therefore stored silently, and its wrongness only surfaces much later as a cryptic *"API key not configured for {provider}"* when a prompt or optimization run finally calls the provider (`LiteLLMModelManager.get_api_key` passes a present-but-invalid key straight through to litellm). Users had no way to know their key was wrong at the point they entered it.

## What changed

| File | Change |
|---|---|
| `model_hub/utils/provider_key_validation.py` *(new)* | `is_provider_key_valid(provider, key)` — probes the provider with a minimal litellm completion. Returns `False` **only** on a definitive `AuthenticationError`; any other outcome (unmapped provider, network/timeout, rate limit) is inconclusive and returns `True` (fail-open). Probe models live in one `PROVIDER_PROBE_MODEL` map. |
| `model_hub/views/run_prompt.py` | `ApiKeyViewSet.create()` and the shared `_update_provider_key()` now validate a flat key before persisting; on rejection they return `400` with `INVALID_API_KEY`. Both write paths guarded — no bypass. |
| `tfc/utils/error_codes.py` | New `INVALID_API_KEY` message (single source of truth for the copy). |
| `sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx` | The save mutations now surface a `400` inline under the input via `setError` (reusing the existing field-error rendering); other failures fall back to a toast. Stale errors clear on re-submit. |

### Design note — why fail-open on non-auth errors

Blocking a save on anything other than a genuine auth rejection would break legitimate saves on a transient network blip, a provider outage, or an air-gapped OSS install. So the probe fails **closed on auth** (a wrong key is rejected) and **open on everything else** (inconclusive → allow). This is intentional and locked by a test. It is *not* an auth/permission gate — the enforcement is server-side; the FE only renders the result.

## Tests included

| Test | Asserts | Red if reverted |
|---|---|---|
| `test_invalid_provider_key_is_rejected_at_save` | real endpoint → `400` + message + **row not persisted** | ✅ returns `200`/persists if the view check is removed |
| `test_valid_provider_key_is_saved` | accepted probe → `200` + row created | ✅ |
| `test_rejects_only_on_authentication_error` | validator returns `False` on `AuthenticationError` | ✅ |
| `test_fails_open_on_non_auth_error` | non-auth error → `True` (never blocks a save) | ✅ locks the fail-open contract |
| `test_valid_key_passes_and_probes_provider` / `test_unmapped_provider_is_not_probed` / `test_missing_key_is_not_probed` | probe semantics | ✅ |
| `KeyCard.test.jsx` — invalid-key surfacing | real component renders the inline error text on a `400` | ✅ error gone if `onError` removed |

Only the network boundary (`litellm.completion`) is mocked; every test drives the real call path.

## How to verify

```bash
# backend — behavioral + validator unit
cd futureagi && ./bin/test model_hub/tests/test_run_prompt_api.py::TestProviderApiKeys \
                             model_hub/tests/test_run_prompt_api.py::TestProviderKeyValidation -v
# frontend — behavioral
cd frontend && yarn vitest run src/sections/develop-detail/Common/ConfigureKeys/KeyCard.test.jsx
```

## Before / after

![Before / after — invalid key on Settings → AI Providers](https://github.com/user-attachments/assets/aaeec207-9c8c-494d-bad3-44b609c8d0a5)

## Demo

https://github.com/user-attachments/assets/e23cc0f2-461e-4e67-a63e-b553a69946ab

## Test suite run (local)

![Local test suite run — 11 backend + 2 frontend passing](https://github.com/user-attachments/assets/4f37fd66-17ff-4dda-a4f5-79259f659ef4)

## Backwards compatibility

- Only flat-key providers in `PROVIDER_PROBE_MODEL` (openai, anthropic, groq, cohere, mistral, gemini, perplexity, together_ai) are probed. JSON-config providers (vertex_ai/azure/bedrock/sagemaker) and any unmapped provider are **not** probed — save behavior is unchanged for them.
- Existing stored keys are untouched. The `GET provider-status` and delete paths are unchanged.
- Empty/absent key → not probed (returns valid), so nothing that skipped a key before is affected.

## Manual verification

- Local stack, Settings → AI Providers, OpenAI card: typing an invalid key + Save shows the inline red error and does **not** persist (confirmed via `GET`/DB). A real (mocked-accepted) key saves as before. Curl against the live endpoint: invalid → `400`, valid → `200`.

## Type of change

Bug fix (customer-facing).

## Checklist

- [x] Root-cause fix (validate at save), not a bandaid
- [x] Behavioral tests on the real call path, red-if-reverted (BE + FE)
- [x] Full run_prompt API test file green locally (128 passed)
- [x] Named constants / centralized error copy — no magic strings
- [x] OSS-only; no EE/billing coupling; fail-open keeps air-gapped installs working
- [x] No secrets, no ticket refs / AI cruft in source

## Backout

Revert this commit — the save path returns to storing keys without validation. No migration, no data change.

Closes TH-6363
