### PR TITLE
fix: emit billing-mode-aware usage in fi-collector

### DIFF
--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -82,7 +82,7 @@ func main() {
 	var usageEmitter server.UsageEmitter = server.NoopUsageEmitter{}
 	var metering server.Metering = server.NoopMetering{}
 	if rdb != nil {
-		usageEmitter = auth.NewUsageEmitter(rdb, log)
+		usageEmitter = auth.NewUsageEmitter(rdb, authenticator.PGRead(), log)
 		metering = auth.NewMetering(rdb, authenticator.PGRead(), log)
 	}
 

--- a/fi-collector/pkg/auth/auth_test.go
+++ b/fi-collector/pkg/auth/auth_test.go
@@ -933,20 +933,17 @@ func TestUsageEmitterEmitIngestionNil(t *testing.T) {
 }
 
 func TestBillingEventIDDeterministic(t *testing.T) {
-	a := billingEventID("trace-abc", "tracing_event")
-	if a != billingEventID("trace-abc", "tracing_event") {
-		t.Error("same dedupKey+eventType must yield the same event_id (re-poll must dedup)")
+	a := billingEventID("trace-abc")
+	if a != billingEventID("trace-abc") {
+		t.Error("same dedupKey must yield the same event_id (re-poll must dedup, even across a mode flip)")
 	}
-	if billingEventID("trace-abc", "observe_add") == a {
-		t.Error("different eventType must yield distinct ids (else the two events collide on unique event_id)")
-	}
-	if billingEventID("trace-xyz", "tracing_event") == a {
+	if billingEventID("trace-xyz") == a {
 		t.Error("different dedupKey must yield distinct ids")
 	}
 }
 
 func TestBillingEventIDEmptyKeyIsRandom(t *testing.T) {
-	if billingEventID("", "tracing_event") == billingEventID("", "tracing_event") {
+	if billingEventID("") == billingEventID("") {
 		t.Error("empty dedupKey must fall back to a random event_id (SDK batches)")
 	}
 }
@@ -1075,8 +1072,7 @@ func TestEmitIngestionDefaultsToStorageWhenModeUnknown(t *testing.T) {
 	}
 }
 
-// Issue B: events-mode tracing amount is traces+spans, and payloadBytes is
-// ignored (span storage isn't billed in events mode).
+// events-mode tracing amount is traces+spans, and payloadBytes is ignored.
 func TestEmitIngestionEventsModeAmountIncludesSpans(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -1091,6 +1087,25 @@ func TestEmitIngestionEventsModeAmountIncludesSpans(t *testing.T) {
 	}
 	if evs[0]["event_type"] != "tracing_event" || evs[0]["amount"] != "7" {
 		t.Errorf("want tracing_event amount=7 (2 traces + 5 spans), got type=%v amount=%v",
+			evs[0]["event_type"], evs[0]["amount"])
+	}
+}
+
+// events mode with spans=0 pins the other boundary of the traces+spans sum.
+func TestEmitIngestionEventsModeTracesOnly(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+	setTracingMode(t, rdb, "org-t", "events")
+
+	u.EmitIngestion("org-t", 2, 0, 999, "trace-1")
+
+	evs := usageStreamEvents(t, rdb)
+	if len(evs) != 1 {
+		t.Fatalf("events mode must emit exactly one event, got %d: %v", len(evs), evs)
+	}
+	if evs[0]["event_type"] != "tracing_event" || evs[0]["amount"] != "2" {
+		t.Errorf("want tracing_event amount=2 (2 traces + 0 spans), got type=%v amount=%v",
 			evs[0]["event_type"], evs[0]["amount"])
 	}
 }

--- a/fi-collector/pkg/auth/auth_test.go
+++ b/fi-collector/pkg/auth/auth_test.go
@@ -921,7 +921,7 @@ func TestResolveResultMissingProjects(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNewUsageEmitterNilRedis(t *testing.T) {
-	u := NewUsageEmitter(nil, slog.Default())
+	u := NewUsageEmitter(nil, nil, slog.Default())
 	if u != nil {
 		t.Fatal("NewUsageEmitter with nil redis must return nil")
 	}
@@ -962,7 +962,8 @@ func TestEmitIngestionEventIDDedupViaRedis(t *testing.T) {
 	}
 	defer mr.Close()
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	u := NewUsageEmitter(rdb, slog.Default())
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+	setTracingMode(t, rdb, "org-1", "events") // events mode → tracing_event is emitted
 
 	// Order: same call twice (re-poll), a different call, then an SDK batch twice.
 	u.EmitIngestion("org-1", 1, 1, 100, "trace-A")
@@ -992,6 +993,105 @@ func TestEmitIngestionEventIDDedupViaRedis(t *testing.T) {
 	}
 	if ids[3] == ids[4] {
 		t.Error("SDK batch (empty dedupKey) must get random event_ids")
+	}
+}
+
+// setTracingMode seeds the org's billing-mode cache key so EmitIngestion
+// resolves a known mode without a Postgres pool.
+func setTracingMode(t *testing.T, rdb *redis.Client, orgID, mode string) {
+	t.Helper()
+	if err := rdb.Set(context.Background(), "tracing_billing_mode:"+orgID, mode, 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// usageStreamEvents returns every event currently on the usage stream.
+func usageStreamEvents(t *testing.T, rdb *redis.Client) []map[string]any {
+	t.Helper()
+	msgs, err := rdb.XRange(context.Background(), usageStreamKey, "-", "+").Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Values)
+	}
+	return out
+}
+
+// storage mode → one observe_add (amount = payloadBytes), no tracing_event.
+func TestEmitIngestionStorageModeEmitsOnlyStorage(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+	setTracingMode(t, rdb, "org-s", "storage")
+
+	u.EmitIngestion("org-s", 3, 7, 500, "trace-1")
+
+	evs := usageStreamEvents(t, rdb)
+	if len(evs) != 1 {
+		t.Fatalf("storage mode must emit exactly one event, got %d: %v", len(evs), evs)
+	}
+	if evs[0]["event_type"] != "observe_add" {
+		t.Errorf("storage mode must emit observe_add, got %v", evs[0]["event_type"])
+	}
+	if evs[0]["amount"] != "500" {
+		t.Errorf("observe_add amount must be payloadBytes=500, got %v", evs[0]["amount"])
+	}
+}
+
+// events mode → one tracing_event (amount = traces+spans), no observe_add.
+func TestEmitIngestionEventsModeEmitsOnlyTracing(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+	setTracingMode(t, rdb, "org-e", "events")
+
+	u.EmitIngestion("org-e", 3, 7, 500, "trace-1")
+
+	evs := usageStreamEvents(t, rdb)
+	if len(evs) != 1 {
+		t.Fatalf("events mode must emit exactly one event, got %d: %v", len(evs), evs)
+	}
+	if evs[0]["event_type"] != "tracing_event" {
+		t.Errorf("events mode must emit tracing_event, got %v", evs[0]["event_type"])
+	}
+	if evs[0]["amount"] != "10" {
+		t.Errorf("tracing_event amount must be traces+spans=10, got %v", evs[0]["amount"])
+	}
+}
+
+// Unknown mode (no cache key, no PG) defaults to storage — matches Python.
+func TestEmitIngestionDefaultsToStorageWhenModeUnknown(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+
+	u.EmitIngestion("org-x", 3, 7, 500, "")
+
+	evs := usageStreamEvents(t, rdb)
+	if len(evs) != 1 || evs[0]["event_type"] != "observe_add" {
+		t.Fatalf("unknown mode must default to storage (observe_add only), got %v", evs)
+	}
+}
+
+// Issue B: events-mode tracing amount is traces+spans, and payloadBytes is
+// ignored (span storage isn't billed in events mode).
+func TestEmitIngestionEventsModeAmountIncludesSpans(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	u := NewUsageEmitter(rdb, nil, slog.Default())
+	setTracingMode(t, rdb, "org-b", "events")
+
+	u.EmitIngestion("org-b", 2, 5, 999, "trace-1")
+
+	evs := usageStreamEvents(t, rdb)
+	if len(evs) != 1 {
+		t.Fatalf("events mode must emit exactly one event (bytes ignored), got %d: %v", len(evs), evs)
+	}
+	if evs[0]["event_type"] != "tracing_event" || evs[0]["amount"] != "7" {
+		t.Errorf("want tracing_event amount=7 (2 traces + 5 spans), got type=%v amount=%v",
+			evs[0]["event_type"], evs[0]["amount"])
 	}
 }
 

--- a/fi-collector/pkg/auth/billingmode.go
+++ b/fi-collector/pkg/auth/billingmode.go
@@ -2,12 +2,9 @@ package auth
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/redis/go-redis/v9"
 )
 
 // tracingBillingModeTTL matches the Python emitter's cache (ee.usage) so both
@@ -15,19 +12,17 @@ import (
 const tracingBillingModeTTL = 5 * time.Minute
 
 // tracingBillingMode resolves the org's tracing billing mode ("storage" or
-// "events"): Redis cache first, Postgres fallback, "storage" default. Mirrors
-// Python _tracing_billing_mode and Metering.getCachedPlan so the dimension we
-// emit is the one we bill.
-func tracingBillingMode(ctx context.Context, rdb *redis.Client, pg *pgxpool.Pool, log *slog.Logger, orgID string) string {
+// "events"): Redis cache first, Postgres fallback, "storage" default.
+func (u *UsageEmitter) tracingBillingMode(ctx context.Context, orgID string) string {
 	cacheKey := "tracing_billing_mode:" + orgID
 
-	if rdb != nil {
-		if cached, err := rdb.Get(ctx, cacheKey).Result(); err == nil && cached != "" {
+	if u.rdb != nil {
+		if cached, err := u.rdb.Get(ctx, cacheKey).Result(); err == nil && cached != "" {
 			return cached
 		}
 	}
 
-	if pg == nil {
+	if u.pg == nil {
 		return "storage"
 	}
 
@@ -35,17 +30,20 @@ func tracingBillingMode(ctx context.Context, rdb *redis.Client, pg *pgxpool.Pool
 		WHERE organization_id = $1 AND deleted = false LIMIT 1`
 
 	mode := "storage"
+	cacheable := true
 	var got string
-	if err := pg.QueryRow(ctx, q, orgID).Scan(&got); err != nil {
+	if err := u.pg.QueryRow(ctx, q, orgID).Scan(&got); err != nil {
 		if err != pgx.ErrNoRows {
-			log.Warn("tracing_billing_mode lookup failed", "err", err, "org", orgID)
+			// Transient PG error: don't pin the storage fallback in the shared cache.
+			u.log.Warn("tracing_billing_mode lookup failed", "err", err, "org", orgID)
+			cacheable = false
 		}
 	} else if got != "" {
 		mode = got
 	}
 
-	if rdb != nil {
-		_ = rdb.SetEx(ctx, cacheKey, mode, tracingBillingModeTTL).Err()
+	if u.rdb != nil && cacheable {
+		_ = u.rdb.SetEx(ctx, cacheKey, mode, tracingBillingModeTTL).Err()
 	}
 
 	return mode

--- a/fi-collector/pkg/auth/billingmode.go
+++ b/fi-collector/pkg/auth/billingmode.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+)
+
+// tracingBillingModeTTL matches the Python emitter's cache (ee.usage) so both
+// services share the same tracing_billing_mode:{org} key.
+const tracingBillingModeTTL = 5 * time.Minute
+
+// tracingBillingMode resolves the org's tracing billing mode ("storage" or
+// "events"): Redis cache first, Postgres fallback, "storage" default. Mirrors
+// Python _tracing_billing_mode and Metering.getCachedPlan so the dimension we
+// emit is the one we bill.
+func tracingBillingMode(ctx context.Context, rdb *redis.Client, pg *pgxpool.Pool, log *slog.Logger, orgID string) string {
+	cacheKey := "tracing_billing_mode:" + orgID
+
+	if rdb != nil {
+		if cached, err := rdb.Get(ctx, cacheKey).Result(); err == nil && cached != "" {
+			return cached
+		}
+	}
+
+	if pg == nil {
+		return "storage"
+	}
+
+	const q = `SELECT tracing_billing_mode FROM usage_organizationsubscription
+		WHERE organization_id = $1 AND deleted = false LIMIT 1`
+
+	mode := "storage"
+	var got string
+	if err := pg.QueryRow(ctx, q, orgID).Scan(&got); err != nil {
+		if err != pgx.ErrNoRows {
+			log.Warn("tracing_billing_mode lookup failed", "err", err, "org", orgID)
+		}
+	} else if got != "" {
+		mode = got
+	}
+
+	if rdb != nil {
+		_ = rdb.SetEx(ctx, cacheKey, mode, tracingBillingModeTTL).Err()
+	}
+
+	return mode
+}

--- a/fi-collector/pkg/auth/usage.go
+++ b/fi-collector/pkg/auth/usage.go
@@ -38,20 +38,20 @@ func NewUsageEmitter(rdb *redis.Client, pg *pgxpool.Pool, log *slog.Logger) *Usa
 // Namespace for deterministic billing event_ids (re-poll → same id → consumer dedups).
 var billingDedupNS = uuid.MustParse("a7c3e1f0-5d29-4b6a-8c14-9f2b0e6d3a71")
 
-// billingEventID is deterministic per (dedupKey, eventType) so re-polls dedup;
-// empty dedupKey → random id (SDK batches don't re-poll).
-func billingEventID(dedupKey, eventType string) string {
+// billingEventID is deterministic per dedupKey so re-polls dedup to a single
+// event even if the org's billing mode flips between polls; empty dedupKey →
+// random id (SDK batches don't re-poll).
+func billingEventID(dedupKey string) string {
 	if dedupKey == "" {
 		return uuid.New().String()
 	}
-	return uuid.NewSHA1(billingDedupNS, []byte(eventType+":"+dedupKey)).String()
+	return uuid.NewSHA1(billingDedupNS, []byte(dedupKey)).String()
 }
 
 // EmitIngestion records usage for the ONE dimension the org is billed on,
-// resolved from its tracing_billing_mode (mirrors Python emit_span_ingestion_usage):
-// storage mode → observe_add (bytes); events mode → tracing_event (traces+spans).
-// Emitting both would double-bill. Non-empty dedupKey → deterministic event_ids
-// so re-exports bill once. Fire-and-forget; errors logged, not returned.
+// resolved from its tracing_billing_mode: storage mode → observe_add (bytes);
+// events mode → tracing_event (traces+spans). Non-empty dedupKey → deterministic
+// event_ids so re-exports bill once. Fire-and-forget; errors logged, not returned.
 func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payloadBytes int64, dedupKey string) {
 	if u == nil {
 		return
@@ -62,10 +62,10 @@ func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payl
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	if tracingBillingMode(ctx, u.rdb, u.pg, u.log, orgID) == "storage" {
+	if u.tracingBillingMode(ctx, orgID) == "storage" {
 		if payloadBytes > 0 {
 			u.xadd(ctx, map[string]any{
-				"event_id":   billingEventID(dedupKey, "observe_add"),
+				"event_id":   billingEventID(dedupKey),
 				"org_id":     orgID,
 				"event_type": "observe_add",
 				"timestamp":  now,
@@ -76,12 +76,11 @@ func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payl
 		return
 	}
 
-	// events mode: bill traces+spans; span storage is not billed here, so
-	// payloadBytes is intentionally ignored.
+	// events mode: payloadBytes intentionally ignored (span storage isn't billed here).
 	tracingUnits := numTraces + numSpans
 	if tracingUnits > 0 {
 		u.xadd(ctx, map[string]any{
-			"event_id":   billingEventID(dedupKey, "tracing_event"),
+			"event_id":   billingEventID(dedupKey),
 			"org_id":     orgID,
 			"event_type": "tracing_event",
 			"timestamp":  now,

--- a/fi-collector/pkg/auth/usage.go
+++ b/fi-collector/pkg/auth/usage.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -21,15 +22,17 @@ const (
 // emitter (ee/usage/services/emitter.py).
 type UsageEmitter struct {
 	rdb *redis.Client
+	pg  *pgxpool.Pool
 	log *slog.Logger
 }
 
 // NewUsageEmitter creates an emitter. Returns nil if rdb is nil (disabled).
-func NewUsageEmitter(rdb *redis.Client, log *slog.Logger) *UsageEmitter {
+// pg (read pool) resolves the org's tracing billing mode; nil → storage default.
+func NewUsageEmitter(rdb *redis.Client, pg *pgxpool.Pool, log *slog.Logger) *UsageEmitter {
 	if rdb == nil {
 		return nil
 	}
-	return &UsageEmitter{rdb: rdb, log: log}
+	return &UsageEmitter{rdb: rdb, pg: pg, log: log}
 }
 
 // Namespace for deterministic billing event_ids (re-poll → same id → consumer dedups).
@@ -44,8 +47,11 @@ func billingEventID(dedupKey, eventType string) string {
 	return uuid.NewSHA1(billingDedupNS, []byte(eventType+":"+dedupKey)).String()
 }
 
-// EmitIngestion records trace + storage usage. Non-empty dedupKey → deterministic
-// event_ids so re-exports bill once. Fire-and-forget; errors logged, not returned.
+// EmitIngestion records usage for the ONE dimension the org is billed on,
+// resolved from its tracing_billing_mode (mirrors Python emit_span_ingestion_usage):
+// storage mode → observe_add (bytes); events mode → tracing_event (traces+spans).
+// Emitting both would double-bill. Non-empty dedupKey → deterministic event_ids
+// so re-exports bill once. Fire-and-forget; errors logged, not returned.
 func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payloadBytes int64, dedupKey string) {
 	if u == nil {
 		return
@@ -56,25 +62,31 @@ func (u *UsageEmitter) EmitIngestion(orgID string, numTraces, numSpans int, payl
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	if numTraces > 0 {
+	if tracingBillingMode(ctx, u.rdb, u.pg, u.log, orgID) == "storage" {
+		if payloadBytes > 0 {
+			u.xadd(ctx, map[string]any{
+				"event_id":   billingEventID(dedupKey, "observe_add"),
+				"org_id":     orgID,
+				"event_type": "observe_add",
+				"timestamp":  now,
+				"amount":     strconv.FormatInt(payloadBytes, 10),
+				"properties": fmt.Sprintf(`{"spans":%d,"source":"fi-collector"}`, numSpans),
+			})
+		}
+		return
+	}
+
+	// events mode: bill traces+spans; span storage is not billed here, so
+	// payloadBytes is intentionally ignored.
+	tracingUnits := numTraces + numSpans
+	if tracingUnits > 0 {
 		u.xadd(ctx, map[string]any{
 			"event_id":   billingEventID(dedupKey, "tracing_event"),
 			"org_id":     orgID,
 			"event_type": "tracing_event",
 			"timestamp":  now,
-			"amount":     strconv.Itoa(numTraces),
-			"properties": fmt.Sprintf(`{"traces":%d,"source":"fi-collector"}`, numTraces),
-		})
-	}
-
-	if payloadBytes > 0 {
-		u.xadd(ctx, map[string]any{
-			"event_id":   billingEventID(dedupKey, "observe_add"),
-			"org_id":     orgID,
-			"event_type": "observe_add",
-			"timestamp":  now,
-			"amount":     strconv.FormatInt(payloadBytes, 10),
-			"properties": fmt.Sprintf(`{"spans":%d,"source":"fi-collector"}`, numSpans),
+			"amount":     strconv.Itoa(tracingUnits),
+			"properties": fmt.Sprintf(`{"traces":%d,"source":"fi-collector"}`, tracingUnits),
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`fi-collector`'s `EmitIngestion` emitted **both** a `tracing_event` and an `observe_add` (storage) usage event on every ingest, ignoring the org's `tracing_billing_mode`. Because the billing consumer bills whatever dimension it receives, this double-billed orgs on the dimension they aren't on (a storage-mode org was also charged tracing events, and an events-mode org was also charged storage). This makes the collector emit the **single** dimension the org is actually billed on — matching the existing Python `emit_span_ingestion_usage` reference — and fixes the tracing amount to count traces **+** spans.

## Linked issues

Fixed TH-6620
Linear: https://linear.app/future-agi/issue/TH-6620

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Mode-aware emit (`pkg/auth/usage.go`)**

- `EmitIngestion` now resolves the org's `tracing_billing_mode` and emits exactly one usage event:
  - `storage` → `observe_add` (amount = payload bytes)
  - `events` → `tracing_event` (amount = traces + spans); payload bytes ignored
- Previously it emitted both unconditionally → downstream double-billing.
- `EmitIngestion`'s signature is unchanged; only `NewUsageEmitter` gains a PG read pool.

**B. Correct tracing amount (`pkg/auth/usage.go`)**

- `tracing_event` amount is now `numTraces + numSpans` (was `numTraces` only), matching the billing model and the Python emitter.

**C. Billing-mode resolver (`pkg/auth/billingmode.go`, new)**

- `tracingBillingMode()`: Redis cache → Postgres (`usage_organizationsubscription`) fallback → `storage` default. Shares the `tracing_billing_mode:{org}` cache key + 5-min TTL with the Python side, mirroring `Metering.getCachedPlan`.
- Wired into the emitter via `NewUsageEmitter(rdb, pg, log)` in `cmd/fi-collector/main.go`.

---

## 2) Why the changes were done

- **Correctness / billing:** emitting both dimensions double-bills; the dimension we fill must be the one we bill. The Go collector now matches the Python `emit_span_ingestion_usage`, which has always been mode-aware.
- **Technical:** the resolver mirrors the proven `getCachedPlan` pattern and shares the cache key with Python, so neither service serves a stale mode and a transient lookup failure fails toward the safe `storage` default.

---

## 3) Tests written + scenarios each covers

**`fi-collector/pkg/auth/auth_test.go`** — emitter mode matrix (Go, miniredis)

- `TestEmitIngestionStorageModeEmitsOnlyStorage` — storage mode → only `observe_add`, amount = payload bytes
- `TestEmitIngestionEventsModeEmitsOnlyTracing` — events mode → only `tracing_event`, amount = traces + spans
- `TestEmitIngestionDefaultsToStorageWhenModeUnknown` — no cache key + no PG → defaults to storage
- `TestEmitIngestionEventsModeAmountIncludesSpans` — amount = traces + spans; payload bytes ignored in events mode
- Existing dedup / nil-emitter tests updated for the new `NewUsageEmitter` signature

> Run result: `go test ./...` green across the whole `fi-collector` module. Also verified end-to-end against a locally rebuilt collector (storage-mode org → only `observe_add`; events-mode org → only `tracing_event`).

---

## 4) How to run / test

```bash
cd fi-collector
go build ./... && go vet ./... && go test ./...
```

Manual: ingest a batch as a `storage`-mode org → exactly one `observe_add` on the `usage:events` stream; switch the org to `events` mode → one `tracing_event` with `amount = traces + spans`, no `observe_add`.

> Note: this is the Go `fi-collector` module, so the Django `bin/test` / frontend `yarn` suites and contract checks do not apply.

---

## 6) Edge cases & considerations

- Unknown / failed mode lookup → defaults to `storage` (matches Python; a transient PG or Redis error can't silently switch the billed dimension).
- `payloadBytes == 0` (storage) or `traces + spans == 0` (events) → nothing emitted.
- Deterministic `dedupKey` behaviour unchanged (one event_id per emitted event, so re-polls still dedup).

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The ingest enforcement gate (`checkUsage`) is still hardcoded to the `tracing_events` dimension (mode-blind). This is deliberately **out of scope** here and tracked separately: with mode-aware emit, storage-mode free orgs stop incrementing the `tracing_events` counter, so the gate's mode-awareness must follow in its own PR.

---

## 8) Architectural / important decisions

- **Shared resolver + cache key with Python** (rather than collector-local mode reads) so both services agree on the billed dimension and warm each other's cache.
- **Signature-stable:** only `NewUsageEmitter` changed; `EmitIngestion`'s signature and the `server` metering interface are untouched, keeping the diff minimal.

---

## Checklist

- [x] I've added tests that prove my fix is effective
- [x] Tests pass locally (`go test ./...` in `fi-collector`)
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked
