### PR TITLE
fix(compose): sync self-host ClickHouse config with ch25 schema requirements

### DIFF
--- a/config/clickhouse/config.xml
+++ b/config/clickhouse/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+  Tiered storage policy for the spans table, matching the backend image's
+  own `.ci/clickhouse-storage-policy.xml` reference config (self-host has
+  no S3, so `cold` is a second local path rather than an S3 disk).
+-->
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <!-- 'default' is already provided by CH at the server's <path>; do not redeclare. -->
+            <cold_local>
+                <path>/var/lib/clickhouse/cold/</path>
+                <keep_free_space_bytes>536870912</keep_free_space_bytes>
+            </cold_local>
+        </disks>
+        <policies>
+            <tiered>
+                <volumes>
+                    <hot>
+                        <disk>default</disk>
+                        <max_data_part_size_bytes>10737418240</max_data_part_size_bytes>
+                    </hot>
+                    <cold>
+                        <disk>cold_local</disk>
+                    </cold>
+                </volumes>
+                <move_factor>0.05</move_factor>
+            </tiered>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,13 @@ x-backend-env: &backend-env
   CH_PASSWORD: ""
   CH_DATABASE: default
   CH_USE_REPLICATED_ENGINES: ${CH_USE_REPLICATED_ENGINES:-false}
+  # Light mode has no PeerDB CDC mirror writing `spans`/friends (those views
+  # are documented as empty until `full` mode is on), so default to dropping
+  # the legacy pre-CH25 tables/columns on boot rather than leaving the v1
+  # shape in place — the ch25 migration can't ALTER v1 into the v2 shape.
+  # If you run `full` mode and rely on the legacy CDC chain, set this to
+  # `false` in .env.
+  CH25_DROP_LEGACY_CDC_CHAIN: ${CH25_DROP_LEGACY_CDC_CHAIN:-true}
 
   # Redis
   REDIS_HOST: redis
@@ -291,12 +298,17 @@ services:
     restart: unless-stopped
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.10.2.80
+    image: clickhouse/clickhouse-server:25.3
+    environment:
+      # App connects as the `default` user with an empty password (CH_USER/CH_PASSWORD
+      # above) — skip the image's default-user lockdown so that account keeps network access.
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
     ports:
       - "127.0.0.1:${CH_HTTP_PORT:-8123}:8123"
       - "127.0.0.1:${CH_PORT:-9000}:9000"
     volumes:
       - clickhouse-data:/var/lib/clickhouse
+      - ./config/clickhouse/config.xml:/etc/clickhouse-server/config.d/custom.xml:ro
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
## Summary

Fixes #1540 — a fresh `git clone` + `./bin/install` crash-loops the `backend`/`worker` containers because `docker-compose.yml` on `main` doesn't provision what the ch25 schema migration (already shipped in `futureagi/future-agi:latest`) requires. Four gaps, fixed here:

- Bump ClickHouse `24.10.2.80` → `25.3` — the v2 spans schema (`002_spans_v2.sql`) needs ClickHouse 25.x's native `JSON` column type.
- Add `CLICKHOUSE_SKIP_USER_SETUP=1` to the `clickhouse` service — the 25.x image otherwise locks the passwordless `default` user to localhost, but the backend connects as that user over the docker network.
- Add `CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}` to the shared backend/worker env — without it, the boot-time schema-ensure hook keeps recreating the old pre-CH25 `spans` shape every start, which the migration's `ALTER TABLE` can't reconcile with the new columns. Defaults `true` for fresh self-host installs; documented that `full`-mode/legacy-CDC users should override to `false`.
- Add `config/clickhouse/config.xml` defining the `tiered` storage policy the v2 schema requires (`storage_policy = 'tiered'`, TTL to `VOLUME 'cold'`) — same shape as the image's own `.ci/clickhouse-storage-policy.xml` reference config, just wired into the self-host compose stack.

## Why now

`main`'s own backend source doesn't contain the `ch25` migration, `002_spans_v2.sql`, or any storage-policy config at all — this is a compose-level sync fix for a schema that's already live in the published image, not new functionality. Cross-checked against `upstream/dev` (~1,900 commits ahead of `main`), which already carries the same `CLICKHOUSE_SKIP_USER_SETUP` and `CH25_DROP_LEGACY_CDC_CHAIN` defaults and the same storage-policy shape — so this brings `main`'s compose file in line with a decision the team already made elsewhere, rather than introducing a new one.

## Test plan

- [x] Fresh `docker compose down -v` + `docker compose up -d` from this branch
- [x] `docker compose logs backend` shows migrations completing, including `CH25 v2 schema apply complete`
- [x] `curl localhost:8000/health/` → `200 {"status":true,"result":"Server is up and running"}`
- [x] Frontend loads at `localhost:3000`
- [x] Verified removing an unrelated leftover ClickHouse `users.xml` override (`allow_experimental_json_type`, needed on 24.x but a no-op default on 25.3 per `system.settings`) still passes all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)