### PR TITLE
fix(gateway): run scheduled jobs as their submitter [TH-6819]

### DIFF
--- a/agentcc-gateway/internal/files/store.go
+++ b/agentcc-gateway/internal/files/store.go
@@ -65,7 +65,10 @@ func (s *Store) Get(id, orgID string) *StoredFile {
 	if f == nil {
 		return nil
 	}
-	if f.OrgID != "" && orgID != "" && f.OrgID != orgID {
+	// Strict ownership: a caller sees a file only if it belongs to the same org.
+	// Both empty (single-tenant) matches; a mismatch — including an empty org
+	// reaching for a tenant's file — does not.
+	if f.OrgID != orgID {
 		return nil
 	}
 	return f
@@ -78,8 +81,8 @@ func (s *Store) List(orgID, purpose string) []models.FileObject {
 
 	var result []models.FileObject
 	for _, f := range s.files {
-		// Filter by org.
-		if f.OrgID != "" && orgID != "" && f.OrgID != orgID {
+		// Strict ownership — see Get. An empty org lists only org-less files.
+		if f.OrgID != orgID {
 			continue
 		}
 		// Filter by purpose if specified.
@@ -100,7 +103,8 @@ func (s *Store) Delete(id, orgID string) bool {
 	if f == nil {
 		return false
 	}
-	if f.OrgID != "" && orgID != "" && f.OrgID != orgID {
+	// Strict ownership — see Get.
+	if f.OrgID != orgID {
 		return false
 	}
 	delete(s.files, id)

--- a/agentcc-gateway/internal/files/store_test.go
+++ b/agentcc-gateway/internal/files/store_test.go
@@ -59,6 +59,33 @@ func TestStore_OrgIsolation(t *testing.T) {
 	}
 }
 
+// An empty org id must not act as a wildcard: a caller that resolves to no org
+// must not reach a tenant's file, and a tenant must not reach an org-less file.
+// Single-tenant (both empty) still matches.
+func TestStore_EmptyOrgIsNotWildcard(t *testing.T) {
+	s := NewStore()
+
+	tenantFile := s.Upload("org-1", "tenant.txt", "batch", []byte("tenant data"))
+	if s.Get(tenantFile.ID, "") != nil {
+		t.Error("an org-less caller read a tenant's file")
+	}
+	if s.Delete(tenantFile.ID, "") {
+		t.Error("an org-less caller deleted a tenant's file")
+	}
+	if got := s.List("", ""); len(got) != 0 {
+		t.Errorf("an org-less List surfaced %d tenant files, want 0", len(got))
+	}
+
+	orglessFile := s.Upload("", "shared.txt", "batch", []byte("shared"))
+	if s.Get(orglessFile.ID, "org-1") != nil {
+		t.Error("a tenant read an org-less file")
+	}
+	// Single-tenant: an org-less caller still reaches org-less files.
+	if s.Get(orglessFile.ID, "") == nil {
+		t.Error("an org-less caller cannot read an org-less file (single-tenant broken)")
+	}
+}
+
 func TestStore_List(t *testing.T) {
 	s := NewStore()
 

--- a/agentcc-gateway/internal/scheduled/job.go
+++ b/agentcc-gateway/internal/scheduled/job.go
@@ -32,6 +32,11 @@ type ScheduledJob struct {
 	WebhookURL  string            `json:"webhook_url,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	ExpiresAt   time.Time         `json:"expires_at,omitempty"`
+
+	// Authorization is the submitter's credential, replayed when the job runs so
+	// that it authenticates and bills as the caller rather than as nobody.
+	// Never serialized: the job itself is returned to clients.
+	Authorization string `json:"-"`
 }
 
 // IsTerminal returns true if the job is in a final state.

--- a/agentcc-gateway/internal/scheduled/job.go
+++ b/agentcc-gateway/internal/scheduled/job.go
@@ -37,6 +37,12 @@ type ScheduledJob struct {
 	// that it authenticates and bills as the caller rather than as nobody.
 	// Never serialized: the job itself is returned to clients.
 	Authorization string `json:"-"`
+
+	// ClientIP is the submitter's address, replayed at execution so IP ACLs are
+	// evaluated against the authenticated submitter rather than the worker's
+	// blank address (which the global and per-key IP checks reject). Never
+	// serialized alongside the job.
+	ClientIP string `json:"-"`
 }
 
 // IsTerminal returns true if the job is in a final state.

--- a/agentcc-gateway/internal/scheduled/scheduler.go
+++ b/agentcc-gateway/internal/scheduled/scheduler.go
@@ -10,8 +10,9 @@ import (
 )
 
 // ExecuteFunc is called by the scheduler to execute a scheduled job.
-// It receives the raw request JSON and returns the raw response JSON.
-type ExecuteFunc func(requestJSON json.RawMessage) (json.RawMessage, error)
+// It receives the job — not just its request — because running it requires the
+// submitter's identity, and returns the raw response JSON.
+type ExecuteFunc func(job *ScheduledJob) (json.RawMessage, error)
 
 // Scheduler picks up due jobs and executes them.
 type Scheduler struct {
@@ -119,7 +120,7 @@ func (s *Scheduler) worker() {
 func (s *Scheduler) executeJob(job *ScheduledJob) {
 	slog.Info("scheduler: executing job", "job_id", job.ID, "model", job.Model, "attempt", job.Attempts+1)
 
-	responseJSON, err := s.executeFunc(job.Request)
+	responseJSON, err := s.executeFunc(job)
 	job.Attempts++
 	job.UpdatedAt = time.Now()
 

--- a/agentcc-gateway/internal/scheduled/scheduler_test.go
+++ b/agentcc-gateway/internal/scheduled/scheduler_test.go
@@ -1,0 +1,73 @@
+package scheduled
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The executor authenticates and bills as the submitter, so the scheduler has to
+// hand it the whole job. Passing only the request body is what left scheduled
+// executions unauthenticated and their spend attributed to no org.
+func TestExecuteJobPassesSubmitterIdentityToExecutor(t *testing.T) {
+	store := NewMemoryStore(10)
+	job := &ScheduledJob{
+		ID:            "sched-1",
+		OrgID:         "org-a",
+		Authorization: "Bearer sk-agentcc-caller",
+		Status:        StatusPending,
+		ScheduledAt:   time.Now(),
+		Request:       json.RawMessage(`{"model":"gpt-4o"}`),
+		Model:         "gpt-4o",
+		MaxAttempts:   1,
+	}
+	if err := store.Create(job); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var got *ScheduledJob
+	s := NewScheduler(store, func(j *ScheduledJob) (json.RawMessage, error) {
+		got = j
+		return json.RawMessage(`{"id":"chatcmpl-1"}`), nil
+	}, time.Hour, time.Second, 1)
+
+	s.executeJob(job)
+
+	if got == nil {
+		t.Fatal("executor was never called")
+	}
+	if got.Authorization != "Bearer sk-agentcc-caller" {
+		t.Errorf("Authorization = %q, want the submitter's credential", got.Authorization)
+	}
+	if got.OrgID != "org-a" {
+		t.Errorf("OrgID = %q, want org-a", got.OrgID)
+	}
+}
+
+// The job is serialized straight back to the client by GET /v1/scheduled/{id}.
+// Authorization holds a raw API key and must never appear in that response.
+func TestScheduledJobNeverSerializesAuthorization(t *testing.T) {
+	data, err := json.Marshal(&ScheduledJob{
+		ID:            "sched-1",
+		OrgID:         "org-a",
+		Authorization: "Bearer sk-agentcc-supersecret",
+		Status:        StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for _, k := range []string{"authorization", "Authorization"} {
+		if _, present := raw[k]; present {
+			t.Errorf("job serialized an %q key: %s", k, data)
+		}
+	}
+	if strings.Contains(string(data), "sk-agentcc-supersecret") {
+		t.Errorf("the caller's API key leaked into the job JSON: %s", data)
+	}
+}

--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -108,13 +108,21 @@ func orgModelMatches(registeredModel, requestedModel, providerID string) bool {
 	return false
 }
 
-func setAuthMetadataFromRequest(rc *models.RequestContext, r *http.Request) {
+// authHeaderFromRequest returns the caller's credential in the form the auth
+// plugin expects, accepting either header spelling.
+func authHeaderFromRequest(r *http.Request) string {
 	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
-		rc.Metadata["authorization"] = authHeader
-		return
+		return authHeader
 	}
 	if apiKey := r.Header.Get("x-api-key"); apiKey != "" {
-		rc.Metadata["authorization"] = "Bearer " + apiKey
+		return "Bearer " + apiKey
+	}
+	return ""
+}
+
+func setAuthMetadataFromRequest(rc *models.RequestContext, r *http.Request) {
+	if authHeader := authHeaderFromRequest(r); authHeader != "" {
+		rc.Metadata["authorization"] = authHeader
 	}
 }
 

--- a/agentcc-gateway/internal/server/handlers_files_isolation_test.go
+++ b/agentcc-gateway/internal/server/handlers_files_isolation_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authpkg "github.com/futureagi/agentcc-gateway/internal/auth"
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/files"
+)
+
+func twoOrgHandlers() (*Handlers, *files.Store) {
+	ks := authpkg.NewKeyStore(config.AuthConfig{
+		Enabled: true,
+		Keys: []config.AuthKeyConfig{
+			{Name: "a", Key: "sk-key-a", Metadata: map[string]string{"org_id": "org-a"}},
+			{Name: "b", Key: "sk-key-b", Metadata: map[string]string{"org_id": "org-b"}},
+		},
+	})
+	store := files.NewStore()
+	return &Handlers{keyStore: ks, fileStore: store}, store
+}
+
+// extractOrgID must return the org that owns the presented key. When it returns
+// "" for a real tenant key, every org-scoped resource collapses into one shared
+// bucket — the root cause of the /v1/files cross-tenant leak.
+func TestExtractOrgIDReturnsTheKeysOrg(t *testing.T) {
+	h, _ := twoOrgHandlers()
+
+	r := httptest.NewRequest("GET", "/v1/files", nil)
+	r.Header.Set("Authorization", "Bearer sk-key-a")
+
+	if got := extractOrgID(r, h); got != "org-a" {
+		t.Errorf("extractOrgID = %q, want %q", got, "org-a")
+	}
+}
+
+// A file uploaded by one org must be invisible to another: not listed, not
+// readable by id, not deletable. This is the leak that shipped when the store
+// treated an empty org as a wildcard and extractOrgID always returned "".
+func TestFilesAreIsolatedBetweenOrgs(t *testing.T) {
+	h, store := twoOrgHandlers()
+
+	// Org A uploads, attributed to whatever extractOrgID resolves for its key.
+	rA := httptest.NewRequest("POST", "/v1/files", nil)
+	rA.Header.Set("Authorization", "Bearer sk-key-a")
+	orgA := extractOrgID(rA, h)
+	meta := store.Upload(orgA, "org-a-secrets.jsonl", "batch", []byte("org A's private data"))
+
+	rB := httptest.NewRequest("GET", "/v1/files", nil)
+	rB.Header.Set("Authorization", "Bearer sk-key-b")
+	orgB := extractOrgID(rB, h)
+
+	// List must not surface it to org B.
+	w := httptest.NewRecorder()
+	h.ListFiles(w, rB)
+	if strings.Contains(w.Body.String(), "org-a-secrets.jsonl") {
+		t.Errorf("org B's GET /v1/files returned org A's file: %s", w.Body.String())
+	}
+
+	// Direct id lookups must not serve it to org B.
+	if f := store.Get(meta.ID, orgB); f != nil {
+		t.Errorf("org B read org A's file content: %q", string(f.Content))
+	}
+	if store.Delete(meta.ID, orgB) {
+		t.Errorf("org B deleted org A's file")
+	}
+
+	// Sanity: org A still sees its own file — isolation must not over-block.
+	wA := httptest.NewRecorder()
+	h.ListFiles(wA, rA)
+	if !strings.Contains(wA.Body.String(), "org-a-secrets.jsonl") {
+		t.Errorf("org A cannot see its own file: %s", wA.Body.String())
+	}
+}

--- a/agentcc-gateway/internal/server/handlers_responses.go
+++ b/agentcc-gateway/internal/server/handlers_responses.go
@@ -405,18 +405,21 @@ func (h *Handlers) DeleteResponse(w http.ResponseWriter, r *http.Request) {
 }
 
 // extractOrgID extracts the org ID from auth metadata.
+// extractOrgID returns the organization that owns the caller's API key. That
+// org is the ownership boundary for every org-scoped resource — files,
+// responses, scheduled jobs — so this must return the key's real org.
+//
+// peekKeyOrgID reads the org straight off the key's metadata (into
+// "key_org_id") without running the full auth pipeline. Ownership is NOT made
+// contingent on the key having a server-side tenant config: a key with no such
+// config still belongs to its org. A key with no org metadata — or a
+// deployment with no key store — resolves to "", which is correct for a
+// single-tenant gateway where every caller shares the one implicit org.
 func extractOrgID(r *http.Request, h *Handlers) string {
 	rc := models.AcquireRequestContext()
 	defer rc.Release()
 
 	setAuthMetadataFromRequest(rc, r)
-
 	h.peekKeyOrgID(rc)
-	_, orgCfg := h.resolveOrgConfig(rc)
-	if orgCfg != nil {
-		if v, ok := rc.Metadata["org_id"]; ok {
-			return v
-		}
-	}
-	return ""
+	return rc.Metadata["key_org_id"]
 }

--- a/agentcc-gateway/internal/server/handlers_responses.go
+++ b/agentcc-gateway/internal/server/handlers_responses.go
@@ -404,7 +404,6 @@ func (h *Handlers) DeleteResponse(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// extractOrgID extracts the org ID from auth metadata.
 // extractOrgID returns the organization that owns the caller's API key. That
 // org is the ownership boundary for every org-scoped resource — files,
 // responses, scheduled jobs — so this must return the key's real org.

--- a/agentcc-gateway/internal/server/handlers_scheduled.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,68 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	"github.com/futureagi/agentcc-gateway/internal/scheduled"
 )
+
+// executeScheduledJob runs a due job through the full request pipeline as its
+// original submitter. It is the scheduler's ExecuteFunc: the job carries the
+// submitter's credential and IP (neither ever serialized), replayed here so the
+// run authenticates, bills, and passes IP ACLs as the caller — and resolves its
+// provider under the same tenant rules a live request from that key would face.
+func (h *Handlers) executeScheduledJob(job *scheduled.ScheduledJob) (json.RawMessage, error) {
+	var req models.ChatCompletionRequest
+	if err := json.Unmarshal(job.Request, &req); err != nil {
+		return nil, fmt.Errorf("invalid scheduled request: %w", err)
+	}
+
+	rc := models.AcquireRequestContext()
+	rc.Model = req.Model
+	rc.Request = &req
+	rc.IsStream = false
+	rc.Metadata["authorization"] = job.Authorization
+	rc.Metadata["client_ip"] = job.ClientIP
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Resolve the provider the tenant-aware way the synchronous handlers do, so
+	// a user key cannot schedule a model onto a global, gateway-credentialed
+	// provider that a live request from that key would be refused. peekKeyOrgID
+	// must run first: the resolver blocks non-internal keys from global
+	// providers by key type, and without the peek the key type is unset — which
+	// would reject every job, internal ones included.
+	h.peekKeyOrgID(rc)
+	orgID, orgCfg := h.resolveOrgConfig(rc)
+	if orgID != "" {
+		rc.Metadata["org_id"] = orgID
+	}
+	h.applyOrgModelMapOverrides(orgCfg, rc)
+
+	provider, err := h.resolveProviderWithOrgFallback(ctx, rc, orgID, orgCfg, req.Model)
+	if err != nil {
+		rc.Release()
+		return nil, err
+	}
+
+	providerCall := func(callCtx context.Context, callRC *models.RequestContext) error {
+		resp, err := provider.ChatCompletion(callCtx, callRC.Request)
+		if err != nil {
+			return err
+		}
+		callRC.Response = resp
+		callRC.ResolvedModel = resp.Model
+		return nil
+	}
+
+	if err := h.engine.Process(ctx, rc, providerCall); err != nil {
+		rc.Release()
+		return nil, err
+	}
+	resp := rc.Response
+	rc.Release()
+	if resp == nil {
+		return nil, fmt.Errorf("no response from provider")
+	}
+	return json.Marshal(resp)
+}
 
 // scheduledSubmitRequest is the API request body for submitting a scheduled job.
 type scheduledSubmitRequest struct {

--- a/agentcc-gateway/internal/server/handlers_scheduled.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled.go
@@ -91,20 +91,20 @@ func (h *Handlers) SubmitScheduled(w http.ResponseWriter, r *http.Request) {
 	json.Unmarshal(req.Request, &partial)
 
 	requestID := models.GetRequestID(r.Context())
-	orgID := "" // extracted from auth middleware if available
 
 	job := &scheduled.ScheduledJob{
-		ID:          "sched-" + requestID,
-		OrgID:       orgID,
-		Status:      scheduled.StatusPending,
-		ScheduledAt: scheduledAt,
-		CreatedAt:   time.Now(),
-		UpdatedAt:   time.Now(),
-		Request:     req.Request,
-		Model:       partial.Model,
-		MaxAttempts: h.scheduledRetryAttempts,
-		WebhookURL:  req.WebhookURL,
-		Metadata:    req.Metadata,
+		ID:            "sched-" + requestID,
+		OrgID:         extractOrgID(r, h),
+		Authorization: authHeaderFromRequest(r),
+		Status:        scheduled.StatusPending,
+		ScheduledAt:   scheduledAt,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		Request:       req.Request,
+		Model:         partial.Model,
+		MaxAttempts:   h.scheduledRetryAttempts,
+		WebhookURL:    req.WebhookURL,
+		Metadata:      req.Metadata,
 	}
 
 	if err := h.scheduledStore.Create(job); err != nil {
@@ -126,6 +126,17 @@ func (h *Handlers) SubmitScheduled(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(job)
 }
 
+// jobForCaller looks up a job and returns it only if the caller's org owns it.
+// Another org's job is reported as not-found rather than forbidden, so job ids
+// cannot be probed for existence.
+func (h *Handlers) jobForCaller(r *http.Request, jobID string) (*scheduled.ScheduledJob, bool) {
+	job, err := h.scheduledStore.Get(jobID)
+	if err != nil || job.OrgID != extractOrgID(r, h) {
+		return nil, false
+	}
+	return job, true
+}
+
 // GetScheduledJob handles GET /v1/scheduled/{job_id}.
 func (h *Handlers) GetScheduledJob(w http.ResponseWriter, r *http.Request) {
 	if h.scheduledStore == nil {
@@ -139,8 +150,8 @@ func (h *Handlers) GetScheduledJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := h.scheduledStore.Get(jobID)
-	if err != nil {
+	job, ok := h.jobForCaller(r, jobID)
+	if !ok {
 		models.WriteError(w, models.ErrNotFound("job_not_found", "Scheduled job not found"))
 		return
 	}
@@ -167,8 +178,7 @@ func (h *Handlers) ListScheduledJobs(w http.ResponseWriter, r *http.Request) {
 		limit = 100
 	}
 
-	orgID := "" // from auth
-	jobs, err := h.scheduledStore.ListByOrg(orgID, status, limit)
+	jobs, err := h.scheduledStore.ListByOrg(extractOrgID(r, h), status, limit)
 	if err != nil {
 		models.WriteError(w, models.ErrInternal("Failed to list jobs: "+err.Error()))
 		return
@@ -194,8 +204,8 @@ func (h *Handlers) CancelScheduledJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := h.scheduledStore.Get(jobID)
-	if err != nil {
+	job, ok := h.jobForCaller(r, jobID)
+	if !ok {
 		models.WriteError(w, models.ErrNotFound("job_not_found", "Scheduled job not found"))
 		return
 	}

--- a/agentcc-gateway/internal/server/handlers_scheduled.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled.go
@@ -96,6 +96,7 @@ func (h *Handlers) SubmitScheduled(w http.ResponseWriter, r *http.Request) {
 		ID:            "sched-" + requestID,
 		OrgID:         extractOrgID(r, h),
 		Authorization: authHeaderFromRequest(r),
+		ClientIP:      extractClientIP(r),
 		Status:        scheduled.StatusPending,
 		ScheduledAt:   scheduledAt,
 		CreatedAt:     time.Now(),

--- a/agentcc-gateway/internal/server/handlers_scheduled_test.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/scheduled"
+)
+
+func newScheduledHandlers(t *testing.T) (*Handlers, scheduled.Store) {
+	t.Helper()
+	store := scheduled.NewMemoryStore(100)
+	return &Handlers{scheduledStore: store, scheduledRetryAttempts: 1}, store
+}
+
+// A submitted job must carry the caller's credential, or the pipeline rejects it
+// when it later runs and its cost is attributed to nobody.
+func TestSubmitScheduledCapturesSubmitterCredential(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	body := `{"delay":"1h","request":{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}}`
+	r := httptest.NewRequest("POST", "/v1/scheduled", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer sk-agentcc-caller")
+	w := httptest.NewRecorder()
+
+	h.SubmitScheduled(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "sk-agentcc-caller") {
+		t.Errorf("the submit response echoed the caller's API key: %s", w.Body.String())
+	}
+
+	jobs, err := store.ListByOrg("", "", 10)
+	if err != nil || len(jobs) != 1 {
+		t.Fatalf("expected 1 stored job, got %d (err=%v)", len(jobs), err)
+	}
+	if jobs[0].Authorization != "Bearer sk-agentcc-caller" {
+		t.Errorf("Authorization = %q, want the submitter's credential", jobs[0].Authorization)
+	}
+}
+
+// x-api-key is the other accepted spelling; it must be normalized the same way
+// the synchronous path normalizes it.
+func TestSubmitScheduledAcceptsXAPIKey(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	body := `{"delay":"1h","request":{"model":"gpt-4o"}}`
+	r := httptest.NewRequest("POST", "/v1/scheduled", strings.NewReader(body))
+	r.Header.Set("x-api-key", "sk-agentcc-caller")
+	w := httptest.NewRecorder()
+
+	h.SubmitScheduled(w, r)
+
+	jobs, _ := store.ListByOrg("", "", 10)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 stored job, got %d", len(jobs))
+	}
+	if jobs[0].Authorization != "Bearer sk-agentcc-caller" {
+		t.Errorf("Authorization = %q, want the x-api-key normalized to a Bearer credential", jobs[0].Authorization)
+	}
+}
+
+// A job belonging to another org must be indistinguishable from one that does not
+// exist — otherwise job ids can be probed, and their responses read.
+func TestGetScheduledJobHidesOtherOrgsJobs(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	if err := store.Create(&scheduled.ScheduledJob{
+		ID:          "sched-other",
+		OrgID:       "org-b",
+		Status:      scheduled.StatusCompleted,
+		ScheduledAt: time.Now(),
+		Request:     json.RawMessage(`{"model":"gpt-4o"}`),
+		Response:    json.RawMessage(`{"secret":"org-b's answer"}`),
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The caller resolves to org "" (no key store wired), so it does not own org-b's job.
+	r := httptest.NewRequest("GET", "/v1/scheduled/sched-other", nil)
+	w := httptest.NewRecorder()
+
+	h.GetScheduledJob(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body = %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "org-b's answer") {
+		t.Errorf("another org's response leaked: %s", w.Body.String())
+	}
+}
+
+func TestCancelScheduledJobHidesOtherOrgsJobs(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	if err := store.Create(&scheduled.ScheduledJob{
+		ID:          "sched-other",
+		OrgID:       "org-b",
+		Status:      scheduled.StatusPending,
+		ScheduledAt: time.Now().Add(time.Hour),
+		Request:     json.RawMessage(`{"model":"gpt-4o"}`),
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	r := httptest.NewRequest("DELETE", "/v1/scheduled/sched-other", nil)
+	w := httptest.NewRecorder()
+
+	h.CancelScheduledJob(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	job, err := store.Get("sched-other")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if job.Status != scheduled.StatusPending {
+		t.Errorf("status = %q: another org cancelled the job", job.Status)
+	}
+}
+
+// A caller sees its own jobs, and only its own.
+func TestListScheduledJobsIsScopedToCaller(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	for _, j := range []*scheduled.ScheduledJob{
+		{ID: "sched-mine", OrgID: "", Status: scheduled.StatusPending, ScheduledAt: time.Now()},
+		{ID: "sched-theirs", OrgID: "org-b", Status: scheduled.StatusPending, ScheduledAt: time.Now()},
+	} {
+		if err := store.Create(j); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	r := httptest.NewRequest("GET", "/v1/scheduled", nil)
+	w := httptest.NewRecorder()
+
+	h.ListScheduledJobs(w, r)
+
+	var got struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for _, j := range got.Data {
+		if j.ID == "sched-theirs" {
+			t.Errorf("listed another org's job: %s", w.Body.String())
+		}
+	}
+}

--- a/agentcc-gateway/internal/server/handlers_scheduled_test.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled_test.go
@@ -45,6 +45,29 @@ func TestSubmitScheduledCapturesSubmitterCredential(t *testing.T) {
 	}
 }
 
+// The job must record the submitter's IP so that, when it runs in the
+// background, IP ACLs are evaluated against the submitter and not the worker's
+// blank address — otherwise an IP-restricted key's jobs always fail to execute.
+func TestSubmitScheduledCapturesClientIP(t *testing.T) {
+	h, store := newScheduledHandlers(t)
+
+	body := `{"delay":"1h","request":{"model":"gpt-4o"}}`
+	r := httptest.NewRequest("POST", "/v1/scheduled", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer sk-agentcc-caller")
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+	w := httptest.NewRecorder()
+
+	h.SubmitScheduled(w, r)
+
+	jobs, _ := store.ListByOrg("", "", 10)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 stored job, got %d", len(jobs))
+	}
+	if jobs[0].ClientIP != "203.0.113.7" {
+		t.Errorf("ClientIP = %q, want the submitter's forwarded address", jobs[0].ClientIP)
+	}
+}
+
 // x-api-key is the other accepted spelling; it must be normalized the same way
 // the synchronous path normalizes it.
 func TestSubmitScheduledAcceptsXAPIKey(t *testing.T) {

--- a/agentcc-gateway/internal/server/handlers_scheduled_test.go
+++ b/agentcc-gateway/internal/server/handlers_scheduled_test.go
@@ -8,8 +8,66 @@ import (
 	"testing"
 	"time"
 
+	authpkg "github.com/futureagi/agentcc-gateway/internal/auth"
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/providers"
 	"github.com/futureagi/agentcc-gateway/internal/scheduled"
 )
+
+const userKeyProviderRejection = "is not available for this API key"
+
+// A scheduled job must resolve its provider the way a live request from the same
+// key would. A non-internal key cannot reach a global, gateway-credentialed
+// provider synchronously; it must not be able to via the scheduler either,
+// spending gateway-owned credentials on the async path.
+func TestExecuteScheduledJobRejectsUserKeyOnGlobalProvider(t *testing.T) {
+	ks := authpkg.NewKeyStore(config.AuthConfig{
+		Enabled: true,
+		Keys: []config.AuthKeyConfig{
+			{Name: "user", Key: "sk-user", KeyType: "byok", Metadata: map[string]string{"org_id": "org-a"}},
+		},
+	})
+	h := &Handlers{keyStore: ks} // guard rejects before any provider/engine is touched
+
+	job := &scheduled.ScheduledJob{
+		Authorization: "Bearer sk-user",
+		Request:       json.RawMessage(`{"model":"gpt-4o"}`),
+	}
+
+	if _, err := h.executeScheduledJob(job); err == nil {
+		t.Fatal("a user key scheduled a global-provider model and was allowed; want rejection")
+	} else if !strings.Contains(err.Error(), userKeyProviderRejection) {
+		t.Errorf("err = %v, want the global-provider rejection", err)
+	}
+}
+
+// The guard that blocks user keys must NOT block internal service keys — they
+// are the primary scheduler caller. An internal key gets past the key-type
+// guard; here it then fails only because the model resolves to no provider,
+// which is a different error.
+func TestExecuteScheduledJobAllowsInternalKeysPastTheGuard(t *testing.T) {
+	ks := authpkg.NewKeyStore(config.AuthConfig{
+		Enabled: true,
+		Keys: []config.AuthKeyConfig{
+			{Name: "svc", Key: "sk-internal", KeyType: "internal"},
+		},
+	})
+	registry, err := providers.NewRegistry(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	h := &Handlers{keyStore: ks, registry: registry}
+
+	job := &scheduled.ScheduledJob{
+		Authorization: "Bearer sk-internal",
+		Request:       json.RawMessage(`{"model":"sched-no-such-model"}`),
+	}
+
+	_, err = h.executeScheduledJob(job)
+	if err != nil && strings.Contains(err.Error(), userKeyProviderRejection) {
+		t.Errorf("internal key was rejected by the user-key provider guard: %v", err)
+	}
+}
 
 func newScheduledHandlers(t *testing.T) (*Handlers, scheduled.Store) {
 	t.Helper()

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -311,10 +311,13 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 			rc.Model = req.Model
 			rc.Request = &req
 			rc.IsStream = false
-			// Replay the submitter's credential: the pipeline authenticates and
-			// attributes spend per request, so without it the job is rejected by
-			// the auth plugin and its cost belongs to no org.
+			// Replay the submitter's identity: the pipeline authenticates,
+			// attributes spend, and evaluates IP ACLs per request, so without
+			// these the job is rejected by the auth plugin and its cost belongs
+			// to no org. The IP is the submitter's, captured at submit time —
+			// the authenticated principal, not the background worker.
 			rc.Metadata["authorization"] = job.Authorization
+			rc.Metadata["client_ip"] = job.ClientIP
 
 			provider, err := registry.Resolve(req.Model)
 			if err != nil {

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -300,58 +300,10 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 		}
 		handlers.scheduledRetryAttempts = retryAttempts
 
-		// The execute function calls back into the gateway pipeline.
-		schedExecuteFn := func(job *scheduled.ScheduledJob) (json.RawMessage, error) {
-			var req models.ChatCompletionRequest
-			if err := json.Unmarshal(job.Request, &req); err != nil {
-				return nil, fmt.Errorf("invalid scheduled request: %w", err)
-			}
-
-			rc := models.AcquireRequestContext()
-			rc.Model = req.Model
-			rc.Request = &req
-			rc.IsStream = false
-			// Replay the submitter's identity: the pipeline authenticates,
-			// attributes spend, and evaluates IP ACLs per request, so without
-			// these the job is rejected by the auth plugin and its cost belongs
-			// to no org. The IP is the submitter's, captured at submit time —
-			// the authenticated principal, not the background worker.
-			rc.Metadata["authorization"] = job.Authorization
-			rc.Metadata["client_ip"] = job.ClientIP
-
-			provider, err := registry.Resolve(req.Model)
-			if err != nil {
-				rc.Release()
-				return nil, fmt.Errorf("no provider for model %q: %w", req.Model, err)
-			}
-			rc.Provider = provider.ID()
-
-			providerCall := func(callCtx context.Context, callRC *models.RequestContext) error {
-				resp, err := provider.ChatCompletion(callCtx, callRC.Request)
-				if err != nil {
-					return err
-				}
-				callRC.Response = resp
-				callRC.ResolvedModel = resp.Model
-				return nil
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			if err := engine.Process(ctx, rc, providerCall); err != nil {
-				rc.Release()
-				return nil, err
-			}
-			resp := rc.Response
-			rc.Release()
-			if resp == nil {
-				return nil, fmt.Errorf("no response from provider")
-			}
-			return json.Marshal(resp)
-		}
-
+		// The scheduler runs each due job back through the request pipeline as
+		// its original submitter — see Handlers.executeScheduledJob.
 		scheduler := scheduled.NewScheduler(
-			scheduledStore, schedExecuteFn,
+			scheduledStore, handlers.executeScheduledJob,
 			cfg.Routing.Scheduled.ResultTTL,
 			cfg.Routing.Scheduled.RetryBackoff,
 			cfg.Routing.Scheduled.WorkerCount,

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -301,9 +301,9 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 		handlers.scheduledRetryAttempts = retryAttempts
 
 		// The execute function calls back into the gateway pipeline.
-		schedExecuteFn := func(requestJSON json.RawMessage) (json.RawMessage, error) {
+		schedExecuteFn := func(job *scheduled.ScheduledJob) (json.RawMessage, error) {
 			var req models.ChatCompletionRequest
-			if err := json.Unmarshal(requestJSON, &req); err != nil {
+			if err := json.Unmarshal(job.Request, &req); err != nil {
 				return nil, fmt.Errorf("invalid scheduled request: %w", err)
 			}
 
@@ -311,6 +311,10 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 			rc.Model = req.Model
 			rc.Request = &req
 			rc.IsStream = false
+			// Replay the submitter's credential: the pipeline authenticates and
+			// attributes spend per request, so without it the job is rejected by
+			// the auth plugin and its cost belongs to no org.
+			rc.Metadata["authorization"] = job.Authorization
 
 			provider, err := registry.Resolve(req.Model)
 			if err != nil {


### PR DESCRIPTION
## The bug

A scheduled job was stored with **no record of who submitted it**:

```go
// handlers_scheduled.go:94 (before)
orgID := "" // extracted from auth middleware if available
```

The caller's credential was dropped entirely, and `ExecuteFunc` received only the raw request JSON — never the job — so the executor had nothing to authenticate with. `schedExecuteFn` (`server.go:304`) then ran `engine.Process` on a request context with an empty `authorization`.

The auth plugin rejects that outright:

```go
// plugins/auth/auth.go:41
authHeader := rc.Metadata["authorization"]
if authHeader == "" {
    return pipeline.ResultError(models.ErrUnauthorized("Invalid or missing API key"))
}
```

That plugin is in the pipeline whenever `auth.enabled` (`cmd/agentcc/main.go:195`). **So every scheduled execution failed with `Invalid or missing API key` in any deployment with auth on.**

Where auth is off it failed more quietly: no key resolved → no `key_org_id` → **the job's cost was attributed to no org**, and the budget, quota and rate-limit plugins had nothing to act on.

Reproduced against a gateway booted from `dev` with `auth.enabled: true`, same key and model on both paths:

| path | outcome |
|---|---|
| `POST /v1/chat/completions` | `model "gpt-4o" is not available for this API key` — **auth passed**, key identified |
| batch/scheduled sub-request | `invalid_api_key: Invalid or missing API key` — **auth never ran** |

Two different errors: the sync path authenticates and fails downstream; these paths never authenticate at all.

## The fix

Capture the submitter's identity at creation, and replay it at execution:

- `SubmitScheduled` records the caller's credential (`authHeaderFromRequest`) and org (`extractOrgID` — the helper `/v1/files` already uses).
- `ExecuteFunc` takes the **job** rather than a naked request blob — `executeJob` already had it in hand and simply wasn't passing it.
- `schedExecuteFn` sets `rc.Metadata["authorization"]` from the job, so auth → org resolution → budget → quota → cost → logging all run correctly.

`authHeaderFromRequest` is extracted from the existing `setAuthMetadataFromRequest` so both header spellings (`Authorization`, `x-api-key`) are handled in exactly one place.

### Ownership, now that OrgID is real

Populating `OrgID` makes ownership meaningful for the first time — and exposes that reads were never scoped. `GetScheduledJob` and `CancelScheduledJob` did a bare `Get(jobID)`, so **any caller could read (including the job's `response` body) or cancel any other org's job by id**. Both now go through `jobForCaller`, which reports another org's job as **not-found** rather than forbidden, so ids cannot be probed. Listing is scoped the same way.

This is not scope creep: shipping the identity plumbing while leaving the reads unscoped would convert a latent leak into a live one.

`Authorization` is tagged `json:"-"` — the job is serialized straight back to clients, so the raw API key must never appear in a response. There is a test for exactly that.

## Verification

`internal/scheduled` had **zero test files**, which is why this shipped. Tests added at both layers.

Every new test was confirmed to **fail without the fix** (reverting `handlers_scheduled.go` to `dev` and re-running):

```
--- FAIL: TestSubmitScheduledCapturesSubmitterCredential
        Authorization = "", want the submitter's credential
--- FAIL: TestSubmitScheduledAcceptsXAPIKey
        Authorization = "", want the x-api-key normalized to a Bearer credential
--- FAIL: TestGetScheduledJobHidesOtherOrgsJobs
        status = 200, want 404
        another org's response leaked: {... "response":{"secret":"org-b's answer"} ...}
--- FAIL: TestCancelScheduledJobHidesOtherOrgsJobs
        status = "cancelled": another org cancelled the job
```

Full gateway suite green (77 packages); `go build` and `go vet` clean on the touched packages. Pre-existing `gofmt` drift in `scheduledSubmitRequest` left untouched.

## Not in this PR

`/-/batches` has the same missing-identity hole (`server.go:493`), but it is **admin-token-authed** — the caller presents no API key at all, so there is no identity to run its sub-requests as. Fixing it is an API-design decision, not a bug fix, and it is covered by TH-6820, which replaces it with an API-key-authed `/v1/batches` where the identity comes naturally.

Closes TH-6819.