### PR TITLE
fix(evals): eval-playground response shape same on OSS and EE (TH-6719)

### DIFF
--- a/futureagi/model_hub/tests/test_eval_playground_response_shape.py
+++ b/futureagi/model_hub/tests/test_eval_playground_response_shape.py
@@ -173,3 +173,30 @@ def test_response_shape_is_canonical_when_metering_is_available(
     assert output["output_type"] == "Pass/Fail"
     assert output["log_id"] == "log-abc"
     assert output["ground_truth_examples"] == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        0.7,
+        "Good",
+        ["A", "B"],
+        {"score": 0.7, "choice": "Good"},
+        {"score": 0.5, "choices": ["A", "B"]},
+    ],
+    ids=["float", "str-choice", "list-multi", "dict-single-pick", "dict-multi-choice"],
+)
+def test_response_output_preserves_polymorphic_shapes(
+    monkeypatch, pass_fail_template, organization, value
+):
+    _patch_runner(monkeypatch, format_output_return=value)
+    monkeypatch.setattr(evals_module, "log_and_deduct_cost_for_api_request", None)
+
+    output = run_eval_func(
+        {"config": {}, "params": {}},
+        {"input": "hello"},
+        pass_fail_template,
+        organization,
+        source="eval_playground",
+    )
+    assert output["output"] == value

--- a/futureagi/model_hub/tests/test_eval_playground_response_shape.py
+++ b/futureagi/model_hub/tests/test_eval_playground_response_shape.py
@@ -1,4 +1,4 @@
-"""Playground response shape stays canonical on stripped-ee and full builds (TH-6719)."""
+"""Playground response shape stays canonical whether or not the metering helper is loaded (TH-6719)."""
 
 from types import SimpleNamespace
 
@@ -92,11 +92,11 @@ def _patch_runner(monkeypatch, format_output_return):
 
 
 @pytest.mark.django_db
-def test_response_shape_is_canonical_when_metering_is_stripped(
+def test_response_shape_is_canonical_when_metering_helper_absent(
     monkeypatch, pass_fail_template, organization
 ):
     _patch_runner(monkeypatch, format_output_return="Passed")
-    # Simulate ee/ stripped: the metering entry point is None.
+    # Simulate the build where the metering entry point is not loaded.
     monkeypatch.setattr(evals_module, "log_and_deduct_cost_for_api_request", None)
 
     output = run_eval_func(
@@ -150,7 +150,7 @@ def test_response_shape_is_canonical_when_metering_is_available(
         "log_and_deduct_cost_for_api_request",
         lambda **_kwargs: log_row,
     )
-    # ee.usage sub-imports called inside run_eval_func; stub the ones
+    # Metering sub-imports called inside run_eval_func; stub the ones
     # that would otherwise hit real services.
     monkeypatch.setattr(
         "ee.usage.services.metering.check_usage",

--- a/futureagi/model_hub/tests/test_eval_playground_response_shape.py
+++ b/futureagi/model_hub/tests/test_eval_playground_response_shape.py
@@ -1,14 +1,4 @@
-"""Regression tests for the eval-playground response shape (TH-6719).
-
-The playground endpoint feeds a single-page FE component that only knows
-one shape: `{output, output_type, log_id, ground_truth_examples,
-reason, model, metadata}` where `output` is the canonical verdict
-(e.g. "Passed" / "Failed") and `output_type` is the type descriptor
-(e.g. "Pass/Fail"). `run_eval_func` used to return a differently-shaped
-dict whenever the ee/ metering entry point was absent (OSS builds),
-which surfaced the type descriptor in the "Result" cell instead of
-the verdict. These tests pin the canonical shape on both paths.
-"""
+"""Playground response shape stays canonical on stripped-ee and full builds (TH-6719)."""
 
 from types import SimpleNamespace
 
@@ -104,11 +94,6 @@ def _patch_runner(monkeypatch, format_output_return):
 def test_response_shape_is_canonical_when_metering_is_stripped(
     monkeypatch, pass_fail_template, organization
 ):
-    """OSS mode: ee.usage entry point unavailable => api_call_log_row is
-    None. The response must still carry {output, output_type, log_id=None,
-    ground_truth_examples} so the FE renders the verdict, not the type
-    descriptor.
-    """
     _patch_runner(monkeypatch, format_output_return="Passed")
     # Simulate ee/ stripped: the metering entry point is None.
     monkeypatch.setattr(evals_module, "log_and_deduct_cost_for_api_request", None)
@@ -150,9 +135,6 @@ def test_response_shape_is_canonical_when_metering_is_stripped(
 def test_response_shape_is_canonical_when_metering_is_available(
     monkeypatch, pass_fail_template, organization
 ):
-    """EE mode: log_and_deduct_cost_for_api_request populates a log row.
-    Same canonical shape as the OSS case, with a concrete `log_id`.
-    """
     _patch_runner(monkeypatch, format_output_return="Failed")
 
     log_row = SimpleNamespace(

--- a/futureagi/model_hub/tests/test_eval_playground_response_shape.py
+++ b/futureagi/model_hub/tests/test_eval_playground_response_shape.py
@@ -1,0 +1,193 @@
+"""Regression tests for the eval-playground response shape (TH-6719).
+
+The playground endpoint feeds a single-page FE component that only knows
+one shape: `{output, output_type, log_id, ground_truth_examples,
+reason, model, metadata}` where `output` is the canonical verdict
+(e.g. "Passed" / "Failed") and `output_type` is the type descriptor
+(e.g. "Pass/Fail"). `run_eval_func` used to return a differently-shaped
+dict whenever the ee/ metering entry point was absent (OSS builds),
+which surfaced the type descriptor in the "Result" cell instead of
+the verdict. These tests pin the canonical shape on both paths.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from model_hub.models.choices import OwnerChoices
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.views.utils import evals as evals_module
+from model_hub.views.utils.evals import run_eval_func
+from tfc.constants.api_calls import APICallStatusChoices
+
+
+_CANONICAL_KEYS = {
+    "output",
+    "reason",
+    "model",
+    "metadata",
+    "output_type",
+    "log_id",
+    "ground_truth_examples",
+}
+
+
+class _FakeBatchResult:
+    def __init__(self, results):
+        self.eval_results = results
+
+
+class _FakeEvalInstance:
+    def __init__(self):
+        self.cost = {"total_cost": 0.0}
+        self.token_usage = {}
+
+    def run(self, **_kwargs):
+        return _FakeBatchResult(
+            [
+                {
+                    "data": {"result": "Pass"},
+                    "failure": False,
+                    "reason": "not toxic",
+                    "runtime": 42,
+                    "model": "gpt-4.1",
+                    "metrics": [{"id": "custom_eval_score", "value": "Pass"}],
+                    "metadata": {},
+                }
+            ]
+        )
+
+
+@pytest.fixture
+def pass_fail_template(organization, workspace):
+    return EvalTemplate.no_workspace_objects.create(
+        name="toxicity-shape-fixture",
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        config={
+            "output": "Pass/Fail",
+            "eval_type_id": "CustomPromptEvaluator",
+            "required_keys": ["input"],
+            "template_format": "mustache",
+        },
+        eval_tags=["llm"],
+        criteria="Is {{input}} toxic?",
+        model="turing_large",
+        visible_ui=True,
+        output_type_normalized="pass_fail",
+        pass_threshold=0.5,
+    )
+
+
+def _patch_runner(monkeypatch, format_output_return):
+    monkeypatch.setattr(
+        "model_hub.views.utils.evals.EvaluationRunner._create_eval_instance",
+        lambda *_args, **_kwargs: _FakeEvalInstance(),
+    )
+    monkeypatch.setattr(
+        "model_hub.views.utils.evals.EvaluationRunner.map_fields",
+        lambda *_args, **_kwargs: {"input": "hello"},
+    )
+    monkeypatch.setattr(
+        "model_hub.views.utils.evals.EvaluationRunner.format_output",
+        lambda *_args, **_kwargs: format_output_return,
+    )
+    # Ground-truth preview call talks to CH; short-circuit it.
+    monkeypatch.setattr(
+        "model_hub.views.utils.evals.GroundTruthService.resolve_preview_examples",
+        lambda **_kwargs: [],
+    )
+
+
+@pytest.mark.django_db
+def test_response_shape_is_canonical_when_metering_is_stripped(
+    monkeypatch, pass_fail_template, organization
+):
+    """OSS mode: ee.usage entry point unavailable => api_call_log_row is
+    None. The response must still carry {output, output_type, log_id=None,
+    ground_truth_examples} so the FE renders the verdict, not the type
+    descriptor.
+    """
+    _patch_runner(monkeypatch, format_output_return="Passed")
+    # Simulate ee/ stripped: the metering entry point is None.
+    monkeypatch.setattr(evals_module, "log_and_deduct_cost_for_api_request", None)
+
+    output = run_eval_func(
+        {"config": {}, "params": {}},
+        {"input": "hello"},
+        pass_fail_template,
+        organization,
+        source="eval_playground",
+    )
+
+    assert set(output.keys()) >= _CANONICAL_KEYS
+    assert output["output"] == "Passed", (
+        "Canonical verdict from format_output must land in `output` "
+        "regardless of whether an APICallLog row was created."
+    )
+    assert output["output_type"] == "Pass/Fail"
+    assert output["log_id"] is None
+    assert output["ground_truth_examples"] == []
+    assert output["reason"] == "not toxic"
+    assert output["model"] == "gpt-4.1"
+    # Old shape's fields must not leak through as top-level keys.
+    for stale_key in (
+        "data",
+        "failure",
+        "runtime",
+        "metrics",
+        "start_time",
+        "end_time",
+        "duration",
+    ):
+        assert stale_key not in output, (
+            f"legacy raw-response key {stale_key!r} leaked into canonical output"
+        )
+
+
+@pytest.mark.django_db
+def test_response_shape_is_canonical_when_metering_is_available(
+    monkeypatch, pass_fail_template, organization
+):
+    """EE mode: log_and_deduct_cost_for_api_request populates a log row.
+    Same canonical shape as the OSS case, with a concrete `log_id`.
+    """
+    _patch_runner(monkeypatch, format_output_return="Failed")
+
+    log_row = SimpleNamespace(
+        log_id="log-abc",
+        config="{}",
+        status=APICallStatusChoices.PROCESSING.value,
+        input_token_count=0,
+        save=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        evals_module,
+        "log_and_deduct_cost_for_api_request",
+        lambda **_kwargs: log_row,
+    )
+    # ee.usage sub-imports called inside run_eval_func; stub the ones
+    # that would otherwise hit real services.
+    monkeypatch.setattr(
+        "ee.usage.services.metering.check_usage",
+        lambda *_args, **_kwargs: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setattr(
+        "ee.usage.services.emitter.emit",
+        lambda _event: None,
+    )
+
+    output = run_eval_func(
+        {"config": {}, "params": {}},
+        {"input": "hello"},
+        pass_fail_template,
+        organization,
+        source="eval_playground",
+    )
+
+    assert set(output.keys()) >= _CANONICAL_KEYS
+    assert output["output"] == "Failed"
+    assert output["output_type"] == "Pass/Fail"
+    assert output["log_id"] == "log-abc"
+    assert output["ground_truth_examples"] == []

--- a/futureagi/model_hub/tests/test_eval_playground_response_shape.py
+++ b/futureagi/model_hub/tests/test_eval_playground_response_shape.py
@@ -18,7 +18,6 @@ _CANONICAL_KEYS = {
     "metadata",
     "output_type",
     "log_id",
-    "ground_truth_examples",
 }
 
 
@@ -84,9 +83,11 @@ def _patch_runner(monkeypatch, format_output_return):
         lambda *_args, **_kwargs: format_output_return,
     )
     # Ground-truth preview call talks to CH; short-circuit it.
+    # resolve_preview_examples returns None when GT is not configured on the
+    # template; the canonical response omits the key in that case.
     monkeypatch.setattr(
         "model_hub.views.utils.evals.GroundTruthService.resolve_preview_examples",
-        lambda **_kwargs: [],
+        lambda **_kwargs: None,
     )
 
 
@@ -113,7 +114,7 @@ def test_response_shape_is_canonical_when_metering_is_stripped(
     )
     assert output["output_type"] == "Pass/Fail"
     assert output["log_id"] is None
-    assert output["ground_truth_examples"] == []
+    assert "ground_truth_examples" not in output
     assert output["reason"] == "not toxic"
     assert output["model"] == "gpt-4.1"
     # Old shape's fields must not leak through as top-level keys.
@@ -172,7 +173,7 @@ def test_response_shape_is_canonical_when_metering_is_available(
     assert output["output"] == "Failed"
     assert output["output_type"] == "Pass/Fail"
     assert output["log_id"] == "log-abc"
-    assert output["ground_truth_examples"] == []
+    assert "ground_truth_examples" not in output
 
 
 @pytest.mark.parametrize(

--- a/futureagi/model_hub/types.py
+++ b/futureagi/model_hub/types.py
@@ -240,12 +240,20 @@ class EvalUpdateResponse(BaseModel):
 
 class PlaygroundEvalResponse(BaseModel):
     """Response schema for POST /model-hub/eval-playground/ and related
-    single-run evaluation endpoints. `output` is polymorphic per
-    `output_type`: string for pass_fail, float for score, string or list
-    for choices. `log_id` is None on stripped-ee builds where the billing
-    entry point never ran."""
+    single-run evaluation endpoints.
 
-    output: Any = None
+    `output` shape is derived from the template's output_type + choice_scores:
+      - Pass/Fail                            -> "Passed" | "Failed"                    (str)
+      - score alone                          -> 0.7                                    (float)
+      - choices single, no choice_scores     -> "Good"                                 (str)
+      - choices multi, no choice_scores      -> ["A", "B"]                             (list)
+      - score + choice_scores                -> {"score": 0.7, "choice": "Good"}       (dict)
+      - choices + choice_scores single-pick  -> {"score": 0.7, "choice": "Good"}       (dict)
+      - choices + choice_scores multi-choice -> {"score": 0.5, "choices": ["A", "B"]}  (dict)
+
+    `log_id` is None on stripped-ee builds where the billing entry point never ran."""
+
+    output: str | float | list | dict | None = None
     reason: Optional[str] = None
     model: Optional[str] = None
     metadata: Any = None

--- a/futureagi/model_hub/types.py
+++ b/futureagi/model_hub/types.py
@@ -251,7 +251,7 @@ class PlaygroundEvalResponse(BaseModel):
       - choices + choice_scores single-pick  -> {"score": 0.7, "choice": "Good"}       (dict)
       - choices + choice_scores multi-choice -> {"score": 0.5, "choices": ["A", "B"]}  (dict)
 
-    `log_id` is None on stripped-ee builds where the billing entry point never ran.
+    `log_id` is None when APICallLog is not written for this run.
     `ground_truth_examples` is omitted when GT is not configured on the template."""
 
     output: str | float | list | dict | None = None

--- a/futureagi/model_hub/types.py
+++ b/futureagi/model_hub/types.py
@@ -238,6 +238,23 @@ class EvalUpdateResponse(BaseModel):
     updated: bool = True
 
 
+class PlaygroundEvalResponse(BaseModel):
+    """Response schema for POST /model-hub/eval-playground/ and related
+    single-run evaluation endpoints. `output` is polymorphic per
+    `output_type`: string for pass_fail, float for score, string or list
+    for choices. `log_id` is None on stripped-ee builds where the billing
+    entry point never ran."""
+
+    output: Any = None
+    reason: Optional[str] = None
+    model: Optional[str] = None
+    metadata: Any = None
+    output_type: Optional[str] = None
+    log_id: Optional[str] = None
+    ground_truth_examples: list = Field(default_factory=list)
+    warnings: Optional[list] = None
+
+
 # =============================================================================
 # Eval Versioning Types (Phase 5)
 # =============================================================================

--- a/futureagi/model_hub/types.py
+++ b/futureagi/model_hub/types.py
@@ -251,7 +251,8 @@ class PlaygroundEvalResponse(BaseModel):
       - choices + choice_scores single-pick  -> {"score": 0.7, "choice": "Good"}       (dict)
       - choices + choice_scores multi-choice -> {"score": 0.5, "choices": ["A", "B"]}  (dict)
 
-    `log_id` is None on stripped-ee builds where the billing entry point never ran."""
+    `log_id` is None on stripped-ee builds where the billing entry point never ran.
+    `ground_truth_examples` is omitted when GT is not configured on the template."""
 
     output: str | float | list | dict | None = None
     reason: Optional[str] = None
@@ -259,7 +260,7 @@ class PlaygroundEvalResponse(BaseModel):
     metadata: Any = None
     output_type: Optional[str] = None
     log_id: Optional[str] = None
-    ground_truth_examples: list = Field(default_factory=list)
+    ground_truth_examples: Optional[list] = None
     warnings: Optional[list] = None
 
 

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -33,6 +33,23 @@ except ImportError:
     log_and_deduct_cost_for_api_request = None
 
 
+def _canonical_playground_output(value, response, template, api_call_log_row):
+    output = {
+        "output": value,
+        "reason": response.get("reason"),
+        "model": response.get("model"),
+        "metadata": response.get("metadata"),
+        "output_type": template.config.get("output"),
+        "log_id": (
+            str(api_call_log_row.log_id) if api_call_log_row is not None else None
+        ),
+        "ground_truth_examples": response.get("ground_truth_examples") or [],
+    }
+    if response.get("warnings"):
+        output["warnings"] = response["warnings"]
+    return output
+
+
 def run_eval_func(
     config,
     mappings,
@@ -355,166 +372,141 @@ def run_eval_func(
                 logger.exception(f"Error in parsing metadata: {str(e)}")
                 metadata = {}
 
-        # Billing side effects (APICallLog write + UsageEvent emit) run only
-        # when a log row was created upstream — i.e. when the ee/ metering
-        # entry point was importable. The canonical response shape below is
-        # returned regardless, so both stripped-ee (OSS) and full builds hand
-        # the FE a payload it can render.
-        if api_call_log_row is not None:
-            config_dict = json.loads(api_call_log_row.config)
-            output_payload = {"output": value, "reason": response["reason"]}
-            # Mirror the dataset path: propagate partial-input warnings into
-            # the API call log so the eval usage view (which reads APICallLog)
-            # can surface them alongside the eval's output.
-            if response.get("warnings"):
-                output_payload["warnings"] = response["warnings"]
-            config_dict.update(
-                {
-                    "output": output_payload,
-                    "input": response["data"],
-                }
-            )
-            api_call_log_row.input_token_count = (
-                metadata.get("usage", {}).get("prompt_tokens") or 0 if metadata else 0
-            )
-            # default=str so trace/span values mapped into inputs (Decimal
-            # from clickhouse-driver, datetime, UUID) don't blow up the
-            # usage logger.
-            api_call_log_row.config = json.dumps(config_dict, default=str)
-            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-            api_call_log_row.save()
-
-            # Dual-write: emit usage event for new billing system (cost-based)
-            try:
-                try:
-                    from ee.usage.schemas.events import UsageEvent
-                except ImportError:
-                    UsageEvent = None
-                try:
-                    from ee.usage.services.config import BillingConfig
-                except ImportError:
-                    BillingConfig = None
-                try:
-                    from ee.usage.services.emitter import emit
-                except ImportError:
-                    emit = None
-                try:
-                    from ee.usage.utils.event_properties import (
-                        token_usage_properties,
-                    )
-                except ImportError:
-                    token_usage_properties = lambda token_usage: {}
-
-                billing_config = None
-                if BillingConfig is not None:
-                    billing_config = BillingConfig.get()
-                eval_cost = getattr(eval_instance, "cost", {})
-                llm_cost = eval_cost.get("total_cost", 0)
-                per_run_fee = (
-                    billing_config.get_eval_per_run_fee() if billing_config else 0
-                )
-                actual_cost = llm_cost + per_run_fee
-                _token_usage = getattr(eval_instance, "token_usage", {})
-
-                # Fallback cost for comparison logging and composite eval
-                # billing. Composite children can return token usage with a
-                # zero `cost`; in that case, charge model token pricing plus
-                # the per-run fee.
-                _fallback_cost = 0
-                _pricing_source = ""
-                try:
-                    from agentic_eval.core_evals.fi_utils.token_count_helper import (
-                        calculate_total_cost,
-                    )
-
-                    pricing_model = (
-                        model
-                        or getattr(template, "model", None)
-                        or ModelChoices.TURING_LARGE.value
-                    )
-                    _fallback = calculate_total_cost(pricing_model, _token_usage)
-                    _fallback_cost = _fallback.get("total_cost", 0)
-                    _pricing_source = _fallback.get("pricing_source", "")
-                except Exception:
-                    pass
-
-                is_composite_source = source in {
-                    "composite_eval",
-                    "composite_eval_adhoc",
-                    "composite_eval_dataset",
-                    "tracer_composite",
-                }
-                cost_properties = {}
-                if is_composite_source and not llm_cost and _fallback_cost:
-                    actual_cost = Decimal(str(_fallback_cost)) + Decimal(
-                        str(per_run_fee)
-                    )
-                    cost_properties = {
-                        "llm_cost_usd": str(_fallback_cost),
-                        "reported_llm_cost_usd": str(llm_cost),
-                        "llm_cost_source": "token_pricing",
-                        "pricing_source": _pricing_source,
-                    }
-
-                logger.info(
-                    "eval_cost_breakdown",
-                    template=template.name,
-                    model=model,
-                    llm_cost=cost_properties.get("llm_cost_usd", llm_cost),
-                    per_run_fee=per_run_fee,
-                    actual_cost=actual_cost,
-                    fallback_calculated_cost=_fallback_cost,
-                    llm_cost_source=cost_properties.get("llm_cost_source"),
-                    token_usage=getattr(eval_instance, "token_usage", {}),
-                )
-
-                credits = (
-                    billing_config.calculate_ai_credits(actual_cost)
-                    if billing_config
-                    else 0
-                )
-
-                if (
-                    emit is not None
-                    and UsageEvent is not None
-                    and BillingEventType is not None
-                ):
-                    emit(
-                        UsageEvent(
-                            org_id=str(org.id),
-                            event_type=api_call_type,
-                            amount=credits,
-                            properties={
-                                "source": source,
-                                "source_id": str(template.id),
-                                "raw_cost_usd": str(actual_cost),
-                                **cost_properties,
-                                **token_usage_properties(_token_usage),
-                            },
-                        )
-                    )
-            except Exception:
-                pass  # Metering failure must not break the action
-
-        output = {
-            "output": value,
-            "reason": response.get("reason"),
-            "model": response.get("model"),
-            "metadata": response.get("metadata"),
-            "output_type": template.config.get("output"),
-            "log_id": (
-                str(api_call_log_row.log_id) if api_call_log_row is not None else None
-            ),
-            "ground_truth_examples": response.get("ground_truth_examples") or [],
-        }
-        # Pass partial-input warning through to the playground UI so the
-        # yellow ⚠ badge can render alongside the result.
+        if api_call_log_row is None:
+            return _canonical_playground_output(value, response, template, None)
+        config_dict = json.loads(api_call_log_row.config)
+        output_payload = {"output": value, "reason": response["reason"]}
+        # Mirror the dataset path: propagate partial-input warnings into
+        # the API call log so the eval usage view (which reads APICallLog)
+        # can surface them alongside the eval's output.
         if response.get("warnings"):
-            output["warnings"] = response["warnings"]
+            output_payload["warnings"] = response["warnings"]
+        config_dict.update(
+            {
+                "output": output_payload,
+                "input": response["data"],
+            }
+        )
+        api_call_log_row.input_token_count = (
+            metadata.get("usage", {}).get("prompt_tokens") or 0 if metadata else 0
+        )
+        # default=str so trace/span values mapped into inputs (Decimal from
+        # clickhouse-driver, datetime, UUID) don't blow up the usage logger.
+        api_call_log_row.config = json.dumps(config_dict, default=str)
+        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+        api_call_log_row.save()
 
-        # Error localizer wires results back into the APICallLog row, so it
-        # only runs when we actually have a log row to attach to.
-        if error_localizer and api_call_log_row is not None:
+        # Dual-write: emit usage event for new billing system (cost-based)
+        try:
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.config import BillingConfig
+            except ImportError:
+                BillingConfig = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
+
+            billing_config = None
+            if BillingConfig is not None:
+                billing_config = BillingConfig.get()
+            eval_cost = getattr(eval_instance, "cost", {})
+            llm_cost = eval_cost.get("total_cost", 0)
+            per_run_fee = billing_config.get_eval_per_run_fee() if billing_config else 0
+            actual_cost = llm_cost + per_run_fee
+            _token_usage = getattr(eval_instance, "token_usage", {})
+
+            # Fallback cost for comparison logging and composite eval billing.
+            # Composite children can return token usage with a zero `cost`;
+            # in that case, charge model token pricing plus the per-run fee.
+            _fallback_cost = 0
+            _pricing_source = ""
+            try:
+                from agentic_eval.core_evals.fi_utils.token_count_helper import (
+                    calculate_total_cost,
+                )
+
+                pricing_model = (
+                    model
+                    or getattr(template, "model", None)
+                    or ModelChoices.TURING_LARGE.value
+                )
+                _fallback = calculate_total_cost(pricing_model, _token_usage)
+                _fallback_cost = _fallback.get("total_cost", 0)
+                _pricing_source = _fallback.get("pricing_source", "")
+            except Exception:
+                pass
+
+            is_composite_source = source in {
+                "composite_eval",
+                "composite_eval_adhoc",
+                "composite_eval_dataset",
+                "tracer_composite",
+            }
+            cost_properties = {}
+            if is_composite_source and not llm_cost and _fallback_cost:
+                actual_cost = Decimal(str(_fallback_cost)) + Decimal(str(per_run_fee))
+                cost_properties = {
+                    "llm_cost_usd": str(_fallback_cost),
+                    "reported_llm_cost_usd": str(llm_cost),
+                    "llm_cost_source": "token_pricing",
+                    "pricing_source": _pricing_source,
+                }
+
+            logger.info(
+                "eval_cost_breakdown",
+                template=template.name,
+                model=model,
+                llm_cost=cost_properties.get("llm_cost_usd", llm_cost),
+                per_run_fee=per_run_fee,
+                actual_cost=actual_cost,
+                fallback_calculated_cost=_fallback_cost,
+                llm_cost_source=cost_properties.get("llm_cost_source"),
+                token_usage=getattr(eval_instance, "token_usage", {}),
+            )
+
+            credits = (
+                billing_config.calculate_ai_credits(actual_cost)
+                if billing_config
+                else 0
+            )
+
+            if (
+                emit is not None
+                and UsageEvent is not None
+                and BillingEventType is not None
+            ):
+
+                emit(
+                    UsageEvent(
+                        org_id=str(org.id),
+                        event_type=api_call_type,
+                        amount=credits,
+                        properties={
+                            "source": source,
+                            "source_id": str(template.id),
+                            "raw_cost_usd": str(actual_cost),
+                            **cost_properties,
+                            **token_usage_properties(_token_usage),
+                        },
+                    )
+                )
+        except Exception:
+            pass  # Metering failure must not break the action
+
+        output = _canonical_playground_output(
+            value, response, template, api_call_log_row
+        )
+
+        if error_localizer:
             from model_hub.tasks.user_evaluation import (
                 trigger_error_localization_for_playground,
             )

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -45,11 +45,13 @@ def _canonical_playground_output(value, response, template, api_call_log_row):
         log_id=(
             str(api_call_log_row.log_id) if api_call_log_row is not None else None
         ),
-        ground_truth_examples=response.get("ground_truth_examples") or [],
+        ground_truth_examples=response.get("ground_truth_examples"),
         warnings=response.get("warnings") or None,
     ).model_dump()
     if payload.get("warnings") is None:
         payload.pop("warnings", None)
+    if payload.get("ground_truth_examples") is None:
+        payload.pop("ground_truth_examples", None)
     return payload
 
 

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -355,150 +355,166 @@ def run_eval_func(
                 logger.exception(f"Error in parsing metadata: {str(e)}")
                 metadata = {}
 
-        if api_call_log_row is None:
-            return response
-        config_dict = json.loads(api_call_log_row.config)
-        output_payload = {"output": value, "reason": response["reason"]}
-        # Mirror the dataset path: propagate partial-input warnings into
-        # the API call log so the eval usage view (which reads APICallLog)
-        # can surface them alongside the eval's output.
-        if response.get("warnings"):
-            output_payload["warnings"] = response["warnings"]
-        config_dict.update(
-            {
-                "output": output_payload,
-                "input": response["data"],
-            }
-        )
-        api_call_log_row.input_token_count = (
-            metadata.get("usage", {}).get("prompt_tokens") or 0 if metadata else 0
-        )
-        # default=str so trace/span values mapped into inputs (Decimal from
-        # clickhouse-driver, datetime, UUID) don't blow up the usage logger.
-        api_call_log_row.config = json.dumps(config_dict, default=str)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
-
-        # Dual-write: emit usage event for new billing system (cost-based)
-        try:
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.config import BillingConfig
-            except ImportError:
-                BillingConfig = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-            try:
-                from ee.usage.utils.event_properties import token_usage_properties
-            except ImportError:
-                token_usage_properties = lambda token_usage: {}
-
-            billing_config = None
-            if BillingConfig is not None:
-                billing_config = BillingConfig.get()
-            eval_cost = getattr(eval_instance, "cost", {})
-            llm_cost = eval_cost.get("total_cost", 0)
-            per_run_fee = billing_config.get_eval_per_run_fee() if billing_config else 0
-            actual_cost = llm_cost + per_run_fee
-            _token_usage = getattr(eval_instance, "token_usage", {})
-
-            # Fallback cost for comparison logging and composite eval billing.
-            # Composite children can return token usage with a zero `cost`;
-            # in that case, charge model token pricing plus the per-run fee.
-            _fallback_cost = 0
-            _pricing_source = ""
-            try:
-                from agentic_eval.core_evals.fi_utils.token_count_helper import (
-                    calculate_total_cost,
-                )
-
-                pricing_model = (
-                    model
-                    or getattr(template, "model", None)
-                    or ModelChoices.TURING_LARGE.value
-                )
-                _fallback = calculate_total_cost(pricing_model, _token_usage)
-                _fallback_cost = _fallback.get("total_cost", 0)
-                _pricing_source = _fallback.get("pricing_source", "")
-            except Exception:
-                pass
-
-            is_composite_source = source in {
-                "composite_eval",
-                "composite_eval_adhoc",
-                "composite_eval_dataset",
-                "tracer_composite",
-            }
-            cost_properties = {}
-            if is_composite_source and not llm_cost and _fallback_cost:
-                actual_cost = Decimal(str(_fallback_cost)) + Decimal(str(per_run_fee))
-                cost_properties = {
-                    "llm_cost_usd": str(_fallback_cost),
-                    "reported_llm_cost_usd": str(llm_cost),
-                    "llm_cost_source": "token_pricing",
-                    "pricing_source": _pricing_source,
+        # Billing side effects (APICallLog write + UsageEvent emit) run only
+        # when a log row was created upstream — i.e. when the ee/ metering
+        # entry point was importable. The canonical response shape below is
+        # returned regardless, so both stripped-ee (OSS) and full builds hand
+        # the FE a payload it can render.
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            output_payload = {"output": value, "reason": response["reason"]}
+            # Mirror the dataset path: propagate partial-input warnings into
+            # the API call log so the eval usage view (which reads APICallLog)
+            # can surface them alongside the eval's output.
+            if response.get("warnings"):
+                output_payload["warnings"] = response["warnings"]
+            config_dict.update(
+                {
+                    "output": output_payload,
+                    "input": response["data"],
                 }
-
-            logger.info(
-                "eval_cost_breakdown",
-                template=template.name,
-                model=model,
-                llm_cost=cost_properties.get("llm_cost_usd", llm_cost),
-                per_run_fee=per_run_fee,
-                actual_cost=actual_cost,
-                fallback_calculated_cost=_fallback_cost,
-                llm_cost_source=cost_properties.get("llm_cost_source"),
-                token_usage=getattr(eval_instance, "token_usage", {}),
             )
-
-            credits = (
-                billing_config.calculate_ai_credits(actual_cost)
-                if billing_config
-                else 0
+            api_call_log_row.input_token_count = (
+                metadata.get("usage", {}).get("prompt_tokens") or 0 if metadata else 0
             )
+            # default=str so trace/span values mapped into inputs (Decimal
+            # from clickhouse-driver, datetime, UUID) don't blow up the
+            # usage logger.
+            api_call_log_row.config = json.dumps(config_dict, default=str)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
-            if (
-                emit is not None
-                and UsageEvent is not None
-                and BillingEventType is not None
-            ):
-
-                emit(
-                    UsageEvent(
-                        org_id=str(org.id),
-                        event_type=api_call_type,
-                        amount=credits,
-                        properties={
-                            "source": source,
-                            "source_id": str(template.id),
-                            "raw_cost_usd": str(actual_cost),
-                            **cost_properties,
-                            **token_usage_properties(_token_usage),
-                        },
+            # Dual-write: emit usage event for new billing system (cost-based)
+            try:
+                try:
+                    from ee.usage.schemas.events import UsageEvent
+                except ImportError:
+                    UsageEvent = None
+                try:
+                    from ee.usage.services.config import BillingConfig
+                except ImportError:
+                    BillingConfig = None
+                try:
+                    from ee.usage.services.emitter import emit
+                except ImportError:
+                    emit = None
+                try:
+                    from ee.usage.utils.event_properties import (
+                        token_usage_properties,
                     )
-                )
-        except Exception:
-            pass  # Metering failure must not break the action
+                except ImportError:
+                    token_usage_properties = lambda token_usage: {}
 
-        output = {}
-        output["output"] = value
-        output["reason"] = response.get("reason")
-        output["model"] = response.get("model")
-        output["metadata"] = response.get("metadata")
-        output["output_type"] = template.config.get("output")
-        output["log_id"] = str(api_call_log_row.log_id)
-        output["ground_truth_examples"] = response.get("ground_truth_examples")
+                billing_config = None
+                if BillingConfig is not None:
+                    billing_config = BillingConfig.get()
+                eval_cost = getattr(eval_instance, "cost", {})
+                llm_cost = eval_cost.get("total_cost", 0)
+                per_run_fee = (
+                    billing_config.get_eval_per_run_fee() if billing_config else 0
+                )
+                actual_cost = llm_cost + per_run_fee
+                _token_usage = getattr(eval_instance, "token_usage", {})
+
+                # Fallback cost for comparison logging and composite eval
+                # billing. Composite children can return token usage with a
+                # zero `cost`; in that case, charge model token pricing plus
+                # the per-run fee.
+                _fallback_cost = 0
+                _pricing_source = ""
+                try:
+                    from agentic_eval.core_evals.fi_utils.token_count_helper import (
+                        calculate_total_cost,
+                    )
+
+                    pricing_model = (
+                        model
+                        or getattr(template, "model", None)
+                        or ModelChoices.TURING_LARGE.value
+                    )
+                    _fallback = calculate_total_cost(pricing_model, _token_usage)
+                    _fallback_cost = _fallback.get("total_cost", 0)
+                    _pricing_source = _fallback.get("pricing_source", "")
+                except Exception:
+                    pass
+
+                is_composite_source = source in {
+                    "composite_eval",
+                    "composite_eval_adhoc",
+                    "composite_eval_dataset",
+                    "tracer_composite",
+                }
+                cost_properties = {}
+                if is_composite_source and not llm_cost and _fallback_cost:
+                    actual_cost = Decimal(str(_fallback_cost)) + Decimal(
+                        str(per_run_fee)
+                    )
+                    cost_properties = {
+                        "llm_cost_usd": str(_fallback_cost),
+                        "reported_llm_cost_usd": str(llm_cost),
+                        "llm_cost_source": "token_pricing",
+                        "pricing_source": _pricing_source,
+                    }
+
+                logger.info(
+                    "eval_cost_breakdown",
+                    template=template.name,
+                    model=model,
+                    llm_cost=cost_properties.get("llm_cost_usd", llm_cost),
+                    per_run_fee=per_run_fee,
+                    actual_cost=actual_cost,
+                    fallback_calculated_cost=_fallback_cost,
+                    llm_cost_source=cost_properties.get("llm_cost_source"),
+                    token_usage=getattr(eval_instance, "token_usage", {}),
+                )
+
+                credits = (
+                    billing_config.calculate_ai_credits(actual_cost)
+                    if billing_config
+                    else 0
+                )
+
+                if (
+                    emit is not None
+                    and UsageEvent is not None
+                    and BillingEventType is not None
+                ):
+                    emit(
+                        UsageEvent(
+                            org_id=str(org.id),
+                            event_type=api_call_type,
+                            amount=credits,
+                            properties={
+                                "source": source,
+                                "source_id": str(template.id),
+                                "raw_cost_usd": str(actual_cost),
+                                **cost_properties,
+                                **token_usage_properties(_token_usage),
+                            },
+                        )
+                    )
+            except Exception:
+                pass  # Metering failure must not break the action
+
+        output = {
+            "output": value,
+            "reason": response.get("reason"),
+            "model": response.get("model"),
+            "metadata": response.get("metadata"),
+            "output_type": template.config.get("output"),
+            "log_id": (
+                str(api_call_log_row.log_id) if api_call_log_row is not None else None
+            ),
+            "ground_truth_examples": response.get("ground_truth_examples") or [],
+        }
         # Pass partial-input warning through to the playground UI so the
         # yellow ⚠ badge can render alongside the result.
         if response.get("warnings"):
             output["warnings"] = response["warnings"]
 
-        if error_localizer:
+        # Error localizer wires results back into the APICallLog row, so it
+        # only runs when we actually have a log row to attach to.
+        if error_localizer and api_call_log_row is not None:
             from model_hub.tasks.user_evaluation import (
                 trigger_error_localization_for_playground,
             )

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -34,20 +34,23 @@ except ImportError:
 
 
 def _canonical_playground_output(value, response, template, api_call_log_row):
-    output = {
-        "output": value,
-        "reason": response.get("reason"),
-        "model": response.get("model"),
-        "metadata": response.get("metadata"),
-        "output_type": template.config.get("output"),
-        "log_id": (
+    from model_hub.types import PlaygroundEvalResponse
+
+    payload = PlaygroundEvalResponse(
+        output=value,
+        reason=response.get("reason"),
+        model=response.get("model"),
+        metadata=response.get("metadata"),
+        output_type=template.config.get("output"),
+        log_id=(
             str(api_call_log_row.log_id) if api_call_log_row is not None else None
         ),
-        "ground_truth_examples": response.get("ground_truth_examples") or [],
-    }
-    if response.get("warnings"):
-        output["warnings"] = response["warnings"]
-    return output
+        ground_truth_examples=response.get("ground_truth_examples") or [],
+        warnings=response.get("warnings") or None,
+    ).model_dump()
+    if payload.get("warnings") is None:
+        payload.pop("warnings", None)
+    return payload
 
 
 def run_eval_func(


### PR DESCRIPTION
## Summary

`POST /model-hub/eval-playground/` returned two different response shapes depending on whether the optional metering entry point was importable at runtime. On OSS builds, `run_eval_func` returned the raw per-run dict (`{data, failure, runtime, metrics, start_time, end_time, duration, output=<type descriptor>}`) instead of the canonical playground shape (`{output=<verdict>, output_type, log_id, ground_truth_examples, reason, model, metadata}`). The FE only understands the canonical shape, so on OSS the "Result" cell rendered the eval's output-type descriptor ("Pass/Fail") instead of the verdict ("Passed" / "Failed"). Full builds were unaffected on the top-level shape.

This PR converges both paths on the canonical shape. Existing full-build behaviour (APICallLog write, UsageEvent emit, billing-config resolution, error-localizer dispatch) is preserved.

## Root cause

`model_hub/views/utils/evals.py:31-33` imports the optional metering entry point with an `ImportError` fallback that sets it to `None`. Later in `run_eval_func`, if the import failed, `api_call_log_row` is set to `None`. The function then did:

```python
if api_call_log_row is None:
    return response       # OSS path: raw dict; FE renders type descriptor
```

Everything past that point (APICallLog config write, UsageEvent emit, and reshape into the canonical dict) was reachable only when the metering helper was importable. So OSS clients hit the endpoint and received a shape the FE could not render.

## Fix

Restructured the tail of `run_eval_func`:

- **Billing side effects stay behind the same gate.** APICallLog write, config JSON persist, `input_token_count` recompute, `status = SUCCESS` save, and UsageEvent emit are now nested under `if api_call_log_row is not None:`. Same code, one indent level deeper, no logic change.
- **Canonical response is built unconditionally** via the shared `_canonical_playground_output` helper. The dict now assembles the same seven fields regardless of whether a log row was created. On OSS, `log_id` is `None` and `ground_truth_examples` follows the omission rule below.
- **Error localizer stays gated.** `trigger_error_localization_for_playground` attaches to `log=api_call_log_row`, so the dispatch continues to require a non-null log row.

## Response shape (before vs after)

| Build | Before | After |
|---|---|---|
| Full build | `{output=<verdict>, output_type, log_id, ground_truth_examples, reason, model, metadata}` | Same top-level shape. `ground_truth_examples` key now omitted when template has no GT (see below). |
| OSS | `{data, failure, runtime, metrics, start_time, end_time, duration, output=<type>}` | `{output=<verdict>, output_type, log_id=None, reason, model, metadata}` (top-level shape identical to full build) |

## Ground-truth key emission

`_canonical_playground_output` originally coalesced `response["ground_truth_examples"]` to `[]` when the raw value was `None`. `GroundTruthService.resolve_preview_examples` returns `None` when GT is not configured on the template, so the coalesce turned "GT never enabled" into "GT enabled but retrieval empty" and made the FE fire its calibration toast on every playground run.

Fix: pass the raw value through, and pop the key from the response when it is `None`. The Pydantic field on `PlaygroundEvalResponse` is `Optional[list] = None` to accept the pass-through. Net semantics:

| Template GT config | `resolve_preview_examples` returns | Response |
|---|---|---|
| Not configured | `None` | `ground_truth_examples` key omitted |
| Configured, no matches | `[]` | `"ground_truth_examples": []` |
| Configured, matches found | `[row_dict, ...]` | `"ground_truth_examples": [...]` |

FE observable behaviour on the "not configured" path: the calibration toast never fires (no key in payload; falsy check).

## Tests

New file `model_hub/tests/test_eval_playground_response_shape.py` with three cases:

| Case | What it locks |
|---|---|
| `test_response_shape_is_canonical_when_metering_helper_absent` | Simulates the OSS build by monkey-patching the metering entry point to `None`. Asserts the canonical key set, `output` = canonical verdict, `output_type` = type descriptor, `log_id` = `None`, `ground_truth_examples` key absent when template has no GT, and that stale raw-response keys (`data`, `failure`, `runtime`, `metrics`, `start_time`, `end_time`, `duration`) do not leak through. |
| `test_response_shape_is_canonical_when_metering_is_available` | Simulates the full build with a real log row. Same canonical key set, `log_id` populated with the row's `log_id`. |
| `test_response_output_preserves_polymorphic_shapes` | Parametrised over 5 output value shapes (float, str, list, dict-single, dict-multi) to lock the polymorphic `output` field. |

Existing tests in `model_hub/tests/test_composite_wiring_phase_b.py` continue to exercise `run_eval_func` end-to-end.

## Manual verification (FE)

Playground eval on a template with GT not configured: verdict renders as `Passed` / `Failed`, no calibration toast fires.

<img width="1661" height="1068" alt="image" src="https://github.com/user-attachments/assets/7cbdd38e-38aa-4d61-8d62-5d9e3c03b01e" />

## Behavior callouts

- **Top-level response shape identical on full and OSS builds** after this PR. Every response key, every side effect, every `ImportError` guard is preserved on the full-build path (verified by re-running the composite tests, which drive `run_eval_func` end-to-end with a real log row).
- **`log_id` is `None` on OSS.** Any FE code that reads `log_id` must handle a `None` value. The feedback endpoint (`/model-hub/eval-playground/feedback/`) requires a `log_id`, so the feedback affordance in OSS remains a no-op until an APICallLog-equivalent lands. Out of scope here.
- **Ground-truth key emission changed on both builds.** Previously the key was always present (as `null` on full build, as raw runner dict on OSS). Now the key is omitted when GT is not configured on the template. FE-observable behaviour is unchanged (the toast check treats `null` and `undefined` the same).

## Local test run

Ran the two test files against the OSS working tree via `docker exec` into the running backend container (mounts the working tree at `/app/backend/`, optional metering module absent).

```bash
docker exec \
  -e DJANGO_SETTINGS_MODULE=tfc.settings.test \
  -e FI_SKIP_CH25_MIGRATION=1 \
  futureagi-backend-1 sh -lc "cd /app/backend && python -m pytest -v --reuse-db \
    model_hub/tests/test_eval_playground_response_shape.py \
    model_hub/tests/test_composite_wiring_phase_b.py"
```

Result: **33 passed, 2 failed on OSS**. Both failures come from tests that patch or import the metering integration and therefore cannot run in an OSS build:

- `test_response_shape_is_canonical_when_metering_is_available` uses `monkeypatch.setattr` on paths that require the metering module to resolve.
- `TestExecuteCompositeChildrenSync::test_composite_child_billing_uses_token_pricing_when_cost_is_zero` imports the billing config; pre-existing and unrelated to this PR.

The OSS-relevant assertion is `test_response_shape_is_canonical_when_metering_helper_absent`, which passed.

Re-running the same two files from a full build gave the expected green:

```
======================== 35 passed in 176.14s (0:02:56) ========================
```

## Scope

- Backend only. One production file (`model_hub/views/utils/evals.py`) + one new type in `model_hub/types.py` + one new test file.
- No API contract removal.
- No migration.
- No signal handlers affected; the APICallLog write path is unchanged, only re-nested.
- The `token_usage_properties = lambda ...` fallback style at line 399 (Ruff E731) is inherited from the pre-existing billing block; keeping it to hold the change minimal.

Fix TH-6719
