### PR TITLE
fix(gateway): send max_completion_tokens to OpenAI and Azure [TH-6810]

### DIFF
--- a/agentcc-gateway/internal/providers/azure/azure.go
+++ b/agentcc-gateway/internal/providers/azure/azure.go
@@ -18,6 +18,14 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 )
 
+const (
+	// defaultAPIVersion is used when the provider config sets no api-version.
+	defaultAPIVersion = "2024-10-21"
+	// minAPIVersionMaxCompletionTokens is the first Azure api-version that accepts
+	// max_completion_tokens. Earlier ones reject it.
+	minAPIVersionMaxCompletionTokens = "2024-09-01"
+)
+
 // Provider implements the Provider interface for Azure OpenAI.
 // Azure uses a different URL format: /openai/deployments/{deployment}/chat/completions?api-version={version}
 type Provider struct {
@@ -49,7 +57,7 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 
 	apiVersion := cfg.Headers["api-version"]
 	if apiVersion == "" {
-		apiVersion = "2024-10-21"
+		apiVersion = defaultAPIVersion
 	}
 
 	transport := &http.Transport{
@@ -117,6 +125,35 @@ func (p *Provider) setAuth(req *http.Request) {
 }
 
 // ChatCompletion sends a non-streaming chat completion request.
+// normalizeMaxTokens rewrites max_tokens to max_completion_tokens, which reasoning
+// deployments require and which Azure rejects alongside max_tokens, so max_tokens
+// is always cleared.
+//
+// Keyed on the api-version rather than the model: Azure routes by deployment name,
+// which the customer chooses freely (the model field in the body is ignored), so a
+// model-name predicate is unreliable here. api-versions before
+// minAPIVersionMaxCompletionTokens reject max_completion_tokens outright and are
+// left untouched.
+//
+// Operates on the caller's copy; the original request is never modified.
+func (p *Provider) normalizeMaxTokens(req *models.ChatCompletionRequest) {
+	if req.MaxTokens == nil || !supportsMaxCompletionTokens(p.apiVersion) {
+		return
+	}
+	if req.MaxCompletionTokens == nil {
+		req.MaxCompletionTokens = req.MaxTokens
+	}
+	req.MaxTokens = nil
+}
+
+// supportsMaxCompletionTokens reports whether an Azure api-version accepts
+// max_completion_tokens. Azure api-versions are date-ordered strings, so a
+// lexicographic compare is sufficient; the newer non-date labels ("preview", "v1")
+// sort above the cutoff, which is correct — they accept it too.
+func supportsMaxCompletionTokens(apiVersion string) bool {
+	return apiVersion >= minAPIVersionMaxCompletionTokens
+}
+
 func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
 	if err := p.acquireSemaphore(ctx); err != nil {
 		return nil, models.ErrGatewayTimeout("provider concurrency limit reached")
@@ -128,6 +165,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletio
 	reqCopy := *req
 	reqCopy.Stream = false
 	// Azure ignores the model field in the body — routing is via URL deployment name.
+	p.normalizeMaxTokens(&reqCopy)
 
 	body, err := json.Marshal(&reqCopy)
 	if err != nil {
@@ -187,6 +225,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *models.ChatCom
 		deployment := resolveDeployment(req.Model)
 		reqCopy := *req
 		reqCopy.Stream = true
+		p.normalizeMaxTokens(&reqCopy)
 
 		body, err := json.Marshal(&reqCopy)
 		if err != nil {

--- a/agentcc-gateway/internal/providers/azure/azure.go
+++ b/agentcc-gateway/internal/providers/azure/azure.go
@@ -124,7 +124,6 @@ func (p *Provider) setAuth(req *http.Request) {
 	}
 }
 
-// ChatCompletion sends a non-streaming chat completion request.
 // normalizeMaxTokens rewrites max_tokens to max_completion_tokens, which reasoning
 // deployments require and which Azure rejects alongside max_tokens, so max_tokens
 // is always cleared.
@@ -154,6 +153,7 @@ func supportsMaxCompletionTokens(apiVersion string) bool {
 	return apiVersion >= minAPIVersionMaxCompletionTokens
 }
 
+// ChatCompletion sends a non-streaming chat completion request.
 func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletionRequest) (*models.ChatCompletionResponse, error) {
 	if err := p.acquireSemaphore(ctx); err != nil {
 		return nil, models.ErrGatewayTimeout("provider concurrency limit reached")

--- a/agentcc-gateway/internal/providers/azure/azure_test.go
+++ b/agentcc-gateway/internal/providers/azure/azure_test.go
@@ -1374,3 +1374,134 @@ func TestClose(t *testing.T) {
 		t.Errorf("Close() returned error: %v", err)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────
+// max_tokens → max_completion_tokens normalization
+// ─────────────────────────────────────────────────────────────
+
+func TestSupportsMaxCompletionTokens(t *testing.T) {
+	tests := []struct {
+		apiVersion string
+		want       bool
+	}{
+		{"2024-10-21", true},  // current default
+		{"2024-09-01", true},  // first supporting version
+		{"2025-01-01-preview", true},
+		{"preview", true}, // newer non-date labels sort above the cutoff
+		{"v1", true},
+		{"2024-08-01-preview", false}, // predates support
+		{"2024-06-01", false},
+		{"2023-05-15", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := supportsMaxCompletionTokens(tt.apiVersion); got != tt.want {
+			t.Errorf("supportsMaxCompletionTokens(%q) = %v, want %v", tt.apiVersion, got, tt.want)
+		}
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func TestNormalizeMaxTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		req        models.ChatCompletionRequest
+		wantMCT    any // nil = key absent from the marshaled body
+		wantMax    any
+	}{
+		{
+			// Deployment names are customer-chosen, so this is model-agnostic.
+			name:       "supported api-version rewrites max_tokens",
+			apiVersion: "2024-10-21",
+			req:        models.ChatCompletionRequest{Model: "my-o3-deployment", MaxTokens: intPtr(64)},
+			wantMCT:    float64(64),
+			wantMax:    nil,
+		},
+		{
+			name:       "both set keeps max_completion_tokens and drops max_tokens",
+			apiVersion: "2024-10-21",
+			req:        models.ChatCompletionRequest{Model: "d", MaxTokens: intPtr(64), MaxCompletionTokens: intPtr(128)},
+			wantMCT:    float64(128),
+			wantMax:    nil,
+		},
+		{
+			// Older api-versions reject max_completion_tokens outright.
+			name:       "unsupported api-version passes max_tokens through untouched",
+			apiVersion: "2024-06-01",
+			req:        models.ChatCompletionRequest{Model: "d", MaxTokens: intPtr(64)},
+			wantMCT:    nil,
+			wantMax:    float64(64),
+		},
+		{
+			name:       "neither set adds neither",
+			apiVersion: "2024-10-21",
+			req:        models.ChatCompletionRequest{Model: "d"},
+			wantMCT:    nil,
+			wantMax:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		for _, streaming := range []bool{false, true} {
+			name := tt.name
+			if streaming {
+				name += " (streaming)"
+			}
+			t.Run(name, func(t *testing.T) {
+				var got map[string]any
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+						t.Errorf("decoding request body: %v", err)
+					}
+					if streaming {
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = w.Write([]byte("data: [DONE]\n\n"))
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(models.ChatCompletionResponse{ID: "chatcmpl-1"})
+				}))
+				defer ts.Close()
+
+				p := newTestProvider(t, ts.URL)
+				p.apiVersion = tt.apiVersion
+
+				req := tt.req
+				req.Messages = []models.Message{{Role: "user", Content: json.RawMessage(`"hi"`)}}
+
+				if streaming {
+					chunks, errs := p.StreamChatCompletion(context.Background(), &req)
+					for chunks != nil || errs != nil {
+						select {
+						case _, ok := <-chunks:
+							if !ok {
+								chunks = nil
+							}
+						case _, ok := <-errs:
+							if !ok {
+								errs = nil
+							}
+						}
+					}
+				} else if _, err := p.ChatCompletion(context.Background(), &req); err != nil {
+					t.Fatalf("ChatCompletion() error: %v", err)
+				}
+
+				if got["max_completion_tokens"] != tt.wantMCT {
+					t.Errorf("max_completion_tokens = %v, want %v", got["max_completion_tokens"], tt.wantMCT)
+				}
+				if got["max_tokens"] != tt.wantMax {
+					t.Errorf("max_tokens = %v, want %v", got["max_tokens"], tt.wantMax)
+				}
+
+				// The caller's request must survive untouched — the cache plugin
+				// hashes it, so mutating it would poison cache keys.
+				if tt.req.MaxTokens != nil && req.MaxTokens == nil {
+					t.Error("caller's request was mutated: MaxTokens cleared")
+				}
+			})
+		}
+	}
+}

--- a/agentcc-gateway/internal/providers/azure/azure_test.go
+++ b/agentcc-gateway/internal/providers/azure/azure_test.go
@@ -1384,8 +1384,8 @@ func TestSupportsMaxCompletionTokens(t *testing.T) {
 		apiVersion string
 		want       bool
 	}{
-		{"2024-10-21", true},  // current default
-		{"2024-09-01", true},  // first supporting version
+		{"2024-10-21", true}, // current default
+		{"2024-09-01", true}, // first supporting version
 		{"2025-01-01-preview", true},
 		{"preview", true}, // newer non-date labels sort above the cutoff
 		{"v1", true},

--- a/agentcc-gateway/internal/providers/openai/openai.go
+++ b/agentcc-gateway/internal/providers/openai/openai.go
@@ -26,6 +26,23 @@ type Provider struct {
 	apiKey     string
 	httpClient *http.Client
 	semaphore  chan struct{}
+	// openAIAPI reports whether baseURL points at the official OpenAI API, whose
+	// max_tokens/max_completion_tokens handling differs from other OpenAI-format
+	// upstreams. See normalizeMaxTokens.
+	openAIAPI bool
+}
+
+// officialAPIHost is the host of the official OpenAI API. Other upstreams speak
+// the same wire format but not the same parameter contract.
+const officialAPIHost = "api.openai.com"
+
+// isOfficialAPI reports whether baseURL points at the official OpenAI API.
+func isOfficialAPI(baseURL string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	return u.Hostname() == officialAPIHost
 }
 
 // New creates a new OpenAI-compatible provider.
@@ -65,7 +82,30 @@ func New(id string, cfg config.ProviderConfig) (*Provider, error) {
 			Timeout:   timeout,
 		},
 		semaphore: make(chan struct{}, maxConcurrent),
+		openAIAPI: isOfficialAPI(cfg.BaseURL),
 	}, nil
+}
+
+// normalizeMaxTokens rewrites max_tokens to max_completion_tokens for the official
+// OpenAI API, which rejects max_tokens on reasoning models but accepts
+// max_completion_tokens on every chat model. Setting both is also rejected, so
+// max_tokens is always cleared.
+//
+// Deliberately keyed on the upstream, not the model name: the set of models that
+// reject max_tokens keeps growing, while "the official API accepts
+// max_completion_tokens" has held for every model. Other OpenAI-format upstreams
+// (vLLM, Ollama, and other self-hosted servers) are left untouched — several only
+// understand max_tokens.
+//
+// Operates on the caller's copy; the original request is never modified.
+func (p *Provider) normalizeMaxTokens(req *models.ChatCompletionRequest) {
+	if !p.openAIAPI || req.MaxTokens == nil {
+		return
+	}
+	if req.MaxCompletionTokens == nil {
+		req.MaxCompletionTokens = req.MaxTokens
+	}
+	req.MaxTokens = nil
 }
 
 // endpoint builds a full upstream URL for a versioned path like "/v1/ocr".
@@ -209,6 +249,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *models.ChatCompletio
 	reqCopy := *req
 	reqCopy.Model = actualModel
 	reqCopy.Stream = false
+	p.normalizeMaxTokens(&reqCopy)
 
 	body, err := json.Marshal(&reqCopy)
 	if err != nil {
@@ -270,6 +311,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *models.ChatCom
 		reqCopy := *req
 		reqCopy.Model = actualModel
 		reqCopy.Stream = true
+		p.normalizeMaxTokens(&reqCopy)
 
 		body, err := json.Marshal(&reqCopy)
 		if err != nil {

--- a/agentcc-gateway/internal/providers/openai/openai.go
+++ b/agentcc-gateway/internal/providers/openai/openai.go
@@ -42,7 +42,7 @@ func isOfficialAPI(baseURL string) bool {
 	if err != nil {
 		return false
 	}
-	return u.Hostname() == officialAPIHost
+	return strings.EqualFold(u.Hostname(), officialAPIHost)
 }
 
 // New creates a new OpenAI-compatible provider.

--- a/agentcc-gateway/internal/providers/openai/openai_test.go
+++ b/agentcc-gateway/internal/providers/openai/openai_test.go
@@ -1240,3 +1240,147 @@ func TestNewProvider_TrailingSlashStripped(t *testing.T) {
 		t.Errorf("baseURL = %q, want no trailing slash", p.baseURL)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────
+// max_tokens → max_completion_tokens normalization
+// ─────────────────────────────────────────────────────────────
+
+func TestIsOfficialAPI(t *testing.T) {
+	tests := []struct {
+		baseURL string
+		want    bool
+	}{
+		{"https://api.openai.com", true},
+		{"https://api.openai.com/v1", true},
+		{"http://localhost:8000/v1", false},
+		{"https://my-vllm.internal/v1", false},
+		{"https://example.azure.com/openai", false},
+		{"https://api.openai.com.evil.test/v1", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isOfficialAPI(tt.baseURL); got != tt.want {
+			t.Errorf("isOfficialAPI(%q) = %v, want %v", tt.baseURL, got, tt.want)
+		}
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+// captureBody starts a server that records the raw JSON body it receives.
+func captureBody(t *testing.T, got *map[string]any, sse bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		if sse {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(models.ChatCompletionResponse{ID: "chatcmpl-1", Model: "m"})
+	}))
+}
+
+func TestNormalizeMaxTokens(t *testing.T) {
+	tests := []struct {
+		name        string
+		officialAPI bool
+		req         models.ChatCompletionRequest
+		wantMCT     any  // expected max_completion_tokens (nil = key absent)
+		wantMax     any  // expected max_tokens (nil = key absent)
+	}{
+		{
+			name:        "official API rewrites max_tokens",
+			officialAPI: true,
+			req:         models.ChatCompletionRequest{Model: "gpt-5.4", MaxTokens: intPtr(64)},
+			wantMCT:     float64(64),
+			wantMax:     nil,
+		},
+		{
+			// Model-agnostic by design: every official-API model accepts
+			// max_completion_tokens, so non-reasoning models are rewritten too.
+			name:        "official API rewrites for non-reasoning models too",
+			officialAPI: true,
+			req:         models.ChatCompletionRequest{Model: "gpt-4o", MaxTokens: intPtr(64)},
+			wantMCT:     float64(64),
+			wantMax:     nil,
+		},
+		{
+			// Both set is a 400 upstream; the client's explicit value wins.
+			name:        "both set keeps max_completion_tokens and drops max_tokens",
+			officialAPI: true,
+			req:         models.ChatCompletionRequest{Model: "gpt-5.4", MaxTokens: intPtr(64), MaxCompletionTokens: intPtr(128)},
+			wantMCT:     float64(128),
+			wantMax:     nil,
+		},
+		{
+			name:        "official API with neither set adds neither",
+			officialAPI: true,
+			req:         models.ChatCompletionRequest{Model: "gpt-5.4"},
+			wantMCT:     nil,
+			wantMax:     nil,
+		},
+		{
+			// vLLM/Ollama and friends only understand max_tokens.
+			name:        "non-official upstream passes max_tokens through untouched",
+			officialAPI: false,
+			req:         models.ChatCompletionRequest{Model: "gpt-5.4", MaxTokens: intPtr(64)},
+			wantMCT:     nil,
+			wantMax:     float64(64),
+		},
+	}
+
+	for _, tt := range tests {
+		for _, streaming := range []bool{false, true} {
+			name := tt.name
+			if streaming {
+				name += " (streaming)"
+			}
+			t.Run(name, func(t *testing.T) {
+				var got map[string]any
+				ts := captureBody(t, &got, streaming)
+				defer ts.Close()
+
+				p := newTestProvider(t, ts.URL)
+				p.openAIAPI = tt.officialAPI
+
+				req := tt.req
+				req.Messages = []models.Message{{Role: "user", Content: json.RawMessage(`"hi"`)}}
+
+				if streaming {
+					chunks, errs := p.StreamChatCompletion(context.Background(), &req)
+					for chunks != nil || errs != nil {
+						select {
+						case _, ok := <-chunks:
+							if !ok {
+								chunks = nil
+							}
+						case _, ok := <-errs:
+							if !ok {
+								errs = nil
+							}
+						}
+					}
+				} else if _, err := p.ChatCompletion(context.Background(), &req); err != nil {
+					t.Fatalf("ChatCompletion() error: %v", err)
+				}
+
+				if got["max_completion_tokens"] != tt.wantMCT {
+					t.Errorf("max_completion_tokens = %v, want %v", got["max_completion_tokens"], tt.wantMCT)
+				}
+				if got["max_tokens"] != tt.wantMax {
+					t.Errorf("max_tokens = %v, want %v", got["max_tokens"], tt.wantMax)
+				}
+
+				// The caller's request must survive untouched — the cache plugin
+				// hashes it, so mutating it would poison cache keys.
+				if tt.req.MaxTokens != nil && req.MaxTokens == nil {
+					t.Error("caller's request was mutated: MaxTokens cleared")
+				}
+			})
+		}
+	}
+}

--- a/agentcc-gateway/internal/providers/openai/openai_test.go
+++ b/agentcc-gateway/internal/providers/openai/openai_test.go
@@ -1289,8 +1289,8 @@ func TestNormalizeMaxTokens(t *testing.T) {
 		name        string
 		officialAPI bool
 		req         models.ChatCompletionRequest
-		wantMCT     any  // expected max_completion_tokens (nil = key absent)
-		wantMax     any  // expected max_tokens (nil = key absent)
+		wantMCT     any // expected max_completion_tokens (nil = key absent)
+		wantMax     any // expected max_tokens (nil = key absent)
 	}{
 		{
 			name:        "official API rewrites max_tokens",


### PR DESCRIPTION
Closes TH-6810. (Re-files TH-4232, which was marked Done on 2026-04-21 with no PR attached — the fix was never written.)

## Problem

GPT-5 and o-series models reject `max_tokens` and require `max_completion_tokens`. **Both** the `openai` and `azure` providers forwarded the request body verbatim — zero references to either field — so every stock OpenAI-compatible client (OpenAI SDK, LangChain, LiteLLM, all of which send `max_tokens` by default) got a 400 on the entire flagship reasoning lineup: `gpt-5`/`5.1`/`5.2`/`5.3`/`5.4` (+ mini/nano), `o1`, `o3`, `o3-mini`, `o4-mini`.

Gemini, Bedrock, Cohere and Anthropic all already normalize. The two providers that needed it were the only ones without it.

## Design: key on the upstream, not the model name

**OpenAI** — gate on the upstream host (`api.openai.com`), then move `max_tokens` → `max_completion_tokens` unconditionally. I verified the premise against the live API rather than assuming it:

| request | result |
|---|---|
| `gpt-5-chat-latest` + `max_completion_tokens` | 200 |
| `gpt-5-search-api` + `max_completion_tokens` | 200 |
| `gpt-4o` + `max_completion_tokens` | 200 |
| `gpt-4o` + **both** fields | **400** `Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.` |

**Every model on the official API accepts `max_completion_tokens`** — including the three that still accept `max_tokens`. So "which models reject `max_tokens`?" never has to be answered: no model list, no upkeep as new families ship. LiteLLM does name-matching ([`gpt_5_transformation.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/openai/chat/gpt_5_transformation.py)) and pays for it with a per-release maintenance treadmill and downstream misclassification bugs; LangChain ([`base.py`](https://github.com/langchain-ai/langchain/blob/master/libs/partners/openai/langchain_openai/chat_models/base.py)) and Bifrost ([`chat.go`](https://github.com/maximhq/bifrost/blob/main/core/providers/openai/chat.go)) rewrite unconditionally for the official API. A name predicate would also misfire on the common self-hosted trick of aliasing a local model to an OpenAI name.

Other OpenAI-format upstreams are deliberately untouched — `api_format: openai` is the documented escape hatch for vLLM / Ollama / LM Studio / self-hosted, and [Ollama only reads `max_tokens`](https://github.com/ollama/ollama/issues/7125), so rewriting there would silently drop the cap.

**Azure** — gate on the configured `api-version` (≥ `2024-09-01`), not the model, because Azure routes by a customer-chosen deployment name and **ignores the model field in the body**, making a name predicate unreliable. `max_completion_tokens` landed in api-version `2024-09-01-preview`; earlier versions reject it outright and are left alone. The default `2024-10-21` supports it.

Why the api-version gate is safe: Azure historically rejected `max_completion_tokens` **per model** (gpt-4 `turbo-2024-04-09` 400'd even on a supporting api-version — see [litellm #8855](https://github.com/BerriAI/litellm/issues/8855)). That hazard is now closed because gpt-4, gpt-4-32k and gpt-35-turbo are **fully retired** ([retirement schedule](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule)); every currently-servable Azure chat model (gpt-4o+, gpt-4.1, gpt-5*, o-series) accepts it.

Since both-set is a 400, `max_tokens` is always cleared — so a client sending both now succeeds instead of 400ing upstream (a latent bug fixed on the way past).

## Safety

Both providers already had a `reqCopy := *req` before marshal; normalization mutates only that copy. The **cache plugin hashes `rc.Request`** (`plugins/cache/plugin.go:282-284`), so mutating the caller's request would poison cache keys. A test asserts the caller's request is unmodified.

## Verification

OpenAI, end-to-end through a locally-built gateway against the **real** OpenAI API:

```
gpt-5.4  + max_tokens             -> 200 "PONG"    (was 400)
gpt-4o   + max_tokens             -> 200 "PONG"    (unchanged)
gpt-5.4  + max_completion_tokens  -> 200           (unchanged)
gpt-4o   + BOTH                   -> 200           (was 400 upstream)
```

Table tests on both providers cover chat + streaming, eligible vs ineligible upstream, both-set, neither-set, and the caller-not-mutated invariant; they assert on the raw wire JSON so key *absence* is genuinely tested. **Confirmed they fail when the fix is disabled** — 12 subtests go red. Full gateway suite green, `go vet` clean.

**Azure is unit-tested only** — there are no Azure credentials available to me, so unlike the OpenAI path it has not been exercised against a live endpoint. Worth a reviewer's eye on the api-version gate.

## Scoped out (deliberate)

- `SubmitBatch` (`openai.go:838-864`) marshals the same struct into batch JSONL and is **not** normalized — same bug class, different path. Ticketed separately rather than widening this PR.
- Pre-existing gofmt drift elsewhere in `openai.go` left alone (no drive-by churn).