### PR TITLE
fix(simulation): key scenario columns by name across datasets

### DIFF
--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -554,15 +554,17 @@ const SimulationTestMode = React.forwardRef(
 
           // -- Scenario columns: display key `scenario.columns.<name>`,
           // persisted mapping value is the column UUID (backend resolver
-          // accepts UUIDs, not names).
+          // accepts UUIDs, not names). scenario_columns is now keyed by the
+          // column name, so read the UUID from each entry's dataset_column_id
+          // rather than the map key.
           const sc = callData.scenario_columns;
           scenarioKeyMap.current = {};
           if (sc && typeof sc === "object") {
-            for (const [uuid, col] of Object.entries(sc)) {
+            for (const [, col] of Object.entries(sc)) {
               if (col?.column_name && col?.value !== undefined) {
                 flat.scenario.columns[col.column_name] = col.value;
                 scenarioKeyMap.current[`scenario.columns.${col.column_name}`] =
-                  uuid;
+                  col.dataset_column_id;
               }
             }
           }

--- a/frontend/src/sections/test-detail/common.js
+++ b/frontend/src/sections/test-detail/common.js
@@ -579,7 +579,7 @@ export const getTestRunDetailFilterDefinition = (columns) => {
       };
     }
     scenarioFilters.push({
-      propertyId: `scenario_${col.scenario_id}_dataset_${col.id}`,
+      propertyId: col.id,
       propertyName: col.column_name,
       filterType: filterType,
       ...extra,

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -17,6 +17,7 @@ from simulate.models import (
 )
 from simulate.serializers.chat_message import ChatMessageSerializer
 from simulate.utils.eval_summary import iter_live_eval_outputs
+from simulate.utils.test_execution_utils import canonical_scenario_column_name
 from tracer.serializers.filters import (
     StrictInputSerializer,
     filter_list_query_param_field,
@@ -902,11 +903,7 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
                         persona_data = {}
                     cell_value = persona_data
 
-                canonical_name = (
-                    "Ideal Outcome"
-                    if dataset_column.name == "outcome"
-                    else dataset_column.name
-                )
+                canonical_name = canonical_scenario_column_name(dataset_column.name)
                 scenario_data[canonical_name] = {
                     "value": cell_value,
                     "visible": True,

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -902,12 +902,17 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
                         persona_data = {}
                     cell_value = persona_data
 
-                scenario_data[str(dataset_column.id)] = {
+                canonical_name = (
+                    "Ideal Outcome"
+                    if dataset_column.name == "outcome"
+                    else dataset_column.name
+                )
+                scenario_data[canonical_name] = {
                     "value": cell_value,
                     "visible": True,
                     "dataset_column_id": str(dataset_column.id),
                     "dataset_id": str(row.dataset.id),
-                    "column_name": dataset_column.name,
+                    "column_name": canonical_name,
                     "data_type": dataset_column.data_type,
                 }
         else:

--- a/futureagi/simulate/tests/test_scenario_column_reconciliation.py
+++ b/futureagi/simulate/tests/test_scenario_column_reconciliation.py
@@ -321,3 +321,31 @@ class TestScenarioDatasetGrouping:
         )
 
         assert CallExecution.objects.filter(id=ce1.id).exists()
+
+    def test_grouping_filter_rejects_sql_injection(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        ce1 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+
+        default_columns = [
+            {
+                "type": "scenario_dataset_column",
+                "id": "Ideal Outcome",
+                "column_name": "Ideal Outcome",
+                "dataset_column_ids": [str(c1.id)],
+            }
+        ]
+        hostile_value = "'; DROP TABLE simulate_call_execution; --"
+
+        TestExecutionUtils()._apply_scenario_dataset_grouping(
+            CallExecution.objects.filter(test_execution=test_execution),
+            row_groups=["status"],
+            group_keys=[hostile_value],
+            default_columns=default_columns,
+        )
+
+        assert CallExecution.objects.filter(id=ce1.id).exists()

--- a/futureagi/simulate/tests/test_scenario_column_reconciliation.py
+++ b/futureagi/simulate/tests/test_scenario_column_reconciliation.py
@@ -298,3 +298,26 @@ class TestScenarioDatasetGrouping:
 
         assert isinstance(results, list)
         assert CallExecution.objects.filter(id=ce1.id).exists()
+
+    def test_legacy_grouping_rejects_sql_injection(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        ce1 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+
+        hostile_group_field = (
+            f"scenario_{s1.id}_dataset_"
+            "b'; DROP TABLE simulate_call_execution; --"
+        )
+
+        TestExecutionUtils()._apply_scenario_dataset_grouping(
+            CallExecution.objects.filter(test_execution=test_execution),
+            row_groups=[hostile_group_field],
+            group_keys=[],
+            default_columns=None,
+        )
+
+        assert CallExecution.objects.filter(id=ce1.id).exists()

--- a/futureagi/simulate/tests/test_scenario_column_reconciliation.py
+++ b/futureagi/simulate/tests/test_scenario_column_reconciliation.py
@@ -1,0 +1,294 @@
+"""Regression tests for name-based scenario dataset columns.
+
+Covers the fix that keys scenario dataset columns by canonical name across
+datasets: the reconciliation service, the cross-dataset filter path, the
+grouping path, the legacy `scenario_<id>_dataset_<uuid>` fallback, and the
+SQL-identifier sanitisation on the grouping alias.
+"""
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import CallExecution, RunTest, Scenarios, TestExecution
+from simulate.utils.test_execution_utils import (
+    TestExecutionUtils,
+    reconcile_scenario_column_order,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_dataset_with_column(organization, workspace, user, name, column_name="outcome"):
+    dataset = Dataset.no_workspace_objects.create(
+        name=f"ds-{name}",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    column = Column.objects.create(
+        dataset=dataset,
+        name=column_name,
+        data_type="text",
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(column.id)]
+    dataset.save()
+    return dataset, column
+
+
+def _make_scenario(organization, workspace, user, name, column_name="outcome"):
+    dataset, column = _make_dataset_with_column(
+        organization, workspace, user, name, column_name
+    )
+    scenario = Scenarios.objects.create(
+        name=name,
+        source="src",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset,
+    )
+    return scenario, dataset, column
+
+
+def _make_row_with_cell(dataset, column, value, order=0):
+    row = Row.objects.create(dataset=dataset, order=order)
+    Cell.objects.create(dataset=dataset, column=column, row=row, value=value)
+    return row
+
+
+@pytest.fixture
+def run_test(organization, workspace):
+    return RunTest.objects.create(
+        name="rt", organization=organization, workspace=workspace
+    )
+
+
+@pytest.fixture
+def test_execution(run_test):
+    return TestExecution.objects.create(
+        run_test=run_test,
+        status=TestExecution.ExecutionStatus.COMPLETED,
+    )
+
+
+class TestReconcileScenarioColumnOrder:
+    def test_collapses_outcome_across_datasets(
+        self, organization, workspace, user
+    ):
+        s1, _, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        s2, _, c2 = _make_scenario(organization, workspace, user, "scenario-b")
+
+        column_order, changed = reconcile_scenario_column_order(
+            scenarios=[s1, s2],
+            call_executions=CallExecution.objects.none(),
+            column_order=[],
+        )
+
+        scenario_cols = [
+            c for c in column_order if c.get("type") == "scenario_dataset_column"
+        ]
+        assert len(scenario_cols) == 1, column_order
+        entry = scenario_cols[0]
+        assert entry["column_name"] == "Ideal Outcome"
+        assert entry["id"] == "Ideal Outcome"
+        assert set(entry["dataset_column_ids"]) == {str(c1.id), str(c2.id)}
+        assert changed is True
+
+    def test_preserves_existing_visibility(self, organization, workspace, user):
+        s1, _, _ = _make_scenario(organization, workspace, user, "scenario-a")
+        seed = [
+            {
+                "type": "scenario_dataset_column",
+                "id": "Ideal Outcome",
+                "column_name": "Ideal Outcome",
+                "visible": False,
+                "dataset_column_ids": ["stale"],
+            }
+        ]
+
+        column_order, _ = reconcile_scenario_column_order(
+            scenarios=[s1],
+            call_executions=CallExecution.objects.none(),
+            column_order=seed,
+        )
+
+        entry = next(
+            c for c in column_order if c.get("type") == "scenario_dataset_column"
+        )
+        assert entry["visible"] is False
+
+    def test_preserves_scenario_block_position(
+        self, organization, workspace, user
+    ):
+        s1, _, _ = _make_scenario(organization, workspace, user, "scenario-a")
+        seed = [
+            {"type": "metadata", "id": "call_details", "column_name": "Call"},
+            {
+                "type": "scenario_dataset_column",
+                "id": "Ideal Outcome",
+                "column_name": "Ideal Outcome",
+                "visible": True,
+                "dataset_column_ids": ["stale"],
+            },
+            {"type": "evaluation", "id": "eval-1", "column_name": "Eval"},
+        ]
+
+        column_order, _ = reconcile_scenario_column_order(
+            scenarios=[s1],
+            call_executions=CallExecution.objects.none(),
+            column_order=seed,
+        )
+
+        types = [c["type"] for c in column_order]
+        # The scenario block stays between the metadata and evaluation columns.
+        assert types == ["metadata", "scenario_dataset_column", "evaluation"]
+
+
+class TestScenarioDatasetColumnFilter:
+    def test_matches_across_datasets(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        s2, ds2, c2 = _make_scenario(organization, workspace, user, "scenario-b")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        r2 = _make_row_with_cell(ds2, c2, "win")
+        ce1 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+        ce2 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s2, row_id=r2.id
+        )
+
+        column_order = [
+            {
+                "type": "scenario_dataset_column",
+                "id": "Ideal Outcome",
+                "column_name": "Ideal Outcome",
+                "dataset_column_ids": [str(c1.id), str(c2.id)],
+            }
+        ]
+        filters = [
+            {
+                "column_id": "Ideal Outcome",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "win",
+                },
+            }
+        ]
+
+        result = TestExecutionUtils()._apply_filters(
+            CallExecution.objects.filter(test_execution=test_execution),
+            filters,
+            [],
+            {},
+            column_order=column_order,
+        )
+
+        ids = {str(ce.id) for ce in result}
+        assert ids == {str(ce1.id), str(ce2.id)}
+
+    def test_legacy_scenario_dataset_column_id_still_filters(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        ce1 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+
+        legacy_id = f"scenario_{s1.id}_dataset_{c1.id}"
+        filters = [
+            {
+                "column_id": legacy_id,
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "win",
+                },
+            }
+        ]
+
+        result = TestExecutionUtils()._apply_filters(
+            CallExecution.objects.filter(test_execution=test_execution),
+            filters,
+            [],
+            {},
+            column_order=[],
+        )
+
+        assert {str(ce.id) for ce in result} == {str(ce1.id)}
+
+
+class TestScenarioDatasetGrouping:
+    def test_groups_across_datasets(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        s2, ds2, c2 = _make_scenario(organization, workspace, user, "scenario-b")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        r2 = _make_row_with_cell(ds2, c2, "win")
+        CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+        CallExecution.objects.create(
+            test_execution=test_execution, scenario=s2, row_id=r2.id
+        )
+
+        default_columns = [
+            {
+                "type": "scenario_dataset_column",
+                "id": "Ideal Outcome",
+                "column_name": "Ideal Outcome",
+                "dataset_column_ids": [str(c1.id), str(c2.id)],
+            }
+        ]
+
+        results = TestExecutionUtils()._apply_scenario_dataset_grouping(
+            CallExecution.objects.filter(test_execution=test_execution),
+            row_groups=[],
+            group_keys=[],
+            default_columns=default_columns,
+        )
+
+        # Both calls carry "win" for their own dataset's column, so they
+        # collapse into a single group across the two datasets.
+        assert len(results) == 1, results
+        assert results[0]["Ideal_Outcome"] == "win"
+        assert results[0]["count"] == 2
+
+    def test_grouping_alias_rejects_sql_injection(
+        self, organization, workspace, user, test_execution
+    ):
+        s1, ds1, c1 = _make_scenario(organization, workspace, user, "scenario-a")
+        r1 = _make_row_with_cell(ds1, c1, "win")
+        ce1 = CallExecution.objects.create(
+            test_execution=test_execution, scenario=s1, row_id=r1.id
+        )
+
+        # A column name that would break out of a quoted SQL identifier if the
+        # alias were not allowlisted to [A-Za-z0-9_].
+        hostile_name = 'foo"; DROP TABLE simulate_call_execution; --'
+        default_columns = [
+            {
+                "type": "scenario_dataset_column",
+                "id": hostile_name,
+                "column_name": hostile_name,
+                "dataset_column_ids": [str(c1.id)],
+            }
+        ]
+
+        # Must run without a SQL error and without dropping the table.
+        results = TestExecutionUtils()._apply_scenario_dataset_grouping(
+            CallExecution.objects.filter(test_execution=test_execution),
+            row_groups=[],
+            group_keys=[],
+            default_columns=default_columns,
+        )
+
+        assert isinstance(results, list)
+        assert CallExecution.objects.filter(id=ce1.id).exists()

--- a/futureagi/simulate/tests/test_scenario_column_reconciliation.py
+++ b/futureagi/simulate/tests/test_scenario_column_reconciliation.py
@@ -7,6 +7,8 @@ SQL-identifier sanitisation on the grouping alias.
 """
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from model_hub.models.choices import DatasetSourceChoices, SourceChoices
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
@@ -181,13 +183,17 @@ class TestScenarioDatasetColumnFilter:
             }
         ]
 
-        result = TestExecutionUtils()._apply_filters(
-            CallExecution.objects.filter(test_execution=test_execution),
-            filters,
-            [],
-            {},
-            column_order=column_order,
-        )
+        with CaptureQueriesContext(connection) as ctx:
+            result = list(
+                TestExecutionUtils()._apply_filters(
+                    CallExecution.objects.filter(test_execution=test_execution),
+                    filters,
+                    [],
+                    {},
+                    column_order=column_order,
+                )
+            )
+        assert len(ctx.captured_queries) == 1, ctx.captured_queries
 
         ids = {str(ce.id) for ce in result}
         assert ids == {str(ce1.id), str(ce2.id)}

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -509,10 +509,8 @@ class TestExecutionUtils:
                                 ~models.Q(scenario__name__icontains=filter_value)
                             )
 
-                elif (
-                    column_id in scenario_dataset_columns
-                    or column_id.startswith("scenario_")
-                    and "dataset" in column_id
+                elif column_id in scenario_dataset_columns or (
+                    column_id.startswith("scenario_") and "_dataset_" in column_id
                 ):
                     column_meta = scenario_dataset_columns.get(str(column_id), {})
                     # Name-based scenario columns carry every dataset's Column

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -3,6 +3,7 @@ Utility functions for generating dynamic prompts for SimulatorAgent based on age
 """
 
 import re
+import uuid
 from datetime import datetime
 
 from django.db import connection, models
@@ -1007,16 +1008,38 @@ class TestExecutionUtils:
                         scenario_id = parts[0].replace("scenario_", "")
                         dataset_column_id = parts[1]
 
-                        # Create a safe column alias (replace hyphens with underscores)
-                        safe_alias = group_field.replace("-", "_")
+                        try:
+                            uuid.UUID(str(scenario_id))
+                            uuid.UUID(str(dataset_column_id))
+                        except (ValueError, AttributeError, TypeError):
+                            continue
 
-                        # Add dataset column value to grouping
+                        safe_alias = re.sub(r"[^A-Za-z0-9_]", "_", group_field)
+
+                        cursor = connection.cursor()
+                        try:
+                            escaped_scenario_id = cursor.mogrify(
+                                "%s", [scenario_id]
+                            ).decode("utf-8")
+                            escaped_dataset_column_id = cursor.mogrify(
+                                "%s", [dataset_column_id]
+                            ).decode("utf-8")
+                        except AttributeError:
+                            escaped_scenario_id = "'{}'".format(
+                                str(scenario_id).replace("'", "''")
+                            )
+                            escaped_dataset_column_id = "'{}'".format(
+                                str(dataset_column_id).replace("'", "''")
+                            )
+                        finally:
+                            cursor.close()
+
                         select_fields.append(
                             f"""
                             (SELECT model_hub_cell.value
                                 FROM model_hub_cell
-                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = '{scenario_id}')
-                                AND model_hub_cell.column_id = '{dataset_column_id}'
+                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = {escaped_scenario_id})
+                                AND model_hub_cell.column_id = {escaped_dataset_column_id}
                                 AND model_hub_cell.row_id = simulate_call_execution.row_id
                                 AND model_hub_cell.deleted = false
                                 LIMIT 1) as {safe_alias}
@@ -1026,8 +1049,8 @@ class TestExecutionUtils:
                             f"""
                             (SELECT model_hub_cell.value
                                 FROM model_hub_cell
-                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = '{scenario_id}')
-                                AND model_hub_cell.column_id = '{dataset_column_id}'
+                                WHERE model_hub_cell.dataset_id = (SELECT dataset_id FROM simulate_scenarios WHERE id = {escaped_scenario_id})
+                                AND model_hub_cell.column_id = {escaped_dataset_column_id}
                                 AND model_hub_cell.row_id = simulate_call_execution.row_id
                                 AND model_hub_cell.deleted = false
                                 LIMIT 1)

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -141,8 +141,12 @@ class TestExecutionUtils:
             return queryset
 
         def apply_scenario_dataset_column_filter(
-            queryset, dataset_column_id, op, value, filter_type, scenario_id=None
+            queryset, dataset_column_ids, op, value, filter_type, scenario_id=None
         ):
+
+            if not isinstance(dataset_column_ids, (list, tuple)):
+                dataset_column_ids = [dataset_column_ids]
+            dataset_column_ids = [str(cid) for cid in dataset_column_ids if cid]
             base = queryset.filter(row_id__isnull=False)
             if scenario_id:
                 base = base.filter(scenario__id=scenario_id)
@@ -152,13 +156,13 @@ class TestExecutionUtils:
                     where=[
                         "EXISTS ("
                         "SELECT 1 FROM model_hub_cell "
-                        "WHERE model_hub_cell.column_id = %s "
+                        "WHERE model_hub_cell.column_id = ANY(%s::uuid[]) "
                         "AND model_hub_cell.row_id = simulate_call_execution.row_id "
                         "AND model_hub_cell.deleted = false "
                         f"AND {value_sql}"
                         ")"
                     ],
-                    params=[dataset_column_id, *params],
+                    params=[dataset_column_ids, *params],
                 )
 
             def not_exists(value_sql, params):
@@ -166,13 +170,13 @@ class TestExecutionUtils:
                     where=[
                         "NOT EXISTS ("
                         "SELECT 1 FROM model_hub_cell "
-                        "WHERE model_hub_cell.column_id = %s "
+                        "WHERE model_hub_cell.column_id = ANY(%s::uuid[]) "
                         "AND model_hub_cell.row_id = simulate_call_execution.row_id "
                         "AND model_hub_cell.deleted = false "
                         f"AND {value_sql}"
                         ")"
                     ],
-                    params=[dataset_column_id, *params],
+                    params=[dataset_column_ids, *params],
                 )
 
             if filter_type in ("text", "string", "categorical"):
@@ -510,17 +514,28 @@ class TestExecutionUtils:
                     and "dataset" in column_id
                 ):
                     column_meta = scenario_dataset_columns.get(str(column_id), {})
-                    scenario_id = column_meta.get("scenario_id")
-                    dataset_column_id = column_id
-                    if column_id not in scenario_dataset_columns:
-                        scenario_id, dataset_column_id = scenario_column_parts(
-                            column_id
-                        )
+                    # Name-based scenario columns carry every dataset's Column
+                    # UUID in dataset_column_ids; matching ANY of them filters
+                    # across all scenarios, so we do not scope by scenario_id.
+                    dataset_column_ids = list(
+                        column_meta.get("dataset_column_ids") or []
+                    )
+                    scenario_id = None
+                    if not dataset_column_ids:
+                        # Legacy: column_id is a raw Column UUID, or the
+                        # scenario_<id>_dataset_<uuid> form.
+                        legacy_id = column_id
+                        if column_id not in scenario_dataset_columns:
+                            scenario_id, legacy_id = scenario_column_parts(column_id)
+                        else:
+                            scenario_id = column_meta.get("scenario_id")
+                        if legacy_id:
+                            dataset_column_ids = [legacy_id]
 
-                    if dataset_column_id:
+                    if dataset_column_ids:
                         call_executions = apply_scenario_dataset_column_filter(
                             call_executions,
-                            dataset_column_id,
+                            dataset_column_ids,
                             filter_op,
                             filter_value,
                             filter_type,
@@ -918,64 +933,58 @@ class TestExecutionUtils:
                 column_type = column.get("type", "")
 
                 if column_type == "scenario_dataset_column":
-                    # Extract the actual column ID from the prefixed ID
-                    actual_column_id = column.get("id")
-                    if actual_column_id and "_dataset_" in actual_column_id:
-                        # If it's a prefixed ID, extract the actual column ID
-                        parts = actual_column_id.split("_dataset_")
-                        if len(parts) == 2:
-                            actual_column_id = parts[1]
+                    # Name-based scenario columns carry every dataset's Column
+                    # UUID in dataset_column_ids. A row belongs to exactly one
+                    # dataset, so matching cells against ANY of the UUIDs makes
+                    # grouping work regardless of which scenario the row is from.
+                    actual_column_ids = list(column.get("dataset_column_ids") or [])
+                    if not actual_column_ids:
+                        # Legacy: single UUID id, or scenario_<id>_dataset_<uuid>.
+                        legacy_id = column.get("id")
+                        if legacy_id and "_dataset_" in legacy_id:
+                            parts = legacy_id.split("_dataset_")
+                            if len(parts) == 2:
+                                legacy_id = parts[1]
+                        if legacy_id:
+                            actual_column_ids = [legacy_id]
+                    if not actual_column_ids:
+                        continue
 
-                    # Create a safe column alias (replace hyphens with underscores)
-                    safe_alias = column_id.replace("-", "_").replace(".", "_")
-                    dataset_id = column.get("dataset_id")
+                    # Create a safe column alias (identifiers cannot contain
+                    # hyphens, dots or spaces without quoting).
+                    safe_alias = (
+                        str(column_id)
+                        .replace("-", "_")
+                        .replace(".", "_")
+                        .replace(" ", "_")
+                    )
 
-                    # Properly escape SQL string values to prevent SQL injection
-                    # Use connection.cursor().mogrify to safely escape parameters
+                    # Properly escape column UUIDs to prevent SQL injection.
                     cursor = connection.cursor()
                     try:
-                        # Use mogrify to get properly escaped SQL string
-                        escaped_dataset_id = cursor.mogrify("%s", [dataset_id]).decode(
-                            "utf-8"
+                        escaped_column_ids = ", ".join(
+                            cursor.mogrify("%s", [cid]).decode("utf-8")
+                            for cid in actual_column_ids
                         )
-                        escaped_column_id = cursor.mogrify(
-                            "%s", [actual_column_id]
-                        ).decode("utf-8")
                     except AttributeError:
-                        # Fallback for backends that don't support mogrify (like SQLite)
-                        # Escape single quotes by doubling them (SQL standard)
-                        escaped_dataset_id = "'{}'".format(
-                            str(dataset_id).replace("'", "''")
-                        )
-                        escaped_column_id = "'{}'".format(
-                            str(actual_column_id).replace("'", "''")
+                        # Fallback for backends without mogrify (like SQLite).
+                        escaped_column_ids = ", ".join(
+                            "'{}'".format(str(cid).replace("'", "''"))
+                            for cid in actual_column_ids
                         )
                     finally:
                         cursor.close()
 
-                    # Add dataset column value to grouping with properly escaped values
-                    select_fields.append(
-                        f"""
+                    cell_value_subquery = f"""
                         (SELECT model_hub_cell.value
                             FROM model_hub_cell
-                            WHERE model_hub_cell.dataset_id = {escaped_dataset_id}
-                            AND model_hub_cell.column_id = {escaped_column_id}
-                            AND model_hub_cell.row_id = simulate_call_execution.row_id
-                            AND model_hub_cell.deleted = false
-                            LIMIT 1) as {safe_alias}
-                    """
-                    )
-                    group_by_fields.append(
-                        f"""
-                        (SELECT model_hub_cell.value
-                            FROM model_hub_cell
-                            WHERE model_hub_cell.dataset_id = {escaped_dataset_id}
-                            AND model_hub_cell.column_id = {escaped_column_id}
+                            WHERE model_hub_cell.column_id IN ({escaped_column_ids})
                             AND model_hub_cell.row_id = simulate_call_execution.row_id
                             AND model_hub_cell.deleted = false
                             LIMIT 1)
                     """
-                    )
+                    select_fields.append(f'{cell_value_subquery} as "{safe_alias}"')
+                    group_by_fields.append(cell_value_subquery)
 
         for group_field in row_groups:
             # Skip fields that are already included in basic context

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -1067,42 +1067,54 @@ class TestExecutionUtils:
         # Add group_keys filtering if provided
         where_conditions = ["simulate_call_execution.deleted = false"]
         if group_keys:
-            for i, group_key in enumerate(group_keys):
-                if i < len(row_groups):
-                    group_field = row_groups[i]
+            cursor = connection.cursor()
+            try:
 
-                    if group_field == "timestamp":
-                        where_conditions.append(
-                            f"DATE(simulate_call_execution.created_at) = '{group_key}'"
-                        )
-                    elif group_field == "status":
-                        where_conditions.append(
-                            f"simulate_call_execution.status = '{group_key}'"
-                        )
-                    elif group_field in ("call_type", "callType"):
-                        where_conditions.append(
-                            f"LOWER(simulate_call_execution.call_type) LIKE '%{group_key.lower()}%'"
-                        )
-                    elif group_field == "scenario":
-                        where_conditions.append(
-                            f"simulate_scenarios.name = '{group_key}'"
-                        )
-                    elif group_field in ("overall_score", "overallScore"):
-                        try:
-                            numeric_key = float(group_key)
+                def _lit(value):
+                    try:
+                        return cursor.mogrify("%s", [value]).decode("utf-8")
+                    except AttributeError:
+                        return "'{}'".format(str(value).replace("'", "''"))
+
+                for i, group_key in enumerate(group_keys):
+                    if i < len(row_groups):
+                        group_field = row_groups[i]
+
+                        if group_field == "timestamp":
                             where_conditions.append(
-                                f"simulate_call_execution.overall_score = {numeric_key}"
+                                f"DATE(simulate_call_execution.created_at) = {_lit(group_key)}"
                             )
-                        except (ValueError, TypeError):
-                            pass
-                    elif group_field in ("response_time", "responseTime"):
-                        try:
-                            numeric_key = float(group_key)
+                        elif group_field == "status":
                             where_conditions.append(
-                                f"simulate_call_execution.response_time_ms = {numeric_key}"
+                                f"simulate_call_execution.status = {_lit(group_key)}"
                             )
-                        except (ValueError, TypeError):
-                            pass
+                        elif group_field in ("call_type", "callType"):
+                            where_conditions.append(
+                                "LOWER(simulate_call_execution.call_type) LIKE "
+                                f"{_lit('%' + str(group_key).lower() + '%')}"
+                            )
+                        elif group_field == "scenario":
+                            where_conditions.append(
+                                f"simulate_scenarios.name = {_lit(group_key)}"
+                            )
+                        elif group_field in ("overall_score", "overallScore"):
+                            try:
+                                numeric_key = float(group_key)
+                                where_conditions.append(
+                                    f"simulate_call_execution.overall_score = {numeric_key}"
+                                )
+                            except (ValueError, TypeError):
+                                pass
+                        elif group_field in ("response_time", "responseTime"):
+                            try:
+                                numeric_key = float(group_key)
+                                where_conditions.append(
+                                    f"simulate_call_execution.response_time_ms = {numeric_key}"
+                                )
+                            except (ValueError, TypeError):
+                                pass
+            finally:
+                cursor.close()
 
         where_clause = " AND ".join(where_conditions)
 

--- a/futureagi/simulate/utils/test_execution_utils.py
+++ b/futureagi/simulate/utils/test_execution_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from django.db import connection, models
 
+from model_hub.models.develop_dataset import Column, Row
 from simulate.models.agent_definition import AgentDefinition
 from simulate.models.agent_version import AgentVersion
 from simulate.utils.persona_filtering import (
@@ -941,7 +942,11 @@ class TestExecutionUtils:
                     if not actual_column_ids:
                         # Legacy: single UUID id, or scenario_<id>_dataset_<uuid>.
                         legacy_id = column.get("id")
-                        if legacy_id and "_dataset_" in legacy_id:
+                        if (
+                            legacy_id
+                            and legacy_id.startswith("scenario_")
+                            and "_dataset_" in legacy_id
+                        ):
                             parts = legacy_id.split("_dataset_")
                             if len(parts) == 2:
                                 legacy_id = parts[1]
@@ -950,14 +955,7 @@ class TestExecutionUtils:
                     if not actual_column_ids:
                         continue
 
-                    # Create a safe column alias (identifiers cannot contain
-                    # hyphens, dots or spaces without quoting).
-                    safe_alias = (
-                        str(column_id)
-                        .replace("-", "_")
-                        .replace(".", "_")
-                        .replace(" ", "_")
-                    )
+                    safe_alias = re.sub(r"[^A-Za-z0-9_]", "_", str(column_id))
 
                     # Properly escape column UUIDs to prevent SQL injection.
                     cursor = connection.cursor()
@@ -1253,3 +1251,152 @@ def generate_simulator_agent_prompt(
         "Please respond naturally and stay consistent with your persona throughout the conversation."
         f"{end_call_instruction}"
     )
+
+
+def canonical_scenario_column_name(raw_name):
+    """Canonical display name for a scenario dataset column."""
+    return "Ideal Outcome" if raw_name == "outcome" else raw_name
+
+
+def reconcile_scenario_column_order(*, scenarios, call_executions, column_order):
+    """Collapse per-dataset scenario columns into one entry per canonical name.
+
+    Each scenario has its own dataset, and each dataset has its own ``Column``
+    rows with distinct UUIDs, so a field like ``outcome`` exists once per
+    dataset. This collapses those per-dataset columns into a single entry keyed
+    by the canonical column name, carrying every dataset's matching ``Column``
+    UUID in ``dataset_column_ids`` so the filter/grouping paths can match a cell
+    against any of them.
+
+    Kept here - alongside the filter/grouping logic that consumes
+    ``dataset_column_ids`` - so requests, celery jobs and Temporal activities
+    can share the same computation. The caller persists ``column_order`` when
+    ``changed`` is True.
+
+    Args:
+        scenarios: iterable of ``Scenarios`` (dataset select_related recommended).
+        call_executions: ``CallExecution`` queryset, used only for the fallback
+            that recovers columns from the first call's dataset row.
+        column_order: the current persisted column order (list of dicts).
+
+    Returns:
+        ``(column_order, changed)`` - the reconciled order and whether it
+        differs from the input.
+    """
+    existing_scenario_visibility = {}
+    first_scenario_idx = None
+    for idx, col in enumerate(column_order):
+        if not isinstance(col, dict):
+            continue
+        if col.get("type") == "scenario_dataset_column":
+            if first_scenario_idx is None:
+                first_scenario_idx = idx
+            vis_key = canonical_scenario_column_name(
+                col.get("column_name") or str(col.get("id"))
+            )
+            existing_scenario_visibility[vis_key] = col.get("visible", True)
+
+    norm_all_col_ids = set()
+    for scenario in scenarios:
+        if scenario.dataset and scenario.dataset.column_order:
+            norm_all_col_ids.update(scenario.dataset.column_order)
+
+    ordered_names = []
+    scenario_cols_by_name = {}
+
+    def _register_scenario_column(col_obj, scenario_id, dataset_id):
+        name = canonical_scenario_column_name(col_obj.name)
+        entry = scenario_cols_by_name.get(name)
+        if entry is None:
+            ordered_names.append(name)
+            scenario_cols_by_name[name] = {
+                "id": name,
+                "column_name": name,
+                "visible": existing_scenario_visibility.get(name, True),
+                "data_type": col_obj.data_type,
+                "type": "scenario_dataset_column",
+                "scenario_id": scenario_id,
+                "dataset_id": dataset_id,
+                "dataset_column_ids": [str(col_obj.id)],
+            }
+        else:
+            cid = str(col_obj.id)
+            if cid not in entry["dataset_column_ids"]:
+                entry["dataset_column_ids"].append(cid)
+
+    if norm_all_col_ids:
+        norm_columns_by_id = {
+            str(col.id): col
+            for col in Column.objects.filter(id__in=norm_all_col_ids, deleted=False)
+        }
+        for scenario in scenarios:
+            if not (scenario.dataset and scenario.dataset.column_order):
+                continue
+            for col_id in scenario.dataset.column_order:
+                col_obj = norm_columns_by_id.get(str(col_id))
+                if col_obj:
+                    _register_scenario_column(
+                        col_obj,
+                        str(scenario.id),
+                        str(scenario.dataset.id),
+                    )
+
+    if not ordered_names:
+        fb_first_call = call_executions.first()
+        fb_row_id = (
+            fb_first_call.call_metadata.get("row_id")
+            if fb_first_call and fb_first_call.call_metadata
+            else None
+        )
+        if fb_row_id:
+            fb_row = (
+                Row.all_objects.filter(id=fb_row_id)
+                .select_related("dataset")
+                .first()
+            )
+            if fb_row and fb_row.dataset and fb_row.dataset.column_order:
+                for col_obj in Column.all_objects.filter(
+                    id__in=fb_row.dataset.column_order, deleted=False
+                ):
+                    _register_scenario_column(col_obj, None, str(fb_row.dataset.id))
+
+    new_scenario_columns = [scenario_cols_by_name[name] for name in ordered_names]
+
+    non_scenario_columns = [
+        col
+        for col in column_order
+        if not (
+            isinstance(col, dict)
+            and col.get("type") == "scenario_dataset_column"
+        )
+    ]
+    if first_scenario_idx is None:
+        # No scenario columns yet: place them before the first evaluation
+        # column, else at the end.
+        insert_idx = next(
+            (
+                i
+                for i, col in enumerate(non_scenario_columns)
+                if isinstance(col, dict) and col.get("type") == "evaluation"
+            ),
+            len(non_scenario_columns),
+        )
+    else:
+        # Preserve the original position of the scenario column block.
+        insert_idx = sum(
+            1
+            for col in column_order[:first_scenario_idx]
+            if not (
+                isinstance(col, dict)
+                and col.get("type") == "scenario_dataset_column"
+            )
+        )
+
+    rebuilt_column_order = (
+        non_scenario_columns[:insert_idx]
+        + new_scenario_columns
+        + non_scenario_columns[insert_idx:]
+    )
+
+    changed = rebuilt_column_order != column_order
+    return rebuilt_column_order, changed

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2095,22 +2095,16 @@ class TestExecutionDetailView(APIView):
                 test_execution.execution_metadata["column_order"] = column_order
                 test_execution.save(update_fields=["execution_metadata"])
 
-
-            if (
-                not column_order
-                or not test_execution.execution_metadata.get("Provider", False)
+            if not column_order or not test_execution.execution_metadata.get(
+                "Provider", False
             ):
                 # Create default column order based on agent type
                 if agent_type == AgentDefinition.AgentTypeChoices.VOICE:
                     default_columns = copy.deepcopy(DEFAULT_VOICE_SIM_COL)
-
                 else:
                     # Chat (text) agent type columns with chat metrics from conversation_metrics_data
                     logger.info("Creating default column order for chat agent")
                     default_columns = copy.deepcopy(DEFAULT_CHAT_SIM_COL)
-
-           
-
 
                 for eval_config in eval_configs:
                     default_columns.append(

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -162,7 +162,10 @@ from simulate.utils.test_execution import (
     DEFAULT_VOICE_SIM_COL,
     LEGACY_SIM_COLUMN_ID_MAP,
 )
-from simulate.utils.test_execution_utils import TestExecutionUtils
+from simulate.utils.test_execution_utils import (
+    TestExecutionUtils,
+    reconcile_scenario_column_order,
+)
 from simulate.views.scoping import run_test_workspace_filter
 from tfc.ee_gates import strip_turing_from_config_options
 from tfc.settings import settings as app_settings
@@ -2126,135 +2129,12 @@ class TestExecutionDetailView(APIView):
                 test_execution.save(update_fields=["execution_metadata"])
                 column_order = default_columns
 
-            def _canonical_scenario_name(raw_name):
-                return "Ideal Outcome" if raw_name == "outcome" else raw_name
-
-            existing_scenario_visibility = {}
-            first_scenario_idx = None
-            for idx, col in enumerate(column_order):
-                if not isinstance(col, dict):
-                    continue
-                if col.get("type") == "scenario_dataset_column":
-                    if first_scenario_idx is None:
-                        first_scenario_idx = idx
-                    vis_key = _canonical_scenario_name(
-                        col.get("column_name") or str(col.get("id"))
-                    )
-                    existing_scenario_visibility[vis_key] = col.get("visible", True)
-
-            norm_scenarios = scenarios
-            norm_all_col_ids = set()
-            for scenario in norm_scenarios:
-                if scenario.dataset and scenario.dataset.column_order:
-                    norm_all_col_ids.update(scenario.dataset.column_order)
-
-            ordered_names = []
-            scenario_cols_by_name = {}
-
-            def _register_scenario_column(col_obj, scenario_id, dataset_id):
-                name = _canonical_scenario_name(col_obj.name)
-                entry = scenario_cols_by_name.get(name)
-                if entry is None:
-                    ordered_names.append(name)
-                    scenario_cols_by_name[name] = {
-                        "id": name,
-                        "column_name": name,
-                        "visible": existing_scenario_visibility.get(name, True),
-                        "data_type": col_obj.data_type,
-                        "type": "scenario_dataset_column",
-                        "scenario_id": scenario_id,
-                        "dataset_id": dataset_id,
-                        "dataset_column_ids": [str(col_obj.id)],
-                    }
-                else:
-                    cid = str(col_obj.id)
-                    if cid not in entry["dataset_column_ids"]:
-                        entry["dataset_column_ids"].append(cid)
-
-            if norm_all_col_ids:
-                norm_columns_by_id = {
-                    str(col.id): col
-                    for col in Column.objects.filter(
-                        id__in=norm_all_col_ids, deleted=False
-                    )
-                }
-                for scenario in norm_scenarios:
-                    if not (scenario.dataset and scenario.dataset.column_order):
-                        continue
-                    for col_id in scenario.dataset.column_order:
-                        col_obj = norm_columns_by_id.get(str(col_id))
-                        if col_obj:
-                            _register_scenario_column(
-                                col_obj,
-                                str(scenario.id),
-                                str(scenario.dataset.id),
-                            )
-
-
-            if not ordered_names:
-                fb_first_call = call_executions.first()
-                fb_row_id = (
-                    fb_first_call.call_metadata.get("row_id")
-                    if fb_first_call and fb_first_call.call_metadata
-                    else None
-                )
-                if fb_row_id:
-                    fb_row = (
-                        Row.all_objects.filter(id=fb_row_id)
-                        .select_related("dataset")
-                        .first()
-                    )
-                    if fb_row and fb_row.dataset and fb_row.dataset.column_order:
-                        for col_obj in Column.all_objects.filter(
-                            id__in=fb_row.dataset.column_order, deleted=False
-                        ):
-                            _register_scenario_column(
-                                col_obj, None, str(fb_row.dataset.id)
-                            )
-
-            new_scenario_columns = [
-                scenario_cols_by_name[name] for name in ordered_names
-            ]
-
-            non_scenario_columns = [
-                col
-                for col in column_order
-                if not (
-                    isinstance(col, dict)
-                    and col.get("type") == "scenario_dataset_column"
-                )
-            ]
-            if first_scenario_idx is None:
-                # No scenario columns yet: place them before the first
-                # evaluation column, else at the end.
-                insert_idx = next(
-                    (
-                        i
-                        for i, col in enumerate(non_scenario_columns)
-                        if isinstance(col, dict)
-                        and col.get("type") == "evaluation"
-                    ),
-                    len(non_scenario_columns),
-                )
-            else:
-                # Preserve the original position of the scenario column block.
-                insert_idx = sum(
-                    1
-                    for col in column_order[:first_scenario_idx]
-                    if not (
-                        isinstance(col, dict)
-                        and col.get("type") == "scenario_dataset_column"
-                    )
-                )
-
-            rebuilt_column_order = (
-                non_scenario_columns[:insert_idx]
-                + new_scenario_columns
-                + non_scenario_columns[insert_idx:]
+            column_order, scenario_columns_changed = reconcile_scenario_column_order(
+                scenarios=scenarios,
+                call_executions=call_executions,
+                column_order=column_order,
             )
-
-            if rebuilt_column_order != column_order:
-                column_order = rebuilt_column_order
+            if scenario_columns_changed:
                 test_execution.execution_metadata["column_order"] = column_order
                 test_execution.save(update_fields=["execution_metadata"])
 

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2030,8 +2030,12 @@ class TestExecutionDetailView(APIView):
             eval_configs_map = {str(config.id): config for config in eval_configs}
 
             # Get scenarios for dynamic columns
-            scenarios = Scenarios.objects.filter(
-                id__in=test_execution.scenario_ids, deleted=False
+            scenarios = list(
+                Scenarios.objects.filter(
+                    id__in=test_execution.scenario_ids, deleted=False
+                )
+                .select_related("dataset")
+                .order_by("name")
             )
             scenarios_map = {str(scenario.id): scenario for scenario in scenarios}
 
@@ -2088,15 +2092,10 @@ class TestExecutionDetailView(APIView):
                 test_execution.execution_metadata["column_order"] = column_order
                 test_execution.save(update_fields=["execution_metadata"])
 
-            # Check if column_order has any scenario columns
-            has_scenario_columns = any(
-                col.get("type") == "scenario_dataset_column" for col in column_order
-            )
 
             if (
                 not column_order
                 or not test_execution.execution_metadata.get("Provider", False)
-                or not has_scenario_columns
             ):
                 # Create default column order based on agent type
                 if agent_type == AgentDefinition.AgentTypeChoices.VOICE:
@@ -2107,100 +2106,9 @@ class TestExecutionDetailView(APIView):
                     logger.info("Creating default column order for chat agent")
                     default_columns = copy.deepcopy(DEFAULT_CHAT_SIM_COL)
 
-                # Get all scenarios used in this test execution
-                scenarios = (
-                    Scenarios.objects.filter(
-                        id__in=test_execution.scenario_ids, deleted=False
-                    )
-                    .select_related("dataset")
-                    .order_by("name")
-                )
+           
 
-                # Collect all column IDs from all scenarios first (batch fetch)
-                all_column_ids = set()
-                scenario_column_map = {}  # scenario_id -> (dataset_id, column_order)
-                for scenario in scenarios:
-                    if scenario.dataset and scenario.dataset.column_order:
-                        all_column_ids.update(scenario.dataset.column_order)
-                        scenario_column_map[scenario.id] = (
-                            scenario.dataset.id,
-                            scenario.dataset.column_order,
-                        )
 
-                # Fetch all columns in a single query
-                columns_by_id = {}
-                if all_column_ids:
-                    columns_by_id = {
-                        col.id: col
-                        for col in Column.objects.filter(
-                            id__in=all_column_ids, deleted=False
-                        )
-                    }
-
-                # Add scenario columns based on source type
-                added_column_ids = set()
-                for scenario in scenarios:
-                    if scenario.id in scenario_column_map:
-                        dataset_id, column_order = scenario_column_map[scenario.id]
-                        for col_id in column_order:
-                            dataset_column = columns_by_id.get(col_id)
-                            if not dataset_column:
-                                continue
-                            # Skip columns that have already been added to avoid duplicates
-                            if dataset_column.id in added_column_ids:
-                                continue
-                            added_column_ids.add(dataset_column.id)
-                            default_columns.append(
-                                {
-                                    "id": str(dataset_column.id),
-                                    "column_name": (
-                                        "Ideal Outcome"
-                                        if dataset_column.name == "outcome"
-                                        else f"{dataset_column.name}"
-                                    ),
-                                    "visible": True,
-                                    "data_type": dataset_column.data_type,
-                                    "type": "scenario_dataset_column",
-                                    "scenario_id": str(scenario.id),
-                                    "dataset_id": str(dataset_id),
-                                }
-                            )
-
-                # If no columns from scenarios, get from call executions' row datasets
-                if not added_column_ids:
-                    first_call = call_executions.first()
-                    row_id = (
-                        first_call.call_metadata.get("row_id")
-                        if first_call and first_call.call_metadata
-                        else None
-                    )
-                    if row_id:
-                        row = (
-                            Row.all_objects.filter(id=row_id)
-                            .select_related("dataset")
-                            .first()
-                        )
-                        if row and row.dataset and row.dataset.column_order:
-                            row_columns = Column.all_objects.filter(
-                                id__in=row.dataset.column_order, deleted=False
-                            )
-                            for col in row_columns:
-                                default_columns.append(
-                                    {
-                                        "id": str(col.id),
-                                        "column_name": (
-                                            "Ideal Outcome"
-                                            if col.name == "outcome"
-                                            else col.name
-                                        ),
-                                        "visible": True,
-                                        "data_type": col.data_type,
-                                        "type": "scenario_dataset_column",
-                                        "dataset_id": str(row.dataset.id),
-                                    }
-                                )
-
-                # Add evaluation metrics columns
                 for eval_config in eval_configs:
                     default_columns.append(
                         {
@@ -2217,6 +2125,138 @@ class TestExecutionDetailView(APIView):
                 test_execution.execution_metadata["Provider"] = True
                 test_execution.save(update_fields=["execution_metadata"])
                 column_order = default_columns
+
+            def _canonical_scenario_name(raw_name):
+                return "Ideal Outcome" if raw_name == "outcome" else raw_name
+
+            existing_scenario_visibility = {}
+            first_scenario_idx = None
+            for idx, col in enumerate(column_order):
+                if not isinstance(col, dict):
+                    continue
+                if col.get("type") == "scenario_dataset_column":
+                    if first_scenario_idx is None:
+                        first_scenario_idx = idx
+                    vis_key = _canonical_scenario_name(
+                        col.get("column_name") or str(col.get("id"))
+                    )
+                    existing_scenario_visibility[vis_key] = col.get("visible", True)
+
+            norm_scenarios = scenarios
+            norm_all_col_ids = set()
+            for scenario in norm_scenarios:
+                if scenario.dataset and scenario.dataset.column_order:
+                    norm_all_col_ids.update(scenario.dataset.column_order)
+
+            ordered_names = []
+            scenario_cols_by_name = {}
+
+            def _register_scenario_column(col_obj, scenario_id, dataset_id):
+                name = _canonical_scenario_name(col_obj.name)
+                entry = scenario_cols_by_name.get(name)
+                if entry is None:
+                    ordered_names.append(name)
+                    scenario_cols_by_name[name] = {
+                        "id": name,
+                        "column_name": name,
+                        "visible": existing_scenario_visibility.get(name, True),
+                        "data_type": col_obj.data_type,
+                        "type": "scenario_dataset_column",
+                        "scenario_id": scenario_id,
+                        "dataset_id": dataset_id,
+                        "dataset_column_ids": [str(col_obj.id)],
+                    }
+                else:
+                    cid = str(col_obj.id)
+                    if cid not in entry["dataset_column_ids"]:
+                        entry["dataset_column_ids"].append(cid)
+
+            if norm_all_col_ids:
+                norm_columns_by_id = {
+                    str(col.id): col
+                    for col in Column.objects.filter(
+                        id__in=norm_all_col_ids, deleted=False
+                    )
+                }
+                for scenario in norm_scenarios:
+                    if not (scenario.dataset and scenario.dataset.column_order):
+                        continue
+                    for col_id in scenario.dataset.column_order:
+                        col_obj = norm_columns_by_id.get(str(col_id))
+                        if col_obj:
+                            _register_scenario_column(
+                                col_obj,
+                                str(scenario.id),
+                                str(scenario.dataset.id),
+                            )
+
+
+            if not ordered_names:
+                fb_first_call = call_executions.first()
+                fb_row_id = (
+                    fb_first_call.call_metadata.get("row_id")
+                    if fb_first_call and fb_first_call.call_metadata
+                    else None
+                )
+                if fb_row_id:
+                    fb_row = (
+                        Row.all_objects.filter(id=fb_row_id)
+                        .select_related("dataset")
+                        .first()
+                    )
+                    if fb_row and fb_row.dataset and fb_row.dataset.column_order:
+                        for col_obj in Column.all_objects.filter(
+                            id__in=fb_row.dataset.column_order, deleted=False
+                        ):
+                            _register_scenario_column(
+                                col_obj, None, str(fb_row.dataset.id)
+                            )
+
+            new_scenario_columns = [
+                scenario_cols_by_name[name] for name in ordered_names
+            ]
+
+            non_scenario_columns = [
+                col
+                for col in column_order
+                if not (
+                    isinstance(col, dict)
+                    and col.get("type") == "scenario_dataset_column"
+                )
+            ]
+            if first_scenario_idx is None:
+                # No scenario columns yet: place them before the first
+                # evaluation column, else at the end.
+                insert_idx = next(
+                    (
+                        i
+                        for i, col in enumerate(non_scenario_columns)
+                        if isinstance(col, dict)
+                        and col.get("type") == "evaluation"
+                    ),
+                    len(non_scenario_columns),
+                )
+            else:
+                # Preserve the original position of the scenario column block.
+                insert_idx = sum(
+                    1
+                    for col in column_order[:first_scenario_idx]
+                    if not (
+                        isinstance(col, dict)
+                        and col.get("type") == "scenario_dataset_column"
+                    )
+                )
+
+            rebuilt_column_order = (
+                non_scenario_columns[:insert_idx]
+                + new_scenario_columns
+                + non_scenario_columns[insert_idx:]
+            )
+
+            if rebuilt_column_order != column_order:
+                column_order = rebuilt_column_order
+                test_execution.execution_metadata["column_order"] = column_order
+                test_execution.save(update_fields=["execution_metadata"])
 
             # Collect any missing tool evaluation columns from call executions' evaluation_data
             # This ensures that tool columns that were added during execution are included


### PR DESCRIPTION
## Summary

Scenario dataset columns are now grouped, serialized, and filtered by their canonical column **name** so a single column spans every scenario's dataset — instead of one column per dataset-specific `Column` UUID. This fixes scenario info being missing/duplicated when a simulation run spans multiple scenarios (datasets).

## Why / problem

Each scenario has its own dataset, and each dataset has its own `Column` rows with distinct UUIDs. Columns were keyed by UUID, so a field like `outcome` produced **one column per dataset** — each populated only for that dataset's rows and blank everywhere else. Across a multi-scenario run this surfaced as missing/duplicated scenario info and broke the run-detail grid and graph.

## What changed

**Backend**
- `simulate/serializers/test_execution.py` — `scenario_columns` is now keyed by the canonical column name (`outcome` → `Ideal Outcome`); each entry still carries `dataset_column_id`.
- `simulate/utils/test_execution_utils.py` — the column-order reconciliation now lives in a reusable `reconcile_scenario_column_order(...)` (returns `(column_order, changed)`) so requests, celery jobs, and Temporal activities can share it instead of it living in the DRF view. Filtering and grouping match cells against **any** of the name's UUIDs (`column_id = ANY(%s::uuid[])` / `column_id IN (...)`) instead of a single UUID + `dataset_id`. Includes a legacy fallback for old `scenario_<id>_dataset_<uuid>` / raw-UUID ids, plus filter-operator normalization and removal of camelCase key fallbacks.
- `simulate/views/run_test.py` — the view now calls `reconcile_scenario_column_order` and persists only when it reports a change. The entry `id` is the name and it carries `dataset_column_ids` (every dataset's matching `Column` UUID). Existing column visibility and block position are preserved.
- **SQL-identifier hardening** — the grouping alias is now allowlisted to `[A-Za-z0-9_]` (`re.sub(r"[^A-Za-z0-9_]", "_", ...)`) so a user-typed scenario column name cannot break out of the quoted identifier. Column UUIDs in the subquery are parameter-escaped via `cursor.mogrify` (SQLite fallback quotes). The grouping legacy-id check now requires the `scenario_` prefix so a name containing `_dataset_` cannot false-match.

**Frontend**
- `frontend/src/sections/test-detail/common.js` — the scenario filter `propertyId` is now the name-based column `id` directly, instead of `scenario_<scenario_id>_dataset_<uuid>`.
- `frontend/src/sections/evals/components/SimulationTestMode.jsx` — since `scenario_columns` is keyed by name, the persisted UUID is read from each entry's `dataset_column_id` rather than the map key.

## Backwards compatibility

Previously-persisted `column_order` entries (raw `Column` UUID or `scenario_<id>_dataset_<uuid>`) are still handled via the legacy fallback in both the filter and grouping paths, so existing saved runs keep working. No data migration required.

## Tests

- New `simulate/tests/test_scenario_column_reconciliation.py` (7 tests) pins the new behaviour: cross-dataset name collapse, existing-visibility preservation, scenario-block position preservation, cross-dataset filter (with an `assertNumQueries`-style guard so no per-row fan-out is reintroduced), cross-dataset grouping, the legacy `scenario_<id>_dataset_<uuid>` fallback, and a SQL-injection regression pin on the grouping alias (hostile column name must not break out of the identifier).
- Existing backend simulation suite (run-test list/detail + execution contract tests) still passes locally via `bin/test simulate/tests/...`.
- CI runs the full backend + frontend suites.

## Commands

```
# backend
bin/test simulate/tests/test_run_test_list_api.py \
         simulate/tests/test_test_execution_api_contract.py \
         simulate/tests/test_test_execution_detail_query_contract.py -v
# frontend
yarn check-all
```

## Behaviour callouts

Two changes here are not obvious from the diff:

- **The `has_scenario_columns` guard on the default-column-order path is removed.** Previously the default column order was rebuilt whenever a saved `column_order` had no scenario columns. That guard is gone; the new `reconcile_scenario_column_order` step (run on every GET) now owns adding/collapsing scenario columns, so net behaviour is preserved without the guard.
- **GET now mutates saved `column_order`.** Per-dataset scenario columns are collapsed into a single name-keyed entry, and the collapsed block is placed at the position of the *first* scenario column. Any previously-saved layout that interleaved scenario columns with non-scenario ones (e.g. `[scenario_A, eval_1, scenario_B, eval_2]`) is reordered on the next fetch and re-persisted. Existing per-column visibility is preserved across the collapse.

## Manual verification

- [x] Run a simulation spanning multiple scenarios/datasets; each scenario column (e.g. `Ideal Outcome`) shows as a single column populated for all rows.
- [x] Filter on a scenario column returns matching rows across all datasets.
- [x] Group-by on a scenario column groups correctly across datasets.
- [ ] Run-detail graph renders for dataset-backed runs.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guide
- [x] Backwards-compatible with existing persisted `column_order`
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII

## Backout

Revert this PR. The legacy fallback means no schema or data migration needs to be undone.

## Linear

Closes TH-6343

