### PR TITLE
chore: remove error boundary test route

### DIFF
--- a/frontend/src/routes/sections/dashboard.jsx
+++ b/frontend/src/routes/sections/dashboard.jsx
@@ -426,10 +426,6 @@ const Executions = lazyWithRetry(
   () => import("src/sections/agent-playground/Executions/Executions"),
 );
 
-// TODO: Remove after verifying the error boundary
-const ErrorBoundaryTest = () => {
-  throw new Error("This is a test error to preview the error boundary UI");
-};
 
 const DashboardRoutes = () => {
   const location = useLocation();
@@ -1422,11 +1418,6 @@ export const dashboardRoutes = (
     {
       path: "dashboards/:dashboardId/widget/:widgetId",
       element: <WidgetEditorView />,
-    },
-    // TODO: Remove this test route after verifying the error boundary
-    {
-      path: "error-test",
-      element: <ErrorBoundaryTest />,
     },
   ];
 


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!
-->

## Summary

This PR removes the `ErrorBoundaryTest` component and the `/error-test` route from `frontend/src/routes/sections/dashboard.jsx`. This was dead code left behind after verifying the error boundary UI and was explicitly marked with a `TODO` for removal.

## Linked issues

Closes ##1442

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Code inspection to ensure no dangling references to `ErrorBoundaryTest`.
- Passed local linting and checks.

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) (Bot will prompt me on first PR)
