### PR TITLE
fix(ai-filter): parallelize + budget dataset pre-fetch so slow CH doesn't take the endpoint down (TH-6624)

### DIFF
--- a/futureagi/model_hub/views/ai_filter.py
+++ b/futureagi/model_hub/views/ai_filter.py
@@ -22,7 +22,9 @@ Three modes:
 """
 
 import json
+import time
 import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import structlog
 from rest_framework.permissions import IsAuthenticated
@@ -515,7 +517,7 @@ def _fetch_dataset_column_values(dataset_id, column_id):
         result = analytics.execute_ch_query(
             sql,
             {"dataset_id": str(dataset_id), "column_id": str(column_id)},
-            timeout_ms=5000,
+            timeout_ms=2500,
         )
         raw = [row["val"] for row in result.data if row.get("val")]
     except Exception as e:
@@ -722,32 +724,53 @@ def _run_smart_agent(query, schema, fetch_values):
     #   - high-cardinality string fields (free-form id/tag/model namespaces
     #     where the value list can grow unboundedly)
     # ------------------------------------------------------------------
+    # Parallelize per-field pre-fetch with a wall-clock budget. Sequential
+    # was ~5s per query for a slow CH cluster, so a schema with 10 columns
+    # blocked the endpoint for 50s+ before the LLM even ran. With a pool
+    # and a total budget we cap the pre-fetch phase; anything that misses
+    # the budget stays marked v_empty so the LLM can still emit a literal
+    # filter (or call `get_field_values` on demand).
     inlined_value_count = 0
-    for entry in compact_fields:
-        fid = entry["f"]
-        if entry["t"] != "string":
-            continue
-        if fid in _HIGH_CARDINALITY_FIELDS:
-            continue
+    prefetch_targets = [
+        entry
+        for entry in compact_fields
+        if entry["t"] == "string" and entry["f"] not in _HIGH_CARDINALITY_FIELDS
+    ]
+    prefetch_budget_s = 4.0
+    if prefetch_targets:
+        deadline = time.monotonic() + prefetch_budget_s
+        results_by_fid: dict[str, list] = {}
+        pool = ThreadPoolExecutor(max_workers=min(8, len(prefetch_targets)))
         try:
-            vals = fetch_values(fid)
-        except Exception:
-            vals = []
-        if not vals:
-            # The field exists in the schema but has no rows in CH yet.
-            # Tell the LLM explicitly so it can still emit a literal-value
-            # filter (the user's intent matters even when the result set
-            # would be empty — e.g. "show voicemails" on a fresh project).
-            entry["v_empty"] = True
-            continue
-        if len(vals) <= _INLINE_VALUE_CAP:
-            entry["v"] = vals
-            inlined_value_count += len(vals)
-        else:
-            # Too many to inline — flag it so the LLM knows to use the
-            # search tool for this field instead of guessing.
-            entry["v_count"] = len(vals)
-            entry["v_searchable"] = True
+            futures = {
+                pool.submit(fetch_values, entry["f"]): entry["f"]
+                for entry in prefetch_targets
+            }
+            try:
+                for future in as_completed(
+                    futures, timeout=max(0.1, deadline - time.monotonic())
+                ):
+                    try:
+                        results_by_fid[futures[future]] = future.result() or []
+                    except Exception:
+                        results_by_fid[futures[future]] = []
+            except TimeoutError:
+                # Budget exhausted — surviving fields get v_empty below and
+                # the LLM can still call get_field_values on demand.
+                pass
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
+        for entry in prefetch_targets:
+            vals = results_by_fid.get(entry["f"], [])
+            if not vals:
+                entry["v_empty"] = True
+                continue
+            if len(vals) <= _INLINE_VALUE_CAP:
+                entry["v"] = vals
+                inlined_value_count += len(vals)
+            else:
+                entry["v_count"] = len(vals)
+                entry["v_searchable"] = True
 
     tools = [
         {


### PR DESCRIPTION
## Summary

AI query on the dataset filter panel returns a 500 (or the FE surfaces "AI unavailable, use filters below"). Root cause: the smart-mode pre-fetch step runs one ClickHouse query per string column in the schema, sequentially, each with a 5s timeout. On dev's slow CH tier every query times out at ~5s, so a 10-column dataset burns ~50s on failed pre-fetches before the LLM is even invoked, and the request eventually 500s at ~75s.

## Root cause

Traced by re-running the flow on dev with SSH and reading gunicorn + `model_hub.views.ai_filter` logs. Every request emits ~10 back-to-back `dataset_column_values_query_failed` entries with `elapsed 5000-5500 ms`, then one `agentcc-gateway` call, then the transaction returns 500.

Source of the sequential fetch: `_run_smart_agent` at `model_hub/views/ai_filter.py:725-751` iterates `compact_fields` and calls `fetch_values(fid)` inline for each string field. `fetch_values` for datasets is `_fetch_dataset_column_values` (`:471+`) which issues a CH `SELECT DISTINCT value FROM model_hub_cell FINAL ...` with `timeout_ms=5000`. Dev's CH cluster consistently exceeds that on `FINAL` scans of `model_hub_cell`, so every one of those calls times out. The exception is caught, the field is marked `v_empty`, and the loop moves on to the next equally-slow query.

The pre-fetch itself is best-effort - the LLM has a `get_field_values` tool it can call on demand. When the pre-fetch phase takes longer than the whole request budget, the tool-based fallback never gets a chance to run.

## Fix

Two changes in `model_hub/views/ai_filter.py`:

1. **Parallelize the pre-fetch loop with a wall-clock budget.** `_run_smart_agent` now submits every eligible string field into a `ThreadPoolExecutor` (max 8 workers) and drains with `as_completed(timeout=budget)`. Budget is 4.0 s total. Anything that misses the budget stays marked `v_empty` so the LLM still has a signal and can call `get_field_values` on the fields it actually needs. Pool is torn down with `cancel_futures=True` so no straggler CH queries live past the phase.
2. **Shrink the per-query CH timeout** in `_fetch_dataset_column_values` from `5000 ms` to `2500 ms`. Combined with the pool this caps the phase at ~budget seconds even in the worst case.

Traces path is untouched because it inherits the same `_run_smart_agent` helper - the fix benefits both sources, but the failure mode was only observed on datasets where `model_hub_cell FINAL` scans are the bottleneck.

## Scope

BE only, 1 file, +48 / -25.