### PR TITLE
fix(contracts): type remaining response_format fields as string-or-object union (TH-5941)

### DIFF
--- a/frontend/scripts/generate-openapi-client.mjs
+++ b/frontend/scripts/generate-openapi-client.mjs
@@ -298,6 +298,18 @@ async function runGeneration(schemaPath) {
       `zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.')`,
       "x-string-or-object zod (optional) → union(string, object)",
     );
+    // Default variant: fields declared with a default (e.g.
+    // PromptTemplateData.response_format's default="text") emit
+    // `.default(<generated constant>)` between .passthrough() and .describe().
+    // Generic over the constant name so any future string-or-object field
+    // with a default is rewritten too, and fail-loud so the union can't
+    // silently regress to object-only for exactly these sites again.
+    zod = assertReplaceRegex(
+      zod,
+      /zod\.object\(\{\n\n\}\)\.passthrough\(\)\.default\((\w+)\)\.describe\('String or JSON object\.'\)/g,
+      "zod.union([zod.string(), zod.object({}).passthrough()]).default($1).describe('String or JSON object.')",
+      "x-string-or-object zod (default) → union(string, object)",
+    );
     // Required variant: kept for forward-compat. No StringOrObjectField is
     // currently declared without `required=False`, so this is intentionally
     // soft — silent no-op is fine because the optional variant above is the

--- a/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
+++ b/frontend/src/api/contracts/__tests__/run-prompt-contract.test.js
@@ -39,4 +39,27 @@ describe("add_run_prompt_column request contract", () => {
     const result = validateContractedRequestConfig(runRequest);
     expect(result.ok).toBe(true);
   });
+
+  it("validates the wire shape: undefined-valued keys are dropped like JSON.stringify does", () => {
+    // The Run Prompt form leaves `run_prompt_config.id: undefined` in the
+    // in-memory payload. axios serializes bodies with JSON.stringify, which
+    // drops undefined keys — so the actual wire payload is valid. The
+    // validator must judge the serialized shape, not the raw object,
+    // otherwise it blocks a request whose real bytes conform (TH-5941).
+    const request = {
+      ...runRequest,
+      data: {
+        ...runRequest.data,
+        config: {
+          ...runRequest.data.config,
+          run_prompt_config: {
+            ...runRequest.data.config.run_prompt_config,
+            id: undefined,
+          },
+        },
+      },
+    };
+    const result = validateContractedRequestConfig(request);
+    expect(result.ok).toBe(true);
+  });
 });

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -58338,8 +58338,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "description": "JSON schema for response format if required. Defaults to None.",
-          "type": "object"
+          "description": "String or JSON object.",
+          "type": "object",
+          "x-string-or-object": true
         },
         "tool_choice": {
           "title": "Tool choice",
@@ -75171,10 +75172,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "description": "Any valid JSON value.",
+          "description": "String or JSON object.",
           "type": "object",
           "x-nullable": true,
-          "x-json-value": true
+          "x-string-or-object": true
         },
         "tool_choice": {
           "title": "Tool choice",
@@ -77201,7 +77202,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "type": "object"
+          "type": "object",
+          "x-string-or-object": true,
+          "description": "String or JSON object."
         },
         "tool_choice": {
           "title": "Tool choice",
@@ -77806,9 +77809,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "response_format": {
           "title": "Response format",
-          "description": "LLM output format: 'text' (plain text), 'json' (free-form JSON), 'json_schema' (structured with schema), UUID string (saved schema reference), or object with 'id' field (prompt playground format). See class docstring for details.",
+          "description": "String or JSON object.",
           "type": "object",
-          "default": "text"
+          "default": "text",
+          "x-string-or-object": true
         },
         "response_schema": {
           "title": "Response schema",

--- a/frontend/src/api/contracts/openapi-contract.js
+++ b/frontend/src/api/contracts/openapi-contract.js
@@ -349,7 +349,30 @@ function parseMaybeJsonBody(data, headers = {}) {
     return Object.fromEntries(data.entries());
   }
 
-  if (typeof data !== "string") return data;
+  if (typeof data !== "string") {
+    // Validate the wire shape, not the in-memory object: axios serializes
+    // plain-object and array bodies with JSON.stringify, which drops
+    // undefined-valued keys (e.g. run_prompt_config.id: undefined).
+    // Validating the raw object would reject payloads whose serialized form
+    // is perfectly valid. Scoped to exactly the shapes axios JSON-serializes
+    // — Blob/File/ArrayBuffer bodies are sent raw and stay untouched here.
+    if (
+      Array.isArray(data) ||
+      (data &&
+        typeof data === "object" &&
+        (Object.getPrototypeOf(data) === Object.prototype ||
+          Object.getPrototypeOf(data) === null))
+    ) {
+      try {
+        return JSON.parse(JSON.stringify(data));
+      } catch {
+        // Circular refs / BigInt — fall back to the raw object, matching
+        // the pre-normalization behavior.
+        return data;
+      }
+    }
+    return data;
+  }
   const contentType =
     headers["Content-Type"] ||
     headers["content-type"] ||

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -1970,9 +1970,9 @@ export interface MessageApi {
 }
 
 /**
- * LLM output format: 'text' (plain text), 'json' (free-form JSON), 'json_schema' (structured with schema), UUID string (saved schema reference), or object with 'id' field (prompt playground format). See class docstring for details.
+ * String or JSON object.
  */
-export type PromptTemplateDataApiResponseFormat = { [key: string]: unknown };
+export type PromptTemplateDataApiResponseFormat = string | { [key: string]: unknown };
 
 /**
  * JSON Schema (Draft 7) for structured outputs. Required when response_format='json_schema'. Example: {'type': 'object', 'properties': {...}, 'required': [...]}
@@ -1994,7 +1994,7 @@ export interface PromptTemplateDataApi {
   prompt_version_id?: string;
   /** Array of message objects with id, role, and content array */
   messages: MessageApi[];
-  /** LLM output format: 'text' (plain text), 'json' (free-form JSON), 'json_schema' (structured with schema), UUID string (saved schema reference), or object with 'id' field (prompt playground format). See class docstring for details. */
+  /** String or JSON object. */
   response_format?: PromptTemplateDataApiResponseFormat;
   /** JSON Schema (Draft 7) for structured outputs. Required when response_format='json_schema'. Example: {'type': 'object', 'properties': {...}, 'required': [...]} */
   response_schema?: PromptTemplateDataApiResponseSchema;
@@ -6938,7 +6938,10 @@ export type ColumnConfigResultApiPromptConfig = { [key: string]: unknown };
 
 export type ColumnConfigResultApiMessages = { [key: string]: unknown };
 
-export type ColumnConfigResultApiResponseFormat = { [key: string]: unknown };
+/**
+ * String or JSON object.
+ */
+export type ColumnConfigResultApiResponseFormat = string | { [key: string]: unknown };
 
 export type ColumnConfigResultApiOptimizedKPrompts = { [key: string]: unknown };
 
@@ -6967,6 +6970,7 @@ export interface ColumnConfigResultApi {
   presence_penalty?: number;
   max_tokens?: number;
   top_p?: number;
+  /** String or JSON object. */
   response_format?: ColumnConfigResultApiResponseFormat;
   tool_choice?: string;
   tools?: string[];
@@ -8159,9 +8163,9 @@ export type PromptConfigApiRunPromptConfig = {[key: string]: { [key: string]: un
 export type PromptConfigApiMessagesItem = {[key: string]: { [key: string]: unknown }};
 
 /**
- * Any valid JSON value.
+ * String or JSON object.
  */
-export type PromptConfigApiResponseFormat = { [key: string]: unknown };
+export type PromptConfigApiResponseFormat = string | { [key: string]: unknown };
 
 export type PromptConfigApiToolsItem = {[key: string]: { [key: string]: unknown }};
 
@@ -8201,7 +8205,7 @@ export interface PromptConfigApi {
      * @maximum 1
      */
   top_p?: number;
-  /** Any valid JSON value. */
+  /** String or JSON object. */
   response_format?: PromptConfigApiResponseFormat;
   /** Tool selection mode: 'auto' or 'required'. */
   tool_choice?: PromptConfigApiToolChoice;
@@ -12822,9 +12826,9 @@ export const LitellmApiOutputFormat = {
 } as const;
 
 /**
- * JSON schema for response format if required. Defaults to None.
+ * String or JSON object.
  */
-export type LitellmApiResponseFormat = { [key: string]: unknown };
+export type LitellmApiResponseFormat = string | { [key: string]: unknown };
 
 /**
  * Tool selection mode: 'auto' or 'required'.
@@ -12890,7 +12894,7 @@ export interface LitellmApi {
      * @maximum 1
      */
   top_p?: number;
-  /** JSON schema for response format if required. Defaults to None. */
+  /** String or JSON object. */
   response_format?: LitellmApiResponseFormat;
   /** Tool selection mode: 'auto' or 'required'. */
   tool_choice?: LitellmApiToolChoice;

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -3192,9 +3192,7 @@ export const AgentPlaygroundGraphsVersionsNodesCreateBody = zod.object({
   "pdf_url": zod.string().url().min(1).optional().describe('PDF URL (required when type=pdf_url)')
 }).describe('Array of content items')).describe('Array of content items')
 }).describe('Array of message objects with id, role, and content array')).describe('Array of message objects with id, role, and content array'),
-  "response_format": zod.object({
-
-}).passthrough().default(agentPlaygroundGraphsVersionsNodesCreateBodyPromptTemplateResponseFormatDefault).describe('LLM output format: \'text\' (plain text), \'json\' (free-form JSON), \'json_schema\' (structured with schema), UUID string (saved schema reference), or object with \'id\' field (prompt playground format). See class docstring for details.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).default(agentPlaygroundGraphsVersionsNodesCreateBodyPromptTemplateResponseFormatDefault).describe('String or JSON object.'),
   "response_schema": zod.object({
 
 }).passthrough().optional().describe('JSON Schema (Draft 7) for structured outputs. Required when response_format=\'json_schema\'. Example: {\'type\': \'object\', \'properties\': {...}, \'required\': [...]}'),
@@ -3329,9 +3327,7 @@ export const AgentPlaygroundGraphsVersionsNodesPartialUpdateBody = zod.object({
   "pdf_url": zod.string().url().min(1).optional().describe('PDF URL (required when type=pdf_url)')
 }).describe('Array of content items')).describe('Array of content items')
 }).describe('Array of message objects with id, role, and content array')).describe('Array of message objects with id, role, and content array'),
-  "response_format": zod.object({
-
-}).passthrough().default(agentPlaygroundGraphsVersionsNodesPartialUpdateBodyPromptTemplateResponseFormatDefault).describe('LLM output format: \'text\' (plain text), \'json\' (free-form JSON), \'json_schema\' (structured with schema), UUID string (saved schema reference), or object with \'id\' field (prompt playground format). See class docstring for details.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).default(agentPlaygroundGraphsVersionsNodesPartialUpdateBodyPromptTemplateResponseFormatDefault).describe('String or JSON object.'),
   "response_schema": zod.object({
 
 }).passthrough().optional().describe('JSON Schema (Draft 7) for structured outputs. Required when response_format=\'json_schema\'. Example: {\'type\': \'object\', \'properties\': {...}, \'required\': [...]}'),
@@ -3405,9 +3401,7 @@ export const AgentPlaygroundGraphsVersionsNodesPartialUpdateResponse = zod.objec
   "pdf_url": zod.string().url().min(1).optional().describe('PDF URL (required when type=pdf_url)')
 }).describe('Array of content items')).describe('Array of content items')
 }).describe('Array of message objects with id, role, and content array')).describe('Array of message objects with id, role, and content array'),
-  "response_format": zod.object({
-
-}).passthrough().default(agentPlaygroundGraphsVersionsNodesPartialUpdateResponsePromptTemplateResponseFormatDefault).describe('LLM output format: \'text\' (plain text), \'json\' (free-form JSON), \'json_schema\' (structured with schema), UUID string (saved schema reference), or object with \'id\' field (prompt playground format). See class docstring for details.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).default(agentPlaygroundGraphsVersionsNodesPartialUpdateResponsePromptTemplateResponseFormatDefault).describe('String or JSON object.'),
   "response_schema": zod.object({
 
 }).passthrough().optional().describe('JSON Schema (Draft 7) for structured outputs. Required when response_format=\'json_schema\'. Example: {\'type\': \'object\', \'properties\': {...}, \'required\': [...]}'),
@@ -15199,9 +15193,7 @@ export const ModelHubColumnConfigReadResponse = zod.object({
   "presence_penalty": zod.number().optional(),
   "max_tokens": zod.number().optional(),
   "top_p": zod.number().optional(),
-  "response_format": zod.object({
-
-}).passthrough().optional(),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.'),
   "tool_choice": zod.string().optional(),
   "tools": zod.array(zod.string().min(1)).optional(),
   "optimize_type": zod.string().optional(),
@@ -17044,9 +17036,7 @@ export const ModelHubDevelopsAddRunPromptColumnCreateBody = zod.object({
   "presence_penalty": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
   "max_tokens": zod.number().min(1).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigMaxTokensMax).optional().describe('Maximum number of tokens to generate. Null = use provider default.'),
   "top_p": zod.number().min(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsAddRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
-  "response_format": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
   "tools": zod.array(zod.record(zod.string(), zod.object({
 
@@ -17316,9 +17306,7 @@ export const ModelHubDevelopsEditRunPromptColumnCreateBody = zod.object({
   "presence_penalty": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
   "max_tokens": zod.number().min(1).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigMaxTokensMax).optional().describe('Maximum number of tokens to generate. Null = use provider default.'),
   "top_p": zod.number().min(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsEditRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
-  "response_format": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
   "tools": zod.array(zod.record(zod.string(), zod.object({
 
@@ -17563,9 +17551,7 @@ export const ModelHubDevelopsPreviewRunPromptColumnCreateBody = zod.object({
   "presence_penalty": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
   "max_tokens": zod.number().min(1).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigMaxTokensMax).optional().describe('Maximum number of tokens to generate. Null = use provider default.'),
   "top_p": zod.number().min(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMin).max(modelHubDevelopsPreviewRunPromptColumnCreateBodyConfigTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
-  "response_format": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
   "tools": zod.array(zod.record(zod.string(), zod.object({
 
@@ -25706,9 +25692,7 @@ export const ModelHubRunPromptCreateBody = zod.object({
   "presence_penalty": zod.number().min(modelHubRunPromptCreateBodyPresencePenaltyMin).max(modelHubRunPromptCreateBodyPresencePenaltyMax).optional().describe('Penalty for new word usage. Value between -2 and 2.'),
   "max_tokens": zod.number().min(1).max(modelHubRunPromptCreateBodyMaxTokensMax).optional().describe('Maximum number of tokens to generate. Null = use provider default.'),
   "top_p": zod.number().min(modelHubRunPromptCreateBodyTopPMin).max(modelHubRunPromptCreateBodyTopPMax).optional().describe('Controls diversity via nucleus sampling. Value between 0 and 1.'),
-  "response_format": zod.object({
-
-}).passthrough().optional().describe('JSON schema for response format if required. Defaults to None.'),
+  "response_format": zod.union([zod.string(), zod.object({}).passthrough()]).optional().describe('String or JSON object.'),
   "tool_choice": zod.union([zod.literal('auto'),zod.literal('required'),zod.literal(null)]).optional().describe('Tool selection mode: \'auto\' or \'required\'.'),
   "tools": zod.array(zod.record(zod.string(), zod.string())).optional().describe('List of tools with tool properties if available.')
 })

--- a/futureagi/agent_playground/serializers/node.py
+++ b/futureagi/agent_playground/serializers/node.py
@@ -12,6 +12,7 @@ from agent_playground.serializers.port import (
     PortReadSerializer,
     PortWriteSerializer,
 )
+from tfc.utils.serializer_fields import StringOrObjectField
 
 
 class NodeReadSerializer(serializers.ModelSerializer):
@@ -297,7 +298,7 @@ class PromptTemplateDataSerializer(serializers.Serializer):
         allow_empty=False,
         help_text="Array of message objects with id, role, and content array",
     )
-    response_format = serializers.JSONField(
+    response_format = StringOrObjectField(
         required=False,
         default="text",
         help_text=(

--- a/futureagi/model_hub/serializers/contracts.py
+++ b/futureagi/model_hub/serializers/contracts.py
@@ -11,6 +11,7 @@ from model_hub.serializers.optimize_dataset import (
 from model_hub.serializers.performance_report import PerformanceReportSerializer
 from model_hub.services.ai_eval_writer_service import OUTPUT_FORMAT_PROMPTS
 from tfc.utils.api_errors import API_ERROR_TYPE_CHOICES
+from tfc.utils.serializer_fields import StringOrObjectField
 from tracer.serializers.filters import (
     SortParamField,
     StrictInputSerializer,
@@ -1265,7 +1266,7 @@ class ColumnConfigResultSerializer(serializers.Serializer):
     presence_penalty = serializers.FloatField(required=False, allow_null=True)
     max_tokens = serializers.IntegerField(required=False, allow_null=True)
     top_p = serializers.FloatField(required=False, allow_null=True)
-    response_format = serializers.JSONField(required=False)
+    response_format = StringOrObjectField(required=False)
     tool_choice = serializers.CharField(
         required=False, allow_blank=True, allow_null=True
     )

--- a/futureagi/model_hub/serializers/run_prompt.py
+++ b/futureagi/model_hub/serializers/run_prompt.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from model_hub.models.api_key import ApiKey
-from tfc.utils.serializer_fields import JsonValueField
+from tfc.utils.serializer_fields import JsonValueField, StringOrObjectField
 
 
 class ApiKeyCreateSerializer(serializers.Serializer):
@@ -127,9 +127,12 @@ class LitellmSerializer(serializers.Serializer):
         default=None,
         help_text="Controls diversity via nucleus sampling. Value between 0 and 1.",
     )
-    response_format = serializers.JSONField(
+    response_format = StringOrObjectField(
         required=False,
-        help_text="JSON schema for response format if required. Defaults to None.",
+        help_text=(
+            "Response format: a string (e.g. 'text', 'json_object') or a JSON "
+            "schema object. Defaults to None."
+        ),
     )
     tool_choice = serializers.ChoiceField(
         choices=["auto", "required", None],
@@ -212,10 +215,13 @@ class PromptConfigSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Controls diversity via nucleus sampling. Value between 0 and 1.",
     )
-    response_format = JsonValueField(
+    response_format = StringOrObjectField(
         required=False,
         allow_null=True,
-        help_text="JSON schema for response format if required. Can be a JSON object or string. Defaults to None.",
+        help_text=(
+            "Response format: a string (e.g. 'text', 'json_object') or a JSON "
+            "schema object. Defaults to None."
+        ),
     )
     tool_choice = serializers.ChoiceField(
         choices=["auto", "required", None],

--- a/futureagi/model_hub/tests/test_response_format_string_or_object.py
+++ b/futureagi/model_hub/tests/test_response_format_string_or_object.py
@@ -1,0 +1,55 @@
+"""Contract tests for `response_format` declaration sites (TH-5941).
+
+`response_format` is legitimately ``string | object`` at the provider level
+(LiteLLM/OpenAI accept ``"text"`` / ``"json_object"`` strings AND structured
+JSON-schema objects). Each declaration site must therefore use
+``StringOrObjectField`` so that:
+
+* the OpenAPI schema carries ``x-string-or-object`` (FE runtime validator and
+  orval post-processor both generate the union from it), and
+* the backend rejects arrays / numbers / booleans at runtime for callers that
+  bypass the FE contract validator (SDK, curl, internal).
+
+These tests pin every site so a future field rename can't silently flip one
+back to object-only ``JSONField`` or too-loose ``JsonValueField``.
+"""
+
+import pytest
+from rest_framework import serializers
+
+from agent_playground.serializers.node import PromptTemplateDataSerializer
+from model_hub.serializers.contracts import ColumnConfigResultSerializer
+from model_hub.serializers.run_prompt import LitellmSerializer, PromptConfigSerializer
+from tfc.utils.serializer_fields import StringOrObjectField
+
+SITES = [
+    LitellmSerializer,
+    PromptConfigSerializer,
+    ColumnConfigResultSerializer,
+    PromptTemplateDataSerializer,
+]
+
+
+@pytest.mark.parametrize("serializer_cls", SITES)
+def test_response_format_is_string_or_object_field(serializer_cls):
+    field = serializer_cls().fields["response_format"]
+    assert isinstance(field, StringOrObjectField), (
+        f"{serializer_cls.__name__}.response_format must stay a "
+        "StringOrObjectField — plain JSONField advertises object-only in the "
+        "contract, JsonValueField degrades it to z.any()."
+    )
+
+
+@pytest.mark.parametrize("serializer_cls", SITES)
+def test_response_format_accepts_string_and_object(serializer_cls):
+    field = serializer_cls().fields["response_format"]
+    assert field.run_validation("text") == "text"
+    assert field.run_validation({"type": "json_object"}) == {"type": "json_object"}
+
+
+@pytest.mark.parametrize("serializer_cls", SITES)
+@pytest.mark.parametrize("bad", [[], [1, 2], 42, 1.5, True])
+def test_response_format_rejects_non_string_non_object(serializer_cls, bad):
+    field = serializer_cls().fields["response_format"]
+    with pytest.raises(serializers.ValidationError):
+        field.run_validation(bad)


### PR DESCRIPTION
Supersedes #960 (closed — that branch lost its merge base with `dev`, and most of its machinery has since landed on `dev` via other merged PRs).

## 1. What changes are done

Four `response_format` declaration sites are flipped to the existing `StringOrObjectField`:

| File | Serializer | Was | Problem |
| --- | --- | --- | --- |
| `model_hub/serializers/run_prompt.py:130` | `LitellmSerializer` | `serializers.JSONField` | Contract advertised **object-only**; `"text"` rejected by generated clients |
| `model_hub/serializers/run_prompt.py:215` | `PromptConfigSerializer` | `JsonValueField` | Contract degraded to **any JSON value** — accepts `42`, `[]`; describes nothing |
| `model_hub/serializers/contracts.py:1269` | `ColumnConfigResultSerializer` | `serializers.JSONField` | Response contract object-only, out of lockstep with the request side |
| `agent_playground/serializers/node.py:301` | `PromptTemplateDataSerializer` | `serializers.JSONField` | Declared schema object-only even though its own `validate_response_format` accepts strings |

Plus a new pinned test module `model_hub/tests/test_response_format_string_or_object.py` and the regenerated contract artifacts (`swagger.json`, `openapi-contract.generated.js`, `api.schemas.ts`, `api.zod.ts`).

**No new infrastructure.** `StringOrObjectField` (with its `to_internal_value` runtime guard), the `x-string-or-object` branch in the FE runtime validator, the orval post-processor in `generate-openapi-client.mjs`, and the field's runtime-guard test suite (`tfc/utils/tests/test_serializer_fields.py`) all already exist on `dev` — they landed through other merged PRs after #960 was written. This PR only applies the field to the sites that never got flipped.

## 2. Why these changes

**History.** The original bug (TH-5941): editing/running a Run Prompt column sent `response_format: "text"` and the FE dev-mode runtime contract validator threw `config.response_format: Expected object, received string`, because every `response_format` was declared as `serializers.JSONField` → drf-yasg emits `type: object` → generated zod was object-only. `response_format` is legitimately `string | object` at the provider level — LiteLLM/OpenAI accept `"text"` / `"json_object"` strings AND structured JSON-schema objects.

**Current state of dev.** The user-facing error no longer reproduces — but only because `PromptConfigSerializer.response_format` became `JsonValueField` (`x-json-value` → "any valid JSON"), which accepts the string by accepting *everything* (`42`, `[]`, `true`). That is exactly the `z.any()` pattern rejected in #960's round-1 review: it makes the error go away while making the contract describe nothing. Meanwhile `Litellm`, `ColumnConfigResult` and `PromptTemplateData` still advertise object-only, so any consumer generating a client from `swagger.json` is still blocked from sending the string the API actually accepts.

**The fix.** `StringOrObjectField` is the honest type for this field, and it is already the established pattern on `dev` (`PromptModelParams.response_format`, `PromptConfigEntry.model` use it today). Flipping the four sites gives, per field:

- swagger: `x-string-or-object: true`
- FE runtime validator: `z.union([z.string(), z.object().passthrough()])`
- generated TS (`api.schemas.ts`): `string | { [key: string]: unknown }`
- generated zod (`api.zod.ts`): `zod.union([zod.string(), zod.object({}).passthrough()])`
- backend runtime: arrays / numbers / booleans rejected in `to_internal_value` for callers that bypass the FE validator (SDK, curl, internal)

**Why not enforce object-only on the frontend instead:** the string is a legitimate provider value, not an FE mistake — wrapping it into an object would add a translation shim on both sides, diverge the published contract from what the API actually accepts for SDK/curl callers, and stored configs with string values would need migrating. The contract should describe reality.

**Why the custom `x-string-or-object` extension and not native `oneOf`:** drf-yasg emits Swagger 2.0, which does not support `oneOf` (schema validation rejects it). Accepted as documented debt in #960's review; tracked for the OpenAPI 3.0 migration (TH-6029). Both consumers of the extension (runtime mapper + orval post-processor with fail-loud `throw` guards) already exist on `dev`.

**Compatibility notes:**
- `PromptTemplateDataSerializer` keeps its stricter `validate_response_format` (normalizes `"text"`/`"json"`/`"json_schema"`/UUID/object) — the field guard runs first, the serializer-level validator still applies after.
- `PromptConfigSerializer.response_format` keeps `allow_null=True`; DRF short-circuits `null` in `validate_empty_values` before the guard, so `null` handling is unchanged at every site.
- Tightening from `JsonValueField`: any payload that now fails (`response_format: 42` / `[]`) was garbage that no execution path could use — the runtime guard failing loudly is the intended behavior.

## 3. Tests — scenarios covered

New `model_hub/tests/test_response_format_string_or_object.py`, parametrized over all four serializers (28 cases):

- the field **is** a `StringOrObjectField` (pins the declaration — a future rename can't silently flip a site back to `JSONField`/`JsonValueField` without failing CI)
- `"text"` and `{"type": "json_object"}` accepted
- `[]`, `[1,2]`, `42`, `1.5`, `True` rejected with `ValidationError`

This closes the round-1 review point from #960 ("no test pinning the fixed behavior") at the declaration sites; the field's own guard behavior was already covered on `dev` by `tfc/utils/tests/test_serializer_fields.py`.


https://github.com/user-attachments/assets/0d4279dc-90cb-4c51-b858-9623f398f496




## 4. Test results

```
model_hub/tests/test_response_format_string_or_object.py .......... 28 passed in 0.19s
```

Affected existing suites (run in the backend container):

```
model_hub/tests/test_run_prompt_api.py
model_hub/tests/test_run_prompt_runtime_contracts.py
tfc/utils/tests/test_serializer_fields.py
agent_playground/tests/serializers/
============================= 460 passed in 14.57s =============================
```

FE runtime validator suite:

```
src/api/contracts/__tests__/openapi-contract.test.js — 24 passed
```

Contracts regenerated via `scripts/generate-openapi-schema.sh` + `npm run contracts:generate` (canonical ordering, full output committed). Ruff clean on all edited files.

Made with [Cursor](https://cursor.com)

## Review round 1 (hadarishav) — addressed

1. **Blocking — `api.zod.ts` self-contradiction fixed.** The post-processor's `.default()` rewrite was anchored to `modelHubExperimentsV2*Default` constants and missed the three agent_playground node entries (`PromptTemplateData.response_format` has `default="text"`), leaving their zod object-only while the `.describe()` and TS types said `string | object`. Added a generic fail-loud rewrite anchored on the `'String or JSON object.'` description (constant-name agnostic), so any future string-or-object field with a default regenerates correctly and a miss fails the build. Regenerated: all 12 string-or-object zod sites are unions; zero object-only entries remain. `contracts:check` (the CI gate) passes.
2. **Behavioral note acknowledged:** `PromptConfigSerializer.response_format` tightened from accept-any-JSON to `string | dict | null` on the input path — add/edit/preview run-prompt-column requests sending an array/number/bool now 400 where they were previously accepted (and unusable downstream). Intended; FE only sends `"text"`/objects; `null` still passes (`allow_null=True`); pinned by the 28-case backend test.

## 5. Follow-up commits: runtime validator judged the in-memory object, not the wire payload

While verifying this fix locally, the Run Prompt add-column form was still blocked — but by a **different, pre-existing validator bug**, not by `response_format`:

```
config.run_prompt_config.id: Invalid input
```

**Dev-only breakage.** This blocking only ever happens locally / in dev: `shouldEnforceApiRequestContracts()` is `false` in production builds, where a contract mismatch merely `console.warn`s and the request still goes out. So production traffic was never affected — but every developer running the Run Prompt flow locally hit a silent dead button.

**Root cause.** The form's in-memory payload contains `run_prompt_config.id: undefined`. axios serializes plain-object bodies with `JSON.stringify`, which **drops undefined-valued keys**, so the actual wire payload is perfectly valid — the backend never sees an `id` key. But `validateContractedRequestConfig` ran the zod schema against the raw in-memory object, where `undefined` fails the `x-json-value` union, and threw before the request left the browser. This affects every contracted endpoint whose form state carries an `undefined` value.

**Fix.** `parseMaybeJsonBody` now normalizes the body through `JSON.parse(JSON.stringify(data))` before validation — i.e. the validator judges exactly the bytes axios will send. No schema is loosened; only the snapshot being validated changes.

**Regression analysis — why this generic change is safe:**

- **Scoped to exactly what axios JSON-serializes.** The normalization only applies to plain objects (`Object.prototype` / null prototype) and arrays — the shapes axios passes through `JSON.stringify`. `FormData` and `URLSearchParams` are handled by their own earlier branches (unchanged), and `Blob` / `File` / `ArrayBuffer` bodies (which axios sends raw, not as JSON) are explicitly left untouched.
- **The round-trip can only make validation MORE wire-accurate, never less.** For a JSON body, what the backend receives is by definition `JSON.parse(JSON.stringify(payload))`. Every difference the round-trip introduces (undefined keys dropped, `Date` → ISO string, `NaN` → `null`, `toJSON()` applied) is a difference that already happens on the wire — previously each of those was a potential false-block, now they validate as sent.
- **Failure fallback preserves old behavior.** If `JSON.stringify` throws (circular refs, BigInt), the validator falls back to the raw object — exactly the pre-change path.
- **Test evidence:** new pinned case in `run-prompt-contract.test.js` (`id: undefined` payload must pass), full contract suite 125 passed, and the entire `src/api` test tree (14 files, **220 passed**) is green with the change.

Kept in this PR (rather than split) because it is the other half of the same user-visible bug: with only the `response_format` union fixed, the Run Prompt form is still blocked by this validator quirk in local dev, so TH-5941 isn't actually closed without it.

