### PR TITLE
fix(datasets): apply Basic filter when a value is typed for text columns (TH-6621)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
@@ -134,11 +134,7 @@ const valuePanelToStore = (val, panelType, operator) => {
     return val;
   }
   if (isNullish(val)) return "";
-  // Free-text entry (usesFreeTextValue → the plain "Enter text…" input) emits a
-  // bare scalar, but the canonical list operators `in`/`not_in` require a list
-  // value — both `validateFilter` and the backend `_apply_filters` text branch
-  // reject a scalar there, silently dropping the filter so the grid never
-  // updates (TH-6621). Wrap the scalar so a single typed value still applies.
+  // in/not_in require a list value; wrap a single typed scalar so it still applies.
   if (operator === "in" || operator === "not_in") {
     return val === "" ? "" : [val];
   }

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
@@ -134,6 +134,14 @@ const valuePanelToStore = (val, panelType, operator) => {
     return val;
   }
   if (isNullish(val)) return "";
+  // Free-text entry (usesFreeTextValue → the plain "Enter text…" input) emits a
+  // bare scalar, but the canonical list operators `in`/`not_in` require a list
+  // value — both `validateFilter` and the backend `_apply_filters` text branch
+  // reject a scalar there, silently dropping the filter so the grid never
+  // updates (TH-6621). Wrap the scalar so a single typed value still applies.
+  if (operator === "in" || operator === "not_in") {
+    return val === "" ? "" : [val];
+  }
   return val;
 };
 

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/__tests__/DevelopFilterBox.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/__tests__/DevelopFilterBox.test.js
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { panelFilterToStore, unwrapScalarValue } from "../DevelopFilterBox";
-import { transformFilter } from "../common";
+import { transformFilter, validateFilter } from "../common";
 
 describe("unwrapScalarValue", () => {
   it("preserves arrays for canonical list operators", () => {
@@ -174,6 +174,64 @@ describe("panelFilterToStore — AI-path regression (TH-4400)", () => {
       value: [undefined],
     });
     expect(out.filterConfig.filterValue).toBe("");
+  });
+});
+
+describe("panelFilterToStore — free-text scalar + list operator (TH-6621)", () => {
+  // Repro: Dataset Detail → Basic filter → pick a text column (its "equals"
+  // label is the canonical list op `in`) → type a value in the free-text
+  // input. That input emits a bare scalar; `in` needs a list, so the row was
+  // dropped by validateFilter and the grid never updated. The store must wrap
+  // the scalar into a single-element list so the same typed value applies —
+  // and crucially, the result must survive validateFilter (the exact gate the
+  // grid's request builder uses).
+  it("wraps a typed scalar into a list for `in` and passes validateFilter", () => {
+    const out = panelFilterToStore({
+      field: "vf",
+      fieldCategory: "dataset",
+      fieldType: "string",
+      operator: "in",
+      value: "02",
+    });
+    expect(out.filterConfig).toMatchObject({
+      filterType: "text",
+      filterOp: "in",
+      filterValue: ["02"],
+    });
+    expect(validateFilter(out)).toBe(true);
+  });
+
+  it("wraps a typed scalar into a list for `not_in` too", () => {
+    const out = panelFilterToStore({
+      field: "vf",
+      fieldType: "string",
+      operator: "not_in",
+      value: "02",
+    });
+    expect(out.filterConfig.filterValue).toEqual(["02"]);
+    expect(validateFilter(out)).toBe(true);
+  });
+
+  it("leaves scalar operators (contains) as a bare scalar", () => {
+    const out = panelFilterToStore({
+      field: "vf",
+      fieldType: "string",
+      operator: "contains",
+      value: "02",
+    });
+    expect(out.filterConfig.filterValue).toBe("02");
+    expect(validateFilter(out)).toBe(true);
+  });
+
+  it("keeps an empty scalar empty so the row stays invalid (not [''])", () => {
+    const out = panelFilterToStore({
+      field: "vf",
+      fieldType: "string",
+      operator: "in",
+      value: "",
+    });
+    expect(out.filterConfig.filterValue).toBe("");
+    expect(validateFilter(out)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

On the **Dataset Detail** page, opening the **Basic** filter, picking a text/string column, and typing a value did nothing — the grid never updated and no filter chip appeared. This fixes it so a typed value applies immediately.

## Why it breaks / where

The Basic filter defaults a text column to the **"equals"** label, which maps to the canonical **list** operator `in` (for strings, `IN (x) ≡ = x`). Text columns on the dataset surface render a **plain free-text input** (`usesFreeTextValue("string","dataset") === true`), which emits a **bare scalar** (e.g. `"02"`).

But `in` / `not_in` are **list** operators. Both gates require an array value:

- FE `validateFilter` (`DevelopFilters/common.js`, via `LIST_FILTER_OPS`) rejects a scalar for a list op.
- Backend `_apply_filters` (`model_hub/views/develop_dataset.py`) → `"'in' requires a non-empty filter_value list."`

So the scalar-value + list-op row was dropped: `validateFilter` returned false → the filter chip never rendered, `gridApi.onFilterChanged()` never fired, and the grid's request builder (`DevelopDataV2.jsx`: `filters.filter(validateFilter).map(transformFilter)`) sent **no filter**. The user types a value and nothing happens.

The panel's own `computeValidFilters` treats a non-empty scalar as valid, so it *did* call `onApply` — the mismatch is purely that the store kept a scalar for a list operator.

## What changed

**`frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx`** (`valuePanelToStore`)
Wrap a non-empty free-text scalar into a single-element list when the operator is `in` / `not_in`, symmetric to the existing `Array.isArray` list-op branch. Scalar operators (`contains`, `starts_with`, …) keep their bare scalar; an empty value stays `""` (row stays invalid). The result flows unchanged through `unwrapScalarValue`, so the store shape now matches both `validateFilter` and the backend contract.

**`.../__tests__/DevelopFilterBox.test.js`**
Added behavioral tests on the real `panelFilterToStore` → `validateFilter` path (the exact functions `handleApply` and the grid request builder use).

## Tests

| Test | Asserts | Red if reverted |
|---|---|---|
| wraps a typed scalar into a list for `in` and passes `validateFilter` | `filterValue === ["02"]` **and** `validateFilter(out) === true` | ✅ |
| wraps a typed scalar into a list for `not_in` too | `filterValue === ["02"]`, `validateFilter` true | ✅ |
| leaves scalar operators (`contains`) as a bare scalar | `filterValue === "02"` (unchanged) | — (guards over-wrapping) |
| keeps an empty scalar empty so the row stays invalid | `filterValue === ""`, `validateFilter` false | — (guards `[""]`) |

Reverting the one-line fix flips exactly the two list-operator tests red; scalar/empty stay green. Full existing suite in this file (TH-4400 regression coverage) stays green — 23/23.

## Commands

```
yarn vitest run src/sections/develop-detail/DataTab/DevelopFilters/__tests__/DevelopFilterBox.test.js
# → 23 passed (23).  Revert the fix → 2 failed (the `in` / `not_in` cases).
```

Verified end-to-end against the live local backend on the real endpoint (`/model-hub/develops/{id}/get-dataset-table/`) with a real dataset:

- **Before** (buggy FE builds `filters: []`) → **3 of 3 rows** returned (unfiltered).
- **After** (fix builds `filter_value: ["sample text 1"]`) → **1 row** returned (`sample text 1`).
- Sending the raw scalar with op `in` directly → backend `400`: `"'in' requires a non-empty filter_value list."` (confirms the wrap is required).

## Before / After

**Real local backend, same dataset** — buggy FE sends no filter → 3 rows; the fix sends the wrapped list → 1 row (`sample text 1`):

![before-after](https://github.com/user-attachments/assets/f528ef21-2615-4624-9e67-ac79165bf02a)

**Behavioral test on the real panel→store path** — 23/23 green with the fix; exactly the two list-operator cases go red when the fix is reverted:

![test-suite](https://github.com/user-attachments/assets/05a6a1eb-c63d-4e52-9788-d2777fb58a8b)

## Backwards compatibility

`valuePanelToStore` is module-local (only consumed by `panelFilterToStore` in the same file). The change only affects the previously-broken scalar + `in`/`not_in` path (which was silently dropped). Scalar operators, list-value multi-select, array/number/date/boolean paths, and the AI-filter path (TH-4400) are unchanged and covered by the existing tests.

## Manual verification

Dataset Detail → filter icon → Basic → pick a text column → type a value → grid narrows to matching rows and the chip renders. `contains` / `starts_with` on a text column still work with a scalar value.

## Type of change

Bug fix (non-breaking).

## Checklist

- [x] Root-cause fix (not a bandaid) in the module the ticket names
- [x] Behavioral test on the real call-path, red if reverted
- [x] Negative branch covered (scalar op stays scalar; empty stays invalid)
- [x] No magic strings (mirrors the file's existing `in`/`not_in` literals)
- [x] Branch `fix/th-6621-…`, base `dev`, off latest `origin/dev`

## Backout

Revert this commit — single, self-contained one-liner + its tests.

## Linear

Closes TH-6621

