### PR TITLE
perf(tracer): CH guardrails on the trace-scanner pipeline

### DIFF
--- a/futureagi/tests/stress/test_scan_guardrails.py
+++ b/futureagi/tests/stress/test_scan_guardrails.py
@@ -1,0 +1,94 @@
+"""Benchmark for the trace-scanner's per-query ClickHouse guardrails.
+
+Two reportable facts, both against a loadgen-seeded ClickHouse:
+
+  1. TRIPWIRE — under ``scan_ch_guardrails()`` with ``max_memory_usage`` pinned
+     down to 1 MB, the scanner's real read (``list_by_trace_ids`` — ``FROM spans
+     FINAL`` pulling the fat JSON columns, unchunked over all noise trace ids) is
+     rejected with a query-level CH **code 241** instead of exhausting the
+     server. A subsequent normal query on the same CH succeeds, proving the
+     server stayed healthy after the query-level rejection (not a box-wide OOM).
+
+  2. HEADROOM — a realistic scanner-sized batch (``_SWEEP_BATCH_SIZE`` trace ids)
+     read under the *real* 4 GiB guardrail completes, and its ``system.query_log``
+     peak ``memory_usage`` sits far below the cap. The peak is printed so the PR
+     can report the measured number.
+
+The guardrail's *sizing* (4 GiB right-headroom-but-below-ceiling) is justified by
+the prod-scale dev-box numbers; this local run proves the *mechanism* end-to-end
+on the scanner's actual reader.
+"""
+
+from __future__ import annotations
+
+import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
+
+from tests.stress import ch_asserts
+from tests.stress.ch_asserts import ch_query_budget
+from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
+from tracer.tasks.trace_scanner import (
+    _SWEEP_BATCH_SIZE,
+    SCAN_CH_GUARDRAILS,
+    scan_ch_guardrails,
+)
+
+pytestmark = pytest.mark.stress
+
+# 1 MB is far below any real spans scan, so the code-241 rejection is
+# deterministic regardless of dataset size.
+_TINY_MEMORY_CAP = 1_000_000  # 1 MB
+
+
+def test_scan_read_rejected_at_tiny_cap_server_stays_healthy(stress_dataset):
+    """The scanner's read fails at the query level (code 241); server survives."""
+    noise = stress_dataset.noise
+
+    # Inner ch_query_settings overrides only max_memory_usage; the execution-time
+    # and external-sort caps from scan_ch_guardrails() stay in effect.
+    with pytest.raises(DatabaseError) as exc_info:
+        with scan_ch_guardrails():
+            with ch_query_settings(max_memory_usage=_TINY_MEMORY_CAP):
+                with get_reader() as reader:
+                    reader.list_by_trace_ids(noise.trace_ids)
+
+    assert "241" in str(exc_info.value)
+
+    # A fresh client outside any guardrail context must still complete a trivial
+    # read — the query-level rejection did not take the server down.
+    client = ch_asserts._client()
+    try:
+        cnt = client.query("SELECT count() FROM spans").result_rows[0][0]
+        assert int(cnt) >= 0
+    finally:
+        client.close()
+
+
+def test_realistic_scan_batch_peaks_below_cap(stress_dataset):
+    """A scanner-sized batch read under the real 4 GiB guardrail; report the peak."""
+    noise = stress_dataset.noise
+    batch = noise.trace_ids[:_SWEEP_BATCH_SIZE]  # the scanner reads in these batches
+
+    with scan_ch_guardrails():
+        with ch_query_budget("scan-guardrail-bench") as budget:
+            with get_reader() as reader:
+                spans = reader.list_by_trace_ids(batch)
+
+    assert budget.count >= 1, "the tagged scanner read was not captured in query_log"
+    peak = budget.max("memory_usage")
+    read_rows = budget.max("read_rows")
+    cap = SCAN_CH_GUARDRAILS["max_memory_usage"]
+
+    # Report the measured peak so the number lands in the PR / terminal output.
+    print(
+        f"\nSCAN-GUARDRAIL-BENCH :: batch={len(batch)} traces "
+        f"spans={len(spans)} read_rows={read_rows:.0f} "
+        f"peak_memory={peak / 2**20:.1f} MiB "
+        f"cap={cap / 2**30:.0f} GiB "
+        f"headroom={cap / max(peak, 1):.0f}x"
+    )
+
+    # A normal scanner batch must sit comfortably under the cap — otherwise the
+    # guardrail would false-positive on legitimate work.
+    assert peak < cap

--- a/futureagi/tracer/tasks/trace_scanner.py
+++ b/futureagi/tracer/tasks/trace_scanner.py
@@ -7,6 +7,7 @@ Activity 3: cluster_scan_issues_task — cluster unclustered issues + match succ
 """
 
 import time
+from contextlib import contextmanager
 from datetime import timedelta
 from typing import List
 
@@ -22,6 +23,7 @@ from tracer.queries.trace_scanner import (
     mark_traces_failed,
 )
 from tracer.services.clickhouse.v2 import get_reader
+from tracer.services.clickhouse.v2.query_settings import ch_query_settings
 from tracer.utils.trace_scanner import (
     cluster_issues,
     embed_trace_inputs,
@@ -38,6 +40,30 @@ _SWEEP_GRACE_SECONDS = 60  # let straggler child spans settle before scanning
 _SWEEP_COLD_START_SECONDS = 900  # first-sweep window when last_swept_at is NULL
 _SWEEP_BATCH_SIZE = 15  # keep each scan task under its time_limit (cf. _trigger_trace_scanner)
 _SWEEP_MAX_LAG_SECONDS = 86400  # cap how far the watermark lags behind a stuck trace (24h)
+
+# Per-query ClickHouse caps for the scanner's spans reads — same box-safe
+# starting values as the eval engine's guardrails. A heavy scan read fails at
+# the query level (a retryable code-241) instead of exhausting server memory and
+# taking the shared CH box down with it; big sorts spill to disk rather than OOM.
+# Baked into each reader's client at construction (via the ``ch_query_settings``
+# contextvar), so ``scan_ch_guardrails()`` must wrap the reader-building call.
+# Tune against dev-GCP once prod-scale headroom is known.
+SCAN_CH_GUARDRAILS: dict[str, int] = {
+    "max_memory_usage": 4 * 2**30,  # 4 GiB — hard cap per query
+    "max_execution_time": 120,  # seconds — kill a runaway query
+    "max_bytes_before_external_sort": 2 * 2**30,  # 2 GiB spill threshold
+}
+
+
+@contextmanager
+def scan_ch_guardrails():
+    """Apply per-query CH guardrails to every v2 reader built inside the block.
+
+    Inner ``ch_query_settings`` overrides win (e.g. a test tightens
+    ``max_memory_usage`` to probe the tripwire).
+    """
+    with ch_query_settings(**SCAN_CH_GUARDRAILS):
+        yield
 
 
 @temporal_activity(time_limit=600, queue="agent_compass", max_retries=1)
@@ -62,7 +88,8 @@ def scan_traces_task(trace_ids: List[str], project_id: str, from_sweep: bool = F
         project_id=project_id,
     )
 
-    results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
+    with scan_ch_guardrails():
+        results = scan_and_write(trace_ids, project_id, mark_unresolved=from_sweep)
 
     issues_found = sum(len(r.issues) for r in results)
     logger.info(
@@ -96,7 +123,8 @@ def embed_trace_inputs_task(
         project_id=project_id,
     )
 
-    stored = embed_trace_inputs(trace_ids, project_id)
+    with scan_ch_guardrails():
+        stored = embed_trace_inputs(trace_ids, project_id)
 
     logger.info(
         "embed_trace_inputs_task_completed",
@@ -186,7 +214,7 @@ def sweep_scannable_traces():
 
     dispatched = 0
     abandoned = 0
-    with get_reader() as reader:
+    with scan_ch_guardrails(), get_reader() as reader:
         now_ch = reader.ch_now()
         upper = now_ch - timedelta(seconds=_SWEEP_GRACE_SECONDS)
         cold_floor = now_ch - timedelta(seconds=_SWEEP_COLD_START_SECONDS)

--- a/futureagi/tracer/tests/test_scan_ch_guardrails.py
+++ b/futureagi/tracer/tests/test_scan_ch_guardrails.py
@@ -1,0 +1,94 @@
+"""Revert-catchers for the scanner's per-query ClickHouse guardrails.
+
+Each scanner activity that reads spans through the v2 reader must run that read
+inside ``scan_ch_guardrails()`` so the memory/time/sort caps are baked into the
+reader's client. These tests drive the real (undecorated) activity body and
+snapshot ``current_settings()`` at the moment the wrapped CH work begins — if the
+``with`` is dropped, or a refactor slips a context-dropping hop in front of the
+read, the snapshot is empty and the test fails. DB-free: every collaborator is
+mocked. ``cluster_scan_issues_task`` is intentionally uncovered — it reads only
+through ``ClickHouseVectorDB`` (a separate client that never sees the contextvar).
+"""
+
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from tracer.services.clickhouse.v2.query_settings import current_settings
+from tracer.tasks import trace_scanner as scanner
+
+_NOW = datetime(2026, 6, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _reader_cm():
+    """A ``with get_reader() as reader`` context manager over a mock reader."""
+    reader = MagicMock()
+    reader.ch_now.return_value = _NOW
+    reader.root_trace_candidates.return_value = []
+    cm = MagicMock()
+    cm.__enter__.return_value = reader
+    cm.__exit__.return_value = False
+    return cm
+
+
+def test_scan_traces_task_runs_scan_and_write_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return []  # empty results are fine — we only need the wrapped call to run
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(scanner, "SCAN_DELAY_SECONDS", 0))
+        stack.enter_context(patch.object(scanner, "scan_and_write", side_effect=spy))
+        # Load-bearing: the activity dispatches embed unconditionally after the
+        # scan, so this mock keeps the real Temporal start_activity out of the test.
+        stack.enter_context(patch.object(scanner, "embed_trace_inputs_task"))
+        scanner.scan_traces_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_embed_trace_inputs_task_runs_embed_inside_guardrails():
+    captured = {}
+
+    def spy(*_a, **_k):
+        captured["settings"] = current_settings()
+        return 0  # stored count
+
+    with patch.object(scanner, "embed_trace_inputs", side_effect=spy):
+        # trigger_clustering=False → no cluster chain to mock.
+        scanner.embed_trace_inputs_task._original_func(["t1"], "p1", False)
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS
+
+
+def test_sweep_builds_reader_inside_guardrails():
+    captured = {}
+
+    def spy_get_reader():
+        captured["settings"] = current_settings()
+        return _reader_cm()
+
+    cfg = MagicMock()
+    cfg.no_workspace_objects.filter.return_value.order_by.return_value.values.return_value = [
+        {"project_id": "p1", "sampling_rate": 1.0, "last_swept_at": None}
+    ]
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch.object(scanner, "get_reader", side_effect=spy_get_reader)
+        )
+        stack.enter_context(patch.object(scanner, "TraceScanConfig", cfg))
+        stack.enter_context(
+            patch.object(scanner, "filter_already_scanned", side_effect=lambda x: x)
+        )
+        stack.enter_context(
+            patch.object(
+                scanner, "is_trace_sampled", side_effect=lambda tid, rate: True
+            )
+        )
+        stack.enter_context(patch.object(scanner, "scan_traces_task"))
+        scanner.sweep_scannable_traces._original_func()
+
+    assert captured["settings"] == scanner.SCAN_CH_GUARDRAILS


### PR DESCRIPTION
> Stacked on #1452 (Phase A finish). Base is `perf/TH-6642-eval-ch-guardrails`; the diff here is only the scanner guardrails. Will retarget to `dev` once the #1431→#1452 stack merges.

## Why

The trace-scanner already OOM'd ClickHouse once (`code: 241`, the TH-6515 storm). That root cause is fixed and merged (PK-prune + `use_skip_indexes_if_final`). This PR is the **defense-in-depth** follow-up, mirroring #1452's eval-engine guardrails: cap per-query CH memory/time/sort on the scanner pipeline so the **next** unanticipated heavy query degrades to a single query-level `code 241` (retryable) instead of exhausting server memory and taking the whole shared ClickHouse box — and every CH-backed UI feature — down with it.

## What

- **`SCAN_CH_GUARDRAILS`** (`tracer/tasks/trace_scanner.py`) — `max_memory_usage` 4 GiB / `max_execution_time` 120 s / `max_bytes_before_external_sort` 2 GiB, applied via the `ch_query_settings` contextvar (baked into each v2 reader's client at construction). Same box-safe starting values as the eval engine; independently tunable per-pipeline at the prod gate.
- **`scan_ch_guardrails()`** wraps the **three** scanner activity bodies that build a v2 `get_reader()`: `scan_traces_task` (around `scan_and_write`), `embed_trace_inputs_task` (around `embed_trace_inputs`), and `sweep_scannable_traces` (around the `get_reader()` block). Big sorts spill to disk; a heavy read is rejected at the query level and retried instead of killing the server.

Deliberately **not** wrapped: `cluster_scan_issues_task`. It reads only through `ClickHouseVectorDB` (a separate client that never consumes the contextvar), so a wrap there would be inert dead code.

**Residual (conscious gap):** those `ClickHouseVectorDB` KNN reads (centroid match / success-trace lookup) stay uncapped on the same box. They're low-risk (top-k partial sorts with `LIMIT k`), so this is a documented residual, not a gap to fix here — capping them is a per-query `SETTINGS` clause in that client, a separate change.

## Tests

**New** `tracer/tests/test_scan_ch_guardrails.py` — 3 DB-free revert-catchers. Each drives the real (undecorated) activity body and snapshots `current_settings()` at the moment the wrapped CH work begins; if the `with` is dropped or a refactor slips a context-dropping hop in front of the read, the snapshot is empty and the test fails. **Mutation-verified**: stripping a wrap turns its test red.

**New** `tests/stress/test_scan_guardrails.py` — loadgen-seeded benchmark on the scanner's actual `list_by_trace_ids` read (`FROM spans FINAL`, fat JSON columns):

| Check | Result |
|---|---|
| **Tripwire** — read under `scan_ch_guardrails()` + `max_memory_usage=1 MB` | Rejected with CH **code 241**; a subsequent normal read on the same CH **succeeds** → server stayed healthy (query-level rejection, not a box-wide OOM) |
| **Headroom** — realistic 15-trace batch under the real **4 GiB** cap | Completes (274 spans); `system.query_log` peak **629.4 MiB**, `read_rows` 98,934 → **7× under the cap** |

```
2 passed in 58.43s
```

The 629 MiB local peak lines up with the prod-scale dev-box number (594 MiB heavy, TH-6515) — a normal scanner batch sits well under 4 GiB (won't false-positive on legit work) while a runaway trips at 241. The 98,934 `read_rows` for 15 traces is the pre-fix unpruned-`FINAL` amplification, which just shows the guardrail is orthogonal insurance that holds regardless of query shape.

Repro: `LOADGEN_BIN=<fi-collector/bin/loadgen> uv run --python 3.13 pytest tests/stress/test_scan_guardrails.py -sv` (CH 25.3.14, `STRESS_SCALE=0.1`).

## Deploy note

The sizing (4 GiB right-headroom-but-below-ceiling) is a starting point tuned against dev-GCP; re-measure peak per-query memory at prod-scale and record the finals before the prod cutover.
