### PR TITLE
feat(experiment): add CSV export button for experiment summary table

### DIFF
--- a/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
@@ -1,24 +1,80 @@
-import { Button } from "@mui/material";
-import React from "react";
+import { Button, Box, CircularProgress } from "@mui/material";
+import React, { useState } from "react";
 import { useExperimentDetailContext } from "../experiment-context";
 import { trackEvent, Events } from "src/utils/Mixpanel";
 import Iconify from "src/components/iconify";
+import { useMutation } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
 
 const ExperimentBarSummaryRightSection = () => {
   const { setChooseWinnerOpen } = useExperimentDetailContext();
+  const { experimentId } = useParams();
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const { mutate: downloadExperiment } = useMutation({
+    mutationFn: () =>
+      axios.get(endpoints.develop.experiment.downloadExperiment(experimentId), {
+        responseType: "blob",
+      }),
+    onMutate: () => {
+      setIsDownloading(true);
+    },
+    onSuccess: (response) => {
+      setIsDownloading(false);
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `experiment-${experimentId}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      enqueueSnackbar("Experiment data downloaded successfully", {
+        variant: "success",
+      });
+    },
+    onError: () => {
+      setIsDownloading(false);
+      enqueueSnackbar("Failed to download experiment data", {
+        variant: "error",
+      });
+    },
+  });
 
   return (
-    <Button
-      variant="contained"
-      color="primary"
-      startIcon={<Iconify icon="mdi:crown-outline" />}
-      onClick={() => {
-        trackEvent(Events.expWinnerClick);
-        setChooseWinnerOpen(true);
-      }}
-    >
-      Choose winner
-    </Button>
+    <Box sx={{ display: "flex", gap: 1 }}>
+      <Button
+        variant="outlined"
+        startIcon={
+          isDownloading ? (
+            <CircularProgress size={16} />
+          ) : (
+            <Iconify icon="material-symbols:download" />
+          )
+        }
+        onClick={() => {
+          trackEvent(Events.experimentDownloadClicked);
+          downloadExperiment();
+        }}
+        disabled={isDownloading}
+      >
+        Download CSV
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        startIcon={<Iconify icon="mdi:crown-outline" />}
+        onClick={() => {
+          trackEvent(Events.expWinnerClick);
+          setChooseWinnerOpen(true);
+        }}
+      >
+        Choose winner
+      </Button>
+    </Box>
   );
 };
 


### PR DESCRIPTION

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

- Add Download CSV button next to Choose winner button
- Use existing backend endpoint for CSV download
- Show CircularProgress loading spinner during download
- Disable button during download to prevent double-clicks
- Success/error snackbar messages for download status
- Filename format: experiment-{experimentId}.csv


<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #1459 

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
