### PR TITLE
chore: fix linter warnings in trace_session.py

### DIFF
--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -3,7 +3,7 @@ import json
 import traceback
 from collections import defaultdict
 from dataclasses import asdict
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 try:
     import orjson
@@ -16,7 +16,7 @@ import pandas as pd
 import structlog
 
 logger = structlog.get_logger(__name__)
-from django.db import OperationalError, connection, models, transaction
+from django.db import OperationalError, models
 from django.db.models import (
     Avg,
     Case,
@@ -720,7 +720,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     if ch_column == "first_message"
                     else "argMax(input, start_time)"
                 )
-                search_clause = f"AND val ILIKE %(search)s" if search else ""
+                search_clause = "AND val ILIKE %(search)s" if search else ""
                 query = f"""
                 SELECT DISTINCT val FROM (
                     SELECT {agg_expr} AS val
@@ -1479,8 +1479,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # resolve it to a set of EndUser UUIDs and pass an end_user_id IN(...)
         # synthetic filter instead (the CH `spans` table keys users via the
         # UUID column `end_user_id`, not the string `user_id`).
-        user_id_raw: Optional[str] = user_id_qp or None
-        _remaining: List[Dict] = []
+        user_id_raw: str | None = user_id_qp or None
+        _remaining: list[dict] = []
         for _f in filters:
             _col, _cfg = FilterEngine._normalize_filter_params(_f)
             _col_type = _cfg.get("col_type", "NORMAL")
@@ -1498,7 +1498,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         # both the UUIDs (to inject as a synthetic end_user_id IN(...)
         # filter) and the display fields (to stitch onto the formatted
         # output later) — fetch them together to save a round-trip.
-        end_user_display: Optional[Dict[str, Any]] = None
+        end_user_display: dict[str, Any] | None = None
         if user_id_raw:
             _eu_qs = EndUser.objects.filter(
                 user_id=user_id_raw,
@@ -1634,7 +1634,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         attr_query, attr_params, timeout_ms=5000
                     )
                     # Aggregate per session: session_id -> {attr_key -> set(values)}
-                    aggregated_attrs: Dict[str, Dict] = {}
+                    aggregated_attrs: dict[str, dict] = {}
                     for attr_row in attr_result.data:
                         sid = str(attr_row.get("session_id", ""))
                         # Skip if this session already has max keys


### PR DESCRIPTION
## Summary
This PR resolves a few minor linter warnings and tech debt found in `trace_session.py` using `ruff`. Specifically, it removes an unused local variable (`trace_session = serializer.data`), removes an unnecessary `f` prefix from a SQL query string, and updates outdated `typing` annotations (`List`, `Dict`, `Optional`) to use modern Python 3.10+ syntax (`list`, `dict`, `| None`).

## Linked issues
N/A

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Ran `ruff check` locally to ensure the linter passes cleanly for `tracer/views/trace_session.py`.

## Screenshots / recordings (if UI)
N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
