### PR TITLE
feat(evals): support custom evaluation tags

### DIFF
--- a/frontend/src/sections/evals/components/CustomTagInput.jsx
+++ b/frontend/src/sections/evals/components/CustomTagInput.jsx
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import TextField from "@mui/material/TextField";
+
+// Free-text tag entry, shared by the create page and the detail page so the two
+// cannot drift. Enter commits the trimmed value; an Enter that only confirms an
+// IME composition is ignored.
+export default function CustomTagInput({ value, onChange, onAdd, sx }) {
+  return (
+    <TextField
+      size="small"
+      placeholder="Add custom tag..."
+      helperText="Press Enter to add"
+      inputProps={{ "aria-label": "Add custom tag" }}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+        event.preventDefault();
+        const newTag = value.trim();
+        if (!newTag) return;
+        onAdd(newTag);
+        onChange("");
+      }}
+      sx={{ mt: 1.5, minWidth: 200, ...sx }}
+    />
+  );
+}
+
+CustomTagInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  sx: PropTypes.object,
+};

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -193,6 +193,7 @@ const EvalCreatePage = () => {
   const errorLocalizerActive =
     errorLocalizerEnabled && !agentEvalLocked && errorLocalizerAvailable;
   const [tags, setTags] = useState([]);
+  const [customTagInput, setCustomTagInput] = useState("");
   const [fewShotExamples, setFewShotExamples] = useState([]);
   const [messages, setMessages] = useState([{ role: "system", content: "" }]);
   const [templateFormat, setTemplateFormat] = useState("mustache");
@@ -482,14 +483,22 @@ const EvalCreatePage = () => {
       return;
     }
     try {
+      const pendingCustomTag = customTagInput.trim();
+      const tagsToSave =
+        pendingCustomTag && !tags.includes(pendingCustomTag)
+          ? [...tags, pendingCustomTag]
+          : tags;
+
       // Publish the draft: set name, mark visible
       await updateDraft.mutateAsync({
         name: name.trim(),
         ...buildUpdatePayload(),
         description: description || null,
-        tags,
+        tags: tagsToSave,
         publish: true,
       });
+      setTags(tagsToSave);
+      setCustomTagInput("");
       publishedRef.current = true;
       enqueueSnackbar("Evaluation saved successfully", { variant: "success" });
       navigate(`/dashboard/evaluations/${draftId}`);
@@ -504,6 +513,7 @@ const EvalCreatePage = () => {
     name,
     description,
     tags,
+    customTagInput,
     buildUpdatePayload,
     updateDraft,
     enqueueSnackbar,
@@ -1219,7 +1229,55 @@ const EvalCreatePage = () => {
                           />
                         );
                       })}
+                      {tags
+                        .filter(
+                          (tag) =>
+                            !EVAL_TAGS.some(
+                              (predefinedTag) => predefinedTag.value === tag,
+                            ),
+                        )
+                        .map((tag) => (
+                          <Chip
+                            key={tag}
+                            icon={<Iconify icon="mdi:tag-outline" width={14} />}
+                            label={tag}
+                            size="small"
+                            color="primary"
+                            onDelete={() =>
+                              setTags((prev) =>
+                                prev.filter((item) => item !== tag),
+                              )
+                            }
+                            sx={{
+                              fontSize: "12px",
+                              "& .MuiChip-icon": { fontSize: "14px" },
+                            }}
+                          />
+                        ))}
                     </Box>
+                    <TextField
+                      size="small"
+                      placeholder="Add custom tag..."
+                      helperText="Press Enter to add"
+                      inputProps={{ "aria-label": "Add custom tag" }}
+                      value={customTagInput}
+                      onChange={(event) => setCustomTagInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (
+                          event.key !== "Enter" ||
+                          event.nativeEvent.isComposing
+                        )
+                          return;
+                        event.preventDefault();
+                        const newTag = customTagInput.trim();
+                        if (!newTag) return;
+                        setTags((prev) =>
+                          prev.includes(newTag) ? prev : [...prev, newTag],
+                        );
+                        setCustomTagInput("");
+                      }}
+                      sx={{ mt: 1.5, minWidth: 200 }}
+                    />
                   </Box>
                 </>
               ) : (

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -36,6 +36,8 @@ import { buildCompositeChildConfigs } from "../Helpers/compositeRuntimeConfig";
 import { useCompositeChildrenUnionKeys } from "../hooks/useCompositeChildrenKeys";
 import CodeEvalEditor, { PYTHON_CODE_TEMPLATE } from "./CodeEvalEditor";
 import CompositeDetailPanel from "./CompositeDetailPanel";
+import CustomTagInput from "./CustomTagInput";
+import { withPendingTag } from "./tagUtils";
 import UnsavedChangesDialog from "src/sections/projects/MonitorsView/UnsavedChangesDialog";
 import {
   extractVariables,
@@ -483,11 +485,7 @@ const EvalCreatePage = () => {
       return;
     }
     try {
-      const pendingCustomTag = customTagInput.trim();
-      const tagsToSave =
-        pendingCustomTag && !tags.includes(pendingCustomTag)
-          ? [...tags, pendingCustomTag]
-          : tags;
+      const tagsToSave = withPendingTag(tags, customTagInput);
 
       // Publish the draft: set name, mark visible
       await updateDraft.mutateAsync({
@@ -1255,28 +1253,14 @@ const EvalCreatePage = () => {
                           />
                         ))}
                     </Box>
-                    <TextField
-                      size="small"
-                      placeholder="Add custom tag..."
-                      helperText="Press Enter to add"
-                      inputProps={{ "aria-label": "Add custom tag" }}
+                    <CustomTagInput
                       value={customTagInput}
-                      onChange={(event) => setCustomTagInput(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (
-                          event.key !== "Enter" ||
-                          event.nativeEvent.isComposing
-                        )
-                          return;
-                        event.preventDefault();
-                        const newTag = customTagInput.trim();
-                        if (!newTag) return;
+                      onChange={setCustomTagInput}
+                      onAdd={(newTag) =>
                         setTags((prev) =>
                           prev.includes(newTag) ? prev : [...prev, newTag],
-                        );
-                        setCustomTagInput("");
-                      }}
-                      sx={{ mt: 1.5, minWidth: 200 }}
+                        )
+                      }
                     />
                   </Box>
                 </>

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -63,6 +63,8 @@ import EvalUsageTab from "./EvalUsageTab";
 import VersionBadge from "./VersionBadge";
 import BulkDeleteDialog from "./BulkDeleteDialog";
 import { EVAL_TAGS } from "../constant";
+import CustomTagInput from "./CustomTagInput";
+import { withPendingTag } from "./tagUtils";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
 import { useAuthContext } from "src/auth/hooks";
@@ -178,6 +180,7 @@ const EvalDetailPage = () => {
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
   const [tags, setTags] = useState([]);
+  const [customTagInput, setCustomTagInput] = useState("");
   const [messages, setMessages] = useState([{ role: "system", content: "" }]);
   const [fewShotExamples, setFewShotExamples] = useState([]);
   const [templateFormat, setTemplateFormat] = useState(
@@ -807,6 +810,7 @@ const EvalDetailPage = () => {
           ? { type: "custom", custom: "" }
           : { type: summaryType };
       const tools = build_tools_payload(connectorIds);
+      const tagsToSave = withPendingTag(tags, customTagInput);
       // Update the template first
       const payload = {
         instructions:
@@ -820,7 +824,7 @@ const EvalDetailPage = () => {
           Object.keys(choiceScores || {}).length > 0 ? choiceScores : null,
         multi_choice: multiChoice,
         description: description || null,
-        tags,
+        tags: tagsToSave,
         check_internet: checkInternet,
         mode: evalType === "agent" ? agentMode : undefined,
         tools: evalType === "agent" ? tools : undefined,
@@ -910,6 +914,7 @@ const EvalDetailPage = () => {
     multiChoice,
     description,
     tags,
+    customTagInput,
     checkInternet,
     agentMode,
     summaryType,
@@ -1885,6 +1890,23 @@ const EvalDetailPage = () => {
                         );
                       })()}
                     </Box>
+                    {!isSystemEval && (
+                      <CustomTagInput
+                        value={customTagInput}
+                        onChange={(next) => {
+                          setCustomTagInput(next);
+                          // Save is gated on isDirty, so typing has to count or
+                          // an uncommitted tag could never be saved.
+                          markDirty();
+                        }}
+                        onAdd={(newTag) => {
+                          setTags((prev) =>
+                            prev.includes(newTag) ? prev : [...prev, newTag],
+                          );
+                          markDirty();
+                        }}
+                      />
+                    )}
                   </Box>
                 )}
               </Box>

--- a/frontend/src/sections/evals/components/__tests__/CustomTagInput.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/CustomTagInput.test.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, userEvent } from "src/utils/test-utils";
+import CustomTagInput from "../CustomTagInput";
+import { withPendingTag } from "../tagUtils";
+
+const setup = (tags = []) => {
+  const onAdd = vi.fn();
+  const onChange = vi.fn();
+  const view = render(
+    <CustomTagInput value="" onChange={onChange} onAdd={onAdd} />,
+  );
+  return { onAdd, onChange, view, tags };
+};
+
+describe("Unit: CustomTagInput", () => {
+  it("commits the trimmed value on Enter and clears the box", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <CustomTagInput
+        value="  client-demo  "
+        onChange={onChange}
+        onAdd={onAdd}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Add custom tag" }),
+      "{Enter}",
+    );
+
+    expect(onAdd).toHaveBeenCalledWith("client-demo");
+    expect(onChange).toHaveBeenLastCalledWith("");
+    rerender(<CustomTagInput value="" onChange={onChange} onAdd={onAdd} />);
+  });
+
+  it("ignores an Enter that only confirms an IME composition", () => {
+    const { onAdd } = setup();
+    const input = screen.getByRole("textbox", { name: "Add custom tag" });
+
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      nativeEvent: { isComposing: true },
+      isComposing: true,
+    });
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not commit a whitespace-only value", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<CustomTagInput value="   " onChange={vi.fn()} onAdd={onAdd} />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Add custom tag" }),
+      "{Enter}",
+    );
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe("Unit: withPendingTag", () => {
+  it("folds an uncommitted tag into the saved list", () => {
+    expect(withPendingTag(["safety"], "  client-demo ")).toEqual([
+      "safety",
+      "client-demo",
+    ]);
+  });
+
+  it("leaves the list alone when the box is empty or whitespace", () => {
+    const tags = ["safety"];
+    expect(withPendingTag(tags, "")).toBe(tags);
+    expect(withPendingTag(tags, "   ")).toBe(tags);
+    expect(withPendingTag(tags, undefined)).toBe(tags);
+  });
+
+  it("does not duplicate a tag that is already selected", () => {
+    const tags = ["client-demo"];
+    expect(withPendingTag(tags, "client-demo")).toBe(tags);
+  });
+});

--- a/frontend/src/sections/evals/components/__tests__/EvalCreatePage.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/EvalCreatePage.test.jsx
@@ -1,0 +1,270 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from "src/utils/test-utils";
+import EvalCreatePage from "../EvalCreatePage";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  axiosGet: vi.fn(),
+  updateMutate: vi.fn(),
+  updateMutateAsync: vi.fn(),
+}));
+
+vi.mock("react-router", async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useParams: () => ({ draftId: "draft-1" }),
+  };
+});
+
+vi.mock("notistack", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+vi.mock("src/auth/hooks", () => ({
+  useAuthContext: () => ({ role: "owner" }),
+}));
+
+vi.mock("src/hooks/useDeploymentMode", () => ({
+  useDeploymentMode: () => ({ isOSS: false }),
+}));
+
+vi.mock("src/utils/rolePermissionMapping", () => ({
+  PERMISSIONS: { EDIT_CREATE_DELETE_EVALS: "edit" },
+  RolePermission: { EVALS: { edit: { owner: true } } },
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: (...args) => mocks.axiosGet(...args),
+    post: vi.fn(),
+  },
+  endpoints: {
+    develop: {
+      eval: {
+        getEvalDetail: (id) => `/evals/${id}`,
+        createEvalTemplateV2: "/evals/",
+      },
+    },
+  },
+}));
+
+vi.mock("../../hooks/useCreateEval", () => ({
+  useCreateEval: () => ({ isLoading: false }),
+}));
+
+vi.mock("../../hooks/useEvalDetail", () => ({
+  useUpdateEval: () => ({
+    isLoading: false,
+    mutate: mocks.updateMutate,
+    mutateAsync: mocks.updateMutateAsync,
+  }),
+}));
+
+vi.mock("../../hooks/useCompositeEval", () => ({
+  useCreateCompositeEval: () => ({ isLoading: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("../../hooks/useCompositeChildrenKeys", () => ({
+  useCompositeChildrenUnionKeys: () => [],
+}));
+
+vi.mock("../../Helpers/compositeRuntimeConfig", () => ({
+  buildCompositeChildConfigs: () => [],
+}));
+
+vi.mock("src/sections/common/EvalPicker/evalPickerConfigUtils", () => ({
+  buildDataInjection: () => ({}),
+}));
+
+vi.mock("src/utils/utils", () => ({
+  extractVariables: () => [],
+  extractVariablesFromMessages: () => [],
+}));
+
+vi.mock("../ModelSelector", () => ({
+  FAGI_MODEL_VALUES: new Set(),
+}));
+
+vi.mock("../InstructionEditor", () => ({ default: () => null }));
+vi.mock("../LLMPromptEditor", () => ({ default: () => null }));
+vi.mock("../FewShotExamples", () => ({ default: () => null }));
+vi.mock("../OutputTypeConfig", () => ({ default: () => null }));
+vi.mock("../CodeEvalEditor", () => ({
+  default: () => null,
+  PYTHON_CODE_TEMPLATE: "def evaluate():\n    return 1",
+}));
+vi.mock("../CompositeDetailPanel", () => ({ default: () => null }));
+vi.mock("../TestPlayground", async () => {
+  const ReactModule = await import("react");
+  const TestPlaygroundMock = ReactModule.forwardRef(
+    function TestPlaygroundMock() {
+      return null;
+    },
+  );
+  return { default: TestPlaygroundMock };
+});
+vi.mock("src/sections/projects/MonitorsView/UnsavedChangesDialog", () => ({
+  default: () => null,
+}));
+vi.mock("src/components/tooltip/CustomTooltip", () => ({
+  default: ({ children }) => children,
+}));
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon }) => <span data-icon={icon} />,
+}));
+vi.mock("src/components/resizablePanels/ResizablePanels", () => ({
+  default: ({ leftPanel, rightPanel }) => (
+    <>
+      {leftPanel}
+      {rightPanel}
+    </>
+  ),
+}));
+
+describe("Unit: EvalCreatePage custom tags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.axiosGet.mockResolvedValue({
+      data: {
+        result: {
+          id: "draft-1",
+          eval_type: "agent",
+          eval_tags: [],
+          config: {},
+        },
+      },
+    });
+  });
+
+  it("adds a trimmed custom tag when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+    const input = screen.getByRole("textbox", { name: "Add custom tag" });
+
+    await user.type(input, "  client-demo{Enter}");
+
+    expect(screen.getByText("client-demo")).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("does not add a custom tag that is already selected", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+    const input = screen.getByPlaceholderText("Add custom tag...");
+
+    await user.type(input, "client-demo{Enter}");
+    await user.type(input, "client-demo{Enter}");
+
+    expect(screen.getAllByText("client-demo")).toHaveLength(1);
+  });
+
+  it("ignores whitespace-only custom tags", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    const advancedButton = screen.getByRole("button", { name: /advanced/i });
+    await user.click(advancedButton);
+    await user.type(
+      screen.getByPlaceholderText("Add custom tag..."),
+      "   {Enter}",
+    );
+
+    expect(advancedButton).not.toHaveTextContent("1 tags");
+  });
+
+  it("shows custom tags loaded from an existing evaluation", async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        result: {
+          id: "draft-1",
+          eval_type: "agent",
+          eval_tags: ["client-demo"],
+          config: {},
+        },
+      },
+    });
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+
+    expect(await screen.findByText("client-demo")).toBeInTheDocument();
+  });
+
+  it("does not add a tag when Enter confirms IME composition", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+    const input = screen.getByRole("textbox", { name: "Add custom tag" });
+    await user.type(input, "client");
+
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      nativeEvent: { isComposing: true },
+      isComposing: true,
+    });
+
+    expect(screen.queryByText("client")).not.toBeInTheDocument();
+    expect(input).toHaveValue("client");
+  });
+
+  it("includes pending custom tag input when saving the evaluation", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.type(
+      screen.getByPlaceholderText("Eg: Hallucination detector"),
+      "Client evaluation",
+    );
+    await user.click(screen.getByRole("tab", { name: "Code" }));
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Add custom tag" }),
+      "pending-tag",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Evaluation" }));
+
+    await waitFor(() => {
+      expect(mocks.updateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ["pending-tag"], publish: true }),
+      );
+    });
+  });
+
+  it("includes custom tags when saving the evaluation", async () => {
+    const user = userEvent.setup();
+    render(<EvalCreatePage />);
+
+    await user.type(
+      screen.getByPlaceholderText("Eg: Hallucination detector"),
+      "Client evaluation",
+    );
+    await user.click(screen.getByRole("tab", { name: "Code" }));
+    await user.click(screen.getByRole("button", { name: /advanced/i }));
+    await user.type(
+      screen.getByPlaceholderText("Add custom tag..."),
+      "client-demo{Enter}",
+    );
+    await user.click(screen.getByRole("button", { name: "Save Evaluation" }));
+
+    await waitFor(() => {
+      expect(mocks.updateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ["client-demo"], publish: true }),
+      );
+    });
+  });
+});

--- a/frontend/src/sections/evals/components/__tests__/EvalCreatePage.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/EvalCreatePage.test.jsx
@@ -37,6 +37,17 @@ vi.mock("src/hooks/useDeploymentMode", () => ({
   useDeploymentMode: () => ({ isOSS: false }),
 }));
 
+// The page renders null until capabilities resolve, so the entitlement hooks are
+// stubbed the same way the other hooks here are.
+vi.mock("src/hooks/useCapabilities", () => ({
+  CAPABILITY: { TURING_MODELS: "turing_models", AGENTIC_EVAL: "agentic_eval" },
+  useFeatureLocked: () => ({ locked: false, isLoading: false }),
+}));
+
+vi.mock("src/hooks/useErrorLocalization", () => ({
+  useErrorLocalizationAvailable: () => true,
+}));
+
 vi.mock("src/utils/rolePermissionMapping", () => ({
   PERMISSIONS: { EDIT_CREATE_DELETE_EVALS: "edit" },
   RolePermission: { EVALS: { edit: { owner: true } } },
@@ -149,7 +160,6 @@ describe("Unit: EvalCreatePage custom tags", () => {
     const user = userEvent.setup();
     render(<EvalCreatePage />);
 
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
     const input = screen.getByRole("textbox", { name: "Add custom tag" });
 
     await user.type(input, "  client-demo{Enter}");
@@ -162,7 +172,6 @@ describe("Unit: EvalCreatePage custom tags", () => {
     const user = userEvent.setup();
     render(<EvalCreatePage />);
 
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
     const input = screen.getByPlaceholderText("Add custom tag...");
 
     await user.type(input, "client-demo{Enter}");
@@ -175,14 +184,15 @@ describe("Unit: EvalCreatePage custom tags", () => {
     const user = userEvent.setup();
     render(<EvalCreatePage />);
 
-    const advancedButton = screen.getByRole("button", { name: /advanced/i });
-    await user.click(advancedButton);
     await user.type(
       screen.getByPlaceholderText("Add custom tag..."),
       "   {Enter}",
     );
 
-    expect(advancedButton).not.toHaveTextContent("1 tags");
+    // Custom chips are the only ones drawn with the generic tag icon.
+    expect(
+      document.querySelectorAll('[data-icon="mdi:tag-outline"]'),
+    ).toHaveLength(0);
   });
 
   it("shows custom tags loaded from an existing evaluation", async () => {
@@ -196,10 +206,7 @@ describe("Unit: EvalCreatePage custom tags", () => {
         },
       },
     });
-    const user = userEvent.setup();
     render(<EvalCreatePage />);
-
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
 
     expect(await screen.findByText("client-demo")).toBeInTheDocument();
   });
@@ -208,7 +215,6 @@ describe("Unit: EvalCreatePage custom tags", () => {
     const user = userEvent.setup();
     render(<EvalCreatePage />);
 
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
     const input = screen.getByRole("textbox", { name: "Add custom tag" });
     await user.type(input, "client");
 
@@ -231,7 +237,6 @@ describe("Unit: EvalCreatePage custom tags", () => {
       "Client evaluation",
     );
     await user.click(screen.getByRole("tab", { name: "Code" }));
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
     await user.type(
       screen.getByRole("textbox", { name: "Add custom tag" }),
       "pending-tag",
@@ -254,7 +259,6 @@ describe("Unit: EvalCreatePage custom tags", () => {
       "Client evaluation",
     );
     await user.click(screen.getByRole("tab", { name: "Code" }));
-    await user.click(screen.getByRole("button", { name: /advanced/i }));
     await user.type(
       screen.getByPlaceholderText("Add custom tag..."),
       "client-demo{Enter}",

--- a/frontend/src/sections/evals/components/tagUtils.js
+++ b/frontend/src/sections/evals/components/tagUtils.js
@@ -1,0 +1,6 @@
+// A tag typed into the box but never committed with Enter is still what the user
+// meant, so both save paths fold it in rather than dropping it.
+export const withPendingTag = (tags, pendingInput) => {
+  const pending = (pendingInput || "").trim();
+  return pending && !tags.includes(pending) ? [...tags, pending] : tags;
+};


### PR DESCRIPTION
## Summary

Adds custom tag entry to the evaluation create/edit page so users are no longer limited to the predefined tag chips. Custom tags are trimmed, deduplicated, rendered as removable chips, restored when editing an existing evaluation, and included in the existing save payload.

## Linked issues

Closes #1456
Linear: N/A

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Custom evaluation tags**

- Added an accessible custom-tag text field below the predefined tag chips.
- Pressing Enter adds a trimmed non-empty tag and clears the input.
- Duplicate selected tags are ignored.
- Custom tags render as removable primary chips while predefined tags retain their existing behavior.
- Existing custom tags loaded from `eval_tags` remain visible in edit flows.
- The existing save path continues to send all selected tags through the `tags` payload.

**B. Regression coverage**

- Added focused React Testing Library coverage for creation, duplicate prevention, whitespace rejection, edit hydration, accessibility, IME composition, pending-input save behavior, and save payload persistence.

---

## 2) Why the changes were done

- **Product/UX:** The backend accepts arbitrary tags, but the evaluation UI only exposed a fixed list. This prevented teams from organizing evaluations with project- or client-specific labels.
- **Technical:** The change extends the existing `tags` state and save payload rather than introducing a new API contract or backend behavior.
- **Architecture:** The implementation stays scoped to `EvalCreatePage.jsx`, matching the issue's non-goals and preserving predefined-tag behavior.

---

## 3) Tests written + scenarios each covers

**`frontend/src/sections/evals/components/__tests__/EvalCreatePage.test.jsx`** — custom tag behavior on the create/edit page

- `adds a trimmed custom tag when Enter is pressed` — accessible input, trimming, chip rendering, and input clearing.
- `does not add a custom tag that is already selected` — duplicate prevention.
- `ignores whitespace-only custom tags` — empty-value rejection.
- `shows custom tags loaded from an existing evaluation` — edit-flow hydration.
- `does not add a tag when Enter confirms IME composition` — composition-safe keyboard handling.
- `includes pending custom tag input when saving the evaluation` — prevents typed-but-unconfirmed input from being lost.
- `includes custom tags when saving the evaluation` — persistence through the existing save payload.

> Focused run result: **7 passed**. CI-equivalent `yarn test:unit`: **14 passed, 2296 skipped, 0 failed**. Production build completed successfully. Full frontend `yarn check-all` (run before the final edge-case additions): **2307 passed across 276 test files**. Changed-file ESLint and Prettier checks are clean.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn install --frozen-lockfile
yarn test:run src/sections/evals/components/__tests__/EvalCreatePage.test.jsx
yarn test:unit
yarn build
```

### UI steps (manual)

1. Start the stack and open **Evaluations → Create**.
2. Expand **Advanced** and locate the **Tags** section.
3. Enter `client-demo` in **Add custom tag...** and press Enter.
4. Verify the tag appears as a selected removable chip.
5. Save the evaluation, reopen it, and verify the custom tag remains selected.
6. Try adding the same tag again and verify no duplicate chip appears.

---

## 5) Screenshots / recordings

Not included. The behavior is covered by focused component tests and the production build.

---

## 6) Edge cases & considerations

- Whitespace around a tag is removed before storage.
- Empty and whitespace-only values are ignored.
- An already selected tag is not added twice.
- Typed tag input is included if the user saves before pressing Enter.
- Enter is ignored while an IME composition is active.
- Custom tags loaded during editing are distinguished from predefined values and remain removable.
- The field has an explicit accessible name, visible keyboard guidance, and a placeholder.

---

## 8) Architectural / important decisions

- **Reuse existing state and API:** Custom tags use the existing `tags` array and save payload because the backend already supports arbitrary strings.
- **Keep scope local:** No backend, predefined-tag, list-filter, or validation-contract changes were introduced.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the feature works
- [ ] `bin/test` passes locally (backend — not applicable; no backend changes)
- [x] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed (not applicable; no API surface change)
- [x] I've updated the documentation where relevant (not required for this scoped UI change)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (will sign when the bot prompts on the first PR)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status (not available for this GitHub issue)
