### PR TITLE
fix: suppress voice-only interruption metrics for chat simulations

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -160,6 +160,15 @@ const VoiceRightPanel = ({
       aiInterruptionCount: data?.ai_interruption_count,
     };
 
+    // Chat simulations don't have audio interruptions — suppress
+    // voice-only metrics ("User Int.", "AI Int.") so the KPI strip
+    // doesn't display misleading zeros.
+    const isChatSim = data?.simulation_call_type === "text";
+    if (isChatSim) {
+      delete apiMetrics.userInterruptionCount;
+      delete apiMetrics.aiInterruptionCount;
+    }
+
     if (isSimulate) {
       return {
         transcript: data?.transcript,


### PR DESCRIPTION
## Summary

Chat simulations incorrectly display "User Int." and "AI Int." KPI cells in the analytics view. These interruption metrics are only meaningful for voice simulations where audio interruptions can occur — for text-based chat conversations, they show misleading zeros.

## Root Cause

`VoiceRightPanel.jsx` passes `userInterruptionCount` and `aiInterruptionCount` from the API response to `CallAnalyticsView` → `KpiStrip` for all simulation types, including chat. The `KpiStrip` renders these as "User Int." and "AI Int." cells whenever the values are non-null, even when they're meaningless (zero) for chat simulations.

## Fix

In `VoiceRightPanel.jsx`, when `data?.simulation_call_type === "text"` (chat simulation), remove `userInterruptionCount` and `aiInterruptionCount` from the `apiMetrics` object before passing it to `CallAnalyticsView`. This causes `KpiStrip` to skip rendering the interruption cells entirely for chat simulations.

## Test Plan

- [ ] Open a chat simulation → analytics view should NOT show "User Int." or "AI Int." cells
- [ ] Open a voice simulation → analytics view should still show "User Int." and "AI Int." cells as before
- [ ] Open a LiveKit voice call → analytics view unchanged (non-simulate path is unaffected)

Closes #1503
