### PR TITLE
fix(persona): auto-select persona created inline from scenario drawer

### DIFF
--- a/frontend/src/sections/persona/PersonaDrawer.jsx
+++ b/frontend/src/sections/persona/PersonaDrawer.jsx
@@ -7,7 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PersonaListView from "./PersonaListView";
 import Iconify from "src/components/iconify";
 import { Collapse } from "@mui/material";
@@ -19,28 +19,9 @@ const PersonaListContent = ({
   onClose,
   onAddPersonas,
   onCreatePersona,
-  preSelectedPersonas,
+  selectedPersonas,
+  onToggleSelect,
 }) => {
-  const [selectedPersonas, setSelectedPersonas] = useState(
-    preSelectedPersonas ?? [],
-  );
-
-  const handleToggleSelect = (persona, newValue) => {
-    setSelectedPersonas((prev) => {
-      if (newValue) {
-        return prev.some((p) => p.id === persona.id)
-          ? prev
-          : [...prev, persona];
-      }
-      return prev.filter((p) => p.id !== persona.id);
-    });
-  };
-
-  const handleAddPersonas = () => {
-    onAddPersonas(selectedPersonas);
-    setSelectedPersonas([]);
-  };
-
   return (
     <Box
       sx={{
@@ -74,7 +55,7 @@ const PersonaListContent = ({
         <PersonaListView
           onCreatePersona={onCreatePersona}
           selectedPersonas={selectedPersonas}
-          onToggleSelect={handleToggleSelect}
+          onToggleSelect={onToggleSelect}
           isSelectable
           personaCreateEditType={personaCreateEditType}
           lockedFilters={lockedFilters}
@@ -112,7 +93,7 @@ const PersonaListContent = ({
           sx={{ minWidth: "160px" }}
           size="small"
           disabled={selectedPersonas?.length === 0}
-          onClick={handleAddPersonas}
+          onClick={() => onAddPersonas(selectedPersonas)}
         >
           Add
         </Button>
@@ -127,10 +108,11 @@ PersonaListContent.propTypes = {
   onClose: PropTypes.func,
   onAddPersonas: PropTypes.func,
   onCreatePersona: PropTypes.func,
-  preSelectedPersonas: PropTypes.array,
+  selectedPersonas: PropTypes.array,
+  onToggleSelect: PropTypes.func,
 };
 
-const PersonaCreateContent = ({ onCancel, type }) => {
+const PersonaCreateContent = ({ onCancel, onSuccess, type }) => {
   return (
     <Box sx={{ width: "700px", height: "100vh" }}>
       <IconButton
@@ -146,7 +128,7 @@ const PersonaCreateContent = ({ onCancel, type }) => {
       </IconButton>
       <PersonaCreateEditForm
         onCancel={onCancel}
-        onSuccess={onCancel}
+        onSuccess={onSuccess}
         type={type}
       />
     </Box>
@@ -155,6 +137,7 @@ const PersonaCreateContent = ({ onCancel, type }) => {
 
 PersonaCreateContent.propTypes = {
   onCancel: PropTypes.func,
+  onSuccess: PropTypes.func,
   type: PropTypes.string,
 };
 
@@ -167,6 +150,34 @@ const PersonaDrawer = ({
   preSelectedPersonas = [],
 }) => {
   const [createEditOpen, setCreateEditOpen] = useState(false);
+  const [selectedPersonas, setSelectedPersonas] = useState(
+    preSelectedPersonas ?? [],
+  );
+
+  useEffect(() => {
+    if (open) setSelectedPersonas(preSelectedPersonas ?? []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleToggleSelect = (persona, newValue) => {
+    setSelectedPersonas((prev) => {
+      if (newValue) {
+        return prev.some((p) => p.id === persona.id)
+          ? prev
+          : [...prev, persona];
+      }
+      return prev.filter((p) => p.id !== persona.id);
+    });
+  };
+
+  const handleCreatedPersona = (response) => {
+    const persona = response?.data?.result || response?.data;
+    setCreateEditOpen(false);
+    if (!persona?.id) return;
+    setSelectedPersonas((prev) =>
+      prev.some((p) => p.id === persona.id) ? prev : [...prev, persona],
+    );
+  };
 
   const handleDrawerClose = () => {
     onClose();
@@ -186,6 +197,7 @@ const PersonaDrawer = ({
       >
         <PersonaCreateContent
           onCancel={handleCreateEditClose}
+          onSuccess={handleCreatedPersona}
           type={personaCreateEditType}
         />
       </Collapse>
@@ -200,7 +212,8 @@ const PersonaDrawer = ({
           onClose={handleDrawerClose}
           onAddPersonas={onAddPersonas}
           onCreatePersona={() => setCreateEditOpen(true)}
-          preSelectedPersonas={preSelectedPersonas}
+          selectedPersonas={selectedPersonas}
+          onToggleSelect={handleToggleSelect}
         />
       </Collapse>
     </Drawer>

--- a/frontend/src/sections/persona/__tests__/PersonaDrawer.test.jsx
+++ b/frontend/src/sections/persona/__tests__/PersonaDrawer.test.jsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent, waitFor, act } from "src/utils/test-utils";
+import PersonaDrawer from "../PersonaDrawer";
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+let listViewProps = null;
+vi.mock("../PersonaListView", () => ({
+  default: (props) => {
+    listViewProps = props;
+    return (
+      <div data-testid="persona-list-view">
+        <button
+          type="button"
+          onClick={() => props.onCreatePersona?.()}
+        >
+          Create new persona
+        </button>
+        {["existing-1", "existing-2"].map((id) => {
+          const isSelected = props.selectedPersonas?.some((p) => p.id === id);
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() =>
+                props.onToggleSelect?.({ id, name: id }, !isSelected)
+              }
+            >
+              toggle-{id} ({isSelected ? "selected" : "unselected"})
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+}));
+
+let createFormOnSuccess = null;
+vi.mock("../PersonaCreateEdit/PersonaCreateEditForm", () => ({
+  default: (props) => {
+    createFormOnSuccess = props.onSuccess;
+    return <div data-testid="persona-create-form">Create form</div>;
+  },
+}));
+
+describe("PersonaDrawer", () => {
+  beforeEach(() => {
+    listViewProps = null;
+    createFormOnSuccess = null;
+  });
+
+  it("auto-selects a persona created inline and shows it in the selected count", async () => {
+    const user = userEvent.setup();
+    const onAddPersonas = vi.fn();
+
+    render(
+      <PersonaDrawer
+        open
+        onClose={vi.fn()}
+        onAddPersonas={onAddPersonas}
+        personaCreateEditType="chat"
+        preSelectedPersonas={[]}
+      />,
+    );
+
+    expect(screen.getByText("Personas selected (0)")).toBeInTheDocument();
+
+    // Open the inline create panel.
+    await user.click(screen.getByRole("button", { name: /create new persona/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-create-form")).toBeInTheDocument();
+    });
+    expect(createFormOnSuccess).toBeTypeOf("function");
+
+    // Simulate the create mutation's onSuccess firing with the axios response shape.
+    act(() => {
+      createFormOnSuccess({ data: { id: "new-persona", name: "New Persona" } });
+    });
+
+    // Drawer should return to the list view.
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-list-view")).toBeInTheDocument();
+    });
+
+    // The newly created persona should now be selected.
+    expect(screen.getByText("Personas selected (1)")).toBeInTheDocument();
+    expect(listViewProps.selectedPersonas).toEqual([
+      { id: "new-persona", name: "New Persona" },
+    ]);
+
+    // Clicking Add should carry the created persona through.
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    expect(onAddPersonas).toHaveBeenCalledWith([
+      { id: "new-persona", name: "New Persona" },
+    ]);
+  });
+
+  it("preserves pre-existing selections across the create round-trip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaDrawer
+        open
+        onClose={vi.fn()}
+        onAddPersonas={vi.fn()}
+        personaCreateEditType="chat"
+        preSelectedPersonas={[{ id: "existing-1", name: "existing-1" }]}
+      />,
+    );
+
+    expect(screen.getByText("Personas selected (1)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /create new persona/i }));
+    await waitFor(() => {
+      expect(createFormOnSuccess).toBeTypeOf("function");
+    });
+
+    act(() => {
+      createFormOnSuccess({ data: { id: "new-persona", name: "New Persona" } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Personas selected (2)")).toBeInTheDocument();
+    });
+    expect(listViewProps.selectedPersonas.map((p) => p.id)).toEqual([
+      "existing-1",
+      "new-persona",
+    ]);
+  });
+
+  it("does not add a duplicate entry if the created persona is already selected", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaDrawer
+        open
+        onClose={vi.fn()}
+        onAddPersonas={vi.fn()}
+        personaCreateEditType="chat"
+        preSelectedPersonas={[{ id: "new-persona", name: "Already there" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /create new persona/i }));
+    await waitFor(() => {
+      expect(createFormOnSuccess).toBeTypeOf("function");
+    });
+
+    act(() => {
+      createFormOnSuccess({ data: { id: "new-persona", name: "New Persona" } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-list-view")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Personas selected (1)")).toBeInTheDocument();
+  });
+
+  it("closes the create panel cleanly without crashing when the response has no usable id", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaDrawer
+        open
+        onClose={vi.fn()}
+        onAddPersonas={vi.fn()}
+        personaCreateEditType="chat"
+        preSelectedPersonas={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /create new persona/i }));
+    await waitFor(() => {
+      expect(createFormOnSuccess).toBeTypeOf("function");
+    });
+
+    expect(() => {
+      act(() => {
+        createFormOnSuccess({ data: null });
+      });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-list-view")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Personas selected (0)")).toBeInTheDocument();
+  });
+
+  it("still supports manual toggle add/remove of existing personas", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PersonaDrawer
+        open
+        onClose={vi.fn()}
+        onAddPersonas={vi.fn()}
+        personaCreateEditType="chat"
+        preSelectedPersonas={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /toggle-existing-1/i }));
+    expect(screen.getByText("Personas selected (1)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /toggle-existing-1/i }));
+    expect(screen.getByText("Personas selected (0)")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

In Simulation → Create Scenario → Persona → "Add persona" drawer, creating a new persona inline via "Create new persona" returned you to the persona list without the new persona selected — you had to scroll, find it, and check it manually before it could be added to the scenario. This happened because the create-form's `onSuccess` was wired to `onCancel` (discarding the created persona), and the list's selection state lived inside `PersonaListContent`, which unmounts (`unmountOnExit`) whenever the create panel is shown, so there was nowhere for the selection to survive the round trip anyway. This PR lifts `selectedPersonas` up into `PersonaDrawer` (which stays mounted) and adds the newly created persona to it on save, mirroring the existing `LabelPicker.handleCreatedLabel` pattern used for annotation labels.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #1393

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Added `frontend/src/sections/persona/__tests__/PersonaDrawer.test.jsx` covering: auto-select of a newly created persona, dedup by `id` when the persona is already selected, no crash / no `undefined` entry when the create response has no usable `id`, and preservation of pre-selected personas across the create round trip.
- Ran `yarn test:run src/sections/persona/__tests__/PersonaDrawer.test.jsx` locally — passing.
- Manually reproduced the bug and verified the fix end-to-end against a local stack (frontend + Django backend + Postgres/ClickHouse/Redis/Temporal via `docker compose`): logged in, created an Agent Definition and a Scenario, opened the Persona drawer, clicked "Create new persona", saved it, and confirmed it came back checked with the "Personas selected (N)" count incremented and the Add button enabled.

## Screenshots / recordings (if UI)

## BEFORE

<img width="1832" height="912" alt="Screenshot 2026-07-12 094947" src="https://github.com/user-attachments/assets/feac1be9-5650-4e79-bd73-08742d7ff592" />

## AFTER

<img width="1823" height="990" alt="Screenshot 2026-07-12 094310" src="https://github.com/user-attachments/assets/2916c542-c042-44c0-aae7-25507ee4aeae" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)