### PR TITLE
perf(eval-tasks): scope + lean CH reads for eval task engine (Phase A)

### DIFF
--- a/fi-collector/cmd/loadgen/fabricate.go
+++ b/fi-collector/cmd/loadgen/fabricate.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// must match converter.go resAttrProjectTy
+const resAttrProjectType = "project_type"
+
+// Span shapes. `mixed` picks one of the others per-trace.
+const (
+	shapeLLM       = "llm"
+	shapeVoice     = "voice"
+	shapeAgentDeep = "agent-deep"
+	shapeFatAttrs  = "fat-attrs"
+	shapeMixed     = "mixed"
+)
+
+// voice transcript sizing and routing. The key carries an overflow prefix
+// (adapter.overflowKeyPrefixes "llm.messages") so the converter routes the
+// payload to attributes_extra rather than a typed Map.
+const (
+	attrVoiceTranscript = "llm.messages.transcript"
+	voiceTranscriptSize = 1258291 // 1.2 MiB, > 1<<20
+	fatAttrsCount       = 80
+)
+
+// Span-attribute keys the converter reads
+const (
+	attrSessionID    = "session.id"
+	attrSpanKind     = "fi.span.kind"
+	attrInputValue   = "input.value"
+	attrOutputValue  = "output.value"
+	attrModelName    = "llm.model_name"
+	attrInputTokens  = "gen_ai.usage.input_tokens"
+	attrOutputTokens = "gen_ai.usage.output_tokens"
+)
+
+type FabricateConfig struct {
+	ProjectID, OrgID, Shape         string
+	Traces, SpansPerTrace, Sessions int
+	Start, End                      time.Time
+}
+
+func fabricateBatch(cfg FabricateConfig, r *rand.Rand) ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ra := rs.Resource().Attributes()
+	ra.PutStr("fi.project_id", cfg.ProjectID)
+	ra.PutStr("fi.org_id", cfg.OrgID)
+	ra.PutStr("service.name", "loadgen")
+	ra.PutStr("fi.semconv", "fi_native")
+	ra.PutStr(resAttrProjectType, "observe")
+	ss := rs.ScopeSpans().AppendEmpty().Spans()
+
+	window := cfg.End.Sub(cfg.Start)
+	for t := 0; t < cfg.Traces; t++ {
+		traceID := randTraceID(r)
+		rootID := randSpanID(r)
+		rootStart := cfg.Start.Add(time.Duration(r.Int63n(int64(window))))
+		sessionID := fmt.Sprintf("session-%08d", r.Intn(cfg.Sessions))
+
+		shape := cfg.Shape
+		if shape == shapeMixed {
+			shape = pickMixedShape(r)
+		}
+		spans := cfg.SpansPerTrace
+		if shape == shapeAgentDeep {
+			spans = 50 + r.Intn(151) // [50,200]
+		}
+
+		appendSpan(ss, r, spanSpec{
+			traceID: traceID, spanID: rootID, name: "root",
+			start: rootStart, sessionID: sessionID, shape: shape, root: true,
+		})
+		for c := 1; c < spans; c++ {
+			start := rootStart.Add(time.Duration(c) * time.Second)
+			if shape == shapeAgentDeep {
+				switch c {
+				case 1:
+					start = rootStart.Add(-time.Second) // child precedes root
+				case 2:
+					start = rootStart // child ties root
+				}
+			}
+			appendSpan(ss, r, spanSpec{
+				traceID: traceID, spanID: randSpanID(r), parentID: rootID,
+				name:      fmt.Sprintf("child-%d", c),
+				start:     start,
+				sessionID: sessionID, shape: shape, llm: r.Intn(5) == 0,
+			})
+		}
+	}
+	return td
+}
+
+// pickMixedShape draws a per-trace shape for the `mixed` profile: mostly the
+// cheap llm shape, with the three stress shapes at 10% each.
+func pickMixedShape(r *rand.Rand) string {
+	switch n := r.Intn(100); {
+	case n < 70:
+		return shapeLLM
+	case n < 80:
+		return shapeVoice
+	case n < 90:
+		return shapeAgentDeep
+	default:
+		return shapeFatAttrs
+	}
+}
+
+// voiceTranscript builds a ~1.2 MiB lowercase-letter payload from r only.
+func voiceTranscript(r *rand.Rand) string {
+	b := make([]byte, voiceTranscriptSize)
+	r.Read(b)
+	for i := range b {
+		b[i] = 'a' + b[i]%26
+	}
+	return string(b)
+}
+
+// spanSpec is the fabrication input for a single span: identifiers, placement,
+// the session it belongs to, and whether it carries LLM attributes.
+type spanSpec struct {
+	traceID   pcommon.TraceID
+	spanID    pcommon.SpanID
+	parentID  pcommon.SpanID
+	name      string
+	start     time.Time
+	sessionID string
+	shape     string
+	root      bool
+	llm       bool
+}
+
+// appendSpan materialises one span onto ss.
+func appendSpan(ss ptrace.SpanSlice, r *rand.Rand, spec spanSpec) {
+	s := ss.AppendEmpty()
+	s.SetTraceID(spec.traceID)
+	s.SetSpanID(spec.spanID)
+	if !spec.parentID.IsEmpty() {
+		s.SetParentSpanID(spec.parentID)
+	}
+	s.SetName(spec.name)
+	s.SetStartTimestamp(pcommon.NewTimestampFromTime(spec.start))
+	latency := time.Duration(r.Intn(2000)+1) * time.Millisecond
+	s.SetEndTimestamp(pcommon.NewTimestampFromTime(spec.start.Add(latency)))
+
+	a := s.Attributes()
+	a.PutStr(attrSessionID, spec.sessionID)
+	a.PutStr(attrInputValue, "prompt for "+spec.name)
+	a.PutStr(attrOutputValue, "response for "+spec.name)
+	if spec.llm {
+		a.PutStr(attrSpanKind, "LLM")
+		a.PutStr(attrModelName, "gpt-4o-mini")
+		a.PutInt(attrInputTokens, int64(r.Intn(500)+1))
+		a.PutInt(attrOutputTokens, int64(r.Intn(500)+1))
+	}
+
+	switch spec.shape {
+	case shapeVoice:
+		if spec.root {
+			a.PutStr(attrVoiceTranscript, voiceTranscript(r))
+		}
+	case shapeFatAttrs:
+		for k := 0; k < fatAttrsCount; k++ {
+			a.PutInt(fmt.Sprintf("attr.k%02d", k), r.Int63())
+		}
+	}
+}
+
+// randTraceID fills an OTel TraceID from r only (seeded PRNG).
+func randTraceID(r *rand.Rand) pcommon.TraceID {
+	var b [16]byte
+	r.Read(b[:])
+	return pcommon.TraceID(b)
+}
+
+func randSpanID(r *rand.Rand) pcommon.SpanID {
+	var b [8]byte
+	r.Read(b[:])
+	return pcommon.SpanID(b)
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/fi-collector/cmd/loadgen/fabricate_test.go
+++ b/fi-collector/cmd/loadgen/fabricate_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	chexp "github.com/future-agi/future-agi/fi-collector/exporter/clickhouse25exporter"
+	"github.com/future-agi/future-agi/fi-collector/pkg/adapter"
+)
+
+func cfg(n, m int) FabricateConfig {
+	return FabricateConfig{
+		ProjectID: "11111111-1111-1111-1111-111111111111",
+		OrgID:     "22222222-2222-2222-2222-222222222222",
+		Shape:     "llm", Traces: n, SpansPerTrace: m, Sessions: 2,
+		Start: mustTime("2026-01-01T00:00:00Z"), End: mustTime("2026-01-31T00:00:00Z"),
+	}
+}
+
+// Same seed → byte-identical output (CI determinism).
+func TestFabricateDeterministic(t *testing.T) {
+	a := fabricateBatch(cfg(10, 5), rand.New(rand.NewSource(42)))
+	b := fabricateBatch(cfg(10, 5), rand.New(rand.NewSource(42)))
+	if a.SpanCount() != b.SpanCount() || a.SpanCount() != 50 {
+		t.Fatalf("span counts: %d vs %d", a.SpanCount(), b.SpanCount())
+	}
+	ra, _ := chexp.Convert(a)
+	rb, _ := chexp.Convert(b)
+	for i := range ra {
+		if ra[i]["id"] != rb[i]["id"] || ra[i]["trace_id"] != rb[i]["trace_id"] {
+			t.Fatalf("row %d differs across same-seed runs", i)
+		}
+	}
+}
+
+// Fabricated spans must survive the production converter: project stamped,
+// exactly one root per trace, curated trace identities collected.
+func TestFabricateConvertsCleanly(t *testing.T) {
+	traces := fabricateBatch(cfg(10, 5), rand.New(rand.NewSource(1)))
+	rows, ids, err := chexp.ConvertWithIdentities(traces)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 50 {
+		t.Fatalf("rows: %d", len(rows))
+	}
+	roots := map[any]int{}
+	for _, r := range rows {
+		if r["project_id"] != "11111111-1111-1111-1111-111111111111" {
+			t.Fatalf("project_id not stamped: %v", r["project_id"])
+		}
+		if r["parent_span_id"] == "" {
+			roots[r["trace_id"]]++
+		}
+	}
+	if len(roots) != 10 {
+		t.Fatalf("expected 10 rooted traces, got %d", len(roots))
+	}
+	if len(ids.Traces()) != 10 {
+		t.Fatalf("curated traces: %d", len(ids.Traces()))
+	}
+}
+
+// resAttrProjectType is copied from the converter's unexported resAttrProjectTy;
+// a converted row must echo it under that key so the two stay aligned.
+func TestFabricateStampsProjectType(t *testing.T) {
+	rows, _ := chexp.Convert(fabricateBatch(cfg(1, 1), rand.New(rand.NewSource(7))))
+	ra, _ := rows[0]["resource_attrs"].(map[string]any)
+	if ra["project_type"] != "observe" {
+		t.Fatalf("project_type resource attr: %v", ra["project_type"])
+	}
+}
+
+// voice: the overflow-routed transcript makes every root's attributes_extra
+// JSON payload ≥ 1 MiB; children stay lean.
+func TestVoiceShapeFatRoots(t *testing.T) {
+	c := cfg(5, 4)
+	c.Shape = shapeVoice
+	rows, _ := chexp.Convert(fabricateBatch(c, rand.New(rand.NewSource(3))))
+	roots := 0
+	for _, row := range rows {
+		of, ok := row["attributes_extra"].(map[string]any)
+		if !ok {
+			t.Fatalf("attributes_extra not a map: %T", row["attributes_extra"])
+		}
+		size := len(adapter.OverflowToJSON(of))
+		if row["parent_span_id"] == "" {
+			roots++
+			if size <= 1<<20 {
+				t.Fatalf("root attributes_extra JSON = %d bytes, want > %d", size, 1<<20)
+			}
+		} else if size > 1<<20 {
+			t.Fatalf("child attributes_extra unexpectedly fat: %d bytes", size)
+		}
+	}
+	if roots != 5 {
+		t.Fatalf("roots: %d, want 5", roots)
+	}
+}
+
+// agent-deep: 50–200 spans/trace, and each trace carries adversarial start
+// ordering — one child starts before its root and one child ties the root
+// (LIMIT 1 BY parity stressors).
+func TestAgentDeepAdversarialOrdering(t *testing.T) {
+	c := cfg(20, 0) // SpansPerTrace ignored: agent-deep draws its own count
+	c.Shape = shapeAgentDeep
+	rows, _ := chexp.Convert(fabricateBatch(c, rand.New(rand.NewSource(9))))
+
+	rootStart := map[string]string{}
+	childStarts := map[string][]string{}
+	perTrace := map[string]int{}
+	for _, row := range rows {
+		tid := row["trace_id"].(string)
+		perTrace[tid]++
+		st := row["start_time"].(string)
+		if row["parent_span_id"] == "" {
+			rootStart[tid] = st
+		} else {
+			childStarts[tid] = append(childStarts[tid], st)
+		}
+	}
+	for tid, n := range perTrace {
+		if n < 50 || n > 200 {
+			t.Fatalf("trace %s has %d spans, want [50,200]", tid, n)
+		}
+	}
+	// At least one trace must exhibit BOTH a precede and a tie (lexicographic
+	// compare is chronological for fixed-width DateTime64 text).
+	found := false
+	for tid, rs := range rootStart {
+		precedes, ties := false, false
+		for _, cs := range childStarts[tid] {
+			if cs < rs {
+				precedes = true
+			}
+			if cs == rs {
+				ties = true
+			}
+		}
+		if precedes && ties {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("no trace has both a child preceding its root and a child tying its root")
+	}
+}
+
+// fat-attrs: ≥ 80 distinct high-cardinality attr keys land on every span
+// (across the typed maps and the overflow tier).
+func TestFatAttrsCardinality(t *testing.T) {
+	c := cfg(3, 4)
+	c.Shape = shapeFatAttrs
+	rows, _ := chexp.Convert(fabricateBatch(c, rand.New(rand.NewSource(5))))
+	for _, row := range rows {
+		if n := countAttrKeys(row, "attr.k"); n < 80 {
+			t.Fatalf("span has %d attr.k* keys, want >= 80", n)
+		}
+	}
+}
+
+// countAttrKeys tallies keys with the given prefix across every attribute
+// destination the converter splits into.
+func countAttrKeys(row map[string]any, prefix string) int {
+	n := 0
+	if m, ok := row["attrs_string"].(map[string]string); ok {
+		for k := range m {
+			if strings.HasPrefix(k, prefix) {
+				n++
+			}
+		}
+	}
+	if m, ok := row["attrs_number"].(map[string]float64); ok {
+		for k := range m {
+			if strings.HasPrefix(k, prefix) {
+				n++
+			}
+		}
+	}
+	if m, ok := row["attrs_bool"].(map[string]uint8); ok {
+		for k := range m {
+			if strings.HasPrefix(k, prefix) {
+				n++
+			}
+		}
+	}
+	if m, ok := row["attributes_extra"].(map[string]any); ok {
+		for k := range m {
+			if strings.HasPrefix(k, prefix) {
+				n++
+			}
+		}
+	}
+	return n
+}

--- a/fi-collector/cmd/loadgen/main.go
+++ b/fi-collector/cmd/loadgen/main.go
@@ -1,0 +1,202 @@
+// loadgen fabricates deterministic SDK-shaped OTLP spans and ingests them
+// THROUGH the production converter + chwriter in-process (no running collector),
+// then writes a manifest describing the seeded dataset. It exists to seed a CH
+// `spans` table for the eval-task data-read benchmarks: a fixed seed reproduces
+// the exact same trace/span ids so the read benchmarks are stable across runs.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	chexp "github.com/future-agi/future-agi/fi-collector/exporter/clickhouse25exporter"
+	"github.com/future-agi/future-agi/fi-collector/pkg/chwriter"
+	"github.com/future-agi/future-agi/fi-collector/pkg/curatedwriter"
+)
+
+// Manifest is the dataset descriptor Tasks 2/3 read to target the seeded rows
+// without re-deriving ids. Field names are the wire contract.
+type Manifest struct {
+	ProjectID             string            `json:"project_id"`
+	TraceIDs              []string          `json:"trace_ids"`
+	RootSpanIDByTrace     map[string]string `json:"root_span_id_by_trace"`
+	SpanCount             int               `json:"span_count"`
+	SessionIDs            []string          `json:"session_ids"`
+	ObservationTypeCounts map[string]int    `json:"observation_type_counts"`
+}
+
+func main() {
+	var (
+		chURL        = flag.String("ch-url", "http://localhost:8123", "ClickHouse HTTP endpoint")
+		projectID    = flag.String("project-id", "", "fi.project_id stamped on every span")
+		orgID        = flag.String("org-id", "", "fi.org_id stamped on every span")
+		traces       = flag.Int("traces", 1000, "number of traces to fabricate")
+		spansPerTr   = flag.Int("spans-per-trace", 8, "spans per trace (1 root + N-1 children)")
+		sessions     = flag.Int("sessions", 4, "size of the session-id pool")
+		shape        = flag.String("shape", "llm", "span shape")
+		seed         = flag.Int64("seed", 42, "PRNG seed (fixed seed → reproducible dataset)")
+		timeRange    = flag.Duration("time-range", 720*time.Hour, "span start-time window, back from --end")
+		end          = flag.String("end", "2026-01-01T00:00:00Z", "fixed RFC3339 window end (reproducibility anchor)")
+		manifestPath = flag.String("manifest", "manifest.json", "manifest output path")
+		batchSize    = flag.Int("batch-size", 10000, "spans per ingest round")
+		trickle      = flag.Int("trickle", 0, "if >0, pace emission at N spans/sec (batch = 1 trace)")
+		otlpEndpoint = flag.String("otlp-endpoint", "", "if set, send via OTLP/gRPC to host:4317 (wire mode; excludes in-process --ch-url ingest)")
+	)
+	flag.Parse()
+
+	switch *shape {
+	case shapeLLM, shapeVoice, shapeAgentDeep, shapeFatAttrs, shapeMixed:
+	default:
+		fatalf("unsupported shape %q; want llm|voice|agent-deep|fat-attrs|mixed", *shape)
+	}
+
+	endTime, err := time.Parse(time.RFC3339, *end)
+	if err != nil {
+		fatalf("parse --end: %v", err)
+	}
+
+	// Wire mode (--otlp-endpoint) and in-process CH ingest are mutually
+	// exclusive: exactly one of sender / (w, curated) is set.
+	var (
+		w       *chwriter.Writer
+		curated *curatedwriter.Writer
+		sender  *otlpSender
+	)
+	if *otlpEndpoint != "" {
+		sender, err = newOTLPSender(*otlpEndpoint)
+		if err != nil {
+			fatalf("otlp dial: %v", err)
+		}
+		defer sender.Close()
+	} else {
+		w, err = chwriter.New(chwriter.Config{
+			URL:            *chURL,
+			Database:       "default",
+			Table:          "spans",
+			DeadLetterFile: filepath.Join(os.TempDir(), "loadgen_dead_letter.jsonl"),
+		})
+		if err != nil {
+			fatalf("chwriter: %v", err)
+		}
+		defer w.Close()
+		curated = curatedwriter.New(w)
+	}
+
+	r := rand.New(rand.NewSource(*seed))
+	ctx := context.Background()
+
+	manifest := Manifest{
+		ProjectID:             *projectID,
+		RootSpanIDByTrace:     map[string]string{},
+		ObservationTypeCounts: map[string]int{},
+	}
+	sessionSeen := map[string]struct{}{}
+	traceSeen := map[string]struct{}{}
+
+	// Batch in traces. --trickle emits one trace at a time, paced by a ticker
+	// sized to N spans/sec (wall-clock; fabrication stays clock-free).
+	tracesPerBatch := max(*batchSize/max(*spansPerTr, 1), 1)
+	var ticker *time.Ticker
+	if *trickle > 0 {
+		tracesPerBatch = 1
+		ticker = time.NewTicker(time.Second / time.Duration(*trickle))
+		defer ticker.Stop()
+	}
+
+	remaining := *traces
+	for remaining > 0 {
+		n := min(tracesPerBatch, remaining)
+		remaining -= n
+		batch := fabricateBatch(FabricateConfig{
+			ProjectID: *projectID, OrgID: *orgID, Shape: *shape,
+			Traces: n, SpansPerTrace: *spansPerTr, Sessions: *sessions,
+			Start: endTime.Add(-*timeRange), End: endTime,
+		}, r)
+
+		// Convert in both modes so the manifest is byte-identical: wire mode
+		// derives ids/counts locally while the collector converts server-side.
+		rows, ids, err := chexp.ConvertWithIdentities(batch)
+		if err != nil {
+			fatalf("convert: %v", err)
+		}
+		if sender != nil {
+			if err := sender.Send(ctx, batch); err != nil {
+				fatalf("otlp send: %v", err)
+			}
+		} else {
+			if err := w.Insert(ctx, rows); err != nil {
+				fatalf("insert: %v", err)
+			}
+			if err := curated.Write(ctx, ids, time.Now().UTC()); err != nil {
+				fmt.Fprintf(os.Stderr, "loadgen: curated write: %v\n", err)
+			}
+		}
+
+		for _, row := range rows {
+			manifest.SpanCount++
+			ot, ok := row["observation_type"].(string)
+			if !ok {
+				fatalf("converter row missing string observation_type (id=%v)", row["id"])
+			}
+			manifest.ObservationTypeCounts[ot]++
+			traceID, ok := row["trace_id"].(string)
+			if !ok {
+				fatalf("converter row missing string trace_id (id=%v)", row["id"])
+			}
+			if _, seen := traceSeen[traceID]; !seen {
+				traceSeen[traceID] = struct{}{}
+				manifest.TraceIDs = append(manifest.TraceIDs, traceID)
+			}
+			if parent, _ := row["parent_span_id"].(string); parent == "" {
+				id, ok := row["id"].(string)
+				if !ok {
+					fatalf("converter row missing string id (id=%v)", row["id"])
+				}
+				manifest.RootSpanIDByTrace[traceID] = id
+			}
+		}
+		for _, s := range ids.Sessions() {
+			if _, seen := sessionSeen[s.ExternalSessionID]; !seen {
+				sessionSeen[s.ExternalSessionID] = struct{}{}
+				manifest.SessionIDs = append(manifest.SessionIDs, s.ExternalSessionID)
+			}
+		}
+
+		if ticker != nil {
+			for i := 0; i < len(rows); i++ {
+				<-ticker.C
+			}
+		}
+	}
+
+	if err := writeManifest(*manifestPath, manifest); err != nil {
+		fatalf("manifest: %v", err)
+	}
+	fmt.Printf("loadgen: ingested %d spans across %d traces → %s\n",
+		manifest.SpanCount, len(manifest.TraceIDs), *manifestPath)
+}
+
+// writeManifest serialises the manifest to a temp file and renames it into
+// place so a reader never observes a partially-written manifest.
+func writeManifest(path string, m Manifest) error {
+	body, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "loadgen: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/fi-collector/cmd/loadgen/send_otlp.go
+++ b/fi-collector/cmd/loadgen/send_otlp.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// otlpSender ships fabricated traces to a running collector over OTLP/gRPC.
+// It is the wire-mode counterpart to the in-process Convert+Insert path:
+// the collector performs the conversion server-side.
+type otlpSender struct {
+	conn   *grpc.ClientConn
+	client ptraceotlp.GRPCClient
+}
+
+// newOTLPSender dials endpoint (host:4317) with an insecure transport.
+func newOTLPSender(endpoint string) (*otlpSender, error) {
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	return &otlpSender{conn: conn, client: ptraceotlp.NewGRPCClient(conn)}, nil
+}
+
+func (s *otlpSender) Send(ctx context.Context, td ptrace.Traces) error {
+	_, err := s.client.Export(ctx, ptraceotlp.NewExportRequestFromTraces(td))
+	return err
+}
+
+func (s *otlpSender) Close() error { return s.conn.Close() }

--- a/futureagi/pytest.ini
+++ b/futureagi/pytest.ini
@@ -42,6 +42,7 @@ markers =
     live_llm: Tests requiring live LLM API calls
     vapi: Tests requiring VAPI service
     phone: Tests requiring phone/telephony services
+    stress: Eval-read stress/budget suite (needs LOADGEN_BIN + test ClickHouse)
 
 DJANGO_SETTINGS_MODULE = tfc.settings.test
 

--- a/futureagi/tests/stress/budgets.py
+++ b/futureagi/tests/stress/budgets.py
@@ -1,0 +1,57 @@
+"""Named budget constants for the eval-read stress suite (TH-6642).
+
+Every budget assertion in tests/stress references a constant here — never an
+inline number. Red-baseline budgets (xfail until their fix lands) encode the
+post-fix target; green budgets pin current behavior against regression.
+Baselines below were measured 2026-07-07 against current code at
+STRESS_SCALE=0.1 (target 8,000 spans / noise 58,777 / ~69k total in CH).
+"""
+
+# ── S4 / A1-A2: root lookup (`list_root_spans_by_trace_ids`) ────────────────
+# read_rows ceiling as a factor of the *target project's* span count: a
+# project-scoped lookup reads ~the target rows; an unscoped one also scans the
+# noise project and fails loudly (scale-invariance trick, design §3.1).
+# Measured baseline: 1,000-trace lookup reads 100,292 rows (the whole spans
+# table) at 69 MB — budget 8,000 × 1.5 = 12,000 rows → red on read_rows.
+ROOT_LOOKUP_MAX_READ_ROWS_FACTOR = 1.5
+ROOT_LOOKUP_MAX_MEMORY = 500 * 2**20
+
+# ── S12 / B1-B3: 500-entry drain batch ──────────────────────────────────────
+# Measured baseline: 500 run_entry calls issue 1,000 CH queries (2/entry),
+# 100,292 read_rows EACH (full-table scan per span lookup), peak 719 MB.
+# CH queries per drained batch (B1 prefetch: O(1) regardless of batch size).
+DRAIN_BATCH_MAX_CH_QUERIES = 6
+# PG queries per entry (B3: claim/terminal writes only; config loads batched).
+DRAIN_PER_ENTRY_MAX_PG_QUERIES = 3
+
+# ── S6 / A4: worker memory while loading one fat trace ──────────────────────
+# Design initial was 64 MiB, calibrated down: current (unfixed) load of one
+# voice trace (8 spans, one 1.2 MiB transcript in attributes_extra) peaks at
+# 2.93 MiB measured — a 64 MiB ceiling could never go red at this trace
+# fatness. 1 MiB sits below a single transcript, so the ceiling is
+# payload-independent: red today, green once A4 loads lean.
+TRACE_LOAD_MAX_PY_PEAK = 2**20
+
+# ── S10 / A7: reconciler requeue UPDATE fan-out ─────────────────────────────
+# One requeue UPDATE + one drop UPDATE, independent of config count.
+# Baseline: one UPDATE per stale config group (3 with a 3-eval task) → red.
+RECONCILE_REQUEUE_MAX_PG_UPDATES = 2
+
+# ── S7 / A5: session resolve (`resolve_session_fields`) remap scoping ───────
+# Same scale-invariance shape as S4: read_rows bounded by the target
+# project's curated session count, not the whole `trace_sessions` table.
+# Measured baseline: resolving the target's 5 sessions reads 140 rows (every
+# project's sessions + remap scan) — budget 5 × 1.5 = 7.5 → red.
+SESSION_RESOLVE_MAX_READ_ROWS_FACTOR = 1.5
+
+# ── S13 (green): desired-row stream over the mixed/fat-attrs project ────────
+# Pins the already-project-scoped `iter_desired_rows` scan: reads ≈ the
+# project's own rows, and the id sort stays well under the server limit.
+# Measured: 67,935 read_rows for 58,777 desired ids (1.16×), peak 8.4 MB.
+DESIRED_STREAM_MAX_READ_ROWS_FACTOR = 1.5
+DESIRED_STREAM_MAX_MEMORY = 512 * 2**20
+
+# ── S15 (green): reap + progress + finalize PG statement floor ──────────────
+# reap = 2 UPDATEs, has_undrained_work = 1 EXISTS, finalize = fetch + EXISTS
+# + UPDATE (+ savepoint bookkeeping under the test transaction).
+REAP_PROGRESS_FINALIZE_MAX_PG_QUERIES = 8

--- a/futureagi/tests/stress/budgets.py
+++ b/futureagi/tests/stress/budgets.py
@@ -1,4 +1,4 @@
-"""Named budget constants for the eval-read stress suite (TH-6642).
+"""Named budget constants for the eval-read stress suite.
 
 Every budget assertion in tests/stress references a constant here — never an
 inline number. Red-baseline budgets (xfail until their fix lands) encode the
@@ -13,7 +13,10 @@ STRESS_SCALE=0.1 (target 8,000 spans / noise 58,777 / ~69k total in CH).
 # noise project and fails loudly (scale-invariance trick, design §3.1).
 # Measured baseline: 1,000-trace lookup reads 100,292 rows (the whole spans
 # table) at 69 MB — budget 8,000 × 1.5 = 12,000 rows → red on read_rows.
-ROOT_LOOKUP_MAX_READ_ROWS_FACTOR = 1.5
+# Granule floor — CH reads whole 8 192-row granules, so a scoped read of an
+# N-row project can round up to ~2 granules per part; 2.5× stays far below
+# the unscoped full-table read.
+ROOT_LOOKUP_MAX_READ_ROWS_FACTOR = 2.5
 ROOT_LOOKUP_MAX_MEMORY = 500 * 2**20
 
 # ── S12 / B1-B3: 500-entry drain batch ──────────────────────────────────────
@@ -38,11 +41,14 @@ TRACE_LOAD_MAX_PY_PEAK = 2**20
 RECONCILE_REQUEUE_MAX_PG_UPDATES = 2
 
 # ── S7 / A5: session resolve (`resolve_session_fields`) remap scoping ───────
-# Same scale-invariance shape as S4: read_rows bounded by the target
-# project's curated session count, not the whole `trace_sessions` table.
-# Measured baseline: resolving the target's 5 sessions reads 140 rows (every
-# project's sessions + remap scan) — budget 5 × 1.5 = 7.5 → red.
-SESSION_RESOLVE_MAX_READ_ROWS_FACTOR = 1.5
+# At CI scale `trace_sessions` holds only ~60 rows (all in ONE 8192-row
+# granule), so read_rows cannot discriminate scoped vs. unscoped — both read
+# the same single granule.  S7 therefore verifies A5 STRUCTURALLY via
+# `EXPLAIN indexes=1`: the planner must show `project_id` in the PrimaryKey
+# condition (not `Condition: true`) when the WHERE pins `project_id`.  This
+# is scale-independent (the planner recognises the sort-key prefix regardless
+# of how many granules are actually skipped at runtime).  No read_rows budget
+# constant needed; the EXPLAIN assertion lives in test_session_lookup.py.
 
 # ── S13 (green): desired-row stream over the mixed/fat-attrs project ────────
 # Pins the already-project-scoped `iter_desired_rows` scan: reads ≈ the

--- a/futureagi/tests/stress/ch_asserts.py
+++ b/futureagi/tests/stress/ch_asserts.py
@@ -1,0 +1,88 @@
+"""CH query-budget helpers: tag eval-path queries with a ``log_comment``,
+then assert `system.query_log` metrics (read_rows / memory_usage / …) and
+query counts against the named constants in ``budgets.py``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import clickhouse_connect
+
+from tracer.services.clickhouse.v2 import get_v2_config
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+
+_FIELDS = ("memory_usage", "read_rows", "read_bytes", "query_duration_ms")
+
+# Server-side timestamp captured before any test query runs (see
+# ``capture_baseline``); bounds the query_log scan so tagged rows left by
+# previous pytest sessions against the same long-lived CH don't count.
+_baseline = None
+
+
+def _client():
+    cfg = get_v2_config()
+    return clickhouse_connect.get_client(
+        host=cfg["host"],
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"] or "",
+        database=cfg["database"],
+    )
+
+
+def capture_baseline() -> None:
+    """Record the CH server clock; called once by the session fixture before
+    any test issues tagged queries."""
+    global _baseline
+    client = _client()
+    try:
+        _baseline = client.command("SELECT now64(6)")
+    finally:
+        client.close()
+
+
+def _query_log_rows(tag: str) -> list[dict]:
+    """All QueryFinish rows tagged ``tag`` since the session baseline."""
+    client = _client()
+    try:
+        client.command("SYSTEM FLUSH LOGS")
+        where = "log_comment = %(t)s AND type = 'QueryFinish'"
+        params: dict = {"t": tag}
+        if _baseline is not None:
+            where += " AND event_time_microseconds >= %(b)s"
+            params["b"] = _baseline
+        rows = client.query(
+            f"SELECT {', '.join(_FIELDS)} FROM system.query_log WHERE {where}",
+            parameters=params,
+        ).result_rows
+    finally:
+        client.close()
+    return [dict(zip(_FIELDS, r, strict=True)) for r in rows]
+
+
+class BudgetResult:
+    """Aggregates the tagged queries' ``system.query_log`` rows."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+
+    def total(self, field: str) -> float:
+        return sum(r[field] for r in self.rows)
+
+    def max(self, field: str) -> float:
+        return max((r[field] for r in self.rows), default=0)
+
+    @property
+    def count(self) -> int:
+        return len(self.rows)
+
+
+@contextmanager
+def ch_query_budget(tag: str):
+    """Tag every CH query in the block with ``tag``; on exit flush logs and
+    load the tagged QueryFinish rows into the yielded ``BudgetResult``."""
+    result = BudgetResult()
+    with ch_query_settings(log_comment=tag):
+        yield result
+    result.rows = _query_log_rows(tag)

--- a/futureagi/tests/stress/conftest.py
+++ b/futureagi/tests/stress/conftest.py
@@ -456,6 +456,7 @@ def eval_task_factory(db, organization, workspace):
         run_type: str = RunType.HISTORICAL,
         spans_limit: int = 1_000_000,
         n_evals: int = 1,
+        custom_eval: bool = False,
     ) -> EvalTask:
         project, _ = Project.objects.get_or_create(
             id=project_id,
@@ -471,12 +472,18 @@ def eval_task_factory(db, organization, workspace):
                 ],
             },
         )
+        template_config = {"type": "pass_fail", "criteria": "stress"}
+        if custom_eval:
+            # Flip on the custom-eval branch in _process_trace_mapping /
+            # _process_session_mapping: a missing attribute resolves to "" instead
+            # of raising, which is what the lean-first heavy-field regression needs.
+            template_config["custom_eval"] = True
         template = EvalTemplate.objects.create(
             name=f"stress-eval-{uuid.uuid4().hex[:8]}",
             description="stress",
             organization=organization,
             workspace=workspace,
-            config={"type": "pass_fail", "criteria": "stress"},
+            config=template_config,
         )
         configs = [
             CustomEvalConfig.objects.create(

--- a/futureagi/tests/stress/conftest.py
+++ b/futureagi/tests/stress/conftest.py
@@ -1,0 +1,354 @@
+"""Fixtures for the eval-read stress suite (TH-6642, design doc
+internal-docs/eval-task-redesign/DATA-READ-OPTIMIZATION-DESIGN.md).
+
+CH data comes only from the loadgen binary (``$LOADGEN_BIN``, built from
+fi-collector/cmd/loadgen); PG control-plane rows come only from
+``eval_task_factory``. The suite skips with a visible reason when
+``LOADGEN_BIN`` is unset.
+
+Database: loadgen's chwriter pins ``?database=default``, so the session
+fixture hard-resets the test CH's ``default`` database, applies the full v2
+schema sequence there (the same ``apply_schema`` mechanism the root conftest
+uses for ``test_tfc`` — 020 removes the 90-day spans TTL that would drop the
+back-dated loadgen rows, 015/017/018 create the curated tables loadgen's
+best-effort writes need), and repoints ``settings.CLICKHOUSE_V2`` at
+``default`` for the session.
+
+Dataset scale: base sizes follow the task brief (target 10k traces × 8,
+noise 30k × 8 mixed); ``STRESS_SCALE`` (default 0.1) scales trace counts so a
+default run seeds ≈100k spans — the design doc's CI-tier size. Scale 1.0
+reproduces the brief-verbatim sizes (needs several GB of free disk: the mixed
+noise project carries ~10% voice traces with 1.2 MiB transcripts).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import clickhouse_connect
+import pytest
+from django.conf import settings
+
+from tests.stress import ch_asserts
+
+# Re-exported engine/cost stubs (same objects tracer/tests uses) so drain
+# scenarios run `run_entry` end-to-end without live LLM or billing calls.
+from tracer.tests.conftest import stub_cost_log, stub_run_eval  # noqa: F401
+
+_SCALE = float(os.environ.get("STRESS_SCALE", "0.1"))
+
+STRESS_ORG_ID = "5712e5ac-0000-4000-8000-000000000000"
+TARGET_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000001"
+NOISE_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000002"
+AGENT_DEEP_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000003"
+VOICE_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000004"
+
+# Covers loadgen's fixed reproducibility anchor (--end 2026-01-01, 30d back).
+# Historical tasks must carry this window: the UI builders' default is
+# now-30d, which excludes the back-dated seed rows.
+SEED_WINDOW = ("2025-11-01T00:00:00Z", "2026-02-01T00:00:00Z")
+
+_CURATED_TABLES = ("spans", "traces", "trace_sessions", "end_users")
+
+
+@dataclass(frozen=True)
+class Manifest:
+    project_id: str
+    trace_ids: list
+    root_span_id_by_trace: dict
+    span_count: int
+    session_ids: list
+    observation_type_counts: dict
+
+    @classmethod
+    def from_file(cls, path: Path) -> Manifest:
+        data = json.loads(path.read_text())
+        return cls(
+            project_id=data["project_id"],
+            trace_ids=data["trace_ids"],
+            root_span_id_by_trace=data["root_span_id_by_trace"],
+            span_count=data["span_count"],
+            session_ids=data["session_ids"],
+            observation_type_counts=data["observation_type_counts"],
+        )
+
+
+@dataclass(frozen=True)
+class StressDataset:
+    target: Manifest
+    noise: Manifest
+    agent_deep: Manifest
+    voice: Manifest
+
+
+def _reset_cached_dict_clients() -> None:
+    from tracer.services.clickhouse.v2 import (
+        end_user_dict_reader,
+        trace_session_dict_reader,
+    )
+
+    trace_session_dict_reader._reset_client()
+    end_user_dict_reader._reset_client()
+
+
+@pytest.fixture(scope="session")
+def _stress_ch(request):
+    """Hard-reset + v2-schema the CH ``default`` database and point the v2
+    readers at it for the session."""
+    # Guard: the DROP DATABASE below is destructive — reject mixed sessions
+    # before any CH operation so non-stress tests are never affected.
+    stress_root = str(Path(__file__).resolve().parent)
+    non_stress = [
+        item
+        for item in request.session.items
+        if not str(item.fspath).startswith(stress_root)
+    ]
+    if non_stress:
+        pytest.exit(
+            "stress suite rebuilds the ClickHouse `default` database — run it "
+            "standalone: uv run pytest tests/stress/ "
+            f"(found non-stress tests in this session: {non_stress[0].nodeid})",
+            returncode=4,
+        )
+
+    loadgen_bin = os.environ.get("LOADGEN_BIN")
+    if not loadgen_bin:
+        pytest.skip(
+            "LOADGEN_BIN not set — build fi-collector/cmd/loadgen and export "
+            "LOADGEN_BIN=<path> to run the stress suite"
+        )
+
+    from tracer.services.clickhouse.v2 import apply_schema, get_v2_config
+
+    cfg = get_v2_config()
+    host = "localhost" if cfg["host"] == "clickhouse" else cfg["host"]
+
+    admin = clickhouse_connect.get_client(
+        host=host,
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"] or "",
+        database="system",
+    )
+    try:
+        admin.command("DROP DATABASE IF EXISTS default")
+        admin.command("CREATE DATABASE default")
+    finally:
+        admin.close()
+
+    rc = apply_schema.main(
+        [
+            "--schema-dir",
+            str(
+                Path(__file__).resolve().parents[2]
+                / "tracer/services/clickhouse/v2/schema"
+            ),
+            "--ch-host",
+            host,
+            "--ch-http-port",
+            str(cfg["http_port"]),
+            "--ch-user",
+            cfg["user"],
+            "--ch-password",
+            cfg["password"] or "",
+            "--ch-database",
+            "default",
+        ]
+    )
+    if rc != 0:
+        pytest.fail(f"v2 schema apply to CH database 'default' failed (rc={rc})")
+
+    prior = settings.CLICKHOUSE_V2.get("CH25_DATABASE")
+    settings.CLICKHOUSE_V2["CH25_DATABASE"] = "default"
+    _reset_cached_dict_clients()
+    ch_asserts.capture_baseline()
+    try:
+        yield {"bin": loadgen_bin, "ch_url": f"http://{host}:{cfg['http_port']}"}
+    finally:
+        if prior is None:
+            settings.CLICKHOUSE_V2.pop("CH25_DATABASE", None)
+        else:
+            settings.CLICKHOUSE_V2["CH25_DATABASE"] = prior
+        _reset_cached_dict_clients()
+
+
+@pytest.fixture(scope="session")
+def loadgen_run(_stress_ch, tmp_path_factory):
+    """Run the loadgen binary against the stress CH; returns the parsed
+    Manifest. Deterministic for a fixed (seed, sizes, end) tuple."""
+    manifest_dir = tmp_path_factory.mktemp("loadgen-manifests")
+    seq = itertools.count()
+
+    def _run(
+        project_id: str,
+        *,
+        traces: int,
+        shape: str,
+        seed: int,
+        spans_per_trace: int = 8,
+        sessions: int = 4,
+        batch_size: int | None = None,
+        end: str | None = None,
+        time_range: str | None = None,
+        trickle: int | None = None,
+    ) -> Manifest:
+        out = manifest_dir / f"{shape}-{seed}-{next(seq)}.json"
+        cmd = [
+            _stress_ch["bin"],
+            "--ch-url",
+            _stress_ch["ch_url"],
+            "--project-id",
+            project_id,
+            "--org-id",
+            STRESS_ORG_ID,
+            "--traces",
+            str(traces),
+            "--spans-per-trace",
+            str(spans_per_trace),
+            "--sessions",
+            str(sessions),
+            "--shape",
+            shape,
+            "--seed",
+            str(seed),
+            "--manifest",
+            str(out),
+        ]
+        if batch_size is not None:
+            cmd += ["--batch-size", str(batch_size)]
+        if end is not None:
+            cmd += ["--end", end]
+        if time_range is not None:
+            cmd += ["--time-range", time_range]
+        if trickle is not None:
+            cmd += ["--trickle", str(trickle)]
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+        if res.returncode != 0:
+            pytest.fail(f"loadgen exited {res.returncode}: {res.stderr[-2000:]}")
+        return Manifest.from_file(out)
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def stress_dataset(loadgen_run) -> StressDataset:
+    """Seed the four read-only stress projects once per session.
+
+    Voice-bearing shapes get a smaller --batch-size: at the default 10k-span
+    batch a mixed batch carries ~150 MB of transcript JSON in one POST, which
+    exceeds chwriter's 30s request timeout.
+    """
+    n = lambda base: max(1, int(base * _SCALE))  # noqa: E731
+    target = loadgen_run(
+        TARGET_PROJECT_ID, traces=n(10_000), sessions=n(50), shape="llm", seed=42
+    )
+    noise = loadgen_run(
+        NOISE_PROJECT_ID,
+        traces=n(30_000),
+        sessions=n(500),
+        shape="mixed",
+        seed=43,
+        batch_size=1000,
+    )
+    agent_deep = loadgen_run(
+        AGENT_DEEP_PROJECT_ID,
+        traces=n(200),
+        sessions=max(2, n(20)),
+        shape="agent-deep",
+        seed=44,
+        batch_size=1000,
+    )
+    voice = loadgen_run(
+        VOICE_PROJECT_ID,
+        traces=max(4, n(40)),
+        sessions=4,
+        shape="voice",
+        seed=45,
+        batch_size=200,
+    )
+    return StressDataset(target=target, noise=noise, agent_deep=agent_deep, voice=voice)
+
+
+@pytest.fixture
+def eval_task_factory(db, organization, workspace):
+    """Persist an EvalTask (+ its CustomEvalConfigs) against a seeded CH
+    project. Creates the PG Project row keyed to the seeded project id.
+
+    Historical tasks default to a filter window covering the seed data
+    (SEED_WINDOW); pass explicit ``filters`` to override — include a
+    ``date_range`` or the builders' now-30d default excludes the seed rows.
+    """
+    from model_hub.models.ai_model import AIModel
+    from model_hub.models.evals_metric import EvalTemplate
+    from tracer.models.custom_eval_config import CustomEvalConfig
+    from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
+    from tracer.models.project import Project
+
+    def _make(
+        project_id: str,
+        row_type: str,
+        *,
+        filters: dict | None = None,
+        sampling_rate: float = 100.0,
+        run_type: str = RunType.HISTORICAL,
+        spans_limit: int = 1_000_000,
+        n_evals: int = 1,
+    ) -> EvalTask:
+        project, _ = Project.objects.get_or_create(
+            id=project_id,
+            defaults={
+                "name": f"stress-{project_id[-4:]}",
+                "organization": organization,
+                "workspace": workspace,
+                "model_type": AIModel.ModelTypes.GENERATIVE_LLM,
+                "trace_type": "observe",
+                "config": [
+                    {"id": "input", "name": "Input", "is_visible": True},
+                    {"id": "output", "name": "Output", "is_visible": True},
+                ],
+            },
+        )
+        template = EvalTemplate.objects.create(
+            name=f"stress-eval-{uuid.uuid4().hex[:8]}",
+            description="stress",
+            organization=organization,
+            workspace=workspace,
+            config={"type": "pass_fail", "criteria": "stress"},
+        )
+        configs = [
+            CustomEvalConfig.objects.create(
+                name=f"stress-cfg-{i}-{uuid.uuid4().hex[:6]}",
+                project=project,
+                eval_template=template,
+                config={"threshold": 0.8},
+                mapping={"input": "input", "output": "output"},
+                filters={},
+            )
+            for i in range(n_evals)
+        ]
+        if filters is None:
+            filters = (
+                {"date_range": list(SEED_WINDOW)}
+                if run_type == RunType.HISTORICAL
+                else {}
+            )
+        task = EvalTask.objects.create(
+            project=project,
+            name=f"stress-task-{uuid.uuid4().hex[:6]}",
+            filters=filters,
+            sampling_rate=sampling_rate,
+            spans_limit=spans_limit,
+            run_type=run_type,
+            status=EvalTaskStatus.PENDING,
+            row_type=row_type,
+        )
+        task.evals.add(*configs)
+        return task
+
+    return _make

--- a/futureagi/tests/stress/conftest.py
+++ b/futureagi/tests/stress/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for the eval-read stress suite (TH-6642, design doc
+"""Fixtures for the eval-read stress suite (design doc
 internal-docs/eval-task-redesign/DATA-READ-OPTIMIZATION-DESIGN.md).
 
 CH data comes only from the loadgen binary (``$LOADGEN_BIN``, built from
@@ -19,6 +19,10 @@ noise 30k × 8 mixed); ``STRESS_SCALE`` (default 0.1) scales trace counts so a
 default run seeds ≈100k spans — the design doc's CI-tier size. Scale 1.0
 reproduces the brief-verbatim sizes (needs several GB of free disk: the mixed
 noise project carries ~10% voice traces with 1.2 MiB transcripts).
+
+Seed reuse: set ``STRESS_REUSE_SEED=1`` to skip the drop + re-ingest + OPTIMIZE
+when the CH ``default`` DB already holds this scale's seeded data intact (fast
+local re-runs, no colima disk growth). Unset (the CI default) always rebuilds.
 """
 
 from __future__ import annotations
@@ -27,6 +31,7 @@ import itertools
 import json
 import os
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,6 +92,80 @@ class StressDataset:
     voice: Manifest
 
 
+# Opt-in reuse: with STRESS_REUSE_SEED set, if the CH `default` DB already holds
+# the expected per-project span counts (from a prior run's cached manifests at
+# this scale) the fixture skips the DROP + loadgen re-ingest + OPTIMIZE and reads
+# the cached manifests instead. Cheap re-runs, no colima disk growth. CI leaves
+# it unset and always seeds fresh.
+_SEED_CACHE_DIR = Path.home() / ".cache" / "fi-stress-seed"
+_DATASET_NAMES = ("target", "noise", "agent_deep", "voice")
+
+
+def _reuse_enabled() -> bool:
+    return os.environ.get("STRESS_REUSE_SEED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _cache_dir() -> Path:
+    return _SEED_CACHE_DIR / f"scale-{_SCALE}"
+
+
+def _load_cached_manifests() -> dict | None:
+    d = _cache_dir()
+    if not all((d / f"{name}.json").exists() for name in _DATASET_NAMES):
+        return None
+    try:
+        return {name: Manifest.from_file(d / f"{name}.json") for name in _DATASET_NAMES}
+    except Exception:
+        return None
+
+
+def _save_cached_manifests(mans: dict) -> None:
+    d = _cache_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    for name, m in mans.items():
+        (d / f"{name}.json").write_text(
+            json.dumps(
+                {
+                    "project_id": m.project_id,
+                    "trace_ids": m.trace_ids,
+                    "root_span_id_by_trace": m.root_span_id_by_trace,
+                    "span_count": m.span_count,
+                    "session_ids": m.session_ids,
+                    "observation_type_counts": m.observation_type_counts,
+                }
+            )
+        )
+
+
+def _ch_data_matches(host: str, cfg: dict, cached: dict) -> bool:
+    """True iff every cached project's live span count matches CH — i.e. the
+    seeded data is intact and safe to reuse without re-ingesting."""
+    client = clickhouse_connect.get_client(
+        host=host,
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"] or "",
+        database="default",
+    )
+    try:
+        for m in cached.values():
+            cnt = client.query(
+                "SELECT count() FROM spans WHERE project_id = %(p)s AND is_deleted = 0",
+                parameters={"p": m.project_id},
+            ).result_rows[0][0]
+            if int(cnt) != m.span_count:
+                return False
+        return True
+    except Exception:
+        return False
+    finally:
+        client.close()
+
+
 def _reset_cached_dict_clients() -> None:
     from tracer.services.clickhouse.v2 import (
         end_user_dict_reader,
@@ -129,47 +208,58 @@ def _stress_ch(request):
     cfg = get_v2_config()
     host = "localhost" if cfg["host"] == "clickhouse" else cfg["host"]
 
-    admin = clickhouse_connect.get_client(
-        host=host,
-        port=cfg["http_port"],
-        username=cfg["user"],
-        password=cfg["password"] or "",
-        database="system",
-    )
-    try:
-        admin.command("DROP DATABASE IF EXISTS default")
-        admin.command("CREATE DATABASE default")
-    finally:
-        admin.close()
+    # Reuse: skip the destructive rebuild when the seeded data is already present
+    # and intact for this scale (see _reuse_enabled / _ch_data_matches).
+    cached = _load_cached_manifests() if _reuse_enabled() else None
+    reused = bool(cached) and _ch_data_matches(host, cfg, cached)
 
-    rc = apply_schema.main(
-        [
-            "--schema-dir",
-            str(
-                Path(__file__).resolve().parents[2]
-                / "tracer/services/clickhouse/v2/schema"
-            ),
-            "--ch-host",
-            host,
-            "--ch-http-port",
-            str(cfg["http_port"]),
-            "--ch-user",
-            cfg["user"],
-            "--ch-password",
-            cfg["password"] or "",
-            "--ch-database",
-            "default",
-        ]
-    )
-    if rc != 0:
-        pytest.fail(f"v2 schema apply to CH database 'default' failed (rc={rc})")
+    if not reused:
+        admin = clickhouse_connect.get_client(
+            host=host,
+            port=cfg["http_port"],
+            username=cfg["user"],
+            password=cfg["password"] or "",
+            database="system",
+        )
+        try:
+            admin.command("DROP DATABASE IF EXISTS default")
+            admin.command("CREATE DATABASE default")
+        finally:
+            admin.close()
+
+        rc = apply_schema.main(
+            [
+                "--schema-dir",
+                str(
+                    Path(__file__).resolve().parents[2]
+                    / "tracer/services/clickhouse/v2/schema"
+                ),
+                "--ch-host",
+                host,
+                "--ch-http-port",
+                str(cfg["http_port"]),
+                "--ch-user",
+                cfg["user"],
+                "--ch-password",
+                cfg["password"] or "",
+                "--ch-database",
+                "default",
+            ]
+        )
+        if rc != 0:
+            pytest.fail(f"v2 schema apply to CH database 'default' failed (rc={rc})")
 
     prior = settings.CLICKHOUSE_V2.get("CH25_DATABASE")
     settings.CLICKHOUSE_V2["CH25_DATABASE"] = "default"
     _reset_cached_dict_clients()
     ch_asserts.capture_baseline()
     try:
-        yield {"bin": loadgen_bin, "ch_url": f"http://{host}:{cfg['http_port']}"}
+        yield {
+            "bin": loadgen_bin,
+            "ch_url": f"http://{host}:{cfg['http_port']}",
+            "reused": reused,
+            "manifests": cached if reused else None,
+        }
     finally:
         if prior is None:
             settings.CLICKHOUSE_V2.pop("CH25_DATABASE", None)
@@ -237,16 +327,34 @@ def loadgen_run(_stress_ch, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def stress_dataset(loadgen_run) -> StressDataset:
+def stress_dataset(loadgen_run, _stress_ch) -> StressDataset:
     """Seed the four read-only stress projects once per session.
 
     Voice-bearing shapes get a smaller --batch-size: at the default 10k-span
     batch a mixed batch carries ~150 MB of transcript JSON in one POST, which
     exceeds chwriter's 30s request timeout.
+
+    time_range="24h" collapses all seed rows into ≤2 daily partitions so CH
+    index granules (8 192 rows) can actually prune on project_id; without it
+    rows scatter across ~30 partitions at ~2 300/part — below one granule.
     """
+    if _stress_ch.get("reused"):
+        m = _stress_ch["manifests"]
+        return StressDataset(
+            target=m["target"],
+            noise=m["noise"],
+            agent_deep=m["agent_deep"],
+            voice=m["voice"],
+        )
+
     n = lambda base: max(1, int(base * _SCALE))  # noqa: E731
     target = loadgen_run(
-        TARGET_PROJECT_ID, traces=n(10_000), sessions=n(50), shape="llm", seed=42
+        TARGET_PROJECT_ID,
+        traces=n(10_000),
+        sessions=n(50),
+        shape="llm",
+        seed=42,
+        time_range="24h",
     )
     noise = loadgen_run(
         NOISE_PROJECT_ID,
@@ -255,6 +363,7 @@ def stress_dataset(loadgen_run) -> StressDataset:
         shape="mixed",
         seed=43,
         batch_size=1000,
+        time_range="24h",
     )
     agent_deep = loadgen_run(
         AGENT_DEEP_PROJECT_ID,
@@ -263,6 +372,7 @@ def stress_dataset(loadgen_run) -> StressDataset:
         shape="agent-deep",
         seed=44,
         batch_size=1000,
+        time_range="24h",
     )
     voice = loadgen_run(
         VOICE_PROJECT_ID,
@@ -271,8 +381,55 @@ def stress_dataset(loadgen_run) -> StressDataset:
         shape="voice",
         seed=45,
         batch_size=200,
+        time_range="24h",
     )
-    return StressDataset(target=target, noise=noise, agent_deep=agent_deep, voice=voice)
+
+    # Merge all parts so granules are dense before budget tests run.  Without
+    # this, freshly-ingested rows sit in many small parts each below one
+    # 8 192-row granule, making granule pruning impossible.
+    from tracer.services.clickhouse.v2 import get_v2_config
+
+    cfg = get_v2_config()
+    host = "localhost" if cfg["host"] == "clickhouse" else cfg["host"]
+    admin = clickhouse_connect.get_client(
+        host=host,
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"] or "",
+        database="default",
+    )
+    try:
+        admin.command("OPTIMIZE TABLE spans FINAL")
+        admin.command("OPTIMIZE TABLE trace_sessions FINAL")
+        admin.command("OPTIMIZE TABLE traces FINAL")
+        # OPTIMIZE returns while projection-materialize mutations and part
+        # merges can still be rewriting parts; a budget read mid-rewrite sees
+        # inflated read_rows. Wait for the storage to settle.
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            busy = admin.command(
+                "SELECT (SELECT count() FROM system.mutations WHERE NOT is_done)"
+                " + (SELECT count() FROM system.merges)"
+            )
+            if int(busy) == 0:
+                break
+            time.sleep(0.5)
+    finally:
+        admin.close()
+
+    dataset = StressDataset(
+        target=target, noise=noise, agent_deep=agent_deep, voice=voice
+    )
+    # Persist manifests so a later STRESS_REUSE_SEED run can skip the reseed.
+    _save_cached_manifests(
+        {
+            "target": target,
+            "noise": noise,
+            "agent_deep": agent_deep,
+            "voice": voice,
+        }
+    )
+    return dataset
 
 
 @pytest.fixture

--- a/futureagi/tests/stress/test_baselines.py
+++ b/futureagi/tests/stress/test_baselines.py
@@ -1,7 +1,8 @@
-"""Red baseline budgets (S10, S12): each asserts the post-fix
-Phase-A/B budget against CURRENT code and must fail today — strict xfail.
+"""Red baseline budgets (S12): each asserts the post-fix
+Phase-B budget against CURRENT code and must fail today — strict xfail.
 The fix packet that lands each fix removes its xfail marker.
 (S6 moved to test_trace_loading.py as part of A4 (lean-first loading).)
+(S10 moved to test_reconcile_counts.py once A7 landed.)
 """
 
 from __future__ import annotations
@@ -13,45 +14,14 @@ from django.test.utils import CaptureQueriesContext
 from tests.stress.budgets import (
     DRAIN_BATCH_MAX_CH_QUERIES,
     DRAIN_PER_ENTRY_MAX_PG_QUERIES,
-    RECONCILE_REQUEUE_MAX_PG_UPDATES,
 )
 from tests.stress.ch_asserts import ch_query_budget
 from tracer.models.eval_task import RowType
-from tracer.models.observation_span import EvalEntryStatus, EvalLogger
 from tracer.services.eval_tasks.entries import claim_pending_batch
 from tracer.services.eval_tasks.reconciler import reconcile
 from tracer.services.eval_tasks.run_entry import run_entry
 
 pytestmark = pytest.mark.stress
-
-
-@pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True, reason="A7 (single-statement requeue) not yet implemented"
-)
-def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
-    m = stress_dataset.target
-    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
-    reconcile(task)
-    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
-        status=EvalEntryStatus.COMPLETED
-    )
-    # Edit every config: hash changes make all completed entries stale.
-    for cfg in task.evals.all():
-        cfg.config = {"threshold": 0.9}
-        cfg.save()
-
-    with CaptureQueriesContext(connection) as ctx:
-        result = reconcile(task)
-
-    assert result.requeued == 180  # parity: every stale entry requeued
-    table = EvalLogger._meta.db_table
-    updates = [
-        q
-        for q in ctx.captured_queries
-        if q["sql"].strip().upper().startswith("UPDATE") and table in q["sql"]
-    ]
-    assert len(updates) <= RECONCILE_REQUEUE_MAX_PG_UPDATES
 
 
 @pytest.mark.django_db

--- a/futureagi/tests/stress/test_baselines.py
+++ b/futureagi/tests/stress/test_baselines.py
@@ -1,11 +1,10 @@
-"""Red baseline budgets (S4, S6, S7, S10, S12): each asserts the post-fix
+"""Red baseline budgets (S10, S12): each asserts the post-fix
 Phase-A/B budget against CURRENT code and must fail today — strict xfail.
-The fix packet that lands each TH-6642 fix removes its xfail marker.
+The fix packet that lands each fix removes its xfail marker.
+(S6 moved to test_trace_loading.py as part of A4 (lean-first loading).)
 """
 
 from __future__ import annotations
-
-import tracemalloc
 
 import pytest
 from django.db import connection
@@ -15,15 +14,10 @@ from tests.stress.budgets import (
     DRAIN_BATCH_MAX_CH_QUERIES,
     DRAIN_PER_ENTRY_MAX_PG_QUERIES,
     RECONCILE_REQUEUE_MAX_PG_UPDATES,
-    ROOT_LOOKUP_MAX_MEMORY,
-    ROOT_LOOKUP_MAX_READ_ROWS_FACTOR,
-    SESSION_RESOLVE_MAX_READ_ROWS_FACTOR,
-    TRACE_LOAD_MAX_PY_PEAK,
 )
-from tests.stress.ch_asserts import _client, ch_query_budget
+from tests.stress.ch_asserts import ch_query_budget
 from tracer.models.eval_task import RowType
 from tracer.models.observation_span import EvalEntryStatus, EvalLogger
-from tracer.services.clickhouse.v2 import get_reader
 from tracer.services.eval_tasks.entries import claim_pending_batch
 from tracer.services.eval_tasks.reconciler import reconcile
 from tracer.services.eval_tasks.run_entry import run_entry
@@ -32,76 +26,9 @@ pytestmark = pytest.mark.stress
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A1")
-def test_s4_root_lookup_prunes_to_project(stress_dataset, eval_task_factory):
-    manifest = stress_dataset.target
-    eval_task_factory(manifest.project_id, row_type=RowType.TRACES)
-    with ch_query_budget("stress:A1:root-lookup") as b:
-        with get_reader() as reader:
-            reader.list_root_spans_by_trace_ids(
-                manifest.trace_ids[:1000], include_heavy=False
-            )
-    assert (
-        b.total("read_rows") <= manifest.span_count * ROOT_LOOKUP_MAX_READ_ROWS_FACTOR
-    )
-    assert b.max("memory_usage") <= ROOT_LOOKUP_MAX_MEMORY
-
-
-@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A4")
-def test_s6_trace_load_python_peak_bounded(stress_dataset):
-    from tracer.services.clickhouse.v2.eval_loader import (
-        eval_read_source,
-        filter_observation_spans_by_trace,
-    )
-
-    manifest = stress_dataset.voice
-    trace_id = manifest.trace_ids[0]
-    with eval_read_source("clickhouse"):
-        tracemalloc.start()
-        try:
-            spans = filter_observation_spans_by_trace(
-                trace_id, project_id=manifest.project_id
-            )
-            peak = tracemalloc.get_traced_memory()[1]
-        finally:
-            tracemalloc.stop()
-    assert len(spans) > 0
-    # Ceiling independent of payload fatness: below one 1.2 MiB transcript.
-    assert peak <= TRACE_LOAD_MAX_PY_PEAK
-
-
-@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A5")
-def test_s7_session_resolve_prunes_to_project(stress_dataset):
-    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
-        resolve_session_fields,
-    )
-
-    manifest = stress_dataset.target
-    client = _client()
-    try:
-        session_uuids = [
-            r[0]
-            for r in client.query(
-                "SELECT toString(trace_session_id) FROM trace_sessions FINAL "
-                "WHERE project_id = %(p)s AND is_deleted = 0",
-                parameters={"p": manifest.project_id},
-            ).result_rows
-        ]
-    finally:
-        client.close()
-    assert len(session_uuids) == len(manifest.session_ids)
-
-    with ch_query_budget("stress:A5:session-resolve") as b:
-        resolved = resolve_session_fields(session_uuids)
-    assert len(resolved) == len(session_uuids)
-    assert (
-        b.total("read_rows")
-        <= len(session_uuids) * SESSION_RESOLVE_MAX_READ_ROWS_FACTOR
-    )
-
-
-@pytest.mark.django_db
-@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A7")
+@pytest.mark.xfail(
+    strict=True, reason="A7 (single-statement requeue) not yet implemented"
+)
 def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
     m = stress_dataset.target
     task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
@@ -128,7 +55,9 @@ def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 B1/B2/B3")
+@pytest.mark.xfail(
+    strict=True, reason="B1/B2/B3 (batch-prefetch drain) not yet implemented"
+)
 def test_s12_drain_batch_query_counts(
     stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
 ):

--- a/futureagi/tests/stress/test_baselines.py
+++ b/futureagi/tests/stress/test_baselines.py
@@ -1,0 +1,150 @@
+"""Red baseline budgets (S4, S6, S7, S10, S12): each asserts the post-fix
+Phase-A/B budget against CURRENT code and must fail today — strict xfail.
+The fix packet that lands each TH-6642 fix removes its xfail marker.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from tests.stress.budgets import (
+    DRAIN_BATCH_MAX_CH_QUERIES,
+    DRAIN_PER_ENTRY_MAX_PG_QUERIES,
+    RECONCILE_REQUEUE_MAX_PG_UPDATES,
+    ROOT_LOOKUP_MAX_MEMORY,
+    ROOT_LOOKUP_MAX_READ_ROWS_FACTOR,
+    SESSION_RESOLVE_MAX_READ_ROWS_FACTOR,
+    TRACE_LOAD_MAX_PY_PEAK,
+)
+from tests.stress.ch_asserts import _client, ch_query_budget
+from tracer.models.eval_task import RowType
+from tracer.models.observation_span import EvalEntryStatus, EvalLogger
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.eval_tasks.entries import claim_pending_batch
+from tracer.services.eval_tasks.reconciler import reconcile
+from tracer.services.eval_tasks.run_entry import run_entry
+
+pytestmark = pytest.mark.stress
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A1")
+def test_s4_root_lookup_prunes_to_project(stress_dataset, eval_task_factory):
+    manifest = stress_dataset.target
+    eval_task_factory(manifest.project_id, row_type=RowType.TRACES)
+    with ch_query_budget("stress:A1:root-lookup") as b:
+        with get_reader() as reader:
+            reader.list_root_spans_by_trace_ids(
+                manifest.trace_ids[:1000], include_heavy=False
+            )
+    assert (
+        b.total("read_rows") <= manifest.span_count * ROOT_LOOKUP_MAX_READ_ROWS_FACTOR
+    )
+    assert b.max("memory_usage") <= ROOT_LOOKUP_MAX_MEMORY
+
+
+@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A4")
+def test_s6_trace_load_python_peak_bounded(stress_dataset):
+    from tracer.services.clickhouse.v2.eval_loader import (
+        eval_read_source,
+        filter_observation_spans_by_trace,
+    )
+
+    manifest = stress_dataset.voice
+    trace_id = manifest.trace_ids[0]
+    with eval_read_source("clickhouse"):
+        tracemalloc.start()
+        try:
+            spans = filter_observation_spans_by_trace(
+                trace_id, project_id=manifest.project_id
+            )
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+    assert len(spans) > 0
+    # Ceiling independent of payload fatness: below one 1.2 MiB transcript.
+    assert peak <= TRACE_LOAD_MAX_PY_PEAK
+
+
+@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A5")
+def test_s7_session_resolve_prunes_to_project(stress_dataset):
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    manifest = stress_dataset.target
+    client = _client()
+    try:
+        session_uuids = [
+            r[0]
+            for r in client.query(
+                "SELECT toString(trace_session_id) FROM trace_sessions FINAL "
+                "WHERE project_id = %(p)s AND is_deleted = 0",
+                parameters={"p": manifest.project_id},
+            ).result_rows
+        ]
+    finally:
+        client.close()
+    assert len(session_uuids) == len(manifest.session_ids)
+
+    with ch_query_budget("stress:A5:session-resolve") as b:
+        resolved = resolve_session_fields(session_uuids)
+    assert len(resolved) == len(session_uuids)
+    assert (
+        b.total("read_rows")
+        <= len(session_uuids) * SESSION_RESOLVE_MAX_READ_ROWS_FACTOR
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 A7")
+def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
+    m = stress_dataset.target
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
+    reconcile(task)
+    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
+        status=EvalEntryStatus.COMPLETED
+    )
+    # Edit every config: hash changes make all completed entries stale.
+    for cfg in task.evals.all():
+        cfg.config = {"threshold": 0.9}
+        cfg.save()
+
+    with CaptureQueriesContext(connection) as ctx:
+        result = reconcile(task)
+
+    assert result.requeued == 180  # parity: every stale entry requeued
+    table = EvalLogger._meta.db_table
+    updates = [
+        q
+        for q in ctx.captured_queries
+        if q["sql"].strip().upper().startswith("UPDATE") and table in q["sql"]
+    ]
+    assert len(updates) <= RECONCILE_REQUEUE_MAX_PG_UPDATES
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(strict=True, reason="fixed by TH-6642 B1/B2/B3")
+def test_s12_drain_batch_query_counts(
+    stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
+):
+    m = stress_dataset.target
+    batch_size = 500
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=batch_size)
+    reconcile(task)
+    entries = claim_pending_batch(task, batch_size)
+    assert len(entries) == batch_size
+
+    with (
+        CaptureQueriesContext(connection) as ctx,
+        ch_query_budget("stress:B:drain-batch") as b,
+    ):
+        for entry in entries:
+            run_entry(entry)
+
+    assert b.count <= DRAIN_BATCH_MAX_CH_QUERIES
+    assert len(ctx.captured_queries) <= batch_size * DRAIN_PER_ENTRY_MAX_PG_QUERIES

--- a/futureagi/tests/stress/test_guardrails.py
+++ b/futureagi/tests/stress/test_guardrails.py
@@ -1,0 +1,56 @@
+"""S14: per-query CH guardrail tripwire.
+
+Inside ``eval_ch_guardrails()`` with ``max_memory_usage`` overridden down to
+1 MB via a nested ``ch_query_settings``, a deliberately heavy read (all noise
+trace ids in one unchunked root lookup with fat JSON columns and no project
+scoping, causing a full-table scan) must raise a CH code-241 query-level
+memory error. A subsequent minimal COUNT on the same CH instance must succeed,
+proving the server stayed healthy after the query-level rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+from tests.stress import ch_asserts
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+from tracer.services.eval_tasks.ch_guardrails import eval_ch_guardrails
+
+pytestmark = pytest.mark.stress
+
+# 1 MB is far below any real spans scan, so the code-241 rejection is
+# deterministic regardless of dataset size.
+_TINY_MEMORY_CAP = 1_000_000  # 1 MB
+
+
+def test_s14_guardrails_reject_heavy_query_server_stays_healthy(stress_dataset):
+    """Query-level memory guard fires as a code-241 error; server stays healthy."""
+    noise = stress_dataset.noise
+
+    # The inner ch_query_settings overrides the outer eval_ch_guardrails value
+    # for max_memory_usage only; execution_time and external_sort thresholds
+    # from eval_ch_guardrails remain in effect.
+    with pytest.raises(DatabaseError) as exc_info:
+        with eval_ch_guardrails():
+            with ch_query_settings(max_memory_usage=_TINY_MEMORY_CAP):
+                with get_reader() as reader:
+                    # All noise trace ids, unchunked, include_heavy=True pulls
+                    # fat JSON columns (attributes_extra, span_events,
+                    # resource_attrs). No project_id → full-table scan.
+                    reader.list_root_spans_by_trace_ids(
+                        noise.trace_ids,
+                        include_heavy=True,
+                    )
+
+    assert "241" in str(exc_info.value)
+
+    # Server is still healthy: a fresh client outside any guardrail context
+    # must complete a trivial count without error.
+    client = ch_asserts._client()
+    try:
+        cnt = client.query("SELECT count() FROM spans").result_rows[0][0]
+        assert int(cnt) >= 0
+    finally:
+        client.close()

--- a/futureagi/tests/stress/test_reconcile_counts.py
+++ b/futureagi/tests/stress/test_reconcile_counts.py
@@ -1,0 +1,40 @@
+"""Stress tests for reconciler PG statement counts."""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from tests.stress.budgets import RECONCILE_REQUEUE_MAX_PG_UPDATES
+from tracer.models.eval_task import RowType
+from tracer.models.observation_span import EvalEntryStatus, EvalLogger
+from tracer.services.eval_tasks.reconciler import reconcile
+
+pytestmark = pytest.mark.stress
+
+
+@pytest.mark.django_db
+def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
+    m = stress_dataset.target
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
+    reconcile(task)
+    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
+        status=EvalEntryStatus.COMPLETED
+    )
+    # Edit every config: hash changes make all completed entries stale.
+    for cfg in task.evals.all():
+        cfg.config = {"threshold": 0.9}
+        cfg.save()
+
+    with CaptureQueriesContext(connection) as ctx:
+        result = reconcile(task)
+
+    assert result.requeued == 180  # parity: every stale entry requeued
+    table = EvalLogger._meta.db_table
+    updates = [
+        q
+        for q in ctx.captured_queries
+        if q["sql"].strip().upper().startswith("UPDATE") and table in q["sql"]
+    ]
+    assert len(updates) <= RECONCILE_REQUEUE_MAX_PG_UPDATES

--- a/futureagi/tests/stress/test_root_lookup.py
+++ b/futureagi/tests/stress/test_root_lookup.py
@@ -1,0 +1,84 @@
+"""A1+A2+A3 root-lookup tests: S4 project-scoped read budget
+(moved + un-xfailed from test_baselines once A1 landed), S5 golden root-pick
+parity against the fabricator manifest, and the IN-list chunk fan-out.
+"""
+
+from __future__ import annotations
+
+import math
+from itertools import cycle, islice
+
+import pytest
+
+from tests.stress.budgets import (
+    ROOT_LOOKUP_MAX_MEMORY,
+    ROOT_LOOKUP_MAX_READ_ROWS_FACTOR,
+)
+from tests.stress.ch_asserts import ch_query_budget
+from tracer.models.eval_task import RowType
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.eval_tasks.entries import _FK_CHUNK, _resolve_entry_fks
+
+pytestmark = pytest.mark.stress
+
+
+@pytest.mark.django_db
+def test_s4_root_lookup_prunes_to_project(stress_dataset, eval_task_factory):
+    manifest = stress_dataset.target
+    eval_task_factory(manifest.project_id, row_type=RowType.TRACES)
+    with ch_query_budget("stress:A1:root-lookup") as b:
+        with get_reader() as reader:
+            reader.list_root_spans_by_trace_ids(
+                manifest.trace_ids[:_FK_CHUNK],
+                include_heavy=False,
+                project_id=manifest.project_id,
+            )
+    assert (
+        b.total("read_rows") <= manifest.span_count * ROOT_LOOKUP_MAX_READ_ROWS_FACTOR
+    )
+    assert b.max("memory_usage") <= ROOT_LOOKUP_MAX_MEMORY
+
+
+def test_root_pick_parity_agent_deep(stress_dataset):
+    # agent-deep dataset seeded by the loadgen fixture (seed 44). The manifest
+    # records the fabricator's root per trace — the parity oracle is the
+    # generator, not a snapshot of old code.
+    manifest = stress_dataset.agent_deep
+    with get_reader() as reader:
+        roots = reader.list_root_spans_by_trace_ids(
+            manifest.trace_ids,
+            include_heavy=False,
+            project_id=manifest.project_id,
+        )
+    got = {tid: root.id for tid, root in roots.items()}
+    assert got == manifest.root_span_id_by_trace
+
+
+def test_fk_resolve_chunks_in_list(stress_dataset):
+    # 2,500 ids -> ceil(2500/1000) = 3 CH queries, each bounded to a single
+    # _FK_CHUNK-id call's read_rows (chunking keeps per-query cost flat).
+    # Reader is constructed *inside* each budget block so query tagging (which
+    # applies at client construction) is captured by the budget context.
+    manifest = stress_dataset.target
+    ids = list(islice(cycle(manifest.trace_ids), 2 * _FK_CHUNK + _FK_CHUNK // 2))
+    expected_chunks = math.ceil(len(ids) / _FK_CHUNK)
+
+    with ch_query_budget("stress:A3:chunk-baseline") as base:
+        with get_reader() as reader:
+            _resolve_entry_fks(
+                reader,
+                RowType.TRACES,
+                manifest.trace_ids[:_FK_CHUNK],
+                project_id=manifest.project_id,
+            )
+    with ch_query_budget("stress:A3:chunk-fanout") as b:
+        with get_reader() as reader:
+            _resolve_entry_fks(
+                reader, RowType.TRACES, ids, project_id=manifest.project_id
+            )
+
+    assert base.count == 1
+    assert b.count == expected_chunks
+    assert (
+        b.max("read_rows") <= base.max("read_rows") * ROOT_LOOKUP_MAX_READ_ROWS_FACTOR
+    )

--- a/futureagi/tests/stress/test_scaffolding.py
+++ b/futureagi/tests/stress/test_scaffolding.py
@@ -1,0 +1,19 @@
+"""Scaffolding probe: `ch_query_settings(log_comment=…)` must reach
+`system.query_log` on every CH client the eval readers construct."""
+
+import pytest
+
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+
+pytestmark = pytest.mark.stress
+
+
+def test_log_comment_reaches_query_log(stress_dataset):
+    tag = "stress:scaffold:probe"
+    with ch_query_settings(log_comment=tag):
+        with get_reader() as reader:
+            reader.list_by_ids(["00000000-0000-0000-0000-000000000000"])
+    from tests.stress.ch_asserts import _query_log_rows
+
+    assert len(_query_log_rows(tag)) == 1

--- a/futureagi/tests/stress/test_scan_guardrails.py
+++ b/futureagi/tests/stress/test_scan_guardrails.py
@@ -1,0 +1,94 @@
+"""Benchmark for the trace-scanner's per-query ClickHouse guardrails.
+
+Two reportable facts, both against a loadgen-seeded ClickHouse:
+
+  1. TRIPWIRE — under ``scan_ch_guardrails()`` with ``max_memory_usage`` pinned
+     down to 1 MB, the scanner's real read (``list_by_trace_ids`` — ``FROM spans
+     FINAL`` pulling the fat JSON columns, unchunked over all noise trace ids) is
+     rejected with a query-level CH **code 241** instead of exhausting the
+     server. A subsequent normal query on the same CH succeeds, proving the
+     server stayed healthy after the query-level rejection (not a box-wide OOM).
+
+  2. HEADROOM — a realistic scanner-sized batch (``_SWEEP_BATCH_SIZE`` trace ids)
+     read under the *real* 4 GiB guardrail completes, and its ``system.query_log``
+     peak ``memory_usage`` sits far below the cap. The peak is printed so the PR
+     can report the measured number.
+
+The guardrail's *sizing* (4 GiB right-headroom-but-below-ceiling) is justified by
+the prod-scale dev-box numbers; this local run proves the *mechanism* end-to-end
+on the scanner's actual reader.
+"""
+
+from __future__ import annotations
+
+import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+from tests.stress import ch_asserts
+from tests.stress.ch_asserts import ch_query_budget
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+from tracer.tasks.trace_scanner import (
+    _SWEEP_BATCH_SIZE,
+    SCAN_CH_GUARDRAILS,
+    scan_ch_guardrails,
+)
+
+pytestmark = pytest.mark.stress
+
+# 1 MB is far below any real spans scan, so the code-241 rejection is
+# deterministic regardless of dataset size.
+_TINY_MEMORY_CAP = 1_000_000  # 1 MB
+
+
+def test_scan_read_rejected_at_tiny_cap_server_stays_healthy(stress_dataset):
+    """The scanner's read fails at the query level (code 241); server survives."""
+    noise = stress_dataset.noise
+
+    # Inner ch_query_settings overrides only max_memory_usage; the execution-time
+    # and external-sort caps from scan_ch_guardrails() stay in effect.
+    with pytest.raises(DatabaseError) as exc_info:
+        with scan_ch_guardrails():
+            with ch_query_settings(max_memory_usage=_TINY_MEMORY_CAP):
+                with get_reader() as reader:
+                    reader.list_by_trace_ids(noise.trace_ids)
+
+    assert "241" in str(exc_info.value)
+
+    # A fresh client outside any guardrail context must still complete a trivial
+    # read — the query-level rejection did not take the server down.
+    client = ch_asserts._client()
+    try:
+        cnt = client.query("SELECT count() FROM spans").result_rows[0][0]
+        assert int(cnt) >= 0
+    finally:
+        client.close()
+
+
+def test_realistic_scan_batch_peaks_below_cap(stress_dataset):
+    """A scanner-sized batch read under the real 4 GiB guardrail; report the peak."""
+    noise = stress_dataset.noise
+    batch = noise.trace_ids[:_SWEEP_BATCH_SIZE]  # the scanner reads in these batches
+
+    with scan_ch_guardrails():
+        with ch_query_budget("scan-guardrail-bench") as budget:
+            with get_reader() as reader:
+                spans = reader.list_by_trace_ids(batch)
+
+    assert budget.count >= 1, "the tagged scanner read was not captured in query_log"
+    peak = budget.max("memory_usage")
+    read_rows = budget.max("read_rows")
+    cap = SCAN_CH_GUARDRAILS["max_memory_usage"]
+
+    # Report the measured peak so the number lands in the PR / terminal output.
+    print(
+        f"\nSCAN-GUARDRAIL-BENCH :: batch={len(batch)} traces "
+        f"spans={len(spans)} read_rows={read_rows:.0f} "
+        f"peak_memory={peak / 2**20:.1f} MiB "
+        f"cap={cap / 2**30:.0f} GiB "
+        f"headroom={cap / max(peak, 1):.0f}x"
+    )
+
+    # A normal scanner batch must sit comfortably under the cap — otherwise the
+    # guardrail would false-positive on legitimate work.
+    assert peak < cap

--- a/futureagi/tests/stress/test_scenarios.py
+++ b/futureagi/tests/stress/test_scenarios.py
@@ -1,0 +1,346 @@
+"""Green scenario matrix cells (S1–S3, S8–S9, S11, S13, S15): parity and
+cheap-path pins against current engine code. Every expected count comes from
+the loadgen manifest or a direct CH probe — never hardcoded.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from tests.stress import ch_asserts
+from tests.stress.budgets import (
+    DESIRED_STREAM_MAX_MEMORY,
+    DESIRED_STREAM_MAX_READ_ROWS_FACTOR,
+    REAP_PROGRESS_FINALIZE_MAX_PG_QUERIES,
+)
+from tests.stress.conftest import SEED_WINDOW
+from tracer.models.eval_task import RowType, RunType
+from tracer.models.observation_span import (
+    EvalEntryStatus,
+    EvalLogger,
+    ObservationType,
+)
+from tracer.selectors.eval_tasks.progress import count_by_status, has_undrained_work
+from tracer.selectors.eval_tasks.row_resolver import iter_desired_rows
+from tracer.services.eval_tasks.entries import claim_pending_batch
+from tracer.services.eval_tasks.reaper import reap_stale_running
+from tracer.services.eval_tasks.reconciler import reconcile
+from tracer.services.eval_tasks.run_entry import run_entry
+
+pytestmark = pytest.mark.stress
+
+_TERMINAL = {
+    EvalEntryStatus.COMPLETED,
+    EvalEntryStatus.ERRORED,
+    EvalEntryStatus.SKIPPED,
+}
+
+# Per-test continuous projects (S8/S9 seed their own increments; the four
+# shared stress_dataset projects stay read-only).
+S8_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000008"
+S9_PROJECT_ID = "5712e5ac-0000-4000-8000-000000000009"
+
+
+def _live(task, **f):
+    return EvalLogger.objects.filter(eval_task_id=str(task.id), **f)
+
+
+def _drain(task, batch_size: int = 100) -> list[str]:
+    statuses = []
+    while True:
+        batch = claim_pending_batch(task, batch_size)
+        if not batch:
+            return statuses
+        statuses.extend(run_entry(entry) for entry in batch)
+
+
+def _window():
+    return (
+        datetime.fromisoformat(SEED_WINDOW[0].replace("Z", "+00:00")),
+        datetime.fromisoformat(SEED_WINDOW[1].replace("Z", "+00:00")),
+    )
+
+
+def _probe_ids(sql: str, params: dict) -> set[str]:
+    client = ch_asserts._client()
+    try:
+        return {r[0] for r in client.query(sql, parameters=params).result_rows}
+    finally:
+        client.close()
+
+
+@pytest.mark.django_db
+def test_s1_historical_spans_full_drain(
+    stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
+):
+    m = stress_dataset.target
+    limit = 200
+    assert m.span_count > limit
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=limit)
+
+    result = reconcile(task)
+    assert result.created == limit
+
+    statuses = _drain(task)
+    assert len(statuses) == limit
+    assert set(statuses) <= _TERMINAL
+    assert has_undrained_work(task) is False
+    counts = count_by_status(task)
+    assert counts.get(EvalEntryStatus.COMPLETED, 0) == limit  # stubbed engine passes
+
+    assert {str(t) for t in _live(task).values_list("trace_id", flat=True)} <= set(
+        m.trace_ids
+    )
+
+
+@pytest.mark.django_db
+def test_s2_selective_filter_matches_manifest(stress_dataset, eval_task_factory):
+    m = stress_dataset.target
+    expected = m.observation_type_counts[ObservationType.LLM]
+    assert 0 < expected < m.span_count
+    task = eval_task_factory(
+        m.project_id,
+        RowType.SPANS,
+        filters={
+            "observation_type": [ObservationType.LLM],
+            "date_range": list(SEED_WINDOW),
+        },
+    )
+    result = reconcile(task)
+    assert result.created == expected
+
+
+@pytest.mark.django_db
+def test_s3_sampling_matches_cityhash_subset(stress_dataset, eval_task_factory):
+    m = stress_dataset.target
+    limit = 2000
+    task = eval_task_factory(
+        m.project_id, RowType.SPANS, sampling_rate=50.0, spans_limit=limit
+    )
+    reconcile(task)
+
+    start, end = _window()
+    # Same hash+order+limit the resolver applies; cityHash64 evaluated by CH,
+    # never reimplemented in Python.
+    expected = _probe_ids(
+        "SELECT id FROM spans FINAL "
+        "WHERE project_id = %(p)s AND is_deleted = 0 "
+        "AND start_time >= %(s)s AND start_time < %(e)s "
+        "AND modulo(cityHash64(%(salt)s, toString(id)), 100) < %(rate)s "
+        "ORDER BY id LIMIT %(lim)s",
+        {
+            "p": m.project_id,
+            "s": start,
+            "e": end,
+            "salt": str(task.id),
+            "rate": 50.0,
+            "lim": limit,
+        },
+    )
+    materialized = set(_live(task).values_list("observation_span_id", flat=True))
+    assert materialized == expected
+
+
+@pytest.mark.django_db
+def test_s8_continuous_spans_incremental_arrival(
+    stress_dataset, eval_task_factory, loadgen_run
+):
+    # Pre-start history (back-dated default --end anchor): never backfilled.
+    loadgen_run(
+        S8_PROJECT_ID, traces=30, spans_per_trace=4, sessions=4, shape="llm", seed=460
+    )
+    task = eval_task_factory(S8_PROJECT_ID, RowType.SPANS, run_type=RunType.CONTINUOUS)
+    # Back-date the start so the cursor has park room (a task younger than the
+    # reconciler's 5-min overlap clamps to its start floor and can't advance).
+    from tracer.models.eval_task import EvalTask
+
+    EvalTask.objects.filter(id=task.id).update(
+        start_time=timezone.now() - timedelta(hours=1)
+    )
+    task.refresh_from_db()
+
+    r1 = reconcile(task)
+    assert r1.created == 0
+    task.refresh_from_db()
+    cursor1 = task.continuous_cursor
+    assert cursor1 is not None
+
+    time.sleep(2)
+    inc = loadgen_run(
+        S8_PROJECT_ID,
+        traces=5,
+        spans_per_trace=3,
+        sessions=2,
+        shape="llm",
+        seed=461,
+        end=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        time_range="1s",
+        trickle=100,
+    )
+    # Child spans start up to (spans_per_trace-1)s after --end; wait for the
+    # resolver's start_time < now() upper bound to pass them.
+    time.sleep(3)
+
+    r2 = reconcile(task)
+    assert r2.created == inc.span_count
+    assert {str(t) for t in _live(task).values_list("trace_id", flat=True)} == set(
+        inc.trace_ids
+    )
+    task.refresh_from_db()
+    assert task.continuous_cursor > cursor1
+
+
+@pytest.mark.django_db
+def test_s9_continuous_traces_root_resolution(
+    stress_dataset, eval_task_factory, loadgen_run
+):
+    # Traces window their continuous floor on the ROOT's created_at (arrival),
+    # not start_time — a back-dated pre-seed wave would legitimately be in
+    # scope. So the "only new rows" pin here is a second arrival wave, not a
+    # pre-start contrast (that's S8's, where spans floor on start_time).
+    task = eval_task_factory(S9_PROJECT_ID, RowType.TRACES, run_type=RunType.CONTINUOUS)
+    from tracer.models.eval_task import EvalTask
+
+    EvalTask.objects.filter(id=task.id).update(
+        start_time=timezone.now() - timedelta(hours=1)
+    )
+    task.refresh_from_db()
+
+    r1 = reconcile(task)
+    assert r1.created == 0  # nothing arrived yet
+    task.refresh_from_db()
+    cursor1 = task.continuous_cursor
+
+    time.sleep(2)
+    inc1 = loadgen_run(
+        S9_PROJECT_ID,
+        traces=5,
+        spans_per_trace=3,
+        sessions=2,
+        shape="llm",
+        seed=471,
+        end=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        time_range="1s",
+        trickle=100,
+    )
+    time.sleep(3)
+
+    r2 = reconcile(task)
+    assert r2.created == len(inc1.trace_ids)
+    task.refresh_from_db()
+    assert task.continuous_cursor > cursor1
+
+    time.sleep(2)
+    inc2 = loadgen_run(
+        S9_PROJECT_ID,
+        traces=5,
+        spans_per_trace=3,
+        sessions=2,
+        shape="llm",
+        seed=472,
+        end=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        time_range="1s",
+        trickle=100,
+    )
+    time.sleep(3)
+
+    r3 = reconcile(task)
+    assert r3.created == len(inc2.trace_ids)  # first wave not re-created
+
+    # Root parity: each entry anchors on its manifest's root span.
+    roots = {**inc1.root_span_id_by_trace, **inc2.root_span_id_by_trace}
+    entries = list(_live(task))
+    assert len(entries) == len(roots)
+    for entry in entries:
+        assert entry.observation_span_id == roots[str(entry.trace_id)]
+
+
+@pytest.mark.django_db
+def test_s11_narrow_filter_drops_pending_keeps_completed(
+    stress_dataset, eval_task_factory
+):
+    m = stress_dataset.target
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=400)
+    reconcile(task)
+    assert _live(task).count() == 400
+
+    completed_ids = list(_live(task).values_list("id", flat=True)[:100])
+    EvalLogger.objects.filter(id__in=completed_ids).update(
+        status=EvalEntryStatus.COMPLETED
+    )
+
+    task.filters = {
+        "observation_type": [ObservationType.LLM],
+        "date_range": list(SEED_WINDOW),
+    }
+    task.save()
+    result = reconcile(task)
+
+    assert result.dropped > 0
+    # Paid data kept: no completed entry was soft-deleted.
+    assert (
+        EvalLogger.all_objects.filter(
+            eval_task_id=str(task.id),
+            status=EvalEntryStatus.COMPLETED,
+            deleted=True,
+        ).count()
+        == 0
+    )
+    assert _live(task, status=EvalEntryStatus.COMPLETED).count() == 100
+    # Surviving pending entries all reference in-filter (llm) spans.
+    llm_ids = _probe_ids(
+        "SELECT id FROM spans FINAL WHERE project_id = %(p)s "
+        "AND is_deleted = 0 AND observation_type = %(ot)s",
+        {"p": m.project_id, "ot": str(ObservationType.LLM)},
+    )
+    pending = set(
+        _live(task, status=EvalEntryStatus.PENDING).values_list(
+            "observation_span_id", flat=True
+        )
+    )
+    assert pending <= llm_ids
+
+
+@pytest.mark.django_db
+def test_s13_desired_stream_budget_on_fat_project(stress_dataset, eval_task_factory):
+    m = stress_dataset.noise  # mixed: carries the fat-attrs + voice traces
+    task = eval_task_factory(m.project_id, RowType.SPANS)
+    with ch_asserts.ch_query_budget("stress:S13:desired-stream") as b:
+        streamed = sum(len(batch) for batch in iter_desired_rows(task))
+    assert streamed == m.span_count
+    assert b.total("read_rows") <= m.span_count * DESIRED_STREAM_MAX_READ_ROWS_FACTOR
+    assert b.max("memory_usage") <= DESIRED_STREAM_MAX_MEMORY
+
+
+@pytest.mark.django_db(transaction=True)
+def test_s15_reap_progress_finalize_statement_floor(stress_dataset, eval_task_factory):
+    # transaction=True: finalize's close_old_connections would kill the
+    # default test-transaction connection.
+    from tfc.temporal.eval_tasks.activities import _finalize_task_sync
+
+    m = stress_dataset.target
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=20)
+    reconcile(task)
+    claimed = claim_pending_batch(task, 20)
+    assert len(claimed) == 20
+    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
+        updated_at=timezone.now() - timedelta(hours=1)
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        requeued, failed = reap_stale_running(
+            task, older_than_seconds=600, max_attempts=3
+        )
+        undrained = has_undrained_work(task)
+        finalize = _finalize_task_sync(str(task.id))
+
+    assert (requeued, failed) == (20, 0)
+    assert undrained is True
+    assert finalize["finalized"] is False  # still pending work
+    assert len(ctx.captured_queries) <= REAP_PROGRESS_FINALIZE_MAX_PG_QUERIES

--- a/futureagi/tests/stress/test_session_lookup.py
+++ b/futureagi/tests/stress/test_session_lookup.py
@@ -1,0 +1,185 @@
+"""S7 / A5: `resolve_session_fields` injects a project_id clause and the clause
+engages the PrimaryKey index.
+
+Moved out of `test_baselines.py` (strict-xfail dropped) once A5 (project scoping) landed
+the `project_id` kwarg. The `trace_sessions` table at CI scale holds only ~60
+rows (5 target + 50 noise + a handful of other projects) — all in ONE 8192-row
+ClickHouse granule. Because granule-skip requires crossing a granule boundary,
+read_rows cannot discriminate scoped vs. unscoped at this table size (both read
+the same single granule). The S4 read_rows approach works for spans (69k rows,
+many granules) but NOT here.
+
+Instead, S7 verifies A5 via two complementary checks:
+
+  (a) Clause injection — the test captures the REAL SQL that `resolve_session_fields`
+      emits (tagged with a unique `log_comment` so `system.query_log` can identify
+      it) and asserts that SQL contains `project_id = `.  This check goes RED if
+      someone removes the `project_clause` append from the production function.
+
+  (b) Structural pruning — `EXPLAIN indexes=1` on the captured emitted SQL must
+      show `project_id` in the PrimaryKey Condition (not `Condition: true` which
+      means full-table scan).  Scale-independent: the planner recognises the
+      sort-key prefix regardless of how many granules are actually skipped at
+      runtime.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.stress.ch_asserts import _client
+
+pytestmark = pytest.mark.stress
+
+
+def _pk_condition_line(client, query: str, params: dict) -> str:
+    """Return the PrimaryKey Condition line from EXPLAIN indexes=1 output.
+
+    Locates the `PrimaryKey` section in the EXPLAIN tree and returns the first
+    `Condition:` line within it. Returns ``""`` if the section is absent (query
+    hits no MergeTree table or the CH version omits it).
+    """
+    rows = client.query(f"EXPLAIN indexes=1 {query}", parameters=params).result_rows
+    in_pk = False
+    for row in rows:
+        line = row[0].strip()
+        if line == "PrimaryKey":
+            in_pk = True
+            continue
+        if in_pk and line.startswith("Condition:"):
+            return line
+        if in_pk and line.startswith("Keys:"):
+            continue  # Condition follows Keys — keep scanning.
+        if in_pk and not any(
+            line.startswith(p)
+            for p in ("Keys:", "Condition:", "project_id", "trace_session_id")
+        ):
+            break  # Left PrimaryKey block without finding Condition.
+    return ""
+
+
+@pytest.mark.django_db
+def test_s7_session_resolve_prunes_to_project(stress_dataset):
+    """A5: resolve_session_fields(project_id=X) injects project_id and prunes.
+
+    Guards the PRODUCTION function — not a hand-crafted query — by:
+      (a) Capturing the real SQL via system.query_log (log_comment tag) and
+          asserting it contains 'project_id = '.  Goes RED if project_clause
+          is removed from resolve_session_fields.
+      (b) Running EXPLAIN indexes=1 on the captured emitted SQL to confirm
+          ClickHouse engages the sort-key prefix (not Condition: true).
+    """
+    from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+    from tracer.services.clickhouse.v2.trace_session_dict_reader import (
+        resolve_session_fields,
+    )
+
+    manifest = stress_dataset.target
+    setup_client = _client()
+    try:
+        session_uuids = [
+            r[0]
+            for r in setup_client.query(
+                "SELECT toString(trace_session_id) FROM trace_sessions FINAL "
+                "WHERE project_id = %(p)s AND is_deleted = 0",
+                parameters={"p": manifest.project_id},
+            ).result_rows
+        ]
+        total_sessions = setup_client.query(
+            "SELECT count() FROM trace_sessions FINAL WHERE is_deleted = 0"
+        ).result_rows[0][0]
+    finally:
+        setup_client.close()
+
+    assert session_uuids, "No seeded sessions for target project — seed may have failed"
+    # Two-project contrast: the whole table has sessions for other projects
+    # too, so there is something to prune.
+    assert total_sessions > len(session_uuids), (
+        "All sessions belong to one project — cross-project noise needed to validate pruning"
+    )
+
+    # Drive the PRODUCTION function under a unique log_comment so we can
+    # recover the actual SQL it emitted from system.query_log.
+    tag = "stress:A5:session-scoped"
+    with ch_query_settings(log_comment=tag):
+        resolve_session_fields(session_uuids, project_id=manifest.project_id)
+
+    # Flush logs and extract the emitted query text.
+    log_client = _client()
+    try:
+        log_client.command("SYSTEM FLUSH LOGS")
+        log_rows = log_client.query(
+            "SELECT query FROM system.query_log "
+            "WHERE log_comment = %(t)s AND type = 'QueryFinish' "
+            "ORDER BY event_time_microseconds DESC LIMIT 5",
+            parameters={"t": tag},
+        ).result_rows
+    finally:
+        log_client.close()
+
+    assert log_rows, (
+        f"No QueryFinish entries in system.query_log for log_comment={tag!r}. "
+        "Ensure CH query_log is enabled (log_queries=1)."
+    )
+
+    # Find the JOIN query that reads trace_sessions (the main fetch in
+    # resolve_session_fields; ignore the PG TraceSessionOverlay queries).
+    emitted_sql: str | None = None
+    for (q,) in log_rows:
+        if "trace_sessions" in q:
+            emitted_sql = q
+            break
+
+    assert emitted_sql is not None, (
+        f"No query touching trace_sessions found under log_comment={tag!r}. "
+        f"Logged queries: {[r[0][:150] for r in log_rows]}"
+    )
+
+    # (a) The production function MUST have injected the project_id clause.
+    assert "project_id = " in emitted_sql or "project_id=" in emitted_sql, (
+        f"resolve_session_fields did NOT emit a project_id clause.\n"
+        f"Emitted SQL (first 600 chars):\n{emitted_sql[:600]}\n"
+        "Did someone remove the project_clause append from resolve_session_fields?"
+    )
+
+    # (b) EXPLAIN on the real emitted SQL must engage the PrimaryKey index.
+    # The captured query has literal values inlined (clickhouse-connect
+    # substitutes %(name)s client-side before sending), so no parameters needed.
+    # Strip the trailing FORMAT clause clickhouse-connect appends — EXPLAIN
+    # rejects a query that ends in FORMAT.
+    explain_sql = re.sub(r"\s+FORMAT\s+\w+\s*;?\s*$", "", emitted_sql, flags=re.I)
+    explain_client = _client()
+    try:
+        cond = _pk_condition_line(explain_client, explain_sql, {})
+    finally:
+        explain_client.close()
+
+    assert cond, (
+        "EXPLAIN produced no PrimaryKey Condition for the emitted SQL — "
+        "check the query shape or the CH version"
+    )
+    assert "true" not in cond.lower(), (
+        f"PrimaryKey Condition is 'Condition: true' (no key engagement); "
+        f"got {cond!r}. project_id clause present but not a recognised sort-key prefix?"
+    )
+    assert "project_id" in cond, (
+        f"Expected 'project_id' in PrimaryKey Condition; got {cond!r}"
+    )
+
+    # Functional smoke: the actual function resolves all target sessions.
+    resolved = resolve_session_fields(session_uuids, project_id=manifest.project_id)
+    assert len(resolved) == len(session_uuids), (
+        f"resolve_session_fields returned {len(resolved)} records, "
+        f"expected {len(session_uuids)}"
+    )
+    for sid in session_uuids:
+        assert sid in resolved, f"Session {sid} missing from resolved result"
+        rec = resolved[sid]
+        assert "external_session_id" in rec
+        assert "first_seen" in rec
+        assert "project_id" in rec
+        assert rec["project_id"] == manifest.project_id, (
+            f"Wrong project_id in resolved record: {rec['project_id']!r}"
+        )

--- a/futureagi/tests/stress/test_trace_loading.py
+++ b/futureagi/tests/stress/test_trace_loading.py
@@ -7,6 +7,11 @@ Parity: a TRACE run_entry whose mapping references a heavy span field
 (``spans.first.llm.messages.transcript``) produces the same resolved
 mapping params as running through a wholesale include_heavy=True load.
 
+Custom-eval parity: the same heavy-field mapping under a ``custom_eval`` template
+— whose missing-attribute branch returns ``""`` instead of raising — must still
+resolve the real transcript under lean-first loading, guarding the up-front
+heavy-id computation that replaced the old ValueError-gated retry.
+
 Session parity: a SESSION run_entry whose mapping references a heavy inner-span
 field (``traces.first.spans.first.llm.messages.transcript``) produces the same
 resolved params whether the eval path uses lean-first loading or a wholesale
@@ -129,6 +134,91 @@ def test_trace_eval_lean_heavy_parity(
         finally:
             _loader_mod.filter_observation_spans_by_trace = _orig
 
+    assert set(lean_params.keys()) == set(heavy_params.keys()), (
+        f"key mismatch: lean={set(lean_params)} heavy={set(heavy_params)}"
+    )
+    for key in lean_params:
+        assert lean_params[key] == heavy_params[key], (
+            f"field '{key}' mismatch\n"
+            f"  lean : {lean_params[key]!r:.200}\n"
+            f"  heavy: {heavy_params[key]!r:.200}"
+        )
+
+
+@pytest.mark.django_db
+def test_trace_eval_custom_lean_heavy_parity(
+    stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
+):
+    """Regression: a ``custom_eval`` template whose mapping references the heavy
+    field ``spans.first.llm.messages.transcript`` must resolve to the real
+    transcript under lean-first loading — NOT silently to ``""``.
+
+    A custom template's ``_process_trace_mapping`` resolves a missing attribute
+    to ``""`` *without* raising ``ValueError``. The old lean-first wrapper only
+    triggered its heavy second pass on ``ValueError``, so a custom eval never
+    retried and evaluated the transcript as empty. Computing the heavy span ids
+    up front fixes it: the single pass loads the referenced span heavy.
+
+    ``test_trace_eval_lean_heavy_parity`` cannot catch this — its factory
+    template is non-custom (``pass_fail``), which raises and retries correctly.
+    """
+    import tracer.services.clickhouse.v2.eval_loader as _loader_mod
+    from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2.eval_loader import (
+        _construct_from_chspan,
+        eval_read_source,
+        get_trace,
+    )
+    from tracer.utils.eval import (
+        _process_trace_mapping,
+        resolve_trace_mapping_lean_first,
+    )
+
+    manifest = stress_dataset.voice
+    trace_id = manifest.trace_ids[0]
+
+    task = eval_task_factory(
+        VOICE_PROJECT_ID, row_type="traces", n_evals=1, custom_eval=True
+    )
+    template_id = task.evals.first().eval_template_id
+
+    with eval_read_source("clickhouse"):
+        trace = get_trace(trace_id, project_id=VOICE_PROJECT_ID)
+
+        # lean-first through the custom template (the previously-broken path).
+        lean_params = resolve_trace_mapping_lean_first(
+            _TRANSCRIPT_MAPPING.copy(), trace, template_id
+        )
+
+        # Reference: wholesale heavy load through the same custom template.
+        with get_reader() as reader:
+            heavy_ch_rows = reader.list_by_trace(
+                trace_id, include_heavy=True, project_id=VOICE_PROJECT_ID
+            )
+        heavy_spans = sorted(
+            [_construct_from_chspan(r) for r in heavy_ch_rows],
+            key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
+        )
+
+        _orig = _loader_mod.filter_observation_spans_by_trace
+
+        def _always_heavy(tid, deleted=False, *, project_id=None, heavy_span_ids=None):
+            return list(heavy_spans)
+
+        _loader_mod.filter_observation_spans_by_trace = _always_heavy
+        try:
+            trace_heavy = get_trace(trace_id, project_id=VOICE_PROJECT_ID)
+            heavy_params = _process_trace_mapping(
+                _TRANSCRIPT_MAPPING.copy(), trace_heavy, template_id
+            )
+        finally:
+            _loader_mod.filter_observation_spans_by_trace = _orig
+
+    # The specific regression: the heavy field must not come back empty.
+    assert lean_params.get("input"), (
+        "custom-eval lean-first resolved the heavy transcript to empty — the "
+        "heavy pass did not fire for the custom template"
+    )
     assert set(lean_params.keys()) == set(heavy_params.keys()), (
         f"key mismatch: lean={set(lean_params)} heavy={set(heavy_params)}"
     )

--- a/futureagi/tests/stress/test_trace_loading.py
+++ b/futureagi/tests/stress/test_trace_loading.py
@@ -1,0 +1,242 @@
+"""Lean-first trace span loading — S6 memory budget + lean/heavy parity.
+
+S6 (moved from test_baselines.py): loading one fat voice trace stays below
+TRACE_LOAD_MAX_PY_PEAK after the A4 lean-first fix (xfail marker removed).
+
+Parity: a TRACE run_entry whose mapping references a heavy span field
+(``spans.first.llm.messages.transcript``) produces the same resolved
+mapping params as running through a wholesale include_heavy=True load.
+
+Session parity: a SESSION run_entry whose mapping references a heavy inner-span
+field (``traces.first.spans.first.llm.messages.transcript``) produces the same
+resolved params whether the eval path uses lean-first loading or a wholesale
+heavy load.  Before the session shim landed, the lean path returned an empty
+value and raised "required attribute not found".
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+
+from tests.stress.budgets import TRACE_LOAD_MAX_PY_PEAK
+from tests.stress.conftest import VOICE_PROJECT_ID
+
+pytestmark = pytest.mark.stress
+
+_TRANSCRIPT_MAPPING = {
+    "input": "spans.first.llm.messages.transcript",
+    "output": "output",
+}
+
+# Session-level mapping: heavy inner-span field + a lean trace-level field.
+# Verified against the voice seed: first trace's first span (sorted by
+# start_time) carries ``llm.messages.transcript`` in attributes_extra.
+_SESSION_TRANSCRIPT_MAPPING = {
+    "input": "traces.first.spans.first.llm.messages.transcript",
+    "output": "traces.first.output",
+}
+
+
+def test_s6_trace_load_python_peak_bounded(stress_dataset):
+    from tracer.services.clickhouse.v2.eval_loader import (
+        eval_read_source,
+        filter_observation_spans_by_trace,
+    )
+
+    manifest = stress_dataset.voice
+    trace_id = manifest.trace_ids[0]
+    with eval_read_source("clickhouse"):
+        tracemalloc.start()
+        try:
+            spans = filter_observation_spans_by_trace(
+                trace_id, project_id=manifest.project_id
+            )
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+    assert len(spans) > 0
+    # Ceiling independent of payload fatness: below one 1.2 MiB transcript.
+    assert peak <= TRACE_LOAD_MAX_PY_PEAK
+
+
+@pytest.mark.django_db
+def test_trace_eval_lean_heavy_parity(
+    stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
+):
+    """A mapping that references ``spans.first.llm.messages.transcript`` (a
+    heavy field in attributes_extra) resolves to the same value whether the
+    eval path uses lean-first loading or a wholesale heavy load.
+
+    Comparison approach:
+      - lean-first: ``resolve_trace_mapping_lean_first`` with the contextvar
+        mechanism (triggers a heavy second-pass for the root span only).
+      - heavy-all: monkeypatch ``filter_observation_spans_by_trace`` to return
+        spans loaded with all heavy columns, then call ``_process_trace_mapping``
+        directly.
+    """
+    import tracer.services.clickhouse.v2.eval_loader as _loader_mod
+    from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2.eval_loader import (
+        _construct_from_chspan,
+        eval_read_source,
+        get_trace,
+    )
+    from tracer.utils.eval import (
+        _process_trace_mapping,
+        resolve_trace_mapping_lean_first,
+    )
+
+    manifest = stress_dataset.voice
+    trace_id = manifest.trace_ids[0]
+
+    # Create PG rows: project + EvalTemplate (needed by _process_trace_mapping
+    # for optional-key lookup).  eval_task_factory handles get_or_create.
+    task = eval_task_factory(VOICE_PROJECT_ID, row_type="traces", n_evals=1)
+    template_id = task.evals.first().eval_template_id
+
+    with eval_read_source("clickhouse"):
+        trace = get_trace(trace_id, project_id=VOICE_PROJECT_ID)
+
+        # Pass 1: lean-first (the A4 path).
+        lean_params = resolve_trace_mapping_lean_first(
+            _TRANSCRIPT_MAPPING.copy(), trace, template_id
+        )
+
+        # Reference: wholesale heavy load — monkeypatch the loader so
+        # filter_observation_spans_by_trace always returns fully-hydrated spans.
+        with get_reader() as reader:
+            heavy_ch_rows = reader.list_by_trace(
+                trace_id, include_heavy=True, project_id=VOICE_PROJECT_ID
+            )
+        heavy_spans = sorted(
+            [_construct_from_chspan(r) for r in heavy_ch_rows],
+            key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
+        )
+
+        _orig = _loader_mod.filter_observation_spans_by_trace
+
+        def _always_heavy(tid, deleted=False, *, project_id=None, heavy_span_ids=None):
+            return list(heavy_spans)
+
+        _loader_mod.filter_observation_spans_by_trace = _always_heavy
+        try:
+            trace_heavy = get_trace(trace_id, project_id=VOICE_PROJECT_ID)
+            heavy_params = _process_trace_mapping(
+                _TRANSCRIPT_MAPPING.copy(), trace_heavy, template_id
+            )
+        finally:
+            _loader_mod.filter_observation_spans_by_trace = _orig
+
+    assert set(lean_params.keys()) == set(heavy_params.keys()), (
+        f"key mismatch: lean={set(lean_params)} heavy={set(heavy_params)}"
+    )
+    for key in lean_params:
+        assert lean_params[key] == heavy_params[key], (
+            f"field '{key}' mismatch\n"
+            f"  lean : {lean_params[key]!r:.200}\n"
+            f"  heavy: {heavy_params[key]!r:.200}"
+        )
+
+
+@pytest.mark.django_db
+def test_session_eval_lean_heavy_parity(
+    stress_dataset, eval_task_factory, stub_run_eval, stub_cost_log
+):
+    """A session mapping that references ``traces.first.spans.first.llm.messages.transcript``
+    (a heavy field in attributes_extra on an inner trace span) resolves to the same
+    value whether the session eval path uses lean-first loading or a wholesale heavy
+    load.  Without the session shim this test fails with "required attribute not found"
+    because inner spans load lean and the heavy overflow field is absent.
+
+    Comparison approach:
+      - lean-first: ``resolve_session_mapping_lean_first`` — triggers a heavy
+        second-pass for the identified span only.
+      - heavy-all: monkeypatch ``filter_observation_spans_by_trace`` to always
+        return spans loaded with all heavy columns, then call plain
+        ``_process_session_mapping``.
+    """
+    import tracer.services.clickhouse.v2.eval_loader as _loader_mod
+    from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2.eval_loader import (
+        _construct_from_chspan,
+        eval_read_source,
+        get_trace_session,
+    )
+    from tracer.utils.eval import (
+        _process_session_mapping,
+        resolve_session_mapping_lean_first,
+    )
+
+    task = eval_task_factory(VOICE_PROJECT_ID, row_type="sessions", n_evals=1)
+    template_id = task.evals.first().eval_template_id
+
+    from tracer.models.project import Project
+
+    project = Project.objects.get(id=VOICE_PROJECT_ID)
+
+    # The manifest records external_session_id values (e.g. ``session-00000000``),
+    # not the internal CH UUID.  Fetch the actual UUID from trace_sessions so
+    # get_trace_session and session_trace_ids receive a valid UUID argument.
+    from tests.stress.ch_asserts import _client
+
+    ch = _client()
+    try:
+        session_uuid_rows = ch.query(
+            "SELECT toString(trace_session_id) FROM trace_sessions FINAL "
+            "WHERE project_id = %(p)s AND is_deleted = 0 LIMIT 1",
+            parameters={"p": VOICE_PROJECT_ID},
+        ).result_rows
+    finally:
+        ch.close()
+    assert session_uuid_rows, "No seeded sessions found for voice project"
+    session_id = session_uuid_rows[0][0]
+
+    with eval_read_source("clickhouse"):
+        session = get_trace_session(session_id, project=project)
+
+        # Pass 1: lean-first (the session shim path).
+        lean_params = resolve_session_mapping_lean_first(
+            _SESSION_TRANSCRIPT_MAPPING.copy(), session, template_id
+        )
+
+        # Reference: wholesale heavy load — pre-load heavy spans for every trace
+        # in the session and monkeypatch so filter_observation_spans_by_trace
+        # always returns them fully-hydrated.
+        with get_reader() as reader:
+            trace_ids = reader.session_trace_ids(str(project.id), str(session_id))
+        heavy_spans_by_trace: dict[str, list] = {}
+        for tid in trace_ids:
+            with get_reader() as reader:
+                heavy_rows = reader.list_by_trace(
+                    tid, include_heavy=True, project_id=str(project.id)
+                )
+            heavy_spans_by_trace[tid] = sorted(
+                [_construct_from_chspan(r) for r in heavy_rows],
+                key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
+            )
+
+        _orig = _loader_mod.filter_observation_spans_by_trace
+
+        def _always_heavy(tid, deleted=False, *, project_id=None, heavy_span_ids=None):
+            return list(heavy_spans_by_trace.get(str(tid), []))
+
+        _loader_mod.filter_observation_spans_by_trace = _always_heavy
+        try:
+            session_heavy = get_trace_session(session_id, project=project)
+            heavy_params = _process_session_mapping(
+                _SESSION_TRANSCRIPT_MAPPING.copy(), session_heavy, template_id
+            )
+        finally:
+            _loader_mod.filter_observation_spans_by_trace = _orig
+
+    assert set(lean_params.keys()) == set(heavy_params.keys()), (
+        f"key mismatch: lean={set(lean_params)} heavy={set(heavy_params)}"
+    )
+    for key in lean_params:
+        assert lean_params[key] == heavy_params[key], (
+            f"field '{key}' mismatch\n"
+            f"  lean : {lean_params[key]!r:.200}\n"
+            f"  heavy: {heavy_params[key]!r:.200}"
+        )

--- a/futureagi/tfc/temporal/eval_tasks/activities.py
+++ b/futureagi/tfc/temporal/eval_tasks/activities.py
@@ -32,6 +32,7 @@ from tfc.temporal.eval_tasks.types import (
     WorkflowLabelsInput,
     WorkflowLabelsOutput,
 )
+from tracer.services.eval_tasks.ch_guardrails import eval_ch_guardrails
 
 # =============================================================================
 # Synchronous helpers (the testable core)
@@ -51,8 +52,9 @@ def _reconcile_sync(task_id: str) -> dict:
         from tracer.models.eval_task import EvalTask
         from tracer.services.eval_tasks.reconciler import reconcile
 
-        task = EvalTask.objects.get(id=task_id)
-        result = reconcile(task)
+        with eval_ch_guardrails():
+            task = EvalTask.objects.get(id=task_id)
+            result = reconcile(task)
         return {
             "task_id": str(task_id),
             "created": result.created,
@@ -96,10 +98,11 @@ def _run_entry_sync(entry_id: str) -> dict:
         from tracer.models.observation_span import EvalLogger
         from tracer.services.eval_tasks.run_entry import run_entry
 
-        entry = EvalLogger.objects.filter(id=entry_id).first()
-        if entry is None:
-            return {"entry_id": str(entry_id), "status": "deleted"}
-        return {"entry_id": str(entry_id), "status": str(run_entry(entry))}
+        with eval_ch_guardrails():
+            entry = EvalLogger.objects.filter(id=entry_id).first()
+            if entry is None:
+                return {"entry_id": str(entry_id), "status": "deleted"}
+            return {"entry_id": str(entry_id), "status": str(run_entry(entry))}
     finally:
         close_old_connections()
 

--- a/futureagi/tracer/services/clickhouse/v2/eval_loader.py
+++ b/futureagi/tracer/services/clickhouse/v2/eval_loader.py
@@ -231,39 +231,12 @@ def filter_observation_spans_by_trace(
     return out
 
 
-def _span_attributes_from_chspan(ch_row) -> dict:
-    """Reconstruct the span_attributes bag from CH typed Map columns.
-
-    Merges the three typed maps (string / number / bool) with the overflow
-    JSON bag (attributes_extra). In lean mode attributes_extra is '' so only
-    the typed maps contribute — heavy overflow fields stay absent until a
-    second heavy fetch replaces the row.
-    """
-    import json as _j
-
-    attrs: dict = {}
-    if ch_row.attrs_string:
-        attrs.update(ch_row.attrs_string)
-    if ch_row.attrs_number:
-        attrs.update(ch_row.attrs_number)
-    if ch_row.attrs_bool:
-        attrs.update({k: bool(v) for k, v in ch_row.attrs_bool.items()})
-    extra_raw = ch_row.attributes_extra
-    if extra_raw:
-        try:
-            extra = _j.loads(extra_raw)
-            if isinstance(extra, dict):
-                attrs.update(extra)
-        except Exception:  # noqa: BLE001
-            pass
-    return attrs
-
-
 def _construct_from_chspan(ch_row) -> ObservationSpan:
     """Shared body of the hybrid-construct logic."""
     import json as _j
 
     from tracer.models.observation_span import ObservationSpan
+    from tracer.services.clickhouse.v2.span_reader import _ch_span_attributes
 
     obj = ObservationSpan(
         id=ch_row.id,
@@ -299,7 +272,7 @@ def _construct_from_chspan(ch_row) -> ObservationSpan:
         obj.input = ch_row.input or None
         obj.output = ch_row.output or None
 
-    obj.span_attributes = _span_attributes_from_chspan(ch_row)
+    obj.span_attributes = _ch_span_attributes(ch_row)
 
     try:
         obj.span_events = _j.loads(ch_row.span_events) if ch_row.span_events else []

--- a/futureagi/tracer/services/clickhouse/v2/eval_loader.py
+++ b/futureagi/tracer/services/clickhouse/v2/eval_loader.py
@@ -170,7 +170,11 @@ def _hybrid_load_from_ch(
 
 
 def filter_observation_spans_by_trace(
-    trace_id: str, deleted: bool = False, *, project_id: str | None = None
+    trace_id: str,
+    deleted: bool = False,
+    *,
+    project_id: str | None = None,
+    heavy_span_ids: set[str] | None = None,
 ):
     """v2 equivalent of `ObservationSpan.objects.filter(trace=trace, deleted=False)`.
 
@@ -181,6 +185,12 @@ def filter_observation_spans_by_trace(
     ``project_id`` scopes the CH read so ClickHouse can prune ``spans`` by the
     ``project_id`` sort-key prefix instead of scanning all projects for the
     trace's spans.
+
+    ``heavy_span_ids`` (optional): ids whose heavy columns (attributes_extra /
+    span_events / resource_attrs) are required. A lean pass loads all spans
+    first; a second heavy pass fetches only those spans in ``heavy_span_ids``
+    that actually appeared in the trace, merging them back in. Spans not in
+    the set stay lean. Pass ``None`` (default) for a fully lean load.
     """
     from tracer.models.observation_span import ObservationSpan
 
@@ -192,7 +202,20 @@ def filter_observation_spans_by_trace(
         from tracer.services.clickhouse.v2 import get_reader
 
         reader = get_reader()
-        ch_rows = reader.list_by_trace(trace_id, project_id=project_id)
+        ch_rows = reader.list_by_trace(
+            trace_id, include_heavy=False, project_id=project_id
+        )
+
+        # Second pass: replace lean rows for the requested heavy span ids.
+        wanted = set(heavy_span_ids or ()) & {r.id for r in ch_rows}
+        if wanted:
+            heavy_map = {
+                r.id: r
+                for r in reader.list_by_ids(
+                    list(wanted), include_heavy=True, project_id=project_id
+                )
+            }
+            ch_rows = [heavy_map.get(r.id, r) for r in ch_rows]
     except Exception as e:  # noqa: BLE001
         if _forced_clickhouse():
             raise
@@ -203,15 +226,43 @@ def filter_observation_spans_by_trace(
 
     out = []
     for ch_row in ch_rows:
-        # _hybrid_load_from_ch builds a single instance from a CHSpan;
-        # invoke the same shaping via a passthrough.
         obj = _construct_from_chspan(ch_row)
         out.append(obj)
     return out
 
 
+def _span_attributes_from_chspan(ch_row) -> dict:
+    """Reconstruct the span_attributes bag from CH typed Map columns.
+
+    Merges the three typed maps (string / number / bool) with the overflow
+    JSON bag (attributes_extra). In lean mode attributes_extra is '' so only
+    the typed maps contribute — heavy overflow fields stay absent until a
+    second heavy fetch replaces the row.
+    """
+    import json as _j
+
+    attrs: dict = {}
+    if ch_row.attrs_string:
+        attrs.update(ch_row.attrs_string)
+    if ch_row.attrs_number:
+        attrs.update(ch_row.attrs_number)
+    if ch_row.attrs_bool:
+        attrs.update({k: bool(v) for k, v in ch_row.attrs_bool.items()})
+    extra_raw = ch_row.attributes_extra
+    if extra_raw:
+        try:
+            extra = _j.loads(extra_raw)
+            if isinstance(extra, dict):
+                attrs.update(extra)
+        except Exception:  # noqa: BLE001
+            pass
+    return attrs
+
+
 def _construct_from_chspan(ch_row) -> ObservationSpan:
     """Shared body of the hybrid-construct logic."""
+    import json as _j
+
     from tracer.models.observation_span import ObservationSpan
 
     obj = ObservationSpan(
@@ -242,13 +293,23 @@ def _construct_from_chspan(ch_row) -> ObservationSpan:
         semconv_source=ch_row.semconv_source,
     )
     try:
-        import json as _j
-
         obj.input = _j.loads(ch_row.input) if ch_row.input else None
         obj.output = _j.loads(ch_row.output) if ch_row.output else None
     except Exception:  # noqa: BLE001
         obj.input = ch_row.input or None
         obj.output = ch_row.output or None
+
+    obj.span_attributes = _span_attributes_from_chspan(ch_row)
+
+    try:
+        obj.span_events = _j.loads(ch_row.span_events) if ch_row.span_events else []
+        obj.resource_attributes = (
+            _j.loads(ch_row.resource_attrs) if ch_row.resource_attrs else {}
+        )
+    except Exception:  # noqa: BLE001
+        obj.span_events = []
+        obj.resource_attributes = {}
+
     obj._state.adding = False
     obj._state.db = "default"
 
@@ -365,7 +426,9 @@ def get_trace_session(session_id: str, *, project: Project) -> TraceSession:
         resolve_session_fields,
     )
 
-    fields = resolve_session_fields([session_id]).get(str(session_id))
+    fields = resolve_session_fields([session_id], project_id=str(project.id)).get(
+        str(session_id)
+    )
     if not fields:
         if _forced_clickhouse():
             raise TraceSession.DoesNotExist(

--- a/futureagi/tracer/services/clickhouse/v2/query_settings.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_settings.py
@@ -1,0 +1,28 @@
+"""Per-context ClickHouse query settings for the v2 readers.
+
+``ch_query_settings(**settings)`` layers settings (``log_comment``,
+``max_memory_usage``, …) onto a ContextVar; every CH client the v2 readers
+construct while the context is active merges them into its client-level
+settings. Nested contexts merge, inner keys win.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_settings: ContextVar[dict | None] = ContextVar("ch_query_settings", default=None)
+
+
+def current_settings() -> dict:
+    return dict(_settings.get() or {})
+
+
+@contextmanager
+def ch_query_settings(**settings):
+    merged = {**current_settings(), **settings}
+    token = _settings.set(merged)
+    try:
+        yield
+    finally:
+        _settings.reset(token)

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -43,6 +43,7 @@ from tracer.services.clickhouse.v2.id_remap_sql import (
     remap_left_join,
     resolved_id_expr,
 )
+from tracer.services.clickhouse.v2.query_settings import current_settings
 
 
 # Field list that the eval runner actually reads off of an ObservationSpan.
@@ -373,6 +374,7 @@ class CHSpanReader:
             password=password,
             database=database,
             send_receive_timeout=timeout_sec,
+            settings=current_settings() or None,
         )
 
     def close(self) -> None:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -166,7 +166,8 @@ _READ_COLUMNS: tuple[str, ...] = (
     "span_events",
     "toJSONString(metadata) AS metadata",
     "toJSONString(resource_attrs) AS resource_attrs",
-    "toJSONString(attributes_extra) AS attributes_extra",
+    # attributes_extra is a plain String column (schema 013); no toJSONString wrapper.
+    "attributes_extra",
     "attrs_string",
     "attrs_number",
     "attrs_bool",
@@ -192,7 +193,7 @@ _SELECT_SQL = ", ".join(_READ_COLUMNS)
 _HEAVY_COLUMNS = {
     "span_events",
     "toJSONString(resource_attrs) AS resource_attrs",
-    "toJSONString(attributes_extra) AS attributes_extra",
+    "attributes_extra",
 }
 _LEAN_SELECT_SQL = ", ".join(
     "''" if col in _HEAVY_COLUMNS else col for col in _READ_COLUMNS
@@ -506,21 +507,30 @@ class CHSpanReader:
 
     # ─── All spans in a trace ────────────────────────────────────────────────
     def list_by_trace(
-        self, trace_id: str, *, project_id: str | None = None
+        self,
+        trace_id: str,
+        *,
+        include_heavy: bool = True,
+        project_id: str | None = None,
     ) -> list[CHSpan]:
         """Equivalent to ObservationSpan.objects.filter(trace=trace, deleted=False).
 
         Returned in start_time, id order so the eval runner's trace-walking
         logic sees spans in a deterministic chronological order. ``project_id``
         (optional) scopes the read to one tenant; omit for prior behavior.
+
+        With ``include_heavy=False`` the fat JSON columns (attributes_extra /
+        span_events / resource_attrs) come back as '' — opt out when only
+        scalar columns are needed (e.g. the lean-first eval path).
         """
+        select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
         where = ["trace_id = %(trace_id)s", "is_deleted = 0"]
         params: dict[str, Any] = {"trace_id": trace_id}
         if project_id:
             where.append("project_id = %(pid)s")
             params["pid"] = str(project_id)
         rows = self._client.query(
-            f"SELECT {_SELECT_SQL} FROM spans FINAL "
+            f"SELECT {select} FROM spans FINAL "
             f"WHERE {' AND '.join(where)} "
             "ORDER BY start_time, id",
             parameters=params,
@@ -813,7 +823,7 @@ class CHSpanReader:
         ("attrs_string", "attrs_string"),
         ("attrs_number", "attrs_number"),
         ("attrs_bool", "attrs_bool"),
-        ("toJSONString(attributes_extra)", "attributes_extra"),
+        ("attributes_extra", "attributes_extra"),
         ("prompt_tokens", "prompt_tokens"),
         ("completion_tokens", "completion_tokens"),
         ("total_tokens", "total_tokens"),
@@ -2009,6 +2019,7 @@ class CHSpanReader:
         *,
         include_heavy: bool = True,
         observation_type: str | None = None,
+        project_id: str | None = None,
     ) -> dict[str, CHSpan]:
         """For each trace_id, return the root span (parent_span_id = '').
         Picks the earliest by (start_time, id) on ties. Returns a dict so
@@ -2020,12 +2031,10 @@ class CHSpanReader:
                                             deleted=False)
                 .order_by("trace_id", "start_time").distinct("trace_id")
 
-        Used by model_hub/services/bulk_selection.py for per-trace root
-        lookups + annotation_queues.py default-queue resolution.
-
         With ``include_heavy=False`` the fat JSON columns (attributes_extra /
         span_events / resource_attrs) come back as '' — opt out when only
-        id/scalar columns are needed.
+        id/scalar columns are needed. Pass ``project_id`` to prune the scan to
+        one project (avoids a full-table scan across every project's spans).
         """
         if not trace_ids:
             return {}
@@ -2036,23 +2045,23 @@ class CHSpanReader:
             "parent_span_id = ''",
         ]
         params: dict[str, Any] = {"tids": tuple(trace_ids)}
+        if project_id:
+            # Qualify with the table name: the SELECT aliases
+            # ``toString(project_id) AS project_id``, which otherwise shadows the
+            # sort-key column here and defeats primary-key partition pruning.
+            where.append("spans.project_id = %(pid)s")
+            params["pid"] = str(project_id)
         if observation_type:
             where.append("observation_type = %(otype)s")
             params["otype"] = observation_type
-        # Single CH query; ORDER BY trace_id, start_time, id; then dedupe by
-        # trace_id in Python keeping the first per trace_id (= earliest).
         rows = self._client.query(
             f"SELECT {select} FROM spans FINAL "
             f"WHERE {' AND '.join(where)} "
-            "ORDER BY trace_id, start_time, id",
+            "ORDER BY trace_id, start_time, id "
+            "LIMIT 1 BY trace_id",
             parameters=params,
         ).result_rows
-        result: dict[str, CHSpan] = {}
-        for r in rows:
-            span = _row_to_chspan(r)
-            if span.trace_id not in result:
-                result[span.trace_id] = span
-        return result
+        return {span.trace_id: span for span in map(_row_to_chspan, rows)}
 
     def aggregate_by_session_ids(
         self,

--- a/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
@@ -348,6 +348,8 @@ def session_exists(project_id: object, trace_session_id: object) -> bool:
 
 def resolve_session_fields(
     trace_session_ids: Iterable[object],
+    *,
+    project_id: str | None = None,
 ) -> dict[str, dict[str, object]]:
     """Batch-resolve ``{trace_session_id (str) -> {external_session_id,
     first_seen, project_id, bookmarked, display_name}}`` — the curated CH identity
@@ -380,6 +382,10 @@ def resolve_session_fields(
       • ``project_id`` is returned as a ``str``.
       • When several input ids resolve to the SAME survivor (straddler old+new
         both passed), each input id maps to its own copy of the one entity.
+      • ``project_id`` (optional kwarg): scope the WHERE to one tenant, pruning on
+        the ``trace_sessions`` ORDER BY ``(project_id, trace_session_id)``
+        sort-key prefix so an eval-path caller reads ~its own sessions instead
+        of the whole table.
       • Returns ``{}`` for empty input (no CH round-trip).
     """
     ids = {str(s) for s in trace_session_ids if s}
@@ -389,6 +395,11 @@ def resolve_session_fields(
     client = _get_client()
     resolved = resolved_id_expr("ids.sid")
     remap_join = remap_left_join("ids.sid", _SESSION_REMAP)
+    params: dict[str, object] = {"ids": list(ids)}
+    project_clause = ""
+    if project_id:
+        params["pid"] = str(project_id)
+        project_clause = " AND ts.project_id = %(pid)s"
     try:
         # Resolve new→old in the inner subquery (plain (input_id, resolved_id)
         # columns), join the curated table on the resolved id as a plain column,
@@ -407,9 +418,9 @@ def resolve_session_fields(
                 # alias BEFORE FINAL (CH syntax); see _resolve_existing_ids.
                 f"INNER JOIN {_SESSIONS_TABLE} AS ts FINAL "
                 f"  ON ts.trace_session_id = r.resolved_id "
-                f"WHERE ts.is_deleted = 0"
+                f"WHERE ts.is_deleted = 0{project_clause}"
             ),
-            parameters={"ids": list(ids)},
+            parameters=params,
         )
     except Exception:
         _reset_client()
@@ -418,14 +429,14 @@ def resolve_session_fields(
     out: dict[str, dict[str, object]] = {}
     resolved_by_input: dict[str, str] = {}
     for row in result.result_rows:
-        input_id, resolved_id, external, first_seen, project_id = row
+        input_id, resolved_id, external, first_seen, proj_id = row
         resolved_by_input[input_id] = resolved_id
         out[input_id] = {
             # '' (PG NULL name coerced on write) → None, parity with the old
             # PG-name read. Overlay defaults filled below.
             "external_session_id": external or None,
             "first_seen": first_seen,
-            "project_id": project_id,
+            "project_id": proj_id,
             "bookmarked": False,
             "display_name": None,
         }

--- a/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
@@ -110,10 +110,13 @@ _LABEL_ATTR = "external_session_id"
 
 _client = None
 _client_lock = threading.Lock()
-# Cached client for non-empty settings contexts. At most one live client per
-# distinct settings dict; replaced (old closed) when the key changes.
-_settings_client = None
-_settings_client_key = None
+# Per-thread cached client for non-empty settings contexts. Thread-local (not a
+# module global) so a concurrent caller with a different settings key can never
+# ``.close()`` a client another thread is mid-query on — ``_get_client`` returns
+# the cached handle and the caller queries it outside ``_client_lock``, so a
+# shared module-global client was a cross-thread close race. At most one live
+# settings-client per thread; replaced (old closed) when that thread's key changes.
+_settings_tls = threading.local()
 
 
 def _get_client():
@@ -121,37 +124,41 @@ def _get_client():
     ``end_user_dict_reader._get_client``; kept separate so a reset here can't
     disturb the enduser reader's or writer's cached handle).
 
-    When ``ch_query_settings`` is active, returns a cached client keyed by the
-    merged settings dict. Reuses it while the key matches; closes and replaces
-    the cached client when the key changes. At most one live settings-client at
-    any time, no per-call leak. The empty-settings path is unchanged."""
+    When ``ch_query_settings`` is active, returns a thread-local client keyed by
+    the merged settings dict. Reuses it while this thread's key matches; closes
+    and replaces this thread's cached client when the key changes. Thread-local,
+    so a settings-client is never shared across threads and a concurrent caller
+    with a different key cannot close a client this thread is mid-query on. The
+    empty-settings path is unchanged."""
     overrides = current_settings()
     if overrides:
-        global _settings_client, _settings_client_key
         key = tuple(sorted(overrides.items()))
-        with _client_lock:
-            if _settings_client_key == key and _settings_client is not None:
-                return _settings_client
-            # Key changed or no cached settings-client: close old, build new.
-            if _settings_client is not None:
-                try:
-                    _settings_client.close()
-                except Exception:
-                    pass
-            import clickhouse_connect
+        client = getattr(_settings_tls, "client", None)
+        if client is not None and getattr(_settings_tls, "key", None) == key:
+            return client
+        # Key changed or first use on this thread: close this thread's old
+        # client and build a new one. Only ever touches this thread's client,
+        # so no other thread's in-flight query can be closed out from under it.
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+        import clickhouse_connect
 
-            cfg = get_v2_config()
-            _settings_client = clickhouse_connect.get_client(
-                host=cfg["host"],
-                port=cfg["http_port"],
-                username=cfg["user"],
-                password=cfg["password"] or "",
-                database=cfg["database"],
-                send_receive_timeout=15,
-                settings=overrides,
-            )
-            _settings_client_key = key
-        return _settings_client
+        cfg = get_v2_config()
+        client = clickhouse_connect.get_client(
+            host=cfg["host"],
+            port=cfg["http_port"],
+            username=cfg["user"],
+            password=cfg["password"] or "",
+            database=cfg["database"],
+            send_receive_timeout=15,
+            settings=overrides,
+        )
+        _settings_tls.client = client
+        _settings_tls.key = key
+        return client
     global _client
     if _client is not None:
         return _client
@@ -172,7 +179,7 @@ def _get_client():
 
 
 def _reset_client() -> None:
-    global _client, _settings_client, _settings_client_key
+    global _client
     with _client_lock:
         try:
             if _client is not None:
@@ -180,13 +187,15 @@ def _reset_client() -> None:
         except Exception:
             pass
         _client = None
+    # Settings-clients are thread-local; only the calling thread's is reachable.
+    client = getattr(_settings_tls, "client", None)
+    if client is not None:
         try:
-            if _settings_client is not None:
-                _settings_client.close()
+            client.close()
         except Exception:
             pass
-        _settings_client = None
-        _settings_client_key = None
+    _settings_tls.client = None
+    _settings_tls.key = None
 
 
 def resolve_external_session_ids(

--- a/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/trace_session_dict_reader.py
@@ -89,6 +89,7 @@ from tracer.services.clickhouse.v2.id_remap_sql import (
     remap_left_join,
     resolved_id_expr,
 )
+from tracer.services.clickhouse.v2.query_settings import current_settings
 
 log = structlog.get_logger("ch25.trace_session_dict_reader")
 
@@ -109,12 +110,48 @@ _LABEL_ATTR = "external_session_id"
 
 _client = None
 _client_lock = threading.Lock()
+# Cached client for non-empty settings contexts. At most one live client per
+# distinct settings dict; replaced (old closed) when the key changes.
+_settings_client = None
+_settings_client_key = None
 
 
 def _get_client():
     """Lazily build + cache a clickhouse-connect client (mirrors
     ``end_user_dict_reader._get_client``; kept separate so a reset here can't
-    disturb the enduser reader's or writer's cached handle)."""
+    disturb the enduser reader's or writer's cached handle).
+
+    When ``ch_query_settings`` is active, returns a cached client keyed by the
+    merged settings dict. Reuses it while the key matches; closes and replaces
+    the cached client when the key changes. At most one live settings-client at
+    any time, no per-call leak. The empty-settings path is unchanged."""
+    overrides = current_settings()
+    if overrides:
+        global _settings_client, _settings_client_key
+        key = tuple(sorted(overrides.items()))
+        with _client_lock:
+            if _settings_client_key == key and _settings_client is not None:
+                return _settings_client
+            # Key changed or no cached settings-client: close old, build new.
+            if _settings_client is not None:
+                try:
+                    _settings_client.close()
+                except Exception:
+                    pass
+            import clickhouse_connect
+
+            cfg = get_v2_config()
+            _settings_client = clickhouse_connect.get_client(
+                host=cfg["host"],
+                port=cfg["http_port"],
+                username=cfg["user"],
+                password=cfg["password"] or "",
+                database=cfg["database"],
+                send_receive_timeout=15,
+                settings=overrides,
+            )
+            _settings_client_key = key
+        return _settings_client
     global _client
     if _client is not None:
         return _client
@@ -135,7 +172,7 @@ def _get_client():
 
 
 def _reset_client() -> None:
-    global _client
+    global _client, _settings_client, _settings_client_key
     with _client_lock:
         try:
             if _client is not None:
@@ -143,6 +180,13 @@ def _reset_client() -> None:
         except Exception:
             pass
         _client = None
+        try:
+            if _settings_client is not None:
+                _settings_client.close()
+        except Exception:
+            pass
+        _settings_client = None
+        _settings_client_key = None
 
 
 def resolve_external_session_ids(

--- a/futureagi/tracer/services/eval_tasks/ch_guardrails.py
+++ b/futureagi/tracer/services/eval_tasks/ch_guardrails.py
@@ -1,0 +1,36 @@
+"""Per-query ClickHouse guardrail settings for the eval-task engine.
+
+These caps ensure that a heavy eval read fails at the query level (a visible,
+retryable error) rather than exhausting server memory. Sorts spill to disk
+instead of OOM-ing the CH process.
+
+Values are conservative starting points. Tune them against dev-GCP reality
+once production-scale data and real server memory headroom are available:
+measure peak per-query memory and execution time there, then record the finals
+here and in the operational runbook.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+
+# Per-query limits applied to every CH read the eval engine issues.
+EVAL_CH_GUARDRAILS: dict[str, int] = {
+    "max_memory_usage": 4 * 2**30,  # 4 GiB — hard cap per query
+    "max_execution_time": 120,  # seconds — kill runaway queries
+    "max_bytes_before_external_sort": 2 * 2**30,  # 2 GiB spill threshold
+}
+
+
+@contextmanager
+def eval_ch_guardrails():
+    """Apply per-query CH guardrails for eval reads.
+
+    Nest around every CH read the eval engine issues. Inner
+    ``ch_query_settings`` overrides win (e.g. test fixtures can tighten
+    ``max_memory_usage`` to a smaller value to probe the tripwire).
+    """
+    with ch_query_settings(**EVAL_CH_GUARDRAILS):
+        yield

--- a/futureagi/tracer/services/eval_tasks/entries.py
+++ b/futureagi/tracer/services/eval_tasks/entries.py
@@ -34,6 +34,7 @@ _TARGET_TYPE = {
 }
 
 _MATERIALIZE_BATCH = 5_000
+_FK_CHUNK = 1000
 
 # Set to the materialized entry's id while the engine runs one entry; the eval
 # core's result write then lands on that entry instead of creating a new row.
@@ -116,7 +117,9 @@ def materialize_pending(task: EvalTask) -> int:
     reader = get_reader()
     try:
         for batch in iter_desired_rows(task, batch_size=_MATERIALIZE_BATCH):
-            fk_by_id = _resolve_entry_fks(reader, task.row_type, batch)
+            fk_by_id = _resolve_entry_fks(
+                reader, task.row_type, batch, project_id=str(task.project_id)
+            )
             rows = []
             for identity in batch:
                 fks = fk_by_id.get(identity)
@@ -213,26 +216,44 @@ def mark_terminal(
 
 
 def _resolve_entry_fks(
-    reader: CHSpanReader, row_type: str, identities: Iterable[str]
+    reader: CHSpanReader,
+    row_type: str,
+    identities: Iterable[str],
+    *,
+    project_id: str,
 ) -> dict[str, dict[str, Any]]:
     """Map each desired row identity to the EvalLogger FK fields for its
     target_type. Rows that can't be shaped (missing span / rootless trace) are
-    absent from the result and skipped by the caller."""
-    if row_type in (RowType.SPANS, RowType.VOICE_CALLS):
-        # Only id + trace_id are used, so skip the fat JSON columns.
-        spans = reader.list_by_ids(list(identities), include_heavy=False)
-        return {
-            s.id: {"observation_span_id": s.id, "trace_id": s.trace_id} for s in spans
-        }
-    if row_type == RowType.TRACES:
-        # Only root.id is used below, so skip the fat JSON columns.
-        roots = reader.list_root_spans_by_trace_ids(
-            list(identities), include_heavy=False
-        )
-        return {
-            trace_id: {"observation_span_id": root.id, "trace_id": trace_id}
-            for trace_id, root in roots.items()
-        }
+    absent from the result and skipped by the caller. CH reads are
+    project-scoped and chunked into ``_FK_CHUNK``-sized IN-lists."""
+    ids = list(identities)
     if row_type == RowType.SESSIONS:
-        return {sid: {"trace_session_id": sid} for sid in identities}
-    raise ValueError(f"Unsupported row_type: {row_type!r}")
+        return {sid: {"trace_session_id": sid} for sid in ids}
+    if row_type not in (RowType.SPANS, RowType.VOICE_CALLS, RowType.TRACES):
+        raise ValueError(f"Unsupported row_type: {row_type!r}")
+    fks: dict[str, dict[str, Any]] = {}
+    for start in range(0, len(ids), _FK_CHUNK):
+        chunk = ids[start : start + _FK_CHUNK]
+        if row_type == RowType.TRACES:
+            # Only root.id is used below, so skip the fat JSON columns.
+            roots = reader.list_root_spans_by_trace_ids(
+                chunk, include_heavy=False, project_id=project_id
+            )
+            fks.update(
+                {
+                    trace_id: {"observation_span_id": root.id, "trace_id": trace_id}
+                    for trace_id, root in roots.items()
+                }
+            )
+        else:
+            # SPANS / VOICE_CALLS: only id + trace_id are used.
+            spans = reader.list_by_ids(
+                chunk, include_heavy=False, project_id=project_id
+            )
+            fks.update(
+                {
+                    s.id: {"observation_span_id": s.id, "trace_id": s.trace_id}
+                    for s in spans
+                }
+            )
+    return fks

--- a/futureagi/tracer/services/eval_tasks/reconciler.py
+++ b/futureagi/tracer/services/eval_tasks/reconciler.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
+from itertools import chain
 
+from django.db.models import Case, CharField, Value, When
 from django.utils import timezone
 
 from tracer.models.eval_task import EvalTask, RowType, RunType
@@ -23,6 +25,9 @@ from tracer.services.eval_tasks.entries import materialize_pending
 # needs to exceed normal ingestion lag (pause/downtime gaps are covered by the
 # persisted cursor, not this overlap).
 _CONTINUOUS_CURSOR_OVERLAP = timedelta(minutes=5)
+
+# Max entry ids per requeue UPDATE — bounds the WHERE id IN (...) list size.
+_REQUEUE_CHUNK = 10_000
 
 
 @dataclass
@@ -109,13 +114,24 @@ def _requeue_and_drop(task: EvalTask) -> tuple[int, int]:
             drop_ids.append(entry.id)  # out of scope, no result yet
 
     requeued = 0
-    for cfg_id, ids in requeue_by_cfg.items():
-        requeued += EvalLogger.objects.filter(id__in=ids).update(
-            status=EvalEntryStatus.PENDING,
-            config_hash=hashes[cfg_id],
-            error=False,
-            skipped_reason=None,
+    # Flatten {cfg_id: [entry_id, ...]} into one flat [entry_id, ...] list.
+    all_ids = list(chain.from_iterable(requeue_by_cfg.values()))
+    if all_ids:
+        hash_case = Case(
+            *[
+                When(custom_eval_config_id=cfg_id, then=Value(hashes[cfg_id]))
+                for cfg_id in requeue_by_cfg
+            ],
+            output_field=CharField(),
         )
+        for chunk_start in range(0, len(all_ids), _REQUEUE_CHUNK):
+            chunk = all_ids[chunk_start : chunk_start + _REQUEUE_CHUNK]
+            requeued += EvalLogger.objects.filter(id__in=chunk).update(
+                status=EvalEntryStatus.PENDING,
+                config_hash=hash_case,
+                error=False,
+                skipped_reason=None,
+            )
     dropped = 0
     if drop_ids:
         dropped = EvalLogger.objects.filter(id__in=drop_ids).update(

--- a/futureagi/tracer/services/eval_tasks/run_entry.py
+++ b/futureagi/tracer/services/eval_tasks/run_entry.py
@@ -87,9 +87,9 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
         _execute_evaluation_for_trace,
         _find_anchor_span,
         _process_mapping,
-        _process_session_mapping,
-        _process_trace_mapping,
         _write_eval_logger,
+        resolve_session_mapping_lean_first,
+        resolve_trace_mapping_lean_first,
     )
 
     task_id = entry.eval_task_id
@@ -128,7 +128,9 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                 ),
                 project_id=config.project_id,
             )
-            run_params = _process_trace_mapping(config.mapping, trace, template_id)
+            run_params = resolve_trace_mapping_lean_first(
+                config.mapping, trace, template_id
+            )
             _execute_evaluation_for_trace(
                 trace=trace,
                 anchor_span=_find_anchor_span(trace),
@@ -138,7 +140,9 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
             )
         elif entry.target_type == EvalTargetType.SESSION:
             session = get_trace_session(entry.trace_session_id, project=config.project)
-            run_params = _process_session_mapping(config.mapping, session, template_id)
+            run_params = resolve_session_mapping_lean_first(
+                config.mapping, session, template_id
+            )
             _execute_evaluation_for_session(
                 trace_session=session,
                 custom_eval_config=config,

--- a/futureagi/tracer/tasks/trace_scanner.py
+++ b/futureagi/tracer/tasks/trace_scanner.py
@@ -7,6 +7,7 @@ Activity 3: cluster_scan_issues_task — cluster unclustered issues + match succ
 """
 
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 from typing import List
 
@@ -22,6 +23,7 @@ from tracer.queries.trace_scanner import (
     mark_traces_failed,
 )
 from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
 from tracer.utils.trace_scanner import (
     cluster_issues,
     embed_trace_inputs,
@@ -38,6 +40,30 @@ _SWEEP_GRACE_SECONDS = 60  # let straggler child spans settle before scanning
 _SWEEP_COLD_START_SECONDS = 900  # first-sweep window when last_swept_at is NULL
 _SWEEP_BATCH_SIZE = 15  # keep each scan task under its time_limit (cf. _trigger_trace_scanner)
 _SWEEP_MAX_LAG_SECONDS = 86400  # cap how far the watermark lags behind a stuck trace (24h)
+
+# Per-query ClickHouse caps for the scanner's spans reads — same box-safe
+# starting values as the eval engine's guardrails. A heavy scan read fails at
+# the query level (a retryable code-241) instead of exhausting server memory and
+# taking the shared CH box down with it; big sorts spill to disk rather than OOM.
+# Baked into each reader's client at construction (via the ``ch_query_settings``
+# contextvar), so ``scan_ch_guardrails()`` must wrap the reader-building call.
+# Tune against dev-GCP once prod-scale headroom is known.
+SCAN_CH_GUARDRAILS: dict[str, int] = {
+    "max_memory_usage": 4 * 2**30,  # 4 GiB — hard cap per query
+    "max_execution_time": 120,  # seconds — kill a runaway query
+    "max_bytes_before_external_sort": 2 * 2**30,  # 2 GiB spill threshold
+}
+
+
+@contextmanager
+def scan_ch_guardrails():
+    """Apply per-query CH guardrails to every v2 reader built inside the block.
+
+    Inner ``ch_query_settings`` overrides win (e.g. a test tightens
+    ``max_memory_usage`` to probe the tripwire).
+    """
+    with ch_query_settings(**SCAN_CH_GUARDRAILS):
+        yield
 
 
 @temporal_activity(time_limit=600, queue="agent_compass", max_retries=1)
@@ -62,7 +88,8 @@ def scan_traces_task(trace_ids: List[str], project_id: str, from_sweep: bool = F
         project_id=project_id,
     )
 
-    results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
+    with scan_ch_guardrails():
+        results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
 
     issues_found = sum(len(r.issues) for r in results)
     logger.info(
@@ -96,7 +123,8 @@ def embed_trace_inputs_task(
         project_id=project_id,
     )
 
-    stored = embed_trace_inputs(trace_ids, project_id)
+    with scan_ch_guardrails():
+        stored = embed_trace_inputs(trace_ids, project_id)
 
     logger.info(
         "embed_trace_inputs_task_completed",
@@ -186,7 +214,7 @@ def sweep_scannable_traces():
 
     dispatched = 0
     abandoned = 0
-    with get_reader() as reader:
+    with scan_ch_guardrails(), get_reader() as reader:
         now_ch = reader.ch_now()
         upper = now_ch - timedelta(seconds=_SWEEP_GRACE_SECONDS)
         cold_floor = now_ch - timedelta(seconds=_SWEEP_COLD_START_SECONDS)

--- a/futureagi/tracer/tests/test_scan_ch_guardrails.py
+++ b/futureagi/tracer/tests/test_scan_ch_guardrails.py
@@ -1,0 +1,94 @@
+"""Revert-catchers for the scanner's per-query ClickHouse guardrails.
+
+Each scanner activity that reads spans through the v2 reader must run that read
+inside ``scan_ch_guardrails()`` so the memory/time/sort caps are baked into the
+reader's client. These tests drive the real (undecorated) activity body and
+snapshot ``current_settings()`` at the moment the wrapped CH work begins — if the
+``with`` is dropped, or a refactor slips a context-dropping hop in front of the
+read, the snapshot is empty and the test fails. DB-free: every collaborator is
+mocked. ``cluster_scan_issues_task`` is intentionally uncovered — it reads only
+through ``ClickHouseVectorDB`` (a separate client that never sees the contextvar).
+"""
+
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from tracer.services.clickhouse.v2.query_settings import current_settings
+from tracer.tasks import trace_scanner as scanner
+
+_NOW = datetime(2026, 6, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _reader_cm():
+    """A ``with get_reader() as reader`` context manager over a mock reader."""
+    reader = MagicMock()
+    reader.ch_now.return_value = _NOW
+    reader.root_trace_candidates.return_value = []
+    cm = MagicMock()
+    cm.__enter__.return_value = reader
+    cm.__exit__.return_value = False
+    return cm
+
+
+def test_scan_traces_task_runs_scan_and_write_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return []  # empty results are fine — we only need the wrapped call to run
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(scanner, "SCAN_DELAY_SECONDS", 0))
+        stack.enter_context(patch.object(scanner, "scan_and_write", side_effect=spy))
+        # Load-bearing: the activity dispatches embed unconditionally after the
+        # scan, so this mock keeps the real Temporal start_activity out of the test.
+        stack.enter_context(patch.object(scanner, "embed_trace_inputs_task"))
+        scanner.scan_traces_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_embed_trace_inputs_task_runs_embed_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return 0  # stored count
+
+    with patch.object(scanner, "embed_trace_inputs", side_effect=spy):
+        # trigger_clustering=False → no cluster chain to mock.
+        scanner.embed_trace_inputs_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_sweep_builds_reader_inside_guardrails():
+    captured = {}
+
+    def spy_get_reader():
+        captured["settings"] = current_settings()
+        return _reader_cm()
+
+    cfg = MagicMock()
+    cfg.no_workspace_objects.filter.return_value.order_by.return_value.values.return_value = [
+        {"project_id": "p1", "sampling_rate": 1.0, "last_swept_at": None}
+    ]
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch.object(scanner, "get_reader", side_effect=spy_get_reader)
+        )
+        stack.enter_context(patch.object(scanner, "TraceScanConfig", cfg))
+        stack.enter_context(
+            patch.object(scanner, "filter_already_scanned", side_effect=lambda x: x)
+        )
+        stack.enter_context(
+            patch.object(
+                scanner, "is_trace_sampled", side_effect=lambda tid, rate: True
+            )
+        )
+        stack.enter_context(patch.object(scanner, "scan_traces_task"))
+        scanner.sweep_scannable_traces._original_func()
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -2661,6 +2661,19 @@ def _resolve_trace_path(trace: Trace, path: str):
     return _MISSING
 
 
+# Per-``resolve_session_mapping_lean_first`` memo for ``_session_traces_ch``:
+# maps ``(project_id, session_id)`` → the ordered hydrated trace list so the
+# session heavy path resolves the trace list once — reused by the up-front
+# heavy-id computation and by every ``traces.*`` lookup in
+# ``_resolve_session_path`` — instead of re-running ``session_trace_ids`` +
+# ``per_trace_root_span_start_times`` + a ``get_trace`` per trace each time.
+# Default None = no active scope → always recompute (behaviour outside the
+# wrapper is unchanged).
+_session_traces_memo: ContextVar[dict | None] = ContextVar(
+    "eval_session_traces_memo", default=None
+)
+
+
 def _session_traces_ch(trace_session) -> list:
     """Return the session's CH traces ordered by earliest root-span start_time.
 
@@ -2680,6 +2693,11 @@ def _session_traces_ch(trace_session) -> list:
     _session_id = getattr(trace_session, "id", None)
     if _project_id is None or _session_id is None:
         return []
+
+    memo = _session_traces_memo.get()
+    cache_key = (str(_project_id), str(_session_id))
+    if memo is not None and cache_key in memo:
+        return memo[cache_key]
 
     with get_reader() as reader:
         _trace_ids = reader.session_trace_ids(str(_project_id), str(_session_id))
@@ -2702,6 +2720,9 @@ def _session_traces_ch(trace_session) -> list:
         return (key is None, key, str(t.id))
 
     traces.sort(key=_trace_order)
+
+    if memo is not None:
+        memo[cache_key] = traces
     return traces
 
 
@@ -2882,11 +2903,29 @@ def _heavy_span_ids_for_trace_mapping(mapping: dict | None, trace) -> frozenset[
     """Return the span ids referenced by heavy-tail ``spans.<sel>.<tail>``
     paths in *mapping*, resolved against *trace*'s lean spans.
 
-    Iterates the mapping values; any value of the form
-    ``spans.<sel>.<tail>`` where ``_is_heavy_span_tail(tail)`` selects a
-    span from the trace's sorted lean list and adds its id to the result.
+    Scans the mapping values for ``spans.<sel>.<tail>`` paths where
+    ``_is_heavy_span_tail(tail)`` and collects their selectors. If none
+    reference a heavy tail, returns empty *without touching CH* — a mapping that
+    only reads ``input``/``output``/scalar fields pays no span load here. When at
+    least one does, loads the trace's sorted lean spans once (same sort key as
+    ``_resolve_trace_path``) and resolves each selector to a span id.
     """
     if not mapping:
+        return frozenset()
+
+    selectors: list[str] = []
+    for attribute in mapping.values():
+        if not attribute or not attribute.startswith("spans."):
+            continue
+        # path: "spans.<sel>[.<tail>]"
+        remainder = attribute[len("spans.") :]
+        parts = remainder.split(".", 1)
+        sel = parts[0]
+        tail = parts[1] if len(parts) > 1 else ""
+        if not tail or not _is_heavy_span_tail(tail):
+            continue
+        selectors.append(sel)
+    if not selectors:
         return frozenset()
 
     from tracer.services.clickhouse.v2.eval_loader import (
@@ -2901,16 +2940,7 @@ def _heavy_span_ids_for_trace_mapping(mapping: dict | None, trace) -> frozenset[
     n = len(spans)
 
     heavy_ids: set[str] = set()
-    for attribute in mapping.values():
-        if not attribute or not attribute.startswith("spans."):
-            continue
-        # path: "spans.<sel>[.<tail>]"
-        remainder = attribute[len("spans.") :]
-        parts = remainder.split(".", 1)
-        sel = parts[0]
-        tail = parts[1] if len(parts) > 1 else ""
-        if not tail or not _is_heavy_span_tail(tail):
-            continue
+    for sel in selectors:
         idx = _selector_index(sel, n)
         if idx is None:
             continue
@@ -2920,17 +2950,24 @@ def _heavy_span_ids_for_trace_mapping(mapping: dict | None, trace) -> frozenset[
 
 
 def resolve_trace_mapping_lean_first(mapping: dict | None, trace, template_id) -> dict:
-    """Two-pass wrapper around ``_process_trace_mapping`` for the CH eval path.
+    """Lean-first wrapper around ``_process_trace_mapping`` for the CH eval path.
 
-    Pass 1 (lean): attempt mapping resolution with all spans loaded lean
-    (heavy JSON columns absent). This suffices for mappings that only touch
-    ``input``/``output``/scalar span fields.
+    Computes the span ids whose heavy columns (attributes_extra / span_events /
+    resource_attrs) the mapping references *up front*, sets the contextvar so
+    ``_resolve_trace_path`` fetches exactly those spans with full columns (all
+    others stay lean), then resolves in a single pass. When the mapping
+    references no heavy field (the common ``input``/``output`` case)
+    ``_heavy_span_ids_for_trace_mapping`` short-circuits without a span load and
+    every span loads lean — so the memory win is preserved.
 
-    Pass 2 (heavy on miss): if pass 1 raises ``ValueError`` (required-key
-    miss), compute the exact span ids whose heavy columns the mapping
-    references, set the contextvar so ``_resolve_trace_path`` fetches those
-    spans with full columns on the second call, then retry once.  If no
-    heavy span ids can be resolved, re-raise the original error.
+    Computing the heavy set up front — rather than gating a heavy retry on a
+    ``ValueError`` from a lean first pass — is required for correctness with
+    custom evals: ``_process_trace_mapping`` resolves a missing attribute to
+    ``""`` for a ``custom_eval`` template *without raising*, so a lean-only first
+    pass would silently evaluate a heavy overflow field (e.g.
+    ``spans.first.llm.messages.transcript``) as empty and never retry. It is also
+    strictly cheaper on the heavy path (one lean + one heavy load, versus the
+    old lean + lean + heavy).
 
     Falls through to plain ``_process_trace_mapping`` when not in CH mode
     (PG path already has full columns).
@@ -2940,18 +2977,10 @@ def resolve_trace_mapping_lean_first(mapping: dict | None, trace, template_id) -
     if _read_source() != "clickhouse":
         return _process_trace_mapping(mapping, trace, template_id)
 
-    token = _heavy_span_ids.set(None)
+    heavy_ids = _heavy_span_ids_for_trace_mapping(mapping, trace)
+    token = _heavy_span_ids.set(heavy_ids or None)
     try:
         return _process_trace_mapping(mapping, trace, template_id)
-    except ValueError:
-        heavy_ids = _heavy_span_ids_for_trace_mapping(mapping, trace)
-        if not heavy_ids:
-            raise
-        retry_token = _heavy_span_ids.set(heavy_ids)
-        try:
-            return _process_trace_mapping(mapping, trace, template_id)
-        finally:
-            _heavy_span_ids.reset(retry_token)
     finally:
         _heavy_span_ids.reset(token)
 
@@ -2972,25 +3001,16 @@ def _heavy_span_ids_for_session_mapping(
     all paths (span ids are globally unique, so a flat set across traces is
     correct for the ``_heavy_span_ids`` contextvar).
 
-    Must be called with ``_heavy_span_ids`` set to ``None`` so the per-trace
-    span loads stay lean — the outer ``resolve_session_mapping_lean_first``
-    guarantees this ordering.
+    Loads each trace's spans lean (it never sets ``_heavy_span_ids``), and the
+    outer ``resolve_session_mapping_lean_first`` calls it before setting that
+    contextvar — so the id computation itself never triggers a heavy fetch.
     """
     if not mapping:
         return frozenset()
 
-    from tracer.services.clickhouse.v2.eval_loader import (
-        filter_observation_spans_by_trace,
-    )
-
-    traces = _session_traces_ch(trace_session)
-    n_traces = len(traces)
-
-    # Cache lean spans per trace index — avoid re-loading for multiple paths
-    # that reference different spans within the same trace.
-    _spans_cache: dict[int, list] = {}
-
-    heavy_ids: set[str] = set()
+    # Parse the heavy-referencing paths first; only touch CH if at least one
+    # ``traces.<sel_t>.spans.<sel_s>.<tail>`` value names a heavy span tail.
+    pairs: list[tuple[str, str]] = []
     for attribute in mapping.values():
         if not attribute or not attribute.startswith("traces."):
             continue
@@ -3007,7 +3027,23 @@ def _heavy_span_ids_for_session_mapping(
         tail = parts_s[1] if len(parts_s) > 1 else ""
         if not tail or not _is_heavy_span_tail(tail):
             continue
+        pairs.append((sel_t, sel_s))
+    if not pairs:
+        return frozenset()
 
+    from tracer.services.clickhouse.v2.eval_loader import (
+        filter_observation_spans_by_trace,
+    )
+
+    traces = _session_traces_ch(trace_session)
+    n_traces = len(traces)
+
+    # Cache lean spans per trace index — avoid re-loading for multiple paths
+    # that reference different spans within the same trace.
+    _spans_cache: dict[int, list] = {}
+
+    heavy_ids: set[str] = set()
+    for sel_t, sel_s in pairs:
         trace_idx = _selector_index(sel_t, n_traces)
         if trace_idx is None:
             continue
@@ -3032,18 +3068,21 @@ def _heavy_span_ids_for_session_mapping(
 def resolve_session_mapping_lean_first(
     mapping: dict | None, trace_session, template_id
 ) -> dict:
-    """Two-pass wrapper around ``_process_session_mapping`` for the CH eval path.
+    """Lean-first wrapper around ``_process_session_mapping`` for the CH eval path.
 
-    Pass 1 (lean): attempt mapping resolution with all spans loaded lean
-    (heavy JSON columns absent). This suffices for mappings that only touch
-    scalar span fields or trace-level fields.
+    Session twin of ``resolve_trace_mapping_lean_first``: computes the inner-span
+    ids the mapping's ``traces.<sel_t>.spans.<sel_s>.<tail>`` paths reference *up
+    front*, sets the contextvar so ``_resolve_trace_path`` heavy-fetches exactly
+    those spans, then resolves in a single pass. Up-front (rather than a
+    ``ValueError``-gated retry) is required for the same custom-eval reason as the
+    trace path — a missing attribute resolves to ``""`` without raising, so a
+    lean-only pass would silently evaluate a heavy overflow field as empty.
 
-    Pass 2 (heavy on miss): if pass 1 raises ``ValueError`` (required-key
-    miss), compute the exact span ids whose heavy columns the mapping
-    references via ``_heavy_span_ids_for_session_mapping``, set the contextvar
-    so ``_resolve_trace_path`` fetches those spans with full columns on retry,
-    then retry once. If no heavy span ids can be resolved, re-raise the
-    original error.
+    Wraps the whole resolution in a ``_session_traces_memo`` scope so the
+    session's ordered trace list is hydrated once and reused by both the
+    heavy-id computation and every ``traces.*`` lookup in ``_resolve_session_path``
+    — the session heavy branch previously re-ran ``session_trace_ids`` +
+    ``per_trace_root_span_start_times`` + a ``get_trace`` per trace several times.
 
     Falls through to plain ``_process_session_mapping`` when not in CH mode
     (PG path already has full columns).
@@ -3053,20 +3092,16 @@ def resolve_session_mapping_lean_first(
     if _read_source() != "clickhouse":
         return _process_session_mapping(mapping, trace_session, template_id)
 
-    token = _heavy_span_ids.set(None)
+    memo_token = _session_traces_memo.set({})
     try:
-        return _process_session_mapping(mapping, trace_session, template_id)
-    except ValueError:
         heavy_ids = _heavy_span_ids_for_session_mapping(mapping, trace_session)
-        if not heavy_ids:
-            raise
-        retry_token = _heavy_span_ids.set(heavy_ids)
+        token = _heavy_span_ids.set(heavy_ids or None)
         try:
             return _process_session_mapping(mapping, trace_session, template_id)
         finally:
-            _heavy_span_ids.reset(retry_token)
+            _heavy_span_ids.reset(token)
     finally:
-        _heavy_span_ids.reset(token)
+        _session_traces_memo.reset(memo_token)
 
 
 def _process_session_mapping(

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1,6 +1,7 @@
 import json
 import time
 import traceback
+from contextvars import ContextVar
 from dataclasses import asdict
 
 import structlog
@@ -2646,7 +2647,9 @@ def _resolve_trace_path(trace: Trace, path: str):
         if _read_source() == "clickhouse":
             spans = sorted(
                 filter_observation_spans_by_trace(
-                    str(trace.id), project_id=trace.project_id
+                    str(trace.id),
+                    project_id=trace.project_id,
+                    heavy_span_ids=_heavy_span_ids.get(),
                 ),
                 key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
             )
@@ -2655,6 +2658,50 @@ def _resolve_trace_path(trace: Trace, path: str):
         return _resolve_collection_path(spans, rest, _resolve_span_path)
 
     return _MISSING
+
+
+def _session_traces_ch(trace_session) -> list:
+    """Return the session's CH traces ordered by earliest root-span start_time.
+
+    Derives trace ids via ``session_trace_ids``, then loads and sorts the
+    hydrated Trace objects by ``(root_start is None, root_start, str(id))``,
+    matching the ordering ``list_traces_of_session`` and ``_resolve_session_path``
+    produce in CH mode. Factored out so ``_heavy_span_ids_for_session_mapping``
+    and ``_resolve_session_path`` share identical ordering without drift.
+
+    Only valid in CH mode — callers are responsible for the ``_read_source()``
+    guard.
+    """
+    from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2.eval_loader import get_trace
+
+    _project_id = getattr(trace_session, "project_id", None)
+    _session_id = getattr(trace_session, "id", None)
+    if _project_id is None or _session_id is None:
+        return []
+
+    with get_reader() as reader:
+        _trace_ids = reader.session_trace_ids(str(_project_id), str(_session_id))
+
+    with get_reader() as reader:
+        root_starts = reader.per_trace_root_span_start_times(
+            [str(t) for t in _trace_ids]
+        )
+        traces = []
+        for tid in _trace_ids:
+            try:
+                traces.append(
+                    get_trace(str(tid), reader=reader, project_id=_project_id)
+                )
+            except Trace.DoesNotExist:
+                continue
+
+    def _trace_order(t):
+        key = root_starts.get(str(t.id)) or t.created_at
+        return (key is None, key, str(t.id))
+
+    traces.sort(key=_trace_order)
+    return traces
 
 
 def _resolve_session_path(trace_session: TraceSession, path: str):
@@ -2681,59 +2728,38 @@ def _resolve_session_path(trace_session: TraceSession, path: str):
         # SDK stamps every trace in a run with the same instant) tie-break
         # by id alphabetically -- picking a "trace 0" the user never sees
         # at the top of the trace list.
-        from django.db.models import OuterRef, Subquery
-        from django.db.models.functions import Coalesce
-
-        from tracer.services.clickhouse.v2 import get_reader
-
-        # Derive the session's trace ids from CH spans, NOT the
-        # ``trace_session.traces`` reverse FK (Slice D, DESIGN §5 /
-        # PG_ORM_READ_MIGRATION): post-flip the ``Trace.session`` FK is ``None``
-        # for EVERY trace, so the reverse accessor returns EMPTY for ALL sessions
-        # (and ``trace_session`` here is the UNSAVED vehicle
-        # ``evaluate_trace_session_observe`` builds — it has no DB rows pointing at
-        # it at all). ``session_trace_ids`` is remap-aware on the input id AND each
-        # span's id, so a straddler yields its old∪new traces as one set and a
-        # net-new session yields its real set. The vehicle carries ``.id`` and
-        # ``.project_id`` (the eval config's project). Trace stays PG → ``id__in``.
-        _project_id = getattr(trace_session, "project_id", None)
-        _session_id = getattr(trace_session, "id", None)
-        if _project_id is None or _session_id is None:
-            _trace_ids: list[str] = []
-        else:
-            with get_reader() as reader:
-                _trace_ids = reader.session_trace_ids(
-                    str(_project_id), str(_session_id)
-                )
-
-        from tracer.services.clickhouse.v2.eval_loader import _read_source, get_trace
+        from tracer.services.clickhouse.v2.eval_loader import _read_source
 
         if _read_source() == "clickhouse":
-            # Order by earliest root-span start_time (parity with the PG branch
-            # and list_traces_of_session), falling back to created_at. One reader
-            # is shared across the root-start lookup and every get_trace hydration
-            # so the CH branch doesn't open (and leak) a reader per trace.
-            with get_reader() as reader:
-                root_starts = reader.per_trace_root_span_start_times(
-                    [str(t) for t in _trace_ids]
-                )
-                traces = []
-                for tid in _trace_ids:
-                    try:
-                        traces.append(
-                            get_trace(
-                                str(tid), reader=reader, project_id=_project_id
-                            )
-                        )
-                    except Trace.DoesNotExist:
-                        continue
-
-            def _trace_order(t):
-                key = root_starts.get(str(t.id)) or t.created_at
-                return (key is None, key, str(t.id))
-
-            traces.sort(key=_trace_order)
+            # Delegate to the shared CH helper so the ordering here and in
+            # ``_heavy_span_ids_for_session_mapping`` cannot drift.
+            traces = _session_traces_ch(trace_session)
         else:
+            from django.db.models import OuterRef, Subquery
+            from django.db.models.functions import Coalesce
+
+            from tracer.services.clickhouse.v2 import get_reader
+
+            # Derive the session's trace ids from CH spans, NOT the
+            # ``trace_session.traces`` reverse FK (Slice D, DESIGN §5 /
+            # PG_ORM_READ_MIGRATION): post-flip the ``Trace.session`` FK is ``None``
+            # for EVERY trace, so the reverse accessor returns EMPTY for ALL sessions
+            # (and ``trace_session`` here is the UNSAVED vehicle
+            # ``evaluate_trace_session_observe`` builds — it has no DB rows pointing at
+            # it at all). ``session_trace_ids`` is remap-aware on the input id AND each
+            # span's id, so a straddler yields its old∪new traces as one set and a
+            # net-new session yields its real set. The vehicle carries ``.id`` and
+            # ``.project_id`` (the eval config's project). Trace stays PG → ``id__in``.
+            _project_id = getattr(trace_session, "project_id", None)
+            _session_id = getattr(trace_session, "id", None)
+            if _project_id is None or _session_id is None:
+                _trace_ids: list[str] = []
+            else:
+                with get_reader() as reader:
+                    _trace_ids = reader.session_trace_ids(
+                        str(_project_id), str(_session_id)
+                    )
+
             root_start = (
                 # Earliest-root-span ordering stays a PG correlated Subquery; the
                 # trace SET is CH-derived above, the ORDERING remains PG.
@@ -2812,6 +2838,234 @@ def _process_trace_mapping(
         parsed[key] = value if isinstance(value, str) else json.dumps(value)
 
     return parsed
+
+
+# ── Lean-first trace-eval two-pass shim (A4: bound worker memory) ────────────────────────
+# Per-execution set of span ids whose heavy columns (attributes_extra /
+# span_events / resource_attrs) are needed for mapping resolution.  The
+# default (None) means "load all spans lean"; the shim sets it to the
+# minimal set on retry so only those spans pay the heavy fetch.
+_heavy_span_ids: ContextVar[frozenset[str] | None] = ContextVar(
+    "eval_trace_heavy_span_ids", default=None
+)
+
+
+def _is_heavy_span_tail(tail: str) -> bool:
+    """True iff ``tail`` is NOT a bare public field — i.e. lives in the
+    heavy JSON bag and won't be present in a lean span."""
+    return tail not in _SPAN_PUBLIC_FIELDS
+
+
+def _selector_index(sel: str, n: int) -> int | None:
+    """Resolve a collection selector token to a list index.
+
+    Returns None if the selector can't be resolved (empty list / out of
+    range / non-integer token that isn't ``first``/``last``).
+    """
+    if n == 0:
+        return None
+    if sel == "first":
+        return 0
+    if sel == "last":
+        return n - 1
+    try:
+        idx = int(sel)
+    except ValueError:
+        return None
+    if idx < 0 or idx >= n:
+        return None
+    return idx
+
+
+def _heavy_span_ids_for_trace_mapping(mapping: dict | None, trace) -> frozenset[str]:
+    """Return the span ids referenced by heavy-tail ``spans.<sel>.<tail>``
+    paths in *mapping*, resolved against *trace*'s lean spans.
+
+    Iterates the mapping values; any value of the form
+    ``spans.<sel>.<tail>`` where ``_is_heavy_span_tail(tail)`` selects a
+    span from the trace's sorted lean list and adds its id to the result.
+    """
+    if not mapping:
+        return frozenset()
+
+    from tracer.services.clickhouse.v2.eval_loader import (
+        filter_observation_spans_by_trace,
+    )
+
+    # Load the sorted lean spans once (same sort key as _resolve_trace_path).
+    spans = sorted(
+        filter_observation_spans_by_trace(str(trace.id), project_id=trace.project_id),
+        key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
+    )
+    n = len(spans)
+
+    heavy_ids: set[str] = set()
+    for attribute in mapping.values():
+        if not attribute or not attribute.startswith("spans."):
+            continue
+        # path: "spans.<sel>[.<tail>]"
+        remainder = attribute[len("spans.") :]
+        parts = remainder.split(".", 1)
+        sel = parts[0]
+        tail = parts[1] if len(parts) > 1 else ""
+        if not tail or not _is_heavy_span_tail(tail):
+            continue
+        idx = _selector_index(sel, n)
+        if idx is None:
+            continue
+        heavy_ids.add(str(spans[idx].id))
+
+    return frozenset(heavy_ids)
+
+
+def resolve_trace_mapping_lean_first(mapping: dict | None, trace, template_id) -> dict:
+    """Two-pass wrapper around ``_process_trace_mapping`` for the CH eval path.
+
+    Pass 1 (lean): attempt mapping resolution with all spans loaded lean
+    (heavy JSON columns absent). This suffices for mappings that only touch
+    ``input``/``output``/scalar span fields.
+
+    Pass 2 (heavy on miss): if pass 1 raises ``ValueError`` (required-key
+    miss), compute the exact span ids whose heavy columns the mapping
+    references, set the contextvar so ``_resolve_trace_path`` fetches those
+    spans with full columns on the second call, then retry once.  If no
+    heavy span ids can be resolved, re-raise the original error.
+
+    Falls through to plain ``_process_trace_mapping`` when not in CH mode
+    (PG path already has full columns).
+    """
+    from tracer.services.clickhouse.v2.eval_loader import _read_source
+
+    if _read_source() != "clickhouse":
+        return _process_trace_mapping(mapping, trace, template_id)
+
+    token = _heavy_span_ids.set(None)
+    try:
+        return _process_trace_mapping(mapping, trace, template_id)
+    except ValueError:
+        heavy_ids = _heavy_span_ids_for_trace_mapping(mapping, trace)
+        if not heavy_ids:
+            raise
+        retry_token = _heavy_span_ids.set(heavy_ids)
+        try:
+            return _process_trace_mapping(mapping, trace, template_id)
+        finally:
+            _heavy_span_ids.reset(retry_token)
+    finally:
+        _heavy_span_ids.reset(token)
+
+
+def _heavy_span_ids_for_session_mapping(
+    mapping: dict | None, trace_session
+) -> frozenset[str]:
+    """Return span ids referenced by heavy-tail ``traces.<sel_t>.spans.<sel_s>.<tail>``
+    paths in *mapping*, resolved against *trace_session*'s ordered lean traces.
+
+    Mirrors ``_heavy_span_ids_for_trace_mapping`` but one level up: iterates
+    mapping values, parses ``traces.<sel_t>.spans.<sel_s>.<tail>`` paths where
+    ``_is_heavy_span_tail(tail)`` is true, resolves ``<sel_t>`` against the
+    session's CH-ordered trace list (via ``_session_traces_ch`` — same ordering
+    as ``_resolve_session_path``), loads each selected trace's lean spans with
+    the same sort key ``_resolve_trace_path`` uses, then resolves ``<sel_s>``
+    via ``_selector_index`` to add that span's id. Returns the flat union across
+    all paths (span ids are globally unique, so a flat set across traces is
+    correct for the ``_heavy_span_ids`` contextvar).
+
+    Must be called with ``_heavy_span_ids`` set to ``None`` so the per-trace
+    span loads stay lean — the outer ``resolve_session_mapping_lean_first``
+    guarantees this ordering.
+    """
+    if not mapping:
+        return frozenset()
+
+    from tracer.services.clickhouse.v2.eval_loader import (
+        filter_observation_spans_by_trace,
+    )
+
+    traces = _session_traces_ch(trace_session)
+    n_traces = len(traces)
+
+    # Cache lean spans per trace index — avoid re-loading for multiple paths
+    # that reference different spans within the same trace.
+    _spans_cache: dict[int, list] = {}
+
+    heavy_ids: set[str] = set()
+    for attribute in mapping.values():
+        if not attribute or not attribute.startswith("traces."):
+            continue
+        # path: "traces.<sel_t>.spans.<sel_s>.<tail>"
+        remainder = attribute[len("traces.") :]
+        parts = remainder.split(".", 1)
+        sel_t = parts[0]
+        rest_t = parts[1] if len(parts) > 1 else ""
+        if not rest_t.startswith("spans."):
+            continue
+        spans_rest = rest_t[len("spans.") :]
+        parts_s = spans_rest.split(".", 1)
+        sel_s = parts_s[0]
+        tail = parts_s[1] if len(parts_s) > 1 else ""
+        if not tail or not _is_heavy_span_tail(tail):
+            continue
+
+        trace_idx = _selector_index(sel_t, n_traces)
+        if trace_idx is None:
+            continue
+        trace = traces[trace_idx]
+
+        if trace_idx not in _spans_cache:
+            _spans_cache[trace_idx] = sorted(
+                filter_observation_spans_by_trace(
+                    str(trace.id), project_id=trace.project_id
+                ),
+                key=lambda s: (s.start_time is None, s.start_time, str(s.id)),
+            )
+        spans = _spans_cache[trace_idx]
+        span_idx = _selector_index(sel_s, len(spans))
+        if span_idx is None:
+            continue
+        heavy_ids.add(str(spans[span_idx].id))
+
+    return frozenset(heavy_ids)
+
+
+def resolve_session_mapping_lean_first(
+    mapping: dict | None, trace_session, template_id
+) -> dict:
+    """Two-pass wrapper around ``_process_session_mapping`` for the CH eval path.
+
+    Pass 1 (lean): attempt mapping resolution with all spans loaded lean
+    (heavy JSON columns absent). This suffices for mappings that only touch
+    scalar span fields or trace-level fields.
+
+    Pass 2 (heavy on miss): if pass 1 raises ``ValueError`` (required-key
+    miss), compute the exact span ids whose heavy columns the mapping
+    references via ``_heavy_span_ids_for_session_mapping``, set the contextvar
+    so ``_resolve_trace_path`` fetches those spans with full columns on retry,
+    then retry once. If no heavy span ids can be resolved, re-raise the
+    original error.
+
+    Falls through to plain ``_process_session_mapping`` when not in CH mode
+    (PG path already has full columns).
+    """
+    from tracer.services.clickhouse.v2.eval_loader import _read_source
+
+    if _read_source() != "clickhouse":
+        return _process_session_mapping(mapping, trace_session, template_id)
+
+    token = _heavy_span_ids.set(None)
+    try:
+        return _process_session_mapping(mapping, trace_session, template_id)
+    except ValueError:
+        heavy_ids = _heavy_span_ids_for_session_mapping(mapping, trace_session)
+        if not heavy_ids:
+            raise
+        retry_token = _heavy_span_ids.set(heavy_ids)
+        try:
+            return _process_session_mapping(mapping, trace_session, template_id)
+        finally:
+            _heavy_span_ids.reset(retry_token)
+    finally:
+        _heavy_span_ids.reset(token)
 
 
 def _process_session_mapping(
@@ -3593,7 +3847,9 @@ def evaluate_trace_session_observe(
         resolve_session_fields,
     )
 
-    _fields = resolve_session_fields([session_id]).get(str(session_id))
+    _fields = resolve_session_fields(
+        [session_id], project_id=str(custom_eval_config.project_id)
+    ).get(str(session_id))
     if not _fields:
         # Parity with the old ``.get`` raising DoesNotExist: no live curated
         # session names this id (unknown / tombstoned / wrong project's id that

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -137,7 +137,9 @@ def _expand_session_group(analytics, canonical_session_id: str) -> tuple[str, ..
         "FROM trace_session_id_remap FINAL "
         "WHERE old_id = %(canonical_id)s"
     )
-    res = analytics.execute_ch_query(q, {"canonical_id": canonical_session_id}, timeout_ms=3000)
+    res = analytics.execute_ch_query(
+        q, {"canonical_id": canonical_session_id}, timeout_ms=3000
+    )
     ids = {canonical_session_id}
     for row in res.data or []:
         val = str(row.get("id") if isinstance(row, dict) else row[0])
@@ -203,6 +205,8 @@ def _resolve_ch_session_fields(request, trace_session_id):
         resolve_session_fields,
     )
 
+    # Workspace-scoped lookup — the project is discovered from the resolved
+    # fields below, so there's no single project_id to scope the read by here.
     session_fields = resolve_session_fields([trace_session_id]).get(
         str(trace_session_id)
     )
@@ -934,7 +938,9 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     resolve_session_fields,
                 )
 
-                session_fields = resolve_session_fields(session_ids)
+                session_fields = resolve_session_fields(
+                    session_ids, project_id=project_id
+                )
                 values = []
                 for row in result.data:
                     value = str(row["val"])
@@ -2217,6 +2223,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         end_user_map: dict = {}
         attr_result_data: list = []
         if session_ids_page:
+
             def _fetch_attrs():
                 try:
                     aq, ap = builder.build_span_attributes_query(session_ids_page)
@@ -2224,7 +2231,9 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         ar = analytics.execute_ch_query(aq, ap, timeout_ms=5000)
                         return ar.data
                 except Exception as exc:
-                    logger.warning("session_enrichment_attrs_failed", error=str(exc)[:200])
+                    logger.warning(
+                        "session_enrichment_attrs_failed", error=str(exc)[:200]
+                    )
                 return []
 
             # Submit the slow attrs query to a background thread (uses only
@@ -2239,13 +2248,17 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                         session_ids_page, _curated_project_ids
                     )
                 except Exception as exc:
-                    logger.warning("session_enrichment_names_failed", error=str(exc)[:200])
+                    logger.warning(
+                        "session_enrichment_names_failed", error=str(exc)[:200]
+                    )
                 try:
                     end_user_map = self._fetch_end_user_info(
                         session_ids_page, analytics, _curated_project_ids
                     )
                 except Exception as exc:
-                    logger.warning("session_enrichment_end_user_failed", error=str(exc)[:200])
+                    logger.warning(
+                        "session_enrichment_end_user_failed", error=str(exc)[:200]
+                    )
                 attr_result_data = f_attrs.result()
 
             for entry in formatted:


### PR DESCRIPTION
## Why

Large eval tasks were full-scanning ClickHouse. Every failed eval-task workflow on dev clustered into one root cause: `list_root_spans_by_trace_ids` ran an **unscoped** `spans FINAL` scan (no `project_id`) and ClickHouse killed it with **code 241 MEMORY_LIMIT_EXCEEDED**. An audit found the same class across the eval read path: unscoped scans, whole-trace loads of multi-MB voice payloads, and a per-entry N+1 in the drain.

This PR ships the **stress harness** + **Phase A** of the fix (A1–A5): make the eval-task engine's CH reads project-scoped, lean, and bounded, each proven by a `system.query_log`-backed budget test. B-phase (batch prefetch) is follow-up; its budgets ship here as `xfail` placeholders.

## What

- **A1–A3 — root-span lookup** (`span_reader.py`, `entries.py`): add `project_id` (qualified `spans.project_id` so the `toString(project_id)` SELECT alias can't shadow the sort-key column — otherwise pruning is silently inert), push per-trace dedupe into CH via `LIMIT 1 BY`, drop the Python dedupe, and chunk the FK-resolve IN-list into `_FK_CHUNK`(1000)-id queries.
- **A4 — lean-first span loading** (`eval_loader.py`, `eval.py`, `run_entry.py`): load trace/session spans lean by default; heavy-fetch only the spans a mapping references, via a `_heavy_span_ids` contextvar two-pass shim (pass-1 lean → on required-key miss compute referenced ids → retry once). Wired into **both** the TRACE and SESSION eval branches. Also reconstructs `span_attributes`/`span_events`/`resource_attrs` on CH-hydrated spans (previously returned `{}`).
- **A5 — session field scoping** (`trace_session_dict_reader.py`): optional `project_id` kwarg prunes `resolve_session_fields` on the `(project_id, trace_session_id)` sort-key prefix; threaded from the eval path.
- **attributes_extra fix**: drop the `toJSONString` wrapper — schema 013 made the column a plain `String`, so the wrapper double-encoded it and broke every `json.loads` consumer (see TH-6660).
- **Stress harness** (`tests/stress/`): loadgen-seeded `read_rows`/memory/query-count budgets over `system.query_log`, granule-floor-aware factors, and an opt-in `STRESS_REUSE_SEED` cache.

## Tests

**New** (`tests/stress/`): `test_root_lookup.py` (S4/S5/chunk), `test_trace_loading.py` (S6 + trace & session lean/heavy parity), `test_session_lookup.py` (S7). Budget baselines for B-phase (S10/S12) ship as strict `xfail`.

**Existing**: `test_ch25_typed_json_roundtrip.py` (+ cluster-RCA / root-trace / voice-consumer) run green against the `attributes_extra` change.

## Per-test scenarios

- **S4** — a project-scoped root lookup reads ~the target project's rows, not the whole table (two-project noise contrast).
- **S5** — `LIMIT 1 BY` picks the same roots as the fabricator manifest, incl. adversarial start-time ties.
- **chunk** — 2,500 ids → 3 CH queries, per-query cost flat.
- **S6** — loading one fat voice trace stays under a payload-independent Python-memory ceiling.
- **trace/session parity** — lean-first mapping resolution equals a wholesale-heavy load (result-field equality); both verified to go red if the heavy-retry is removed.
- **S7** — `resolve_session_fields` emits the `project_id` clause (captured from `system.query_log`) and `EXPLAIN` engages the PrimaryKey index; goes red if the clause is removed.

## Commands

```bash
cd fi-collector && go build -o bin/loadgen ./cmd/loadgen
cd ../futureagi && docker compose -f docker-compose.test.yml -p futureagi-test up -d
LOADGEN_BIN=$PWD/../fi-collector/bin/loadgen uv run pytest tests/stress/ -v
```

## Local-test steps

1. Build loadgen for the local arch (above).
2. Bring up the test stack (`docker-compose.test.yml`).
3. Run the stress suite. First run seeds (~3 min); `STRESS_REUSE_SEED=1` reuses the seed on repeat runs.

## Terminal output (evidence)

```
tests/stress/test_root_lookup.py ...                          [ 3 passed ]
tests/stress/test_trace_loading.py ...  (S6 + trace + session parity)
tests/stress/test_session_lookup.py .   (S7 EXPLAIN + query-log guard)
================== 16 passed, 2 xfailed in 41m (local, degraded CH) ==================
```
S4 before/after the scoping fix: **98,934 → 8,192 read_rows** (full-table → one granule). Seed reuse: **161.7s → 11.0s** on repeat runs.

## Architectural rationale

- **Every fix ships with a budget test that fails before it and passes after** — the S4 read_rows budget is what caught the `spans.project_id` alias shadow that made the initial scoping *look* correct but do nothing.
- **Reader vs engine split** across commits: CH reader-layer changes + harness (commit 1), eval-engine lean-first consumer (commit 2), session reader + callers (commit 3) — each a valid buildable state.
- **Discovered pre-existing bugs are ticketed, not silently folded**: TH-6657 (the `project_id` alias shadow, repo-wide across ~30 reader sites) and TH-6660 (the `toJSONString` double-encode). The reader-layer part of TH-6660 lands here because A4 depends on it; the broader consumer sweep is tracked on the ticket.

Follow-up: A6 guardrails + A7 requeue collapse (Phase A finish), then B1–B3 batch prefetch (Phase B — un-xfails S10/S12), then dev-GCP prod-scale gates.
