### PR TITLE
[TH-6683] Clamp long snackbar messages to 3 lines with Show more

### DIFF
--- a/frontend/src/components/snackbar/ClampedContent.jsx
+++ b/frontend/src/components/snackbar/ClampedContent.jsx
@@ -1,0 +1,27 @@
+import React, { forwardRef } from "react";
+import PropTypes from "prop-types";
+import { StyledNotistack } from "./styles";
+import ClampedMessage from "./ClampedMessage";
+
+const ClampedContent = forwardRef(function ClampedContent(props, ref) {
+  const { message, ...rest } = props;
+  return (
+    <StyledNotistack
+      ref={ref}
+      {...rest}
+      message={
+        React.isValidElement(message) ? (
+          message
+        ) : (
+          <ClampedMessage>{message}</ClampedMessage>
+        )
+      }
+    />
+  );
+});
+
+ClampedContent.propTypes = {
+  message: PropTypes.node,
+};
+
+export default ClampedContent;

--- a/frontend/src/components/snackbar/ClampedMessage.jsx
+++ b/frontend/src/components/snackbar/ClampedMessage.jsx
@@ -1,0 +1,65 @@
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { Box } from "@mui/material";
+import PropTypes from "prop-types";
+
+const MAX_LINES = 3;
+
+export default function ClampedMessage({ children }) {
+  const textRef = useRef(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // Measure once against the collapsed (clamped) height; a toast's message
+  // never changes over its lifetime, so this stays correct across toggles.
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (el) setOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [children]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+      <Box
+        ref={textRef}
+        sx={{
+          wordBreak: "break-word",
+          ...(expanded
+            ? {}
+            : {
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: MAX_LINES,
+                overflow: "hidden",
+              }),
+        }}
+      >
+        {children}
+      </Box>
+      {overflowing && (
+        <Box
+          component="button"
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((prev) => !prev)}
+          sx={{
+            alignSelf: "flex-start",
+            p: 0,
+            border: "none",
+            background: "none",
+            cursor: "pointer",
+            font: "inherit",
+            fontWeight: 600,
+            color: "text.secondary",
+            textDecoration: "underline",
+            "&:hover": { color: "text.primary" },
+          }}
+        >
+          {expanded ? "Show less" : "Show more"}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+ClampedMessage.propTypes = {
+  children: PropTypes.node,
+};

--- a/frontend/src/components/snackbar/ClampedMessage.jsx
+++ b/frontend/src/components/snackbar/ClampedMessage.jsx
@@ -47,7 +47,7 @@ export default function ClampedMessage({ children }) {
             background: "none",
             cursor: "pointer",
             font: "inherit",
-            fontWeight: 600,
+            fontWeight: "fontWeightSemiBold",
             color: "text.secondary",
             textDecoration: "underline",
             "&:hover": { color: "text.primary" },

--- a/frontend/src/components/snackbar/snackbar-provider.jsx
+++ b/frontend/src/components/snackbar/snackbar-provider.jsx
@@ -11,7 +11,8 @@ import IconButton from "@mui/material/IconButton";
 
 import Iconify from "../iconify";
 import { useSettingsContext } from "../settings";
-import { StyledIcon, StyledNotistack, SNACKBAR_AUTO_HIDE_MS } from "./styles";
+import { StyledIcon, SNACKBAR_AUTO_HIDE_MS } from "./styles";
+import ClampedContent from "./ClampedContent";
 
 // ----------------------------------------------------------------------
 
@@ -55,11 +56,11 @@ export default function SnackbarProvider({ children, ...other }) {
         ),
       }}
       Components={{
-        default: StyledNotistack,
-        info: StyledNotistack,
-        success: StyledNotistack,
-        warning: StyledNotistack,
-        error: StyledNotistack,
+        default: ClampedContent,
+        info: ClampedContent,
+        success: ClampedContent,
+        warning: ClampedContent,
+        error: ClampedContent,
       }}
       action={(snackbarId) => (
         <IconButton


### PR DESCRIPTION
**Ticket:** [TH-6683](https://linear.app/future-agi/issue/TH-6683/trim-down-snackbar-message-in-frontend-as-a-fallback) — Fixes TH-6683

## What was the bug
Some snackbars surface raw, unbounded backend errors (e.g. the Workbench "Run Prompt" timeout dumps a full serialized JSON payload: `Timed out waiting for prompt run output: {…}`). These overflow the toast and are unreadable. There was no global fallback to keep an over-long message legible.

## What changes have been done
- `frontend/src/components/snackbar/ClampedMessage.jsx` (new) — clamps a string message to 3 lines and shows a "Show more"/"Show less" toggle only when the text actually overflows. Measures overflow once in `useLayoutEffect`; toggle carries `aria-expanded`.
- `frontend/src/components/snackbar/ClampedContent.jsx` (new) — `forwardRef` wrapper around the existing `StyledNotistack`. Clamps plain-string messages; passes any `React.isValidElement` message (custom JSX toasts) straight through untouched.
- `frontend/src/components/snackbar/snackbar-provider.jsx` — points all 5 variant `Components` at `ClampedContent`, making the clamp global with no call-site changes.

## Why the changes
- The trim has to be a global fallback, so it lives at the single notistack `Components` layer every toast funnels through — no changes across the ~1000 `enqueueSnackbar` call sites.
- Only plain strings are clamped. Existing custom-JSX toasts (`SnackbarWithAction`, `DisconnectedNodesToast`) own their own layout/overflow, so `React.isValidElement` gates them out.
- Overflow is measured with dep `[children]` only — a toast's message never changes over its lifetime, and re-measuring after expand would wrongly hide the "Show less" toggle.
- Auto-hide is unchanged: notistack already pauses the timer on hover, so an expanded long message stays readable while hovered.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Short single-line message | Renders as before, no toggle |
| 2 | Long string message (any variant) | Clamps to 3 lines + "Show more"; expand/collapse works |
| 3 | Workbench Run Prompt timeout (raw JSON error) | Clamped to 3 lines with Show more (previously overflowed) |
| 4 | Custom JSX toast (`SnackbarWithAction`) | Renders unchanged — no clamp, action button intact |
| 5 | Hover an expanded long toast | Does not auto-dismiss while hovered |

## How to reproduce (original bug)
1. Open a prompt in Workbench → **Run Prompt**.
2. Let the run time out (or point it at a slow/failing model).
3. Before: the error toast dumps the full JSON payload and overflows. After: it clamps to 3 lines with a Show more toggle.

## Commands
```bash
cd frontend && yarn lint src/components/snackbar
```

## Videos and screenshots

https://github.com/user-attachments/assets/11c632e6-0d7d-4441-b17c-13912978e419

