### PR TITLE
fix(auth): OAuth login honors returnTo instead of falling back to falcon (TH-6817)

### DIFF
--- a/frontend/src/auth/guard/auth-guard.jsx
+++ b/frontend/src/auth/guard/auth-guard.jsx
@@ -76,6 +76,7 @@ function Container({ children }) {
         const isRelativePath =
           returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//");
         if (isRelativePath) {
+          localStorage.setItem("initial-render", "done");
           localStorage.removeItem("redirectUrl");
           window.location.href = returnTo;
         } else {


### PR DESCRIPTION
## Summary
OAuth login (Google / GitHub / SSO) was ignoring the `returnTo` redirect and always landing the user on `/dashboard/falcon-ai`. This fixes it so OAuth honors `returnTo`, matching the credentials and passkey flows.

## Why / problem
Clicking **Open my work** while signed out sets a `returnTo`, but after signing in via OAuth the Falcon URL overwrites it.

Root cause:
- The credentials and passkey flows set `localStorage["initial-render"] = "done"` when a `returnTo` is present (`jwt-login-view.jsx:242`, `:369`). That flag suppresses AuthGuard's fallback first-render redirect, so the user lands on `returnTo`.
- The OAuth flow round-trips through the provider and comes back to `AuthGuard.check()`, which navigates to `returnTo` via `window.location.href` and clears `redirectUrl` — but it **never sets `initial-render = "done"`**.
- After that full page reload and `user` hydration, the first-render effect (`auth-guard.jsx:190-202`) sees `initial-render` still unset and runs `router.replace(postLoginPath)`. Since `redirectUrl` was already cleared, `usePostLoginPath()` resolves to `paths.dashboard.falconAI` (`/dashboard/falcon-ai`), clobbering the intended `returnTo`.

## What changed
- `frontend/src/auth/guard/auth-guard.jsx`: in the OAuth token-handling branch of `check()`, set `localStorage.setItem("initial-render", "done")` when honoring a valid relative `returnTo`, mirroring the credentials/passkey flows. This suppresses the fallback redirect so OAuth lands on `returnTo`.

This single guard change covers both OAuth login and OAuth register, since both entry points return through the same `AuthGuard.check()`.

## Tests
- [ ] OAuth (Google/GitHub) from a URL carrying `returnTo` → lands on `returnTo`, not falcon.
- [ ] Credentials login with `returnTo` → still lands on `returnTo` (unchanged).
- [ ] OAuth without `returnTo` → still lands on the normal post-login path (falcon / get-started).
- [ ] New OAuth signup without `returnTo` → still routes through org-setup / get-started.

## Commands
- `yarn lint` (frontend)

## Backwards compatibility
No API or contract changes. Behavior only changes for the OAuth-with-`returnTo` case, which was broken; all other flows are unchanged.

## Manual verification
- [ ] Sign out, click **Open my work**, sign in with Google → verify you land on the work URL, not `/dashboard/falcon-ai`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Self-reviewed the change
- [x] No lint errors introduced
- [ ] Manually verified the OAuth returnTo flow

## Backout
Revert this commit — restores prior behavior (OAuth ignores `returnTo`).

## Linear
Closes TH-6817
