### PR TITLE
fix(simulation): render audio error localizer + dedupe eval-save toast

### DIFF
--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -211,6 +211,9 @@ const EvalErrorLocalization = ({
       // Empty object — analysis ran but found no segments. Fall through
       // to the "run" card so users can re-trigger if they suspect it.
     } else {
+      const isAudioLocalization = entries.some(([, value]) =>
+        (Array.isArray(value) ? value : []).some((e) => e?.orgSegment),
+      );
       return (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
           <Typography
@@ -225,9 +228,7 @@ const EvalErrorLocalization = ({
           >
             Possible Error
           </Typography>
-          {entries.some(([, value]) =>
-            (Array.isArray(value) ? value : []).some((e) => e?.orgSegment),
-          ) ? (
+          {isAudioLocalization ? (
             <AudioErrorCard
               valueInfos={{ errorAnalysis: analysis }}
               column={selectedInputKey || "input"}

--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -8,6 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import AudioErrorCard from "src/components/custom-audio/AudioErrorCard";
 import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
 import { canonicalEntries } from "src/utils/utils";
 
@@ -224,15 +225,24 @@ const EvalErrorLocalization = ({
           >
             Possible Error
           </Typography>
-          {entries.map(([key, value]) => (
-            <ErrorLocalizeCard
-              key={key}
-              value={value}
-              column={selectedInputKey || key}
-              tabValue="raw"
-              datapoint={datapoint}
+          {entries.some(([, value]) =>
+            (Array.isArray(value) ? value : []).some((e) => e?.orgSegment),
+          ) ? (
+            <AudioErrorCard
+              valueInfos={{ errorAnalysis: analysis }}
+              column={selectedInputKey || "input"}
             />
-          ))}
+          ) : (
+            entries.map(([key, value]) => (
+              <ErrorLocalizeCard
+                key={key}
+                value={value}
+                column={selectedInputKey || key}
+                tabValue="raw"
+                datapoint={datapoint}
+              />
+            ))
+          )}
         </Box>
       );
     }

--- a/frontend/src/sections/evals/components/EvalResultDisplay.jsx
+++ b/frontend/src/sections/evals/components/EvalResultDisplay.jsx
@@ -11,6 +11,7 @@ import PropTypes from "prop-types";
 import React, { useMemo, useState } from "react";
 import Editor from "@monaco-editor/react";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import AudioErrorCard from "src/components/custom-audio/AudioErrorCard";
 import Iconify from "src/components/iconify";
 import { InlineAudio } from "src/components/inline-audio/inline-row-audio";
 import SkippedLocalizationBanner from "src/sections/common/SkippedLocalizationBanner";
@@ -603,6 +604,13 @@ const ErrorLocalizationSection = ({ result }) => {
     input_types: inputTypes,
   };
 
+  const allLocalizerEntries = entriesMap
+    ? Object.values(entriesMap).flat()
+    : entries || [];
+  const isAudioLocalization = allLocalizerEntries.some(
+    (entry) => entry?.orgSegment,
+  );
+
   // If no entries ended up with content, don't render anything - the eval
   // might have passed or the localizer might have found nothing to flag.
   const mapHasContent =
@@ -635,7 +643,12 @@ const ErrorLocalizationSection = ({ result }) => {
       >
         Error Localization
       </Typography>
-      {entriesMap ? (
+      {isAudioLocalization ? (
+        <AudioErrorCard
+          valueInfos={{ errorAnalysis: errorDetails }}
+          column={selectedInputKey || "input"}
+        />
+      ) : entriesMap ? (
         Object.entries(entriesMap)
           .filter(([, v]) => v && (Array.isArray(v) ? v.length > 0 : true))
           .map(([key, value]) => (

--- a/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
+++ b/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
@@ -92,25 +92,18 @@ const TestDetailConfigureEval = () => {
     async (evalConfig) => {
       if (!testId || !editingEvalItem?.id) return;
       const payload = serializeEvalConfig(evalConfig);
-      try {
-        await updateEvalAsync({
-          evalConfigId: editingEvalItem.id,
-          payload: {
-            ...payload,
-            ...(executionId
-              ? { run: true, test_execution_id: executionId }
-              : {}),
-          },
-        });
+      await updateEvalAsync({
+        evalConfigId: editingEvalItem.id,
+        payload: {
+          ...payload,
+          ...(executionId
+            ? { run: true, test_execution_id: executionId }
+            : {}),
+        },
+      });
 
-        enqueueSnackbar("Eval updated successfully", { variant: "success" });
-        handleRefresh();
-      } catch (error) {
-        enqueueSnackbar(error?.response?.data?.error || "Failed to save eval", {
-          variant: "error",
-        });
-        throw error;
-      }
+      enqueueSnackbar("Eval updated successfully", { variant: "success" });
+      handleRefresh();
     },
     [testId, executionId, editingEvalItem, updateEvalAsync, handleRefresh],
   );

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -98,25 +98,18 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
       if (!testId) return;
       const editing = editingEvalItem;
       const payload = serializeEvalConfig(evalConfig);
-      try {
-        if (editing?.id) {
-          await updateEvalAsync({
-            evalConfigId: editing.id,
-            payload,
-          });
-          enqueueSnackbar("Eval updated successfully", { variant: "success" });
-        } else {
-          await addEvalsAsync({ evaluations_config: [payload] });
-          enqueueSnackbar("Eval added successfully", { variant: "success" });
-        }
-        handleRefresh();
-        setEditingEvalItem(null);
-      } catch (error) {
-        enqueueSnackbar(error?.response?.data?.error || "Failed to save eval", {
-          variant: "error",
+      if (editing?.id) {
+        await updateEvalAsync({
+          evalConfigId: editing.id,
+          payload,
         });
-        throw error;
+        enqueueSnackbar("Eval updated successfully", { variant: "success" });
+      } else {
+        await addEvalsAsync({ evaluations_config: [payload] });
+        enqueueSnackbar("Eval added successfully", { variant: "success" });
       }
+      handleRefresh();
+      setEditingEvalItem(null);
     },
     [addEvalsAsync, updateEvalAsync, handleRefresh, testId, editingEvalItem],
   );

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
@@ -84,26 +84,18 @@ const SimulationEvaluationDrawer = ({ open, onClose, onSuccess }) => {
       if (!simulationId) return;
       const editing = editingEvalItem;
       const payload = serializeEvalConfig(evalConfig);
-      try {
-        if (editing?.id) {
-          await updateEvalAsync({
-            evalConfigId: editing.id,
-            payload,
-          });
-          enqueueSnackbar("Eval updated successfully", { variant: "success" });
-        } else {
-          await addEvalsAsync({ evaluations_config: [payload] });
-          enqueueSnackbar("Eval added successfully", { variant: "success" });
-        }
-        handleRefresh();
-        setEditingEvalItem(null);
-      } catch (error) {
-        enqueueSnackbar(error?.response?.data?.error || "Failed to save eval", {
-          variant: "error",
+      if (editing?.id) {
+        await updateEvalAsync({
+          evalConfigId: editing.id,
+          payload,
         });
-        // Rethrow so EvalPickerConfigFull keeps the user on the config step.
-        throw error;
+        enqueueSnackbar("Eval updated successfully", { variant: "success" });
+      } else {
+        await addEvalsAsync({ evaluations_config: [payload] });
+        enqueueSnackbar("Eval added successfully", { variant: "success" });
       }
+      handleRefresh();
+      setEditingEvalItem(null);
     },
     [
       addEvalsAsync,


### PR DESCRIPTION
## Summary

Two simulation-related frontend fixes, one commit each:

1. **Audio error localizer not rendering** — audio inputs now render the audio card instead of a broken text card.
2. **Duplicate error toast on eval config save** — only the backend validation message shows, not a second generic toast.

## Why / problem

**Audio localizer (TH-6664).** Audio error-localizer entries carry an `orgSegment` (url + time range) instead of a text `orgSen` (char indices). `ErrorLocalizeCard` only handles text/image, so audio entries fell into the text path, looked for `orgSen.startIdx` (undefined), and tried to highlight the audio URL string — rendering nothing usable. Text and image worked fine.

**Duplicate toast (TH-6665).** Saving an eval config showed two error toasts: the backend validation message **and** a generic `"Failed to save eval"`. The global react-query `mutationCache.onError` already surfaces the backend message via `error.result`; the local `handleEvalAdded` catch also toasted, reading `error.response.data.error` — but the axios interceptor flattens the error (strips `.response`), so it always fell back to the generic string.

## What changed

**Audio localizer** (commit `940b85ffb`)
- Detect entries with `orgSegment` and render `AudioErrorCard` (audio player + reason) instead of `ErrorLocalizeCard`, matching the existing `EvalSection` / `DatapointDrawerV2` pattern.
- `frontend/src/sections/evals/components/EvalResultDisplay.jsx` — simulation / dataset-test / tracing-test / test-playground / task-preview surfaces.
- `frontend/src/components/traceDetail/EvalErrorLocalization.jsx` — trace detail eval tab (`EvalsTabView` → `EvalTableRow`).

**Duplicate toast** (commit `d396598e1`)
- Removed the redundant local error toast (and now-useless try/catch); rely on the global handler for the backend message. `EvalPickerDrawer` still catches the rejection to keep the user on the config step.
- `frontend/src/sections/test-detail/TestDetailConfigureEval.jsx`
- `frontend/src/sections/test/TestEvaluationDrawer.jsx`
- `frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx`

## Tests

- [ ] Frontend lint passes (`yarn lint`) — changed files lint clean (0 errors)

## Backwards compatibility

Frontend-only. Text/image error localization and success toasts are unchanged; additive audio branch + removal of a redundant toast.

## Manual verification

- [x] Audio eval with error-localizer (simulation test mode) → renders `AudioErrorCard` (player + reason), not a broken text card
- [x] Audio eval in trace detail eval tab → same audio card renders
- [x] Text error localization still renders highlighted segments (no regression)
- [x] Image error localization still renders the overlay (no regression)
- [x] Save eval config against a non-completed execution → single backend toast ("Only test executions with COMPLETED, CANCELLED, or FAILED status can have evaluations rerun"), no "Failed to save eval"
- [x] Valid eval save → single "Eval updated/added successfully"; picker stays on config step on error

## Type of change

- [x] Bug fix

## Backout

Revert commits `d396598e1` (toast) and/or `940b85ffb` (audio); no data or migration impact.

## Linear

Closes TH-6664
Closes TH-6665

🤖 Generated with [Claude Code](https://claude.com/claude-code)