### PR TITLE
fix(dataset): unblock end-to-end Synthetic Data flow on local (TH-6521 / 6666-6669)

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -69303,13 +69303,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "columns": {
           "type": "array",
           "items": {
-            "type": "string",
-            "x-nullable": true
+            "$ref": "#/definitions/SyntheticDatasetColumn"
           }
         },
         "dataset": {
-          "title": "Dataset",
-          "type": "object"
+          "$ref": "#/definitions/SyntheticDatasetPayload"
         },
         "kb_id": {
           "title": "Kb id",
@@ -69338,12 +69336,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "columns": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "#/definitions/SyntheticDatasetColumn"
           }
         },
         "dataset": {
-          "title": "Dataset",
-          "type": "object"
+          "$ref": "#/definitions/SyntheticDatasetPayload"
         },
         "kb_id": {
           "title": "Kb id",
@@ -69405,13 +69402,11 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "columns": {
           "type": "array",
           "items": {
-            "type": "string",
-            "x-nullable": true
+            "$ref": "#/definitions/SyntheticDatasetColumn"
           }
         },
         "dataset": {
-          "title": "Dataset",
-          "type": "object"
+          "$ref": "#/definitions/SyntheticDatasetPayload"
         },
         "kb_id": {
           "title": "Kb id",
@@ -88743,6 +88738,69 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "$ref": "#/definitions/SyncLog"
           }
+        }
+      }
+    },
+    "SyntheticDatasetColumn": {
+      "required": [
+        "name",
+        "data_type",
+        "description",
+        "property"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string",
+          "minLength": 1
+        },
+        "data_type": {
+          "title": "Data type",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "property": {
+          "title": "Property",
+          "type": "object"
+        },
+        "skip": {
+          "title": "Skip",
+          "type": "boolean"
+        },
+        "is_new": {
+          "title": "Is new",
+          "type": "boolean"
+        }
+      }
+    },
+    "SyntheticDatasetPayload": {
+      "required": [
+        "description",
+        "objective",
+        "patterns"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "objective": {
+          "title": "Objective",
+          "type": "string"
+        },
+        "patterns": {
+          "title": "Patterns",
+          "type": "string"
         }
       }
     },

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -92340,7 +92340,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "reason_column",
         "is_numeric_eval",
         "is_numeric_eval_percentage",
-        "eval_tag",
         "metadata",
         "choices_map"
       ],
@@ -92415,8 +92414,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "boolean"
         },
         "eval_tag": {
-          "title": "Eval tag",
-          "type": "object"
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
         },
         "metadata": {
           "title": "Metadata",

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -8876,8 +8876,6 @@ export interface DatasetTableMetadataApi {
   status?: DatasetTableMetadataApiStatus;
 }
 
-export type DatasetTableColumnApiEvalTag = { [key: string]: unknown };
-
 export type DatasetTableColumnApiMetadata = { [key: string]: unknown };
 
 export type DatasetTableColumnApiChoicesMap = { [key: string]: unknown };
@@ -8903,7 +8901,7 @@ export interface DatasetTableColumnApi {
   reason_column: boolean;
   is_numeric_eval: boolean;
   is_numeric_eval_percentage: boolean;
-  eval_tag: DatasetTableColumnApiEvalTag;
+  eval_tag?: string[];
   metadata: DatasetTableColumnApiMetadata;
   choices_map: DatasetTableColumnApiChoicesMap;
 }

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -8309,12 +8309,30 @@ export interface CreateEmptyDatasetRequestApi {
   row?: number;
 }
 
-export type SyntheticDatasetCreationApiDataset = { [key: string]: unknown };
+export type SyntheticDatasetColumnApiProperty = { [key: string]: unknown };
+
+export interface SyntheticDatasetColumnApi {
+  /** @minLength 1 */
+  name: string;
+  /** @minLength 1 */
+  data_type: string;
+  description: string;
+  property: SyntheticDatasetColumnApiProperty;
+  skip?: boolean;
+  is_new?: boolean;
+}
+
+export interface SyntheticDatasetPayloadApi {
+  name?: string;
+  description: string;
+  objective: string;
+  patterns: string;
+}
 
 export interface SyntheticDatasetCreationApi {
   num_rows: number;
-  columns: string[];
-  dataset: SyntheticDatasetCreationApiDataset;
+  columns: SyntheticDatasetColumnApi[];
+  dataset: SyntheticDatasetPayloadApi;
   kb_id?: string;
 }
 
@@ -8768,12 +8786,10 @@ export interface DatasetStaticColumnRequestApi {
   source?: string;
 }
 
-export type SyntheticDataApiDataset = { [key: string]: unknown };
-
 export interface SyntheticDataApi {
   num_rows: number;
-  columns: string[];
-  dataset: SyntheticDataApiDataset;
+  columns: SyntheticDatasetColumnApi[];
+  dataset: SyntheticDatasetPayloadApi;
   kb_id?: string;
   fill_existing_rows?: boolean;
 }
@@ -9088,14 +9104,10 @@ export interface SyntheticDatasetConfigResponseApi {
   result: SyntheticDatasetConfigResultApi;
 }
 
-export type SyntheticDatasetConfigApiColumnsItem = { [key: string]: unknown };
-
-export type SyntheticDatasetConfigApiDataset = { [key: string]: unknown };
-
 export interface SyntheticDatasetConfigApi {
   num_rows: number;
-  columns: SyntheticDatasetConfigApiColumnsItem[];
-  dataset: SyntheticDatasetConfigApiDataset;
+  columns: SyntheticDatasetColumnApi[];
+  dataset: SyntheticDatasetPayloadApi;
   kb_id?: string;
   regenerate?: boolean;
 }

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -18128,6 +18128,7 @@ export const ModelHubDevelopsGetDatasetTableListQueryParams = zod.object({
 
 
 
+export const modelHubDevelopsGetDatasetTableListResponseResultColumnConfigItemEvalTagDefault = [];
 
 export const ModelHubDevelopsGetDatasetTableListResponse = zod.object({
   "status": zod.boolean(),
@@ -18158,9 +18159,7 @@ export const ModelHubDevelopsGetDatasetTableListResponse = zod.object({
   "reason_column": zod.boolean(),
   "is_numeric_eval": zod.boolean(),
   "is_numeric_eval_percentage": zod.boolean(),
-  "eval_tag": zod.object({
-
-}).passthrough(),
+  "eval_tag": zod.array(zod.string().min(1)).default(modelHubDevelopsGetDatasetTableListResponseResultColumnConfigItemEvalTagDefault),
   "metadata": zod.object({
 
 }).passthrough(),
@@ -18570,6 +18569,7 @@ export const ModelHubDevelopsGetExperimentDatasetTableListParams = zod.object({
 
 
 
+export const modelHubDevelopsGetExperimentDatasetTableListResponseResultColumnConfigItemEvalTagDefault = [];
 
 export const ModelHubDevelopsGetExperimentDatasetTableListResponse = zod.object({
   "status": zod.boolean(),
@@ -18600,9 +18600,7 @@ export const ModelHubDevelopsGetExperimentDatasetTableListResponse = zod.object(
   "reason_column": zod.boolean(),
   "is_numeric_eval": zod.boolean(),
   "is_numeric_eval_percentage": zod.boolean(),
-  "eval_tag": zod.object({
-
-}).passthrough(),
+  "eval_tag": zod.array(zod.string().min(1)).default(modelHubDevelopsGetExperimentDatasetTableListResponseResultColumnConfigItemEvalTagDefault),
   "metadata": zod.object({
 
 }).passthrough(),

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -17200,12 +17200,28 @@ export const ModelHubDevelopsCreateEmptyDatasetCreateResponse = zod.object({
 })
 
 
+
+
+
+
 export const ModelHubDevelopsCreateSyntheticDatasetCreateBody = zod.object({
   "num_rows": zod.number(),
-  "columns": zod.array(zod.string()),
-  "dataset": zod.object({
+  "columns": zod.array(zod.object({
+  "name": zod.string().min(1),
+  "data_type": zod.string().min(1),
+  "description": zod.string(),
+  "property": zod.object({
 
 }).passthrough(),
+  "skip": zod.boolean().optional(),
+  "is_new": zod.boolean().optional()
+})),
+  "dataset": zod.object({
+  "name": zod.string().optional(),
+  "description": zod.string(),
+  "objective": zod.string(),
+  "patterns": zod.string()
+}),
   "kb_id": zod.string().uuid().optional()
 })
 
@@ -17872,14 +17888,28 @@ export const ModelHubDevelopsAddSyntheticDataCreateParams = zod.object({
   "dataset_id": zod.string()
 })
 
+
+
 export const modelHubDevelopsAddSyntheticDataCreateBodyFillExistingRowsDefault = false;
 
 export const ModelHubDevelopsAddSyntheticDataCreateBody = zod.object({
   "num_rows": zod.number(),
-  "columns": zod.array(zod.string()),
-  "dataset": zod.object({
+  "columns": zod.array(zod.object({
+  "name": zod.string().min(1),
+  "data_type": zod.string().min(1),
+  "description": zod.string(),
+  "property": zod.object({
 
 }).passthrough(),
+  "skip": zod.boolean().optional(),
+  "is_new": zod.boolean().optional()
+})),
+  "dataset": zod.object({
+  "name": zod.string().optional(),
+  "description": zod.string(),
+  "objective": zod.string(),
+  "patterns": zod.string()
+}),
   "kb_id": zod.string().uuid().optional(),
   "fill_existing_rows": zod.boolean().default(modelHubDevelopsAddSyntheticDataCreateBodyFillExistingRowsDefault)
 })
@@ -18386,16 +18416,28 @@ export const ModelHubDevelopsUpdateSyntheticConfigUpdateParams = zod.object({
   "dataset_id": zod.string()
 })
 
+
+
 export const modelHubDevelopsUpdateSyntheticConfigUpdateBodyRegenerateDefault = false;
 
 export const ModelHubDevelopsUpdateSyntheticConfigUpdateBody = zod.object({
   "num_rows": zod.number(),
   "columns": zod.array(zod.object({
-
-}).passthrough()),
-  "dataset": zod.object({
+  "name": zod.string().min(1),
+  "data_type": zod.string().min(1),
+  "description": zod.string(),
+  "property": zod.object({
 
 }).passthrough(),
+  "skip": zod.boolean().optional(),
+  "is_new": zod.boolean().optional()
+})),
+  "dataset": zod.object({
+  "name": zod.string().optional(),
+  "description": zod.string(),
+  "objective": zod.string(),
+  "patterns": zod.string()
+}),
   "kb_id": zod.string().uuid().optional(),
   "regenerate": zod.boolean().default(modelHubDevelopsUpdateSyntheticConfigUpdateBodyRegenerateDefault)
 })

--- a/frontend/src/sections/develop-detail/DatasetsSelectRow.jsx
+++ b/frontend/src/sections/develop-detail/DatasetsSelectRow.jsx
@@ -61,7 +61,7 @@ const DatasetsSelectRow = ({
   );
 
   const isData = Boolean(tableData?.data?.result?.table?.length);
-  const isSyntheticDataset = Boolean(tableData?.data?.result?.syntheticDataset);
+  const isSyntheticDataset = Boolean(tableData?.data?.result?.synthetic_dataset);
   const plusRef = useRef(null);
   const compareRef = useRef(null);
   const theme = useTheme();

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
@@ -73,7 +73,7 @@ const DevelopBarLeftSection = ({
   const { processingComplete } = useDatasetOriginStore();
 
   const isData = Boolean(tableData?.data?.result?.table?.length);
-  const isSyntheticDataset = Boolean(tableData?.data?.result?.syntheticDataset);
+  const isSyntheticDataset = Boolean(tableData?.data?.result?.synthetic_dataset);
   const theme = useTheme();
   const { search, setSearch } = useDevelopSearchStore();
   const setCellHeight = useDevelopCellHeight((s) => s.setCellHeight);

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataRightSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataRightSection.jsx
@@ -68,7 +68,7 @@ const DevelopDataRightSection = ({ hideScenarioFeatures = false }) => {
   const { processingComplete } = useDatasetOriginStore();
 
   const isData = Boolean(tableData?.data?.result?.table?.length);
-  const isSyntheticDataset = Boolean(tableData?.data?.result?.syntheticDataset);
+  const isSyntheticDataset = Boolean(tableData?.data?.result?.synthetic_dataset);
   const processingData = Boolean(tableData?.data?.result?.isProcessingData);
   const buttonStyles = {
     color: "text.primary",

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx
@@ -78,7 +78,7 @@ const SyntheticDataDrawer = ({
   const navigate = useNavigate();
 
   const { data: knowledgeBaseList, refetch: refetchKnowledgeBaseList } =
-    useKnowledgeBaseList("", { enabled: !!open }, { status: true });
+    useKnowledgeBaseList("", { enabled: !!open });
 
   const knowledgeBaseOptions = useMemo(
     () =>

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/DetailForm.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/DetailForm.jsx
@@ -23,9 +23,7 @@ const DetailForm = ({
   const [sameRows, setSameRow] = useState(true);
   const navigate = useNavigate();
   const { data: knowledgeBaseList, isPending: isKnowledgeBaseListPending } =
-    useKnowledgeBaseList("", null, {
-      status: true,
-    });
+    useKnowledgeBaseList("", null);
 
   const knowledgeBaseOptions = useMemo(
     () =>

--- a/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx
@@ -165,9 +165,7 @@ const CreateSyntheticDataView = ({
       : navigate("/dashboard/develop");
   };
 
-  const { data: knowledgeBaseList } = useKnowledgeBaseList("", null, {
-    status: true,
-  });
+  const { data: knowledgeBaseList } = useKnowledgeBaseList("", null);
 
   const knowledgeBaseOptions = useMemo(
     () =>

--- a/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
@@ -47,9 +47,7 @@ const SyntheticSummary = ({ summaryData = {}, onClose, isLoading }) => {
     columns = [],
   } = summaryData;
 
-  const { data: knowledgeBaseList } = useKnowledgeBaseList("", null, {
-    status: true,
-  });
+  const { data: knowledgeBaseList } = useKnowledgeBaseList("", null);
 
   const knowledgeBaseOptions = useMemo(
     () =>

--- a/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx
@@ -42,8 +42,8 @@ const SyntheticSummary = ({ summaryData = {}, onClose, isLoading }) => {
   const theme = useTheme();
   const {
     dataset = {},
-    numRows: rowNumber = "",
-    kbId = "",
+    num_rows: rowNumber = "",
+    kb_id: kbId = "",
     columns = [],
   } = summaryData;
 
@@ -259,11 +259,11 @@ export default function SyntheticSummaryDrawer() {
   const { data, isLoading } = useQuery({
     queryKey: [
       dataset,
-      tableData?.data?.result?.syntheticDataset,
+      tableData?.data?.result?.synthetic_dataset,
       openSummaryDrawer,
     ],
     queryFn: () => axios.get(endpoints.develop.getSyntheticConfig(dataset)),
-    enabled: !!dataset && !!tableData?.data?.result?.syntheticDataset,
+    enabled: !!dataset && !!tableData?.data?.result?.synthetic_dataset,
     select: (d) => d.data?.result?.data,
   });
 

--- a/futureagi/model_hub/serializers/develop_dataset.py
+++ b/futureagi/model_hub/serializers/develop_dataset.py
@@ -47,86 +47,41 @@ class UploadFileForm(forms.Form):
     )
 
 
+class SyntheticDatasetColumnSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    data_type = serializers.CharField()
+    description = serializers.CharField(allow_blank=True)
+    property = serializers.JSONField()
+    skip = serializers.BooleanField(required=False)
+    is_new = serializers.BooleanField(required=False)
+
+
+class SyntheticDatasetPayloadSerializer(serializers.Serializer):
+    # `name` is optional on the nested type so the fill-existing-rows /
+    # config-update flows can reuse it; the create serializer requires it
+    # explicitly in `validate_dataset`.
+    name = serializers.CharField(required=False, allow_blank=True)
+    description = serializers.CharField(allow_blank=True)
+    objective = serializers.CharField(allow_blank=True)
+    patterns = serializers.CharField(allow_blank=True)
+
+
 class SyntheticDatasetCreationSerializer(serializers.Serializer):
     num_rows = serializers.IntegerField()
-    columns = serializers.ListField()
-    dataset = serializers.JSONField()
+    columns = SyntheticDatasetColumnSerializer(many=True)
+    dataset = SyntheticDatasetPayloadSerializer()
     kb_id = serializers.UUIDField(required=False)
 
     def validate_dataset(self, value):
-        if not isinstance(value, dict):
-            raise serializers.ValidationError("dataset must be a JSON object.")
-
-        required_keys = {"name", "description", "objective", "patterns"}
-
-        missing_keys = required_keys - value.keys()
-        if missing_keys:
-            raise serializers.ValidationError(
-                f"dataset must contain the keys: {', '.join(required_keys)}."
-            )
-
-        return value
-
-    def validate_columns(self, value):
-        if not isinstance(value, list):
-            raise serializers.ValidationError("columns must be a list of JSON objects.")
-
-        required_keys = {"name", "data_type", "description", "property"}
-
-        for item in value:
-            if not isinstance(item, dict):
-                raise serializers.ValidationError(
-                    "Each item in columns must be a JSON object."
-                )
-
-            missing_keys = required_keys - item.keys()
-            if missing_keys:
-                raise serializers.ValidationError(
-                    f"Each JSON object in columns must contain the keys: {', '.join(sorted(missing_keys))}."
-                )
-
+        if not value.get("name"):
+            raise serializers.ValidationError("dataset must contain a 'name'.")
         return value
 
 
 class SyntheticDataSerializer(SyntheticDatasetCreationSerializer):
     fill_existing_rows = serializers.BooleanField(default=False)
 
-    def validate_columns(self, value):
-        if not isinstance(value, list):
-            raise serializers.ValidationError("columns must be a list of JSON objects.")
-
-        required_keys = {
-            "name",
-            "data_type",
-            "description",
-            "skip",
-            "is_new",
-            "property",
-        }
-
-        for item in value:
-            if not isinstance(item, dict):
-                raise serializers.ValidationError(
-                    "Each item in columns must be a JSON object."
-                )
-
-            missing_keys = required_keys - item.keys()
-            if missing_keys:
-                raise serializers.ValidationError(
-                    f"Each JSON object in columns must contain the keys: {', '.join(sorted(missing_keys))}."
-                )
-
-        return value
-
     def validate_dataset(self, value):
-        if not isinstance(value, dict):
-            raise serializers.ValidationError("dataset must be a JSON object.")
-        required_keys = {"description", "objective", "patterns"}
-        missing_keys = required_keys - value.keys()
-        if missing_keys:
-            raise serializers.ValidationError(
-                f"dataset must contain the keys: {', '.join(required_keys)}."
-            )
         return value
 
 
@@ -134,29 +89,10 @@ class SyntheticDatasetConfigSerializer(serializers.Serializer):
     """Serializer for getting and updating synthetic dataset configuration"""
 
     num_rows = serializers.IntegerField()
-    columns = serializers.ListField(child=serializers.JSONField())
-    dataset = serializers.JSONField()
+    columns = SyntheticDatasetColumnSerializer(many=True)
+    dataset = SyntheticDatasetPayloadSerializer()
     kb_id = serializers.UUIDField(required=False, allow_null=True)
     regenerate = serializers.BooleanField(required=False, default=False)
-
-    def validate_columns(self, value):
-        if not isinstance(value, list):
-            raise serializers.ValidationError("columns must be a list of JSON objects.")
-
-        required_keys = {"name", "data_type", "description", "property"}
-        for item in value:
-            if not isinstance(item, dict):
-                raise serializers.ValidationError(
-                    "Each item in columns must be a JSON object."
-                )
-
-            missing_keys = required_keys - item.keys()
-            if missing_keys:
-                raise serializers.ValidationError(
-                    f"Each JSON object in columns must contain the keys: {', '.join(sorted(missing_keys))}."
-                )
-
-        return value
 
     def validate_dataset(self, value):
         if not isinstance(value, dict):

--- a/futureagi/model_hub/serializers/develop_dataset.py
+++ b/futureagi/model_hub/serializers/develop_dataset.py
@@ -57,9 +57,7 @@ class SyntheticDatasetColumnSerializer(serializers.Serializer):
 
 
 class SyntheticDatasetPayloadSerializer(serializers.Serializer):
-    # `name` is optional on the nested type so the fill-existing-rows /
-    # config-update flows can reuse it; the create serializer requires it
-    # explicitly in `validate_dataset`.
+    # Optional here; each caller enforces name in `validate_dataset`.
     name = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(allow_blank=True)
     objective = serializers.CharField(allow_blank=True)
@@ -95,37 +93,8 @@ class SyntheticDatasetConfigSerializer(serializers.Serializer):
     regenerate = serializers.BooleanField(required=False, default=False)
 
     def validate_dataset(self, value):
-        if not isinstance(value, dict):
-            raise serializers.ValidationError("dataset must be a JSON object.")
-
-        required_keys = {"name", "description", "objective", "patterns"}
-
-        missing_keys = required_keys - value.keys()
-        if missing_keys:
-            raise serializers.ValidationError(
-                f"dataset must contain the keys: {', '.join(required_keys)}."
-            )
-
-        return value
-
-    def validate_columns(self, value):
-        if not isinstance(value, list):
-            raise serializers.ValidationError("columns must be a list of JSON objects.")
-
-        required_keys = {"name", "data_type", "description", "property"}
-
-        for item in value:
-            if not isinstance(item, dict):
-                raise serializers.ValidationError(
-                    "Each item in columns must be a JSON object."
-                )
-
-            missing_keys = required_keys - item.keys()
-            if missing_keys:
-                raise serializers.ValidationError(
-                    f"Each JSON object in columns must contain the keys: {', '.join(required_keys)}."
-                )
-
+        if not value.get("name"):
+            raise serializers.ValidationError("dataset must contain a 'name'.")
         return value
 
 

--- a/futureagi/model_hub/serializers/develop_dataset_contracts.py
+++ b/futureagi/model_hub/serializers/develop_dataset_contracts.py
@@ -114,7 +114,7 @@ class DatasetTableColumnSerializer(serializers.Serializer):
     reason_column = serializers.BooleanField()
     is_numeric_eval = serializers.BooleanField()
     is_numeric_eval_percentage = serializers.BooleanField()
-    eval_tag = serializers.JSONField()
+    eval_tag = serializers.ListField(child=serializers.CharField(), default=list)
     metadata = serializers.JSONField()
     choices_map = serializers.JSONField()
 

--- a/futureagi/model_hub/tests/test_dataset_creation_import_api.py
+++ b/futureagi/model_hub/tests/test_dataset_creation_import_api.py
@@ -52,7 +52,7 @@ def _synthetic_create_payload(name, num_rows=10, columns=None, regenerate=None):
             "name": name,
             "description": "Dataset",
             "objective": "Generate rows",
-            "patterns": [],
+            "patterns": "",
         },
     }
     if regenerate is not None:
@@ -77,7 +77,7 @@ def _synthetic_add_rows_payload(num_rows=10):
         "dataset": {
             "description": "Dataset",
             "objective": "Generate rows",
-            "patterns": [],
+            "patterns": "",
         },
     }
 

--- a/futureagi/model_hub/tests/test_dataset_creation_import_api.py
+++ b/futureagi/model_hub/tests/test_dataset_creation_import_api.py
@@ -1067,3 +1067,62 @@ def test_update_synthetic_invalid_regenerate_does_not_mutate_dataset(
     assert Row.objects.filter(dataset=dataset, deleted=False).count() == 1
     assert Column.objects.filter(dataset=dataset, deleted=False).count() == 1
     assert Cell.objects.filter(dataset=dataset, deleted=False).count() == 1
+
+
+@pytest.mark.django_db
+def test_add_synthetic_data_accepts_columns_without_skip_or_is_new(
+    auth_client, organization, workspace, user, monkeypatch
+):
+    dataset = Dataset.objects.create(
+        name="Minimal Column Payload Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        column_order=[],
+        column_config={},
+    )
+    column = Column.objects.create(
+        name="answer",
+        dataset=dataset,
+        data_type=DataTypeChoices.TEXT.value,
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(column.id)]
+    dataset.column_config = {str(column.id): {"is_visible": True, "is_frozen": None}}
+    dataset.save(update_fields=["column_order", "column_config"])
+    queued_tasks = []
+    monkeypatch.setattr(
+        "model_hub.views.datasets.add_rows.synthetic.generate_new_rows.delay",
+        lambda *args, **kwargs: queued_tasks.append(("add_rows", args, kwargs)),
+    )
+    monkeypatch.setattr(
+        "model_hub.views.datasets.add_rows.synthetic.generate_new_columns.delay",
+        lambda *args, **kwargs: queued_tasks.append(("gen_cols", args, kwargs)),
+    )
+
+    payload = {
+        "num_rows": 10,
+        "fill_existing_rows": False,
+        "columns": [
+            {
+                "name": "answer",
+                "data_type": "text",
+                "description": "Answer",
+                "property": "answer",
+            }
+        ],
+        "dataset": {
+            "description": "Dataset",
+            "objective": "Generate rows",
+            "patterns": "",
+        },
+    }
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/add_synthetic_data/",
+        payload,
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert any(name == "add_rows" for name, _, _ in queued_tasks)

--- a/futureagi/model_hub/views/datasets/add_rows/synthetic.py
+++ b/futureagi/model_hub/views/datasets/add_rows/synthetic.py
@@ -79,9 +79,9 @@ class AddSyntheticData(APIView):
                 return self._gm.bad_request(get_error_message("10_ROWS_REQUIRED"))
 
             columns = validated_data["columns"]
-            gen_columns = [col for col in columns if not col["skip"]]
-            new_columns = [col for col in columns if col["is_new"]]
-            gen_new_columns = [col for col in gen_columns if col["is_new"]]
+            gen_columns = [col for col in columns if not col.get("skip", False)]
+            new_columns = [col for col in columns if col.get("is_new", False)]
+            gen_new_columns = [col for col in gen_columns if col.get("is_new", False)]
 
             # Generate New Columns
             generated_columns = []

--- a/futureagi/model_hub/views/datasets/create/synthetic.py
+++ b/futureagi/model_hub/views/datasets/create/synthetic.py
@@ -394,7 +394,10 @@ class UpdateSyntheticDatasetConfigView(APIView):
                             status=CellStatus.RUNNING.value,
                         )
 
-                dataset.synthetic_dataset_config = validated_data
+                config_data = dict(validated_data)
+                if config_data.get("kb_id"):
+                    config_data["kb_id"] = str(config_data["kb_id"])
+                dataset.synthetic_dataset_config = config_data
                 dataset.save()
 
                 request_uuid = task_manager.start_task(str(dataset.id))


### PR DESCRIPTION
## Summary

Unblocks the end-to-end Synthetic Data flow on local dev, which was broken at five distinct places between the create-dataset click and the regenerate loop. Every fix is one class of drift: API contracts, snake_case, or a UUID edge case in a JSONField write, and all five surfaced while walking the same reviewer path (create synthetic dataset -> open Configure Synthetic Data drawer -> regenerate).

Nothing here is a feature change: the FE and BE already agreed on the intended shapes at runtime; the schema / serializers / callers were the parts that drifted.

## Per-fix breakdown

| Commit | Ticket | Class | What broke, in one line |
|---|---|---|---|
| `76040787d` | TH-6521 | Dead FE query param | `useKnowledgeBaseList` sent `?status=true` to a `StrictInputSerializer` that rejects it, so the KB dropdown 400ed the moment the drawer opened. |
| `16638c292` | TH-6666 | Contract drift on request body | `SyntheticDatasetCreationSerializer` typed `columns` as a bare `ListField` and `dataset` as `JSONField`, so codegen emitted `string[]` and `Record<string, unknown>`; the FE (correctly) sent objects and the local strict request-contract validator blocked every create call before it hit the network. |
| `adc086177` | TH-6667 | Contract drift on response body | `DatasetTableColumn.eval_tag` was typed as `JSONField` but returned as `string[]`; the response validator rejected the whole payload, and every downstream consumer of the dataset detail (including the Configure Synthetic Data drawer's gate) got `undefined`. |
| `faec25669` | TH-6668 | Snake_case drift | Four FE readers checked `result.syntheticDataset` (camelCase); the BE emits `result.synthetic_dataset` (snake_case). Every synthetic dataset was treated as non-synthetic, and the Configure drawer never fired its config fetch. |
| `71d0884f3` | TH-6669 | Pre-existing UUID-in-JSONField | The `regenerate: true` branch of `update-synthetic-config` assigned `validated_data` (with a `UUID` for `kb_id`) directly to a JSONField; `full_clean` threw `Value must be valid JSON`. The other two persistence sites in the same file already stringify `kb_id`; this one was skipped. Exposed the moment the FE actually clicked "Regenerate".

## Per-file changes

**BE:**

| File | Change |
|---|---|
| `futureagi/model_hub/serializers/develop_dataset.py` | Two new nested serializers (`SyntheticDatasetColumnSerializer`, `SyntheticDatasetPayloadSerializer`) wired into all three synthetic-dataset serializers; redundant manual `validate_columns`/`validate_dataset` methods deleted; `name`-required kept as a one-line override on the create serializer so the fill-existing-rows / update-config paths can share the base shape. |
| `futureagi/model_hub/serializers/develop_dataset_contracts.py` | `DatasetTableColumn.eval_tag` retyped from `JSONField` to `ListField(child=CharField(), default=list)` to match what the view actually returns. |
| `futureagi/model_hub/views/datasets/create/synthetic.py` | Regenerate branch of `UpdateSyntheticDatasetConfigView.put` now copies the dict and stringifies `kb_id` before assigning to `synthetic_dataset_config`; mirrors the two sibling persistence sites in the same file. |
| `api_contracts/openapi/swagger.json` | Regenerated. Two new definitions for the synthetic-dataset request body; three call sites now `$ref` them instead of bare `ListField` / `JSONField`. `DatasetTableColumn.eval_tag` now typed as `string[]`. |

**FE (regenerated) (regen from BE):**

| File | Change |
|---|---|
| `frontend/src/api/contracts/openapi-contract.generated.js` | Same regen. |
| `frontend/src/generated/api-contracts/api.schemas.ts` | New `SyntheticDatasetColumnApi` and `SyntheticDatasetPayloadApi` interfaces; `DatasetTableColumnApi.eval_tag` is now `string[]`. |
| `frontend/src/generated/api-contracts/api.zod.ts` | Regenerated. |

**FE (hand-edited):**

| File | Change |
|---|---|
| `frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData.jsx` | Drop `{status: true}` from the `useKnowledgeBaseList` call. |
| `frontend/src/sections/develop/AddRowDrawer/CreateSyntheticDataView.jsx` | Same. |
| `frontend/src/sections/develop/AddRowDrawer/CreateSyntheticData/DetailForm.jsx` | Same. |
| `frontend/src/sections/develop/AddRowDrawer/EditSyntheticData/SyntheticSummaryDrawer.jsx` | Same, plus the snake_case fix: gate reads `result.synthetic_dataset`, and `SyntheticSummary` destructure aliases `num_rows -> rowNumber` and `kb_id -> kbId` so the child JSX is unchanged. |
| `frontend/src/sections/develop-detail/DatasetsSelectRow.jsx` | Read `result.synthetic_dataset` (snake_case). |
| `frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx` | Same. |
| `frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataRightSection.jsx` | Same. |

## Behaviour callouts

- `SyntheticDatasetCreationSerializer`'s nested column serializer accepts `skip` and `is_new` as optional; the fill-existing-rows path can carry them without breaking the vanilla create path. Same nested types are reused by `SyntheticDatasetConfigSerializer` (get / update) so all three endpoints agree on shape.
- Zod `.passthrough()` and DRF's default behaviour both silently accept extras, so anything the FE spreads through `...item` on columns is preserved on FE validation and dropped at DRF's `validated_data` boundary. No caller changes needed.
- `DatasetTableColumn.eval_tag` is retyped in the response schema only. Existing rows on disk are unchanged; there is no backfill and none is required. The runtime already emits `list[str]`; only the contract was drifting.

## Scope out

- No FE contract fallback (`row.x ?? row.X`) is introduced anywhere. All snake_case reads switch to the canonical shape; if any consumer relied on the camel alias it will surface as a real bug.
- Celery workers are still commented out of the dev docker-compose (this repo uses Temporal for synthetic generation and the workflow ran end-to-end on `temporal-worker-dev` while I was verifying). Out of scope for this PR.

## Test coverage

Existing FE contract tests (`frontend/src/api/contracts/__tests__/openapi-contract.test.js`) already assert the pipeline against a captured `get-dataset-table` response. The regenerated `api.schemas.ts` and `api.zod.ts` are exercised at import time by `yarn contracts:check`, which is green.

No unit-test additions in this PR:

- The BE nested serializers duplicate the invariants the deleted manual `validate_*` methods asserted; the assertions are now declarative on the field definitions.
- The `kb_id` stringify is a one-line mirror of the same pattern already present at `synthetic.py:189-192` and `synthetic.py:626-629`; adding a new test here without touching the other two sites would be uneven coverage.
- The snake_case fix is a rename at the call site; the destination key is what the BE serializer emits, so a fixture-backed hook test would just re-assert the shape the FE now reads.

## Local test runbook

```
# BE swagger
DJANGO_SETTINGS_MODULE=tfc.settings.test ./scripts/generate-openapi-schema.sh

# FE contracts
cd frontend && yarn contracts:generate && yarn contracts:check
```

Manual verification, in one pass:

1. Local FE on `fix/th-6521-kb-status-param`, `VITE_API_CONTRACTS` unset. Network tab open, filter `knowledge-base`.
2. Develop -> New dataset -> pick Synthetic Data. `GET /model-hub/knowledge-base/get/` should be 200 with no `?status=true`. KB dropdown populates.
3. Fill name / description / 10+ rows / at least 2 columns. Click Create Dataset. `POST /create-synthetic-dataset/` returns 200; UI navigates to `/develop/{new_id}?tab=data`. Console has no `[CONTRACT-DEBUG]` line.
4. On the dataset detail page, open the "Configure Synthetic Data" chip. Right drawer opens; body renders Name / Knowledge Base / Description / No. of rows / one card per column. `GET .../synthetic-config/` fires and returns 200. `get-dataset-table` also 200 with no `eval_tag: Expected object, received array` in the console.
5. Click "Edit Configuration", change a field, click Regenerate. `PUT .../update-synthetic-config/` returns 200 with `regenerate: true` in the payload. The dataset flips back to `Generating synthetic data`. On the BE side the Temporal workflow `task-create_synthetic_dataset-*` picks up on the `tasks_xl` queue and the activity progresses (verified via temporal-worker-dev logs; the LLM is Vertex Gemini 2.5 Pro on the codepath used here).

## Screenshot / Video

Existing bad-path screenshot (kept for the KB 400 that TH-6521 fixes):

<img width="2562" height="1880" alt="image" src="https://github.com/user-attachments/assets/da871b0b-efab-46bf-a790-631038d3ad79" />

End-to-end flow after all five fixes (create -> populated drawer -> regenerate -> generation in progress):

https://github.com/user-attachments/assets/4fe53a2a-fd58-440b-b938-68a38284bd08

## Linear

Fix TH-6521
Fix TH-6666
Fix TH-6667
Fix TH-6668
Fix TH-6669
