### PR TITLE
[TH-6534] Fix filter panel floating away from its parent on first value select

### DIFF
--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -399,16 +399,11 @@ const TaskFilterBar = ({
   }, [formFilters]);
 
   const [anchorEl, setAnchorEl] = useState(null);
-  const addBtnRef = useRef(null);
-
-  // Re-anchor when chips swap the trigger DOM node, so an open popover
-  // doesn't end up attached to a detached element.
-  const hasFiltersForEffect = panelFilters.length > 0;
-  useEffect(() => {
-    if (anchorEl && addBtnRef.current && anchorEl !== addBtnRef.current) {
-      setAnchorEl(addBtnRef.current);
-    }
-  }, [hasFiltersForEffect, anchorEl]);
+  // Anchor the panel to the filter bar row (not the "+", which drifts as chips
+  // wrap). It opens flush below the bar and stays glued there as filters are
+  // added/removed — avoiding the value-dropdown float, the "chases the +"
+  // drift, and the stranded panel on delete (TH-6534).
+  const barRef = useRef(null);
 
   const applyPanelFilters = useCallback(
     (next) => {
@@ -434,14 +429,34 @@ const TaskFilterBar = ({
     applyPanelFilters([]);
   }, [applyPanelFilters]);
 
-  const openPanel = useCallback((e) => {
-    setAnchorEl(e?.currentTarget || addBtnRef.current);
-  }, []);
+  const anchorToBar = useCallback(
+    () => ({
+      nodeType: 1,
+      getBoundingClientRect: () => barRef.current?.getBoundingClientRect(),
+    }),
+    [],
+  );
+
+  const openPanel = useCallback(() => {
+    if (!barRef.current) return;
+    setAnchorEl(anchorToBar());
+  }, [anchorToBar]);
+
+  // Keep the panel glued just below the bar as chips wrap/unwrap while it's
+  // open: a size change swaps in a fresh anchor object so MUI re-positions.
+  const isPanelOpen = Boolean(anchorEl);
+  useEffect(() => {
+    const el = barRef.current;
+    if (!isPanelOpen || !el) return undefined;
+    const ro = new ResizeObserver(() => setAnchorEl(anchorToBar()));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [isPanelOpen, anchorToBar]);
 
   const hasFilters = panelFilters.length > 0;
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+    <Box ref={barRef} sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       {hasFilters ? (
         <Box
           sx={{
@@ -459,9 +474,7 @@ const TaskFilterBar = ({
             />
           ))}
 
-          {/* + button to add another filter */}
           <Box
-            ref={addBtnRef}
             component="button"
             type="button"
             onClick={openPanel}
@@ -471,6 +484,7 @@ const TaskFilterBar = ({
               justifyContent: "center",
               width: 26,
               height: 26,
+              p: 0,
               border: "1px solid",
               borderColor: "divider",
               borderRadius: "6px",
@@ -480,7 +494,6 @@ const TaskFilterBar = ({
                   : "background.paper",
               color: "text.secondary",
               cursor: "pointer",
-              p: 0,
               "&:hover": {
                 color: "text.primary",
                 bgcolor:
@@ -512,7 +525,6 @@ const TaskFilterBar = ({
         </Box>
       ) : (
         <Button
-          ref={addBtnRef}
           onClick={openPanel}
           variant="outlined"
           size="small"


### PR DESCRIPTION
**Ticket:** [TH-6534](https://linear.app/future-agi/issue/TH-6534/the-filter-selector-floating-away-its-parent-container-as-user-applies) — Fixes TH-6534

## What was the bug

In **Create Task → filter builder**, the value multi-select dropdown floated to the top-left of the page the **first time** a filter value was selected. Root cause: the panel was re-anchored to the **"+" / "Add filter" trigger**, which shifts position the moment the first chip appears (the empty→has-filters layout swap reflows the row), so MUI's popover snapped to the trigger's new/stale coordinates instead of staying put.

## What changes have been done

- `TaskFilterBar.jsx` — anchor the filter panel to the **always-present bar wrapper** (`barRef`) instead of the drifting trigger. A `ResizeObserver` swaps in a fresh virtual anchor when chips wrap/unwrap so the panel re-positions and stays glued flush below the bar. Removed the old re-anchor effect and the `addBtnRef` that pointed at the "+".

## Why the changes

- The old anchor target (the "+"/"Add filter" button) is exactly the element that moves when filters are added/removed, so anchoring to it caused the float on first selection, the "chases the +" drift, and a stranded panel on delete.
- The outer wrapper `<Box>` is the one element rendered in both the empty and has-filters states, so anchoring to it gives a stable reference. Its rect bottom is the bar's bottom (the panel is portaled out of flow), so the panel opens flush below the bar.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Create Task → add first filter → pick a value | Value dropdown stays under the bar; no float to top-left |
| 2 | Add several filters until chips wrap to a new line | Panel stays glued flush below the (now taller) bar |
| 3 | Delete filters while panel is open | Panel re-positions with the shrinking bar; not stranded |
| 4 | LLM Tracing filter panel (shared `TraceFilterPanel`) | Unchanged — behaves exactly as before |

## How to reproduce (original bug)

Create Task → open the filter builder → add a filter → select its first value → the value dropdown jumps to the top-left of the page.

## Commands

```bash
# none — UI-only change
```

## Videos and screenshots

https://github.com/user-attachments/assets/b0d313d2-8d5a-4fde-8a98-4730f38aada3


