### PR TITLE
fix(datasets): show loading skeleton immediately for newly added columns (TH-6535)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -39,6 +39,8 @@ import {
   getTypeDefinitions,
   onCellValueChangedWrapper,
   postProcessPopup,
+  RefreshStatus,
+  withPendingColumnLoadingState,
 } from "./common";
 import JsonCellEditor from "./DoubleClickEditCell/JsonCellEditor";
 import { defaultRowHeightMapping } from "src/utils/constants";
@@ -86,13 +88,6 @@ import { OutputTypes } from "../../common/DevelopCellRenderer/CellRenderers/cell
 import { useAuthContext } from "src/auth/hooks";
 import { ROLES } from "src/utils/rolePermissionMapping";
 const PdfPreviewDrawer = lazy(() => import("src/components/PdfPreviewDrawer"));
-const RefreshStatus = [
-  "Running",
-  "NotStarted",
-  "Editing",
-  "ExperimentEvaluation",
-  "PartialRun",
-];
 
 const getResultColumnConfig = (result) => result?.column_config ?? [];
 const getResultIsProcessingData = (result) =>
@@ -291,7 +286,10 @@ const getDataSource = (
           if (getResultIsSyntheticDataset(result)) {
             updateProcessingSyntheticData(false);
           }
-          const fetchedRows = rows || [];
+          const fetchedRows = withPendingColumnLoadingState(
+            rows || [],
+            columnConfig,
+          );
           const isLastPage = fetchedRows.length < DATASET_ROWS_LIMIT;
 
           params.success({
@@ -1029,7 +1027,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
             });
           }
           const transaction = {
-            update: rows,
+            update: withPendingColumnLoadingState(rows, columnConfig),
           };
 
           // if we are getting processing percentage for synthetic data we don't to put data in the grid hence returning early

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { enhanceCol, getColumnConfig } from "../common";
+import {
+  enhanceCol,
+  getColumnConfig,
+  RefreshStatus,
+  withPendingColumnLoadingState,
+} from "../common";
+import { StatusTypes } from "src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 
 describe("enhanceCol", () => {
   it("preserves null data_type from snake_case input", () => {
@@ -88,5 +94,58 @@ describe("getColumnConfig valueGetter", () => {
       data: {},
     });
     expect(result).toBe(undefined);
+  });
+});
+
+describe("withPendingColumnLoadingState", () => {
+  // A just-added eval-prompt/dynamic column: column status is a refreshing
+  // value while the async worker has not yet flipped the cells to "running".
+  const refreshingConfig = [
+    { id: "colDone", status: "Completed" },
+    { id: "colPending", status: "NotStarted" },
+  ];
+  const mkRows = () => [
+    { rowId: 1, colDone: { cell_value: "answer", status: "pass" } },
+    { rowId: 2, colDone: { cell_value: "answer", status: "pass" } },
+  ];
+
+  it("marks blank cells of a refreshing column as running so they load", () => {
+    const rows = mkRows();
+    const result = withPendingColumnLoadingState(rows, refreshingConfig);
+    // The pending column had no cell at all in the row -> now a running cell.
+    expect(result[0].colPending.status).toBe(StatusTypes.RUNNING);
+    expect(result[1].colPending.status).toBe(StatusTypes.RUNNING);
+  });
+
+  it("NotStarted is one of the statuses that triggers loading", () => {
+    // Guards against the constant drifting away from the render behaviour.
+    expect(RefreshStatus).toContain("NotStarted");
+    expect(RefreshStatus).toContain("Running");
+  });
+
+  it("leaves cells that already have a value untouched", () => {
+    const result = withPendingColumnLoadingState(mkRows(), refreshingConfig);
+    expect(result[0].colDone.cell_value).toBe("answer");
+    expect(result[0].colDone.status).toBe("pass");
+  });
+
+  it("does not mark cells when the column has finished (Completed)", () => {
+    const rows = [{ rowId: 1, colDone: { cell_value: "", status: "pass" } }];
+    const config = [{ id: "colDone", status: "Completed" }];
+    const result = withPendingColumnLoadingState(rows, config);
+    expect(result[0].colDone.status).toBe("pass");
+  });
+
+  it("preserves an existing error status on a refreshing column", () => {
+    const rows = [{ rowId: 1, colPending: { status: "error" } }];
+    const config = [{ id: "colPending", status: "Running" }];
+    const result = withPendingColumnLoadingState(rows, config);
+    expect(result[0].colPending.status).toBe("error");
+  });
+
+  it("returns rows unchanged when no column is refreshing", () => {
+    const rows = mkRows();
+    const config = [{ id: "colDone", status: "Completed" }];
+    expect(withPendingColumnLoadingState(rows, config)).toBe(rows);
   });
 });

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -41,6 +41,51 @@ const STATUS = {
   FAILED: "Failed",
 };
 
+// Column-level statuses that mean the column's cells are still being
+// (re)computed server-side. Single source of truth shared by the grid poll
+// (DevelopDataV2) and the optimistic loading helper below so they never drift.
+export const RefreshStatus = [
+  "Running",
+  "NotStarted",
+  "Editing",
+  "ExperimentEvaluation",
+  "PartialRun",
+];
+
+// A just-added column carries a refreshing column-status before the async
+// worker flips its cells to "running", so those cells render blank instead of a
+// loading skeleton. For every refreshing column, mark its not-yet-populated
+// cells as running so the skeleton shows immediately; cells that already have a
+// value/error/running status are left for the next server poll to replace.
+export const withPendingColumnLoadingState = (rows, columnConfig) => {
+  if (!Array.isArray(rows) || !Array.isArray(columnConfig)) return rows;
+  const pendingColumnIds = columnConfig
+    .filter((column) => RefreshStatus.includes(column?.status))
+    .map((column) => column?.id);
+  if (pendingColumnIds.length === 0) return rows;
+
+  return rows.map((row) => {
+    let nextRow = row;
+    for (const columnId of pendingColumnIds) {
+      const cell = row?.[columnId];
+      const cellValue = cell?.cell_value ?? cell?.cellValue;
+      const hasValue =
+        cellValue !== undefined && cellValue !== null && cellValue !== "";
+      const cellStatus = cell?.status?.toLowerCase?.();
+      if (
+        hasValue ||
+        cellStatus === StatusTypes.RUNNING ||
+        cellStatus === StatusTypes.ERROR
+      ) {
+        continue;
+      }
+      if (nextRow === row) nextRow = { ...row };
+      nextRow[columnId] = { ...(cell ?? {}), status: StatusTypes.RUNNING };
+    }
+    return nextRow;
+  });
+};
+
 const DEFAULT_MIN_WIDTH = 300;
 
 const NonEditableColumns = [


### PR DESCRIPTION
## Summary

Dataset cells for a newly added **eval prompt** or **dynamic column** stayed blank for a few seconds after the add, instead of entering a loading state immediately. This makes it look like nothing happened until the skeletons finally appear.

The grid decides "is this cell loading?" purely from the **per-cell** status (`status === "running"`). But on add, the column is created with a refreshing **column** status (`NotStarted` for run-prompt, `Running` for dynamic columns) *synchronously*, while each cell is only flipped to `running` later — inside the async worker (`run_all_prompts_task`, `apply_async`). In that window the cells have no value and no `running` status, so they render blank.

Fix: bridge that window on the client. When a column's status is still refreshing, show the loading skeleton on its not-yet-populated cells immediately — driven by the column status that the backend sets synchronously on add.

## Why / where it breaks

- `CustomCellRender.jsx` shows the skeleton only when the cell's own `status === "running"`.
- On add, `refreshGrid()` refetches, but the immediate refetch races ahead of the async worker, so the new column's cells come back without a `running` status → blank.
- The 5s grid poll that would eventually surface `running` cells only arms once a fetch already reports a running column, compounding the delay.

## What changed (per file)

**`frontend/src/sections/develop-detail/DataTab/common.js`**
- Moved `RefreshStatus` here as the single source of truth (was a local const in `DevelopDataV2.jsx`).
- Added `withPendingColumnLoadingState(rows, columnConfig)`: for every column whose status is still refreshing, marks its blank cells `running` so the existing skeleton renderer shows immediately. Cells that already have a value / error / running status are untouched, and the next server poll replaces the optimistic status.

**`frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx`**
- Imports `RefreshStatus` + `withPendingColumnLoadingState` from `./common` (removes the duplicated local const).
- Applies the helper at both row-building sites: the server-side datasource `getRows` and the poll `refreshRowsManual`.

## Before / After

![Before / After — verdict column cells: blank (before) vs loading skeleton (after)](https://github.com/user-attachments/assets/39c84eb0-bc16-4a3d-9132-8a1d0e53d3f6)

https://github.com/user-attachments/assets/ed20cb4f-0f4e-4a78-9420-cecfea53a7d0

## Tests included

| Test | Asserts |
|---|---|
| marks blank cells of a refreshing column as running | blank cells of a `NotStarted` column become `running` (skeleton) — **red if reverted** |
| NotStarted / Running trigger loading | the refreshing-status set stays aligned with the render behaviour |
| leaves cells that already have a value untouched | real values are never overwritten |
| does not mark cells when the column has finished | a `Completed` column never skeletons |
| preserves an existing error status | error cells stay error, not skeleton |
| returns rows unchanged when no column is refreshing | pure no-op when nothing is loading (same array reference) |

Behavioral, on the real helper (imports the real `StatusTypes` constant). Confirmed **red when the fix is reverted**, green with it.

## Commands + verification

```bash
cd frontend
npx vitest run src/sections/develop-detail/DataTab/__tests__/common.test.js
# 14 passed
npx vitest run src/sections/develop-detail src/sections/common/DevelopCellRenderer
# 9 files, 74 passed
```

![vitest — 74 passed across the touched areas on Node 22](https://github.com/user-attachments/assets/5c3cd56a-f5e9-4420-a16b-8d515417acf0)

## Backwards compatibility

| Caller | Before | After |
|---|---|---|
| `getRows` (server-side datasource) | passes `result.table` straight to the grid | same rows, refreshing columns' blank cells get an optimistic `running` status |
| `refreshRowsManual` (5s poll) | `applyServerSideTransaction({ update: rows })` | same, through the helper |
| Completed / idle columns | unchanged | unchanged (helper is a no-op) |
| Whole-dataset processing (`DUMMY_ROWS`) | already all-`running` | unchanged (helper no-op) |

No API/shape change. The optimistic status is client-only and replaced by the next server poll.

## Manual verification

Reproduced locally on a real dataset: set a column to the just-added state (`NotStarted` status, blank cells) and loaded the grid.
- Before: the column's cells render blank.
- After: the column's cells render the loading skeleton immediately.

See the before/after above.

## Type

Bug fix (frontend, non-breaking).

## Checklist

- [x] Root-cause fix (drives loading from the synchronously-set column status), not a bandaid
- [x] Behavioral test on the real call-path, red if reverted
- [x] Full local suite green (74 tests in the touched areas)
- [x] No magic strings — `RefreshStatus` single source of truth
- [x] Guards fail safe on absent inputs
- [x] No API / backwards-compat break

## Backout

Revert this commit. The helper is additive and isolated to two call sites; reverting restores the previous (blank-then-delayed) behaviour with no data or schema impact.

Closes TH-6535
