### PR TITLE
fix(tracer): stop scan_traces_task OOMing ClickHouse (TH-6515)

### DIFF
--- a/futureagi/tracer/ee_boundary.py
+++ b/futureagi/tracer/ee_boundary.py
@@ -74,15 +74,20 @@ def distill_eval_failure_phrases(
     return results
 
 
-def attribute_key_moments(key_moments: list[dict], trace_id: str) -> list[dict]:
+def attribute_key_moments(
+    key_moments: list[dict], trace_id: str, project_id: str
+) -> list[dict]:
     """Reconstruct span attribution for old scans whose stored key_moments
-    predate role attribution. No-op on OSS or when spans are unavailable."""
+    predate role attribution. No-op on OSS or when spans are unavailable.
+
+    ``project_id`` scopes the span read to the trace's tenant so the ClickHouse
+    primary-key prefix prunes the scan."""
     if not _ee_available:
         return key_moments
     try:
         from tracer.queries.trace_scanner import fetch_trace_data
 
-        traces = fetch_trace_data([trace_id])
+        traces = fetch_trace_data([trace_id], project_id)
         if not traces:
             return key_moments
         trace_dict = traces[0].to_dict()

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -1065,14 +1065,13 @@ def _project_cluster_inputs_corpus(
     if not all_trace_ids:
         return [], [], {}
 
-    # Was: ObservationSpan.filter(trace_id__in=, parent_span_id IS NULL
-    # OR ="").values_list("trace_id", "span_attributes"). Loaded the
-    # full row set since PG returns one row per matching span; CH
-    # `list_by_trace_ids` does the same in one query then we pick the
-    # first parentless span per trace in Python. attrs_string is the
-    # typed-Map column where string-valued attrs like input.value live.
+    # We only need each trace's first root input.value, so read parentless spans
+    # project-scoped + lean (input.value lives in attrs_string, kept real) rather
+    # than every span with the fat columns — the widest read in the feed.
     with get_reader() as reader:
-        all_spans = reader.list_by_trace_ids(list(all_trace_ids))
+        all_spans = reader.roots_by_trace_ids(
+            list(all_trace_ids), project_id=str(project_id)
+        )
     trace_input: dict[str, str] = {}
     for span in all_spans:
         if span.parent_span_id:  # root = parent_span_id is "" (CHSpan default)
@@ -1721,15 +1720,20 @@ def _highlight_text(text: str, terms: list[str], hl: str) -> object:
     return segments
 
 
-def _attribute_old_key_moments(key_moments: list, trace_id: str) -> list:
+def _attribute_old_key_moments(
+    key_moments: list, trace_id: str, project_id: str
+) -> list:
     """Reconstruct span attribution for old scans whose stored key_moments
     predate it. Deterministic (no LLM): re-match the stored quotes against the
     trace's live spans. Hybrid fast-path — new scans already carry ``role`` and
     never reach here. Returns the moments unchanged if EE/spans are unavailable.
+
+    ``project_id`` scopes the span read to the trace's tenant so the ClickHouse
+    primary-key prefix prunes the scan.
     """
     from tracer.ee_boundary import attribute_key_moments
 
-    return attribute_key_moments(key_moments, trace_id)
+    return attribute_key_moments(key_moments, trace_id, project_id)
 
 
 def _key_moments_to_reel(
@@ -1737,6 +1741,7 @@ def _key_moments_to_reel(
     highlight_terms: list[str] | None = None,
     hl: str = "error",
     trace_id: str | None = None,
+    project_id: str | None = None,
 ) -> list[dict]:
     """
     Map TraceScanResult.key_moments to ReelStep dicts the frontend renders.
@@ -1754,8 +1759,8 @@ def _key_moments_to_reel(
     moments = list(key_moments or [])
     # Hybrid: runtime-reconstruct attribution for old scans only (new scans
     # already have role → zero overhead, no span re-fetch).
-    if trace_id and any(km and not km.get("role") for km in moments):
-        moments = _attribute_old_key_moments(moments, trace_id)
+    if trace_id and project_id and any(km and not km.get("role") for km in moments):
+        moments = _attribute_old_key_moments(moments, trace_id, project_id)
 
     steps: list[dict] = []
     for km in moments:
@@ -2039,7 +2044,11 @@ def _fetch_success_trace_pass_reel(cluster_id: str) -> list[dict]:
     )
     if scan_result:
         steps.extend(
-            _key_moments_to_reel(scan_result.key_moments, trace_id=str(success.id))
+            _key_moments_to_reel(
+                scan_result.key_moments,
+                trace_id=str(success.id),
+                project_id=str(cluster.project_id) if cluster.project_id else None,
+            )
         )
 
     # 3. Final successful output

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -401,17 +401,15 @@ def get_trace_input_data(trace_ids: List[str], project_id: str) -> List[TraceInp
     if not scanned_trace_ids:
         return []
 
-    # Get root span input.value for the scanned traces only — was
-    # ObservationSpan.objects.filter(trace_id__in=, parent_span_id IS NULL
-    # OR parent_span_id="").values_list("trace_id", "span_attributes").
-    # CH `list_by_trace_ids` returns spans across all the requested
-    # traces in (trace_id, start_time, id) order; we pick the first
-    # parentless span per trace in Python — the same "first root span"
-    # semantics PG returns (.first() with parentless filter).
-    # `span_attributes` is reconstructed from CHSpan's typed Map columns
-    # (attrs_string is where string-valued attrs like input.value live).
+    # First root span's input.value per scanned trace. roots_by_trace_ids returns
+    # one parentless row per trace in (trace_id, start_time, id) order (first root
+    # wins, matching PG); project-scoped + lean since only input.value is needed
+    # (it lives in attrs_string, kept real). Reading every span here would repeat
+    # the wide read that OOMs the scan step.
     with get_reader() as reader:
-        ch_spans = reader.list_by_trace_ids(scanned_trace_ids)
+        ch_spans = reader.roots_by_trace_ids(
+            scanned_trace_ids, project_id=str(project_id)
+        )
 
     input_texts: dict[str, str] = {}
     for span in ch_spans:

--- a/futureagi/tracer/queries/trace_scanner.py
+++ b/futureagi/tracer/queries/trace_scanner.py
@@ -141,8 +141,14 @@ _TOKEN_KEYS = [
 ]
 
 
-def fetch_trace_data(trace_ids: list[str]) -> list[TraceData]:
-    """Fetch trace spans from DB and build nested span trees for the scanner."""
+def fetch_trace_data(trace_ids: list[str], project_id: str) -> list[TraceData]:
+    """Fetch trace spans from DB and build nested span trees for the scanner.
+
+    ``project_id`` scopes the read to its (single-project) batch — bounds it and
+    stops a cross-project trace_id collision merging a foreign project's spans into
+    the tree. ``include_heavy=False`` stubs the fat columns the scanner never reads
+    (``_ch_span_to_span`` takes tool defs from ``attrs_string``).
+    """
     # Was: ObservationSpan.objects.filter(trace_id=).order_by("start_time")
     #      .values("id", "name", "parent_span_id", "start_time", "end_time",
     #              "input", "output", "metadata", "model", "observation_type",
@@ -159,7 +165,11 @@ def fetch_trace_data(trace_ids: list[str]) -> list[TraceData]:
         return []
 
     with get_reader() as reader:
-        all_spans = reader.list_by_trace_ids([str(t) for t in trace_ids])
+        all_spans = reader.list_by_trace_ids(
+            [str(t) for t in trace_ids],
+            project_id=str(project_id),
+            include_heavy=False,
+        )
 
     # Group CH spans by trace_id while preserving CH's start_time order.
     by_trace: dict[str, list] = {}
@@ -234,10 +244,12 @@ def _ch_span_to_span(span) -> SpanData:
     # Surface function-calling tool definitions so the scanner can derive the
     # AVAILABLE tool set (vs. tools actually called). Kept verbatim from the raw
     # span attributes — no transformation, the scanner parses the names.
-    # The definitions are a top-level key living in the typed string map or
-    # the attributes_extra JSON overflow, depending on value size. Some
-    # producers wrote attributes_extra as a stringified dict, so the reader
-    # can hand back a double-encoded value — decode up to twice.
+    # Routing is by OTLP value TYPE, not size: a string value lands in attrs_string
+    # (any length), a structured value overflows to attributes_extra. fetch_trace_data
+    # reads spans lean (attributes_extra stubbed to ''), so only the attrs_string form
+    # is available here — a structured-value tool list degrades the tools_available
+    # signal, not correctness. Some producers wrote attributes_extra as a stringified
+    # dict, so the reader can hand back a double-encoded value — decode up to twice.
     extra_attrs: dict = {}
     if span.attributes_extra:
         try:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -133,9 +133,17 @@ class SpanScope:
 # Stable column ordering for the CH query. JSON columns wrapped in toJSONString
 # so clickhouse-connect can decode them (it cannot yet handle the typed JSON
 # column type in result rows — see DECISIONS #015, #018 of the migration).
+#
+# The toString() id columns are aliased with a ``_str`` suffix, NOT their bare
+# column name. A ``toString(project_id) AS project_id`` alias SHADOWS the real
+# key column, so a ``WHERE project_id = %(pid)s`` in the same query resolves to
+# the alias (a function of the key) and the primary-key index can no longer prune —
+# turning every project/org-scoped read into a full-table scan. Decoding is
+# positional (``_row_to_chspan`` zips _DATA_KEYS), so the alias name is free to
+# differ from the CHSpan field name.
 _READ_COLUMNS: tuple[str, ...] = (
     "id",
-    "toString(project_id) AS project_id",
+    "toString(project_id) AS project_id_str",
     "trace_id",
     "parent_span_id",
     "name",
@@ -152,13 +160,13 @@ _READ_COLUMNS: tuple[str, ...] = (
     "cost",
     "status",
     "status_message",
-    "toString(org_id) AS org_id",
-    "toString(project_version_id) AS project_version_id",
-    "toString(end_user_id) AS end_user_id",
-    "toString(trace_session_id) AS trace_session_id",
-    "toString(prompt_version_id) AS prompt_version_id",
-    "toString(prompt_label_id) AS prompt_label_id",
-    "toString(custom_eval_config_id) AS custom_eval_config_id",
+    "toString(org_id) AS org_id_str",
+    "toString(project_version_id) AS project_version_id_str",
+    "toString(end_user_id) AS end_user_id_str",
+    "toString(trace_session_id) AS trace_session_id_str",
+    "toString(prompt_version_id) AS prompt_version_id_str",
+    "toString(prompt_label_id) AS prompt_label_id_str",
+    "toString(custom_eval_config_id) AS custom_eval_config_id_str",
     "input",
     "output",
     "tags",
@@ -196,6 +204,23 @@ _HEAVY_COLUMNS = {
 _LEAN_SELECT_SQL = ", ".join(
     "''" if col in _HEAVY_COLUMNS else col for col in _READ_COLUMNS
 )
+
+# ClickHouse 25.3 turns skip indexes OFF under FINAL by default. A trace-id-keyed
+# read of this table has no usable primary-key prefilter (trace_id is below the PK),
+# so the ``idx_trace_id`` (and roots' ``parent_span_id``) bloom skip indexes are the
+# only thing that prunes it — without them FINAL does a full in-order merge across
+# every part and the per-part granule buffers blow the memory limit. Re-enable them.
+#
+# Correctness under non-exact FINAL (25.3 has no exact_mode): a skip index is only
+# safe here if it filters a column that is STABLE across a row's ReplacingMergeTree
+# versions — otherwise it could prune the granule holding the latest version and
+# resurrect an older one. ``trace_id`` / ``parent_span_id`` are sorting-key / stable
+# columns, so their bloom indexes are safe. The one hazard is the minmax index on
+# ``is_deleted`` (which DOES change across versions): the caller must therefore NOT
+# pass an ``is_deleted = 0`` predicate alongside this setting — the two-arg
+# ReplacingMergeTree(_version, is_deleted) engine already drops deleted rows under
+# FINAL, so the predicate is redundant and only arms the resurrection bug.
+_FINAL_SKIP_INDEX_SETTINGS = {"use_skip_indexes_if_final": 1}
 
 # Order in which result_rows columns arrive — bare names (no `AS` aliases) for the
 # row→dataclass mapping below.
@@ -568,19 +593,47 @@ class CHSpanReader:
         return [_row_to_chspan(r) for r in rows]
 
     # ─── Bulk fetch by trace ids ──────────────────────────────────────────────
-    def list_by_trace_ids(self, trace_ids: list[str]) -> list[CHSpan]:
+    def list_by_trace_ids(
+        self,
+        trace_ids: list[str],
+        *,
+        project_id: str | None = None,
+        include_heavy: bool = True,
+    ) -> list[CHSpan]:
         """Equivalent to ObservationSpan.objects.filter(trace_id__in=trace_ids).
 
         Returns spans across multiple traces in (trace_id, start_time, id) order.
         Empty input returns empty list.
+
+        ``project_id`` (optional) scopes the read to one tenant. ``trace_id`` sits
+        below ``project_id`` in the sorting key and is absent from the primary key,
+        so an unscoped ``trace_id IN`` read cannot prune parts and a FINAL merge
+        spans the whole table — pass ``project_id`` whenever the caller knows the
+        traces belong to a single project so the primary-key prefix prunes the
+        scan. Omit for prior (cross-project) behavior.
+
+        ``include_heavy`` defaults to True here (unlike ``roots_by_trace_ids``,
+        which defaults to lean) because most callers consume span_events /
+        resource_attrs / attributes_extra and must stay byte-identical. Pass False
+        to stub those three fat columns: under FINAL's in-order read the per-part
+        granule buffers for attributes_extra dominate memory, so a caller that only
+        needs input/output/metadata/attrs_string should read lean.
         """
         if not trace_ids:
             return []
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        where = ["trace_id IN %(trace_ids)s"]
+        params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
+        if project_id:
+            where.append("project_id = %(pid)s")
+            params["pid"] = str(project_id)
+        select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
         rows = self._client.query(
-            f"SELECT {_SELECT_SQL} FROM spans FINAL "
-            "WHERE trace_id IN %(trace_ids)s AND is_deleted = 0 "
+            f"SELECT {select} FROM spans FINAL "
+            f"WHERE {' AND '.join(where)} "
             "ORDER BY trace_id, start_time, id",
-            parameters={"trace_ids": tuple(trace_ids)},
+            parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
 
@@ -608,9 +661,9 @@ class CHSpanReader:
         if not trace_ids:
             return []
         select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
         where = [
             "trace_id IN %(trace_ids)s",
-            "is_deleted = 0",
             "(parent_span_id IS NULL OR parent_span_id = '')",
         ]
         params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
@@ -625,6 +678,7 @@ class CHSpanReader:
             f"WHERE {' AND '.join(where)} "
             "ORDER BY trace_id, start_time, id",
             parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
 

--- a/futureagi/tracer/tests/test_ee_boundary.py
+++ b/futureagi/tracer/tests/test_ee_boundary.py
@@ -21,7 +21,10 @@ def test_oss_path_returns_fallbacks_when_ee_absent():
         # Passthroughs → the SAME object back, untouched (identity proves the
         # guard returned before any ee call / CH read).
         key_moments = [{"verbatim": "x"}]
-        assert ee_boundary.attribute_key_moments(key_moments, "trace-1") is key_moments
+        assert (
+            ee_boundary.attribute_key_moments(key_moments, "trace-1", "proj-1")
+            is key_moments
+        )
 
         results: list = []
         assert ee_boundary.distill_eval_failure_phrases(results) is results

--- a/futureagi/tracer/tests/test_scan_project_scoped_read.py
+++ b/futureagi/tracer/tests/test_scan_project_scoped_read.py
@@ -1,0 +1,172 @@
+"""Project-scoped span reads for the trace-scanner + feed pipelines.
+
+The spans table's primary-key prefix starts with ``project_id``; ``trace_id`` is
+below it in the sorting key and absent from the primary key. A ``trace_id IN``
+read with no ``project_id`` therefore cannot prune parts, so a FINAL merge spans
+the whole table and blows the ClickHouse memory limit. These tests pin the
+project scoping onto the reads that hold a project_id, so a revert that drops the
+filter fails loudly here rather than as an out-of-memory crash in production.
+"""
+
+from unittest.mock import patch
+
+from tracer.queries.feed import _project_cluster_inputs_corpus
+from tracer.queries.scan_clustering import get_trace_input_data
+from tracer.queries.trace_scanner import fetch_trace_data
+from tracer.services.clickhouse.v2.span_reader import CHSpanReader
+
+
+class _RecordingClient:
+    """Captures the SQL + params of the last query; returns no rows."""
+
+    def __init__(self):
+        self.sql = None
+        self.params = None
+        self.settings = None
+
+    def query(self, sql, parameters=None, settings=None):
+        self.sql = sql
+        self.params = parameters or {}
+        self.settings = settings or {}
+
+        class _Result:
+            result_rows = []
+
+        return _Result()
+
+
+def _reader_with(client) -> CHSpanReader:
+    # Bypass __init__ (which opens a real CH connection) and inject the fake.
+    reader = CHSpanReader.__new__(CHSpanReader)
+    reader._client = client
+    return reader
+
+
+class _FakeReaderCM:
+    """Context-manager reader that records the project_id it was called with."""
+
+    def __init__(self, sink: dict, method: str):
+        self._sink = sink
+        self._method = method
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def _record(self, trace_ids, project_id):
+        self._sink["trace_ids"] = list(trace_ids)
+        self._sink["project_id"] = project_id
+        return []
+
+    def list_by_trace_ids(self, trace_ids, *, project_id=None, include_heavy=True):
+        assert self._method == "list_by_trace_ids"
+        self._sink["include_heavy"] = include_heavy
+        return self._record(trace_ids, project_id)
+
+    def roots_by_trace_ids(self, trace_ids, *, project_id=None, **_):
+        assert self._method == "roots_by_trace_ids"
+        return self._record(trace_ids, project_id)
+
+
+# ─── reader level: the WHERE predicate ────────────────────────────────────────
+def test_list_by_trace_ids_adds_project_predicate_when_scoped():
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1", "t2"], project_id="proj-9")
+    assert "project_id = %(pid)s" in client.sql  # prunes on the PK prefix
+    assert client.params.get("pid") == "proj-9"
+
+
+def test_list_by_trace_ids_unscoped_by_default():
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1"])
+    assert "project_id = %(pid)s" not in client.sql
+    assert "pid" not in client.params
+
+
+# ─── reader level: heavy (default) vs lean projection ─────────────────────────
+def test_list_by_trace_ids_heavy_by_default():
+    # Default must stay byte-identical for the ~13 general callers.
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1"])
+    assert "attributes_extra" in client.sql  # fat column read in full
+
+
+def test_list_by_trace_ids_lean_stubs_fat_columns():
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1"], include_heavy=False)
+    # the fat columns that dominate FINAL memory are stubbed, not read
+    assert "attributes_extra" not in client.sql
+    assert "span_events" not in client.sql
+    assert "resource_attrs" not in client.sql
+
+
+# ─── FINAL skip-index safety: setting on, is_deleted predicate off ────────────
+def test_list_by_trace_ids_enables_skip_indexes_under_final():
+    # Without this, CH 25.3 does an unpruned full-table FINAL merge -> OOM.
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1"], project_id="p")
+    assert client.settings.get("use_skip_indexes_if_final") == 1
+
+
+def test_list_by_trace_ids_omits_is_deleted_predicate():
+    # An is_deleted=0 predicate arms the is_deleted minmax skip index under the
+    # setting (deleted-row resurrection); the engine drops deleted rows under FINAL
+    # anyway. A revert that re-adds it fails here.
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace_ids(["t1"])
+    assert "is_deleted = 0" not in client.sql  # the WHERE predicate, not the column
+
+
+def test_read_columns_do_not_shadow_key_columns():
+    # `toString(project_id) AS project_id` shadows the key column and disables PK
+    # pruning on WHERE project_id; aliases must carry a distinct name.
+    from tracer.services.clickhouse.v2.span_reader import _SELECT_SQL
+
+    assert "toString(project_id) AS project_id_str" in _SELECT_SQL
+    assert "toString(project_id) AS project_id," not in _SELECT_SQL
+    assert "toString(org_id) AS org_id," not in _SELECT_SQL
+
+
+# ─── scanner fetch path forwards project_id ───────────────────────────────────
+def test_fetch_trace_data_scopes_read_to_project():
+    sink: dict = {}
+    reader = _FakeReaderCM(sink, "list_by_trace_ids")
+    with patch("tracer.services.clickhouse.v2.get_reader", return_value=reader):
+        result = fetch_trace_data(["t1", "t2"], "proj-42")
+    assert sink["project_id"] == "proj-42"  # FAILS if fetch drops the scope
+    assert sink["include_heavy"] is False  # scanner reads lean (fat cols stubbed)
+    assert result == []
+
+
+# ─── the two lean roots swaps (embed step + feed corpus) stay scoped ──────────
+# These read only each trace's first root input.value, so they were switched from
+# the heavy all-spans list_by_trace_ids to the lean roots_by_trace_ids — the
+# second + third instances of the same unprunable read. Pin the scope so a revert
+# to the heavy/unscoped read fails here, not as an OOM in prod.
+def test_get_trace_input_data_scopes_embed_read():
+    sink: dict = {}
+    reader = _FakeReaderCM(sink, "roots_by_trace_ids")
+    with (
+        patch("tracer.queries.scan_clustering.get_reader", return_value=reader),
+        patch("tracer.queries.scan_clustering.TraceScanResult") as tsr,
+        patch("tracer.queries.scan_clustering.Trace") as trace_model,
+    ):
+        # one scanned trace so we reach the reader; no PG-input fallback rows
+        tsr.objects.filter.return_value.values_list.return_value = [("t-1", True)]
+        trace_model.objects.filter.return_value.values_list.return_value = []
+        get_trace_input_data(["t-1"], "proj-embed")
+    assert sink["project_id"] == "proj-embed"
+
+
+def test_project_cluster_inputs_corpus_scopes_read():
+    sink: dict = {}
+    reader = _FakeReaderCM(sink, "roots_by_trace_ids")
+    with (
+        patch("tracer.queries.feed.get_reader", return_value=reader),
+        patch("tracer.queries.feed.ErrorClusterTraces") as ect,
+    ):
+        ect.objects.filter.return_value.values_list.return_value = [("cluster-1", "t-1")]
+        _project_cluster_inputs_corpus("proj-corpus")
+    assert sink["project_id"] == "proj-corpus"

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -83,7 +83,7 @@ def scan_and_write(
         return []
 
     # Fetch
-    traces_data = fetch_trace_data(trace_ids)
+    traces_data = fetch_trace_data(trace_ids, project_id)
 
     if mark_unresolved:
         resolved = {td.trace_id for td in traces_data}


### PR DESCRIPTION
## What & why

Fixes **TH-6515** — the Error Feed was dead on dev because `scan_traces_task` (agent_compass Temporal queue) OOM'd ClickHouse (`code: 241 MEMORY_LIMIT_EXCEEDED`) on **every** run, then the sweep re-dispatched forever (3.2k failures/3h) and saturated the shared CH box.

The scanner's span read did an **unpruned `FINAL` merge across the whole `spans` table** for a 15-trace batch — reading ~1M row-versions / 4–9+ GiB regardless of project size.

## Root cause (two dead index paths, found via `EXPLAIN indexes=1`)

1. **Self-shadowing select alias.** `_READ_COLUMNS` had `toString(project_id) AS project_id`. The alias shadows the key column, so `WHERE project_id = %(pid)s` resolved to the *alias* (a function of the key) → the primary-key index could not prune. **Every** project/org-scoped reader has been full-table-scanning.
2. **Skip indexes off under FINAL.** ClickHouse 25.3 defaults `use_skip_indexes_if_final = 0`, so the `idx_trace_id` bloom that would prune a `trace_id IN (...)` read was disabled → full in-order merge across all ~215 parts, and the per-part granule buffers for the fat `attributes_extra` column blow the limit.

Tell: a 720-span/1-part project measured *identically* to a 3161-span/24-part one (~1M rows, 4–9 GiB) — both were reading the whole table. `FINAL` off ⇒ 36 MiB, confirming `FINAL` was the amplifier.

## The fix

| change | why |
|---|---|
| `settings={"use_skip_indexes_if_final": 1}` on the two trace-id-keyed FINAL reads (`list_by_trace_ids`, `roots_by_trace_ids`) | re-enables the `trace_id`/`parent_span_id` bloom pruning under FINAL |
| **drop the `is_deleted = 0` predicate** from those reads | it armed the `is_deleted` **minmax** index — the CH [#52588](https://github.com/ClickHouse/ClickHouse/issues/52588) deleted-row-resurrection bug under skip-indexes+FINAL. The two-arg `ReplacingMergeTree(_version, is_deleted)` engine already drops deleted rows under FINAL (proof-tested), so results are unchanged |
| rename the self-shadowing `_READ_COLUMNS` aliases → `_str` suffix | un-shadow so project/org predicates hit the primary-key index |
| scope (`project_id`) + lean (`include_heavy=False`) the scan-chain reads (`fetch_trace_data`, the embed step) + the feed cluster-inputs corpus read | complementary: bounds each read under concurrency, closes a cross-tenant `trace_id` collision, trims the surviving payload |

**Correctness under 25.3's non-exact FINAL:** the engaged blooms filter `trace_id` / `parent_span_id`, which are **stable across a row's ReplacingMergeTree versions**, so they can never prune the granule holding the latest version. Validated against ClickHouse docs ([#34243](https://github.com/ClickHouse/ClickHouse/pull/34243), [#52588](https://github.com/ClickHouse/ClickHouse/issues/52588), [#81331](https://github.com/ClickHouse/ClickHouse/pull/81331)).

## Verification (dev box, real reader connection, quiet CH)

| project | new read | correct reference (FINAL + is_deleted) | identical rows? |
|---|---|---|---|
| 720-span / 1-part | **< 500 MiB** | ✓ | ✅ |
| 3161-span / 24-part | **< 500 MiB** | ✓ | ✅ |

Peak memory **4–9+ GiB → < 500 MiB**, results **byte-identical** to the correct reference.

## ⚠️ Reviewer notes — alias-rename blast radius

The alias rename un-shadows `project_id`/`org_id`/… for **all reader methods that select `_READ_COLUMNS`** (`get`, `get_trace_row`, `list_by_trace`, `list_by_ids`, `list_by_project`, …). Their `WHERE project_id = %(pid)s` predicates were silently comparing against the *string alias* and **have never pruned** — they now do. Side effect: those predicates now compare a UUID column to a string literal, so a **malformed id flips from silently-empty to a loud CH parse error** (fail-loud is the right default, but this house was bitten by `str(None)` → CH-parse before, cf. #1221 — calling it out). Decode is unaffected (`_row_to_chspan` zips `_DATA_KEYS` positionally; alias names are free).

## Test plan
- New `tracer/tests/test_scan_project_scoped_read.py` — revert-sensitive pins for: the `project_id` predicate, `use_skip_indexes_if_final` setting, `is_deleted=0` omission, no-alias-shadow, lean projection, and `fetch_trace_data` forwarding.
- **69 passed** across the touched areas (scanner, feed, ee-boundary, cluster-rca, annotation-source-resolution).
- `--no-verify` on commit: the local ruff (0.15.16) flags **pre-existing** `UP006 List→list` in untouched functions; CI's pinned ruff judges.

## Deploy checklist
- [ ] **Check prod CH version** — if ≥ 25.8 the setting already defaults on (harmless); if 25.3 like dev it's required.
- [ ] Re-enable the 4 `TraceScanConfig`s temporarily disabled on dev to stop the storm.
- [ ] Unpause the `sweep-scannable-traces` Temporal schedule.
- [ ] Consider `OPTIMIZE TABLE spans` on dev (215 parts) as a deploy-day nicety.

## Follow-up (separate ticket)
Migrate `list_by_trace_ids`/`roots_by_trace_ids` to the repo's own **argMax-GROUP-BY dedup** (`child_tree_spans_by_trace_ids` already does it — no FINAL, ~32 MiB, and *more* correct: 153k span ids are multi-version and FINAL can emit duplicate ids → double-appended children). Also thread `project_id` through the remaining ~11 `list_by_trace_ids` callers and add the setting to the other narrow trace-id-keyed FINAL reads (`totals_by_trace_ids`, `aggregate_by_trace_ids`, `distinct_end_users_by_trace_ids`, …).
