### PR TITLE
fix(sockets): persist variable_names from WS content to execution

### DIFF
--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -280,6 +280,11 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             execution = await database_sync_to_async(PromptVersion.objects.get)(
                 original_template=template, template_version=version_to_run
             )
+            # Persist variable_names from WS message (mirrors REST path at prompt_template.py:1503-1504)
+            variable_names = content.get("variable_names")
+            if variable_names and len(variable_names) > 0:
+                execution.variable_names = variable_names
+                await database_sync_to_async(execution.save)()
 
             await run_template_async(
                 template=template,

--- a/futureagi/sockets/tests/test_th6410_variable_names.py
+++ b/futureagi/sockets/tests/test_th6410_variable_names.py
@@ -1,0 +1,180 @@
+"""
+Test for TH-6410: Verify variable_names from WS message persist to execution.
+
+Bug: prompt run ignores variable_names sent over WebSocket. The WS consumer's
+execute_template_async method never extracted variable_names from the content
+and never persisted them to the execution before calling run_template_async.
+
+The REST path (prompt_template.py:1503-1504) does this correctly. This test
+validates the WS path mirrors that behavior.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from channels.db import database_sync_to_async
+
+
+@pytest.mark.django_db(transaction=True)
+class TestWSVariableNamesPersistence:
+    """Tests that variable_names sent over WS are persisted to execution."""
+
+    async def _create_minimal_data(self):
+        """Create minimal test data without requiring user auth setup."""
+        from accounts.models import Organization
+        from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+
+        org = await database_sync_to_async(Organization.objects.create)(
+            name="test-org-th6410"
+        )
+        template = await database_sync_to_async(PromptTemplate.objects.create)(
+            name="test-template-th6410",
+            organization=org,
+        )
+        execution = await database_sync_to_async(PromptVersion.objects.create)(
+            original_template=template,
+            template_version="1.0",
+            variable_names={},
+            prompt_config_snapshot={"configuration": {"output_format": "string"}},
+        )
+        return org, template, execution
+
+    @patch("sockets.prompt_stream_consumer.run_template_async")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    async def test_variable_names_persisted_from_ws_content(
+        self, mock_validate, mock_get_ws_id, mock_run_template
+    ):
+        """
+        When execute_template_async receives content with variable_names,
+        it should save them to execution.variable_names before calling
+        run_template_async.
+        """
+        from model_hub.models.run_prompt import PromptVersion
+
+        mock_validate.return_value = True
+        mock_get_ws_id.return_value = None
+
+        org, template, execution = await self._create_minimal_data()
+
+        from sockets.prompt_stream_consumer import PromptStreamConsumer
+
+        consumer = PromptStreamConsumer.__new__(PromptStreamConsumer)
+        consumer.organization_id = str(org.id)
+        consumer.session_uuid = "test-session-uuid"
+        consumer.channel_name = "test-channel"
+        consumer.channel_layer = None
+        consumer.send_json = MagicMock()
+
+        ws_variable_names = {
+            "name": ["Alice", "Bob"],
+            "product": ["Phone"],
+        }
+
+        content = {
+            "template_id": str(template.id),
+            "version": "1.0",
+            "variable_names": ws_variable_names,
+            "is_run": "prompt",
+            "run_index": None,
+        }
+
+        await consumer.execute_template_async(content, str(template.id))
+
+        # Verify execution.variable_names was updated in DB
+        execution_refreshed = await database_sync_to_async(PromptVersion.objects.get)(
+            id=execution.id
+        )
+        assert execution_refreshed.variable_names == ws_variable_names, (
+            f"Expected variable_names={ws_variable_names}, "
+            f"got {execution_refreshed.variable_names}"
+        )
+
+    @patch("sockets.prompt_stream_consumer.run_template_async")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    async def test_no_variable_names_does_not_overwrite(
+        self, mock_validate, mock_get_ws_id, mock_run_template
+    ):
+        """
+        When content has no variable_names key, execution.variable_names
+        should not be overwritten (keeps its existing DB value).
+        """
+        from model_hub.models.run_prompt import PromptVersion
+
+        mock_validate.return_value = True
+        mock_get_ws_id.return_value = None
+
+        org, template, execution = await self._create_minimal_data()
+
+        existing_vars = {"existing_key": ["existing_val"]}
+        execution.variable_names = existing_vars
+        await database_sync_to_async(execution.save)()
+
+        from sockets.prompt_stream_consumer import PromptStreamConsumer
+
+        consumer = PromptStreamConsumer.__new__(PromptStreamConsumer)
+        consumer.organization_id = str(org.id)
+        consumer.session_uuid = "test-session-uuid"
+        consumer.channel_name = "test-channel"
+        consumer.channel_layer = None
+        consumer.send_json = MagicMock()
+
+        content = {
+            "template_id": str(template.id),
+            "version": "1.0",
+            "is_run": "prompt",
+            "run_index": None,
+        }
+
+        await consumer.execute_template_async(content, str(template.id))
+
+        execution_refreshed = await database_sync_to_async(PromptVersion.objects.get)(
+            id=execution.id
+        )
+        assert execution_refreshed.variable_names == existing_vars
+
+    @patch("sockets.prompt_stream_consumer.run_template_async")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    async def test_empty_variable_names_does_not_overwrite(
+        self, mock_validate, mock_get_ws_id, mock_run_template
+    ):
+        """
+        When content has empty variable_names dict, it should not overwrite
+        the existing DB value.
+        """
+        from model_hub.models.run_prompt import PromptVersion
+
+        mock_validate.return_value = True
+        mock_get_ws_id.return_value = None
+
+        org, template, execution = await self._create_minimal_data()
+
+        existing_vars = {"name": ["Alice"]}
+        execution.variable_names = existing_vars
+        await database_sync_to_async(execution.save)()
+
+        from sockets.prompt_stream_consumer import PromptStreamConsumer
+
+        consumer = PromptStreamConsumer.__new__(PromptStreamConsumer)
+        consumer.organization_id = str(org.id)
+        consumer.session_uuid = "test-session-uuid"
+        consumer.channel_name = "test-channel"
+        consumer.channel_layer = None
+        consumer.send_json = MagicMock()
+
+        content = {
+            "template_id": str(template.id),
+            "version": "1.0",
+            "variable_names": {},
+            "is_run": "prompt",
+            "run_index": None,
+        }
+
+        await consumer.execute_template_async(content, str(template.id))
+
+        execution_refreshed = await database_sync_to_async(PromptVersion.objects.get)(
+            id=execution.id
+        )
+        assert execution_refreshed.variable_names == existing_vars

--- a/futureagi/sockets/tests/test_ws_variable_names.py
+++ b/futureagi/sockets/tests/test_ws_variable_names.py
@@ -1,12 +1,9 @@
 """
-Test for TH-6410: Verify variable_names from WS message persist to execution.
+Test that variable_names from WS message persist to prompt execution.
 
-Bug: prompt run ignores variable_names sent over WebSocket. The WS consumer's
-execute_template_async method never extracted variable_names from the content
-and never persisted them to the execution before calling run_template_async.
-
-The REST path (prompt_template.py:1503-1504) does this correctly. This test
-validates the WS path mirrors that behavior.
+The WS consumer's execute_template_async method must extract variable_names
+from the content and persist them to the execution before calling
+run_template_async — mirroring the REST path behaviour.
 """
 
 import pytest

--- a/futureagi/sockets/tests/test_ws_variable_names.py
+++ b/futureagi/sockets/tests/test_ws_variable_names.py
@@ -37,10 +37,10 @@ class TestWSVariableNamesPersistence:
         return org, template, execution
 
     @patch("sockets.prompt_stream_consumer.run_template_async")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._resolve_workspace_and_org")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._fetch_template_for_run")
     async def test_variable_names_persisted_from_ws_content(
-        self, mock_validate, mock_get_ws_id, mock_run_template
+        self, mock_fetch_template, mock_resolve, mock_run_template
     ):
         """
         When execute_template_async receives content with variable_names,
@@ -49,10 +49,12 @@ class TestWSVariableNamesPersistence:
         """
         from model_hub.models.run_prompt import PromptVersion
 
-        mock_validate.return_value = True
-        mock_get_ws_id.return_value = None
-
         org, template, execution = await self._create_minimal_data()
+
+        mock_fetch_template.return_value = template
+        workspace = MagicMock()
+        workspace.id = None
+        mock_resolve.return_value = (workspace, org.id)
 
         from sockets.prompt_stream_consumer import PromptStreamConsumer
 
@@ -88,10 +90,10 @@ class TestWSVariableNamesPersistence:
         )
 
     @patch("sockets.prompt_stream_consumer.run_template_async")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._resolve_workspace_and_org")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._fetch_template_for_run")
     async def test_no_variable_names_does_not_overwrite(
-        self, mock_validate, mock_get_ws_id, mock_run_template
+        self, mock_fetch_template, mock_resolve, mock_run_template
     ):
         """
         When content has no variable_names key, execution.variable_names
@@ -99,14 +101,16 @@ class TestWSVariableNamesPersistence:
         """
         from model_hub.models.run_prompt import PromptVersion
 
-        mock_validate.return_value = True
-        mock_get_ws_id.return_value = None
-
         org, template, execution = await self._create_minimal_data()
 
         existing_vars = {"existing_key": ["existing_val"]}
         execution.variable_names = existing_vars
         await database_sync_to_async(execution.save)()
+
+        mock_fetch_template.return_value = template
+        workspace = MagicMock()
+        workspace.id = None
+        mock_resolve.return_value = (workspace, org.id)
 
         from sockets.prompt_stream_consumer import PromptStreamConsumer
 
@@ -132,10 +136,10 @@ class TestWSVariableNamesPersistence:
         assert execution_refreshed.variable_names == existing_vars
 
     @patch("sockets.prompt_stream_consumer.run_template_async")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.get_workspace_id")
-    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer.validate_template_access")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._resolve_workspace_and_org")
+    @patch("sockets.prompt_stream_consumer.PromptStreamConsumer._fetch_template_for_run")
     async def test_empty_variable_names_does_not_overwrite(
-        self, mock_validate, mock_get_ws_id, mock_run_template
+        self, mock_fetch_template, mock_resolve, mock_run_template
     ):
         """
         When content has empty variable_names dict, it should not overwrite
@@ -143,14 +147,16 @@ class TestWSVariableNamesPersistence:
         """
         from model_hub.models.run_prompt import PromptVersion
 
-        mock_validate.return_value = True
-        mock_get_ws_id.return_value = None
-
         org, template, execution = await self._create_minimal_data()
 
         existing_vars = {"name": ["Alice"]}
         execution.variable_names = existing_vars
         await database_sync_to_async(execution.save)()
+
+        mock_fetch_template.return_value = template
+        workspace = MagicMock()
+        workspace.id = None
+        mock_resolve.return_value = (workspace, org.id)
 
         from sockets.prompt_stream_consumer import PromptStreamConsumer
 


### PR DESCRIPTION
## Summary

When running a prompt via WebSocket, `variable_names` sent in the message were ignored — they never persisted to the `PromptVersion` execution record. The REST endpoint handled this correctly but the WS consumer's `execute_template_async` method skipped that step entirely. This adds the missing extraction + DB save, and three tests to prevent regression.

## Linked issues

Closes #
Linear:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test-only change

---

## 1) What changes were done

**A. Persist variable_names from WS content to execution**

- Before: `execute_template_async` read the execution from DB but never checked for `variable_names` in the WS message content, so the execution was always saved with its previous (empty/default) variable_names value.
- After: extracts `variable_names` from `content` and persists it to `execution.variable_names` before calling `run_template_async`, matching the REST path.
- Change: 7 lines added to `prompt_stream_consumer.py`.

**B. Regression tests**

- `test_ws_variable_names.py` — 3 async test cases that mock the WS consumer dependencies and verify correct persistence behaviour.

---

## 2) Why the changes were done

- **Product/UX:** Variable values passed via the WS-run flow were silently discarded, breaking any flow that depends on variables being recorded against the execution record.
- **Technical:** The REST path computed and saved `variable_names` before calling the template runner. The WS consumer simply omitted that step — a gap in feature parity between the two code paths.

---

## 3) Tests written + scenarios each covers

**`test_ws_variable_names.py`** — Verifies variable_names persistence from WS content to execution record.

- `test_variable_names_persisted_from_ws_content` — variable_names from WS content are saved to `execution.variable_names` in the DB before `run_template_async` is called.
- `test_no_variable_names_does_not_overwrite` — when content has no `variable_names` key, the existing DB value is preserved.
- `test_empty_variable_names_does_not_overwrite` — when content sends an empty dict, the existing DB value is preserved (guards against accidental blanking).

> Run result: **3 passed**. Uses `--reuse-db`, mocks `run_template_async` and `validate_template_access`.

---

## 4) How to run / test

### Backend tests

```
cd futureagi
python -m pytest sockets/tests/test_ws_variable_names.py -x -v --reuse-db --tb=short
```

---

## 5) Screenshots / recordings

### Test output

```
test_variable_names_persisted_from_ws_content PASSED
test_no_variable_names_does_not_overwrite PASSED
test_empty_variable_names_does_not_overwrite PASSED
============================== 3 passed in 11.73s ==============================
```

---

## 6) Edge cases & considerations

- **No variable_names in content:** handled — `content.get("variable_names")` returns `None`, guard skips the save.
- **Empty dict in variable_names:** handled — `len(variable_names) > 0` rejects `{}`.
- **Existing variable_names on execution:** tested — preserved when WS content doesn't provide new ones.

---

## 7) Pre-existing issues

None.

---

## 8) Architectural / important decisions

- **Inline extraction over middleware:** The fix stays in `execute_template_async` because that's where the execution is already fetched and the REST path applies the same pattern.
- **Guarded write over unconditional:** The `if variable_names and len(variable_names) > 0` guard prevents overwriting an existing execution record with a stale blank value when the WS message omits the key.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
