### PR TITLE
fix(dataset): read snake_case dataset_name in SDK add-dataset flow

### DIFF
--- a/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
@@ -29,6 +29,7 @@ import { FormCodeEditor } from "src/components/form-code-editor";
 import { trackEvent, Events, PropertyName } from "src/utils/Mixpanel";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { getRequestErrorMessage } from "src/utils/errorUtils";
+import { getCreatedDatasetName } from "./sdkCreateDatasetResponse";
 
 const defaultValues = {
   name: "",
@@ -109,7 +110,7 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
       onCloseClick();
       //@ts-ignore
       addRowSDK({
-        dataset_name: data?.data?.result?.datasetName,
+        dataset_name: getCreatedDatasetName(data),
       });
       setIsNext(true);
     },

--- a/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.test.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "src/utils/test-utils";
+import { getCreatedDatasetName } from "./sdkCreateDatasetResponse";
+
+const postMock = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: (...args) => postMock(...args) },
+  endpoints: {
+    develop: { createEmptyDataset: "/model-hub/develops/create-empty-dataset/" },
+    row: { addRowSdk: "/model-hub/develops/add_rows_sdk/" },
+  },
+}));
+vi.mock("src/components/snackbar", () => ({ enqueueSnackbar: vi.fn() }));
+vi.mock("src/utils/Mixpanel", () => ({
+  trackEvent: vi.fn(),
+  Events: {},
+  PropertyName: {},
+}));
+// Monaco is only shown in the second (post-create) modal and is heavy in jsdom.
+vi.mock("src/components/form-code-editor", () => ({
+  FormCodeEditor: () => null,
+}));
+
+import AddSDKModal from "./AddSDKModal";
+
+// Mirrors the real CreateEmptyDatasetView response — snake_case, not camelCase.
+const CREATE_RESPONSE = {
+  data: {
+    result: {
+      message: "Empty dataset created successfully",
+      dataset_id: "11111111-1111-1111-1111-111111111111",
+      dataset_name: "vafvfdafvd",
+      dataset_model_type: "GenerativeLLM",
+    },
+  },
+};
+
+const renderModal = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AddSDKModal open onClose={() => {}} refreshGrid={() => {}} />
+    </QueryClientProvider>,
+  );
+};
+
+describe("getCreatedDatasetName", () => {
+  it("reads the canonical snake_case create-empty-dataset response", () => {
+    expect(getCreatedDatasetName(CREATE_RESPONSE)).toBe("vafvfdafvd");
+  });
+
+  it("keeps the legacy camelCase response fallback", () => {
+    expect(
+      getCreatedDatasetName({ data: { result: { datasetName: "camel_ds" } } }),
+    ).toBe("camel_ds");
+  });
+
+  it("falls back to a bare name key", () => {
+    expect(getCreatedDatasetName({ result: { name: "bare_ds" } })).toBe(
+      "bare_ds",
+    );
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(getCreatedDatasetName({ data: { result: {} } })).toBeNull();
+  });
+});
+
+describe("AddSDKModal — SDK dataset create flow", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    postMock.mockImplementation((url) => {
+      if (url.includes("create-empty-dataset")) {
+        return Promise.resolve(CREATE_RESPONSE);
+      }
+      if (url.includes("add_rows_sdk")) {
+        return Promise.resolve({
+          data: {
+            result: {
+              dataset: { id: CREATE_RESPONSE.data.result.dataset_id, name: "vafvfdafvd" },
+              api_keys: { api_key: "ak", secret_key: "sk" },
+              code: {},
+            },
+          },
+        });
+      }
+      return Promise.resolve({ data: { result: {} } });
+    });
+  });
+
+  it("passes the created dataset's real snake_case name to add_rows_sdk (not undefined)", async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByPlaceholderText("Enter dataset name"), {
+      target: { value: "vafvfdafvd" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
+
+    await waitFor(() => {
+      const addRowsCall = postMock.mock.calls.find(([url]) =>
+        url.includes("add_rows_sdk"),
+      );
+      expect(addRowsCall).toBeTruthy();
+      // Reverts to undefined if the create response is read via camelCase.
+      expect(addRowsCall[1]).toEqual({ dataset_name: "vafvfdafvd" });
+    });
+  });
+});

--- a/frontend/src/sections/develop/AddDatasetDrawer/sdkCreateDatasetResponse.js
+++ b/frontend/src/sections/develop/AddDatasetDrawer/sdkCreateDatasetResponse.js
@@ -1,0 +1,4 @@
+export function getCreatedDatasetName(response) {
+  const result = response?.data?.result || response?.result || {};
+  return result.dataset_name || result.datasetName || result.name || null;
+}


### PR DESCRIPTION
## Summary

Creating a dataset through **Add Dataset → "Add data using SDK"** showed a false error toast — **"The specified dataset does not exist or has been deleted."** — even though the dataset was created successfully and appears in the list.

Root cause: after the create call succeeds, the flow reads `result.datasetName` (camelCase) from the response and passes it to the follow-up `add_rows_sdk` call. The API returns `dataset_name` (snake_case) and responses are **not** camelCased, so `datasetName` was `undefined`. `add_rows_sdk` was posted with an empty body, the backend returned `DATASET_NOT_FOUND`, and its message surfaced as an error toast.

![before / after](https://github.com/user-attachments/assets/7f52fc6a-bc4f-4e29-84f4-122654c7ecf2)

## Why / where it breaks

`frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx` — `createEmptyDataset` `onSuccess`:

```js
addRowSDK({ dataset_name: data?.data?.result?.datasetName }); // datasetName is undefined
```

- `CreateEmptyDatasetView` returns `{ result: { dataset_id, dataset_name, dataset_model_type } }` (snake_case).
- The default DRF renderer is a plain `JSONRenderer` and the axios layer only validates the response — nothing camelCases it, so `datasetName` never exists.
- `AddSDKRowsView` receives no `dataset_name` (and no `dataset_id`), filters on `id=None`, finds nothing, and returns `DATASET_NOT_FOUND`.

Confirmed on the live local stack:

| Call | Before | After |
|---|---|---|
| `POST /model-hub/develops/create-empty-dataset/` | `200` (dataset created) | `200` |
| `POST /model-hub/develops/add_rows_sdk/` body | `{}` → **`404`** | `{"dataset_name":"…"}` → **`200`** |

## What changed

| File | Change |
|---|---|
| `AddDatasetDrawer/sdkCreateDatasetResponse.js` | **New** — `getCreatedDatasetName(response)` extractor: `dataset_name \|\| datasetName \|\| name \|\| null`. Mirrors the existing `manualCreateDatasetResponse.js` / `duplicateDatasetResponse.js` helpers. |
| `AddDatasetDrawer/AddSDKModal.jsx` | Read the created name via `getCreatedDatasetName(data)` instead of the camelCase-only `data?.data?.result?.datasetName`. |
| `AddDatasetDrawer/AddSDKModal.test.jsx` | **New** — unit tests for the helper + a behavioral test that drives the real submit and asserts `add_rows_sdk` receives the real `dataset_name`. |

Keeping the snake/camel/`name` fallback matches the two sibling helpers already in this directory and is resilient if a future contract change re-introduces camelCase aliasing.

## Tests included

| Test | Asserts | Red if reverted? |
|---|---|---|
| `getCreatedDatasetName` — canonical snake_case | reads `result.dataset_name` | — |
| `getCreatedDatasetName` — camelCase / bare-name fallback / null | resilient extraction | — |
| `AddSDKModal` — SDK create flow (behavioral) | after submit, `add_rows_sdk` is posted with `{ dataset_name: "…" }` (not `undefined`) | **Yes** — reverting the read to `datasetName` fails this test (`dataset_name: undefined`) |

## Commands + verification

```bash
cd frontend
npx vitest run src/sections/develop/AddDatasetDrawer   # 2 files, 7 tests passed
```

RED→GREEN proof (behavioral test fails with the fix reverted, passes with it applied):

![red-if-reverted then green](https://github.com/user-attachments/assets/c3f34105-031e-4516-ac9c-bfbefb21fadf)

## Video — before (false error) → after (success)

https://github.com/user-attachments/assets/cb7eeedf-516e-4dbf-8392-1fdd5916cabe

## Backwards compatibility

| Caller of the create response | Impact |
|---|---|
| `AddSDKModal.jsx` (this flow) | Fixed — now reads the real name. |
| `ManuallyCreateDataset.jsx` | Unaffected — already uses `getCreatedDatasetId` helper. |
| `SetEmptyRow.jsx` | Unaffected — does not read the name from the response. |
| `AddRowDrawer/AddSDKModal.jsx` (existing dataset) | Unaffected — sends `dataset_id` from props. |

No API/contract change; frontend-only read fix.

## Manual verification

Verified on a local stack (Datasets → Add Dataset → Add data using SDK):
- **Before:** dataset created, but the error toast fired; `add_rows_sdk` posted `{}` → `404`.
- **After:** dataset created, the "Add Rows via SDK or API" modal renders (Dataset ID + SDK snippet), no error toast; `add_rows_sdk` posted `{"dataset_name":"…"}` → `200`.

## Type

Bug fix (frontend).

## Checklist

- [x] Root-cause fix in the module the ticket names
- [x] Behavioral test on the real call-path (red if reverted)
- [x] Changed-area suite green locally
- [x] No API/contract change; no magic strings
- [x] Before/after + video + test-run proof attached

## Notes / out of scope

While in this file I noticed the success modal reads `result.apiKeys` (camelCase) for the API/Secret Key display, but the backend returns `api_keys` (snake_case) — a separate, pre-existing cosmetic mismatch that leaves those fields blank (the SDK snippet already uses `YOUR_API_KEY` placeholders). Left out of scope for this notification fix.

## Backout

Revert this PR — single frontend module, no migrations or data changes.

Closes TH-6538
