### PR TITLE
chore(evals): tune choice_scores mapping on the tone system eval

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 15
+SYSTEM_EVALS_VERSION = 16
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/agent/tone.yaml
+++ b/futureagi/model_hub/system_evals/agent/tone.yaml
@@ -44,11 +44,11 @@ config:
   rule_prompt: "You are evaluating the emotional tone of the output and classifying it using the provided tone labels.\n\n## Criteria\n\n1. Label coverage: Every distinct emotional state present in the text should receive its corresponding label, none missed.\n   - Pass: \"I'm thrilled but worried about the timeline\" -> joy + fear (both selected).\n   - Fail: Selects only joy when fear is also clearly expressed.\n\n2. Label precision: Each selected label must be grounded in specific textual evidence; no false positives.\n   - Pass: Selects 'anger' only when hostile language or angry markers are present.\n   - Fail: Assigns 'joy' to polite professional language that has no emotional markers.\n\n3. Surface vs. intent: Sarcastic or ironic content is classified by its underlying emotion, not its literal wording.\n   - Pass: \"Oh great, another delay...\" -> annoyance (not joy).\n   - Fail: Labels sarcastic praise as 'joy' based on the surface words.\n\n## Anti-bias Rules\n\n- DO NOT classify polite professional language as 'joy' or 'love'; assign 'neutral' when no emotional markers are present.\n- Short or ambiguous content should receive fewer labels; avoid over-classification.\n- Multiple labels are appropriate only when multiple distinct emotional states are simultaneously expressed.\n\n## Scoring\n\nSelect every label that reflects a distinct emotional state present in the content. Available labels: neutral, joy, love, fear, surprise, sadness, anger, annoyance, confusion. Assign 'neutral' for calm, factual content with no emotional markers. Only select labels grounded in specific textual evidence.\n\n## Inputs\n\n<output>{{output}}</output>"
 choice_scores:
   neutral: 1.0
-  joy: 1.0
-  love: 0.75
+  joy: 0.75
+  love: 0.5
   surprise: 0.5
-  confusion: 0.25
-  sadness: 0.25
+  sadness: 0.5
+  confusion: 0.5
   fear: 0.25
   annoyance: 0.0
   anger: 0.0

--- a/futureagi/model_hub/system_evals/agent/tone.yaml
+++ b/futureagi/model_hub/system_evals/agent/tone.yaml
@@ -42,3 +42,13 @@ config:
     - ARRAY
     - DATETIME
   rule_prompt: "You are evaluating the emotional tone of the output and classifying it using the provided tone labels.\n\n## Criteria\n\n1. Label coverage: Every distinct emotional state present in the text should receive its corresponding label, none missed.\n   - Pass: \"I'm thrilled but worried about the timeline\" -> joy + fear (both selected).\n   - Fail: Selects only joy when fear is also clearly expressed.\n\n2. Label precision: Each selected label must be grounded in specific textual evidence; no false positives.\n   - Pass: Selects 'anger' only when hostile language or angry markers are present.\n   - Fail: Assigns 'joy' to polite professional language that has no emotional markers.\n\n3. Surface vs. intent: Sarcastic or ironic content is classified by its underlying emotion, not its literal wording.\n   - Pass: \"Oh great, another delay...\" -> annoyance (not joy).\n   - Fail: Labels sarcastic praise as 'joy' based on the surface words.\n\n## Anti-bias Rules\n\n- DO NOT classify polite professional language as 'joy' or 'love'; assign 'neutral' when no emotional markers are present.\n- Short or ambiguous content should receive fewer labels; avoid over-classification.\n- Multiple labels are appropriate only when multiple distinct emotional states are simultaneously expressed.\n\n## Scoring\n\nSelect every label that reflects a distinct emotional state present in the content. Available labels: neutral, joy, love, fear, surprise, sadness, anger, annoyance, confusion. Assign 'neutral' for calm, factual content with no emotional markers. Only select labels grounded in specific textual evidence.\n\n## Inputs\n\n<output>{{output}}</output>"
+choice_scores:
+  neutral: 1.0
+  joy: 1.0
+  love: 0.75
+  surprise: 0.5
+  confusion: 0.25
+  sadness: 0.25
+  fear: 0.25
+  annoyance: 0.0
+  anger: 0.0


### PR DESCRIPTION
## Why

Small tune-up on the `agent/tone.yaml` system eval. Attaches an explicit `choice_scores` mapping so the tone classifier's output can gate a numeric score for downstream pass/fail thresholds, instead of relying on the runtime default.

## What changed

Two files.

**`futureagi/model_hub/system_evals/agent/tone.yaml`**: adds a `choice_scores` block. Values in `[0.0, 1.0]`, matching the range every other deterministic eval uses. `multi_choice: true` is preserved; runtime aggregates the mapped scores across selected labels.

```yaml
choice_scores:
  neutral: 1.0
  joy: 0.75
  love: 0.5
  surprise: 0.5
  sadness: 0.5
  confusion: 0.5
  fear: 0.25
  annoyance: 0.0
  anger: 0.0
```

**`futureagi/model_hub/management/commands/seed_system_evals.py`**: bumps `SYSTEM_EVALS_VERSION` from `15` to `16` so the seeder re-applies the tone update on next deploy instead of short-circuiting on the cached version.

The eval itself is a classifier (labels every emotion present in the output), so a numeric score for tone is inherently a product decision layered on top. This mapping picks a support-agent default: `neutral` is the target (matches the eval's own anti-bias rule for professional / factual output), `anger` and `annoyance` are the two labels the criteria treats as clear negatives, `joy` sits just below `neutral` (positive but not target), and the ambiguous middle band (`love`, `surprise`, `sadness`, `confusion`) sits at `0.5` because each of these fires in both good contexts (empathy, polite clarification-seeking) and off-brand contexts (over-intimate, agent-clueless) and the eval cannot distinguish the two flavours.

Reviewer / product can nudge specific values before merge; the range and structure are the load-bearing bits.

## Verification

```
python3 -c "import yaml; d = yaml.safe_load(open('futureagi/model_hub/system_evals/agent/tone.yaml')); assert set(d['choice_scores'].keys()) == set(d['choices']); assert all(0.0 <= float(v) <= 1.0 for v in d['choice_scores'].values()); print('OK')"
```

Parses cleanly, keys match `choices`, values in `[0.0, 1.0]`. Seeder version bumped so the deploy re-syncs.

## Linear

Closes TH-6677
