### PR TITLE
fix(scenarios/annotation-queues): three medium-low UI fixes (TH-6556, TH-6549, TH-6177)

### DIFF
--- a/frontend/src/sections/annotations/queues/view/queue-item-filters.js
+++ b/frontend/src/sections/annotations/queues/view/queue-item-filters.js
@@ -12,7 +12,7 @@ export const ITEM_SOURCE_FILTER_OPTIONS = [
   { value: "trace", label: "Trace" },
   { value: "observation_span", label: "Span" },
   { value: "trace_session", label: "Session" },
-  { value: "prototype_run", label: "Prototype" },
+  // { value: "prototype_run", label: "Prototype" },
   { value: "call_execution", label: "Simulation" },
 ];
 

--- a/frontend/src/sections/scenarios/CustomInstruction.jsx
+++ b/frontend/src/sections/scenarios/CustomInstruction.jsx
@@ -62,7 +62,6 @@ export default function CustomInstruction({ control }) {
             >
               <Typography
                 fontWeight={"fontWeightRegular"}
-                color={"background.paper"}
                 typography={"s2"}
               >
                 {watchedCustomInstructionDisabled

--- a/frontend/src/sections/scenarios/PersonaSection.jsx
+++ b/frontend/src/sections/scenarios/PersonaSection.jsx
@@ -4,7 +4,7 @@ import CreateScenarioHeader from "./CreateScenarioHeader";
 import SvgColor from "src/components/svg-color";
 import SwitchField from "src/components/Switch/SwitchField";
 import PropTypes from "prop-types";
-import { useFieldArray, useWatch } from "react-hook-form";
+import { useFieldArray, useWatch, useFormState } from "react-hook-form";
 import { ShowComponent } from "src/components/show";
 import PersonaDrawer from "../persona/PersonaDrawer";
 import GenericCard from "../persona/GenericCard/GenericCard";
@@ -26,6 +26,13 @@ const PersonaSection = ({ control, description = "" }) => {
     control,
     name: "agentType",
   });
+  const { errors } = useFormState({ control });
+  const personaError =
+    typeof errors?.personas?.message === "string"
+      ? errors.personas.message
+      : typeof errors?.personas?.root?.message === "string"
+        ? errors.personas.root.message
+        : "";
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: "12px" }}>
       <CreateScenarioHeader
@@ -118,6 +125,11 @@ const PersonaSection = ({ control, description = "" }) => {
           </Box>
         </CustomTooltip>
       </Box>
+      <ShowComponent condition={!addPersonaAutomatically && !!personaError}>
+        <Typography typography="s2_1" color="error.main">
+          {personaError}
+        </Typography>
+      </ShowComponent>
       <ShowComponent condition={!addPersonaAutomatically}>
         <Box
           sx={{

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -142,6 +142,18 @@ export const CreateScenarioValidationSchema = z
   ])
   .refine(
     (data) => {
+      if (!data.addPersonaAutomatically) {
+        return Array.isArray(data.personas) && data.personas.length > 0;
+      }
+      return true;
+    },
+    {
+      message: "Add at least one persona",
+      path: ["personas"],
+    },
+  )
+  .refine(
+    (data) => {
       // Validate agent definition fields when source type is agent_definition
       if (data.sourceType === "agent_definition") {
         return data.agentDefinitionId && data.agentDefinitionId.length > 0;


### PR DESCRIPTION
## Summary

Three independent medium/low-priority UI fixes, one commit each.

## What changed

- **TH-6556 — Able to create scenarios when persona auto-add is off.** Added a `.refine` to `CreateScenarioValidationSchema` requiring at least one persona when the "Add by default" toggle is disabled, and surfaced the error inline in `PersonaSection`. Previously a scenario could be created with the toggle off and zero personas.
- **TH-6549 — Auto-create message not visible in dark theme.** Removed the hardcoded `color="background.paper"` on the custom-instruction disabled message so it uses a theme-aware color and is legible in dark mode.
- **TH-6177 — Remove Prototype as an item source.** Commented out the `prototype_run` / "Prototype" option in the annotation-queue item source filter list.

## Tests

- [ ] TH-6556: with the persona "Add by default" toggle off and no personas added, Create is blocked and "Add at least one persona" shows; adding one clears it; toggle on submits fine
- [ ] TH-6549: in dark theme, the custom-instruction disabled message is visible on the create-scenario page
- [ ] TH-6177: the annotation-queue source filter no longer lists "Prototype"

## Commands

```
cd frontend && yarn check-all
```

## Backwards compatibility

No API or schema changes. Frontend-only.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the style guide
- [x] ESLint clean on all touched files
- [x] No hardcoded secrets, URLs, or PII

## Backout

Revert this PR — frontend-only, no migrations.

## Linear

Closes TH-6556
Closes TH-6549
Closes TH-6177