### PR TITLE
feat: add JSONL dataset loader support

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/base_loader.py
@@ -4,14 +4,16 @@ from enum import Enum
 
 import structlog
 
-logger = structlog.get_logger(__name__)
 from agentic_eval.core_evals.fi_utils.evals_result import DataPoint
+
+logger = structlog.get_logger(__name__)
 
 
 class LoadFormat(Enum):
     """Supported load formats."""
 
     JSON = "json"
+    JSONL = "jsonl"
     DICT = "dict"
     FI = "fi"
 
@@ -44,6 +46,8 @@ class BaseLoader(ABC):
         """
         if format == LoadFormat.JSON.value:
             return self.load_json(**kwargs)
+        elif format == LoadFormat.JSONL.value:
+            return self.load_jsonl(**kwargs)
         elif format == LoadFormat.DICT.value:
             return self.load_dict(**kwargs)
         elif format == LoadFormat.FI.value:
@@ -66,6 +70,37 @@ class BaseLoader(ABC):
                 return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.error(f"Error loading JSON: {e}")
+            raise
+
+    def load_jsonl(self, filename: str) -> list[DataPoint]:
+        """
+        Loads and processes data from a JSON Lines file.
+
+        Raises:
+            FileNotFoundError: If the specified JSONL file is not found.
+            json.JSONDecodeError: If a non-blank line is not valid JSON.
+        """
+        try:
+            raw_dataset = []
+            with open(filename) as f:
+                for line_number, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        raw_dataset.append(json.loads(line))
+                    except json.JSONDecodeError as e:
+                        raise json.JSONDecodeError(
+                            f"{e.msg} at JSONL line {line_number}",
+                            e.doc,
+                            e.pos,
+                        ) from e
+
+            self._raw_dataset = raw_dataset
+            self.process()
+            return self._processed_dataset  # type: ignore[attr-defined,no-any-return]
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.error(f"Error loading JSONL: {e}")
             raise
 
     def load_dict(self, data: list) -> list[DataPoint]:

--- a/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader.py
+++ b/futureagi/agentic_eval/core_evals/fi_loaders/tests/test_base_loader.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from agentic_eval.core_evals.fi_loaders.base_loader import BaseLoader, LoadFormat
+from agentic_eval.core_evals.fi_loaders.loader import Loader
+
+
+class DummyLoader(BaseLoader):
+    def __init__(self):
+        self._raw_dataset = []
+        self._processed_dataset = []
+
+    def process(self):
+        self._processed_dataset = [
+            {"processed": item} for item in self._raw_dataset
+        ]
+        return self._processed_dataset
+
+    def load_fi_inferences(self, data: dict):
+        raise NotImplementedError
+
+
+def test_load_jsonl_parses_records_and_skips_blank_lines(tmp_path):
+    path = tmp_path / "dataset.jsonl"
+    path.write_text(
+        '{"query": "q1", "response": "r1"}\n'
+        "\n"
+        '{"query": "q2", "response": "r2"}\n',
+        encoding="utf-8",
+    )
+    loader = DummyLoader()
+
+    result = loader.load(LoadFormat.JSONL.value, filename=str(path))
+
+    assert loader.raw_dataset == [
+        {"query": "q1", "response": "r1"},
+        {"query": "q2", "response": "r2"},
+    ]
+    assert result == [
+        {"processed": {"query": "q1", "response": "r1"}},
+        {"processed": {"query": "q2", "response": "r2"}},
+    ]
+
+
+def test_load_jsonl_reports_invalid_line_number(tmp_path):
+    path = tmp_path / "dataset.jsonl"
+    path.write_text(
+        '{"query": "q1", "response": "r1"}\n'
+        "{not-json}\n",
+        encoding="utf-8",
+    )
+    loader = DummyLoader()
+
+    with pytest.raises(json.JSONDecodeError, match="JSONL line 2"):
+        loader.load_jsonl(str(path))
+
+
+def test_load_jsonl_works_with_generic_loader(tmp_path):
+    path = tmp_path / "dataset.jsonl"
+    path.write_text(
+        (
+            '{"query": "What is Python?", '
+            '"context": ["Python is a programming language."], '
+            '"response": "Python is a programming language."}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    result = Loader().load(LoadFormat.JSONL.value, filename=str(path))
+
+    assert result == [
+        {
+            "query": "What is Python?",
+            "context": ["Python is a programming language."],
+            "response": "Python is a programming language.",
+            "expected_response": None,
+        }
+    ]


### PR DESCRIPTION
﻿## Summary

- Add `jsonl` as a supported dataset load format.
- Parse JSON Lines into the existing raw dataset list shape, skipping blank lines and reporting invalid line numbers.
- Add loader tests for JSONL dispatch, invalid-line errors, and the generic loader path.

Fixes #1095

## Tests

- `uv run ruff check agentic_eval\core_evals\fi_loaders\base_loader.py agentic_eval\core_evals\fi_loaders\tests\test_base_loader.py`
- `uv run pytest agentic_eval\core_evals\fi_loaders\tests\test_base_loader.py`
