### PR TITLE
fix(frontend): correct yesterday date range

### DIFF
--- a/frontend/src/sections/model/journey/__tests__/insights-date-selector.test.jsx
+++ b/frontend/src/sections/model/journey/__tests__/insights-date-selector.test.jsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getDateRange } from "../insights-date-selector";
+
+const formatDate = (date) => date.toISOString().split("T")[0];
+
+const expectedYesterdayRange = (reference) => {
+  const yesterday = new Date(reference);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const date = formatDate(yesterday);
+
+  return `${date}:${date}`;
+};
+
+describe("getDateRange", () => {
+  it("uses yesterday for both date boundaries", () => {
+    const reference = new Date(2026, 5, 15, 12);
+
+    expect(getDateRange("yesterday", reference)).toBe(
+      expectedYesterdayRange(reference),
+    );
+  });
+
+  it("handles yesterday across a month boundary", () => {
+    const reference = new Date(2024, 2, 1, 12);
+
+    expect(getDateRange("yesterday", reference)).toBe(
+      expectedYesterdayRange(reference),
+    );
+  });
+
+  it("handles yesterday across a year boundary", () => {
+    const reference = new Date(2026, 0, 1, 12);
+
+    expect(getDateRange("yesterday", reference)).toBe(
+      expectedYesterdayRange(reference),
+    );
+  });
+
+  it("does not mutate the reference date", () => {
+    const reference = new Date(2026, 5, 15, 12);
+    const originalTime = reference.getTime();
+
+    getDateRange("yesterday", reference);
+
+    expect(reference.getTime()).toBe(originalTime);
+  });
+});

--- a/frontend/src/sections/model/journey/insights-date-selector.jsx
+++ b/frontend/src/sections/model/journey/insights-date-selector.jsx
@@ -10,16 +10,17 @@ const formatDate = (date) => {
   return date.toISOString().split("T")[0]; // Format as 'YYYY-MM-DD'
 };
 
-export function getDateRange(range) {
-  const toDate = new Date(); // 'to' date is today
-  const fromDate = new Date(); // Start with today for 'from' date
+export function getDateRange(range, reference = new Date()) {
+  const toDate = new Date(reference); // 'to' date is today
+  const fromDate = new Date(reference); // Start with today for 'from' date
 
   switch (range) {
     case "today":
       // 1 day means today, so 'from' date is the same as 'to' date
       break;
     case "yesterday":
-      fromDate.setDate(toDate.getDate() - 1);
+      fromDate.setDate(fromDate.getDate() - 1);
+      toDate.setDate(toDate.getDate() - 1);
       break;
     case "7d":
       fromDate.setDate(toDate.getDate() - 6); // Subtract 6 days (7 days including today)


### PR DESCRIPTION
## Summary

The model insights date selector previously returned a range from yesterday through today when the user selected **Yesterday**. This PR makes both date boundaries resolve to the previous day and adds deterministic regression coverage for normal and boundary dates.

## Linked issues

Closes #1483

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Correct the Yesterday preset**

- Move both `fromDate` and `toDate` back by one calendar day.
- Keep the existing `YYYY-MM-DD:YYYY-MM-DD` response format unchanged.
- Allow a reference date to be injected so date-boundary behavior can be tested deterministically.

**B. Add regression coverage**

- Cover a regular date.
- Cover month and year boundaries.
- Verify that the injected reference date is not mutated.

---

## 2) Why the changes were done

- **Product/UX:** Selecting Yesterday should query only the previous calendar day, not a two-day range ending today.
- **Technical:** Cloning an optional reference date keeps production behavior unchanged while making boundary tests deterministic.

---

## 3) Tests written + scenarios each covers

**`src/sections/model/journey/__tests__/insights-date-selector.test.jsx`** — date range regression coverage

- `uses yesterday for both date boundaries` — verifies both endpoints use the previous day.
- `handles yesterday across a month boundary` — verifies March 1 rolls back into February.
- `handles yesterday across a year boundary` — verifies January 1 rolls back into the prior year.
- `does not mutate the reference date` — verifies helper input immutability.

> Targeted result: **4 passed**. ESLint and Prettier checks for both changed files are clean.

---

## 4) How to run / test

```bash
cd frontend
npx --yes -p node@22.18.0 -p yarn@1.22.22 yarn test:run src/sections/model/journey/__tests__/insights-date-selector.test.jsx
```

Full frontend suite on Node 22: **2319 passed, 1 timed out**. The unrelated timeout was:

```text
AnnotationComparisonPanel > keeps request actions reachable when targeted feedback drafts grow
```

The timed-out test passed when rerun in isolation: **1 passed, 111 skipped**.

### UI steps

1. Open the model insights graph.
2. Select **Yesterday** in the date filter.
3. Verify the request date range has the same previous-day value for both boundaries.

---

## 5) Screenshots / recordings

Not included because this change only corrects the date-range value passed by an existing control and does not alter rendered UI.

---

## 6) Edge cases & considerations

- Month boundary: handled through native calendar date rollover.
- Year boundary: handled through native calendar date rollover.
- Input mutation: avoided by cloning the reference date for both boundaries.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The full test run can time out on the annotation targeted-feedback test under concurrent suite load; the same test passes in isolation in 5.2 seconds.
- The repository currently reports 409 ESLint warnings and 0 errors; neither changed file adds a warning.

---

## 8) Architectural / important decisions

- Kept the fix in the existing helper to avoid a broader date-filter refactor.
- Added only an optional reference argument for deterministic testing; existing callers require no changes.

---

## Checklist

- [x] My code follows the style guide
- [x] I have added tests that prove the fix is effective
- [ ] `yarn test:run` passes locally (one unrelated concurrent-suite timeout; isolated rerun passes)
- [x] Contracts are unchanged
- [x] No hardcoded secrets, URLs, or PII
- [ ] I have signed the CLA (pending first-PR bot prompt)
- [x] PR title follows Conventional Commits
