### PR TITLE
fix(develop): show loading skeleton for dynamic column cells before data lands (TH-6548)

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
@@ -76,6 +76,16 @@ export const StatusTypes = {
   ERROR: "error",
 };
 
+// Column-level statuses meaning the column is still computing. Shared with the
+// grid polling gate in DevelopDataV2.
+export const RefreshStatus = [
+  "Running",
+  "NotStarted",
+  "Editing",
+  "ExperimentEvaluation",
+  "PartialRun",
+];
+
 export const OriginTypes = {
   EVALUATION: "evaluation",
   RUN_PROMPT: "run_prompt",

--- a/frontend/src/sections/common/DevelopCellRenderer/CustomCellRender.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CustomCellRender.jsx
@@ -22,6 +22,7 @@ import {
   OriginTypes,
   StatusTypes,
   OutputTypes,
+  RefreshStatus,
 } from "./CellRenderers/cellRendererHelper";
 import { useRowHover } from "src/hooks/use-row-hover";
 import { useQueryClient } from "@tanstack/react-query";
@@ -278,7 +279,12 @@ const CustomCellRender = (props) => {
     );
   }
 
-  if (status === StatusTypes.RUNNING) {
+  // run_prompt/node-type cells skip a per-cell "running" status, so fall back to
+  // the column status — but only for cells with no data yet, so finished cells render.
+  if (
+    status === StatusTypes.RUNNING ||
+    (!cellData && RefreshStatus.includes(column?.status))
+  ) {
     return (
       <RunningSkeletonRenderer
         originType={props.colDef.col.originType}

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -82,17 +82,13 @@ import DatasetLoader from "../../develop/loaders/DatasetLoader";
 import { useEditSyntheticDataStore } from "src/sections/develop/AddRowDrawer/EditSyntheticData/state";
 import RunningSkeletonRenderer from "src/sections/common/DevelopCellRenderer/CellRenderers/RunningSkeletonRenderer";
 import { APP_CONSTANTS } from "src/utils/constants";
-import { OutputTypes } from "../../common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
+import {
+  OutputTypes,
+  RefreshStatus,
+} from "../../common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 import { useAuthContext } from "src/auth/hooks";
 import { ROLES } from "src/utils/rolePermissionMapping";
 const PdfPreviewDrawer = lazy(() => import("src/components/PdfPreviewDrawer"));
-const RefreshStatus = [
-  "Running",
-  "NotStarted",
-  "Editing",
-  "ExperimentEvaluation",
-  "PartialRun",
-];
 
 const getResultColumnConfig = (result) => result?.column_config ?? [];
 const getResultIsProcessingData = (result) =>


### PR DESCRIPTION
## Bug (TH-6548)
When a **dynamic column** is added/run on the dataset table, its cells show **no loading state** — the column sits empty and the finished data just pops in. This affects Run Prompt and all node-type columns; Evaluation showed a loader but only after a delay (worse on slow connections).

## Root cause
The per-cell loading skeleton (`RunningSkeletonRenderer`) is gated **only** on a cell's own `status === "running"`. But `run_prompt` and the node-type columns **never write a per-cell `running` status** — their cells go straight from *absent* → *finished* (`pass`/`error`), so the skeleton has nothing to latch onto. Evaluation does write `running` cells, but the first fetch after adding the column races ahead of cell creation, so its loader waited for the 5s poll.

Every dynamic column **does** expose a **column-level** status of `Running`/`NotStarted` from the first fetch (while cells are still absent) — that's the signal we now use.

### Dynamic columns — what status they return while computing
| Column type | `SourceChoices` | Column status while computing | Emits per-cell `running`? | Loader before this fix |
|---|---|---|---|---|
| Evaluation | `evaluation` | `NotStarted` → `Running` | Yes | shown, but delayed |
| Run Prompt | `run_prompt` | `Running` | No | **none** |
| Retrieval | `vector_db` | `Running` | No | **none** |
| Extract a JSON Key | `extracted_json` | `Running` | No | **none** |
| Classification | `classification` | `Running` | No | **none** |
| Extract Entities | `extracted_entities` | `Running` | No | **none** |
| API Calls | `api_call` | `Running` | No | **none** |
| Python Code | `python_code` | `Running` | No | **none** |
| Conditional Node | `conditional` | `Running` | No | **none** |

`Running` and `NotStarted` are both in the frontend's `RefreshStatus` set.

## Changes
- Extract `RefreshStatus` into the shared cell-renderer helper (single source of truth); `DevelopDataV2` now imports it instead of keeping a local duplicate (behaviour unchanged).
- In `CustomCellRender`, render the skeleton when **the cell is running OR the cell has not been produced yet and its column is still computing**:
  ```js
  status === StatusTypes.RUNNING ||
  (!cellData && RefreshStatus.includes(column?.status))
  ```
  The `!cellData` guard means cells that **already have data keep rendering their value** — so a partially-finished column shows data for the done rows and skeletons only for the rows still computing.

## Why
The column-level status is the only loading signal these column types expose, and it's present immediately (~0.4s after the column is added). Keying off it makes the loader appear right away for every dynamic type and self-clear per row as each cell's data lands — without masking cells that already finished.

## Test-case scenarios
- Add a **Run Prompt** column → cells show a skeleton immediately, clearing per row as values arrive.
- Add any **node** column (API Calls / Classification / Retrieval / …) → skeleton shows during compute instead of a blank cell.
- Add an **Evaluation** → loader appears immediately, not after the 5s poll.
- **Partial completion** → finished rows show their data while unfinished rows still show a skeleton.
- **Static / base columns** and completed-but-empty cells → no skeleton (column status is `Completed`).

## How to reproduce (before the fix)
Open a dataset → **Add Column → Run Prompt** (or **API Calls**). The new column's cells stay blank until the whole column finishes, then the data appears with no loading indicator.

## Commands
- `yarn lint` → 0 errors on the changed files
- No API contract surface (no axios / serializer fields touched)

## Videos / screenshots

https://github.com/user-attachments/assets/1026955a-86a9-4342-bf22-dba25e57d3c8


