### PR TITLE
perf(eval-tasks): CH guardrails + single-statement requeue (Phase A finish)

### DIFF
--- a/futureagi/tests/stress/test_baselines.py
+++ b/futureagi/tests/stress/test_baselines.py
@@ -1,7 +1,8 @@
-"""Red baseline budgets (S10, S12): each asserts the post-fix
-Phase-A/B budget against CURRENT code and must fail today — strict xfail.
+"""Red baseline budgets (S12): each asserts the post-fix
+Phase-B budget against CURRENT code and must fail today — strict xfail.
 The fix packet that lands each fix removes its xfail marker.
 (S6 moved to test_trace_loading.py as part of A4 (lean-first loading).)
+(S10 moved to test_reconcile_counts.py once A7 landed.)
 """
 
 from __future__ import annotations
@@ -13,45 +14,14 @@ from django.test.utils import CaptureQueriesContext
 from tests.stress.budgets import (
     DRAIN_BATCH_MAX_CH_QUERIES,
     DRAIN_PER_ENTRY_MAX_PG_QUERIES,
-    RECONCILE_REQUEUE_MAX_PG_UPDATES,
 )
 from tests.stress.ch_asserts import ch_query_budget
 from tracer.models.eval_task import RowType
-from tracer.models.observation_span import EvalEntryStatus, EvalLogger
 from tracer.services.eval_tasks.entries import claim_pending_batch
 from tracer.services.eval_tasks.reconciler import reconcile
 from tracer.services.eval_tasks.run_entry import run_entry
 
 pytestmark = pytest.mark.stress
-
-
-@pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True, reason="A7 (single-statement requeue) not yet implemented"
-)
-def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
-    m = stress_dataset.target
-    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
-    reconcile(task)
-    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
-        status=EvalEntryStatus.COMPLETED
-    )
-    # Edit every config: hash changes make all completed entries stale.
-    for cfg in task.evals.all():
-        cfg.config = {"threshold": 0.9}
-        cfg.save()
-
-    with CaptureQueriesContext(connection) as ctx:
-        result = reconcile(task)
-
-    assert result.requeued == 180  # parity: every stale entry requeued
-    table = EvalLogger._meta.db_table
-    updates = [
-        q
-        for q in ctx.captured_queries
-        if q["sql"].strip().upper().startswith("UPDATE") and table in q["sql"]
-    ]
-    assert len(updates) <= RECONCILE_REQUEUE_MAX_PG_UPDATES
 
 
 @pytest.mark.django_db

--- a/futureagi/tests/stress/test_guardrails.py
+++ b/futureagi/tests/stress/test_guardrails.py
@@ -1,0 +1,56 @@
+"""S14: per-query CH guardrail tripwire.
+
+Inside ``eval_ch_guardrails()`` with ``max_memory_usage`` overridden down to
+1 MB via a nested ``ch_query_settings``, a deliberately heavy read (all noise
+trace ids in one unchunked root lookup with fat JSON columns and no project
+scoping, causing a full-table scan) must raise a CH code-241 query-level
+memory error. A subsequent minimal COUNT on the same CH instance must succeed,
+proving the server stayed healthy after the query-level rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+from tests.stress import ch_asserts
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+from tracer.services.eval_tasks.ch_guardrails import eval_ch_guardrails
+
+pytestmark = pytest.mark.stress
+
+# 1 MB is far below any real spans scan, so the code-241 rejection is
+# deterministic regardless of dataset size.
+_TINY_MEMORY_CAP = 1_000_000  # 1 MB
+
+
+def test_s14_guardrails_reject_heavy_query_server_stays_healthy(stress_dataset):
+    """Query-level memory guard fires as a code-241 error; server stays healthy."""
+    noise = stress_dataset.noise
+
+    # The inner ch_query_settings overrides the outer eval_ch_guardrails value
+    # for max_memory_usage only; execution_time and external_sort thresholds
+    # from eval_ch_guardrails remain in effect.
+    with pytest.raises(DatabaseError) as exc_info:
+        with eval_ch_guardrails():
+            with ch_query_settings(max_memory_usage=_TINY_MEMORY_CAP):
+                with get_reader() as reader:
+                    # All noise trace ids, unchunked, include_heavy=True pulls
+                    # fat JSON columns (attributes_extra, span_events,
+                    # resource_attrs). No project_id → full-table scan.
+                    reader.list_root_spans_by_trace_ids(
+                        noise.trace_ids,
+                        include_heavy=True,
+                    )
+
+    assert "241" in str(exc_info.value)
+
+    # Server is still healthy: a fresh client outside any guardrail context
+    # must complete a trivial count without error.
+    client = ch_asserts._client()
+    try:
+        cnt = client.query("SELECT count() FROM spans").result_rows[0][0]
+        assert int(cnt) >= 0
+    finally:
+        client.close()

--- a/futureagi/tests/stress/test_reconcile_counts.py
+++ b/futureagi/tests/stress/test_reconcile_counts.py
@@ -1,0 +1,40 @@
+"""Stress tests for reconciler PG statement counts."""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from tests.stress.budgets import RECONCILE_REQUEUE_MAX_PG_UPDATES
+from tracer.models.eval_task import RowType
+from tracer.models.observation_span import EvalEntryStatus, EvalLogger
+from tracer.services.eval_tasks.reconciler import reconcile
+
+pytestmark = pytest.mark.stress
+
+
+@pytest.mark.django_db
+def test_s10_reconcile_requeue_update_fanout(stress_dataset, eval_task_factory):
+    m = stress_dataset.target
+    task = eval_task_factory(m.project_id, RowType.SPANS, spans_limit=60, n_evals=3)
+    reconcile(task)
+    EvalLogger.objects.filter(eval_task_id=str(task.id)).update(
+        status=EvalEntryStatus.COMPLETED
+    )
+    # Edit every config: hash changes make all completed entries stale.
+    for cfg in task.evals.all():
+        cfg.config = {"threshold": 0.9}
+        cfg.save()
+
+    with CaptureQueriesContext(connection) as ctx:
+        result = reconcile(task)
+
+    assert result.requeued == 180  # parity: every stale entry requeued
+    table = EvalLogger._meta.db_table
+    updates = [
+        q
+        for q in ctx.captured_queries
+        if q["sql"].strip().upper().startswith("UPDATE") and table in q["sql"]
+    ]
+    assert len(updates) <= RECONCILE_REQUEUE_MAX_PG_UPDATES

--- a/futureagi/tests/stress/test_scan_guardrails.py
+++ b/futureagi/tests/stress/test_scan_guardrails.py
@@ -1,0 +1,94 @@
+"""Benchmark for the trace-scanner's per-query ClickHouse guardrails.
+
+Two reportable facts, both against a loadgen-seeded ClickHouse:
+
+  1. TRIPWIRE — under ``scan_ch_guardrails()`` with ``max_memory_usage`` pinned
+     down to 1 MB, the scanner's real read (``list_by_trace_ids`` — ``FROM spans
+     FINAL`` pulling the fat JSON columns, unchunked over all noise trace ids) is
+     rejected with a query-level CH **code 241** instead of exhausting the
+     server. A subsequent normal query on the same CH succeeds, proving the
+     server stayed healthy after the query-level rejection (not a box-wide OOM).
+
+  2. HEADROOM — a realistic scanner-sized batch (``_SWEEP_BATCH_SIZE`` trace ids)
+     read under the *real* 4 GiB guardrail completes, and its ``system.query_log``
+     peak ``memory_usage`` sits far below the cap. The peak is printed so the PR
+     can report the measured number.
+
+The guardrail's *sizing* (4 GiB right-headroom-but-below-ceiling) is justified by
+the prod-scale dev-box numbers; this local run proves the *mechanism* end-to-end
+on the scanner's actual reader.
+"""
+
+from __future__ import annotations
+
+import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+from tests.stress import ch_asserts
+from tests.stress.ch_asserts import ch_query_budget
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+from tracer.tasks.trace_scanner import (
+    _SWEEP_BATCH_SIZE,
+    SCAN_CH_GUARDRAILS,
+    scan_ch_guardrails,
+)
+
+pytestmark = pytest.mark.stress
+
+# 1 MB is far below any real spans scan, so the code-241 rejection is
+# deterministic regardless of dataset size.
+_TINY_MEMORY_CAP = 1_000_000  # 1 MB
+
+
+def test_scan_read_rejected_at_tiny_cap_server_stays_healthy(stress_dataset):
+    """The scanner's read fails at the query level (code 241); server survives."""
+    noise = stress_dataset.noise
+
+    # Inner ch_query_settings overrides only max_memory_usage; the execution-time
+    # and external-sort caps from scan_ch_guardrails() stay in effect.
+    with pytest.raises(DatabaseError) as exc_info:
+        with scan_ch_guardrails():
+            with ch_query_settings(max_memory_usage=_TINY_MEMORY_CAP):
+                with get_reader() as reader:
+                    reader.list_by_trace_ids(noise.trace_ids)
+
+    assert "241" in str(exc_info.value)
+
+    # A fresh client outside any guardrail context must still complete a trivial
+    # read — the query-level rejection did not take the server down.
+    client = ch_asserts._client()
+    try:
+        cnt = client.query("SELECT count() FROM spans").result_rows[0][0]
+        assert int(cnt) >= 0
+    finally:
+        client.close()
+
+
+def test_realistic_scan_batch_peaks_below_cap(stress_dataset):
+    """A scanner-sized batch read under the real 4 GiB guardrail; report the peak."""
+    noise = stress_dataset.noise
+    batch = noise.trace_ids[:_SWEEP_BATCH_SIZE]  # the scanner reads in these batches
+
+    with scan_ch_guardrails():
+        with ch_query_budget("scan-guardrail-bench") as budget:
+            with get_reader() as reader:
+                spans = reader.list_by_trace_ids(batch)
+
+    assert budget.count >= 1, "the tagged scanner read was not captured in query_log"
+    peak = budget.max("memory_usage")
+    read_rows = budget.max("read_rows")
+    cap = SCAN_CH_GUARDRAILS["max_memory_usage"]
+
+    # Report the measured peak so the number lands in the PR / terminal output.
+    print(
+        f"\nSCAN-GUARDRAIL-BENCH :: batch={len(batch)} traces "
+        f"spans={len(spans)} read_rows={read_rows:.0f} "
+        f"peak_memory={peak / 2**20:.1f} MiB "
+        f"cap={cap / 2**30:.0f} GiB "
+        f"headroom={cap / max(peak, 1):.0f}x"
+    )
+
+    # A normal scanner batch must sit comfortably under the cap — otherwise the
+    # guardrail would false-positive on legitimate work.
+    assert peak < cap

--- a/futureagi/tfc/temporal/eval_tasks/activities.py
+++ b/futureagi/tfc/temporal/eval_tasks/activities.py
@@ -32,6 +32,7 @@ from tfc.temporal.eval_tasks.types import (
     WorkflowLabelsInput,
     WorkflowLabelsOutput,
 )
+from tracer.services.eval_tasks.ch_guardrails import eval_ch_guardrails
 
 # =============================================================================
 # Synchronous helpers (the testable core)
@@ -51,8 +52,9 @@ def _reconcile_sync(task_id: str) -> dict:
         from tracer.models.eval_task import EvalTask
         from tracer.services.eval_tasks.reconciler import reconcile
 
-        task = EvalTask.objects.get(id=task_id)
-        result = reconcile(task)
+        with eval_ch_guardrails():
+            task = EvalTask.objects.get(id=task_id)
+            result = reconcile(task)
         return {
             "task_id": str(task_id),
             "created": result.created,
@@ -96,10 +98,11 @@ def _run_entry_sync(entry_id: str) -> dict:
         from tracer.models.observation_span import EvalLogger
         from tracer.services.eval_tasks.run_entry import run_entry
 
-        entry = EvalLogger.objects.filter(id=entry_id).first()
-        if entry is None:
-            return {"entry_id": str(entry_id), "status": "deleted"}
-        return {"entry_id": str(entry_id), "status": str(run_entry(entry))}
+        with eval_ch_guardrails():
+            entry = EvalLogger.objects.filter(id=entry_id).first()
+            if entry is None:
+                return {"entry_id": str(entry_id), "status": "deleted"}
+            return {"entry_id": str(entry_id), "status": str(run_entry(entry))}
     finally:
         close_old_connections()
 

--- a/futureagi/tracer/services/eval_tasks/ch_guardrails.py
+++ b/futureagi/tracer/services/eval_tasks/ch_guardrails.py
@@ -1,0 +1,36 @@
+"""Per-query ClickHouse guardrail settings for the eval-task engine.
+
+These caps ensure that a heavy eval read fails at the query level (a visible,
+retryable error) rather than exhausting server memory. Sorts spill to disk
+instead of OOM-ing the CH process.
+
+Values are conservative starting points. Tune them against dev-GCP reality
+once production-scale data and real server memory headroom are available:
+measure peak per-query memory and execution time there, then record the finals
+here and in the operational runbook.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+
+# Per-query limits applied to every CH read the eval engine issues.
+EVAL_CH_GUARDRAILS: dict[str, int] = {
+    "max_memory_usage": 4 * 2**30,  # 4 GiB — hard cap per query
+    "max_execution_time": 120,  # seconds — kill runaway queries
+    "max_bytes_before_external_sort": 2 * 2**30,  # 2 GiB spill threshold
+}
+
+
+@contextmanager
+def eval_ch_guardrails():
+    """Apply per-query CH guardrails for eval reads.
+
+    Nest around every CH read the eval engine issues. Inner
+    ``ch_query_settings`` overrides win (e.g. test fixtures can tighten
+    ``max_memory_usage`` to a smaller value to probe the tripwire).
+    """
+    with ch_query_settings(**EVAL_CH_GUARDRAILS):
+        yield

--- a/futureagi/tracer/services/eval_tasks/reconciler.py
+++ b/futureagi/tracer/services/eval_tasks/reconciler.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
+from itertools import chain
 
+from django.db.models import Case, CharField, Value, When
 from django.utils import timezone
 
 from tracer.models.eval_task import EvalTask, RowType, RunType
@@ -23,6 +25,9 @@ from tracer.services.eval_tasks.entries import materialize_pending
 # needs to exceed normal ingestion lag (pause/downtime gaps are covered by the
 # persisted cursor, not this overlap).
 _CONTINUOUS_CURSOR_OVERLAP = timedelta(minutes=5)
+
+# Max entry ids per requeue UPDATE — bounds the WHERE id IN (...) list size.
+_REQUEUE_CHUNK = 10_000
 
 
 @dataclass
@@ -109,13 +114,24 @@ def _requeue_and_drop(task: EvalTask) -> tuple[int, int]:
             drop_ids.append(entry.id)  # out of scope, no result yet
 
     requeued = 0
-    for cfg_id, ids in requeue_by_cfg.items():
-        requeued += EvalLogger.objects.filter(id__in=ids).update(
-            status=EvalEntryStatus.PENDING,
-            config_hash=hashes[cfg_id],
-            error=False,
-            skipped_reason=None,
+    # Flatten {cfg_id: [entry_id, ...]} into one flat [entry_id, ...] list.
+    all_ids = list(chain.from_iterable(requeue_by_cfg.values()))
+    if all_ids:
+        hash_case = Case(
+            *[
+                When(custom_eval_config_id=cfg_id, then=Value(hashes[cfg_id]))
+                for cfg_id in requeue_by_cfg
+            ],
+            output_field=CharField(),
         )
+        for chunk_start in range(0, len(all_ids), _REQUEUE_CHUNK):
+            chunk = all_ids[chunk_start : chunk_start + _REQUEUE_CHUNK]
+            requeued += EvalLogger.objects.filter(id__in=chunk).update(
+                status=EvalEntryStatus.PENDING,
+                config_hash=hash_case,
+                error=False,
+                skipped_reason=None,
+            )
     dropped = 0
     if drop_ids:
         dropped = EvalLogger.objects.filter(id__in=drop_ids).update(

--- a/futureagi/tracer/tasks/trace_scanner.py
+++ b/futureagi/tracer/tasks/trace_scanner.py
@@ -7,6 +7,7 @@ Activity 3: cluster_scan_issues_task — cluster unclustered issues + match succ
 """
 
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 from typing import List
 
@@ -22,6 +23,7 @@ from tracer.queries.trace_scanner import (
     mark_traces_failed,
 )
 from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
 from tracer.utils.trace_scanner import (
     cluster_issues,
     embed_trace_inputs,
@@ -38,6 +40,30 @@ _SWEEP_GRACE_SECONDS = 60  # let straggler child spans settle before scanning
 _SWEEP_COLD_START_SECONDS = 900  # first-sweep window when last_swept_at is NULL
 _SWEEP_BATCH_SIZE = 15  # keep each scan task under its time_limit (cf. _trigger_trace_scanner)
 _SWEEP_MAX_LAG_SECONDS = 86400  # cap how far the watermark lags behind a stuck trace (24h)
+
+# Per-query ClickHouse caps for the scanner's spans reads — same box-safe
+# starting values as the eval engine's guardrails. A heavy scan read fails at
+# the query level (a retryable code-241) instead of exhausting server memory and
+# taking the shared CH box down with it; big sorts spill to disk rather than OOM.
+# Baked into each reader's client at construction (via the ``ch_query_settings``
+# contextvar), so ``scan_ch_guardrails()`` must wrap the reader-building call.
+# Tune against dev-GCP once prod-scale headroom is known.
+SCAN_CH_GUARDRAILS: dict[str, int] = {
+    "max_memory_usage": 4 * 2**30,  # 4 GiB — hard cap per query
+    "max_execution_time": 120,  # seconds — kill a runaway query
+    "max_bytes_before_external_sort": 2 * 2**30,  # 2 GiB spill threshold
+}
+
+
+@contextmanager
+def scan_ch_guardrails():
+    """Apply per-query CH guardrails to every v2 reader built inside the block.
+
+    Inner ``ch_query_settings`` overrides win (e.g. a test tightens
+    ``max_memory_usage`` to probe the tripwire).
+    """
+    with ch_query_settings(**SCAN_CH_GUARDRAILS):
+        yield
 
 
 @temporal_activity(time_limit=600, queue="agent_compass", max_retries=1)
@@ -62,7 +88,8 @@ def scan_traces_task(trace_ids: List[str], project_id: str, from_sweep: bool = F
         project_id=project_id,
     )
 
-    results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
+    with scan_ch_guardrails():
+        results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
 
     issues_found = sum(len(r.issues) for r in results)
     logger.info(
@@ -96,7 +123,8 @@ def embed_trace_inputs_task(
         project_id=project_id,
     )
 
-    stored = embed_trace_inputs(trace_ids, project_id)
+    with scan_ch_guardrails():
+        stored = embed_trace_inputs(trace_ids, project_id)
 
     logger.info(
         "embed_trace_inputs_task_completed",
@@ -186,7 +214,7 @@ def sweep_scannable_traces():
 
     dispatched = 0
     abandoned = 0
-    with get_reader() as reader:
+    with scan_ch_guardrails(), get_reader() as reader:
         now_ch = reader.ch_now()
         upper = now_ch - timedelta(seconds=_SWEEP_GRACE_SECONDS)
         cold_floor = now_ch - timedelta(seconds=_SWEEP_COLD_START_SECONDS)

--- a/futureagi/tracer/tests/test_scan_ch_guardrails.py
+++ b/futureagi/tracer/tests/test_scan_ch_guardrails.py
@@ -1,0 +1,94 @@
+"""Revert-catchers for the scanner's per-query ClickHouse guardrails.
+
+Each scanner activity that reads spans through the v2 reader must run that read
+inside ``scan_ch_guardrails()`` so the memory/time/sort caps are baked into the
+reader's client. These tests drive the real (undecorated) activity body and
+snapshot ``current_settings()`` at the moment the wrapped CH work begins — if the
+``with`` is dropped, or a refactor slips a context-dropping hop in front of the
+read, the snapshot is empty and the test fails. DB-free: every collaborator is
+mocked. ``cluster_scan_issues_task`` is intentionally uncovered — it reads only
+through ``ClickHouseVectorDB`` (a separate client that never sees the contextvar).
+"""
+
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from tracer.services.clickhouse.v2.query_settings import current_settings
+from tracer.tasks import trace_scanner as scanner
+
+_NOW = datetime(2026, 6, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _reader_cm():
+    """A ``with get_reader() as reader`` context manager over a mock reader."""
+    reader = MagicMock()
+    reader.ch_now.return_value = _NOW
+    reader.root_trace_candidates.return_value = []
+    cm = MagicMock()
+    cm.__enter__.return_value = reader
+    cm.__exit__.return_value = False
+    return cm
+
+
+def test_scan_traces_task_runs_scan_and_write_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return []  # empty results are fine — we only need the wrapped call to run
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(scanner, "SCAN_DELAY_SECONDS", 0))
+        stack.enter_context(patch.object(scanner, "scan_and_write", side_effect=spy))
+        # Load-bearing: the activity dispatches embed unconditionally after the
+        # scan, so this mock keeps the real Temporal start_activity out of the test.
+        stack.enter_context(patch.object(scanner, "embed_trace_inputs_task"))
+        scanner.scan_traces_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_embed_trace_inputs_task_runs_embed_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return 0  # stored count
+
+    with patch.object(scanner, "embed_trace_inputs", side_effect=spy):
+        # trigger_clustering=False → no cluster chain to mock.
+        scanner.embed_trace_inputs_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_sweep_builds_reader_inside_guardrails():
+    captured = {}
+
+    def spy_get_reader():
+        captured["settings"] = current_settings()
+        return _reader_cm()
+
+    cfg = MagicMock()
+    cfg.no_workspace_objects.filter.return_value.order_by.return_value.values.return_value = [
+        {"project_id": "p1", "sampling_rate": 1.0, "last_swept_at": None}
+    ]
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch.object(scanner, "get_reader", side_effect=spy_get_reader)
+        )
+        stack.enter_context(patch.object(scanner, "TraceScanConfig", cfg))
+        stack.enter_context(
+            patch.object(scanner, "filter_already_scanned", side_effect=lambda x: x)
+        )
+        stack.enter_context(
+            patch.object(
+                scanner, "is_trace_sampled", side_effect=lambda tid, rate: True
+            )
+        )
+        stack.enter_context(patch.object(scanner, "scan_traces_task"))
+        scanner.sweep_scannable_traces._original_func()
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS


### PR DESCRIPTION
> Stacked on #1431 (Phase A). Base is `perf/TH-6642-eval-data-reads`; the diff here is only A6 + A7. Will retarget to `dev` when #1431 merges.

## Why

Phase A (#1431) fixes the *known* heavy eval reads (scoping, lean loading, chunking). This PR adds the Phase-A finishers:
- **A6** — insurance for the *unknown* heavy query: a per-query ClickHouse cap so a query the fixes didn't anticipate degrades to a single query-level error instead of OOM-ing the whole ClickHouse server (the code-241 blast radius).
- **A7** — a small reconciler cleanup: collapse the per-config requeue UPDATE fan-out into one statement.

## What

- **A6 — CH guardrails** (`ch_guardrails.py`, `activities.py`): attach `max_memory_usage` (~4 GiB) / `max_execution_time` (~120s) / `max_bytes_before_external_sort` (~2 GiB) to the eval engine's CH reads via the `ch_query_settings` contextvar. Wraps only the two activities that read CH (`reconcile`, `run_entry`). Big sorts spill to disk; a heavy query is rejected (code 241) and retried instead of killing the server. Values are starting points, tuned at the prod-scale gate.
- **A7 — single-statement requeue** (`reconciler.py`): replace the N-config `UPDATE` loop with one `Case`/`When` UPDATE keyed on `custom_eval_config_id` (each entry still gets its own config's `config_hash`), chunked at `_REQUEUE_CHUNK` (10k) to stay under Postgres's 65,535-parameter limit. Behavior unchanged.

## Tests

**New**: `test_guardrails.py` (S14), `test_reconcile_counts.py` (S10, un-xfailed from `test_baselines.py`).

## Per-test scenarios

- **S14** — inside the guardrails, a query given a tiny memory cap is rejected with code 241, and a subsequent normal read on the same CH still succeeds (proves the server stayed healthy, not just that the query failed).
- **S10** — a task with multiple stale eval configs; `reconcile` issues ≤ the budgeted number of requeue UPDATEs (1 for a normal task, not N), and the requeue *count* matches the pre-collapse behavior (parity).

## Commands

```bash
cd fi-collector && go build -o bin/loadgen ./cmd/loadgen
cd ../futureagi && docker compose -f docker-compose.test.yml -p futureagi-test up -d
LOADGEN_BIN=$PWD/../fi-collector/bin/loadgen uv run pytest tests/stress/test_guardrails.py tests/stress/test_reconcile_counts.py -v
```

## Local-test steps

Build loadgen, bring up the test stack, run the two stress files above. First run seeds (~2 min per file); the seed-heavy tests need a fresh CH per run on low-RAM machines.

## Terminal output (evidence)

```
tests/stress/test_guardrails.py::test_s14_...           PASSED  (1 passed in 86s)
tests/stress/test_reconcile_counts.py::test_s10_...     PASSED  (1 passed in 121s)
```
Both gated green locally on a fresh ClickHouse.

## Architectural rationale

- A6 is defense-in-depth: A1-A5 prevent the known heavy queries; A6 caps the unknown ones so the *next* surprise degrades gracefully instead of taking ClickHouse (and every ClickHouse-backed UI feature) down. `max_execution_time` also frees concurrency slots faster, easing the code-202 "too many simultaneous queries" pressure that B1 (next PR) fully addresses.
- A7's `Case`/`When` preserves exact per-config `config_hash` stamping in one write; parity is guaranteed by construction (every requeued id belongs to a config that has a matching `When`), verified in review and by S10.
