### PR TITLE
fix(frontend): block 0-byte file uploads in scenario configuration (f…

### DIFF
--- a/frontend/src/sections/scenarios/CallChatSOPOption.jsx
+++ b/frontend/src/sections/scenarios/CallChatSOPOption.jsx
@@ -22,6 +22,15 @@ const CallChatSOPOption = ({ control }) => {
     const files = Array.from(acceptedFiles);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
+    const emptyFiles = files.filter((file) => file?.size === 0);
+
+    if (emptyFiles.length > 0) {
+      enqueueSnackbar("File cannot be empty", {
+        variant: "error",
+      });
+      return;
+    }
+
     const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
 
     if (filesLargerThanMaxSize.length > 0) {

--- a/frontend/src/sections/scenarios/UploadScriptOption.jsx
+++ b/frontend/src/sections/scenarios/UploadScriptOption.jsx
@@ -22,6 +22,15 @@ const UploadScriptOption = ({ control }) => {
     const files = Array.from(acceptedFiles);
     const maxSize = 5 * 1024 * 1024; // 5MB
 
+    const emptyFiles = files.filter((file) => file?.size === 0);
+
+    if (emptyFiles.length > 0) {
+      enqueueSnackbar("File cannot be empty", {
+        variant: "error",
+      });
+      return;
+    }
+
     const filesLargerThanMaxSize = files.filter((file) => file?.size > maxSize);
 
     if (filesLargerThanMaxSize.length > 0) {


### PR DESCRIPTION
### Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

### How was this tested?
Tested locally by simulating a 0-byte file upload in both the Call/Chat SOP scenario upload dropzone and the generic Script Upload dropzone. Verified that the UI now correctly blocks the upload and surfaces the 'File cannot be empty' error snackbar, whereas previously it silently accepted the invalid file.

### Screenshots / recordings (if UI)
N/A

### Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA