### PR TITLE
feat(datasets): allow limiting row count when importing from existing dataset

### DIFF
--- a/frontend/src/sections/develop/AddRowDrawer/ExistingDatasetModal.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/ExistingDatasetModal.jsx
@@ -171,6 +171,7 @@ const ExistingDatasetModal = ({
       name: "",
       value: "",
       dataType: "ImportDataPromptConfiguration",
+      num_rows: "",
       config: {
         mapping: {},
       },
@@ -372,6 +373,9 @@ const ExistingDatasetModal = ({
       payload = {
         source_dataset_id: selectedValue,
         column_mapping: output,
+        ...(formData.num_rows !== "" && formData.num_rows != null
+          ? { num_rows: Number(formData.num_rows) }
+          : {}),
       };
     } else {
       const columns = {};
@@ -536,6 +540,19 @@ const ExistingDatasetModal = ({
                     error={""}
                     helperText={""}
                   />
+                  {dataset && (
+                    <FormTextFieldV2
+                      control={control}
+                      fieldName="num_rows"
+                      size="small"
+                      label="No. of rows"
+                      variant="outlined"
+                      fullWidth
+                      isSpinnerField
+                      fieldType="number"
+                      placeholder="Enter number of rows (leave blank to import all)"
+                    />
+                  )}
                   <RadioField
                     control={control}
                     fieldName={"dataType"}

--- a/frontend/src/sections/develop/AddRowDrawer/validation.js
+++ b/frontend/src/sections/develop/AddRowDrawer/validation.js
@@ -40,6 +40,12 @@ export const existingDatasetValidationSchema = (datasetId, checkboxHandle) =>
       }),
     value: z.string().min(1, "Value is required"),
     dataType: z.string().min(1, "Data type is required"),
+    num_rows: z
+      .union([
+        z.coerce.number().int().min(1, { message: "Must be at least 1" }),
+        z.literal(""),
+      ])
+      .optional(),
     config: z.object({
       mapping: z
         .record(z.string())

--- a/futureagi/model_hub/serializers/contracts.py
+++ b/futureagi/model_hub/serializers/contracts.py
@@ -2845,6 +2845,9 @@ class DatasetAddRowsRequestSerializer(serializers.Serializer):
 class DatasetAddRowsFromExistingRequestSerializer(serializers.Serializer):
     source_dataset_id = serializers.UUIDField()
     column_mapping = serializers.DictField(child=serializers.UUIDField())
+    num_rows = serializers.IntegerField(
+        required=False, min_value=1, allow_null=True
+    )
 
 
 class DatasetUpdateColumnNameRequestSerializer(serializers.Serializer):

--- a/futureagi/model_hub/tests/test_dataset_copy_api.py
+++ b/futureagi/model_hub/tests/test_dataset_copy_api.py
@@ -437,3 +437,139 @@ def test_add_as_new_rejects_columns_outside_source_before_usage_or_creation(
         organization=organization,
         deleted=False,
     ).exists()
+
+
+def _stub_existing_dataset_usage(monkeypatch):
+    """Make the add-rows-from-existing view's billing hook a no-op that succeeds.
+
+    Returns the list that records each usage call so tests can assert on the
+    `total_rows` that was charged.
+    """
+    usage_calls = []
+
+    def record_usage(*args, **kwargs):
+        usage_calls.append((args, kwargs))
+        return _SuccessfulResourceCallLog()
+
+    monkeypatch.setattr(
+        "model_hub.views.datasets.add_rows.existing_dataset."
+        "log_and_deduct_cost_for_resource_request",
+        record_usage,
+    )
+    return usage_calls
+
+
+@pytest.mark.django_db
+def test_add_rows_from_existing_imports_first_n_rows(
+    auth_client, dataset_factory, monkeypatch
+):
+    source_dataset, source_input, _source_output = dataset_factory("Row cap source")
+    target_dataset, target_input, _target_output = dataset_factory("Row cap target")
+    add_row(source_dataset, {source_input: "r0"}, order=0)
+    add_row(source_dataset, {source_input: "r1"}, order=1)
+    add_row(source_dataset, {source_input: "r2"}, order=2)
+    usage_calls = _stub_existing_dataset_usage(monkeypatch)
+
+    response = auth_client.post(
+        f"/model-hub/develops/{target_dataset.id}/add_rows_from_existing_dataset/",
+        {
+            "source_dataset_id": str(source_dataset.id),
+            "column_mapping": {str(source_input.id): str(target_input.id)},
+            "num_rows": 2,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["result"]["rows_added"] == 2
+    imported = list(
+        Cell.objects.filter(
+            dataset=target_dataset, column=target_input, deleted=False
+        )
+        .order_by("row__order")
+        .values_list("value", flat=True)
+    )
+    # only the first two source rows (ordered by `order`) are copied
+    assert imported == ["r0", "r1"]
+    # the usage charge reflects the capped count, not the full source
+    assert usage_calls[0][1]["config"]["total_rows"] == 2
+
+
+@pytest.mark.django_db
+def test_add_rows_from_existing_blank_imports_all_rows(
+    auth_client, dataset_factory, monkeypatch
+):
+    source_dataset, source_input, _source_output = dataset_factory("Import all source")
+    target_dataset, target_input, _target_output = dataset_factory("Import all target")
+    add_row(source_dataset, {source_input: "a"}, order=0)
+    add_row(source_dataset, {source_input: "b"}, order=1)
+    add_row(source_dataset, {source_input: "c"}, order=2)
+    _stub_existing_dataset_usage(monkeypatch)
+
+    # no num_rows key -> backward-compatible "import everything" behaviour
+    response = auth_client.post(
+        f"/model-hub/develops/{target_dataset.id}/add_rows_from_existing_dataset/",
+        {
+            "source_dataset_id": str(source_dataset.id),
+            "column_mapping": {str(source_input.id): str(target_input.id)},
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["result"]["rows_added"] == 3
+    assert (
+        Row.objects.filter(dataset=target_dataset, deleted=False).count() == 3
+    )
+
+
+@pytest.mark.django_db
+def test_add_rows_from_existing_num_rows_exceeding_source_imports_all(
+    auth_client, dataset_factory, monkeypatch
+):
+    source_dataset, source_input, _source_output = dataset_factory("Over cap source")
+    target_dataset, target_input, _target_output = dataset_factory("Over cap target")
+    add_row(source_dataset, {source_input: "only-a"}, order=0)
+    add_row(source_dataset, {source_input: "only-b"}, order=1)
+    usage_calls = _stub_existing_dataset_usage(monkeypatch)
+
+    response = auth_client.post(
+        f"/model-hub/develops/{target_dataset.id}/add_rows_from_existing_dataset/",
+        {
+            "source_dataset_id": str(source_dataset.id),
+            "column_mapping": {str(source_input.id): str(target_input.id)},
+            "num_rows": 50,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    # capped by the available rows, not the requested 50 -> no error, no crash
+    assert response.json()["result"]["rows_added"] == 2
+    assert (
+        Row.objects.filter(dataset=target_dataset, deleted=False).count() == 2
+    )
+    assert usage_calls[0][1]["config"]["total_rows"] == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_add_rows_from_existing_rejects_non_positive_num_rows(
+    auth_client, dataset_factory, bad_value
+):
+    source_dataset, source_input, _source_output = dataset_factory("Bad num source")
+    target_dataset, target_input, _target_output = dataset_factory("Bad num target")
+    add_row(source_dataset, {source_input: "x"}, order=0)
+
+    response = auth_client.post(
+        f"/model-hub/develops/{target_dataset.id}/add_rows_from_existing_dataset/",
+        {
+            "source_dataset_id": str(source_dataset.id),
+            "column_mapping": {str(source_input.id): str(target_input.id)},
+            "num_rows": bad_value,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert Row.objects.filter(dataset=target_dataset, deleted=False).count() == 0

--- a/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
+++ b/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
@@ -81,6 +81,7 @@ class AddRowsFromExistingView(APIView):
             data = request.validated_data
             source_dataset_id = data.get("source_dataset_id")
             column_mapping = data.get("column_mapping")
+            num_rows = data.get("num_rows")
 
             if source_dataset_id == dataset_id:
                 return self._gm.bad_request(
@@ -169,6 +170,9 @@ class AddRowsFromExistingView(APIView):
             new_rows_count = Row.objects.filter(
                 dataset=source_dataset, deleted=False
             ).count()
+            if num_rows is not None:
+                # cap the accounting to what will actually be imported
+                new_rows_count = min(new_rows_count, num_rows)
             if log_and_deduct_cost_for_resource_request is not None:
                 call_log_row = log_and_deduct_cost_for_resource_request(
                     getattr(request, "organization", None) or request.user.organization,
@@ -204,10 +208,18 @@ class AddRowsFromExistingView(APIView):
             source_rows = Row.objects.filter(
                 dataset=source_dataset, deleted=False
             ).order_by("order")
+            if num_rows is not None:
+                # cap the import to the first `num_rows` rows (ordered by order)
+                source_rows = list(source_rows[:num_rows])
             batch_size = 1000
             current_order = max_order + 1
+            total_source_rows = (
+                len(source_rows)
+                if isinstance(source_rows, list)
+                else source_rows.count()
+            )
 
-            for i in range(0, source_rows.count(), batch_size):
+            for i in range(0, total_source_rows, batch_size):
                 batch_rows = source_rows[i : i + batch_size]
                 new_rows = []
                 new_cells = []
@@ -272,7 +284,7 @@ class AddRowsFromExistingView(APIView):
             return self._gm.success_response(
                 {
                     "message": "Rows Imported successfully",
-                    "rows_added": source_rows.count(),
+                    "rows_added": total_source_rows,
                 }
             )
 


### PR DESCRIPTION
Add an optional "No. of rows" input to the "Add from existing model dataset or experiment" drawer so users can import just the first N rows of a source dataset instead of always copying every row.

- serializer: accept optional num_rows (min 1) so the request is no longer rejected by reject_unknown_fields
- view: cap the copy and the billing/row-limit accounting to num_rows, and report the actual imported count in rows_added
- frontend: render the spinner input only for the existing-dataset case, send num_rows only when provided (blank = import all), and validate that it is a positive integer client-side
- tests: cover first-N import, blank-imports-all, num_rows exceeding the source, and rejection of non-positive values

## Summary

Importing into an existing dataset previously copied **every** row from the source, with no way to limit the count — unlike the sibling Hugging Face and "Add empty row" flows, which already expose a row-count input. This PR adds an optional **"No. of rows"** field to the existing-dataset import drawer and threads it through the API. Leaving it blank preserves today's "import everything" behavior, so the change is fully backward compatible.

## Linked issues

Closes #1385

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

**Automated (backend):** `pytest model_hub/tests/test_dataset_copy_api.py`, **16 passed** against a live Postgres DB, including 4 new tests for this feature:
- `test_add_rows_from_existing_imports_first_n_rows`, `num_rows=2` imports exactly the first 2 rows (by `order`) and charges usage for 2, not the full source.
- `test_add_rows_from_existing_blank_imports_all_rows`, omitting `num_rows` imports all rows (backward compatible).
- `test_add_rows_from_existing_num_rows_exceeding_source_imports_all`, `num_rows` larger than the source imports all available rows, no error.
- `test_add_rows_from_existing_rejects_non_positive_num_rows[0/-1]`, non-positive values are rejected.

The 11 pre-existing tests in the same file continue to pass (no regressions).

**Automated (frontend):** ESLint and Prettier pass on the changed files; the zod schema was exercised to confirm blank/valid-int are accepted and `0`, negatives, and decimals are rejected.

**Manual (UI):** Ran the full dev stack and verified in the drawer that:
- the "No. of rows" field appears only when importing into an existing dataset,
- entering `0`/negative/decimal is blocked client-side (request not sent),
- entering `N` imports exactly the first N rows, and leaving it blank imports all.

## Screenshots / recordings (if UI)

### BEFORE (There does not exist the add row number input box)

<img width="1053" height="669" alt="Screenshot 2026-07-08 222917" src="https://github.com/user-attachments/assets/71024022-736e-4432-a5a7-fafe919114c0" />

<img width="1913" height="898" alt="Screenshot 2026-07-08 222858" src="https://github.com/user-attachments/assets/d298a74a-ad73-41b5-be4a-b25aa6fa0133" />

### AFTER (There exisits a add row number input box, and it has checks implemented. I have tested the same by putting a negative and  decimal number.)  

<img width="1056" height="624" alt="Screenshot 2026-07-08 221902" src="https://github.com/user-attachments/assets/a2e7a5ed-c887-4fc3-bafe-419137d3eafc" />
<img width="1904" height="901" alt="Screenshot 2026-07-08 221747" src="https://github.com/user-attachments/assets/f0405622-2458-4c81-915e-548cc6ecdcf9" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)