### PR TITLE
security: fix timing attack vulnerability in manage_redis_key

### DIFF
--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -1,4 +1,5 @@
 # views.py
+from django.utils.crypto import constant_time_compare
 from datetime import datetime, timedelta
 
 import requests
@@ -55,7 +56,7 @@ def manage_redis_key(request):
     gm = GeneralMethods()
     try:
         # Verify access token
-        access_token_id = request.data.get("access_token_id")
+       if not constant_time_compare(access_token_id or '', settings.SECRET_KEY):
         if access_token_id != settings.SECRET_KEY:
             return gm.bad_request("Invalid or expired token")
 

--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -1,5 +1,4 @@
 # views.py
-from django.utils.crypto import constant_time_compare
 from datetime import datetime, timedelta
 
 import requests
@@ -8,6 +7,7 @@ from django.contrib.auth.hashers import check_password
 from django.core.cache import cache
 from django.db import transaction
 from django.utils import timezone
+from django.utils.crypto import constant_time_compare
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -56,8 +56,8 @@ def manage_redis_key(request):
     gm = GeneralMethods()
     try:
         # Verify access token
-       if not constant_time_compare(access_token_id or '', settings.SECRET_KEY):
-        if access_token_id != settings.SECRET_KEY:
+        access_token_id = request.data.get("access_token_id")
+        if not constant_time_compare(access_token_id or '', settings.SECRET_KEY):
             return gm.bad_request("Invalid or expired token")
 
         key = request.data.get("key")
@@ -756,6 +756,7 @@ def get_user_info(request):
             except WorkspaceMembership.DoesNotExist:
                 workspace_role = None
 
+            # Determine effective role based on hierarchy
             data["default_workspace_role"] = get_effective_workspace_role(
                 current_org_role, workspace_role
             )


### PR DESCRIPTION
## Summary

This PR addresses a critical security vulnerability in the `manage_redis_key` view where the `access_token_id` was compared to the `SECRET_KEY` using a standard string comparison. This created a timing attack vector that could potentially allow an attacker to leak the system's `SECRET_KEY`. I have replaced this with `constant_time_compare` from `django.utils.crypto` to ensure the comparison time is independent of the input.

## Linked issues

Closes #N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Manual code review and verification of the `constant_time_compare` implementation. Verified that the endpoint still correctly validates the `access_token_id` while ensuring the comparison logic is now resistant to timing analysis.

## Screenshots / recordings (if UI)

N/A (Backend security fix)

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

