### PR TITLE
fix(observe): custom-column picker reads span attributes, not eval attributes

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1267,6 +1267,22 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     enabled: Boolean(observeId),
   });
 
+  // The "Add custom columns" dialog promotes span attributes to table columns,
+  // so its picker must be sourced from span-attribute-keys — not the
+  // eval-attributes list above, which is empty for any project without
+  // configured evals and left the picker blank even when spans carry
+  // attributes (issue #1380).
+  const { data: spanAttributes } = useQuery({
+    queryKey: ["span-attribute-keys", observeId],
+    queryFn: () =>
+      axios.get(endpoints.project.spanAttributeKeys(), {
+        params: { project_id: observeId },
+      }),
+    select: (data) => data.data?.result || [],
+    enabled: Boolean(observeId),
+  });
+
+  // Shared node click handler for agent graph/path views
   const handleAgentNodeClick = useCallback(
     (nodeData) => {
       if (!nodeData?.type) return;
@@ -4547,7 +4563,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             <CustomColumnDialog
               open={openCustomColumn}
               onClose={() => setOpenCustomColumn(false)}
-              attributes={attributes}
+              attributes={spanAttributes}
               existingColumns={columns[columnKey]}
               onAddColumns={handleAddCustomColumns}
               onRemoveColumns={handleRemoveCustomColumns}

--- a/frontend/src/sections/projects/LLMTracing/__tests__/CustomColumnDialog.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/CustomColumnDialog.test.jsx
@@ -83,3 +83,51 @@ describe("CustomColumnDialog — TH-4139", () => {
     expect(onAddColumns).not.toHaveBeenCalled();
   });
 });
+
+describe("CustomColumnDialog — span attribute source (#1380)", () => {
+  // The picker is sourced from the span-attribute-keys endpoint, which returns
+  // objects shaped { key, type, count } — not the plain strings the earlier
+  // tests cover, and not the eval-attributes list it was wired to before the
+  // fix. Feeding that object shape must render each attribute's key as a
+  // selectable row.
+  it("renders span-attribute-keys objects ({ key, type, count }) as selectable columns", () => {
+    renderWithProviders(
+      <CustomColumnDialog
+        open
+        onClose={vi.fn()}
+        attributes={[
+          { key: "llm.model_name", type: "string", count: 12 },
+          { key: "test_string", type: "string", count: 3 },
+        ]}
+        existingColumns={[]}
+        onAddColumns={vi.fn()}
+        onRemoveColumns={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("llm.model_name")).toBeInTheDocument();
+    expect(screen.getByText("test_string")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the source returns no attributes", () => {
+    // Before #1380 the dialog was fed the eval-attributes list, which was
+    // empty for any project without configured evals — leaving the picker
+    // permanently blank. An empty source must surface the explicit empty
+    // state, and (post-fix) a project whose spans carry attributes no longer
+    // hits this path.
+    renderWithProviders(
+      <CustomColumnDialog
+        open
+        onClose={vi.fn()}
+        attributes={[]}
+        existingColumns={[]}
+        onAddColumns={vi.fn()}
+        onRemoveColumns={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("No attributes found for this project"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -934,16 +934,20 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const [openCustomColumn, setOpenCustomColumn] = useState(false);
   const pendingCustomColumnsRef = useRef([]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
+  // The custom column dialog promotes span attributes to columns, so it must
+  // be sourced from span-attribute-keys — not the eval-attributes list, which
+  // is empty for any project without configured evals and left the picker
+  // blank even when spans carry attributes (issue #1380).
+  const { data: spanAttributes } = useQuery({
+    queryKey: ["span-attribute-keys", observeId],
     queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: { filters: JSON.stringify({ project_id: observeId }) },
+      axios.get(endpoints.project.spanAttributeKeys(), {
+        params: { project_id: observeId },
       }),
-    select: (data) => data.data?.result,
+    select: (data) => data.data?.result || [],
     enabled: Boolean(observeId),
   });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
+  const attributes = useMemo(() => spanAttributes || [], [spanAttributes]);
 
   const handleAddCustomColumns = useCallback((newCols) => {
     setSessionColumns((prev) => {

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -111,18 +111,20 @@ const UserTraceTabV2 = ({ dateFilter }) => {
     return base;
   }, [userId, dateFilter]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", projectId],
+  // The custom column dialog promotes span attributes to columns, so it must
+  // be sourced from span-attribute-keys — not the eval-attributes list, which
+  // is empty for any project without configured evals and left the picker
+  // blank even when spans carry attributes (issue #1380).
+  const { data: spanAttributes } = useQuery({
+    queryKey: ["span-attribute-keys", projectId],
     queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: projectId }),
-        },
+      axios.get(endpoints.project.spanAttributeKeys(), {
+        params: { project_id: projectId },
       }),
-    select: (data) => data.data?.result,
+    select: (data) => data.data?.result || [],
     enabled: Boolean(projectId),
   });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
+  const attributes = useMemo(() => spanAttributes || [], [spanAttributes]);
 
   const handleAddCustomColumns = (newCols) => {
     setColumns((prev) => {

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -189,19 +189,20 @@ const UsersView = ({
     }
   }, [gridApi, autoSizeAllCols]);
 
-  // --- Eval attributes for custom column dialog (mirrors LLMTracingView) ---
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
+  // --- Span attributes for the custom column dialog (mirrors LLMTracingView).
+  // The dialog promotes span attributes to columns, so it must be sourced from
+  // span-attribute-keys — not the eval-attributes list, which is empty for any
+  // project without configured evals and left the picker blank (issue #1380).
+  const { data: spanAttributes } = useQuery({
+    queryKey: ["span-attribute-keys", observeId],
     queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: observeId }),
-        },
+      axios.get(endpoints.project.spanAttributeKeys(), {
+        params: { project_id: observeId },
       }),
-    select: (data) => data.data?.result,
+    select: (data) => data.data?.result || [],
     enabled: Boolean(observeId),
   });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
+  const attributes = useMemo(() => spanAttributes || [], [spanAttributes]);
 
   // --- Observe header refresh wiring (TH-4023) ---
   // Expose a refresh callback to the shared ObserveHeader so the refresh


### PR DESCRIPTION
## Summary

The **Add custom columns** dialog (Observe → LLM Tracing → Display, and the same picker in the Users, User-trace and Sessions views) lets you promote span attributes into table columns. Its subtitle reads *"Select span attributes to show as columns"* — but it was sourced from the **eval-attributes** endpoint, which only returns attributes referenced by evals.

On any project that has traces but no configured evals, that list comes back empty, so the picker shows *"No attributes found for this project"* and you can never add a custom column — even though the spans clearly carry attributes.

## Fix

Point the dialog at `span-attribute-keys` (the endpoint the Attributes view already uses), across all four views that render it:

- **LLMTracingView** — added a dedicated span-attributes query for the dialog. The existing eval-attributes query still feeds the filter panel, so filter behaviour is unchanged.
- **UsersView**, **UserTraceTabV2**, **Sessions-view** — the attribute state feeds only the dialog, so the source is swapped directly.

The dialog already handles the `{ key, type, count }` shape this endpoint returns (`attrKey` reads `.key`), so no dialog changes were needed.

## Scope note

In `LLMTracingView` the eval-attributes query still backs the trace/span filter panel's "Attribute" options. That may warrant the same treatment, but it's out of scope here and left untouched.

## Testing

- Added dialog tests for the `{ key, type, count }` span-attribute shape and the empty-source state.
- All affected view suites pass (194 tests).

Closes #1380