### PR TITLE
fix(dataset): CSV upload fails when curly quotes appear as literal content inside quoted fields (TH-6715)

### DIFF
--- a/futureagi/model_hub/tests/test_file_reader.py
+++ b/futureagi/model_hub/tests/test_file_reader.py
@@ -183,3 +183,148 @@ class TestReadCsvSmartQuotes:
         assert len(df) == 2
         assert df.iloc[0]["first_name"] == "John"
         assert df.iloc[0]["bot_response"] == "Hello, John. How can I help you today?"
+
+
+@pytest.mark.unit
+class TestReadCsvCurlyQuotesAsContent:
+    """Curly quotes as literal *content* inside properly-quoted fields.
+
+    The smart-quote normalization (TH-3546) used to run unconditionally
+    before parsing. That rescues files whose field *wrappers* are curly
+    quotes, but corrupts files where curly quotes are ordinary text inside
+    straight-quoted fields: the rewrite injects unescaped '"' mid-field,
+    desyncing the reader's quoting state until every delimiter yields
+    inconsistent column counts and the upload fails. The parser now tries
+    the file as-is first and only falls back to the normalized text, keeping
+    whichever candidate parses widest.
+    """
+
+    def _make_file(self, content: str) -> io.BytesIO:
+        f = io.BytesIO(content.encode("utf-8"))
+        f.name = "test.csv"
+        return f
+
+    def test_curly_quotes_inside_straight_quoted_fields(self):
+        """The regression: curly quotes as content must not break parsing."""
+        csv = (
+            "id,transcript\n"
+            '1,"The agent said \u201cplease hold, sir\u201d and hung up."\n'
+            '2,"She replied \u201cno, thanks\u201d twice."\n'
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["id", "transcript"]
+        assert len(df) == 2
+        # Content is preserved verbatim — the normalization candidate must
+        # not win and rewrite the curly quotes.
+        assert df.iloc[0]["transcript"] == (
+            "The agent said \u201cplease hold, sir\u201d and hung up."
+        )
+
+    def test_quoted_json_cells_with_colons_newlines_and_curly_quotes(self):
+        """Mimics the failing production dataset: JSON blobs in quoted cells.
+
+        Covers three old failure modes at once: the unrestricted Sniffer
+        picking ':' from the JSON as delimiter, embedded newlines inside
+        quoted fields, and curly quotes as literal content.
+        """
+        json_cell = (
+            '"{""role"": ""system"", ""content"": ""Say \u201chi\u201d to the\n'
+            'customer, then stop.""}"'
+        )
+        csv = (
+            "id,assistant,score\n"
+            f"a1,{json_cell},0.9\n"
+            f"a2,{json_cell},0.7\n"
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["id", "assistant", "score"]
+        assert len(df) == 2
+        assert df.iloc[0]["assistant"].startswith('{"role": "system"')
+        assert "\u201chi\u201d" in df.iloc[0]["assistant"]
+
+    def test_widest_consistent_parse_wins_over_single_column(self):
+        """A delimiter absent from the file always yields a 'consistent'
+        1-column parse; the true delimiter's wider parse must win."""
+        csv = (
+            "a;b;c\n"
+            "1;2;3\n"
+            "4;5;6\n"
+        )
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["a", "b", "c"]
+        assert len(df) == 2
+
+    def test_single_column_csv_still_parses(self):
+        """Genuine single-column files remain accepted."""
+        csv = "only_column\nvalue one\nvalue two\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["only_column"]
+        assert len(df) == 2
+
+
+@pytest.mark.unit
+class TestReadCsvDelimiterSelection:
+    """Delimiter-selection guarantees of the widest-consistent-parse rule."""
+
+    def _make_file(self, content: str) -> io.BytesIO:
+        f = io.BytesIO(content.encode("utf-8"))
+        f.name = "test.csv"
+        return f
+
+    def test_malformed_multicolumn_csv_errors_instead_of_one_column(self):
+        """A file with ragged rows must raise, not silently import each raw
+        line as a single-column DataFrame (every absent delimiter yields a
+        trivially 'consistent' 1-column parse)."""
+        csv = "id,name,age\n1,a,b,c\n2,d\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert df is None
+        assert "inconsistent column counts" in err
+
+    def test_exotic_colon_delimiter_still_detected(self):
+        """Genuine ':'-delimited files must keep working: the restricted
+        sniff misses ':', so the unrestricted sniff supplies it as an extra
+        candidate and its 3-column parse beats the 1-column comma parse."""
+        csv = "a:b:c\n1:2:3\n4:5:6\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["a", "b", "c"]
+        assert len(df) == 2
+
+    def test_header_only_file_raises_specific_error(self):
+        """A file with just a header row keeps its dedicated error message."""
+        csv = "col_a,col_b,col_c\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert df is None
+        assert "only a header row" in err
+
+    def test_single_column_with_unquoted_comma_in_header(self):
+        """Dev parity: a single-column file whose header contains an unquoted
+        comma must parse as one column, not be rejected — only the header
+        splits; every data row is a single cell."""
+        csv = "first,second\nhello\nworld\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["first,second"]
+        assert len(df) == 2
+        assert df.iloc[0, 0] == "hello"
+
+    def test_single_column_with_unquoted_semicolon_in_header(self):
+        """Same parity guarantee for a stray semicolon in the header."""
+        csv = "a;b\nhello\nworld\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert err is None
+        assert list(df.columns) == ["a;b"]
+        assert len(df) == 2
+
+    def test_delimiter_in_some_data_rows_still_rejected(self):
+        """The malformed-file guard must survive the parity refinement: when
+        the delimiter appears in the *data* rows with ragged counts, the file
+        errors instead of importing as one column."""
+        csv = "id,name\n1,a\nlonely\n2,b\n"
+        df, err = FileProcessor.process_file(self._make_file(csv))
+        assert df is None
+        assert "inconsistent column counts" in err

--- a/futureagi/model_hub/utils/file_reader.py
+++ b/futureagi/model_hub/utils/file_reader.py
@@ -94,6 +94,104 @@ class FileProcessor:
         raise FileProcessingError("Unsupported file format")
 
     @staticmethod
+    def _normalize_smart_quotes(text: str) -> str:
+        return (
+            text.replace("\u201c", '"')
+            .replace("\u201d", '"')
+            .replace("\u201e", '"')
+            .replace("\u201f", '"')
+        )
+
+    @staticmethod
+    def _try_parse_csv_text(
+        text: str, fallback_delimiters: list[str]
+    ) -> tuple[pd.DataFrame | None, int, int, bool]:
+        """Attempt to parse CSV text.
+
+        Returns ``(df, col_count, max_row_count, saw_wider_inconsistent)``:
+
+        * ``df`` / ``col_count`` — the widest consistent parse found, if any.
+          Widest wins rather than first-consistent: a delimiter absent from
+          the file produces "1 column per line" rows that look consistent but
+          collapse every real column into a single string.
+        * ``max_row_count`` — the most rows any delimiter attempt produced;
+          used by the caller to distinguish header-only files from
+          inconsistent ones.
+        * ``saw_wider_inconsistent`` — True when some delimiter produced a
+          multi-column header whose data rows had mismatched counts. The
+          caller uses it to reject a degenerate 1-column "success" on a file
+          that clearly meant to be multi-column.
+        """
+        sample = text[:4096]
+        try:
+            # Restrict Sniffer to real CSV delimiters; otherwise it will
+            # happily pick a letter (e.g. 'n' from "first_name") whenever
+            # that character happens to split rows into equal counts.
+            delimiter = csv.Sniffer().sniff(
+                sample, delimiters="".join(fallback_delimiters)
+            ).delimiter
+        except csv.Error:
+            delimiter = None
+
+        delimiters_to_try = [delimiter] if delimiter else []
+        for d in fallback_delimiters:
+            if d not in delimiters_to_try:
+                delimiters_to_try.append(d)
+
+        try:
+            exotic = csv.Sniffer().sniff(sample).delimiter
+            if (
+                exotic
+                and not exotic.isalnum()
+                # csv.reader raises ValueError for these, they can never be
+                # real delimiters.
+                and exotic not in '"\r\n'
+                and exotic not in delimiters_to_try
+            ):
+                delimiters_to_try.append(exotic)
+        except csv.Error:
+            pass
+
+        best_df: pd.DataFrame | None = None
+        best_cols = 0
+        max_row_count = 0
+        saw_wider_inconsistent = False
+        for delim in delimiters_to_try:
+            try:
+                rows = list(
+                    csv.reader(StringIO(text), delimiter=delim, quotechar='"')
+                )
+            except (csv.Error, ValueError):
+                # ValueError: csv.reader rejects the delimiter char itself
+                # (e.g. a quote or newline) — skip it, never abort the whole
+                # candidate parse.
+                continue
+            max_row_count = max(max_row_count, len(rows))
+            if not rows or len(rows) < 2:
+                continue
+            header = rows[0]
+            expected_cols = len(header)
+            if any(len(r) != expected_cols for r in rows[1:]):
+                # Flag only when the delimiter actually appears in the *data*
+                # (some mismatching row splits into >1 column). A header-only
+                # split — e.g. a single-column file whose header contains an
+                # unquoted comma ("first,second\nhello\nworld") — is
+                # single-column intent, not a ragged multi-column file, and
+                # must keep parsing as one column (dev parity).
+                if expected_cols > 1 and any(len(r) > 1 for r in rows[1:]):
+                    saw_wider_inconsistent = True
+                continue
+            if expected_cols <= best_cols:
+                continue
+            header = FileProcessor._deduplicate_columns(header)
+            df = pd.DataFrame(rows[1:], columns=header)
+            df.reset_index(drop=True, inplace=True)
+            best_df = df
+            best_cols = expected_cols
+
+        return best_df, best_cols, max_row_count, saw_wider_inconsistent
+
+    @staticmethod
     def _read_csv_file(file_obj: Any) -> pd.DataFrame:
         encodings = ["utf-8", "latin1", "cp1252", "iso-8859-1"]
         fallback_delimiters = [",", "\t", ";", "|"]
@@ -105,61 +203,39 @@ class FileProcessor:
                 if isinstance(raw_data, bytes):
                     raw_data = raw_data.decode(encoding)
 
-                # Normalize smart/curly quotes to straight quotes so that
-                # csv.reader (which uses quotechar='"') can recognise them.
-                # Without this, CSVs exported from Excel or Google Sheets that
-                # use typographic quotes will have their quoted-field commas
-                # treated as delimiters, leading to wrong column counts and
-                # ultimately all columns being merged into one.
-                raw_data = (
-                    raw_data.replace("\u201c", '"')
-                    .replace("\u201d", '"')
-                    .replace("\u201e", '"')
-                    .replace("\u201f", '"')
-                )
+                candidates = [raw_data]
+                normalized = FileProcessor._normalize_smart_quotes(raw_data)
+                if normalized != raw_data:
+                    candidates.append(normalized)
 
-                # Try to detect delimiter using Sniffer with large sample
-                sample = raw_data[:4096]
-                try:
-                    dialect = csv.Sniffer().sniff(sample)
-                    delimiter = dialect.delimiter
-                except csv.Error:
-                    delimiter = None
-
-                # Candidate delimiters to try, prioritized
-                delimiters_to_try = [delimiter] if delimiter else []
-                for d in fallback_delimiters:
-                    if d not in delimiters_to_try:
-                        delimiters_to_try.append(d)
-
-                # Try each delimiter until rows are consistent
-                last_delimiter_rows = None
-                for delim in delimiters_to_try:
-                    reader = csv.reader(
-                        StringIO(raw_data), delimiter=delim, quotechar='"'
+                best_df: pd.DataFrame | None = None
+                best_cols = 0
+                max_row_count = 0
+                saw_wider_inconsistent = False
+                for candidate in candidates:
+                    df, cols, rows_seen, saw_wider = (
+                        FileProcessor._try_parse_csv_text(
+                            candidate, fallback_delimiters
+                        )
                     )
-                    rows = list(reader)
-                    last_delimiter_rows = len(rows) if rows else 0
-                    if not rows or len(rows) < 2:
-                        continue
-                    header = rows[0]
-                    expected_cols = len(header)
-                    # Check if all rows have matching number of columns
-                    bad_rows = [
-                        i + 2 for i, r in enumerate(rows[1:]) if len(r) != expected_cols
-                    ]
-                    if bad_rows:
-                        # inconsistent columns, try next delimiter
-                        continue
-                    # Handle duplicate column names
-                    header = FileProcessor._deduplicate_columns(header)
-                    # All rows consistent, create DataFrame
-                    df = pd.DataFrame(rows[1:], columns=header)
-                    df.reset_index(drop=True, inplace=True)
-                    return df
+                    if df is not None and cols > best_cols:
+                        best_df = df
+                        best_cols = cols
+                    max_row_count = max(max_row_count, rows_seen)
+                    saw_wider_inconsistent = saw_wider_inconsistent or saw_wider
 
-                # If no delimiter worked:
-                if last_delimiter_rows == 1:
+                # A 1-column "success" on a file where some delimiter split
+                # the header into multiple columns is almost certainly a
+                # malformed multi-column file (e.g. rows with extra/missing
+                # cells), not a genuine single-column dataset. Surface the
+                # data-quality error instead of silently importing every line
+                # as one string.
+                if best_df is not None and not (
+                    best_cols == 1 and saw_wider_inconsistent
+                ):
+                    return best_df
+
+                if max_row_count == 1:
                     raise FileProcessingError(
                         "The file contains only a header row with no data."
                     )
@@ -167,13 +243,10 @@ class FileProcessor:
                     "Unable to detect delimiter correctly; rows have inconsistent column counts."
                 )
             except UnicodeDecodeError:
-                # Try next encoding
                 continue
             except FileProcessingError:
-                # Re-raise file processing errors (e.g., inconsistent columns)
                 raise
             except Exception as e:
-                # Log and try next encoding
                 logger.warning(f"Error reading CSV with encoding {encoding}: {str(e)}")
                 continue
 


### PR DESCRIPTION
**Ticket:** [TH-6715 — Unable to upload a CSV file in dataset](https://linear.app/future-agi/issue/TH-6715/unable-to-upload-a-csv-file-in-dataset)

## 1. What changes are done

CSV dataset uploads failed with *"Unable to detect delimiter correctly; rows have inconsistent column counts"* for perfectly valid CSVs — specifically files whose quoted cells contain curly/typographic quotes (`\u201c` `\u201d`) as **literal text** (chat transcripts, LLM prompts, JSON blobs). Reproduced with a real exported dataset: straight-quoted comma CSV, 10 columns, 111 curly quotes inside cell content — the old parser rejected it; the new one parses it as 26 rows × 10 columns.

All changes are in `model_hub/utils/file_reader.py` (single file, plus tests):

| Change | What it fixes |
| --- | --- |
| Smart-quote normalization is no longer unconditional — the parser tries the file **as-is first**, then retries with curly quotes rewritten to `"` , keeping whichever candidate parses into the widest consistent table | The rewrite was corrupting valid files: replacing curly quotes that are *content inside* straight-quoted fields injects unescaped `"` mid-field, desyncing the reader's quoting state until every delimiter yields inconsistent column counts |
| `csv.Sniffer().sniff(...)` now restricted to the real candidate delimiters (`,` `\t` `;` `\|`) | The unrestricted Sniffer picks arbitrary characters — on the reproduction file it chose `:` (a colon from JSON inside a cell) as the delimiter |
| Delimiter selection changed from "first consistent parse wins" to "**widest** consistent parse wins" | A delimiter absent from the file splits every line into exactly 1 column — trivially "consistent" — so a bad sniffed delimiter tried first could return a garbage single-column DataFrame instead of the real 10-column parse |
| Parse-attempt logic extracted into `_try_parse_csv_text()` / `_normalize_smart_quotes()` helpers | The candidate loop (raw text, then normalized text) needs to run the same attempt twice; behavior of the extracted code is otherwise unchanged |

Error paths are preserved byte-for-byte: header-only files still raise *"The file contains only a header row with no data."*, unparseable files still raise the inconsistent-columns error, and the encoding-retry loop (`utf-8` → `latin1` → `cp1252` → `iso-8859-1`) is untouched.

## 2. Why these changes

The original smart-quote handling (TH-3546) solved a real problem: Excel/Google Sheets exports whose field *wrappers* are typographic quotes. But it ran unconditionally, which bakes in the assumption that curly quotes are always broken quoting — never data. Any dataset containing conversational text or LLM output breaks that assumption. Trying both candidates and keeping the widest consistent parse preserves the TH-3546 rescue (the normalized candidate wins for genuinely curly-wrapped files) while never corrupting files where the raw text already parses (the as-is candidate wins).

"Widest consistent parse" is the right tiebreak because the failure mode of a wrong delimiter is always a *narrower* table — typically the degenerate 1-column parse. A wrong delimiter can only beat the true one if every row contains equal counts of it outside quotes, which is adversarial input; the old first-wins ordering had a strictly worse version of the same ambiguity.


https://github.com/user-attachments/assets/4888f2c7-26d1-412f-bd67-8a30d9fa151b


## 3. Tests — scenarios covered

New test class `TestReadCsvCurlyQuotesAsContent` in `model_hub/tests/test_file_reader.py` (4 tests):

- **The regression:** curly quotes as literal content inside straight-quoted fields must parse, and the content must be preserved verbatim (the normalization candidate must not win and rewrite the data).
- **The production shape:** quoted JSON cells with embedded colons, newlines, escaped `""` quotes, and curly quotes — covers the bogus-Sniffer, embedded-newline, and content-corruption failure modes in one test.
- **Widest-parse tiebreak:** a semicolon-delimited file must yield the 3-column parse, not the degenerate 1-column comma parse.
- **Single-column guard:** genuinely single-column CSVs remain accepted.

Verified the tests pin the fix: with the old parser restored, 3 of the 4 fail (the single-column guard passes on both, as intended — it guards the new tiebreak logic against over-rejecting).

All 11 pre-existing TH-3546 tests pass unchanged — the Excel curly-wrapper rescue still works.

## Self-review findings addressed (second pass)

A structured review of the first push surfaced four issues; all are fixed in the current diff:

1. **1-column false-accept (pre-existing, now fixed).** A malformed multi-column file (ragged rows) used to fall through to a delimiter absent from the file, whose "1 column per line" parse is trivially consistent — silently importing every raw line as one string. The old first-consistent-wins code had the identical behavior. Now `_try_parse_csv_text` reports `saw_wider_inconsistent` — set only when a mismatching **data** row itself splits into >1 column (per review: a header-only split, e.g. a single-column file with an unquoted comma in its header, is single-column intent and keeps parsing as one column). A 1-column "success" on a genuinely ragged file raises the inconsistent-column-counts error instead of silently importing every line as one string.
2. **Exotic-delimiter regression (introduced in first push, now fixed).** Restricting the Sniffer to `,\t;|` broke genuine `:`- or space-delimited files the unrestricted Sniffer used to rescue. The unrestricted sniff is now re-added as a *lowest-priority extra candidate*, with two rails: alphanumeric picks are rejected outright (the Sniffer chooses letters like `o` by character frequency on small files — the original TH-3546 bug), and any other bogus pick (e.g. `:` from JSON cell content) parses inconsistently and self-eliminates under the widest-consistent rule.
3. **Comment/behavior drift (fixed).** The candidates comment claimed "try as-is first, then retry" while the code evaluates both and keeps the widest. The comment now documents the actual (and intentional) rule — strict raw-first would be wrong, since the raw text can produce a degenerate 1-column consistent parse that would shadow the normalized candidate's correct multi-column parse.
4. **Header-only error misfire (fixed).** The header-only vs inconsistent-columns dispatch used the row count of the *last* delimiter attempt, which a later candidate could clobber. It now uses the maximum row count across all attempts, so "only a header row" fires only when the file genuinely has one logical row.

New tests pinning each: `test_malformed_multicolumn_csv_errors_instead_of_one_column`, `test_exotic_colon_delimiter_still_detected`, `test_header_only_file_raises_specific_error`, plus review-round additions `test_single_column_with_unquoted_comma_in_header`, `test_single_column_with_unquoted_semicolon_in_header`, `test_delimiter_in_some_data_rows_still_rejected` (class `TestReadCsvDelimiterSelection`).

A 24-shape differential battery (old dev algorithm vs this branch, run in-container) confirmed every standard case is byte-identical to dev; the only behavior diffs are the intended ones (curly-quote content fix, ragged files now error, and three cases where dev's unrestricted Sniffer letter-split single-column files into silent garbage — now parsed correctly).

## 4. Test results

```
model_hub/tests/test_file_reader.py .....................   21 passed
model_hub/tests/test_file_reader.py + test_dataset_creation_import_api.py
                                                       43 passed in 43.66s
```

End-to-end check with the real failing dataset export (4,206 physical lines, JSON cells, 111 curly quotes): parses to `shape (26, 10)` with the correct headers.

Ruff clean on both edited files.


