### PR TITLE
fix(pricing): send empty body on PAYG/downgrade POST (TH-6687)

### DIFF
--- a/frontend/src/sections/settings/PricingV3/PricingPage.jsx
+++ b/frontend/src/sections/settings/PricingV3/PricingPage.jsx
@@ -591,7 +591,7 @@ export default function PricingPage() {
 
   const upgradeMutation = useMutation({
     mutationFn: async () => {
-      const res = await axios.post(endpoints.settings.v2.upgradeToPayg);
+      const res = await axios.post(endpoints.settings.v2.upgradeToPayg, {});
       const checkoutUrl = res.data?.result?.checkout_url;
       if (!checkoutUrl) throw new Error("Failed to create checkout session");
       // Redirect to Stripe Checkout — user enters card on Stripe's hosted page
@@ -652,7 +652,7 @@ export default function PricingPage() {
   });
 
   const downgradeMutation = useMutation({
-    mutationFn: () => axios.post(endpoints.settings.v2.downgradeToFree),
+    mutationFn: () => axios.post(endpoints.settings.v2.downgradeToFree, {}),
     onSuccess: () => {
       enqueueSnackbar("Downgraded to Free plan", { variant: "success" });
       queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });


### PR DESCRIPTION
## Summary
The **Pay-as-you-go** button did nothing — clicking it never fired the API call.

## Root cause
`upgrade-to-payg` (and `downgrade-to-free`) are contracted with `UsageEmptyRequest` and `runtimeRequestValidation`, but the frontend called them with **no body**. axios sends `data = undefined`, which fails the `z.object({})` request-body schema. Request-contract enforcement is **strict in dev** (`VITE_API_CONTRACTS !== "off"`), so the axios request interceptor **rejected the call before it was sent**.

## What changed
Pass `{}` as the body on both POSTs so the empty-object body validates and the request fires:
- `axios.post(endpoints.settings.v2.upgradeToPayg, {})`
- `axios.post(endpoints.settings.v2.downgradeToFree, {})`

## Note on the console contract warnings
The `features: Expected object, received number` / `isCustomPricing: Required` messages on `GET /usage/v2/plans-and-addons/` are **non-blocking** — response-contract enforcement is warn-only by default (`VITE_API_CONTRACT_STRICT_RESPONSES` unset), so the page still loads. Those are real contract drift but were not the PAYG bug; leaving them for a separate cleanup.

## Tests
- [ ] Click "Upgrade to PAYG" → request fires, redirects to Stripe checkout
- [ ] Downgrade to Free → request fires

## Type of change
- [x] 🐛 Bug fix (non-breaking)

## Linear
Closes TH-6687