### PR TITLE
fix(tooling): pre-commit hook fails on Windows (#1340)

### DIFF
--- a/scripts/lint-staged-frontend.mjs
+++ b/scripts/lint-staged-frontend.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -66,15 +66,30 @@ const prettierFiles = uniqueFiles.filter((file) =>
   prettierExtensions.has(path.extname(file)),
 );
 
+// Resolve a frontend tool's real JS entry-point from its package.json "bin"
+// field instead of the node_modules/.bin shim. The shim is a POSIX symlink (or a
+// .cmd wrapper on Windows); since Node's CVE-2024-27980 hardening, spawnSync
+// cannot launch a .cmd without shell:true, so spawning the shim fails on Windows
+// with "Task failed to spawn". Running the resolved script with process.execPath
+// is cross-platform and needs no shell.
+const resolveBin = (bin) => {
+  const pkgDir = path.join(frontendDir, "node_modules", bin);
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  if (!existsSync(pkgJsonPath)) return null;
+  const binField = JSON.parse(readFileSync(pkgJsonPath, "utf8")).bin;
+  const entry = typeof binField === "string" ? binField : binField?.[bin];
+  return entry ? path.join(pkgDir, entry) : null;
+};
+
 const run = (bin, args) => {
-  const command = path.join(frontendDir, "node_modules", ".bin", bin);
-  if (!existsSync(command)) {
+  const entry = resolveBin(bin);
+  if (!entry || !existsSync(entry)) {
     console.error(
       `Missing ${bin}. Run "yarn --cwd frontend install" before committing.`,
     );
     process.exit(1);
   }
-  const result = spawnSync(command, args, {
+  const result = spawnSync(process.execPath, [entry, ...args], {
     cwd: frontendDir,
     stdio: "inherit",
   });


### PR DESCRIPTION
Fixes #1340

.lintstagedrc.cjs was building paths to
frontend/node_modules/.bin/eslint and frontend/node_modules/.bin/prettier
then passing them directly to spawnSync.

Those .bin entries are POSIX symlinks. Since the Node CVE-2024-27980
hardening there is no way to spawn them on Windows: the bare shims are
not executable, and spawning .cmd/.bat files requires shell:true which
opens its own set of issues. Result: every git commit on Windows fails
before a single file is linted.

Fix: read the real JS entry point from each tool's package.json bin
field and invoke it with process.execPath (the Node binary that is
already running). This works the same on Windows, macOS, and Linux
with no shell, and exit codes propagate correctly so lint failures
still block the commit.

Changes:
- .lintstagedrc.cjs