### PR TITLE
fix(sdk): use snake_case field names from API response in AddSDKModal

### DIFF
--- a/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
@@ -109,7 +109,7 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
       onCloseClick();
       //@ts-ignore
       addRowSDK({
-        dataset_name: data?.data?.result?.datasetName,
+        dataset_name: data?.data?.result?.dataset_name,
       });
       setIsNext(true);
     },
@@ -375,13 +375,13 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.apiKey}
+                    {data?.data?.result?.api_keys?.api_key}
                   </Typography>
                   <IconButton
                     size="small"
                     onClick={() =>
                       copyToClipboard(
-                        data?.data?.result?.apiKeys?.apiKey,
+                        data?.data?.result?.api_keys?.api_key,
                         "API Key",
                       )
                     }
@@ -410,13 +410,13 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.secretKey}
+                    {data?.data?.result?.api_keys?.secret_key}
                   </Typography>
                   <IconButton
                     size="small"
                     onClick={() =>
                       copyToClipboard(
-                        data?.data?.result?.apiKeys?.secretKey,
+                        data?.data?.result?.api_keys?.secret_key,
                         "Secret Key",
                       )
                     }


### PR DESCRIPTION
## Summary

The "Add data using SDK" flow errored out silently after the user entered a dataset name and clicked Next. The root cause was a field-name mismatch between the frontend and the API response: `AddSDKModal.jsx` was reading camelCase keys (`datasetName`, `apiKeys.apiKey`, `apiKeys.secretKey`) but the backend returns all fields in snake_case (`dataset_name`, `api_keys.api_key`, `api_keys.secret_key`). Because the camelCase reads resolved to `undefined`, the dataset name passed downstream was empty, the API keys displayed as blank, and copy-to-clipboard silently copied nothing. Fixed by updating all three field accesses to match the actual response shape.

Closes TH-6211.

## Test plan

- [ ] Open "Add data using SDK", enter a dataset name, click Next — should proceed without error and move to the credentials step
- [ ] API Key and Secret Key are displayed correctly on the credentials step
- [ ] Copy-to-clipboard works for both API Key and Secret Key

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII