### PR TITLE
fix: add inline editing for workflow node names

### DIFF
--- a/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/ConversationNode.jsx
@@ -82,6 +82,7 @@ const ConversationNode = ({ data, isConnectable, id }) => {
           }}
         />
         <NodeHeader
+          id={id}
           type="conversation"
           title={data?.name}
           badge={

--- a/frontend/src/components/GraphBuilder/nodes/EndCallNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/EndCallNode.jsx
@@ -72,7 +72,7 @@ const EndCallNode = ({ id, data, isConnectable }) => {
             : theme.palette.red[600],
         }}
       />
-      <NodeHeader type="end" title={data?.name} />
+      <NodeHeader id={id} type="end" title={data?.name} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/EndChatNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/EndChatNode.jsx
@@ -72,7 +72,7 @@ const EndChatNode = ({ id, data, isConnectable }) => {
             : theme.palette.red[600],
         }}
       />
-      <NodeHeader type="endChat" title={data?.name} />
+      <NodeHeader id={id} type="endChat" title={data?.name} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
@@ -1,13 +1,75 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { Box, Divider, Typography } from "@mui/material";
+import { Box, Divider, InputBase, Typography } from "@mui/material";
 import SvgColor from "src/components/svg-color";
 import { GRAPH_NODES } from "../common";
+import { useGraphStore } from "../store/graphStore";
 
-const NodeHeader = ({ type, title, badge }) => {
+const NodeHeader = ({ id, type, title, badge }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(title || "");
+  const shouldSkipBlurSave = useRef(false);
+  const renameNode = useGraphStore((state) => state.renameNode);
   const node = GRAPH_NODES.find((n) => n.type === type);
+  const label = title || node?.name || "";
+
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(label);
+    }
+  }, [isEditing, label]);
+
+  const handleSave = useCallback(() => {
+    if (shouldSkipBlurSave.current) {
+      shouldSkipBlurSave.current = false;
+      return;
+    }
+
+    const nextValue = editValue.trim();
+
+    setIsEditing(false);
+
+    if (!id || !nextValue || nextValue === label) {
+      setEditValue(label);
+      return;
+    }
+
+    renameNode(id, nextValue);
+  }, [editValue, id, label, renameNode]);
+
+  const handleCancel = useCallback(() => {
+    shouldSkipBlurSave.current = true;
+    setEditValue(label);
+    setIsEditing(false);
+  }, [label]);
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        handleSave();
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel, handleSave],
+  );
+
+  const handleEditStart = useCallback(
+    (event) => {
+      event.stopPropagation();
+      setEditValue(label);
+      setIsEditing(true);
+    },
+    [label],
+  );
+
   if (!node) return null;
-  const { color, backgroundColor, icon, name } = node;
+  const { color, backgroundColor, icon } = node;
+
   return (
     <>
       <Box
@@ -39,9 +101,51 @@ const NodeHeader = ({ type, title, badge }) => {
             }}
           />
         </Box>
-        <Typography typography="s2" fontWeight="fontWeightMedium">
-          {title || name}
-        </Typography>
+        {isEditing ? (
+          <InputBase
+            autoFocus
+            className="nodrag"
+            value={editValue}
+            onBlur={handleSave}
+            onChange={(event) => setEditValue(event.target.value)}
+            onClick={(event) => event.stopPropagation()}
+            onFocus={(event) => event.target.select()}
+            onKeyDown={handleKeyDown}
+            onMouseDown={(event) => event.stopPropagation()}
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              border: "1px solid",
+              borderColor: "primary.main",
+              borderRadius: 0.5,
+              px: 0.75,
+              py: 0.25,
+              "& .MuiInputBase-input": {
+                typography: "s2",
+                fontWeight: "fontWeightMedium",
+                p: 0,
+              },
+            }}
+          />
+        ) : (
+          <Typography
+            className="nodrag"
+            typography="s2"
+            fontWeight="fontWeightMedium"
+            onClick={handleEditStart}
+            onMouseDown={(event) => event.stopPropagation()}
+            sx={{
+              cursor: "text",
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {label}
+          </Typography>
+        )}
         {badge && <Box sx={{ marginLeft: "auto" }}>{badge}</Box>}
       </Box>
       <Divider />
@@ -50,6 +154,7 @@ const NodeHeader = ({ type, title, badge }) => {
 };
 
 NodeHeader.propTypes = {
+  id: PropTypes.string,
   type: PropTypes.string,
   title: PropTypes.string,
   badge: PropTypes.node,

--- a/frontend/src/components/GraphBuilder/nodes/TransferCallNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/TransferCallNode.jsx
@@ -73,7 +73,7 @@ const TransferCallNode = ({ id, data, isConnectable }) => {
             : theme.palette.orange[600],
         }}
       />
-      <NodeHeader type="transfer" title={data?.name} />
+      <NodeHeader id={id} type="transfer" title={data?.name} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/TransferChatNode.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/TransferChatNode.jsx
@@ -73,7 +73,7 @@ const TransferChatNode = ({ id, data, isConnectable }) => {
             : theme.palette.orange[600],
         }}
       />
-      <NodeHeader type="transferChat" title={data?.name} />
+      <NodeHeader id={id} type="transferChat" title={data?.name} />
       <Box>
         <Typography typography="s1" fontWeight="fontWeightMedium">
           Message

--- a/frontend/src/components/GraphBuilder/nodes/__tests__/NodeHeader.test.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/__tests__/NodeHeader.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import NodeHeader from "../NodeHeader";
+import { NODE_TYPES, useGraphStore } from "../../store/graphStore";
+
+vi.mock("src/components/svg-color", () => ({
+  default: () => <span data-testid="node-icon" />,
+}));
+
+const theme = createTheme();
+
+function renderNodeHeader(props = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <NodeHeader
+        id="node-1"
+        type={NODE_TYPES.CONVERSATION}
+        title="Conversation_1"
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe("NodeHeader", () => {
+  beforeEach(() => {
+    useGraphStore.setState({
+      nodes: [
+        {
+          id: "node-1",
+          type: NODE_TYPES.CONVERSATION,
+          data: { name: "Conversation_1" },
+        },
+      ],
+      edges: [
+        { id: "edge-1", source: "node-1", target: "node-2" },
+        { id: "edge-2", source: "node-3", target: "node-1" },
+      ],
+      activeNodeId: "node-1",
+      activeEdgeId: null,
+    });
+  });
+
+  it("switches to edit mode when the node name is clicked", () => {
+    renderNodeHeader();
+
+    fireEvent.click(screen.getByText("Conversation_1"));
+
+    expect(screen.getByRole("textbox")).toHaveValue("Conversation_1");
+  });
+
+  it("saves the updated node name on Enter", () => {
+    renderNodeHeader();
+
+    fireEvent.click(screen.getByText("Conversation_1"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Greeting" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useGraphStore.getState().nodes[0]).toMatchObject({
+      id: "Greeting",
+      data: { name: "Greeting" },
+    });
+    expect(useGraphStore.getState().edges[0].source).toBe("Greeting");
+    expect(useGraphStore.getState().edges[1].target).toBe("Greeting");
+    expect(useGraphStore.getState().activeNodeId).toBe("Greeting");
+  });
+
+  it("saves the updated node name on blur", () => {
+    renderNodeHeader();
+
+    fireEvent.click(screen.getByText("Conversation_1"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Blurred name" } });
+    fireEvent.blur(input);
+
+    expect(useGraphStore.getState().nodes[0].data.name).toBe("Blurred name");
+  });
+
+  it("cancels editing on Escape", () => {
+    renderNodeHeader();
+
+    fireEvent.click(screen.getByText("Conversation_1"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Draft name" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(useGraphStore.getState().nodes[0].data.name).toBe("Conversation_1");
+  });
+});

--- a/frontend/src/components/GraphBuilder/store/graphStore.js
+++ b/frontend/src/components/GraphBuilder/store/graphStore.js
@@ -159,6 +159,33 @@ export const useGraphStore = create((set, get) => ({
       ),
     });
   },
+  renameNode: (nodeId, name) => {
+    set((state) => {
+      const nextName = name.trim();
+
+      if (
+        !nextName ||
+        state.nodes.some((node) => node.id !== nodeId && node.id === nextName)
+      ) {
+        return state;
+      }
+
+      return {
+        nodes: state.nodes.map((node) =>
+          node.id === nodeId
+            ? { ...node, id: nextName, data: { ...node.data, name: nextName } }
+            : node,
+        ),
+        edges: state.edges.map((edge) => ({
+          ...edge,
+          source: edge.source === nodeId ? nextName : edge.source,
+          target: edge.target === nodeId ? nextName : edge.target,
+        })),
+        activeNodeId:
+          state.activeNodeId === nodeId ? nextName : state.activeNodeId,
+      };
+    });
+  },
   updateNode: (nodeId, newData) => {
     set({
       nodes: get().nodes.map((node) =>


### PR DESCRIPTION
## Summary
- add click-to-edit behavior to Workflow Builder node headers
- save renamed node labels on Enter or blur, and cancel edits on Escape
- rename nodes through the graph store so `id`, `data.name`, connected edge endpoints, and active node selection stay in sync
- wire all Workflow Builder node types to pass their node id into the shared header
- add regression coverage for edit, save, blur-save, cancel, and edge remapping behavior

Fixes #1504.

## Testing
- `git diff --check origin/dev..HEAD`
- `corepack yarn --cwd frontend install --frozen-lockfile`
- `corepack yarn --cwd frontend vitest run src/components/GraphBuilder/nodes/__tests__/NodeHeader.test.jsx --reporter=verbose`

Note: dependency install completed successfully; Yarn reported the existing optional `canvas` native install failure as safe to ignore on Windows/Node 22.