### PR TITLE
fix(upload): reject 0-byte files in scenario and knowledge-base uploads

### DIFF
--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
@@ -5,6 +5,8 @@ import { RHFUpload } from "src/components/hook-form";
 import Iconify from "src/components/iconify";
 import { useController } from "react-hook-form";
 
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
   const { field } = useController({
     name: "file",
@@ -12,30 +14,24 @@ const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
   });
 
   const handleFileChange = (acceptedFiles, rejected = []) => {
-    // const file = acceptedFiles;
-    const files = Array.from(acceptedFiles);
-    const maxSize = 5 * 1024 * 1024; // 5MB
+    const files = Array.from(acceptedFiles || []);
 
-    const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
-
-    if (filesLargerThanMaxSize.length > 0) {
+    const safeRejected = Array.isArray(rejected) ? rejected : [];
+    if (safeRejected.some((r) => r?.errors?.some?.((e) => e?.code === "file-too-large"))) {
       handleShowSdkInfo();
     }
 
     const existingFiles = field?.value?.file || [];
-    // const fileLists = files.map(file => allowedTypes.includes(file.type) ? )
-
-    const validFiles = files.filter((file) => file.size <= maxSize);
 
     const updatedFiles = [
       ...existingFiles,
-      ...validFiles.map((file) => ({ item: file, status: "not_started" })),
-      ...rejected.map((item) => {
-        const { file, errors } = item;
+      ...files.map((file) => ({ item: file, status: "not_started" })),
+      ...safeRejected.map((item) => {
+        const { file, errors = [] } = item || {};
         return {
           item: file,
           status: "error",
-          statusReason: errors?.[0]?.message,
+          statusReason: errors?.[0]?.message || "File was rejected",
         };
       }),
     ];
@@ -85,12 +81,13 @@ const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
         showIllustration={false}
         accept={{
           "application/pdf": [".pdf"],
-          // "application/msword": [".doc"],
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
             [".docx"],
           "text/plain": [".txt"],
           "text/rtf": [".rtf"],
         }}
+        maxSize={MAX_FILE_SIZE}
+        minSize={1}
         sx={{ paddingY: 3 }}
         onDrop={handleFileChange}
       />

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
@@ -4,10 +4,12 @@ import React from "react";
 import { RHFUpload } from "src/components/hook-form";
 import Iconify from "src/components/iconify";
 import { useController } from "react-hook-form";
+import { useSnackbar } from "src/components/snackbar";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
 const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
+  const { enqueueSnackbar } = useSnackbar();
   const { field } = useController({
     name: "file",
     control,
@@ -17,23 +19,61 @@ const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
     const files = Array.from(acceptedFiles || []);
 
     const safeRejected = Array.isArray(rejected) ? rejected : [];
-    if (safeRejected.some((r) => r?.errors?.some?.((e) => e?.code === "file-too-large"))) {
+
+    // Show SDK info dialog if any file is too large
+    if (
+      safeRejected.some((r) =>
+        (r?.errors || []).some((e) => e?.code === "file-too-large"),
+      )
+    ) {
       handleShowSdkInfo();
     }
 
+    // Report rejected files via snackbar (do not add them to the file list —
+    // oversized rows would block the Create button for other valid files)
+    safeRejected.forEach((item) => {
+      const { file, errors } = item || {};
+
+      // Skip rejections with no file to prevent downstream crashes
+      // (CreateKnowledgeBaseDrawer reads file.item.size / file.item.type without guards)
+      if (!file) return;
+
+      const safeErrors = errors || [];
+      const isTooSmall = safeErrors.some((e) => e?.code === "file-too-small");
+      const isInvalidType = safeErrors.some(
+        (e) => e?.code === "file-invalid-type",
+      );
+      const isTooLarge = safeErrors.some((e) => e?.code === "file-too-large");
+
+      if (isTooSmall) {
+        enqueueSnackbar(
+          `"${file.name}" is empty. Please upload a file with content.`,
+          { variant: "error" },
+        );
+      } else if (isInvalidType) {
+        enqueueSnackbar(
+          "Unsupported file type. Please upload a PDF, DOCX, RTF, or TXT file.",
+          { variant: "error" },
+        );
+      } else if (isTooLarge) {
+        enqueueSnackbar(
+          "File size is too large. Please upload a file under 5 MB.",
+          { variant: "error" },
+        );
+      } else {
+        enqueueSnackbar(
+          `"${file.name}" could not be uploaded. ${safeErrors[0]?.message || "File was rejected"}`,
+          { variant: "error" },
+        );
+      }
+    });
+
     const existingFiles = field?.value?.file || [];
 
+    // Only add accepted files — rejected files are reported via toasts / SDK dialog
     const updatedFiles = [
       ...existingFiles,
       ...files.map((file) => ({ item: file, status: "not_started" })),
-      ...safeRejected.map((item) => {
-        const { file, errors = [] } = item || {};
-        return {
-          item: file,
-          status: "error",
-          statusReason: errors?.[0]?.message || "File was rejected",
-        };
-      }),
     ];
 
     if (field?.onChange) {

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.test.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.test.jsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let capturedOnDrop = null;
+
+vi.mock("react-dropzone", () => ({
+  useDropzone: vi.fn((props) => {
+    capturedOnDrop = props.onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      isDragReject: false,
+      fileRejections: [],
+    };
+  }),
+}));
+
+const mockEnqueue = vi.fn();
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
+
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { useForm, FormProvider } from "react-hook-form";
+import UploadKnowledgeBaseFile from "./UploadKnowledgeBaseFile";
+
+const mockShowSdkInfo = vi.fn();
+
+let methods;
+
+function TestWrapper() {
+  methods = useForm({
+    defaultValues: { file: { file: [] } },
+  });
+  return React.createElement(
+    FormProvider,
+    { ...methods },
+    React.createElement(UploadKnowledgeBaseFile, {
+      control: methods.control,
+      handleShowSdkInfo: mockShowSdkInfo,
+      isPending: false,
+    }),
+  );
+}
+
+function createFile(name, content, type) {
+  return new File([content], name, { type });
+}
+
+function triggerDrop(acceptedFiles, fileRejections) {
+  act(() => {
+    capturedOnDrop(acceptedFiles, fileRejections);
+  });
+}
+
+describe("UploadKnowledgeBaseFile", () => {
+  beforeEach(() => {
+    capturedOnDrop = null;
+    mockEnqueue.mockClear();
+    mockShowSdkInfo.mockClear();
+  });
+
+  it("renders the upload dropzone", () => {
+    render(React.createElement(TestWrapper));
+    expect(
+      screen.getByText("Choose a file or drag & drop it here"),
+    ).toBeTruthy();
+  });
+
+  it("rejects a 0-byte file and shows an error snackbar", () => {
+    render(React.createElement(TestWrapper));
+
+    const emptyFile = createFile("empty.pdf", "", "application/pdf");
+    const rejection = {
+      file: emptyFile,
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.stringContaining("empty.pdf"),
+      { variant: "error" },
+    );
+    // Rejected file is not added to the list
+    expect(methods.getValues("file").file).toHaveLength(0);
+  });
+
+  it("adds a valid file to the list", () => {
+    render(React.createElement(TestWrapper));
+
+    const validFile = createFile("doc.pdf", "%PDF-1.4", "application/pdf");
+    triggerDrop([validFile], []);
+
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    const updated = methods.getValues("file").file;
+    expect(updated).toHaveLength(1);
+    expect(updated[0].status).toBe("not_started");
+    expect(updated[0].item.name).toBe("doc.pdf");
+  });
+
+  it("does not add a rejected file alongside an accepted one", () => {
+    render(React.createElement(TestWrapper));
+
+    const validFile = createFile("good.txt", "content", "text/plain");
+    const rejection = {
+      file: createFile("bad.pdf", "", "application/pdf"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([validFile], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const updated = methods.getValues("file").file;
+    expect(updated).toHaveLength(1);
+    expect(updated[0].item.name).toBe("good.txt");
+  });
+
+  it("shows SDK info dialog and toast for an oversized file", () => {
+    render(React.createElement(TestWrapper));
+
+    const rejection = {
+      file: createFile(
+        "big.pdf",
+        "x".repeat(6 * 1024 * 1024),
+        "application/pdf",
+      ),
+      errors: [
+        {
+          code: "file-too-large",
+          message: "File is larger than 5242880 bytes",
+        },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockShowSdkInfo).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "File size is too large. Please upload a file under 5 MB.",
+      { variant: "error" },
+    );
+    // Oversized file is not added to the list (does not block Create)
+    expect(methods.getValues("file").file).toHaveLength(0);
+  });
+
+  it("shows friendly message for file-invalid-type", () => {
+    render(React.createElement(TestWrapper));
+
+    const rejection = {
+      file: createFile("notes.txt", "content", "image/png"),
+      errors: [
+        { code: "file-invalid-type", message: "File type must be .pdf,.docx" },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "Unsupported file type. Please upload a PDF, DOCX, RTF, or TXT file.",
+      { variant: "error" },
+    );
+  });
+
+  it("does not crash on rejection item with null file", () => {
+    render(React.createElement(TestWrapper));
+
+    const rejection = {
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    // Nothing is added, nothing crashes
+    expect(methods.getValues("file").file).toHaveLength(0);
+  });
+
+  it("does not crash on rejection item with no errors array", () => {
+    render(React.createElement(TestWrapper));
+
+    const rejection = {
+      file: createFile("unknown.pdf", "", "application/pdf"),
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when errors is null", () => {
+    render(React.createElement(TestWrapper));
+
+    const rejection = {
+      file: createFile("doc.txt", "", "text/plain"),
+      errors: null,
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes minSize and maxSize to useDropzone", async () => {
+    render(React.createElement(TestWrapper));
+
+    const { useDropzone } = await import("react-dropzone");
+    expect(useDropzone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minSize: 1,
+        maxSize: 5 * 1024 * 1024,
+      }),
+    );
+  });
+});

--- a/frontend/src/sections/scenarios/CallChatSOPOption.jsx
+++ b/frontend/src/sections/scenarios/CallChatSOPOption.jsx
@@ -100,6 +100,8 @@ const CallChatSOPOption = ({ control }) => {
             "text/plain": [".txt"],
             "application/pdf": [".pdf"],
           }}
+          maxSize={5 * 1024 * 1024}
+          minSize={1}
           sx={{ paddingY: (theme) => theme.spacing(3) }}
           onDrop={handleFileChange}
         />

--- a/frontend/src/sections/scenarios/CallChatSOPOption.jsx
+++ b/frontend/src/sections/scenarios/CallChatSOPOption.jsx
@@ -7,7 +7,10 @@ import PropTypes from "prop-types";
 import { useController } from "react-hook-form";
 import SvgColor from "src/components/svg-color";
 import { ShowComponent } from "src/components/show";
-import { createScenarioFileDropHandler } from "./common";
+import {
+  createScenarioFileDropHandler,
+  MAX_SCENARIO_FILE_SIZE,
+} from "./common";
 
 const CallChatSOPOption = ({ control }) => {
   const fieldName = "config.sopUrl";
@@ -100,7 +103,7 @@ const CallChatSOPOption = ({ control }) => {
             "text/plain": [".txt"],
             "application/pdf": [".pdf"],
           }}
-          maxSize={5 * 1024 * 1024}
+          maxSize={MAX_SCENARIO_FILE_SIZE}
           minSize={1}
           sx={{ paddingY: (theme) => theme.spacing(3) }}
           onDrop={handleFileChange}

--- a/frontend/src/sections/scenarios/UploadScriptOption.jsx
+++ b/frontend/src/sections/scenarios/UploadScriptOption.jsx
@@ -100,6 +100,8 @@ const UploadScriptOption = ({ control }) => {
             "text/plain": [".txt"],
             "application/pdf": [".pdf"],
           }}
+          maxSize={5 * 1024 * 1024}
+          minSize={1}
           sx={{ paddingY: (theme) => theme.spacing(3) }}
           onDrop={handleFileChange}
         />

--- a/frontend/src/sections/scenarios/UploadScriptOption.jsx
+++ b/frontend/src/sections/scenarios/UploadScriptOption.jsx
@@ -7,7 +7,10 @@ import PropTypes from "prop-types";
 import { useController } from "react-hook-form";
 import SvgColor from "src/components/svg-color";
 import { ShowComponent } from "src/components/show";
-import { createScenarioFileDropHandler } from "./common";
+import {
+  createScenarioFileDropHandler,
+  MAX_SCENARIO_FILE_SIZE,
+} from "./common";
 
 const UploadScriptOption = ({ control }) => {
   const fieldName = "config.scriptUrl";
@@ -100,7 +103,7 @@ const UploadScriptOption = ({ control }) => {
             "text/plain": [".txt"],
             "application/pdf": [".pdf"],
           }}
-          maxSize={5 * 1024 * 1024}
+          maxSize={MAX_SCENARIO_FILE_SIZE}
           minSize={1}
           sx={{ paddingY: (theme) => theme.spacing(3) }}
           onDrop={handleFileChange}

--- a/frontend/src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx
+++ b/frontend/src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let capturedOnDrop = null;
+
+vi.mock("react-dropzone", () => ({
+  useDropzone: vi.fn((props) => {
+    capturedOnDrop = props.onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      isDragReject: false,
+      fileRejections: [],
+    };
+  }),
+}));
+
+const mockEnqueue = vi.fn();
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
+
+import React from "react";
+import PropTypes from "prop-types";
+import { render, screen, act } from "@testing-library/react";
+import { useForm, FormProvider } from "react-hook-form";
+import CallChatSOPOption from "../CallChatSOPOption";
+
+function TestWrapper({ children }) {
+  const methods = useForm({
+    defaultValues: { "config.sopUrl": null },
+  });
+  return React.createElement(FormProvider, { ...methods }, children);
+}
+
+TestWrapper.propTypes = {
+  children: PropTypes.node,
+};
+
+function createFile(name, content, type) {
+  return new File([content], name, { type });
+}
+
+function triggerDrop(acceptedFiles, fileRejections) {
+  act(() => {
+    capturedOnDrop(acceptedFiles, fileRejections);
+  });
+}
+
+describe("CallChatSOPOption", () => {
+  beforeEach(() => {
+    capturedOnDrop = null;
+    mockEnqueue.mockClear();
+  });
+
+  it("renders the upload dropzone", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+    expect(screen.getByText("Call/Chat SOP")).toBeTruthy();
+  });
+
+  it("rejects a 0-byte file and shows an error snackbar", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const emptyFile = createFile("empty.pdf", "", "application/pdf");
+    const rejection = {
+      file: emptyFile,
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.stringContaining("empty.pdf"),
+      { variant: "error" },
+    );
+  });
+
+  it("accepts a valid file without showing an error", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const validFile = createFile("script.txt", "print('hello')", "text/plain");
+    triggerDrop([validFile], []);
+
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid PDF file", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const validPdf = createFile("doc.pdf", "%PDF-1.4", "application/pdf");
+    triggerDrop([validPdf], []);
+
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("shows snackbar for each rejected file", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const rejection1 = {
+      file: createFile("empty1.pdf", "", "application/pdf"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+    const rejection2 = {
+      file: createFile("empty2.pdf", "", "application/pdf"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([], [rejection1, rejection2]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("processes an accepted file alongside a rejected one", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const validFile = createFile("good.txt", "content", "text/plain");
+    const rejection = {
+      file: createFile("bad.pdf", "", "application/pdf"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([validFile], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when fileRejections is null", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const validFile = createFile("doc.txt", "text", "text/plain");
+
+    expect(() => triggerDrop([validFile], null)).not.toThrow();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("does not crash when acceptedFiles is null", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    expect(() => triggerDrop(null, [])).not.toThrow();
+  });
+
+  it("does not crash on rejection item with no errors array", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const rejection = {
+      file: createFile("unknown.pdf", "", "application/pdf"),
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash on rejection item with null file", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(CallChatSOPOption, null),
+    ));
+
+    const rejection = {
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+  });
+});

--- a/frontend/src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx
+++ b/frontend/src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx
@@ -22,7 +22,7 @@ vi.mock("src/components/snackbar", () => ({
 
 import React from "react";
 import PropTypes from "prop-types";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { useForm, FormProvider } from "react-hook-form";
 import CallChatSOPOption from "../CallChatSOPOption";
 
@@ -54,16 +54,24 @@ describe("CallChatSOPOption", () => {
   });
 
   it("renders the upload dropzone", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
     expect(screen.getByText("Call/Chat SOP")).toBeTruthy();
   });
 
   it("rejects a 0-byte file and shows an error snackbar", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const emptyFile = createFile("empty.pdf", "", "application/pdf");
     const rejection = {
@@ -83,9 +91,13 @@ describe("CallChatSOPOption", () => {
   });
 
   it("accepts a valid file without showing an error", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const validFile = createFile("script.txt", "print('hello')", "text/plain");
     triggerDrop([validFile], []);
@@ -94,9 +106,13 @@ describe("CallChatSOPOption", () => {
   });
 
   it("accepts a valid PDF file", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const validPdf = createFile("doc.pdf", "%PDF-1.4", "application/pdf");
     triggerDrop([validPdf], []);
@@ -105,9 +121,13 @@ describe("CallChatSOPOption", () => {
   });
 
   it("shows snackbar for each rejected file", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const rejection1 = {
       file: createFile("empty1.pdf", "", "application/pdf"),
@@ -127,10 +147,14 @@ describe("CallChatSOPOption", () => {
     expect(mockEnqueue).toHaveBeenCalledTimes(2);
   });
 
-  it("processes an accepted file alongside a rejected one", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+  it("processes an accepted file alongside a rejected one", async () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const validFile = createFile("good.txt", "content", "text/plain");
     const rejection = {
@@ -142,13 +166,27 @@ describe("CallChatSOPOption", () => {
 
     triggerDrop([validFile], [rejection]);
 
+    // Rejection shows an error
     expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.stringContaining("bad.pdf"),
+      { variant: "error" },
+    );
+
+    // Accepted file is still processed — it appears in the UI
+    await waitFor(() => {
+      expect(screen.getByText("good.txt")).toBeTruthy();
+    });
   });
 
   it("does not crash when fileRejections is null", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const validFile = createFile("doc.txt", "text", "text/plain");
 
@@ -157,17 +195,25 @@ describe("CallChatSOPOption", () => {
   });
 
   it("does not crash when acceptedFiles is null", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     expect(() => triggerDrop(null, [])).not.toThrow();
   });
 
   it("does not crash on rejection item with no errors array", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const rejection = {
       file: createFile("unknown.pdf", "", "application/pdf"),
@@ -178,9 +224,13 @@ describe("CallChatSOPOption", () => {
   });
 
   it("does not crash on rejection item with null file", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(CallChatSOPOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
 
     const rejection = {
       errors: [
@@ -189,5 +239,133 @@ describe("CallChatSOPOption", () => {
     };
 
     expect(() => triggerDrop([], [rejection])).not.toThrow();
+    // Shows a generic message instead of being silent
+    expect(mockEnqueue).toHaveBeenCalledWith("File could not be uploaded", {
+      variant: "error",
+    });
+  });
+
+  it("passes minSize and maxSize to useDropzone", async () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
+
+    const { useDropzone } = await import("react-dropzone");
+    expect(useDropzone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minSize: 1,
+        maxSize: 5 * 1024 * 1024,
+      }),
+    );
+  });
+
+  it("rejects a too-many-files and aggregates into one toast", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
+
+    const file1 = createFile("a.txt", "content", "text/plain");
+    const file2 = createFile("b.txt", "content", "text/plain");
+
+    const rejection1 = {
+      file: file1,
+      errors: [{ code: "too-many-files", message: "Too many files" }],
+    };
+    const rejection2 = {
+      file: file2,
+      errors: [{ code: "too-many-files", message: "Too many files" }],
+    };
+
+    triggerDrop([], [rejection1, rejection2]);
+
+    // Aggregated into one toast, not two
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith("Please upload only one file.", {
+      variant: "error",
+    });
+  });
+
+  it("shows friendly message for file-invalid-type", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile("notes.docx", "", "application/msword"),
+      errors: [
+        {
+          code: "file-invalid-type",
+          message: "File type must be text/plain,.txt,application/pdf,.pdf",
+        },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "Unsupported file type. Please upload a TXT or PDF file.",
+      { variant: "error" },
+    );
+  });
+
+  it("shows friendly message for file-too-large", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile(
+        "big.pdf",
+        "x".repeat(6 * 1024 * 1024),
+        "application/pdf",
+      ),
+      errors: [
+        {
+          code: "file-too-large",
+          message: "File is larger than 5242880 bytes",
+        },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "File size is too large. Please upload a file under 5 MB.",
+      { variant: "error" },
+    );
+  });
+
+  it("does not crash when errors is null", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(CallChatSOPOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile("doc.txt", "", "text/plain"),
+      errors: null,
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/sections/scenarios/__tests__/UploadScriptOption.test.jsx
+++ b/frontend/src/sections/scenarios/__tests__/UploadScriptOption.test.jsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let capturedOnDrop = null;
+
+vi.mock("react-dropzone", () => ({
+  useDropzone: vi.fn((props) => {
+    capturedOnDrop = props.onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      isDragReject: false,
+      fileRejections: [],
+    };
+  }),
+}));
+
+const mockEnqueue = vi.fn();
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
+
+import React from "react";
+import PropTypes from "prop-types";
+import { render, screen, act } from "@testing-library/react";
+import { useForm, FormProvider } from "react-hook-form";
+import UploadScriptOption from "../UploadScriptOption";
+
+function TestWrapper({ children }) {
+  const methods = useForm({
+    defaultValues: { "config.scriptUrl": null },
+  });
+  return React.createElement(FormProvider, { ...methods }, children);
+}
+
+TestWrapper.propTypes = {
+  children: PropTypes.node,
+};
+
+function createFile(name, content, type) {
+  return new File([content], name, { type });
+}
+
+function triggerDrop(acceptedFiles, fileRejections) {
+  act(() => {
+    capturedOnDrop(acceptedFiles, fileRejections);
+  });
+}
+
+describe("UploadScriptOption", () => {
+  beforeEach(() => {
+    capturedOnDrop = null;
+    mockEnqueue.mockClear();
+  });
+
+  it("renders the upload dropzone", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+    expect(screen.getByText("Upload Script")).toBeTruthy();
+  });
+
+  it("rejects a 0-byte file and shows an error snackbar", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const emptyFile = createFile("empty.pdf", "", "application/pdf");
+    const rejection = {
+      file: emptyFile,
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.stringContaining("empty.pdf"),
+      { variant: "error" },
+    );
+  });
+
+  it("accepts a valid file without showing an error", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const validFile = createFile("script.txt", "print('hello')", "text/plain");
+    triggerDrop([validFile], []);
+
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("shows snackbar for each rejected file", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const rejection1 = {
+      file: createFile("empty1.txt", "", "text/plain"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+    const rejection2 = {
+      file: createFile("empty2.txt", "", "text/plain"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([], [rejection1, rejection2]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("processes an accepted file alongside a rejected one", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const validFile = createFile("good.txt", "content", "text/plain");
+    const rejection = {
+      file: createFile("bad.pdf", "", "application/pdf"),
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    triggerDrop([validFile], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when fileRejections is null", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const validFile = createFile("doc.txt", "text", "text/plain");
+
+    expect(() => triggerDrop([validFile], null)).not.toThrow();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it("does not crash when acceptedFiles is null", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    expect(() => triggerDrop(null, [])).not.toThrow();
+  });
+
+  it("does not crash on rejection item with no errors array", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const rejection = {
+      file: createFile("unknown.pdf", "", "application/pdf"),
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash on rejection item with null file", () => {
+    render(React.createElement(TestWrapper, null,
+      React.createElement(UploadScriptOption, null),
+    ));
+
+    const rejection = {
+      errors: [
+        { code: "file-too-small", message: "File is smaller than 1 bytes" },
+      ],
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+  });
+});

--- a/frontend/src/sections/scenarios/__tests__/UploadScriptOption.test.jsx
+++ b/frontend/src/sections/scenarios/__tests__/UploadScriptOption.test.jsx
@@ -22,7 +22,7 @@ vi.mock("src/components/snackbar", () => ({
 
 import React from "react";
 import PropTypes from "prop-types";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { useForm, FormProvider } from "react-hook-form";
 import UploadScriptOption from "../UploadScriptOption";
 
@@ -54,16 +54,24 @@ describe("UploadScriptOption", () => {
   });
 
   it("renders the upload dropzone", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
     expect(screen.getByText("Upload Script")).toBeTruthy();
   });
 
   it("rejects a 0-byte file and shows an error snackbar", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const emptyFile = createFile("empty.pdf", "", "application/pdf");
     const rejection = {
@@ -83,9 +91,13 @@ describe("UploadScriptOption", () => {
   });
 
   it("accepts a valid file without showing an error", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const validFile = createFile("script.txt", "print('hello')", "text/plain");
     triggerDrop([validFile], []);
@@ -94,9 +106,13 @@ describe("UploadScriptOption", () => {
   });
 
   it("shows snackbar for each rejected file", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const rejection1 = {
       file: createFile("empty1.txt", "", "text/plain"),
@@ -116,10 +132,14 @@ describe("UploadScriptOption", () => {
     expect(mockEnqueue).toHaveBeenCalledTimes(2);
   });
 
-  it("processes an accepted file alongside a rejected one", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+  it("processes an accepted file alongside a rejected one", async () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const validFile = createFile("good.txt", "content", "text/plain");
     const rejection = {
@@ -131,13 +151,27 @@ describe("UploadScriptOption", () => {
 
     triggerDrop([validFile], [rejection]);
 
+    // Rejection shows an error
     expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.stringContaining("bad.pdf"),
+      { variant: "error" },
+    );
+
+    // Accepted file is still processed — it appears in the UI
+    await waitFor(() => {
+      expect(screen.getByText("good.txt")).toBeTruthy();
+    });
   });
 
   it("does not crash when fileRejections is null", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const validFile = createFile("doc.txt", "text", "text/plain");
 
@@ -146,17 +180,25 @@ describe("UploadScriptOption", () => {
   });
 
   it("does not crash when acceptedFiles is null", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     expect(() => triggerDrop(null, [])).not.toThrow();
   });
 
   it("does not crash on rejection item with no errors array", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const rejection = {
       file: createFile("unknown.pdf", "", "application/pdf"),
@@ -167,9 +209,13 @@ describe("UploadScriptOption", () => {
   });
 
   it("does not crash on rejection item with null file", () => {
-    render(React.createElement(TestWrapper, null,
-      React.createElement(UploadScriptOption, null),
-    ));
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
 
     const rejection = {
       errors: [
@@ -178,5 +224,133 @@ describe("UploadScriptOption", () => {
     };
 
     expect(() => triggerDrop([], [rejection])).not.toThrow();
+    // Shows a generic message instead of being silent
+    expect(mockEnqueue).toHaveBeenCalledWith("File could not be uploaded", {
+      variant: "error",
+    });
+  });
+
+  it("passes minSize and maxSize to useDropzone", async () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
+
+    const { useDropzone } = await import("react-dropzone");
+    expect(useDropzone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minSize: 1,
+        maxSize: 5 * 1024 * 1024,
+      }),
+    );
+  });
+
+  it("rejects a too-many-files and aggregates into one toast", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
+
+    const file1 = createFile("a.txt", "content", "text/plain");
+    const file2 = createFile("b.txt", "content", "text/plain");
+
+    const rejection1 = {
+      file: file1,
+      errors: [{ code: "too-many-files", message: "Too many files" }],
+    };
+    const rejection2 = {
+      file: file2,
+      errors: [{ code: "too-many-files", message: "Too many files" }],
+    };
+
+    triggerDrop([], [rejection1, rejection2]);
+
+    // Aggregated into one toast, not two
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledWith("Please upload only one file.", {
+      variant: "error",
+    });
+  });
+
+  it("shows friendly message for file-invalid-type", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile("notes.docx", "", "application/msword"),
+      errors: [
+        {
+          code: "file-invalid-type",
+          message: "File type must be text/plain,.txt,application/pdf,.pdf",
+        },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "Unsupported file type. Please upload a TXT or PDF file.",
+      { variant: "error" },
+    );
+  });
+
+  it("shows friendly message for file-too-large", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile(
+        "big.pdf",
+        "x".repeat(6 * 1024 * 1024),
+        "application/pdf",
+      ),
+      errors: [
+        {
+          code: "file-too-large",
+          message: "File is larger than 5242880 bytes",
+        },
+      ],
+    };
+
+    triggerDrop([], [rejection]);
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      "File size is too large. Please upload a file under 5 MB.",
+      { variant: "error" },
+    );
+  });
+
+  it("does not crash when errors is null", () => {
+    render(
+      React.createElement(
+        TestWrapper,
+        null,
+        React.createElement(UploadScriptOption, null),
+      ),
+    );
+
+    const rejection = {
+      file: createFile("doc.txt", "", "text/plain"),
+      errors: null,
+    };
+
+    expect(() => triggerDrop([], [rejection])).not.toThrow();
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -266,7 +266,7 @@ export const extractVersionFromScenarioName = (name, basePattern) => {
 export const createScenarioFileDropHandler =
   ({ enqueueSnackbar, onChange }) =>
   (acceptedFiles, fileRejections = []) => {
-    if (fileRejections.length > 0) {
+    if (fileRejections?.length > 0) {
       fileRejections.forEach((rejection) => {
         const { file, errors = [] } = rejection || {};
         if (!file) return;
@@ -287,7 +287,7 @@ export const createScenarioFileDropHandler =
       return;
     }
 
-    const files = Array.from(acceptedFiles);
+    const files = Array.from(acceptedFiles || []);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
     const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -267,15 +267,23 @@ export const createScenarioFileDropHandler =
   ({ enqueueSnackbar, onChange }) =>
   (acceptedFiles, fileRejections = []) => {
     if (fileRejections.length > 0) {
-      const hasTypeError = fileRejections.some((rejection) =>
-        rejection.errors?.some((err) => err.code === "file-invalid-type"),
-      );
-      enqueueSnackbar(
-        hasTypeError
-          ? "Unsupported file type. Please upload a TXT or PDF file."
-          : "File could not be uploaded",
-        { variant: "error" },
-      );
+      fileRejections.forEach((rejection) => {
+        const { file, errors = [] } = rejection || {};
+        if (!file) return;
+
+        const isTooSmall = errors.some((e) => e?.code === "file-too-small");
+        if (isTooSmall) {
+          enqueueSnackbar(
+            `"${file.name}" is empty. Please upload a file with content.`,
+            { variant: "error" },
+          );
+        } else {
+          enqueueSnackbar(
+            `"${file.name}" could not be uploaded. ${errors[0]?.message || "File was rejected"}`,
+            { variant: "error" },
+          );
+        }
+      });
       return;
     }
 

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -288,23 +288,11 @@ export const createScenarioFileDropHandler =
     }
 
     const files = Array.from(acceptedFiles || []);
-    const maxSize = 5 * 1024 * 1024; // 5MB
 
-    const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
-
-    if (filesLargerThanMaxSize.length > 0) {
-      enqueueSnackbar("File size is too large", {
-        variant: "error",
-      });
-      return;
-    }
-
-    const validFiles = files.filter((file) => file.size <= maxSize);
-
-    const processedFiles = validFiles.map((file) => ({
+    const processedFiles = files.map((file) => ({
       file: file,
-      name: file.name,
-      size: file.size,
+      name: file?.name,
+      size: file?.size,
     }));
 
     if (onChange) {

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -271,13 +271,14 @@ export const createScenarioFileDropHandler =
   (acceptedFiles, fileRejections = []) => {
     const safeRejections = fileRejections || [];
     let tooManyFilesSeen = false;
+    let filelessRejectionSeen = false;
 
     safeRejections.forEach((rejection) => {
       const { file, errors } = rejection || {};
 
       if (!file) {
-        // Still show a generic message so the drop isn't silent
-        enqueueSnackbar("File could not be uploaded", { variant: "error" });
+        // Aggregate fileless rejections into a single message below.
+        filelessRejectionSeen = true;
         return;
       }
 
@@ -290,14 +291,11 @@ export const createScenarioFileDropHandler =
       const isTooMany = safeErrors.some((e) => e?.code === "too-many-files");
 
       if (isTooMany) {
-        // Aggregate too-many-files into a single message below —
-        // still process other rejection types for this file.
+        // react-dropzone only tags too-many-files on files that already passed
+        // accept/size validation, so it's always the sole code here — aggregate
+        // it into a single message below instead of one toast per file.
         tooManyFilesSeen = true;
-        if (!isTooSmall && !isInvalidType && !isTooLarge) {
-          // This file was ONLY rejected for too-many-files —
-          // don't show a per-file message for it.
-          return;
-        }
+        return;
       }
 
       if (isTooSmall) {
@@ -315,7 +313,7 @@ export const createScenarioFileDropHandler =
           "File size is too large. Please upload a file under 5 MB.",
           { variant: "error" },
         );
-      } else if (!isTooMany) {
+      } else {
         enqueueSnackbar(
           `"${file.name}" could not be uploaded. ${safeErrors[0]?.message || "File was rejected"}`,
           { variant: "error" },
@@ -326,6 +324,11 @@ export const createScenarioFileDropHandler =
     // Show a single aggregate message for too-many-files rejections
     if (tooManyFilesSeen) {
       enqueueSnackbar("Please upload only one file.", { variant: "error" });
+    }
+
+    // And one for fileless rejections so the drop isn't silent
+    if (filelessRejectionSeen) {
+      enqueueSnackbar("File could not be uploaded", { variant: "error" });
     }
 
     // Always process accepted files — react-dropzone already filters

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -4,6 +4,9 @@ import { AGENT_TYPES } from "../agents/constants";
 // Mirrors BE `no_of_rows.min_value`.
 export const MIN_DATASET_ROWS = 10;
 
+/** Maximum file size for scenario uploads (5 MB). */
+export const MAX_SCENARIO_FILE_SIZE = 5 * 1024 * 1024;
+
 export const CreateScenarioType = {
   DATASET: "dataset",
   SCRIPT: "script",
@@ -266,28 +269,69 @@ export const extractVersionFromScenarioName = (name, basePattern) => {
 export const createScenarioFileDropHandler =
   ({ enqueueSnackbar, onChange }) =>
   (acceptedFiles, fileRejections = []) => {
-    if (fileRejections?.length > 0) {
-      fileRejections.forEach((rejection) => {
-        const { file, errors = [] } = rejection || {};
-        if (!file) return;
+    const safeRejections = fileRejections || [];
+    let tooManyFilesSeen = false;
 
-        const isTooSmall = errors.some((e) => e?.code === "file-too-small");
-        if (isTooSmall) {
-          enqueueSnackbar(
-            `"${file.name}" is empty. Please upload a file with content.`,
-            { variant: "error" },
-          );
-        } else {
-          enqueueSnackbar(
-            `"${file.name}" could not be uploaded. ${errors[0]?.message || "File was rejected"}`,
-            { variant: "error" },
-          );
+    safeRejections.forEach((rejection) => {
+      const { file, errors } = rejection || {};
+
+      if (!file) {
+        // Still show a generic message so the drop isn't silent
+        enqueueSnackbar("File could not be uploaded", { variant: "error" });
+        return;
+      }
+
+      const safeErrors = errors || [];
+      const isTooSmall = safeErrors.some((e) => e?.code === "file-too-small");
+      const isInvalidType = safeErrors.some(
+        (e) => e?.code === "file-invalid-type",
+      );
+      const isTooLarge = safeErrors.some((e) => e?.code === "file-too-large");
+      const isTooMany = safeErrors.some((e) => e?.code === "too-many-files");
+
+      if (isTooMany) {
+        // Aggregate too-many-files into a single message below —
+        // still process other rejection types for this file.
+        tooManyFilesSeen = true;
+        if (!isTooSmall && !isInvalidType && !isTooLarge) {
+          // This file was ONLY rejected for too-many-files —
+          // don't show a per-file message for it.
+          return;
         }
-      });
-      return;
+      }
+
+      if (isTooSmall) {
+        enqueueSnackbar(
+          `"${file.name}" is empty. Please upload a file with content.`,
+          { variant: "error" },
+        );
+      } else if (isInvalidType) {
+        enqueueSnackbar(
+          "Unsupported file type. Please upload a TXT or PDF file.",
+          { variant: "error" },
+        );
+      } else if (isTooLarge) {
+        enqueueSnackbar(
+          "File size is too large. Please upload a file under 5 MB.",
+          { variant: "error" },
+        );
+      } else if (!isTooMany) {
+        enqueueSnackbar(
+          `"${file.name}" could not be uploaded. ${safeErrors[0]?.message || "File was rejected"}`,
+          { variant: "error" },
+        );
+      }
+    });
+
+    // Show a single aggregate message for too-many-files rejections
+    if (tooManyFilesSeen) {
+      enqueueSnackbar("Please upload only one file.", { variant: "error" });
     }
 
+    // Always process accepted files — react-dropzone already filters
+    // by minSize / maxSize / accept, so no manual size check is needed.
     const files = Array.from(acceptedFiles || []);
+    if (files.length === 0) return;
 
     const processedFiles = files.map((file) => ({
       file: file,


### PR DESCRIPTION
## What

The scenario Call/Chat SOP upload, Upload Script, and Knowledge Base file upload all accepted 0-byte (empty) files with no validation. An empty PDF or TXT could be attached and saved, causing downstream processing failures.

## Root cause

The three components bypassed react-dropzone's built-in `minSize` / `maxSize` validation and reimplemented size checking manually in `handleFileChange`. The manual check only enforced the upper bound (`file.size <= 5MB`), so a 0-byte file satisfied the condition and was accepted.

`showDropRejection` was set to `false` on all three components, hiding react-dropzone's native rejection display without providing an alternative path for rejected files.

## Fix

Three changes across the upload call chain:

1. **Pass `minSize` and `maxSize` to react-dropzone** via RHFUpload props. The library now rejects empty and oversized files before they reach `handleFileChange`.

2. **Handle rejected files from `onDrop`'s second argument**. react-dropzone calls `onDrop(acceptedFiles, fileRejections, event)` — the `fileRejections` parameter was being ignored. Rejected files now produce a friendly snackbar message mapped from the rejection code (`file-too-small`, `file-invalid-type`, `file-too-large`), with the raw library string only as a last-resort fallback for unknown codes.

3. **Clean up redundant manual validation**. Removed the hand-written `file.size > maxSize` / `file.size <= maxSize` filtering from `handleFileChange` in `CallChatSOPOption` and `UploadScriptOption` since react-dropzone now handles it. In `UploadKnowledgeBaseFile`, kept `handleShowSdkInfo` but wired it to `file-too-large` rejection codes instead of manual filtering.

### Behaviour notes

- **Valid files are never discarded.** Rejections are reported via toasts, then the handler always falls through to process `acceptedFiles` — so a valid file dropped alongside a rejected one still uploads (e.g. one valid `.txt` + one empty `.txt` → the empty file gets an error toast, the valid file is still attached).
- **`too-many-files` is aggregated into a single toast.** react-dropzone tags every excess file with `too-many-files`; the shared handler collapses these into one "Please upload only one file." message instead of stacking one near-identical toast per file. (See the Architecture note below — this branch is currently unreachable from the shared handler's actual consumers, both of which are single-file scenario dropzones; the multi-file Knowledge Base path uses its own handler that does not aggregate `too-many-files`.)
- **Knowledge Base rejected files don't block creation.** Rejected files are reported via toasts / the SDK dialog but are not appended to the file list with `status: "error"` rows, so the Create button stays enabled for the remaining valid files. An oversized file additionally opens the SDK info dialog — the toast + dialog combination here is intentional: the toast is consistent per-rejection feedback (same as empty / invalid-type), while the dialog is the separate large-file upsell flow.
- **Empty / invalid / oversized files produce friendly, named messages.** `"<name>" is empty. Please upload a file with content.`, `Unsupported file type. Please upload a TXT or PDF file.`, `File size is too large. Please upload a file under 5 MB.` — raw react-dropzone strings only appear as a fallback for unknown codes.

### Robustness additions

The `handleFileChange` callback is now defensive against malformed data from the dropzone:

- `acceptedFiles` — guarded with `|| []` before `Array.from`
- `fileRejections` items — `errors` normalized with `|| []` (covers both `undefined` and `null`), `file` guarded with `if (!file)`
- `rejected` array in `UploadKnowledgeBaseFile` — validated with `Array.isArray()`
- Error code check — `e?.code` optional chaining on each error object

These guards prevent the component from crashing if react-dropzone returns rejection data in an unexpected shape (version changes, browser quirks), and specifically prevent the Knowledge Base drawer from throwing when a rejection arrives without a `file` (the drawer reads `file.item.size` / `file.item.type` unguarded).

## Architecture note — `too-many-files` aggregation in the shared handler

`createScenarioFileDropHandler` (in `common.js`) contains a `too-many-files` branch that aggregates excess-file rejections into a single toast. I want to flag a design question for reviewers:

- The Call/Chat SOP and Upload Script dropzones both render `RHFUpload` **without** `multiple`, so they default to `multiple={false}`. In single-file mode react-dropzone only emits `too-many-files` when `acceptedFiles.length > 1`, which effectively never happens here — so the aggregation branch is **currently unreachable from the two scenario components that share this handler**.
- The multi-file Knowledge Base dropzone (`multiple={true}`) is the real consumer of `too-many-files`, but it uses its **own** `handleFileChange` in `UploadKnowledgeBaseFile.jsx`, not the shared handler.

So the `too-many-files` aggregation in the shared handler is, strictly, dead code today. Two reasonable options:

- **Keep it** (current choice): treat the shared handler as the single source of truth for dropzone rejection UX, with a clarifying comment. If either scenario dropzone is later switched to `multiple`, the aggregation already works.
- **Delete it**: keep the shared scenario handler lean (it only ever sees single-file drops), and let the KB handler own `too-many-files` if/when it needs it.

I've left it in for now and would like a reviewer call on delete-vs-keep before merge.

## Comparison with the other open PRs for #1392

There are two other open PRs targeting the same issue — #1397 and #1451. All three fix the empty-file acceptance, but they differ in scope and approach:

- **#1397** and **#1451** add a manual `file.size === 0` check next to the existing size filter, scoped to the two scenario files only. They emit a generic "File is empty" / "File cannot be empty" toast on an early `return`.
- **This PR (#1396)** uses react-dropzone's native `minSize`/`maxSize` validation instead of a hand-rolled `size === 0` check, and additionally fixes the **Knowledge Base upload**, which has the identical gap but is out of scope for the other two.

Why the native-validation approach here is preferable:

1. **Correct layer.** Size validation lives in the dropzone config, not reimplemented in the handler. Less code to maintain, and the library handles browser/version edge cases.
2. **Broader coverage.** The KB upload is fixed here too; #1397/#1451 leave it broken.
3. **No silent discard.** The other two PRs `return` on the first empty file, so dropping a valid file next to an empty one throws the valid file away. This PR reports the rejection via toast and still attaches the valid file.
4. **Real error mapping.** Friendly, per-code messages (`file-too-small` / `file-invalid-type` / `file-too-large`) instead of one generic string; `too-many-files` is aggregated; invalid/oversized types get proper feedback.
5. **No crash path.** Defensive `null`/missing-`file`/`errors` guards prevent the KB drawer from unmounting on malformed rejection data.
6. **Tests lock the fix.** 39 regression tests, including one that asserts `minSize`/`maxSize` are actually passed to `useDropzone` — so deleting `minSize={1}` fails CI (the other PRs add no tests in their descriptions).

## Files changed

| File | Change |
|------|--------|
| `frontend/src/sections/scenarios/CallChatSOPOption.jsx` | Switch to react-dropzone native validation + handle `fileRejections` |
| `frontend/src/sections/scenarios/UploadScriptOption.jsx` | Same |
| `frontend/src/sections/scenarios/common.js` | Shared `createScenarioFileDropHandler` factory + `MAX_SCENARIO_FILE_SIZE` |
| `frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx` | Add `minSize`/`maxSize` props, update `handleShowSdkInfo` trigger |
| `frontend/src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx` | 15 regression tests |
| `frontend/src/sections/scenarios/__tests__/UploadScriptOption.test.jsx` | 14 regression tests |
| `frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.test.jsx` | 10 regression tests |

## Test results

### New tests — 39/39 passed

```
✓ src/sections/scenarios/__tests__/CallChatSOPOption.test.jsx (15)
✓ src/sections/scenarios/__tests__/UploadScriptOption.test.jsx (14)
✓ src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.test.jsx (10)
```

Coverage includes: 0-byte rejection, valid file acceptance, mixed accept/reject (valid file still uploads), `too-many-files` aggregation, friendly messages for `file-too-small` / `file-invalid-type` / `file-too-large`, null-safety for `fileRejections` / `acceptedFiles` / `errors` / `file`, and `minSize` / `maxSize` propagation to `useDropzone`.

## Demo

https://github.com/user-attachments/assets/114b223f-4304-42d0-8706-ee136699b283

## Related

Closes #1392.
Intended to supersede #1397 and #1451 (both scope a manual `size === 0` check to the two scenario files only; this PR additionally fixes the Knowledge Base upload via react-dropzone's native `minSize`).
