### PR TITLE
fix(gateway): always emit a content key on chat completion choices [TH-6812]

### DIFF
--- a/agentcc-gateway/internal/models/response.go
+++ b/agentcc-gateway/internal/models/response.go
@@ -21,6 +21,31 @@ type Choice struct {
 	Logprobs     *json.RawMessage `json:"logprobs,omitempty"`
 }
 
+// MarshalJSON guarantees the assistant message always carries a "content" key.
+//
+// Message.Content is omitempty (it has to be: the same struct is marshaled back
+// out on the request path, where a null content is rejected upstream), so a
+// message with no text drops the key entirely. Providers that translate a
+// non-OpenAI response leave Content unset whenever the model returned no text —
+// a tool-call-only reply, or one where reasoning consumed the whole budget — and
+// clients that expect the OpenAI shape then read a message with no content field
+// at all. Normalizing here rather than in each provider keeps the guarantee in
+// one place; Choice is only ever marshaled on the response path.
+//
+// The value mirrors OpenAI: null when the model called tools, empty string
+// otherwise.
+func (c Choice) MarshalJSON() ([]byte, error) {
+	type Alias Choice
+	if c.Message.Content == nil {
+		if len(c.Message.ToolCalls) > 0 {
+			c.Message.Content = json.RawMessage(`null`)
+		} else {
+			c.Message.Content = json.RawMessage(`""`)
+		}
+	}
+	return json.Marshal((*Alias)(&c))
+}
+
 type Usage struct {
 	PromptTokens            int              `json:"prompt_tokens"`
 	CompletionTokens        int              `json:"completion_tokens"`

--- a/agentcc-gateway/internal/models/response_test.go
+++ b/agentcc-gateway/internal/models/response_test.go
@@ -1,0 +1,122 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// decodeMessage marshals a Choice and returns the raw "message" object, so that
+// the ABSENCE of a key is observable — a typed struct would silently fill it in.
+func decodeMessage(t *testing.T, c Choice) map[string]json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	var choice struct {
+		Message map[string]json.RawMessage `json:"message"`
+	}
+	if err := json.Unmarshal(data, &choice); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	return choice.Message
+}
+
+func TestChoiceMarshalAlwaysEmitsContent(t *testing.T) {
+	toolCall := ToolCall{
+		ID:       "call_0",
+		Type:     "function",
+		Function: FunctionCall{Name: "get_weather", Arguments: `{"city":"SF"}`},
+	}
+
+	tests := []struct {
+		name        string
+		message     Message
+		wantContent string
+	}{
+		{
+			name:        "tool calls only: null, as OpenAI sends",
+			message:     Message{Role: "assistant", ToolCalls: []ToolCall{toolCall}},
+			wantContent: `null`,
+		},
+		{
+			name:        "no text and no tool calls: empty string, as OpenAI sends when reasoning consumed the budget",
+			message:     Message{Role: "assistant", ReasoningContent: "thinking..."},
+			wantContent: `""`,
+		},
+		{
+			name:        "text is passed through untouched",
+			message:     Message{Role: "assistant", Content: json.RawMessage(`"hello"`)},
+			wantContent: `"hello"`,
+		},
+		{
+			name:        "text alongside tool calls is passed through untouched",
+			message:     Message{Role: "assistant", Content: json.RawMessage(`"on it"`), ToolCalls: []ToolCall{toolCall}},
+			wantContent: `"on it"`,
+		},
+		{
+			name:        "explicit null from an upstream that already sent one is preserved",
+			message:     Message{Role: "assistant", Content: json.RawMessage(`null`), ToolCalls: []ToolCall{toolCall}},
+			wantContent: `null`,
+		},
+		{
+			name:        "multipart content is passed through untouched",
+			message:     Message{Role: "assistant", Content: json.RawMessage(`[{"type":"text","text":"hi"}]`)},
+			wantContent: `[{"type":"text","text":"hi"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := decodeMessage(t, Choice{Index: 0, Message: tt.message, FinishReason: "stop"})
+
+			got, ok := msg["content"]
+			if !ok {
+				t.Fatalf("content key absent; OpenAI always emits one")
+			}
+			if string(got) != tt.wantContent {
+				t.Errorf("content = %s, want %s", got, tt.wantContent)
+			}
+		})
+	}
+}
+
+// The caller's Choice must not be mutated: providers hand the same response to
+// the plugin chain (logging, cache) after it is written.
+func TestChoiceMarshalDoesNotMutateCaller(t *testing.T) {
+	c := Choice{
+		Index:        0,
+		Message:      Message{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_0", Type: "function"}}},
+		FinishReason: "tool_calls",
+	}
+
+	if _, err := json.Marshal(c); err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if c.Message.Content != nil {
+		t.Errorf("Content = %s, want nil: marshaling must not mutate the caller's Choice", c.Message.Content)
+	}
+}
+
+// The request path must keep omitting content — a null content on an outbound
+// user message is rejected upstream. This is why the fix lives on Choice and not
+// on Message.
+func TestRequestMessageStillOmitsEmptyContent(t *testing.T) {
+	data, err := json.Marshal(ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_0", Type: "function"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var req struct {
+		Messages []map[string]json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if _, ok := req.Messages[0]["content"]; ok {
+		t.Errorf("request message gained a content key: %s", data)
+	}
+}


### PR DESCRIPTION
## The bug

`Message.Content` is `json.RawMessage` with `omitempty` (`internal/models/request.go:107`). Every provider that **translates** a non-OpenAI response only assigns it when the model returned text, audio or images:

- `providers/gemini/translate.go:682-728`
- `providers/anthropic/translate.go:529-537`
- `providers/bedrock/translate.go:631-640` (and `converse.go:415`)
- `providers/cohere/translate.go:185-190`

When the model returns **no text**, `Content` stays nil and the `content` key **disappears from the response entirely** — not `null`, absent. Clients written against the OpenAI shape read the field unconditionally and break.

Two replies hit this, and the ticket only named the second:

1. **A tool-call-only reply** — the model returns just a tool-use block and no text. This is the *common agentic path*, on four providers.
2. **Reasoning consumed the whole budget** (`finish_reason: "length"`, zero visible text) — the case TH-6812 was filed for.

The OpenAI/Azure passthrough path was never affected: it unmarshals the upstream body, which already carries an explicit `content`.

## The fix

One `MarshalJSON` on `Choice`, mirroring the existing `ChatCompletionRequest.MarshalJSON` idiom (`internal/models/request.go:85`).

**Why `Choice` and not `Message`:** `Message` is shared with the **request** path — `openai`/`azure` re-marshal the inbound request and forward it upstream, where a `null` content on a user message is rejected. `omitempty` has to stay. `Choice` is only ever marshaled on the response path, so the guarantee lives there and cannot leak into an outbound request by construction.

**Why not patch the four providers:** the same change in five places, and the next provider added would reintroduce it. One seam also covers the batch and cached-replay paths for free.

**The value mirrors OpenAI:** `null` when the model called tools, `""` otherwise. These genuinely differ upstream, so both are matched rather than blanket-nulled — verified against the live API below.

## Verification

### Live A/B on the translate path — two providers

Gateway booted from source against **live upstreams**, forced tool call. Only `internal/models/response.go` differs between the two runs (`git checkout origin/dev -- response.go`):

| provider / model | `origin/dev` | this branch |
|---|---|---|
| **Gemini** `gemini-2.5-flash` | `['role', 'tool_calls']` — **content absent** | `['role', 'content', 'tool_calls']` → `null` |
| **Bedrock** `claude-haiku-4-5` (inference profile) | `['role', 'tool_calls']` — **content absent** | `['role', 'content', 'tool_calls']` → present |

### Live regression check on the passthrough path

Real `gpt-4o` through a gateway booted from this branch:

| request | result |
|---|---|
| forced tool call | `"content": null` preserved, `tool_calls: [get_weather]` |
| plain text | `"content": "hello"` unchanged |

### Is `null` the right value?

Live `api.openai.com`, `gpt-4o`, forced tool call returns `content: null` with the key present — matching what this PR emits.

### Unit tests

`internal/models/response_test.go` asserts on the raw JSON object, so key **absence** is observable — a typed struct would silently paper over it. Covers both empty cases, three pass-through cases, non-mutation of the caller's `Choice`, and that the **request** path still omits content.

### Not verified live

- **Anthropic direct** — the available API key has no credit balance (`"Your credit balance is too low"`), so no call could be made. Note the Bedrock run above *is* a Claude model through `providers/bedrock`, so the Anthropic-family translation shape is exercised; `providers/anthropic` itself is not.
- **Cohere** — no API key exists in this repo.
- **All-thoughts / `finish_reason: length`** — thinking is not enabled for the available Gemini key, so this could not be forced against a live model. Covered by unit test and a mock-upstream A/B (key absent on `dev` → `""` on this branch).

Full gateway suite green; `go vet` clean on the touched package (pre-existing warnings elsewhere left untouched, as is the pre-existing `gofmt` drift in `StreamChunk`).

Closes TH-6812.