### PR TITLE
fix(annotations): land on items list after labelling the last queue item (TH-6445)

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -1040,6 +1040,8 @@ export default function AnnotateWorkspaceView() {
                   );
                   if (nextItem?.id) {
                     dispatch({ type: "push", id: nextItem.id });
+                  } else {
+                    navigate(`/dashboard/annotations/queues/${queueId}`);
                   }
                 },
                 onError: () => {
@@ -1063,6 +1065,7 @@ export default function AnnotateWorkspaceView() {
       requiresReview,
       includeCompletedItems,
       enqueueSnackbar,
+      navigate,
     ],
   );
 


### PR DESCRIPTION
## Bug
In the annotation queue **annotate** workspace, labelling the **last** item left the user stranded on the annotate page — after "Submit & Next" there was no next item to load, so nothing happened. The user had to manually click "Back to Queue" to get out. Expected: finishing the last item should land you back on the queue's items-list page.

## Changes
`annotations/queues/annotate/annotate-workspace-view.jsx` — in `handleSubmitAndNext`, added the missing `else` branch: when the complete response has no `nextItem`, navigate to the queue items list instead of doing nothing. `navigate` added to the `useCallback` deps.

```jsx
if (nextItem?.id) {
  dispatch({ type: "push", id: nextItem.id });
} else {
  navigate(`/dashboard/annotations/queues/${queueId}`);
}
```

## Why
The review flow (`handleReviewSuccess`) and the "Back to Queue" button already navigate to `/dashboard/annotations/queues/${queueId}` on the no-next-item case. The plain label/submit path was simply missing that `else`, so it was the one way to finish a queue that left you stuck. This brings it in line with the existing, correct pattern — same route, same behavior.

## Blast radius
Only the **Submit & Next** path changes (button + keyboard submit both route through `handleSubmitAndNext`). Review approve/reject, Back, and the prev/next arrows already behaved correctly and are untouched. Skip on the last item intentionally clears to an empty state (pre-existing, out of scope).

## Test-case scenarios
- Label the last remaining item → Submit & Next → lands on the queue items-list page.
- Keyboard submit on the last item → same navigation (routes through the same handler).
- Non-last item → Submit & Next still advances to the next item as before.
- Review mode / Back button → unchanged.

## How to reproduce (before fix)
1. Open an annotation queue with a single remaining (or the last) item → Annotate.
2. Fill the required labels and click **Submit & Next**.
3. Before: nothing happens, you're stuck on the annotate page. After: you land on the queue items-list page.

## Commands
- `yarn lint` — clean on the changed file.

## Videos / screenshots

### BEFORE FIX

https://github.com/user-attachments/assets/e766c39a-9338-4d32-b91d-75bd865b5681

### AFTER FIX

https://github.com/user-attachments/assets/d2afb3c9-adcc-4476-9f56-9c33f8d5f6a6

