### PR TITLE
Fix vector database integrations: UUID serialization, Litellm fallbac…

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/ChromaForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/ChromaForm.jsx
@@ -1,0 +1,8 @@
+import PropTypes from "prop-types";
+import VectorStoreForm from "./VectorStoreForm";
+
+const ChromaForm = (props) => <VectorStoreForm {...props} provider="Chroma" />;
+
+ChromaForm.propTypes = { allColumns: PropTypes.array, control: PropTypes.object };
+
+export default ChromaForm;

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/EmbeddingConfigField.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/EmbeddingConfigField.jsx
@@ -25,6 +25,31 @@ const EmbeddingConfigField = ({ control }) => {
         value: "huggingface",
         disabled: false,
       },
+      {
+        label: "Cohere",
+        value: "cohere",
+        disabled: false,
+      },
+      {
+        label: "Gemini",
+        value: "gemini",
+        disabled: false,
+      },
+      {
+        label: "Vertex AI",
+        value: "vertex_ai",
+        disabled: false,
+      },
+      {
+        label: "Voyage",
+        value: "voyage",
+        disabled: false,
+      },
+      {
+        label: "Mistral",
+        value: "mistral",
+        disabled: false,
+      },
     ];
 
     defaultOptions.forEach((item, index) => {

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/MilvusForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/MilvusForm.jsx
@@ -1,0 +1,8 @@
+import PropTypes from "prop-types";
+import VectorStoreForm from "./VectorStoreForm";
+
+const MilvusForm = (props) => <VectorStoreForm {...props} provider="Milvus" requiresApiKey />;
+
+MilvusForm.propTypes = { allColumns: PropTypes.array, control: PropTypes.object };
+
+export default MilvusForm;

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/PgvectorForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/PgvectorForm.jsx
@@ -1,0 +1,8 @@
+import PropTypes from "prop-types";
+import VectorStoreForm from "./VectorStoreForm";
+
+const PgvectorForm = (props) => <VectorStoreForm {...props} provider="pgvector" />;
+
+PgvectorForm.propTypes = { allColumns: PropTypes.array, control: PropTypes.object };
+
+export default PgvectorForm;

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/Retrieval.jsx
@@ -12,6 +12,9 @@ import { enqueueSnackbar } from "src/components/snackbar";
 import PineConeForm from "./PineConeForm";
 import QdrantForm from "./QdrantForm";
 import WeivateForm from "./WeivateForm";
+import ChromaForm from "./ChromaForm";
+import MilvusForm from "./MilvusForm";
+import PgvectorForm from "./PgvectorForm";
 import { RetrievalValidationSchema } from "./validation";
 import { LoadingButton } from "@mui/lab";
 import PreviewAddColumn from "../PreviewAddColumn";
@@ -39,7 +42,7 @@ export const RetrievalChild = ({
   const { refreshGrid } = useDevelopDetailContext();
   // Using individual store
 
-  const { control, handleSubmit, watch, reset } = useForm({
+  const { control, handleSubmit, watch, reset, setValue } = useForm({
     defaultValues: {
       newColumnName: "",
       subType: "",
@@ -48,6 +51,23 @@ export const RetrievalChild = ({
   });
 
   const subType = watch("subType");
+  const [prevSubType, setPrevSubType] = React.useState(null);
+
+  useEffect(() => {
+    if (prevSubType && prevSubType !== subType) {
+      const fieldsToClear = [
+        "apiKey",
+        "indexName",
+        "namespace",
+        "url",
+        "collectionName",
+        "searchType",
+        "queryKey",
+      ];
+      fieldsToClear.forEach((field) => setValue(field, ""));
+    }
+    setPrevSubType(subType);
+  }, [subType, prevSubType, setValue]);
 
   const { dataset } = useParams();
   const allColumns = useDatasetColumnConfig(dataset);
@@ -84,6 +104,12 @@ export const RetrievalChild = ({
       return <QdrantForm control={control} allColumns={allColumns} />;
     } else if (subType === "weaviate") {
       return <WeivateForm control={control} allColumns={allColumns} />;
+    } else if (subType === "chroma") {
+      return <ChromaForm control={control} allColumns={allColumns} />;
+    } else if (subType === "milvus") {
+      return <MilvusForm control={control} allColumns={allColumns} />;
+    } else if (subType === "pgvector") {
+      return <PgvectorForm control={control} allColumns={allColumns} />;
     }
   };
 
@@ -126,13 +152,36 @@ export const RetrievalChild = ({
   });
 
   const transformFormToApi = (formValues) => {
-    const { newColumnName, subType: st, columnId, kbId, ...rest } = formValues;
+    const {
+      newColumnName,
+      subType: st,
+      columnId,
+      kbId,
+      apiKey,
+      indexName,
+      collectionName,
+      searchType,
+      topK,
+      queryKey,
+      vectorLength,
+      embeddingConfig,
+      ...rest
+    } = formValues;
+
     return {
       ...rest,
       new_column_name: newColumnName,
       sub_type: st,
       ...(columnId && { column_id: columnId }),
       ...(kbId && { kb_id: kbId }),
+      ...(apiKey && { api_key: apiKey }),
+      ...(indexName && { index_name: indexName }),
+      ...(collectionName && { collection_name: collectionName }),
+      ...(searchType && { search_type: searchType }),
+      ...(topK !== undefined && { top_k: topK }),
+      ...(queryKey && { query_key: queryKey }),
+      ...(vectorLength !== undefined && { vector_length: vectorLength }),
+      ...(embeddingConfig && { embedding_config: embeddingConfig }),
     };
   };
 
@@ -223,6 +272,9 @@ export const RetrievalChild = ({
               { label: "Pinecone", value: "pinecone" },
               { label: "Qdrant", value: "qdrant" },
               { label: "Weaviate", value: "weaviate" },
+              { label: "Chroma", value: "chroma" },
+              { label: "Milvus", value: "milvus" },
+              { label: "pgvector", value: "pgvector" },
             ]}
             fullWidth
           />

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/VectorStoreForm.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/VectorStoreForm.jsx
@@ -1,0 +1,65 @@
+import { Box, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+import HelperText from "../../Common/HelperText";
+import HeadingAndSubHeading from "src/components/HeadingAndSubheading/HeadingAndSubheading";
+import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+import SecretSelect from "src/sections/common/SecretSelect/SecretSelect";
+import EmbeddingConfigField from "./EmbeddingConfigField";
+import { RetrievalFormItemWrapper } from "./RetrievalComponents";
+
+const VectorStoreForm = ({ allColumns, control, provider, requiresApiKey }) => (
+  <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+    <HeadingAndSubHeading
+      heading={
+        <FormSearchSelectFieldControl
+          fullWidth
+          label="Column"
+          size="small"
+          control={control}
+          fieldName="columnId"
+          options={allColumns?.map((column) => ({ label: column.headerName, value: column.field }))}
+        />
+      }
+      subHeading={<Typography typography="s2" color="text.primary">Query to send to the vector database</Typography>}
+    />
+    <Box sx={{ display: "flex", flexDirection: "column", border: "2px solid", borderColor: "background.neutral", borderRadius: "8px", "& > *:last-child": { borderBottom: "none" } }}>
+      {requiresApiKey && (
+        <RetrievalFormItemWrapper>
+          <SecretSelect label={`${provider} API Key`} control={control} fieldName="apiKey" fullWidth size="small" helperText={<HelperText text={`API key for authenticating with ${provider}`} />} />
+        </RetrievalFormItemWrapper>
+      )}
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label={`${provider} URL`} size="small" control={control} fieldName="url" fullWidth helperText={<HelperText text="Connection URL for the vector database" />} />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Collection Name" size="small" control={control} fieldName="collectionName" fullWidth helperText={<HelperText text="Collection or table to search" />} />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Number of chunks to fetch" size="small" control={control} fieldName="topK" type="number" fieldType="number" fullWidth />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper><EmbeddingConfigField control={control} /></RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Key to extract" size="small" control={control} fieldName="key" fullWidth helperText={<HelperText text="Optional field to return from each match" />} />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Vector column" size="small" control={control} fieldName="queryKey" fullWidth helperText={<HelperText text="Vector field name; used by pgvector" />} />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Vector Length" size="small" control={control} fieldName="vectorLength" type="number" fieldType="number" fullWidth />
+      </RetrievalFormItemWrapper>
+      <RetrievalFormItemWrapper>
+        <FormTextFieldV2 label="Concurrency" size="small" control={control} fieldName="concurrency" type="number" fieldType="number" fullWidth />
+      </RetrievalFormItemWrapper>
+    </Box>
+  </Box>
+);
+
+VectorStoreForm.propTypes = {
+  allColumns: PropTypes.array,
+  control: PropTypes.object,
+  provider: PropTypes.string.isRequired,
+  requiresApiKey: PropTypes.bool,
+};
+
+export default VectorStoreForm;

--- a/frontend/src/sections/develop-detail/AddColumn/Retrieval/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/Retrieval/validation.js
@@ -132,5 +132,27 @@ export const RetrievalValidationSchema = (
       key: z.string().min(1, "Please enter a key"),
       vectorLength: z.number().positive("Please enter vector length"),
     }),
+    ...["chroma", "milvus", "pgvector"].map((subType) =>
+      z.object({
+        subType: z.literal(subType),
+        newColumnName:
+          isConditionalNodez || isEdit
+            ? z.string().optional()
+            : z.string().min(1, "Column name is required"),
+        columnId: z.string().min(1, "Please select a column"),
+        apiKey: z.string().optional(),
+        url: z.string().min(1, "Please enter a connection URL"),
+        collectionName: z.string().min(1, "Please enter a collection name"),
+        topK: z.number().positive("Please enter number of chunks to fetch"),
+        queryKey: z.string().optional(),
+        key: z.string().optional(),
+        embeddingConfig: z.object({
+          model: z.string().min(1, "Model is required"),
+          type: z.string().min(1, "Type is required"),
+        }),
+        concurrency: z.number().positive("Please enter a positive concurrency value"),
+        vectorLength: z.number().positive("Please enter vector length"),
+      }),
+    ),
   ]);
 };

--- a/futureagi/model_hub/serializers/contracts.py
+++ b/futureagi/model_hub/serializers/contracts.py
@@ -1188,7 +1188,7 @@ class VectorDBColumnRequestSerializer(serializers.Serializer):
     column_id = serializers.UUIDField()
     new_column_name = serializers.CharField(required=False, allow_blank=True)
     sub_type = serializers.CharField()
-    api_key = serializers.CharField()
+    api_key = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     collection_name = serializers.CharField(required=False, allow_blank=True)
     url = serializers.CharField(required=False, allow_blank=True)
     search_type = serializers.CharField(required=False, allow_blank=True)

--- a/futureagi/model_hub/tests/test_dataset_dynamic_columns.py
+++ b/futureagi/model_hub/tests/test_dataset_dynamic_columns.py
@@ -102,8 +102,9 @@ class DynamicColumnsBaseTestCase(APITestCase):
         workspace = self.workspace
 
         def initial_with_workspace(view_self, request, *args, **view_kwargs):
-            # Inject workspace before view processing
             request.workspace = workspace
+            if getattr(self, "request_organization", None):
+                request.organization = self.request_organization
             return self.original_initial(view_self, request, *args, **view_kwargs)
 
         self.workspace_patcher = patch.object(
@@ -1352,3 +1353,39 @@ class TestAddVectorDBColumnView(DynamicColumnsBaseTestCase):
         assert response.status_code == status.HTTP_200_OK
         assert "new_column_id" in response.json()["result"]
         mock_task.assert_called_once()
+
+    @patch("model_hub.views.dynamic_columns.add_vector_db_column_async.delay")
+    def test_vector_db_serializes_request_organization_id_for_async_task(self, mock_task):
+        """The task payload must contain an organization UUID, never the model object."""
+        # Production middleware places an Organization model on the request.
+        self.request_organization = self.organization
+        dataset, columns, _ = self.create_test_dataset()
+        secret = SecretModel.objects.create(
+            name="Async Pinecone Key",
+            key="test-pinecone-api-key",
+            organization=self.organization,
+        )
+        url = reverse("add_vector_db_column", kwargs={"dataset_id": str(dataset.id)})
+
+        response = self.client.post(
+            url,
+            data={
+                "column_id": str(columns[0].id),
+                "new_column_name": "Vector Result",
+                "sub_type": "pinecone",
+                "api_key": str(secret.id),
+                "index_name": "test-index",
+                "top_k": 1,
+                "embedding_config": {
+                    "type": "openai",
+                    "model": "text-embedding-3-small",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_task.assert_called_once()
+        organization_id = mock_task.call_args.args[4]
+        assert organization_id == str(self.organization.id)
+        assert isinstance(organization_id, str)

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -10448,6 +10448,23 @@ class AddVectorDBColumnView(APIView):
     def _query_vector_db(self, text_input, config, organization_id, workspace_id=None):
         """Query vector database using text input"""
         try:
+            # Normalize config keys from camelCase to snake_case
+            normalized_config = {
+                "collection_name": config.get("collection_name") or config.get("collectionName"),
+                "url": config.get("url"),
+                "search_type": config.get("search_type") or config.get("searchType"),
+                "key": config.get("key"),
+                "limit": config.get("limit", 1),
+                "index_name": config.get("index_name") or config.get("indexName"),
+                "top_k": config.get("top_k") or config.get("topK") or 1,
+                "namespace": config.get("namespace"),
+                "api_key": config.get("api_key") or config.get("apiKey"),
+                "embedding_config": config.get("embedding_config") or config.get("embeddingConfig", {}),
+                "query_key": config.get("query_key") or config.get("queryKey"),
+                "vector_length": config.get("vector_length") or config.get("vectorLength"),
+                "sub_type": config.get("sub_type") or config.get("subType"),
+            }
+            config = normalized_config
             # 1. Set up the embedding model based on config
             embedding_config = config.get("embedding_config", {})
             embedding_type = embedding_config.get("type", "")
@@ -10484,6 +10501,58 @@ class AddVectorDBColumnView(APIView):
                         )
                     },
                 )
+            elif embedding_type == "cohere":
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    "cohere",
+                    embedding_config.get("model", "embed-english-v3.0"),
+                    model_params={
+                        "api_key": self._get_api_key_for_provider(
+                            organization_id, workspace_id, "cohere"
+                        )
+                    },
+                )
+            elif embedding_type in ["gemini", "vertex_ai"]:
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    embedding_type,
+                    embedding_config.get("model", "text-embedding-004"),
+                    model_params={
+                        "api_key": self._get_api_key_for_provider(
+                            organization_id, workspace_id, embedding_type
+                        )
+                    },
+                )
+            elif embedding_type == "voyage":
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    "voyage",
+                    embedding_config.get("model", "voyage-2"),
+                    model_params={
+                        "api_key": self._get_api_key_for_provider(
+                            organization_id, workspace_id, "voyage"
+                        )
+                    },
+                )
+            elif embedding_type == "mistral":
+                api_key = self._get_api_key_for_provider(
+                    organization_id, workspace_id, "mistral"
+                )
+                try:
+                    import litellm
+                    litellm.drop_params = True
+                    model_name = embedding_config.get("model", "mistral/mistral-embed")
+                    if "/" not in model_name:
+                        model_name = f"mistral/{model_name}"
+                    response = litellm.embedding(
+                        model=model_name,
+                        input=[text_input] if isinstance(text_input, str) else text_input,
+                        api_key=api_key
+                    )
+                    embedding_vector = response.data[0]["embedding"]
+                except Exception as e:
+                    logger.error(f"Error fetching embeddings via litellm: {str(e)}")
+                    raise ValueError(f"Failed to fetch embeddings: {str(e)}")
             else:
                 raise ValueError(f"Unsupported embedding type: {embedding_type}")
 
@@ -10523,6 +10592,15 @@ class AddVectorDBColumnView(APIView):
                 return self._query_weaviate(
                     embedding_vector, text_input, config, organization_id, workspace_id
                 )
+
+            elif sub_type == "chroma":
+                return self._query_chroma(embedding_vector, config)
+
+            elif sub_type == "milvus":
+                return self._query_milvus(embedding_vector, config)
+
+            elif sub_type == "pgvector":
+                return self._query_pgvector(embedding_vector, config)
 
             else:
                 raise ValueError(f"Unsupported vector database type: {sub_type}")
@@ -10740,10 +10818,120 @@ class AddVectorDBColumnView(APIView):
             logger.error("Error in _query_weaviate", exc_info=True)
             raise ValueError(f"Failed to query Weaviate: {e}")  # noqa: B904
 
+    def _query_chroma(self, query, config):
+        try:
+            import chromadb
+            from urllib.parse import urlparse
+
+            parsed = urlparse(config.get("url", ""))
+            client = chromadb.HttpClient(
+                host=parsed.hostname or "localhost",
+                port=parsed.port or 8000,
+            )
+            collection = client.get_collection(name=config["collection_name"])
+            results = collection.query(
+                query_embeddings=[query],
+                n_results=config.get("top_k", 5)
+            )
+            if not results or not results.get("metadatas") or not results["metadatas"][0]:
+                return "No matches found"
+
+            metadata_list = []
+            for metadata in results["metadatas"][0]:
+                if config.get("key") and config.get("key") in metadata:
+                    metadata = metadata[config.get("key")]
+                metadata_list.append(metadata)
+            return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying Chroma: {str(e)}")
+            raise ValueError(f"Failed to query Chroma: {str(e)}")
+
+    def _query_milvus(self, query, config):
+        try:
+            from pymilvus import MilvusClient
+
+            api_key_obj = SecretModel.objects.filter(id=config.get("api_key")).first() if config.get("api_key") else None
+            token = api_key_obj.actual_key if api_key_obj else ""
+
+            client = MilvusClient(
+                uri=config["url"],
+                token=token
+            )
+
+            results = client.search(
+                collection_name=config["collection_name"],
+                data=[query],
+                limit=config.get("top_k", 5),
+                output_fields=[config.get("key")] if config.get("key") else ["*"]
+            )
+
+            if not results or not results[0]:
+                return "No matches found"
+
+            metadata_list = []
+            for match in results[0]:
+                metadata = match.get("entity", {})
+                if config.get("key") and config.get("key") in metadata:
+                    metadata = metadata.get(config.get("key"))
+                metadata_list.append(metadata)
+
+            return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying Milvus: {str(e)}")
+            raise ValueError(f"Failed to query Milvus: {str(e)}")
+
+    def _query_pgvector(self, query, config):
+        try:
+            import psycopg
+            from psycopg import sql
+
+            conn_string = config["url"]
+            table_name = config["collection_name"]
+            limit = config.get("top_k", 5)
+            vector_str = "[" + ",".join(map(str, query)) + "]"
+            vector_col = config.get("query_key", "embedding")
+            return_col = config.get("key")
+
+            # These values are SQL identifiers, not query parameters. Restrict
+            # them to PostgreSQL identifiers before composing the statement.
+            identifiers = (table_name, vector_col, return_col)
+            if any(value and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value) for value in identifiers):
+                raise ValueError("Table and column names must be valid PostgreSQL identifiers")
+            selected_column = sql.SQL("*") if not return_col else sql.Identifier(return_col)
+
+            with psycopg.connect(conn_string) as conn:
+                with conn.cursor() as cur:
+                    query_sql = sql.SQL(
+                        "SELECT {} FROM {} ORDER BY {} <-> %s::vector LIMIT %s"
+                    ).format(
+                        selected_column,
+                        sql.Identifier(table_name),
+                        sql.Identifier(vector_col),
+                    )
+                    cur.execute(query_sql, (vector_str, limit))
+
+                    rows = cur.fetchall()
+                    if not rows:
+                        return "No matches found"
+
+                    metadata_list = []
+                    for row in rows:
+                        if return_col:
+                            metadata_list.append(row[0])
+                        else:
+                            metadata_list.append(row)
+                    return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying pgvector: {str(e)}")
+            raise ValueError(f"Failed to query pgvector: {str(e)}")
+
     def _process_row(self, row, column, config, organization_id, workspace_id=None):
         try:
-            input_cell = Cell.objects.get(row=row, column=column)
-            query = input_cell.value
+            if hasattr(column, "id"):
+                input_cell = Cell.objects.get(row=row, column=column)
+                query = input_cell.value
+            else:
+                query = row.metadata.get(column) if hasattr(row, 'metadata') and row.metadata else None
             result_info = self._query_vector_db(
                 query, config, organization_id, workspace_id
             )
@@ -10756,21 +10944,29 @@ class AddVectorDBColumnView(APIView):
     def post(self, request, dataset_id, *args, **kwargs):
         try:
             config = request.data
-            self.organization_id = (
-                getattr(request, "organization", None) or request.user.organization.id
-            )
+            org = getattr(request, "organization", None)
+            self.organization_id = str(org.id) if org and hasattr(org, "id") else (str(org) if org else str(request.user.organization.id))
             column_id = config.get("column_id")
             new_column_name = config.get("new_column_name", "Vector DB Result")
             concurrency = config.get("concurrency", 5)
 
-            if not all([column_id, config.get("sub_type"), config.get("api_key")]):
+            if not column_id or not config.get("sub_type"):
+                return self._gm.bad_request(
+                    get_error_message("MISSING_COLUMN_ID_SUB_TYPE_AND_API_KEY")
+                )
+            if config.get("sub_type") in ["pinecone", "qdrant", "weaviate"] and not config.get("api_key"):
                 return self._gm.bad_request(
                     get_error_message("MISSING_COLUMN_ID_SUB_TYPE_AND_API_KEY")
                 )
 
-            input_column = get_object_or_404(
-                Column, id=column_id, dataset_id=dataset_id
-            )
+            try:
+                import uuid
+                uuid.UUID(str(column_id))
+                input_column = get_object_or_404(
+                    Column, id=column_id, dataset_id=dataset_id
+                )
+            except ValueError:
+                input_column = column_id
 
             if Column.objects.filter(
                 name=new_column_name, dataset=dataset_id, deleted=False
@@ -10784,17 +10980,18 @@ class AddVectorDBColumnView(APIView):
                 dataset_id=dataset_id,
                 metadata={
                     "vector_db_config": {
-                        "sub_type": config["sub_type"],
-                        "collection_name": config.get("collection_name"),
+                        "sub_type": config.get("sub_type") or config.get("subType"),
+                        "collection_name": config.get("collection_name") or config.get("collectionName"),
                         "url": config.get("url"),
-                        "search_type": config.get("search_type"),
+                        "search_type": config.get("search_type") or config.get("searchType"),
                         "key": config.get("key"),
                         "limit": config.get("limit", 1),
-                        "index_name": config.get("index_name"),
-                        "top_k": config.get("top_k", 1),
+                        "index_name": config.get("index_name") or config.get("indexName"),
+                        "top_k": config.get("top_k") or config.get("topK") or 1,
                         "namespace": config.get("namespace"),
-                        "api_key": config.get("api_key"),
-                        "embedding_config": config.get("embedding_config"),
+                        "api_key": config.get("api_key") or config.get("apiKey"),
+                        "embedding_config": config.get("embedding_config") or config.get("embeddingConfig"),
+                        "query_key": config.get("query_key") or config.get("queryKey"),
                     },
                     "source_column_id": str(column_id),
                     "concurrency": concurrency,
@@ -10822,8 +11019,8 @@ class AddVectorDBColumnView(APIView):
                 serializable_config,
                 dataset_id,
                 concurrency,
-                str(input_column.id),
-                getattr(request, "organization", None) or request.user.organization.id,
+                str(input_column.id) if hasattr(input_column, "id") else str(input_column),
+                self.organization_id,
                 new_column.id,
                 str(request.workspace.id) if request.workspace else None,
             )
@@ -10862,7 +11059,12 @@ def add_vector_db_column_async(
     if isinstance(config, str):
         config = json.loads(config)
     view = AddVectorDBColumnView()
-    input_column = Column.objects.get(id=input_column_id)
+    try:
+        import uuid
+        uuid.UUID(str(input_column_id))
+        input_column = Column.objects.get(id=input_column_id)
+    except ValueError:
+        input_column = input_column_id
     rows = Row.objects.filter(dataset_id=dataset_id, deleted=False)
     new_cells = []
     total_processed = 0

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -147,6 +147,23 @@ class AddVectorDBColumnView(APIView):
     def _query_vector_db(self, text_input, config, organization_id, workspace_id=None):
         """Query vector database using text input"""
         try:
+            # Normalize config keys from camelCase to snake_case
+            normalized_config = {
+                "collection_name": config.get("collection_name") or config.get("collectionName"),
+                "url": config.get("url"),
+                "search_type": config.get("search_type") or config.get("searchType"),
+                "key": config.get("key"),
+                "limit": config.get("limit", 1),
+                "index_name": config.get("index_name") or config.get("indexName"),
+                "top_k": config.get("top_k") or config.get("topK") or 1,
+                "namespace": config.get("namespace"),
+                "api_key": config.get("api_key") or config.get("apiKey"),
+                "embedding_config": config.get("embedding_config") or config.get("embeddingConfig", {}),
+                "query_key": config.get("query_key") or config.get("queryKey"),
+                "vector_length": config.get("vector_length") or config.get("vectorLength"),
+                "sub_type": config.get("sub_type") or config.get("subType"),
+            }
+            config = normalized_config
             # 1. Set up the embedding model based on config
             embedding_config = config.get("embedding_config", {})
             embedding_type = embedding_config.get("type", "")
@@ -180,6 +197,55 @@ class AddVectorDBColumnView(APIView):
                     embedding_config.get("model", "all-mpnet-base-v2"),
                     model_params={"api_key": api_key},
                 )
+            elif embedding_type == "cohere":
+                api_key = self._get_api_key_for_provider(
+                    organization_id, workspace_id, "cohere"
+                )
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    "cohere",
+                    embedding_config.get("model", "embed-english-v3.0"),
+                    model_params={"api_key": api_key},
+                )
+            elif embedding_type in ["gemini", "vertex_ai"]:
+                api_key = self._get_api_key_for_provider(
+                    organization_id, workspace_id, embedding_type
+                )
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    embedding_type,
+                    embedding_config.get("model", "text-embedding-004"),
+                    model_params={"api_key": api_key},
+                )
+            elif embedding_type == "voyage":
+                api_key = self._get_api_key_for_provider(
+                    organization_id, workspace_id, "voyage"
+                )
+                embedding_vector = model_manager.get_embeddings(
+                    text_input,
+                    "voyage",
+                    embedding_config.get("model", "voyage-2"),
+                    model_params={"api_key": api_key},
+                )
+            elif embedding_type == "mistral":
+                api_key = self._get_api_key_for_provider(
+                    organization_id, workspace_id, "mistral"
+                )
+                try:
+                    import litellm
+                    litellm.drop_params = True
+                    model_name = embedding_config.get("model", "mistral/mistral-embed")
+                    if "/" not in model_name:
+                        model_name = f"mistral/{model_name}"
+                    response = litellm.embedding(
+                        model=model_name,
+                        input=[text_input] if isinstance(text_input, str) else text_input,
+                        api_key=api_key
+                    )
+                    embedding_vector = response.data[0]["embedding"]
+                except Exception as e:
+                    logger.error(f"Error fetching embeddings via litellm: {str(e)}")
+                    raise ValueError(f"Failed to fetch embeddings: {str(e)}")
             else:
                 raise ValueError(f"Unsupported embedding type: {embedding_type}")
 
@@ -213,6 +279,15 @@ class AddVectorDBColumnView(APIView):
                 return self._query_weaviate(
                     embedding_vector, text_input, config, organization_id, workspace_id
                 )
+
+            elif sub_type == "chroma":
+                return self._query_chroma(embedding_vector, config)
+
+            elif sub_type == "milvus":
+                return self._query_milvus(embedding_vector, config)
+
+            elif sub_type == "pgvector":
+                return self._query_pgvector(embedding_vector, config)
 
             else:
                 raise ValueError(f"Unsupported vector database type: {sub_type}")
@@ -427,10 +502,120 @@ class AddVectorDBColumnView(APIView):
             logger.error("Error in _query_weaviate", exc_info=True)
             raise ValueError(f"Failed to query Weaviate: {e}")  # noqa: B904
 
+    def _query_chroma(self, query, config):
+        try:
+            import chromadb
+            from urllib.parse import urlparse
+
+            parsed = urlparse(config.get("url", ""))
+            client = chromadb.HttpClient(
+                host=parsed.hostname or "localhost",
+                port=parsed.port or 8000,
+            )
+            collection = client.get_collection(name=config["collection_name"])
+            results = collection.query(
+                query_embeddings=[query],
+                n_results=config.get("top_k", 5)
+            )
+            if not results or not results.get("metadatas") or not results["metadatas"][0]:
+                return "No matches found"
+
+            metadata_list = []
+            for metadata in results["metadatas"][0]:
+                if config.get("key") and config.get("key") in metadata:
+                    metadata = metadata[config.get("key")]
+                metadata_list.append(metadata)
+            return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying Chroma: {str(e)}")
+            raise ValueError(f"Failed to query Chroma: {str(e)}")
+
+    def _query_milvus(self, query, config):
+        try:
+            from pymilvus import MilvusClient
+
+            api_key_obj = SecretModel.objects.filter(id=config.get("api_key")).first() if config.get("api_key") else None
+            token = api_key_obj.actual_key if api_key_obj else ""
+
+            client = MilvusClient(
+                uri=config["url"],
+                token=token
+            )
+
+            results = client.search(
+                collection_name=config["collection_name"],
+                data=[query],
+                limit=config.get("top_k", 5),
+                output_fields=[config.get("key")] if config.get("key") else ["*"]
+            )
+
+            if not results or not results[0]:
+                return "No matches found"
+
+            metadata_list = []
+            for match in results[0]:
+                metadata = match.get("entity", {})
+                if config.get("key") and config.get("key") in metadata:
+                    metadata = metadata.get(config.get("key"))
+                metadata_list.append(metadata)
+
+            return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying Milvus: {str(e)}")
+            raise ValueError(f"Failed to query Milvus: {str(e)}")
+
+    def _query_pgvector(self, query, config):
+        try:
+            import psycopg
+            from psycopg import sql
+
+            conn_string = config["url"]
+            table_name = config["collection_name"]
+            limit = config.get("top_k", 5)
+            vector_str = "[" + ",".join(map(str, query)) + "]"
+            vector_col = config.get("query_key", "embedding")
+            return_col = config.get("key")
+
+            # These values are SQL identifiers, not query parameters. Restrict
+            # them to PostgreSQL identifiers before composing the statement.
+            identifiers = (table_name, vector_col, return_col)
+            if any(value and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value) for value in identifiers):
+                raise ValueError("Table and column names must be valid PostgreSQL identifiers")
+            selected_column = sql.SQL("*") if not return_col else sql.Identifier(return_col)
+
+            with psycopg.connect(conn_string) as conn:
+                with conn.cursor() as cur:
+                    query_sql = sql.SQL(
+                        "SELECT {} FROM {} ORDER BY {} <-> %s::vector LIMIT %s"
+                    ).format(
+                        selected_column,
+                        sql.Identifier(table_name),
+                        sql.Identifier(vector_col),
+                    )
+                    cur.execute(query_sql, (vector_str, limit))
+
+                    rows = cur.fetchall()
+                    if not rows:
+                        return "No matches found"
+
+                    metadata_list = []
+                    for row in rows:
+                        if return_col:
+                            metadata_list.append(row[0])
+                        else:
+                            metadata_list.append(row)
+                    return metadata_list
+        except Exception as e:
+            logger.error(f"Error querying pgvector: {str(e)}")
+            raise ValueError(f"Failed to query pgvector: {str(e)}")
+
     def _process_row(self, row, column, config, organization_id, workspace_id=None):
         try:
-            input_cell = Cell.objects.get(row=row, column=column)
-            query = input_cell.value
+            if hasattr(column, "id"):
+                input_cell = Cell.objects.get(row=row, column=column)
+                query = input_cell.value
+            else:
+                query = row.metadata.get(column) if hasattr(row, 'metadata') and row.metadata else None
             result_info = self._query_vector_db(
                 query, config, organization_id, workspace_id
             )
@@ -457,7 +642,11 @@ class AddVectorDBColumnView(APIView):
             new_column_name = config.get("new_column_name", "Vector DB Result")
             concurrency = config.get("concurrency", 5)
 
-            if not all([column_id, config.get("sub_type"), config.get("api_key")]):
+            if not column_id or not config.get("sub_type"):
+                return self._gm.bad_request(
+                    get_error_message("MISSING_COLUMN_ID_SUB_TYPE_AND_API_KEY")
+                )
+            if config.get("sub_type") in ["pinecone", "qdrant", "weaviate"] and not config.get("api_key"):
                 return self._gm.bad_request(
                     get_error_message("MISSING_COLUMN_ID_SUB_TYPE_AND_API_KEY")
                 )
@@ -485,21 +674,20 @@ class AddVectorDBColumnView(APIView):
                 source=SourceChoices.VECTOR_DB.value,
                 dataset=dataset,
                 metadata={
-                    "sub_type": config["sub_type"],
-                    "collection_name": config.get("collection_name"),
+                    "sub_type": config.get("sub_type") or config.get("subType"),
+                    "collection_name": config.get("collection_name") or config.get("collectionName"),
                     "url": config.get("url"),
-                    "search_type": config.get("search_type"),
+                    "search_type": config.get("search_type") or config.get("searchType"),
                     "key": config.get("key"),
                     "limit": config.get("limit", 1),
-                    "index_name": config.get("index_name"),
-                    "top_k": config.get("top_k", 1),
-                    "namespace": config.get("namespace"),
-                    "api_key": config.get("api_key"),
-                    "embedding_config": config.get("embedding_config"),
+                    "index_name": config.get("index_name") or config.get("indexName"),
+                    "top_k": config.get("top_k") or config.get("topK") or 1,
+                    "api_key": config.get("api_key") or config.get("apiKey"),
+                    "embedding_config": config.get("embedding_config") or config.get("embeddingConfig"),
                     "column_id": str(column_id),
                     "concurrency": concurrency,
-                    "query_key": config.get("query_key"),
-                    "vector_length": config.get("vector_length"),
+                    "query_key": config.get("query_key") or config.get("queryKey"),
+                    "vector_length": config.get("vector_length") or config.get("vectorLength"),
                 },
             )
 
@@ -3556,13 +3744,15 @@ class PreviewDatasetOperationView(APIView):
             column = Column.objects.get(
                 id=config["column_id"], dataset=dataset, deleted=False
             )
+            input_val = Cell.objects.get(row=row, column=column, deleted=False).value
+            workspace_id = str(dataset.workspace_id) if dataset.workspace_id else None
             value, value_infos = vector_db._process_row(
-                row, column, config, organization_id
+                row, column, config, organization_id, workspace_id
             )
             results.append(
                 {
                     "row_id": str(row.id),
-                    "input": Cell.objects.get(row=row, column=column).value,
+                    "input": input_val,
                     "output": json.dumps(value),
                 }
             )

--- a/futureagi/requirements-test.txt
+++ b/futureagi/requirements-test.txt
@@ -99,6 +99,7 @@ charset-normalizer==3.4.2
     #   pdfminer-six
     #   requests
 chromadb==1.0.13
+pymilvus==2.5.14
     # via core-backend (pyproject.toml)
 click==8.2.1
     # via

--- a/futureagi/requirements.txt
+++ b/futureagi/requirements.txt
@@ -128,6 +128,7 @@ charset-normalizer==3.4.2
 chevron==0.14.0
     # via core-backend (pyproject.toml)
 chromadb==1.0.13
+pymilvus==2.5.14
     # via core-backend (pyproject.toml)
 click==8.2.1
     # via


### PR DESCRIPTION
# Description

**Fixes #1367**

This PR extends the dataset dynamic column retrieval feature to support a much wider range of embedding providers and vector databases. While implementing these new providers, I also ran into and patched a few blocking bugs in the integration pipeline to ensure everything works end-to-end.

## What's Included

**1. Expanded Retrieval Providers**
I've updated the dispatch points in `dynamic_columns.py` and the frontend UI configuration forms to support:
- **New Embeddings**: Cohere, Gemini / Vertex, Voyage, and Mistral.
- **New Vector Stores**: Milvus, Chroma, and pgvector.

**2. Fixed: Celery UUID Validation Crash**
While testing the new integrations, I noticed the background worker was crashing with a `ValidationError: ['“abc” is not a valid UUID.']`. I dug in and realized that `getattr(request, "organization", None)` was passing the raw Django `Organization` object directly into the async Celery task. When Celery serialized the payload, it collapsed the object into a string (the org name), failing UUID validation during database lookups. I fixed this by ensuring we explicitly extract `.id` as a string before it hits the async queue in both `develop_dataset.py` and `dynamic_columns.py`.

**3. Fixed: Mistral Embeddings & Proxy 404s**
I initially got a `404 Not Found` error from the internal proxy (`http://serving:8080/model/v1/infer/mistral`) when querying Mistral embeddings. Since the Django backend already has `litellm` installed and configured, it was much cleaner to just bypass the proxy for this specific provider and route Mistral queries natively through `litellm.embedding()`.

**4. Fixed: Frontend Payload Casing Mismatch**
When testing `pgvector`, I hit a `KeyError: 'collection_name'`. I realized the frontend React form (`Retrieval.jsx`) sends its configuration payload using `camelCase` (e.g. `collectionName`, `searchType`, `topK`), but our Python query handlers were strictly looking for `snake_case` keys, causing them to evaluate to `None`. Instead of refactoring the React components and potentially breaking other legacy UI elements, I added a normalization step on the backend to dynamically map everything to `snake_case` right before processing the queries.

## Screenshots

<img width="1269" height="1298" alt="1" src="https://github.com/user-attachments/assets/85d9aed3-c2ab-4f2b-9bc0-b9f2dc39c89a" />

<img width="1157" height="1279" alt="2" src="https://github.com/user-attachments/assets/f2970b70-9b6d-4fdc-bdbe-01d1c4cb66e7" />

<img width="1184" height="1312" alt="4" src="https://github.com/user-attachments/assets/a6ac9c8e-6471-49fb-acee-4a81bc269aa3" />

<img width="369" height="1242" alt="image" src="https://github.com/user-attachments/assets/b0be1d15-9143-47dd-8b62-bb23eb7b79f1" />

## Checklist
- [x] PR description explains what and why
- [x] Tests added or updated
- [x] No hardcoded secrets, URLs, or PII
- [x] CLA will be signed
