### PR TITLE
fix(datasets): hide empty pinned summary row at bottom of dataset grid

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -437,7 +437,7 @@ const getDefaultColDefs = () => {
   ];
 };
 
-const getAverageColumnConfig = (columns, tableRows) => {
+export const getAverageColumnConfig = (columns, tableRows) => {
   if (!columns?.length) {
     return [];
   }
@@ -550,6 +550,12 @@ const getAverageColumnConfig = (columns, tableRows) => {
             : `Average : ${eachCol?.averageScore}%`
           : "";
     }
+  }
+
+  // Skip the pinned summary row when no column has a value to show; otherwise
+  // every cell is "" and AG Grid renders a blank placeholder row at the bottom.
+  if (!Object.values(bottomRow).some(Boolean)) {
+    return [];
   }
 
   return [

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/DevelopDataV2.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/DevelopDataV2.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { getAverageColumnConfig } from "../DevelopDataV2";
+
+// getAverageColumnConfig feeds AG Grid's `pinnedBottomRowData`. It must only
+// produce a pinned summary row when a column actually has an average to show;
+// otherwise the grid renders a blank placeholder row at the bottom.
+describe("getAverageColumnConfig", () => {
+  it("returns no pinned row when no column has a value to summarise", () => {
+    const columns = [
+      { id: "col1", metadata: {} },
+      { id: "col2", metadata: {} },
+    ];
+
+    expect(getAverageColumnConfig(columns, [])).toEqual([]);
+  });
+
+  it("returns a pinned row when a column has an average score", () => {
+    const columns = [{ id: "col1", averageScore: 87, metadata: {} }];
+
+    const result = getAverageColumnConfig(columns, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].col1).toBe("Average : 87%");
+  });
+
+  it("keeps the pinned row for a genuine 0% average (0 is a value, not empty)", () => {
+    const columns = [{ id: "col1", averageScore: 0, metadata: {} }];
+
+    const result = getAverageColumnConfig(columns, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].col1).toBe("Average : 0%");
+  });
+
+  it("returns no pinned row when there are no columns", () => {
+    expect(getAverageColumnConfig([], [])).toEqual([]);
+    expect(getAverageColumnConfig(undefined, undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The dataset grid always rendered an extra empty row pinned at the bottom, even for datasets that have no eval averages to summarise. This hides that row so the grid ends cleanly on the last data row.

## Why it happens / where it breaks

The grid's pinned bottom row (AG Grid's `pinnedBottomRowData`) is built by `getAverageColumnConfig` in `DevelopDataV2.jsx`. It walks every column and fills a `bottomRow` cell with the column's average (`"Average : 87%"`, a latency/cost element, …) or, when the column has nothing to summarise, `""`.

For a plain dataset with no eval columns, every cell resolves to `""` — but the function still returned a one-element array `[{ checkbox: "", ...allEmptyCells }]`. AG Grid renders that as a visible blank placeholder row. Because `getDatasetViewOptions` defaults `bottomRow` to `true`, every dataset hit this — matching the ticket's "always displayed".

## What changed

**`frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx`**
- `getAverageColumnConfig` now returns `[]` when no column produced a value (`!Object.values(bottomRow).some(Boolean)`), so no pinned row is emitted and the grid renders no trailing blank row.
- A genuine `0` / `0%` average is a non-empty string (`"Average : 0%"`), so it is still truthy and the summary row is kept — only all-empty rows are dropped.
- Exported the function so it can be unit-tested directly on the real call path.

**`frontend/src/sections/develop-detail/DataTab/__tests__/DevelopDataV2.test.js`** (new, co-located with the existing `common.test.js`)
- Behavioral tests for the exact function that feeds `pinnedBottomRowData`.

## Tests

| Test | Asserts |
|---|---|
| returns no pinned row when no column has a value to summarise | the bug case → `[]` (RED if the fix is reverted) |
| returns a pinned row when a column has an average score | real average still shows |
| keeps the pinned row for a genuine 0% average | `0` is a value, not empty |
| returns no pinned row when there are no columns | empty / undefined input |

Red-if-reverted: with the guard removed, `returns no pinned row when no column has a value` fails (`expected [ Array(1) ] to deeply equal []`); the other three still pass — so the test proves the behavior, not a flag.

## Commands

```bash
cd frontend
npx vitest run src/sections/develop-detail/DataTab/__tests__/DevelopDataV2.test.js
# Test Files 1 passed (1) · Tests 4 passed (4)   (Node 22)
```

## Before / after

Captured on the live local grid (a 5-row dataset with no evals). Before the fix the grid renders a blank pinned bottom row; after the fix it renders none — grounded in the DOM: `.ag-floating-bottom .ag-row` count goes **1 → 0**. Before/after image + recorded walkthrough to be inlined here.

![before-after](https://github.com/user-attachments/assets/82be1e73-3e0d-4ba1-81ec-40509f6a11e0)

## Video

https://github.com/user-attachments/assets/8d1efd01-e318-41d1-bfae-edabffd406d4

## Test suite run

`vitest` — 4 passed with the fix; the bug-case test goes red (`expected [ Array(1) ] to deeply equal []`) when the guard is reverted. Screenshot to be inlined here.

![test-suite](https://github.com/user-attachments/assets/7a980108-9a62-4309-9f6f-30c7f72f641a)

## Backwards compatibility

`getAverageColumnConfig` is consumed only in `DevelopDataV2.jsx` (the memoised `bottomRow` → `pinnedBottomRowData`). Datasets that DO have eval averages are unaffected — a non-empty cell keeps the summary row exactly as before. The only behavior change is: an all-empty summary row is no longer emitted.

| Caller | Effect |
|---|---|
| `DevelopDataV2` `bottomRow` memo → grid `pinnedBottomRowData` | empty summary → no pinned row; real summary → unchanged |

## Manual verification

Verified against the live local grid on a 5-row dataset with no evals: before the fix the grid showed the empty pinned row (AG Grid renders 1 empty pinned bottom row); after the fix the grid renders 0 pinned bottom rows and ends on the last data row. Grounded in the DOM (`.ag-floating-bottom .ag-row` count: 1 → 0).

## Type

Bug fix (frontend, no API/schema change).

## Checklist

- [x] Root-cause fix in the module the ticket names
- [x] Behavioral test on the real call path; red if the fix is reverted
- [x] Positive, zero-value, and empty-input branches covered
- [x] No new magic strings / constants; logic-only change
- [x] Rebased on latest `dev`

## Backout

Revert this commit — restores the previous (buggy) behavior with no data or schema impact.

## Linear

Closes TH-6178

