### PR TITLE
[TH-6638] Block saving scenario graphs with disconnected nodes

### DIFF
--- a/frontend/src/components/GraphBuilder/DisconnectedNodesToast.jsx
+++ b/frontend/src/components/GraphBuilder/DisconnectedNodesToast.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+
+const MAX_VISIBLE_NAMES = 3;
+
+const DisconnectedNodesToast = ({ names = [] }) => {
+  const visible = names.slice(0, MAX_VISIBLE_NAMES);
+  const remaining = names.length - visible.length;
+  const label =
+    visible.join(", ") + (remaining > 0 ? `, +${remaining} more` : "");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Typography typography="s1">
+        {names.length === 1 ? "Disconnected node: " : "Disconnected nodes: "}
+        <Box component="span" fontWeight="fontWeightSemiBold">
+          {label}
+        </Box>
+      </Typography>
+      <Typography typography="s2" color="text.secondary">
+        Connect all nodes before saving.
+      </Typography>
+    </Box>
+  );
+};
+
+DisconnectedNodesToast.propTypes = {
+  names: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default DisconnectedNodesToast;

--- a/frontend/src/components/GraphBuilder/DisconnectedNodesToast.jsx
+++ b/frontend/src/components/GraphBuilder/DisconnectedNodesToast.jsx
@@ -13,13 +13,16 @@ const DisconnectedNodesToast = ({ names = [] }) => {
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
       <Typography typography="s1">
-        {names.length === 1 ? "Disconnected node: " : "Disconnected nodes: "}
+        {names.length === 1
+          ? "Node not reachable from Start: "
+          : "Nodes not reachable from Start: "}
         <Box component="span" fontWeight="fontWeightSemiBold">
           {label}
         </Box>
       </Typography>
       <Typography typography="s2" color="text.secondary">
-        Connect all nodes before saving.
+        The flow only follows outgoing edges from the Start node. Connect these
+        nodes downstream of Start before saving.
       </Typography>
     </Box>
   );

--- a/frontend/src/components/GraphBuilder/GraphBuilder.jsx
+++ b/frontend/src/components/GraphBuilder/GraphBuilder.jsx
@@ -9,10 +9,8 @@ import GraphBuilderLeftBar from "./GraphBuilderLeftBar";
 import PropTypes from "prop-types";
 import GraphView from "./GraphView";
 import NodeEdgeConfigureForm from "./ConfigForms/NodeEdgeConfigureForm";
-import {
-  ValidateAndTransformGraphSchema,
-  validateGraphConnectivity,
-} from "./validation";
+import { ValidateAndTransformGraphSchema } from "./validation";
+import { validateGraphConnectivity } from "./connectivity";
 import DisconnectedNodesToast from "./DisconnectedNodesToast";
 import { useSnackbar } from "src/components/snackbar";
 import { dagreTransformAndLayout } from "./common";
@@ -56,11 +54,17 @@ const GraphBuilder = ({ value, onChange, saveLoading, agentType }) => {
       return;
     }
 
-    const { orphanNames, orphanIds } = validateGraphConnectivity(
+    const { orphanNames, orphanIds, noStartNode } = validateGraphConnectivity(
       currentNodes,
       currentEdges,
     );
     useGraphStore.getState().setOrphanHighlights(orphanIds);
+    if (noStartNode) {
+      enqueueSnackbar("Graph has no start node. Add one before saving.", {
+        variant: "error",
+      });
+      return;
+    }
     if (orphanIds.length > 0) {
       enqueueSnackbar(<DisconnectedNodesToast names={orphanNames} />, {
         variant: "error",

--- a/frontend/src/components/GraphBuilder/GraphBuilder.jsx
+++ b/frontend/src/components/GraphBuilder/GraphBuilder.jsx
@@ -9,7 +9,11 @@ import GraphBuilderLeftBar from "./GraphBuilderLeftBar";
 import PropTypes from "prop-types";
 import GraphView from "./GraphView";
 import NodeEdgeConfigureForm from "./ConfigForms/NodeEdgeConfigureForm";
-import { ValidateAndTransformGraphSchema } from "./validation";
+import {
+  ValidateAndTransformGraphSchema,
+  validateGraphConnectivity,
+} from "./validation";
+import DisconnectedNodesToast from "./DisconnectedNodesToast";
 import { useSnackbar } from "src/components/snackbar";
 import { dagreTransformAndLayout } from "./common";
 import { ReactFlowProvider } from "@xyflow/react";
@@ -36,9 +40,12 @@ const GraphBuilder = ({ value, onChange, saveLoading, agentType }) => {
   }, []);
 
   const onSave = useCallback(() => {
+    const currentNodes = useGraphStore.getState().nodes;
+    const currentEdges = useGraphStore.getState().edges;
+
     const validatedGraph = ValidateAndTransformGraphSchema().safeParse({
-      nodes: useGraphStore.getState().nodes,
-      edges: useGraphStore.getState().edges,
+      nodes: currentNodes,
+      edges: currentEdges,
     });
 
     if (!validatedGraph.success) {
@@ -48,6 +55,19 @@ const GraphBuilder = ({ value, onChange, saveLoading, agentType }) => {
       enqueueSnackbar(messageString, { variant: "error" });
       return;
     }
+
+    const { orphanNames, orphanIds } = validateGraphConnectivity(
+      currentNodes,
+      currentEdges,
+    );
+    useGraphStore.getState().setOrphanHighlights(orphanIds);
+    if (orphanIds.length > 0) {
+      enqueueSnackbar(<DisconnectedNodesToast names={orphanNames} />, {
+        variant: "error",
+      });
+      return;
+    }
+
     onChange({
       ...value,
       nodes: validatedGraph.data.nodes,

--- a/frontend/src/components/GraphBuilder/GraphView.jsx
+++ b/frontend/src/components/GraphBuilder/GraphView.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import {
   ReactFlow,
   Background,
@@ -52,7 +52,25 @@ const GraphView = ({
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
 
-  const { screenToFlowPosition } = useReactFlow();
+  const { screenToFlowPosition, fitView } = useReactFlow();
+
+  const orphanFocusSignal = useGraphStore((state) => state.orphanFocusSignal);
+
+  useEffect(() => {
+    if (!editMode || orphanFocusSignal === 0) return;
+    const highlightedNodes = useGraphStore
+      .getState()
+      .nodes.filter((node) => node?.data?.highlightColor === "error")
+      .map((node) => ({ id: node.id }));
+    if (highlightedNodes.length === 0) return;
+    fitView({
+      nodes: highlightedNodes,
+      padding: 0.4,
+      duration: 500,
+      maxZoom: 1,
+    });
+  }, [orphanFocusSignal, editMode, fitView]);
+
   const onDrop = useCallback(
     (event) => {
       event.preventDefault();

--- a/frontend/src/components/GraphBuilder/common.js
+++ b/frontend/src/components/GraphBuilder/common.js
@@ -111,13 +111,15 @@ const extractEdgeData = (edge) => {
 // src/sections/scenarios/scenario-detail/common.js
 export const transformNode = (node, extraData = {}) => {
   const nodeType = getTypeFromNodeData(node);
+  const data = { ...extractNodeData(node, nodeType), ...extraData };
   return {
     id: node?.name ?? getRandomId(),
     type: nodeType,
     position: node?.metadata?.position
       ? node?.metadata?.position
       : { x: 250, y: 50 },
-    data: { ...extractNodeData(node, nodeType), ...extraData },
+    data,
+    ...(data.isStart && { deletable: false }),
   };
 };
 

--- a/frontend/src/components/GraphBuilder/connectivity.js
+++ b/frontend/src/components/GraphBuilder/connectivity.js
@@ -1,0 +1,37 @@
+export const validateGraphConnectivity = (nodes, edges) => {
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    return { orphanNames: [], orphanIds: [], noStartNode: false };
+  }
+  const startIds = nodes
+    .filter((node) => node?.data?.isStart)
+    .map((node) => node.id);
+  if (startIds.length === 0) {
+    return { orphanNames: [], orphanIds: [], noStartNode: true };
+  }
+  const outgoing = new Map();
+  edges?.forEach((edge) => {
+    if (!outgoing.has(edge.source)) {
+      outgoing.set(edge.source, []);
+    }
+    outgoing.get(edge.source).push(edge.target);
+  });
+  const visited = new Set(startIds);
+  const queue = [...startIds];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    (outgoing.get(current) || []).forEach((target) => {
+      if (!visited.has(target)) {
+        visited.add(target);
+        queue.push(target);
+      }
+    });
+  }
+  const orphans = nodes.filter(
+    (node) => !node?.data?.isGlobal && !visited.has(node.id),
+  );
+  return {
+    orphanNames: orphans.map((node) => node?.data?.name || node.id),
+    orphanIds: orphans.map((node) => node.id),
+    noStartNode: false,
+  };
+};

--- a/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
@@ -4,6 +4,7 @@ import { Box, Chip, Typography, useTheme } from "@mui/material";
 import SvgColor from "src/components/svg-color";
 import Iconify from "src/components/iconify";
 import { NODE_TYPES, useGraphStore } from "../store/graphStore";
+import Label from "src/components/label";
 import NodeHeader from "./NodeHeader";
 import PropTypes from "prop-types";
 import { ShowComponent } from "src/components/show";
@@ -80,7 +81,17 @@ const ConversationNode = ({ data, isConnectable, id }) => {
             borderColor: theme.palette.primary.main,
           }}
         />
-        <NodeHeader type="conversation" title={data?.name} />
+        <NodeHeader
+          type="conversation"
+          title={data?.name}
+          badge={
+            data?.isStart ? (
+              <Label color="primary" variant="soft">
+                Start
+              </Label>
+            ) : null
+          }
+        />
         <ShowComponent condition={data?.isGlobal}>
           <Chip
             icon={<Iconify icon="mdi:earth" width={14} />}

--- a/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
@@ -4,7 +4,7 @@ import { Box, Divider, Typography } from "@mui/material";
 import SvgColor from "src/components/svg-color";
 import { GRAPH_NODES } from "../common";
 
-const NodeHeader = ({ type, title }) => {
+const NodeHeader = ({ type, title, badge }) => {
   const node = GRAPH_NODES.find((n) => n.type === type);
   if (!node) return null;
   const { color, backgroundColor, icon, name } = node;
@@ -42,6 +42,7 @@ const NodeHeader = ({ type, title }) => {
         <Typography typography="s2" fontWeight="fontWeightMedium">
           {title || name}
         </Typography>
+        {badge && <Box sx={{ marginLeft: "auto" }}>{badge}</Box>}
       </Box>
       <Divider />
     </>
@@ -51,6 +52,7 @@ const NodeHeader = ({ type, title }) => {
 NodeHeader.propTypes = {
   type: PropTypes.string,
   title: PropTypes.string,
+  badge: PropTypes.node,
 };
 
 export default NodeHeader;

--- a/frontend/src/components/GraphBuilder/store/graphStore.js
+++ b/frontend/src/components/GraphBuilder/store/graphStore.js
@@ -75,6 +75,7 @@ const initialEdges = [];
 export const useGraphStore = create((set, get) => ({
   nodes: getInitialNodes(),
   edges: initialEdges,
+  orphanFocusSignal: 0,
 
   onNodesChange: (changes) => {
     set({
@@ -100,8 +101,23 @@ export const useGraphStore = create((set, get) => ({
       },
     };
 
+    const reconnected = new Set([connection.source, connection.target]);
+    let clearedHighlight = false;
+    const nodes = get().nodes.map((node) => {
+      if (!reconnected.has(node.id) || node.data?.highlightColor !== "error") {
+        return node;
+      }
+      clearedHighlight = true;
+      const data = { ...node.data };
+      delete data.highlightColor;
+      return { ...node, data };
+    });
     set({
       edges: addEdge(edge, get().edges),
+      nodes,
+      orphanFocusSignal: clearedHighlight
+        ? get().orphanFocusSignal + 1
+        : get().orphanFocusSignal,
     });
   },
 
@@ -139,6 +155,25 @@ export const useGraphStore = create((set, get) => ({
             : { ...node, ...newData }
           : node,
       ),
+    });
+  },
+
+  setOrphanHighlights: (orphanIds) => {
+    const idSet = new Set(orphanIds ?? []);
+    set({
+      orphanFocusSignal: get().orphanFocusSignal + 1,
+      nodes: get().nodes.map((node) => {
+        const shouldHighlight = idSet.has(node.id);
+        const isHighlighted = node.data?.highlightColor === "error";
+        if (shouldHighlight === isHighlighted) return node;
+        const data = { ...node.data };
+        if (shouldHighlight) {
+          data.highlightColor = "error";
+        } else {
+          delete data.highlightColor;
+        }
+        return { ...node, data };
+      }),
     });
   },
 

--- a/frontend/src/components/GraphBuilder/store/graphStore.js
+++ b/frontend/src/components/GraphBuilder/store/graphStore.js
@@ -7,6 +7,7 @@ import {
 } from "@xyflow/react";
 import { getRandomId } from "src/utils/utils";
 import logger from "src/utils/logger";
+import { validateGraphConnectivity } from "../connectivity";
 
 export const NODE_TYPES = {
   CONVERSATION: "conversation",
@@ -62,6 +63,7 @@ const getInitialNodes = () => {
       id: `Conversation_${randomId}`,
       type: NODE_TYPES.CONVERSATION,
       position: { x: 250, y: 50 },
+      deletable: false,
       data: {
         ...getDefaultNodeData(NODE_TYPES.CONVERSATION, randomId),
         isStart: true,
@@ -101,10 +103,21 @@ export const useGraphStore = create((set, get) => ({
       },
     };
 
-    const reconnected = new Set([connection.source, connection.target]);
+    const edges = addEdge(edge, get().edges);
+    const currentNodes = get().nodes;
+    const hasErrorHighlight = currentNodes.some(
+      (node) => node.data?.highlightColor === "error",
+    );
+    if (!hasErrorHighlight) {
+      set({ edges });
+      return;
+    }
+
+    const { orphanIds } = validateGraphConnectivity(currentNodes, edges);
+    const stillOrphan = new Set(orphanIds);
     let clearedHighlight = false;
-    const nodes = get().nodes.map((node) => {
-      if (!reconnected.has(node.id) || node.data?.highlightColor !== "error") {
+    const nodes = currentNodes.map((node) => {
+      if (node.data?.highlightColor !== "error" || stillOrphan.has(node.id)) {
         return node;
       }
       clearedHighlight = true;
@@ -113,11 +126,11 @@ export const useGraphStore = create((set, get) => ({
       return { ...node, data };
     });
     set({
-      edges: addEdge(edge, get().edges),
-      nodes,
-      orphanFocusSignal: clearedHighlight
-        ? get().orphanFocusSignal + 1
-        : get().orphanFocusSignal,
+      edges,
+      ...(clearedHighlight && {
+        nodes,
+        orphanFocusSignal: get().orphanFocusSignal + 1,
+      }),
     });
   },
 
@@ -229,6 +242,7 @@ export const useGraphStore = create((set, get) => ({
       position: { x: node.position.x + 200, y: node.position.y + 200 },
       data: {
         ...node.data,
+        ...(node.data?.isStart && { isStart: false }),
         name: newNodeName,
       },
       // Explicitly reset React Flow properties that might cause grouping

--- a/frontend/src/components/GraphBuilder/validation.js
+++ b/frontend/src/components/GraphBuilder/validation.js
@@ -196,24 +196,6 @@ export const ValidateAndTransformEdgeSchema = () =>
       },
     }));
 
-export const validateGraphConnectivity = (nodes, edges) => {
-  if (!Array.isArray(nodes) || nodes.length <= 1) {
-    return { orphanNames: [], orphanIds: [] };
-  }
-  const connectedIds = new Set();
-  edges?.forEach((edge) => {
-    connectedIds.add(edge.source);
-    connectedIds.add(edge.target);
-  });
-  const orphans = nodes.filter(
-    (node) => !node?.data?.isGlobal && !connectedIds.has(node.id),
-  );
-  return {
-    orphanNames: orphans.map((node) => node?.data?.name || node.id),
-    orphanIds: orphans.map((node) => node.id),
-  };
-};
-
 export const ValidateAndTransformGraphSchema = () =>
   z.object({
     nodes: z.array(ValidateAndTransformNodeSchema()),

--- a/frontend/src/components/GraphBuilder/validation.js
+++ b/frontend/src/components/GraphBuilder/validation.js
@@ -196,6 +196,24 @@ export const ValidateAndTransformEdgeSchema = () =>
       },
     }));
 
+export const validateGraphConnectivity = (nodes, edges) => {
+  if (!Array.isArray(nodes) || nodes.length <= 1) {
+    return { orphanNames: [], orphanIds: [] };
+  }
+  const connectedIds = new Set();
+  edges?.forEach((edge) => {
+    connectedIds.add(edge.source);
+    connectedIds.add(edge.target);
+  });
+  const orphans = nodes.filter(
+    (node) => !node?.data?.isGlobal && !connectedIds.has(node.id),
+  );
+  return {
+    orphanNames: orphans.map((node) => node?.data?.name || node.id),
+    orphanIds: orphans.map((node) => node.id),
+  };
+};
+
 export const ValidateAndTransformGraphSchema = () =>
   z.object({
     nodes: z.array(ValidateAndTransformNodeSchema()),

--- a/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
@@ -9,10 +9,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { enqueueSnackbar } from "src/components/snackbar";
 import axios, { endpoints } from "src/utils/axios";
 import { ReactFlowProvider } from "@xyflow/react";
-import {
-  ValidateAndTransformGraphSchema,
-  validateGraphConnectivity,
-} from "src/components/GraphBuilder/validation";
+import { ValidateAndTransformGraphSchema } from "src/components/GraphBuilder/validation";
+import { validateGraphConnectivity } from "src/components/GraphBuilder/connectivity";
 import DisconnectedNodesToast from "src/components/GraphBuilder/DisconnectedNodesToast";
 import { useGraphStore } from "src/components/GraphBuilder/store/graphStore";
 import { hasGraphChanged } from "./common";
@@ -100,11 +98,18 @@ const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
       return;
     }
 
-    const { orphanNames, orphanIds } = validateGraphConnectivity(
+    const { orphanNames, orphanIds, noStartNode } = validateGraphConnectivity(
       currentNodes,
       currentEdges,
     );
     useGraphStore.getState().setOrphanHighlights(orphanIds);
+    if (noStartNode) {
+      enqueueSnackbar("Graph has no start node. Add one before saving.", {
+        variant: "error",
+      });
+      setOpenConfirmClose(false);
+      return;
+    }
     if (orphanIds.length > 0) {
       enqueueSnackbar(<DisconnectedNodesToast names={orphanNames} />, {
         variant: "error",

--- a/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
@@ -9,7 +9,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { enqueueSnackbar } from "src/components/snackbar";
 import axios, { endpoints } from "src/utils/axios";
 import { ReactFlowProvider } from "@xyflow/react";
-import { ValidateAndTransformGraphSchema } from "src/components/GraphBuilder/validation";
+import {
+  ValidateAndTransformGraphSchema,
+  validateGraphConnectivity,
+} from "src/components/GraphBuilder/validation";
+import DisconnectedNodesToast from "src/components/GraphBuilder/DisconnectedNodesToast";
 import { useGraphStore } from "src/components/GraphBuilder/store/graphStore";
 import { hasGraphChanged } from "./common";
 import ModalWrapper from "src/components/ModalWrapper/ModalWrapper";
@@ -79,9 +83,12 @@ const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
   };
 
   const handleSaveChanges = () => {
+    const currentNodes = useGraphStore.getState().nodes;
+    const currentEdges = useGraphStore.getState().edges;
+
     const validatedGraph = ValidateAndTransformGraphSchema().safeParse({
-      nodes: useGraphStore.getState().nodes,
-      edges: useGraphStore.getState().edges,
+      nodes: currentNodes,
+      edges: currentEdges,
     });
 
     if (!validatedGraph.success) {
@@ -89,6 +96,19 @@ const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
         ?.map((error) => error.message)
         .join(", ");
       enqueueSnackbar(messageString, { variant: "error" });
+      setOpenConfirmClose(false);
+      return;
+    }
+
+    const { orphanNames, orphanIds } = validateGraphConnectivity(
+      currentNodes,
+      currentEdges,
+    );
+    useGraphStore.getState().setOrphanHighlights(orphanIds);
+    if (orphanIds.length > 0) {
+      enqueueSnackbar(<DisconnectedNodesToast names={orphanNames} />, {
+        variant: "error",
+      });
       setOpenConfirmClose(false);
       return;
     }

--- a/frontend/src/sections/scenarios/scenario-detail/common.js
+++ b/frontend/src/sections/scenarios/scenario-detail/common.js
@@ -11,6 +11,7 @@ export function normalizeGraph(graph) {
     position: undefined,
     selected: undefined,
     dragging: undefined,
+    deletable: undefined,
     data: {
       ...data,
       editMode: undefined, // ignore editMode

--- a/frontend/src/sections/scenarios/scenario-detail/common.js
+++ b/frontend/src/sections/scenarios/scenario-detail/common.js
@@ -14,6 +14,7 @@ export function normalizeGraph(graph) {
     data: {
       ...data,
       editMode: undefined, // ignore editMode
+      highlightColor: undefined, // ignore transient orphan highlight
     },
   }));
 


### PR DESCRIPTION
**Ticket:** [TH-6638](https://linear.app/future-agi/issue/TH-6638/workflow-builder-allows-saving-invalid-graph-structures) — Fixes TH-6638

## What was the bug
The Scenario Workflow Builder let users save a graph containing disconnected (orphan) nodes — nodes not connected to the rest of the graph by any edge. No validation or warning was shown. Such nodes are silently dropped during branch/case generation, so the user thinks they added coverage they actually didn't.

## What changes have been done
- `frontend/src/components/GraphBuilder/validation.js` — new `validateGraphConnectivity(nodes, edges)` that returns the orphan nodes (`{ orphanNames, orphanIds }`). A node is an orphan when it isn't a source/target of any edge and isn't a global node. Single-node graphs are exempt.
- `frontend/src/components/GraphBuilder/DisconnectedNodesToast.jsx` — new formatted error toast (names comma-separated, `+N more` beyond 3).
- `frontend/src/components/GraphBuilder/store/graphStore.js` — `setOrphanHighlights` flags orphans red via `highlightColor`, `orphanFocusSignal` drives the canvas pan, and `onConnect` clears a node's highlight the moment it's connected.
- `frontend/src/components/GraphBuilder/GraphView.jsx` — reactive `fitView` that pans/zooms to the highlighted orphan nodes (edit-mode only).
- `frontend/src/components/GraphBuilder/GraphBuilder.jsx` / `frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx` — both save paths run field validation first, then the connectivity gate; on failure they toast + highlight + block save.
- `frontend/src/sections/scenarios/scenario-detail/common.js` — strip the transient `highlightColor` in `normalizeGraph` so the dirty-check doesn't report a false "Unsaved Changes".

## Why the changes
- The graph payload is stored verbatim by the backend with no structural validation, and orphan nodes are silently skipped at generation time — so the guard has to live client-side.
- Both the create (manual builder) and edit flows share `GraphBuilder.onSave`, so validating there covers both; `handleSaveChanges` (save-on-close) is the one separate path and gets the same guard.
- Field validation runs before connectivity so users fix missing names/prompts first, and the viewport isn't yanked around before the basics are filled in.
- `highlightColor` is a runtime-only flag (never persisted); `normalizeGraph` already neutralizes other transient fields like `editMode`, so it belongs there too.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Save graph with an unconnected node | Save blocked, toast lists the node, node turns red, canvas pans to it |
| 2 | Connect the flagged node, save again | Highlight clears on connect, save succeeds |
| 3 | Multiple orphans, connect them one by one | View re-frames to the remaining orphans as each is connected |
| 4 | Default single-node graph | Saves fine (single-node exempt) |
| 5 | Global (`isGlobal`) node with no edges | Not flagged (exempt) |
| 6 | Node missing name/prompt AND disconnected | Field error shows first; connectivity gate only after fields are valid |
| 7 | Open edit drawer on a graph with a pre-existing orphan, Save (blocked), close | No false "Unsaved Changes" prompt |

## How to reproduce (original bug)
1. Open a Scenario → Edit the workflow graph.
2. Drag a new node onto the canvas without connecting it.
3. Click Save.
4. Before: the graph saves with no warning. After: save is blocked with a toast + the node highlighted.

## Videos and screenshots

https://github.com/user-attachments/assets/3816c28e-587f-45e7-9fe3-7124e4f7c079


https://github.com/user-attachments/assets/144be266-4f66-49fa-abd7-16178fc8fa95

