### PR TITLE
fix: block future custom date ranges

### DIFF
--- a/frontend/src/components/custom-datepicker/Calender.jsx
+++ b/frontend/src/components/custom-datepicker/Calender.jsx
@@ -11,6 +11,7 @@ export default function Calendar({
   onSelect,
   onPrevMonth,
   onNextMonth,
+  maxDate,
 }) {
   const monthStart = startOfMonth(currentDate);
   const startDate = startOfWeek(monthStart, { weekStartsOn: 0 });
@@ -29,6 +30,7 @@ export default function Calendar({
           monthStart={monthStart}
           range={range}
           onClick={() => onSelect(cloneDay)}
+          maxDate={maxDate}
         />,
       );
       day = addDays(day, 1);
@@ -110,4 +112,5 @@ Calendar.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onPrevMonth: PropTypes.func.isRequired,
   onNextMonth: PropTypes.func.isRequired,
+  maxDate: PropTypes.instanceOf(Date),
 };

--- a/frontend/src/components/custom-datepicker/DateCell.jsx
+++ b/frontend/src/components/custom-datepicker/DateCell.jsx
@@ -2,8 +2,9 @@ import React from "react";
 import { isSameDay, isWithinInterval, isSameMonth, isToday } from "date-fns";
 import { Box, ButtonBase } from "@mui/material";
 import PropTypes from "prop-types";
+import { isDateSelectable } from "./dateRangeLimits";
 
-export default function DateCell({ day, monthStart, range, onClick }) {
+export default function DateCell({ day, monthStart, range, onClick, maxDate }) {
   const { start, end } = range;
 
   const isStart = start && isSameDay(day, start);
@@ -11,6 +12,7 @@ export default function DateCell({ day, monthStart, range, onClick }) {
   const inRange = start && end && isWithinInterval(day, { start, end });
   const isCurrentMonth = isSameMonth(day, monthStart);
   const today = isToday(day);
+  const isDisabled = !isDateSelectable(day, maxDate);
 
   if (!isCurrentMonth) {
     return <Box sx={{ p: 0, textAlign: "center", color: "transparent" }}></Box>;
@@ -19,6 +21,7 @@ export default function DateCell({ day, monthStart, range, onClick }) {
   return (
     <ButtonBase
       onClick={onClick}
+      disabled={isDisabled}
       sx={{
         width: "100%",
         aspectRatio: "1 / 1",
@@ -37,7 +40,13 @@ export default function DateCell({ day, monthStart, range, onClick }) {
             : inRange
               ? "action.hover"
               : "transparent",
-        color: isStart || isEnd ? "white" : "text.primary",
+        color: isDisabled
+          ? "text.disabled"
+          : isStart || isEnd
+            ? "white"
+            : "text.primary",
+        opacity: isDisabled ? 0.4 : 1,
+        cursor: isDisabled ? "not-allowed" : "pointer",
         "&:hover": {
           bgcolor:
             isStart || isEnd
@@ -66,4 +75,5 @@ DateCell.propTypes = {
     end: PropTypes.instanceOf(Date),
   }).isRequired,
   onClick: PropTypes.func.isRequired,
+  maxDate: PropTypes.instanceOf(Date),
 };

--- a/frontend/src/components/custom-datepicker/DatePicker.jsx
+++ b/frontend/src/components/custom-datepicker/DatePicker.jsx
@@ -5,6 +5,7 @@ import { Box, Button, Divider, Popover } from "@mui/material";
 import { useForm } from "react-hook-form";
 import FormTextFieldV2 from "../FormTextField/FormTextFieldV2.jsx";
 import PropType from "prop-types";
+import { getMaxSelectableDate, isDateSelectable } from "./dateRangeLimits";
 
 export default function CustomDateRangePicker({
   open,
@@ -17,8 +18,11 @@ export default function CustomDateRangePicker({
   const [range, setRange] = useState({ start: null, end: null });
   const [currentDate1, setCurrentDate1] = useState(new Date());
   const [currentDate2, setCurrentDate2] = useState(addMonths(new Date(), 1));
+  const maxSelectableDate = getMaxSelectableDate();
 
   const handleSelectDate = (date) => {
+    if (!isDateSelectable(date, maxSelectableDate)) return;
+
     if (!range.start || (range.start && range.end)) {
       setRange({ start: date, end: null });
     } else if (range.start && !range.end) {
@@ -33,6 +37,7 @@ export default function CustomDateRangePicker({
   const handleInputChange = (value, type) => {
     const parsedDate = parseISO(value);
     if (!isValid(parsedDate)) return;
+    if (!isDateSelectable(parsedDate, maxSelectableDate)) return;
 
     setRange((prev) => {
       if (type === "start") {
@@ -123,6 +128,7 @@ export default function CustomDateRangePicker({
               }}
               range={range}
               onSelect={handleSelectDate}
+              maxDate={maxSelectableDate}
             />
           </Box>
 
@@ -161,6 +167,7 @@ export default function CustomDateRangePicker({
               }}
               range={range}
               onSelect={handleSelectDate}
+              maxDate={maxSelectableDate}
             />
           </Box>
         </Box>

--- a/frontend/src/components/custom-datepicker/__tests__/dateRangeLimits.test.js
+++ b/frontend/src/components/custom-datepicker/__tests__/dateRangeLimits.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getMaxSelectableDate, isDateSelectable } from "../dateRangeLimits";
+
+describe("dateRangeLimits", () => {
+  it("treats dates through the max date as selectable", () => {
+    const maxDate = new Date("2026-07-08T23:59:59.999");
+
+    expect(isDateSelectable(new Date("2026-07-08T00:00:00"), maxDate)).toBe(
+      true,
+    );
+    expect(isDateSelectable(new Date("2026-07-08T23:59:59.999"), maxDate)).toBe(
+      true,
+    );
+  });
+
+  it("rejects dates after the max date", () => {
+    const maxDate = new Date("2026-07-08T23:59:59.999");
+
+    expect(isDateSelectable(new Date("2026-07-09T00:00:00"), maxDate)).toBe(
+      false,
+    );
+  });
+
+  it("rejects invalid dates and preserves an explicit max date", () => {
+    const maxDate = new Date("2026-07-08T23:59:59.999");
+
+    expect(isDateSelectable(new Date("invalid"), maxDate)).toBe(false);
+    expect(getMaxSelectableDate(maxDate)).toBe(maxDate);
+  });
+});

--- a/frontend/src/components/custom-datepicker/dateRangeLimits.js
+++ b/frontend/src/components/custom-datepicker/dateRangeLimits.js
@@ -1,0 +1,6 @@
+import { endOfToday, isAfter, isValid } from "date-fns";
+
+export const getMaxSelectableDate = (maxDate) => maxDate ?? endOfToday();
+
+export const isDateSelectable = (date, maxDate) =>
+  isValid(date) && !isAfter(date, getMaxSelectableDate(maxDate));


### PR DESCRIPTION
Fixes #1383

## Summary

Prevents the shared custom date-range picker from selecting dates after today.

The calendar now disables future day cells, and the date picker handlers reject future values as a backstop for both calendar clicks and typed Start/End dates. Today remains selectable because the cap uses `endOfToday()`.

## Root Cause

The custom date picker did not have an upper-bound check. Calendar cells always rendered as clickable buttons, and the typed input handler accepted any valid parsed date. That allowed eval usage log filters to apply all-future ranges, which can never return logs.

## Changes

- Added a small `dateRangeLimits` helper for the max selectable date and selectable-date check.
- Disabled future calendar cells in `DateCell`.
- Passed the shared max date through `Calendar`.
- Rejected future dates in `CustomDateRangePicker` click and input handlers.
- Added unit coverage for selectable boundary dates, future dates, and invalid dates.

## Testing

```bash
.\node_modules\.bin\vitest.cmd run src/components/custom-datepicker/__tests__/dateRangeLimits.test.js
.\node_modules\.bin\prettier.cmd --check src/components/custom-datepicker/DateCell.jsx src/components/custom-datepicker/Calender.jsx src/components/custom-datepicker/DatePicker.jsx src/components/custom-datepicker/dateRangeLimits.js src/components/custom-datepicker/__tests__/dateRangeLimits.test.js
.\node_modules\.bin\eslint.cmd src/components/custom-datepicker/DateCell.jsx src/components/custom-datepicker/Calender.jsx src/components/custom-datepicker/DatePicker.jsx src/components/custom-datepicker/dateRangeLimits.js src/components/custom-datepicker/__tests__/dateRangeLimits.test.js
```

The pre-commit hook also ran `lint-staged` for the five changed frontend files.