### PR TITLE
fix(annotations): resolve collector traces/spans via CH — queue-add, score, render + annotate panel (TH-6647 + TH-6622)

### DIFF
--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -144,6 +144,11 @@ class _ReaderCM:
             return []
         return [self._span] if str(self._span.trace_id) in set(trace_ids) else []
 
+    def list_by_trace(self, trace_id, *, project_id=None):
+        if self._span is None:
+            return []
+        return [self._span] if str(self._span.trace_id) == str(trace_id) else []
+
 
 # ─────────────────────────── observation_span: resolve ───────────────────────
 
@@ -707,10 +712,7 @@ def test_collector_span_round_trips_create_to_annotate(
         organization=organization, workspace=workspace, queue=queue, span=span
     )
 
-    url = (
-        f"/model-hub/annotation-queues/{queue.id}"
-        f"/items/{item.id}/annotations/submit/"
-    )
+    url = f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/annotations/submit/"
     with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
         resp = auth_client.post(
             url,
@@ -830,3 +832,162 @@ def test_list_serializer_batches_collector_ch_reads(organization, workspace, use
     span_previews = [p for p in previews if p["type"] == "observation_span"]
     assert len(span_previews) == 3
     assert all(p["name"] == "collector root span" for p in span_previews)
+
+
+# ─────────────────────────────── trace (TH-6647) ─────────────────────────────
+# A non-voice grid "Add to annotation queue" stores a `source_type=trace` item.
+# For a collector trace (no PG row) the add/render paths must resolve it from CH
+# via its root span, instead of the old PG miss → "Not found: trace=…".
+
+
+def _collector_trace_item(*, organization, workspace, queue, trace_id):
+    """A QueueItem whose trace_id points at a collector trace (NO PG Trace row)."""
+    return QueueItem.objects.create(
+        queue=queue,
+        source_type=QueueItemSourceType.TRACE.value,
+        trace_id=trace_id,
+        organization=organization,
+        workspace=workspace,
+        status=QueueItemStatus.PENDING.value,
+    )
+
+
+@pytest.mark.django_db
+def test_collector_trace_resolves_via_ch(organization, workspace):
+    """A collector trace (no PG row) resolves through the CH fallback via its root
+    span, returning a soft-id source (``.id`` = trace_id). FAILS on revert (the
+    trace branch bailed → None → "Not found: trace=…", the TH-6647 bug)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    trace_id = str(uuid.uuid4())
+    root_span = _make_chspan(project_id=project.id, trace_id=trace_id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(root_span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.TRACE.value,
+            trace_id,
+            organization=organization,
+            workspace=workspace,
+            allow_ch_fallback=True,
+        )
+    assert resolved is not None
+    assert str(resolved.id) == trace_id
+    assert str(resolved.project_id) == str(project.id)
+
+
+@pytest.mark.django_db
+def test_collector_trace_cross_org_denied(organization, workspace):
+    """A collector trace whose root span belongs to a DIFFERENT org is denied (the
+    CH fallback re-checks tenant scope against PG). FAILS if the gate is removed."""
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="Other Org (trace)")
+    other_project = _make_project(organization=other_org, workspace=None)
+    trace_id = str(uuid.uuid4())
+    root_span = _make_chspan(project_id=other_project.id, trace_id=trace_id)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(root_span)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.TRACE.value,
+            trace_id,
+            organization=organization,  # requesting org != other_org
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_collector_trace_absent_returns_none(organization):
+    """A trace with no spans in CH (nothing to annotate) resolves to None."""
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(None)):
+        resolved = helpers.resolve_source_object(
+            QueueItemSourceType.TRACE.value,
+            str(uuid.uuid4()),
+            organization=organization,
+            allow_ch_fallback=True,
+        )
+    assert resolved is None
+
+
+@pytest.mark.django_db
+def test_ch_trace_source_always_available(organization, workspace):
+    """A CH-resolved collector trace has no PG reverse relation, so the in-progress
+    availability guard treats it as available (it's surfaced from CH once done)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    trace_id = str(uuid.uuid4())
+    root_span = _make_chspan(project_id=project.id, trace_id=trace_id)
+    ch_source = helpers._CHTraceSource(trace_id, root_span)
+
+    available, reason = helpers.is_source_available_for_annotation(
+        QueueItemSourceType.TRACE.value, ch_source
+    )
+    assert available is True
+    assert reason is None
+
+
+@pytest.mark.django_db
+def test_collector_trace_preview_renders_from_ch(organization, workspace, user):
+    """Preview of a collector trace (no PG row) renders from the CH root span, NOT
+    the deleted sentinel. FAILS on revert (FK access → deleted/error dict)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    trace_id = str(uuid.uuid4())
+    root_span = _make_chspan(project_id=project.id, trace_id=trace_id)
+    item = _collector_trace_item(
+        organization=organization, workspace=workspace, queue=queue, trace_id=trace_id
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(root_span)):
+        preview = helpers.resolve_source_preview(item)
+
+    assert preview["type"] == "trace"
+    assert "deleted" not in preview
+    assert preview["name"] == "collector root span"
+    assert preview["latency_ms"] == 2000
+
+
+@pytest.mark.django_db
+def test_collector_trace_content_renders_from_ch(organization, workspace, user):
+    """Content of a collector trace returns type=trace with the CH-resolved
+    root_span_id (the non-voice render focus) and the root span's fields."""
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    trace_id = str(uuid.uuid4())
+    root_span = _make_chspan(project_id=project.id, trace_id=trace_id)
+    item = _collector_trace_item(
+        organization=organization, workspace=workspace, queue=queue, trace_id=trace_id
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(root_span)):
+        content = helpers.resolve_source_content(item)
+
+    assert content["type"] == "trace"
+    assert "deleted" not in content
+    assert content["trace_id"] == trace_id
+    # trace items render via InlineTraceView(trace_id); span_id is dropped so a
+    # score never mis-attaches to the root span as if it were a span item.
+    assert "span_id" not in content
+    assert content["status"] == "OK"
+
+
+@pytest.mark.django_db
+def test_collector_trace_content_deleted_when_ch_missing(organization, workspace, user):
+    """If the trace has no spans in CH either, content returns the deleted
+    sentinel (same shape as today) rather than raising."""
+    project = _make_project(organization=organization, workspace=workspace)
+    queue = _queue(
+        organization=organization, workspace=workspace, user=user, project=project
+    )
+    item = _collector_trace_item(
+        organization=organization,
+        workspace=workspace,
+        queue=queue,
+        trace_id=str(uuid.uuid4()),
+    )
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(None)):
+        content = helpers.resolve_source_content(item)
+    assert content == {"type": "trace", "deleted": True}

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -36,6 +36,7 @@ Each test FAILS if the fix is reverted:
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime
 from unittest import mock
@@ -78,9 +79,13 @@ def _make_project(*, organization, workspace, name="ch25-collector-proj"):
     )
 
 
-def _make_chspan(*, project_id, span_id=None, trace_id=None, parent_span_id=""):
+def _make_chspan(
+    *, project_id, span_id=None, trace_id=None, parent_span_id="", org_id=None
+):
     """A fully-populated CHSpan dataclass standing in for a collector span row
-    (the shape ``CHSpanReader.get`` returns). No PG row exists for it."""
+    (the shape ``CHSpanReader.get`` returns). No PG row exists for it. ``org_id``
+    is populated for the org-scoped ``resolve_ch_span_source`` gate; the
+    project-scoped fallback path ignores it, so it defaults to None."""
     return CHSpan(
         id=span_id or f"ch-span-{uuid.uuid4().hex[:12]}",
         project_id=str(project_id),
@@ -100,7 +105,7 @@ def _make_chspan(*, project_id, span_id=None, trace_id=None, parent_span_id=""):
         cost=0.0021,
         status="OK",
         status_message="",
-        org_id=None,
+        org_id=str(org_id) if org_id is not None else None,
         project_version_id=None,
         end_user_id=None,
         trace_session_id=None,
@@ -731,6 +736,77 @@ def test_collector_span_round_trips_create_to_annotate(
     # Score persists the collector soft id — and NO PG ObservationSpan backs it.
     assert str(score.observation_span_id) == str(span.id)
     assert not ObservationSpan.objects.filter(id=span.id).exists()
+
+
+# ─────────── for_source: collector trace span_notes (TH-6622) ────────────────
+
+
+@pytest.mark.django_db
+def test_for_source_collector_trace_span_notes_resolves_via_ch(
+    auth_client, organization, workspace, user
+):
+    """The trace-detail annotate panel calls ``for-source`` with a trace source
+    carrying ``span_notes_source_id`` = the (collector, CH-only) root span. Pre-fix
+    the endpoint resolved that span via PG only and 404'd with "Span notes source
+    not found"; the CH fallback makes the panel load. Revert → PG miss → 404
+    (TH-6622)."""
+    project = _make_project(organization=organization, workspace=workspace)
+    # org_id must match the requester — resolve_ch_span_source is org-gated.
+    span = _make_chspan(project_id=project.id, org_id=organization.pk)
+    reader = _ReaderCM(span)
+
+    with mock.patch(CH_READER_PATH, return_value=reader):
+        resp = auth_client.get(
+            "/model-hub/annotation-queues/for-source/",
+            {
+                "sources": json.dumps(
+                    [
+                        {
+                            "source_type": "trace",
+                            "source_id": str(uuid.uuid4()),
+                            "span_notes_source_id": span.id,
+                        }
+                    ]
+                ),
+            },
+        )
+
+    assert resp.status_code == 200, resp.data
+    # The CH fallback actually ran (proves it's not a lucky PG hit)...
+    assert str(span.id) in reader.get_calls
+    # ...and no PG ObservationSpan backs the collector root span.
+    assert not ObservationSpan.objects.filter(id=span.id).exists()
+
+
+@pytest.mark.django_db
+def test_for_source_collector_span_notes_cross_org_denied(
+    auth_client, organization, workspace
+):
+    """The CH span-notes fallback re-checks org scope: a collector root span owned
+    by a DIFFERENT org must still 404 — no cross-org leak into ``for_source``."""
+    from accounts.models.organization import Organization
+
+    other_org = Organization.objects.create(name="Other Org (for_source span_notes)")
+    other_project = _make_project(organization=other_org, workspace=None)
+    span = _make_chspan(project_id=other_project.id, org_id=other_org.pk)
+
+    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)):
+        resp = auth_client.get(
+            "/model-hub/annotation-queues/for-source/",
+            {
+                "sources": json.dumps(
+                    [
+                        {
+                            "source_type": "trace",
+                            "source_id": str(uuid.uuid4()),
+                            "span_notes_source_id": span.id,
+                        }
+                    ]
+                ),
+            },
+        )
+
+    assert resp.status_code == 404, resp.data
 
 
 # ───────────────────── N+1 batch (CollectorSourceCache) ───────────────────────

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -1530,3 +1530,58 @@ class TestScoreOnCollectorOnlySpan:
         ).exists()
         # SpanNotes written by id (the FK rejects a CHSpan OBJECT) on the CH span id
         assert SpanNotes.objects.filter(span_id=ch_span_id).exists()
+
+
+@pytest.mark.django_db
+class TestScoreOnCollectorOnlyTrace:
+    """Annotating a collector-only trace (no PG row) resolves via CH, not 404.
+
+    TH-6647: the Observe grid stores a source_type=trace item; scoring it must
+    CH-resolve the trace (via its root span) and attribute the score to a queue.
+    """
+
+    def _fake_trace_reader(self, monkeypatch, trace_id, project):
+        from types import SimpleNamespace
+
+        root_span = SimpleNamespace(
+            id="ch_" + uuid.uuid4().hex[:16],
+            project_id=str(project.id),
+            trace_id=str(trace_id),
+            parent_span_id="",  # root span
+            observation_type="agent",
+        )
+
+        class _R:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+            def list_by_trace(self_inner, tid, *, project_id=None):
+                return [root_span] if str(tid) == str(trace_id) else []
+
+            def close(self_inner):
+                pass
+
+        monkeypatch.setattr("tracer.services.clickhouse.v2.get_reader", lambda: _R())
+
+    def test_create_score_on_ch_only_trace(
+        self, auth_client, observe_project, organization, star_label, monkeypatch
+    ):
+        """A collector trace scores end-to-end (200, not the TH-6647 404). Uses the
+        default-queue path, so it also exercises the CH `_resolve_default_queue_scope`
+        project fallback."""
+        trace_id = str(uuid.uuid4())  # collector trace: NO PG row
+        self._fake_trace_reader(monkeypatch, trace_id, observe_project)
+        payload = {
+            "source_type": "trace",
+            "source_id": trace_id,
+            "label_id": str(star_label.id),
+            "value": {"rating": 4},
+        }
+        resp = auth_client.post(SCORE_URL, payload, format="json")
+        assert resp.status_code == status.HTTP_200_OK, resp.content  # NOT 404
+        s = Score.objects.get(trace_id=trace_id, deleted=False)
+        assert s.source_type == "trace"
+        assert s.queue_item_id is not None  # attributed to a queue

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -180,6 +180,12 @@ def is_source_available_for_annotation(source_type, source_obj):
     if source_type != QueueItemSourceType.TRACE.value:
         return True, None
 
+    # CH-resolved collector trace (duck-typed :class:`_CHTraceSource`, no PG
+    # reverse relation): it's surfaced from CH only once complete, so it's
+    # always available. The in-progress guard below is the voice/PG lifecycle.
+    if not hasattr(source_obj, "observation_spans"):
+        return True, None
+
     root_spans = source_obj.observation_spans.filter(_root_span_filter())
     if not root_spans.exists():
         return True, None
@@ -223,8 +229,19 @@ def filter_available_source_ids_for_annotation(
             Q(_has_root_span=False) | Q(_has_terminal_root_span=True)
         ).values_list("id", flat=True)
     }
+    # Collector (CH-only) traces have no PG row — the resolver already tenant-
+    # scoped them, and they're surfaced from CH once complete, so keep them
+    # rather than silently dropping every collector trace as "in progress".
+    pg_trace_ids = {
+        str(trace_id)
+        for trace_id in Trace.objects.filter(id__in=ordered_ids).values_list(
+            "id", flat=True
+        )
+    }
     available_ids = [
-        source_id for source_id in ordered_ids if source_id in available_set
+        source_id
+        for source_id in ordered_ids
+        if source_id not in pg_trace_ids or source_id in available_set
     ]
     unavailable_count = len(ordered_ids) - len(available_ids)
     if unavailable_count <= 0:
@@ -267,6 +284,17 @@ def _resolve_default_queue_scope(source_type, source_obj, organization=None):
         project = None
         if source_type == QueueItemSourceType.TRACE.value:
             project = getattr(source_obj, "project", None)
+            if project is None:
+                # CH trace path (_CHTraceSource): no FK, resolve the PG Project by
+                # the carried project_id, org-scoped (fail closed).
+                pid = getattr(source_obj, "project_id", None)
+                if pid:
+                    from tracer.models.project import Project
+
+                    qs = Project.objects.filter(id=pid)
+                    if organization is not None:
+                        qs = qs.filter(organization=organization)
+                    project = qs.first()
         elif source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
             # Django ObservationSpan: walk .project (or .trace.project).
             project = getattr(source_obj, "project", None) or getattr(
@@ -499,7 +527,12 @@ def resolve_default_queue_item_for_source(source_type, source_obj, organization,
 
 
 def resolve_source_object(
-    source_type, source_id, organization=None, workspace=None, *, allow_ch_fallback=False
+    source_type,
+    source_id,
+    organization=None,
+    workspace=None,
+    *,
+    allow_ch_fallback=False,
 ):
     """Look up a source model instance by type and ID.
 
@@ -591,6 +624,23 @@ def _tenant_scoped_project(project_id, *, organization=None, workspace=None):
     return project
 
 
+class _CHTraceSource:
+    """Duck-typed collector trace for annotation resolution (no PG ``Trace`` row).
+
+    Exposes the soft id the add path stores (``.id`` / ``.pk`` = trace_id) plus the
+    ``.project_id`` and resolved root :class:`CHSpan` the availability/render paths
+    read. Mirrors how a collector observation_span is duck-typed as a bare CHSpan.
+    Deliberately has no ``.observation_spans`` reverse relation — availability keys
+    off its absence to skip the PG in-progress check.
+    """
+
+    def __init__(self, trace_id, root_span):
+        self.id = str(trace_id)
+        self.pk = str(trace_id)
+        self.root_span = root_span
+        self.project_id = str(getattr(root_span, "project_id", "") or "") or None
+
+
 def _resolve_ch_source_object(
     source_type, source_id, *, organization=None, workspace=None
 ):
@@ -635,7 +685,30 @@ def _resolve_ch_source_object(
             source_id, organization=organization, workspace=workspace
         )
 
-    # trace (voice) and other source types are not CH-resolvable in this wave.
+    if source_type == QueueItemSourceType.TRACE.value:
+        # Collector trace (no PG row): resolve its root span from CH for the
+        # project_id, tenant-gate, and duck-type the trace so the add path
+        # stores the soft trace_id. The item is annotated at this root span.
+        root_span = _ch_root_span_for_trace(source_id)
+        if root_span is None:
+            return None
+        if (
+            _tenant_scoped_project(
+                getattr(root_span, "project_id", None),
+                organization=organization,
+                workspace=workspace,
+            )
+            is None
+        ):
+            logger.warning(
+                "ch_source_tenant_denied",
+                source_type=source_type,
+                source_id=str(source_id),
+            )
+            return None
+        return _CHTraceSource(source_id, root_span)
+
+    # other source types are not CH-resolvable in this wave.
     return None
 
 
@@ -702,6 +775,32 @@ def _ch_span_for_item(span_id):
     except Exception as exc:
         logger.warning("ch_span_render_error", span_id=str(span_id), error=str(exc))
         return None
+
+
+def _ch_root_span_for_trace(trace_id):
+    """Best-effort CH read of a collector trace's root span (resolve/render path).
+
+    Mirrors ``_get_item_spans``' trace branch: list the trace's CH spans, prefer
+    the conversation root, else the first parentless span. A non-voice trace item
+    is annotated at this root span. Returns the :class:`CHSpan` or ``None``
+    (missing / CH error). FAIL OPEN — logs, never raises into the page."""
+    if not trace_id:
+        return None
+    from tracer.services.clickhouse.v2 import get_reader
+
+    try:
+        with get_reader() as reader:
+            spans = reader.list_by_trace(str(trace_id))
+    except Exception as exc:
+        logger.warning("ch_trace_render_error", trace_id=str(trace_id), error=str(exc))
+        return None
+    root_spans = [s for s in spans if not s.parent_span_id]
+    if not root_spans:
+        return None
+    for span in root_spans:
+        if span.observation_type == "conversation":
+            return span
+    return root_spans[0]
 
 
 def _ch_session_fields_for_item(session_id):
@@ -988,9 +1087,24 @@ def resolve_source_preview(item, *, ch_cache=None):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE.value:
-            trace = item.trace
+            trace = _safe_related(item, "trace")
             if not trace:
-                return {"type": "trace", "deleted": True}
+                # collector trace: no PG row, preview from the CH root span.
+                root_span = _ch_root_span_for_trace(item.trace_id)
+                if root_span is None:
+                    return {"type": "trace", "deleted": True}
+                return {
+                    "type": "trace",
+                    "name": root_span.name or "",
+                    "project_id": (
+                        str(root_span.project_id) if root_span.project_id else None
+                    ),
+                    "input_preview": _truncate(str(root_span.input or ""), 200),
+                    "output_preview": _truncate(str(root_span.output or ""), 200),
+                    # CH has no response_time column; latency is the only signal.
+                    "latency_ms": root_span.latency_ms,
+                    "response_time_ms": root_span.latency_ms,
+                }
             primary_span = _trace_primary_span(trace)
             metrics = _metric_payload(primary_span) if primary_span else {}
             return {
@@ -1144,9 +1258,27 @@ def resolve_source_content(item, *, ch_cache=None):
             return data
 
         elif item.source_type == QueueItemSourceType.TRACE.value:
-            trace = item.trace
+            trace = _safe_related(item, "trace")
             if not trace:
-                return {"type": "trace", "deleted": True}
+                # collector trace: no PG row. Render from the CH root span; the
+                # non-voice UI focuses it via ``root_span_id`` (a render choice —
+                # the stored item stays a trace).
+                root_span = _ch_root_span_for_trace(item.trace_id)
+                if root_span is None:
+                    return {"type": "trace", "deleted": True}
+                from tracer.services.clickhouse.v2.span_reader import (
+                    chspan_to_annotation_source_dict,
+                )
+
+                # Headline content of the trace = its root span, reshaped to the
+                # trace dict. Drop span_id: the FE renders a trace item via
+                # InlineTraceView(trace_id) and only reads span_id for an
+                # observation_span item, so it's dead + mis-attachment-prone here.
+                data = chspan_to_annotation_source_dict(root_span)
+                data["type"] = "trace"
+                data["trace_id"] = str(item.trace_id)
+                data.pop("span_id", None)
+                return data
             project_source = trace.project.source if trace.project_id else None
             primary_span = _trace_primary_span(trace)
             span_metrics = _metric_payload(primary_span) if primary_span else {}

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -125,6 +125,7 @@ from model_hub.utils.annotation_queue_helpers import (
     filter_available_source_ids_for_annotation,
     get_fk_field_name,
     is_source_available_for_annotation,
+    resolve_ch_span_source,
     resolve_source_content,
     resolve_source_object,
 )
@@ -4181,8 +4182,14 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             sid = src.get("source_id")
             span_notes_source_id = src.get("span_notes_source_id")
             if span_notes_source_id:
+                # A collector root span lives only in CH (no PG row), so the PG
+                # resolve misses; fall back to the CH resolver (matches scores.py)
+                # so the trace-detail annotate panel loads instead of 404ing.
                 span_notes_source = resolve_source_object(
                     "observation_span",
+                    span_notes_source_id,
+                    organization=request.organization,
+                ) or resolve_ch_span_source(
                     span_notes_source_id,
                     organization=request.organization,
                 )
@@ -4453,6 +4460,13 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                         from tracer.models.trace import Trace
 
                         if st == "trace":
+                            # PG-only on purpose: a collector trace (no PG row)
+                            # returns False here, but the trace-detail panel always
+                            # co-sends its root observation_span (both gated on the
+                            # same spanId in buildTraceAnnotationSources), which
+                            # matches this same project-scoped queue via the
+                            # CH-aware branch below. Making this CH-aware would add
+                            # the N×M per-(queue,trace) round-trips codex P2 removed.
                             exists = Trace.objects.filter(
                                 id=sid, project_id=dq.project_id, deleted=False
                             ).exists()

--- a/futureagi/model_hub/views/scores.py
+++ b/futureagi/model_hub/views/scores.py
@@ -352,14 +352,17 @@ class ScoreViewSet(viewsets.ModelViewSet):
         if not fk_field:
             return self._gm.bad_request(f"Invalid source_type: {source_type}")
 
+        # Collector traces/spans have no PG row, so resolve from CH instead of
+        # 404ing. Trace uses the standard project-scoped CH resolver (returns a
+        # duck-typed source); observation_span keeps its dedicated org_id-scoped
+        # fallback below.
         source_obj = resolve_source_object(
             source_type,
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
+            allow_ch_fallback=(source_type == "trace"),
         )
-        # CDC-off fallback: collector-only spans have no PG row, so resolve from CH
-        # instead of 404ing. CHSpan duck-types as a source object for the writes below.
         if not source_obj and source_type == "observation_span":
             source_obj = resolve_ch_span_source(
                 source_id,
@@ -467,13 +470,15 @@ class ScoreViewSet(viewsets.ModelViewSet):
         if not fk_field:
             return self._gm.bad_request(f"Invalid source_type: {source_type}")
 
+        # Collector traces/spans have no PG row (see create()): trace resolves
+        # from CH via the standard resolver, observation_span via its fallback.
         source_obj = resolve_source_object(
             source_type,
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
+            allow_ch_fallback=(source_type == "trace"),
         )
-        # CDC-off fallback: collector-only spans live only in CH (see create()).
         if not source_obj and source_type == "observation_span":
             source_obj = resolve_ch_span_source(
                 source_id,


### PR DESCRIPTION
> **This PR fixes two same-root-cause tickets:** **TH-6647** (add a collector trace to a queue from the Observe grid) and **TH-6622** (add a label on a collector trace from the trace-detail Annotate panel). Both are the same gap — a collector (ClickHouse-only, no PG row) trace/span isn't resolvable by the annotation subsystem — surfacing at two entry points. They're folded together because TH-6622's label-*save* posts `source_type=trace`, which needs TH-6647's `scores.py` CH fallback (not on `dev`), so neither fix works end-to-end alone.

---

## TH-6622 — add label on a trace not working

**Bug (Urgent).** Trace-detail → **Annotations** tab → **Add Label** on an fi-collector trace → toast `Span notes source not found: <span_id>`, panel dies.

**Root cause.** The panel opens by calling `GET /model-hub/annotation-queues/for-source/` with `{source_type: trace, span_notes_source_id: <root_span_id>}` (`buildTraceAnnotationSources`). `for_source` resolved `span_notes_source_id` via `resolve_source_object("observation_span", …)` with **no** CH fallback → the collector root span has no PG row → `None` → 404 for the whole request → panel can't load.

**Fix.** `model_hub/views/annotation_queues.py` `for_source`: add the `resolve_ch_span_source` fallback (org-scoped; **mirrors `scores.py` `bulk_create` exactly**, which already does this on `dev`). Org-only tenancy matches the endpoint (`for_source` is org-scoped throughout — no workspace filter). Also documented the sibling default-queue `trace` branch whose PG-only existence check is intentionally masked by the co-sent `observation_span` source (making it CH-aware would reintroduce the N×M round-trips codex-P2 removed).

**Tests** (`test_ch25_annotation_collector_source_resolution.py`): `test_for_source_collector_trace_span_notes_resolves_via_ch` (200 not 404, asserts the CH read actually ran) + `test_for_source_collector_span_notes_cross_org_denied` (foreign-org span still 404s). Regression-locked: reverting the fallback flips the first to 404.

> `org_id` reliably backs the org-gate: fi-collector stamps `fi.org_id` server-side on every resolvable span and drops unresolvable ones (`fi-collector/pkg/auth/stamp.go` → `clickhouse25exporter/converter.go`), so the fix is prod-effective, not a no-op.

---

## What & why

Fixes **TH-6647** (Urgent): on the Observe → Tracing grid, selecting traces → **Actions → Add to annotation queue** failed with `Couldn't add to <queue>: Not found: trace=<uuid>` for **fi-collector projects**.

**Root cause.** The grid sends `source_type=trace`. A collector trace lives only in ClickHouse (no PG `Trace` row), and `resolve_source_object("trace", …)` had no CH fallback — `_resolve_ch_source_object` bailed on `trace` — so the add errored with "Not found". (The queue "Add items" picker dodged this by converting non-voice traces to their root span on the FE.)

## Approach

Make `source_type=trace` **CH-resolvable end-to-end**, mirroring the existing `observation_span` collector branches. A collector trace is resolved from ClickHouse via its **root span** (`reader.list_by_trace` → conversation root, else first parentless span — the same resolution `_get_item_spans` already does). This is the CH25-aligned direction: `_get_item_spans` and `resolve_filtered_trace_ids` were already CH-only, and all traces (voice included, via fi-collector) are CH-first.

The queue item stays a `trace` (soft `trace_id`); the non-voice UI focuses the root span at render via `root_span_id`. No conversion, no source-type swap — so **PG traces keep resolving via the PG-first path unchanged**.

## Changes (backend-only, one file)

`model_hub/utils/annotation_queue_helpers.py`:
- `_CHTraceSource` — duck-typed collector trace (`.id`/`.pk`=trace_id, `.project_id`, `.root_span`).
- `_ch_root_span_for_trace` — CH root-span read (fail-open, mirrors `_get_item_spans`).
- `_resolve_ch_source_object` — new `trace` branch: resolve root span → tenant-gate → `_CHTraceSource` (fail-closed on missing/cross-org).
- `resolve_source_content` / `resolve_source_preview` — CH fallback for a collector trace; content carries `trace_id` + `root_span_id`.
- `is_source_available_for_annotation` — a CH-resolved trace is always available (no PG in-progress guard).
- `filter_available_source_ids_for_annotation` — keep CH-only traces instead of silently dropping them → fixes **select-all** for collector projects too.
- `_resolve_default_queue_scope` — trace `project_id`→PG fallback for the CH-resolved source (inline `/scores/` default-queue path).

`model_hub/views/scores.py`:
- `create()` / `bulk_create()` — CH-resolve a collector trace (`allow_ch_fallback=(source_type == "trace")`) so **annotating** an added trace writes the score instead of 404ing.

> ⚠️ **Reviewer note:** `scores.py` intentionally has **two** CH-resolution mechanisms side by side — `trace` via the project-scoped `resolve_source_object(..., allow_ch_fallback=True)` (`_tenant_scoped_project`), and `observation_span` via the existing `resolve_ch_span_source` (`org_id`-scoped). This is deliberate: the tenancy mechanisms are **not** interchangeable, and flipping the span path to the helper would silently change span tenancy. Don't "tidy" them into one here — unifying is a separate follow-up.

No frontend change (the grid already sends `source_type=trace`).

## Tests

- `test_ch25_annotation_collector_source_resolution.py`: +7 trace tests (resolve via CH, cross-org denied, absent→None, availability, preview/content render, deleted-when-missing) → 29 pass.
- `test_bulk_add_items_filter.py`: 37 pass unchanged (B keeps `source_type=trace`, so PG-trace fixtures resolve via PG exactly as before).
- Broader annotation sweep (queue_items / render / submit / voice / rules / sliceE): 146 pass.

## Deferred (separate surfaces, not this bug)

- Automation-rule trace annotation (`_annotate_trace_for_rules`) — still PG.
- `_resolve_default_queue_scope` trace→CH project fallback — inline `/scores/` path only, not the add path.
- Migrating the queue **picker** to store `source_type=trace` too (it still converts to `observation_span`), to unify the two entry points.

