### PR TITLE
fix(error-feed): make Error Feed CH-native (survive tracer PG-table drop)

### DIFF
--- a/futureagi/ai_tools/tools/tracing/analyze_project_traces.py
+++ b/futureagi/ai_tools/tools/tracing/analyze_project_traces.py
@@ -8,7 +8,6 @@ same as the old beat task did. Results appear on the feed once clustering comple
 The tool returns immediately — analysis runs in the background via Temporal.
 """
 
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -57,8 +56,9 @@ class AnalyzeProjectTracesTool(BaseTool):
         import structlog
 
         from tracer.models.project import Project
-        from tracer.models.trace import Trace, TraceErrorAnalysisStatus
         from tracer.models.trace_error_analysis import TraceErrorAnalysis
+        from tracer.queries import deep_analysis_state
+        from tracer.services.clickhouse.v2 import get_reader
 
         logger = structlog.get_logger(__name__)
 
@@ -71,37 +71,39 @@ class AnalyzeProjectTracesTool(BaseTool):
         except Project.DoesNotExist:
             return ToolResult.not_found("Project", str(params.project_id))
 
-        # Determine which traces to analyze
+        # Determine which traces to analyze. Traces live only in CH post-cutover,
+        # so listing/validating goes through the CH root spans.
         if params.trace_ids and len(params.trace_ids) > 0:
-            # Specific traces requested — validate they exist
-            traces = list(
-                Trace.objects.filter(
-                    id__in=params.trace_ids,
-                    project=project,
-                ).values_list("id", flat=True)
-            )
-            if not traces:
+            # Specific traces requested — validate they exist in this project.
+            with get_reader() as reader:
+                found = reader.root_ids_by_trace_ids(
+                    [str(t) for t in params.trace_ids], project_ids=[str(project.id)]
+                )
+            trace_ids = list(found.keys())
+            if not trace_ids:
                 return ToolResult.error(
                     "None of the specified trace IDs were found in this project."
                 )
-            trace_ids = [str(t) for t in traces]
         else:
-            # Find un-analyzed traces in the project
-            already_analyzed = set(
-                TraceErrorAnalysis.objects.filter(project=project).values_list(
+            # Find un-analyzed traces in the project (analyzed set is feed-owned).
+            already_analyzed = {
+                str(t)
+                for t in TraceErrorAnalysis.objects.filter(project=project).values_list(
                     "trace_id", flat=True
                 )
-            )
-            all_trace_ids = list(
-                Trace.objects.filter(project=project)
-                .order_by("-created_at")
-                .values_list("id", flat=True)[: params.max_traces]
-            )
-            trace_ids = [str(t) for t in all_trace_ids if t not in already_analyzed]
+            }
+            with get_reader() as reader:
+                all_trace_ids = reader.recent_root_trace_ids_by_project(
+                    str(project.id), limit=params.max_traces
+                )
+            trace_ids = [t for t in all_trace_ids if t not in already_analyzed]
 
             if not trace_ids:
                 # All traces already analyzed — offer to re-analyze
-                total = Trace.objects.filter(project=project).count()
+                with get_reader() as reader:
+                    total = reader.count_with_filters(
+                        project_id=str(project.id), roots_only=True
+                    )
                 analyzed = len(already_analyzed)
                 return ToolResult(
                     content=section(
@@ -117,10 +119,9 @@ class AnalyzeProjectTracesTool(BaseTool):
                     },
                 )
 
-        # Mark traces as processing
-        Trace.objects.filter(id__in=trace_ids).update(
-            error_analysis_status=TraceErrorAnalysisStatus.PROCESSING
-        )
+        # Mark traces as running so the feed reflects in-flight analysis.
+        for tid in trace_ids:
+            deep_analysis_state.set_running(str(tid))
 
         # Dispatch via Temporal in batches of 10 (same as old beat task)
         try:

--- a/futureagi/ai_tools/tools/tracing/submit_trace_scores.py
+++ b/futureagi/ai_tools/tools/tracing/submit_trace_scores.py
@@ -82,8 +82,10 @@ class SubmitTraceScoresTool(BaseTool):
     def execute(
         self, params: SubmitTraceScoresInput, context: ToolContext
     ) -> ToolResult:
-        from tracer.models.trace import Trace, TraceErrorAnalysisStatus
+        from tracer.models.project import Project
         from tracer.models.trace_error_analysis import TraceErrorAnalysis
+        from tracer.queries import deep_analysis_state
+        from tracer.services.clickhouse.v2 import get_reader
 
         # Validate priority
         priority = params.recommended_priority.upper()
@@ -93,13 +95,21 @@ class SubmitTraceScoresTool(BaseTool):
                 "Must be HIGH, MEDIUM, or LOW."
             )
 
-        # Verify trace access
-        try:
-            trace = Trace.objects.select_related("project").get(
-                id=params.trace_id,
-                project__organization=context.organization,
-            )
-        except Trace.DoesNotExist:
+        # Verify trace access. The trace lives only in CH post-cutover; resolve
+        # its project from the CH root span and check org access via the PG
+        # Project (kept).
+        with get_reader() as reader:
+            roots = reader.root_ids_by_trace_ids([str(params.trace_id)])
+        root = roots.get(str(params.trace_id))
+        project_id = root[1] if root else None
+        project = (
+            Project.objects.filter(
+                id=project_id, organization=context.organization
+            ).first()
+            if project_id
+            else None
+        )
+        if project is None:
             return ToolResult.not_found("Trace", str(params.trace_id))
 
         # Find the analysis record
@@ -108,7 +118,7 @@ class SubmitTraceScoresTool(BaseTool):
             try:
                 analysis = TraceErrorAnalysis.objects.get(
                     id=params.analysis_id,
-                    trace=trace,
+                    trace_id=params.trace_id,
                 )
             except TraceErrorAnalysis.DoesNotExist:
                 analysis = None
@@ -116,7 +126,7 @@ class SubmitTraceScoresTool(BaseTool):
         # Fallback: get the most recent analysis for this trace
         if analysis is None:
             analysis = (
-                TraceErrorAnalysis.objects.filter(trace=trace)
+                TraceErrorAnalysis.objects.filter(trace_id=params.trace_id)
                 .order_by("-analysis_date")
                 .first()
             )
@@ -124,8 +134,8 @@ class SubmitTraceScoresTool(BaseTool):
         # If still no analysis, create one (scores-only, no findings)
         if analysis is None:
             analysis = TraceErrorAnalysis.objects.create(
-                trace=trace,
-                project=trace.project,
+                trace_id=params.trace_id,
+                project=project,
                 overall_score=params.overall_score,
                 total_errors=0,
                 recommended_priority=priority,
@@ -161,9 +171,8 @@ class SubmitTraceScoresTool(BaseTool):
             ]
         )
 
-        # Mark trace analysis as completed
-        trace.error_analysis_status = TraceErrorAnalysisStatus.COMPLETED
-        trace.save(update_fields=["error_analysis_status"])
+        # Done derives from the TraceErrorAnalysis row above; release the marker.
+        deep_analysis_state.clear(str(params.trace_id))
 
         # Trigger embedding ingestion for this trace's errors
         try:
@@ -182,11 +191,11 @@ class SubmitTraceScoresTool(BaseTool):
         try:
             from tracer.tasks.error_analysis import cluster_project_errors
 
-            cluster_project_errors.delay(str(trace.project_id))
+            cluster_project_errors.delay(str(project.id))
         except Exception as e:
             logger.warning(
                 "clustering_trigger_failed",
-                project_id=str(trace.project_id),
+                project_id=str(project.id),
                 error=str(e),
             )
 

--- a/futureagi/tracer/queries/deep_analysis_state.py
+++ b/futureagi/tracer/queries/deep_analysis_state.py
@@ -1,0 +1,62 @@
+"""Transient per-trace deep-analysis job state.
+
+The Error Feed's on-demand "Run Deep Analysis" used to track its per-trace job
+state in ``Trace.error_analysis_status`` (a PG column on ``tracer_trace``).
+Post CH-cutover that table is gone, so the column can't be read or written.
+
+The only genuinely *transient* state is "running": a finished run is recorded by
+a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which is the
+source of truth for "done". So the marker lives in the cache, not a table:
+
+- ``set_running`` is an atomic ``cache.add`` — two rapid dispatches collapse to
+  one (double-click guard), and a crashed worker self-heals when the marker
+  TTLs out. The old column left such traces stuck in PROCESSING forever.
+- "done" is never stored here — it derives from ``TraceErrorAnalysis`` existence.
+"""
+
+from django.core.cache import cache
+
+# Ceiling matches the analysis activity's ``time_limit``; a marker that outlives
+# a crashed run TTLs back to "idle" so the "Run Deep Analysis" button re-enables.
+_TTL_SECONDS = 3600
+
+_RUNNING = "running"
+_FAILED = "failed"
+
+
+def _key(trace_id: str) -> str:
+    return f"deep_analysis:state:{trace_id}"
+
+
+def set_running(trace_id: str) -> bool:
+    """Claim the trace as running. Returns ``True`` if this call set the marker,
+    ``False`` if a run was already in flight — an atomic double-click guard."""
+    return bool(cache.add(_key(trace_id), _RUNNING, _TTL_SECONDS))
+
+
+def is_running(trace_id: str) -> bool:
+    return cache.get(_key(trace_id)) == _RUNNING
+
+
+def set_failed(trace_id: str) -> None:
+    """Record a failed run so the UI can surface it until the marker TTLs out."""
+    cache.set(_key(trace_id), _FAILED, _TTL_SECONDS)
+
+
+def clear(trace_id: str) -> None:
+    cache.delete(_key(trace_id))
+
+
+def status(trace_id: str, *, has_analysis: bool) -> str:
+    """Frontend job state: ``done`` | ``running`` | ``failed`` | ``idle``.
+
+    A completed ``TraceErrorAnalysis`` row wins ("done"). Otherwise the transient
+    marker ("running"/"failed"), else "idle". Mirrors the old
+    status→feed-state map without touching the dropped column.
+    """
+    if has_analysis:
+        return "done"
+    marker = cache.get(_key(trace_id))
+    if marker in (_RUNNING, _FAILED):
+        return marker
+    return "idle"

--- a/futureagi/tracer/queries/deep_analysis_state.py
+++ b/futureagi/tracer/queries/deep_analysis_state.py
@@ -4,13 +4,18 @@ The Error Feed's on-demand "Run Deep Analysis" used to track its per-trace job
 state in ``Trace.error_analysis_status`` (a PG column on ``tracer_trace``).
 Post CH-cutover that table is gone, so the column can't be read or written.
 
-The only genuinely *transient* state is "running": a finished run is recorded by
-a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which is the
-source of truth for "done". So the marker lives in the cache, not a table:
+The only genuinely *transient* state is "running" / "failed": a finished run is
+recorded by a ``TraceErrorAnalysis`` row (feed-owned PG, survives the drop) which
+is the source of truth for "done". So the marker lives in the cache, not a table.
 
-- ``set_running`` is an atomic ``cache.add`` — two rapid dispatches collapse to
-  one (double-click guard), and a crashed worker self-heals when the marker
-  TTLs out. The old column left such traces stuck in PROCESSING forever.
+Two distinct keys back it so the failed state can never block a retry:
+
+- ``set_running`` is an atomic ``cache.add`` on the RUNNING key — two rapid
+  dispatches collapse to one (double-click guard), and a crashed worker
+  self-heals when the marker TTLs out (the old column left such traces stuck in
+  PROCESSING forever). It first clears any FAILED marker so a retry claims cleanly.
+- ``set_failed`` clears the RUNNING key and sets the FAILED key, so the next
+  ``set_running`` claim isn't blocked by a stale running marker.
 - "done" is never stored here — it derives from ``TraceErrorAnalysis`` existence.
 """
 
@@ -20,43 +25,50 @@ from django.core.cache import cache
 # a crashed run TTLs back to "idle" so the "Run Deep Analysis" button re-enables.
 _TTL_SECONDS = 3600
 
-_RUNNING = "running"
-_FAILED = "failed"
+
+def _running_key(trace_id: str) -> str:
+    return f"deep_analysis:running:{trace_id}"
 
 
-def _key(trace_id: str) -> str:
-    return f"deep_analysis:state:{trace_id}"
+def _failed_key(trace_id: str) -> str:
+    return f"deep_analysis:failed:{trace_id}"
 
 
 def set_running(trace_id: str) -> bool:
     """Claim the trace as running. Returns ``True`` if this call set the marker,
-    ``False`` if a run was already in flight — an atomic double-click guard."""
-    return bool(cache.add(_key(trace_id), _RUNNING, _TTL_SECONDS))
+    ``False`` if a run was already in flight — an atomic double-click guard. A
+    prior failure never blocks the claim (its marker is cleared first)."""
+    cache.delete(_failed_key(trace_id))
+    return bool(cache.add(_running_key(trace_id), "1", _TTL_SECONDS))
 
 
 def is_running(trace_id: str) -> bool:
-    return cache.get(_key(trace_id)) == _RUNNING
+    return cache.get(_running_key(trace_id)) is not None
 
 
 def set_failed(trace_id: str) -> None:
-    """Record a failed run so the UI can surface it until the marker TTLs out."""
-    cache.set(_key(trace_id), _FAILED, _TTL_SECONDS)
+    """Record a failed run (until it TTLs out) and release the running claim so a
+    retry can re-dispatch."""
+    cache.delete(_running_key(trace_id))
+    cache.set(_failed_key(trace_id), "1", _TTL_SECONDS)
 
 
 def clear(trace_id: str) -> None:
-    cache.delete(_key(trace_id))
+    cache.delete(_running_key(trace_id))
+    cache.delete(_failed_key(trace_id))
 
 
 def status(trace_id: str, *, has_analysis: bool) -> str:
     """Frontend job state: ``done`` | ``running`` | ``failed`` | ``idle``.
 
     A completed ``TraceErrorAnalysis`` row wins ("done"). Otherwise the transient
-    marker ("running"/"failed"), else "idle". Mirrors the old
-    status→feed-state map without touching the dropped column.
+    running/failed marker, else "idle" — mirroring the old status→feed-state map
+    without touching the dropped column.
     """
     if has_analysis:
         return "done"
-    marker = cache.get(_key(trace_id))
-    if marker in (_RUNNING, _FAILED):
-        return marker
+    if cache.get(_running_key(trace_id)) is not None:
+        return "running"
+    if cache.get(_failed_key(trace_id)) is not None:
+        return "failed"
     return "idle"

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -32,7 +32,6 @@ from scipy.stats import ks_2samp
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 
 from tracer.models.observation_span import EvalLogger, EvalTargetType
-from tracer.models.trace import Trace, TraceErrorAnalysisStatus
 from tracer.models.trace_error_analysis import (
     ClusterSource,
     ErrorClusterTraces,
@@ -42,6 +41,7 @@ from tracer.models.trace_error_analysis import (
     TraceErrorGroup,
 )
 from tracer.models.trace_scan import TraceScanIssue, TraceScanResult
+from tracer.queries import deep_analysis_state
 from tracer.services.clickhouse.v2 import get_reader
 from tracer.services.clickhouse.v2.span_reader import CHSpan
 from tracer.types.feed_types import (
@@ -149,7 +149,9 @@ def _base_qs(project_ids: list[str]) -> QuerySet:
     return (
         TraceErrorGroup.objects.filter(project_id__in=project_ids, deleted=False)
         .exclude(issue_group__isnull=True)
-        .select_related("project", "assignee", "success_trace")
+        # ``success_trace`` (FK → dropped ``tracer_trace``) is only dereferenced
+        # in the detail path, which resolves it from CH; list/stats never read it.
+        .select_related("project", "assignee")
     )
 
 
@@ -298,24 +300,36 @@ def _fetch_users_affected_batch(cluster_ids: list[str]) -> dict:
 
 
 def _fetch_sessions_batch(cluster_ids: list[str]) -> dict:
-    """Return {cluster_id: distinct_session_count}."""
+    """Return {cluster_id: distinct_session_count}.
+
+    Session members carry their session on the junction row; trace members
+    resolve theirs from the CH root span's ``trace_session_id`` (the PG
+    ``Trace.session`` FK is gone post-cutover). Distinct session ids are counted
+    per cluster in Python — mirrors the old cross-store SQL COUNT(DISTINCT).
+    """
     if not cluster_ids:
         return {}
 
-    # Session members store the session directly on the junction row;
-    # trace members reach theirs through trace.session. Coalesce keeps it
-    # one query for mixed batches.
-    rows = (
-        ErrorClusterTraces.objects.filter(cluster__cluster_id__in=cluster_ids)
-        .filter(Q(trace__session__isnull=False) | Q(trace_session__isnull=False))
-        .values("cluster__cluster_id")
-        .annotate(
-            sessions=Count(
-                Coalesce("trace_session_id", "trace__session_id"), distinct=True
-            )
-        )
+    rows = list(
+        ErrorClusterTraces.objects.filter(
+            cluster__cluster_id__in=cluster_ids
+        ).values_list("cluster__cluster_id", "trace_id", "trace_session_id")
     )
-    return {r["cluster__cluster_id"]: r["sessions"] for r in rows}
+
+    # Trace members (no junction session) get their session from CH; batch once.
+    trace_ids = {str(tid) for _cid, tid, sid in rows if tid and not sid}
+    ch_sessions: dict[str, str | None] = {}
+    if trace_ids:
+        with get_reader() as reader:
+            ch_sessions = reader.trace_session_ids_by_trace_ids(list(trace_ids))
+
+    sessions_by_cluster: dict[str, set] = {}
+    for cid, tid, sid in rows:
+        session_id = str(sid) if sid else (ch_sessions.get(str(tid)) if tid else None)
+        if session_id:
+            sessions_by_cluster.setdefault(cid, set()).add(session_id)
+
+    return {cid: len(s) for cid, s in sessions_by_cluster.items() if s}
 
 
 def _fetch_latest_trace_id_batch(cluster_ids: list[str]) -> dict:
@@ -548,7 +562,7 @@ def get_cluster_detail(
     cluster_id is hashed from project+content).
     """
     qs = TraceErrorGroup.objects.filter(deleted=False).select_related(
-        "project", "assignee", "success_trace"
+        "project", "assignee"
     )
     if project_ids is not None:
         qs = qs.filter(project_id__in=project_ids)
@@ -572,22 +586,20 @@ def get_cluster_detail(
 
     success_trace: TracePreview | None = None
     if cluster.success_trace_id:
-        success_trace = TracePreview(
-            trace_id=str(cluster.success_trace_id),
-            input=_trace_input_str(cluster.success_trace),
-            output=_trace_output_str(cluster.success_trace),
-        )
+        success_trace = _ch_trace_preview(str(cluster.success_trace_id))
     elif cluster.source == ClusterSource.EVAL and cluster.eval_config_id:
         # Eval clusters never get the scanner's KNN success match. A genuine
         # PASSING result for the same eval is the honest "working" reference
         # (powers the failing-vs-working comparison, e.g. voice call compare).
+        # Project scope comes off the eval config (project-scoped, PG-resident)
+        # instead of the trace/session FK, which points at the dropped tables.
         if cluster.eval_target_type == EvalTargetType.SESSION:
             # Session evals anchor to the session (trace NULL): find a
             # passing session and represent it by its latest trace.
             _, member_session_ids = _cluster_member_ids(cluster.cluster_id)
             passing_session = (
                 EvalLogger.objects.filter(
-                    trace_session__project_id=cluster.project_id,
+                    custom_eval_config__project_id=cluster.project_id,
                     custom_eval_config_id=cluster.eval_config_id,
                     deleted=False,
                 )
@@ -601,49 +613,32 @@ def get_cluster_detail(
                 rep_tid = _session_rep_trace_map(
                     [str(passing_session)], str(cluster.project_id)
                 ).get(str(passing_session))
-                rep_trace = (
-                    Trace.objects.filter(id=rep_tid).first() if rep_tid else None
-                )
-                if rep_trace:
-                    success_trace = TracePreview(
-                        trace_id=str(rep_trace.id),
-                        input=_trace_input_str(rep_trace),
-                        output=_trace_output_str(rep_trace),
-                    )
+                if rep_tid:
+                    success_trace = _ch_trace_preview(str(rep_tid))
         else:
             member_ids = _trace_ids_for_cluster(
                 cluster.cluster_id, str(cluster.project_id)
             )
-            passing = (
+            passing_trace_id = (
                 EvalLogger.objects.filter(
-                    trace__project_id=cluster.project_id,
+                    custom_eval_config__project_id=cluster.project_id,
                     custom_eval_config_id=cluster.eval_config_id,
                     deleted=False,
                 )
                 .filter(Q(output_bool=True) | Q(output_float__gte=1.0))
                 .exclude(trace_id__in=member_ids)
-                .select_related("trace")
                 .order_by("-created_at")
+                .values_list("trace_id", flat=True)
                 .first()
             )
-            if passing and passing.trace:
-                success_trace = TracePreview(
-                    trace_id=str(passing.trace_id),
-                    input=_trace_input_str(passing.trace),
-                    output=_trace_output_str(passing.trace),
-                )
+            if passing_trace_id:
+                success_trace = _ch_trace_preview(str(passing_trace_id))
 
     representative_trace: TracePreview | None = None
     if row.trace_id:
-        # Direct Trace fetch — session clusters' latest_trace_id is an
-        # effective trace (the session's rep), which has no junction row.
-        rep_trace_obj = Trace.objects.filter(id=row.trace_id).first()
-        if rep_trace_obj:
-            representative_trace = TracePreview(
-                trace_id=str(rep_trace_obj.id),
-                input=_trace_input_str(rep_trace_obj),
-                output=_trace_output_str(rep_trace_obj),
-            )
+        # Session clusters' latest_trace_id is an effective trace (the session's
+        # rep) with no junction row — hydrate it from the CH root span.
+        representative_trace = _ch_trace_preview(str(row.trace_id))
 
     rca = RcaSummary(
         synthesis=cluster.rca_synthesis,
@@ -747,6 +742,32 @@ def _trace_output_str(trace) -> str | None:
     return _safe_str(trace.output)
 
 
+def _ch_trace_preview(trace_id: str) -> TracePreview | None:
+    """``TracePreview`` for a trace hydrated from its CH root span — the sole
+    source post-cutover (no PG ``Trace`` row). Input/output prefer the typed
+    ``input.value``/``output.value`` attrs, falling back to the span's raw
+    input/output payload, matching the pass-reel precedence so the same trace
+    renders identically across surfaces. ``None`` if the trace has no CH root.
+    """
+    if not trace_id:
+        return None
+    root = _get_root_span(str(trace_id))
+    if root is None:
+        return None
+    attrs = root.attrs_string or {}
+    input_text = attrs.get("input.value")
+    if input_text is None and root.input is not None:
+        input_text = _safe_str(root.input)
+    output_text = attrs.get("output.value")
+    if output_text is None and root.output is not None:
+        output_text = _safe_str(root.output)
+    return TracePreview(
+        trace_id=str(trace_id),
+        input=input_text,
+        output=output_text,
+    )
+
+
 class _CHTraceShim:
     """Trace-like view backed by the CH root span, for post-cutover traces
     that have no PG ``Trace`` row. Exposes the attributes the row / rep
@@ -762,24 +783,21 @@ class _CHTraceShim:
 
 
 def _resolve_member_traces(trace_ids: list[str]) -> dict:
-    """``{trace_id: trace-like}`` for cluster members — PG ``Trace`` where it
-    exists, else a CH-backed shim built from the root span.
-
-    Post-CH-cutover traces are CH-only (no PG ``Trace`` row), so resolving
-    members through PG alone silently drops every collector trace from the
-    Traces tab / Overview. Hydrate the missing ones from the spans table.
+    """``{trace_id: trace-like}`` for cluster members, hydrated from the CH
+    root span. Post-cutover traces are CH-only (no PG ``Trace`` row), so the
+    root span is the sole source for the attrs the row/rep builders read
+    (``id``, ``created_at``, ``input``, ``output``). Members with no root span
+    in CH are omitted (same as an unresolvable trace before the cutover).
     """
     ids = [str(t) for t in trace_ids if t]
     if not ids:
         return {}
-    out: dict = {str(t.id): t for t in Trace.objects.filter(id__in=ids)}
-    missing = [tid for tid in ids if tid not in out]
-    if missing:
-        roots = _get_root_spans_batch(missing)
-        for tid in missing:
-            root = roots.get(tid)
-            if root is not None:
-                out[tid] = _CHTraceShim(tid, root)
+    roots = _get_root_spans_batch(ids)
+    out: dict = {}
+    for tid in ids:
+        root = roots.get(tid)
+        if root is not None:
+            out[tid] = _CHTraceShim(tid, root)
     return out
 
 
@@ -827,29 +845,29 @@ def _session_traces_map(
     # All sessions in one call belong to the project being queried.
     sid_to_trace_ids: dict[str, list[str]] = {}
     all_trace_ids: set[str] = set()
+    start_times: dict[str, datetime | None] = {}
     with get_reader() as reader:
         for sid in sid_set:
             tids = reader.session_trace_ids(project_id, sid)
             if tids:
                 sid_to_trace_ids[sid] = [str(t) for t in tids]
                 all_trace_ids.update(sid_to_trace_ids[sid])
+        if not all_trace_ids:
+            return {}
+        # Order newest-first by the CH root-span start_time (session_trace_ids
+        # returns an unordered DISTINCT set; callers require the latest turn
+        # first). Cross-store PG ``Trace.created_at`` is gone post-cutover.
+        start_times = reader.per_trace_root_span_start_times(list(all_trace_ids))
 
-    if not all_trace_ids:
-        return {}
+    def _rank(tid: str) -> datetime:
+        st = start_times.get(tid)
+        if st is None:
+            return datetime.min.replace(tzinfo=UTC)  # no CH root → sort last
+        return st if st.tzinfo else st.replace(tzinfo=UTC)
 
-    # Re-order newest-first: session_trace_ids returns an unordered DISTINCT set,
-    # but callers (rep-trace map) require the latest turn first.
-    order_rank = {
-        str(tid): i
-        for i, tid in enumerate(
-            Trace.objects.filter(id__in=all_trace_ids)
-            .order_by("-created_at")
-            .values_list("id", flat=True)
-        )
-    }
     out: dict[str, list[str]] = {}
     for sid, tids in sid_to_trace_ids.items():
-        out[sid] = sorted(tids, key=lambda t: order_rank.get(t, len(order_rank)))
+        out[sid] = sorted(tids, key=_rank, reverse=True)
     return out
 
 
@@ -1901,7 +1919,7 @@ def _avg_session_eval_score(session_ids: list[str]) -> float | None:
 
 
 def _build_representative_trace(
-    trace: Trace,
+    trace: "_CHTraceShim",
     has_issues: bool,
     pass_reel: list[dict] | None = None,
     highlight_terms: list[str] | None = None,
@@ -2012,41 +2030,40 @@ def _fetch_success_trace_pass_reel(cluster_id: str) -> list[dict]:
     own root input + output (+ key_moments if they exist) so the reel always
     has something useful to show.
     """
-    cluster = (
-        TraceErrorGroup.objects.filter(cluster_id=cluster_id)
-        .select_related("success_trace")
-        .first()
-    )
-    if not cluster or not cluster.success_trace:
+    cluster = TraceErrorGroup.objects.filter(cluster_id=cluster_id).first()
+    if not cluster or not cluster.success_trace_id:
         return []
 
-    success = cluster.success_trace
+    success_id = str(cluster.success_trace_id)
     steps: list[dict] = []
 
-    # 1. User input (from root span or Trace.input)
-    root = _get_root_span(str(success.id))
+    # 1. User input/output from the CH root span — the sole source post-cutover.
+    root = _get_root_span(success_id)
     input_text = None
     output_text = None
     if root:
-        # CHSpan typed-Map string-valued attrs live in attrs_string.
+        # CHSpan typed-Map string-valued attrs live in attrs_string; fall back
+        # to the raw span payload when the typed attr is absent.
         attrs = root.attrs_string or {}
         input_text = attrs.get("input.value")
         output_text = attrs.get("output.value")
-    input_text = input_text or _trace_input_str(success)
-    output_text = output_text or _trace_output_str(success)
+        if input_text is None and root.input is not None:
+            input_text = _safe_str(root.input)
+        if output_text is None and root.output is not None:
+            output_text = _safe_str(root.output)
 
     if input_text:
         steps.append({"label": "USER INPUT", "text": input_text, "meta": None})
 
     # 2. Any key_moments the scanner captured (often empty for clean traces)
     scan_result = (
-        TraceScanResult.objects.filter(trace_id=success.id).only("key_moments").first()
+        TraceScanResult.objects.filter(trace_id=success_id).only("key_moments").first()
     )
     if scan_result:
         steps.extend(
             _key_moments_to_reel(
                 scan_result.key_moments,
-                trace_id=str(success.id),
+                trace_id=success_id,
                 project_id=str(cluster.project_id) if cluster.project_id else None,
             )
         )
@@ -2090,7 +2107,8 @@ def _fetch_representative_traces(
 
     qs = (
         ErrorClusterTraces.objects.filter(cluster__cluster_id=cluster_id)
-        .select_related("trace")
+        # Only raw ``trace_id``/``trace_session_id`` are read below; member
+        # traces hydrate from CH via ``_resolve_member_traces``.
         .order_by("-created_at")
     )
     ect_rows = list(
@@ -2312,7 +2330,7 @@ def _fetch_trace_rows(
     """Paginated list of traces in the cluster for the AG Grid."""
     base = (
         ErrorClusterTraces.objects.filter(cluster__cluster_id=cluster_id)
-        .select_related("trace")
+        # Raw ``trace_id``/``trace_session_id`` only; traces hydrate from CH.
         .order_by("-created_at")
     )
 
@@ -2487,10 +2505,20 @@ def _project_scope_total(project_id: str, source: str, start, end=None) -> int:
     projects), so denominator = trace rows in the project window.
     """
     if source == ClusterSource.EVAL:
-        qs = Trace.objects.filter(project_id=project_id, created_at__gte=start)
-        if end is not None:
-            qs = qs.filter(created_at__lt=end)
-        return qs.count()
+        # Denominator = distinct traces in the window. The PG ``Trace`` table is
+        # gone, so count CH root spans (one per trace) over the same window.
+        with get_reader() as reader:
+            if end is not None:
+                return reader.count_with_filters(
+                    project_id=str(project_id),
+                    created_at_range=(start, end),
+                    roots_only=True,
+                )
+            return reader.count_with_filters(
+                project_id=str(project_id),
+                created_at_gte=start,
+                roots_only=True,
+            )
     qs = TraceScanResult.objects.filter(project_id=project_id, created_at__gte=start)
     if end is not None:
         qs = qs.filter(created_at__lt=end)
@@ -3206,31 +3234,6 @@ def _build_recommendations(
     return result
 
 
-_TRACE_STATUS_TO_FEED = {
-    TraceErrorAnalysisStatus.PENDING: "idle",
-    TraceErrorAnalysisStatus.SKIPPED: "idle",
-    TraceErrorAnalysisStatus.PROCESSING: "running",
-    TraceErrorAnalysisStatus.COMPLETED: "done",
-    TraceErrorAnalysisStatus.FAILED: "failed",
-}
-
-
-def _deep_analysis_status(trace: Trace, has_analysis: bool) -> str:
-    """Map ``Trace.error_analysis_status`` to the frontend state machine.
-
-    One nuance: a trace can be in COMPLETED state but have zero
-    ``TraceErrorDetail`` rows (the analysis ran, found nothing). We still
-    return ``done`` — the frontend decides what to render when the lists
-    are empty. Conversely, if status is COMPLETED but the
-    ``TraceErrorAnalysis`` row got deleted (e.g. cascade from a trace
-    delete), we treat that as ``idle`` so the button re-enables.
-    """
-    status = _TRACE_STATUS_TO_FEED.get(trace.error_analysis_status, "idle")
-    if status == "done" and not has_analysis:
-        return "idle"
-    return status
-
-
 def _cluster_has_trace(
     cluster_id: str, trace_id: str, project_ids: list[str] | None = None
 ) -> bool:
@@ -3260,16 +3263,12 @@ def get_deep_analysis(
     if not _cluster_has_trace(cluster_id, trace_id, project_ids):
         return None
 
-    trace = Trace.objects.filter(id=trace_id).only("error_analysis_status").first()
-    if not trace:
-        return None
-
     analysis = (
         TraceErrorAnalysis.objects.filter(trace_id=trace_id)
         .order_by("-analysis_date")
         .first()
     )
-    status = _deep_analysis_status(trace, has_analysis=bool(analysis))
+    status = deep_analysis_state.status(str(trace_id), has_analysis=bool(analysis))
 
     if not analysis or status != "done":
         return DeepAnalysisResponse(
@@ -3320,11 +3319,10 @@ def dispatch_deep_analysis(
     - If cached results already exist and ``force=False``, return a
       ``done`` response without dispatching — the frontend will just
       scroll to the existing panel.
-    - If the trace is already in PROCESSING state, return ``running``
-      without re-dispatching (idempotent double-click protection).
-    - Otherwise: set ``Trace.error_analysis_status=PROCESSING``
-      synchronously and dispatch the Temporal activity. The view returns
-      202 ``running``.
+    - If the trace is already running, return ``running`` without
+      re-dispatching (idempotent double-click protection).
+    - Otherwise: claim the running marker and dispatch the Temporal
+      activity. The view returns 202 ``running``.
     """
     # Import here to avoid pulling the Temporal runtime into module-load
     # time for everything that imports `feed.py`. Task modules can have
@@ -3337,10 +3335,6 @@ def dispatch_deep_analysis(
     if not _cluster_has_trace(cluster_id, trace_id, project_ids):
         return None
 
-    trace = Trace.objects.filter(id=trace_id).only("error_analysis_status").first()
-    if not trace:
-        return None
-
     has_analysis = TraceErrorAnalysis.objects.filter(trace_id=trace_id).exists()
 
     # Idempotent click: cached result exists and user didn't ask for a
@@ -3348,15 +3342,12 @@ def dispatch_deep_analysis(
     if has_analysis and not force:
         return DeepAnalysisDispatchResponse(status="done", trace_id=str(trace_id))
 
-    # Already running → don't double-dispatch.
-    if trace.error_analysis_status == TraceErrorAnalysisStatus.PROCESSING:
+    # Atomic claim (cache.add): a second click while a run is in flight gets
+    # False and returns ``running`` without re-dispatching. ``force`` re-runs
+    # even mid-flight (the marker is already set, so the guard is skipped).
+    claimed = deep_analysis_state.set_running(str(trace_id))
+    if not claimed and not force:
         return DeepAnalysisDispatchResponse(status="running", trace_id=str(trace_id))
-
-    # Flip status synchronously so the first frontend poll sees the
-    # running state without racing the Temporal worker.
-    Trace.objects.filter(id=trace_id).update(
-        error_analysis_status=TraceErrorAnalysisStatus.PROCESSING
-    )
 
     run_deep_analysis_on_demand.delay(str(trace_id), bool(force))
 

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -2506,7 +2506,9 @@ def _project_scope_total(project_id: str, source: str, start, end=None) -> int:
     """
     if source == ClusterSource.EVAL:
         # Denominator = distinct traces in the window. The PG ``Trace`` table is
-        # gone, so count CH root spans (one per trace) over the same window.
+        # gone, so count distinct CH root traces over the same window. (CH uses an
+        # inclusive BETWEEN vs the scanner branch's exclusive ``created_at__lt``
+        # below — a boundary-microsecond difference on a rate denominator.)
         with get_reader() as reader:
             if end is not None:
                 return reader.count_with_filters(

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -15,7 +15,6 @@ from django.utils import timezone
 
 from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
 from agentic_eval.core.embeddings.embedding_manager import model_manager
-from tracer.models.trace import Trace
 from tracer.models.trace_error_analysis import (
     ClusterSource,
     ErrorClusterTraces,
@@ -388,13 +387,8 @@ def get_trace_input_data(trace_ids: List[str], project_id: str) -> List[TraceInp
         if input_text:
             input_texts[trace_id_str] = str(input_text)
 
-    # Fallback: check Trace.input for any missing
-    missing = [tid for tid in scanned_trace_ids if tid not in input_texts]
-    if missing:
-        traces = Trace.objects.filter(id__in=missing).values_list("id", "input")
-        for trace_id, trace_input in traces:
-            if trace_input:
-                input_texts[str(trace_id)] = str(trace_input)
+    # The CH root span's ``input.value`` is the only source post-cutover; a trace
+    # with no root input simply contributes no text (handled below).
 
     # Build typed results — only scanned traces with known has_issues state
     result = []

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1048,6 +1048,34 @@ class CHSpanReader:
         ).result_rows
         return [str(row[0]) for row in rows]
 
+    def recent_root_trace_ids_by_project(
+        self,
+        project_id: str,
+        *,
+        limit: int,
+        exclude_trace_ids: list[str] | None = None,
+    ) -> list[str]:
+        """Distinct trace_ids for a project, newest first, capped at ``limit`` —
+        one row per trace (root span). Replaces the PG
+        ``Trace.objects.filter(project=…).order_by('-created_at')[:limit]`` walk
+        used to pick recent traces to analyze. ``exclude_trace_ids`` drops
+        already-handled traces CH-side."""
+        if not project_id or limit <= 0:
+            return []
+        where = ["project_id = %(pid)s", "is_deleted = 0", "parent_span_id = ''"]
+        params: dict[str, Any] = {"pid": str(project_id), "lim": int(limit)}
+        if exclude_trace_ids:
+            where.append("trace_id NOT IN %(exclude)s")
+            params["exclude"] = tuple(exclude_trace_ids)
+        rows = self._client.query(
+            "SELECT toString(trace_id) AS tid, max(start_time) AS st "
+            "FROM spans FINAL "
+            f"WHERE {' AND '.join(where)} "
+            "GROUP BY tid ORDER BY st DESC LIMIT %(lim)s",
+            parameters=params,
+        ).result_rows
+        return [str(r[0]) for r in rows]
+
     def scope_by_ids(self, span_ids: list[str]) -> dict[str, SpanScope]:
         """Map ``span_id -> SpanScope(project_id, trace_id)``, reading ONLY those
         two columns instead of the full span row.
@@ -1122,6 +1150,51 @@ class CHSpanReader:
             tid = str(tid)
             if tid not in result:  # first root per trace wins
                 result[tid] = (str(sid), _norm(pid))
+        return result
+
+    def trace_session_ids_by_trace_ids(
+        self, trace_ids: list[str], project_ids: list[str] | None = None
+    ) -> dict[str, str | None]:
+        """``{trace_id: trace_session_id}`` read from each trace's root span,
+        ids only — the reverse of ``session_trace_ids``. Lets callers count
+        distinct sessions across trace members without the dropped PG
+        ``Trace.session`` FK. The session id is resolved new→old (remap) so a
+        cross-cutover straddler's turns collapse to one session downstream."""
+        if not trace_ids:
+            return {}
+        join = remap_left_join(
+            "spans.trace_session_id", "trace_session_id_remap", "ts_remap"
+        )
+        resolved_ts = resolved_id_expr("spans.trace_session_id", "ts_remap")
+        where = [
+            "trace_id IN %(trace_ids)s",
+            "is_deleted = 0",
+            "(parent_span_id IS NULL OR parent_span_id = '')",
+        ]
+        params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
+        if project_ids:
+            where.append("project_id IN %(project_ids)s")
+            params["project_ids"] = tuple(project_ids)
+        rows = self._client.query(
+            f"SELECT toString(trace_id) AS trace_id, toString({resolved_ts}) AS tsid "
+            f"FROM spans FINAL {join} "
+            f"WHERE {' AND '.join(where)} "
+            "ORDER BY trace_id, start_time, id",
+            parameters=params,
+        ).result_rows
+
+        def _norm(v: Any) -> str | None:
+            return (
+                None
+                if v in (None, "", "NULL", "00000000-0000-0000-0000-000000000000")
+                else str(v)
+            )
+
+        result: dict[str, str | None] = {}
+        for tid, tsid in rows:
+            tid = str(tid)
+            if tid not in result:  # first root per trace wins
+                result[tid] = _norm(tsid)
         return result
 
     # ─── Aggregations across many traces ──────────────────────────────────────
@@ -1619,6 +1692,7 @@ class CHSpanReader:
         session_id: str | list[str] | None = None,
         created_at_gte: datetime | None = None,
         created_at_range: tuple[datetime, datetime] | None = None,
+        roots_only: bool = False,
     ) -> int:
         """Replaces ObservationSpan.objects.filter(<Q-object>).count() for
         the specific filter set produced by parsing_evaltask_filters().
@@ -1626,6 +1700,10 @@ class CHSpanReader:
         Equivalent to building a Q with those kwargs and counting. NOT
         a general-purpose Q→CH translator; intentionally narrow to the
         eval-task filter shape so behavior is testable in isolation.
+
+        ``roots_only`` counts one row per trace (root span = empty parent),
+        turning this into a trace count — used where the PG path counted
+        ``Trace`` rows in a window rather than spans.
 
         Codex wave-2 fixes (2026-05-26):
           • P1: created_at_* predicates target the CH `created_at` column
@@ -1638,6 +1716,8 @@ class CHSpanReader:
         where = ["is_deleted = 0"]
         params: dict[str, Any] = {}
         session_join = ""
+        if roots_only:
+            where.append("parent_span_id = ''")
         if project_id:
             where.append("project_id = %(pid)s")
             params["pid"] = project_id

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -1763,8 +1763,12 @@ class CHSpanReader:
         if created_at_range:
             where.append("created_at BETWEEN %(cr_s)s AND %(cr_e)s")
             params["cr_s"], params["cr_e"] = created_at_range
+        # roots_only counts distinct traces, not root rows — a trace with more
+        # than one parentless span must count once (mirrors the GROUP BY tid /
+        # first-root-per-trace dedupe elsewhere in this reader).
+        select = "count(DISTINCT trace_id)" if roots_only else "count()"
         rows = self._client.query(
-            f"SELECT count() FROM spans FINAL {session_join} "
+            f"SELECT {select} FROM spans FINAL {session_join} "
             f"WHERE {' AND '.join(where)}",
             parameters=params,
         ).result_rows

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -34,18 +34,18 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
     avoid doing work no one reads (and to sidestep the orphan-rows-on-
     re-run problem).
     """
-    from accounts.models.user import User
     try:
         from ee.agenthub.traceerroragent.traceerror import TraceErrorAnalysisAgent
     except ImportError:
         if settings.DEBUG:
             logger.warning("Could not import ee.agenthub.traceerroragent.traceerror", exc_info=True)
         return None
-    from tracer.models.observation_span import Trace
-    from tracer.models.trace import TraceErrorAnalysisStatus
+    from tracer.models.project import Project
     from tracer.models.trace_error_analysis import TraceErrorAnalysis
+    from tracer.queries import deep_analysis_state
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
     from tracer.queries.helpers import get_default_workspace_for_project
+    from tracer.services.clickhouse.v2 import get_reader
     from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
@@ -70,16 +70,23 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 "skipped": True,
             }
 
-        try:
-            trace = Trace.objects.select_related("project__organization").get(
-                id=trace_id
-            )
-            organization = trace.project.organization
-        except Trace.DoesNotExist:
+        # Trace lives only in CH post-cutover; resolve its project (org + billing)
+        # from the CH root span's project_id, then load the PG Project (kept).
+        with get_reader() as reader:
+            roots = reader.root_ids_by_trace_ids([str(trace_id)])
+        root = roots.get(str(trace_id))
+        project_id = root[1] if root else None
+        project = (
+            Project.objects.select_related("organization").filter(id=project_id).first()
+            if project_id
+            else None
+        )
+        if project is None:
             logger.warning(f"Trace {trace_id} not found, skipping analysis.")
             return {"success": False, "trace_id": trace_id, "error": "Trace not found"}
+        organization = project.organization
 
-        workspace = get_default_workspace_for_project(trace.project)
+        workspace = get_default_workspace_for_project(project)
 
         # Pre-check usage before the LLM call
         try:
@@ -92,9 +99,7 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 str(organization.id), APICallTypeChoices.TRACE_ERROR_ANALYSIS.value
             )
             if not usage_check.allowed:
-                Trace.objects.filter(id=trace_id).update(
-                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
-                )
+                deep_analysis_state.set_failed(str(trace_id))
                 raise ValueError(usage_check.reason or "Usage limit exceeded")
 
         # Log and deduct cost for the analysis upfront.
@@ -107,17 +112,15 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 source_id=str(trace_id),
                 config={
                     "trace_id": str(trace_id),
-                    "project_id": str(trace.project.id),
-                    "reference_id": str(trace.project.id),
+                    "project_id": str(project.id),
+                    "reference_id": str(project.id),
                 },
             )
 
             if not api_call_log_row:
                 error_message = "Failed to create API call log for trace analysis."
                 logger.error(error_message)
-                Trace.objects.filter(id=trace_id).update(
-                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
-                )
+                deep_analysis_state.set_failed(str(trace_id))
                 return {"success": False, "trace_id": trace_id, "error": error_message}
 
         agent = TraceErrorAnalysisAgent(
@@ -134,9 +137,10 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             f"Successfully analyzed trace {trace_id} - found {error_count} errors"
         )
 
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.COMPLETED
-        )
+        # Success is recorded by the TraceErrorAnalysis row the agent wrote
+        # (save_to_db=True) — the feed derives "done" from it. Just release the
+        # transient running marker.
+        deep_analysis_state.clear(str(trace_id))
 
         if error_count > 0 and ingest_embeddings:
             error_analysis_db = TraceErrorAnalysisDB()
@@ -209,10 +213,8 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             api_call_log_row.status = APICallStatusChoices.ERROR.value
             api_call_log_row.save(update_fields=["status"])
 
-        # Mark trace as failed
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.FAILED
-        )
+        # Mark the run failed (transient marker; TTLs back to idle).
+        deep_analysis_state.set_failed(str(trace_id))
 
         return {"success": False, "trace_id": trace_id, "error": str(e)}
     finally:
@@ -239,10 +241,10 @@ def run_deep_analysis_on_demand(trace_id: str, force: bool = False) -> dict:
       ``TraceErrorAnalysis`` row (cascades to ``TraceErrorDetail`` via
       FK CASCADE) so the downstream agent produces fresh results.
 
-    The view sets ``Trace.error_analysis_status=PROCESSING`` synchronously
-    before dispatching so the first frontend poll sees the running state
-    without racing the Temporal worker. ``analyze_single_trace`` flips it
-    to COMPLETED/FAILED at the end.
+    The dispatcher claims a ``deep_analysis_state`` running marker before
+    dispatching so the first frontend poll sees the running state without
+    racing the Temporal worker; ``analyze_single_trace`` clears it on success
+    (done derives from the ``TraceErrorAnalysis`` row) or marks it failed.
 
     Embeddings are deliberately skipped — the Feed Revamp reads
     ``TraceErrorDetail`` rows directly and has no use for the ClickHouse
@@ -449,14 +451,22 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
     from ai_tools.base import ToolContext
     from tfc.middleware.workspace_context import set_workspace_context
-    from tracer.models.trace import Trace, TraceErrorAnalysisStatus
+    from tracer.models.project import Project
+    from tracer.queries import deep_analysis_state
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
 
     close_old_connections()
 
     try:
-        trace = Trace.objects.select_related("project__organization").get(id=trace_id)
-        org = trace.project.organization
+        # The caller passes project_id (traces live only in CH post-cutover);
+        # load the PG Project (kept) for org / user / workspace resolution.
+        project = (
+            Project.objects.select_related("organization").filter(id=project_id).first()
+        )
+        if project is None:
+            logger.error(f"Project {project_id} not found, skipping trace {trace_id}")
+            return {"success": False, "trace_id": trace_id, "error": "Project not found"}
+        org = project.organization
 
         # Find a user in this org for the conversation
         from accounts.models.user import User
@@ -469,7 +479,7 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
         # Get workspace
         from tracer.queries.helpers import get_default_workspace_for_project
 
-        workspace = get_default_workspace_for_project(trace.project)
+        workspace = get_default_workspace_for_project(project)
 
         set_workspace_context(workspace=workspace, organization=org, user=user)
         ctx = ToolContext(user=user, organization=org, workspace=workspace)
@@ -571,8 +581,8 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
         if not analysis:
             # Falcon found no errors — create a clean analysis record
             analysis = TraceErrorAnalysis.objects.create(
-                trace=trace,
-                project=trace.project,
+                trace_id=trace_id,
+                project=project,
                 overall_score=4.0,
                 total_errors=0,
                 high_impact_errors=0,
@@ -612,9 +622,8 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
         error_count = analysis.total_errors or 0
 
-        # Always mark trace as completed
-        trace.error_analysis_status = TraceErrorAnalysisStatus.COMPLETED
-        trace.save(update_fields=["error_analysis_status"])
+        # Done is derived from the TraceErrorAnalysis row above; release marker.
+        deep_analysis_state.clear(str(trace_id))
 
         # Ingest embeddings for clustering if there are errors
         if error_count > 0:
@@ -666,9 +675,7 @@ def _falcon_analyze_single_trace(trace_id: str, project_id: str):
 
     except Exception as e:
         logger.exception(f"Falcon analysis failed for trace {trace_id}: {str(e)}")
-        Trace.objects.filter(id=trace_id).update(
-            error_analysis_status=TraceErrorAnalysisStatus.FAILED
-        )
+        deep_analysis_state.set_failed(str(trace_id))
         return {"success": False, "trace_id": trace_id, "error": str(e)}
     finally:
         close_old_connections()

--- a/futureagi/tracer/tests/test_feed_pg_drop_repro.py
+++ b/futureagi/tracer/tests/test_feed_pg_drop_repro.py
@@ -1,0 +1,278 @@
+"""Repro + regression harness for the Error Feed after the legacy tracer PG
+tables are dropped.
+
+Traces now live only in ClickHouse (fi-collector -> CH); the legacy
+``tracer_trace`` / ``tracer_observation_span`` / ``trace_session`` /
+``tracer_enduser`` PG tables are being dropped org-wide. Every FK from the
+feed's own tables to those models is ``db_constraint=False`` so the raw
+``*_id`` columns survive the drop -- but any ORM JOIN (``select_related``,
+``trace__session`` traversal) or ``Trace.objects.*`` read still targets the
+missing relation and raises ``ProgrammingError`` (42P01), which also poisons
+the request transaction.
+
+These tests seed a cluster + its trace **in ClickHouse only**, drop the four
+tracer PG tables inside the test transaction (Postgres DDL is transactional,
+so it rolls back at teardown), then exercise every feed read path. Before the
+CH-native conversion each path raises 42P01; after it, each returns CH-sourced
+data.
+
+One drop+call per test: the first 42P01 aborts the transaction, so isolating
+each path keeps a real 42P01 from masquerading as "transaction is aborted" on
+the paths that follow.
+"""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.db import ProgrammingError, connection
+from django.utils import timezone
+
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.trace import Trace
+from tracer.models.trace_error_analysis import (
+    ClusterSource,
+    ErrorClusterTraces,
+    FeedIssueStatus,
+    Priority,
+    TraceErrorGroup,
+)
+from tracer.tests._ch_seed import seed_ch_span
+from tracer.utils import feed as feed_service
+
+# The tracer-owned PG tables being dropped. Order/‑CASCADE handles any
+# leftover dependent objects; all FKs into them are already db_constraint=False.
+_DROPPED_TABLES = (
+    "tracer_observation_span",
+    "tracer_trace",
+    "trace_session",
+    "tracer_enduser",
+)
+
+
+def _drop_tracer_pg_tables():
+    """Simulate the org-wide drop inside the test transaction."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "DROP TABLE IF EXISTS "
+            + ", ".join(_DROPPED_TABLES)
+            + " CASCADE"
+        )
+
+
+def _seed_ch_root(project, trace_id, *, status="OK", parent="", input_=None, output=None):
+    """Seed ONE CH root span for ``trace_id`` (no PG Trace row).
+
+    The span carries an UNSAVED ``Trace`` so ``seed_ch_span`` reads its FK from
+    the instance cache instead of hitting PG for a trace that lives only in CH.
+    """
+    span = ObservationSpan(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=Trace(id=trace_id, project=project),
+        parent_span_id=parent,
+        name="root",
+        observation_type="llm",
+        start_time=timezone.now() - timedelta(seconds=5),
+        end_time=timezone.now(),
+        input=input_ if input_ is not None else {"prompt": "hi"},
+        output=output if output is not None else {"response": "hello"},
+        model="gpt-4",
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        latency_ms=500,
+        status=status,
+    )
+    seed_ch_span(span)
+    return span
+
+
+@pytest.fixture
+def seeded_cluster(db, project):
+    """A scanner cluster + one CH-only member trace + a CH-only success trace.
+
+    Returns ``(cluster, trace_id, success_trace_id)``. Nothing is written to the
+    tracer PG tables — the trace exists purely in ClickHouse.
+    """
+    now = timezone.now()
+    trace_id = str(uuid.uuid4())
+    success_trace_id = str(uuid.uuid4())
+
+    cluster = TraceErrorGroup.objects.create(
+        project=project,
+        cluster_id="K-DROP-1",
+        error_type="drop-error",
+        source=ClusterSource.SCANNER,
+        issue_group="Tool Failures",
+        issue_category="Language-only",
+        fix_layer="Tools",
+        title="drop repro issue",
+        status=FeedIssueStatus.ESCALATING,
+        priority=Priority.MEDIUM,
+        first_seen=now,
+        last_seen=now,
+        error_count=1,
+        unique_traces=1,
+        success_trace_id=success_trace_id,
+    )
+    ErrorClusterTraces.objects.create(cluster=cluster, trace_id=trace_id)
+
+    _seed_ch_root(project, trace_id, input_={"prompt": "fail"}, output={"response": "bad"})
+    _seed_ch_root(
+        project, success_trace_id, input_={"prompt": "ok"}, output={"response": "good"}
+    )
+    return cluster, trace_id, success_trace_id
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestFeedSurvivesTracerPgDrop:
+    """Every feed read path must resolve trace data from CH, never PG."""
+
+    def _pids(self, cluster):
+        return [str(cluster.project_id)]
+
+    def test_list_clusters(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        resp = feed_service.list_feed_issues(self._pids(cluster))
+        assert resp.total == 1
+        assert resp.data[0].cluster_id == "K-DROP-1"
+
+    def test_stats(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        stats = feed_service.get_feed_stats(self._pids(cluster))
+        assert stats is not None
+
+    def test_cluster_detail(self, seeded_cluster):
+        cluster, trace_id, success_trace_id = seeded_cluster
+        _drop_tracer_pg_tables()
+        detail = feed_service.get_feed_detail("K-DROP-1", self._pids(cluster))
+        assert detail is not None
+        # success + representative previews must hydrate from the CH root span.
+        assert detail.success_trace is not None
+        assert detail.success_trace.trace_id == success_trace_id
+
+    def test_overview(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        # The pattern-summary baseline hits the agentic_eval vector store (a
+        # separate CH on :9000, unaffected by the tracer PG drop and absent from
+        # the test stack); stub it so this test isolates the PG-drop paths.
+        from unittest.mock import patch
+
+        with patch("tracer.queries.feed._passing_baseline_trace_ids", return_value=[]):
+            overview = feed_service.get_overview_tab("K-DROP-1", self._pids(cluster))
+        assert overview is not None
+        assert overview.representative_total >= 1
+
+    def test_traces_tab(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        traces = feed_service.get_traces_tab("K-DROP-1", self._pids(cluster))
+        assert traces is not None
+
+    def test_trends_tab(self, seeded_cluster):
+        cluster, _, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        trends = feed_service.get_trends_tab("K-DROP-1", self._pids(cluster))
+        assert trends is not None
+
+    def test_sidebar(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        sidebar = feed_service.get_sidebar(
+            "K-DROP-1", self._pids(cluster), trace_id=trace_id
+        )
+        assert sidebar is not None
+
+    def test_deep_analysis_get(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        resp = feed_service.get_deep_analysis(
+            "K-DROP-1", self._pids(cluster), trace_id=trace_id
+        )
+        # No analysis rows seeded -> status is a non-error "idle"/"pending".
+        assert resp is not None
+
+    def test_deep_analysis_dispatch(self, seeded_cluster):
+        cluster, trace_id, _ = seeded_cluster
+        _drop_tracer_pg_tables()
+        from unittest.mock import patch
+
+        # Lazily imported inside dispatch_deep_analysis, so patch it at its home.
+        with patch("tracer.tasks.run_deep_analysis_on_demand") as task:
+            resp = feed_service.dispatch_deep_analysis(
+                "K-DROP-1", self._pids(cluster), trace_id=trace_id
+            )
+        assert resp is not None
+        assert resp.status == "running"
+        assert task.delay.called
+
+
+class TestDeepAnalysisState:
+    """The transient per-trace marker that replaces Trace.error_analysis_status."""
+
+    def setup_method(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_double_click_guard_and_lifecycle(self):
+        from tracer.queries import deep_analysis_state as das
+
+        tid = str(uuid.uuid4())
+        # Nothing set → idle; no completed analysis.
+        assert das.status(tid, has_analysis=False) == "idle"
+        # First claim wins, a rapid second claim loses (single dispatch).
+        assert das.set_running(tid) is True
+        assert das.set_running(tid) is False
+        assert das.status(tid, has_analysis=False) == "running"
+        # A completed analysis row always wins over the marker.
+        assert das.status(tid, has_analysis=True) == "done"
+        # Failure is surfaced until it TTLs out.
+        das.set_failed(tid)
+        assert das.status(tid, has_analysis=False) == "failed"
+        # Clearing (worker success) drops back to idle when no analysis exists.
+        das.clear(tid)
+        assert das.status(tid, has_analysis=False) == "idle"
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_new_ch_reader_methods_smoke(project):
+    """Direct smoke of the CH reader methods the feed CH-native swap added/changed
+    — the SQL must compile and run against real ClickHouse (these paths aren't
+    all hit by the feed-endpoint tests above)."""
+    from tracer.services.clickhouse.v2 import get_reader
+
+    tid = str(uuid.uuid4())
+    _seed_ch_root(project, tid, input_={"prompt": "hi"})
+
+    with get_reader() as reader:
+        # trace_id → trace_session_id (root has no session → None, no crash)
+        sessions = reader.trace_session_ids_by_trace_ids([tid])
+        assert tid in sessions
+
+        # roots_only window count = trace count (one root per trace), not spans
+        trace_count = reader.count_with_filters(
+            project_id=str(project.id), roots_only=True
+        )
+        assert trace_count >= 1
+
+        # distinct trace_ids for the project, newest first
+        recent = reader.recent_root_trace_ids_by_project(str(project.id), limit=10)
+        assert tid in recent
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_drop_actually_removes_table(project):
+    """Guard: the drop truly removes the relation (so the read-path tests are
+    a real 42P01 repro, not a no-op), and it rolls back cleanly afterwards."""
+    _drop_tracer_pg_tables()
+    with pytest.raises(ProgrammingError):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1 FROM tracer_trace LIMIT 1")

--- a/futureagi/tracer/tests/test_feed_pg_drop_repro.py
+++ b/futureagi/tracer/tests/test_feed_pg_drop_repro.py
@@ -239,6 +239,17 @@ class TestDeepAnalysisState:
         das.clear(tid)
         assert das.status(tid, has_analysis=False) == "idle"
 
+    def test_failed_run_does_not_block_retry(self):
+        from tracer.queries import deep_analysis_state as das
+
+        tid = str(uuid.uuid4())
+        assert das.set_running(tid) is True
+        das.set_failed(tid)
+        assert das.status(tid, has_analysis=False) == "failed"
+        # A retry must claim cleanly — the failed marker can't wedge the guard.
+        assert das.set_running(tid) is True
+        assert das.status(tid, has_analysis=False) == "running"
+
 
 @pytest.mark.integration
 @pytest.mark.django_db

--- a/futureagi/tracer/tests/test_scan_project_scoped_read.py
+++ b/futureagi/tracer/tests/test_scan_project_scoped_read.py
@@ -151,11 +151,10 @@ def test_get_trace_input_data_scopes_embed_read():
     with (
         patch("tracer.queries.scan_clustering.get_reader", return_value=reader),
         patch("tracer.queries.scan_clustering.TraceScanResult") as tsr,
-        patch("tracer.queries.scan_clustering.Trace") as trace_model,
     ):
-        # one scanned trace so we reach the reader; no PG-input fallback rows
+        # one scanned trace so we reach the reader (CH root input is the sole
+        # source post-cutover — no PG Trace.input fallback).
         tsr.objects.filter.return_value.values_list.return_value = [("t-1", True)]
-        trace_model.objects.filter.return_value.values_list.return_value = []
         get_trace_input_data(["t-1"], "proj-embed")
     assert sink["project_id"] == "proj-embed"
 


### PR DESCRIPTION
Makes **all Error Feed reads + the deep-analysis worker + the live scanner** CH-native so they survive the drop of the legacy tracer PG tables (`tracer_trace` / `tracer_observation_span` / `trace_session` / `tracer_enduser`). Traces are CH-only post the fi-collector cutover; these tables are going away org-wide.

## Problem
Once those tables drop, every feed read that JOINed or queried them 42P01'd — `relation "tracer_trace" does not exist` (the same failure surfaced in prod on `GET /tracer/feed/issues/`). All FKs into them are `db_constraint=False`, so the raw `*_id` columns survive; only ORM **JOINs** (`select_related`, `trace__…` traversals) and `Trace.objects.*` break.

## Fix (all in `tracer/queries/feed.py` unless noted)
- Drop `success_trace` / `trace` `select_related` JOINs; hydrate trace previews from the CH root span via new `_ch_trace_preview` (typed `input.value` → else raw span input).
- `_resolve_member_traces` CH-only; `_session_traces_map` orders by `per_trace_root_span_start_times`; `_fetch_sessions_batch` resolves trace→session via new `trace_session_ids_by_trace_ids`.
- Re-route EvalLogger success-trace project scoping `trace__project_id` → `custom_eval_config__project_id` (config is project-scoped and stays).
- Eval-rate denominator via `count_with_filters(roots_only=True)` (distinct-trace count).
- **`deep_analysis_state.py`** (new): thin cache marker replacing the dropped `Trace.error_analysis_status` column — separate running/failed keys (a failure can't wedge the double-click guard); `done` derives from the surviving `TraceErrorAnalysis` row. Used by feed dispatch/GET, the worker, and ai_tools.
- **`span_reader.py`**: `trace_session_ids_by_trace_ids` (lean, remap-aware), `recent_root_trace_ids_by_project`, `count_with_filters(roots_only=)`.
- **`tasks/error_analysis.py` + `ai_tools/*`**: resolve org/project from the CH span's `project_id` → PG `Project`; job state via `deep_analysis_state`.
- **`scan_clustering.py`**: drop the one PG `Trace.input` fallback (CH root is the source).
- The legacy compass sampler (`get_traces_to_process_for_task` / `commit_traces_for_processing`) is **dead code** (its beat is disabled) — left untouched for a separate cleanup PR.

## Testing
- **`test_feed_pg_drop_repro.py`** (13 tests): drops all 4 tables in-transaction and exercises every feed path + the new reader methods + the state marker. **Regression-proven** — re-adding one `success_trace` JOIN reproduces the exact prod 42P01.
- 23 tests green; 48 existing feed/scanner/worker tests pass.
- **Verified end-to-end on a live stack** with the 4 tracer PG tables renamed away: `list / stats / detail / overview / traces / sidebar / deep-analysis GET + dispatch` all return CH-sourced data, zero 500s; the detail preview hydrated from CH.
- An adversarial architect review of the implementation caught a critical bug (the deep-analysis agent silently no-op'd) — fixed here + in the companion ee PR.

## Dependencies
- Stacked on **#1495** (`feat/annotation-ch-native-reads`) — retarget to `dev` once that merges.
- Companion **future-agi/ee#146** (deep-analysis agent + analysis-save CH-native).

