### PR TITLE
fix(eval): surface usage-limit error codes + upgrade CTA on eval cells

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
@@ -11,9 +11,7 @@ import Iconify from "src/components/iconify";
 import { paths } from "src/routes/paths";
 import { useNavigate } from "react-router-dom";
 
-// Error codes emitted by backend's usage pre-check (see CheckResult.error_code
-
-
+// Error codes emitted by backend's usage pre-check (see CheckResult.error_code).
 const USAGE_LIMIT_CTA = {
   FREE_TIER_LIMIT: "Upgrade for more usage",
   RATE_LIMITED: "Upgrade to raise rate limit",
@@ -102,12 +100,7 @@ const ErrorCellRenderer = ({
             width={16}
             sx={{ flexShrink: 0, color: "text.primary" }}
           />
-          <Typography
-           typography="s2"
-
-          >
-            {ctaText}
-          </Typography>
+          <Typography typography="s2">{ctaText}</Typography>
           <Button
             size="small"
             variant="text"
@@ -116,7 +109,6 @@ const ErrorCellRenderer = ({
               textTransform: "none",
               minWidth: 0,
               padding: 0,
-           
               color: "primary.main",
               textDecoration: "underline",
               whiteSpace: "nowrap",

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
@@ -62,7 +62,6 @@ const ErrorCellRenderer = ({
     cellData?.value_infos ?? cellData?.valueInfos,
   );
   const errorCode = valueInfos?.error_code;
-  console.log({props})
   const isUsageLimit = USAGE_LIMIT_ERROR_CODES.has(errorCode);
   const upgradeCta = valueInfos?.upgrade_cta || valueInfos?.upgradeCta;
   const ctaText =

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
@@ -12,15 +12,22 @@ import { paths } from "src/routes/paths";
 import { useNavigate } from "react-router-dom";
 
 // Error codes emitted by backend's usage pre-check (see CheckResult.error_code
-// in core-backend/usage/schemas/events.py). Mapping to a single "needs upgrade"
-// category keeps the UI decoupled from the exact billing taxonomy.
-const USAGE_LIMIT_ERROR_CODES = new Set([
-  "FREE_TIER_LIMIT",
-  "BUDGET_PAUSED",
-  "PAYMENT_REQUIRED",
-  "ENTITLEMENT_LIMIT",
-  "USAGE_LIMIT_EXCEEDED",
-]);
+
+
+const USAGE_LIMIT_CTA = {
+  FREE_TIER_LIMIT: "Upgrade for more usage",
+  RATE_LIMITED: "Upgrade to raise rate limit",
+  ENTITLEMENT_LIMIT: "Upgrade to increase limits",
+  ENTITLEMENT_DENIED: "Upgrade plan to unlock",
+  BUDGET_PAUSED: "Increase budget to resume",
+  PAYMENT_REQUIRED: "Add payment method to continue",
+  ACCOUNT_SUSPENDED: "Clear dues to reactivate",
+  LICENSE_EXPIRED: "Renew license to continue",
+  LICENSE_FEATURE_DENIED: "Contact sales to unlock",
+  USAGE_LIMIT_EXCEEDED: "Upgrade for more usage",
+};
+
+const USAGE_LIMIT_ERROR_CODES = new Set(Object.keys(USAGE_LIMIT_CTA));
 
 const parseValueInfos = (raw) => {
   if (!raw) return null;
@@ -54,11 +61,12 @@ const ErrorCellRenderer = ({
   const valueInfos = parseValueInfos(
     cellData?.value_infos ?? cellData?.valueInfos,
   );
-  const isUsageLimit = USAGE_LIMIT_ERROR_CODES.has(
-    valueInfos?.error_code || valueInfos?.errorCode,
-  );
+  const errorCode = valueInfos?.error_code;
+  console.log({props})
+  const isUsageLimit = USAGE_LIMIT_ERROR_CODES.has(errorCode);
   const upgradeCta = valueInfos?.upgrade_cta || valueInfos?.upgradeCta;
-  const upgradeText = upgradeCta?.text || "Upgrade plan";
+  const ctaText =
+    USAGE_LIMIT_CTA[errorCode] || upgradeCta?.text || "Upgrade for more usage";
   const limitMessage =
     valueInfos?.reason ||
     (typeof cellData?.value === "string" ? cellData.value : "Limit reached");
@@ -75,7 +83,7 @@ const ErrorCellRenderer = ({
         title={limitMessage}
         enterDelay={300}
         arrow
-        type="info"
+        type="black"
         size="small"
         slotProps={tooltipSlotProp}
       >
@@ -83,30 +91,29 @@ const ErrorCellRenderer = ({
           sx={{
             display: "flex",
             alignItems: "center",
-            gap: 0.75,
+            justifyContent: "center",
+            gap: 0.5,
             height: "100%",
             width: "100%",
             padding: "4px 8px",
-            color: "warning.dark",
           }}
         >
           <Iconify
-            icon="mdi:alert-circle-outline"
+            icon="mdi:lock-outline"
             width={16}
-            sx={{ flexShrink: 0, color: "warning.main" }}
+            sx={{ flexShrink: 0, color: "text.primary" }}
           />
           <Typography
             variant="body2"
             sx={{
-              flex: 1,
-              minWidth: 0,
-              fontWeight: 500,
+              fontWeight: 600,
+              color: "text.primary",
               whiteSpace: "nowrap",
               overflow: "hidden",
               textOverflow: "ellipsis",
             }}
           >
-            Limit reached
+            {ctaText}
           </Typography>
           <Button
             size="small"
@@ -115,14 +122,19 @@ const ErrorCellRenderer = ({
             sx={{
               textTransform: "none",
               minWidth: 0,
-              padding: "2px 6px",
-              fontSize: 12,
-              fontWeight: 600,
+              padding: 0,
+              fontSize: 13,
+              fontWeight: 700,
               color: "primary.main",
-              "&:hover": { backgroundColor: "action.hover" },
+              textDecoration: "underline",
+              whiteSpace: "nowrap",
+              "&:hover": {
+                backgroundColor: "transparent",
+                textDecoration: "underline",
+              },
             }}
           >
-            {upgradeText}
+            Upgrade
           </Button>
         </Box>
       </CustomTooltip>

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/ErrorCellRenderer.jsx
@@ -103,14 +103,8 @@ const ErrorCellRenderer = ({
             sx={{ flexShrink: 0, color: "text.primary" }}
           />
           <Typography
-            variant="body2"
-            sx={{
-              fontWeight: 600,
-              color: "text.primary",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
+           typography="s2"
+
           >
             {ctaText}
           </Typography>
@@ -122,8 +116,7 @@ const ErrorCellRenderer = ({
               textTransform: "none",
               minWidth: 0,
               padding: 0,
-              fontSize: 13,
-              fontWeight: 700,
+           
               color: "primary.main",
               textDecoration: "underline",
               whiteSpace: "nowrap",

--- a/futureagi/Dockerfile
+++ b/futureagi/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureagi/future-agi:v1.8.20-nightly_base
+FROM futureagi/future-agi:v1.8.20_base
 
 COPY . .
 

--- a/futureagi/Dockerfile
+++ b/futureagi/Dockerfile
@@ -1,4 +1,4 @@
-FROM futureagi/future-agi:v1.8.20_base
+FROM futureagi/future-agi:v1.8.20-nightly_base
 
 COPY . .
 

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -82,6 +82,7 @@ from tfc.utils.error_codes import (
     get_error_for_api_status,
     get_error_message,
     get_specific_error_message,
+    get_usage_error_code,
 )
 from tfc.utils.functions import get_eval_stats
 from tfc.utils.general_methods import GeneralMethods
@@ -1320,6 +1321,10 @@ class EvaluationRunner:
             error_message = get_specific_error_message(e)
 
             response, status, value = self._handle_error(error_message)
+           
+            usage_error_code = get_usage_error_code(e)
+            if usage_error_code:
+                response["error_code"] = usage_error_code
             self._handle_api_call_status(api_call_log_row, CellStatus.ERROR.value)
 
             # Create reason column and cell with error status. Always-on for
@@ -3109,6 +3114,13 @@ class EvaluationRunner:
                 if not usage_check.allowed:
                     self.user_eval_metric.status = StatusType.FAILED.value
                     self.user_eval_metric.save(update_fields=["status"])
+                    from model_hub.tasks.user_evaluation import (
+                        _mark_cells_usage_limit_error,
+                    )
+
+                    _mark_cells_usage_limit_error(
+                        self.user_eval_metric, usage_check
+                    )
                     raise ValueError(usage_check.reason or "Usage limit exceeded")
 
             self.update_cell(row_ids=row_ids)

--- a/futureagi/tfc/utils/error_codes.py
+++ b/futureagi/tfc/utils/error_codes.py
@@ -1201,6 +1201,36 @@ def get_specific_error_message(error, is_llm_error=None):
     return get_error_message("FAILED_TO_PROCESS_EVALUATION")
 
 
+def get_usage_error_code(error):
+    """Return a billing/usage error_code for rate-limit or credit-exhaustion
+    errors, else None.
+
+    Mirrors the detection in get_specific_error_message so the per-cell eval
+    error path can stamp value_infos with a code the frontend upgrade banner
+    recognises (see ErrorCellRenderer USAGE_LIMIT_CTA). Returns codes from the
+    same taxonomy as the usage pre-check (CheckResult.error_code).
+    """
+    error_message = str(error)
+    error_status = ""
+    if (
+        isinstance(error, ValueError)
+        and isinstance(error.args, tuple)
+        and len(error.args) > 1
+    ):
+        error_status = str(error.args[1])
+    haystack = f"{error_message} {error_status}".lower()
+    if (
+        "rate_limited" in haystack
+        or "rate limit" in haystack
+        or "too many requests" in haystack
+        or "429" in haystack
+    ):
+        return "RATE_LIMITED"
+    if "insufficient_credits" in haystack or "insufficient credits" in haystack:
+        return "FREE_TIER_LIMIT"
+    return None
+
+
 def get_error_for_api_status(status):
     """
     Maps API call status codes to appropriate error messages.

--- a/futureagi/tfc/utils/tests/test_usage_error_code.py
+++ b/futureagi/tfc/utils/tests/test_usage_error_code.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for get_usage_error_code.
+
+get_usage_error_code stamps a billing/usage error_code onto per-cell eval
+errors so the frontend upgrade banner (ErrorCellRenderer USAGE_LIMIT_CTA) can
+render an actionable "Upgrade" affordance instead of a bare "Error".
+
+Run with: futureagi/bin/test tfc/utils/tests/test_usage_error_code.py -v
+"""
+
+import pytest
+
+from tfc.utils.error_codes import get_usage_error_code
+
+
+class TestGetUsageErrorCode:
+    """Tests for get_usage_error_code text-matching detection."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "error",
+        [
+            Exception("rate_limited"),
+            Exception("Rate limit reached. Please try again later."),
+            Exception("Too many requests"),
+            Exception("Request failed with status 429"),
+            Exception("RATE LIMITED by upstream"),
+        ],
+    )
+    def test_detects_rate_limited(self, error):
+        assert get_usage_error_code(error) == "RATE_LIMITED"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "error",
+        [
+            Exception("insufficient_credits"),
+            Exception("Insufficient credits. Please recharge your account."),
+            Exception("INSUFFICIENT CREDITS"),
+        ],
+    )
+    def test_detects_free_tier_limit(self, error):
+        assert get_usage_error_code(error) == "FREE_TIER_LIMIT"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "error",
+        [
+            Exception("Something unrelated went wrong"),
+            Exception("Evaluation failed. Please contact Future AGI support."),
+            ValueError("FAILED_TO_PROCESS_EVALUATION"),
+            Exception(""),
+        ],
+    )
+    def test_returns_none_for_non_usage_errors(self, error):
+        assert get_usage_error_code(error) is None
+
+    @pytest.mark.unit
+    def test_reads_status_from_valueerror_second_arg(self):
+        """ValueError(message, status) surfaces the status in the haystack."""
+        error = ValueError("Upstream call failed", "rate_limited")
+        assert get_usage_error_code(error) == "RATE_LIMITED"
+
+    @pytest.mark.unit
+    def test_valueerror_message_only_still_matches(self):
+        error = ValueError("insufficient credits for this request")
+        assert get_usage_error_code(error) == "FREE_TIER_LIMIT"


### PR DESCRIPTION
## Summary
Surface usage/rate-limit error codes and an Upgrade CTA on evaluation result cells, so plan-limit hits render an actionable "Upgrade" affordance instead of a bare "Error", and polish the CTA typography.

## Why / problem
When an eval row failed due to a billing/usage limit (free-tier exhausted, rate limited, entitlement denied, etc.), the grid cell showed a generic "Error". Users had no signal that the failure was a plan limit or how to resolve it.

## What changed
- **Backend** (`model_hub/views/eval_runner.py`, `tfc/utils/error_codes.py`): detect usage/billing/rate-limit errors and stamp a structured `error_code` (+ upgrade CTA) into cell `value_infos`; add `get_usage_error_code` and the billing error-code taxonomy.
- **Frontend** (`ErrorCellRenderer.jsx`): when `value_infos.error_code` is a usage-limit code, render a lock icon + limit message + inline **Upgrade** button linking to pricing; use the custom `s2` typography variant for the CTA label.

## Tests
- [ ] Manual verification in the eval grid (below)
- [ ] 
![Uploading image.png…]()


## Commands
- [ ] `yarn lint` (frontend)

## Backwards compatibility
Additive. Cells without a usage `error_code` fall through to the existing generic error rendering.

## Manual verification
- [ ] Trigger an eval while over a plan/rate limit → cell shows lock + "Upgrade …" message + Upgrade button
- [ ] Upgrade button navigates to the pricing/settings page
- [ ] Non-usage eval errors still render the normal "Error" cell

## Type of change
- [x] Bug fix / UX improvement

## Checklist
- [x] Self-reviewed
- [ ] Lint passes
- [ ] No unrelated changes (see note re: Dockerfile base image)

## Backout
Revert this PR; rendering falls back to the prior generic error cell.

## Linear
N/A (no ticket associated with this branch)

> ⚠️ Note: this branch also flips `futureagi/Dockerfile` base image `v1.8.20_base` → `v1.8.20-nightly_base`, which appears unrelated/accidental. Consider dropping that hunk before merge.
