### PR TITLE
feat: add click-to-edit functionality for node names in Workflow Builder

### DIFF
--- a/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
@@ -80,7 +80,7 @@ const ConversationNode = ({ data, isConnectable, id }) => {
             borderColor: theme.palette.primary.main,
           }}
         />
-        <NodeHeader type="conversation" title={data?.name} />
+        <NodeHeader type="conversation" title={data?.name} nodeId={id} />
         <ShowComponent condition={data?.isGlobal}>
           <Chip
             icon={<Iconify icon="mdi:earth" width={14} />}

--- a/frontend/src/components/GraphBuilder/nodes/EndCallNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/EndCallNode.jsx
@@ -72,7 +72,7 @@ const EndCallNode = ({ id, data, isConnectable }) => {
             : theme.palette.red[600],
         }}
       />
-      <NodeHeader type="end" title={data?.name} />
+      <NodeHeader type="end" title={data?.name} nodeId={id} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/EndChatNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/EndChatNode.jsx
@@ -72,7 +72,7 @@ const EndChatNode = ({ id, data, isConnectable }) => {
             : theme.palette.red[600],
         }}
       />
-      <NodeHeader type="endChat" title={data?.name} />
+      <NodeHeader type="endChat" title={data?.name} nodeId={id} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
@@ -1,10 +1,83 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Box, Divider, Typography } from "@mui/material";
+import { Box, Divider, InputBase, Typography } from "@mui/material";
 import SvgColor from "src/components/svg-color";
 import { GRAPH_NODES } from "../common";
+import { useGraphStore } from "../store/graphStore";
 
-const NodeHeader = ({ type, title }) => {
+const EditableNodeTitle = ({ nodeId, currentTitle }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(currentTitle || "");
+  const updateNodeData = useGraphStore((state) => state.updateNodeData);
+
+  const handleSave = useCallback(() => {
+    const newName = editValue.trim();
+    setIsEditing(false);
+
+    if (newName && newName !== currentTitle) {
+      updateNodeData(nodeId, { name: newName });
+    } else {
+      setEditValue(currentTitle);
+    }
+  }, [editValue, currentTitle, nodeId, updateNodeData]);
+
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setEditValue(currentTitle);
+        setIsEditing(false);
+      }
+    },
+    [handleSave, currentTitle],
+  );
+
+  const handleClick = useCallback(() => {
+    setEditValue(currentTitle);
+    setIsEditing(true);
+  }, [currentTitle]);
+
+  if (isEditing) {
+    return (
+      <InputBase
+        autoFocus
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleSave}
+        sx={{
+          typography: "s2",
+          fontWeight: "fontWeightMedium",
+          border: "1px solid",
+          borderColor: "primary.main",
+          borderRadius: 0.5,
+          px: 0.5,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Typography
+      typography="s2"
+      fontWeight="fontWeightMedium"
+      onClick={handleClick}
+      sx={{ cursor: "pointer" }}
+    >
+      {currentTitle}
+    </Typography>
+  );
+};
+
+EditableNodeTitle.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+  currentTitle: PropTypes.string,
+};
+
+const NodeHeader = ({ type, title, nodeId }) => {
   const node = GRAPH_NODES.find((n) => n.type === type);
   if (!node) return null;
   const { color, backgroundColor, icon, name } = node;
@@ -39,9 +112,7 @@ const NodeHeader = ({ type, title }) => {
             }}
           />
         </Box>
-        <Typography typography="s2" fontWeight="fontWeightMedium">
-          {title || name}
-        </Typography>
+        <EditableNodeTitle nodeId={nodeId} currentTitle={title || name} />
       </Box>
       <Divider />
     </>
@@ -51,6 +122,7 @@ const NodeHeader = ({ type, title }) => {
 NodeHeader.propTypes = {
   type: PropTypes.string,
   title: PropTypes.string,
+  nodeId: PropTypes.string.isRequired,
 };
 
 export default NodeHeader;

--- a/frontend/src/components/GraphBuilder/nodes/TransferCallNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/TransferCallNode.jsx
@@ -73,7 +73,7 @@ const TransferCallNode = ({ id, data, isConnectable }) => {
             : theme.palette.orange[600],
         }}
       />
-      <NodeHeader type="transfer" title={data?.name} />
+      <NodeHeader type="transfer" title={data?.name} nodeId={id} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/TransferChatNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/TransferChatNode.jsx
@@ -73,7 +73,7 @@ const TransferChatNode = ({ id, data, isConnectable }) => {
             : theme.palette.orange[600],
         }}
       />
-      <NodeHeader type="transferChat" title={data?.name} />
+      <NodeHeader type="transferChat" title={data?.name} nodeId={id} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message


### PR DESCRIPTION
## Summary

Adds inline click-to-edit functionality for node names in the Workflow Builder. Users can now click on any node name to rename it inline.

## Changes

- **NodeHeader.jsx** — Added `EditableNodeTitle` component with `useState`/`useCallback` hooks and `InputBase` for inline editing. Click to edit, Enter/blur to save, Escape to cancel. Empty names are rejected and revert to the original.
- **5 node components** (ConversationNode, TransferCallNode, EndCallNode, TransferChatNode, EndChatNode) — Pass `nodeId={id}` prop through to `NodeHeader`.

## Behavior

- Clicking on a node name switches it to edit mode with a focused input field
- Pressing Enter saves the new name and exits edit mode
- Pressing Escape cancels editing and reverts to the original name
- Clicking outside the input field (blur) saves the new name
- Empty or whitespace-only names are rejected and revert to the original name
- The updated name appears immediately via the existing `updateNodeData` store action

## Design Notes

The implementation follows the same pattern as the existing `EditableLabel.jsx` component in the codebase (`frontend/src/sections/agent-playground/AgentBuilder/nodes/EditableLabel.jsx`). No changes to the Zustand store, backend APIs, or database schema were needed — names are stored in frontend state only.

Closes #1504