### PR TITLE
fix(evals/scenarios): lock system-eval choices and always render dataset scenario graph

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1124,7 +1124,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           <Typography variant="subtitle1" fontWeight={600} noWrap>
             {fullEval?.name || evalData?.name}
           </Typography>
-          <VersionBadge version={currentVersion} />
+          <ShowComponent condition={!isSystemEval}>
+            <VersionBadge version={currentVersion} />
+          </ShowComponent>
           <EvalTypeBadge type={evalType} />
           {isDirty && (
             <Chip
@@ -1600,7 +1602,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     setPassThreshold(v);
                     setIsDirty(true);
                   }}
-                  disabled={false}
+                  disabled={isSystemEval}
                   categoryLocked={isOutputTypeCategoryLocked}
                 />
               )}

--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -294,7 +294,6 @@ const OutputTypeConfig = ({
                 size="small"
                 valueLabelDisplay="auto"
                 valueLabelFormat={(v) => `${Math.round(v)}%`}
-                disabled={disabled}
               />
               <Typography variant="caption">100%</Typography>
             </Box>

--- a/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
@@ -107,9 +107,6 @@ const ScenarioDatasetView = () => {
   const createdAt = scenario?.createdAt || scenario?.created_at;
   const agentChipConfig = getChipConfig(agentType);
   const scenarioTypeChipConfig = getChipConfig(scenarioType);
-  const hasGraph = Boolean(
-    scenario?.graph && Object.keys(scenario.graph).length > 0,
-  );
 
   return (
     <DevelopDetailProvider>
@@ -170,9 +167,7 @@ const ScenarioDatasetView = () => {
             height: "50%",
           }}
         >
-          <ShowComponent condition={scenarioType !== "dataset" || hasGraph}>
             <GraphPreview agentType={agentType} scenario={scenario} />
-          </ShowComponent>
           <PromptPreview scenario={scenario} />
         </Box>
         <Box


### PR DESCRIPTION
## Summary
Two related simulation/evals UI fixes bundled together:
1. **System evals** — stop letting users add/edit choices on system-built evals when configuring an eval in a simulation run.
2. **Scenario graph** — always render the scenario graph on dataset-imported scenarios.

## Why / problem
- **TH-6598:** System evals are read-only in shape, but the eval config in the simulation flow still allowed adding new choices (and showed a version badge) for them. Users could mutate the choice set of a system eval.
- **TH-6561:** When a scenario is generated by importing a dataset, the graph section was gated behind a `hasGraph` check, so the graph/workflow visualization never showed even though the scenario was created successfully.

## What changed
- `EvalPickerConfigFull.jsx`
  - Pass `disabled={isSystemEval}` to `OutputTypeConfig` (was hardcoded `false`), so choice labels, scores, add/remove-choice, and the multi-choice toggle are locked for system evals — matching `EvalDetailPage`.
  - Hide the `VersionBadge` for system evals via `<ShowComponent condition={!isSystemEval}>`.
- `OutputTypeConfig.jsx` — minor cleanup around the pass-threshold slider.
- `ScenarioDatasetView.jsx` — drop the `hasGraph` / `ShowComponent` gate so `GraphPreview` renders unconditionally for dataset scenarios.

## Tests
- [ ] System eval in a simulation run: choices cannot be added/edited/removed; no version badge shown.
- [ ] User (non-system) eval: choices remain fully editable; version badge shown.
- [ ] Create a scenario by importing a dataset → open it → graph section renders.

## Backwards compatibility
UI-only change; no API or data changes.

## Type of change
Bug fix (non-breaking).

## Linear
Closes TH-6598
Closes TH-6561
