### PR TITLE
docs: fix create-branch.sh path in BRANCH_NAMING_CONVENTION.md

### DIFF
--- a/BRANCH_NAMING_CONVENTION.md
+++ b/BRANCH_NAMING_CONVENTION.md
@@ -136,13 +136,13 @@ Configure your IDE to suggest branch names:
 Use the provided script for easy branch creation:
 ```bash
 # Create a feat branch with ticket ID
-./scripts/create-branch.sh feat user-authentication AUTH-123
+./frontend/scripts/create-branch.sh feat user-authentication AUTH-123
 
 # Create a fix branch with ticket ID
-./scripts/create-branch.sh fix login-error BUG-456
+./frontend/scripts/create-branch.sh fix login-error BUG-456
 
 # Create a docs branch without ticket ID
-./scripts/create-branch.sh docs update-readme
+./frontend/scripts/create-branch.sh docs update-readme
 ```
 
 The script will:


### PR DESCRIPTION
Fixes #1366

The script is inside frontend/scripts/, not scripts/ at the repo root.
The root scripts/ directory does not even exist, so every example in
the "Branch Creation Helper Script" section was broken for anyone who
tried to follow it.

Before:
  ./scripts/create-branch.sh feat user-authentication AUTH-123

After:
  ./frontend/scripts/create-branch.sh feat user-authentication AUTH-123

Changes:
- BRANCH_NAMING_CONVENTION.md