### PR TITLE
fix(evals): emails and decimals should not count as links (#1342)

### DIFF
--- a/futureagi/model_hub/system_evals/function/contains_valid_link.yaml
+++ b/futureagi/model_hub/system_evals/function/contains_valid_link.yaml
@@ -23,15 +23,40 @@ config:
         import urllib.request
         text = kwargs.get("text", output or "")
         text = str(text)
-        pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
-        link_match = re.search(pattern, text)
-        if not link_match:
+        # Match URLs with explicit scheme, www. prefix, or bare domain.
+        # TLD must be 2+ alpha characters so decimals (3.14) never match.
+        # Lookbehind on \w and @ stops matches inside words or emails.
+        URL_RE = re.compile(
+            r"(?<![\w@])"
+            r"(?:https?://[^\s<>\"']+"
+            r"|www\.[a-zA-Z0-9][a-zA-Z0-9\-]*\.[a-zA-Z]{2,}(?:[^\s<>\"']*)"
+            r"|(?<![.@])[a-zA-Z0-9][a-zA-Z0-9\-]*\.[a-zA-Z]{2,}(?:[^\s<>\"']*)?)",
+            re.IGNORECASE,
+        )
+        # Common file extensions that look like TLDs but are not web addresses.
+        # This prevents "load data.csv" or "run script.py" from being flagged.
+        FILE_EXTS = {
+            "csv","txt","pdf","doc","docx","xls","xlsx","ppt","pptx",
+            "py","js","ts","jsx","tsx","java","cpp","c","h","go","rs",
+            "sh","bat","md","yaml","yml","json","xml","html","css","sql",
+            "zip","tar","gz","png","jpg","jpeg","gif","svg","mp4","mp3",
+            "log","env","cfg","ini","toml","lock","rb","php","swift","kt",
+        }
+        def _is_file(m):
+            if m.startswith(("http://", "https://", "www.")):
+                return False
+            ext = m.rsplit(".", 1)[-1].split("/")[0].split("?")[0].lower()
+            return ext in FILE_EXTS
+        matches = URL_RE.findall(text)
+        links = [m for m in matches if "@" not in m and not _is_file(m)]
+        if not links:
             return {"score": 0.0, "reason": "No link found in output"}
-        url = link_match.group()
+        url = links[0]
         if not url.startswith(("http://", "https://")):
-            url = "http://" + url
+            url = "https://" + url
         try:
-            req = urllib.request.Request(url, method='HEAD')
+            req = urllib.request.Request(url, method="HEAD",
+                                         headers={"User-Agent": "FutureAGI-eval/1.0"})
             resp = urllib.request.urlopen(req, timeout=5)
             if resp.status == 200:
                 return {"score": 1.0, "reason": f"Link {url} found and valid (status 200)"}

--- a/futureagi/model_hub/system_evals/function/no_invalid_links.yaml
+++ b/futureagi/model_hub/system_evals/function/no_invalid_links.yaml
@@ -23,17 +23,41 @@ config:
         import urllib.request
         text = kwargs.get("text", output or "")
         text = str(text)
-        pattern = r"(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+"
-        links = re.findall(pattern, text)
+        # Match URLs with explicit scheme, www. prefix, or bare domain.
+        # TLD must be 2+ alpha characters so decimals (3.14) never match.
+        # Lookbehind on \w and @ stops matches inside words or emails.
+        URL_RE = re.compile(
+            r"(?<![\w@])"
+            r"(?:https?://[^\s<>\"']+"
+            r"|www\.[a-zA-Z0-9][a-zA-Z0-9\-]*\.[a-zA-Z]{2,}(?:[^\s<>\"']*)"
+            r"|(?<![.@])[a-zA-Z0-9][a-zA-Z0-9\-]*\.[a-zA-Z]{2,}(?:[^\s<>\"']*)?)",
+            re.IGNORECASE,
+        )
+        # Common file extensions that look like TLDs but are not web addresses.
+        FILE_EXTS = {
+            "csv","txt","pdf","doc","docx","xls","xlsx","ppt","pptx",
+            "py","js","ts","jsx","tsx","java","cpp","c","h","go","rs",
+            "sh","bat","md","yaml","yml","json","xml","html","css","sql",
+            "zip","tar","gz","png","jpg","jpeg","gif","svg","mp4","mp3",
+            "log","env","cfg","ini","toml","lock","rb","php","swift","kt",
+        }
+        def _is_file(m):
+            if m.startswith(("http://", "https://", "www.")):
+                return False
+            ext = m.rsplit(".", 1)[-1].split("/")[0].split("?")[0].lower()
+            return ext in FILE_EXTS
+        matches = URL_RE.findall(text)
+        links = [m for m in matches if "@" not in m and not _is_file(m)]
         if not links:
             return {"score": 1.0, "reason": "No links found in output, so none are invalid"}
         invalid_links = []
         for link in links:
             url = link
             if not url.startswith(("http://", "https://")):
-                url = "http://" + url
+                url = "https://" + url
             try:
-                req = urllib.request.Request(url, method='HEAD')
+                req = urllib.request.Request(url, method="HEAD",
+                                             headers={"User-Agent": "FutureAGI-eval/1.0"})
                 resp = urllib.request.urlopen(req, timeout=5)
                 if resp.status != 200:
                     invalid_links.append(f"{url} (status {resp.status})")


### PR DESCRIPTION
Fixes #1342

The regex r`(?!.*@)(?:https?://)?(?:www\.)?\S+\.\S+` had two problems:

1. The negative lookahead does not stop re.findall from retrying past
   the @, so support@acme.io still gets flagged as a link and triggers
   a HEAD request to acme.io.

2. \S+\.\S+ matches 3.14, e.g., v1.0, data.csv, script.py and similar.
   no_invalid_links then tries to HEAD-request http://3.14 which is
   unreachable, failing perfectly clean text.

Fix: replace the pattern with a URL regex that requires either an
explicit scheme (https?://), www. prefix, or a bare domain where the
TLD is 2+ alphabetic characters. Decimals like .14 are purely numeric
so they never match. Added a second filter for common file extensions
(csv, py, js, etc.) as a safety net for cases like data.csv.

Also switched default scheme to https:// and added a User-Agent header
since some servers return 403 on bare HEAD requests.

Changes:
- futureagi/model_hub/system_evals/function/contains_valid_link.yaml
- futureagi/model_hub/system_evals/function/no_invalid_links.yaml