### PR TITLE
feat(ai-providers): reject invalid provider API keys at save time

### DIFF
--- a/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
+++ b/frontend/src/sections/develop-detail/Common/ConfigureKeys/KeyCard.jsx
@@ -15,6 +15,7 @@ import { ShowComponent } from "src/components/show";
 import APIKeyReadOnlyView from "src/components/custom-model-dropdown/APIKeyReadOnlyView";
 import Actions from "./Actions";
 import { LOGO_WITH_BLACK_BACKGROUND } from "src/components/custom-model-dropdown/common";
+import { getRequestErrorMessage } from "src/utils/errorUtils";
 
 const KeyCardComponent = ({ data, onDeleteClick }) => {
   const theme = useTheme();
@@ -97,6 +98,11 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
       setEditMode(false);
       hasClearedOnceRef.current = false;
     },
+    onError: (error) => {
+      enqueueSnackbar(getRequestErrorMessage(error, "Failed to save API key"), {
+        variant: "error",
+      });
+    },
   });
 
   const { mutate: updateApiKey, isPending: isUpdatingApiKey } = useMutation({
@@ -109,6 +115,11 @@ const KeyCardComponent = ({ data, onDeleteClick }) => {
       queryClient.invalidateQueries({ queryKey: ["api-key-status"] });
       setEditMode(false);
       hasClearedOnceRef.current = false;
+    },
+    onError: (error) => {
+      enqueueSnackbar(getRequestErrorMessage(error, "Failed to save API key"), {
+        variant: "error",
+      });
     },
   });
   const handleFormSubmit = async (formData) => {

--- a/futureagi/model_hub/tests/test_api_key_viewset.py
+++ b/futureagi/model_hub/tests/test_api_key_viewset.py
@@ -1,0 +1,105 @@
+"""
+Tests for ApiKeyViewSet — POST /model-hub/api-keys/
+
+Covers the save-time provider key validation wired into
+ApiKeyViewSet.create() (model_hub/views/run_prompt.py).
+
+Run with: pytest model_hub/tests/test_api_key_viewset.py -v
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from model_hub.models.api_key import ApiKey
+from tfc.middleware.workspace_context import set_workspace_context
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name="Test Organization")
+
+
+@pytest.fixture
+def user(db, organization):
+    return User.objects.create_user(
+        email="test@example.com",
+        password="testpassword123",
+        name="Test User",
+        organization=organization,
+    )
+
+
+@pytest.fixture
+def workspace(db, organization, user):
+    return Workspace.objects.create(
+        name="Default Workspace",
+        organization=organization,
+        is_default=True,
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def auth_client(user, workspace):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    set_workspace_context(workspace=workspace, organization=user.organization)
+    return client
+
+
+class TestApiKeyViewSetCreate:
+    def test_rejects_and_does_not_persist_invalid_key(self, auth_client, organization):
+        with patch(
+            "model_hub.views.run_prompt.validate_provider_key",
+            return_value=(
+                False,
+                "Invalid API key for openai — the provider rejected it.",
+            ),
+        ):
+            response = auth_client.post(
+                "/model-hub/api-keys/",
+                {"provider": "openai", "key": "sk-bad-key"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not ApiKey.objects.filter(
+            provider="openai", organization=organization
+        ).exists()
+
+    def test_accepts_and_persists_valid_key(self, auth_client, organization):
+        with patch(
+            "model_hub.views.run_prompt.validate_provider_key",
+            return_value=(True, None),
+        ):
+            response = auth_client.post(
+                "/model-hub/api-keys/",
+                {"provider": "openai", "key": "sk-good-key"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert ApiKey.objects.filter(
+            provider="openai", organization=organization
+        ).exists()
+
+    def test_validation_skipped_provider_still_persists(
+        self, auth_client, organization
+    ):
+        """Providers without a probe (e.g. huggingface) should save exactly
+        as before — validate_provider_key fails open for them."""
+        response = auth_client.post(
+            "/model-hub/api-keys/",
+            {"provider": "huggingface", "key": "hf-some-key"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert ApiKey.objects.filter(
+            provider="huggingface", organization=organization
+        ).exists()

--- a/futureagi/model_hub/tests/test_provider_key_validation.py
+++ b/futureagi/model_hub/tests/test_provider_key_validation.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for model_hub.utils.provider_key_validation.validate_provider_key
+
+Run with: pytest model_hub/tests/test_provider_key_validation.py -v
+"""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from model_hub.utils.provider_key_validation import validate_provider_key
+
+
+def _mock_response(status_code):
+    response = MagicMock()
+    response.status_code = status_code
+    return response
+
+
+class TestValidateProviderKey:
+    def test_unprobed_provider_skips_validation(self):
+        with patch("model_hub.utils.provider_key_validation.requests") as mock_requests:
+            is_valid, error = validate_provider_key("vertex_ai", "some-key")
+
+        assert is_valid is True
+        assert error is None
+        mock_requests.get.assert_not_called()
+        mock_requests.post.assert_not_called()
+
+    def test_missing_key_skips_validation(self):
+        is_valid, error = validate_provider_key("openai", None)
+
+        assert is_valid is True
+        assert error is None
+
+    def test_valid_key_accepted(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(200),
+        ) as mock_get:
+            is_valid, error = validate_provider_key("openai", "sk-good-key")
+
+        assert is_valid is True
+        assert error is None
+        mock_get.assert_called_once()
+        called_url = mock_get.call_args.args[0]
+        assert called_url == "https://api.openai.com/v1/models"
+
+    def test_invalid_key_rejected_on_401(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(401),
+        ):
+            is_valid, error = validate_provider_key("openai", "sk-bad-key")
+
+        assert is_valid is False
+        assert "openai" in error
+        assert "401" in error
+
+    def test_invalid_key_rejected_on_403(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(403),
+        ):
+            is_valid, error = validate_provider_key("groq", "gsk-bad-key")
+
+        assert is_valid is False
+        assert "groq" in error
+
+    def test_non_auth_error_status_still_accepted(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(500),
+        ):
+            is_valid, error = validate_provider_key("mistral", "some-key")
+
+        assert is_valid is True
+        assert error is None
+
+    def test_network_error_fails_open(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            is_valid, error = validate_provider_key("cohere", "some-key")
+
+        assert is_valid is True
+        assert error is None
+
+    def test_anthropic_uses_header_auth(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(200),
+        ) as mock_get:
+            is_valid, _ = validate_provider_key("anthropic", "sk-ant-key")
+
+        assert is_valid is True
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["x-api-key"] == "sk-ant-key"
+
+    def test_gemini_uses_query_param_auth(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(200),
+        ) as mock_get:
+            is_valid, _ = validate_provider_key("gemini", "AIza-key")
+
+        assert is_valid is True
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["key"] == "AIza-key"
+
+    def test_perplexity_uses_chat_completions_probe(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.post",
+            return_value=_mock_response(200),
+        ) as mock_post:
+            is_valid, _ = validate_provider_key("perplexity", "pplx-key")
+
+        assert is_valid is True
+        mock_post.assert_called_once()
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://api.perplexity.ai/chat/completions"
+
+    def test_together_ai_invalid_key_rejected(self):
+        with patch(
+            "model_hub.utils.provider_key_validation.requests.get",
+            return_value=_mock_response(401),
+        ):
+            is_valid, error = validate_provider_key("together_ai", "bad-key")
+
+        assert is_valid is False
+        assert "together_ai" in error

--- a/futureagi/model_hub/tests/test_run_prompt_api.py
+++ b/futureagi/model_hub/tests/test_run_prompt_api.py
@@ -859,6 +859,20 @@ class TestRunPromptForRowsView:
 
 @pytest.mark.django_db
 class TestProviderApiKeys:
+    @pytest.fixture(autouse=True)
+    def _skip_provider_key_probe(self):
+        """These tests cover key storage/masking, not provider authentication.
+
+        ``ApiKeyViewSet.create`` probes the provider's API so an invalid key is
+        rejected at save time. Unpatched, the dummy keys below would trigger a
+        live HTTPS call to the real provider, come back 401, and 400 the save.
+        """
+        with patch(
+            "model_hub.views.run_prompt.validate_provider_key",
+            return_value=(True, None),
+        ):
+            yield
+
     def test_text_provider_key_responses_are_masked_only(self, auth_client):
         raw_key = "secret-provider-key-value"
         updated_raw_key = "secret-provider-key-value-updated"

--- a/futureagi/model_hub/utils/provider_key_validation.py
+++ b/futureagi/model_hub/utils/provider_key_validation.py
@@ -1,0 +1,120 @@
+"""Lightweight, save-time validation of LLM provider API keys.
+
+Probes a provider's "list models" endpoint (or closest equivalent) to confirm
+a key is actually authenticated before it gets persisted, without making a
+paid completion call. Deliberately fails open: a provider we don't have a
+probe for, or an ambiguous network/response outcome, is always treated as
+valid so a transient issue never blocks a legitimate save.
+"""
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 8
+
+_AUTH_FAILURE_STATUS_CODES = {401, 403}
+
+
+def _probe_openai_style(key, base_url):
+    response = requests.get(
+        f"{base_url}/models",
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return response.status_code
+
+
+def _probe_openai(key):
+    return _probe_openai_style(key, "https://api.openai.com/v1")
+
+
+def _probe_groq(key):
+    return _probe_openai_style(key, "https://api.groq.com/openai/v1")
+
+
+def _probe_together_ai(key):
+    return _probe_openai_style(key, "https://api.together.xyz/v1")
+
+
+def _probe_cohere(key):
+    return _probe_openai_style(key, "https://api.cohere.ai/v1")
+
+
+def _probe_mistral(key):
+    return _probe_openai_style(key, "https://api.mistral.ai/v1")
+
+
+def _probe_anthropic(key):
+    response = requests.get(
+        "https://api.anthropic.com/v1/models",
+        headers={"x-api-key": key, "anthropic-version": "2023-06-01"},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return response.status_code
+
+
+def _probe_gemini(key):
+    response = requests.get(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        params={"key": key},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return response.status_code
+
+
+def _probe_perplexity(key):
+    # Perplexity has no public models-list endpoint, so probe with the
+    # cheapest possible chat completion instead.
+    response = requests.post(
+        "https://api.perplexity.ai/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={
+            "model": "sonar",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1,
+        },
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return response.status_code
+
+
+# Probe map — only providers we can confidently auth-check with a cheap
+# request. Any provider not listed here skips validation entirely.
+PROVIDER_PROBES = {
+    "openai": _probe_openai,
+    "anthropic": _probe_anthropic,
+    "gemini": _probe_gemini,
+    "groq": _probe_groq,
+    "cohere": _probe_cohere,
+    "mistral": _probe_mistral,
+    "perplexity": _probe_perplexity,
+    "together_ai": _probe_together_ai,
+}
+
+
+def validate_provider_key(provider, key):
+    """Best-effort, save-time validation of a provider API key.
+
+    Returns (is_valid, error_message). Only rejects on an explicit auth
+    failure (401/403) from a provider we have a probe for; everything else
+    (unprobed provider, missing key, network error, non-auth error status)
+    is treated as valid so we never block a save we can't confidently verify.
+    """
+    probe = PROVIDER_PROBES.get(provider)
+    if probe is None or not key:
+        return True, None
+
+    try:
+        status_code = probe(key)
+    except requests.RequestException:
+        logger.warning("provider_key_probe_unreachable", provider=provider)
+        return True, None
+
+    if status_code in _AUTH_FAILURE_STATUS_CODES:
+        return (
+            False,
+            f"Invalid API key for {provider} — the provider rejected it (HTTP {status_code}).",
+        )
+    return True, None

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -79,6 +79,7 @@ from model_hub.services.column_service import (
 from model_hub.utils.model_provider_update import (
     one_time_model_providers_update,
 )
+from model_hub.utils.provider_key_validation import validate_provider_key
 from model_hub.utils.utils import (
     get_model_mode,
     remove_empty_text_from_messages,
@@ -272,6 +273,12 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=payload)
         if serializer.is_valid():
             validated_data = serializer.validated_data
+
+            is_key_valid, key_error_message = validate_provider_key(
+                validated_data.get("provider"), validated_data.get("key")
+            )
+            if not is_key_valid:
+                return self._gm.bad_request(key_error_message)
 
             # First try to get existing API key
             try:


### PR DESCRIPTION
## Summary

Adding a key for an LLM provider on the **AI Providers** settings page used to persist it without ever checking it, and the user got no feedback — a typo'd or revoked key "saved" fine and only surfaced later as a confusing prompt-run failure. This wires up **save-time validation**: the backend probes the eight key-validated providers (OpenAI, Anthropic, Gemini, Groq, Cohere, Mistral, Perplexity, Together AI) and rejects a bad key with a `400`, and the frontend now surfaces that rejection as an error toast instead of failing silently. It fails open by design — an unprobed provider, a missing key, or a transient network error never blocks a save.

## Linked issues

Closes #1364

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

**Automated** — added regression tests covering every branch of the validator (valid/invalid key, 401/403 rejection, non-auth status, network fail-open, per-provider auth scheme, unprobed provider, missing key) and the endpoint wwiring (bad key → `400` + not persisted, good key → saved, unprobed → saved).

```bash
cd futureagi
pytest model_hub/tests/test_provider_key_validation.py \
       model_hub/tests/test_api_key_viewset.py \
       model_hub/tests/test_run_prompt_api.py
# => 117 passed  (14 new + the full existing run_prompt API suite, no regressions)
```

Also verified: Django system check clean, both modules import cleanly with all 8 probes registered, and the changed frontend file passes `prettier --check`.

**Manual** (dev stack: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`):

1. Settings → AI Providers.
2. OpenAI + a deliberately bad key → **Save** → red error toast, key **not** saved.
3. OpenAI + a valid key → **Save** → saves, green checkmark.
4. HuggingFace (unprobed) → saves unchanged (fails open).

## Screenshots / recordings (if UI)

### BEFORE CHANGES (Wrong API, still shows correct)

<img width="1710" height="893" alt="Screenshot 2026-07-07 214349" src="https://github.com/user-attachments/assets/615add92-eddc-4641-b801-770af8712296" />


### AFTER CHANGES (Wrong API, shows wrong, Correct API shows green)

<img width="1704" height="888" alt="Screenshot 2026-07-07 213405" src="https://github.com/user-attachments/assets/56355236-6c1f-46e2-a3eb-a96c19b85bb6" />
<img width="445" height="137" alt="Screenshot 2026-07-07 213417" src="https://github.com/user-attachments/assets/c31ccf89-d75b-43d9-a331-b5e62afe4854" />
<img width="1704" height="890" alt="Screenshot 2026-07-07 213617" src="https://github.com/user-attachments/assets/23877220-fc8f-4bf4-83cd-f4109bf8ad42" />
<img width="335" height="96" alt="Screenshot 2026-07-07 213625" src="https://github.com/user-attachments/assets/2bca451d-36e5-4e15-9915-03bb22bf838c" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)