### PR TITLE
fix(mcp): consume OAuth authorization codes atomically to prevent replay (#1134)

### DIFF
--- a/futureagi/mcp_server/tests/test_oauth.py
+++ b/futureagi/mcp_server/tests/test_oauth.py
@@ -201,3 +201,90 @@ class TestMCPOAuthCodeModel:
         )
         code.refresh_from_db()
         assert code.is_expired
+
+
+@pytest.mark.django_db
+class TestAuthorizationCodeConsumption:
+    """Authorization codes are single-use bearer grants (see issue #1134)."""
+
+    def _setup_code(self, user, workspace, *, client_id, code_value):
+        from mcp_server.models.oauth_client import MCPOAuthClient
+        from mcp_server.models.oauth_code import MCPOAuthCode
+        from mcp_server.oauth_utils import hash_client_secret
+        from tfc.middleware.workspace_context import set_workspace_context
+
+        set_workspace_context(
+            workspace=workspace, organization=user.organization, user=user
+        )
+        client = MCPOAuthClient.objects.create(
+            client_id=client_id,
+            client_secret_hash=hash_client_secret("test-secret"),
+            name="Test Client",
+            redirect_uris=["https://example.com/callback"],
+        )
+        MCPOAuthCode.objects.create(
+            code=code_value,
+            client=client,
+            user=user,
+            organization=user.organization,
+            workspace=workspace,
+            redirect_uri="https://example.com/callback",
+            scope=["evaluations"],
+        )
+        return client
+
+    def _exchange(self, code_value, client_id):
+        from rest_framework.test import APIClient
+
+        return APIClient().post(
+            "/mcp/oauth/token/",
+            {
+                "grant_type": "authorization_code",
+                "code": code_value,
+                "client_id": client_id,
+                "client_secret": "test-secret",
+                "redirect_uri": "https://example.com/callback",
+            },
+            format="json",
+        )
+
+    def test_valid_code_exchange_succeeds(self, user, workspace):
+        """Regression guard: the happy path still mints tokens."""
+        self._setup_code(user, workspace, client_id="cc-1", code_value="code-ok")
+
+        response = self._exchange("code-ok", "cc-1")
+
+        assert response.status_code == 200
+        assert response.data["access_token"]
+        assert response.data["refresh_token"]
+        assert response.data["token_type"] == "Bearer"
+
+    def test_reused_code_is_rejected(self, user, workspace):
+        """Replaying a consumed code must fail with invalid_grant."""
+        self._setup_code(user, workspace, client_id="cc-2", code_value="code-replay")
+
+        first = self._exchange("code-replay", "cc-2")
+        assert first.status_code == 200
+
+        second = self._exchange("code-replay", "cc-2")
+        assert second.status_code == 400
+        assert second.data["error"] == "invalid_grant"
+
+    def test_concurrent_claim_yields_single_winner(self, user, workspace):
+        """Simulate two simultaneous exchanges: the atomic compare-and-swap
+        lets exactly one flip used False->True. The second claim affects 0 rows,
+        which is what drives the invalid_grant response in the view."""
+        from mcp_server.models.oauth_code import MCPOAuthCode
+
+        self._setup_code(user, workspace, client_id="cc-3", code_value="code-race")
+        code = MCPOAuthCode.objects.get(code="code-race")
+
+        first_claim = MCPOAuthCode.objects.filter(pk=code.pk, used=False).update(
+            used=True
+        )
+        second_claim = MCPOAuthCode.objects.filter(pk=code.pk, used=False).update(
+            used=True
+        )
+
+        assert first_claim == 1
+        assert second_claim == 0

--- a/futureagi/mcp_server/views/oauth.py
+++ b/futureagi/mcp_server/views/oauth.py
@@ -320,9 +320,28 @@ class MCPOAuthTokenView(APIView):
                 status=400,
             )
 
-        # Mark code as used
-        auth_code.used = True
-        auth_code.save(update_fields=["used"])
+        # Atomically claim the code before minting tokens. Django compiles this to a
+        # single `UPDATE ... SET used=true WHERE pk=? AND used=false`, so exactly one
+        # of two concurrent exchanges can flip the flag; `.update()` returns the number
+        # of rows it changed. Without this compare-and-swap, two requests could both
+        # pass the `used=False` read above and each mint a valid token (code replay).
+        claimed = MCPOAuthCode.objects.filter(pk=auth_code.pk, used=False).update(
+            used=True
+        )
+        if not claimed:
+            # Lost the race — another exchange consumed this code first.
+            logger.warning(
+                "oauth_code_replay_rejected",
+                client_id=client_id,
+                user_id=str(auth_code.user.id),
+            )
+            return Response(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Code already used",
+                },
+                status=400,
+            )
 
         # Generate tokens
         access_token, expires_at = generate_oauth_token(


### PR DESCRIPTION
## Summary

OAuth authorization codes are single-use bearer grants, but the MCP token
endpoint consumed them **non-atomically**: `_handle_authorization_code` reads
the code with `.get(..., used=False)` and only later flips `auth_code.used = True`
with a separate `save()`. Two concurrent `grant_type=authorization_code`
exchanges of the same code can both pass the `used=False` read before either
write lands, so **each request mints a valid access + refresh token** — a code
replay window.

This PR closes the race by claiming the code with an atomic compare-and-swap:
`MCPOAuthCode.objects.filter(pk=..., used=False).update(used=True)` compiles to a
single `UPDATE ... WHERE used=false` and returns the number of rows changed.
Exactly one of two concurrent exchanges gets `1`; the loser gets `0` and receives
`invalid_grant`. Tokens are only minted after a successful claim. No schema
change, no migration, no behavior change on the happy path.

## Linked issues

Closes #1134

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Added `TestAuthorizationCodeConsumption` in
`futureagi/mcp_server/tests/test_oauth.py`:

- `test_valid_code_exchange_succeeds` — regression guard: happy-path exchange
  still returns `200` with access + refresh tokens.
- `test_reused_code_is_rejected` — replaying a consumed code returns `400`
  `invalid_grant`.
- `test_concurrent_claim_yields_single_winner` — simulates two simultaneous
  exchanges: the first atomic claim affects 1 row, the second affects 0 — the
  exact condition that drives the `invalid_grant` response in the view.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] `make check-all` / `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (bot will prompt on first PR)
