### PR TITLE
perf(evals): cut update-eval p95 from 426ms to 35ms (TH-6570)

### DIFF
--- a/futureagi/model_hub/tests/test_eval_detail.py
+++ b/futureagi/model_hub/tests/test_eval_detail.py
@@ -2,6 +2,8 @@
 Tests for Phase 4: Eval Detail & Update API.
 """
 
+import copy
+
 import pytest
 
 from model_hub.models.choices import OwnerChoices
@@ -375,3 +377,132 @@ class TestEvalTemplateUpdateAPI:
             user_template.config["code"] == "def evaluate(a, b):\n    return a == b\n"
         )
         assert user_template.config["language"] == "python"
+
+    # --- Autosave: dirty-field-only save() semantics ---
+
+    def test_autosave_batch_persists_every_column_and_every_config_key(
+        self, auth_client, user_template
+    ):
+        """FE autosave debounces multiple field edits into one request.
+        Every top-level column AND every nested config key in the payload
+        must land on disk; otherwise the diff-based save silently drops
+        in-place JSONField mutations.
+        """
+        response = auth_client.put(
+            self._url(user_template.id),
+            {
+                "description": "batched autosave",
+                "model": "turing_small",
+                "instructions": "Check {{answer}} against reference.",
+                "output_type": "percentage",
+                "pass_threshold": 0.8,
+                "mode": "auto",
+                "tools": {"internet": True, "connectors": []},
+                "knowledge_bases": ["kb-a"],
+                "data_injection": {"variables_only": True},
+                "summary": {"type": "short"},
+                "check_internet": True,
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        user_template.refresh_from_db()
+        assert user_template.description == "batched autosave"
+        assert user_template.model == "turing_small"
+        assert user_template.criteria == "Check {{answer}} against reference."
+        assert user_template.output_type_normalized == "percentage"
+        assert user_template.pass_threshold == 0.8
+        cfg = user_template.config
+        assert cfg["model"] == "turing_small"
+        assert cfg["rule_prompt"] == "Check {{answer}} against reference."
+        assert "answer" in cfg["required_keys"]
+        assert cfg["output"] == "score"
+        assert cfg["pass_threshold"] == 0.8
+        assert cfg["agent_mode"] == "auto"
+        assert cfg["tools"] == {"internet": True, "connectors": []}
+        assert cfg["knowledge_bases"] == ["kb-a"]
+        assert cfg["data_injection"] == {"variables_only": True}
+        assert cfg["summary"] == {"type": "short"}
+        assert cfg["check_internet"] is True
+
+    def test_autosave_noop_when_payload_matches_current_state(
+        self, auth_client, user_template
+    ):
+        """Payload identical to current state must not fire an UPDATE and
+        must not bump updated_at. The endpoint always writes
+        config["template_format"], so the fixture must already carry that
+        key for the write to genuinely no-op.
+        """
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        user_template.config["template_format"] = "mustache"
+        user_template.save(update_fields=["config"])
+        user_template.refresh_from_db()
+        original_updated_at = user_template.updated_at
+        original_config = copy.deepcopy(user_template.config)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = auth_client.put(
+                self._url(user_template.id),
+                {"description": user_template.description},
+                format="json",
+            )
+        assert response.status_code == 200
+        update_queries = [
+            q
+            for q in ctx.captured_queries
+            if q["sql"].lstrip().upper().startswith("UPDATE ")
+            and "model_hub_evaltemplate" in q["sql"].lower()
+        ]
+        assert update_queries == [], (
+            f"no-op autosave should skip UPDATE, saw: {[q['sql'] for q in update_queries]}"
+        )
+        user_template.refresh_from_db()
+        assert user_template.updated_at == original_updated_at
+        assert user_template.config == original_config
+
+    def test_autosave_description_only_hits_minimal_query_count(
+        self, auth_client, user_template
+    ):
+        """Description-only autosave must not fan out FK re-fetches. The
+        select_related on the initial .get() caps the fetch to one query,
+        and update_fields on save() writes only the touched columns.
+        Total queries against the template table = 1 initial SELECT + 2
+        uniqueness checks from EvalTemplate.clean() (user-org + system) +
+        1 UPDATE; the pre-PR code fired ~7-8 on the same payload.
+        """
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        user_template.config["template_format"] = "mustache"
+        user_template.save(update_fields=["config"])
+        user_template.refresh_from_db()
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = auth_client.put(
+                self._url(user_template.id),
+                {"description": "perf-lock"},
+                format="json",
+            )
+        assert response.status_code == 200
+        template_queries = [
+            q
+            for q in ctx.captured_queries
+            if "model_hub_evaltemplate" in q["sql"].lower()
+        ]
+        assert len(template_queries) <= 4, (
+            f"expected <=4 template-table queries (initial SELECT, 2 clean() "
+            f"uniqueness scans, UPDATE); saw {len(template_queries)}: "
+            f"{[q['sql'] for q in template_queries]}"
+        )
+        update_queries = [
+            q
+            for q in template_queries
+            if q["sql"].lstrip().upper().startswith("UPDATE ")
+        ]
+        assert len(update_queries) == 1
+        assert '"config"' not in update_queries[0]["sql"], (
+            f"description-only save should not rewrite config; saw: "
+            f"{update_queries[0]['sql']}"
+        )

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import math
 import traceback
@@ -2486,8 +2487,10 @@ class EvalTemplateUpdateView(APIView):
                 )
 
             # Snapshot for update_fields diffing at save() below.
+            # deepcopy so in-place JSONField mutations (template.config[...] = ...)
+            # register as changes; a shallow reference would alias the same dict.
             _original_field_values = {
-                f.attname: getattr(template, f.attname)
+                f.attname: copy.deepcopy(getattr(template, f.attname))
                 for f in template._meta.concrete_fields
             }
 

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -2470,7 +2470,11 @@ class EvalTemplateUpdateView(APIView):
             )
 
             try:
-                template = EvalTemplate.objects.get(
+                # select_related caches the org + workspace FKs so downstream
+                # accesses stay in Python instead of firing fresh SELECTs.
+                template = EvalTemplate.objects.select_related(
+                    "organization", "workspace"
+                ).get(
                     id=template_id,
                     organization=organization,
                     owner=OwnerChoices.USER.value,
@@ -2481,14 +2485,21 @@ class EvalTemplateUpdateView(APIView):
                     "Eval template not found or cannot be edited (system templates are read-only)."
                 )
 
+            # Snapshot for update_fields diffing at save() below.
+            _original_field_values = {
+                f.attname: getattr(template, f.attname)
+                for f in template._meta.concrete_fields
+            }
+
             # Update fields if provided
-            if req.name is not None:
+            # Skip the validation + uniqueness scan when the name is unchanged;
+            # autosave otherwise fires the collision query on every keystroke.
+            if req.name is not None and req.name.strip() != template.name:
                 cleaned = req.name.strip()
                 if not re.match(r"^[a-z0-9_-]+$", cleaned):
                     return self._gm.bad_request(
                         "Name can only contain lowercase letters, numbers, hyphens, or underscores."
                     )
-                # Check uniqueness
                 if (
                     EvalTemplate.objects.filter(
                         name=cleaned, organization=organization, deleted=False
@@ -2727,7 +2738,17 @@ class EvalTemplateUpdateView(APIView):
             if req.publish:
                 template.visible_ui = True
 
-            template.save()
+            # Write only dirty columns; default save() rewrites the whole row.
+            _dirty_fields = [
+                name
+                for name, orig in _original_field_values.items()
+                if getattr(template, name) != orig
+            ]
+            if _dirty_fields:
+                # auto_now=True on updated_at only fires if it's in update_fields.
+                if "updated_at" not in _dirty_fields:
+                    _dirty_fields.append("updated_at")
+                template.save(update_fields=_dirty_fields)
 
             # Lazy V1 on first publish (idempotent).
             if req.publish:


### PR DESCRIPTION
## Summary

The eval-template autosave endpoint `PUT /model-hub/eval-templates/<id>/update/` was slow enough to be visible in the eval builder UI: every FE debounce tick took **~53 ms p50 / ~426 ms p95** on the server side, and each request fanned out to **8 SQL round-trips** on a payload that only carried `{"description": "..."}`. FE debounces autosave into batched requests carrying multiple fields, so any real edit paid the same overhead per keystroke burst.

This PR reduces that to **~8.7 ms p50 / ~35 ms p95** with **4 round-trips** (initial SELECT with an FK-cache JOIN + 2 uniqueness scans from `EvalTemplate.clean()` + 1 narrow UPDATE) via three surgical edits inside `EvalTemplateUpdateView.put`. The endpoint's request/response contract and side effects are unchanged.

## Why this PR exists

Autosave debounce fires on every keystroke burst in the eval builder. When each request costs 50+ ms server-side and rewrites the entire `EvalTemplate` row (including the multi-KB `config` JSONField), the UI feels laggy and the database carries write amplification proportional to the length of an edit session. The endpoint is on the hot path for anyone editing an eval, so tail latency matters more than the median.

## Root cause

Instrumented the endpoint with per-phase `perf_counter` timers and `CaptureQueriesContext`. Ran 10 warmup + 10 measured samples of a description-only payload against a local backend on a cold PgBouncer. Three bugs jumped out:

1. **`template.save()` rewrote every column on every keystroke.** The `config` JSONField alone is tens of KB on complex evals, so every debounced autosave was writing the whole eval config, dirtying every index on the row, and forcing MVCC to mark the old row version dead. Biggest single cost.
2. **Name-uniqueness collision scan ran even when the name did not change.** The `if req.name is not None:` branch fired the query unconditionally, so autosaves with an unchanged `name` field still fired a `SELECT 1 FROM eval_template WHERE name=X AND owner=Y AND id!=Z`.
3. **Foreign keys (`organization`, `workspace`) were fetched twice.** The initial `.get()` did not `select_related`, so downstream code accessing `template.organization` / `template.workspace` triggered fresh SELECTs on each FK.

Attribution across the 8 pre-fix queries on a description-only autosave:

| # | Query | Necessary? | Why |
|---|---|---|---|
| 1 | `SELECT eval_template.*` (initial `.get()`) | yes | The fetch. Now joins `organization` + `workspace`. |
| 2 | `SELECT 1 FROM accounts_organization WHERE id=X` | no | Middleware already resolved it; folded into the JOIN of row 1 via `select_related`. |
| 3 | `SELECT 1 FROM accounts_workspace WHERE id=X` | no | Same. |
| 4 | `SELECT accounts_organization.*` | no | Same. |
| 5 | `SELECT 1 FROM eval_template LEFT JOIN accounts_workspace ...` | no | Redundant re-check of a row 1 already loaded. |
| 6 | `SELECT 1 FROM eval_template WHERE name=X AND owner=Y AND id!=Z` | no | Name-uniqueness scan; only needed when the name actually changed. |
| 7 | `SELECT accounts_workspace.*` | no | Same as row 3. |
| 8 | `UPDATE eval_template SET (every column)` | yes | The write. Now narrowed via `update_fields`. |

`EvalTemplate.save()` still calls `self.full_clean()`, which fires two more `SELECT 1` uniqueness scans from the model's `clean()` (user-org + system). Those are unchanged by this PR and are counted in the post-fix numbers below.

## Fix

Three surgical edits in `EvalTemplateUpdateView.put`, plus one supporting `import`:

1. **`select_related("organization", "workspace")` on the initial `.get()`.** The template row arrives with both FKs loaded as Python objects. Any downstream access (`template.organization`, `template.workspace`, plus `self.organization` inside `clean()`'s uniqueness filter) is served from the ORM cache. That eliminates rows 2, 3, 4, 5, 7.
2. **Snapshot every concrete field on fetch (via `copy.deepcopy`), diff before `save()`, pass only the dirty column names in `update_fields`.** Default `save()` rewrites every column; this narrows the UPDATE to the ones the request actually touched. `deepcopy` is load-bearing because `template.config` is a Python dict that the endpoint mutates in place (`template.config["required_keys"] = ...`, `template.config["model"] = ...`, etc.); a shallow reference would alias the same dict and the diff would silently miss every mutation. `updated_at` is appended when any other field is dirty so `auto_now=True` still refreshes on real writes. When nothing is dirty, `save()` is skipped entirely.
3. **Guard the endpoint-level name-uniqueness scan** behind `if req.name.strip() != template.name:`. Query in row 6 no longer runs on the common autosave path. The model's `clean()` still runs its own two uniqueness scans; unchanged.

No `post_save` handlers on `EvalTemplate` (verified across the repo), so `update_fields` does not skip any signal side effect.

## Behavior callouts

- **`updated_at` on a fully no-op autosave (payload matches current state on every column and every config key) no longer bumps.** Previously the unconditional `save()` refreshed `updated_at` on every request. If any downstream consumer reads `updated_at` as "last user interaction" (analytics, sort order), it will now report a stale timestamp for empty autosaves. No behavior change for any request that actually touches a field.
- **`config["template_format"]` still auto-populates when absent.** The endpoint writes `template.config["template_format"] = "mustache"` on every request as a legacy back-compat guarantee. If the incoming template lacks this key (legacy rows that predate the field), that mutation registers as dirty and the row gets one UPDATE. That's identical to pre-PR behavior; it only surfaces here because the diff-based save exposes it as a one-time seed write. Subsequent autosaves on the same template are true no-ops.

## Benchmarks

Methodology: per-phase `perf_counter` timers and `CaptureQueriesContext` inside the view. 10 warmup + 10 measured samples of a description-only payload (`{"description": "profile-run"}`) against a local backend on a cold PgBouncer. Instrumentation lived on a scratch branch and is not part of this PR; the shipping change is only the three fixes above.

| Metric | Before | After | Change |
|---|---|---|---|
| Server total p50 | 53.2 ms | **8.7 ms** | 6.1x |
| Server total p95 | 426.3 ms | **35.4 ms** | 12.0x |
| Server total max | 659.1 ms | **44.8 ms** | 14.7x |
| Query count per request | 8 (16 with debug cursor double-log) | **4** | 2.0x |
| `fetch_template` phase p95 | 370.8 ms | 27.1 ms | 13.7x |
| `template_save` phase p95 | 93.1 ms | 2.6 ms | 35.8x |
| `field_mutations` phase p95 | 7.2 ms | 3.3 ms | 2.2x |
| Client wall-clock p50 | 159 ms | **44 ms** | 3.6x |
| Client wall-clock p95 | 536 ms | **150 ms** | 3.6x |

The `template_save` collapse is the largest single win: dropping the full-row rewrite to a narrow-column UPDATE removes about 90 ms of tail per request. Post-fix query count of 4 = 1 initial SELECT (with the org+workspace JOIN) + 2 uniqueness scans from `EvalTemplate.clean()` (unchanged from pre-PR) + 1 narrow UPDATE. If the residual `clean()` cost matters in production, a follow-up could conditionally skip `full_clean()` when `name` did not change; deferred until we see it in profiles.

Live curl runbook to reproduce the timing locally:

```bash
time curl -sS -X PUT "http://localhost:8000/model-hub/eval-templates/<id>/update/" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <token>" \
  -d '{"description":"benchmark"}' -o /dev/null
```

## Tests

### Backend

Three new cases in `model_hub/tests/test_eval_detail.py::TestEvalTemplateUpdateAPI` alongside 16 pre-existing update-API cases that continue to pass:

| Case | What it locks |
|---|---|
| `test_autosave_batch_persists_every_column_and_every_config_key` | Multi-field payload (description + model + instructions + output_type + pass_threshold + mode + tools + kb + data_injection + summary + check_internet) writes every top-level column AND every nested `config` key. Guards the deepcopy: without it, every in-place `config[...]` mutation would silently drop. |
| `test_autosave_noop_when_payload_matches_current_state` | Payload matching current state fires zero UPDATE queries and leaves `updated_at` untouched. |
| `test_autosave_description_only_hits_minimal_query_count` | Description-only autosave stays within a 4-query budget on the template table (1 initial SELECT + 2 `clean()` uniqueness scans + 1 UPDATE) AND the UPDATE does not carry the `config` column. |

Command to run the test file this PR touches (6 Detail-API cases + 19 Update-API cases: 16 pre-existing + 3 new autosave cases; 25/25 green locally):

```bash
bin/test model_hub/tests/test_eval_detail.py -v -m e2e
```

<img width="1102" height="340" alt="image" src="https://github.com/user-attachments/assets/0d66b6c7-572a-4ef8-add6-b19ff76d0948" />

### Frontend


https://github.com/user-attachments/assets/6932aaf6-2bba-4785-b7bf-12e9d9e0dbf8



## Scope

- Postgres only. No ClickHouse involvement.
- Backend only. One view file + one test file. 25 insertions + 4 deletions on the view, 131 insertions on tests.
- No API contract change: request and response shapes are identical (verified against `EvalUpdateRequest` / `EvalUpdateResponse` in `model_hub/types.py`).
- No migration.
- No signal handlers on `EvalTemplate`, so `update_fields` cannot skip any listener that assumed a full-row save.
- Follow-up worth flagging separately: `EvalTemplateCreateV2View` uses `EvalTemplate.objects.create()`, which is one full-row write per template. Negligible today (fires once per new template, not per keystroke), but the same diff-based narrowing pattern could apply if it shows up on profiles later.
- `EvalTemplateUpdateView.put` carries its per-field business logic inline; extracting it into a dedicated update service would read cleaner but is deferred to keep this PR strictly a perf change.

Fix TH-6570




