### PR TITLE
fix(datasets): register HuggingFace `List` feature type for streaming import (TH-6520)

### DIFF
--- a/futureagi/model_hub/tests/test_huggingface_api.py
+++ b/futureagi/model_hub/tests/test_huggingface_api.py
@@ -381,3 +381,58 @@ class TestCreateDatasetFromHuggingFaceE2E:
             print(f"Response: {response.status_code} - {response.json()}")
             # Skip assertion if there are other validation errors
             pytest.skip(f"API returned {response.status_code}: {response.json()}")
+
+
+class TestHuggingFaceListFeatureCompat:
+    """
+    Streaming ingestion (process_huggingface_dataset -> load_hf_dataset_with_retries
+    -> datasets.load_dataset) parses the dataset's feature metadata before yielding
+    rows. The Hub now emits the `List` feature type (datasets 4.0) that the pinned
+    datasets 3.6.0 cannot resolve, which crashed the load for datasets such as
+    rajpurkar/squad and left every cell empty. Importing model_hub.utils.utils must
+    register `List` so the real parse path succeeds.
+    """
+
+    # The `answers` feature of rajpurkar/squad, exactly as the Hub emits it.
+    SQUAD_ANSWERS_SCHEMA = {
+        "answers": {
+            "text": {
+                "feature": {"dtype": "string", "_type": "Value"},
+                "_type": "List",
+            },
+            "answer_start": {
+                "feature": {"dtype": "int32", "_type": "Value"},
+                "_type": "List",
+            },
+        }
+    }
+
+    def test_list_feature_type_parses_on_real_load_path(self):
+        """
+        RED without the fix: datasets.Features.from_dict — the function
+        load_dataset() calls to parse feature metadata — raises
+        "Feature type 'List' not found". GREEN once model_hub.utils.utils
+        aliases `List` to LargeList at import.
+        """
+        import model_hub.utils.utils  # noqa: F401  (import installs the List alias)
+        from datasets import Features
+
+        features = Features.from_dict(self.SQUAD_ANSWERS_SCHEMA)
+
+        assert "answers" in features
+        rebuilt = features.to_dict()["answers"]
+        list_like = {"List", "LargeList", "Sequence"}
+        assert rebuilt["text"]["_type"] in list_like
+        assert rebuilt["answer_start"]["_type"] in list_like
+
+    def test_top_level_list_feature_parses(self):
+        """A plain List-of-scalars column (the other Hub shape) also parses."""
+        import model_hub.utils.utils  # noqa: F401
+        from datasets import Features
+
+        features = Features.from_dict(
+            {"tags": {"feature": {"dtype": "string", "_type": "Value"}, "_type": "List"}}
+        )
+
+        assert "tags" in features
+        assert features.to_dict()["tags"]["_type"] in {"List", "LargeList", "Sequence"}

--- a/futureagi/model_hub/utils/utils.py
+++ b/futureagi/model_hub/utils/utils.py
@@ -47,7 +47,7 @@ try:
     if hasattr(_hf_features, "_FEATURE_TYPES") and hasattr(_hf_features, "LargeList"):
         _hf_features._FEATURE_TYPES.setdefault("List", _hf_features.LargeList)
 except Exception:  # defensive: datasets internals moved
-    pass
+    logger.warning("hf List feature-type shim did not install", exc_info=True)
 
 
 class MyCustomLLM(CustomLLM):

--- a/futureagi/model_hub/utils/utils.py
+++ b/futureagi/model_hub/utils/utils.py
@@ -37,6 +37,18 @@ from tfc.utils.clickhouse import ClickHouseClientSingleton
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.types import ClickhouseDatatypes
 
+# The HuggingFace Hub now emits the `List` feature type (datasets 4.0) in dataset
+# metadata, which pinned datasets 3.6.0 can't parse: load_dataset() raises
+# "Feature type 'List' not found" and streaming ingestion loads zero rows. Alias it
+# to the 3.6.0 equivalent (LargeList); setdefault leaves a future upgrade untouched.
+try:
+    from datasets.features import features as _hf_features
+
+    if hasattr(_hf_features, "_FEATURE_TYPES") and hasattr(_hf_features, "LargeList"):
+        _hf_features._FEATURE_TYPES.setdefault("List", _hf_features.LargeList)
+except Exception:  # defensive: datasets internals moved
+    pass
+
 
 class MyCustomLLM(CustomLLM):
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Summary

Importing a HuggingFace dataset (e.g. `rajpurkar/squad`) created the dataset and its columns, but **every cell stayed empty / errored** — the data never loaded. Root cause is a `datasets` library version incompatibility. This registers the missing feature type so streaming ingestion parses modern HF metadata.

## Why it breaks / where

The dataset grid is populated by a background task:

`process_huggingface_dataset` → `load_hf_dataset_with_retries(streaming=True)` → `datasets.load_dataset(...)`

`load_dataset` parses the dataset's exported feature metadata before yielding rows. The HuggingFace Hub now emits the **`List`** feature type (introduced in `datasets` 4.0). The pinned **`datasets==3.6.0`** doesn't know that type, so parsing raises:

```
ValueError: Feature type 'List' not found.
Available feature types: ['Value','ClassLabel','LargeList','Sequence','Array2D',...]
```

The exception is caught by the task's handler, which then marks **all cells `error` with empty values** — the "dataset not loading" symptom.

The **preview** step (`GetHuggingFaceDatasetConfigView`, `streaming=False`) survives because it uses the raw `datasets-server.huggingface.co` HTTP API, not the `datasets` library — which is why columns appear but data doesn't.

> Note: the local dev venv ships `datasets==4.5.0` (where `List` is native), which **masked** this bug locally. CI and the deployed image pin `3.6.0`, where it breaks.

## What changed

**`futureagi/model_hub/utils/utils.py`** (+12) — at import, alias the `List` feature type to its 3.6.0 equivalent `LargeList` in the `datasets` feature registry. `setdefault` + a `hasattr` guard so a future `datasets` upgrade that ships `List` natively is left untouched (self-disabling), and a registry-layout change can't crash import. This is the single `load_dataset` call site, so it covers both **create-dataset** and **add-rows** HuggingFace flows.

**`futureagi/model_hub/tests/test_huggingface_api.py`** (+55) — behavioral tests on the real parse path.

## Tests

| Test | Asserts | Red if reverted |
|---|---|---|
| `test_list_feature_type_parses_on_real_load_path` | `datasets.Features.from_dict` (the function `load_dataset` calls) parses a squad-shaped `List` feature | ✅ raises `ValueError: Feature type 'List' not found` |
| `test_top_level_list_feature_parses` | a plain `List`-of-scalars column also parses | ✅ same |

Run on the pinned `datasets==3.6.0` (same as CI / prod):

```bash
docker compose exec backend python -m pytest \
  model_hub/tests/test_huggingface_api.py::TestHuggingFaceListFeatureCompat -v
# with fix:      2 passed
# fix reverted:  2 failed — ValueError: Feature type 'List' not found
```

![Behavioral test red→green](https://github.com/user-attachments/assets/6b988019-9bd6-4b62-bfc1-f4555657203e)

## Proof (real ingestion path)

Ran the actual `process_huggingface_dataset(...)` on `rajpurkar/squad` against real DB rows — **before** (registry without `List`) vs **after** (fix):

![Before/after — real ingestion of rajpurkar/squad](https://github.com/user-attachments/assets/a0869ac1-53d2-4a12-b499-4f32354f4589)

https://github.com/user-attachments/assets/1227b3bf-561a-41ab-b278-cb354f1ebe29

| column | before | after |
|---|---|---|
| `title` | `error` · `''` | `pass` · `University_of_Notre_Dame` |
| `question` | `error` · `''` | `pass` · `To whom did the Virgin Mary allegedly appear in…` |
| `answers` | `error` · `''` | `pass` · `{'text': ['Saint Bernadette Soubirous'], …}` |

## Backwards compatibility

| Caller | Before | After |
|---|---|---|
| Create dataset from HuggingFace | error cells on `List`-metadata datasets | rows load |
| Add rows from HuggingFace (same `load_dataset` path) | same failure | rows load |
| `datasets` 4.x (future upgrade) | n/a | `setdefault` no-ops — no behavior change |
| Datasets without `List` metadata (e.g. plain text) | worked | unchanged |

## Type

Bug fix (dependency-compatibility shim). No schema change, no migration, no API change.

## Backout

Revert the commit — the ingestion path returns to raising `Feature type 'List' not found` on affected datasets. No data migration to undo.

## Checklist

- [x] Root-cause fix (not a bandaid)
- [x] Behavioral test on the real path, red if reverted
- [x] Runs on the pinned `datasets==3.6.0` (CI/prod version)
- [x] No new endpoint / migration / secret
- [x] Import-safe (guarded try/except)

Closes TH-6520
