### PR TITLE
fix(gateway): enforce MCP tool schema validation on empty arguments

### DIFF
--- a/agentcc-gateway/internal/mcp/server.go
+++ b/agentcc-gateway/internal/mcp/server.go
@@ -381,7 +381,7 @@ func (s *Server) handleToolsCall(w http.ResponseWriter, r *http.Request, msg *Me
 	}
 
 	// Validate arguments against input schema if available.
-	if len(regTool.Tool.InputSchema) > 0 && len(params.Arguments) > 0 {
+	if len(regTool.Tool.InputSchema) > 0 {
 		if errMsg := validateArgsAgainstSchema(regTool.Tool.InputSchema, params.Arguments); errMsg != "" {
 			writeJSONRPCError(w, msg.ID, ErrCodeInvalidParams, errMsg)
 			return

--- a/agentcc-gateway/internal/mcp/server_test.go
+++ b/agentcc-gateway/internal/mcp/server_test.go
@@ -940,6 +940,48 @@ func TestSchemaValidation_WrongType(t *testing.T) {
 	}
 }
 
+func TestSchemaValidation_EmptyArgumentsStillChecksRequired(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	schema := `{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`
+	tools := []Tool{{Name: "action", InputSchema: json.RawMessage(schema)}}
+	s.Registry().RegisterServer("srv", tools)
+
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg Message
+		json.NewDecoder(r.Body).Decode(&msg)
+		resp, _ := NewResponse(msg.ID, ToolCallResult{Content: []ContentPart{{Type: "text", Text: "ok"}}})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockUpstream.Close()
+
+	client := NewClient(ClientConfig{ServerID: "srv", URL: mockUpstream.URL, TransportType: "http"})
+	client.transport = NewHTTPTransport(mockUpstream.URL, AuthConfig{})
+	client.healthy.Store(true)
+	client.tools.Store(&tools)
+	s.clientsMu.Lock()
+	s.clients["srv"] = client
+	s.clientsMu.Unlock()
+
+	sessionID := initializeSession(t, s)
+
+	// Empty arguments, but "name" is required.
+	params := ToolCallParams{Name: "srv_action", Arguments: map[string]interface{}{}}
+	paramsData, _ := json.Marshal(params)
+	msg := &Message{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: MethodToolsCall, Params: paramsData}
+
+	w := postMCP(t, s, msg, map[string]string{"MCP-Session-Id": sessionID})
+	resp := decodeResponse(t, w)
+	if resp.Error == nil {
+		t.Fatal("expected error for missing required field with empty arguments")
+	}
+	if resp.Error.Code != ErrCodeInvalidParams {
+		t.Fatalf("expected code %d, got %d", ErrCodeInvalidParams, resp.Error.Code)
+	}
+}
+
 func TestSchemaValidation_ValidArgs(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Close()


### PR DESCRIPTION
## Description
Resolves #1242. 

This PR fixes a schema validation vulnerability in the `agentcc-gateway`. Previously, `handleToolsCall` would short-circuit the JSON Schema validation if `len(params.Arguments) == 0`. This allowed agents to submit empty argument maps and completely bypass `required` fields defined in the tool's `InputSchema`, resulting in malformed requests reaching upstream MCP servers.

**Changes:**
* Removed the `&& len(params.Arguments) > 0` bypass in `server.go`, enforcing native schema validation even when arguments are empty.
* Added the `TestSchemaValidation_EmptyArgumentsStillChecksRequired` regression test to `server_test.go` to explicitly lock down this behavior.

## Impact
A zero-dependency architectural fix that strictly enforces Model Context Protocol (MCP) compliance and protects upstream tool execution environments.

cc @nik13  - following up on our email, this patch strictly enforces schema validation for the gateway.