### PR TITLE
fix(sdk): use snake_case field names from API response in AddSDKModal

### DIFF
--- a/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
@@ -109,7 +109,7 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
       onCloseClick();
       //@ts-ignore
       addRowSDK({
-        dataset_name: data?.data?.result?.datasetName,
+        dataset_name: data?.data?.result?.dataset_name,
       });
       setIsNext(true);
     },
@@ -375,13 +375,13 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.apiKey}
+                    {data?.data?.result?.api_keys?.api_key}
                   </Typography>
                   <IconButton
                     size="small"
                     onClick={() =>
                       copyToClipboard(
-                        data?.data?.result?.apiKeys?.apiKey,
+                        data?.data?.result?.api_keys?.api_key,
                         "API Key",
                       )
                     }
@@ -410,13 +410,13 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.secretKey}
+                    {data?.data?.result?.api_keys?.secret_key}
                   </Typography>
                   <IconButton
                     size="small"
                     onClick={() =>
                       copyToClipboard(
-                        data?.data?.result?.apiKeys?.secretKey,
+                        data?.data?.result?.api_keys?.secret_key,
                         "Secret Key",
                       )
                     }


### PR DESCRIPTION
## Summary

Clicking "Add data using SDK", entering a dataset name, and hitting Next would immediately show an error like "dataset is deleted or does not exist" and the flow would stay stuck on step 1 — the second modal (which shows the SDK code snippets, API key, and Secret Key) never opened.

The bug was a field-name mismatch in \`frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx\`. The flow has two sequential mutations: \`createEmptyDataset\` (creates the dataset) followed immediately by \`addRowSDK\` (fetches the SDK code snippets for that dataset). Both mutations succeeded individually, but the \`onSuccess\` handler of \`createEmptyDataset\` was reading \`data?.data?.result?.datasetName\` (camelCase) to pass the dataset name into \`addRowSDK\`. The backend actually returns \`dataset_name\` (snake\_case), so this read resolved to \`undefined\`. \`addRowSDK\` was then called with \`{ dataset_name: undefined }\`, the backend could not find the dataset by that key, and returned the "dataset deleted or does not exist" error. Because \`addRowSDK.onError\` calls \`setIsNext(false)\`, the second modal never opened.

The same snake\_case/camelCase mismatch existed in two more places in the second modal's render: the API Key field and copy-to-clipboard handler were reading \`data?.data?.result?.apiKeys?.apiKey\` (camelCase), and the Secret Key field and its copy handler were reading \`data?.data?.result?.apiKeys?.secretKey\`. Both resolved to \`undefined\` silently — had the second modal somehow opened, the API Key and Secret Key rows would have been blank and copying them would have written an empty string to the clipboard.

## Changes

**File:** \`frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx\`

- **Line 112** — \`createEmptyDataset\` \`onSuccess\`: changed \`data?.data?.result?.datasetName\` → \`data?.data?.result?.dataset_name\`. This is the field that gets passed as the \`dataset_name\` argument to \`addRowSDK\`; fixing it is what unblocks the entire flow and lets the second modal open.
- **Lines 378 & 384** — API Key \`<Typography>\` display and \`copyToClipboard\` call: changed \`data?.data?.result?.apiKeys?.apiKey\` → \`data?.data?.result?.api_keys?.api_key\`.
- **Lines 413 & 419** — Secret Key \`<Typography>\` display and \`copyToClipboard\` call: changed \`data?.data?.result?.apiKeys?.secretKey\` → \`data?.data?.result?.api_keys?.secret_key\`.

## Before / After


https://github.com/user-attachments/assets/ce12d84f-2a94-40ad-9f06-e8579e825832


**Before:** Enter dataset name → click Next → backend creates the dataset successfully, but \`addRowSDK\` is immediately called with \`{ dataset_name: undefined }\` → backend returns "dataset deleted or does not exist" → error toast shown → \`setIsNext(false)\` keeps the user on step 1 with no way to proceed.

**After:** Enter dataset name → click Next → backend creates the dataset → \`addRowSDK\` is called with the correct \`dataset_name\` → backend returns SDK snippets + API credentials → \`setIsNext(true)\` → second modal opens showing Dataset Name, Dataset ID, API Key, Secret Key, and the Python / TypeScript / Curl code snippets populated correctly. Copy-to-clipboard on both keys works as expected.

Closes TH-6211.

## Test plan

- [ ] Open "Add data using SDK", enter a dataset name, click Next — flow proceeds to the second modal without any error toast
- [ ] Second modal shows Dataset Name, Dataset ID, API Key, and Secret Key all populated (not blank)
- [ ] Copy-to-clipboard copies the correct value for API Key and Secret Key
- [ ] Python, TypeScript, and Curl code snippet tabs all render with the correct dataset name embedded
- [ ] Clicking Done navigates to the newly created dataset's data tab

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII