### PR TITLE
fix(frontend): trim whitespace on simulation form name/description fields

### DIFF
--- a/frontend/src/sections/agents/__tests__/helper.test.js
+++ b/frontend/src/sections/agents/__tests__/helper.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { createAgentDefinitionSchema } from "../helper";
+
+// Regression tests for issue #1389:
+// Agent definition name/description must be trimmed of leading/trailing
+// whitespace and whitespace-only values must be rejected by the required check.
+describe("createAgentDefinitionSchema whitespace handling", () => {
+  const schema = createAgentDefinitionSchema();
+
+  const validAgent = {
+    agentType: "text",
+    agentName: "test",
+    languages: ["en"],
+    description: "desc",
+    inbound: false,
+    commitMessage: "init",
+  };
+
+  it("trims surrounding whitespace from agentName and description", async () => {
+    const result = await schema.safeParseAsync({
+      ...validAgent,
+      agentName: "  test  ",
+      description: "  desc  ",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.agentName).toBe("test");
+    expect(result.data.description).toBe("desc");
+  });
+
+  it("preserves interior spaces in agentName", async () => {
+    const result = await schema.safeParseAsync({
+      ...validAgent,
+      agentName: "hello world",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.agentName).toBe("hello world");
+  });
+
+  it("rejects whitespace-only agentName", async () => {
+    const result = await schema.safeParseAsync({
+      ...validAgent,
+      agentName: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only description", async () => {
+    const result = await schema.safeParseAsync({
+      ...validAgent,
+      description: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -76,7 +76,7 @@ export const createAgentDefinitionSchema = (options) => {
     .object({
       // Basic Information
       agentType: z.string().min(1, "Agent type is required"),
-      agentName: z.string().min(1, "Agent name is required"),
+      agentName: z.string().trim().min(1, "Agent name is required"),
       languages: z
         .array(z.string())
         .min(1, "At least one language is required"),
@@ -105,7 +105,7 @@ export const createAgentDefinitionSchema = (options) => {
         .optional(),
 
       // Behaviour
-      description: z.string().min(1, "Description is required"),
+      description: z.string().trim().min(1, "Description is required"),
       knowledgeBase: z.string().optional(),
       countryCode: z.string().optional(),
       contactNumber: z.string().optional(),

--- a/frontend/src/sections/persona/PersonaCreateEdit/__tests__/common.test.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/__tests__/common.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { PersonCreateValidationSchema } from "../common";
+
+// Regression tests for issue #1389:
+// Persona name/description must be trimmed of leading/trailing whitespace and
+// whitespace-only values must be rejected by the required check.
+describe("PersonCreateValidationSchema whitespace handling", () => {
+  const validPersona = {
+    multilingual: false,
+    language: "en",
+    simulationType: "text",
+    name: "test",
+    description: "A description",
+    gender: [],
+    ageGroup: [],
+    location: [],
+    profession: [],
+    personality: [],
+    communicationStyle: [],
+    accent: [],
+    customProperties: [],
+    additionalInstruction: null,
+  };
+
+  it("trims surrounding whitespace from name and description", async () => {
+    const result = await PersonCreateValidationSchema.safeParseAsync({
+      ...validPersona,
+      name: "  test  ",
+      description: "  A description  ",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.name).toBe("test");
+    expect(result.data.description).toBe("A description");
+  });
+
+  it("preserves interior spaces", async () => {
+    const result = await PersonCreateValidationSchema.safeParseAsync({
+      ...validPersona,
+      name: "hello world",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.name).toBe("hello world");
+  });
+
+  it("rejects whitespace-only name", async () => {
+    const result = await PersonCreateValidationSchema.safeParseAsync({
+      ...validPersona,
+      name: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only description", async () => {
+    const result = await PersonCreateValidationSchema.safeParseAsync({
+      ...validPersona,
+      description: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -361,8 +361,8 @@ export const getPersonaDefaultValues = (editPersona) => {
 
 const PersonCreateBaseValidationSchema = z.object({
   simulationType: z.enum(["voice", "text"]),
-  name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().min(1, "Description is required"),
   gender: z.array(z.string()).transform((val) => (val.length ? val : null)),
   ageGroup: z.array(z.string()).transform((val) => (val.length ? val : null)),
   location: z.array(z.string()).transform((val) => (val.length ? val : null)),

--- a/frontend/src/sections/scenarios/__tests__/common.test.js
+++ b/frontend/src/sections/scenarios/__tests__/common.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  CreateScenarioValidationSchema,
+  CreateScenarioType,
+  SourceType,
+} from "../common";
+
+// Regression tests for issue #1389:
+// Scenario name/description must be trimmed of leading/trailing whitespace and
+// a whitespace-only name must be rejected by the required check.
+describe("CreateScenarioValidationSchema whitespace handling", () => {
+  const validScenario = {
+    kind: CreateScenarioType.GRAPH,
+    sourceType: SourceType.PROMPT,
+    sourceId: "src-1",
+    name: "test",
+    description: "desc",
+    promptTemplateId: "pt-1",
+    promptVersionId: "pv-1",
+    customInstructionDisabled: true,
+    noOfRows: 20,
+    addPersonaAutomatically: true,
+    columns: [],
+    personas: [],
+    config: { graph: {}, generateGraph: false },
+  };
+
+  it("trims surrounding whitespace from name and description", async () => {
+    const result = await CreateScenarioValidationSchema.safeParseAsync({
+      ...validScenario,
+      name: "  test  ",
+      description: "  desc  ",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.name).toBe("test");
+    expect(result.data.description).toBe("desc");
+  });
+
+  it("preserves interior spaces in name", async () => {
+    const result = await CreateScenarioValidationSchema.safeParseAsync({
+      ...validScenario,
+      name: "hello world",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.name).toBe("hello world");
+  });
+
+  it("rejects whitespace-only name", async () => {
+    const result = await CreateScenarioValidationSchema.safeParseAsync({
+      ...validScenario,
+      name: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -64,8 +64,8 @@ const CreateScenarioDefaultSchema = {
     .default("agent_definition"),
   sourceId: z.string().min(1, "Source is required"),
   sourceLabel: z.string().optional(), // Used for auto-generating scenario name, not sent to API
-  name: z.string().min(1, "Name is required"),
-  description: z.string().optional(),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().optional(),
   agentDefinitionId: z.string().optional(),
   agentDefinitionVersionId: z.string().optional(),
   promptTemplateId: z.string().optional(),


### PR DESCRIPTION
## Summary

The persona create/edit, Create Scenario, and Create Agent Definition forms persisted `name`/`description` verbatim, so inputs like `" test "` were saved with leading/trailing whitespace. This produced apparent duplicates that sort separately in lists, and all-whitespace values slipped past the "required" check because they technically have length > 0. This PR trims those fields in the zod validation schemas.

## Linked issues

Closes #1389

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Trim name/description in simulation form validation schemas**

- Persona create/edit (`frontend/src/sections/persona/PersonaCreateEdit/common.js`): `name`, `description`
- Create Scenario (`frontend/src/sections/scenarios/common.js`): `name`, `description`
- Create Agent Definition (`frontend/src/sections/agents/helper.jsx`): `agentName`, `description`

Each field now uses `z.string().trim()...`. Because validation runs through the existing `zodResolver`, trimmed values flow to the  submit handlers with no handler changes.

**B. Regression tests** — added `__tests__` suites for all three schemas.

## 2) Why the changes were done

- **Product/UX:** Trailing/leading spaces created look-alike duplicates that sorted apart and confused users; whitespace-only  names were silently accepted.
- **Technical:** `.trim()` in the schema is the smallest, centralized fix — trimmed output reaches submit handlers automatically via `zodResolver`. Interior spaces (e.g. `"hello world"`) are preserved.

## 3) Tests written + scenarios each covers

**`persona/PersonaCreateEdit/__tests__/common.test.js`**
- trims surrounding whitespace from name and description
- preserves interior spaces
- rejects whitespace-only name
- rejects whitespace-only description

**`scenarios/__tests__/common.test.js`**
- trims surrounding whitespace from name and description
- preserves interior spaces in name
- rejects whitespace-only name

**`agents/__tests__/helper.test.js`**
- trims surrounding whitespace from agentName and description
- preserves interior spaces in agentName
- rejects whitespace-only agentName
- rejects whitespace-only description

> Run result: **11 passed** across the three suites. ESLint clean (0 errors).

## 4) How to run / test

```bash
cd frontend
yarn install
yarn test:run