### PR TITLE
fix(dynamic-columns): use snake_case form fields matching backend contract (TH-6543)

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -32,9 +32,6 @@ import { transformDynamicColumnConfig } from "../common";
 
 const getDefaultValue = () => {
   return {
-    // snake_case fields match the backend metadata shape directly so
-    // `reset(initialData)` on edit hydrates the form without a transform
-    // (same fix pattern as PR #1309 / TH-6423 / TH-6543).
     column_name: "",
     config: {
       url: "",
@@ -84,9 +81,6 @@ export const AddColumnApiCallChild = ({
     ),
   });
 
-  // Track which editId we've already loaded data for so that background
-  // re-renders (e.g. React Query refetches on window-focus) don't silently
-  // overwrite the user's in-progress edits via reset().
   const loadedEditIdRef = useRef(null);
 
   useEffect(() => {
@@ -94,7 +88,6 @@ export const AddColumnApiCallChild = ({
       reset(initialData);
       loadedEditIdRef.current = editId;
     } else if (!editId) {
-      // Reset to default values when opening for new column (no editId)
       reset(getDefaultValue());
       loadedEditIdRef.current = null;
     }
@@ -154,11 +147,6 @@ export const AddColumnApiCallChild = ({
     },
   });
 
-  // Form fields already match backend snake_case (see defaultValues above)
-  // — pass formValues straight through.
-
-  // Block columns whose name contains a dot (dot is the JSON path separator).
-  // Uses raw form values so we have display names + array indices for setError.
   const validateDotInColumnNames = () => {
     const dotCols = allColumns.filter((c) => c.headerName?.includes("."));
     if (!dotCols.length) return true;
@@ -202,15 +190,12 @@ export const AddColumnApiCallChild = ({
     return true;
   };
 
-  // If body is a bare {{variable}}, only allow a top-level JSON/array column
-  // (no dot-paths — input.prompt could resolve to a plain string).
   const validateBodyVariable = (formValues) => {
     const body = formValues?.config?.body;
     if (typeof body !== "string") return true;
     const m = body.trim().match(/^\{\{(.+)\}\}$/);
     if (!m) return true;
     const ref = m[1].trim();
-    // Must be an exact column UUID (36 chars, no trailing path)
     const col = allColumns.find((c) => c.field === ref);
     if (col && ["json", "array"].includes(col.dataType)) return true;
     setError("config.body", {
@@ -242,9 +227,6 @@ export const AddColumnApiCallChild = ({
     if (!validateDotInColumnNames()) return;
     if (!validateBodyVariable(formValues)) return;
     if (!onFormSubmit) {
-      // Preview endpoint only needs the `config` payload (url/body/params/…).
-      // Form fields are already snake_case natively (see defaultValues), so
-      // no transform is needed on the way out.
       preview({ config: formValues.config });
     }
   });
@@ -407,7 +389,6 @@ export const AddColumnApiCallChild = ({
             color="primary"
             fullWidth
             size="small"
-            // onClick={handleSubmit(addColumn)}
           >
             {editId
               ? "Update Column"
@@ -449,8 +430,6 @@ const AddColumnApiCall = ({ initialData, onFormSubmit }) => {
 
   const allColumns = useDatasetColumnConfig(dataset, true);
 
-  // Memoize so the child receives a stable reference and its useEffect
-  // does not fire on every parent re-render.
   const memoizedInitialData = useMemo(() => {
     return columnConfig
       ? transformDynamicColumnConfig("api_call", columnConfig, allColumns)

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -32,14 +32,17 @@ import { transformDynamicColumnConfig } from "../common";
 
 const getDefaultValue = () => {
   return {
-    columnName: "",
+    // snake_case fields match the backend metadata shape directly so
+    // `reset(initialData)` on edit hydrates the form without a transform
+    // (same fix pattern as PR #1309 / TH-6423 / TH-6543).
+    column_name: "",
     config: {
       url: "",
       method: "POST",
       params: [],
       headers: [],
       body: "",
-      outputType: "string",
+      output_type: "string",
     },
     concurrency: "",
   };
@@ -151,18 +154,8 @@ export const AddColumnApiCallChild = ({
     },
   });
 
-  const transformFormToApi = (formValues) => {
-    const { columnName, ...rest } = formValues;
-    const { outputType, ...configRest } = rest.config || {};
-    return {
-      ...rest,
-      config: {
-        ...configRest,
-        output_type: outputType,
-      },
-      column_name: columnName,
-    };
-  };
+  // Form fields already match backend snake_case (see defaultValues above)
+  // — pass formValues straight through.
 
   // Block columns whose name contains a dot (dot is the JSON path separator).
   // Uses raw form values so we have display names + array indices for setError.
@@ -233,7 +226,7 @@ export const AddColumnApiCallChild = ({
     if (!validateBodyVariable(formValues)) return;
     if (editId) {
       updateColumn({
-        config: { ...transformFormToApi(formValues) },
+        config: { ...formValues },
         operation_type: "api_call",
       });
       return;
@@ -241,7 +234,7 @@ export const AddColumnApiCallChild = ({
     if (onFormSubmit) {
       onFormSubmit({ ...formValues, type: "api_call" });
     } else {
-      addColumn(transformFormToApi(formValues));
+      addColumn(formValues);
     }
   };
 
@@ -249,8 +242,10 @@ export const AddColumnApiCallChild = ({
     if (!validateDotInColumnNames()) return;
     if (!validateBodyVariable(formValues)) return;
     if (!onFormSubmit) {
-      const { config } = transformFormToApi(formValues);
-      preview({ config });
+      // Preview endpoint only needs the `config` payload (url/body/params/…).
+      // Form fields are already snake_case natively (see defaultValues), so
+      // no transform is needed on the way out.
+      preview({ config: formValues.config });
     }
   });
 
@@ -309,7 +304,7 @@ export const AddColumnApiCallChild = ({
               size="small"
               placeholder="Enter name"
               control={control}
-              fieldName="columnName"
+              fieldName="column_name"
             />
           </ShowComponent>
           <FormSearchSelectFieldControl
@@ -317,7 +312,7 @@ export const AddColumnApiCallChild = ({
             label="Output Type"
             size="small"
             control={control}
-            fieldName="config.outputType"
+            fieldName="config.output_type"
             options={OutputTypeOptions}
           />
           <RequestBody

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/validation.js
@@ -9,7 +9,7 @@ export const getAddColumnApiCallValidation = (
 ) => {
   return z.object({
     type: z.string().optional(),
-    columnName:
+    column_name:
       isConditionalNode || isEdit
         ? z.string().optional()
         : z.string().min(1, "Name is required"),
@@ -110,7 +110,7 @@ export const getAddColumnApiCallValidation = (
           if (BARE_VARIABLE_RE.test(value)) return value;
           return JSON.parse(value);
         }),
-      outputType: z.string().min(1, "Output type is required"),
+      output_type: z.string().min(1, "Output type is required"),
     }),
     concurrency: z.number().positive("Concurrency must be a positive integer"),
   });

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
@@ -47,15 +47,7 @@ export const ClassificationChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
-    // snake_case fields match backend metadata → `reset(initialData)`
-    // populates directly on edit (fix pattern from PR #1309).
-    defaultValues: {
-      column_id: "",
-      labels: [],
-      language_model_id: "",
-      concurrency: "",
-      new_column_name: "",
-    },
+    defaultValues: getDefaultValue(),
     resolver: zodResolver(
       ClassificationValidationSchema(!!onFormSubmit, !!editId),
     ),
@@ -122,8 +114,6 @@ export const ClassificationChild = ({
     },
   });
 
-  // Form fields are already snake_case (see defaultValues above), so we pass
-  // formValues straight through — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
@@ -30,11 +30,11 @@ import { ShowComponent } from "../../../../components/show";
 
 const getDefaultValue = () => {
   return {
-    columnId: "",
+    column_id: "",
     labels: [],
-    languageModelId: "",
+    language_model_id: "",
     concurrency: "",
-    newColumnName: "",
+    new_column_name: "",
   };
 };
 
@@ -47,12 +47,14 @@ export const ClassificationChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
+    // snake_case fields match backend metadata → `reset(initialData)`
+    // populates directly on edit (fix pattern from PR #1309).
     defaultValues: {
-      columnId: "",
+      column_id: "",
       labels: [],
-      languageModelId: "",
+      language_model_id: "",
       concurrency: "",
-      newColumnName: "",
+      new_column_name: "",
     },
     resolver: zodResolver(
       ClassificationValidationSchema(!!onFormSubmit, !!editId),
@@ -120,20 +122,12 @@ export const ClassificationChild = ({
     },
   });
 
-  const transformFormToApi = (formValues) => {
-    const { columnId, newColumnName, languageModelId, ...rest } = formValues;
-    return {
-      ...rest,
-      column_id: columnId,
-      new_column_name: newColumnName,
-      language_model_id: languageModelId,
-    };
-  };
-
+  // Form fields are already snake_case (see defaultValues above), so we pass
+  // formValues straight through — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({
-        config: transformFormToApi(formValues),
+        config: formValues,
         operation_type: "classify",
       });
       return;
@@ -141,13 +135,13 @@ export const ClassificationChild = ({
     if (onFormSubmit) {
       onFormSubmit({ ...formValues, type: "classification" });
     } else {
-      addColumn(transformFormToApi(formValues));
+      addColumn(formValues);
     }
   };
 
   const handlePreview = handleSubmit((formValues) => {
     if (!onFormSubmit) {
-      preview(transformFormToApi(formValues));
+      preview(formValues);
     }
   });
 
@@ -206,7 +200,7 @@ export const ClassificationChild = ({
               placeholder="Enter column name"
               control={control}
               required={!onFormSubmit}
-              fieldName="newColumnName"
+              fieldName="new_column_name"
             />
           )}
           <FormSearchSelectFieldControl
@@ -215,7 +209,7 @@ export const ClassificationChild = ({
             label="Column"
             size="small"
             control={control}
-            fieldName="columnId"
+            fieldName="column_id"
             options={allColumns.map((column) => ({
               label: column.headerName,
               value: column.field,
@@ -237,7 +231,7 @@ export const ClassificationChild = ({
           </Accordion>
           <CustomModelDropdownControl
             control={control}
-            fieldName="languageModelId"
+            fieldName="language_model_id"
             label="Model"
             searchDropdown
             size="small"

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/Classification.jsx
@@ -60,7 +60,6 @@ export const ClassificationChild = ({
     if (initialData) {
       reset(initialData);
     } else if (!editId) {
-      // Reset to default values when opening for new column (no editId)
       reset(getDefaultValue());
     }
   }, [initialData, reset, editId]);
@@ -73,7 +72,6 @@ export const ClassificationChild = ({
         variant: "success",
       });
       reset();
-      // null for gridRef option and true for set column.
       refreshGrid(null, true);
       onClose();
     },
@@ -296,7 +294,6 @@ ClassificationChild.propTypes = {
 };
 
 const Classification = ({ initialData, onFormSubmit }) => {
-  // Using individual store
   const { openClassification, setOpenClassification } =
     useClassificationStore();
 

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/validation.js
@@ -1,9 +1,5 @@
 import { z } from "zod";
 
-// Field names match the snake_case shape the backend returns from
-// `GET /model-hub/columns/{id}/operation-config/` → `result.metadata`, so
-// `reset(initialData)` on edit hydrates the form directly without a
-// snake↔camel transform. Same pattern PR #1309 established for extract_json.
 export const ClassificationValidationSchema = (
   isConditionalNode = false,
   isEdit = false,

--- a/frontend/src/sections/develop-detail/AddColumn/Classification/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/Classification/validation.js
@@ -1,17 +1,15 @@
 import { z } from "zod";
 
-// columnId: "",
-// labels: [],
-// languageModelId: "",
-// concurrency: "",
-// newColumnName: "",
-
+// Field names match the snake_case shape the backend returns from
+// `GET /model-hub/columns/{id}/operation-config/` → `result.metadata`, so
+// `reset(initialData)` on edit hydrates the form directly without a
+// snake↔camel transform. Same pattern PR #1309 established for extract_json.
 export const ClassificationValidationSchema = (
   isConditionalNode = false,
   isEdit = false,
 ) => {
   return z.object({
-    columnId: z
+    column_id: z
       .string({
         required_error: "Column is required",
       })
@@ -27,7 +25,7 @@ export const ClassificationValidationSchema = (
       )
       .min(1, "At least one label is required")
       .transform((t) => t.map((e) => e.value)),
-    languageModelId: z
+    language_model_id: z
       .string({
         required_error: "Language Model is required",
       })
@@ -35,7 +33,7 @@ export const ClassificationValidationSchema = (
         message: "Language Model is required",
       }),
     concurrency: z.number().positive("Concurrency must be a positive integer"),
-    newColumnName:
+    new_column_name:
       isConditionalNode || isEdit
         ? z.string().optional()
         : z

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
@@ -56,6 +56,50 @@ const FORM_COMPONENTS = {
   api_call: AddColumnApiCallChild,
 };
 
+const getEmptyBranchConfig = () => ({
+  column_id: "",
+  instruction: "",
+  language_model_id: "",
+  column_name: "",
+  url: "",
+  method: "POST",
+  params: {},
+  headers: {},
+  body: "",
+  output_type: "string",
+  concurrency: "",
+  json_key: "",
+  code: `# Function name should be main only. You can access any column of the row using the kwargs.
+def main(**kwargs):
+    return kwargs.get("column_name")
+`,
+  new_column_name: "",
+  labels: [],
+  subType: "",
+  apiKey: "",
+  indexName: "",
+  namespace: "",
+  topK: "",
+  queryKey: "",
+  embeddingConfig: { model: "", type: "" },
+  collectionName: "",
+  searchType: "",
+  key: "",
+  vectorLength: "",
+  name: "",
+  model: "",
+  outputFormat: "string",
+  messages: [{ id: getRandomId(), role: "user", content: "" }],
+  responseFormat: null,
+  temperature: 0.5,
+  topP: 1,
+  maxTokens: 4085,
+  presencePenalty: 1,
+  frequencyPenalty: 1,
+  toolChoice: "none",
+  tools: [],
+});
+
 const defaultValues = {
   new_column_name: "",
   type: "conditional",
@@ -65,56 +109,7 @@ const defaultValues = {
       condition: "",
       branch_node_config: {
         type: "",
-        config: {
-          column_id: "",
-          instruction: "",
-          language_model_id: "",
-          columnName: "",
-          url: "",
-          method: "POST",
-          params: {},
-          headers: {},
-          body: "",
-          outputType: "",
-          concurrency: "",
-          jsonKey: "",
-          code: `# Function name should be main only. You can access any column of the row using the kwargs.
-def main(**kwargs):
-    return kwargs.get("column_name")
-`,
-          newColumnName: "",
-          labels: [],
-          subType: "",
-          apiKey: "",
-          indexName: "", // For Pinecone
-          namespace: "", // For Pinecone
-          topK: "", // Common across retrieval types
-          queryKey: "", // For Pinecone
-          embeddingConfig: { model: "", type: "" },
-          collectionName: "", // For Qdrant and Weaviate
-          searchType: "", // For Weaviate
-          key: "",
-          vectorLength: "",
-          name: "",
-          model: "",
-          outputFormat: "string",
-          messages: [
-            {
-              id: getRandomId(),
-              role: "user",
-              content: "",
-            },
-          ],
-          responseFormat: null,
-          temperature: 0.5,
-          topP: 1,
-          maxTokens: 4085,
-          presencePenalty: 1,
-          frequencyPenalty: 1,
-          toolChoice: "none",
-          tools: [],
-          // runType: "",
-        },
+        config: getEmptyBranchConfig(),
       },
     },
   ],
@@ -194,56 +189,7 @@ const ConditionalNodeChild = ({ editId }) => {
       condition: currentConfig.condition,
       branch_node_config: {
         type: value,
-        config: {
-          column_id: "",
-          instruction: "",
-          language_model_id: "",
-          columnName: "",
-          url: "",
-          method: "POST",
-          params: {},
-          headers: {},
-          body: "",
-          outputType: "string",
-          concurrency: "",
-          jsonKey: "",
-          newColumnName: "",
-          code: `# Function name should be main only. You can access any column of the row using the kwargs.
-def main(**kwargs):
-    return kwargs.get("column_name")
-`,
-          labels: [],
-          subType: "",
-          columnId: "",
-          apiKey: "",
-          indexName: "",
-          namespace: "",
-          topK: "",
-          queryKey: "",
-          embeddingConfig: { model: "", type: "" },
-          collectionName: "",
-          searchType: "",
-          key: "",
-          vectorLength: "",
-          name: "",
-          model: "",
-          outputFormat: "string",
-          messages: [
-            {
-              id: getRandomId(),
-              role: "user",
-              content: "",
-            },
-          ],
-          responseFormat: null,
-          temperature: 0.5,
-          topP: 1,
-          maxTokens: 4085,
-          presencePenalty: 1,
-          frequencyPenalty: 1,
-          toolChoice: "none",
-          tools: [],
-        },
+        config: getEmptyBranchConfig(),
       },
     };
 
@@ -282,56 +228,7 @@ def main(**kwargs):
       condition: "",
       branch_node_config: {
         type: "",
-        config: {
-          column_id: "",
-          instruction: "",
-          language_model_id: "",
-          columnName: "",
-          url: "",
-          method: "POST",
-          params: {},
-          headers: {},
-          body: "",
-          outputType: "string",
-          concurrency: "",
-          jsonKey: "",
-          newColumnName: "",
-          code: `# Function name should be main only. You can access any column of the row using the kwargs.
-def main(**kwargs):
-    return kwargs.get("column_name")
-`,
-          labels: [],
-          subType: "",
-          columnId: "",
-          apiKey: "",
-          indexName: "", // For Pinecone
-          namespace: "", // For Pinecone
-          topK: "", // Common across retrieval types
-          queryKey: "", // For Pinecone
-          embeddingConfig: { model: "", type: "" },
-          collectionName: "", // For Qdrant and Weaviate
-          searchType: "", // For Weaviate
-          key: "",
-          vectorLength: "",
-          name: "",
-          model: "",
-          outputFormat: "string",
-          messages: [
-            {
-              id: getRandomId(),
-              role: "user",
-              content: "",
-            },
-          ],
-          responseFormat: null,
-          temperature: 0.5,
-          topP: 1,
-          maxTokens: 4085,
-          presencePenalty: 1,
-          frequencyPenalty: 1,
-          toolChoice: "none",
-          tools: [], // runType: ""
-        },
+        config: getEmptyBranchConfig(),
       },
     });
   };
@@ -423,11 +320,6 @@ def main(**kwargs):
         };
         break;
       case "classification":
-        // Child form now writes snake_case fields (column_id,
-        // language_model_id, new_column_name) natively — see PR #1309 +
-        // TH-6543 refactor — so ...formData already carries the right
-        // shape. The explicit camelCase remaps that used to live here
-        // would now overwrite the real values with `undefined`.
         updateConfig = {
           ...currentConfig,
           branch_node_config: {
@@ -463,8 +355,6 @@ def main(**kwargs):
       case "extract_entities":
       case "extract_json":
       case "extract_code":
-        // Child forms now write snake_case natively (PR #1309 + TH-6543);
-        // ...formData carries the correct shape without a remap.
         updateConfig = {
           ...currentConfig,
           branch_node_config: {
@@ -554,10 +444,6 @@ def main(**kwargs):
         switch (data.branch_node_config.type) {
           case "api_call":
             {
-              // New branches (post-TH-6543) persist `column_name` and
-              // `output_type` snake-side. Legacy branches saved before
-              // this PR still have `columnName` / `outputType` (camel).
-              // Read snake first, fall back to camel — no migration needed.
               const cfg = data.branch_node_config.config || {};
               const configData = {
                 branch_type: data.branch_type,
@@ -570,8 +456,8 @@ def main(**kwargs):
                     params: cfg.params,
                     headers: cfg.headers,
                     body: body.length ? JSON.parse(body) : {},
-                    column_name: cfg.column_name ?? cfg.columnName,
-                    output_type: cfg.output_type ?? cfg.outputType,
+                    column_name: cfg.column_name,
+                    output_type: cfg.output_type,
                     concurrency: cfg.concurrency,
                   },
                 },
@@ -653,55 +539,37 @@ def main(**kwargs):
           case "extract_json":
           case "extract_code":
             {
-              // New branches (post-PR #1309 + TH-6543) are stored in
-              // snake_case. Old branches persisted before those PRs kept
-              // camelCase (jsonKey, newColumnName). Read new first, fall
-              // back to legacy — no data migration needed.
               const cfg = data.branch_node_config.config || {};
+              const branchType = data.branch_node_config.type;
+              const config = {
+                new_column_name: cfg.new_column_name,
+                concurrency: cfg.concurrency,
+              };
+              if (branchType === "extract_entities" || branchType === "extract_json") {
+                config.column_id = cfg.column_id;
+              }
+              if (branchType === "extract_json") {
+                config.json_key = cfg.json_key;
+              }
+              if (branchType === "extract_entities") {
+                config.language_model_id = cfg.language_model_id;
+                config.instruction = cfg.instruction;
+              }
+              if (branchType === "extract_code") {
+                config.code = cfg.code;
+              }
               const configData = {
                 branch_type: data.branch_type,
                 condition: transformCondition(data.condition, allColumns),
                 branch_node_config: {
-                  type: cfg.type,
-                  config: {
-                    ...cfg,
-                    // Legacy-camel → snake fallbacks (harmless if already
-                    // snake, since ...cfg above set the snake key first).
-                    // extract_code has no `column_id` on either shape, so
-                    // skip that key entirely for that type to avoid
-                    // polluting the payload with `column_id: undefined`.
-                    ...((data.branch_node_config.type === "extract_json" ||
-                      data.branch_node_config.type === "extract_entities") && {
-                      column_id: cfg.column_id ?? cfg.columnId,
-                    }),
-                    ...(data.branch_node_config.type === "extract_json" && {
-                      json_key: cfg.json_key ?? cfg.jsonKey,
-                    }),
-                    ...(data.branch_node_config.type ===
-                      "extract_entities" && {
-                      language_model_id:
-                        cfg.language_model_id ?? cfg.languageModelId,
-                    }),
-                    new_column_name:
-                      cfg.new_column_name ?? cfg.newColumnName,
-                    concurrency: cfg.concurrency,
-                  },
+                  type: branchType,
+                  config,
                 },
               };
               formattedData.config.push(configData);
             }
             break;
           case "classification": {
-            // New branches (post-TH-6543) persist snake_case throughout.
-            // Legacy branches saved before this PR have `newColumnName`
-            // / `columnId` / `languageModelId`. Read snake first, fall
-            // back to camel — no migration needed.
-            //
-            // Labels: the child's zod schema `.transform((t) => t.map((e) => e.value))`
-            // already reduces `[{id,value}]` to `[value,value]` at submit
-            // time, so `cfg.labels` here is already the string-array the
-            // backend wants. Guard against the legacy object-array shape
-            // too in case a mid-session state slipped through.
             const cfg = data.branch_node_config.config || {};
             const labels = Array.isArray(cfg.labels)
               ? cfg.labels.map((item) =>
@@ -714,12 +582,11 @@ def main(**kwargs):
               branch_node_config: {
                 type: data.branch_node_config.config.type,
                 config: {
-                  column_id: cfg.column_id ?? cfg.columnId,
+                  column_id: cfg.column_id,
                   labels,
-                  new_column_name: cfg.new_column_name ?? cfg.newColumnName,
+                  new_column_name: cfg.new_column_name,
                   concurrency: cfg.concurrency,
-                  language_model_id:
-                    cfg.language_model_id ?? cfg.languageModelId,
+                  language_model_id: cfg.language_model_id,
                 },
               },
             };

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
@@ -131,7 +131,6 @@ const transformCondition = (condition, allColumns) => {
 
 const ConditionalNodeChild = ({ editId }) => {
   const { refreshGrid } = useDevelopDetailContext();
-  // Using individual stores
   const { setOpenConditionalNode } = useConditionalNodeStore();
 
   const onClose = () => {
@@ -272,12 +271,6 @@ const ConditionalNodeChild = ({ editId }) => {
     let updateConfig = {};
     switch (formData.type) {
       case "api_call": {
-        // Child now writes snake_case natively (TH-6543): top-level
-        // `column_name`, `concurrency`, and a nested `config` with
-        // `url/method/params/headers/body/output_type`. Flatten the nested
-        // `config` into `branch_node_config.config` so the persisted shape
-        // matches what the api_call read block (formattedData) below reads
-        // — no dead camelCase remaps.
         const { config: apiCallConfig = {}, type: _type, ...rest } = formData;
         updateConfig = {
           ...currentConfig,
@@ -314,7 +307,6 @@ const ConditionalNodeChild = ({ editId }) => {
                   ? undefined
                   : formData.config.toolChoice,
               tools: formData.config.tools || [],
-              // runType  : formData.config.runType,
             },
           },
         };
@@ -497,7 +489,6 @@ const ConditionalNodeChild = ({ editId }) => {
                         ? undefined
                         : data.branch_node_config.config.config.toolChoice,
                     tools: data.branch_node_config.config.config.tools || [],
-                    // runType: branch.branch_node_config.config.runType,
                   },
                 },
               };
@@ -635,7 +626,6 @@ const ConditionalNodeChild = ({ editId }) => {
           width: "550px",
         }}
         component="form"
-        // onSubmit={handleCreateColumn}
       >
         <Box
           sx={{
@@ -785,7 +775,6 @@ const ConditionalNodeChild = ({ editId }) => {
             Test
           </LoadingButton>
           <LoadingButton
-            // type="submit"
             variant="contained"
             color="primary"
             fullWidth
@@ -806,7 +795,6 @@ ConditionalNodeChild.propTypes = {
 };
 
 const ConditionalNode = () => {
-  // Using individual stores
   const { openConditionalNode, setOpenConditionalNode } =
     useConditionalNodeStore();
 

--- a/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ConditionalNode/ConditionalNode.jsx
@@ -374,26 +374,26 @@ def main(**kwargs):
     setType(formData.type);
     let updateConfig = {};
     switch (formData.type) {
-      case "api_call":
+      case "api_call": {
+        // Child now writes snake_case natively (TH-6543): top-level
+        // `column_name`, `concurrency`, and a nested `config` with
+        // `url/method/params/headers/body/output_type`. Flatten the nested
+        // `config` into `branch_node_config.config` so the persisted shape
+        // matches what the api_call read block (formattedData) below reads
+        // — no dead camelCase remaps.
+        const { config: apiCallConfig = {}, type: _type, ...rest } = formData;
         updateConfig = {
           ...currentConfig,
           branch_node_config: {
             ...currentConfig.branch_node_config,
             config: {
-              ...formData,
-              // column_id:formData.columnId,
-              url: formData.config.url,
-              method: formData.config.method,
-              params: formData.config.params,
-              headers: formData.config.headers,
-              body: formData.config.body,
-              outputType: formData.config.outputType,
-              concurrency: formData.concurrency,
-              columnName: formData.columnName,
+              ...rest, // column_name, concurrency
+              ...apiCallConfig, // url, method, params, headers, body, output_type
             },
           },
         };
         break;
+      }
       case "run_prompt":
         updateConfig = {
           ...currentConfig,
@@ -423,18 +423,16 @@ def main(**kwargs):
         };
         break;
       case "classification":
+        // Child form now writes snake_case fields (column_id,
+        // language_model_id, new_column_name) natively — see PR #1309 +
+        // TH-6543 refactor — so ...formData already carries the right
+        // shape. The explicit camelCase remaps that used to live here
+        // would now overwrite the real values with `undefined`.
         updateConfig = {
           ...currentConfig,
           branch_node_config: {
             ...currentConfig.branch_node_config,
-            config: {
-              ...formData,
-              column_id: formData.columnId,
-              language_model_id: formData.languageModelId,
-              concurrency: formData.concurrency,
-              labels: formData.labels,
-              newColumnName: formData.newColumnName,
-            },
+            config: { ...formData },
           },
         };
         break;
@@ -463,47 +461,15 @@ def main(**kwargs):
         };
         break;
       case "extract_entities":
-        updateConfig = {
-          ...currentConfig,
-          branch_node_config: {
-            ...currentConfig.branch_node_config,
-            config: {
-              ...formData,
-              column_id: formData.columnId,
-              language_model_id: formData.languageModelId,
-              concurrency: formData.concurrency,
-              instruction: formData.instruction,
-              newColumnName: formData.newColumnName,
-            },
-          },
-        };
-        break;
       case "extract_json":
-        updateConfig = {
-          ...currentConfig,
-          branch_node_config: {
-            ...currentConfig.branch_node_config,
-            config: {
-              ...formData,
-              column_id: formData.columnId,
-              jsonKey: formData.jsonKey,
-              concurrency: formData.concurrency,
-              newColumnName: formData.newColumnName,
-            },
-          },
-        };
-        break;
       case "extract_code":
+        // Child forms now write snake_case natively (PR #1309 + TH-6543);
+        // ...formData carries the correct shape without a remap.
         updateConfig = {
           ...currentConfig,
           branch_node_config: {
             ...currentConfig.branch_node_config,
-            config: {
-              ...formData,
-              code: formData.code,
-              concurrency: formData.concurrency,
-              newColumnName: formData.newColumnName,
-            },
+            config: { ...formData },
           },
         };
         break;
@@ -588,20 +554,25 @@ def main(**kwargs):
         switch (data.branch_node_config.type) {
           case "api_call":
             {
+              // New branches (post-TH-6543) persist `column_name` and
+              // `output_type` snake-side. Legacy branches saved before
+              // this PR still have `columnName` / `outputType` (camel).
+              // Read snake first, fall back to camel — no migration needed.
+              const cfg = data.branch_node_config.config || {};
               const configData = {
                 branch_type: data.branch_type,
                 condition: transformCondition(data.condition, allColumns),
                 branch_node_config: {
                   type: data.branch_node_config.type,
                   config: {
-                    url: data.branch_node_config.config.url,
-                    method: data.branch_node_config.config.method,
-                    params: data.branch_node_config.config.params,
-                    headers: data.branch_node_config.config.headers,
+                    url: cfg.url,
+                    method: cfg.method,
+                    params: cfg.params,
+                    headers: cfg.headers,
                     body: body.length ? JSON.parse(body) : {},
-                    column_name: data.branch_node_config.config.columnName,
-                    output_type: data.branch_node_config.config.outputType,
-                    concurrency: data.branch_node_config.config.concurrency,
+                    column_name: cfg.column_name ?? cfg.columnName,
+                    output_type: cfg.output_type ?? cfg.outputType,
+                    concurrency: cfg.concurrency,
                   },
                 },
               };
@@ -679,58 +650,41 @@ def main(**kwargs):
             break;
 
           case "extract_entities":
-            {
-              const configData = {
-                branch_type: data.branch_type,
-                condition: transformCondition(data.condition, allColumns),
-                branch_node_config: {
-                  type: data.branch_node_config.config.type,
-                  config: {
-                    column_id: data.branch_node_config.config.column_id,
-                    instruction: data.branch_node_config.config.instruction,
-                    language_model_id:
-                      data.branch_node_config.config.language_model_id,
-                    new_column_name:
-                      data.branch_node_config.config.newColumnName,
-                    concurrency: data.branch_node_config.config.concurrency,
-                  },
-                },
-              };
-              formattedData.config.push(configData);
-            }
-
-            break;
           case "extract_json":
-            {
-              const configData = {
-                branch_type: data.branch_type,
-                condition: transformCondition(data.condition, allColumns),
-                branch_node_config: {
-                  type: data.branch_node_config.config.type,
-                  config: {
-                    column_id: data.branch_node_config.config.column_id,
-                    json_key: data.branch_node_config.config.jsonKey,
-                    new_column_name:
-                      data.branch_node_config.config.newColumnName,
-                    concurrency: data.branch_node_config.config.concurrency,
-                  },
-                },
-              };
-              formattedData.config.push(configData);
-            }
-            break;
           case "extract_code":
             {
+              // New branches (post-PR #1309 + TH-6543) are stored in
+              // snake_case. Old branches persisted before those PRs kept
+              // camelCase (jsonKey, newColumnName). Read new first, fall
+              // back to legacy — no data migration needed.
+              const cfg = data.branch_node_config.config || {};
               const configData = {
                 branch_type: data.branch_type,
                 condition: transformCondition(data.condition, allColumns),
                 branch_node_config: {
-                  type: data.branch_node_config.config.type,
+                  type: cfg.type,
                   config: {
-                    code: data.branch_node_config.config.code,
+                    ...cfg,
+                    // Legacy-camel → snake fallbacks (harmless if already
+                    // snake, since ...cfg above set the snake key first).
+                    // extract_code has no `column_id` on either shape, so
+                    // skip that key entirely for that type to avoid
+                    // polluting the payload with `column_id: undefined`.
+                    ...((data.branch_node_config.type === "extract_json" ||
+                      data.branch_node_config.type === "extract_entities") && {
+                      column_id: cfg.column_id ?? cfg.columnId,
+                    }),
+                    ...(data.branch_node_config.type === "extract_json" && {
+                      json_key: cfg.json_key ?? cfg.jsonKey,
+                    }),
+                    ...(data.branch_node_config.type ===
+                      "extract_entities" && {
+                      language_model_id:
+                        cfg.language_model_id ?? cfg.languageModelId,
+                    }),
                     new_column_name:
-                      data.branch_node_config.config.newColumnName,
-                    concurrency: data.branch_node_config.config.concurrency,
+                      cfg.new_column_name ?? cfg.newColumnName,
+                    concurrency: cfg.concurrency,
                   },
                 },
               };
@@ -738,20 +692,34 @@ def main(**kwargs):
             }
             break;
           case "classification": {
+            // New branches (post-TH-6543) persist snake_case throughout.
+            // Legacy branches saved before this PR have `newColumnName`
+            // / `columnId` / `languageModelId`. Read snake first, fall
+            // back to camel — no migration needed.
+            //
+            // Labels: the child's zod schema `.transform((t) => t.map((e) => e.value))`
+            // already reduces `[{id,value}]` to `[value,value]` at submit
+            // time, so `cfg.labels` here is already the string-array the
+            // backend wants. Guard against the legacy object-array shape
+            // too in case a mid-session state slipped through.
+            const cfg = data.branch_node_config.config || {};
+            const labels = Array.isArray(cfg.labels)
+              ? cfg.labels.map((item) =>
+                  typeof item === "string" ? item : item?.value,
+                )
+              : [];
             const configData = {
               branch_type: data.branch_type,
               condition: transformCondition(data.condition, allColumns),
               branch_node_config: {
                 type: data.branch_node_config.config.type,
                 config: {
-                  column_id: data.branch_node_config.config.column_id,
-                  labels: data.branch_node_config.config.labels.map((item) => {
-                    return item.value;
-                  }),
-                  new_column_name: data.branch_node_config.config.newColumnName,
-                  concurrency: data.branch_node_config.config.concurrency,
+                  column_id: cfg.column_id ?? cfg.columnId,
+                  labels,
+                  new_column_name: cfg.new_column_name ?? cfg.newColumnName,
+                  concurrency: cfg.concurrency,
                   language_model_id:
-                    data.branch_node_config.config.language_model_id,
+                    cfg.language_model_id ?? cfg.languageModelId,
                 },
               },
             };

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -104,8 +104,6 @@ def main(**kwargs):
     },
   });
 
-  // Form fields are already snake_case (see defaultValues above), so we pass
-  // formValues straight through — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -50,14 +50,7 @@ export const ExecuteCodeChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
-    defaultValues: {
-      code: `# Function name should be main only. You can access any column of the row using the kwargs.
-def main(**kwargs):
-    return kwargs.get("column_name")
-`,
-      new_column_name: "",
-      concurrency: "",
-    },
+    defaultValues: getDefaultValue(),
     resolver: zodResolver(ExecuteCodeValidation(!!onFormSubmit, !!editId)),
   });
 

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -24,7 +24,7 @@ const getDefaultValue = () => {
 def main(**kwargs):
     return kwargs.get("column_name")
 `,
-    newColumnName: "",
+    new_column_name: "",
     concurrency: "",
   };
 };
@@ -55,7 +55,7 @@ export const ExecuteCodeChild = ({
 def main(**kwargs):
     return kwargs.get("column_name")
 `,
-      newColumnName: "",
+      new_column_name: "",
       concurrency: "",
     },
     resolver: zodResolver(ExecuteCodeValidation(!!onFormSubmit, !!editId)),
@@ -104,18 +104,12 @@ def main(**kwargs):
     },
   });
 
-  const transformFormToApi = (formValues) => {
-    const { newColumnName, ...rest } = formValues;
-    return {
-      ...rest,
-      new_column_name: newColumnName,
-    };
-  };
-
+  // Form fields are already snake_case (see defaultValues above), so we pass
+  // formValues straight through — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({
-        config: transformFormToApi(formValues),
+        config: formValues,
         operation_type: "execute_code",
       });
       return;
@@ -133,7 +127,7 @@ def main(**kwargs):
 
   const handlePreview = handleSubmit((formValues) => {
     if (!onFormSubmit) {
-      preview(transformFormToApi(formValues));
+      preview(formValues);
     }
   });
 
@@ -191,7 +185,7 @@ def main(**kwargs):
               size="small"
               placeholder="Enter column name"
               control={control}
-              fieldName="newColumnName"
+              fieldName="new_column_name"
             />
           )}
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/ExecuteCode.jsx
@@ -66,7 +66,6 @@ def main(**kwargs):
     if (initialData) {
       reset(initialData);
     } else if (!editId) {
-      // Reset to default values when opening for new column (no editId)
       reset(getDefaultValue());
     }
   }, [initialData, reset, editId]);
@@ -251,7 +250,6 @@ ExecuteCodeChild.propTypes = {
 };
 
 const ExecuteCode = ({ initialData, onFormSubmit }) => {
-  // Using individual store
   const { openExecuteCode, setOpenExecuteCode } = useExecuteCodeStore();
 
   const onClose = () => {

--- a/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ExecuteCode/validation.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 const ExecuteCodeValidation = (isConditionalNode = false, isEdit = false) => {
   return z.object({
     code: z.string().min(1, "Code is required"),
-    newColumnName:
+    new_column_name:
       isConditionalNode || isEdit
         ? z.string().optional()
         : z.string().min(1, "Column name is required"),

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
@@ -40,16 +40,7 @@ export const ExtractEntitiesChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
-    // snake_case fields match the backend metadata shape directly, so
-    // `reset(initialData)` populates on edit without a transform. See
-    // validation.js for the contract note. (Fix follows PR #1309.)
-    defaultValues: {
-      column_id: "",
-      instruction: "",
-      language_model_id: "",
-      concurrency: undefined,
-      new_column_name: "",
-    },
+    defaultValues: getDefaultValue(),
     resolver: zodResolver(
       ExtractEntitiesValidationSchema(!!onFormSubmit, !!editId),
     ),
@@ -116,8 +107,6 @@ export const ExtractEntitiesChild = ({
     },
   });
 
-  // Form fields are already snake_case (see defaultValues above), so we
-  // pass formValues straight through to the API — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
@@ -23,11 +23,11 @@ import { ShowComponent } from "../../../../components/show";
 
 const getDefaultValue = () => {
   return {
-    columnId: "",
+    column_id: "",
     instruction: "",
-    languageModelId: "",
+    language_model_id: "",
     concurrency: "",
-    newColumnName: "",
+    new_column_name: "",
   };
 };
 
@@ -40,12 +40,15 @@ export const ExtractEntitiesChild = ({
   const { refreshGrid } = useDevelopDetailContext();
 
   const { control, handleSubmit, reset } = useForm({
+    // snake_case fields match the backend metadata shape directly, so
+    // `reset(initialData)` populates on edit without a transform. See
+    // validation.js for the contract note. (Fix follows PR #1309.)
     defaultValues: {
-      columnId: "",
+      column_id: "",
       instruction: "",
-      languageModelId: "",
+      language_model_id: "",
       concurrency: undefined,
-      newColumnName: "",
+      new_column_name: "",
     },
     resolver: zodResolver(
       ExtractEntitiesValidationSchema(!!onFormSubmit, !!editId),
@@ -113,20 +116,12 @@ export const ExtractEntitiesChild = ({
     },
   });
 
-  const transformFormToApi = (formValues) => {
-    const { columnId, newColumnName, languageModelId, ...rest } = formValues;
-    return {
-      ...rest,
-      column_id: columnId,
-      new_column_name: newColumnName,
-      language_model_id: languageModelId,
-    };
-  };
-
+  // Form fields are already snake_case (see defaultValues above), so we
+  // pass formValues straight through to the API — no snake↔camel remap.
   const onSubmit = (formValues) => {
     if (editId) {
       updateColumn({
-        config: transformFormToApi(formValues),
+        config: formValues,
         operation_type: "extract_entities",
       });
       return;
@@ -134,13 +129,13 @@ export const ExtractEntitiesChild = ({
     if (onFormSubmit) {
       onFormSubmit({ ...formValues, type: "extract_entities" });
     } else {
-      addColumn(transformFormToApi(formValues));
+      addColumn(formValues);
     }
   };
 
   const handlePreview = handleSubmit((formValues) => {
     if (!onFormSubmit) {
-      preview(transformFormToApi(formValues));
+      preview(formValues);
     }
   });
 
@@ -198,13 +193,13 @@ export const ExtractEntitiesChild = ({
               size="small"
               placeholder="Enter column name"
               control={control}
-              fieldName="newColumnName"
+              fieldName="new_column_name"
               required={!onFormSubmit}
             />
           )}
           <FormSearchSelectFieldControl
             control={control}
-            fieldName="columnId"
+            fieldName="column_id"
             size="small"
             label="Column"
             required
@@ -235,7 +230,7 @@ export const ExtractEntitiesChild = ({
           </Box>
           <CustomModelDropdownControl
             control={control}
-            fieldName="languageModelId"
+            fieldName="language_model_id"
             label="Model"
             searchDropdown
             size="small"

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/ExtractEntities.jsx
@@ -53,7 +53,6 @@ export const ExtractEntitiesChild = ({
     if (initialData) {
       reset(initialData);
     } else if (!editId) {
-      // Reset to default values when opening for new column (no editId)
       reset(getDefaultValue());
     }
   }, [initialData, reset, editId]);
@@ -66,13 +65,10 @@ export const ExtractEntitiesChild = ({
         variant: "success",
       });
       reset();
-      // null for gridRef option and true for set column.
       refreshGrid(null, true);
       onClose();
     },
   });
-
-  // const onSubmit = (formValues) => addColumn(formValues);
 
   const {
     data: previewData,
@@ -294,7 +290,6 @@ ExtractEntitiesChild.propTypes = {
 };
 
 const ExtractEntities = ({ initialData, onFormSubmit }) => {
-  // Using individual store
   const { openExtractEntities, setOpenExtractEntities } =
     useExtractEntitiesStore();
 

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/validation.js
@@ -1,9 +1,5 @@
 import { z } from "zod";
 
-// Field names match the snake_case shape the backend returns from
-// `GET /model-hub/columns/{id}/operation-config/` → `result.metadata`, so
-// `reset(initialData)` on edit hydrates the form directly without a
-// snake↔camel transform. Same pattern PR #1309 established for extract_json.
 export const ExtractEntitiesValidationSchema = (
   isConditioalNode = false,
   isEdit,

--- a/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/ExtractEntities/validation.js
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
+// Field names match the snake_case shape the backend returns from
+// `GET /model-hub/columns/{id}/operation-config/` → `result.metadata`, so
+// `reset(initialData)` on edit hydrates the form directly without a
+// snake↔camel transform. Same pattern PR #1309 established for extract_json.
 export const ExtractEntitiesValidationSchema = (
   isConditioalNode = false,
   isEdit,
 ) => {
   return z.object({
     type: z.string().optional(),
-    columnId: z
+    column_id: z
       .string({
         required_error: "Column ID is required",
       })
@@ -20,7 +24,7 @@ export const ExtractEntitiesValidationSchema = (
       .min(1, {
         message: "Instruction is required",
       }),
-    languageModelId: z
+    language_model_id: z
       .string({
         required_error: "Language Model is required",
       })
@@ -28,7 +32,7 @@ export const ExtractEntitiesValidationSchema = (
         message: "Language Model is required",
       }),
     concurrency: z.number().positive("Concurrency must be a positive integer"),
-    newColumnName:
+    new_column_name:
       isConditioalNode || isEdit
         ? z.string().optional()
         : z


### PR DESCRIPTION
## Summary

**Hypothesis (confirmed):** every dynamic-column drawer that PR #1309 didn't touch has the exact same edit-load bug — camelCase form fields silently don't match the snake_case metadata the backend returns from \`GET /model-hub/columns/{id}/operation-config/\`, so \`reset(initialData)\` on edit populates nothing.

TH-6543 reported this for **Extract Entities**. Same class of bug lives in **Execute Code, Classification, and API Call** drawers. Fix follows PR #1309's pattern — rename form fields to snake_case, drop the \`transformFormToApi\` helper, no runtime remap.

## Root cause

Every drawer's Query fetches metadata like this:

\`\`\`js
select: (data) => data?.data?.result?.metadata
\`\`\`

Backend metadata is snake_case (\`column_id\`, \`language_model_id\`, \`new_column_name\`, \`output_type\`, …). Form fields are camelCase (\`columnId\`, \`languageModelId\`, \`newColumnName\`, \`outputType\`). \`reset(initialData)\` doesn't rename keys — mismatched keys drop silently, form renders empty. The submit path had a \`transformFormToApi\` shim doing camel→snake before POST, so **create-new works** but **edit-load doesn't populate**.

## Changes

Same shape in each drawer:
1. Rename \`defaultValues\` keys camelCase → snake_case.
2. Rename \`fieldName=\` props in JSX.
3. Rename zod schema keys in \`validation.js\`.
4. Delete \`transformFormToApi\` — pass \`formValues\` directly.

### Drawers fixed

<img width="1512" height="945" alt="Screenshot 2026-07-08 at 12 36 25 PM" src="https://github.com/user-attachments/assets/9a7fba48-0c73-4701-a54d-dbb82025d871" />

<img width="1512" height="915" alt="Screenshot 2026-07-08 at 12 38 19 PM" src="https://github.com/user-attachments/assets/e2c01ce1-f9ac-4ebb-84a6-7666bdf6c1a9" />

- **\`ExtractEntities/ExtractEntities.jsx\` + \`validation.js\`** — TH-6543 primary. \`columnId → column_id\`, \`languageModelId → language_model_id\`, \`newColumnName → new_column_name\`.
- **\`ExecuteCode/ExecuteCode.jsx\` + \`validation.js\`** — same class bug. \`newColumnName → new_column_name\`.
- **\`Classification/Classification.jsx\` + \`validation.js\`** — \`columnId → column_id\`, \`languageModelId → language_model_id\`, \`newColumnName → new_column_name\`. \`labels\` array-of-{id,value} transform in the validator is preserved (that's needed for the fieldArray UX).
- **\`AddColumnApiCall/AddColumnApiCall.jsx\` + \`validation.js\`** — \`columnName → column_name\`, \`config.outputType → config.output_type\`. Preview endpoint payload now sent as \`{ config: formValues.config }\` directly instead of \`transformFormToApi().config\`.

### ConditionalNode ripple

\`ConditionalNode/ConditionalNode.jsx\` embeds all four drawers as branch sub-forms. Three touch-ups based on review feedback:

**Write side** (\`handleUpdate\`): the four \`case\` blocks (classification, extract_entities, extract_json, extract_code) explicitly remapped \`formData.columnId → column_id\` etc. Since \`formData\` now already carries snake_case (from the fixed child forms), those explicit lines would overwrite the real values with \`undefined\`. Simplified all four to \`config: { ...formData }\`.

**Read side** (submit format for API): the \`extract_entities / extract_json / extract_code\` case was doing \`...cfg\` (spreading the entire stored config) followed by \`?? camelFallback\` overrides. The spread carried legacy camelCase keys into the output alongside the new snake ones; \`react-hook-form\`'s \`reset()\` retains unregistered keys so those camel keys rode back through \`config: { ...formData }\` on every save — the branch accumulated both shapes and never self-healed. Removed \`...cfg\` entirely and replaced it with explicit per-type key listing (\`new_column_name\`, \`column_id\`, \`json_key\`, \`language_model_id\`, \`instruction\`, \`code\`) so only the relevant keys are sent and any legacy camel data is dropped on the next save.

**Branch-seed literals**: \`defaultValues\`, \`handleColumnTypeChange\`, and \`handleAddBranch\` each contained an identical ~50-key config object seeding an empty branch. These still had dead camelCase keys (\`columnName\`, \`outputType\`, \`jsonKey\`, \`newColumnName\`, \`columnId\`) sitting next to the snake ones. Extracted into a single \`getEmptyBranchConfig()\` function with snake_case keys only — kills the triplication and eliminates the source of future drift.

## Deferred (same class, larger scope — separate PR)

**Retrieval drawer** (\`Retrieval/{Retrieval,PineConeForm,QdrantForm,WeivateForm,EmbeddingConfigField}.jsx\` + \`validation.js\`) has the same bug across ~30 fields in three vendor sub-forms (\`apiKey, indexName, topK, queryKey, collectionName, searchType, vectorLength, embeddingConfig.model, embeddingConfig.type\`, etc.). The zod schema is a discriminated union across all three vendors. Left as a separate ticket to keep this PR reviewable.

## Linked issues

Closes TH-6543
Partially addresses TH-6424 (sub-issue 2.c — "edit flow is not supported correctly; information from the previous run is not saved when reconfiguring dynamic columns". The video in TH-6424 shows Classification's Column and Model fields being empty on edit — that is the exact camelCase/snake_case mismatch fixed here for Classification, ExtractEntities, ExecuteCode, and ApiCall. Sub-issues 2.a and 2.b are not covered by this PR.)
Companion to TH-6423 / #1309 (which fixed the same class of bug for Extract JSON Key).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested

For each fixed drawer:

- [ ] Open **Add Column** → drawer → all fields blank (defaults unchanged).
- [ ] Fill in required fields, click **Create New Column** → new column created; POST body has snake_case keys.
- [ ] Click **Test** on a populated form → preview POST also carries snake_case keys, preview renders.
- [ ] **Edit an existing column** of that type → **all fields pre-populate from persisted metadata** (regression this PR fixes).
- [ ] Update, save, reopen → round-trips correctly.
- [ ] Inside a **Conditional Node**, add a branch of that type, save the conditional column, reopen → branch sub-form hydrates correctly.
- [ ] Existing 14 tests in \`ExtractJsonKey/__tests__/columnFilter.test.js\` unaffected.