### PR TITLE
fix(develop-dataset): import normalize_search_for_name in eval-list search branch

### DIFF
--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7100,6 +7100,7 @@ class GetEvalsListView(APIView):
         )
 
         if search_text:
+            from model_hub.utils.eval_list import normalize_search_for_name
             eval_templates = eval_templates.filter(normalize_search_for_name(search_text))
 
         if validated_data.get("eval_tags"):


### PR DESCRIPTION
## Summary

`GetEvalsListView.get` calls `normalize_search_for_name(search_text)` in three branches — the two around the user-eval-list use inline `from model_hub.utils.eval_list import normalize_search_for_name` before the call, but the eval-templates search branch was missing its import. Any request that hit that branch raised `NameError: name 'normalize_search_for_name' is not defined`.

This PR adds the same inline import at the missing site so it mirrors the two adjacent branches.

## Change

Single-line addition in `futureagi/model_hub/views/develop_dataset.py` inside the `GetEvalsListView.get` search-text branch for `eval_templates`.

## Test plan

- [ ] Search evals via `GET /model-hub/develops/get-eval-list/` with a `search` query param and confirm the eval-templates search branch no longer 500s.