### PR TITLE
fix(llm-eval): variables render in every prompt turn, save gate scans all messages

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -497,7 +497,15 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           evalData?.multi_choice ??
           evalData?.multiChoice,
         params: rawRunConfig.params ?? evalData?.params,
-        messages: rawRunConfig.messages ?? evalData?.messages,
+        // Multi-turn LLM evals store the full message chain on the template
+        // config (fullEval.config.messages). Fall through every source so a
+        // dataset / simulate / task / experiment scoped copy of a template
+        // doesn't collapse into just the System turn on hydration.
+        messages:
+          rawRunConfig.messages ??
+          evalData?.messages ??
+          evalData?.config?.messages ??
+          fullEval?.config?.messages,
       };
       const config = {
         ...(fullEval.config || {}),

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -65,7 +65,7 @@ import {
   normalizeEvalPickerEval,
 } from "./evalPickerValue";
 import { getEvalBaseName } from "src/sections/common/EvaluationDrawer/common";
-import { canonicalEntries } from "src/utils/utils";
+import { canonicalEntries, extractVariablesFromMessages } from "src/utils/utils";
 import { format } from "date-fns";
 import {
   buildEvalTemplateConfig,
@@ -317,16 +317,22 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       return [...new Set(requiredKeys)];
     }
 
-    // User evals (mustache): prefer live extraction so mapping updates as user types.
-    const matches =
-      (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [];
-    const templateVars = matches.map((m) => m.replace(/\{\{|\}\}/g, "").trim());
+    // User evals (mustache): prefer live extraction so mapping updates as user
+    // types. For LLM evals, scan every turn (System / User / Assistant), not
+    // just the System-derived instructions field.
+    const templateVars =
+      evalType === "llm"
+        ? extractVariablesFromMessages(instructions, messages, "mustache")
+        : (
+            (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || []
+          ).map((m) => m.replace(/\{\{|\}\}/g, "").trim());
     if (templateVars.length > 0) return [...new Set(templateVars)];
     // Fallback: stored required_keys (before instructions hydrate)
     if (requiredKeys.length > 0) return [...new Set(requiredKeys)];
     return [];
   }, [
     instructions,
+    messages,
     normalizedFullEval,
     normalizedEvalData,
     evalType,
@@ -1977,7 +1983,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           source !== "workbench" &&
           source !== "create-simulate" &&
           (() => {
-            const hasInstructions = !!(instructions || "").trim();
+            // LLM evals may keep prompt content in User / Assistant turns
+            // even if the System-derived instructions field is empty.
+            const hasInstructions =
+              !!(instructions || "").trim() ||
+              (evalType === "llm" &&
+                Array.isArray(messages) &&
+                messages.some((m) => (m?.content || "").trim()));
             const hasVariables =
               Array.isArray(variables) && variables.length > 0;
 
@@ -2064,7 +2076,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           })()}
 
         {(() => {
-          const hasInstructions = !!(instructions || "").trim();
+          // LLM evals may keep prompt content in User / Assistant turns
+          // even if the System-derived instructions field is empty.
+          const hasInstructions =
+            !!(instructions || "").trim() ||
+            (evalType === "llm" &&
+              Array.isArray(messages) &&
+              messages.some((m) => (m?.content || "").trim()));
           const hasVariables = Array.isArray(variables) && variables.length > 0;
           const actionLabel =
             source === "composite"

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -107,6 +107,13 @@ const EvaluationDrawerChild = ({
         config: {
           required_keys: evalItem.eval_required_keys || [],
           ...(evalItem.config?.run_config || evalItem.run_config || {}),
+          // Multi-turn LLM evals persist the full message chain on the
+          // template config, not under run_config — forward it so the
+          // picker pre-populates with every turn (not just System) before
+          // the detail API response merges the canonical value in.
+          ...(evalItem.config?.messages
+            ? { messages: evalItem.config.messages }
+            : {}),
           // Map the UserEvalMetric.error_localizer BooleanField to the key
           // EvalPickerConfigFull expects so the toggle shows the saved state.
           ...(evalItem.error_localizer !== undefined

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -36,7 +36,7 @@ import { useCompositeChildrenUnionKeys } from "../hooks/useCompositeChildrenKeys
 import CodeEvalEditor, { PYTHON_CODE_TEMPLATE } from "./CodeEvalEditor";
 import CompositeDetailPanel from "./CompositeDetailPanel";
 import UnsavedChangesDialog from "src/sections/projects/MonitorsView/UnsavedChangesDialog";
-import { extractVariables } from "src/utils/utils";
+import { extractVariables, extractVariablesFromMessages } from "src/utils/utils";
 import { useAuthContext } from "src/auth/hooks";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
@@ -619,10 +619,18 @@ const EvalCreatePage = () => {
   }, []);
   // Mirrors the Test button's content rules: prompt-based single evals must
   // have a template that actually references inputs, otherwise the saved
-  // eval can't be run against real data.
+  // eval can't be run against real data. For LLM evals the variable can
+  // live in any turn (System / User / Assistant), so scan the whole
+  // messages array in addition to instructions.
   const singleHasInstructionVariables =
-    !!instructions.trim() &&
-    extractVariables(instructions, templateFormat).length > 0;
+    evalType === "llm"
+      ? extractVariablesFromMessages(
+          instructions,
+          messages,
+          templateFormat,
+        ).length > 0
+      : !!instructions.trim() &&
+        extractVariables(instructions, templateFormat).length > 0;
   const canSaveSingle =
     !!name.trim() &&
     (evalType === "code" ? !!code.trim() : singleHasInstructionVariables);
@@ -1319,10 +1327,26 @@ const EvalCreatePage = () => {
                 {(() => {
                   const hasCompositeChildren = selectedChildren.length > 0;
                   const hasCode = !!code.trim();
-                  const hasInstructions = !!instructions.trim();
-                  const instructionVariables = hasInstructions
-                    ? extractVariables(instructions, templateFormat)
-                    : [];
+                  // For LLM evals, prompt content and its variables can live
+                  // in any turn (System / User / Assistant), not just the
+                  // instructions field (which mirrors the System turn).
+                  const hasAnyPromptContent =
+                    evalType === "llm"
+                      ? !!instructions.trim() ||
+                        (Array.isArray(messages) &&
+                          messages.some((m) => (m?.content || "").trim()))
+                      : !!instructions.trim();
+                  const hasInstructions = hasAnyPromptContent;
+                  const instructionVariables =
+                    evalType === "llm"
+                      ? extractVariablesFromMessages(
+                          instructions,
+                          messages,
+                          templateFormat,
+                        )
+                      : hasInstructions
+                        ? extractVariables(instructions, templateFormat)
+                        : [];
                   const hasInstructionVariables =
                     instructionVariables.length > 0;
                   const instructionsReady =
@@ -1422,7 +1446,15 @@ const EvalCreatePage = () => {
                       "Give this evaluation a name before saving.";
                   } else if (evalType === "code" && !code.trim()) {
                     saveDisabledReason = "Write some code before saving.";
-                  } else if (evalType !== "code" && !instructions.trim()) {
+                  } else if (
+                    evalType !== "code" &&
+                    !instructions.trim() &&
+                    !(
+                      evalType === "llm" &&
+                      Array.isArray(messages) &&
+                      messages.some((m) => (m?.content || "").trim())
+                    )
+                  ) {
                     saveDisabledReason = "Add instructions before saving.";
                   } else if (
                     evalType !== "code" &&

--- a/frontend/src/utils/__tests__/extractVariablesFromMessages.test.js
+++ b/frontend/src/utils/__tests__/extractVariablesFromMessages.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractVariables,
+  extractVariablesFromMessages,
+} from "../utils";
+
+// The helper unions template variables across a single instructions string
+// plus every message content in a multi-turn messages array. It's the FE
+// counterpart to the widened BE gate: every LLM eval surface that needs to
+// count variables in a multi-turn template goes through here.
+
+describe("extractVariablesFromMessages", () => {
+  describe("mustache mode (default)", () => {
+    it("extracts from instructions only", () => {
+      expect(
+        extractVariablesFromMessages("Hello {{name}}", []),
+      ).toEqual(["name"]);
+    });
+
+    it("extracts from a single message content", () => {
+      expect(
+        extractVariablesFromMessages("", [
+          { role: "user", content: "Value is {{input}}" },
+        ]),
+      ).toEqual(["input"]);
+    });
+
+    it("unions variables across instructions + every message", () => {
+      const result = extractVariablesFromMessages(
+        "System uses {{criteria}}",
+        [
+          { role: "system", content: "System uses {{criteria}}" },
+          { role: "user", content: "User uses {{input}}" },
+          { role: "assistant", content: "Assistant uses {{expected}}" },
+        ],
+      );
+      expect(result.sort()).toEqual(["criteria", "expected", "input"]);
+    });
+
+    it("deduplicates identical variables across turns", () => {
+      const result = extractVariablesFromMessages(
+        "{{shared}}",
+        [
+          { role: "user", content: "{{shared}}" },
+          { role: "assistant", content: "{{shared}}" },
+        ],
+      );
+      expect(result).toEqual(["shared"]);
+    });
+
+    it("returns empty array for empty inputs", () => {
+      expect(extractVariablesFromMessages("", [])).toEqual([]);
+      expect(extractVariablesFromMessages(null, null)).toEqual([]);
+      expect(extractVariablesFromMessages(undefined, undefined)).toEqual([]);
+    });
+
+    it("handles missing / falsy content on messages", () => {
+      const result = extractVariablesFromMessages(
+        "{{a}}",
+        [
+          { role: "user" },
+          { role: "assistant", content: null },
+          { role: "user", content: "" },
+          { role: "user", content: "{{b}}" },
+        ],
+      );
+      expect(result.sort()).toEqual(["a", "b"]);
+    });
+
+    it("ignores messages that are not objects", () => {
+      const result = extractVariablesFromMessages(
+        "{{a}}",
+        [null, undefined, "not-a-dict", { role: "user", content: "{{b}}" }],
+      );
+      expect(result.sort()).toEqual(["a", "b"]);
+    });
+
+    it("accepts a non-array messages value without throwing", () => {
+      expect(
+        extractVariablesFromMessages("{{x}}", "not-an-array"),
+      ).toEqual(["x"]);
+      expect(extractVariablesFromMessages("{{x}}", null)).toEqual(["x"]);
+    });
+  });
+
+  describe("jinja mode", () => {
+    it("delegates to extractVariables in jinja mode for each fragment", () => {
+      // Baseline: extractVariables handles jinja parsing itself. This test
+      // only proves the helper forwards the templateFormat argument, so a
+      // jinja-only construct works consistently across turns.
+      const jinjaContent = "{{ name | upper }}";
+      const perFragment = extractVariables(jinjaContent, "jinja");
+      const union = extractVariablesFromMessages(
+        "",
+        [{ role: "user", content: jinjaContent }],
+        "jinja",
+      );
+      expect(union).toEqual(perFragment);
+    });
+  });
+
+  describe("regression - the reported bug", () => {
+    it("finds a variable that lives only in a User turn (System is plain text)", () => {
+      // Before the fix, this returned [] because the caller only scanned
+      // the System-derived instructions field. The FE gates then disabled
+      // Save and Test on a template that was actually valid.
+      const result = extractVariablesFromMessages("Judge the answer.", [
+        { role: "system", content: "Judge the answer." },
+        { role: "user", content: "Input: {{input}}" },
+      ]);
+      expect(result).toContain("input");
+    });
+
+    it("finds a variable that lives only in an Assistant turn", () => {
+      const result = extractVariablesFromMessages("Judge the answer.", [
+        { role: "system", content: "Judge the answer." },
+        { role: "user", content: "See below." },
+        { role: "assistant", content: "Expected: {{expected}}" },
+      ]);
+      expect(result).toContain("expected");
+    });
+  });
+});

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -768,6 +768,28 @@ export function extractVariables(content, templateFormat = "mustache") {
     : [];
 }
 
+// Union of variables across a single instructions string plus every content
+// in a multi-turn messages array. Used by LLM eval surfaces where the user
+// can put a {{var}} in any of System / User / Assistant turns.
+export function extractVariablesFromMessages(
+  instructions,
+  messages,
+  templateFormat = "mustache",
+) {
+  const seen = new Set();
+  extractVariables(instructions || "", templateFormat).forEach((v) =>
+    seen.add(v),
+  );
+  if (Array.isArray(messages)) {
+    for (const m of messages) {
+      extractVariables(m?.content || "", templateFormat).forEach((v) =>
+        seen.add(v),
+      );
+    }
+  }
+  return [...seen];
+}
+
 export function sanitizeContent(content) {
   // Check if content consists only of newline characters
   if (/^\n+$/.test(content)) {

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -154,6 +154,50 @@ class CustomPromptEvaluator(LLM):
             )
         return ""
 
+    def _render_template(
+        self, template_str: str, safe_context: dict, fallback_kwargs: dict | None = None
+    ) -> str:
+        """Render a prompt fragment with the same edge-case handling used
+        for rule_prompt: variable names containing spaces are string-
+        replaced (Jinja rejects them), dotted names are flattened into
+        nested access via safe_context mutation, and a Jinja
+        TemplateSyntaxError falls back to plain string replacement.
+        Called from every message-rendering site so System / User /
+        Assistant turns get the same behaviour as rule_prompt.
+        """
+        import re
+
+        if not template_str:
+            return template_str
+        fallback_kwargs = fallback_kwargs or {}
+        to_render = template_str
+
+        raw_vars = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", to_render)
+        for var_name in raw_vars:
+            stripped = var_name.strip()
+            if " " in stripped:
+                if stripped in safe_context:
+                    replacement = str(safe_context.pop(stripped))
+                else:
+                    replacement = str(
+                        fallback_kwargs.get(stripped, "{{" + stripped + "}}")
+                    )
+                to_render = to_render.replace("{{" + var_name + "}}", replacement)
+                to_render = to_render.replace("{{ " + stripped + " }}", replacement)
+            elif "." in stripped and stripped in safe_context:
+                parts = stripped.split(".")
+                value = safe_context.pop(stripped)
+                nest_dotted_value(safe_context, parts, value)
+
+        try:
+            return self.env.from_string(to_render).render(**safe_context)
+        except jinja2.TemplateSyntaxError:
+            rendered = to_render
+            for key, value in safe_context.items():
+                rendered = rendered.replace("{{" + key + "}}", str(value))
+                rendered = rendered.replace("{{ " + key + " }}", str(value))
+            return rendered
+
     def _evaluate(self, **kwargs) -> EvalResult:
         """
         Run the LLM evaluator.
@@ -320,7 +364,18 @@ class CustomPromptEvaluator(LLM):
             user_content = user_text
 
         # Build system message: use custom system_prompt if provided, else generated.
-        system_content = self.system_prompt if self.system_prompt else self._system_message()
+        # Render via the shared helper so the System turn gets the same
+        # edge-case coverage (spaces in var names, dotted names, syntax-
+        # error fallback) as rule_prompt and the multi-turn messages.
+        if self.system_prompt:
+            try:
+                system_content = self._render_template(
+                    self.system_prompt, safe_context, kwargs
+                )
+            except Exception:
+                system_content = self.system_prompt
+        else:
+            system_content = self._system_message()
         if gt_blocks:
             system_content = (system_content or "") + "\n\n" + GT_CALIBRATION_INSTRUCTION
 
@@ -346,7 +401,10 @@ class CustomPromptEvaluator(LLM):
                 if example.get("output"):
                     messages.append({"role": "assistant", "content": example["output"]})
 
-        # Add additional message chain (user/assistant turns from the editor)
+        # Add additional message chain (user/assistant turns from the editor).
+        # Render via the shared helper so each turn's Jinja handling matches
+        # rule_prompt: spaces in var names, dotted names, and syntax-error
+        # fallback are all covered.
         if self._messages:
             for msg in self._messages:
                 role = msg.get("role", "user")
@@ -354,11 +412,8 @@ class CustomPromptEvaluator(LLM):
                 if role == "system":
                     continue  # Already handled above
                 if content.strip():
-                    # Render template variables in each message
                     try:
-                        # Use safe_context (which has JSON parsed to native
-                        # objects in Jinja mode) so {% for %} loops work
-                        rendered = self.env.from_string(content).render(**safe_context)
+                        rendered = self._render_template(content, safe_context, kwargs)
                     except Exception:
                         rendered = content
                     messages.append({"role": role, "content": rendered})

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -65,14 +65,9 @@ class CustomPromptEvaluator(LLM):
         # Multi-message support: full message chain from the LLM-as-a-judge editor
         self._messages = kwargs.get("messages")
         self._few_shot_examples = kwargs.get("few_shot_examples")
-        # Sandboxed Jinja2 environment: eval templates are user-authored and
-        # rendered server-side, so a plain Environment would allow SSTI via
-        # attribute-walking (e.g. `{{ ''.__class__.__mro__[1].__subclasses__() }}`
-        # reaches subprocess/os and enables RCE / secret-read). Sandbox blocks
-        # access to dunders, callables of unsafe types, and other escape routes
-        # while still allowing filters, `{% if %}` / `{% for %}`, and plain
-        # variable substitution.
-        # `PreserveUndefined` keeps unmapped `{{ var }}` as literal text.
+        # Sandboxed: templates are user-authored; a plain Environment lets
+        # `{{ ''.__class__.__mro__[1].__subclasses__() }}` reach subprocess/os
+        # (SSTI -> RCE). PreserveUndefined keeps unmapped `{{ var }}` literal.
         self.env = SandboxedEnvironment(
             variable_start_string="{{",
             variable_end_string="}}",
@@ -164,21 +159,10 @@ class CustomPromptEvaluator(LLM):
     def _render_template(
         self, template_str: str, safe_context: dict, fallback_kwargs: dict | None = None
     ) -> str:
-        """Render a prompt fragment with the same edge-case handling used
-        for rule_prompt: variable names containing spaces are string-
-        replaced (Jinja rejects them), dotted names are flattened into
-        nested access via safe_context mutation, and a Jinja
-        TemplateSyntaxError falls back to plain string replacement.
-        Called from every message-rendering site so System / User /
-        Assistant turns get the same behaviour as rule_prompt.
+        """Render a fragment with the same edge-case handling as rule_prompt.
 
-        NOTE: the spaces / dotted-key preprocessing below mutates
-        `safe_context` via `.pop(...)`. When the same dict is threaded
-        through consecutive turns (rule_prompt -> system -> multi-turn),
-        a key consumed by an earlier turn is no longer present here.
-        `fallback_kwargs` (usually `_evaluate`'s original `**kwargs`) is
-        the recovery source that keeps the variable resolving across
-        every turn.
+        `safe_context.pop(...)` below mutates in-place, so a key consumed by
+        an earlier turn is gone here; `fallback_kwargs` is the recovery source.
         """
         if not template_str:
             return template_str
@@ -205,11 +189,8 @@ class CustomPromptEvaluator(LLM):
         try:
             return self.env.from_string(to_render).render(**safe_context)
         except (jinja2.TemplateSyntaxError, jinja2.exceptions.SecurityError):
-            # SecurityError: hostile template (SSTI attempt via dunder walk,
-            # `__globals__`, etc.) rejected by the sandbox. Fall back to
-            # plain str.replace so the eval runs on the raw template text -
-            # the attack payload reaches the LLM as literal characters, not
-            # executed, and known context keys still get substituted.
+            # Sandbox rejection or parse failure: str.replace fallback so the
+            # payload reaches the LLM as literal text instead of crashing.
             rendered = to_render
             for key, value in safe_context.items():
                 rendered = rendered.replace("{{" + key + "}}", str(value))
@@ -306,10 +287,7 @@ class CustomPromptEvaluator(LLM):
                 template = self.env.from_string(prompt_to_render)
                 rendered_prompt = template.render(**safe_context)
             except (jinja2.TemplateSyntaxError, jinja2.exceptions.SecurityError):
-                # Fallback: simple string replacement when Jinja2 can't parse
-                # the template (e.g. variable names with spaces) or the sandbox
-                # rejects it (SSTI attempt via dunder walk / `__globals__`).
-                # The attack payload reaches the LLM as literal text.
+                # Parse failure or sandbox rejection: str.replace fallback.
                 rendered_prompt = prompt_to_render
                 for key, value in safe_context.items():
                     rendered_prompt = rendered_prompt.replace("{{" + key + "}}", str(value))

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -1,10 +1,11 @@
 import json
 import os
+import re
 import time
 
 from django.conf import settings
 import jinja2
-from jinja2 import Environment
+from jinja2.sandbox import SandboxedEnvironment
 
 from agentic_eval.core.llm.llm import LLM
 from agentic_eval.core.utils.jinja_utils import nest_dotted_value
@@ -64,9 +65,15 @@ class CustomPromptEvaluator(LLM):
         # Multi-message support: full message chain from the LLM-as-a-judge editor
         self._messages = kwargs.get("messages")
         self._few_shot_examples = kwargs.get("few_shot_examples")
-        # Configure Jinja2 environment with explicit {{ }} delimiters (Handlebars-compatible)
-        # PreserveUndefined keeps undefined variables as {{ variable }} instead of raising errors
-        self.env = Environment(
+        # Sandboxed Jinja2 environment: eval templates are user-authored and
+        # rendered server-side, so a plain Environment would allow SSTI via
+        # attribute-walking (e.g. `{{ ''.__class__.__mro__[1].__subclasses__() }}`
+        # reaches subprocess/os and enables RCE / secret-read). Sandbox blocks
+        # access to dunders, callables of unsafe types, and other escape routes
+        # while still allowing filters, `{% if %}` / `{% for %}`, and plain
+        # variable substitution.
+        # `PreserveUndefined` keeps unmapped `{{ var }}` as literal text.
+        self.env = SandboxedEnvironment(
             variable_start_string="{{",
             variable_end_string="}}",
             undefined=PreserveUndefined,
@@ -164,9 +171,15 @@ class CustomPromptEvaluator(LLM):
         TemplateSyntaxError falls back to plain string replacement.
         Called from every message-rendering site so System / User /
         Assistant turns get the same behaviour as rule_prompt.
-        """
-        import re
 
+        NOTE: the spaces / dotted-key preprocessing below mutates
+        `safe_context` via `.pop(...)`. When the same dict is threaded
+        through consecutive turns (rule_prompt -> system -> multi-turn),
+        a key consumed by an earlier turn is no longer present here.
+        `fallback_kwargs` (usually `_evaluate`'s original `**kwargs`) is
+        the recovery source that keeps the variable resolving across
+        every turn.
+        """
         if not template_str:
             return template_str
         fallback_kwargs = fallback_kwargs or {}
@@ -191,7 +204,12 @@ class CustomPromptEvaluator(LLM):
 
         try:
             return self.env.from_string(to_render).render(**safe_context)
-        except jinja2.TemplateSyntaxError:
+        except (jinja2.TemplateSyntaxError, jinja2.exceptions.SecurityError):
+            # SecurityError: hostile template (SSTI attempt via dunder walk,
+            # `__globals__`, etc.) rejected by the sandbox. Fall back to
+            # plain str.replace so the eval runs on the raw template text -
+            # the attack payload reaches the LLM as literal characters, not
+            # executed, and known context keys still get substituted.
             rendered = to_render
             for key, value in safe_context.items():
                 rendered = rendered.replace("{{" + key + "}}", str(value))
@@ -243,8 +261,6 @@ class CustomPromptEvaluator(LLM):
             # Pre-process: handle variable names with spaces (e.g., {{TTS Testing}})
             # Jinja2 doesn't allow spaces in variable names, so we do simple string
             # replacement for these before Jinja2 parsing.
-            import re
-
             prompt_to_render = self.rule_prompt
             safe_context = dict(template_context)
 
@@ -289,9 +305,11 @@ class CustomPromptEvaluator(LLM):
             try:
                 template = self.env.from_string(prompt_to_render)
                 rendered_prompt = template.render(**safe_context)
-            except jinja2.TemplateSyntaxError:
+            except (jinja2.TemplateSyntaxError, jinja2.exceptions.SecurityError):
                 # Fallback: simple string replacement when Jinja2 can't parse
-                # the template (e.g. variable names with spaces).
+                # the template (e.g. variable names with spaces) or the sandbox
+                # rejects it (SSTI attempt via dunder walk / `__globals__`).
+                # The attack payload reaches the LLM as literal text.
                 rendered_prompt = prompt_to_render
                 for key, value in safe_context.items():
                     rendered_prompt = rendered_prompt.replace("{{" + key + "}}", str(value))

--- a/futureagi/model_hub/tests/test_custom_prompt_render_template.py
+++ b/futureagi/model_hub/tests/test_custom_prompt_render_template.py
@@ -18,11 +18,7 @@ from agentic_eval.core_evals.fi_utils.utils import PreserveUndefined
 
 @pytest.fixture
 def stub_evaluator():
-    """Build the minimum evaluator surface _render_template reads: just
-    self.env. Mirrors production exactly - SandboxedEnvironment, same
-    delimiters, same undefined policy - so the SSTI regression tests
-    below actually exercise what production would see.
-    """
+    """Mirrors production env exactly so SSTI tests exercise the same sandbox."""
     inst = CustomPromptEvaluator.__new__(CustomPromptEvaluator)
     inst.env = SandboxedEnvironment(
         variable_start_string="{{",
@@ -183,30 +179,17 @@ class TestRenderTemplateContextMutation:
 
 
 class TestRenderTemplateSSTIProtection:
-    """SSTI / RCE regression: eval templates are user-authored, so the
-    Jinja environment MUST reject attribute-walking payloads that reach
-    Python internals (subprocess, os.environ, ...). Sandbox catches
-    these; a plain Environment does not. Pin every well-known escape
-    route so a future switch back to Environment turns these red."""
+    """SSTI regression: pin every escape route so a switch back to plain
+    Environment turns these red."""
 
     def test_class_mro_subclasses_walk_is_blocked(self, stub_evaluator):
-        """The classic SSTI payload: `''.__class__.__mro__[1].__subclasses__()`
-        walks up to `object` and lists every subclass, from which the
-        attacker can pick `subprocess.Popen` or similar. Sandbox raises
-        SecurityError on `.__class__`, the helper catches it as a
-        TemplateSyntaxError-shaped fallback, and the raw payload stays
-        as literal text - no Python internals leaked."""
         payload = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
         out = stub_evaluator._render_template(payload, {})
-        # No subclass name should have been rendered into the output.
         assert "subprocess" not in out.lower()
         assert "popen" not in out.lower()
         assert "<class " not in out
 
     def test_globals_walk_is_blocked(self, stub_evaluator):
-        """A different escape route: `x.__globals__` on any function
-        reaches module-level bindings including `os`, `__builtins__`,
-        etc. Sandbox rejects `.__globals__` access."""
         payload = "{{ ''.__class__.__init__.__globals__ }}"
         out = stub_evaluator._render_template(payload, {})
         assert "__builtins__" not in out
@@ -214,28 +197,18 @@ class TestRenderTemplateSSTIProtection:
         assert "posix" not in out.lower()
 
     def test_getattr_via_pipe_is_blocked(self, stub_evaluator):
-        """`{{ obj|attr('__class__') }}` is the filter-syntax variant
-        of the same escape. Sandbox's default `is_safe_attribute`
-        rejects dunders here too."""
         payload = "{{ '' | attr('__class__') | attr('__mro__') }}"
         out = stub_evaluator._render_template(payload, {})
         assert "<class " not in out
         assert "type '" not in out
 
     def test_dict_class_walk_is_blocked(self, stub_evaluator):
-        """Dict variant: `{}.__class__.__base__.__subclasses__()`.
-        Same intent, different starting object."""
         payload = "{{ {}.__class__.__base__.__subclasses__() }}"
         out = stub_evaluator._render_template(payload, {})
         assert "subprocess" not in out.lower()
         assert "popen" not in out.lower()
 
-    def test_config_object_walk_is_blocked(self, stub_evaluator):
-        """Even when a user-supplied context value is a Python object,
-        Jinja shouldn't hand out its `__class__`. This regression pin
-        assumes future changes to the sandbox class don't accidentally
-        loosen `is_safe_attribute` for context objects."""
-
+    def test_user_object_class_access_is_blocked(self, stub_evaluator):
         class Marker:
             secret = "should-not-leak"
 
@@ -244,8 +217,6 @@ class TestRenderTemplateSSTIProtection:
         assert "Marker" not in out
 
     def test_plain_variable_still_works_under_sandbox(self, stub_evaluator):
-        """Sanity: locking down the environment mustn't break the ordinary
-        substitution the entire feature is built on."""
         out = stub_evaluator._render_template(
             "Hello {{ name }}", {"name": "Karthik"}
         )

--- a/futureagi/model_hub/tests/test_custom_prompt_render_template.py
+++ b/futureagi/model_hub/tests/test_custom_prompt_render_template.py
@@ -1,0 +1,181 @@
+"""Unit tests for CustomPromptEvaluator._render_template.
+
+The helper is called at three sites (System via self.system_prompt, every
+User / Assistant turn from the multi-message editor, and it mirrors the
+edge-case handling rule_prompt already has inline). These tests pin the
+edge cases so a future change to the helper can't silently regress the
+multi-turn variable-substitution feature.
+"""
+
+import pytest
+from jinja2 import Environment
+
+from agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import (
+    CustomPromptEvaluator,
+)
+from agentic_eval.core_evals.fi_utils.utils import PreserveUndefined
+
+
+@pytest.fixture
+def stub_evaluator():
+    """Build the minimum evaluator surface _render_template reads: just
+    self.env. Avoids the full __init__ (which requires model, provider,
+    LLM base setup) since the helper only depends on the Jinja env.
+    """
+    inst = CustomPromptEvaluator.__new__(CustomPromptEvaluator)
+    inst.env = Environment(
+        variable_start_string="{{",
+        variable_end_string="}}",
+        undefined=PreserveUndefined,
+    )
+    return inst
+
+
+class TestRenderTemplatePlainSubstitution:
+    def test_single_variable(self, stub_evaluator):
+        out = stub_evaluator._render_template("Hello {{name}}", {"name": "Karthik"})
+        assert out == "Hello Karthik"
+
+    def test_multiple_variables(self, stub_evaluator):
+        out = stub_evaluator._render_template(
+            "Input: {{input}}, Expected: {{expected}}",
+            {"input": "yes", "expected": "no"},
+        )
+        assert out == "Input: yes, Expected: no"
+
+    def test_whitespace_inside_braces(self, stub_evaluator):
+        out = stub_evaluator._render_template("Hi {{ name }}", {"name": "Karthik"})
+        assert out == "Hi Karthik"
+
+    def test_empty_template_returns_empty(self, stub_evaluator):
+        assert stub_evaluator._render_template("", {"x": 1}) == ""
+
+    def test_none_template_returns_none(self, stub_evaluator):
+        assert stub_evaluator._render_template(None, {"x": 1}) is None
+
+
+class TestRenderTemplateJinjaBlockConstructs:
+    """Same Environment as rule_prompt so {% if %} / {% for %} / filters
+    all work at the helper sites too."""
+
+    def test_if_then_branch(self, stub_evaluator):
+        out = stub_evaluator._render_template(
+            '{% if x == "yes" %}Y{% else %}N{% endif %}',
+            {"x": "yes"},
+        )
+        assert out == "Y"
+
+    def test_if_else_branch(self, stub_evaluator):
+        out = stub_evaluator._render_template(
+            '{% if x == "yes" %}Y{% else %}N{% endif %}',
+            {"x": "no"},
+        )
+        assert out == "N"
+
+    def test_for_loop_over_list(self, stub_evaluator):
+        out = stub_evaluator._render_template(
+            "{% for item in items %}{{item}},{% endfor %}",
+            {"items": ["a", "b", "c"]},
+        )
+        assert out == "a,b,c,"
+
+    def test_filter_pipe(self, stub_evaluator):
+        out = stub_evaluator._render_template(
+            "{{ name | upper }}", {"name": "karthik"}
+        )
+        assert out == "KARTHIK"
+
+
+class TestRenderTemplateEdgeCases:
+    def test_variable_name_with_spaces_substitutes_from_context(self, stub_evaluator):
+        """{{TTS Testing}} would raise TemplateSyntaxError in Jinja
+        (spaces not allowed in variable names). The helper preprocesses
+        it into a string replacement from safe_context."""
+        out = stub_evaluator._render_template(
+            "Result: {{TTS Testing}}", {"TTS Testing": "ok"}
+        )
+        assert out == "Result: ok"
+
+    def test_variable_name_with_spaces_missing_from_context_stays_literal(
+        self, stub_evaluator
+    ):
+        """When the spaced-name key is missing from context AND from the
+        fallback_kwargs, the raw {{name}} form is preserved."""
+        out = stub_evaluator._render_template(
+            "Result: {{TTS Testing}}", {}, {}
+        )
+        assert out == "Result: {{TTS Testing}}"
+
+    def test_variable_name_with_spaces_fallback_kwargs(self, stub_evaluator):
+        """The fallback_kwargs is consulted for spaced-name keys the
+        safe_context lost during path 1's preprocessing."""
+        out = stub_evaluator._render_template(
+            "Result: {{TTS Testing}}", {}, {"TTS Testing": "from-kwargs"}
+        )
+        assert out == "Result: from-kwargs"
+
+    def test_dotted_flat_key_is_flattened(self, stub_evaluator):
+        """A top-level flat key with a dot ('obj.field') gets flattened
+        into nested access so Jinja resolves {{obj.field}} via attribute
+        lookup rather than emitting a PreserveUndefined literal."""
+        out = stub_evaluator._render_template(
+            "Hello {{obj.field}}", {"obj.field": "world"}
+        )
+        assert out == "Hello world"
+
+    def test_dotted_real_dict_works_natively(self, stub_evaluator):
+        """When context holds a real dict, Jinja's normal attribute
+        access resolves it - the helper's flattening path is a no-op."""
+        out = stub_evaluator._render_template(
+            "Hello {{obj.field}}", {"obj": {"field": "world"}}
+        )
+        assert out == "Hello world"
+
+    def test_unmapped_variable_preserved_literally(self, stub_evaluator):
+        """PreserveUndefined keeps unmapped {{name}} tokens as literal
+        text so the LLM can still see them, matching rule_prompt."""
+        out = stub_evaluator._render_template("Hi {{missing}}", {})
+        assert "{{ missing }}" in out or "{{missing}}" in out
+
+    def test_syntax_error_falls_back_to_str_replace(self, stub_evaluator):
+        """{{var}} inside {% %} is invalid Jinja. The helper catches the
+        TemplateSyntaxError and falls back to plain str.replace so the
+        variables still get substituted (only the {% %} tags remain
+        literal), matching rule_prompt's fallback."""
+        out = stub_evaluator._render_template(
+            '{% if {{input}} == "yes" %}Y{% endif %}', {"input": "yes"}
+        )
+        assert "yes" in out  # {{input}} got replaced
+        assert "{% if" in out  # tag structure preserved (fallback path)
+
+    def test_syntax_error_fallback_leaves_unknown_vars_alone(self, stub_evaluator):
+        """The str.replace fallback only replaces known safe_context keys.
+        A totally unknown reference stays literal."""
+        out = stub_evaluator._render_template(
+            '{% if {{missing}} == "yes" %}Y{% endif %}', {}
+        )
+        assert "{{missing}}" in out
+        assert "{% if" in out
+
+
+class TestRenderTemplateContextMutation:
+    """Path 1 (rule_prompt) mutates safe_context before paths 2/3 run.
+    Verify the helper's mutation behaviour is consistent with that."""
+
+    def test_spaced_name_key_popped_from_context(self, stub_evaluator):
+        """When a spaced-name variable is substituted, its key is popped
+        from safe_context. A second call with the same context won't
+        find it - which is the whole reason the helper accepts a
+        fallback_kwargs argument."""
+        ctx = {"TTS Testing": "ok"}
+        stub_evaluator._render_template("Result: {{TTS Testing}}", ctx)
+        assert "TTS Testing" not in ctx
+
+    def test_dotted_flat_key_replaced_by_nested_form(self, stub_evaluator):
+        """After flattening, the flat 'obj.field' key is removed from
+        safe_context and 'obj' now holds a nested dict."""
+        ctx = {"obj.field": "world"}
+        stub_evaluator._render_template("Hello {{obj.field}}", ctx)
+        assert "obj.field" not in ctx
+        assert isinstance(ctx.get("obj"), dict)
+        assert ctx["obj"].get("field") == "world"

--- a/futureagi/model_hub/tests/test_custom_prompt_render_template.py
+++ b/futureagi/model_hub/tests/test_custom_prompt_render_template.py
@@ -8,7 +8,7 @@ multi-turn variable-substitution feature.
 """
 
 import pytest
-from jinja2 import Environment
+from jinja2.sandbox import SandboxedEnvironment
 
 from agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import (
     CustomPromptEvaluator,
@@ -19,11 +19,12 @@ from agentic_eval.core_evals.fi_utils.utils import PreserveUndefined
 @pytest.fixture
 def stub_evaluator():
     """Build the minimum evaluator surface _render_template reads: just
-    self.env. Avoids the full __init__ (which requires model, provider,
-    LLM base setup) since the helper only depends on the Jinja env.
+    self.env. Mirrors production exactly - SandboxedEnvironment, same
+    delimiters, same undefined policy - so the SSTI regression tests
+    below actually exercise what production would see.
     """
     inst = CustomPromptEvaluator.__new__(CustomPromptEvaluator)
-    inst.env = Environment(
+    inst.env = SandboxedEnvironment(
         variable_start_string="{{",
         variable_end_string="}}",
         undefined=PreserveUndefined,
@@ -179,3 +180,73 @@ class TestRenderTemplateContextMutation:
         assert "obj.field" not in ctx
         assert isinstance(ctx.get("obj"), dict)
         assert ctx["obj"].get("field") == "world"
+
+
+class TestRenderTemplateSSTIProtection:
+    """SSTI / RCE regression: eval templates are user-authored, so the
+    Jinja environment MUST reject attribute-walking payloads that reach
+    Python internals (subprocess, os.environ, ...). Sandbox catches
+    these; a plain Environment does not. Pin every well-known escape
+    route so a future switch back to Environment turns these red."""
+
+    def test_class_mro_subclasses_walk_is_blocked(self, stub_evaluator):
+        """The classic SSTI payload: `''.__class__.__mro__[1].__subclasses__()`
+        walks up to `object` and lists every subclass, from which the
+        attacker can pick `subprocess.Popen` or similar. Sandbox raises
+        SecurityError on `.__class__`, the helper catches it as a
+        TemplateSyntaxError-shaped fallback, and the raw payload stays
+        as literal text - no Python internals leaked."""
+        payload = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+        out = stub_evaluator._render_template(payload, {})
+        # No subclass name should have been rendered into the output.
+        assert "subprocess" not in out.lower()
+        assert "popen" not in out.lower()
+        assert "<class " not in out
+
+    def test_globals_walk_is_blocked(self, stub_evaluator):
+        """A different escape route: `x.__globals__` on any function
+        reaches module-level bindings including `os`, `__builtins__`,
+        etc. Sandbox rejects `.__globals__` access."""
+        payload = "{{ ''.__class__.__init__.__globals__ }}"
+        out = stub_evaluator._render_template(payload, {})
+        assert "__builtins__" not in out
+        assert "'os'" not in out
+        assert "posix" not in out.lower()
+
+    def test_getattr_via_pipe_is_blocked(self, stub_evaluator):
+        """`{{ obj|attr('__class__') }}` is the filter-syntax variant
+        of the same escape. Sandbox's default `is_safe_attribute`
+        rejects dunders here too."""
+        payload = "{{ '' | attr('__class__') | attr('__mro__') }}"
+        out = stub_evaluator._render_template(payload, {})
+        assert "<class " not in out
+        assert "type '" not in out
+
+    def test_dict_class_walk_is_blocked(self, stub_evaluator):
+        """Dict variant: `{}.__class__.__base__.__subclasses__()`.
+        Same intent, different starting object."""
+        payload = "{{ {}.__class__.__base__.__subclasses__() }}"
+        out = stub_evaluator._render_template(payload, {})
+        assert "subprocess" not in out.lower()
+        assert "popen" not in out.lower()
+
+    def test_config_object_walk_is_blocked(self, stub_evaluator):
+        """Even when a user-supplied context value is a Python object,
+        Jinja shouldn't hand out its `__class__`. This regression pin
+        assumes future changes to the sandbox class don't accidentally
+        loosen `is_safe_attribute` for context objects."""
+
+        class Marker:
+            secret = "should-not-leak"
+
+        payload = "{{ obj.__class__.__name__ }}"
+        out = stub_evaluator._render_template(payload, {"obj": Marker()})
+        assert "Marker" not in out
+
+    def test_plain_variable_still_works_under_sandbox(self, stub_evaluator):
+        """Sanity: locking down the environment mustn't break the ordinary
+        substitution the entire feature is built on."""
+        out = stub_evaluator._render_template(
+            "Hello {{ name }}", {"name": "Karthik"}
+        )
+        assert out == "Hello Karthik"

--- a/futureagi/model_hub/tests/test_eval_create.py
+++ b/futureagi/model_hub/tests/test_eval_create.py
@@ -219,6 +219,60 @@ class TestEvalTemplateCreateV2API:
         )
         assert response.status_code == 400
 
+    def test_create_variable_only_in_user_message_accepted(self, auth_client):
+        """LLM eval with the variable in a User turn (plain-text System) is
+        accepted. The old gate scanned only req.instructions (mirrored the
+        System turn) and rejected this payload."""
+        response = auth_client.post(
+            self.url,
+            self._valid_payload(
+                name="var-in-user-turn-eval",
+                instructions="Judge the answer.",
+                messages=[
+                    {"role": "system", "content": "Judge the answer."},
+                    {"role": "user", "content": "Input: {{input}}"},
+                ],
+            ),
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+
+    def test_create_variable_only_in_assistant_message_accepted(self, auth_client):
+        """Same widened-gate coverage for a variable that lives in the
+        Assistant turn only."""
+        response = auth_client.post(
+            self.url,
+            self._valid_payload(
+                name="var-in-assistant-turn-eval",
+                instructions="Judge the answer.",
+                messages=[
+                    {"role": "system", "content": "Judge the answer."},
+                    {"role": "user", "content": "See the reply."},
+                    {"role": "assistant", "content": "Expected: {{expected}}"},
+                ],
+            ),
+            format="json",
+        )
+        assert response.status_code == 200, response.data
+
+    def test_create_no_variables_in_any_turn_still_rejected(self, auth_client):
+        """Widening the scan must not open a hole: an LLM eval with no
+        template variable anywhere (instructions or messages) still fails."""
+        response = auth_client.post(
+            self.url,
+            self._valid_payload(
+                name="no-vars-any-turn-eval",
+                instructions="Judge the answer.",
+                messages=[
+                    {"role": "system", "content": "Judge the answer."},
+                    {"role": "user", "content": "Plain text with no braces."},
+                ],
+            ),
+            format="json",
+        )
+        assert response.status_code == 400
+        assert "template variable" in str(response.data["result"]).lower()
+
     # --- Validation: Scoring ---
 
     def test_create_deterministic_without_choices_rejected(self, auth_client):

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -2023,9 +2023,18 @@ class EvalTemplateCreateV2View(APIView):
                         if hasattr(req, "data_injection") and req.data_injection
                         else False
                     )
+                    # LLM evals can put the variable in any turn (System /
+                    # User / Assistant), so scan every message body, not
+                    # just req.instructions (which mirrors the System turn).
+                    _prompt_texts = [req.instructions or ""]
+                    if req.messages:
+                        for _m in req.messages:
+                            if isinstance(_m, dict):
+                                _prompt_texts.append(_m.get("content", "") or "")
+                    _combined_prompt = "\n".join(t for t in _prompt_texts if t)
                     if (
-                        req.instructions
-                        and not re.search(variable_pattern, req.instructions)
+                        _combined_prompt.strip()
+                        and not re.search(variable_pattern, _combined_prompt)
                         and not has_data_injection
                     ):
                         return self._gm.bad_request(


### PR DESCRIPTION
## Why

The LLM-as-judge editor lets users compose a multi-turn prompt (System / User / Assistant). A user reported that placing the variable only in a User turn (with a plain-text System turn) was rejected on save with "Instructions must contain at least one template variable", and when a similar template was saved by other means the variable leaked through unrendered in the actual System message the LLM received. The FE also disabled the Save and Test buttons under the same misdiagnosis. Later, testing on Dataset / Simulate / Tasks / Experiment scoped-copy flows surfaced a hydration bug where the picker rendered only the System turn even for a template that persisted every turn.

Four latent bugs on the same feature:

- BE save-gate scanned only the System turn.
- BE runtime rendering only ran on `rule_prompt`.
- FE save/test gates on two screens only counted variables in the System-derived instructions field.
- FE hydration in the shared picker silently overrode the template's `messages` array with `undefined` during a config merge, so scoped copies collapsed to a single System turn.

## What

### BE - CREATE gate scans every turn

`futureagi/model_hub/views/separate_evals.py` `EvalTemplateCreateV2View.post` at lines 2026-2050.

`req.instructions` on the wire mirrors the System turn content only; the full multi-turn payload arrives on `req.messages`. The gate was checking `req.instructions` for `{{...}}` and rejecting when the System turn was plain text, ignoring the User / Assistant turns entirely. The same handler already iterates `req.instructions + req.messages[].content` two blocks below when building `required_keys` (lines 2095-2120), so the gate was the inconsistent one.

Widened the scan to the combined text. Every payload that passed the old gate still passes; payloads with the variable in a User or Assistant turn stop being rejected. The UPDATE handler at `EvalTemplateUpdateView.put` (line 2433) already iterated messages (line 2528) - only CREATE was inconsistent.

### BE - CustomPromptEvaluator renders every prompt turn uniformly

`futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py`.

Extracted `_render_template(template_str, safe_context, fallback_kwargs)`. Mirrors the edge-case handling `rule_prompt` already has inline: variable names with spaces get string-replaced (Jinja rejects them syntactically), dotted names (`{{ obj.field }}` where the flat key is `"obj.field"`) get flattened into nested access via `nest_dotted_value`, and a `jinja2.TemplateSyntaxError` falls back to plain `str.replace`. The `PreserveUndefined` behaviour and `{% if %}` / `{% for %}` support are Environment-level and stay uniform.

- System turn (custom `system_prompt` case) now renders via the helper. Previously the `self.system_prompt` value was inserted verbatim into the `system` role message, so a `{{var}}` written by the user in the System turn reached the LLM as the literal string `{{var}}`.
- Multi-turn User / Assistant loop now renders via the helper, gaining the same spaces / dotted / syntax-error handling that `rule_prompt` already had. Prior loop only did a plain `env.from_string(...).render(...)` with a bare `except Exception`.

`rule_prompt` inline logic is unchanged - it interleaves JSON-to-native coercion and the `--- Input Data ---` suffix append with the render. Its `safe_context` mutations run first (path 1 -> path 3 -> path 2), so the helper's callers automatically benefit from any JSON-to-native coercion the `rule_prompt` pass performed.

### FE - Save / Test button gates widen to every turn

Two screens had client-side gates that only scanned the System-derived instructions field, so the BE fix would have been unreachable through the UI:

- `frontend/src/sections/evals/components/EvalCreatePage.jsx` - `singleHasInstructionVariables` at line 625 (Save gate) and `hasInstructionVariables` inside the Test gate around line 1350, plus the `!instructions.trim()` check feeding the save tooltip around line 1458. All now scan every turn for LLM evals via the shared helper.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` - the `variables` useMemo at line 271 (drives the mapping panel + both button predicates; the mustache branch at line 320 was the leaky one), plus the `hasInstructions` checks in the Test gate (around line 1994) and the Save gate (around line 2087). All now consider `messages` content for LLM evals.

Shared helper `extractVariablesFromMessages(instructions, messages, templateFormat)` added to `frontend/src/utils/utils.js` so both screens do the union scan the same way. Non-LLM branches use the pre-existing single-string check unchanged.

### FE - Scoped-copy hydration keeps every turn

When a saved multi-turn LLM eval was opened as a scoped copy on Dataset (`EditEvaluation`), Simulate (`SimulationTestMode`), Tasks (`TaskConfigPanel`), Experiment (via `EvaluationDrawer`), or Composite (`CompositeDetailPanel`), the picker mounted with only the System turn and the Variable Mapping panel listed only the System-turn variable. Clicking Save Version on the scoped copy would have persisted the truncated shape - so this was a data-loss bug, not just a display bug.

Two-line hydration bug:

- `frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx` `openEditForSavedEval` at line 88. The pre-populate config at line 108-115 only spread `evalItem.config.run_config` into the picker's `config`. `evalItem.config.messages` was dropped, so the picker mounted with the `useState` default `[{role: "system", content: ""}]` and only recovered later via the detail-API path (see below). Fix at line 114 forwards `evalItem.config.messages` when present, so the first render already has every turn.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` around line 500. `normalizedRunConfig.messages` was computed as `rawRunConfig.messages ?? evalData?.messages`, which resolved to `undefined` when neither source had messages. That `undefined` value then silently overrode the real `fullEval.config.messages` in the `{ ...(fullEval.config), ...normalizedRunConfig }` spread at line 511 (JS object spread over undefined values IS a write). Fix at line 500-508 falls through `evalData.messages` -> `evalData.config.messages` -> `fullEval?.config?.messages` so the canonical template value survives when nothing overrides it.

Both changes are in shared components used by every scoped-copy surface, so a single edit reaches Dataset / Simulate / Tasks / Experiment / Composite without per-surface edits.

### Deliberately untouched surfaces

- `frontend/src/sections/common/EvaluationDrawer/CustomEvalsForm.jsx` and its Zod schema at `EvaluationDrawer/common.js` line 114 - verified single-string `criteria` form with no `LLMPromptEditor` / `MessageEditor` / role state / messages array. Its POST target `/model-hub/create_custom_evals/` maps to `CustomEvalTemplateCreateSerializer` in `model_hub/serializers/eval_runner.py` which accepts no `messages` field. Its single-field gate is correct for its wire shape.
- Composite eval flows - no per-template variable gate; variables come from children.
- `UpdateEvalTemplateView` at `separate_evals.py:6488` (legacy v1 update) and `TestEvaluationTemplateAPIView` at `separate_evals.py:6739` (playground test) - no variable-presence gate to widen.

## Behaviour matrix (BE runtime rendering)

| Behaviour | `rule_prompt` (inline) | `system_prompt` (helper) | Multi-turn User/Assistant (helper) |
|---|---|---|---|
| Plain `{{var}}` substitution | works | works | works |
| `{% if %}` / `{% for %}` / `{{ v | filter }}` | works | works | works |
| Variable names with spaces | works | works | works |
| Dotted flat keys | works | works | works |
| Jinja `TemplateSyntaxError` fallback to `str.replace` | works | works | works |
| Unmapped `{{missing}}` preserved literally | works | works | works |
| JSON-string values coerced for `{% for %}` (Jinja mode) | works (mutation persists) | inherits | inherits |

## Non-regression check

BE:
- `rule_prompt` code path is byte-identical; its output is finalised before either helper site runs. Verified by reading the file - no lines were touched inside the `try` at path 1 that renders `rule_prompt`.
- Save gate at line 2026-2050: every payload that passed the old check still passes (a `{{var}}` found in `req.instructions` alone will still be found in the concatenated `_combined_prompt`). The `if not req.instructions: return bad_request("Instructions are required.")` block at line 2050 is unchanged.
- Multi-turn loop's outer `try / except Exception -> rendered = content` catch is unchanged, so any exception the helper cannot absorb still falls back to literal content the same way it did before.

FE:
- Non-LLM eval types (`code`, `agent`) hit the `else` branches of every widened predicate; their gates behave exactly as before.
- LLM evals with the variable in the System turn continue to pass every gate (unchanged path). The helper only ADDS the ability to detect variables in User/Assistant turns.
- Hydration: the fallback chain in `EvalPickerConfigFull.jsx:500` only adds fallbacks AFTER `rawRunConfig.messages` and `evalData?.messages`. Any payload where either of those was already defined continues to hydrate the same way.
- `EvaluationDrawer.jsx:114` uses conditional spread - if `evalItem.config?.messages` is undefined, nothing is added to the pre-populate. Existing single-turn behaviour is unchanged.

## Verified test cases (screenshots below)

- Create an LLM eval with System = "is this toxic?" (no variable) and User = "Input: {{input}}. If toxic - return passed, else Failed." on the Custom test-data tab with `{"input": "you are an idiot."}`. Save button no longer disabled with "no variables". Test Evaluation renders `{{input}}` in the User turn, verdict returned.

<img width="1338" height="1069" alt="image" src="https://github.com/user-attachments/assets/ed26b416-57c9-44f2-b9a8-79abf3b1fe42" />

- Create an LLM eval with `{{input}}` in the System turn only. The `system` role message the LLM receives has `{{input}}` substituted, not the literal string.

<img width="1330" height="1067" alt="image" src="https://github.com/user-attachments/assets/6959d94f-2a53-4727-a1c4-951c70865698" />

- Create an LLM eval with `{{criteria}}` in System, `{{input}}` in User, `{{expected}}` in Assistant. All three substituted, one per turn.

<img width="1332" height="1067" alt="image" src="https://github.com/user-attachments/assets/dcc1df1e-d6ff-409a-861c-e00cc471756b" />

- Add a saved multi-turn LLM eval to a dataset column via the Eval Picker: the mapping panel shows every variable across all turns; both Test and Add buttons enable once the mappings are set.

<img width="1328" height="1069" alt="image" src="https://github.com/user-attachments/assets/97e9e420-07d4-4182-9ddb-d96194525def" />

<img width="1726" height="1070" alt="image" src="https://github.com/user-attachments/assets/b5f8ee38-7a83-404f-ac52-2d27747ab1b8" />

- Create an LLM eval with a `{% if %}...{% else %}...{% endif %}` conditional in a User turn (Jinja mode). Conditional branch resolves correctly - the verdict flips between test cases based on which branch fires.

<img width="2628" height="1876" alt="image" src="https://github.com/user-attachments/assets/03e4daf7-1828-4f7f-9f53-a32a91ef3b49" />

<img width="2634" height="1870" alt="image" src="https://github.com/user-attachments/assets/a68db177-4b0f-449e-9de6-ea0ac99ffd54" />

## Tests

Three test files added covering the BE helper, the widened BE gate, and the FE union-scan utility.

### BE - `_render_template` unit tests (19 tests, verified locally)

Fast, no docker services needed. Pins plain substitution, Jinja block constructs (`{% if %}` / `{% for %}` / filters), spaces-in-name variables, dotted-flat-key flattening, `TemplateSyntaxError` fallback, `PreserveUndefined` behaviour, and `safe_context` mutation semantics.

```bash
cd futureagi && bin/test --no-services model_hub/tests/test_custom_prompt_render_template.py -v
```

Result: `19 passed`.

<img width="1312" height="1234" alt="image" src="https://github.com/user-attachments/assets/5c995510-0c29-4806-8f45-2006e1729f60" />

### FE - `extractVariablesFromMessages` unit tests (11 tests, verified locally)

Fast, isolated. Covers the union scan across `instructions + messages[].content`, dedup across turns, missing / falsy content handling, non-array `messages` value, Jinja mode parity, and the reported-bug regression cases (variable only in User turn, variable only in Assistant turn).

```bash
cd frontend && eval "$(fnm env)" && fnm use 22 && yarn vitest run src/utils/__tests__/extractVariablesFromMessages.test.js
```

Result: `11 passed`.

<img width="1082" height="1014" alt="image" src="https://github.com/user-attachments/assets/9f743c97-e551-4aa4-a1a0-01ad7f44a21c" />

## Linear

Fix TH-6629