### PR TITLE
fix: aggregate call statuses for chat simulation test execution status

### DIFF
--- a/futureagi/simulate/tests/test_call_status_aggregation.py
+++ b/futureagi/simulate/tests/test_call_status_aggregation.py
@@ -1,0 +1,82 @@
+"""Unit tests for aggregate_call_status.
+
+Covers the acceptance criteria of the "chat simulation status shows test
+execution state instead of aggregated call states" fix: the overall status is
+computed from individual call statuses by picking the least-advanced (earliest)
+one, with a fallback when there are no calls.
+"""
+
+import pytest
+
+from simulate.models.test_execution import CallExecution
+from simulate.views.run_test import aggregate_call_status
+
+Status = CallExecution.CallStatus
+
+# Lifecycle order the aggregate must honor (earliest -> latest).
+LIFECYCLE_ORDER = [
+    Status.PENDING.value,  # "pending"
+    Status.REGISTERED.value,  # "queued"
+    Status.ONGOING.value,  # "ongoing"
+    Status.ANALYZING.value,  # "analyzing"
+    Status.COMPLETED.value,  # "completed"
+    Status.FAILED.value,  # "failed"
+    Status.CANCELLED.value,  # "cancelled"
+]
+
+
+@pytest.mark.unit
+def test_mixed_statuses_report_earliest():
+    # Some calls pending, some ongoing -> overall reflects the earliest state.
+    assert (
+        aggregate_call_status(
+            [Status.ONGOING.value, Status.PENDING.value, Status.ONGOING.value],
+            fallback=Status.COMPLETED.value,
+        )
+        == Status.PENDING.value
+    )
+
+
+@pytest.mark.unit
+def test_uniform_statuses_report_that_status():
+    assert (
+        aggregate_call_status(
+            [Status.ONGOING.value, Status.ONGOING.value],
+            fallback=Status.PENDING.value,
+        )
+        == Status.ONGOING.value
+    )
+
+
+@pytest.mark.unit
+def test_no_calls_uses_fallback():
+    assert aggregate_call_status([], fallback=Status.COMPLETED.value) == (
+        Status.COMPLETED.value
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", LIFECYCLE_ORDER)
+def test_single_status_returns_itself(status):
+    # Every valid CallStatus value is handled and returned unchanged.
+    assert aggregate_call_status([status], fallback="unused") == status
+
+
+@pytest.mark.unit
+def test_priority_ordering_is_pending_to_cancelled():
+    # For each adjacent pair, the earlier status must win regardless of order.
+    for i in range(len(LIFECYCLE_ORDER) - 1):
+        earlier, later = LIFECYCLE_ORDER[i], LIFECYCLE_ORDER[i + 1]
+        assert aggregate_call_status([later, earlier], fallback="unused") == earlier
+        assert aggregate_call_status([earlier, later], fallback="unused") == earlier
+
+
+@pytest.mark.unit
+def test_unknown_status_does_not_mask_a_real_earlier_status():
+    # A stray/unknown value sorts last, so a genuine earlier status still wins.
+    assert (
+        aggregate_call_status(
+            ["some_unknown_state", Status.ONGOING.value], fallback="unused"
+        )
+        == Status.ONGOING.value
+    )

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -1919,6 +1919,37 @@ class RunTestCallExecutionsView(APIView):
         return snapshot_as_call_exec
 
 
+# Lifecycle order of a single call's status. Lower number = earlier in the
+# workflow. Used to aggregate many call statuses into one overall status by
+# picking the least-advanced call, so an in-progress run never appears further
+# along than its slowest call. Keyed on the raw string ``.value`` because
+# ``values_list("status", flat=True)`` yields plain strings, not enum members.
+_CALL_STATUS_PRIORITY = {
+    CallExecution.CallStatus.PENDING.value: 0,  # "pending"
+    CallExecution.CallStatus.REGISTERED.value: 1,  # "queued"
+    CallExecution.CallStatus.ONGOING.value: 2,  # "ongoing"
+    CallExecution.CallStatus.ANALYZING.value: 3,  # "analyzing"
+    CallExecution.CallStatus.COMPLETED.value: 4,  # "completed"
+    CallExecution.CallStatus.FAILED.value: 5,  # "failed"
+    CallExecution.CallStatus.CANCELLED.value: 6,  # "cancelled"
+}
+
+
+def aggregate_call_status(call_statuses, fallback):
+    """Compute an overall status from individual call-execution statuses.
+
+    Returns the "earliest" status by lifecycle priority so the aggregate never
+    looks further along than its least-advanced call (e.g. mixed
+    pending/ongoing calls report "pending"). Falls back to ``fallback`` (the
+    test execution's own status) when there are no calls. Unknown status values
+    sort last so a stray value can't mask a genuinely earlier one.
+    """
+    statuses = list(call_statuses)
+    if not statuses:
+        return fallback
+    return min(statuses, key=lambda s: _CALL_STATUS_PRIORITY.get(s, 999))
+
+
 class TestExecutionDetailView(APIView):
     """
     API View to retrieve a specific test execution with all its details and paginated call executions
@@ -2484,7 +2515,13 @@ class TestExecutionDetailView(APIView):
             response_data = paginated_response.data
             response_data["column_order"] = column_order
             response_data["error_messages"] = error_messages
-            response_data["status"] = test_execution.status
+            # Report the aggregated status of all call executions rather than the
+            # test execution's own status field, which can lag behind the calls
+            # and show e.g. "pending" while calls are already running.
+            response_data["status"] = aggregate_call_status(
+                test_execution.calls.values_list("status", flat=True),
+                fallback=test_execution.status,
+            )
             response_data["provider"] = (
                 test_execution.agent_definition.provider
                 if test_execution.agent_definition


### PR DESCRIPTION
Fixes #1524

The test execution detail view returned \`test_execution.status\`, which can lag behind its calls (showing 'pending' while calls run). Now aggregates the individual call statuses, picking the earliest in the lifecycle per the acceptance criteria, with a fallback when there are no calls.

Extracted as a pure \`aggregate_call_status()\` helper (kept in run_test.py, within the issue's scope) so the logic is unit-testable without the full view/DB pipeline. Added unit tests for each acceptance-criteria bullet.

Note: the summary and AC differ slightly on the mixed pending/ongoing case (AC specifies earliest-state = 'pending'); I followed the AC's explicit ordering. Happy to switch to 'furthest-along' if that's the intended UX.