### PR TITLE
feat(experiment): add CSV export to experiment summary table

### DIFF
--- a/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
@@ -1,24 +1,77 @@
-import { Button } from "@mui/material";
-import React from "react";
+import { Button, Box, CircularProgress } from "@mui/material";
+import React, { useState } from "react";
 import { useExperimentDetailContext } from "../experiment-context";
 import { trackEvent, Events } from "src/utils/Mixpanel";
 import Iconify from "src/components/iconify";
+import { useMutation } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
 
 const ExperimentBarSummaryRightSection = () => {
   const { setChooseWinnerOpen } = useExperimentDetailContext();
+  const { experimentId } = useParams();
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const { mutate: downloadExperiment } = useMutation({
+    mutationFn: () =>
+      axios.get(endpoints.develop.experiment.downloadExperiment(experimentId), {
+        responseType: "blob",
+      }),
+    onMutate: () => {
+      enqueueSnackbar("Download has been started...", { variant: "info" });
+      setIsDownloading(true);
+    },
+    onSuccess: (response) => {
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `experiment-${experimentId}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      enqueueSnackbar("Experiment data downloaded successfully", {
+        variant: "success",
+      });
+    },
+    onSettled: () => {
+      setIsDownloading(false);
+    },
+  });
 
   return (
-    <Button
-      variant="contained"
-      color="primary"
-      startIcon={<Iconify icon="mdi:crown-outline" />}
-      onClick={() => {
-        trackEvent(Events.expWinnerClick);
-        setChooseWinnerOpen(true);
-      }}
-    >
-      Choose winner
-    </Button>
+    <Box sx={{ display: "flex", gap: 1 }}>
+      <Button
+        variant="contained"
+        color="primary"
+        startIcon={<Iconify icon="mdi:crown-outline" />}
+        onClick={() => {
+          trackEvent(Events.expWinnerClick);
+          setChooseWinnerOpen(true);
+        }}
+      >
+        Choose winner
+      </Button>
+
+      <Button
+        variant="outlined"
+        startIcon={
+          isDownloading ? (
+            <CircularProgress size={16} />
+          ) : (
+            <Iconify icon="material-symbols:download" />
+          )
+        }
+        onClick={() => {
+          trackEvent(Events.expDownloadClick);
+          downloadExperiment();
+        }}
+      >
+        Download CSV
+      </Button>
+    </Box>
   );
 };
 

--- a/frontend/src/utils/Mixpanel/EventNames.js
+++ b/frontend/src/utils/Mixpanel/EventNames.js
@@ -256,6 +256,7 @@ export const Events = {
   expRowReRunSuccess: "Dataset_experiment_row_re-run_successful",
   expWinnerClick: "Dataset_experiment_winner_clicked",
   expWinnerSelect: "Dataset_experiment_winner_selected",
+  expDownloadClick: "Dataset_experiment_download_clicked",
 
   //summary
   summaryViewed: "Dataset_summarypage_loaded",


### PR DESCRIPTION
Closes #1459.

## What
Adds a **Download CSV** button next to the existing **Choose winner** button in the experiment Summary tab (`ExperimentBarSummaryRightSection.jsx`).

## How
- Follows the established dataset-download pattern (`DevelopDataRightSection.jsx`): `useMutation` -> `axios.get(endpoints.develop.experiment.downloadExperiment(experimentId), { responseType: 'blob' })` -> create object URL -> anchor click -> revoke.
- Uses the **already-existing** `endpoints.develop.experiment.downloadExperiment` endpoint (no backend change needed).
- Reuses the `Box` + `CircularProgress` loading state from the reference implementation.
- Adds the `expDownloadClick` Mixpanel event in `EventNames.js` (mirrors `expWinnerClick`).

## Notes
The issue's suggested snippet used `onError`; I matched the codebase's actual convention (`onSettled`) from `DevelopDataRightSection`. The button uses `variant="outlined"` to visually distinguish it from the primary 'Choose winner' action.