### PR TITLE
fix(frontend): align edge data field name with validation schema

### DIFF
--- a/frontend/src/components/GraphBuilder/store/graphStore.js
+++ b/frontend/src/components/GraphBuilder/store/graphStore.js
@@ -96,7 +96,7 @@ export const useGraphStore = create((set, get) => ({
         type: MarkerType.ArrowClosed,
       },
       data: {
-        condition: "Default condition",
+        prompt: "Default condition",
       },
     };
 


### PR DESCRIPTION
## Summary

When connecting two nodes in the workflow builder, the edge data used the field name `condition` while the rest of the system (Zod validation, edge label renderer, configure form) expected `prompt`. Saving a workflow with a freshly connected edge failed validation with an unhelpful "Required" toast because `data.prompt` was undefined.

Changed the initial edge data field from `condition` to `prompt` so fresh edges pass validation and show "Default condition" in the edge label.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Fix edge data field name in `graphStore.js`**

- `onConnect` now sets `data.prompt = "Default condition"` instead of `data.condition = "Default condition"`
- The edge label now shows "Default condition" on fresh edges instead of a red "No Condition Specified" warning
- Save validation no longer fails with a bare "Required" error when edges are freshly created

---

## 2) Why the changes were done

- **Product/UX:** Users saw an unhelpful "Required" toast when saving workflows with newly connected edges
- **Technical:** The field name mismatch between `onConnect` (`condition`) and the validation schema (`prompt`) caused Zod to emit its default "Required" error for the missing `prompt` field

---

## 3) Tests written + scenarios each covers

No tests exist for the GraphBuilder validation flow. Existing frontend test suite (`yarn test:run`) passes with 0 regressions.

---

## 4) How to run / test

### UI steps

1. Navigate to **Scenarios** → **Create New Scenario**
2. Select a source and version, open the Workflow Builder
3. Connect two nodes by dragging from one node's handle to another
4. Click **Save Flow** — should succeed (no error toast)
5. Re-open the builder, click the edge label — condition field shows "Default condition"
6. Add a disconnected node with no prompt and save — should show a meaningful error like "End node needs a prompt"

---

## 5) Screenshots / recordings

### UI testing

<!-- Screenshot or video of the feature working in the browser -->

https://github.com/user-attachments/assets/b7caf016-fce7-4056-9f4b-517b7ef91370

---

## 6) Edge cases & considerations

- **Edges loaded from backend** use `transformEdge` which already sets `data.prompt` — unaffected
- **Edges edited in the config panel** merge `{ prompt: newValue }` via `updateEdgeData` — unaffected
- **Node validation** is separate and continues to show meaningful custom messages ("Conversation node needs a prompt")

---

## 7) Pre-existing issues (NOT introduced by this PR)

---

## 8) Architectural / important decisions

- **One-line fix:** The simplest change that resolves the mismatch. The `data.condition` field was never read anywhere in the codebase.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
