### PR TITLE
fix(model_hub): resolve 0113 migration leaf conflict by renaming backfill to 0114

### DIFF
--- a/futureagi/model_hub/migrations/0114_backfill_eval_version_is_default.py
+++ b/futureagi/model_hub/migrations/0114_backfill_eval_version_is_default.py
@@ -43,7 +43,7 @@ def backfill_is_default(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("model_hub", "0112_eval_ground_truth_tenant_scope"),
+        ("model_hub", "0113_annotation_queue_label_required_default"),
     ]
 
     operations = [

--- a/futureagi/model_hub/tests/test_eval_version_default_backfill_migration.py
+++ b/futureagi/model_hub/tests/test_eval_version_default_backfill_migration.py
@@ -1,4 +1,4 @@
-"""Tests for migration 0113_backfill_eval_version_is_default.
+"""Tests for migration 0114_backfill_eval_version_is_default.
 
 Data-migration guarantees under test:
   * A template with zero is_default=True versions gets its highest-numbered
@@ -18,7 +18,7 @@ from model_hub.models.evals_metric import EvalTemplate, EvalTemplateVersion
 
 
 backfill_module = importlib.import_module(
-    "model_hub.migrations.0113_backfill_eval_version_is_default"
+    "model_hub.migrations.0114_backfill_eval_version_is_default"
 )
 backfill_is_default = backfill_module.backfill_is_default
 


### PR DESCRIPTION
## Summary
`model_hub` had two leaf `0113` migrations — `0113_annotation_queue_label_required_default` (TH-6670) and `0113_backfill_eval_version_is_default` — so Django couldn't pick a single tip and `makemigrations --check` errored on setup, blocking `backend-contracts` CI on unrelated PRs (e.g. #1460).

Since `0113_backfill_eval_version_is_default` was only just merged to `dev` and hasn't been applied anywhere yet, renamed it to `0114_backfill_eval_version_is_default.py` and updated its `dependencies` to chain after `0113_annotation_queue_label_required_default` instead of `0112_eval_ground_truth_tenant_scope`. This gives a single linear leaf instead of adding an empty merge node.

Also updated `model_hub/tests/test_eval_version_default_backfill_migration.py`'s `importlib.import_module(...)` path and docstring to match the new module name.

## Verification
- `python manage.py makemigrations --check --dry-run` → `No changes detected` (previously errored with the leaf-conflict `CommandError`).
- `pytest model_hub/tests/test_eval_version_default_backfill_migration.py` → 4/4 passing against the renamed module.
- Diffed the migration's own `operations` before/after the rename — untouched, only the filename + `dependencies` changed.

## Type of change
- [x] 🐛 Bug fix (unblocks CI for other PRs)