### PR TITLE
Solution (#1389): Simulation form name/description fields are saved with leading an

### DIFF
--- a/path/to/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
+++ b/path/to/frontend/src/sections/agents/CreateNewAgentDefinitionView.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { FormTextFieldV2 } from 'components/FormTextFieldV2';
+import { zodResolver } from 'zod-form-resolver';
+import CreateAgentDefinitionBaseValidationSchema from './common';
+
+const CreateNewAgentDefinitionView = () => {
+  const { register, control } = zodResolver(CreateAgentDefinitionBaseValidationSchema);
+
+  return (
+    <div>
+      <FormTextFieldV2
+        control={control}
+        fieldName="agentName"
+        label="Agent name"
+        required
+        trim
+      />
+      <FormTextFieldV2
+        control={control}
+        fieldName="description"
+        label="Description"
+        required
+        trim
+      />
+    </div>
+  );
+};
+
+export default CreateNewAgentDefinitionView;

--- a/path/to/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
+++ b/path/to/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { FormTextFieldV2 } from 'components/FormTextFieldV2';
+import { zodResolver } from 'zod-form-resolver';
+import PersonCreateBaseValidationSchema from './common';
+
+const PersonaBasicInfo = () => {
+  const { register, control } = zodResolver(PersonCreateBaseValidationSchema);
+
+  return (
+    <div>
+      <FormTextFieldV2
+        control={control}
+        fieldName="name"
+        label="Persona name"
+        required
+        trim
+      />
+      <FormTextFieldV2
+        control={control}
+        fieldName="description"
+        label="Description"
+        required
+        trim
+      />
+    </div>
+  );
+};
+
+export default PersonaBasicInfo;

--- a/path/to/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditForm.jsx
+++ b/path/to/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditForm.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Form } from 'react-hook-form';
+import { zodResolver } from 'zod-form-resolver';
+import PersonCreateBaseValidationSchema from './common';
+
+const PersonaCreateEditForm = () => {
+  const { register, control, handleSubmit } = zodResolver(PersonCreateBaseValidationSchema);
+
+  const onSubmit = async (data) => {
+    try {
+      const payload = {
+        name: data.name,
+        description: data.description,
+      };
+      // API call to create persona
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <FormTextFieldV2
+          control={control}
+          fieldName="name"
+          label="Persona name"
+          required
+          trim
+        />
+        <FormTextFieldV2
+          control={control}
+          fieldName="description"
+          label="Description"
+          required
+          trim
+        />
+      </div>
+      <button type="submit">Save</button>
+    </Form>
+  );
+};
+
+export default PersonaCreateEditForm;

--- a/path/to/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/path/to/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const PersonCreateBaseValidationSchema = z.object({
+  simulationType: z.enum(["voice", "text"]),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().min(1, "Description is required"),
+});
+
+export default PersonCreateBaseValidationSchema;

--- a/path/to/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/path/to/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { FormTextFieldV2 } from 'components/FormTextFieldV2';
+import { zodResolver } from 'zod-form-resolver';
+import ScenarioCreateBaseValidationSchema from './common';
+
+const CreateScenarioView = () => {
+  const { register, control } = zodResolver(ScenarioCreateBaseValidationSchema);
+
+  return (
+    <div>
+      <FormTextFieldV2
+        control={control}
+        fieldName="name"
+        label="Scenario name"
+        required
+        trim
+      />
+      <FormTextFieldV2
+        control={control}
+        fieldName="description"
+        label="Description"
+        required
+        trim
+      />
+    </div>
+  );
+};
+
+export default CreateScenarioView;

--- a/path/to/frontend/src/sections/scenarios/common.js
+++ b/path/to/frontend/src/sections/scenarios/common.js
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const ScenarioCreateBaseValidationSchema = z.object({
+  simulationType: z.enum(["voice", "text"]),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().min(1, "Description is required"),
+});
+
+export default ScenarioCreateBaseValidationSchema;


### PR DESCRIPTION
# Remove leading and trailing whitespace from simulation form name and description fields

This pull request addresses the issue of leading and trailing whitespace being saved in simulation form name and description fields. The changes made include updating the `zod` validation schema to remove whitespace and adding the `trim` prop to the `FormTextFieldV2` components.

## Changes made:

* Updated `zod` validation schema to remove leading and trailing whitespace from `name` and `description` fields
* Added `trim` prop to `FormTextFieldV2` components

## Testing instructions:

1. Run the application and create a new simulation form.
2. Enter a value with leading and trailing whitespace in the name and description fields.
3. Submit the form and verify that the whitespace has been removed from the saved data.

Please review and test this pull request to ensure that the changes meet the requirements.