### PR TITLE
feat(simulate): add Voice/Chat type filter to simulate tables

### DIFF
--- a/frontend/src/components/run-tests/RunTestsContent.jsx
+++ b/frontend/src/components/run-tests/RunTestsContent.jsx
@@ -9,6 +9,8 @@ import {
   Menu,
   MenuItem,
   Popover,
+  Stack,
+  TextField,
   Tooltip,
   Typography,
   useTheme,
@@ -29,6 +31,7 @@ import { ShowComponent } from "src/components/show";
 import CustomDialog from "src/sections/develop-detail/Common/CustomDialog/CustomDialog";
 
 import { useAuthContext } from "src/auth/hooks";
+import { AGENT_TYPES } from "src/sections/agents/constants";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
@@ -296,6 +299,7 @@ const RunTestsContent = ({
   const queryClient = useQueryClient();
 
   const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState(""); // "" = All types
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
   const [testToDelete, setTestToDelete] = useState(null);
@@ -359,12 +363,20 @@ const RunTestsContent = ({
       search: debouncedSearchQuery,
       simulation_type: simulationType,
       summary: true,
+      ...(typeFilter && { agent_type: typeFilter }),
     };
     if (simulationType === SIMULATION_TYPE.PROMPT && promptTemplateId) {
       params.prompt_template_id = promptTemplateId;
     }
     return params;
-  }, [page, pageSize, debouncedSearchQuery, simulationType, promptTemplateId]);
+  }, [
+    page,
+    pageSize,
+    debouncedSearchQuery,
+    simulationType,
+    promptTemplateId,
+    typeFilter,
+  ]);
 
   const { isPending, data } = useQuery({
     queryKey: [
@@ -374,6 +386,7 @@ const RunTestsContent = ({
       page,
       pageSize,
       debouncedSearchQuery,
+      typeFilter,
     ],
     queryFn: () => axios.get(endpoints.runTests.list, { params: queryParams }),
     select: (d) => d.data,
@@ -385,7 +398,11 @@ const RunTestsContent = ({
   const hasData = items.length > 0;
 
   const showEmptyScreen =
-    !isPending && data && total === 0 && debouncedSearchQuery === "";
+    !isPending &&
+    data &&
+    total === 0 &&
+    debouncedSearchQuery === "" &&
+    !typeFilter;
 
   const canManage =
     RolePermission.SIMULATION_AGENT[PERMISSIONS.UPDATE][role] &&
@@ -617,19 +634,39 @@ const RunTestsContent = ({
               }}
             >
               <ShowComponent condition={showSearch}>
-                <FormSearchField
-                  value={searchQuery}
-                  onChange={(e) => {
-                    setSearchQuery(e.target.value);
-                    setPage(0);
-                  }}
-                  size="small"
-                  placeholder="Search"
-                  sx={{
-                    minWidth: "250px",
-                    "& .MuiOutlinedInput-root": { height: "30px" },
-                  }}
-                />
+                <Stack direction="row" spacing={1.5} alignItems="center">
+                  <FormSearchField
+                    value={searchQuery}
+                    onChange={(e) => {
+                      setSearchQuery(e.target.value);
+                      setPage(0);
+                    }}
+                    size="small"
+                    placeholder="Search"
+                    sx={{
+                      minWidth: "250px",
+                      "& .MuiOutlinedInput-root": { height: "30px" },
+                    }}
+                  />
+                  <TextField
+                    select
+                    size="small"
+                    value={typeFilter}
+                    onChange={(e) => {
+                      setTypeFilter(e.target.value);
+                      setPage(0); // reset to first page when the filter changes
+                    }}
+                    SelectProps={{ displayEmpty: true }}
+                    sx={{
+                      minWidth: 140,
+                      "& .MuiOutlinedInput-root": { height: "30px" },
+                    }}
+                  >
+                    <MenuItem value="">All types</MenuItem>
+                    <MenuItem value={AGENT_TYPES.VOICE}>Voice</MenuItem>
+                    <MenuItem value={AGENT_TYPES.CHAT}>Chat</MenuItem>
+                  </TextField>
+                </Stack>
               </ShowComponent>
               <ShowComponent condition={!showSearch}>
                 <Box />

--- a/frontend/src/pages/dashboard/agent-definitions/AgentDefinitions.jsx
+++ b/frontend/src/pages/dashboard/agent-definitions/AgentDefinitions.jsx
@@ -1,5 +1,13 @@
 /* eslint-disable react/prop-types */
-import { Box, Button, Divider, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Divider,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import React, { useCallback, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -100,6 +108,7 @@ function AgentDefinitions() {
   const queryClient = useQueryClient();
 
   const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState(""); // "" = All types
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
   const [rowSelection, setRowSelection] = useState({});
@@ -108,13 +117,20 @@ function AgentDefinitions() {
   const debouncedSearchQuery = useDebounce(searchQuery.trim(), 500);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["agentDefinitions", page, pageSize, debouncedSearchQuery],
+    queryKey: [
+      "agentDefinitions",
+      page,
+      pageSize,
+      debouncedSearchQuery,
+      typeFilter,
+    ],
     queryFn: () =>
       axios.get(endpoints.agentDefinitions.list, {
         params: {
           page: page + 1,
           limit: pageSize,
           search: debouncedSearchQuery,
+          ...(typeFilter && { agent_type: typeFilter }),
         },
       }),
     select: (d) => d.data,
@@ -127,7 +143,11 @@ function AgentDefinitions() {
   // Show the empty screen only when there are truly zero agents (first page,
   // no search). `data` becomes defined after the first fetch.
   const showEmptyScreen =
-    !isLoading && data && total === 0 && debouncedSearchQuery === "";
+    !isLoading &&
+    data &&
+    total === 0 &&
+    debouncedSearchQuery === "" &&
+    !typeFilter;
 
   // Selected items — derived from rowSelection index map.
   const selectedItems = useMemo(
@@ -331,19 +351,39 @@ function AgentDefinitions() {
                 gap: 2,
               }}
             >
-              <FormSearchField
-                size="small"
-                placeholder="Search"
-                sx={{
-                  minWidth: "250px",
-                  "& .MuiOutlinedInput-root": { height: "30px" },
-                }}
-                searchQuery={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  setPage(0);
-                }}
-              />
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FormSearchField
+                  size="small"
+                  placeholder="Search"
+                  sx={{
+                    minWidth: "250px",
+                    "& .MuiOutlinedInput-root": { height: "30px" },
+                  }}
+                  searchQuery={searchQuery}
+                  onChange={(e) => {
+                    setSearchQuery(e.target.value);
+                    setPage(0);
+                  }}
+                />
+                <TextField
+                  select
+                  size="small"
+                  value={typeFilter}
+                  onChange={(e) => {
+                    setTypeFilter(e.target.value);
+                    setPage(0); // reset to first page when the filter changes
+                  }}
+                  SelectProps={{ displayEmpty: true }}
+                  sx={{
+                    minWidth: 140,
+                    "& .MuiOutlinedInput-root": { height: "30px" },
+                  }}
+                >
+                  <MenuItem value="">All types</MenuItem>
+                  <MenuItem value={AGENT_TYPES.VOICE}>Voice</MenuItem>
+                  <MenuItem value={AGENT_TYPES.CHAT}>Chat</MenuItem>
+                </TextField>
+              </Stack>
               {selectedItems.length > 0 ? (
                 <Box
                   sx={{

--- a/frontend/src/pages/dashboard/scenarios/Scenarios.jsx
+++ b/frontend/src/pages/dashboard/scenarios/Scenarios.jsx
@@ -1,5 +1,12 @@
 /* eslint-disable react/prop-types */
-import { Box, Button, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -18,6 +25,7 @@ import ScenarioStatusChip from "src/components/scenarios/CustomCellRenderers/Sce
 import { isScenarioInProgress } from "src/utils/scenarioStatus";
 
 import { useAuthContext } from "src/auth/hooks";
+import { AGENT_TYPES } from "src/sections/agents/constants";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
@@ -92,6 +100,7 @@ function Scenarios() {
   const queryClient = useQueryClient();
 
   const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState(""); // "" = All types
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
 
@@ -103,13 +112,14 @@ function Scenarios() {
   const debouncedSearchQuery = useDebounce(searchQuery.trim(), 500);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["scenarios", page, pageSize, debouncedSearchQuery],
+    queryKey: ["scenarios", page, pageSize, debouncedSearchQuery, typeFilter],
     queryFn: () =>
       axios.get(endpoints.scenarios.list, {
         params: {
           page: page + 1,
           limit: pageSize,
           search: debouncedSearchQuery,
+          ...(typeFilter && { agent_type: typeFilter }),
         },
       }),
     select: (d) => d.data,
@@ -127,7 +137,11 @@ function Scenarios() {
   const total = data?.count ?? 0;
 
   const showEmptyScreen =
-    !isLoading && data && total === 0 && debouncedSearchQuery === "";
+    !isLoading &&
+    data &&
+    total === 0 &&
+    debouncedSearchQuery === "" &&
+    !typeFilter;
 
   const handleRowClick = useCallback(
     (row) => {
@@ -348,19 +362,39 @@ function Scenarios() {
                 alignItems: "center",
               }}
             >
-              <FormSearchField
-                size="small"
-                placeholder="Search"
-                sx={{
-                  minWidth: "250px",
-                  "& .MuiOutlinedInput-root": { height: "30px" },
-                }}
-                searchQuery={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  setPage(0);
-                }}
-              />
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <FormSearchField
+                  size="small"
+                  placeholder="Search"
+                  sx={{
+                    minWidth: "250px",
+                    "& .MuiOutlinedInput-root": { height: "30px" },
+                  }}
+                  searchQuery={searchQuery}
+                  onChange={(e) => {
+                    setSearchQuery(e.target.value);
+                    setPage(0);
+                  }}
+                />
+                <TextField
+                  select
+                  size="small"
+                  value={typeFilter}
+                  onChange={(e) => {
+                    setTypeFilter(e.target.value);
+                    setPage(0); // reset to first page when the filter changes
+                  }}
+                  SelectProps={{ displayEmpty: true }}
+                  sx={{
+                    minWidth: 140,
+                    "& .MuiOutlinedInput-root": { height: "30px" },
+                  }}
+                >
+                  <MenuItem value="">All types</MenuItem>
+                  <MenuItem value={AGENT_TYPES.VOICE}>Voice</MenuItem>
+                  <MenuItem value={AGENT_TYPES.CHAT}>Chat</MenuItem>
+                </TextField>
+              </Stack>
             </Box>
 
             {/* Table */}

--- a/futureagi/simulate/serializers/requests/run_test.py
+++ b/futureagi/simulate/serializers/requests/run_test.py
@@ -31,6 +31,12 @@ class RunTestFilterSerializer(StrictInputSerializer):
         allow_blank=True,
         default="",
     )
+    agent_type = serializers.ChoiceField(
+        choices=AgentDefinition.AgentTypeChoices.choices,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
     prompt_template_id = serializers.UUIDField(required=False, allow_null=True)
     page = serializers.IntegerField(
         required=False, default=1, min_value=1, max_value=100

--- a/futureagi/simulate/tests/test_run_test_agent_type_filter.py
+++ b/futureagi/simulate/tests/test_run_test_agent_type_filter.py
@@ -1,0 +1,133 @@
+"""
+API tests for the ``agent_type`` (Voice / Chat) filter on
+GET /simulate/run-tests/ (RunTestListView).
+
+The frontend Run Simulation table sends ``agent_type=voice`` or
+``agent_type=text``. Chat/text must also include prompt-based sims, which
+have no linked agent_definition. See issue #1387.
+"""
+
+import pytest
+from rest_framework import status
+
+from simulate.models import AgentDefinition, RunTest
+
+
+@pytest.fixture
+def voice_agent(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Voice Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        contact_number="+12345678901",
+        inbound=True,
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def text_agent(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Text Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+        inbound=True,
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def voice_run_test(db, organization, workspace, voice_agent):
+    return RunTest.objects.create(
+        name="Voice sim",
+        organization=organization,
+        workspace=workspace,
+        agent_definition=voice_agent,
+        source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+    )
+
+
+@pytest.fixture
+def text_run_test(db, organization, workspace, text_agent):
+    return RunTest.objects.create(
+        name="Text sim",
+        organization=organization,
+        workspace=workspace,
+        agent_definition=text_agent,
+        source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+    )
+
+
+@pytest.fixture
+def prompt_run_test(db, organization, workspace):
+    # Prompt-based sim: no agent_definition, source_type=PROMPT.
+    return RunTest.objects.create(
+        name="Prompt sim",
+        organization=organization,
+        workspace=workspace,
+        source_type=RunTest.SourceTypes.PROMPT,
+    )
+
+
+def _ids(response):
+    return {r["id"] for r in response.json()["results"]}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRunTestAgentTypeFilter:
+    def test_voice_returns_only_voice(
+        self, auth_client, voice_run_test, text_run_test, prompt_run_test
+    ):
+        response = auth_client.get("/simulate/run-tests/?agent_type=voice")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = _ids(response)
+        assert str(voice_run_test.id) in ids
+        assert str(text_run_test.id) not in ids
+        assert str(prompt_run_test.id) not in ids
+
+    def test_text_includes_text_agent_and_prompt_sims(
+        self, auth_client, voice_run_test, text_run_test, prompt_run_test
+    ):
+        response = auth_client.get("/simulate/run-tests/?agent_type=text")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = _ids(response)
+        assert str(text_run_test.id) in ids
+        # Prompt-based sims have no agent_definition -> treated as chat/text.
+        assert str(prompt_run_test.id) in ids
+        assert str(voice_run_test.id) not in ids
+
+    def test_no_agent_type_returns_all(
+        self, auth_client, voice_run_test, text_run_test, prompt_run_test
+    ):
+        response = auth_client.get("/simulate/run-tests/")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = _ids(response)
+        assert {
+            str(voice_run_test.id),
+            str(text_run_test.id),
+            str(prompt_run_test.id),
+        } <= ids
+
+    def test_agent_type_combines_with_search(
+        self, auth_client, voice_run_test, text_run_test
+    ):
+        # Search matches both by name substring "sim"; agent_type narrows to voice.
+        response = auth_client.get(
+            "/simulate/run-tests/?agent_type=voice&search=sim"
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = _ids(response)
+        assert str(voice_run_test.id) in ids
+        assert str(text_run_test.id) not in ids
+
+    def test_invalid_agent_type_is_rejected(self, auth_client):
+        response = auth_client.get("/simulate/run-tests/?agent_type=bogus")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -560,6 +560,7 @@ class RunTestListView(APIView):
             simulation_type = query_data.get("simulation_type", "").strip()
             prompt_template_id = query_data.get("prompt_template_id")
             summary = query_data.get("summary", False)
+            agent_type = query_data.get("agent_type")
 
             # Filter run tests by organization (only non-deleted)
             # Prefetch simulate_eval_configs to avoid N+1 in serializer's to_representation
@@ -584,6 +585,14 @@ class RunTestListView(APIView):
                 run_tests = run_tests.filter(
                     source_type=RunTest.SourceTypes.AGENT_DEFINITION
                 )
+
+            # Apply agent_type (Voice/Chat) filter. Prompt-based sims have no
+            # linked agent_definition, so treat them as chat/text.
+            if agent_type:
+                subquery = Q(agent_definition__agent_type=agent_type)
+                if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
+                    subquery |= Q(source_type=RunTest.SourceTypes.PROMPT)
+                run_tests = run_tests.filter(subquery)
 
             # Apply search filter if search query is provided
             if search_query:


### PR DESCRIPTION
## Summary

Adds a **type filter dropdown (All types / Voice / Chat)** to the toolbars of the three Simulate tables, **Agent Definitions**, **Scenarios**, and **Run Simulation**, so users can narrow a table to just voice or just chat rows instead of eyeballing the Type column page by page. The dropdown sits beside the existing search box, combines with search and pagination, and resets to page 1 on change. The default "All types" sends no `agent_type` param, so existing behavior is unchanged.

This is UI-only for Agent Definitions and Scenarios (their list endpoints already applied `agent_type`); Run Simulation needed a small backend addition to accept and apply the param.

## Linked issues

Closes #1387

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

### What changed

**Frontend** (`AgentDefinitions.jsx`, `Scenarios.jsx`, `RunTestsContent.jsx`)
- New `typeFilter` state threaded into each table's list query key + params, sent only when set: `...(typeFilter && { agent_type: typeFilter })`.
- A `<TextField select>` dropdown rendered beside the search field. `SelectProps={{ displayEmpty: true }}` renders the **"All types"** label for the empty (no-filter) value, without it MUI shows a blank box.
- Empty-state guard extended with `!typeFilter` so a zero-result filter shows the normal empty table, not the onboarding screen.

**Backend** (`serializers/requests/run_test.py`, `views/run_test.py`)
- `RunTestFilterSerializer` gains an `agent_type` `ChoiceField` (rejects invalid values with 400).
- `RunTestListView` applies the filter. Prompt-based sims have no linked `agent_definition`, so they are treated as chat/text:

  ```python
  if agent_type:
      subquery = Q(agent_definition__agent_type=agent_type)
      if agent_type == AgentDefinition.AgentTypeChoices.TEXT:
          subquery |= Q(source_type=RunTest.SourceTypes.PROMPT)
      run_tests = run_tests.filter(subquery)
  ```

## How was this tested?

**Automated backend regression tests** (new `simulate/tests/test_run_test_agent_type_filter.py`, run against the `bin/test` Postgres stack):

```bash
cd futureagi && bin/test up
pytest simulate/tests/test_run_test_agent_type_filter.py --reuse-db
# 5 passed
```

Covers: `agent_type=voice` → voice only; `agent_type=text` → text agents **plus** prompt-based sims; no param → all rows; filter combined with `search`; invalid value → `400`.

**Automated no regressions:** existing `test_run_test_list_api.py`, `test_agent_definition_api.py`, and `test_scenarios_api.py` still pass (the only failures were a pre-existing, unrelated `TestAddScenarioColumnsView` EE-entitlements issue, reproduced on `main` without this change).

**Static:** `eslint` clean on all three changed JSX files; frontend production build succeeds.

**Manual (UI):** ran the app locally, seeded a voice + chat mix, and verified on all three tables:
- Selecting **Voice** shows only voice rows; **Chat** shows only chat rows (Run Simulation's Chat also includes prompt-based sims).
- The request query string contains `agent_type=voice` / `agent_type=text`; **All types** sends none.
- Changing the filter resets to page 1; filter combines with search; zero results shows the normal empty message.

## Screenshots / recordings (if UI)
Note: Kindly ignore the dark and light theme, i was testing in all the ways i can to make sure no bugs remain from my side. 
Also I will paste the screen shots all the 3 dashboards in the comments. Below are just some. 

### BEFORE ( No filter, just types mentioned)

<img width="1897" height="401" alt="Screenshot 2026-07-08 123146" src="https://github.com/user-attachments/assets/a26d23d6-48df-4fd9-b246-15bf422f90a1" />


### AFTER (There are 3 filters, namely All types, Chat and Voice)
Note: I have also added the screenshot of the networks tab of my system to show how the request is being processed. 

<img width="946" height="404" alt="Screenshot 2026-07-08 121911" src="https://github.com/user-attachments/assets/5933c6c4-39fc-4e36-8ec1-87cf70083b90" />
<img width="1902" height="357" alt="Screenshot 2026-07-08 122050" src="https://github.com/user-attachments/assets/3f34af18-60e8-40ee-ad3e-614a135a4690" />
<img width="1910" height="364" alt="Screenshot 2026-07-08 122057" src="https://github.com/user-attachments/assets/e1d31cf5-248d-4bc2-ac66-b8a02cd53401" />
<img width="1907" height="343" alt="Screenshot 2026-07-08 122106" src="https://github.com/user-attachments/assets/53ab24c1-cfd3-4f7d-bfda-d40dfc5c2878" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally <!-- frontend lint + build clean; backend agent_type regression suite green -->
- [ ] I've updated the documentation where relevant <!-- N/A, no user-facing docs for this control -->
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) <!-- bot will prompt on first PR -->