### PR TITLE
fix: preserve eval tags on version load

### DIFF
--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -58,6 +58,7 @@ import VersionBadge from "./VersionBadge";
 import BulkDeleteDialog from "./BulkDeleteDialog";
 import { EVAL_TAGS } from "../constant";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
+import { getEvalTags } from "./evalTags";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
 
 const extract_selected_tools = (tools) => {
@@ -252,9 +253,7 @@ const EvalDetailPage = () => {
       viewingVersion.is_default ?? viewingVersion.isDefault ?? false;
     if (freshFlag !== localFlag) {
       setViewingVersion((prev) =>
-        prev
-          ? { ...prev, is_default: freshFlag, isDefault: freshFlag }
-          : prev,
+        prev ? { ...prev, is_default: freshFlag, isDefault: freshFlag } : prev,
       );
     }
   }, [versionsData, viewingVersion]);
@@ -360,7 +359,7 @@ const EvalDetailPage = () => {
               config.error_localizer_enabled ??
               false,
           );
-          setTags(evalData.tags || evalData.eval_tags || []);
+          setTags(getEvalTags(evalData));
           if (config.messages && config.messages.length > 0) {
             setMessages(config.messages);
           } else if (evalData.eval_type === "llm" && promptText) {
@@ -382,14 +381,13 @@ const EvalDetailPage = () => {
       // Load version config into the form
       isPopulatingRef.current = true;
       setViewingVersion(versionToLoad);
+      setTags(getEvalTags(evalData));
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
           next.set(
             "v",
-            String(
-              versionToLoad.version_number ?? versionToLoad.versionNumber,
-            ),
+            String(versionToLoad.version_number ?? versionToLoad.versionNumber),
           );
           return next;
         },
@@ -518,7 +516,6 @@ const EvalDetailPage = () => {
   const initialLoadDone = useRef(false);
   useEffect(() => {
     if (evalData && !viewingVersion) {
-
       const isCustom = evalData.owner !== "system";
       const urlVersion = searchParams.get("v");
       if (urlVersion && !initialLoadDone.current) {
@@ -625,7 +622,7 @@ const EvalDetailPage = () => {
             config.error_localizer_enabled ??
             false,
         );
-        setTags(evalData.tags || evalData.eval_tags || []);
+        setTags(getEvalTags(evalData));
         if (config.messages && config.messages.length > 0) {
           setMessages(config.messages);
         } else if (evalData.eval_type === "llm" && promptText) {
@@ -1661,7 +1658,7 @@ const EvalDetailPage = () => {
                   ))}
 
                 {/* Error Localization */}
-                {!isComposite && evalType !== "code"  && (
+                {!isComposite && evalType !== "code" && (
                   <Box>
                     <FormControlLabel
                       control={
@@ -1964,7 +1961,11 @@ const EvalDetailPage = () => {
                         variant={isComposite ? "contained" : "outlined"}
                         size="small"
                         onClick={handleTestEvaluation}
-                        disabled={isTesting || !isPlaygroundReady || needsTemplateVariable}
+                        disabled={
+                          isTesting ||
+                          !isPlaygroundReady ||
+                          needsTemplateVariable
+                        }
                         startIcon={
                           isTesting ? (
                             <CircularProgress size={14} />
@@ -1999,12 +2000,17 @@ const EvalDetailPage = () => {
                           variant="contained"
                           size="small"
                           onClick={handleSaveVersion}
-                          disabled={isSaving || !isDirty || needsTemplateVariable}
+                          disabled={
+                            isSaving || !isDirty || needsTemplateVariable
+                          }
                           startIcon={
                             isSaving ? (
                               <CircularProgress size={14} />
                             ) : (
-                              <Iconify icon="mdi:content-save-outline" width={16} />
+                              <Iconify
+                                icon="mdi:content-save-outline"
+                                width={16}
+                              />
                             )
                           }
                           sx={{ textTransform: "none" }}
@@ -2037,7 +2043,10 @@ const EvalDetailPage = () => {
                             isSaving ? (
                               <CircularProgress size={14} />
                             ) : (
-                              <Iconify icon="mdi:content-save-outline" width={16} />
+                              <Iconify
+                                icon="mdi:content-save-outline"
+                                width={16}
+                              />
                             )
                           }
                           sx={{ textTransform: "none" }}

--- a/frontend/src/sections/evals/components/__tests__/evalTags.test.js
+++ b/frontend/src/sections/evals/components/__tests__/evalTags.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getEvalTags } from "../evalTags";
+
+describe("getEvalTags", () => {
+  it("reads template-level tags from the eval detail payload", () => {
+    expect(getEvalTags({ tags: ["SAFETY", "RAG"] })).toEqual(["SAFETY", "RAG"]);
+  });
+
+  it("falls back to eval_tags for legacy payloads", () => {
+    expect(getEvalTags({ eval_tags: ["LEGACY"] })).toEqual(["LEGACY"]);
+  });
+
+  it("returns an empty list when tags are missing", () => {
+    expect(getEvalTags(null)).toEqual([]);
+    expect(getEvalTags({})).toEqual([]);
+  });
+});

--- a/frontend/src/sections/evals/components/evalTags.js
+++ b/frontend/src/sections/evals/components/evalTags.js
@@ -1,0 +1,2 @@
+export const getEvalTags = (evalData) =>
+  evalData?.tags || evalData?.eval_tags || [];


### PR DESCRIPTION
Fixes #1382

## Summary

Keeps eval tags visible on the eval detail page when a saved version is loaded.

`EvalDetailPage` already restored tags from the top-level eval detail payload on initial load and when deselecting a version. This adds the same tag hydration to the version-load path, where the page previously populated every other field from the version snapshot but left `tags` stale or empty.

## Root Cause

Tags are template-level eval metadata, not version-scoped config. The version selection path reads from `config_snapshot`, which does not include tags, and never copied tags from the top-level `evalData` payload. User-created evals with a default saved version route through that path on initial load, so their tags were not selected on the detail page.

## Changes

- Added a small `getEvalTags` helper that reads `tags`, falls back to `eval_tags`, and defaults to `[]`.
- Reused the helper in the existing tag hydration paths.
- Added the missing tag hydration immediately after `setViewingVersion(versionToLoad)` so it also runs for version loads and composite-version early returns.
- Added unit coverage for normal tags, legacy `eval_tags`, and missing tag payloads.

## Testing

```bash
.\node_modules\.bin\vitest.cmd run src/sections/evals/components/__tests__/evalTags.test.js
.\node_modules\.bin\prettier.cmd --check src/sections/evals/components/EvalDetailPage.jsx src/sections/evals/components/evalTags.js src/sections/evals/components/__tests__/evalTags.test.js
.\node_modules\.bin\eslint.cmd src/sections/evals/components/EvalDetailPage.jsx src/sections/evals/components/evalTags.js src/sections/evals/components/__tests__/evalTags.test.js
```

ESLint completed with 0 errors and existing hook dependency warnings in `EvalDetailPage`. The pre-commit hook also ran `lint-staged` for the three changed frontend files.