### PR TITLE
fix: send trace tags as string payload

### DIFF
--- a/frontend/src/components/traceDetail/AddTagsPopover.jsx
+++ b/frontend/src/components/traceDetail/AddTagsPopover.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Box, Popover, Stack, Typography } from "@mui/material";
+import { Popover, Stack, Typography } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "src/utils/axios";
 import { enqueueSnackbar } from "notistack";
 import { normalizeTags } from "./tagUtils";
+import { serializeTraceTags } from "./traceTagPayload";
 import TagChip from "./TagChip";
 import TagInput from "./TagInput";
 
@@ -31,7 +32,9 @@ const AddTagsPopover = ({
   }, [open, currentTags, isBulk]);
 
   const patchTrace = (id, newTags) =>
-    axios.patch(`/tracer/trace/${id}/tags/`, { tags: newTags });
+    axios.patch(`/tracer/trace/${id}/tags/`, {
+      tags: serializeTraceTags(newTags),
+    });
   const patchSpan = (id, newTags) =>
     axios.post(`/tracer/observation-span/update-tags/`, {
       span_id: id,

--- a/frontend/src/components/traceDetail/__tests__/traceTagPayload.test.js
+++ b/frontend/src/components/traceDetail/__tests__/traceTagPayload.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { serializeTraceTags } from "../traceTagPayload";
+
+describe("serializeTraceTags", () => {
+  it("converts rich trace tags to the string payload expected by the API", () => {
+    expect(
+      serializeTraceTags([
+        { name: "customer-escalation", color: "#EF4444" },
+        { name: "needs-review", color: "#3B82F6" },
+      ]),
+    ).toEqual(["customer-escalation", "needs-review"]);
+  });
+
+  it("keeps existing string tags and supports clearing all tags", () => {
+    expect(serializeTraceTags(["existing-tag"])).toEqual(["existing-tag"]);
+    expect(serializeTraceTags([])).toEqual([]);
+  });
+});

--- a/frontend/src/components/traceDetail/traceTagPayload.js
+++ b/frontend/src/components/traceDetail/traceTagPayload.js
@@ -1,0 +1,2 @@
+export const serializeTraceTags = (traceTags) =>
+  traceTags.map((tag) => (typeof tag === "string" ? tag : tag.name));


### PR DESCRIPTION
Fixes #1378

## Summary

Updates the trace tag PATCH payload so trace-level tag updates send an array of tag names instead of the UI's rich `{ name, color }` tag objects.

The UI still keeps normalized tag objects for display and color handling. Only the network payload for `/tracer/trace/{id}/tags/` is serialized to `string[]`, matching the backend contract.

## Root Cause

`AddTagsPopover` stores trace tags as `{ name, color }` objects for rendering, then passed that same array directly to the trace tags endpoint. The endpoint expects `tags` to be an array of strings, so request-contract validation rejected the payload.

## Changes

- Added a small `serializeTraceTags` helper for trace tag payloads.
- Used that helper in the trace PATCH path.
- Added regression tests covering rich tag objects, existing string tags, and clearing all tags.
- Removed an unused `Box` import from `AddTagsPopover`.

## Testing

```bash
.\node_modules\.bin\vitest.cmd run src/components/traceDetail/__tests__/traceTagPayload.test.js
.\node_modules\.bin\prettier.cmd --check src/components/traceDetail/AddTagsPopover.jsx src/components/traceDetail/traceTagPayload.js src/components/traceDetail/__tests__/traceTagPayload.test.js
.\node_modules\.bin\eslint.cmd src/components/traceDetail/AddTagsPopover.jsx src/components/traceDetail/traceTagPayload.js src/components/traceDetail/__tests__/traceTagPayload.test.js
```

The pre-commit hook also ran `lint-staged` for the three changed frontend files.