### PR TITLE
[TH-6586][TH-6661] Remove deprecated annotation flow & fix compare 'no common columns'

### DIFF
--- a/frontend/src/sections/develop-detail/BaseColumnsDrawer.jsx
+++ b/frontend/src/sections/develop-detail/BaseColumnsDrawer.jsx
@@ -58,7 +58,7 @@ const BaseColumnDrawer = ({
       });
     },
     onSuccess: (data) => {
-      const baseColumns = data?.data?.result?.baseColumns || [];
+      const baseColumns = data?.data?.result?.base_columns || [];
       setBaseColumnsData(baseColumns);
       setIsDataLoaded(true);
       setLoading(false);

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/CompareDatasetEvalsCards.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/CompareDatasetEvalsCards.jsx
@@ -5,15 +5,12 @@ import { CustomTab, CustomTabs, TabWrapper } from "./SummaryStyle";
 import { ShowComponent } from "src/components/show";
 import DatasetCompareEvalSummary from "./DatasetCompareEvalSummary";
 import DatasetComparePromptSummary from "./DatasetComparePromptSummary";
-import DatasetCompareAnnotationSummary from "./DatasetCompareAnnotationSummary";
 import EvalsCard from "./EvalsCard/EvalsCard";
 import PromptCard from "./PromptCard";
-import AnnotationCard from "./AnnotationCard";
 
 const tabOptions = [
   { label: "Evals", value: "evals", disabled: false },
   { label: "Prompt", value: "prompt", disabled: false },
-  { label: "Annotation", value: "annotation", disabled: false },
 ];
 
 const CompareDatasetEvalsCards = (props) => {
@@ -104,13 +101,6 @@ const CompareDatasetEvalsCards = (props) => {
               datasetId={datasetId}
               datasetIndex={selectedIndex}
             />
-          )}
-        </ShowComponent>
-        <ShowComponent condition={currentTab === "annotation"}>
-          {isCompare ? (
-            <DatasetCompareAnnotationSummary />
-          ) : (
-            <AnnotationCard datasetId={datasetId} setCurrentTab={() => {}} />
           )}
         </ShowComponent>
       </Box>

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/DatasetSummaryTab.jsx
@@ -10,14 +10,12 @@ import { useGetDatasetDetail } from "src/api/develop/develop-detail";
 import { useParams } from "react-router";
 import StyledChip from "./styledChip";
 import PropmtCard from "./PromptCard";
-import AnnotationCard from "./AnnotationCard";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 
 const tabOptions = [
   { label: "Evals", value: "evals", disabled: false },
   { label: "Prompt", value: "prompt", disabled: false },
-  { label: "Annotation", value: "annotation", disabled: false },
 ];
 
 const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
@@ -127,15 +125,13 @@ const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
           </CustomTabs>
         </TabWrapper>
 
-        {currentTab != "annotation" && (
-          <FilterSummary
-            columnLists={columnLists}
-            handleApplyFilter={handleApplyFilter}
-            selectedColumn={selectedColumn}
-            setSelectedColumn={setSelectedColumn}
-            appliedFilter={appliedFilter}
-          />
-        )}
+        <FilterSummary
+          columnLists={columnLists}
+          handleApplyFilter={handleApplyFilter}
+          selectedColumn={selectedColumn}
+          setSelectedColumn={setSelectedColumn}
+          appliedFilter={appliedFilter}
+        />
       </Box>
       <Box sx={{ overflow: "auto", height: "calc(100vh - 200px)" }}>
         <Box display="flex" gap={2} marginBottom={2}>
@@ -169,14 +165,6 @@ const DatasetSummaryTab = ({ setCurrentTabs, datasetId, datasetIndex }) => {
         </ShowComponent>
         <ShowComponent condition={currentTab === "prompt"}>
           <PropmtCard
-            setCurrentTab={setCurrentTabs}
-            selectedColumns={appliedFilter?.map((item) => item.sourceId)}
-            datasetId={datasetId}
-            datasetIndex={datasetIndex}
-          />
-        </ShowComponent>
-        <ShowComponent condition={currentTab === "annotation"}>
-          <AnnotationCard
             setCurrentTab={setCurrentTabs}
             selectedColumns={appliedFilter?.map((item) => item.sourceId)}
             datasetId={datasetId}

--- a/frontend/src/sections/develop-detail/DatasetsSelectRow.jsx
+++ b/frontend/src/sections/develop-detail/DatasetsSelectRow.jsx
@@ -171,7 +171,7 @@ const DatasetsSelectRow = ({
 
     if (shouldHideDevelopBar) {
       const datasetId = currentPath.split("/")[3];
-      navigate(`/dashboard/develop/${datasetId}?tab=annotations`);
+      navigate(`/dashboard/develop/${datasetId}?tab=data`);
       return;
     }
 

--- a/frontend/src/sections/develop-detail/DevelopBar/DevelopBar.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBar/DevelopBar.jsx
@@ -13,11 +13,6 @@ import { useAuthContext } from "src/auth/hooks";
 const TabOptions = [
   { label: "Data", value: "data", icons: "/assets/icons/summary/database.svg" },
   {
-    label: "Annotations",
-    value: "annotations",
-    icons: "/assets/icons/ic_annotaion.svg",
-  },
-  {
     label: "Experiments",
     value: "experiments",
     icons: "/assets/icons/navbar/ic_experiment.svg",
@@ -135,7 +130,6 @@ const DevelopBar = ({
             onChange={(e, value) => {
               setCurrentTab(value);
               setRowSelected([]);
-              if (value === "annotations") trackEvent(Events.annViewed);
               // if (value === "optimization") trackEvent(Events.optViewed);
               if (value === "experiments") trackEvent(Events.expViewed);
               if (value === "summary") trackEvent(Events.summaryViewed);
@@ -158,10 +152,6 @@ const DevelopBar = ({
             }}
           >
             {TabOptions.map((tab) => {
-              // Hide deprecated Annotations tab (replaced by unified Scores)
-              if (tab.value === "annotations") {
-                return null;
-              }
               // If hideScenarioFeatures is true, only show the Data tab
               if (hideScenarioFeatures && tab.value !== "data") {
                 return null;

--- a/frontend/src/sections/develop-detail/DevelopDetailView.jsx
+++ b/frontend/src/sections/develop-detail/DevelopDetailView.jsx
@@ -44,7 +44,6 @@ import ExperimentTabHeader from "./ExperimentTab/ExperimentTabHeader";
 
 const TabOptions = [
   { label: "Data", value: "data" },
-  { label: "Annotations", value: "annotations" },
   { label: "Experiments", value: "experiments" },
   { label: "Optimization", value: "optimization" },
   { label: "Summary", value: "summary" },


### PR DESCRIPTION
**Tickets:** [TH-6586](https://linear.app/future-agi/issue/TH-6586/add-annotation-leads-no-where) — Fixes TH-6586 · [TH-6661](https://linear.app/future-agi/issue/TH-6661/compare-datasets-falsely-shows-no-common-columns-frontend-reads) — Fixes TH-6661

## What was the bug

1. **Annotation leads nowhere (TH-6586):** In dataset **Summary → Annotation**, the "+ Add annotation" button navigated to a deprecated top-level `annotations` tab that was hidden and had no render branch, so the page went blank (plus a MUI "invalid tab value" warning). The old annotation flow was already replaced by the unified annotation queues / inline-scoring system.
2. **Compare shows "no common columns" (TH-6661):** The dataset **Compare → Select Base Columns** drawer always showed "There are no common columns to compare" — even for a dataset and its exact duplicate.

## What changes have been done

- `BaseColumnsDrawer.jsx` — read `data.result.base_columns` instead of `baseColumns`.
- `DatasetSummaryTab.jsx` — remove the Annotation sub-tab (option + render + import); drop the now-always-true `currentTab != "annotation"` guard around `FilterSummary`.
- `CompareDatasetEvalsCards.jsx` — remove the Annotation sub-tab (option + render + imports) from compare Summary.
- `DevelopBar.jsx` — remove the deprecated top-level `annotations` tab entry and the `return null` hide-hack.
- `DevelopDetailView.jsx` — remove the `annotations` entry from its `TabOptions`.
- `DatasetsSelectRow.jsx` — repoint the preview back-nav from the removed `?tab=annotations` to `?tab=data`.

## Why the changes

- The `get-base-columns` API returns shared columns under `base_columns` (snake_case), matching the generated contract (`api.schemas.ts`, `api.zod.ts`). Reading `baseColumns` (camelCase) was always `undefined` → fell back to `[]` → "no common columns".
- The annotation tab/sub-tab is dead: replaced by the unified annotation queues / inline-scoring flow. Its only entry point was the broken button, so removing the surface fixes the bug and clears the leftover dead code.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Compare a dataset with its duplicate → Select Base Columns | Shared columns are listed (not "no common columns") |
| 2 | Compare two datasets with no overlap | Still correctly shows "no common columns to compare" |
| 3 | Dataset → Summary | Sub-tabs are Evals / Prompt only (no Annotation); no blank page |
| 4 | Compare → Summary | Same — no Annotation sub-tab |
| 5 | Visit a stale `?tab=annotations` URL | Falls through to a real tab, not blank (back-nav no longer generates it) |

## How to reproduce (original bugs)

**TH-6586:** Open a dataset → Summary → Annotation sub-tab → click "+ Add annotation" → blank page.

**TH-6661:** Duplicate a dataset → select both → Compare → Select Base Columns → "There are no common columns to compare" despite identical columns.

## Videos and screenshots

<img width="1372" height="888" alt="Screenshot 2026-07-08 at 12 40 35 PM" src="https://github.com/user-attachments/assets/a477c89e-bab4-4bac-9722-113d41671df3" />
<img width="1006" height="454" alt="Screenshot 2026-07-08 at 12 40 24 PM" src="https://github.com/user-attachments/assets/367dacae-4be2-473f-83eb-765301623d58" />
<img width="1441" height="1068" alt="Screenshot 2026-07-08 at 12 40 11 PM" src="https://github.com/user-attachments/assets/3c532984-4379-4bf1-8687-999a8f755a9b" />
<img width="1032" height="489" alt="Screenshot 2026-07-08 at 12 39 34 PM" src="https://github.com/user-attachments/assets/30d9eb5c-c536-4d9c-8e62-dca4a1009fb8" />
