### PR TITLE
feat(annotations): CH-native reads for tracer sources (supersedes #1214)

### DIFF
--- a/futureagi/ai_tools/tools/tracing/analyze_project_traces.py
+++ b/futureagi/ai_tools/tools/tracing/analyze_project_traces.py
@@ -8,7 +8,6 @@ same as the old beat task did. Results appear on the feed once clustering comple
 The tool returns immediately — analysis runs in the background via Temporal.
 """
 
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -57,8 +56,9 @@ class AnalyzeProjectTracesTool(BaseTool):
         import structlog
 
         from tracer.models.project import Project
-        from tracer.models.trace import Trace, TraceErrorAnalysisStatus
         from tracer.models.trace_error_analysis import TraceErrorAnalysis
+        from tracer.queries import deep_analysis_state
+        from tracer.services.clickhouse.v2 import get_reader
 
         logger = structlog.get_logger(__name__)
 
@@ -71,37 +71,39 @@ class AnalyzeProjectTracesTool(BaseTool):
         except Project.DoesNotExist:
             return ToolResult.not_found("Project", str(params.project_id))
 
-        # Determine which traces to analyze
+        # Determine which traces to analyze. Traces live only in CH post-cutover,
+        # so listing/validating goes through the CH root spans.
         if params.trace_ids and len(params.trace_ids) > 0:
-            # Specific traces requested — validate they exist
-            traces = list(
-                Trace.objects.filter(
-                    id__in=params.trace_ids,
-                    project=project,
-                ).values_list("id", flat=True)
-            )
-            if not traces:
+            # Specific traces requested — validate they exist in this project.
+            with get_reader() as reader:
+                found = reader.root_ids_by_trace_ids(
+                    [str(t) for t in params.trace_ids], project_ids=[str(project.id)]
+                )
+            trace_ids = list(found.keys())
+            if not trace_ids:
                 return ToolResult.error(
                     "None of the specified trace IDs were found in this project."
                 )
-            trace_ids = [str(t) for t in traces]
         else:
-            # Find un-analyzed traces in the project
-            already_analyzed = set(
-                TraceErrorAnalysis.objects.filter(project=project).values_list(
+            # Find un-analyzed traces in the project (analyzed set is feed-owned).
+            already_analyzed = {
+                str(t)
+                for t in TraceErrorAnalysis.objects.filter(project=project).values_list(
                     "trace_id", flat=True
                 )
-            )
-            all_trace_ids = list(
-                Trace.objects.filter(project=project)
-                .order_by("-created_at")
-                .values_list("id", flat=True)[: params.max_traces]
-            )
-            trace_ids = [str(t) for t in all_trace_ids if t not in already_analyzed]
+            }
+            with get_reader() as reader:
+                all_trace_ids = reader.recent_root_trace_ids_by_project(
+                    str(project.id), limit=params.max_traces
+                )
+            trace_ids = [t for t in all_trace_ids if t not in already_analyzed]
 
             if not trace_ids:
                 # All traces already analyzed — offer to re-analyze
-                total = Trace.objects.filter(project=project).count()
+                with get_reader() as reader:
+                    total = reader.count_with_filters(
+                        project_id=str(project.id), roots_only=True
+                    )
                 analyzed = len(already_analyzed)
                 return ToolResult(
                     content=section(
@@ -117,10 +119,9 @@ class AnalyzeProjectTracesTool(BaseTool):
                     },
                 )
 
-        # Mark traces as processing
-        Trace.objects.filter(id__in=trace_ids).update(
-            error_analysis_status=TraceErrorAnalysisStatus.PROCESSING
-        )
+        # Mark traces as running so the feed reflects in-flight analysis.
+        for tid in trace_ids:
+            deep_analysis_state.set_running(str(tid))
 
         # Dispatch via Temporal in batches of 10 (same as old beat task)
         try:

--- a/futureagi/ai_tools/tools/tracing/submit_trace_scores.py
+++ b/futureagi/ai_tools/tools/tracing/submit_trace_scores.py
@@ -82,8 +82,10 @@ class SubmitTraceScoresTool(BaseTool):
     def execute(
         self, params: SubmitTraceScoresInput, context: ToolContext
     ) -> ToolResult:
-        from tracer.models.trace import Trace, TraceErrorAnalysisStatus
+        from tracer.models.project import Project
         from tracer.models.trace_error_analysis import TraceErrorAnalysis
+        from tracer.queries import deep_analysis_state
+        from tracer.services.clickhouse.v2 import get_reader
 
         # Validate priority
         priority = params.recommended_priority.upper()
@@ -93,13 +95,21 @@ class SubmitTraceScoresTool(BaseTool):
                 "Must be HIGH, MEDIUM, or LOW."
             )
 
-        # Verify trace access
-        try:
-            trace = Trace.objects.select_related("project").get(
-                id=params.trace_id,
-                project__organization=context.organization,
-            )
-        except Trace.DoesNotExist:
+        # Verify trace access. The trace lives only in CH post-cutover; resolve
+        # its project from the CH root span and check org access via the PG
+        # Project (kept).
+        with get_reader() as reader:
+            roots = reader.root_ids_by_trace_ids([str(params.trace_id)])
+        root = roots.get(str(params.trace_id))
+        project_id = root[1] if root else None
+        project = (
+            Project.objects.filter(
+                id=project_id, organization=context.organization
+            ).first()
+            if project_id
+            else None
+        )
+        if project is None:
             return ToolResult.not_found("Trace", str(params.trace_id))
 
         # Find the analysis record
@@ -108,7 +118,7 @@ class SubmitTraceScoresTool(BaseTool):
             try:
                 analysis = TraceErrorAnalysis.objects.get(
                     id=params.analysis_id,
-                    trace=trace,
+                    trace_id=params.trace_id,
                 )
             except TraceErrorAnalysis.DoesNotExist:
                 analysis = None
@@ -116,7 +126,7 @@ class SubmitTraceScoresTool(BaseTool):
         # Fallback: get the most recent analysis for this trace
         if analysis is None:
             analysis = (
-                TraceErrorAnalysis.objects.filter(trace=trace)
+                TraceErrorAnalysis.objects.filter(trace_id=params.trace_id)
                 .order_by("-analysis_date")
                 .first()
             )
@@ -124,8 +134,8 @@ class SubmitTraceScoresTool(BaseTool):
         # If still no analysis, create one (scores-only, no findings)
         if analysis is None:
             analysis = TraceErrorAnalysis.objects.create(
-                trace=trace,
-                project=trace.project,
+                trace_id=params.trace_id,
+                project=project,
                 overall_score=params.overall_score,
                 total_errors=0,
                 recommended_priority=priority,
@@ -161,9 +171,8 @@ class SubmitTraceScoresTool(BaseTool):
             ]
         )
 
-        # Mark trace analysis as completed
-        trace.error_analysis_status = TraceErrorAnalysisStatus.COMPLETED
-        trace.save(update_fields=["error_analysis_status"])
+        # Done derives from the TraceErrorAnalysis row above; release the marker.
+        deep_analysis_state.clear(str(params.trace_id))
 
         # Trigger embedding ingestion for this trace's errors
         try:
@@ -182,11 +191,11 @@ class SubmitTraceScoresTool(BaseTool):
         try:
             from tracer.tasks.error_analysis import cluster_project_errors
 
-            cluster_project_errors.delay(str(trace.project_id))
+            cluster_project_errors.delay(str(project.id))
         except Exception as e:
             logger.warning(
                 "clustering_trigger_failed",
-                project_id=str(trace.project_id),
+                project_id=str(project.id),
                 error=str(e),
             )
 

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -582,7 +582,6 @@ class QueueItemSerializer(serializers.ModelSerializer):
                     source_id,
                     organization=organization,
                     workspace=workspace,
-                    allow_ch_fallback=True,
                 )
                 if source_obj:
                     # Store the soft id, not the FK object: a CH-resolved source

--- a/futureagi/model_hub/tests/test_annotation_e2e_gaps.py
+++ b/futureagi/model_hub/tests/test_annotation_e2e_gaps.py
@@ -27,12 +27,11 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from conftest import create_categorical_label
-
 from accounts.models.organization import Organization
 from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.user import User
 from accounts.models.workspace import Workspace, WorkspaceMembership
+from conftest import create_categorical_label
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
     AnnotationQueueAnnotator,
@@ -53,7 +52,6 @@ from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 from tfc.middleware.workspace_context import set_workspace_context
 from tracer.models.project import Project
-
 
 SCORE_URL = "/model-hub/scores/"
 LABEL_URL = "/model-hub/annotations-labels/"
@@ -807,6 +805,7 @@ class TestSubmitNextItemRoundTrip:
         )
         from tracer.models.observation_span import ObservationSpan
         from tracer.models.trace import Trace
+        from tracer.tests._ch_seed import seed_ch_span
 
         # Two spans on the same project so we can have two queue items
         traces = [
@@ -839,6 +838,9 @@ class TestSubmitNextItemRoundTrip:
             )
             for i in range(2)
         ]
+        # Tracer sources resolve CH-native — mirror the spans into ClickHouse.
+        for _span in spans:
+            seed_ch_span(_span)
 
         # Active queue with one required label and the user as annotator
         queue = AnnotationQueue.objects.create(
@@ -1174,6 +1176,7 @@ def observation_span_factory(db, project, organization, workspace):
     """Factory fixture so tests can mint multiple spans on demand."""
     from tracer.models.observation_span import ObservationSpan
     from tracer.models.trace import Trace
+    from tracer.tests._ch_seed import seed_ch_span
 
     def _make():
         trace = Trace.objects.create(
@@ -1183,7 +1186,7 @@ def observation_span_factory(db, project, organization, workspace):
             output={},
         )
         span_id = f"span_{uuid.uuid4().hex[:16]}"
-        return ObservationSpan.objects.create(
+        span = ObservationSpan.objects.create(
             id=span_id,
             project=project,
             trace=trace,
@@ -1201,6 +1204,9 @@ def observation_span_factory(db, project, organization, workspace):
             latency_ms=10,
             status="OK",
         )
+        # Tracer sources resolve CH-native — mirror the span into ClickHouse.
+        seed_ch_span(span)
+        return span
 
     return _make
 

--- a/futureagi/model_hub/tests/test_annotation_submit_e2e.py
+++ b/futureagi/model_hub/tests/test_annotation_submit_e2e.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -8,7 +9,6 @@ from rest_framework import status
 
 # These tests verify that queue annotation submission correctly creates Score
 # records, adds queue annotators, manages reservations, and validates permissions.
-
 from accounts.models import User
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
@@ -76,12 +76,28 @@ def _create_trace_project(organization, workspace, name="Annotation E2E Project"
 
 
 def _create_trace(project, name="Annotation E2E Trace"):
-    return Trace.objects.create(
+    from tracer.models.observation_span import ObservationSpan
+    from tracer.tests._ch_seed import seed_ch_span
+
+    trace = Trace.objects.create(
         project=project,
         name=name,
         input={"prompt": "hello"},
         output={"response": "world"},
     )
+    # Tracer sources resolve CH-native — seed a CH-only root span (never PG).
+    root = ObservationSpan(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(root)  # CH only — NOT ObservationSpan.objects.create
+    return trace
 
 
 def _create_trace_queue(

--- a/futureagi/model_hub/tests/test_bulk_add_items_filter.py
+++ b/futureagi/model_hub/tests/test_bulk_add_items_filter.py
@@ -21,10 +21,30 @@ from tracer.models.observation_span import ObservationSpan
 from tracer.models.project import Project, ProjectSourceChoices
 from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
+from tracer.tests._ch_seed import seed_ch_span
 
 # --------------------------------------------------------------------------
 # Fixtures
 # --------------------------------------------------------------------------
+
+
+def _seed_ch_trace_root(trace):
+    """Give a bare PG ``trace`` a CH-only root span so the enumerated add path
+    resolves it CH-native (tracer sources are read from ClickHouse only). Built in
+    memory and seeded to CH — never written to PG (the tracer tables are dropped)."""
+    import uuid
+
+    span = ObservationSpan(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=trace.project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(span)  # CH only — NOT ObservationSpan.objects.create
 
 
 @pytest.fixture
@@ -71,6 +91,7 @@ def _api_filter(column_id, filter_type, filter_op, filter_value):
 class TestAddItemsEnumeratedRegression:
     def test_enumerated_happy_path(self, auth_client, active_queue, observe_project):
         t = Trace.objects.create(project=observe_project, name="t1")
+        _seed_ch_trace_root(t)
         resp = auth_client.post(
             _add_items_url(active_queue.id),
             {"items": [{"source_type": "trace", "source_id": str(t.id)}]},
@@ -86,6 +107,7 @@ class TestAddItemsEnumeratedRegression:
         self, auth_client, active_queue, observe_project
     ):
         t = Trace.objects.create(project=observe_project, name="t-dup")
+        _seed_ch_trace_root(t)
         payload = {"items": [{"source_type": "trace", "source_id": str(t.id)}]}
         auth_client.post(_add_items_url(active_queue.id), payload, format="json")
         resp = auth_client.post(_add_items_url(active_queue.id), payload, format="json")
@@ -187,6 +209,8 @@ class TestAddItemsFilterMode:
             Trace.objects.create(project=observe_project, name=f"t-{i}")
             for i in range(3)
         ]
+        for _t in traces:
+            _seed_ch_trace_root(_t)
         # Pre-add one via the enumerated path.
         auth_client.post(
             _add_items_url(active_queue.id),
@@ -525,18 +549,18 @@ class TestAddItemsFilterModeSpan:
         now = timezone.now()
         spans = []
         for i in range(3):
-            spans.append(
-                ObservationSpan.objects.create(
-                    id=f"spd-{i}-{span_parent_trace.id.hex[:6]}",
-                    project=observe_project,
-                    trace=span_parent_trace,
-                    name=f"spd-{i}",
-                    observation_type="llm",
-                    start_time=now - timedelta(minutes=i),
-                    end_time=now - timedelta(minutes=i) + timedelta(seconds=1),
-                    parent_span_id=None,
-                )
+            span = ObservationSpan.objects.create(
+                id=f"spd-{i}-{span_parent_trace.id.hex[:6]}",
+                project=observe_project,
+                trace=span_parent_trace,
+                name=f"spd-{i}",
+                observation_type="llm",
+                start_time=now - timedelta(minutes=i),
+                end_time=now - timedelta(minutes=i) + timedelta(seconds=1),
+                parent_span_id=None,
             )
+            seed_ch_span(span)
+            spans.append(span)
         # Pre-add one via enumerated path
         auth_client.post(
             _add_items_url(active_queue.id),

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -154,6 +154,18 @@ class _ReaderCM:
             return []
         return [self._span] if str(self._span.trace_id) == str(trace_id) else []
 
+    def roots_by_trace_ids(
+        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None
+    ):
+        # Mirror the real reader: parentless spans for the given traces.
+        if self._span is None or getattr(self._span, "parent_span_id", None):
+            return []
+        return (
+            [self._span]
+            if str(self._span.trace_id) in {str(t) for t in trace_ids}
+            else []
+        )
+
 
 # ─────────────────────────── observation_span: resolve ───────────────────────
 

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -171,7 +171,6 @@ def test_collector_span_resolves_via_ch(organization, workspace):
             span.id,
             organization=organization,
             workspace=workspace,
-            allow_ch_fallback=True,
         )
     assert resolved is span
     assert resolved.id == span.id
@@ -192,7 +191,6 @@ def test_collector_span_cross_org_denied(organization, workspace, django_user_mo
             QueueItemSourceType.OBSERVATION_SPAN.value,
             span.id,
             organization=organization,  # requesting org != other_org
-            allow_ch_fallback=True,
         )
     assert resolved is None
 
@@ -238,7 +236,6 @@ def test_collector_span_org_omitted_denied():
             QueueItemSourceType.OBSERVATION_SPAN.value,
             span.id,
             # org AND workspace deliberately omitted — mirrors the serializer hole
-            allow_ch_fallback=True,
         )
     assert resolved is None
 
@@ -254,7 +251,6 @@ def test_collector_span_empty_project_id_denied(organization):
             QueueItemSourceType.OBSERVATION_SPAN.value,
             span.id,
             organization=organization,
-            allow_ch_fallback=True,
         )
     assert resolved is None
 
@@ -267,74 +263,8 @@ def test_span_absent_in_both_pg_and_ch_returns_none(organization):
             QueueItemSourceType.OBSERVATION_SPAN.value,
             f"missing-{uuid.uuid4().hex}",
             organization=organization,
-            allow_ch_fallback=True,
         )
     assert resolved is None
-
-
-@pytest.mark.django_db
-def test_pg_span_resolves_without_touching_ch(organization, workspace):
-    """Regression guard: an existing PG ObservationSpan still resolves via the PG
-    branch and the CH reader is NOT called (PG-first)."""
-    project = _make_project(organization=organization, workspace=workspace)
-    from tracer.models.trace import Trace
-
-    trace = Trace.objects.create(project=project, name="pg-trace")
-    pg_span = ObservationSpan.objects.create(
-        id=f"pg-span-{uuid.uuid4().hex[:12]}",
-        project=project,
-        trace=trace,
-        parent_span_id=None,
-        name="pg span",
-        observation_type="agent",
-        start_time=datetime.now(tz=UTC),
-        status="OK",
-    )
-
-    with mock.patch(CH_READER_PATH) as get_reader:
-        resolved = helpers.resolve_source_object(
-            QueueItemSourceType.OBSERVATION_SPAN.value,
-            pg_span.id,
-            organization=organization,
-            workspace=workspace,
-            allow_ch_fallback=True,  # even WITH fallback allowed, PG wins
-        )
-    assert resolved.id == pg_span.id
-    get_reader.assert_not_called()
-
-
-# ───────────────── opt-in CH fallback: out-of-scope callers stay PG-only ──────
-
-
-@pytest.mark.django_db
-def test_ch_fallback_is_opt_in(organization, workspace):
-    """``resolve_source_object`` must NOT return a CH object by default: callers
-    that dereference ``.pk`` / FK relations (scores, span-notes — out of scope)
-    keep the PG-only behavior, so my change can't turn their graceful not-found
-    into a crash. Only ``allow_ch_fallback=True`` reaches CH."""
-    project = _make_project(organization=organization, workspace=workspace)
-    span = _make_chspan(project_id=project.id)
-
-    with mock.patch(CH_READER_PATH, return_value=_ReaderCM(span)) as get_reader:
-        # default (out-of-scope callers): PG-only → None, CH never queried.
-        resolved_default = helpers.resolve_source_object(
-            QueueItemSourceType.OBSERVATION_SPAN.value,
-            span.id,
-            organization=organization,
-            workspace=workspace,
-        )
-        assert resolved_default is None
-        get_reader.assert_not_called()
-
-        # opt-in (in-scope add paths): CH fallback fires.
-        resolved_optin = helpers.resolve_source_object(
-            QueueItemSourceType.OBSERVATION_SPAN.value,
-            span.id,
-            organization=organization,
-            workspace=workspace,
-            allow_ch_fallback=True,
-        )
-        assert resolved_optin is span
 
 
 # ─────────────────────── observation_span: serializer store ──────────────────
@@ -594,7 +524,6 @@ def test_collector_session_resolves_via_ch(organization, workspace):
             session_id,
             organization=organization,
             workspace=workspace,
-            allow_ch_fallback=True,
         )
     assert resolved is not None
     assert str(resolved.id) == session_id
@@ -625,7 +554,6 @@ def test_collector_session_cross_project_denied(organization, workspace):
             QueueItemSourceType.TRACE_SESSION.value,
             session_id,
             organization=organization,
-            allow_ch_fallback=True,
         )
     assert resolved is None
 
@@ -943,7 +871,6 @@ def test_collector_trace_resolves_via_ch(organization, workspace):
             trace_id,
             organization=organization,
             workspace=workspace,
-            allow_ch_fallback=True,
         )
     assert resolved is not None
     assert str(resolved.id) == trace_id
@@ -966,7 +893,6 @@ def test_collector_trace_cross_org_denied(organization, workspace):
             QueueItemSourceType.TRACE.value,
             trace_id,
             organization=organization,  # requesting org != other_org
-            allow_ch_fallback=True,
         )
     assert resolved is None
 
@@ -979,7 +905,6 @@ def test_collector_trace_absent_returns_none(organization):
             QueueItemSourceType.TRACE.value,
             str(uuid.uuid4()),
             organization=organization,
-            allow_ch_fallback=True,
         )
     assert resolved is None
 

--- a/futureagi/model_hub/tests/test_per_queue_scoring_e2e.py
+++ b/futureagi/model_hub/tests/test_per_queue_scoring_e2e.py
@@ -43,6 +43,7 @@ from model_hub.models.choices import (
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.score import Score
+from tracer.tests._ch_seed import seed_ch_span
 
 # Reuse the fixtures from test_scores_api.py via pytest's collection. They
 # live in the same package so importing here would create a circular
@@ -50,6 +51,29 @@ from model_hub.models.score import Score
 
 SCORE_URL = "/model-hub/scores/"
 QUEUE_URL = "/model-hub/annotation-queues/"
+
+
+def _seed_ch_trace_root(trace):
+    """Give a bare PG ``trace`` a CH-only root span so it resolves CH-native (tracer
+    sources are read from ClickHouse only). Built in memory and seeded to CH — never
+    written to PG (the tracer tables are dropped in prod)."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from tracer.models.observation_span import ObservationSpan
+
+    span = ObservationSpan(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=trace.project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(span)  # CH only — NOT ObservationSpan.objects.create
 
 
 # ---------------------------------------------------------------------------
@@ -76,12 +100,15 @@ def observe_project(db, organization, workspace):
 def trace(db, observe_project):
     from tracer.models.trace import Trace
 
-    return Trace.objects.create(
+    trace = Trace.objects.create(
         project=observe_project,
         name="Test Trace",
         input={"prompt": "hello"},
         output={"response": "world"},
     )
+    # Tracer sources resolve CH-native — a trace resolves via its CH root span.
+    _seed_ch_trace_root(trace)
+    return trace
 
 
 @pytest.fixture
@@ -103,7 +130,7 @@ def observation_span(db, observe_project, trace):
     from tracer.models.observation_span import ObservationSpan
 
     span_id = f"span_{uuid.uuid4().hex[:16]}"
-    return ObservationSpan.objects.create(
+    span = ObservationSpan.objects.create(
         id=span_id,
         project=observe_project,
         trace=trace,
@@ -116,6 +143,8 @@ def observation_span(db, observe_project, trace):
         model="gpt-4",
         status="OK",
     )
+    seed_ch_span(span)
+    return span
 
 
 @pytest.fixture

--- a/futureagi/model_hub/tests/test_phase6_e2e.py
+++ b/futureagi/model_hub/tests/test_phase6_e2e.py
@@ -35,9 +35,30 @@ from model_hub.models.choices import (
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.score import Score
+from tracer.tests._ch_seed import seed_ch_span
 
 SCORE_URL = "/model-hub/scores/"
 QUEUE_URL = "/model-hub/annotation-queues/"
+
+
+def _seed_ch_trace_root(trace):
+    """Give a bare PG ``trace`` a CH-only root span so it resolves CH-native (tracer
+    sources are read from ClickHouse only). The span is built in memory and seeded
+    to CH — never written to PG (the tracer tables are dropped in prod). Used by
+    trace-only tests that don't also create an ``observation_span``."""
+    from tracer.models.observation_span import ObservationSpan
+
+    span = ObservationSpan(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=trace.project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(span)  # CH only — NOT ObservationSpan.objects.create
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +109,7 @@ def observation_span(db, observe_project, trace):
     from tracer.models.observation_span import ObservationSpan
 
     span_id = f"e2e_span_{uuid.uuid4().hex[:12]}"
-    return ObservationSpan.objects.create(
+    span = ObservationSpan.objects.create(
         id=span_id,
         project=observe_project,
         trace=trace,
@@ -106,6 +127,9 @@ def observation_span(db, observe_project, trace):
         latency_ms=500,
         status="OK",
     )
+    # Tracer sources resolve CH-native — mirror this root span into ClickHouse.
+    seed_ch_span(span)
+    return span
 
 
 @pytest.fixture
@@ -249,6 +273,7 @@ class TestCrossSourceVisibility:
         self, auth_client, trace, thumbs_label
     ):
         """Score on trace is visible via for-source?source_type=trace."""
+        _seed_ch_trace_root(trace)
         auth_client.post(
             SCORE_URL,
             {

--- a/futureagi/model_hub/tests/test_queue_items_api.py
+++ b/futureagi/model_hub/tests/test_queue_items_api.py
@@ -16,7 +16,6 @@ from django.utils import timezone
 from rest_framework import status
 
 from conftest import create_categorical_label
-
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
     AnnotationQueueAnnotator,
@@ -120,6 +119,7 @@ class TestAddItems:
         from model_hub.models.ai_model import AIModel
         from tracer.models.project import Project
         from tracer.models.trace_session import TraceSession
+        from tracer.tests._ch_seed import seed_ch_trace_sessions
 
         project = Project.objects.create(
             name=f"Session Add Project {uuid.uuid4().hex[:8]}",
@@ -132,6 +132,8 @@ class TestAddItems:
             project=project,
             name="queue-session-source",
         )
+        # Tracer sources resolve CH-native — mirror the session into ClickHouse.
+        seed_ch_trace_sessions([session])
 
         resp = auth_client.post(
             add_items_url(queue),

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -1472,6 +1472,12 @@ class TestScoreOnCollectorOnlySpan:
         )
 
         class _R:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
             def get(self, sid):
                 return fake if str(sid) == ch_span_id else None
 
@@ -1493,6 +1499,12 @@ class TestScoreOnCollectorOnlySpan:
         )
 
         class _R:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
             def get(self, sid):
                 return fake if str(sid) == ch_span_id else None
 
@@ -1501,21 +1513,31 @@ class TestScoreOnCollectorOnlySpan:
 
         monkeypatch.setattr("tracer.services.clickhouse.v2.get_reader", lambda: _R())
 
-    @pytest.mark.parametrize("foreign_org", ["", str(uuid.uuid4())])
     def test_ch_only_span_denied_cross_org(
         self,
         auth_client,
-        observe_project,
         trace,
         organization,
         star_label,
         monkeypatch,
-        foreign_org,
     ):
-        """CH span with empty/foreign org_id must 404 (the org-scope guard failed OPEN on empty org)."""
+        """A CH span whose PROJECT belongs to another org must 404. The project is
+        the tenant boundary (``_tenant_scoped_project``) — a span is cross-org iff
+        its project is, so seed the span under a foreign-org project."""
+        from accounts.models.organization import Organization
+        from model_hub.models.ai_model import AIModel
+        from tracer.models.project import Project
+
+        foreign_org = Organization.objects.create(name=f"Foreign {uuid.uuid4().hex[:8]}")
+        foreign_project = Project.objects.create(
+            name="Foreign project",
+            organization=foreign_org,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+        )
         ch_span_id = "ch_" + uuid.uuid4().hex[:16]
         self._fake_reader_with_org(
-            monkeypatch, ch_span_id, observe_project, foreign_org, trace
+            monkeypatch, ch_span_id, foreign_project, str(foreign_org.id), trace
         )
         payload = {
             "source_type": "observation_span",
@@ -1584,6 +1606,7 @@ class TestScoreOnCollectorOnlyTrace:
             trace_id=str(trace_id),
             parent_span_id="",  # root span
             observation_type="agent",
+            status="OK",  # terminal → not "in progress"
         )
 
         class _R:
@@ -1595,6 +1618,11 @@ class TestScoreOnCollectorOnlyTrace:
 
             def list_by_trace(self_inner, tid, *, project_id=None):
                 return [root_span] if str(tid) == str(trace_id) else []
+
+            def roots_by_trace_ids(
+                self_inner, tids, *, include_heavy=False, project_id=None, org_id=None
+            ):
+                return [root_span] if str(trace_id) in {str(t) for t in tids} else []
 
             def close(self_inner):
                 pass

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -59,6 +59,9 @@ def observe_project(db, organization, workspace):
 def trace(db, observe_project):
     from tracer.models.trace import Trace
 
+    # CH-native note: a trace resolves from its CH root span, so tests that annotate
+    # a *bare* trace seed one (via ``observation_span`` or ``seed_ch_span``); this
+    # fixture stays PG-only so it never adds a competing root to another test's span.
     return Trace.objects.create(
         project=observe_project,
         name="Test Trace",
@@ -70,11 +73,15 @@ def trace(db, observe_project):
 @pytest.fixture
 def trace_session(db, observe_project):
     from tracer.models.trace_session import TraceSession
+    from tracer.tests._ch_seed import seed_ch_trace_sessions
 
-    return TraceSession.objects.create(
+    session = TraceSession.objects.create(
         project=observe_project,
         name="Test Session",
     )
+    # CH-native: session resolution reads the CH ``trace_sessions`` table.
+    seed_ch_trace_sessions([session])
+    return session
 
 
 @pytest.fixture
@@ -84,9 +91,10 @@ def observation_span(db, observe_project, trace):
     from django.utils import timezone
 
     from tracer.models.observation_span import ObservationSpan
+    from tracer.tests._ch_seed import seed_ch_span
 
     span_id = f"span_{uuid.uuid4().hex[:16]}"
-    return ObservationSpan.objects.create(
+    span = ObservationSpan.objects.create(
         id=span_id,
         project=observe_project,
         trace=trace,
@@ -104,6 +112,32 @@ def observation_span(db, observe_project, trace):
         latency_ms=500,
         status="OK",
     )
+    # CH-native: annotation resolves the span from ClickHouse — seed it there.
+    seed_ch_span(span)
+    return span
+
+
+def _seed_ch_trace_root(trace):
+    """Seed a CH root span so a *bare* trace resolves under CH-native annotation
+    (trace resolution reads the trace's root span from CH, not the PG row)."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from tracer.models.observation_span import ObservationSpan
+    from tracer.tests._ch_seed import seed_ch_span
+
+    span = ObservationSpan.objects.create(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=trace.project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(span)
 
 
 @pytest.fixture
@@ -232,6 +266,7 @@ class TestCreateScore:
 
     def test_create_score_on_trace(self, auth_client, trace, thumbs_label):
         """Create a score on a trace."""
+        _seed_ch_trace_root(trace)
         payload = {
             "source_type": "trace",
             "source_id": str(trace.id),

--- a/futureagi/model_hub/tests/test_team_a_annotations_full_matrix.py
+++ b/futureagi/model_hub/tests/test_team_a_annotations_full_matrix.py
@@ -241,12 +241,13 @@ def observation_span(db, project, trace):
 
 
 def _seed_ch_trace_root(trace):
-    """Seed a CH root span so a *bare* trace resolves under CH-native annotation
-    (trace resolution reads the trace's root span from CH, not the PG row)."""
+    """Seed a CH-only root span so a *bare* trace resolves under CH-native annotation
+    (trace resolution reads the trace's root span from CH, not the PG row). Built in
+    memory and seeded to CH — never written to PG (the tracer tables are dropped)."""
     from tracer.models.observation_span import ObservationSpan
     from tracer.tests._ch_seed import seed_ch_span
 
-    span = ObservationSpan.objects.create(
+    span = ObservationSpan(
         id=f"chroot_{uuid.uuid4().hex[:16]}",
         project=trace.project,
         trace=trace,
@@ -256,7 +257,7 @@ def _seed_ch_trace_root(trace):
         end_time=timezone.now(),
         status="OK",
     )
-    seed_ch_span(span)
+    seed_ch_span(span)  # CH only — NOT ObservationSpan.objects.create
 
 
 @pytest.fixture

--- a/futureagi/model_hub/tests/test_team_a_annotations_full_matrix.py
+++ b/futureagi/model_hub/tests/test_team_a_annotations_full_matrix.py
@@ -23,43 +23,36 @@ import io
 import json
 import uuid
 from datetime import timedelta
-from typing import Any, Dict, Tuple
 
 import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from conftest import create_categorical_label
-
-from accounts.models.user import User
 from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from conftest import create_categorical_label
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
-    AnnotationQueueAnnotator,
     AnnotationQueueLabel,
     AutomationRule,
-    ItemAnnotation,
     QueueItem,
     QueueItemAssignment,
 )
 from model_hub.models.choices import (
     AnnotationQueueStatusChoices,
     AnnotationTypeChoices,
-    AnnotatorRole,
-    AssignmentStrategy,
     AutomationRuleTriggerFrequency,
     QueueItemSourceType,
     QueueItemStatus,
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.develop_dataset import Dataset, Row
-from model_hub.models.score import SCORE_SOURCE_FK_MAP, Score
+from model_hub.models.score import Score
 from model_hub.serializers.annotation_queues import QueueExportQuerySerializer
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 from tfc.middleware.workspace_context import set_workspace_context
 from tracer.models.trace_annotation import TraceAnnotation
-
 
 # ---------------------------------------------------------------------------
 # URL constants & helpers
@@ -196,6 +189,9 @@ def project(db, organization, workspace):
 def trace(db, project):
     from tracer.models.trace import Trace
 
+    # CH-native note: a trace resolves from its CH root span, so tests that annotate
+    # a *bare* trace seed one (via ``observation_span`` or ``seed_ch_span``); this
+    # fixture stays PG-only so it never adds a competing root to another test's span.
     return Trace.objects.create(
         project=project,
         name="Trace A",
@@ -207,16 +203,21 @@ def trace(db, project):
 @pytest.fixture
 def trace_session(db, project):
     from tracer.models.trace_session import TraceSession
+    from tracer.tests._ch_seed import seed_ch_trace_sessions
 
-    return TraceSession.objects.create(project=project, name="Session A")
+    session = TraceSession.objects.create(project=project, name="Session A")
+    # CH-native: session resolution reads the CH ``trace_sessions`` table.
+    seed_ch_trace_sessions([session])
+    return session
 
 
 @pytest.fixture
 def observation_span(db, project, trace):
     from tracer.models.observation_span import ObservationSpan
+    from tracer.tests._ch_seed import seed_ch_span
 
     span_id = f"span_{uuid.uuid4().hex[:16]}"
-    return ObservationSpan.objects.create(
+    span = ObservationSpan.objects.create(
         id=span_id,
         project=project,
         trace=trace,
@@ -234,6 +235,28 @@ def observation_span(db, project, trace):
         latency_ms=200,
         status="OK",
     )
+    # CH-native: annotation resolves the span from ClickHouse — seed it there.
+    seed_ch_span(span)
+    return span
+
+
+def _seed_ch_trace_root(trace):
+    """Seed a CH root span so a *bare* trace resolves under CH-native annotation
+    (trace resolution reads the trace's root span from CH, not the PG row)."""
+    from tracer.models.observation_span import ObservationSpan
+    from tracer.tests._ch_seed import seed_ch_span
+
+    span = ObservationSpan.objects.create(
+        id=f"chroot_{uuid.uuid4().hex[:16]}",
+        project=trace.project,
+        trace=trace,
+        name="trace root",
+        observation_type="agent",
+        start_time=timezone.now() - timedelta(seconds=1),
+        end_time=timezone.now(),
+        status="OK",
+    )
+    seed_ch_span(span)
 
 
 @pytest.fixture
@@ -314,8 +337,6 @@ def categorical_label(db, organization, workspace, project):
     )
 
 
-
-
 @pytest.fixture
 def queue(db, auth_client, user, organization):
     """Active queue. Creator is auto-registered as MANAGER by the serializer."""
@@ -379,9 +400,8 @@ class TestScoreCreate:
         assert score.created_at is not None
         assert score.deleted is False
 
-    def test_score_on_trace_db_verified(
-        self, auth_client, trace, thumbs_label, user
-    ):
+    def test_score_on_trace_db_verified(self, auth_client, trace, thumbs_label, user):
+        _seed_ch_trace_root(trace)
         payload = {
             "source_type": "trace",
             "source_id": str(trace.id),
@@ -411,11 +431,15 @@ class TestScoreCreate:
         assert score.trace_session_id == trace_session.id
         assert score.value == {"rating": 5}
         # No TraceAnnotation expected for trace_session source.
-        assert not TraceAnnotation.objects.filter(
-            annotation_label=star_label,
-            user_id=score.annotator_id,
-            deleted=False,
-        ).filter(trace__isnull=True).exists()
+        assert (
+            not TraceAnnotation.objects.filter(
+                annotation_label=star_label,
+                user_id=score.annotator_id,
+                deleted=False,
+            )
+            .filter(trace__isnull=True)
+            .exists()
+        )
 
     def test_score_on_dataset_row_db_verified(
         self, auth_client, dataset_with_rows, star_label
@@ -523,9 +547,7 @@ class TestScoreCreate:
         )
         assert resp.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_upsert_does_not_duplicate(
-        self, auth_client, observation_span, star_label
-    ):
+    def test_upsert_does_not_duplicate(self, auth_client, observation_span, star_label):
         """Score POST is upsert-by-(source, label, annotator) → no duplicates."""
         for v in (1, 2, 5):
             resp = self._post(
@@ -638,7 +660,7 @@ class TestScoreList:
 
     def _seed(
         self, auth_client, span, trace, label_a, label_b
-    ) -> Tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    ) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
         # 2 scores on span (label_a, label_b), 1 score on trace (label_a)
         a = auth_client.post(
             SCORE_URL,
@@ -800,7 +822,9 @@ class TestAutoCompleteQueueItems:
             workspace=workspace,
             status=AnnotationQueueStatusChoices.ACTIVE.value,
         )
-        AnnotationQueueLabel.objects.create(queue=queue, label=star_label, required=True)
+        AnnotationQueueLabel.objects.create(
+            queue=queue, label=star_label, required=True
+        )
         AnnotationQueueLabel.objects.create(
             queue=queue, label=thumbs_label, required=True
         )
@@ -901,6 +925,7 @@ class TestAutoCreateQueueItemsForDefault:
         trace,
         star_label,
     ):
+        _seed_ch_trace_root(trace)
         # Auto-create runs in ``transaction.on_commit``. See note in
         # ``test_completes_when_all_required_scored`` for why we wrap in
         # ``captureOnCommitCallbacks(execute=True)``.
@@ -919,9 +944,7 @@ class TestAutoCreateQueueItemsForDefault:
             queue=default_queue, label=star_label, required=False
         )
         # Pre-state: zero items.
-        assert (
-            QueueItem.objects.filter(queue=default_queue, deleted=False).count() == 0
-        )
+        assert QueueItem.objects.filter(queue=default_queue, deleted=False).count() == 0
 
         # Score the trace
         with TestCase.captureOnCommitCallbacks(execute=True):
@@ -954,9 +977,7 @@ class TestAutoCreateQueueItemsForDefault:
                 },
                 format="json",
             )
-        assert (
-            QueueItem.objects.filter(queue=default_queue, deleted=False).count() == 1
-        )
+        assert QueueItem.objects.filter(queue=default_queue, deleted=False).count() == 1
 
 
 # ===========================================================================
@@ -1152,9 +1173,7 @@ class TestQueueCRUD:
         assert "Alpha" in names
         assert "Beta" not in names
 
-    def test_list_queues_filter_by_status(
-        self, auth_client, organization, workspace
-    ):
+    def test_list_queues_filter_by_status(self, auth_client, organization, workspace):
         AnnotationQueue.objects.create(
             name="A",
             organization=organization,
@@ -1205,11 +1224,15 @@ class TestQueueCRUD:
 
     def test_hard_delete_requires_force_and_name(self, auth_client, queue, user):
         # missing force
-        resp = auth_client.post(_hard_delete_url(queue), {"confirm_name": "Team A Queue"}, format="json")
+        resp = auth_client.post(
+            _hard_delete_url(queue), {"confirm_name": "Team A Queue"}, format="json"
+        )
         assert resp.status_code == 400
         # wrong name
         resp = auth_client.post(
-            _hard_delete_url(queue), {"force": True, "confirm_name": "wrong"}, format="json"
+            _hard_delete_url(queue),
+            {"force": True, "confirm_name": "wrong"},
+            format="json",
         )
         assert resp.status_code == 400
         # success
@@ -1234,7 +1257,9 @@ class TestQueueStatusTransitions:
         )
         qid = resp.data["id"]
         # The serializer auto-adds creator as MANAGER, so update-status works.
-        r = auth_client.post(_update_status_url(qid), {"status": "active"}, format="json")
+        r = auth_client.post(
+            _update_status_url(qid), {"status": "active"}, format="json"
+        )
         assert r.status_code == 200
         q = AnnotationQueue.objects.get(pk=qid)
         assert q.status == "active"
@@ -1402,13 +1427,13 @@ class TestQueueForSource:
         # Result is a list of {queue: {id, ...}, item: {...}, labels: [...]}
         assert isinstance(result, list)
         queue_ids_returned = [
-            entry.get("queue", {}).get("id") for entry in result if isinstance(entry, dict)
+            entry.get("queue", {}).get("id")
+            for entry in result
+            if isinstance(entry, dict)
         ]
         assert str(queue) in queue_ids_returned
 
-    def test_rejects_legacy_source_aliases(
-        self, auth_client, queue, dataset_with_rows
-    ):
+    def test_rejects_legacy_source_aliases(self, auth_client, queue, dataset_with_rows):
         _, rows = dataset_with_rows
 
         resp = auth_client.get(
@@ -1452,9 +1477,7 @@ class TestQueueForSource:
 @pytest.mark.django_db
 @pytest.mark.integration
 class TestAddItems:
-    def test_manual_mode_db_verified(
-        self, auth_client, queue, dataset_with_rows
-    ):
+    def test_manual_mode_db_verified(self, auth_client, queue, dataset_with_rows):
         _, rows = dataset_with_rows
         items = [
             {"source_type": "dataset_row", "source_id": str(rows[0].id)},
@@ -1480,9 +1503,7 @@ class TestAddItems:
         assert resp.status_code == 200
         assert _result(resp)["duplicates"] == 1
         assert _result(resp)["added"] == 0
-        assert (
-            QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 1
-        )
+        assert QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 1
 
     def test_manual_mode_rejects_legacy_item_aliases(
         self, auth_client, queue, dataset_with_rows
@@ -1515,11 +1536,9 @@ class TestAddItems:
         result = _result(resp)
         # The trace fixture lives in this project; should be at least 1.
         assert result["added"] >= 1
-        assert (
-            QueueItem.objects.filter(
-                queue_id=queue, trace=trace, deleted=False
-            ).exists()
-        )
+        assert QueueItem.objects.filter(
+            queue_id=queue, trace=trace, deleted=False
+        ).exists()
 
 
 # ===========================================================================
@@ -1608,9 +1627,7 @@ class TestBulkRemoveItems:
             qi = QueueItem.all_objects.get(pk=iid)
             assert qi.deleted is True
             assert qi.deleted_at is not None
-        assert (
-            QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 1
-        )
+        assert QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 1
 
 
 # ===========================================================================
@@ -1650,7 +1667,7 @@ class TestAssignItems:
         )
         assert assignments.count() == 2
         # All point to the user we assigned.
-        assert set(a.user_id for a in assignments) == {user.id}
+        assert {a.user_id for a in assignments} == {user.id}
 
         # Unassign — view contract: user_id=None + action="set" + empty user_ids
         # clears all assignments.
@@ -1683,9 +1700,7 @@ class TestSubmitAnnotations:
 
     def _setup(self, auth_client, queue, dataset_with_rows, label):
         _, rows = dataset_with_rows
-        AnnotationQueueLabel.objects.create(
-            queue_id=queue, label=label, required=True
-        )
+        AnnotationQueueLabel.objects.create(queue_id=queue, label=label, required=True)
         auth_client.post(
             _add_items_url(queue),
             {"items": [{"source_type": "dataset_row", "source_id": str(rows[0].id)}]},
@@ -1780,14 +1795,15 @@ class TestSubmitAnnotations:
     ):
         item = self._setup(auth_client, queue, dataset_with_rows, categorical_label)
         # Pause the queue
-        auth_client.post(
-            _update_status_url(queue), {"status": "paused"}, format="json"
-        )
+        auth_client.post(_update_status_url(queue), {"status": "paused"}, format="json")
         resp = auth_client.post(
             _submit_url(queue, item.id),
             {
                 "annotations": [
-                    {"label_id": str(categorical_label.id), "value": {"selected": ["Good"]}}
+                    {
+                        "label_id": str(categorical_label.id),
+                        "value": {"selected": ["Good"]},
+                    }
                 ]
             },
             format="json",
@@ -1803,13 +1819,9 @@ class TestSubmitAnnotations:
 @pytest.mark.django_db
 @pytest.mark.integration
 class TestCompleteAndSkip:
-    def _setup_pending(
-        self, auth_client, queue, dataset_with_rows, label
-    ):
+    def _setup_pending(self, auth_client, queue, dataset_with_rows, label):
         _, rows = dataset_with_rows
-        AnnotationQueueLabel.objects.create(
-            queue_id=queue, label=label, required=True
-        )
+        AnnotationQueueLabel.objects.create(queue_id=queue, label=label, required=True)
         auth_client.post(
             _add_items_url(queue),
             {"items": [{"source_type": "dataset_row", "source_id": str(rows[0].id)}]},
@@ -1828,7 +1840,10 @@ class TestCompleteAndSkip:
             _submit_url(queue, item.id),
             {
                 "annotations": [
-                    {"label_id": str(categorical_label.id), "value": {"selected": ["Good"]}}
+                    {
+                        "label_id": str(categorical_label.id),
+                        "value": {"selected": ["Good"]},
+                    }
                 ]
             },
             format="json",
@@ -1859,9 +1874,7 @@ class TestCompleteAndSkip:
 class TestNextItemAndAnnotateDetail:
     def _seed_two_items(self, auth_client, queue, dataset_with_rows, label):
         _, rows = dataset_with_rows
-        AnnotationQueueLabel.objects.create(
-            queue_id=queue, label=label, required=True
-        )
+        AnnotationQueueLabel.objects.create(queue_id=queue, label=label, required=True)
         auth_client.post(
             _add_items_url(queue),
             {
@@ -1913,9 +1926,7 @@ class TestNextItemAndAnnotateDetail:
 class TestQueueAnalytics:
     def _seed(self, auth_client, queue, dataset_with_rows, label):
         _, rows = dataset_with_rows
-        AnnotationQueueLabel.objects.create(
-            queue_id=queue, label=label, required=True
-        )
+        AnnotationQueueLabel.objects.create(queue_id=queue, label=label, required=True)
         auth_client.post(
             _add_items_url(queue),
             {
@@ -1951,9 +1962,12 @@ class TestQueueAnalytics:
         assert resp.status_code == 200, resp.data
         result = _result(resp)
         # Must report total of 3 items
-        assert result.get("total") == 3 or result.get("total_items") == 3 or any(
-            isinstance(v, dict) and v.get("total") == 3 for v in result.values()
-        ) or result.get("status_counts") is not None
+        assert (
+            result.get("total") == 3
+            or result.get("total_items") == 3
+            or any(isinstance(v, dict) and v.get("total") == 3 for v in result.values())
+            or result.get("status_counts") is not None
+        )
 
     def test_analytics_endpoint(
         self, auth_client, queue, dataset_with_rows, categorical_label
@@ -1981,9 +1995,7 @@ class TestQueueAnalytics:
         # 3 items exported.
         assert len(result) == 3
 
-    def test_export_csv(
-        self, auth_client, queue, dataset_with_rows, categorical_label
-    ):
+    def test_export_csv(self, auth_client, queue, dataset_with_rows, categorical_label):
         self._seed(auth_client, queue, dataset_with_rows, categorical_label)
         resp = auth_client.get(_export_url(queue), {"export_format": "csv"})
         assert resp.status_code == 200
@@ -2098,9 +2110,7 @@ class TestAutomationRules:
             organization=organization,
         )
         # Pre-state: no items.
-        assert (
-            QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 0
-        )
+        assert QueueItem.objects.filter(queue_id=queue, deleted=False).count() == 0
         resp = auth_client.post(_rule_evaluate_url(queue, rule.id), {}, format="json")
         # The endpoint may be 200/201 — we just ensure it doesn't 5xx.
         assert resp.status_code in (200, 201, 400, 404), resp.data
@@ -2114,15 +2124,11 @@ class TestAutomationRules:
 @pytest.mark.django_db
 @pytest.mark.integration
 class TestGetAnnotationLabelsLegacy:
-    def test_returns_org_labels(
-        self, api_client, user, star_label, thumbs_label
-    ):
+    def test_returns_org_labels(self, api_client, user, star_label, thumbs_label):
         api_client.force_authenticate(user=user)
         resp = api_client.get(TRACER_LABELS)
         if resp.status_code != 200:
-            pytest.skip(
-                f"Expected 200, got {resp.status_code}: {resp.data}"
-            )
+            pytest.skip(f"Expected 200, got {resp.status_code}: {resp.data}")
         result = _result(resp)
         ids = [str(r["id"]) for r in result]
         assert str(star_label.id) in ids
@@ -2132,9 +2138,7 @@ class TestGetAnnotationLabelsLegacy:
         api_client.force_authenticate(user=user)
         resp = api_client.get(TRACER_LABELS, {"project_id": str(project.id)})
         if resp.status_code != 200:
-            pytest.skip(
-                f"Expected 200, got {resp.status_code}: {resp.data}"
-            )
+            pytest.skip(f"Expected 200, got {resp.status_code}: {resp.data}")
         result = _result(resp)
         ids = [str(r["id"]) for r in result]
         # star_label is project-scoped to ``project`` so it must appear
@@ -2180,9 +2184,7 @@ class TestGetAnnotationLabelsLegacy:
         assert resp.status_code == 200, resp.data
         result = _result(resp)
         annotation_cols = [
-            c
-            for c in result["config"]
-            if c.get("group_by") == "Annotation Metrics"
+            c for c in result["config"] if c.get("group_by") == "Annotation Metrics"
         ]
         cols_by_id = {str(c["id"]): c for c in annotation_cols}
         expected_types = {
@@ -2286,7 +2288,6 @@ class TestQueuePermissionEnforcement:
     """Matrix #10 directive: non-managers must get 403 on update."""
 
     def _make_other_user(self, organization):
-        from accounts.models.organization_membership import OrganizationMembership
 
         u = User.objects.create_user(
             email=f"other-{uuid.uuid4().hex[:8]}@futureagi.com",

--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -1164,10 +1164,13 @@ class TestVoiceAnnotationRegressionE2E:
         root_conversation_span,
         thumbs_label,
     ):
-        root_conversation_span.span_attributes = {
-            "customer": {"tier": "gold"},
-            "score": 7,
-        }
+        # Top-level scalar attrs: they land in the typed CH Maps (attrs_string /
+        # attrs_number) and round-trip cleanly. A NESTED value (dict/list) would
+        # overflow to the ``attributes_extra`` column, which is JSON in prod but
+        # String in the test CH (schema drift), so nested export paths can't be
+        # exercised here — the flatten logic itself is covered on the JSON-typed
+        # resource_attributes elsewhere.
+        root_conversation_span.span_attributes = {"tier": "gold", "score": 7}
         root_conversation_span.response_time = 321.0
         root_conversation_span.save(update_fields=["span_attributes", "response_time"])
         # Re-seed CH after mutating the span: export fields read span_attributes
@@ -1267,9 +1270,7 @@ class TestVoiceAnnotationRegressionE2E:
         default_fields = {
             item["field"] for item in fields_resp.data["result"]["default_mapping"]
         }
-        assert any(
-            field["id"] == "attr:span_attributes.customer.tier" for field in fields
-        )
+        assert any(field["id"] == "attr:span_attributes.tier" for field in fields)
         assert "eval_metrics" in default_fields
         assert "annotation_metrics" in default_fields
 
@@ -1375,7 +1376,7 @@ class TestVoiceAnnotationRegressionE2E:
                         "enabled": True,
                     },
                     {
-                        "field": "attr:span_attributes.customer.tier",
+                        "field": "attr:span_attributes.tier",
                         "column": "customer_tier",
                         "enabled": True,
                     },
@@ -1397,7 +1398,8 @@ class TestVoiceAnnotationRegressionE2E:
         }
         assert cells["source_identifier"] == root_conversation_span.id
         assert cells["latency_ms"] == "1000"
-        assert cells["response_time_ms"] == "321.0"
+        # CH has no response_time column — response_time_ms collapses to latency_ms.
+        assert cells["response_time_ms"] == "1000"
         # Per-queue scoping: SpanNote ("whole item export note") was never
         # written through this queue's annotation flow, so item_notes is
         # empty for this queue's export. Pre-revamp the span-level note
@@ -1429,12 +1431,12 @@ class TestVoiceAnnotationRegressionE2E:
         )
         assert (
             Column.objects.get(dataset=dataset, name="customer_score").data_type
-            == DataTypeChoices.INTEGER.value
+            == DataTypeChoices.FLOAT.value
         )
         assert json.loads(cells["eval_metrics"])["Export Quality"]["score"] == 0.82
         assert cells["export_quality_score"] == "0.82"
         assert cells["customer_tier"] == "gold"
-        assert cells["customer_score"] == "7"
+        assert cells["customer_score"] == "7.0"  # CH attrs_number is Float64
         assert row.metadata["annotations"][str(thumbs_label.id)][0]["notes"] == (
             "label export note"
         )
@@ -1446,8 +1448,8 @@ class TestVoiceAnnotationRegressionE2E:
         )
         assert download_resp.status_code == status.HTTP_200_OK, download_resp.data
         exported_item = download_resp.data["result"][0]
-        assert exported_item["source"]["span_attributes"]["customer"]["tier"] == "gold"
-        assert exported_item["source"]["span_attributes"]["score"] == 7
+        assert exported_item["source"]["span_attributes"]["tier"] == "gold"
+        assert exported_item["source"]["span_attributes"]["score"] == 7.0
         assert exported_item["annotations"][1]["annotator_email"] == (
             second_annotator.email
         )
@@ -1622,7 +1624,7 @@ class TestVoiceAnnotationRegressionE2E:
         )
         assert (
             Column.objects.get(dataset=dataset, name="customer_score").data_type
-            == DataTypeChoices.INTEGER.value
+            == DataTypeChoices.FLOAT.value
         )
         dataset.refresh_from_db()
         assert (
@@ -1643,7 +1645,7 @@ class TestVoiceAnnotationRegressionE2E:
         }
         assert exported_cells["source_identifier"] == root_conversation_span.id
         assert exported_cells["thumbs_annotation_1_score"] == "up"
-        assert exported_cells["customer_score"] == "7"
+        assert exported_cells["customer_score"] == "7.0"  # CH attrs_number is Float64
         assert exported_cells["existing_only"] == ""
         assert exported_row.metadata["queue_item_id"] == str(item.id)
 

--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -47,6 +47,7 @@ from tracer.models.observation_span import EvalLogger, ObservationSpan
 from tracer.models.project import Project
 from tracer.models.span_notes import SpanNotes
 from tracer.models.trace import Trace
+from tracer.tests._ch_seed import seed_ch_span
 
 
 @pytest.fixture
@@ -72,7 +73,7 @@ def observe_trace(db, observe_project):
 
 @pytest.fixture
 def root_conversation_span(db, observe_project, observe_trace):
-    return ObservationSpan.objects.create(
+    span = ObservationSpan.objects.create(
         id=f"voice_root_{uuid.uuid4().hex[:16]}",
         project=observe_project,
         trace=observe_trace,
@@ -85,6 +86,10 @@ def root_conversation_span(db, observe_project, observe_trace):
         latency_ms=1000,
         status="OK",
     )
+    # Tracer sources resolve CH-native; mirror this root span into ClickHouse so
+    # the trace/span resolves (the PG row alone is no longer read).
+    seed_ch_span(span)
+    return span
 
 
 @pytest.fixture
@@ -285,7 +290,7 @@ class TestVoiceAnnotationRegressionE2E:
             project=observe_project,
             name="In-progress voice call trace",
         )
-        ObservationSpan.objects.create(
+        in_progress_span = ObservationSpan.objects.create(
             id=f"voice_in_progress_{uuid.uuid4().hex[:16]}",
             project=observe_project,
             trace=in_progress_trace,
@@ -295,6 +300,7 @@ class TestVoiceAnnotationRegressionE2E:
             parent_span_id=None,
             status="UNSET",
         )
+        seed_ch_span(in_progress_span)
 
         resp = auth_client.post(
             _add_items_url(queue),
@@ -341,7 +347,7 @@ class TestVoiceAnnotationRegressionE2E:
             project=observe_project,
             name="In-progress voice call trace",
         )
-        ObservationSpan.objects.create(
+        in_progress_span = ObservationSpan.objects.create(
             id=f"voice_filter_in_progress_{uuid.uuid4().hex[:16]}",
             project=observe_project,
             trace=in_progress_trace,
@@ -351,6 +357,7 @@ class TestVoiceAnnotationRegressionE2E:
             parent_span_id=None,
             status="UNSET",
         )
+        seed_ch_span(in_progress_span)
 
         resp = auth_client.post(
             _add_items_url(queue),
@@ -1101,8 +1108,9 @@ class TestVoiceAnnotationRegressionE2E:
         simulation_agent_definition,
         simulation_call_execution,
     ):
-        root_conversation_span.response_time = 123.5
-        root_conversation_span.save(update_fields=["response_time"])
+        # CH has no separate response_time column — a span's response_time_ms
+        # collapses to latency_ms (the only CH timing signal). The call_execution
+        # branch is PG-backed and keeps its distinct response_time_ms.
         simulation_call_execution.response_time_ms = 456
         simulation_call_execution.avg_agent_latency_ms = 789
         simulation_call_execution.save(
@@ -1141,7 +1149,7 @@ class TestVoiceAnnotationRegressionE2E:
         span_preview = next(p for p in previews if p["type"] == "observation_span")
         call_preview = next(p for p in previews if p["type"] == "call_execution")
         assert span_preview["latency_ms"] == 1000
-        assert span_preview["response_time_ms"] == 123.5
+        assert span_preview["response_time_ms"] == 1000  # == latency_ms (CH-native)
         assert call_preview["latency_ms"] == 789
         assert call_preview["response_time_ms"] == 456
         assert call_preview["duration_seconds"] == 42
@@ -1162,6 +1170,9 @@ class TestVoiceAnnotationRegressionE2E:
         }
         root_conversation_span.response_time = 321.0
         root_conversation_span.save(update_fields=["span_attributes", "response_time"])
+        # Re-seed CH after mutating the span: export fields read span_attributes
+        # CH-native, so the PG-only write above must be mirrored.
+        seed_ch_span(root_conversation_span)
         queue = _queue(
             "TH-4735 export queue",
             organization,
@@ -1502,6 +1513,8 @@ class TestVoiceAnnotationRegressionE2E:
     ):
         root_conversation_span.span_attributes = {"score": 7}
         root_conversation_span.save(update_fields=["span_attributes"])
+        # Re-seed CH after mutating span_attributes: export reads them CH-native.
+        seed_ch_span(root_conversation_span)
         queue = _queue(
             "Existing dataset export queue",
             organization,

--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -1164,13 +1164,10 @@ class TestVoiceAnnotationRegressionE2E:
         root_conversation_span,
         thumbs_label,
     ):
-        # Top-level scalar attrs: they land in the typed CH Maps (attrs_string /
-        # attrs_number) and round-trip cleanly. A NESTED value (dict/list) would
-        # overflow to the ``attributes_extra`` column, which is JSON in prod but
-        # String in the test CH (schema drift), so nested export paths can't be
-        # exercised here — the flatten logic itself is covered on the JSON-typed
-        # resource_attributes elsewhere.
-        root_conversation_span.span_attributes = {"tier": "gold", "score": 7}
+        root_conversation_span.span_attributes = {
+            "customer": {"tier": "gold"},
+            "score": 7,
+        }
         root_conversation_span.response_time = 321.0
         root_conversation_span.save(update_fields=["span_attributes", "response_time"])
         # Re-seed CH after mutating the span: export fields read span_attributes
@@ -1270,7 +1267,9 @@ class TestVoiceAnnotationRegressionE2E:
         default_fields = {
             item["field"] for item in fields_resp.data["result"]["default_mapping"]
         }
-        assert any(field["id"] == "attr:span_attributes.tier" for field in fields)
+        assert any(
+            field["id"] == "attr:span_attributes.customer.tier" for field in fields
+        )
         assert "eval_metrics" in default_fields
         assert "annotation_metrics" in default_fields
 
@@ -1376,7 +1375,7 @@ class TestVoiceAnnotationRegressionE2E:
                         "enabled": True,
                     },
                     {
-                        "field": "attr:span_attributes.tier",
+                        "field": "attr:span_attributes.customer.tier",
                         "column": "customer_tier",
                         "enabled": True,
                     },
@@ -1448,7 +1447,7 @@ class TestVoiceAnnotationRegressionE2E:
         )
         assert download_resp.status_code == status.HTTP_200_OK, download_resp.data
         exported_item = download_resp.data["result"][0]
-        assert exported_item["source"]["span_attributes"]["tier"] == "gold"
+        assert exported_item["source"]["span_attributes"]["customer"]["tier"] == "gold"
         assert exported_item["source"]["span_attributes"]["score"] == 7.0
         assert exported_item["annotations"][1]["annotator_email"] == (
             second_annotator.email

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -159,25 +159,26 @@ def is_source_available_for_annotation(source_type, source_obj):
 
 
 def filter_available_source_ids_for_annotation(
-    source_type, source_ids, *, organization=None, workspace=None
+    source_type, source_ids, *, organization=None, workspace=None, project_id=None
 ):
     """Split resolved filter-mode trace IDs into available / unavailable.
 
     CH-native mirror of :func:`is_source_available_for_annotation` for the bulk
     filter path: a trace is in progress while its CH root span is not terminal.
-    Reads the roots LEAN and org-scoped in one batched call (OOM-safe) via
-    :func:`_batch_ch_trace_roots`; a trace with no CH root reads as available
-    (it was never resolvable as in-progress). FAIL OPEN on a CH error — a
-    transient read must not silently drop every add. Returns
-    ``(available_ids, unavailable_count, unavailable_message)`` preserving input
-    order. Never query PG.
+    Reads the roots LEAN in one batched call (OOM-safe) via
+    :func:`_batch_ch_trace_roots`, scoped by ``project_id`` (the filter selection is
+    per-project). A trace with no CH root reads as available (it was never resolvable
+    as in-progress). FAIL OPEN on a CH error — a transient read must not silently
+    drop every add. ``organization`` / ``workspace`` are already applied upstream by
+    ``resolve_filtered_trace_ids``. Returns ``(available_ids, unavailable_count,
+    unavailable_message)`` preserving input order. Never query PG.
     """
     ordered_ids = [str(source_id) for source_id in source_ids]
     if source_type != QueueItemSourceType.TRACE.value or not ordered_ids:
         return ordered_ids, 0, None
 
     roots_by_trace = _batch_ch_trace_roots(
-        ordered_ids, org_id=str(organization.pk) if organization is not None else None
+        ordered_ids, project_id=str(project_id) if project_id else None
     )
 
     def _available(trace_id):
@@ -523,11 +524,11 @@ def _tenant_scoped_project(project_id, *, organization=None, workspace=None):
 class _CHTraceSource:
     """Duck-typed collector trace for annotation resolution (no PG ``Trace`` row).
 
-    Exposes the soft id the add path stores (``.id`` / ``.pk`` = trace_id) plus the
-    ``.project_id`` and resolved root :class:`CHSpan` the availability/render paths
-    read. Mirrors how a collector observation_span is duck-typed as a bare CHSpan.
-    Deliberately has no ``.observation_spans`` reverse relation — availability keys
-    off its absence to skip the PG in-progress check.
+    Exposes the soft id the add path stores (``.id`` / ``.pk`` = trace_id), the
+    ``.project_id``, and the resolved ``.root_span`` (:class:`CHSpan`). Mirrors how a
+    collector observation_span is duck-typed as a bare CHSpan. The in-progress guard
+    reads ``.root_span.status`` (terminal = addable) — the trace already resolved
+    from its CH root, so no extra read is needed.
     """
 
     def __init__(self, trace_id, root_span):
@@ -740,19 +741,23 @@ def _batch_ch_spans(span_ids):
 _CH_TRACE_ID_BATCH = 500
 
 
-def _batch_ch_trace_roots(trace_ids, *, org_id=None):
-    """Batch CH read of each trace's root span for a render/export path:
+def _batch_ch_trace_roots(trace_ids, *, project_id=None):
+    """Batch CH read of each trace's root span for a render/availability path:
     ``{str(trace_id): CHSpan}`` over *trace_ids* (chunked, LEAN).
 
     Reads the parentless (root) spans LEAN — input / output / metadata /
     span_attributes stay real; the heavy ``resource_attributes`` and ``events`` come
     back empty. That is a deliberate trade against ClickHouse OOM: those columns
     carry the voice raw_log on the CONVERSATION ROOT, and a batched heavy read of
-    many roots is exactly the code-241 shape on the shared cluster. ``org_id`` scopes
-    the read to one tenant. CH error → ``{}`` (FAIL OPEN — the per-item collector
-    branch then does its own point-read or renders the ``deleted`` sentinel). Backs
-    :class:`CollectorSourceCache` so a list/export over CH traces does one read per
-    chunk, not one per item."""
+    many roots is exactly the code-241 shape on the shared cluster. ``project_id``
+    (optional) scopes the read to one tenant on the non-null PK-prefix column — do
+    NOT scope by ``org_id`` here: a collector span row may carry a NULL ``org_id``
+    (``ObservationSpan.org_id`` is nullable and copied verbatim in the backfill), so
+    an org filter would silently drop those roots and read them as "no root". When
+    *project_id* is omitted the ``trace_ids`` are already tenant-scoped by the caller.
+    CH error → ``{}`` (FAIL OPEN — the per-item branch then does its own point-read
+    or renders the ``deleted`` sentinel). Backs :class:`CollectorSourceCache` so a
+    list page over CH traces does one read per chunk, not one per item."""
     if not trace_ids:
         return {}
     from tracer.services.clickhouse.v2 import get_reader
@@ -764,7 +769,7 @@ def _batch_ch_trace_roots(trace_ids, *, org_id=None):
             for start in range(0, len(ids), _CH_TRACE_ID_BATCH):
                 chunk = ids[start : start + _CH_TRACE_ID_BATCH]
                 for span in reader.roots_by_trace_ids(
-                    chunk, include_heavy=False, org_id=org_id
+                    chunk, include_heavy=False, project_id=project_id
                 ):
                     roots_by_trace.setdefault(str(span.trace_id), []).append(span)
     except Exception as exc:
@@ -820,7 +825,6 @@ class CollectorSourceCache:
         sessions by soft id. Empty id-sets short-circuit, so a page with no items of
         a kind pays for no read of that kind."""
         span_ids, session_ids, trace_ids = set(), set(), set()
-        org_id = None
         for item in items or []:
             source_type = getattr(item, "source_type", None)
             if (
@@ -833,17 +837,15 @@ class CollectorSourceCache:
                 and item.trace_session_id
             ):
                 session_ids.add(str(item.trace_session_id))
-            elif (
-                source_type == QueueItemSourceType.TRACE.value and item.trace_id
-            ):
+            elif source_type == QueueItemSourceType.TRACE.value and item.trace_id:
                 trace_ids.add(str(item.trace_id))
-                org_id = org_id or getattr(item, "organization_id", None)
+        # A page's items can span projects, so the trace-root read isn't project-
+        # scoped; the ids are the tenant's own queue items. (No org_id scoping —
+        # a collector span row may carry a NULL org_id; see _batch_ch_trace_roots.)
         return cls(
             spans=_batch_ch_spans(span_ids),
             sessions=_batch_ch_session_fields(session_ids),
-            trace_roots=_batch_ch_trace_roots(
-                trace_ids, org_id=str(org_id) if org_id else None
-            ),
+            trace_roots=_batch_ch_trace_roots(trace_ids),
         )
 
     def span(self, span_id):

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -904,13 +904,17 @@ class CollectorSourceCache:
 class _CHTraceSessionSource:
     """Duck-typed stand-in for a PG ``TraceSession`` resolved from CH. Carries only
     the attributes the annotation scope/store/render path reads off a session
-    (``id`` / ``project_id`` / ``name`` / ``first_seen``); it is NOT a Django model
-    and must never be assigned to a relation (the store path uses the soft id)."""
+    (``id`` / ``pk`` / ``project_id`` / ``name`` / ``first_seen``); it is NOT a Django
+    model and must never be assigned to a relation (the store path uses the soft id).
 
-    __slots__ = ("id", "project_id", "name", "first_seen")
+    ``pk`` mirrors ``id`` for Django-model parity — the score store reads
+    ``source_obj.pk`` (same as :class:`CHSpan` and :class:`_CHTraceSource`)."""
+
+    __slots__ = ("id", "pk", "project_id", "name", "first_seen")
 
     def __init__(self, *, id, project_id, name, first_seen):
         self.id = id
+        self.pk = str(id)
         self.project_id = project_id
         self.name = name
         self.first_seen = first_seen

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -4,7 +4,7 @@ from typing import Any, TypedDict
 import structlog
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError
-from django.db.models import DateTimeField, Exists, F, FloatField, OuterRef, Q
+from django.db.models import DateTimeField, F, FloatField, Q
 from django.db.models.functions import Cast
 
 from model_hub.constants import ANNOTATION_LABEL_VALUE_KEYS
@@ -67,6 +67,14 @@ TRACE_IN_PROGRESS_ADD_ERROR = (
     "Trace is still in progress and can't be added to an annotation queue yet."
 )
 
+# A trace's root span is terminal (the trace is complete and addable) once its
+# status reaches OK / ERROR; any other value (e.g. UNSET) means still in progress.
+_TERMINAL_SPAN_STATUSES = frozenset({"OK", "ERROR"})
+
+
+def _is_terminal_span_status(status):
+    return (status or "").upper() in _TERMINAL_SPAN_STATUSES
+
 
 def _automation_rule_filter_error_message(exc):
     """Return a short public error while full exception details stay in logs."""
@@ -74,47 +82,6 @@ def _automation_rule_filter_error_message(exc):
     if isinstance(exc, ValueError) and message and "\n" not in message:
         return message[:240]
     return AUTOMATION_RULE_FILTER_ERROR_MESSAGE
-
-
-def _trace_primary_span(trace):
-    if not trace:
-        return None
-
-    prefetched_spans = getattr(trace, "_queue_export_spans", None)
-    if prefetched_spans is not None:
-        spans = list(prefetched_spans)
-        root_spans = [
-            span for span in spans if not getattr(span, "parent_span_id", None)
-        ]
-        return (
-            next(
-                (
-                    span
-                    for span in root_spans
-                    if getattr(span, "observation_type", None) == "conversation"
-                ),
-                None,
-            )
-            or (root_spans[0] if root_spans else None)
-            or (spans[0] if spans else None)
-        )
-
-    spans = trace.observation_spans.filter(deleted=False)
-    root_spans = spans.filter(Q(parent_span_id__isnull=True) | Q(parent_span_id=""))
-    return (
-        root_spans.filter(observation_type="conversation")
-        .order_by("start_time", "created_at")
-        .first()
-        or root_spans.order_by("start_time", "created_at").first()
-        or spans.order_by("start_time", "created_at").first()
-    )
-
-
-def _metric_payload(obj, *, response_field="response_time"):
-    return {
-        "latency_ms": getattr(obj, "latency_ms", None),
-        "response_time_ms": getattr(obj, response_field, None),
-    }
 
 
 def _call_execution_metric_payload(call):
@@ -167,14 +134,6 @@ def get_fk_field_name(source_type):
     return fk_field
 
 
-def _root_span_filter():
-    return Q(parent_span_id__isnull=True) | Q(parent_span_id="")
-
-
-def _terminal_trace_span_status_filter():
-    return Q(status__iexact="OK") | Q(status__iexact="ERROR")
-
-
 def _trace_project_workspace_filter(workspace):
     if getattr(workspace, "is_default", False):
         return Q(project__workspace=workspace) | Q(project__workspace__isnull=True)
@@ -182,25 +141,19 @@ def _trace_project_workspace_filter(workspace):
 
 
 def is_source_available_for_annotation(source_type, source_obj):
-    """Return ``(is_available, reason)`` for queue add-items.
+    """Return ``(is_available, reason)`` for a single queue add-item.
 
-    A visible in-progress trace has a root span whose status is still UNSET
-    or null. Bare legacy Trace fixtures with no root span are left untouched;
-    they are not the voice-call "in progress" state surfaced in Observe.
+    CH-native: a trace is in progress while its CH root span has not reached a
+    terminal status (OK / ERROR); otherwise it's addable. ``source_obj`` is the
+    duck-typed :class:`_CHTraceSource` the resolver already built, so its
+    ``root_span`` is in hand — no extra CH read. A source with no resolvable root
+    never reaches here (the resolver returns ``None`` first); defensively, a
+    missing root reads as available. Never query PG.
     """
     if source_type != QueueItemSourceType.TRACE.value:
         return True, None
-
-    # CH-resolved collector trace (duck-typed :class:`_CHTraceSource`, no PG
-    # reverse relation): it's surfaced from CH only once complete, so it's
-    # always available. The in-progress guard below is the voice/PG lifecycle.
-    if not hasattr(source_obj, "observation_spans"):
-        return True, None
-
-    root_spans = source_obj.observation_spans.filter(_root_span_filter())
-    if not root_spans.exists():
-        return True, None
-    if root_spans.filter(_terminal_trace_span_status_filter()).exists():
+    root_span = getattr(source_obj, "root_span", None)
+    if root_span is None or _is_terminal_span_status(getattr(root_span, "status", None)):
         return True, None
     return False, TRACE_IN_PROGRESS_ADD_ERROR
 
@@ -208,67 +161,70 @@ def is_source_available_for_annotation(source_type, source_obj):
 def filter_available_source_ids_for_annotation(
     source_type, source_ids, *, organization=None, workspace=None
 ):
-    """Split resolved filter-mode IDs into available/unavailable IDs.
+    """Split resolved filter-mode trace IDs into available / unavailable.
 
-    Returns ``(available_ids, unavailable_count, unavailable_message)`` while
-    preserving the input ordering of available IDs.
+    CH-native mirror of :func:`is_source_available_for_annotation` for the bulk
+    filter path: a trace is in progress while its CH root span is not terminal.
+    Reads the roots LEAN and org-scoped in one batched call (OOM-safe) via
+    :func:`_batch_ch_trace_roots`; a trace with no CH root reads as available
+    (it was never resolvable as in-progress). FAIL OPEN on a CH error — a
+    transient read must not silently drop every add. Returns
+    ``(available_ids, unavailable_count, unavailable_message)`` preserving input
+    order. Never query PG.
     """
     ordered_ids = [str(source_id) for source_id in source_ids]
     if source_type != QueueItemSourceType.TRACE.value or not ordered_ids:
         return ordered_ids, 0, None
 
-    from tracer.models.observation_span import ObservationSpan
-    from tracer.models.trace import Trace
-
-    root_spans = ObservationSpan.objects.filter(
-        trace_id=OuterRef("id"),
-    ).filter(_root_span_filter())
-    available_qs = Trace.objects.filter(id__in=ordered_ids).annotate(
-        _has_root_span=Exists(root_spans),
-        _has_terminal_root_span=Exists(
-            root_spans.filter(_terminal_trace_span_status_filter())
-        ),
+    roots_by_trace = _batch_ch_trace_roots(
+        ordered_ids, org_id=str(organization.pk) if organization is not None else None
     )
-    if organization is not None:
-        available_qs = available_qs.filter(project__organization=organization)
-    if workspace is not None:
-        available_qs = available_qs.filter(_trace_project_workspace_filter(workspace))
 
-    available_set = {
-        str(trace_id)
-        for trace_id in available_qs.filter(
-            Q(_has_root_span=False) | Q(_has_terminal_root_span=True)
-        ).values_list("id", flat=True)
-    }
-    # Collector (CH-only) traces have no PG row — the resolver already tenant-
-    # scoped them, and they're surfaced from CH once complete, so keep them
-    # rather than silently dropping every collector trace as "in progress".
-    pg_trace_ids = {
-        str(trace_id)
-        for trace_id in Trace.objects.filter(id__in=ordered_ids).values_list(
-            "id", flat=True
-        )
-    }
-    available_ids = [
-        source_id
-        for source_id in ordered_ids
-        if source_id not in pg_trace_ids or source_id in available_set
-    ]
+    def _available(trace_id):
+        root = roots_by_trace.get(trace_id)
+        # No CH root → available (matches the single-add no-root branch); else
+        # addable only once the root span reaches a terminal status.
+        return root is None or _is_terminal_span_status(getattr(root, "status", None))
+
+    available_ids = [sid for sid in ordered_ids if _available(sid)]
     unavailable_count = len(ordered_ids) - len(available_ids)
     if unavailable_count <= 0:
         return available_ids, 0, None
 
-    noun = "trace" if unavailable_count == 1 else "traces"
-    verb = "is" if unavailable_count == 1 else "are"
-    message = (
-        f"{unavailable_count} {noun} {verb} still in progress and "
-        "were not added to the annotation queue."
-    )
     if unavailable_count == 1:
         message = (
             "1 trace is still in progress and was not added to the annotation queue."
         )
+    else:
+        message = (
+            f"{unavailable_count} traces are still in progress and "
+            "were not added to the annotation queue."
+        )
     return available_ids, unavailable_count, message
+
+
+def source_project(source_obj, organization=None):
+    """Return the PG ``Project`` for *source_obj*, or ``None``.
+
+    A tracer source resolves CH-native and duck-types (``_CHTraceSource`` /
+    :class:`CHSpan` / ``_CHTraceSessionSource``) — it carries only ``project_id``,
+    not a ``.project`` relation. Resolve the Project row directly (org-scoped when
+    given, fail-closed): the default-queue scope row lives in PG, which is not a
+    tracer table, and cross-store FK joins aren't possible. A PG-backed source
+    (dataset_row / call_execution) still exposes ``.project`` and short-circuits.
+    """
+    project = getattr(source_obj, "project", None)
+    if project is not None:
+        return project
+    project_id = getattr(source_obj, "project_id", None)
+    if not project_id:
+        return None
+    from tracer.models.project import Project
+
+    qs = Project.objects.filter(id=project_id)
+    if organization is not None:
+        qs = qs.filter(organization=organization)
+    return qs.first()
 
 
 def _resolve_default_queue_scope(source_type, source_obj, organization=None):
@@ -280,65 +236,13 @@ def _resolve_default_queue_scope(source_type, source_obj, organization=None):
     they're not per-row. This helper centralises the mapping so the scores
     endpoints and the explicit ``get-or-create-default`` endpoint agree on
     what counts as "the default queue" for a given source.
-
-    CH 25.3 duck-typing: *source_obj* may be either a Django model instance
-    (with a ``project`` FK / related-object) or a CH-loaded dataclass like
-    :class:`CHSpan` (only carries ``project_id``). For the CH path we look
-    the Project row up directly in PG since the default-queue scope row
-    lives in PG and FK joins across stores aren't possible.
     """
     if source_type in (
         QueueItemSourceType.TRACE.value,
         QueueItemSourceType.OBSERVATION_SPAN.value,
         QueueItemSourceType.TRACE_SESSION.value,
     ):
-        project = None
-        if source_type == QueueItemSourceType.TRACE.value:
-            project = getattr(source_obj, "project", None)
-            if project is None:
-                # CH trace path (_CHTraceSource): no FK, resolve the PG Project by
-                # the carried project_id, org-scoped (fail closed).
-                pid = getattr(source_obj, "project_id", None)
-                if pid:
-                    from tracer.models.project import Project
-
-                    qs = Project.objects.filter(id=pid)
-                    if organization is not None:
-                        qs = qs.filter(organization=organization)
-                    project = qs.first()
-        elif source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
-            # Django ObservationSpan: walk .project (or .trace.project).
-            project = getattr(source_obj, "project", None) or getattr(
-                getattr(source_obj, "trace", None), "project", None
-            )
-            if project is None:
-                # CHSpan path: no FK traversals available, but the row
-                # carries project_id. Resolve the PG Project explicitly.
-                # Codex wave-2 P2: scope the PG lookup by organization when
-                # one is provided. Defense-in-depth — current CHSpan callers
-                # gate on org upstream, but a future caller could forget;
-                # fail closed here.
-                pid = getattr(source_obj, "project_id", None)
-                if pid:
-                    from tracer.models.project import Project
-
-                    qs = Project.objects.filter(id=pid)
-                    if organization is not None:
-                        qs = qs.filter(organization=organization)
-                    project = qs.first()
-        else:  # trace_session
-            project = getattr(source_obj, "project", None)
-            if project is None:
-                # CH trace_session path (_CHTraceSessionSource): no FK, resolve the
-                # PG Project by the carried project_id, org-scoped (fail closed).
-                pid = getattr(source_obj, "project_id", None)
-                if pid:
-                    from tracer.models.project import Project
-
-                    qs = Project.objects.filter(id=pid)
-                    if organization is not None:
-                        qs = qs.filter(organization=organization)
-                    project = qs.first()
+        project = source_project(source_obj, organization)
         if not project:
             return None, None
         scope_name = (
@@ -740,19 +644,6 @@ def _resolve_ch_trace_session(source_id, *, organization=None, workspace=None):
     )
 
 
-def _safe_related(item, attr):
-    """Read a ``db_constraint=False`` FK whose target row may not exist in PG
-    (collector data lives only in CH). Collapse a missing target
-    (``ObjectDoesNotExist``) to ``None`` so the caller can fall back to CH; other
-    errors propagate."""
-    from django.core.exceptions import ObjectDoesNotExist
-
-    try:
-        return getattr(item, attr)
-    except ObjectDoesNotExist:
-        return None
-
-
 def _ch_span_for_item(span_id):
     """Best-effort CH point-read for a render path (preview/content). Returns the
     :class:`CHSpan` or ``None`` (genuinely-gone span OR CH error). FAIL OPEN on the
@@ -769,30 +660,39 @@ def _ch_span_for_item(span_id):
         return None
 
 
-def _ch_root_span_for_trace(trace_id):
-    """Best-effort CH read of a collector trace's root span (resolve/render path).
+def _pick_conversation_root(root_spans):
+    """From a trace's parentless (root) spans, prefer the conversation root, else
+    the first. Shared by the per-item (:func:`_ch_root_span_for_trace`) and batched
+    (:func:`_batch_ch_trace_roots`) CH trace reads so both pick identically."""
+    if not root_spans:
+        return None
+    for span in root_spans:
+        if getattr(span, "observation_type", None) == "conversation":
+            return span
+    return root_spans[0]
 
-    Mirrors ``_get_item_spans``' trace branch: list the trace's CH spans, prefer
-    the conversation root, else the first parentless span. A non-voice trace item
-    is annotated at this root span. Returns the :class:`CHSpan` or ``None``
-    (missing / CH error). FAIL OPEN — logs, never raises into the page."""
+
+def _ch_root_span_for_trace(trace_id):
+    """Best-effort CH read of a trace's root span (resolve/render path).
+
+    Reads ONLY the parentless (root) spans, LEAN, via ``roots_by_trace_ids``: a
+    voice conversation root carries its whole raw log in the heavy columns, and a
+    full ``list_by_trace`` here is the exact TH-6442 code-241 OOM shape on the
+    shared cluster — this runs on every trace resolution. Prefers the conversation
+    root, else the first parentless span; a trace with no parentless span in CH
+    resolves to ``None`` (fail closed — never a full scan to find one root). FAIL
+    OPEN on CH error — logs, never raises into the page."""
     if not trace_id:
         return None
     from tracer.services.clickhouse.v2 import get_reader
 
     try:
         with get_reader() as reader:
-            spans = reader.list_by_trace(str(trace_id))
+            roots = reader.roots_by_trace_ids([str(trace_id)], include_heavy=False)
     except Exception as exc:
         logger.warning("ch_trace_render_error", trace_id=str(trace_id), error=str(exc))
         return None
-    root_spans = [s for s in spans if not s.parent_span_id]
-    if not root_spans:
-        return None
-    for span in root_spans:
-        if span.observation_type == "conversation":
-            return span
-    return root_spans[0]
+    return _pick_conversation_root(roots)
 
 
 def _ch_session_fields_for_item(session_id):
@@ -834,6 +734,48 @@ def _batch_ch_spans(span_ids):
     return {str(span.id): span for span in spans}
 
 
+# Chunk the trace-id IN-list so one batch can't grow unbounded; a queue's selection
+# reaches 10k items. The read itself is LEAN (see below), so peak memory is bounded
+# by row count, not by the fat voice columns.
+_CH_TRACE_ID_BATCH = 500
+
+
+def _batch_ch_trace_roots(trace_ids, *, org_id=None):
+    """Batch CH read of each trace's root span for a render/export path:
+    ``{str(trace_id): CHSpan}`` over *trace_ids* (chunked, LEAN).
+
+    Reads the parentless (root) spans LEAN — input / output / metadata /
+    span_attributes stay real; the heavy ``resource_attributes`` and ``events`` come
+    back empty. That is a deliberate trade against ClickHouse OOM: those columns
+    carry the voice raw_log on the CONVERSATION ROOT, and a batched heavy read of
+    many roots is exactly the code-241 shape on the shared cluster. ``org_id`` scopes
+    the read to one tenant. CH error → ``{}`` (FAIL OPEN — the per-item collector
+    branch then does its own point-read or renders the ``deleted`` sentinel). Backs
+    :class:`CollectorSourceCache` so a list/export over CH traces does one read per
+    chunk, not one per item."""
+    if not trace_ids:
+        return {}
+    from tracer.services.clickhouse.v2 import get_reader
+
+    ids = [str(t) for t in trace_ids]
+    roots_by_trace: dict[str, list] = {}
+    try:
+        with get_reader() as reader:
+            for start in range(0, len(ids), _CH_TRACE_ID_BATCH):
+                chunk = ids[start : start + _CH_TRACE_ID_BATCH]
+                for span in reader.roots_by_trace_ids(
+                    chunk, include_heavy=False, org_id=org_id
+                ):
+                    roots_by_trace.setdefault(str(span.trace_id), []).append(span)
+    except Exception as exc:
+        logger.warning("ch_trace_roots_batch_error", count=len(ids), error=str(exc))
+        return {}
+    return {
+        trace_id: _pick_conversation_root(spans)
+        for trace_id, spans in roots_by_trace.items()
+    }
+
+
 def _batch_ch_session_fields(session_ids):
     """Batch CH read of session identity fields: ``{str(id): fields}`` in one query.
     CH error → ``{}`` (FAIL OPEN). Companion to :func:`_batch_ch_spans`."""
@@ -853,30 +795,32 @@ def _batch_ch_session_fields(session_ids):
 
 
 class CollectorSourceCache:
-    """Page-scoped batch cache of CH-resolved collector sources.
+    """Page-scoped batch cache of CH-resolved sources (trace / span / session).
 
-    ``resolve_source_preview`` / ``resolve_source_content`` run once per item; for
-    collector spans/sessions (CH-only, no PG row) each call would otherwise do its
-    own CH point-read — an N+1 against ClickHouse on every list/export page (PG
-    sources are prefetchable, CH has no ORM prefetch). Build one cache per page with
+    ``resolve_source_preview`` / ``resolve_source_content`` run once per item; tracer
+    sources (trace / observation_span / trace_session) are read CH-only, so each call
+    would otherwise do its own CH point-read — an N+1 against ClickHouse on every
+    list/export page (CH has no ORM prefetch). Build one cache per page with
     :meth:`for_items` and pass it as ``ch_cache=`` so the page does a single CH read
-    per kind. Only the collector branch consults it (a PG hit never does); a cache
-    miss returns ``None`` → ``deleted`` sentinel, matching the single-read fail-open.
+    per kind. A cache miss returns ``None`` → ``deleted`` sentinel, matching the
+    single-read fail-open.
     """
 
-    __slots__ = ("_spans", "_sessions")
+    __slots__ = ("_spans", "_sessions", "_trace_roots")
 
-    def __init__(self, *, spans=None, sessions=None):
+    def __init__(self, *, spans=None, sessions=None, trace_roots=None):
         self._spans = spans or {}
         self._sessions = sessions or {}
+        self._trace_roots = trace_roots or {}
 
     @classmethod
     def for_items(cls, items):
-        """Collect the collector span/session ids across *items* and batch-resolve
-        each kind from CH in one read. ``source_type=trace`` is PG-backed this wave,
-        so only spans and sessions are cached. PG-backed ids may also be fetched (one
-        bounded query); harmless, since the cache is consulted only on a PG miss."""
-        span_ids, session_ids = set(), set()
+        """Collect the tracer source ids across *items* and batch-resolve each kind
+        from CH in one read. Traces resolve to their root span (LEAN), spans and
+        sessions by soft id. Empty id-sets short-circuit, so a page with no items of
+        a kind pays for no read of that kind."""
+        span_ids, session_ids, trace_ids = set(), set(), set()
+        org_id = None
         for item in items or []:
             source_type = getattr(item, "source_type", None)
             if (
@@ -889,13 +833,24 @@ class CollectorSourceCache:
                 and item.trace_session_id
             ):
                 session_ids.add(str(item.trace_session_id))
+            elif (
+                source_type == QueueItemSourceType.TRACE.value and item.trace_id
+            ):
+                trace_ids.add(str(item.trace_id))
+                org_id = org_id or getattr(item, "organization_id", None)
         return cls(
             spans=_batch_ch_spans(span_ids),
             sessions=_batch_ch_session_fields(session_ids),
+            trace_roots=_batch_ch_trace_roots(
+                trace_ids, org_id=str(org_id) if org_id else None
+            ),
         )
 
     def span(self, span_id):
         return self._spans.get(str(span_id)) if span_id else None
+
+    def trace_root(self, trace_id):
+        return self._trace_roots.get(str(trace_id)) if trace_id else None
 
     def session_fields(self, session_id):
         return self._sessions.get(str(session_id)) if session_id else None
@@ -918,60 +873,6 @@ class _CHTraceSessionSource:
         self.project_id = project_id
         self.name = name
         self.first_seen = first_seen
-
-
-def resolve_ch_span_source(source_id, organization=None, workspace=None):
-    """CDC-off fallback for ``resolve_source_object('observation_span', …)``.
-
-    Collector-only spans live only in CH with no PG row; resolve from CH and return
-    the CHSpan (duck-types as a source object). None when absent or org/workspace mismatch.
-    """
-    try:
-        from tracer.services.clickhouse.v2 import get_reader
-
-        reader = get_reader()
-        try:
-            ch = reader.get(str(source_id))
-        finally:
-            close = getattr(reader, "close", None)
-            if callable(close):
-                close()
-    except Exception:
-        logger.exception("resolve_ch_span_source_failed", source_id=str(source_id))
-        return None
-    if ch is None:
-        return None
-
-    if organization is not None:
-        ch_org = str(getattr(ch, "org_id", "") or "")
-        # Deny by default: an empty/missing org is unattributable and must not resolve
-        # under another org's request (a `ch_org and ...` guard would fail open).
-        if ch_org != str(organization.pk):
-            logger.warning(
-                "ch_span_source_org_mismatch",
-                source_id=str(source_id),
-                expected_org=str(organization.pk),
-                actual_org=ch_org or "<empty>",
-            )
-            return None
-
-    if workspace is not None:
-        from tracer.models.project import Project
-
-        proj = Project.objects.filter(id=getattr(ch, "project_id", None)).first()
-        obj_ws = getattr(proj, "workspace", None) if proj else None
-        ws_match = obj_ws == workspace or (
-            obj_ws is None and getattr(workspace, "is_default", False)
-        )
-        if not ws_match:
-            logger.warning(
-                "ch_span_source_workspace_mismatch",
-                source_id=str(source_id),
-                expected_workspace=str(workspace.pk),
-            )
-            return None
-
-    return ch
 
 
 def _get_source_organization(obj):
@@ -1067,9 +968,10 @@ def _get_source_workspace(obj):
 def resolve_source_preview(item, *, ch_cache=None):
     """Return a standardized preview dict for a QueueItem's source.
 
-    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, collector
-    span/session sources read from the page-batched map instead of a per-item CH
-    point-read. Single-item callers pass ``None`` and keep the per-item read."""
+    Tracer sources (trace / observation_span / trace_session) are read CH-only.
+    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, they read
+    from the page-batched map instead of a per-item CH point-read. Single-item
+    callers pass ``None`` and keep the per-item read."""
     try:
         if item.source_type == QueueItemSourceType.DATASET_ROW.value:
             row = item.dataset_row
@@ -1083,65 +985,46 @@ def resolve_source_preview(item, *, ch_cache=None):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE.value:
-            trace = _safe_related(item, "trace")
-            if not trace:
-                # collector trace: no PG row, preview from the CH root span.
-                root_span = _ch_root_span_for_trace(item.trace_id)
-                if root_span is None:
-                    return {"type": "trace", "deleted": True}
-                return {
-                    "type": "trace",
-                    "name": root_span.name or "",
-                    "project_id": (
-                        str(root_span.project_id) if root_span.project_id else None
-                    ),
-                    "input_preview": _truncate(str(root_span.input or ""), 200),
-                    "output_preview": _truncate(str(root_span.output or ""), 200),
-                    # CH has no response_time column; latency is the only signal.
-                    "latency_ms": root_span.latency_ms,
-                    "response_time_ms": root_span.latency_ms,
-                }
-            primary_span = _trace_primary_span(trace)
-            metrics = _metric_payload(primary_span) if primary_span else {}
+            # CH-only: a trace previews from its CH root span (conversation root
+            # preferred). The PG tracer tables are dropped — never read them.
+            root_span = (
+                ch_cache.trace_root(item.trace_id)
+                if ch_cache is not None
+                else _ch_root_span_for_trace(item.trace_id)
+            )
+            if root_span is None:
+                return {"type": "trace", "deleted": True}
             return {
                 "type": "trace",
-                "name": trace.name or "",
-                "project_id": str(trace.project_id) if trace.project_id else None,
-                "input_preview": _truncate(str(trace.input or ""), 200),
-                "output_preview": _truncate(str(trace.output or ""), 200),
-                **metrics,
+                "name": root_span.name or "",
+                "project_id": (
+                    str(root_span.project_id) if root_span.project_id else None
+                ),
+                "input_preview": _truncate(str(root_span.input or ""), 200),
+                "output_preview": _truncate(str(root_span.output or ""), 200),
+                # CH has no response_time column; latency is the only signal.
+                "latency_ms": root_span.latency_ms,
+                "response_time_ms": root_span.latency_ms,
             }
 
         elif item.source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
-            span = _safe_related(item, "observation_span")
-            if not span:
-                # collector span: no PG row, resolve from CH by the soft id
-                ch_span = (
-                    ch_cache.span(item.observation_span_id)
-                    if ch_cache is not None
-                    else _ch_span_for_item(item.observation_span_id)
-                )
-                if ch_span is None:
-                    return {"type": "observation_span", "deleted": True}
-                return {
-                    "type": "observation_span",
-                    "name": ch_span.name or "",
-                    "observation_type": ch_span.observation_type or "",
-                    "input_preview": _truncate(str(ch_span.input or ""), 200),
-                    "output_preview": _truncate(str(ch_span.output or ""), 200),
-                    # CH has no response_time column; latency is the only signal.
-                    "latency_ms": ch_span.latency_ms,
-                    "response_time_ms": ch_span.latency_ms,
-                }
+            # CH-only: resolve the span from CH by its soft id.
+            ch_span = (
+                ch_cache.span(item.observation_span_id)
+                if ch_cache is not None
+                else _ch_span_for_item(item.observation_span_id)
+            )
+            if ch_span is None:
+                return {"type": "observation_span", "deleted": True}
             return {
                 "type": "observation_span",
-                "name": span.name or "",
-                "observation_type": getattr(span, "observation_type", ""),
-                "input_preview": _truncate(str(getattr(span, "input", "") or ""), 200),
-                "output_preview": _truncate(
-                    str(getattr(span, "output", "") or ""), 200
-                ),
-                **_metric_payload(span),
+                "name": ch_span.name or "",
+                "observation_type": ch_span.observation_type or "",
+                "input_preview": _truncate(str(ch_span.input or ""), 200),
+                "output_preview": _truncate(str(ch_span.output or ""), 200),
+                # CH has no response_time column; latency is the only signal.
+                "latency_ms": ch_span.latency_ms,
+                "response_time_ms": ch_span.latency_ms,
             }
 
         elif item.source_type == QueueItemSourceType.PROTOTYPE_RUN.value:
@@ -1168,31 +1051,23 @@ def resolve_source_preview(item, *, ch_cache=None):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE_SESSION.value:
-            session = _safe_related(item, "trace_session")
-            if not session:
-                # collector session: no PG row, resolve identity from CH
-                fields = (
-                    ch_cache.session_fields(item.trace_session_id)
-                    if ch_cache is not None
-                    else _ch_session_fields_for_item(item.trace_session_id)
-                )
-                if fields is None:
-                    return {"type": "trace_session", "deleted": True}
-                return {
-                    "type": "trace_session",
-                    "session_id": str(item.trace_session_id),
-                    "name": fields.get("display_name")
-                    or fields.get("external_session_id")
-                    or "",
-                    "project_id": (
-                        str(fields["project_id"]) if fields.get("project_id") else None
-                    ),
-                }
+            # CH-only: resolve the session identity fields from CH.
+            fields = (
+                ch_cache.session_fields(item.trace_session_id)
+                if ch_cache is not None
+                else _ch_session_fields_for_item(item.trace_session_id)
+            )
+            if fields is None:
+                return {"type": "trace_session", "deleted": True}
             return {
                 "type": "trace_session",
-                "session_id": str(session.id),
-                "name": session.name or "",
-                "project_id": str(session.project_id) if session.project_id else None,
+                "session_id": str(item.trace_session_id),
+                "name": fields.get("display_name")
+                or fields.get("external_session_id")
+                or "",
+                "project_id": (
+                    str(fields["project_id"]) if fields.get("project_id") else None
+                ),
             }
 
     except Exception as e:
@@ -1204,9 +1079,10 @@ def resolve_source_preview(item, *, ch_cache=None):
 def resolve_source_content(item, *, ch_cache=None):
     """Return full renderable content for a QueueItem's source (used in annotation view).
 
-    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, collector
-    span/session sources read from the page-batched map instead of a per-item CH
-    point-read. Single-item callers pass ``None`` and keep the per-item read."""
+    Tracer sources (trace / observation_span / trace_session) are read CH-only.
+    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, they read
+    from the page-batched map instead of a per-item CH point-read. Single-item
+    callers pass ``None`` and keep the per-item read."""
     try:
         if item.source_type == QueueItemSourceType.DATASET_ROW.value:
             row = item.dataset_row
@@ -1254,113 +1130,45 @@ def resolve_source_content(item, *, ch_cache=None):
             return data
 
         elif item.source_type == QueueItemSourceType.TRACE.value:
-            trace = _safe_related(item, "trace")
-            if not trace:
-                # collector trace: no PG row. Render from the CH root span; the
-                # non-voice UI focuses it via ``root_span_id`` (a render choice —
-                # the stored item stays a trace).
-                root_span = _ch_root_span_for_trace(item.trace_id)
-                if root_span is None:
-                    return {"type": "trace", "deleted": True}
-                from tracer.services.clickhouse.v2.span_reader import (
-                    chspan_to_annotation_source_dict,
-                )
+            # CH-only: render a trace from its CH root span (conversation root
+            # preferred). The PG tracer tables are dropped — never read them. The
+            # non-voice UI focuses the root via ``root_span_id`` (a render choice —
+            # the stored item stays a trace).
+            root_span = (
+                ch_cache.trace_root(item.trace_id)
+                if ch_cache is not None
+                else _ch_root_span_for_trace(item.trace_id)
+            )
+            if root_span is None:
+                return {"type": "trace", "deleted": True}
+            from tracer.services.clickhouse.v2.span_reader import (
+                chspan_to_annotation_source_dict,
+            )
 
-                # Headline content of the trace = its root span, reshaped to the
-                # trace dict. Drop span_id: the FE renders a trace item via
-                # InlineTraceView(trace_id) and only reads span_id for an
-                # observation_span item, so it's dead + mis-attachment-prone here.
-                data = chspan_to_annotation_source_dict(root_span)
-                data["type"] = "trace"
-                data["trace_id"] = str(item.trace_id)
-                data.pop("span_id", None)
-                return data
-            project_source = trace.project.source if trace.project_id else None
-            primary_span = _trace_primary_span(trace)
-            span_metrics = _metric_payload(primary_span) if primary_span else {}
-            trace_latency = getattr(trace, "latency", None)
-            trace_status = getattr(trace, "status", None)
-            return {
-                "type": "trace",
-                "trace_id": str(trace.id),
-                "name": trace.name or "",
-                "project_id": str(trace.project_id) if trace.project_id else None,
-                "project_source": project_source,
-                "created_at": trace.created_at,
-                "updated_at": trace.updated_at,
-                "input": trace.input,
-                "output": trace.output,
-                "metadata": trace.metadata if hasattr(trace, "metadata") else {},
-                "latency": trace_latency,
-                "latency_ms": (
-                    span_metrics.get("latency_ms")
-                    if span_metrics.get("latency_ms") is not None
-                    else trace_latency
-                ),
-                "response_time_ms": span_metrics.get("response_time_ms"),
-                "status": (
-                    trace_status
-                    if trace_status is not None
-                    else getattr(primary_span, "status", None)
-                    if primary_span
-                    else None
-                ),
-                "span_attributes": (
-                    getattr(primary_span, "span_attributes", {}) if primary_span else {}
-                ),
-                "resource_attributes": (
-                    getattr(primary_span, "resource_attributes", {})
-                    if primary_span
-                    else {}
-                ),
-            }
+            # Headline content of the trace = its root span, reshaped to the trace
+            # dict. Drop span_id: the FE renders a trace item via
+            # InlineTraceView(trace_id) and only reads span_id for an
+            # observation_span item, so it's dead + mis-attachment-prone here.
+            data = chspan_to_annotation_source_dict(root_span)
+            data["type"] = "trace"
+            data["trace_id"] = str(item.trace_id)
+            data.pop("span_id", None)
+            return data
 
         elif item.source_type == QueueItemSourceType.OBSERVATION_SPAN.value:
-            span = _safe_related(item, "observation_span")
-            if not span:
-                # collector span: no PG row, rebuild content from CH via the mapper
-                ch_span = (
-                    ch_cache.span(item.observation_span_id)
-                    if ch_cache is not None
-                    else _ch_span_for_item(item.observation_span_id)
-                )
-                if ch_span is None:
-                    return {"type": "observation_span", "deleted": True}
-                from tracer.services.clickhouse.v2.span_reader import (
-                    chspan_to_annotation_source_dict,
-                )
+            # CH-only: rebuild content from CH via the canonical mapper.
+            ch_span = (
+                ch_cache.span(item.observation_span_id)
+                if ch_cache is not None
+                else _ch_span_for_item(item.observation_span_id)
+            )
+            if ch_span is None:
+                return {"type": "observation_span", "deleted": True}
+            from tracer.services.clickhouse.v2.span_reader import (
+                chspan_to_annotation_source_dict,
+            )
 
-                return chspan_to_annotation_source_dict(ch_span)
-            return {
-                "type": "observation_span",
-                "span_id": str(span.id),
-                "trace_id": str(span.trace_id) if span.trace_id else None,
-                "name": span.name or "",
-                "observation_type": getattr(span, "observation_type", ""),
-                "project_id": str(span.project_id) if span.project_id else None,
-                "created_at": span.created_at,
-                "updated_at": span.updated_at,
-                "start_time": span.start_time,
-                "end_time": span.end_time,
-                "input": getattr(span, "input", None),
-                "output": getattr(span, "output", None),
-                "metadata": getattr(span, "metadata", {}),
-                "events": getattr(span, "events", []),
-                "latency_ms": getattr(span, "latency_ms", None),
-                "response_time_ms": getattr(span, "response_time", None),
-                "model": getattr(span, "model", None),
-                "provider": getattr(span, "provider", None),
-                "cost": getattr(span, "cost", None),
-                "prompt_tokens": getattr(span, "prompt_tokens", None),
-                "completion_tokens": getattr(span, "completion_tokens", None),
-                "total_tokens": getattr(span, "total_tokens", None),
-                "status": getattr(span, "status", None),
-                "status_message": getattr(span, "status_message", None),
-                "tags": getattr(span, "tags", []),
-                "span_attributes": getattr(span, "span_attributes", {}),
-                "resource_attributes": getattr(span, "resource_attributes", {}),
-                "eval_attributes": getattr(span, "eval_attributes", {}),
-            }
+            return chspan_to_annotation_source_dict(ch_span)
 
         elif item.source_type == QueueItemSourceType.PROTOTYPE_RUN.value:
             run = item.prototype_run
@@ -1445,39 +1253,28 @@ def resolve_source_content(item, *, ch_cache=None):
             }
 
         elif item.source_type == QueueItemSourceType.TRACE_SESSION.value:
-            session = _safe_related(item, "trace_session")
-            if not session:
-                # collector session: no PG row, resolve from CH (first_seen is the
-                # created_at/updated_at proxy — CH has no audit columns)
-                fields = (
-                    ch_cache.session_fields(item.trace_session_id)
-                    if ch_cache is not None
-                    else _ch_session_fields_for_item(item.trace_session_id)
-                )
-                if fields is None:
-                    return {"type": "trace_session", "deleted": True}
-                first_seen = fields.get("first_seen")
-                return {
-                    "type": "trace_session",
-                    "session_id": str(item.trace_session_id),
-                    "source_id": str(item.trace_session_id),
-                    "name": fields.get("display_name")
-                    or fields.get("external_session_id")
-                    or "",
-                    "project_id": (
-                        str(fields["project_id"]) if fields.get("project_id") else None
-                    ),
-                    "created_at": first_seen,
-                    "updated_at": first_seen,
-                }
+            # CH-only: resolve the session from CH (first_seen is the
+            # created_at/updated_at proxy — CH has no audit columns).
+            fields = (
+                ch_cache.session_fields(item.trace_session_id)
+                if ch_cache is not None
+                else _ch_session_fields_for_item(item.trace_session_id)
+            )
+            if fields is None:
+                return {"type": "trace_session", "deleted": True}
+            first_seen = fields.get("first_seen")
             return {
                 "type": "trace_session",
-                "session_id": str(session.id),
-                "source_id": str(session.id),
-                "name": session.name or "",
-                "project_id": str(session.project_id) if session.project_id else None,
-                "created_at": session.created_at,
-                "updated_at": session.updated_at,
+                "session_id": str(item.trace_session_id),
+                "source_id": str(item.trace_session_id),
+                "name": fields.get("display_name")
+                or fields.get("external_session_id")
+                or "",
+                "project_id": (
+                    str(fields["project_id"]) if fields.get("project_id") else None
+                ),
+                "created_at": first_seen,
+                "updated_at": first_seen,
             }
 
     except Exception as e:

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -40,6 +40,17 @@ SOURCE_MODEL_MAP = {
     ),
 }
 
+# Tracer-owned sources live only in ClickHouse (the tracer app is CH-native; the
+# legacy PG tables are gone). Annotation reads of these resolve/render/filter from
+# CH, never PG. The remaining source types stay PG-backed.
+_CH_NATIVE_SOURCE_TYPES = frozenset(
+    {
+        QueueItemSourceType.TRACE.value,
+        QueueItemSourceType.OBSERVATION_SPAN.value,
+        QueueItemSourceType.TRACE_SESSION.value,
+    }
+)
+
 FILTER_MODE_SOURCE_TYPES = {
     QueueItemSourceType.DATASET_ROW.value,
     QueueItemSourceType.TRACE.value,
@@ -526,49 +537,30 @@ def resolve_default_queue_item_for_source(source_type, source_obj, organization,
     return item
 
 
-def resolve_source_object(
-    source_type,
-    source_id,
-    organization=None,
-    workspace=None,
-    *,
-    allow_ch_fallback=False,
-):
-    """Look up a source model instance by type and ID.
+def resolve_source_object(source_type, source_id, organization=None, workspace=None):
+    """Look up a source object by type and ID.
 
-    When *organization* is provided the returned object is verified to belong
-    to that organization.  The check accounts for the fact that some source
-    models store ``organization`` directly while others reach it through a
-    related FK (e.g. ``project.organization`` or ``dataset.organization``).
-    ``None`` is returned when the object exists but does not belong to the
-    requested organization.
+    Tracer sources (trace / observation_span / trace_session) live only in
+    ClickHouse — the tracer app is CH-native — so they resolve straight from CH and
+    come back duck-typed (``.id`` / ``.project_id``); the CH resolver tenant-scopes
+    them against the PG ``Project`` (which is not a tracer table), fail-closed.
 
-    When *workspace* is provided, an additional check ensures the object
-    belongs to that workspace (via direct FK or through a related project /
-    dataset).  ``None`` is returned on mismatch.
-
-    ``allow_ch_fallback`` (opt-in): when ``True`` and no PG row exists, fall back
-    to ClickHouse for collector observation_span / trace_session sources, returning
-    a duck-typed CH object (``.id`` / ``.project_id``). Only soft-id-storing add
-    paths opt in; callers that deref ``.pk`` / FKs keep the PG-only default.
+    Non-tracer source types (dataset_row / call_execution / prototype_run) are
+    PG-backed models, verified to belong to *organization* / *workspace* (directly or
+    via a related project / dataset). ``None`` on mismatch or absence.
     """
+    if source_type in _CH_NATIVE_SOURCE_TYPES:
+        return _resolve_ch_source_object(
+            source_type, source_id, organization=organization, workspace=workspace
+        )
+
     model = get_source_model(source_type)
     if not model:
         return None
 
-    # PG-first by row existence, not by source type: a curated span/session has a
-    # PG row and must resolve there (richer object, no CH round-trip); only a
-    # collector one (no PG row) needs CH. `source_type` alone can't tell them apart
-    # — both are e.g. `observation_span` — so the missing row is the discriminator.
     obj = model.objects.filter(pk=source_id).first()
     if obj is None:
-        if not allow_ch_fallback:
-            return None
-        # No PG row: collector spans/sessions live only in CH (fail closed). A
-        # PG-native source type that's genuinely absent resolves to None there.
-        return _resolve_ch_source_object(
-            source_type, source_id, organization=organization, workspace=workspace
-        )
+        return None
 
     if organization is not None:
         obj_org = _get_source_organization(obj)

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1326,10 +1326,10 @@ def _item_note_rows(item):
 def _span_note_rows(span):
     """Return SpanNotes for the given span.
 
-    *span* may be a Django ``ObservationSpan`` (span-source items, still PG)
-    or a ``CHSpan`` dataclass (trace-source items, loaded from CH 25 via
-    ``_span_notes_target_for_queue_item``). Both expose a string ``.id``
-    that the ``SpanNotes.span`` FK accepts as an ``span_id=`` filter value.
+    *span* is a ``CHSpan`` resolved from CH via
+    ``_span_notes_target_for_queue_item`` (or a Django ``ObservationSpan`` on the
+    legacy path); both expose a string ``.id`` that the ``SpanNotes.span`` FK
+    accepts as a ``span_id=`` filter value.
     """
     if span is None:
         return []
@@ -1434,54 +1434,6 @@ def _latest_item_note(item):
         .first()
     )
     return queue_note.notes if queue_note else ""
-
-
-def _span_note_targets_for_queue_items(items):
-    """Resolve whole-item note spans in bulk for export.
-
-    Pairs ``_span_notes_target_for_queue_item`` semantics with a bulk fetch:
-    span-source items use the FK Django ``ObservationSpan`` (still PG);
-    trace-source items pick the trace root span from CH 25 in one bulk
-    query (conversation root preferred, then first-by-(start_time, id)).
-    Currently unused — kept for the export builders that may re-adopt it.
-    """
-    targets = {}
-    trace_ids = []
-    for item in items:
-        if item.source_type == "observation_span" and item.observation_span_id:
-            targets[item.id] = item.observation_span
-        elif item.source_type == "trace" and item.trace_id:
-            trace_ids.append(str(item.trace_id))
-
-    if trace_ids:
-        # CH read replaces:
-        #   ObservationSpan.objects.filter(trace_id__in=trace_ids, deleted=False)
-        #     .filter(Q(parent_span_id__isnull=True) | Q(parent_span_id=""))
-        #     .order_by("trace_id", "start_time", "created_at")
-        # CHSpanReader.list_by_trace_ids already excludes is_deleted=1 and
-        # orders by (trace_id, start_time, id). Root-span filtering happens
-        # in Python (parent_span_id is non-nullable string in CH 25 schema).
-        from tracer.services.clickhouse.v2 import get_reader
-
-        with get_reader() as reader:
-            spans = reader.list_by_trace_ids(trace_ids)
-        first_root_by_trace = {}
-        first_conversation_by_trace = {}
-        for span in spans:
-            if span.parent_span_id:
-                continue
-            first_root_by_trace.setdefault(span.trace_id, span)
-            if span.observation_type == "conversation":
-                first_conversation_by_trace.setdefault(span.trace_id, span)
-        for item in items:
-            if item.source_type == "trace" and item.trace_id:
-                target = first_conversation_by_trace.get(
-                    str(item.trace_id)
-                ) or first_root_by_trace.get(str(item.trace_id))
-                if target is not None:
-                    targets[item.id] = target
-
-    return targets
 
 
 def _latest_item_notes_for_queue_items(items):
@@ -4606,12 +4558,12 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 "reviewed_by",
             )
             .prefetch_related(
+                # Tracer sources (trace / observation_span / trace_session) render
+                # CH-native via the serializer's CollectorSourceCache — no PG
+                # prefetch on them (a SELECT from the dropped tracer tables would 500).
                 "dataset_row",
-                "trace",
-                "observation_span",
                 "prototype_run",
                 "call_execution",
-                "trace_session",
                 Prefetch(
                     "assignments",
                     queryset=QueueItemAssignment.objects.filter(
@@ -5382,38 +5334,16 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 ).update(deleted=True, deleted_at=now, updated_at=now)
 
         if span_notes_target is not None and item_notes is not None:
-            # `span_notes_target` is either a Django ObservationSpan (span
-            # source items) or a CHSpan dataclass (trace source items, root
-            # span loaded from CH). Both expose a string `.id` that the
-            # SpanNotes.span FK accepts as the `span_id=` argument; the FK
-            # column itself remains a PG CharField pointing at
-            # tracer_observation_span.id.
-            #
-            # Codex consolidated review P1 (2026-05-26): if the CH span has
-            # no matching PG ObservationSpan row (e.g. dual-write skew, or
-            # OTel-direct-to-CH cutover before PG dual-write removed),
-            # SpanNotes.update_or_create raises ForeignKey IntegrityError
-            # AFTER scores + queue-notes were already committed earlier in
-            # this submit handler. Catch and degrade gracefully — span notes
-            # are annotator commentary, not load-bearing; the operator gets
-            # a warning log and the user still sees their annotation land.
+            # `span_notes_target` is a Django ObservationSpan (span-source items)
+            # or a CHSpan (trace-source items, root loaded from CH); both expose a
+            # string `.id`. SpanNotes.span is a db_constraint=False soft FK, so the
+            # write must NOT gate on a PG ObservationSpan lookup — a CH-only
+            # collector span has no PG row, and the PG tracer tables are dropped.
+            # Write the soft id directly; the try/except stays defensive.
             from django.db import IntegrityError
 
-            from tracer.models.observation_span import ObservationSpan
-
             target_id = span_notes_target.id
-            pg_span_exists = ObservationSpan.no_workspace_objects.filter(
-                id=target_id
-            ).exists()
-            if not pg_span_exists:
-                logger.warning(
-                    "span_notes_skipped_no_pg_row",
-                    span_id=str(target_id),
-                    queue_item_id=str(item.id),
-                    user_id=str(request.user.id),
-                    reason="CH has the span but PG ObservationSpan FK target missing",
-                )
-            elif item_notes:
+            if item_notes:
                 try:
                     SpanNotes.objects.update_or_create(
                         span_id=target_id,

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -5004,6 +5004,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             resolved_ids,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
+            project_id=project_id,
         )
         errors = [unavailable_error] if unavailable_error else []
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -141,7 +141,7 @@ from tfc.utils.base_viewset import BaseModelViewSetMixinWithUserOrg
 from tfc.utils.email import email_helper
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.pagination import ExtendedPageNumberPagination
-from tracer.models.observation_span import EvalLogger, ObservationSpan
+from tracer.models.observation_span import EvalLogger
 from tracer.models.project import Project
 from tracer.models.span_notes import SpanNotes
 
@@ -162,14 +162,12 @@ MAX_SELECTION_CAP = 10_000
 
 
 def _queue_item_export_prefetches():
+    # Tracer sources (trace / observation_span) render CH-native via
+    # CollectorSourceCache, so there is no PG trace-span prefetch here — a
+    # ``trace__observation_spans`` Prefetch would query the dropped tracer tables.
+    # call_execution is a simulate model (not tracer), so its transcript prefetch
+    # stays.
     return (
-        Prefetch(
-            "trace__observation_spans",
-            queryset=ObservationSpan.objects.filter(deleted=False).order_by(
-                "start_time", "created_at"
-            ),
-            to_attr="_queue_export_spans",
-        ),
         Prefetch(
             "call_execution__transcripts",
             queryset=CallTranscript.objects.filter(
@@ -1269,44 +1267,27 @@ def _reopen_items_missing_required_labels(queue):
 def _span_notes_target_for_queue_item(item):
     """Return the span that stores whole-item notes for queue annotation.
 
-    Span-source items return the PG ``ObservationSpan`` (writes still live in
-    PG), falling back to the CH span for collector data with no PG row.
-    Trace-source items pick the trace's root span from
-    CH 25 — preference order is ``observation_type="conversation"`` root span
-    (voice projects) → first root span by start_time → ``None``.
+    CH-native: span-source items resolve the span from CH by its soft id;
+    trace-source items pick the trace's root span from CH (lean) — preference
+    order ``observation_type="conversation"`` root (voice) → first root span →
+    ``None``. Downstream only reads ``.id``. Never query PG (tables are dropped).
     """
-    if item.source_type == "observation_span" and item.observation_span_id:
-        try:
-            return item.observation_span
-        except ObservationSpan.DoesNotExist:
-            # Collector span: no PG row. Resolve from CH — downstream only reads
-            # `.id` (CHSpan exposes it), same as the trace-root CH spans below.
-            from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2 import get_reader
 
-            with get_reader() as reader:
-                return reader.get(str(item.observation_span_id))
+    if item.source_type == "observation_span" and item.observation_span_id:
+        with get_reader() as reader:
+            return reader.get(str(item.observation_span_id))
     if item.source_type != "trace" or not item.trace_id:
         return None
 
-    # CH read replaces the prior PG path:
-    #   root_spans = ObservationSpan.objects.filter(trace_id=item.trace_id,
-    #       deleted=False).filter(Q(parent_span_id__isnull=True) |
-    #       Q(parent_span_id=""))
-    #   conversation root → start_time root → None
-    # CHSpanReader.list_by_trace drops deleted rows (via FINAL) and orders by
-    # (start_time, id). Root spans have empty parent_span_id (CH stores it
-    # as a non-nullable String — see schema 001), so we filter in Python.
-    from tracer.services.clickhouse.v2 import get_reader
-
     with get_reader() as reader:
-        spans = reader.list_by_trace(str(item.trace_id))
-    root_spans = [s for s in spans if not s.parent_span_id]
-    if not root_spans:
+        roots = reader.roots_by_trace_ids([str(item.trace_id)], include_heavy=False)
+    if not roots:
         return None
-    for s in root_spans:
+    for s in roots:
         if s.observation_type == "conversation":
             return s
-    return root_spans[0]
+    return roots[0]
 
 
 def _serialize_queue_item_note(note):
@@ -2172,29 +2153,16 @@ def _build_annotation_queue_export_fields(queue, sample_items=None):
         fields.append(field)
 
     if sample_items is None:
-        # KEEP-PG (transitional bridge): the Prefetch hydrates
-        # `trace._queue_export_spans` which downstream callers
-        # (`_trace_primary_span`, `resolve_source_content`) read as a list of
-        # Django ObservationSpan objects with `.span_attributes` /
-        # `.resource_attributes` dict access. Migrating that chain requires
-        # either teaching `resolve_source_content` about CHSpan or attaching
-        # CHSpan objects through `Prefetch.to_attr`, which Django's prefetch
-        # machinery does not support for non-model objects. Wave-3
-        # (commit 93c5c415f) added 9 new reader methods but none hydrate
-        # CHSpan via Prefetch.to_attr (that's structurally a Django ORM
-        # concept that doesn't bridge to dataclasses). Deferred to a
-        # follow-up commit that refactors the export path to assemble its
-        # own per-trace span maps via CHSpanReader instead of leaning on
-        # Prefetch — see also DECISIONS.
+        # Tracer sources (trace / observation_span / trace_session) resolve
+        # CH-native via CollectorSourceCache below — no PG select_related on them
+        # (a join to the dropped tracer tables would 500). dataset_row /
+        # prototype_run / call_execution stay PG-backed.
         sample_items = (
             QueueItem.objects.filter(queue=queue, deleted=False)
             .select_related(
-                "trace",
-                "observation_span",
                 "dataset_row",
                 "prototype_run",
                 "call_execution",
-                "trace_session",
             )
             .prefetch_related(*_queue_item_export_prefetches())
             .order_by("order", "created_at")[:100]
@@ -3367,22 +3335,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         query_params = request.validated_query_data
 
         queue = self.get_object()
-        # KEEP-PG (transitional bridge): same Prefetch pattern as
-        # `_build_annotation_queue_export_fields` — see the comment there for
-        # the deferral rationale. The exported rows flow through
-        # `resolve_source_content`/`_trace_primary_span` which expect Django
-        # ObservationSpan objects.
+        # Tracer sources resolve CH-native via CollectorSourceCache below, so no
+        # PG select_related on trace / observation_span / trace_session (a join to
+        # the dropped tracer tables would 500).
         items_qs = (
             QueueItem.objects.filter(queue=queue, deleted=False)
             .select_related(
                 "queue",
                 "reviewed_by",
-                "trace",
-                "observation_span",
                 "dataset_row",
                 "prototype_run",
                 "call_execution",
-                "trace_session",
             )
             .prefetch_related(*_queue_item_export_prefetches())
         )
@@ -3687,21 +3650,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 user=request.user,
             )
 
-        # KEEP-PG (transitional bridge): same Prefetch pattern as
-        # `_build_annotation_queue_export_fields` and `export_annotations` —
-        # `resolve_source_content` reads Django ObservationSpan attrs off the
-        # prefetched chain. See the comment on the first occurrence above.
+        # Tracer sources resolve CH-native via CollectorSourceCache below — no PG
+        # select_related on trace / observation_span / trace_session (a join to the
+        # dropped tracer tables would 500).
         items_qs = (
             QueueItem.objects.filter(queue=queue, deleted=False)
             .select_related(
                 "queue",
                 "reviewed_by",
-                "trace",
-                "observation_span",
                 "dataset_row",
                 "prototype_run",
                 "call_execution",
-                "trace_session",
             )
             .prefetch_related(*_queue_item_export_prefetches())
         )
@@ -5807,11 +5766,10 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         query_params = request.validated_query_data
 
         try:
+            # Tracer sources (trace / observation_span) resolve CH-native — no PG
+            # select_related on them (a join to the dropped tracer tables would 500).
             item = QueueItem.objects.select_related(
                 "dataset_row",
-                "trace",
-                "trace__project",
-                "observation_span",
                 "prototype_run",
                 "call_execution",
                 "assigned_to",

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -4432,11 +4432,26 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 for src in sources
                 if src["source_type"] == "observation_span"
             ]
-            if _span_source_ids:
+            # Same N×M / OOM rationale for traces: a trace's project is a lean
+            # 2-column CH read (``project_by_trace_ids``), precomputed once so the
+            # scope branches below do an in-memory dict lookup instead of a PG
+            # ``Trace.objects`` join — the PG tracer tables are dropped.
+            _ch_project_by_trace: dict[str, str | None] = {}
+            _trace_source_ids = [
+                str(src["source_id"])
+                for src in sources
+                if src["source_type"] == "trace"
+            ]
+            if _span_source_ids or _trace_source_ids:
                 from tracer.services.clickhouse.v2 import get_reader as _gr_bulk
 
                 with _gr_bulk() as _reader_bulk:
-                    _ch_scope_by_span = _reader_bulk.scope_by_ids(_span_source_ids)
+                    if _span_source_ids:
+                        _ch_scope_by_span = _reader_bulk.scope_by_ids(_span_source_ids)
+                    if _trace_source_ids:
+                        _ch_project_by_trace = _reader_bulk.project_by_trace_ids(
+                            _trace_source_ids
+                        )
 
             for dq in missing_defaults:
                 if dq.id in seen_queues:
@@ -4454,19 +4469,13 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                         "observation_span",
                         "trace_session",
                     ):
-                        from tracer.models.trace import Trace
-
                         if st == "trace":
-                            # PG-only on purpose: a collector trace (no PG row)
-                            # returns False here, but the trace-detail panel always
-                            # co-sends its root observation_span (both gated on the
-                            # same spanId in buildTraceAnnotationSources), which
-                            # matches this same project-scoped queue via the
-                            # CH-aware branch below. Making this CH-aware would add
-                            # the N×M per-(queue,trace) round-trips codex P2 removed.
-                            exists = Trace.objects.filter(
-                                id=sid, project_id=dq.project_id, deleted=False
-                            ).exists()
+                            # CH-only: the trace's project (lean 2-column read,
+                            # prefetched above) must match this project-scoped
+                            # default queue. No PG ``Trace`` row exists to join.
+                            exists = _ch_project_by_trace.get(str(sid)) == str(
+                                dq.project_id
+                            )
                         elif st == "observation_span":
                             # Bulk-prefetched above; in-memory dict lookup
                             # (avoids N×M CH round-trips per codex P2).
@@ -4526,14 +4535,19 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                         "observation_span",
                         "trace_session",
                     ):
-                        from tracer.models.trace import Trace
-
                         if st == "trace":
-                            exists = Trace.objects.filter(
-                                id=sid,
-                                project__observability_providers__agent_definition=dq.agent_definition_id,
-                                deleted=False,
-                            ).exists()
+                            # CH-only: read the trace's project from CH (prefetched)
+                            # then verify the agent-definition linkage in PG
+                            # (Project → ObservabilityProvider → AgentDefinition),
+                            # mirroring the observation_span branch below.
+                            _pid = _ch_project_by_trace.get(str(sid))
+                            exists = (
+                                _pid is not None
+                                and Project.objects.filter(
+                                    id=_pid,
+                                    observability_providers__agent_definition=dq.agent_definition_id,
+                                ).exists()
+                            )
                         elif st == "observation_span":
                             # Bulk-prefetched above. FK traversal
                             # `project__observability_providers__agent_definition`

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -125,13 +125,12 @@ from model_hub.utils.annotation_queue_helpers import (
     filter_available_source_ids_for_annotation,
     get_fk_field_name,
     is_source_available_for_annotation,
-    resolve_ch_span_source,
     resolve_source_content,
     resolve_source_object,
 )
+from model_hub.utils.utils import send_message_to_channel
 from simulate.models.test_execution import CallTranscript
 from simulate.utils.stored_transcript_roles import get_displayable_transcript_roles
-from model_hub.utils.utils import send_message_to_channel
 from tfc.utils.api_contracts import validated_request
 from tfc.utils.api_serializers import (
     ApiSelectionTooLargeErrorSerializer,
@@ -180,6 +179,7 @@ def _queue_item_export_prefetches():
             to_attr="_displayable_transcripts",
         ),
     )
+
 
 SOURCE_TYPE_EXPORT_LABELS = {
     QueueItemSourceType.DATASET_ROW.value: "dataset row",
@@ -1783,10 +1783,7 @@ def _eval_metrics_for_queue_items(items):
             and item.observation_span_id
         ):
             span_item_ids[str(item.observation_span_id)].append(item.id)
-        elif (
-            item.source_type == QueueItemSourceType.TRACE.value
-            and item.trace_id
-        ):
+        elif item.source_type == QueueItemSourceType.TRACE.value and item.trace_id:
             trace_item_ids[str(item.trace_id)].append(item.id)
         elif (
             item.source_type == QueueItemSourceType.CALL_EXECUTION.value
@@ -1848,6 +1845,7 @@ LABEL_TYPE_TO_DATA_TYPE = {
     AnnotationTypeChoices.STAR.value: DataTypeChoices.FLOAT.value,
     AnnotationTypeChoices.THUMBS_UP_DOWN.value: DataTypeChoices.TEXT.value,
 }
+
 
 def _unique_export_column_name(name, used):
     base = (name or "column").strip() or "column"
@@ -4191,9 +4189,6 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                     "observation_span",
                     span_notes_source_id,
                     organization=request.organization,
-                ) or resolve_ch_span_source(
-                    span_notes_source_id,
-                    organization=request.organization,
                 )
                 if not span_notes_source:
                     return self._gm.not_found(
@@ -4867,8 +4862,6 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 source_id,
                 organization=request.organization,
                 workspace=getattr(request, "workspace", None),
-                # stores the soft id below, so a CH-resolved collector source is fine
-                allow_ch_fallback=True,
             )
             if not source_obj:
                 errors.append(f"Not found: {source_type}={source_id}")

--- a/futureagi/model_hub/views/scores.py
+++ b/futureagi/model_hub/views/scores.py
@@ -27,9 +27,9 @@ from model_hub.serializers.scores import (
     UpdateScoreSerializer,
 )
 from model_hub.utils.annotation_queue_helpers import (
-    resolve_ch_span_source,
     resolve_default_queue_item_for_source,
     resolve_source_object,
+    source_project,
 )
 from tfc.constants.roles import OrganizationRoles
 from tfc.utils.api_contracts import validated_request
@@ -192,7 +192,9 @@ def _auto_complete_queue_items(source_type, source_obj, annotator):
             )
 
 
-def _auto_create_queue_items_for_default_queues(source_type, source_obj, label_ids):
+def _auto_create_queue_items_for_default_queues(
+    source_type, source_obj, label_ids, organization=None
+):
     """
     For default queues: auto-create a QueueItem when someone annotates a source
     that belongs to the queue's scope (project, dataset, or agent_definition).
@@ -212,8 +214,10 @@ def _auto_create_queue_items_for_default_queues(source_type, source_obj, label_i
     # Build scope filters for default queues this source belongs to
     scope_q = Q()
 
-    # Project-scoped: trace, observation_span, trace_session have project FK
-    project = getattr(source_obj, "project", None)
+    # Project-scoped: trace, observation_span, trace_session. Their CH duck-typed
+    # sources carry only ``project_id`` (no ``.project`` relation), so resolve the
+    # Project row org-scoped rather than reading a relation that's always None.
+    project = source_project(source_obj, organization)
     if project:
         scope_q |= Q(project=project)
 
@@ -352,22 +356,14 @@ class ScoreViewSet(viewsets.ModelViewSet):
         if not fk_field:
             return self._gm.bad_request(f"Invalid source_type: {source_type}")
 
-        # Collector traces/spans have no PG row, so resolve from CH instead of
-        # 404ing. Trace uses the standard project-scoped CH resolver (returns a
-        # duck-typed source); observation_span keeps its dedicated org_id-scoped
-        # fallback below.
+        # Tracer sources (trace / observation_span / trace_session) resolve
+        # CH-native via the single boundary — the PG tracer tables are dropped.
         source_obj = resolve_source_object(
             source_type,
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
         )
-        if not source_obj and source_type == "observation_span":
-            source_obj = resolve_ch_span_source(
-                source_id,
-                organization=request.organization,
-                workspace=getattr(request, "workspace", None),
-            )
         if not source_obj:
             return self._gm.not_found(f"Source not found: {source_type}={source_id}")
 
@@ -439,7 +435,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
             # write that already happened.
             transaction.on_commit(
                 lambda: _safe_auto_create_queue_items_for_default_queues(
-                    source_type, source_obj, [label_id]
+                    source_type, source_obj, [label_id], request.organization
                 )
             )
             transaction.on_commit(
@@ -469,20 +465,13 @@ class ScoreViewSet(viewsets.ModelViewSet):
         if not fk_field:
             return self._gm.bad_request(f"Invalid source_type: {source_type}")
 
-        # Collector traces/spans have no PG row (see create()): trace resolves
-        # from CH via the standard resolver, observation_span via its fallback.
+        # Tracer sources resolve CH-native via the single boundary (see create()).
         source_obj = resolve_source_object(
             source_type,
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
         )
-        if not source_obj and source_type == "observation_span":
-            source_obj = resolve_ch_span_source(
-                source_id,
-                organization=request.organization,
-                workspace=getattr(request, "workspace", None),
-            )
         if not source_obj:
             return self._gm.not_found(f"Source not found: {source_type}={source_id}")
 
@@ -493,10 +482,6 @@ class ScoreViewSet(viewsets.ModelViewSet):
             elif span_notes_source_id:
                 span_notes_target = resolve_source_object(
                     "observation_span",
-                    span_notes_source_id,
-                    organization=request.organization,
-                    workspace=getattr(request, "workspace", None),
-                ) or resolve_ch_span_source(
                     span_notes_source_id,
                     organization=request.organization,
                     workspace=getattr(request, "workspace", None),
@@ -629,7 +614,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
             scored_label_ids = [s["label_id"] for s in data["scores"]]
             transaction.on_commit(
                 lambda: _safe_auto_create_queue_items_for_default_queues(
-                    source_type, source_obj, scored_label_ids
+                    source_type, source_obj, scored_label_ids, request.organization
                 )
             )
             transaction.on_commit(

--- a/futureagi/model_hub/views/scores.py
+++ b/futureagi/model_hub/views/scores.py
@@ -361,7 +361,6 @@ class ScoreViewSet(viewsets.ModelViewSet):
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
-            allow_ch_fallback=(source_type == "trace"),
         )
         if not source_obj and source_type == "observation_span":
             source_obj = resolve_ch_span_source(
@@ -477,7 +476,6 @@ class ScoreViewSet(viewsets.ModelViewSet):
             source_id,
             organization=request.organization,
             workspace=getattr(request, "workspace", None),
-            allow_ch_fallback=(source_type == "trace"),
         )
         if not source_obj and source_type == "observation_span":
             source_obj = resolve_ch_span_source(

--- a/futureagi/tracer/queries/deep_analysis_state.py
+++ b/futureagi/tracer/queries/deep_analysis_state.py
@@ -1,0 +1,62 @@
+"""Transient per-trace deep-analysis job state.
+
+The Error Feed's on-demand "Run Deep Analysis" used to track its per-trace job
+state in ``Trace.error_analysis_status`` (a PG column on ``tracer_trace``).
+Post CH-cutover that table is gone, so the column can't be read or written.
+
+The only genuinely *transient* state is "running": a finished run is recorded by
+a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which is the
+source of truth for "done". So the marker lives in the cache, not a table:
+
+- ``set_running`` is an atomic ``cache.add`` — two rapid dispatches collapse to
+  one (double-click guard), and a crashed worker self-heals when the marker
+  TTLs out. The old column left such traces stuck in PROCESSING forever.
+- "done" is never stored here — it derives from ``TraceErrorAnalysis`` existence.
+"""
+
+from django.core.cache import cache
+
+# Ceiling matches the analysis activity's ``time_limit``; a marker that outlives
+# a crashed run TTLs back to "idle" so the "Run Deep Analysis" button re-enables.
+_TTL_SECONDS = 3600
+
+_RUNNING = "running"
+_FAILED = "failed"
+
+
+def _key(trace_id: str) -> str:
+    return f"deep_analysis:state:{trace_id}"
+
+
+def set_running(trace_id: str) -> bool:
+    """Claim the trace as running. Returns ``True`` if this call set the marker,
+    ``False`` if a run was already in flight — an atomic double-click guard."""
+    return bool(cache.add(_key(trace_id), _RUNNING, _TTL_SECONDS))
+
+
+def is_running(trace_id: str) -> bool:
+    return cache.get(_key(trace_id)) == _RUNNING
+
+
+def set_failed(trace_id: str) -> None:
+    """Record a failed run so the UI can surface it until the marker TTLs out."""
+    cache.set(_key(trace_id), _FAILED, _TTL_SECONDS)
+
+
+def clear(trace_id: str) -> None:
+    cache.delete(_key(trace_id))
+
+
+def status(trace_id: str, *, has_analysis: bool) -> str:
+    """Frontend job state: ``done`` | ``running`` | ``failed`` | ``idle``.
+
+    A completed ``TraceErrorAnalysis`` row wins ("done"). Otherwise the transient
+    marker ("running"/"failed"), else "idle". Mirrors the old
+    status→feed-state map without touching the dropped column.
+    """
+    if has_analysis:
+        return "done"
+    marker = cache.get(_key(trace_id))
+    if marker in (_RUNNING, _FAILED):
+        return marker
+    return "idle"

--- a/futureagi/tracer/queries/deep_analysis_state.py
+++ b/futureagi/tracer/queries/deep_analysis_state.py
@@ -4,13 +4,18 @@ The Error Feed's on-demand "Run Deep Analysis" used to track its per-trace job
 state in ``Trace.error_analysis_status`` (a PG column on ``tracer_trace``).
 Post CH-cutover that table is gone, so the column can't be read or written.
 
-The only genuinely *transient* state is "running": a finished run is recorded by
-a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which is the
-source of truth for "done". So the marker lives in the cache, not a table:
+The only genuinely *transient* state is "running" / "failed": a finished run is
+recorded by a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which
+is the source of truth for "done". So the marker lives in the cache, not a table.
 
-- ``set_running`` is an atomic ``cache.add`` — two rapid dispatches collapse to
-  one (double-click guard), and a crashed worker self-heals when the marker
-  TTLs out. The old column left such traces stuck in PROCESSING forever.
+Two distinct keys back it so the failed state can never block a retry:
+
+- ``set_running`` is an atomic ``cache.add`` on the RUNNING key — two rapid
+  dispatches collapse to one (double-click guard), and a crashed worker
+  self-heals when the marker TTLs out (the old column left such traces stuck in
+  PROCESSING forever). It first clears any FAILED marker so a retry claims cleanly.
+- ``set_failed`` clears the RUNNING key and sets the FAILED key, so the next
+  ``set_running`` claim isn't blocked by a stale running marker.
 - "done" is never stored here — it derives from ``TraceErrorAnalysis`` existence.
 """
 
@@ -20,43 +25,50 @@ from django.core.cache import cache
 # a crashed run TTLs back to "idle" so the "Run Deep Analysis" button re-enables.
 _TTL_SECONDS = 3600
 
-_RUNNING = "running"
-_FAILED = "failed"
+
+def _running_key(trace_id: str) -> str:
+    return f"deep_analysis:running:{trace_id}"
 
 
-def _key(trace_id: str) -> str:
-    return f"deep_analysis:state:{trace_id}"
+def _failed_key(trace_id: str) -> str:
+    return f"deep_analysis:failed:{trace_id}"
 
 
 def set_running(trace_id: str) -> bool:
     """Claim the trace as running. Returns ``True`` if this call set the marker,
-    ``False`` if a run was already in flight — an atomic double-click guard."""
-    return bool(cache.add(_key(trace_id), _RUNNING, _TTL_SECONDS))
+    ``False`` if a run was already in flight — an atomic double-click guard. A
+    prior failure never blocks the claim (its marker is cleared first)."""
+    cache.delete(_failed_key(trace_id))
+    return bool(cache.add(_running_key(trace_id), "1", _TTL_SECONDS))
 
 
 def is_running(trace_id: str) -> bool:
-    return cache.get(_key(trace_id)) == _RUNNING
+    return cache.get(_running_key(trace_id)) is not None
 
 
 def set_failed(trace_id: str) -> None:
-    """Record a failed run so the UI can surface it until the marker TTLs out."""
-    cache.set(_key(trace_id), _FAILED, _TTL_SECONDS)
+    """Record a failed run (until it TTLs out) and release the running claim so a
+    retry can re-dispatch."""
+    cache.delete(_running_key(trace_id))
+    cache.set(_failed_key(trace_id), "1", _TTL_SECONDS)
 
 
 def clear(trace_id: str) -> None:
-    cache.delete(_key(trace_id))
+    cache.delete(_running_key(trace_id))
+    cache.delete(_failed_key(trace_id))
 
 
 def status(trace_id: str, *, has_analysis: bool) -> str:
     """Frontend job state: ``done`` | ``running`` | ``failed`` | ``idle``.
 
     A completed ``TraceErrorAnalysis`` row wins ("done"). Otherwise the transient
-    marker ("running"/"failed"), else "idle". Mirrors the old
-    status→feed-state map without touching the dropped column.
+    running/failed marker, else "idle" — mirroring the old status→feed-state map
+    without touching the dropped column.
     """
     if has_analysis:
         return "done"
-    marker = cache.get(_key(trace_id))
-    if marker in (_RUNNING, _FAILED):
-        return marker
+    if cache.get(_running_key(trace_id)) is not None:
+        return "running"
+    if cache.get(_failed_key(trace_id)) is not None:
+        return "failed"
     return "idle"

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -32,7 +32,6 @@ from scipy.stats import ks_2samp
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 
 from tracer.models.observation_span import EvalLogger, EvalTargetType
-from tracer.models.trace import Trace, TraceErrorAnalysisStatus
 from tracer.models.trace_error_analysis import (
     ClusterSource,
     ErrorClusterTraces,
@@ -42,6 +41,7 @@ from tracer.models.trace_error_analysis import (
     TraceErrorGroup,
 )
 from tracer.models.trace_scan import TraceScanIssue, TraceScanResult
+from tracer.queries import deep_analysis_state
 from tracer.services.clickhouse.v2 import get_reader
 from tracer.services.clickhouse.v2.span_reader import CHSpan
 from tracer.types.feed_types import (
@@ -149,7 +149,9 @@ def _base_qs(project_ids: list[str]) -> QuerySet:
     return (
         TraceErrorGroup.objects.filter(project_id__in=project_ids, deleted=False)
         .exclude(issue_group__isnull=True)
-        .select_related("project", "assignee", "success_trace")
+        # ``success_trace`` (FK → dropped ``tracer_trace``) is only dereferenced
+        # in the detail path, which resolves it from CH; list/stats never read it.
+        .select_related("project", "assignee")
     )
 
 
@@ -298,24 +300,36 @@ def _fetch_users_affected_batch(cluster_ids: list[str]) -> dict:
 
 
 def _fetch_sessions_batch(cluster_ids: list[str]) -> dict:
-    """Return {cluster_id: distinct_session_count}."""
+    """Return {cluster_id: distinct_session_count}.
+
+    Session members carry their session on the junction row; trace members
+    resolve theirs from the CH root span's ``trace_session_id`` (the PG
+    ``Trace.session`` FK is gone post-cutover). Distinct session ids are counted
+    per cluster in Python — mirrors the old cross-store SQL COUNT(DISTINCT).
+    """
     if not cluster_ids:
         return {}
 
-    # Session members store the session directly on the junction row;
-    # trace members reach theirs through trace.session. Coalesce keeps it
-    # one query for mixed batches.
-    rows = (
-        ErrorClusterTraces.objects.filter(cluster__cluster_id__in=cluster_ids)
-        .filter(Q(trace__session__isnull=False) | Q(trace_session__isnull=False))
-        .values("cluster__cluster_id")
-        .annotate(
-            sessions=Count(
-                Coalesce("trace_session_id", "trace__session_id"), distinct=True
-            )
-        )
+    rows = list(
+        ErrorClusterTraces.objects.filter(
+            cluster__cluster_id__in=cluster_ids
+        ).values_list("cluster__cluster_id", "trace_id", "trace_session_id")
     )
-    return {r["cluster__cluster_id"]: r["sessions"] for r in rows}
+
+    # Trace members (no junction session) get their session from CH; batch once.
+    trace_ids = {str(tid) for _cid, tid, sid in rows if tid and not sid}
+    ch_sessions: dict[str, str | None] = {}
+    if trace_ids:
+        with get_reader() as reader:
+            ch_sessions = reader.trace_session_ids_by_trace_ids(list(trace_ids))
+
+    sessions_by_cluster: dict[str, set] = {}
+    for cid, tid, sid in rows:
+        session_id = str(sid) if sid else (ch_sessions.get(str(tid)) if tid else None)
+        if session_id:
+            sessions_by_cluster.setdefault(cid, set()).add(session_id)
+
+    return {cid: len(s) for cid, s in sessions_by_cluster.items() if s}
 
 
 def _fetch_latest_trace_id_batch(cluster_ids: list[str]) -> dict:
@@ -548,7 +562,7 @@ def get_cluster_detail(
     cluster_id is hashed from project+content).
     """
     qs = TraceErrorGroup.objects.filter(deleted=False).select_related(
-        "project", "assignee", "success_trace"
+        "project", "assignee"
     )
     if project_ids is not None:
         qs = qs.filter(project_id__in=project_ids)
@@ -572,22 +586,20 @@ def get_cluster_detail(
 
     success_trace: TracePreview | None = None
     if cluster.success_trace_id:
-        success_trace = TracePreview(
-            trace_id=str(cluster.success_trace_id),
-            input=_trace_input_str(cluster.success_trace),
-            output=_trace_output_str(cluster.success_trace),
-        )
+        success_trace = _ch_trace_preview(str(cluster.success_trace_id))
     elif cluster.source == ClusterSource.EVAL and cluster.eval_config_id:
         # Eval clusters never get the scanner's KNN success match. A genuine
         # PASSING result for the same eval is the honest "working" reference
         # (powers the failing-vs-working comparison, e.g. voice call compare).
+        # Project scope comes off the eval config (project-scoped, PG-resident)
+        # instead of the trace/session FK, which points at the dropped tables.
         if cluster.eval_target_type == EvalTargetType.SESSION:
             # Session evals anchor to the session (trace NULL): find a
             # passing session and represent it by its latest trace.
             _, member_session_ids = _cluster_member_ids(cluster.cluster_id)
             passing_session = (
                 EvalLogger.objects.filter(
-                    trace_session__project_id=cluster.project_id,
+                    custom_eval_config__project_id=cluster.project_id,
                     custom_eval_config_id=cluster.eval_config_id,
                     deleted=False,
                 )
@@ -601,49 +613,32 @@ def get_cluster_detail(
                 rep_tid = _session_rep_trace_map(
                     [str(passing_session)], str(cluster.project_id)
                 ).get(str(passing_session))
-                rep_trace = (
-                    Trace.objects.filter(id=rep_tid).first() if rep_tid else None
-                )
-                if rep_trace:
-                    success_trace = TracePreview(
-                        trace_id=str(rep_trace.id),
-                        input=_trace_input_str(rep_trace),
-                        output=_trace_output_str(rep_trace),
-                    )
+                if rep_tid:
+                    success_trace = _ch_trace_preview(str(rep_tid))
         else:
             member_ids = _trace_ids_for_cluster(
                 cluster.cluster_id, str(cluster.project_id)
             )
-            passing = (
+            passing_trace_id = (
                 EvalLogger.objects.filter(
-                    trace__project_id=cluster.project_id,
+                    custom_eval_config__project_id=cluster.project_id,
                     custom_eval_config_id=cluster.eval_config_id,
                     deleted=False,
                 )
                 .filter(Q(output_bool=True) | Q(output_float__gte=1.0))
                 .exclude(trace_id__in=member_ids)
-                .select_related("trace")
                 .order_by("-created_at")
+                .values_list("trace_id", flat=True)
                 .first()
             )
-            if passing and passing.trace:
-                success_trace = TracePreview(
-                    trace_id=str(passing.trace_id),
-                    input=_trace_input_str(passing.trace),
-                    output=_trace_output_str(passing.trace),
-                )
+            if passing_trace_id:
+                success_trace = _ch_trace_preview(str(passing_trace_id))
 
     representative_trace: TracePreview | None = None
     if row.trace_id:
-        # Direct Trace fetch — session clusters' latest_trace_id is an
-        # effective trace (the session's rep), which has no junction row.
-        rep_trace_obj = Trace.objects.filter(id=row.trace_id).first()
-        if rep_trace_obj:
-            representative_trace = TracePreview(
-                trace_id=str(rep_trace_obj.id),
-                input=_trace_input_str(rep_trace_obj),
-                output=_trace_output_str(rep_trace_obj),
-            )
+        # Session clusters' latest_trace_id is an effective trace (the session's
+        # rep) with no junction row — hydrate it from the CH root span.
+        representative_trace = _ch_trace_preview(str(row.trace_id))
 
     rca = RcaSummary(
         synthesis=cluster.rca_synthesis,
@@ -747,6 +742,32 @@ def _trace_output_str(trace) -> str | None:
     return _safe_str(trace.output)
 
 
+def _ch_trace_preview(trace_id: str) -> TracePreview | None:
+    """``TracePreview`` for a trace hydrated from its CH root span — the sole
+    source post-cutover (no PG ``Trace`` row). Input/output prefer the typed
+    ``input.value``/``output.value`` attrs, falling back to the span's raw
+    input/output payload, matching the pass-reel precedence so the same trace
+    renders identically across surfaces. ``None`` if the trace has no CH root.
+    """
+    if not trace_id:
+        return None
+    root = _get_root_span(str(trace_id))
+    if root is None:
+        return None
+    attrs = root.attrs_string or {}
+    input_text = attrs.get("input.value")
+    if input_text is None and root.input is not None:
+        input_text = _safe_str(root.input)
+    output_text = attrs.get("output.value")
+    if output_text is None and root.output is not None:
+        output_text = _safe_str(root.output)
+    return TracePreview(
+        trace_id=str(trace_id),
+        input=input_text,
+        output=output_text,
+    )
+
+
 class _CHTraceShim:
     """Trace-like view backed by the CH root span, for post-cutover traces
     that have no PG ``Trace`` row. Exposes the attributes the row / rep
@@ -762,24 +783,21 @@ class _CHTraceShim:
 
 
 def _resolve_member_traces(trace_ids: list[str]) -> dict:
-    """``{trace_id: trace-like}`` for cluster members — PG ``Trace`` where it
-    exists, else a CH-backed shim built from the root span.
-
-    Post-CH-cutover traces are CH-only (no PG ``Trace`` row), so resolving
-    members through PG alone silently drops every collector trace from the
-    Traces tab / Overview. Hydrate the missing ones from the spans table.
+    """``{trace_id: trace-like}`` for cluster members, hydrated from the CH
+    root span. Post-cutover traces are CH-only (no PG ``Trace`` row), so the
+    root span is the sole source for the attrs the row/rep builders read
+    (``id``, ``created_at``, ``input``, ``output``). Members with no root span
+    in CH are omitted (same as an unresolvable trace before the cutover).
     """
     ids = [str(t) for t in trace_ids if t]
     if not ids:
         return {}
-    out: dict = {str(t.id): t for t in Trace.objects.filter(id__in=ids)}
-    missing = [tid for tid in ids if tid not in out]
-    if missing:
-        roots = _get_root_spans_batch(missing)
-        for tid in missing:
-            root = roots.get(tid)
-            if root is not None:
-                out[tid] = _CHTraceShim(tid, root)
+    roots = _get_root_spans_batch(ids)
+    out: dict = {}
+    for tid in ids:
+        root = roots.get(tid)
+        if root is not None:
+            out[tid] = _CHTraceShim(tid, root)
     return out
 
 
@@ -827,29 +845,29 @@ def _session_traces_map(
     # All sessions in one call belong to the project being queried.
     sid_to_trace_ids: dict[str, list[str]] = {}
     all_trace_ids: set[str] = set()
+    start_times: dict[str, datetime | None] = {}
     with get_reader() as reader:
         for sid in sid_set:
             tids = reader.session_trace_ids(project_id, sid)
             if tids:
                 sid_to_trace_ids[sid] = [str(t) for t in tids]
                 all_trace_ids.update(sid_to_trace_ids[sid])
+        if not all_trace_ids:
+            return {}
+        # Order newest-first by the CH root-span start_time (session_trace_ids
+        # returns an unordered DISTINCT set; callers require the latest turn
+        # first). Cross-store PG ``Trace.created_at`` is gone post-cutover.
+        start_times = reader.per_trace_root_span_start_times(list(all_trace_ids))
 
-    if not all_trace_ids:
-        return {}
+    def _rank(tid: str) -> datetime:
+        st = start_times.get(tid)
+        if st is None:
+            return datetime.min.replace(tzinfo=UTC)  # no CH root → sort last
+        return st if st.tzinfo else st.replace(tzinfo=UTC)
 
-    # Re-order newest-first: session_trace_ids returns an unordered DISTINCT set,
-    # but callers (rep-trace map) require the latest turn first.
-    order_rank = {
-        str(tid): i
-        for i, tid in enumerate(
-            Trace.objects.filter(id__in=all_trace_ids)
-            .order_by("-created_at")
-            .values_list("id", flat=True)
-        )
-    }
     out: dict[str, list[str]] = {}
     for sid, tids in sid_to_trace_ids.items():
-        out[sid] = sorted(tids, key=lambda t: order_rank.get(t, len(order_rank)))
+        out[sid] = sorted(tids, key=_rank, reverse=True)
     return out
 
 
@@ -1901,7 +1919,7 @@ def _avg_session_eval_score(session_ids: list[str]) -> float | None:
 
 
 def _build_representative_trace(
-    trace: Trace,
+    trace: "_CHTraceShim",
     has_issues: bool,
     pass_reel: list[dict] | None = None,
     highlight_terms: list[str] | None = None,
@@ -2012,41 +2030,40 @@ def _fetch_success_trace_pass_reel(cluster_id: str) -> list[dict]:
     own root input + output (+ key_moments if they exist) so the reel always
     has something useful to show.
     """
-    cluster = (
-        TraceErrorGroup.objects.filter(cluster_id=cluster_id)
-        .select_related("success_trace")
-        .first()
-    )
-    if not cluster or not cluster.success_trace:
+    cluster = TraceErrorGroup.objects.filter(cluster_id=cluster_id).first()
+    if not cluster or not cluster.success_trace_id:
         return []
 
-    success = cluster.success_trace
+    success_id = str(cluster.success_trace_id)
     steps: list[dict] = []
 
-    # 1. User input (from root span or Trace.input)
-    root = _get_root_span(str(success.id))
+    # 1. User input/output from the CH root span — the sole source post-cutover.
+    root = _get_root_span(success_id)
     input_text = None
     output_text = None
     if root:
-        # CHSpan typed-Map string-valued attrs live in attrs_string.
+        # CHSpan typed-Map string-valued attrs live in attrs_string; fall back
+        # to the raw span payload when the typed attr is absent.
         attrs = root.attrs_string or {}
         input_text = attrs.get("input.value")
         output_text = attrs.get("output.value")
-    input_text = input_text or _trace_input_str(success)
-    output_text = output_text or _trace_output_str(success)
+        if input_text is None and root.input is not None:
+            input_text = _safe_str(root.input)
+        if output_text is None and root.output is not None:
+            output_text = _safe_str(root.output)
 
     if input_text:
         steps.append({"label": "USER INPUT", "text": input_text, "meta": None})
 
     # 2. Any key_moments the scanner captured (often empty for clean traces)
     scan_result = (
-        TraceScanResult.objects.filter(trace_id=success.id).only("key_moments").first()
+        TraceScanResult.objects.filter(trace_id=success_id).only("key_moments").first()
     )
     if scan_result:
         steps.extend(
             _key_moments_to_reel(
                 scan_result.key_moments,
-                trace_id=str(success.id),
+                trace_id=success_id,
                 project_id=str(cluster.project_id) if cluster.project_id else None,
             )
         )
@@ -2090,7 +2107,8 @@ def _fetch_representative_traces(
 
     qs = (
         ErrorClusterTraces.objects.filter(cluster__cluster_id=cluster_id)
-        .select_related("trace")
+        # Only raw ``trace_id``/``trace_session_id`` are read below; member
+        # traces hydrate from CH via ``_resolve_member_traces``.
         .order_by("-created_at")
     )
     ect_rows = list(
@@ -2312,7 +2330,7 @@ def _fetch_trace_rows(
     """Paginated list of traces in the cluster for the AG Grid."""
     base = (
         ErrorClusterTraces.objects.filter(cluster__cluster_id=cluster_id)
-        .select_related("trace")
+        # Raw ``trace_id``/``trace_session_id`` only; traces hydrate from CH.
         .order_by("-created_at")
     )
 
@@ -2487,10 +2505,20 @@ def _project_scope_total(project_id: str, source: str, start, end=None) -> int:
     projects), so denominator = trace rows in the project window.
     """
     if source == ClusterSource.EVAL:
-        qs = Trace.objects.filter(project_id=project_id, created_at__gte=start)
-        if end is not None:
-            qs = qs.filter(created_at__lt=end)
-        return qs.count()
+        # Denominator = distinct traces in the window. The PG ``Trace`` table is
+        # gone, so count CH root spans (one per trace) over the same window.
+        with get_reader() as reader:
+            if end is not None:
+                return reader.count_with_filters(
+                    project_id=str(project_id),
+                    created_at_range=(start, end),
+                    roots_only=True,
+                )
+            return reader.count_with_filters(
+                project_id=str(project_id),
+                created_at_gte=start,
+                roots_only=True,
+            )
     qs = TraceScanResult.objects.filter(project_id=project_id, created_at__gte=start)
     if end is not None:
         qs = qs.filter(created_at__lt=end)
@@ -3206,31 +3234,6 @@ def _build_recommendations(
     return result
 
 
-_TRACE_STATUS_TO_FEED = {
-    TraceErrorAnalysisStatus.PENDING: "idle",
-    TraceErrorAnalysisStatus.SKIPPED: "idle",
-    TraceErrorAnalysisStatus.PROCESSING: "running",
-    TraceErrorAnalysisStatus.COMPLETED: "done",
-    TraceErrorAnalysisStatus.FAILED: "failed",
-}
-
-
-def _deep_analysis_status(trace: Trace, has_analysis: bool) -> str:
-    """Map ``Trace.error_analysis_status`` to the frontend state machine.
-
-    One nuance: a trace can be in COMPLETED state but have zero
-    ``TraceErrorDetail`` rows (the analysis ran, found nothing). We still
-    return ``done`` — the frontend decides what to render when the lists
-    are empty. Conversely, if status is COMPLETED but the
-    ``TraceErrorAnalysis`` row got deleted (e.g. cascade from a trace
-    delete), we treat that as ``idle`` so the button re-enables.
-    """
-    status = _TRACE_STATUS_TO_FEED.get(trace.error_analysis_status, "idle")
-    if status == "done" and not has_analysis:
-        return "idle"
-    return status
-
-
 def _cluster_has_trace(
     cluster_id: str, trace_id: str, project_ids: list[str] | None = None
 ) -> bool:
@@ -3260,16 +3263,12 @@ def get_deep_analysis(
     if not _cluster_has_trace(cluster_id, trace_id, project_ids):
         return None
 
-    trace = Trace.objects.filter(id=trace_id).only("error_analysis_status").first()
-    if not trace:
-        return None
-
     analysis = (
         TraceErrorAnalysis.objects.filter(trace_id=trace_id)
         .order_by("-analysis_date")
         .first()
     )
-    status = _deep_analysis_status(trace, has_analysis=bool(analysis))
+    status = deep_analysis_state.status(str(trace_id), has_analysis=bool(analysis))
 
     if not analysis or status != "done":
         return DeepAnalysisResponse(
@@ -3320,11 +3319,10 @@ def dispatch_deep_analysis(
     - If cached results already exist and ``force=False``, return a
       ``done`` response without dispatching — the frontend will just
       scroll to the existing panel.
-    - If the trace is already in PROCESSING state, return ``running``
-      without re-dispatching (idempotent double-click protection).
-    - Otherwise: set ``Trace.error_analysis_status=PROCESSING``
-      synchronously and dispatch the Temporal activity. The view returns
-      202 ``running``.
+    - If the trace is already running, return ``running`` without
+      re-dispatching (idempotent double-click protection).
+    - Otherwise: claim the running marker and dispatch the Temporal
+      activity. The view returns 202 ``running``.
     """
     # Import here to avoid pulling the Temporal runtime into module-load
     # time for everything that imports `feed.py`. Task modules can have
@@ -3337,10 +3335,6 @@ def dispatch_deep_analysis(
     if not _cluster_has_trace(cluster_id, trace_id, project_ids):
         return None
 
-    trace = Trace.objects.filter(id=trace_id).only("error_analysis_status").first()
-    if not trace:
-        return None
-
     has_analysis = TraceErrorAnalysis.objects.filter(trace_id=trace_id).exists()
 
     # Idempotent click: cached result exists and user didn't ask for a
@@ -3348,15 +3342,12 @@ def dispatch_deep_analysis(
     if has_analysis and not force:
         return DeepAnalysisDispatchResponse(status="done", trace_id=str(trace_id))
 
-    # Already running → don't double-dispatch.
-    if trace.error_analysis_status == TraceErrorAnalysisStatus.PROCESSING:
+    # Atomic claim (cache.add): a second click while a run is in flight gets
+    # False and returns ``running`` without re-dispatching. ``force`` re-runs
+    # even mid-flight (the marker is already set, so the guard is skipped).
+    claimed = deep_analysis_state.set_running(str(trace_id))
+    if not claimed and not force:
         return DeepAnalysisDispatchResponse(status="running", trace_id=str(trace_id))
-
-    # Flip status synchronously so the first frontend poll sees the
-    # running state without racing the Temporal worker.
-    Trace.objects.filter(id=trace_id).update(
-        error_analysis_status=TraceErrorAnalysisStatus.PROCESSING
-    )
 
     run_deep_analysis_on_demand.delay(str(trace_id), bool(force))
 

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -2506,7 +2506,9 @@ def _project_scope_total(project_id: str, source: str, start, end=None) -> int:
     """
     if source == ClusterSource.EVAL:
         # Denominator = distinct traces in the window. The PG ``Trace`` table is
-        # gone, so count CH root spans (one per trace) over the same window.
+        # gone, so count distinct CH root traces over the same window. (CH uses an
+        # inclusive BETWEEN vs the scanner branch's exclusive ``created_at__lt``
+        # below — a boundary-microsecond difference on a rate denominator.)
         with get_reader() as reader:
             if end is not None:
                 return reader.count_with_filters(

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -15,7 +15,6 @@ from django.utils import timezone
 
 from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
 from agentic_eval.core.embeddings.embedding_manager import model_manager
-from tracer.models.trace import Trace
 from tracer.models.trace_error_analysis import (
     ClusterSource,
     ErrorClusterTraces,
@@ -388,13 +387,8 @@ def get_trace_input_data(trace_ids: List[str], project_id: str) -> List[TraceInp
         if input_text:
             input_texts[trace_id_str] = str(input_text)
 
-    # Fallback: check Trace.input for any missing
-    missing = [tid for tid in scanned_trace_ids if tid not in input_texts]
-    if missing:
-        traces = Trace.objects.filter(id__in=missing).values_list("id", "input")
-        for trace_id, trace_input in traces:
-            if trace_input:
-                input_texts[str(trace_id)] = str(trace_input)
+    # The CH root span's ``input.value`` is the only source post-cutover; a trace
+    # with no root input simply contributes no text (handled below).
 
     # Build typed results — only scanned traces with known has_issues state
     result = []

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1048,6 +1048,34 @@ class CHSpanReader:
         ).result_rows
         return [str(row[0]) for row in rows]
 
+    def recent_root_trace_ids_by_project(
+        self,
+        project_id: str,
+        *,
+        limit: int,
+        exclude_trace_ids: list[str] | None = None,
+    ) -> list[str]:
+        """Distinct trace_ids for a project, newest first, capped at ``limit`` —
+        one row per trace (root span). Replaces the PG
+        ``Trace.objects.filter(project=…).order_by('-created_at')[:limit]`` walk
+        used to pick recent traces to analyze. ``exclude_trace_ids`` drops
+        already-handled traces CH-side."""
+        if not project_id or limit <= 0:
+            return []
+        where = ["project_id = %(pid)s", "is_deleted = 0", "parent_span_id = ''"]
+        params: dict[str, Any] = {"pid": str(project_id), "lim": int(limit)}
+        if exclude_trace_ids:
+            where.append("trace_id NOT IN %(exclude)s")
+            params["exclude"] = tuple(exclude_trace_ids)
+        rows = self._client.query(
+            "SELECT toString(trace_id) AS tid, max(start_time) AS st "
+            "FROM spans FINAL "
+            f"WHERE {' AND '.join(where)} "
+            "GROUP BY tid ORDER BY st DESC LIMIT %(lim)s",
+            parameters=params,
+        ).result_rows
+        return [str(r[0]) for r in rows]
+
     def scope_by_ids(self, span_ids: list[str]) -> dict[str, SpanScope]:
         """Map ``span_id -> SpanScope(project_id, trace_id)``, reading ONLY those
         two columns instead of the full span row.
@@ -1122,6 +1150,51 @@ class CHSpanReader:
             tid = str(tid)
             if tid not in result:  # first root per trace wins
                 result[tid] = (str(sid), _norm(pid))
+        return result
+
+    def trace_session_ids_by_trace_ids(
+        self, trace_ids: list[str], project_ids: list[str] | None = None
+    ) -> dict[str, str | None]:
+        """``{trace_id: trace_session_id}`` read from each trace's root span,
+        ids only — the reverse of ``session_trace_ids``. Lets callers count
+        distinct sessions across trace members without the dropped PG
+        ``Trace.session`` FK. The session id is resolved new→old (remap) so a
+        cross-cutover straddler's turns collapse to one session downstream."""
+        if not trace_ids:
+            return {}
+        join = remap_left_join(
+            "spans.trace_session_id", "trace_session_id_remap", "ts_remap"
+        )
+        resolved_ts = resolved_id_expr("spans.trace_session_id", "ts_remap")
+        where = [
+            "trace_id IN %(trace_ids)s",
+            "is_deleted = 0",
+            "(parent_span_id IS NULL OR parent_span_id = '')",
+        ]
+        params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
+        if project_ids:
+            where.append("project_id IN %(project_ids)s")
+            params["project_ids"] = tuple(project_ids)
+        rows = self._client.query(
+            f"SELECT toString(trace_id) AS trace_id, toString({resolved_ts}) AS tsid "
+            f"FROM spans FINAL {join} "
+            f"WHERE {' AND '.join(where)} "
+            "ORDER BY trace_id, start_time, id",
+            parameters=params,
+        ).result_rows
+
+        def _norm(v: Any) -> str | None:
+            return (
+                None
+                if v in (None, "", "NULL", "00000000-0000-0000-0000-000000000000")
+                else str(v)
+            )
+
+        result: dict[str, str | None] = {}
+        for tid, tsid in rows:
+            tid = str(tid)
+            if tid not in result:  # first root per trace wins
+                result[tid] = _norm(tsid)
         return result
 
     # ─── Aggregations across many traces ──────────────────────────────────────
@@ -1619,6 +1692,7 @@ class CHSpanReader:
         session_id: str | list[str] | None = None,
         created_at_gte: datetime | None = None,
         created_at_range: tuple[datetime, datetime] | None = None,
+        roots_only: bool = False,
     ) -> int:
         """Replaces ObservationSpan.objects.filter(<Q-object>).count() for
         the specific filter set produced by parsing_evaltask_filters().
@@ -1626,6 +1700,10 @@ class CHSpanReader:
         Equivalent to building a Q with those kwargs and counting. NOT
         a general-purpose Q→CH translator; intentionally narrow to the
         eval-task filter shape so behavior is testable in isolation.
+
+        ``roots_only`` counts one row per trace (root span = empty parent),
+        turning this into a trace count — used where the PG path counted
+        ``Trace`` rows in a window rather than spans.
 
         Codex wave-2 fixes (2026-05-26):
           • P1: created_at_* predicates target the CH `created_at` column
@@ -1638,6 +1716,8 @@ class CHSpanReader:
         where = ["is_deleted = 0"]
         params: dict[str, Any] = {}
         session_join = ""
+        if roots_only:
+            where.append("parent_span_id = ''")
         if project_id:
             where.append("project_id = %(pid)s")
             params["pid"] = project_id

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1071,6 +1071,36 @@ class CHSpanReader:
             for sid, pid, tid in rows
         }
 
+    def project_by_trace_ids(self, trace_ids: list[str]) -> dict[str, str | None]:
+        """Map ``trace_id -> project_id``, reading ONLY those two columns.
+
+        The trace equivalent of :meth:`scope_by_ids`: the annotation ``for-source``
+        scope checks need each trace's project to match a default queue's scope, and
+        a single panel-open must not OOM the shared cluster on the wide JSON columns
+        (a voice root carries its whole raw log — code 241). Project is stable across
+        a trace's spans, so ``any(project_id)`` per trace answers it; ``FINAL`` +
+        ``is_deleted = 0`` mirror ``scope_by_ids`` and a two-column grouped read
+        stays well under the memory limit.
+        """
+        if not trace_ids:
+            return {}
+        rows = self._client.query(
+            "SELECT toString(trace_id) AS trace_id, "
+            "toString(any(project_id)) AS project_id FROM spans FINAL "
+            "WHERE trace_id IN %(ids)s AND is_deleted = 0 "
+            "GROUP BY trace_id",
+            parameters={"ids": tuple(trace_ids)},
+        ).result_rows
+
+        def _norm(v: Any) -> str | None:
+            return (
+                None
+                if v in (None, "", "NULL", "00000000-0000-0000-0000-000000000000")
+                else str(v)
+            )
+
+        return {str(tid): _norm(pid) for tid, pid in rows}
+
     # ─── Aggregations across many traces ──────────────────────────────────────
     def aggregate_by_trace_ids(self, trace_ids: list[str]) -> dict[str, Any]:
         """Sum(tokens, cost) + count across multiple traces in one query.

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1084,12 +1084,20 @@ class CHSpanReader:
         """
         if not trace_ids:
             return {}
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS (the two-arg
+        # ReplacingMergeTree drops deleted rows under FINAL; the setting re-arms the
+        # trace_id bloom that FINAL otherwise disables, so this prunes instead of
+        # full-scanning). GROUP BY (trace_id, project_id) returns the real pairs —
+        # collision-proof vs any() if two projects ever share a client-generated OTLP
+        # trace_id — and the dict keeps the first per trace (the normal 1:1).
         rows = self._client.query(
-            "SELECT toString(trace_id) AS trace_id, "
-            "toString(any(project_id)) AS project_id FROM spans FINAL "
-            "WHERE trace_id IN %(ids)s AND is_deleted = 0 "
-            "GROUP BY trace_id",
+            "SELECT toString(trace_id) AS trace_id, toString(project_id) AS project_id "
+            "FROM spans FINAL "
+            "WHERE trace_id IN %(ids)s "
+            "GROUP BY trace_id, project_id "
+            "ORDER BY trace_id, project_id",
             parameters={"ids": tuple(trace_ids)},
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
 
         def _norm(v: Any) -> str | None:
@@ -1099,7 +1107,10 @@ class CHSpanReader:
                 else str(v)
             )
 
-        return {str(tid): _norm(pid) for tid, pid in rows}
+        result: dict[str, str | None] = {}
+        for tid, pid in rows:
+            result.setdefault(str(tid), _norm(pid))
+        return result
 
     # ─── Aggregations across many traces ──────────────────────────────────────
     def aggregate_by_trace_ids(self, trace_ids: list[str]) -> dict[str, Any]:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1763,8 +1763,12 @@ class CHSpanReader:
         if created_at_range:
             where.append("created_at BETWEEN %(cr_s)s AND %(cr_e)s")
             params["cr_s"], params["cr_e"] = created_at_range
+        # roots_only counts distinct traces, not root rows — a trace with more
+        # than one parentless span must count once (mirrors the GROUP BY tid /
+        # first-root-per-trace dedupe elsewhere in this reader).
+        select = "count(DISTINCT trace_id)" if roots_only else "count()"
         rows = self._client.query(
-            f"SELECT count() FROM spans FINAL {session_join} "
+            f"SELECT {select} FROM spans FINAL {session_join} "
             f"WHERE {' AND '.join(where)}",
             parameters=params,
         ).result_rows

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -34,18 +34,18 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
     avoid doing work no one reads (and to sidestep the orphan-rows-on-
     re-run problem).
     """
-    from accounts.models.user import User
     try:
         from ee.agenthub.traceerroragent.traceerror import TraceErrorAnalysisAgent
     except ImportError:
         if settings.DEBUG:
             logger.warning("Could not import ee.agenthub.traceerroragent.traceerror", exc_info=True)
         return None
-    from tracer.models.observation_span import Trace
-    from tracer.models.trace import TraceErrorAnalysisStatus
+    from tracer.models.project import Project
     from tracer.models.trace_error_analysis import TraceErrorAnalysis
+    from tracer.queries import deep_analysis_state
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
     from tracer.queries.helpers import get_default_workspace_for_project
+    from tracer.services.clickhouse.v2 import get_reader
     from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
@@ -70,16 +70,23 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 "skipped": True,
             }
 
-        try:
-            trace = Trace.objects.select_related("project__organization").get(
-                id=trace_id
-            )
-            organization = trace.project.organization
-        except Trace.DoesNotExist:
+        # Trace lives only in CH post-cutover; resolve its project (org + billing)
+        # from the CH root span's project_id, then load the PG Project (kept).
+        with get_reader() as reader:
+            roots = reader.root_ids_by_trace_ids([str(trace_id)])
+        root = roots.get(str(trace_id))
+        project_id = root[1] if root else None
+        project = (
+            Project.objects.select_related("organization").filter(id=project_id).first()
+            if project_id
+            else None
+        )
+        if project is None:
             logger.warning(f"Trace {trace_id} not found, skipping analysis.")
             return {"success": False, "trace_id": trace_id, "error": "Trace not found"}
+        organization = project.organization
 
-        workspace = get_default_workspace_for_project(trace.project)
+        workspace = get_default_workspace_for_project(project)
 
         # Pre-check usage before the LLM call
         try:
@@ -92,9 +99,7 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 str(organization.id), APICallTypeChoices.TRACE_ERROR_ANALYSIS.value
             )
             if not usage_check.allowed:
-                Trace.objects.filter(id=trace_id).update(
-                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
-                )
+                deep_analysis_state.set_failed(str(trace_id))
                 raise ValueError(usage_check.reason or "Usage limit exceeded")
 
         # Log and deduct cost for the analysis upfront.
@@ -107,17 +112,15 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 source_id=str(trace_id),
                 config={
                     "trace_id": str(trace_id),
-                    "project_id": str(trace.project.id),
-                    "reference_id": str(trace.project.id),
+                    "project_id": str(project.id),
+                    "reference_id": str(project.id),
                 },
             )
 
             if not api_call_log_row:
                 error_message = "Failed to create API call log for trace analysis."
                 logger.error(error_message)
-                Trace.objects.filter(id=trace_id).update(
-                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
-                )
+                deep_analysis_state.set_failed(str(trace_id))
                 return {"success": False, "trace_id": trace_id, "error": error_message}
 
         agent = TraceErrorAnalysisAgent(
@@ -134,9 +137,10 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             f"Successfully analyzed trace {trace_id} - found {error_count} errors"
         )
 
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.COMPLETED
-        )
+        # Success is recorded by the TraceErrorAnalysis row the agent wrote
+        # (save_to_db=True) — the feed derives "done" from it. Just release the
+        # transient running marker.
+        deep_analysis_state.clear(str(trace_id))
 
         if error_count > 0 and ingest_embeddings:
             error_analysis_db = TraceErrorAnalysisDB()
@@ -209,10 +213,8 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             api_call_log_row.status = APICallStatusChoices.ERROR.value
             api_call_log_row.save(update_fields=["status"])
 
-        # Mark trace as failed
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.FAILED
-        )
+        # Mark the run failed (transient marker; TTLs back to idle).
+        deep_analysis_state.set_failed(str(trace_id))
 
         return {"success": False, "trace_id": trace_id, "error": str(e)}
     finally:
@@ -239,10 +241,10 @@ def run_deep_analysis_on_demand(trace_id: str, force: bool = False) -> dict:
       ``TraceErrorAnalysis`` row (cascades to ``TraceErrorDetail`` via
       FK CASCADE) so the downstream agent produces fresh results.
 
-    The view sets ``Trace.error_analysis_status=PROCESSING`` synchronously
-    before dispatching so the first frontend poll sees the running state
-    without racing the Temporal worker. ``analyze_single_trace`` flips it
-    to COMPLETED/FAILED at the end.
+    The dispatcher claims a ``deep_analysis_state`` running marker before
+    dispatching so the first frontend poll sees the running state without
+    racing the Temporal worker; ``analyze_single_trace`` clears it on success
+    (done derives from the ``TraceErrorAnalysis`` row) or marks it failed.
 
     Embeddings are deliberately skipped — the Feed Revamp reads
     ``TraceErrorDetail`` rows directly and has no use for the ClickHouse
@@ -449,14 +451,22 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
     from ai_tools.base import ToolContext
     from tfc.middleware.workspace_context import set_workspace_context
-    from tracer.models.trace import Trace, TraceErrorAnalysisStatus
+    from tracer.models.project import Project
+    from tracer.queries import deep_analysis_state
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
 
     close_old_connections()
 
     try:
-        trace = Trace.objects.select_related("project__organization").get(id=trace_id)
-        org = trace.project.organization
+        # The caller passes project_id (traces live only in CH post-cutover);
+        # load the PG Project (kept) for org / user / workspace resolution.
+        project = (
+            Project.objects.select_related("organization").filter(id=project_id).first()
+        )
+        if project is None:
+            logger.error(f"Project {project_id} not found, skipping trace {trace_id}")
+            return {"success": False, "trace_id": trace_id, "error": "Project not found"}
+        org = project.organization
 
         # Find a user in this org for the conversation
         from accounts.models.user import User
@@ -469,7 +479,7 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
         # Get workspace
         from tracer.queries.helpers import get_default_workspace_for_project
 
-        workspace = get_default_workspace_for_project(trace.project)
+        workspace = get_default_workspace_for_project(project)
 
         set_workspace_context(workspace=workspace, organization=org, user=user)
         ctx = ToolContext(user=user, organization=org, workspace=workspace)
@@ -571,8 +581,8 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
         if not analysis:
             # Falcon found no errors — create a clean analysis record
             analysis = TraceErrorAnalysis.objects.create(
-                trace=trace,
-                project=trace.project,
+                trace_id=trace_id,
+                project=project,
                 overall_score=4.0,
                 total_errors=0,
                 high_impact_errors=0,
@@ -612,9 +622,8 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
         error_count = analysis.total_errors or 0
 
-        # Always mark trace as completed
-        trace.error_analysis_status = TraceErrorAnalysisStatus.COMPLETED
-        trace.save(update_fields=["error_analysis_status"])
+        # Done is derived from the TraceErrorAnalysis row above; release marker.
+        deep_analysis_state.clear(str(trace_id))
 
         # Ingest embeddings for clustering if there are errors
         if error_count > 0:
@@ -666,9 +675,7 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
     except Exception as e:
         logger.exception(f"Falcon analysis failed for trace {trace_id}: {str(e)}")
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.FAILED
-        )
+        deep_analysis_state.set_failed(str(trace_id))
         return {"success": False, "trace_id": trace_id, "error": str(e)}
     finally:
         close_old_connections()

--- a/futureagi/tracer/tests/test_feed_pg_drop_repro.py
+++ b/futureagi/tracer/tests/test_feed_pg_drop_repro.py
@@ -1,0 +1,278 @@
+"""Repro + regression harness for the Error Feed after the legacy tracer PG
+tables are dropped.
+
+Traces now live only in ClickHouse (fi-collector -> CH); the legacy
+``tracer_trace`` / ``tracer_observation_span`` / ``trace_session`` /
+``tracer_enduser`` PG tables are being dropped org-wide. Every FK from the
+feed's own tables to those models is ``db_constraint=False`` so the raw
+``*_id`` columns survive the drop -- but any ORM JOIN (``select_related``,
+``trace__session`` traversal) or ``Trace.objects.*`` read still targets the
+missing relation and raises ``ProgrammingError`` (42P01), which also poisons
+the request transaction.
+
+These tests seed a cluster + its trace **in ClickHouse only**, drop the four
+tracer PG tables inside the test transaction (Postgres DDL is transactional,
+so it rolls back at teardown), then exercise every feed read path. Before the
+CH-native conversion each path raises 42P01; after it, each returns CH-sourced
+data.
+
+One drop+call per test: the first 42P01 aborts the transaction, so isolating
+each path keeps a real 42P01 from masquerading as "transaction is aborted" on
+the paths that follow.
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.db import ProgrammingError, connection
+from django.utils import timezone
+
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.trace import Trace
+from tracer.models.trace_error_analysis import (
+    ClusterSource,
+    ErrorClusterTraces,
+    FeedIssueStatus,
+    Priority,
+    TraceErrorGroup,
+)
+from tracer.tests._ch_seed import seed_ch_span
+from tracer.utils import feed as feed_service
+
+# The tracer-owned PG tables being dropped. Order/‑CASCADE handles any
+# leftover dependent objects; all FKs into them are already db_constraint=False.
+_DROPPED_TABLES = (
+    "tracer_observation_span",
+    "tracer_trace",
+    "trace_session",
+    "tracer_enduser",
+)
+
+
+def _drop_tracer_pg_tables():
+    """Simulate the org-wide drop inside the test transaction."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "DROP TABLE IF EXISTS "
+            + ", ".join(_DROPPED_TABLES)
+            + " CASCADE"
+        )
+
+
+def _seed_ch_root(project, trace_id, *, status="OK", parent="", input_=None, output=None):
+    """Seed ONE CH root span for ``trace_id`` (no PG Trace row).
+
+    The span carries an UNSAVED ``Trace`` so ``seed_ch_span`` reads its FK from
+    the instance cache instead of hitting PG for a trace that lives only in CH.
+    """
+    span = ObservationSpan(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=Trace(id=trace_id, project=project),
+        parent_span_id=parent,
+        name="root",
+        observation_type="llm",
+        start_time=timezone.now() - timedelta(seconds=5),
+        end_time=timezone.now(),
+        input=input_ if input_ is not None else {"prompt": "hi"},
+        output=output if output is not None else {"response": "hello"},
+        model="gpt-4",
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        latency_ms=500,
+        status=status,
+    )
+    seed_ch_span(span)
+    return span
+
+
+@pytest.fixture
+def seeded_cluster(db, project):
+    """A scanner cluster + one CH-only member trace + a CH-only success trace.
+
+    Returns ``(cluster, trace_id, success_trace_id)``. Nothing is written to the
+    tracer PG tables — the trace exists purely in ClickHouse.
+    """
+    now = timezone.now()
+    trace_id = str(uuid.uuid4())
+    success_trace_id = str(uuid.uuid4())
+
+    cluster = TraceErrorGroup.objects.create(
+        project=project,
+        cluster_id="K-DROP-1",
+        error_type="drop-error",
+        source=ClusterSource.SCANNER,
+        issue_group="Tool Failures",
+        issue_category="Language-only",
+        fix_layer="Tools",
+        title="drop repro issue",
+        status=FeedIssueStatus.ESCALATING,
+        priority=Priority.MEDIUM,
+        first_seen=now,
+        last_seen=now,
+        error_count=1,
+        unique_traces=1,
+        success_trace_id=success_trace_id,
+    )
+    ErrorClusterTraces.objects.create(cluster=cluster, trace_id=trace_id)
+
+    _seed_ch_root(project, trace_id, input_={"prompt": "fail"}, output={"response": "bad"})
+    _seed_ch_root(
+        project, success_trace_id, input_={"prompt": "ok"}, output={"response": "good"}
+    )
+    return cluster, trace_id, success_trace_id
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestFeedSurvivesTracerPgDrop:
+    """Every feed read path must resolve trace data from CH, never PG."""
+
+    def _pids(self, cluster):
+        return [str(cluster.project_id)]
+
+    def test_list_clusters(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        resp = feed_service.list_feed_issues(self._pids(cluster))
+        assert resp.total == 1
+        assert resp.data[0].cluster_id == "K-DROP-1"
+
+    def test_stats(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        stats = feed_service.get_feed_stats(self._pids(cluster))
+        assert stats is not None
+
+    def test_cluster_detail(self, seeded_cluster):
+        cluster, trace_id, success_trace_id = seeded_cluster
+        _drop_tracer_pg_tables()
+        detail = feed_service.get_feed_detail("K-DROP-1", self._pids(cluster))
+        assert detail is not None
+        # success + representative previews must hydrate from the CH root span.
+        assert detail.success_trace is not None
+        assert detail.success_trace.trace_id == success_trace_id
+
+    def test_overview(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        # The pattern-summary baseline hits the agentic_eval vector store (a
+        # separate CH on :9000, unaffected by the tracer PG drop and absent from
+        # the test stack); stub it so this test isolates the PG-drop paths.
+        from unittest.mock import patch
+
+        with patch("tracer.queries.feed._passing_baseline_trace_ids", return_value=[]):
+            overview = feed_service.get_overview_tab("K-DROP-1", self._pids(cluster))
+        assert overview is not None
+        assert overview.representative_total >= 1
+
+    def test_traces_tab(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        traces = feed_service.get_traces_tab("K-DROP-1", self._pids(cluster))
+        assert traces is not None
+
+    def test_trends_tab(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        trends = feed_service.get_trends_tab("K-DROP-1", self._pids(cluster))
+        assert trends is not None
+
+    def test_sidebar(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        sidebar = feed_service.get_sidebar(
+            "K-DROP-1", self._pids(cluster), trace_id=trace_id
+        )
+        assert sidebar is not None
+
+    def test_deep_analysis_get(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        resp = feed_service.get_deep_analysis(
+            "K-DROP-1", self._pids(cluster), trace_id=trace_id
+        )
+        # No analysis rows seeded -> status is a non-error "idle"/"pending".
+        assert resp is not None
+
+    def test_deep_analysis_dispatch(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        from unittest.mock import patch
+
+        # Lazily imported inside dispatch_deep_analysis, so patch it at its home.
+        with patch("tracer.tasks.run_deep_analysis_on_demand") as task:
+            resp = feed_service.dispatch_deep_analysis(
+                "K-DROP-1", self._pids(cluster), trace_id=trace_id
+            )
+        assert resp is not None
+        assert resp.status == "running"
+        assert task.delay.called
+
+
+class TestDeepAnalysisState:
+    """The transient per-trace marker that replaces Trace.error_analysis_status."""
+
+    def setup_method(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_double_click_guard_and_lifecycle(self):
+        from tracer.queries import deep_analysis_state as das
+
+        tid = str(uuid.uuid4())
+        # Nothing set → idle; no completed analysis.
+        assert das.status(tid, has_analysis=False) == "idle"
+        # First claim wins, a rapid second claim loses (single dispatch).
+        assert das.set_running(tid) is True
+        assert das.set_running(tid) is False
+        assert das.status(tid, has_analysis=False) == "running"
+        # A completed analysis row always wins over the marker.
+        assert das.status(tid, has_analysis=True) == "done"
+        # Failure is surfaced until it TTLs out.
+        das.set_failed(tid)
+        assert das.status(tid, has_analysis=False) == "failed"
+        # Clearing (worker success) drops back to idle when no analysis exists.
+        das.clear(tid)
+        assert das.status(tid, has_analysis=False) == "idle"
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_new_ch_reader_methods_smoke(project):
+    """Direct smoke of the CH reader methods the feed CH-native swap added/changed
+    — the SQL must compile and run against real ClickHouse (these paths aren't
+    all hit by the feed-endpoint tests above)."""
+    from tracer.services.clickhouse.v2 import get_reader
+
+    tid = str(uuid.uuid4())
+    _seed_ch_root(project, tid, input_={"prompt": "hi"})
+
+    with get_reader() as reader:
+        # trace_id → trace_session_id (root has no session → None, no crash)
+        sessions = reader.trace_session_ids_by_trace_ids([tid])
+        assert tid in sessions
+
+        # roots_only window count = trace count (one root per trace), not spans
+        trace_count = reader.count_with_filters(
+            project_id=str(project.id), roots_only=True
+        )
+        assert trace_count >= 1
+
+        # distinct trace_ids for the project, newest first
+        recent = reader.recent_root_trace_ids_by_project(str(project.id), limit=10)
+        assert tid in recent
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_drop_actually_removes_table(project):
+    """Guard: the drop truly removes the relation (so the read-path tests are
+    a real 42P01 repro, not a no-op), and it rolls back cleanly afterwards."""
+    _drop_tracer_pg_tables()
+    with pytest.raises(ProgrammingError):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1 FROM tracer_trace LIMIT 1")

--- a/futureagi/tracer/tests/test_feed_pg_drop_repro.py
+++ b/futureagi/tracer/tests/test_feed_pg_drop_repro.py
@@ -239,6 +239,17 @@ class TestDeepAnalysisState:
         das.clear(tid)
         assert das.status(tid, has_analysis=False) == "idle"
 
+    def test_failed_run_does_not_block_retry(self):
+        from tracer.queries import deep_analysis_state as das
+
+        tid = str(uuid.uuid4())
+        assert das.set_running(tid) is True
+        das.set_failed(tid)
+        assert das.status(tid, has_analysis=False) == "failed"
+        # A retry must claim cleanly — the failed marker can't wedge the guard.
+        assert das.set_running(tid) is True
+        assert das.status(tid, has_analysis=False) == "running"
+
 
 @pytest.mark.integration
 @pytest.mark.django_db

--- a/futureagi/tracer/tests/test_scan_project_scoped_read.py
+++ b/futureagi/tracer/tests/test_scan_project_scoped_read.py
@@ -151,11 +151,10 @@ def test_get_trace_input_data_scopes_embed_read():
     with (
         patch("tracer.queries.scan_clustering.get_reader", return_value=reader),
         patch("tracer.queries.scan_clustering.TraceScanResult") as tsr,
-        patch("tracer.queries.scan_clustering.Trace") as trace_model,
     ):
-        # one scanned trace so we reach the reader; no PG-input fallback rows
+        # one scanned trace so we reach the reader (CH root input is the sole
+        # source post-cutover — no PG Trace.input fallback).
         tsr.objects.filter.return_value.values_list.return_value = [("t-1", True)]
-        trace_model.objects.filter.return_value.values_list.return_value = []
         get_trace_input_data(["t-1"], "proj-embed")
     assert sink["project_id"] == "proj-embed"
 


### PR DESCRIPTION
## What & why

The tracer app is migrating fully to ClickHouse — the legacy PG tracer tables (`tracer_trace`, `tracer_observation_span`, `trace_session`, `tracer_enduser`) are being **dropped**, CDC is going away, and traces ingest via the `fi-collector` → CH. This converts the **annotation subsystem's reads of tracer-owned data to ClickHouse-only**, so PG is never queried for trace / observation_span / trace_session data on these paths. The annotation subsystem's own PG tables (AnnotationQueue, QueueItem, Score, SpanNotes, labels) and PG `Project` stay.

This **supersedes #1214** (the drop-safety draft): rather than *guarding* the PG reads with savepoints/42P01 catches, this **removes** them — the correct end-state once the tables are gone.

## Scope (annotation read paths)
- **Resolution** — `resolve_source_object` resolves trace/span/session straight from CH (duck-typed sources), tenant-gated against PG `Project`, fail-closed.
- **Render** — `resolve_source_preview` / `resolve_source_content` drop the PG-first `_safe_related` branch; always CH. `CollectorSourceCache` batches trace roots (lean, OOM-safe).
- **Availability** — the in-progress guard reads the CH root span's status (single via the resolved root; bulk via a lean batched read, scoped by `project_id`).
- **for-source probes** — the default-queue `Trace.objects…exists()` probes replaced with a lean `project_by_trace_ids` CH prefetch (mirrors `scope_by_ids`).
- **Scores** — `_auto_create_queue_items_for_default_queues` no longer silently no-ops for CH duck-typed sources (shared `source_project()` helper); redundant `resolve_ch_span_source` boundary removed.
- **Export** — dropped the `trace__observation_spans` prefetch + `select_related` on tracer FKs (dead + would 500 on the dropped tables); export attributes read CH-native.

## OOM
Every hot CH read is lean: `roots_by_trace_ids(include_heavy=False)`, the 2-column `project_by_trace_ids`, and chunked `_batch_ch_trace_roots` — avoiding the TH-6442 code-241 shape on fat voice roots. `_ch_root_span_for_trace` switched off the full `list_by_trace`.

## Not in this PR
`bulk_selection` / automation-rules filter query builders (`resolve_filtered_*_ids`, `_annotate_*_for_rules`) still build PG `Trace` querysets — that's the next PR. Test-side source spans/traces still write PG rows where the still-PG filter path needs them; those get swept when bulk_selection goes CH.

## Tests
All annotation suites green (575 passing across 12 suites). Three unrelated failures are pre-existing on `dev` (verified): `test_th5123` voice_call_detail (a tracer endpoint, not annotation), an NLTK-env corpus test, and a call_execution simulation-grid test.
