### PR TITLE
[TH-6713] Don't open trace/span detail drawer when clicking a tag cell

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -578,6 +578,9 @@ const SpanGrid = React.forwardRef(
         if (event?.column?.colId === "status") {
           return;
         }
+        if (RENDERER_CONFIG.tagColumns.includes(event?.column?.getColId())) {
+          return;
+        }
         if (
           event.column.getColId() === APP_CONSTANTS.AG_GRID_SELECTION_COLUMN
         ) {

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -25,6 +25,7 @@ import {
   normalizeConfigKeys,
   toBackendFilters,
 } from "./common";
+import { RENDERER_CONFIG } from "./Renderers/common";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { userTraceRowHeightMapping } from "../UsersView/common";
 import { statusBar } from "src/components/run-insights/traces-tab/common";
@@ -478,6 +479,8 @@ const TraceGrid = React.forwardRef(
           return;
         }
         if (event?.column?.colId === "status") return;
+        if (RENDERER_CONFIG.tagColumns.includes(event?.column?.getColId()))
+          return;
         if (
           event.column.getColId() === APP_CONSTANTS.AG_GRID_SELECTION_COLUMN
         ) {


### PR DESCRIPTION
**Ticket:** [TH-6713](https://linear.app/future-agi/issue/TH-6713/clicking-on-add-tags-is-opening-the-trace-detail-drawer) — Fixes TH-6713

## What was the bug
Clicking the **+ Tag** (or an existing tag chip) in a trace/span row's Tags column opened the row's detail drawer instead of just opening the add-tags popover.

## What changes have been done
- `frontend/src/sections/projects/LLMTracing/TraceGrid.jsx` — in `handleCellClick`, early-return when the clicked column is a tag column (`RENDERER_CONFIG.tagColumns`), before the drawer-open path. Added the `RENDERER_CONFIG` import.
- `frontend/src/sections/projects/LLMTracing/SpanGrid.jsx` — same guard in its `handleCellClick` (this grid had the same latent bug).

## Why the changes
The drawer is opened by AG-Grid's grid-level `onCellClicked` → `handleCellClick` → `setTraceDetailDrawerOpen`. That callback fires from AG-Grid's own **native** click listener, which runs before React's synthetic event system — so `TagsCell`'s React `event.stopPropagation()` can never cancel it. The fix guards at the grid level (mirroring the existing `status`-column guard), which is robust regardless of native-vs-synthetic event ordering. Single source of truth via `RENDERER_CONFIG.tagColumns` (`["tags", "labels"]`).

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Click **+ Tag** on an untagged trace/span row | Add-tags popover opens; detail drawer does **not** open |
| 2 | Click an existing tag chip in the Tags column | Popover opens; drawer does not open |
| 3 | Click a normal cell (Model, Latency, Output, etc.) | Detail drawer opens as before (no regression) |
| 4 | Click the status cell / selection checkbox | Unchanged behavior |

## How to reproduce (original bug)
1. Open Observe → a project → Trace (or Span) grid.
2. Click the **+ Tag** button in a row's Tags column.
3. Bug: the trace/span detail drawer opens instead of the tag popover.

## Verification
Verified live in the running app via a dev log-sink: tag-column clicks hit `handleCellClick` with `isTagCol: true` and produced **no** drawer-open; normal cells (`model`, `output`) still fired the drawer-open. All instrumentation removed before commit.

## Videos and screenshots

https://github.com/user-attachments/assets/61712a89-2890-47c4-b3c4-eaad96ae996d

