### PR TITLE
fix(accounts): reject expired API keys during authentication

### DIFF
--- a/futureagi/accounts/admin.py
+++ b/futureagi/accounts/admin.py
@@ -211,6 +211,7 @@ class OrgApiKeyAdmin(admin.ModelAdmin):
         "organization",
         "type",
         "enabled",
+        "expires_at",
         "user",
         "workspace",
         "created_at",
@@ -223,7 +224,7 @@ class OrgApiKeyAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {"fields": ("name", "organization", "type")}),
         ("Access Control", {"fields": ("user", "workspace")}),
-        ("Status", {"fields": ("enabled",)}),
+        ("Status", {"fields": ("enabled", "expires_at")}),
         ("Keys", {"fields": ("api_key", "secret_key")}),
         ("Metadata", {"fields": ("id", "created_at")}),
     )

--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -123,6 +123,18 @@ class APIKeyAuthentication(BaseAuthentication):
                 organization_id=str(user.organization.id)
             )
 
+    def _reject_if_expired(self, org_api_key):
+        """Raise and disable ``org_api_key`` if its expiry has passed.
+
+        ``expires_at=None`` means the key never expires (backward compatible
+        default for existing keys). Disabling on expiry gives admins
+        visibility in the keys list without needing a separate status field.
+        """
+        if org_api_key.expires_at and org_api_key.expires_at < timezone.now():
+            org_api_key.enabled = False
+            org_api_key.save(update_fields=["enabled"])
+            raise AuthenticationFailed("API key has expired")
+
     def authenticate(self, request):
         # Check for JWT token first
         auth_token = (
@@ -167,9 +179,10 @@ class APIKeyAuthentication(BaseAuthentication):
             ).get(
                 api_key=api_key,
                 secret_key=secret_key,
-                enabled=True,
                 deleted=False,
             )
+
+            self._reject_if_expired(org_api_key)
 
             # Validate that the API key has a valid organization
             if not org_api_key.organization:
@@ -579,14 +592,18 @@ class LangfuseBasicAuthentication(APIKeyAuthentication):
             ).get(
                 api_key=public_key,
                 secret_key=secret_key,
-                enabled=True,
                 deleted=False,
             )
         except OrgApiKey.DoesNotExist as e:
             raise AuthenticationFailed("Invalid API key or secret key") from e
 
+        self._reject_if_expired(org_api_key)
+
         if not org_api_key.organization:
             raise AuthenticationFailed("API key has no organization")
+
+        if not org_api_key.enabled:
+            raise AuthenticationFailed("API key is disabled")
 
         # Resolve user (same logic as parent class)
         if org_api_key.type == "system":

--- a/futureagi/accounts/migrations/0025_orgapikey_expires_at.py
+++ b/futureagi/accounts/migrations/0025_orgapikey_expires_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0024_sosloginproxy"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="orgapikey",
+            name="expires_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="Optional expiry timestamp. Null means the key never expires.",
+                null=True,
+            ),
+        ),
+    ]

--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -314,6 +314,11 @@ class OrgApiKey(BaseModel):
         choices=[("system", "System"), ("user", "User"), ("mcp", "MCP")],
     )
     enabled = models.BooleanField(default=True)
+    expires_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="Optional expiry timestamp. Null means the key never expires.",
+    )
     user = models.ForeignKey(
         User,
         on_delete=models.CASCADE,

--- a/futureagi/accounts/tests/test_multi_org_auth.py
+++ b/futureagi/accounts/tests/test_multi_org_auth.py
@@ -12,9 +12,11 @@ These are integration tests that hit the actual auth layer.
 """
 
 import base64
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 
 from accounts.authentication import APIKeyAuthentication, LangfuseBasicAuthentication
@@ -192,6 +194,168 @@ class TestAPIKeyAuthentication:
 
         with pytest.raises(AuthenticationFailed):
             LangfuseBasicAuthentication().authenticate(request)
+
+    def test_expired_api_key_is_rejected(self, auth_instance, auth_user, org_primary):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Expired API auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance.authenticate(request)
+
+        key.refresh_from_db()
+        assert key.enabled is False
+
+    def test_expired_basic_api_key_is_rejected(self, auth_user, org_primary):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Expired basic auth key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        encoded = base64.b64encode(
+            f"{key.api_key}:{key.secret_key}".encode()
+        ).decode("ascii")
+        request = _make_request()
+        request.META = {"HTTP_AUTHORIZATION": f"Basic {encoded}"}
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            LangfuseBasicAuthentication().authenticate(request)
+
+        key.refresh_from_db()
+        assert key.enabled is False
+
+    def test_expired_api_key_message_persists_after_auto_disable(
+        self, auth_instance, auth_user, org_primary
+    ):
+        """The "expired" message must not degrade to a generic one once the
+        key gets auto-disabled — otherwise only the first request after
+        expiry is diagnosable and every retry looks like a wrong key."""
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Repeatedly expired key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance.authenticate(request)
+
+        # Second attempt, after auto-disable — still "expired", not
+        # "Invalid API key or secret key".
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance.authenticate(request)
+
+    def test_disabled_non_expired_api_key_is_rejected(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Manually disabled key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            enabled=False,
+        )
+        request = _make_request(
+            headers={
+                "X-Api-Key": key.api_key,
+                "X-Secret-Key": key.secret_key,
+            }
+        )
+
+        with pytest.raises(AuthenticationFailed, match="API key is disabled"):
+            auth_instance.authenticate(request)
+
+    def test_disabled_non_expired_basic_api_key_is_rejected(
+        self, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Manually disabled basic key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            enabled=False,
+        )
+        encoded = base64.b64encode(
+            f"{key.api_key}:{key.secret_key}".encode()
+        ).decode("ascii")
+        request = _make_request()
+        request.META = {"HTTP_AUTHORIZATION": f"Basic {encoded}"}
+
+        with pytest.raises(AuthenticationFailed, match="API key is disabled"):
+            LangfuseBasicAuthentication().authenticate(request)
+
+
+# ---------------------------------------------------------------------------
+# _reject_if_expired tests
+# ---------------------------------------------------------------------------
+
+
+class TestRejectIfExpired:
+    """Tests for APIKeyAuthentication._reject_if_expired()."""
+
+    def test_no_expiry_is_a_noop(self, auth_instance, auth_user, org_primary):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Never expires key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+        )
+        assert key.expires_at is None
+
+        auth_instance._reject_if_expired(key)  # should not raise
+
+        key.refresh_from_db()
+        assert key.enabled is True
+
+    def test_future_expiry_is_a_noop(self, auth_instance, auth_user, org_primary):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Not yet expired key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() + timedelta(days=1),
+        )
+
+        auth_instance._reject_if_expired(key)  # should not raise
+
+        key.refresh_from_db()
+        assert key.enabled is True
+
+    def test_past_expiry_raises_and_disables_key(
+        self, auth_instance, auth_user, org_primary
+    ):
+        key = OrgApiKey.no_workspace_objects.create(
+            name="Expired key",
+            organization=org_primary,
+            type="user",
+            user=auth_user,
+            expires_at=timezone.now() - timedelta(seconds=1),
+        )
+
+        with pytest.raises(AuthenticationFailed, match="API key has expired"):
+            auth_instance._reject_if_expired(key)
+
+        key.refresh_from_db()
+        assert key.enabled is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`OrgApiKey` had no `expires_at` field, so keys created with an expiry date in the past still authenticated successfully — there was no enforcement path at all. This adds `expires_at` to `OrgApiKey` and rejects expired keys in both `APIKeyAuthentication` and `LangfuseBasicAuthentication`, auto-disabling the key on first use past expiry so it's visible in the admin/keys list. The initial DB lookup no longer pre-filters on `enabled=True`, so the `"API key has expired"` message stays consistent on every subsequent request instead of degrading to a generic `"Invalid API key or secret key"` after the key auto-disables — this also makes the previously-unreachable `"API key is disabled"` check live for manually-disabled keys on both auth paths. `expires_at` is also surfaced in the Django admin fieldsets/list so it can be set without a shell.

## Linked issues

Closes #1458

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Added regression tests in `accounts/tests/test_multi_org_auth.py`: expired key rejected on both auth paths, `expires_at=None`/future-dated keys still authenticate, the "expired" message persists across repeated requests after auto-disable, and manually-disabled (non-expired) keys get "API key is disabled" on both auth paths.
- `pytest accounts/tests/test_multi_org_auth.py`, 39/39 passed.
- `pytest accounts/tests/` (full app), 1123 passed; the 8 failed / 73 errored are pre-existing, unrelated fixture issues verified present on a clean `dev` checkout with these changes stashed out (identical counts).
- `black --check`, `isort --check`, `ruff check` clean on all changed files.
- `mypy` diffed against `mypy-baseline.txt`, byte-identical, no new errors.
- Manual end-to-end verification: ran the actual backend + frontend locally, created a real API key through the `/dashboard/keys` UI, backdated `expires_at` via the new Django admin field, confirmed a real authenticated endpoint returns `401 "API key has expired"` on every subsequent request (not just the first), confirmed the key shows a "Disabled" chip in the frontend after auto-disable, and confirmed a manually re-enabled non-expired key with `enabled=False` gets `"API key is disabled"` instead.

## Screenshots / recordings (if UI)

backend-only change. `expires_at` is exposed in Django admin (not part of this issue's frontend scope) so it can be set for testing/administration without a shell.

Here is how it would look, i put a random API key in django and hit the end point with postman, (The API key is expired)
### With invalid / disabled key, it shows invalid API key on Postman
<img width="1744" height="874" alt="Screenshot 2026-07-10 000024" src="https://github.com/user-attachments/assets/e94e1d17-ecce-45be-835d-04c4a98d551e" />
<img width="1418" height="835" alt="Screenshot 2026-07-10 000150" src="https://github.com/user-attachments/assets/fc360d12-6196-4e73-b0cd-985545017ab4" />

### With enables API key, when the endpoint is hit, it shows API key has expired
<img width="892" height="931" alt="Screenshot 2026-07-10 000405" src="https://github.com/user-attachments/assets/c6a864e1-9817-40be-9685-42d51f09c0fb" />
<img width="1423" height="850" alt="Screenshot 2026-07-10 000434" src="https://github.com/user-attachments/assets/02a49b89-f5ce-44e3-9c18-8cafd0a860dc" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)