### PR TITLE
fix(model_hub): raise exception in update_eval_record when record not found

### DIFF
--- a/futureagi/model_hub/utils/clickhouse.py
+++ b/futureagi/model_hub/utils/clickhouse.py
@@ -135,9 +135,9 @@ def update_eval_record(
         """
         client.execute(delete_query, {"primary_key_value": primary_key_value})
     else:
-        # TODO throw exception
-        # print(f'Error in update_eval_record for primary key value {primary_key_value}')
-        pass
+        raise ValueError(
+            f"{table_name} has no record with {primary_key_field}={primary_key_value}"
+        )
 
     merged_values["UUID"] = str(uuid.uuid4())
 


### PR DESCRIPTION
## Summary
Replace the incomplete `# TODO throw exception` / `pass` in `update_eval_record()` with a `ValueError` that fires when the target record does not exist in ClickHouse. Previously the function silently inserted a garbage record with only a UUID populated, causing silent data corruption with no error log.

## Linked issues
Closes #1467

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?
- Python `py_compile` syntax check passes
- Ruff linter reports 0 issues on the modified file
- The `else` branch now raises before reaching the INSERT at line 142, preventing any garbage insert
- The change only activates on the error path -- happy path behavior is unchanged

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] The change is minimal and only activates on the error path -- no regression possible for normal operations
- [x] No hardcoded secrets, URLs, or PII
