### PR TITLE
fix(evals): suppress (not in row) chip on traces and voiceCalls (TH-6291)

### DIFF
--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -1086,12 +1086,13 @@ const VariableMappingView = ({
 }) => {
   const fieldSet = useMemo(() => new Set(fieldNames), [fieldNames]);
   const hasEvals = evalsDetails.length > 0;
-  // For sessions the lazy fetch only covers `traces[0].spans`, so the
-  // walker over the preview detail can't witness paths into other traces
-  // or beyond the first trace's loaded spans. The `(not in row)` chip
-  // becomes misinformation in that regime — the BE is the authoritative
-  // resolver at test time. Suppress the check entirely for sessions.
-  const skipRowCheck = rowType === "sessions";
+  // Walker paths only line up with the mapping shape for `spans`; for
+  // sessions / traces / voiceCalls the BE is the authoritative resolver
+  // at test time, so the local (not in row) chip would misfire.
+  const skipRowCheck =
+    rowType === "sessions" ||
+    rowType === "traces" ||
+    rowType === "voiceCalls";
 
   if (!hasEvals) return null;
 


### PR DESCRIPTION
## Summary

Task Live Preview renders a cosmetic `(not in row)` chip next to variable mappings when the FE walker cannot find the mapped path on the preview row. On trace and voiceCall rows the walker's paths do not line up with the shape saved in the mapping, so the chip fires for mappings that are actually resolved server-side at test time. The eval passes with real content, but the UI tells the user the field is missing.

## Root cause

Three separate resolution regimes in `sections/tasks/components/TaskLivePreview.jsx`:

1. FE `fieldNames` / `fieldSet.has(field)` for the chip (`:432-473`).
2. FE `flatValueMap` for local `resolveMapping` (`:498-536`).
3. BE resolver at test time, invoked via `evalExecution.js:34-46` with just `trace_id` and told to resolve `{{span}}` / `{{trace}}` / `{{session}}` server-side.

Trace preview shape at `TaskLivePreview.jsx:353-357`:

```js
const traceInfo = traceResult?.trace || {};
const allSpans = flattenSpanTree(spans);
detailData = { ...traceInfo, spans: allSpans };
```

Walker on this shape produces paths like `spans.0.output.value`. `stripAttributePathPrefix` (`utils/utils.js:1361`) collapses `.span_attributes.` but does not collapse the `spans.N.` prefix, so `fieldNames` holds `spans.0.output.value` while the saved mapping stores `output.value` (the shape the BE resolver exposes to the picker).

Result: `fieldSet.has("output.value")` is `false`, chip renders `(not in row)`. `flatValueMap["output.value"]` is `undefined`, local preview shows no value. BE still resolves the mapping correctly at test time and the eval passes with real data. Same failure mode already recognised for sessions; the guard just did not extend to traces or voiceCalls.

## Fix

Extend `skipRowCheck` at `TaskLivePreview.jsx:1094` to cover traces and voiceCalls in addition to sessions. `rowType === "spans"` is unchanged because for spans the walker's paths do match the mapping shape and the chip is meaningful there.

Comment tightened to a single sentence describing the invariant. FE only, 7 insertions / 6 deletions.