### PR TITLE
fix: wire up onClick handler in DatasetFilterCard

### DIFF
--- a/frontend/src/sections/model/datasets/DatasetFilter/DatasetFilterCard.jsx
+++ b/frontend/src/sections/model/datasets/DatasetFilter/DatasetFilterCard.jsx
@@ -1,8 +1,9 @@
 import { Box, Button, Card } from "@mui/material";
 import React from "react";
+import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 
-const DatasetFilterCard = () => {
+const DatasetFilterCard = ({ addFilter }) => {
   return (
     <Card sx={{ padding: 2, border: "none", display: "flex" }}>
       <Box sx={{ flex: 1 }} />
@@ -10,7 +11,7 @@ const DatasetFilterCard = () => {
         <Button
           variant="contained"
           color="primary"
-          onClick={() => {}}
+          onClick={addFilter}
           startIcon={<Iconify icon="ic:round-plus" />}
           sx={{
             "& .MuiButton-startIcon": {
@@ -21,6 +22,10 @@ const DatasetFilterCard = () => {
       </Box>
     </Card>
   );
+};
+
+DatasetFilterCard.propTypes = {
+  addFilter: PropTypes.func.isRequired,
 };
 
 export default DatasetFilterCard;


### PR DESCRIPTION
## Summary

The "Add Filter" button in `DatasetFilterCard` had an empty `onClick` handler (`onClick={() => {}}`), making it completely non-functional.

## Fix

Accept an `addFilter` prop and call it on button click. Added PropTypes validation for the required `addFilter` prop.

## Changes

- `DatasetFilterCard.jsx`: Accept `addFilter` prop, wire it to button's `onClick`, add PropTypes

## Test Plan

- [ ] Import `DatasetFilterCard` with an `addFilter` callback → button click should invoke the callback
- [ ] Existing `DatasetFilter` component (which has its own working "Add Filter" button) is unaffected

Closes #1499
