### PR TITLE
fix(frontend): datetime filters send wrong time for non-UTC users

### DIFF
--- a/frontend/src/utils/__tests__/formatISOCustom.test.js
+++ b/frontend/src/utils/__tests__/formatISOCustom.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatISOCustom } from "src/utils/utils";
+
+describe("formatISOCustom", () => {
+  it("returns the exact UTC instant, preserving milliseconds", () => {
+    const instant = new Date("2026-01-15T10:30:45.678Z");
+
+    // The pre-fix implementation reformatted the local wall-clock time and
+    // hardcoded ".000Z", so it dropped the milliseconds (and, for non-UTC
+    // users, shifted the whole timestamp by the UTC offset). This exact-match
+    // assertion fails against that behavior in every timezone.
+    expect(formatISOCustom(instant)).toBe("2026-01-15T10:30:45.678Z");
+  });
+
+  it("round-trips to the same instant it was given", () => {
+    const instant = new Date("2026-07-04T23:15:00.500Z");
+
+    expect(new Date(formatISOCustom(instant)).getTime()).toBe(
+      instant.getTime(),
+    );
+  });
+});

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1,4 +1,4 @@
-import { format, formatISO } from "date-fns";
+import { format } from "date-fns";
 import React, { useCallback, useEffect, useRef } from "react";
 import { palette } from "src/theme/palette";
 
@@ -574,8 +574,13 @@ const hexToRgba = (hex, alpha) => {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
+// Converts a Date object to a UTC ISO-8601 string for backend filter payloads.
+// Using Date.prototype.toISOString() guarantees the correct UTC instant regardless
+// of the user's local timezone — the old formatISO().split("+") approach relabelled
+// the local wall-clock time as UTC, shifting all filter windows by the UTC offset.
+// Fixes: https://github.com/future-agi/future-agi/issues/1338
 export const formatISOCustom = (date) => {
-  return formatISO(date).split("+")[0] + ".000Z";
+  return new Date(date).toISOString();
 };
 
 // Start Generation Here


### PR DESCRIPTION
Fixes #1338

formatISOCustom in frontend/src/utils/utils.js was doing this:

  formatISO(date).split('+')[0] + '.000Z'

formatISO from date-fns returns local time with an offset, for example
2026-07-06T10:00:00+05:30. Splitting on '+' and appending .000Z
relabels that local wall-clock time as UTC, so the timestamp reaching
the backend is off by however many hours the user is from UTC.

For users west of UTC it is even worse: the offset has a '-' so
split('+') does nothing and the backend receives a malformed string
like 2026-07-06T10:00:00-04:00.000Z which has both an offset and a
Z suffix.

Fix is one line. Date.prototype.toISOString() always returns the
correct UTC instant regardless of local timezone:

  return new Date(date).toISOString();

Also removed the now-unused formatISO import from date-fns.

Changes:
- frontend/src/utils/utils.js