### PR TITLE
fix(dataset): CSV upload fails when curly quotes appear as literal content inside quoted fields

### DIFF
--- a/futureagi/model_hub/tests/test_file_reader.py
+++ b/futureagi/model_hub/tests/test_file_reader.py
@@ -183,3 +183,84 @@ class TestReadCsvSmartQuotes:
         assert len(df) == 2
         assert df.iloc[0]["first_name"] == "John"
         assert df.iloc[0]["bot_response"] == "Hello, John. How can I help you today?"
+
+
+@pytest.mark.unit
+class TestReadCsvCurlyQuotesAsContent:
+    """Curly quotes as literal *content* inside properly-quoted fields.
+
+    The smart-quote normalization (TH-3546) used to run unconditionally
+    before parsing. That rescues files whose field *wrappers* are curly
+    quotes, but corrupts files where curly quotes are ordinary text inside
+    straight-quoted fields: the rewrite injects unescaped '"' mid-field,
+    desyncing the reader's quoting state until every delimiter yields
+    inconsistent column counts and the upload fails. The parser now tries
+    the file as-is first and only falls back to the normalized text, keeping
+    whichever candidate parses widest.
+    """
+
+    def _make_file(self, content: str) -> io.BytesIO:
+        f = io.BytesIO(content.encode("utf-8"))
+        f.name = "test.csv"
+        return f
+
+    def test_curly_quotes_inside_straight_quoted_fields(self):
+        """The regression: curly quotes as content must not break parsing."""
+        csv = (
+            "id,transcript\n"
+            '1,"The agent said \u201cplease hold, sir\u201d and hung up."\n'
+            '2,"She replied \u201cno, thanks\u201d twice."\n'
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["id", "transcript"]
+        assert len(df) == 2
+        # Content is preserved verbatim — the normalization candidate must
+        # not win and rewrite the curly quotes.
+        assert df.iloc[0]["transcript"] == (
+            "The agent said \u201cplease hold, sir\u201d and hung up."
+        )
+
+    def test_quoted_json_cells_with_colons_newlines_and_curly_quotes(self):
+        """Mimics the failing production dataset: JSON blobs in quoted cells.
+
+        Covers three old failure modes at once: the unrestricted Sniffer
+        picking ':' from the JSON as delimiter, embedded newlines inside
+        quoted fields, and curly quotes as literal content.
+        """
+        json_cell = (
+            '"{""role"": ""system"", ""content"": ""Say \u201chi\u201d to the\n'
+            'customer, then stop.""}"'
+        )
+        csv = (
+            "id,assistant,score\n"
+            f"a1,{json_cell},0.9\n"
+            f"a2,{json_cell},0.7\n"
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["id", "assistant", "score"]
+        assert len(df) == 2
+        assert df.iloc[0]["assistant"].startswith('{"role": "system"')
+        assert "\u201chi\u201d" in df.iloc[0]["assistant"]
+
+    def test_widest_consistent_parse_wins_over_single_column(self):
+        """A delimiter absent from the file always yields a 'consistent'
+        1-column parse; the true delimiter's wider parse must win."""
+        csv = (
+            "a;b;c\n"
+            "1;2;3\n"
+            "4;5;6\n"
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["a", "b", "c"]
+        assert len(df) == 2
+
+    def test_single_column_csv_still_parses(self):
+        """Genuine single-column files remain accepted."""
+        csv = "only_column\nvalue one\nvalue two\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["only_column"]
+        assert len(df) == 2

--- a/futureagi/model_hub/utils/file_reader.py
+++ b/futureagi/model_hub/utils/file_reader.py
@@ -94,6 +94,69 @@ class FileProcessor:
         raise FileProcessingError("Unsupported file format")
 
     @staticmethod
+    def _normalize_smart_quotes(text: str) -> str:
+        return (
+            text.replace("\u201c", '"')
+            .replace("\u201d", '"')
+            .replace("\u201e", '"')
+            .replace("\u201f", '"')
+        )
+
+    @staticmethod
+    def _try_parse_csv_text(
+        text: str, fallback_delimiters: list[str]
+    ) -> tuple[pd.DataFrame | None, int, int | None]:
+        """Attempt to parse CSV text; return (df, col_count, last_row_count).
+
+        Picks the delimiter that yields the widest consistent parse rather
+        than the first one that lines up — a wrong delimiter absent from the
+        file produces "1 column per line" rows that look consistent but
+        collapse every real column into a single string.
+        """
+        sample = text[:4096]
+        try:
+            # Restrict Sniffer to real CSV delimiters; otherwise it will
+            # happily pick a letter (e.g. 'n' from "first_name") whenever
+            # that character happens to split rows into equal counts.
+            delimiter = csv.Sniffer().sniff(
+                sample, delimiters="".join(fallback_delimiters)
+            ).delimiter
+        except csv.Error:
+            delimiter = None
+
+        delimiters_to_try = [delimiter] if delimiter else []
+        for d in fallback_delimiters:
+            if d not in delimiters_to_try:
+                delimiters_to_try.append(d)
+
+        best_df: pd.DataFrame | None = None
+        best_cols = 0
+        last_row_count: int | None = None
+        for delim in delimiters_to_try:
+            try:
+                rows = list(
+                    csv.reader(StringIO(text), delimiter=delim, quotechar='"')
+                )
+            except csv.Error:
+                continue
+            last_row_count = len(rows) if rows else 0
+            if not rows or len(rows) < 2:
+                continue
+            header = rows[0]
+            expected_cols = len(header)
+            if any(len(r) != expected_cols for r in rows[1:]):
+                continue
+            if expected_cols <= best_cols:
+                continue
+            header = FileProcessor._deduplicate_columns(header)
+            df = pd.DataFrame(rows[1:], columns=header)
+            df.reset_index(drop=True, inplace=True)
+            best_df = df
+            best_cols = expected_cols
+
+        return best_df, best_cols, last_row_count
+
+    @staticmethod
     def _read_csv_file(file_obj: Any) -> pd.DataFrame:
         encodings = ["utf-8", "latin1", "cp1252", "iso-8859-1"]
         fallback_delimiters = [",", "\t", ";", "|"]
@@ -105,61 +168,34 @@ class FileProcessor:
                 if isinstance(raw_data, bytes):
                     raw_data = raw_data.decode(encoding)
 
-                # Normalize smart/curly quotes to straight quotes so that
-                # csv.reader (which uses quotechar='"') can recognise them.
-                # Without this, CSVs exported from Excel or Google Sheets that
-                # use typographic quotes will have their quoted-field commas
-                # treated as delimiters, leading to wrong column counts and
-                # ultimately all columns being merged into one.
-                raw_data = (
-                    raw_data.replace("\u201c", '"')
-                    .replace("\u201d", '"')
-                    .replace("\u201e", '"')
-                    .replace("\u201f", '"')
-                )
+                # Try the file as-is first, then retry after rewriting curly
+                # quotes to straight quotes. The rewrite rescues CSVs whose
+                # fields are wrapped in typographic quotes (Excel/Google Sheets
+                # exports) but corrupts CSVs where curly quotes appear as
+                # literal text inside properly-quoted fields, so it must not
+                # run unconditionally.
+                candidates = [raw_data]
+                normalized = FileProcessor._normalize_smart_quotes(raw_data)
+                if normalized != raw_data:
+                    candidates.append(normalized)
 
-                # Try to detect delimiter using Sniffer with large sample
-                sample = raw_data[:4096]
-                try:
-                    dialect = csv.Sniffer().sniff(sample)
-                    delimiter = dialect.delimiter
-                except csv.Error:
-                    delimiter = None
-
-                # Candidate delimiters to try, prioritized
-                delimiters_to_try = [delimiter] if delimiter else []
-                for d in fallback_delimiters:
-                    if d not in delimiters_to_try:
-                        delimiters_to_try.append(d)
-
-                # Try each delimiter until rows are consistent
-                last_delimiter_rows = None
-                for delim in delimiters_to_try:
-                    reader = csv.reader(
-                        StringIO(raw_data), delimiter=delim, quotechar='"'
+                best_df: pd.DataFrame | None = None
+                best_cols = 0
+                last_row_count: int | None = None
+                for candidate in candidates:
+                    df, cols, rows_seen = FileProcessor._try_parse_csv_text(
+                        candidate, fallback_delimiters
                     )
-                    rows = list(reader)
-                    last_delimiter_rows = len(rows) if rows else 0
-                    if not rows or len(rows) < 2:
-                        continue
-                    header = rows[0]
-                    expected_cols = len(header)
-                    # Check if all rows have matching number of columns
-                    bad_rows = [
-                        i + 2 for i, r in enumerate(rows[1:]) if len(r) != expected_cols
-                    ]
-                    if bad_rows:
-                        # inconsistent columns, try next delimiter
-                        continue
-                    # Handle duplicate column names
-                    header = FileProcessor._deduplicate_columns(header)
-                    # All rows consistent, create DataFrame
-                    df = pd.DataFrame(rows[1:], columns=header)
-                    df.reset_index(drop=True, inplace=True)
-                    return df
+                    if df is not None and cols > best_cols:
+                        best_df = df
+                        best_cols = cols
+                    if rows_seen is not None:
+                        last_row_count = rows_seen
 
-                # If no delimiter worked:
-                if last_delimiter_rows == 1:
+                if best_df is not None:
+                    return best_df
+
+                if last_row_count == 1:
                     raise FileProcessingError(
                         "The file contains only a header row with no data."
                     )
@@ -167,13 +203,10 @@ class FileProcessor:
                     "Unable to detect delimiter correctly; rows have inconsistent column counts."
                 )
             except UnicodeDecodeError:
-                # Try next encoding
                 continue
             except FileProcessingError:
-                # Re-raise file processing errors (e.g., inconsistent columns)
                 raise
             except Exception as e:
-                # Log and try next encoding
                 logger.warning(f"Error reading CSV with encoding {encoding}: {str(e)}")
                 continue
 


### PR DESCRIPTION
## 1. What changes are done

CSV dataset uploads failed with *"Unable to detect delimiter correctly; rows have inconsistent column counts"* for perfectly valid CSVs — specifically files whose quoted cells contain curly/typographic quotes (`\u201c` `\u201d`) as **literal text** (chat transcripts, LLM prompts, JSON blobs). Reproduced with a real exported dataset: straight-quoted comma CSV, 10 columns, 111 curly quotes inside cell content — the old parser rejected it; the new one parses it as 26 rows × 10 columns.

All changes are in `model_hub/utils/file_reader.py` (single file, plus tests):

| Change | What it fixes |
| --- | --- |
| Smart-quote normalization is no longer unconditional — the parser tries the file **as-is first**, then retries with curly quotes rewritten to `"` , keeping whichever candidate parses into the widest consistent table | The rewrite was corrupting valid files: replacing curly quotes that are *content inside* straight-quoted fields injects unescaped `"` mid-field, desyncing the reader's quoting state until every delimiter yields inconsistent column counts |
| `csv.Sniffer().sniff(...)` now restricted to the real candidate delimiters (`,` `\t` `;` `\|`) | The unrestricted Sniffer picks arbitrary characters — on the reproduction file it chose `:` (a colon from JSON inside a cell) as the delimiter |
| Delimiter selection changed from "first consistent parse wins" to "**widest** consistent parse wins" | A delimiter absent from the file splits every line into exactly 1 column — trivially "consistent" — so a bad sniffed delimiter tried first could return a garbage single-column DataFrame instead of the real 10-column parse |
| Parse-attempt logic extracted into `_try_parse_csv_text()` / `_normalize_smart_quotes()` helpers | The candidate loop (raw text, then normalized text) needs to run the same attempt twice; behavior of the extracted code is otherwise unchanged |

Error paths are preserved byte-for-byte: header-only files still raise *"The file contains only a header row with no data."*, unparseable files still raise the inconsistent-columns error, and the encoding-retry loop (`utf-8` → `latin1` → `cp1252` → `iso-8859-1`) is untouched.

## 2. Why these changes

The original smart-quote handling (TH-3546) solved a real problem: Excel/Google Sheets exports whose field *wrappers* are typographic quotes. But it ran unconditionally, which bakes in the assumption that curly quotes are always broken quoting — never data. Any dataset containing conversational text or LLM output breaks that assumption. Trying both candidates and keeping the widest consistent parse preserves the TH-3546 rescue (the normalized candidate wins for genuinely curly-wrapped files) while never corrupting files where the raw text already parses (the as-is candidate wins).

"Widest consistent parse" is the right tiebreak because the failure mode of a wrong delimiter is always a *narrower* table — typically the degenerate 1-column parse. A wrong delimiter can only beat the true one if every row contains equal counts of it outside quotes, which is adversarial input; the old first-wins ordering had a strictly worse version of the same ambiguity.

## 3. Tests — scenarios covered

New test class `TestReadCsvCurlyQuotesAsContent` in `model_hub/tests/test_file_reader.py` (4 tests):

- **The regression:** curly quotes as literal content inside straight-quoted fields must parse, and the content must be preserved verbatim (the normalization candidate must not win and rewrite the data).
- **The production shape:** quoted JSON cells with embedded colons, newlines, escaped `""` quotes, and curly quotes — covers the bogus-Sniffer, embedded-newline, and content-corruption failure modes in one test.
- **Widest-parse tiebreak:** a semicolon-delimited file must yield the 3-column parse, not the degenerate 1-column comma parse.
- **Single-column guard:** genuinely single-column CSVs remain accepted.

Verified the tests pin the fix: with the old parser restored, 3 of the 4 fail (the single-column guard passes on both, as intended — it guards the new tiebreak logic against over-rejecting).

All 11 pre-existing TH-3546 tests pass unchanged — the Excel curly-wrapper rescue still works.

## 4. Test results

```
model_hub/tests/test_file_reader.py ...............   15 passed
model_hub/tests/test_file_reader.py + test_dataset_creation_import_api.py
                                                       37 passed in 44.37s
```

End-to-end check with the real failing dataset export (4,206 physical lines, JSON cells, 111 curly quotes): parses to `shape (26, 10)` with the correct headers.

Ruff clean on both edited files.

Made with [Cursor](https://cursor.com)