### PR TITLE
fix(frontend): reject empty PDF/TXT uploads in scenario forms

### DIFF
--- a/frontend/src/sections/scenarios/CallChatSOPOption.jsx
+++ b/frontend/src/sections/scenarios/CallChatSOPOption.jsx
@@ -22,6 +22,15 @@ const CallChatSOPOption = ({ control }) => {
     const files = Array.from(acceptedFiles);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
+    const emptyFiles = files.filter((file) => file?.size === 0);
+
+    if (emptyFiles.length > 0) {
+      enqueueSnackbar("File is empty. Please upload a file with content.", {
+        variant: "error",
+      });
+      return;
+    }
+    
     const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
 
     if (filesLargerThanMaxSize.length > 0) {
@@ -31,7 +40,9 @@ const CallChatSOPOption = ({ control }) => {
       return;
     }
 
-    const validFiles = files.filter((file) => file.size <= maxSize);
+    const validFiles = files.filter(
+      (file) => file.size > 0 && file.size <= maxSize
+    );
 
     // Process each file to create preview URLs and metadata
     const processedFiles = validFiles.map((file) => {

--- a/frontend/src/sections/scenarios/UploadScriptOption.jsx
+++ b/frontend/src/sections/scenarios/UploadScriptOption.jsx
@@ -22,6 +22,17 @@ const UploadScriptOption = ({ control }) => {
     const files = Array.from(acceptedFiles);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
+
+    const emptyFiles = files.filter((file) => file?.size === 0);
+
+    if (emptyFiles.length > 0) {
+      enqueueSnackbar("File is empty. Please upload a file with content.", {
+        variant: "error",
+      });
+      return;
+    }
+
+
     const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
 
     if (filesLargerThanMaxSize.length > 0) {
@@ -31,8 +42,9 @@ const UploadScriptOption = ({ control }) => {
       return;
     }
 
-    const validFiles = files.filter((file) => file.size <= maxSize);
-
+    const validFiles = files.filter(
+      (file) => file.size > 0 && file.size <= maxSize
+    );
     // Process each file to create preview URLs and metadata
     const processedFiles = validFiles.map((file) => {
       //   const fileId = getRandomId();


### PR DESCRIPTION
## Summary

Fixes #1392.

### Changes
- Added validation to reject empty (0-byte) PDF/TXT uploads.
- Displays an error snackbar when an empty file is selected.
- Updated the valid file filter to require file size > 0.
- Applied the same validation to:
  - CallChatSOPOption.jsx
  - UploadScriptOption.jsx

### Behavior
- Empty PDF/TXT files are rejected with an error message.
- Files between 1 byte and 5 MB continue to work.
- Files larger than 5 MB continue to be rejected.