### PR TITLE
fix(simulate): show current execution's timestamp on rerun detail page (TH-6486)

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -70191,6 +70191,20 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "readOnly": true,
           "minLength": 1
+        },
+        "started_at": {
+          "title": "Started at",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "x-nullable": true
+        },
+        "created_at": {
+          "title": "Created at",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "x-nullable": true
         }
       }
     },

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -17876,6 +17876,8 @@ export interface TestExecutionDetailResponseApi {
   readonly provider?: string;
   /** @minLength 1 */
   readonly agent_type?: string;
+  readonly started_at?: string;
+  readonly created_at?: string;
 }
 
 /**

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -33147,7 +33147,9 @@ export const SimulateTestExecutionsReadResponse = zod.object({
   "error_messages": zod.array(zod.string().min(1)).optional(),
   "status": zod.string().min(1).optional(),
   "provider": zod.string().min(1).optional(),
-  "agent_type": zod.string().min(1).optional()
+  "agent_type": zod.string().min(1).optional(),
+  "started_at": zod.string().datetime({"offset":true}).optional(),
+  "created_at": zod.string().datetime({"offset":true}).optional()
 })
 
 

--- a/frontend/src/hooks/useTestExecutionDetail.js
+++ b/frontend/src/hooks/useTestExecutionDetail.js
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+
+// The endpoint is paginated call rows, but the parent test_execution
+// timestamps (started_at, created_at) live at the top level of the
+// response, so page=1 / limit=1 is enough for the header lookup.
+export const useTestExecutionDetail = (executionId) => {
+  const result = useQuery({
+    queryKey: ["test-execution-detail", executionId],
+    queryFn: () =>
+      axios.get(endpoints.testExecutions.list(executionId), {
+        params: { page: 1, limit: 1 },
+      }),
+    select: (d) => d?.data,
+    enabled: Boolean(executionId),
+  });
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+  };
+};
+
+export default useTestExecutionDetail;

--- a/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
+++ b/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
@@ -23,6 +23,7 @@ import { AGENT_TYPES } from "../agents/constants";
 import axios, { endpoints } from "src/utils/axios";
 import TestDetailBreadcrumb from "./TestDetailBreadcrumb";
 import useTestRunDetails from "src/hooks/useTestRunDetails";
+import useTestExecutionDetail from "src/hooks/useTestExecutionDetail";
 import CallStatus from "../test/CallLogs/CallStatus";
 import CallMetadataSection from "./components/CallMetadataSection";
 import { formatStartTimeByRequiredFormat } from "src/utils/utils";
@@ -53,6 +54,7 @@ const TestRunDetailHeader = () => {
     },
   );
   const { data: testData } = useTestRunDetails(testId);
+  const { data: executionDetail } = useTestExecutionDetail(executionId);
   const { data: kpis } = useKpis(executionId);
   const agentType = kpis?.agent_type;
   const handleRerun = () => {
@@ -92,8 +94,14 @@ const TestRunDetailHeader = () => {
       },
     });
   };
+  // Prefer the current execution's start time so rerun detail pages show
+  // that execution's timestamp instead of the parent RunTest.created_at.
+  const runStartTimestamp =
+    executionDetail?.started_at ??
+    executionDetail?.created_at ??
+    testData?.created_at;
   const formattedStartTime = formatStartTimeByRequiredFormat(
-    testData?.created_at,
+    runStartTimestamp,
     "dd-MM-yyyy HH:mm:ss",
   );
 
@@ -343,7 +351,7 @@ const TestRunDetailHeader = () => {
                   },
                   {
                     id: "time",
-                    condition: testData?.created_at && !!formattedStartTime,
+                    condition: !!runStartTimestamp && !!formattedStartTime,
                     value: `Run Start: ${formattedStartTime}`,
                   },
                   {

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -1223,6 +1223,14 @@ class TestExecutionDetailResponseSerializer(serializers.Serializer):
     status = serializers.CharField(read_only=True, required=False)
     provider = serializers.CharField(read_only=True, required=False)
     agent_type = serializers.CharField(read_only=True, required=False)
+    # Per-execution timestamps so a rerun detail page can render its own
+    # start time rather than the parent RunTest's created_at.
+    started_at = serializers.DateTimeField(
+        read_only=True, required=False, allow_null=True
+    )
+    created_at = serializers.DateTimeField(
+        read_only=True, required=False, allow_null=True
+    )
 
 
 class RunTestKPIsResponseSerializer(serializers.Serializer):

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2361,6 +2361,8 @@ class TestExecutionDetailView(APIView):
                         "current_page": page,
                         "column_order": column_order,
                         "error_messages": error_messages,
+                        "started_at": test_execution.started_at,
+                        "created_at": test_execution.created_at,
                     },
                     status=status.HTTP_200_OK,
                 )
@@ -2395,6 +2397,8 @@ class TestExecutionDetailView(APIView):
                         "column_order": column_order,
                         "error_messages": error_messages,
                         "status": test_execution.status,
+                        "started_at": test_execution.started_at,
+                        "created_at": test_execution.created_at,
                     },
                     status=status.HTTP_200_OK,
                 )
@@ -2527,6 +2531,8 @@ class TestExecutionDetailView(APIView):
                 else "prompt"
             )
             response_data["agent_type"] = agent_type
+            response_data["started_at"] = test_execution.started_at
+            response_data["created_at"] = test_execution.created_at
 
             return Response(response_data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Summary

`Execution Detail` header used to render `Run Start` from the parent `RunTest.created_at`, which never changes on rerun. Every execution detail page (first run or rerun) therefore showed the same original test-creation time. This PR wires the header to the current execution's own timestamp with a fallback to the parent test's created_at.

## Root cause

`sections/test-detail/TestRunDetailHeader.jsx` read the display value from `useTestRunDetails(testId)` which hits `GET /simulate/run-tests/{run_test_id}/`. On rerun, only a new `TestExecution` row is created; the parent `RunTest.created_at` is untouched, so the header value is stale.

Two backend surfaces already expose per-execution timestamps:

- `TestExecutionSerializer` for the `/simulate/run-tests/{id}/executions/` list.
- `TestExecutionDetailResponseSerializer` for `/simulate/test-executions/{id}/` - but that response only shipped `count`, `results`, `column_order`, `error_messages`, `status`, `provider`, `agent_type`; no per-execution timestamps.

The detail endpoint is the natural anchor for the header (single execution by id), but it wasn't emitting the fields the header needed.

## Fix

**Backend (additive, no migration):**

- `simulate/serializers/test_execution.py`: add `started_at` and `created_at` to `TestExecutionDetailResponseSerializer`.
- `simulate/views/run_test.py`: `TestExecutionDetailView.get` now includes both fields in all three response branches (normal paginated, grouped, empty).

**Frontend:**

- New hook `src/hooks/useTestExecutionDetail.js` calls `endpoints.testExecutions.list(executionId)` with `page=1&limit=1` and returns just the top-level fields we need.
- `TestRunDetailHeader.jsx` prefers `executionDetail.started_at`, falls back to `executionDetail.created_at`, then to `testData.created_at`, so we never regress on legacy executions that predate `started_at`.

**Regenerated artefacts** (per repo convention any time a serializer field changes):

- `api_contracts/openapi/swagger.json`
- `frontend/src/api/contracts/openapi-contract.generated.js`
- `frontend/src/generated/api-contracts/api.schemas.ts`
- `frontend/src/generated/api-contracts/api.zod.ts`

`yarn contracts:check` is green.

## Scope

BE 2 files (+14), FE 2 files + 1 new hook (+36), regen 4 files (+31). Net +81 / -3.