### PR TITLE
refactor(evals): route composite child scoring through the shared score helper

### DIFF
--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -142,29 +142,11 @@ def apply_version_overrides(config, resolved_version, criteria=None):
     return config, criteria
 
 
-def resolve_pass_threshold(
-    eval_template,
-    runtime_config: dict | None = None,
-    resolved_version=None,
-) -> float:
-    """Priority: runtime_config[run_config][pass_threshold] > runtime_config[pass_threshold] > resolved_version.pass_threshold > eval_template.pass_threshold > 0.5."""
-    if isinstance(runtime_config, dict):
-        run_config = runtime_config.get("run_config") or {}
-        if isinstance(run_config, dict) and run_config.get("pass_threshold") is not None:
-            return float(run_config["pass_threshold"])
-        if runtime_config.get("pass_threshold") is not None:
-            return float(runtime_config["pass_threshold"])
-
-    if resolved_version is not None:
-        version_threshold = getattr(resolved_version, "pass_threshold", None)
-        if version_threshold is not None:
-            return float(version_threshold)
-
-    template_threshold = getattr(eval_template, "pass_threshold", None)
-    if template_threshold is not None:
-        return float(template_threshold)
-
-    return 0.5
+# Canonical implementation lives in ``model_hub.utils.scoring``; keep the
+# import at this call site so downstream modules that already imported
+# ``from evaluations.engine.instance import resolve_pass_threshold`` still
+# resolve.
+from model_hub.utils.scoring import resolve_pass_threshold  # noqa: E402, F401
 
 
 def _get_api_key(model, organization_id, workspace_id=None):

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -142,11 +142,50 @@ def apply_version_overrides(config, resolved_version, criteria=None):
     return config, criteria
 
 
-# Canonical implementation lives in ``model_hub.utils.scoring``; keep the
-# import at this call site so downstream modules that already imported
-# ``from evaluations.engine.instance import resolve_pass_threshold`` still
-# resolve.
-from model_hub.utils.scoring import resolve_pass_threshold  # noqa: E402, F401
+def _coerce_threshold(value) -> float | None:
+    """Return a valid pass_threshold in [0, 1] or ``None`` if the input is
+    non-numeric or out of range. Guards every source
+    ``resolve_pass_threshold`` consults so a malformed override falls through
+    to the next one instead of raising."""
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    v = float(value)
+    if v < 0.0 or v > 1.0:
+        return None
+    return v
+
+
+def resolve_pass_threshold(
+    eval_template,
+    runtime_config: dict | None = None,
+    resolved_version=None,
+) -> float:
+    """Priority: ``runtime_config[run_config][pass_threshold]`` >
+    ``runtime_config[pass_threshold]`` > ``resolved_version.pass_threshold`` >
+    ``eval_template.pass_threshold`` > ``0.5``. Non-numeric or out-of-range
+    values from any source are skipped."""
+    if isinstance(runtime_config, dict):
+        run_config = runtime_config.get("run_config") or {}
+        if isinstance(run_config, dict):
+            v = _coerce_threshold(run_config.get("pass_threshold"))
+            if v is not None:
+                return v
+        v = _coerce_threshold(runtime_config.get("pass_threshold"))
+        if v is not None:
+            return v
+
+    if resolved_version is not None:
+        v = _coerce_threshold(getattr(resolved_version, "pass_threshold", None))
+        if v is not None:
+            return v
+
+    v = _coerce_threshold(getattr(eval_template, "pass_threshold", None))
+    if v is not None:
+        return v
+
+    return 0.5
 
 
 def _get_api_key(model, organization_id, workspace_id=None):

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -142,48 +142,27 @@ def apply_version_overrides(config, resolved_version, criteria=None):
     return config, criteria
 
 
-def _coerce_threshold(value) -> float | None:
-    """Return a valid pass_threshold in [0, 1] or ``None`` if the input is
-    non-numeric or out of range. Guards every source
-    ``resolve_pass_threshold`` consults so a malformed override falls through
-    to the next one instead of raising."""
-    if value is None or isinstance(value, bool):
-        return None
-    if not isinstance(value, (int, float)):
-        return None
-    v = float(value)
-    if v < 0.0 or v > 1.0:
-        return None
-    return v
-
-
 def resolve_pass_threshold(
     eval_template,
     runtime_config: dict | None = None,
     resolved_version=None,
 ) -> float:
-    """Priority: ``runtime_config[run_config][pass_threshold]`` >
-    ``runtime_config[pass_threshold]`` > ``resolved_version.pass_threshold`` >
-    ``eval_template.pass_threshold`` > ``0.5``. Non-numeric or out-of-range
-    values from any source are skipped."""
+    """Priority: runtime_config[run_config][pass_threshold] > runtime_config[pass_threshold] > resolved_version.pass_threshold > eval_template.pass_threshold > 0.5."""
     if isinstance(runtime_config, dict):
         run_config = runtime_config.get("run_config") or {}
-        if isinstance(run_config, dict):
-            v = _coerce_threshold(run_config.get("pass_threshold"))
-            if v is not None:
-                return v
-        v = _coerce_threshold(runtime_config.get("pass_threshold"))
-        if v is not None:
-            return v
+        if isinstance(run_config, dict) and run_config.get("pass_threshold") is not None:
+            return float(run_config["pass_threshold"])
+        if runtime_config.get("pass_threshold") is not None:
+            return float(runtime_config["pass_threshold"])
 
     if resolved_version is not None:
-        v = _coerce_threshold(getattr(resolved_version, "pass_threshold", None))
-        if v is not None:
-            return v
+        version_threshold = getattr(resolved_version, "pass_threshold", None)
+        if version_threshold is not None:
+            return float(version_threshold)
 
-    v = _coerce_threshold(getattr(eval_template, "pass_threshold", None))
-    if v is not None:
-        return v
+    template_threshold = getattr(eval_template, "pass_threshold", None)
+    if template_threshold is not None:
+        return float(template_threshold)
 
     return 0.5
 

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -352,8 +352,8 @@ class TestExecuteCompositeChildrenSync:
         )
 
         def _choices_fake_run_eval_func(_cfg, _mapping, template, *_a, **_k):
-            # Mirror the EE-path shape of `run_eval_func`: `output` carries the
-            # already-formatted verdict dict produced by `format_eval_value`.
+            # `run_eval_func` returns `output` as the formatted verdict dict from
+            # `format_eval_value` — `{"score": float, "choice": str}` for choices.
             canned = {
                 "choices-child-a": {"score": 1.0, "choice": "Sad"},
                 "choices-child-b": {"score": 0.5, "choice": "Sad"},

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -347,7 +347,7 @@ class TestExecuteCompositeChildrenSync:
 
         def _choices_fake_run_eval_func(_cfg, _mapping, template, *_a, **_k):
             # `run_eval_func` returns `output` as the formatted verdict dict from
-            # `format_eval_value` — `{"score": float, "choice": str}` for choices.
+            # `format_eval_value`: `{"score": float, "choice": str}` for choices.
             canned = {
                 "choices-child-a": {"score": 1.0, "choice": "Sad"},
                 "choices-child-b": {"score": 0.5, "choice": "Sad"},
@@ -934,7 +934,7 @@ class TestCompositeOutputTypesEndToEnd:
     def test_code_children_score_correctly(
         self, db, organization, workspace
     ):
-        # Code eval with output_type_normalized="percentage" — the runtime
+        # Code eval with output_type_normalized="percentage": the runtime
         # emits a numeric score directly via the CustomCodeEval evaluator.
         child = EvalTemplate.no_workspace_objects.create(
             name="code-child",

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -301,13 +301,7 @@ class TestExecuteCompositeChildrenSync:
     def test_choices_children_score_via_shared_helper(
         self, db, organization, workspace
     ):
-        """Composite children with `output_type_normalized="deterministic"` and a
-        `choice_scores` mapping route the picked label to its numeric score via
-        the shared `score_eval_output` helper.
-
-        Regression pin for the case where the composite runner was passing the
-        run_eval_func response dict straight to `normalize_score`, which does
-        not resolve the choice label and returns `0.0` for every child."""
+        """Deterministic-typed children route the picked label to its choice_scores value."""
         child_a = EvalTemplate.no_workspace_objects.create(
             name="choices-child-a",
             organization=organization,
@@ -509,11 +503,6 @@ class TestExecuteCompositeChildrenSync:
         )
 
 
-# ---------------------------------------------------------------------------
-# Behaviour tests: aggregation functions, threshold precedence, output types
-# ---------------------------------------------------------------------------
-
-
 def _make_percentage_child(
     organization, workspace, name, pass_threshold=0.5
 ):
@@ -570,9 +559,7 @@ def _canned_by_name(name_to_output, output_type="score"):
 
 @pytest.mark.django_db
 class TestCompositeAggregationFunctions:
-    """Behaviour tests: each of the 5 aggregation functions applied to a
-    real composite with real EvalTemplate + CompositeEvalChild rows,
-    exercising the runner end-to-end with `run_eval_func` mocked."""
+    """One test per aggregation function against a real 3-child composite."""
 
     def _build(self, organization, workspace, function, weights):
         children = [
@@ -670,8 +657,7 @@ class TestCompositeAggregationFunctions:
         assert outcome.aggregate_pass is True
 
     def test_pass_rate_uses_per_child_thresholds(self, db, organization, workspace):
-        """pass_rate compares each child's score against ITS OWN pass_threshold,
-        then returns fraction of scored children that passed."""
+        """pass_rate gates each child on its own threshold, returns pass fraction."""
         child_a = _make_percentage_child(
             organization, workspace, "pr-child-a", pass_threshold=0.5
         )
@@ -712,10 +698,7 @@ class TestCompositeAggregationFunctions:
 
 @pytest.mark.django_db
 class TestCompositeChildThresholdPrecedence:
-    """The runner resolves each child's effective pass_threshold from a
-    four-source precedence chain: link.config -> pinned_version -> live
-    template -> default 0.5. Each branch is pinned by a targeted test that
-    varies exactly the source it exercises."""
+    """One test per source in link.config -> pinned_version -> live -> 0.5."""
 
     def _setup_pass_rate_composite(
         self,
@@ -870,8 +853,7 @@ class TestCompositeChildThresholdPrecedence:
 
 @pytest.mark.django_db
 class TestCompositeOutputTypesEndToEnd:
-    """A composite child can be one of four axes: pass_fail, percentage,
-    choices, code. Each should score correctly through the shared helper."""
+    """Score routing across the four child output-type axes."""
 
     def test_pass_fail_children_score_correctly(
         self, db, organization, workspace

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -867,30 +867,6 @@ class TestCompositeChildThresholdPrecedence:
             )
         assert outcome.aggregate_score == pytest.approx(1.0)
 
-    def test_link_config_invalid_pass_threshold_falls_through(
-        self, db, organization, workspace
-    ):
-        # Values outside [0, 1] or wrong types are ignored; next source used.
-        parent, links = self._setup_pass_rate_composite(
-            organization,
-            workspace,
-            child_pass_threshold=0.4,
-            link_config={"pass_threshold": "not-a-number"},
-        )
-        with patch(
-            "model_hub.views.utils.evals.run_eval_func",
-            side_effect=_canned_by_name({"prec-child": 0.45}),
-        ):
-            outcome = execute_composite_children_sync(
-                parent=parent,
-                child_links=links,
-                mapping={"input": "x"},
-                config={},
-                org=organization,
-            )
-        # Live template 0.4 used, 0.45 passes.
-        assert outcome.aggregate_score == pytest.approx(1.0)
-
 
 @pytest.mark.django_db
 class TestCompositeOutputTypesEndToEnd:

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -510,6 +510,629 @@ class TestExecuteCompositeChildrenSync:
 
 
 # ---------------------------------------------------------------------------
+# Behaviour tests: aggregation functions, threshold precedence, output types
+# ---------------------------------------------------------------------------
+
+
+def _make_percentage_child(
+    organization, workspace, name, pass_threshold=0.5
+):
+    return EvalTemplate.no_workspace_objects.create(
+        name=name,
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        config={"output": "score", "eval_type_id": "CustomPromptEvaluator"},
+        output_type_normalized="percentage",
+        pass_threshold=pass_threshold,
+    )
+
+
+def _make_composite(
+    organization,
+    workspace,
+    name,
+    aggregation_function,
+    pass_threshold=0.5,
+    aggregation_enabled=True,
+):
+    return EvalTemplate.no_workspace_objects.create(
+        name=name,
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        template_type="composite",
+        aggregation_enabled=aggregation_enabled,
+        aggregation_function=aggregation_function,
+        pass_threshold=pass_threshold,
+        config={},
+    )
+
+
+def _fake_response(output, output_type="score"):
+    """Build a run_eval_func-shaped response dict for the given output value."""
+    return {
+        "output": output,
+        "reason": "canned",
+        "output_type": output_type,
+        "model": "turing_large",
+        "metadata": {},
+        "log_id": None,
+    }
+
+
+def _canned_by_name(name_to_output, output_type="score"):
+    """Return a side_effect that maps template.name to a canned response dict."""
+    def _inner(_cfg, _mapping, template, *_a, **_k):
+        return _fake_response(name_to_output.get(template.name, 0.0), output_type)
+    return _inner
+
+
+@pytest.mark.django_db
+class TestCompositeAggregationFunctions:
+    """Behaviour tests: each of the 5 aggregation functions applied to a
+    real composite with real EvalTemplate + CompositeEvalChild rows,
+    exercising the runner end-to-end with `run_eval_func` mocked."""
+
+    def _build(self, organization, workspace, function, weights):
+        children = [
+            _make_percentage_child(organization, workspace, f"child-{k}")
+            for k in ("a", "b", "c")
+        ]
+        parent = _make_composite(organization, workspace, f"comp-{function}", function)
+        for i, (child, w) in enumerate(zip(children, weights)):
+            CompositeEvalChild.objects.create(
+                parent=parent, child=child, order=i, weight=w
+            )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        return parent, links, children
+
+    def test_weighted_avg_honours_link_weights(self, db, organization, workspace):
+        parent, links, _ = self._build(
+            organization, workspace, "weighted_avg", weights=[1.0, 2.0, 3.0]
+        )
+        canned = {"child-a": 0.1, "child-b": 0.5, "child-c": 0.9}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # (0.1*1 + 0.5*2 + 0.9*3) / (1+2+3) = 3.8 / 6 = 0.6333...
+        assert outcome.aggregate_score == pytest.approx(0.6333, abs=1e-3)
+        assert outcome.aggregate_pass is True
+
+    def test_avg_ignores_weights(self, db, organization, workspace):
+        parent, links, _ = self._build(
+            organization, workspace, "avg", weights=[1.0, 2.0, 3.0]
+        )
+        canned = {"child-a": 0.1, "child-b": 0.5, "child-c": 0.9}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # Simple mean = (0.1 + 0.5 + 0.9) / 3 = 0.5, weights ignored.
+        assert outcome.aggregate_score == pytest.approx(0.5)
+
+    def test_min_returns_worst_child_score(self, db, organization, workspace):
+        parent, links, _ = self._build(
+            organization, workspace, "min", weights=[1.0, 1.0, 1.0]
+        )
+        canned = {"child-a": 0.9, "child-b": 0.2, "child-c": 0.7}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(0.2)
+        # Below default parent threshold of 0.5 → fail.
+        assert outcome.aggregate_pass is False
+
+    def test_max_returns_best_child_score(self, db, organization, workspace):
+        parent, links, _ = self._build(
+            organization, workspace, "max", weights=[1.0, 1.0, 1.0]
+        )
+        canned = {"child-a": 0.2, "child-b": 0.9, "child-c": 0.5}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(0.9)
+        assert outcome.aggregate_pass is True
+
+    def test_pass_rate_uses_per_child_thresholds(self, db, organization, workspace):
+        """pass_rate compares each child's score against ITS OWN pass_threshold,
+        then returns fraction of scored children that passed."""
+        child_a = _make_percentage_child(
+            organization, workspace, "pr-child-a", pass_threshold=0.5
+        )
+        child_b = _make_percentage_child(
+            organization, workspace, "pr-child-b", pass_threshold=0.5
+        )
+        child_c = _make_percentage_child(
+            organization, workspace, "pr-child-c", pass_threshold=0.9
+        )
+        parent = _make_composite(organization, workspace, "pr-comp", "pass_rate")
+        for i, child in enumerate([child_a, child_b, child_c]):
+            CompositeEvalChild.objects.create(
+                parent=parent, child=child, order=i, weight=1.0
+            )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        # child_a passes (0.6 >= 0.5), child_b fails (0.4 < 0.5),
+        # child_c fails (0.85 < 0.9).
+        canned = {"pr-child-a": 0.6, "pr-child-b": 0.4, "pr-child-c": 0.85}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # 1 out of 3 passed against their own threshold.
+        assert outcome.aggregate_score == pytest.approx(1.0 / 3.0, abs=1e-6)
+        assert outcome.aggregate_pass is False  # 0.333 < parent threshold 0.5
+
+
+@pytest.mark.django_db
+class TestCompositeChildThresholdPrecedence:
+    """The runner resolves each child's effective pass_threshold from a
+    four-source precedence chain: link.config -> pinned_version -> live
+    template -> default 0.5. Each branch is pinned by a targeted test that
+    varies exactly the source it exercises."""
+
+    def _setup_pass_rate_composite(
+        self,
+        organization,
+        workspace,
+        child_pass_threshold=0.5,
+        link_config=None,
+        pinned_version_threshold=None,
+    ):
+        child = _make_percentage_child(
+            organization,
+            workspace,
+            "prec-child",
+            pass_threshold=child_pass_threshold,
+        )
+        parent = _make_composite(
+            organization, workspace, "prec-comp", "pass_rate"
+        )
+        pinned_version = None
+        if pinned_version_threshold is not None:
+            from model_hub.models.evals_metric import EvalTemplateVersion
+
+            pinned_version = EvalTemplateVersion.all_objects.create(
+                eval_template=child,
+                version_number=1,
+                config_snapshot=child.config,
+                model=child.model or "",
+                pass_threshold=pinned_version_threshold,
+                output_type_normalized="percentage",
+                is_default=False,
+            )
+        CompositeEvalChild.objects.create(
+            parent=parent,
+            child=child,
+            order=0,
+            weight=1.0,
+            config=link_config,
+            pinned_version=pinned_version,
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        return parent, links
+
+    def test_link_config_pass_threshold_wins_over_all_others(
+        self, db, organization, workspace
+    ):
+        # link.config=0.9 should win; pinned_version=0.6 and child=0.3 ignored.
+        parent, links = self._setup_pass_rate_composite(
+            organization,
+            workspace,
+            child_pass_threshold=0.3,
+            link_config={"pass_threshold": 0.9},
+            pinned_version_threshold=0.6,
+        )
+        # Child scores 0.8: fails 0.9 gate (link.config), passes 0.6 & 0.3.
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"prec-child": 0.8}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # 0 of 1 passed → pass_rate = 0.0
+        assert outcome.aggregate_score == pytest.approx(0.0)
+
+    def test_pinned_version_threshold_used_when_link_config_absent(
+        self, db, organization, workspace
+    ):
+        # pinned_version=0.7 wins over child=0.3.
+        parent, links = self._setup_pass_rate_composite(
+            organization,
+            workspace,
+            child_pass_threshold=0.3,
+            link_config=None,
+            pinned_version_threshold=0.7,
+        )
+        # Child scores 0.6: fails 0.7 gate (pinned), passes 0.3.
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"prec-child": 0.6}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(0.0)
+
+    def test_live_template_threshold_used_when_link_and_version_absent(
+        self, db, organization, workspace
+    ):
+        parent, links = self._setup_pass_rate_composite(
+            organization,
+            workspace,
+            child_pass_threshold=0.4,
+            link_config=None,
+            pinned_version_threshold=None,
+        )
+        # Child scores 0.45: passes 0.4 gate.
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"prec-child": 0.45}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(1.0)
+
+    def test_default_0_5_when_all_sources_are_missing(
+        self, db, organization, workspace
+    ):
+        # child.pass_threshold=None (missing on model). Should default to 0.5.
+        child = _make_percentage_child(organization, workspace, "def-child")
+        child.pass_threshold = None
+        child.save(update_fields=["pass_threshold"])
+        parent = _make_composite(organization, workspace, "def-comp", "pass_rate")
+        CompositeEvalChild.objects.create(
+            parent=parent, child=child, order=0, weight=1.0
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        # Score 0.6 passes 0.5 default.
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"def-child": 0.6}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(1.0)
+
+    def test_link_config_invalid_pass_threshold_falls_through(
+        self, db, organization, workspace
+    ):
+        # Values outside [0, 1] or wrong types are ignored; next source used.
+        parent, links = self._setup_pass_rate_composite(
+            organization,
+            workspace,
+            child_pass_threshold=0.4,
+            link_config={"pass_threshold": "not-a-number"},
+        )
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"prec-child": 0.45}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # Live template 0.4 used, 0.45 passes.
+        assert outcome.aggregate_score == pytest.approx(1.0)
+
+
+@pytest.mark.django_db
+class TestCompositeOutputTypesEndToEnd:
+    """A composite child can be one of four axes: pass_fail, percentage,
+    choices, code. Each should score correctly through the shared helper."""
+
+    def test_pass_fail_children_score_correctly(
+        self, db, organization, workspace
+    ):
+        child_a = EvalTemplate.no_workspace_objects.create(
+            name="pf-a",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "Pass/Fail", "eval_type_id": "CustomPromptEvaluator"},
+            output_type_normalized="pass_fail",
+            pass_threshold=0.5,
+        )
+        child_b = EvalTemplate.no_workspace_objects.create(
+            name="pf-b",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "Pass/Fail", "eval_type_id": "CustomPromptEvaluator"},
+            output_type_normalized="pass_fail",
+            pass_threshold=0.5,
+        )
+        parent = _make_composite(organization, workspace, "pf-comp", "avg")
+        CompositeEvalChild.objects.create(parent=parent, child=child_a, order=0, weight=1.0)
+        CompositeEvalChild.objects.create(parent=parent, child=child_b, order=1, weight=1.0)
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+
+        def _fake(_cfg, _map, template, *_a, **_k):
+            return _fake_response(
+                "Passed" if template.name == "pf-a" else "Failed",
+                output_type="Pass/Fail",
+            )
+
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_fake,
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        by_name = {cr.child_name: cr for cr in outcome.child_results}
+        assert by_name["pf-a"].score == pytest.approx(1.0)
+        assert by_name["pf-b"].score == pytest.approx(0.0)
+        assert outcome.aggregate_score == pytest.approx(0.5)
+
+    def test_percentage_children_score_correctly(
+        self, db, organization, workspace
+    ):
+        parent, links, _ = TestCompositeAggregationFunctions()._build(
+            organization, workspace, "avg", weights=[1.0, 1.0, 1.0]
+        )
+        canned = {"child-a": 0.2, "child-b": 0.6, "child-c": 1.0}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name(canned),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        by_name = {cr.child_name: cr for cr in outcome.child_results}
+        assert by_name["child-a"].score == pytest.approx(0.2)
+        assert by_name["child-b"].score == pytest.approx(0.6)
+        assert by_name["child-c"].score == pytest.approx(1.0)
+        assert outcome.aggregate_score == pytest.approx(0.6)
+
+    def test_code_children_score_correctly(
+        self, db, organization, workspace
+    ):
+        # Code eval with output_type_normalized="percentage" — the runtime
+        # emits a numeric score directly via the CustomCodeEval evaluator.
+        child = EvalTemplate.no_workspace_objects.create(
+            name="code-child",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            eval_type="code",
+            config={
+                "output": "score",
+                "eval_type_id": "CustomCodeEval",
+                "code": "def evaluate(**kwargs): return 0.7",
+                "language": "python",
+            },
+            output_type_normalized="percentage",
+            pass_threshold=0.5,
+        )
+        parent = _make_composite(organization, workspace, "code-comp", "avg")
+        CompositeEvalChild.objects.create(
+            parent=parent, child=child, order=0, weight=1.0
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"code-child": 0.7}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.child_results[0].score == pytest.approx(0.7)
+        assert outcome.aggregate_score == pytest.approx(0.7)
+        assert outcome.aggregate_pass is True
+
+
+@pytest.mark.django_db
+class TestCompositeAggregationEdgeCases:
+    def test_all_children_fail_aggregate_is_none(
+        self, db, organization, workspace
+    ):
+        parent, links, _ = TestCompositeAggregationFunctions()._build(
+            organization, workspace, "avg", weights=[1.0, 1.0, 1.0]
+        )
+
+        def _all_raise(*_a, **_k):
+            raise RuntimeError("boom")
+
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_all_raise,
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score is None
+        assert outcome.aggregate_pass is None
+        assert all(cr.status == "failed" for cr in outcome.child_results)
+
+    def test_pass_rate_denominator_excludes_failed_children(
+        self, db, organization, workspace
+    ):
+        """Documented behaviour: pass_rate denominator = number of scored children,
+        not total children. If children fail, pass_rate can inflate."""
+        parent, links, children = TestCompositeAggregationFunctions()._build(
+            organization, workspace, "pass_rate", weights=[1.0, 1.0, 1.0]
+        )
+
+        def _mixed(_cfg, _map, template, *_a, **_k):
+            if template.name == "child-a":
+                raise RuntimeError("simulated failure")
+            return _fake_response(0.8)  # both remaining pass 0.5 gate
+
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_mixed,
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        # 2 completed children, both pass → 2/2 = 1.0. Failed child excluded.
+        assert outcome.aggregate_score == pytest.approx(1.0)
+
+    def test_aggregate_pass_true_when_score_meets_threshold(
+        self, db, organization, workspace
+    ):
+        parent = _make_composite(
+            organization, workspace, "at-comp", "avg", pass_threshold=0.7
+        )
+        child = _make_percentage_child(organization, workspace, "at-child")
+        CompositeEvalChild.objects.create(
+            parent=parent, child=child, order=0, weight=1.0
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"at-child": 0.75}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(0.75)
+        assert outcome.aggregate_pass is True
+
+    def test_aggregate_pass_false_when_score_below_threshold(
+        self, db, organization, workspace
+    ):
+        parent = _make_composite(
+            organization, workspace, "bt-comp", "avg", pass_threshold=0.7
+        )
+        child = _make_percentage_child(organization, workspace, "bt-child")
+        CompositeEvalChild.objects.create(
+            parent=parent, child=child, order=0, weight=1.0
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_canned_by_name({"bt-child": 0.65}),
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+            )
+        assert outcome.aggregate_score == pytest.approx(0.65)
+        assert outcome.aggregate_pass is False
+
+
+# ---------------------------------------------------------------------------
 # CompositeEvaluationRunner
 # ---------------------------------------------------------------------------
 

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -298,6 +298,95 @@ class TestExecuteCompositeChildrenSync:
         assert outcome.summary is None
         assert len(outcome.child_results) == 2
 
+    def test_choices_children_score_via_shared_helper(
+        self, db, organization, workspace
+    ):
+        """Composite children with `output_type_normalized="deterministic"` and a
+        `choice_scores` mapping route the picked label to its numeric score via
+        the shared `score_eval_output` helper.
+
+        Regression pin for the case where the composite runner was passing the
+        run_eval_func response dict straight to `normalize_score`, which does
+        not resolve the choice label and returns `0.0` for every child."""
+        child_a = EvalTemplate.no_workspace_objects.create(
+            name="choices-child-a",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "choices", "eval_type_id": "CustomPromptEvaluator"},
+            output_type_normalized="deterministic",
+            choices=["Sad", "Happy", "Neutral"],
+            choice_scores={"Sad": 1.0, "Happy": 0.5, "Neutral": 0.0},
+            pass_threshold=0.5,
+            multi_choice=True,
+        )
+        child_b = EvalTemplate.no_workspace_objects.create(
+            name="choices-child-b",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "choices", "eval_type_id": "AgentEvaluator"},
+            output_type_normalized="deterministic",
+            choices=["Happy", "Sad", "Neutral"],
+            choice_scores={"Sad": 0.5, "Happy": 0.5, "Neutral": 0.5},
+            pass_threshold=0.5,
+        )
+        parent = EvalTemplate.no_workspace_objects.create(
+            name="choices-composite",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            template_type="composite",
+            aggregation_enabled=True,
+            aggregation_function="avg",
+            pass_threshold=0.5,
+            config={},
+        )
+        CompositeEvalChild.objects.create(parent=parent, child=child_a, order=0, weight=1.0)
+        CompositeEvalChild.objects.create(parent=parent, child=child_b, order=1, weight=1.0)
+
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+
+        def _choices_fake_run_eval_func(_cfg, _mapping, template, *_a, **_k):
+            # Mirror the EE-path shape of `run_eval_func`: `output` carries the
+            # already-formatted verdict dict produced by `format_eval_value`.
+            canned = {
+                "choices-child-a": {"score": 1.0, "choice": "Sad"},
+                "choices-child-b": {"score": 0.5, "choice": "Sad"},
+            }
+            payload = canned.get(template.name)
+            return {
+                "output": payload,
+                "reason": f"{template.name} labelled Sad",
+                "output_type": "choices",
+                "model": "turing_large",
+                "metadata": {},
+                "log_id": None,
+            }
+
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_choices_fake_run_eval_func,
+        ):
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "I am very sad today."},
+                config={},
+                org=organization,
+            )
+
+        by_name = {cr.child_name: cr for cr in outcome.child_results}
+        assert by_name["choices-child-a"].score == pytest.approx(1.0)
+        assert by_name["choices-child-b"].score == pytest.approx(0.5)
+        # Simple average, both weights 1.0 → (1.0 + 0.5) / 2 = 0.75
+        assert outcome.aggregate_score == pytest.approx(0.75)
+        assert outcome.aggregate_pass is True
+
     def test_failing_child_is_captured_not_raised(self, composite_parent, organization):
         links = list(
             CompositeEvalChild.objects.filter(parent=composite_parent)

--- a/futureagi/model_hub/tests/test_scoring.py
+++ b/futureagi/model_hub/tests/test_scoring.py
@@ -569,3 +569,13 @@ class TestScoreEvalOutputDefaultScore:
     def test_value_key_dict_scores_correctly(self):
         template = _Template(output_type_normalized="percentage")
         assert score_eval_output({"value": 0.85}, template) == 0.85
+
+    def test_default_score_none_surfaces_unscoreable_as_none(self):
+        # Composite runner opts into None so its exclusion branch fires.
+        template = _Template(output_type_normalized="pass_fail")
+        assert score_eval_output("maybe", template, default_score=None) is None
+
+    def test_default_score_none_leaves_valid_scores_intact(self):
+        template = _Template(output_type_normalized="pass_fail")
+        assert score_eval_output("Passed", template, default_score=None) == 1.0
+        assert score_eval_output("Failed", template, default_score=None) == 0.0

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -23,24 +23,13 @@ from model_hub.utils.composite_aggregation import (
     aggregate_scores,
     aggregate_summaries,
 )
-from model_hub.utils.scoring import determine_pass_fail, score_eval_output
+from model_hub.utils.scoring import (
+    determine_pass_fail,
+    resolve_pass_threshold,
+    score_eval_output,
+)
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_PASS_THRESHOLD = 0.5
-
-
-def _resolve_child_pass_threshold(link: CompositeEvalChild) -> float:
-    """Precedence: link.config override -> pinned_version -> live template -> default."""
-    if link.config and isinstance(link.config, dict):
-        v = link.config.get("pass_threshold")
-        if isinstance(v, (int, float)) and 0.0 <= float(v) <= 1.0:
-            return float(v)
-    if link.pinned_version and link.pinned_version.pass_threshold is not None:
-        return float(link.pinned_version.pass_threshold)
-    if link.child.pass_threshold is not None:
-        return float(link.child.pass_threshold)
-    return _DEFAULT_PASS_THRESHOLD
 
 
 @dataclass
@@ -344,7 +333,11 @@ def execute_composite_children_sync(
 
     if parent.aggregation_enabled:
         threshold_map = {
-            str(link.child_id): _resolve_child_pass_threshold(link)
+            str(link.child_id): resolve_pass_threshold(
+                eval_template=link.child,
+                runtime_config=link.config or {},
+                resolved_version=link.pinned_version,
+            )
             for link in child_links
         }
         scores_and_weights: list[tuple[float, float]] = []

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -23,7 +23,7 @@ from model_hub.utils.composite_aggregation import (
     aggregate_scores,
     aggregate_summaries,
 )
-from model_hub.utils.scoring import determine_pass_fail, normalize_score
+from model_hub.utils.scoring import determine_pass_fail, score_eval_output
 
 logger = logging.getLogger(__name__)
 
@@ -131,37 +131,9 @@ def _execute_child(
             call_context=call_context,
         )
 
-        score: float | None = None
-        _output_type = child_template.output_type_normalized
-        if not _output_type:
-            # Older / code-created templates may not have output_type_normalized
-            # set. Derive it from config["output"] before falling back to a
-            # dumb numeric cast so "Passed"/"Failed" strings score correctly.
-            _config_output = (getattr(child_template, "config", None) or {}).get("output", "")
-            _output_type = {
-                "Pass/Fail": "pass_fail",
-                "score": "percentage",
-                "choices": "choices",
-            }.get(_config_output)
-
-        if _output_type:
-            score = normalize_score(
-                result.get("output"),
-                _output_type,
-                child_template.choice_scores,
-            )
-        else:
-            # Last resort — best-effort numeric fallback.
-            try:
-                raw = result.get("output")
-                if raw is not None:
-                    score = max(0.0, min(1.0, float(raw)))
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Child %s has no output_type_normalized and a non-numeric "
-                    "output — skipping in aggregation",
-                    child_template.name,
-                )
+        score: float = score_eval_output(
+            result.get("output"), child_template, default_score=0.0
+        )
 
         return CompositeChildResult(
             child_id=str(child_template.id),

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -27,6 +27,21 @@ from model_hub.utils.scoring import determine_pass_fail, score_eval_output
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_PASS_THRESHOLD = 0.5
+
+
+def _resolve_child_pass_threshold(link: CompositeEvalChild) -> float:
+    """Precedence: link.config override -> pinned_version -> live template -> default."""
+    if link.config and isinstance(link.config, dict):
+        v = link.config.get("pass_threshold")
+        if isinstance(v, (int, float)) and 0.0 <= float(v) <= 1.0:
+            return float(v)
+    if link.pinned_version and link.pinned_version.pass_threshold is not None:
+        return float(link.pinned_version.pass_threshold)
+    if link.child.pass_threshold is not None:
+        return float(link.child.pass_threshold)
+    return _DEFAULT_PASS_THRESHOLD
+
 
 @dataclass
 class CompositeRunOutcome:
@@ -329,11 +344,7 @@ def execute_composite_children_sync(
 
     if parent.aggregation_enabled:
         threshold_map = {
-            str(link.child_id): (
-                link.child.pass_threshold
-                if link.child.pass_threshold is not None
-                else 0.5
-            )
+            str(link.child_id): _resolve_child_pass_threshold(link)
             for link in child_links
         }
         scores_and_weights: list[tuple[float, float]] = []

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -23,11 +23,8 @@ from model_hub.utils.composite_aggregation import (
     aggregate_scores,
     aggregate_summaries,
 )
-from model_hub.utils.scoring import (
-    determine_pass_fail,
-    resolve_pass_threshold,
-    score_eval_output,
-)
+from evaluations.engine.instance import resolve_pass_threshold
+from model_hub.utils.scoring import determine_pass_fail, score_eval_output
 
 logger = logging.getLogger(__name__)
 

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -132,8 +132,9 @@ def _execute_child(
             call_context=call_context,
         )
 
-        score: float = score_eval_output(
-            result.get("output"), child_template, default_score=0.0
+        # None: unscoreable children fall through to the exclusion branch below.
+        score: float | None = score_eval_output(
+            result.get("output"), child_template, default_score=None
         )
 
         return CompositeChildResult(

--- a/futureagi/model_hub/utils/scoring.py
+++ b/futureagi/model_hub/utils/scoring.py
@@ -215,6 +215,52 @@ def validate_pass_threshold(threshold) -> list[str]:
     return []
 
 
+def _coerce_threshold(value: Any) -> float | None:
+    """Return a valid pass_threshold in [0, 1] or ``None`` if the input is
+    non-numeric or out of range. Guards every source ``resolve_pass_threshold``
+    consults so a malformed override falls through to the next one instead of
+    raising."""
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    v = float(value)
+    if v < 0.0 or v > 1.0:
+        return None
+    return v
+
+
+def resolve_pass_threshold(
+    eval_template,
+    runtime_config: dict | None = None,
+    resolved_version=None,
+) -> float:
+    """Priority: ``runtime_config[run_config][pass_threshold]`` >
+    ``runtime_config[pass_threshold]`` > ``resolved_version.pass_threshold`` >
+    ``eval_template.pass_threshold`` > ``0.5``. Non-numeric or out-of-range
+    values from any source are skipped."""
+    if isinstance(runtime_config, dict):
+        run_config = runtime_config.get("run_config") or {}
+        if isinstance(run_config, dict):
+            v = _coerce_threshold(run_config.get("pass_threshold"))
+            if v is not None:
+                return v
+        v = _coerce_threshold(runtime_config.get("pass_threshold"))
+        if v is not None:
+            return v
+
+    if resolved_version is not None:
+        v = _coerce_threshold(getattr(resolved_version, "pass_threshold", None))
+        if v is not None:
+            return v
+
+    v = _coerce_threshold(getattr(eval_template, "pass_threshold", None))
+    if v is not None:
+        return v
+
+    return 0.5
+
+
 def score_eval_output(
     value_or_result: Any,
     eval_template: Any,

--- a/futureagi/model_hub/utils/scoring.py
+++ b/futureagi/model_hub/utils/scoring.py
@@ -218,11 +218,12 @@ def validate_pass_threshold(threshold) -> list[str]:
 def score_eval_output(
     value_or_result: Any,
     eval_template: Any,
-    default_score: float = 0.0,
-) -> float:
-    """Canonical eval-output → normalized 0-1 score. Accepts raw ``eval_instance.run()``
-    or a formatted value; falls back to ``default_score`` on inputs that cannot
-    be interpreted under the template's output type."""
+    default_score: float | None = 0.0,
+) -> float | None:
+    """Canonical eval-output → normalized 0-1 score. Falls back to
+    ``default_score`` when the value cannot be interpreted under the
+    template's output type; pass ``default_score=None`` to surface that
+    case as ``None`` instead of a hard 0.0."""
     if hasattr(value_or_result, "eval_results"):
         from evaluations.engine.formatting import (
             extract_raw_result,

--- a/futureagi/model_hub/utils/scoring.py
+++ b/futureagi/model_hub/utils/scoring.py
@@ -215,52 +215,6 @@ def validate_pass_threshold(threshold) -> list[str]:
     return []
 
 
-def _coerce_threshold(value: Any) -> float | None:
-    """Return a valid pass_threshold in [0, 1] or ``None`` if the input is
-    non-numeric or out of range. Guards every source ``resolve_pass_threshold``
-    consults so a malformed override falls through to the next one instead of
-    raising."""
-    if value is None or isinstance(value, bool):
-        return None
-    if not isinstance(value, (int, float)):
-        return None
-    v = float(value)
-    if v < 0.0 or v > 1.0:
-        return None
-    return v
-
-
-def resolve_pass_threshold(
-    eval_template,
-    runtime_config: dict | None = None,
-    resolved_version=None,
-) -> float:
-    """Priority: ``runtime_config[run_config][pass_threshold]`` >
-    ``runtime_config[pass_threshold]`` > ``resolved_version.pass_threshold`` >
-    ``eval_template.pass_threshold`` > ``0.5``. Non-numeric or out-of-range
-    values from any source are skipped."""
-    if isinstance(runtime_config, dict):
-        run_config = runtime_config.get("run_config") or {}
-        if isinstance(run_config, dict):
-            v = _coerce_threshold(run_config.get("pass_threshold"))
-            if v is not None:
-                return v
-        v = _coerce_threshold(runtime_config.get("pass_threshold"))
-        if v is not None:
-            return v
-
-    if resolved_version is not None:
-        v = _coerce_threshold(getattr(resolved_version, "pass_threshold", None))
-        if v is not None:
-            return v
-
-    v = _coerce_threshold(getattr(eval_template, "pass_threshold", None))
-    if v is not None:
-        return v
-
-    return 0.5
-
-
 def score_eval_output(
     value_or_result: Any,
     eval_template: Any,


### PR DESCRIPTION
## 1. What changes are done

### Backend

| File | Change |
| --- | --- |
| `futureagi/model_hub/utils/composite_execution.py` | `_execute_child` routes each child's score through `model_hub/utils/scoring.py::score_eval_output` so output-type derivation and choice-label resolution happen in the same helper every other eval consumer uses. Threshold map builds its per-child values via `evaluations/engine/instance.py::resolve_pass_threshold`, so composite bindings honour `runtime_config[run_config][pass_threshold] > runtime_config[pass_threshold] > resolved_version.pass_threshold > eval_template.pass_threshold > 0.5` (the exact precedence `model_hub/tasks/user_evaluation.py` already calls). Column shape (`weighted_avg`, `avg`, `min`, `max`, `pass_rate`), aggregation-off short-circuit, error-localizer surface, and APICallLog usage-log emission preserved verbatim. |
| `futureagi/model_hub/tests/test_composite_wiring_phase_b.py` | 16 new behaviour tests across four suites, fixture and mock pattern reused from the pre-existing 11 tests in this file. |

### Frontend

| File | Change |
| --- | --- |
| (none) | Net diff against `origin/dev` is empty. |

### Contracts (auto-generated)

| File | Change |
| --- | --- |
| (none) | No serializer fields or endpoints change; `yarn contracts:check` and `swagger.json` are unchanged. |

## 2. Why these changes

- **One canonical helper for eval scoring.** `score_eval_output` in `model_hub/utils/scoring.py` owns the shape-aware output-type derivation and `choice_scores` mapping; the composite runner routes each child's score through it (opting into `default_score=None` so unscoreable-completed cases surface as `None`). The composite-local `_output_type` derivation and hand-rolled numeric fallback are removed. `resolve_pass_threshold` reuse (Section 1) is the mature-parity claim: same helper `model_hub/tasks/user_evaluation.py` uses at 6 sites and `evaluations/engine/instance.py`.
- **One canonical helper for pass_threshold precedence.** `resolve_pass_threshold` at `evaluations/engine/instance.py:145` already resolves the four sources composite bindings can carry; reusing it keeps the composite runner and `user_evaluation.py` on the same policy, so a change to either surface never forks the resolution rules.
- **`pass_rate` semantics respect per-binding overrides.** `pass_rate` compares each child's score against the threshold resolved via the four-source chain in Section 1, so `CompositeEvalChild.config.pass_threshold` (per-binding override the composite editor writes) and `pinned_version.pass_threshold` (version snapshot) both apply as intended.
- **Choices-typed children score through the correct extraction path.** `result.get("output")` from `run_eval_func` is the formatted verdict dict (`{"score": float, "choice": str}` for choices) produced by `evaluations/engine/formatting.py::format_eval_value`. `score_eval_output` extracts the scalar via `extract_eval_value` before scoring, so a picked label maps to its `choice_scores` value.

## 3. Behavior callouts

- **`pass_rate` aggregation changes numerically for composites with per-binding thresholds.** A composite that used `pass_rate` and had a child threshold edited in the composite editor (`CompositeEvalChild.config.pass_threshold`) or pinned to a snapshot version (`pinned_version.pass_threshold`) now compares each child's score against that value rather than the live template's `pass_threshold`. Composites that did not edit either source are unaffected.
- **Composite children on `output_type_normalized="deterministic"` templates now surface their mapped `choice_scores` value rather than `0.0`.** Rows written before this PR keep their previously-persisted score; no backfill in this PR.
- **Composite children that complete but can't be scored under their output type surface as `None` and are excluded from aggregation, not counted as `0.0`.** `score_eval_output` gains an optional `float | None` return; `default_score=None` opts into the exclusion-from-aggregate semantics the composite runner already documents via the `elif cr.status == "completed" and cr.score is None:` branch. Relevant for a bounded set of legacy `EvalTemplate` rows created in a closed window (2026-04-27 → 2026-05-04) whose `output_type_normalized` is `NULL`; under a naive `score_eval_output` swap these would silently regress from correctly-scored to `0.0`, dragging `avg` / `pass_rate` down. Durable backfill of the `NULL` field + a `pre_save` derivation that closes the gap for future writes are tracked in TH-6414.

## 4. Tests: scenarios covered

New / extended file: `futureagi/model_hub/tests/test_composite_wiring_phase_b.py`. 16 new behaviour tests across four suites, plus `test_choices_children_score_via_shared_helper` in the same file that pins the choices-child regression this PR addresses; pre-existing 11 tests in this file untouched. Two additional pins added to `futureagi/model_hub/tests/test_scoring.py::TestScoreEvalOutputDefaultScore` (`test_default_score_none_surfaces_unscoreable_as_none` and `test_default_score_none_leaves_valid_scores_intact`) lock the `default_score=None` opt-in.

### `TestCompositeAggregationFunctions`: one test per aggregation function against a real 3-child composite

| # | Test | Scenario covered |
| --- | --- | --- |
| 1 | `test_weighted_avg_honours_link_weights` | `weighted_avg` respects per-link weights (1:2:3). |
| 2 | `test_avg_ignores_weights` | `avg` treats every child equally, ignoring weights. |
| 3 | `test_min_returns_worst_child_score` | `min` collapses to the lowest child score. |
| 4 | `test_max_returns_best_child_score` | `max` collapses to the highest child score. |
| 5 | `test_pass_rate_uses_per_child_thresholds` | `pass_rate` gates each child on its own threshold, returns pass fraction. |

### `TestCompositeChildThresholdPrecedence`: one test per source in the precedence chain

| # | Test | Scenario covered |
| --- | --- | --- |
| 6 | `test_link_config_pass_threshold_wins_over_all_others` | `link.config.pass_threshold` overrides pinned + live + default. |
| 7 | `test_pinned_version_threshold_used_when_link_config_absent` | Pinned version snapshot wins over live template. |
| 8 | `test_live_template_threshold_used_when_link_and_version_absent` | Live template value used when nothing else set. |
| 9 | `test_default_0_5_when_all_sources_are_missing` | Falls back to `0.5` when every source is `None`. |

### `TestCompositeOutputTypesEndToEnd`: score routing across the four child output-type axes

| # | Test | Scenario covered |
| --- | --- | --- |
| 10 | `test_pass_fail_children_score_correctly` | `pass_fail`-typed children map `Passed` / `Failed` to `1.0` / `0.0`. |
| 11 | `test_percentage_children_score_correctly` | `percentage`-typed children pass numeric scores through clamped to `[0, 1]`. |
| 12 | `test_code_children_score_correctly` | `code`-typed children extract the scalar from `{"score": float, "reason": str}`. |

`choices` is already covered by `test_choices_children_score_via_shared_helper` (pin for the `0.0`-on-labels regression).

### `TestCompositeAggregationEdgeCases`: degenerate inputs to the aggregation layer

| # | Test | Scenario covered |
| --- | --- | --- |
| 13 | `test_all_children_fail_aggregate_is_none` | Aggregate is `None` when every child fails to produce a score. |
| 14 | `test_pass_rate_denominator_excludes_failed_children` | `pass_rate` divides by the number of scored children, not the total link count. |
| 15 | `test_aggregate_pass_true_at_threshold` | Parent `aggregate_pass` is `True` when the aggregate meets the parent threshold. |
| 16 | `test_aggregate_pass_false_below_threshold` | Parent `aggregate_pass` is `False` when the aggregate is below the parent threshold. |

## 5. Commands to run the tests

```bash
bin/test --no-services \
  model_hub/tests/test_composite_wiring_phase_b.py \
  model_hub/tests/test_composite_eval.py
```

Expect **43 passed** (28 in `test_composite_wiring_phase_b.py` + 15 in `test_composite_eval.py`).

<img width="1772" height="1522" alt="image" src="https://github.com/user-attachments/assets/9481939e-d105-49c3-b7f0-aa0a6d5a2b3f" />


## 6. Steps to test on local

1. Check out `fix/th-6678-composite-scoring-helper`.
2. Restart backend with `./dc.sh` and wait for the backend + `temporal-worker-dev` containers to come back healthy.
3. In the FE, open `Evaluations` and create a composite eval named `composite_scoring_smoketest`.
4. Add `customer_agent_query_handling` and `customer_agent_clarification_seeking` as children; both ship `output_type_normalized="deterministic"` with `never / occasionally / frequently / always` mapped to `0.0 / 0.33 / 0.66 / 1.0`.
5. Leave aggregation on `weighted_avg` with equal weights (`1.0` each).
6. Save the composite and add it as a column on any dataset that has an `output` column populated with agent transcripts.
7. Run the composite on a row whose transcript clearly matches one of the mid-range labels.
8. Confirm each child result carries the mapped non-zero score for the label the child picked.
9. Confirm the composite aggregate equals the weighted average of the two child scores.

## 7. FE screenshots

<img width="3446" height="2138" alt="image" src="https://github.com/user-attachments/assets/24c478dd-ede7-4631-ae20-fe1d962d8d4b" />

<img width="3446" height="2138" alt="image" src="https://github.com/user-attachments/assets/feeeb571-5de1-45eb-9907-30e78878006f" />

## 8. Scope out (follow-ups)

- **Viewing or editing per-child configuration on a saved composite from the FE.** The composite detail view intentionally does not expose the individual child configs, weights, or thresholds for edit today; the composite is treated as an atomic unit after save. This PR fixes how per-child thresholds resolve at run time when they are already stored in the DB (via `CompositeEvalChild.config` or `pinned_version`), but it does not add a UI surface for changing them after the composite exists. Adding that surface is out of scope; tracked separately.
- Migrating `model_hub/views/separate_evals.py:5388-5411` (the only remaining direct `normalize_score` caller that carries the same manual-extraction gap) to route through `score_eval_output`. Deferred to keep this PR's diff scoped to the composite runner; not blocked on any other work.
- `model_hub/services/error_localizer_service.py:53` also calls `normalize_score` directly but already extracts inline (`extract_eval_value` on line 45), so it does not share the same failure mode and is not in scope for the follow-up.

## Linear

Closes TH-6678