### PR TITLE
fix(tracing): use span attributes for custom columns

### DIFF
--- a/frontend/src/api/project/__tests__/llm-tracing.test.js
+++ b/frontend/src/api/project/__tests__/llm-tracing.test.js
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "src/utils/axios";
+import { fetchSpanAttributeKeys } from "../llm-tracing";
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: vi.fn() },
+  endpoints: {
+    project: {
+      spanAttributeKeys: () => "/api/traces/span-attribute-keys/",
+      getEvalAttributeList: () =>
+        "/tracer/observation-span/get_eval_attributes_list/",
+    },
+  },
+}));
+
+describe("fetchSpanAttributeKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads the project's span attributes", async () => {
+    const response = { data: { result: [{ key: "llm.model_name" }] } };
+    axios.get.mockResolvedValueOnce(response);
+
+    await expect(fetchSpanAttributeKeys("project-1")).resolves.toBe(response);
+    expect(axios.get).toHaveBeenCalledWith("/api/traces/span-attribute-keys/", {
+      params: { project_id: "project-1" },
+    });
+  });
+
+  it("falls back to eval attributes when the span lookup fails", async () => {
+    const response = { data: { result: ["legacy.attribute"] } };
+    axios.get
+      .mockRejectedValueOnce(new Error("ClickHouse unavailable"))
+      .mockResolvedValueOnce(response);
+
+    await expect(fetchSpanAttributeKeys("project-1")).resolves.toBe(response);
+    expect(axios.get).toHaveBeenNthCalledWith(
+      2,
+      "/tracer/observation-span/get_eval_attributes_list/",
+      {
+        params: {
+          filters: JSON.stringify({ project_id: "project-1" }),
+        },
+      },
+    );
+  });
+});

--- a/frontend/src/api/project/llm-tracing.js
+++ b/frontend/src/api/project/llm-tracing.js
@@ -19,6 +19,20 @@ export async function fetchRootSpans(traceIds) {
   return res.data?.result || {};
 }
 
+export async function fetchSpanAttributeKeys(projectId) {
+  try {
+    return await axios.get(endpoints.project.spanAttributeKeys(), {
+      params: { project_id: projectId },
+    });
+  } catch {
+    return axios.get(endpoints.project.getEvalAttributeList(), {
+      params: {
+        filters: JSON.stringify({ project_id: projectId }),
+      },
+    });
+  }
+}
+
 export const useGetTraceProperties = () => {
   return useQuery({
     queryKey: ["trace-properties"],

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -215,6 +215,7 @@ const USER_DETAIL_TAB_TYPE = "user_detail";
 import TraceGrid from "./TraceGrid";
 import SpanGrid from "./SpanGrid";
 import { useAgentGraph } from "src/api/project/agent-graph";
+import { fetchSpanAttributeKeys } from "src/api/project/llm-tracing";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 
 // Lazy load graph components — only loaded when viewMode changes
@@ -1242,14 +1243,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     },
   );
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: observeId }),
-        },
-      }),
+  const { data: spanAttributes } = useQuery({
+    queryKey: ["span-attribute-keys", observeId],
+    queryFn: () => fetchSpanAttributeKeys(observeId),
     select: (data) => data.data?.result,
     enabled: Boolean(observeId),
   });
@@ -1447,8 +1443,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const [attributes, setAttributes] = useState([]);
 
   useEffect(() => {
-    setAttributes(evalAttributes || []);
-  }, [evalAttributes]);
+    setAttributes(spanAttributes || []);
+  }, [spanAttributes]);
 
   // User mode only — project mode already scopes to a single project.
   const projectFilterField = useProjectFilterField({ enabled: isUserMode });


### PR DESCRIPTION
## Summary

The LLM Tracing custom-column picker now loads keys from the project's span attributes. Projects that have traces but no configured evals can list their trace attributes instead of showing an empty picker.

The existing eval-attributes request remains as a fallback when the span-attribute request fails.

## Linked issues

Closes #1380
Linear: N/A (external contribution)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior)
- [ ] Documentation only
- [ ] Chore / refactor
- [ ] Performance improvement
- [ ] Test-only change

---

## 1) What changes were done

**A. Span-backed custom columns**

- Added an API helper for the `spanAttributeKeys` endpoint.
- Updated `LLMTracingView` to populate the custom-column picker from span keys.

**B. Compatibility fallback**

- If the span-key request fails, the helper falls back to the existing eval-attributes endpoint.
- The fallback stays in the API layer, so the view consumes one response shape.

---

## 2) Why the changes were done

- **Product/UX:** The picker should show attributes present on traces even when the project has no eval configuration.
- **Technical:** The previous query used an eval-scoped endpoint, which cannot discover arbitrary span attributes.
- **Architecture:** Keeping the fallback in the API helper avoids duplicating request behavior in the view.

---

## 3) Tests written + scenarios each covers

**`frontend/src/api/project/__tests__/llm-tracing.test.js`** - covers custom-column attribute discovery.

- Uses `spanAttributeKeys` when the span-key request succeeds.
- Falls back to `getEvalAttributeList` only when the primary request fails.

> Run result on Node 22.22.2 against `dev`: `yarn check-all --minWorkers=2 --maxWorkers=2` passed. ESLint completed with 0 errors and 411 existing warnings; the repository has no `tsconfig.json`, so its type-check script skipped as designed; the full Vitest suite passed.

---

## 4) How to run / test

```bash
cd frontend
yarn install --frozen-lockfile
yarn check-all --minWorkers=2 --maxWorkers=2
```

### UI steps

1. Open a project that has traces with custom span attributes but no configured evals.
2. Go to Observe, then open **Add custom columns**.
3. Confirm that the span attribute keys are available.
4. Make the span-attribute endpoint unavailable and confirm that the eval-attribute fallback still populates the picker when eval attributes exist.

---

## 5) Screenshots / recordings

Not included. Manual UI verification was not run locally because the full application stack and a populated project were not available; the request behavior is covered by regression tests.

---

## 6) Edge cases & considerations

- Projects without evals use span keys directly and no longer depend on eval configuration.
- A failed span-key request preserves the prior eval-attribute behavior.
- An empty successful span-key response remains empty rather than triggering an unrelated fallback request.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- ESLint reports 411 warnings and 0 errors on the current `dev` baseline.
- On this WSL host, the default Vitest worker count caused one annotation test to exceed its 30-second timeout. That test passed when its 112-test file was rerun, and the complete suite passed with two workers.
- The optional `canvas` dependency has no Node 22 ABI prebuilt package. Yarn treats its install failure as optional, and the complete suite passes without it.

---

## 8) Architectural / important decisions

- **Fallback location:** The compatibility fallback lives in the API helper so callers receive one consistent response shape.
- **Fallback condition:** Fallback occurs only on request failure, not on a valid empty response.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [ ] `bin/test` passes locally (not applicable; frontend-only change)
- [x] `yarn test:run` passes locally
- [x] `yarn contracts:check` is not required because no API surface changed
- [x] Documentation changes are not required for this scoped bug fix
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (waiting for the CLA bot)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked (not available to external contributors)