### PR TITLE
fix(frontend): clarify Share dialog Close button and add no-access-control note

### DIFF
--- a/frontend/src/components/Share/Share.jsx
+++ b/frontend/src/components/Share/Share.jsx
@@ -78,6 +78,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
         >
           {body}
         </Typography>
+        <Typography mb={2} variant="caption" color="text.secondary">
+          Note: This creates a direct link without access control.
+        </Typography>
 
         <Box display="flex" alignItems="center" gap={theme.spacing(1)} mt={2}>
           <Box flex={8}>
@@ -152,9 +155,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
             Cancel
           </Button>
           <Button
-            aria-label="finish-share-project"
-            variant="contained"
-            color="primary"
+            aria-label="close-share-project"
+            variant="outlined"
+            color="inherit"
             onClick={onClose}
             sx={{
               flex: 1,
@@ -162,7 +165,7 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
               fontSize: "13px",
             }}
           >
-            Done
+            Close
           </Button>
         </Box>
       </DialogActions>

--- a/frontend/src/components/Share/__tests__/Share.test.jsx
+++ b/frontend/src/components/Share/__tests__/Share.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "src/utils/test-utils";
+import Share from "../Share";
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("src/utils/utils", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: { pExperimentProjectShared: "pExperimentProjectShared" },
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("src/components/iconify", () => ({
+  __esModule: true,
+  default: ({ icon }) => <span data-testid={`iconify-${icon}`} />,
+}));
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  title: "Share as link",
+  body: "Share this link to give others access to the selected runs.",
+};
+
+describe("Share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression for #1501: misleading "Done" button should now be "Close"
+  it("renders the confirmation button with text 'Close' instead of 'Done'", () => {
+    render(<Share {...defaultProps} />);
+    expect(screen.getByText("Close")).toBeInTheDocument();
+    expect(screen.queryByText("Done")).toBeNull();
+  });
+
+  it("uses aria-label 'close-share-project' on the confirmation button", () => {
+    render(<Share {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: /close-share-project/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /finish-share-project/i }),
+    ).toBeNull();
+  });
+
+  it("renders the confirmation button as variant='outlined' (not 'contained')", () => {
+    render(<Share {...defaultProps} />);
+    const closeBtn = screen.getByRole("button", {
+      name: /close-share-project/i,
+    });
+    expect(closeBtn).toHaveClass("MuiButton-outlined");
+    expect(closeBtn).not.toHaveClass("MuiButton-contained");
+  });
+
+  // Acceptance criterion: dialog description clarifies no access control
+  it("renders a clarification note that the link has no access control", () => {
+    render(<Share {...defaultProps} />);
+    expect(screen.getByText(/without access control/i)).toBeInTheDocument();
+  });
+
+  // Preserves the body prop API (callers can still pass custom body text)
+  it("renders the body prop text passed by the caller", () => {
+    const customBody = "Custom body text from caller";
+    render(<Share {...defaultProps} body={customBody} />);
+    expect(screen.getByText(customBody)).toBeInTheDocument();
+  });
+
+  // Regression: Cancel button must remain unchanged
+  it("renders the Cancel button unchanged (outlined, aria-label 'Cancel-share-project')", () => {
+    render(<Share {...defaultProps} />);
+    const cancelBtn = screen.getByRole("button", {
+      name: /Cancel-share-project/i,
+    });
+    expect(cancelBtn).toBeInTheDocument();
+    expect(cancelBtn).toHaveTextContent("Cancel");
+    expect(cancelBtn).toHaveClass("MuiButton-outlined");
+  });
+
+  it("calls onClose exactly once when the Close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<Share {...defaultProps} onClose={onClose} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /close-share-project/i }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Edge case: body is optional — should not crash when omitted
+  it("renders without crashing when body prop is omitted", () => {
+    const { container } = render(<Share open={true} onClose={vi.fn()} />);
+    expect(container).toBeDefined();
+    // clarification note should still render
+    expect(screen.getByText(/without access control/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The `Share` component's primary button was labeled "Done" with `variant="contained"` and `color="primary"`, implying a save action — but `onClick` only calls `onClose` without persisting any sharing/access-control configuration. This is misleading in a dialog whose body says "Anyone with the link will be able to view the data." The fix relabels the button to "Close" with `outlined`/`inherit` styling and adds a static clarification note that the link has no access control.

## Linked issues

Closes #1501

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Approach

**Bug class:** Misleading primary CTA — a button styled as the primary action (`contained` + `primary`) but which only closes the dialog. The fix makes the button's appearance and labeling honestly reflect that it is a dismiss action, and clarifies in the dialog body that no access control is applied.

**Changes (all in `frontend/src/components/Share/Share.jsx`, +7/-4):**

1. Confirmation button:
   - text: `Done` → `Close`
   - variant: `contained` → `outlined`
   - color: `primary` → `inherit`
   - aria-label: `finish-share-project` → `close-share-project`
2. Added a static `Typography` (caption, `text.secondary`) below the `{body}` prop:
   > "Note: This creates a direct link without access control."

**Why not replace `{body}` with hardcoded text (the issue's literal suggestion)?**

`body` is a prop, not a hardcoded string — `ProjectDetailView.jsx` passes a domain-specific body (`"Share this link to give others access to the selected runs..."`). Replacing `{body}` would break the component's prop API and silently ignore the caller's body text. The chosen approach (static note below `{body}`) satisfies the acceptance criterion while preserving the component contract.

**Non-goals respected (from issue):**
- Did not implement actual access control (would require backend integration)
- Did not modify `share-dialog/ShareDialog.jsx`
- Did not change URL copy logic
- Did not modify `DatasetsSelectRow.jsx`

## How was this tested?

**New tests** — `frontend/src/components/Share/__tests__/Share.test.jsx` (8 tests, RTL + Vitest, following the existing pattern in `rate-limit-modal/__tests__/RateLimitModal.test.jsx`):

| # | Test | Purpose |
|---|------|---------|
| 1 | renders confirmation button with text 'Close' instead of 'Done' | Regression — button text |
| 2 | uses aria-label 'close-share-project' on confirmation button | Regression — aria-label |
| 3 | renders confirmation button as variant='outlined' (not 'contained') | Regression — button variant |
| 4 | renders a clarification note that the link has no access control | Acceptance criterion |
| 5 | renders the body prop text passed by the caller | Prop API preserved |
| 6 | renders the Cancel button unchanged | Regression — Cancel untouched |
| 7 | calls onClose exactly once when Close is clicked | Behavior unchanged |
| 8 | renders without crashing when body prop is omitted | Edge case — body optional |

**Commands run (all green):**
```bash
cd frontend
yarn test:run src/components/Share/__tests__/Share.test.jsx   # 8 passed (8), 175ms
npx eslint src/components/Share/Share.jsx src/components/Share/__tests__/Share.test.jsx   # 0 errors, 0 warnings
npx prettier --check src/components/Share/Share.jsx src/components/Share/__tests__/Share.test.jsx   # All matched files use Prettier code style
```

## Screenshots / recordings (if UI)

N/A — visual change is minimal (button label/variant + one line of caption text). Can provide on request.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `yarn check-all` passes locally (lint + prettier + tests on changed files)
- [x] I've updated the documentation where relevant (no user-facing docs to update)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) (will sign on first PR via bot)