### PR TITLE
fix(annotations): stop CH point-reads OOMing on voice spans; honest add toast (TH-6442)

### DIFF
--- a/frontend/src/sections/annotations/queues/items/__tests__/add-items-results.test.js
+++ b/frontend/src/sections/annotations/queues/items/__tests__/add-items-results.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeAddResults,
+  addResultToast,
+} from "../add-items-results";
+
+// Backend body is { status, result: { added, duplicates, errors } }; the axios
+// interceptor hands back the full response, so it lives at resp.data.result.
+const resp = (added, duplicates = 0, errors = []) => ({
+  data: { result: { added, duplicates, errors } },
+});
+
+describe("summarizeAddResults", () => {
+  it("accumulates added/duplicates/errors across batched responses", () => {
+    const s = summarizeAddResults([
+      resp(2, 1, ["Not found: observation_span=a"]),
+      resp(3, 0, []),
+      resp(0, 2, ["Not found: observation_span=b"]),
+    ]);
+    expect(s).toEqual({
+      added: 5,
+      duplicates: 3,
+      errors: [
+        "Not found: observation_span=a",
+        "Not found: observation_span=b",
+      ],
+    });
+  });
+
+  it("tolerates an unwrapped body and missing fields", () => {
+    expect(summarizeAddResults([{ data: { added: 4 } }, {}])).toEqual({
+      added: 4,
+      duplicates: 0,
+      errors: [],
+    });
+  });
+});
+
+describe("addResultToast", () => {
+  it("reports a real success", () => {
+    expect(addResultToast({ added: 3, duplicates: 0, errors: [] })).toEqual({
+      message: "3 items added to queue",
+      variant: "success",
+    });
+  });
+
+  it("warns when some succeeded but others were skipped", () => {
+    const t = addResultToast({ added: 2, duplicates: 1, errors: ["x"] });
+    expect(t.variant).toBe("warning");
+    expect(t.message).toContain("2 items added");
+    expect(t.message).toContain("1 already in queue");
+  });
+
+  // The core regression: added:0 with errors used to render a green
+  // "3 items added" (the requested count). It must now be an error toast.
+  it("surfaces an error instead of a false success when nothing was added", () => {
+    const t = addResultToast({
+      added: 0,
+      duplicates: 0,
+      errors: ["Not found: observation_span=a"],
+    });
+    expect(t.variant).toBe("error");
+    expect(t.message).toContain("Not found: observation_span=a");
+  });
+
+  it("reports all-duplicates as info, not success", () => {
+    const t = addResultToast({ added: 0, duplicates: 3, errors: [] });
+    expect(t.variant).toBe("info");
+    expect(t.message).toContain("already in the queue");
+  });
+
+  it("never claims success when added is 0", () => {
+    expect(
+      addResultToast({ added: 0, duplicates: 0, errors: [] }).variant,
+    ).not.toBe("success");
+  });
+});

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -90,6 +90,7 @@ import {
 } from "./add-items-session-utils";
 import "src/styles/clean-data-table.css";
 import { fetchRootSpans } from "src/api/project/llm-tracing";
+import { summarizeAddResults, addResultToast } from "./add-items-results";
 
 const panelFilterToApi = (panel) =>
   panelFilterToApiBase(panel, { includeMeta: true });
@@ -551,8 +552,6 @@ export default function AddItemsDialog({ open, onClose, queueId, queue }) {
           sourceType === "call_execution");
 
       if (isBackendFilterMode) {
-        const totalCount =
-          selectAllInfo.totalCount - selectAllInfo.excludedIds.size;
         addItems(
           {
             queueId,
@@ -568,11 +567,11 @@ export default function AddItemsDialog({ open, onClose, queueId, queue }) {
             },
           },
           {
-            onSuccess: () => {
-              enqueueSnackbar(
-                `${totalCount} item${totalCount !== 1 ? "s" : ""} added to queue`,
-                { variant: "success" },
+            onSuccess: (resp) => {
+              const { message, variant } = addResultToast(
+                summarizeAddResults([resp]),
               );
+              enqueueSnackbar(message, { variant });
               resetSelection();
               setSourceType(null);
               onClose();
@@ -674,18 +673,21 @@ export default function AddItemsDialog({ open, onClose, queueId, queue }) {
       const BATCH_SIZE = 500;
       const totalCount = itemsToAdd.length;
       if (totalCount > BATCH_SIZE) {
+        const responses = [];
         for (let i = 0; i < totalCount; i += BATCH_SIZE) {
           const batch = itemsToAdd.slice(i, i + BATCH_SIZE);
-          await new Promise((resolve, reject) => {
+          const resp = await new Promise((resolve, reject) => {
             addItems(
               { queueId, items: batch },
               { onSuccess: resolve, onError: reject },
             );
           });
+          responses.push(resp);
         }
-        enqueueSnackbar(`${totalCount} items added to queue`, {
-          variant: "success",
-        });
+        const { message, variant } = addResultToast(
+          summarizeAddResults(responses),
+        );
+        enqueueSnackbar(message, { variant });
         resetSelection();
         setSourceType(null);
         onClose();
@@ -693,11 +695,11 @@ export default function AddItemsDialog({ open, onClose, queueId, queue }) {
         addItems(
           { queueId, items: itemsToAdd },
           {
-            onSuccess: () => {
-              enqueueSnackbar(
-                `${totalCount} item${totalCount !== 1 ? "s" : ""} added to queue`,
-                { variant: "success" },
+            onSuccess: (resp) => {
+              const { message, variant } = addResultToast(
+                summarizeAddResults([resp]),
               );
+              enqueueSnackbar(message, { variant });
               resetSelection();
               setSourceType(null);
               onClose();

--- a/frontend/src/sections/annotations/queues/items/add-items-results.js
+++ b/frontend/src/sections/annotations/queues/items/add-items-results.js
@@ -1,0 +1,44 @@
+// Add-result toast helpers — report what the BACKEND actually did, not what we
+// asked for. The `add-items` endpoint returns 200 with `{added, duplicates,
+// errors}` even when it adds nothing (a source that fails to resolve, is
+// unavailable, or is already queued), so echoing the requested count reported
+// phantom successes. Read the real counts, accumulate across batched requests,
+// and on `added === 0` surface the reason instead of a false "N added".
+
+export function summarizeAddResults(responses) {
+  return responses.reduce(
+    (acc, resp) => {
+      const r = resp?.data?.result || resp?.data || {};
+      acc.added += r.added || 0;
+      acc.duplicates += r.duplicates || 0;
+      if (Array.isArray(r.errors)) acc.errors.push(...r.errors);
+      return acc;
+    },
+    { added: 0, duplicates: 0, errors: [] },
+  );
+}
+
+export function addResultToast({ added, duplicates, errors }) {
+  const n = (c) => `${c} item${c !== 1 ? "s" : ""}`;
+  if (added > 0) {
+    const extra = [];
+    if (duplicates) extra.push(`${duplicates} already in queue`);
+    if (errors.length) extra.push(`${n(errors.length)} skipped`);
+    return {
+      message: extra.length
+        ? `${n(added)} added · ${extra.join(" · ")}`
+        : `${n(added)} added to queue`,
+      variant: errors.length ? "warning" : "success",
+    };
+  }
+  if (errors.length) {
+    return { message: `Couldn't add ${n(errors.length)}: ${errors[0]}`, variant: "error" };
+  }
+  if (duplicates) {
+    return {
+      message: `${n(duplicates)} already in the queue — nothing to add`,
+      variant: "info",
+    };
+  }
+  return { message: "No items were added", variant: "warning" };
+}

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1292,7 +1292,7 @@ def _span_notes_target_for_queue_item(item):
     #       deleted=False).filter(Q(parent_span_id__isnull=True) |
     #       Q(parent_span_id=""))
     #   conversation root → start_time root → None
-    # CHSpanReader.list_by_trace already filters is_deleted=0 and orders by
+    # CHSpanReader.list_by_trace drops deleted rows (via FINAL) and orders by
     # (start_time, id). Root spans have empty parent_span_id (CH stores it
     # as a non-nullable String — see schema 001), so we filter in Python.
     from tracer.services.clickhouse.v2 import get_reader

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -463,8 +463,16 @@ class CHSpanReader:
         """Equivalent to ObservationSpan.objects.get(id=span_id), returns None
         if absent (matches the pattern most callers wrap with try/except).
 
-        ``project_id`` (optional) scopes to one tenant; omit for prior behavior."""
-        where = ["id = %(span_id)s", "is_deleted = 0"]
+        ``project_id`` (optional) scopes to one tenant; omit for prior behavior.
+
+        ``id`` is below the primary-key prefix, so a bare ``id =`` read prunes
+        only via the ``idx_id`` bloom — which CH 25.3 disables under FINAL by
+        default. Without it a point-read does a full in-order merge over every
+        part and the fat ``attributes_extra`` granule buffers blow the memory
+        limit on a wide (voice) span. Re-enable skip indexes; ``id`` is stable
+        across a row's ReplacingMergeTree versions, so the bloom is safe."""
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        where = ["id = %(span_id)s"]
         params: dict[str, Any] = {"span_id": span_id}
         if project_id:
             where.append("project_id = %(pid)s")
@@ -473,6 +481,7 @@ class CHSpanReader:
             f"SELECT {_SELECT_SQL} FROM spans FINAL "
             f"WHERE {' AND '.join(where)} LIMIT 1",
             parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         if not rows:
             return None
@@ -536,8 +545,14 @@ class CHSpanReader:
         Returned in start_time, id order so the eval runner's trace-walking
         logic sees spans in a deterministic chronological order. ``project_id``
         (optional) scopes the read to one tenant; omit for prior behavior.
+
+        ``trace_id`` sits below the primary-key prefix, so this prunes only via
+        the ``idx_trace_id`` bloom — off under FINAL on CH 25.3 by default,
+        leaving a full merge that OOMs on a fat (voice) trace's spans. Re-enable
+        skip indexes (``trace_id`` is a stable sorting-key column, so safe).
         """
-        where = ["trace_id = %(trace_id)s", "is_deleted = 0"]
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        where = ["trace_id = %(trace_id)s"]
         params: dict[str, Any] = {"trace_id": trace_id}
         if project_id:
             where.append("project_id = %(pid)s")
@@ -547,6 +562,7 @@ class CHSpanReader:
             f"WHERE {' AND '.join(where)} "
             "ORDER BY start_time, id",
             parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
 
@@ -556,12 +572,15 @@ class CHSpanReader:
         Single-row CH read — replaces listing every span in a trace just to
         find the first LLM/TOOL/etc. span.
         """
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS. Prunes via
+        # the ``idx_trace_id`` bloom (off under FINAL without the setting).
         rows = self._client.query(
             f"SELECT {_LEAN_SELECT_SQL} FROM spans FINAL "
-            "WHERE trace_id = %(trace_id)s AND is_deleted = 0 "
+            "WHERE trace_id = %(trace_id)s "
             "AND lower(observation_type) = %(otype)s "
             "ORDER BY start_time, id LIMIT 1",
             parameters={"trace_id": trace_id, "otype": observation_type.lower()},
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return _row_to_chspan(rows[0]) if rows else None
 
@@ -719,11 +738,15 @@ class CHSpanReader:
         ordered by start_time, id. `limit` caps the result for display-list paths
         (e.g. `[:20]` slices that the AI-tools `get_span` does)."""
         lim_clause = f" LIMIT {int(limit)}" if limit else ""
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS. Prunes via
+        # the ``idx_parent_span_id`` bloom (off under FINAL without the setting);
+        # parent_span_id is stable across versions, so the bloom is safe.
         rows = self._client.query(
             f"SELECT {_SELECT_SQL} FROM spans FINAL "
-            "WHERE parent_span_id = %(parent)s AND is_deleted = 0 "
+            "WHERE parent_span_id = %(parent)s "
             f"ORDER BY start_time, id{lim_clause}",
             parameters={"parent": parent_span_id},
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
 
@@ -749,7 +772,10 @@ class CHSpanReader:
         if not span_ids:
             return []
         select = _SELECT_SQL if include_heavy else _LEAN_SELECT_SQL
-        where = ["id IN %(ids)s", "is_deleted = 0"]
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS. Prunes via
+        # the ``idx_id`` bloom (off under FINAL without the setting); a fat
+        # (voice) span in the batch otherwise OOMs the full in-order merge.
+        where = ["id IN %(ids)s"]
         params: dict[str, Any] = {"ids": tuple(span_ids)}
         if project_id:
             where.append("project_id = %(pid)s")
@@ -760,6 +786,7 @@ class CHSpanReader:
         rows = self._client.query(
             f"SELECT {select} FROM spans FINAL WHERE {' AND '.join(where)} ORDER BY id",
             parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [_row_to_chspan(r) for r in rows]
 

--- a/futureagi/tracer/tests/test_span_reader_point_read_oom.py
+++ b/futureagi/tracer/tests/test_span_reader_point_read_oom.py
@@ -1,0 +1,87 @@
+"""Point / trace / id CH span reads must not OOM under FINAL (TH-6442).
+
+TH-6515 (PR #1373) gave the multi-trace batch reads
+(``list_by_trace_ids`` / ``roots_by_trace_ids``) the ``use_skip_indexes_if_final``
+setting and dropped the redundant ``is_deleted = 0`` predicate, but left the
+single-row / point-read siblings that back the annotation add + trace-detail
+render paths. Each does ``SELECT <fat cols incl attributes_extra> FROM spans
+FINAL WHERE <id | trace_id | parent_span_id> = X`` — pruning only via a bloom
+skip index, which CH 25.3 disables under FINAL by default. Without the setting
+the read does a full in-order merge over every part and OOMs (code 241) on a
+wide (voice) span whose ``attributes_extra`` carries a whole raw log.
+
+A 9 GiB OOM can't be reproduced in test-CH, so — mirroring
+``test_scan_project_scoped_read.py`` — these pin the two levers that prevent the
+unpruned merge: the skip-index setting is on, and the ``is_deleted = 0``
+predicate (which, alongside the setting, arms the ``is_deleted`` minmax-index
+resurrection bug — the 2-arg ReplacingMergeTree drops deleted rows under FINAL
+anyway) is off. A revert of either fails here rather than as a prod OOM.
+"""
+
+from tracer.services.clickhouse.v2.span_reader import CHSpanReader
+
+
+class _RecordingClient:
+    """Captures the SQL + settings of the last query; returns no rows."""
+
+    def __init__(self):
+        self.sql = None
+        self.params = None
+        self.settings = None
+
+    def query(self, sql, parameters=None, settings=None):
+        self.sql = sql
+        self.params = parameters or {}
+        self.settings = settings or {}
+
+        class _Result:
+            result_rows = []
+
+        return _Result()
+
+
+def _reader_with(client) -> CHSpanReader:
+    # Bypass __init__ (opens a real CH connection) and inject the fake.
+    reader = CHSpanReader.__new__(CHSpanReader)
+    reader._client = client
+    return reader
+
+
+def _assert_final_oom_safe(client, key_predicate):
+    # skip indexes re-enabled under FINAL (else a full-table merge -> OOM)
+    assert client.settings.get("use_skip_indexes_if_final") == 1
+    # the is_deleted=0 predicate is dropped (redundant under FINAL; keeping it
+    # alongside the setting arms the is_deleted minmax resurrection bug)
+    assert "is_deleted = 0" not in client.sql
+    # still prunes on the stable bloom-indexed column
+    assert key_predicate in client.sql
+
+
+def test_get_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).get("span-1")
+    _assert_final_oom_safe(client, "id = %(span_id)s")
+
+
+def test_list_by_trace_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).list_by_trace("trace-1")
+    _assert_final_oom_safe(client, "trace_id = %(trace_id)s")
+
+
+def test_first_span_by_type_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).first_span_by_type("trace-1", "llm")
+    _assert_final_oom_safe(client, "trace_id = %(trace_id)s")
+
+
+def test_list_by_parent_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).list_by_parent("parent-1")
+    _assert_final_oom_safe(client, "parent_span_id = %(parent)s")
+
+
+def test_list_by_ids_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).list_by_ids(["s1", "s2"])
+    _assert_final_oom_safe(client, "id IN %(ids)s")


### PR DESCRIPTION
## What & why

Fixes **TH-6442** (Urgent): on the annotation "Add items" picker, selecting **voice/collector spans** (or traces) returned a green "N items added to queue" toast but **added nothing**; opening a voice item for annotation **500'd**. Reproduced end-to-end on dev (org `780a1c67`, project "debt collection1").

**Root cause — the same ClickHouse OOM as TH-6515, on the point-read siblings that PR missed.** A "Vapi Call" span carries its whole raw log in the fat `attributes_extra` / `resource_attrs` / `span_events` columns. Reads shaped `SELECT <fat cols> FROM spans FINAL WHERE <id | trace_id | parent_span_id> = X` prune **only** via a bloom skip-index — and **CH 25.3 disables skip indexes under FINAL by default**, so each does a full in-order merge over every part and blows the 9.31 GiB per-query limit (**code 241**). TH-6515 gave `use_skip_indexes_if_final` to the multi-trace batch reads but left the single-row / point-reads.

It surfaced three ways (all one root cause):

| Symptom | Path | Reader method | Failure |
|---|---|---|---|
| "spans not getting added" | add-items → resolve | `reader.get()` | OOM **swallowed** → `added:0`; toast showed the requested count, not `added` |
| voice items render as *deleted* | queue list → `_batch_ch_spans` | `reader.list_by_ids()` | OOM **swallowed** → `{}` |
| **annotate-detail 500** | open item | `reader.list_by_trace()` | OOM **propagates** |

The "only one org fails" report was this: that org holds the fat voice data; other orgs have normal spans that don't OOM.

## Changes

**Backend — `tracer/services/clickhouse/v2/span_reader.py`** (mirror the TH-6515 pattern exactly): add `settings=_FINAL_SKIP_INDEX_SETTINGS` and drop the now-redundant `is_deleted = 0` on the 5 point-reads on the annotation add + trace-detail render surface: `get`, `list_by_trace`, `first_span_by_type`, `list_by_parent`, `list_by_ids`. Each keys on a **stable** bloom-indexed column (`id` / `trace_id` / `parent_span_id`), so the skip index is safe under non-exact FINAL; and the 2-arg `ReplacingMergeTree(_version, is_deleted)` already drops deleted rows under FINAL, so results are **byte-identical** (keeping `is_deleted=0` alongside the setting would arm the `is_deleted` minmax resurrection bug). Also unstales one comment my change invalidated (`annotation_queues.py`).

**Frontend — `add-items-dialog.jsx` + new `add-items-results.js`**: report the backend's `{added, duplicates, errors}` instead of the requested count. The endpoint returns **200 even when it adds nothing** (a source that fails to resolve, is unavailable, or is already queued), so the old toast reported phantom successes — this is why the OOM was invisible. Now `added === 0` surfaces the reason, and counts accumulate across batched requests.

## Deliberately out of scope (follow-ups, not this bug)

- **`list_by_session`**: its predicate is `coalesce(remap_join.old_id, spans.trace_session_id) = X` — not bloom-mappable, so the setting wouldn't prune it; and it's **eval-only** (not the annotation/trace-detail surface). Latent voice-session OOM on the eval path — ticket separately.
- **Lean `list_by_trace` overload**: `_span_notes_target_for_queue_item` reads the whole trace heavy just to pick the root span; post-prune it's bounded (not an OOM), but a lean variant would be cheaper on long voice traces. Perf follow-up.
- The **FE toast honesty** fix incidentally makes *any* silent add-drop (dup / unavailable) visible, not just the OOM case.

## Tests

- `tracer/tests/test_span_reader_point_read_oom.py` — 5 recording-client tests, one per fixed method: asserts `use_skip_indexes_if_final == 1`, `"is_deleted = 0"` absent, and the correct key predicate. Mirrors `test_scan_project_scoped_read.py` (a 9 GiB OOM can't be reproduced in test-CH; the SQL/settings invariant is the contract). **Fail-on-revert verified.**
- `add-items-results.test.js` — toast summarizer, incl. the core regression: `added:0` → error/info toast, never a phantom success.
- `test_scan_project_scoped_read.py` (TH-6515) + `test_ch25_annotation_collector_source_resolution.py` (22) still green.

Two independent architect reviews (pre-implementation + final, opus): **GO** — byte-identical results, no caller regressions (eval/dataset callers get the same rows), complete coverage of the add + render heavy-read surface.
