### PR TITLE
fix(evals): drop instructions field from create/update payload when empty (TH-6572)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -767,7 +767,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     }
     try {
       const payload = {
-        instructions: evalType === "code" ? "" : instructions,
+        instructions: instructions || undefined,
         code: evalType === "code" ? code : undefined,
         code_language: evalType === "code" ? codeLanguage : undefined,
         model,

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -767,7 +767,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     }
     try {
       const payload = {
-        instructions: instructions || undefined,
+        instructions:
+          evalType === "code" ? undefined : instructions || undefined,
         code: evalType === "code" ? code : undefined,
         code_language: evalType === "code" ? codeLanguage : undefined,
         model,

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -280,7 +280,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const buildPayload = useCallback(
     () => ({
       eval_type: evalType,
-      instructions: evalType === "code" ? "" : instructions,
+      instructions: instructions || undefined,
       code: evalType === "code" ? code : undefined,
       code_language: evalType === "code" ? codeLanguage : undefined,
       model,

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -280,7 +280,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const buildPayload = useCallback(
     () => ({
       eval_type: evalType,
-      instructions: instructions || undefined,
+      instructions:
+        evalType === "code" ? undefined : instructions || undefined,
       code: evalType === "code" ? code : undefined,
       code_language: evalType === "code" ? codeLanguage : undefined,
       model,

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -778,7 +778,7 @@ const EvalDetailPage = () => {
       const tools = build_tools_payload(connectorIds);
       // Update the template first
       const payload = {
-        instructions: evalType === "code" ? "" : instructions,
+        instructions: instructions || undefined,
         code: evalType === "code" ? code : undefined,
         code_language: evalType === "code" ? codeLanguage : undefined,
         model,
@@ -960,7 +960,7 @@ const EvalDetailPage = () => {
             : { type: summaryType };
         const tools = build_tools_payload(connectorIds);
         await updateEval.mutateAsync({
-          instructions: evalType === "code" ? "" : instructions,
+          instructions: instructions || undefined,
           code: evalType === "code" ? code : undefined,
           code_language: evalType === "code" ? codeLanguage : undefined,
           model,

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -778,7 +778,8 @@ const EvalDetailPage = () => {
       const tools = build_tools_payload(connectorIds);
       // Update the template first
       const payload = {
-        instructions: instructions || undefined,
+        instructions:
+          evalType === "code" ? undefined : instructions || undefined,
         code: evalType === "code" ? code : undefined,
         code_language: evalType === "code" ? codeLanguage : undefined,
         model,
@@ -960,7 +961,8 @@ const EvalDetailPage = () => {
             : { type: summaryType };
         const tools = build_tools_payload(connectorIds);
         await updateEval.mutateAsync({
-          instructions: instructions || undefined,
+          instructions:
+            evalType === "code" ? undefined : instructions || undefined,
           code: evalType === "code" ? code : undefined,
           code_language: evalType === "code" ? codeLanguage : undefined,
           model,


### PR DESCRIPTION
## Summary

Custom Code evaluations were fully broken: creating or saving a Code eval failed with `instructions: This field may not be blank.`, and switching between the Agents / LLM-As-A-Judge / Code tabs in every drawer or detail-page eval flow triggered the same toast. The bug also surfaced from Datasets → Add Custom Eval and Tasks / Experiments / Composite / Simulation eval-picker flows since they all share the same payload builders.

## Root cause

`EvalTemplateUpdateV2Request.instructions` in the generated OpenAPI contract carries `minLength: 1` (the peer DRF field is `CharField(required=False, allow_null=True)` without `allow_blank=True`). The FE payload builders in every eval surface except `EvalCreatePage.jsx` used the pattern:

```js
instructions: evalType === "code" ? "" : instructions,
```

Which unconditionally emitted `""` on the Code tab and could emit `""` on the Agent / LLM tab whenever the state was untyped. In production this reached the BE and returned 400 with a user-facing toast. Locally the Vite strict OpenAPI request validator threw at `axios.js:40-42` before the PUT even fired, surfacing a generic "Something went wrong". Two failure modes, one root cause.

## Fix

Adopt the safer pattern already used by `EvalCreatePage.jsx:348-350`:

```js
instructions: evalType === "code" ? undefined : instructions || undefined,
```

`undefined` is stripped by `JSON.stringify`, so the field is omitted from the payload whenever it would otherwise be blank. The BE update handler at `separate_evals.py:2500-2555` gates all downstream state mutations on `if req.instructions is not None:`, so omitting the field means `template.criteria`, `template.config["rule_prompt"]`, and `template.config["required_keys"]` are left untouched, instead of being blindly reset with an empty string on every Code-eval save.

## Semantic audit

| Tab | Before | After | Effect |
| --- | --- | --- | --- |
| Code, empty instructions state | `""` sent, BE resets `rule_prompt=""` and `required_keys=[]` | field omitted, BE skips the block | no silent reset |
| Code, stale instructions from prior LLM tab | `""` sent, resets both fields | field omitted, no leak of LLM text into code eval config | no leak |
| Agent / LLM, empty state | `""` sent, 400 `instructions may not be blank` | field omitted, request passes | bug fixed |
| Agent / LLM, populated state | value sent, BE processes normally | identical | unchanged |

Populated flows are byte-identical. Every changed case is either a bug removal or removal of a silent unnecessary reset.

## Surfaces covered

| File | Line | Endpoint |
| --- | --- | --- |
| `common/EvalPicker/EvalPickerCreateNew.jsx` | 283 | PUT `/model-hub/eval-templates/{id}/update/` (drawer draft autosave + publish) |
| `common/EvalPicker/EvalPickerConfigFull.jsx` | 770 | PUT `/model-hub/eval-templates/{id}/update/` (edit existing template via picker) |
| `evals/components/EvalDetailPage.jsx` | 781 | PUT `/model-hub/eval-templates/{id}/update/` (detail-page Save) |
| `evals/components/EvalDetailPage.jsx` | 963 | PUT `/model-hub/eval-templates/{id}/update/` (detail-page Save + new version) |

These are every FE surface that constructs a payload for `PUT /eval-templates/{id}/update/`. The peer `EvalCreatePage.jsx:348` already used the safe pattern and is unchanged.

## Broader audit

Verified across the full FE that the only strict-blank contract on eval-template fields is `EvalTemplateUpdateV2Request.instructions`. Peer endpoints accept blank on their equivalent fields:

- POST `/model-hub/eval-templates/create-v2/` (`EvalTemplateCreateV2Request.instructions` allows blank)
- POST `/model-hub/eval-templates/{id}/versions/create/` (`EvalTemplateVersionCreateRequest.criteria` allows blank)
- POST `/model-hub/create_custom_evals/` (legacy custom-eval endpoint uses `criteria` with allow_blank)
- POST `/model-hub/develops/{dataset_id}/edit_and_run_user_eval/{eval_id}/` (config-blob path, no strict field)
- Composite create / update endpoints (no top-level instructions field)

No other payload builder needed changes.