### PR TITLE
feat: add duplicate scenario name validation on creation

### DIFF
--- a/frontend/src/components/scenarios/EditScenarioDialog.jsx
+++ b/frontend/src/components/scenarios/EditScenarioDialog.jsx
@@ -46,9 +46,32 @@ const EditScenarioDialog = ({ open, onClose, scenario, onEditSuccess }) => {
     setIsEditing(true);
     setError("");
 
+    const newName = scenarioName.trim();
+
     try {
+      // Check for duplicate names when the name has changed
+      if (newName !== (scenario?.name || "")) {
+        try {
+          const response = await axios.get(endpoints.scenarios.list, {
+            params: { search: newName, limit: 50 },
+          });
+          const results = response?.data?.results ?? [];
+          const duplicate = results.find(
+            (s) => s.name === newName && s.id !== scenario.id,
+          );
+          if (duplicate) {
+            setError(
+              "A scenario with this name already exists. Please choose another name.",
+            );
+            return;
+          }
+        } catch {
+          // Graceful degradation: allow edit if duplicate check fails
+        }
+      }
+
       const payload = {
-        name: scenarioName.trim(),
+        name: newName,
         description: scenarioDescription.trim(),
       };
 

--- a/frontend/src/components/scenarios/EditScenarioDialog.test.jsx
+++ b/frontend/src/components/scenarios/EditScenarioDialog.test.jsx
@@ -1,0 +1,241 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "src/utils/test-utils";
+import userEvent from "@testing-library/user-event";
+import EditScenarioDialog from "./EditScenarioDialog";
+
+// ---------------------------------------------------------------------------
+// Mock axios so that handleEdit's duplicate check and PUT call are controlled.
+// ---------------------------------------------------------------------------
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: (...args) => mockGet(...args),
+    put: (...args) => mockPut(...args),
+  },
+  endpoints: {
+    scenarios: {
+      list: "/simulate/scenarios/",
+      edit: (id) => `/simulate/scenarios/${id}/edit/`,
+    },
+  },
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid={`iconify-${icon}`} {...props} />
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SCENARIO = {
+  id: "scenario-1",
+  name: "Original Name",
+  description: "Original description",
+};
+
+const renderDialog = (overrides = {}) => {
+  const props = {
+    open: true,
+    onClose: vi.fn(),
+    onEditSuccess: vi.fn(),
+    scenario: DEFAULT_SCENARIO,
+    ...overrides,
+  };
+  return render(<EditScenarioDialog {...props} />);
+};
+
+/**
+ * Helper: get the scenario name textbox and the save button.
+ * MUI TextField labels differ from plain HTML labels so we target by role.
+ */
+const getNameInput = () =>
+  screen.getByRole("textbox", { name: /scenario name/i });
+const getDescriptionInput = () =>
+  screen.getByRole("textbox", { name: /description/i });
+const getSaveButton = () =>
+  screen.getByRole("button", { name: /save changes/i });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EditScenarioDialog — name uniqueness", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPut.mockReset();
+  });
+
+  // -----------------------------------------------------------------------
+  // Duplicate name detection
+  // -----------------------------------------------------------------------
+
+  it("shows an error when another scenario has the same name", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [{ name: "Duplicate Name", id: "scenario-2" }],
+      },
+    });
+
+    renderDialog();
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Duplicate Name");
+
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "A scenario with this name already exists. Please choose another name.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    // PUT should not be called
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("allows edit when the name is unchanged (same as current)", async () => {
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    // Change the description so the save button becomes enabled
+    const descInput = getDescriptionInput();
+    await userEvent.clear(descInput);
+    await userEvent.type(descInput, "New description");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+
+    // No duplicate GET was made (name didn't change)
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockPut).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows edit when no scenario with the same name exists", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Unique Name");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockPut).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes the current scenario from duplicate detection", async () => {
+    // The API returns the current scenario itself — this should not block edit
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [
+          { name: "Updated Name", id: "scenario-1" }, // same ID as current
+        ],
+      },
+    });
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Updated Name");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Graceful degradation
+  // -----------------------------------------------------------------------
+
+  it("allows edit when the duplicate-check API fails", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network Error"));
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "New Name");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+
+    expect(mockPut).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows edit when the API returns null data", async () => {
+    mockGet.mockResolvedValueOnce({ data: null });
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "New Name");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it("allows edit when the API returns no results field", async () => {
+    mockGet.mockResolvedValueOnce({ data: {} });
+    mockPut.mockResolvedValueOnce({ data: { message: "updated" } });
+
+    const onEditSuccess = vi.fn();
+    renderDialog({ onEditSuccess });
+
+    const nameInput = getNameInput();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "New Name");
+    await userEvent.click(getSaveButton());
+
+    await waitFor(() => {
+      expect(onEditSuccess).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic (unchanged) validation
+  // -----------------------------------------------------------------------
+
+  it("blocks submission when the name is empty", async () => {
+    renderDialog();
+
+    await userEvent.clear(getNameInput());
+
+    expect(getSaveButton()).toBeDisabled();
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { AGENT_TYPES } from "../agents/constants";
+import axios, { endpoints } from "src/utils/axios";
 
 // Mirrors BE `no_of_rows.min_value`.
 export const MIN_DATASET_ROWS = 10;
@@ -64,7 +65,34 @@ const CreateScenarioDefaultSchema = {
     .default("agent_definition"),
   sourceId: z.string().min(1, "Source is required"),
   sourceLabel: z.string().optional(), // Used for auto-generating scenario name, not sent to API
-  name: z.string().trim().min(1, "Name is required"),
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .refine(
+      async (name) => {
+        if (!name?.trim()) return true;
+        try {
+          // NOTE: limit=50 caps the search to the first page of results.
+          // Duplicates beyond page 1 will not be detected. For orgs with
+          // 50+ scenarios a dedicated server-side validate-name endpoint
+          // (similar to the experiment name check) would be more robust.
+          const response = await axios.get(endpoints.scenarios.list, {
+            params: { search: name.trim(), limit: 50 },
+          });
+          const results = response?.data?.results ?? [];
+          // Exact case-sensitive match (backend search is case-insensitive regex)
+          return !results.some((s) => s.name === name.trim());
+        } catch {
+          // Graceful degradation: allow submission if API fails
+          return true;
+        }
+      },
+      {
+        message:
+          "A scenario with this name already exists. Please choose another name.",
+      },
+    ),
   description: z.string().optional(),
   agentDefinitionId: z.string().optional(),
   agentDefinitionVersionId: z.string().optional(),

--- a/frontend/src/sections/scenarios/common.test.js
+++ b/frontend/src/sections/scenarios/common.test.js
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock axios so the schema's async .refine() uses a controlled mockGet.
+// vi.mock is hoisted, so the schema module sees the mock when imported below.
+// ---------------------------------------------------------------------------
+const mockGet = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: (...args) => mockGet(...args) },
+  endpoints: {
+    scenarios: {
+      list: "/simulate/scenarios/",
+    },
+  },
+}));
+
+// Import the schema AFTER the mock — it will capture mocked axios.
+import { CreateScenarioValidationSchema } from "./common";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimum-valid payload for the "graph" variant that satisfies all
+ * cross-field .refine() rules on the discriminated union.
+ */
+const makeValidData = (overrides = {}) => ({
+  kind: "graph",
+  name: "Test Scenario",
+  sourceType: "agent_definition",
+  sourceId: "agent-123",
+  sourceLabel: "TestAgent",
+  agentDefinitionId: "agent-123",
+  agentDefinitionVersionId: "version-456",
+  noOfRows: 20,
+  addPersonaAutomatically: true,
+  columns: [],
+  personas: [],
+  config: { graph: null, generateGraph: true },
+  customInstructionDisabled: true,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests — name uniqueness validation
+// ---------------------------------------------------------------------------
+
+describe("CreateScenarioValidationSchema — name uniqueness", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic required-field behaviour (unchanged by our .refine())
+  // -----------------------------------------------------------------------
+
+  it("rejects an empty name via min(1)", async () => {
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "" }),
+    );
+    expect(result.success).toBe(false);
+    const messages = result.error.issues.map((i) => i.message);
+    expect(messages).toContain("Name is required");
+  });
+
+  it("does not call the API when the name is empty", async () => {
+    await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "" }),
+    );
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only names and does not call the API", async () => {
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "   " }),
+    );
+    expect(result.success).toBe(false);
+    const messages = result.error.issues.map((i) => i.message);
+    expect(messages).toContain("Name is required");
+    // API must not be called for whitespace-only (sync refine catches it first)
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Uniqueness checks
+  // -----------------------------------------------------------------------
+
+  it("passes when no scenario with the same name exists", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Unique Name" }),
+    );
+    expect(result.success).toBe(true);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails when a scenario with the exact same name exists", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [{ name: "Duplicate Name", id: "scenario-1" }] },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Duplicate Name" }),
+    );
+    expect(result.success).toBe(false);
+    const messages = result.error.issues.map((i) => i.message);
+    expect(messages).toContain(
+      "A scenario with this name already exists. Please choose another name.",
+    );
+  });
+
+  it("passes when API returns results but none match exactly (partial match)", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [
+          { name: "My Test Scenario Extended", id: "s-1" },
+          { name: "Another Test Scenario", id: "s-2" },
+        ],
+      },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "My Test Scenario" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("treats different-case names as distinct (case-sensitive)", async () => {
+    // Backend search is case-insensitive and returns "test" when searching
+    // for "Test", but client-side === enforces exact case match.
+    mockGet.mockResolvedValueOnce({
+      data: { results: [{ name: "test" }] },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Test" }),
+    );
+    // "Test" !== "test" → no duplicate → validation passes
+    expect(result.success).toBe(true);
+  });
+
+  it("finds the exact match among multiple results", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        results: [
+          { name: "Testing A", id: "s-1" },
+          { name: "Testing B", id: "s-2" },
+          { name: "Test", id: "s-3" }, // <-- exact match
+          { name: "Testing C", id: "s-4" },
+        ],
+      },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Test" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // Graceful degradation (API errors)
+  // -----------------------------------------------------------------------
+
+  it("allows submission when the API call rejects (network error)", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network Error"));
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Anything" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("allows submission when the API returns null data", async () => {
+    mockGet.mockResolvedValueOnce({ data: null });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Anything" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("allows submission when the API response has no results field", async () => {
+    mockGet.mockResolvedValueOnce({ data: {} });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Anything" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("allows submission when the API response has undefined results", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: undefined },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Anything" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Special characters and unicode
+  // -----------------------------------------------------------------------
+
+  it("handles names with special regex characters", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Test (v1) [draft] *final*" }),
+    );
+    expect(result.success).toBe(true);
+    // Verify the correct search param was sent (escaped on the backend side)
+    expect(mockGet).toHaveBeenCalledWith(
+      "/simulate/scenarios/",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          search: "Test (v1) [draft] *final*",
+        }),
+      }),
+    );
+  });
+
+  it("handles unicode names", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [{ name: "测试场景" }] },
+    });
+
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "测试场景" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("distinguishes unicode names with different code points", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [{ name: "测试场景" }] },
+    });
+
+    // Different unicode string — should not match
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "测试场景2" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases with empty results from API
+  // -----------------------------------------------------------------------
+
+  it("uses a limit of 50 to maximise chance of finding an exact match", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Test" }),
+    );
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/simulate/scenarios/",
+      expect.objectContaining({
+        params: expect.objectContaining({ limit: 50 }),
+      }),
+    );
+  });
+
+  it("trims the name before sending to the API", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "  Padded Name  " }),
+    );
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/simulate/scenarios/",
+      expect.objectContaining({
+        params: expect.objectContaining({ search: "Padded Name" }),
+      }),
+    );
+  });
+
+  it("allows submission when results is not an array", async () => {
+    // .some() is only available on arrays; nullish coalescing handles this
+    mockGet.mockResolvedValueOnce({
+      data: { results: "not-an-array" },
+    });
+
+    // String doesn't have .some(), so this would throw.
+    // But our ?? [] ensures results is always an array.
+    const result = await CreateScenarioValidationSchema.safeParseAsync(
+      makeValidData({ name: "Test" }),
+    );
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds client-side validation to prevent creating or editing scenarios with duplicate names. Both the creation form and the edit dialog now check the existing list via the scenarios API and show a validation error when a name is already taken.

## Why

The form currently only checks that the name field is non-empty. Users can create multiple scenarios with identical names, leading to confusion in the list view. This catches duplicates before submission so users get immediate feedback.

Issue: #1489

## Changes

- **`frontend/src/sections/scenarios/common.js`** — Added `axios` import, an async `.refine()` that queries `endpoints.scenarios.list` to detect exact name matches. On API failure, validation passes so the form is never stuck. Added a code comment noting the `limit=50` pagination ceiling.
- **`frontend/src/sections/scenarios/common.test.js`** — 18 unit tests covering empty names, whitespace-only names, exact duplicates, case sensitivity, partial matches, API failures (network error, null data, missing results field), special characters, and unicode.
- **`frontend/src/components/scenarios/EditScenarioDialog.jsx`** — Added a duplicate-name check before the PUT request. Skips the check when the name hasn't changed and excludes the current scenario's own ID from duplicate detection. Uses the same graceful-degradation pattern as the creation form.
- **`frontend/src/components/scenarios/EditScenarioDialog.test.jsx`** — 8 unit tests covering duplicate detection, unchanged-name skip, self-exclusion, API failures, null data, missing results field, and empty-name guard.

## How it works

### Creation form

1. User types a name in the scenario creation form
2. `zod` runs `min(1)` → rejects empty strings
3. `.trim()` normalises whitespace
4. Async `.refine()` calls `GET /simulate/scenarios/?search=<name>&limit=50`
5. If any result has the exact same name (case-sensitive `===`), validation fails with: "A scenario with this name already exists. Please choose another name."
6. If the API call fails for any reason, validation passes (graceful degradation)

### Edit dialog

1. User changes the name and clicks "Save Changes"
2. If the new name differs from the original, the dialog queries `GET /simulate/scenarios/?search=<newName>&limit=50`
3. It looks for an exact match whose `id` differs from the current scenario's `id`
4. On match → inline error, PUT is not called
5. On API failure → graceful degradation, edit proceeds

## Test results

```
✓ src/sections/scenarios/common.test.js (18 tests)
✓ src/components/scenarios/EditScenarioDialog.test.jsx (8 tests)
  26 tests passed, 0 failures
```

## Known limitations

- **Pagination ceiling (`limit=50`):** Duplicates beyond the first page of search results are not detected. A dedicated server-side validate-name endpoint (similar to `endpoints.develop.experiment.validateName`) would be more robust. This is noted in a code comment in `common.js`.
- **Client-side only:** The backend `Scenarios` model has no `unique` constraint on `name`, and neither the create nor edit serializers check for duplicates. Direct API calls (curl, Postman) bypass this validation entirely.
- **TOCTOU race:** Two users submitting the same name simultaneously may both pass the client-side check before either scenario is persisted.
- **File naming:** The new test file follows the existing `common.test.js` naming convention in the scenarios directory. Per `frontend/README.md` the codebase is migrating toward `snake_case`, but co-located test files currently mirror their parent module's casing.

## Linked issues

Closes #1489

## Type of change

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Chore / refactor
- [ ] Performance improvement
- [ ] Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [x] I have signed the CLA