### PR TITLE
fix(huggingface): populate subset/split params when adding rows to existing dataset

### DIFF
--- a/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
@@ -20,17 +20,37 @@ const HuggingFaceDetailDrawer = ({
 }) => {
   useEffect(() => {
     if (!show) return;
-    if (show && showNameField && huggingFaceDetail?.name) {
-      const defaultValues = { name: huggingFaceDetail.name };
-      if (subsetOptions?.length > 0) {
-        defaultValues.huggingface_dataset_config = subsetOptions[0].value;
-      }
-      if (splitOptions?.length > 0) {
-        defaultValues.huggingface_dataset_split = splitOptions[0].value;
-      }
-      defaultValues.num_rows = 1;
-      reset(defaultValues);
+
+    const defaultValues = {};
+
+    // Set name field only when creating a new dataset (showNameField=true
+    // and an existing huggingFaceDetail is being edited). When adding
+    // rows to an already-created dataset, showNameField=false and we
+    // intentionally skip the name field — the existing dataset's name
+    // should not be overwritten.
+    if (showNameField && huggingFaceDetail?.name) {
+      defaultValues.name = huggingFaceDetail.name;
     }
+
+    // subset / split / num_rows must populate in BOTH flows
+    // (create-new-dataset AND add-rows-to-existing-dataset). The previous
+    // implementation gated `reset(defaultValues)` inside the
+    // `if (showNameField && huggingFaceDetail?.name)` block, which meant
+    // the add-rows flow never reset the form and the new rows were
+    // submitted with stale (or missing) subset/split/num_rows values —
+    // causing them to be written to the wrong location in the dataset.
+    // See issue #1500.
+    if (subsetOptions?.length > 0) {
+      defaultValues.huggingface_dataset_config = subsetOptions[0].value;
+    }
+    if (splitOptions?.length > 0) {
+      defaultValues.huggingface_dataset_split = splitOptions[0].value;
+    }
+
+    // Always set default row count.
+    defaultValues.num_rows = 1;
+
+    reset(defaultValues);
   }, [
     show,
     showNameField,


### PR DESCRIPTION
## Summary

The HuggingFace dataset import drawer failed to populate subset/split dropdown parameters when adding rows to an existing dataset. The `useEffect` in `HuggingFaceDetailDrawer` gated all form parameter population behind `showNameField && huggingFaceDetail?.name`, so when `showNameField` was false (add-rows workflow), the form fields stayed empty even when the options were successfully loaded from the API.

Closes #1500

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Approach

Restructured the `useEffect` to separate two concerns that were incorrectly bundled behind a single conjunction:

1. **Name field population** — still gated behind `showNameField && huggingFaceDetail?.name` (only relevant when creating a new dataset)
2. **Parameter population** (subset / split / `num_rows`) — now always runs when the drawer is shown (`show=true`) and the options are available

This mirrors the working pattern in [`frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx`](frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx), where the same form fields are populated without the problematic conditional restriction. The implementation follows the suggested fix in the issue body verbatim.

### Before

```javascript
useEffect(() => {
  if (!show) return;
  if (show && showNameField && huggingFaceDetail?.name) {
    const defaultValues = { name: huggingFaceDetail.name };
    if (subsetOptions?.length > 0) {
      defaultValues.huggingface_dataset_config = subsetOptions[0].value;
    }
    if (splitOptions?.length > 0) {
      defaultValues.huggingface_dataset_split = splitOptions[0].value;
    }
    defaultValues.num_rows = 1;
    reset(defaultValues);
  }
}, [show, showNameField, huggingFaceDetail?.name, reset, subsetOptions, splitOptions]);
```

### After

```javascript
useEffect(() => {
  if (!show) return;

  const defaultValues = {};

  // Set name field only when appropriate (creating new dataset)
  if (showNameField && huggingFaceDetail?.name) {
    defaultValues.name = huggingFaceDetail.name;
  }

  // Always set parameters when available, regardless of showNameField
  if (subsetOptions?.length > 0) {
    defaultValues.huggingface_dataset_config = subsetOptions[0].value;
  }
  if (splitOptions?.length > 0) {
    defaultValues.huggingface_dataset_split = splitOptions[0].value;
  }

  // Always set default row count
  defaultValues.num_rows = 1;

  reset(defaultValues);
}, [show, showNameField, huggingFaceDetail?.name, reset, subsetOptions, splitOptions]);
```

## How was this tested?

- **Code inspection**: confirmed the fix mirrors the working pattern in `ImportFromHuggingFace.jsx`
- **Behavioral trace** through all 4 scenarios from the issue's acceptance criteria:
  - Add rows to existing dataset (`showNameField=false`) → subset/split now populate ✅
  - Create new dataset with name (`showNameField=true`, `huggingFaceDetail.name` present) → all fields populate ✅
  - Create new dataset before name loads (`showNameField=true`, `huggingFaceDetail.name` absent) → subset/split still populate, name omitted ✅
  - Drawer closed (`show=false`) → early return, no-op ✅
- `yarn check-all` (ESLint + Prettier) — passes locally

## Notes for reviewer

- Followed the suggested fix from the issue body exactly — no deviation in logic, only minor stylistic alignment with the surrounding code.
- Did not add a regression test: the `frontend/src/sections/huggingface/` directory currently has no test files (4 `.jsx`/`.js` files, 0 tests), so introducing a new test setup would expand scope beyond a bug fix. Happy to add one if the team prefers — a RTL test could assert that `reset` is called with `huggingface_dataset_config` when `showNameField=false` and `subsetOptions` is non-empty.
- Pre-existing PropTypes inconsistency noted but **not** fixed (out of scope): `HuggingFaceDetailDrawer.propTypes` declares `setShow: PropTypes.func.isRequired`, but `setShow` is not destructured or used in the component. Worth a separate cleanup PR.

## Acceptance criteria

- [x] Subset dropdown populates with available options when adding rows to existing dataset
- [x] Split dropdown populates with available options when adding rows to existing dataset
- [x] Name field still only appears when creating new datasets (`showNameField=true`)
- [x] Name field still gets populated when creating new datasets and dataset name exists
- [x] Form validation still works for required subset and split fields
- [x] Default `num_rows` value is still set to 1 in all scenarios
- [x] Existing "create new dataset" workflow continues to work unchanged

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests — see notes above (no test infrastructure in directory, offered to add one)
- [x] `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [x] CLA — will sign when the bot prompts
