### PR TITLE
fix: sync eval prompt required keys

### DIFF
--- a/futureagi/model_hub/services/eval_version_pinning.py
+++ b/futureagi/model_hub/services/eval_version_pinning.py
@@ -7,6 +7,7 @@ so the view stays thin.
 import json
 
 from model_hub.models.evals_metric import EvalTemplateVersion
+from model_hub.utils.eval_prompt_variables import sync_required_keys_from_prompt
 from model_hub.utils.prompt_migration import config_to_prompt_messages
 
 
@@ -31,6 +32,7 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
     req_config = request_data.get("config") or {}
     inner_config = req_config.get("config", {})
     run_config = req_config.get("run_config", {})
+    mapping = req_config.get("mapping") or (eval_metric.config or {}).get("mapping", {})
     resolved_model = (
         request_data.get("model") or eval_metric.model
         or tpl.model or ""
@@ -52,6 +54,8 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
     criteria = rule_prompt or tpl.criteria or ""
     if rule_prompt:
         snap["messages"] = [{"role": "system", "content": rule_prompt}]
+
+    sync_required_keys_from_prompt(snap, mapping=mapping)
 
     # Dedup: skip if the full canonical snapshot matches the pinned version.
     # Sorting keys ensures stable comparison regardless of insertion order.

--- a/futureagi/model_hub/tests/test_eval_versioning.py
+++ b/futureagi/model_hub/tests/test_eval_versioning.py
@@ -1848,6 +1848,49 @@ class TestMaybePinNewVersion:
             f"config has {config_rule_prompt!r} but snapshot has {snapshot_rule_prompt!r}"
         )
 
+    def test_prompt_edit_syncs_required_keys_from_mapping(
+        self, organization, workspace, user, user_template
+    ):
+        """A drawer edit that adds {{order_json}} must snapshot it as an input."""
+        from model_hub.services.eval_version_pinning import maybe_pin_new_version
+
+        user_template.config = {
+            "eval_type_id": "AgentEvaluator",
+            "output": "Pass/Fail",
+            "custom_eval": True,
+            "required_keys": ["json"],
+            "rule_prompt": "{{json}}",
+        }
+        user_template.save()
+        uem = self._make_uem(organization, workspace, user, user_template)
+
+        maybe_pin_new_version(
+            uem,
+            {
+                "config": {
+                    "config": {
+                        "eval_type_id": "AgentEvaluator",
+                        "custom_eval": True,
+                        "required_keys": ["json"],
+                        "rule_prompt": "{{json}}\n\n{{order_json}}",
+                    },
+                    "mapping": {
+                        "json": "json-col",
+                        "order_json": "order-col",
+                    },
+                }
+            },
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        assert uem.pinned_version is not None
+        assert uem.pinned_version.config_snapshot["required_keys"] == [
+            "json",
+            "order_json",
+        ]
+
     def test_version_switch_with_no_config_change_keeps_selected_version(
         self, organization, workspace, user, user_template
     ):
@@ -1878,3 +1921,70 @@ class TestMaybePinNewVersion:
         assert uem.pinned_version_id == v1.id, "Switching back to v1 with same config should keep v1 pinned"
         version_count = EvalTemplateVersion.objects.filter(eval_template=user_template).count()
         assert version_count == 2, f"No new version should be created, found {version_count}"
+
+    def test_runner_map_fields_uses_pinned_snapshot_required_keys(
+        self, organization, workspace, user, user_template
+    ):
+        """Dataset runs must recover mapped prompt variables from stale versions.
+
+        Regression for the drawer edit path: usage logs received the new input
+        value, but the evaluator got stale required_keys from EvalTemplate.config
+        and left the new placeholder unresolved.
+        """
+        from model_hub.views.eval_runner import EvaluationRunner
+
+        user_template.config = {
+            "eval_type_id": "AgentEvaluator",
+            "output": "Pass/Fail",
+            "custom_eval": True,
+            "required_keys": ["json"],
+            "rule_prompt": "{{json}}\n\n{{order_json}}",
+        }
+        user_template.save()
+
+        version = EvalTemplateVersion.objects.create_version(
+            eval_template=user_template,
+            criteria="{{json}}\n\n{{order_json}}",
+            model="turing_large",
+            config_snapshot={
+                "eval_type_id": "AgentEvaluator",
+                "output": "Pass/Fail",
+                "custom_eval": True,
+                "required_keys": ["json"],
+                "rule_prompt": "{{json}}\n\n{{order_json}}",
+            },
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        uem = self._make_uem(
+            organization,
+            workspace,
+            user,
+            user_template,
+            config={"mapping": {"json": "json-col", "order_json": "order-col"}},
+        )
+        uem.pinned_version = version
+        uem.save()
+
+        runner = object.__new__(EvaluationRunner)
+        runner.eval_template = user_template
+        runner.user_eval_metric = uem
+        runner.user_eval_metric_id = str(uem.id)
+        runner.futureagi_eval = False
+        runner.organization_id = organization.id
+        runner.workspace_id = workspace.id
+        runner.criteria = None
+        runner._resolved_version = version
+        runner.get_few_shot_examples = lambda mapping, required_field=None: []
+
+        mapped = runner.map_fields(
+            required_field=["json", "order_json"],
+            mapping=['{"id": 1, "name": "Alice"}', '{"order_id": 10}'],
+            config={},
+        )
+
+        assert mapped["json"] == '{"id": 1, "name": "Alice"}'
+        assert mapped["order_json"] == '{"order_id": 10}'
+        assert mapped["required_keys"] == ["json", "order_json"]
+        assert mapped["optional_keys"] == ["json", "order_json"]

--- a/futureagi/model_hub/utils/eval_prompt_variables.py
+++ b/futureagi/model_hub/utils/eval_prompt_variables.py
@@ -1,0 +1,73 @@
+"""Helpers for keeping custom-eval prompt variables and required_keys aligned."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from model_hub.utils.jinja_variables import extract_jinja_variables
+
+
+def extract_eval_prompt_variables(config: dict | None) -> list[str]:
+    """Extract input variables referenced by eval prompt fields."""
+    if not isinstance(config, dict):
+        return []
+
+    texts: list[str] = []
+    for key in ("rule_prompt", "system_prompt", "criteria"):
+        value = config.get(key)
+        if isinstance(value, str) and value:
+            texts.append(value)
+
+    messages = config.get("messages") or []
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and content:
+                texts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        texts.append(part["text"])
+
+    variables: list[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        for variable in extract_jinja_variables(text):
+            if variable not in seen:
+                seen.add(variable)
+                variables.append(variable)
+
+    return variables
+
+
+def sync_required_keys_from_prompt(
+    config: dict | None,
+    mapping: dict | None = None,
+    extra_allowed_keys: Iterable[str] | None = None,
+) -> dict | None:
+    """Add mapped prompt variables to config.required_keys in place."""
+    if not isinstance(config, dict):
+        return config
+
+    prompt_variables = extract_eval_prompt_variables(config)
+    if not prompt_variables:
+        return config
+
+    allowed_keys = set(mapping or {})
+    if extra_allowed_keys:
+        allowed_keys.update(str(key) for key in extra_allowed_keys if key is not None)
+
+    required_keys = list(config.get("required_keys") or config.get("requiredKeys") or [])
+    seen = set(required_keys)
+    for variable in prompt_variables:
+        if variable in seen:
+            continue
+        if allowed_keys and variable not in allowed_keys:
+            continue
+        required_keys.append(variable)
+        seen.add(variable)
+
+    config["required_keys"] = required_keys
+    return config

--- a/futureagi/model_hub/utils/eval_prompt_variables.py
+++ b/futureagi/model_hub/utils/eval_prompt_variables.py
@@ -47,7 +47,17 @@ def sync_required_keys_from_prompt(
     mapping: dict | None = None,
     extra_allowed_keys: Iterable[str] | None = None,
 ) -> dict | None:
-    """Add mapped prompt variables to config.required_keys in place."""
+    """Add mapped prompt variables to config.required_keys in place.
+
+    Filter semantics: when either `mapping` or `extra_allowed_keys` is
+    provided, prompt variables are only added if they appear in the
+    combined allowed set. When both are None/empty, the filter is
+    intentionally skipped and **every** prompt variable is promoted —
+    this is the "allow-all" mode used by the write-side helper that
+    trusts its caller to have already vetted the prompt. Callers that
+    want strict filtering must pass a non-empty mapping/extras set;
+    callers that want lax mode should pass nothing.
+    """
     if not isinstance(config, dict):
         return config
 
@@ -58,13 +68,16 @@ def sync_required_keys_from_prompt(
     allowed_keys = set(mapping or {})
     if extra_allowed_keys:
         allowed_keys.update(str(key) for key in extra_allowed_keys if key is not None)
+    # Empty allowed_keys → allow-all (documented above). Explicit local so
+    # the branch below reads intentionally instead of as a short-circuit.
+    filter_by_allowed = bool(allowed_keys)
 
     required_keys = list(config.get("required_keys") or config.get("requiredKeys") or [])
     seen = set(required_keys)
     for variable in prompt_variables:
         if variable in seen:
             continue
-        if allowed_keys and variable not in allowed_keys:
+        if filter_by_allowed and variable not in allowed_keys:
             continue
         required_keys.append(variable)
         seen.add(variable)

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7995,13 +7995,25 @@ class EditAndRunUserEvalView(APIView):
                     new_config = normalize_eval_runtime_config(
                         eval_metric.template.config, new_config
                     )
+                    from model_hub.utils.eval_prompt_variables import (
+                        sync_required_keys_from_prompt,
+                    )
+
+                    sync_required_keys_from_prompt(
+                        new_config.get("config"),
+                        mapping=new_config.get("mapping", {}),
+                    )
                     from model_hub.utils.eval_validators import (
                         get_required_mapping_keys_for_template,
                         validate_required_key_mapping,
                     )
+                    required_mapping_keys = (
+                        new_config.get("config", {}).get("required_keys")
+                        or get_required_mapping_keys_for_template(eval_metric.template)
+                    )
                     missing_keys = validate_required_key_mapping(
                         new_config.get("mapping", {}),
-                        get_required_mapping_keys_for_template(eval_metric.template),
+                        required_mapping_keys,
                     )
                     if missing_keys:
                         return self._gm.bad_request(

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -3,6 +3,7 @@ import json
 import re
 import traceback
 import uuid
+from types import SimpleNamespace
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
@@ -848,6 +849,13 @@ class EvaluationRunner:
         self.workspace_id = workspace_id
         self.version_number = version_number
         self._resolved_version = None
+        # Memoized effective config (template_config + snapshot overlay).
+        # Populated on first _get_effective_eval_config() call and reused
+        # for the rest of the run since neither eval_template nor the
+        # resolved version change per row. Invalidated in map_fields when
+        # a caller passes an explicit `eval_template` arg.
+        self._effective_config_cache: dict | None = None
+        self._effective_config_cache_key: tuple | None = None
         if not format_output:
             self._initialize_eval_metric()
 
@@ -931,7 +939,25 @@ class EvaluationRunner:
         self.user_eval_metric.save(update_fields=["status"])
 
     def _get_effective_eval_config(self):
-        """Return template config with the resolved version snapshot applied."""
+        """Return template config with the resolved version snapshot applied.
+
+        The overlay covers only the config *dict* — model-level attributes
+        (`choice_scores`, `choices`, `criteria`, `multi_choice`) are still
+        read from the live `self.eval_template`. Callers that need those
+        should not assume this fully represents the pinned version.
+
+        Memoized on `self` — invariant across rows within a single run,
+        invalidated automatically when `self.eval_template` or
+        `self._resolved_version` identity changes.
+        """
+        cache_key = (id(getattr(self, "eval_template", None)),
+                     id(getattr(self, "_resolved_version", None)))
+        if (
+            self._effective_config_cache is not None
+            and self._effective_config_cache_key == cache_key
+        ):
+            return self._effective_config_cache
+
         template_config = getattr(self.eval_template, "config", None) or {}
         effective_config = (
             dict(template_config) if isinstance(template_config, dict) else {}
@@ -965,6 +991,12 @@ class EvaluationRunner:
         if isinstance(snapshot, dict):
             effective_config.update(snapshot)
 
+        # Refresh the cache key in case _resolved_version got populated above.
+        self._effective_config_cache_key = (
+            id(getattr(self, "eval_template", None)),
+            id(getattr(self, "_resolved_version", None)),
+        )
+        self._effective_config_cache = effective_config
         return effective_config
 
     def _get_column_config(self, dataset):
@@ -1580,6 +1612,9 @@ class EvaluationRunner:
         input_required_field = list(required_field or [])
         if eval_template:
             self.eval_template = eval_template
+            # Invalidate memoized effective config — caller swapped the template.
+            self._effective_config_cache = None
+            self._effective_config_cache_key = None
 
             if not self.organization_id and eval_template.organization:
                 self.organization_id = eval_template.organization.id
@@ -1782,8 +1817,11 @@ class EvaluationRunner:
                 "Invalid UserEvalMetric ID or EvalTemplate does not exist."
             )
 
-        # Fetch the eval class from the eval_type_id in the config
-        eval_type_id = self.eval_template.config.get("eval_type_id")
+        # Fetch the eval class from the eval_type_id in the config — read
+        # through the overlay so a pinned version that snapshots a different
+        # eval_type_id (rare, but possible for user templates) resolves to
+        # the correct class instead of the live template's.
+        eval_type_id = self._get_effective_eval_config().get("eval_type_id")
         from evaluations.engine.registry import get_eval_class
 
         self.eval_class = get_eval_class(eval_type_id)
@@ -1930,7 +1968,7 @@ class EvaluationRunner:
             if isinstance(data, dict):
                 value = "Passed" if not result_data.get("failure") else "Failed"
             elif (
-                self.eval_template.config.get("eval_type_id")
+                self._get_effective_eval_config().get("eval_type_id")
                 == "DeterministicEvaluator"
             ):
                 if not self.eval_template.multi_choice:
@@ -2153,11 +2191,8 @@ class EvaluationRunner:
 
         validation_template = self.eval_template
         if effective_config != (getattr(self.eval_template, "config", None) or {}):
-            validation_template = type(
-                "EffectiveEvalTemplate",
-                (),
-                {"config": effective_config},
-            )()
+            # Confirmed validate_eval_inputs only reads `.config`.
+            validation_template = SimpleNamespace(config=effective_config)
 
         partial_input_warning, _normalized_values = validate_eval_inputs(
             validation_template,
@@ -2295,7 +2330,7 @@ class EvaluationRunner:
             row,
             self.replace_column_id,
             self.column.id,
-            self.eval_template.config.get("run_prompt_column", False),
+            self._get_effective_eval_config().get("run_prompt_column", False),
             runner=self,
             eval_template_name=self.eval_template.name,
         )

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -68,6 +68,7 @@ from model_hub.serializers.eval_runner import (
     EvalTemplateSerializer,
     EvalUserTemplateSerializer,
 )
+from model_hub.utils.eval_prompt_variables import sync_required_keys_from_prompt
 from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 from model_hub.utils.evals import prepare_user_eval_config  # noqa: E402
 from model_hub.utils.json_path_resolver import (  # noqa: E402
@@ -929,6 +930,43 @@ class EvaluationRunner:
         self.user_eval_metric.status = StatusType.RUNNING.value
         self.user_eval_metric.save(update_fields=["status"])
 
+    def _get_effective_eval_config(self):
+        """Return template config with the resolved version snapshot applied."""
+        template_config = getattr(self.eval_template, "config", None) or {}
+        effective_config = (
+            dict(template_config) if isinstance(template_config, dict) else {}
+        )
+
+        resolved_version = getattr(self, "_resolved_version", None)
+        if (
+            resolved_version is None
+            and getattr(self, "version_number", None) is not None
+            and getattr(self, "eval_template", None) is not None
+        ):
+            try:
+                resolved_version = EvalTemplateVersion.objects.filter(
+                    eval_template=self.eval_template,
+                    version_number=self.version_number,
+                    deleted=False,
+                ).first()
+                self._resolved_version = resolved_version
+            except Exception:
+                logger.warning(
+                    "effective_config_version_resolution_failed",
+                    path="eval_runner",
+                    eval_template_id=str(getattr(self.eval_template, "id", "")),
+                    version_number=self.version_number,
+                    exc_info=True,
+                )
+        if resolved_version is None and getattr(self, "user_eval_metric", None):
+            resolved_version = getattr(self.user_eval_metric, "pinned_version", None)
+
+        snapshot = getattr(resolved_version, "config_snapshot", None)
+        if isinstance(snapshot, dict):
+            effective_config.update(snapshot)
+
+        return effective_config
+
     def _get_column_config(self, dataset):
         """Get column configuration based on eval type"""
         logger.info(
@@ -1515,7 +1553,8 @@ class EvaluationRunner:
         if not self.user_eval_metric or not self.eval_template:
             return [], {}
 
-        run_prompt_column = self.eval_template.config.get("run_prompt_column", False)
+        effective_config = self._get_effective_eval_config()
+        run_prompt_column = effective_config.get("run_prompt_column", False)
         mappings = self.user_eval_metric.config.get("mapping")
 
         col_ids = list(mappings.values())
@@ -1530,7 +1569,7 @@ class EvaluationRunner:
                 final_required_field.append(col_ids[key])
             if run_prompt_column:
                 break
-        if self.eval_template.config.get("eval_type_id") == "DeterministicEvaluator":
+        if effective_config.get("eval_type_id") == "DeterministicEvaluator":
             return final_required_field, final_mapping
 
         return final_required_field, final_mapping
@@ -1538,6 +1577,7 @@ class EvaluationRunner:
     def map_fields(
         self, required_field, mapping, eval_template=None, config=None, bypass=False
     ):
+        input_required_field = list(required_field or [])
         if eval_template:
             self.eval_template = eval_template
 
@@ -1546,6 +1586,8 @@ class EvaluationRunner:
                 self.workspace_id = (
                     eval_template.workspace.id if eval_template.workspace else None
                 )
+
+        effective_config = self._get_effective_eval_config()
 
         if self.eval_template and self.futureagi_eval:
             if bypass:
@@ -1596,26 +1638,29 @@ class EvaluationRunner:
             mapping.append(self.eval_template.name)
 
             required_field.append("required_keys")
+            runtime_eval_config = (
+                config if bypass and isinstance(config, dict) else effective_config
+            )
             if bypass:
-                mapping.append(config.get("required_keys"))
+                mapping.append(runtime_eval_config.get("required_keys"))
             else:
-                mapping.append(self.eval_template.config.get("required_keys"))
+                mapping.append(effective_config.get("required_keys"))
 
             # Pass param_modalities for validation
-            if "param_modalities" in self.eval_template.config:
+            if "param_modalities" in runtime_eval_config:
                 required_field.append("param_modalities")
-                mapping.append(self.eval_template.config.get("param_modalities"))
+                mapping.append(runtime_eval_config.get("param_modalities"))
 
             # Pass parameter descriptions so deterministic evaluator can provide
             # explicit variable-to-key context to the model.
-            if "config_params_desc" in self.eval_template.config:
+            if "config_params_desc" in runtime_eval_config:
                 required_field.append("config_params_desc")
                 if bypass:
-                    mapping.append(config.get("config_params_desc", {}))
+                    mapping.append(runtime_eval_config.get("config_params_desc", {}))
                 else:
-                    mapping.append(self.eval_template.config.get("config_params_desc"))
+                    mapping.append(effective_config.get("config_params_desc"))
 
-        if self.eval_template.config.get("eval_type_id") in (
+        if effective_config.get("eval_type_id") in (
             "CustomPromptEvaluator",
             "AgentEvaluator",
         ):
@@ -1639,9 +1684,17 @@ class EvaluationRunner:
                 required_field.append("few_shots")
                 mapping.append(few_shot_examples)
 
-            template_required_keys = (
-                self.eval_template.config.get("required_keys") or []
-            )
+            template_required_keys = list(effective_config.get("required_keys") or [])
+            if getattr(self.eval_template, "owner", None) == OwnerChoices.USER.value:
+                runtime_key_config = {"required_keys": template_required_keys}
+                for key in ("rule_prompt", "system_prompt", "criteria", "messages"):
+                    if key in effective_config:
+                        runtime_key_config[key] = effective_config[key]
+                sync_required_keys_from_prompt(
+                    runtime_key_config,
+                    extra_allowed_keys=input_required_field,
+                )
+                template_required_keys = runtime_key_config.get("required_keys") or []
             required_field.append("required_keys")
             mapping.append(template_required_keys)
 
@@ -1659,7 +1712,7 @@ class EvaluationRunner:
                 getattr(self.eval_template, "owner", None) == OwnerChoices.SYSTEM.value
             )
             if is_system_eval:
-                declared_optional = self.eval_template.config.get("optional_keys")
+                declared_optional = effective_config.get("optional_keys")
                 if declared_optional is not None:
                     required_field.append("optional_keys")
                     mapping.append(declared_optional)
@@ -1692,9 +1745,10 @@ class EvaluationRunner:
                     self.dataset.workspace.id if self.dataset.workspace else None
                 )
 
+            effective_config = self._get_effective_eval_config()
             self.futureagi_eval = (
                 True
-                if self.eval_template.config.get("eval_type_id") in FUTUREAGI_EVAL_TYPES
+                if effective_config.get("eval_type_id") in FUTUREAGI_EVAL_TYPES
                 else False
             )
             logger.info(
@@ -1995,6 +2049,7 @@ class EvaluationRunner:
         """Run one evaluation for a single row with input validation."""
         # Build ordered inputs from mapping keys and row values.
         required_field, mapping = self._prepare_mapping_data(row, mappings)
+        effective_config = self._get_effective_eval_config()
         config_copy = config.copy()
         kb_id = (
             str(self.user_eval_metric.kb_id)
@@ -2038,10 +2093,10 @@ class EvaluationRunner:
         required_keys = []
         optional_keys = []
         is_user_custom_eval = False
-        if getattr(self.eval_template, "config", None):
-            required_keys = self.eval_template.config.get("required_keys", [])
-            optional_keys = self.eval_template.config.get("optional_keys", [])
-            is_user_custom_eval = self.eval_template.config.get("custom_eval", False)
+        if effective_config:
+            required_keys = effective_config.get("required_keys", [])
+            optional_keys = effective_config.get("optional_keys", [])
+            is_user_custom_eval = effective_config.get("custom_eval", False)
 
         # Emptiness rules live in the shared validator so dataset,
         # playground, tracing, and SDK paths apply the same logic.
@@ -2096,8 +2151,16 @@ class EvaluationRunner:
                 if key not in values_for_validation:
                     values_for_validation[key] = None
 
+        validation_template = self.eval_template
+        if effective_config != (getattr(self.eval_template, "config", None) or {}):
+            validation_template = type(
+                "EffectiveEvalTemplate",
+                (),
+                {"config": effective_config},
+            )()
+
         partial_input_warning, _normalized_values = validate_eval_inputs(
-            self.eval_template,
+            validation_template,
             values_for_validation,
             mapped_keys=mapped_keys_for_validation,
         )
@@ -2114,11 +2177,7 @@ class EvaluationRunner:
 
         # Validate param modalities for function evals (deterministic evals
         # validate inside their own _validate_param_modalities).
-        param_modalities = (
-            self.eval_template.config.get("param_modalities", {})
-            if getattr(self.eval_template, "config", None)
-            else {}
-        )
+        param_modalities = effective_config.get("param_modalities", {})
         if param_modalities and not self.futureagi_eval:
             for key in required_keys:
                 if key not in param_modalities or key not in required_field:
@@ -2193,7 +2252,7 @@ class EvaluationRunner:
                 "data_injection", {}
             ) or _uem_cfg.get("data_injection", {})
         if not _di_raw and self.eval_template:
-            _di_raw = self.eval_template.config.get("data_injection", {})
+            _di_raw = effective_config.get("data_injection", {})
         _di = _di_normalize(_di_raw)
 
         if _di["full_row"] and "row_context" not in _mapped:
@@ -2391,7 +2450,7 @@ class EvaluationRunner:
         if eval_class:
             self.eval_class = eval_class
         elif not self.eval_class:
-            eval_type_id = self.eval_template.config.get("eval_type_id", "")
+            eval_type_id = self._get_effective_eval_config().get("eval_type_id", "")
             self.eval_class = get_eval_class(eval_type_id)
 
         if runtime_config is None and self.user_eval_metric:
@@ -2418,7 +2477,8 @@ class EvaluationRunner:
 
     def _prepare_eval_config(self, config, model=ModelChoices.TURING_LARGE.value):
         """Prepare evaluation configuration"""
-        eval_type_id = self.eval_template.config.get("eval_type_id")
+        effective_config = self._get_effective_eval_config()
+        eval_type_id = effective_config.get("eval_type_id")
 
         if eval_type_id == "CustomCodeEval":
             # Code evals only need the code string — strip everything else.
@@ -2426,15 +2486,15 @@ class EvaluationRunner:
             # update via the API, criteria holds the LLM-prompt text, not
             # Python code, which would produce a silent "skip" result.
             config = {
-                "code": self.eval_template.config.get("code") or config.get("code", ""),
+                "code": effective_config.get("code") or config.get("code", ""),
             }
             return config
 
         if eval_type_id == "AgentEvaluator":
             # Agent eval — uses Falcon AI AgentLoop for multi-turn reasoning
-            config["rule_prompt"] = self.eval_template.config.get("rule_prompt")
-            config["model"] = model or self.eval_template.config.get("model")
-            raw_output = self.eval_template.config.get("output")
+            config["rule_prompt"] = effective_config.get("rule_prompt")
+            config["model"] = model or effective_config.get("model")
+            raw_output = effective_config.get("output")
             if self.eval_template.choice_scores and raw_output != "Pass/Fail":
                 config["output_type"] = "choices"
             else:
@@ -2454,19 +2514,13 @@ class EvaluationRunner:
                 else 0.5
             )
             config["reverse_output"] = bool(
-                self.eval_template.config.get("reverse_output", False)
+                effective_config.get("reverse_output", False)
             )
-            config["check_internet"] = self.eval_template.config.get(
-                "check_internet", False
-            )
-            config["knowledge_base_id"] = self.eval_template.config.get(
-                "knowledge_base_id"
-            )
-            config["agent_mode"] = self.eval_template.config.get("agent_mode", "agent")
-            config["tools"] = self.eval_template.config.get("tools", {})
-            config["knowledge_bases"] = self.eval_template.config.get(
-                "knowledge_bases", []
-            )
+            config["check_internet"] = effective_config.get("check_internet", False)
+            config["knowledge_base_id"] = effective_config.get("knowledge_base_id")
+            config["agent_mode"] = effective_config.get("agent_mode", "agent")
+            config["tools"] = effective_config.get("tools", {})
+            config["knowledge_bases"] = effective_config.get("knowledge_bases", [])
             # data_injection: prefer user's eval metric config (run_config),
             # fall back to the base template config. Normalize to canonical
             # snake_case flags so downstream code never has to re-handle aliases.
@@ -2476,11 +2530,9 @@ class EvaluationRunner:
                     "data_injection", {}
                 ) or self.user_eval_metric.config.get("data_injection", {})
             config["data_injection"] = _di_normalize(
-                _uem_di or self.eval_template.config.get("data_injection", {})
+                _uem_di or effective_config.get("data_injection", {})
             )
-            config["summary"] = self.eval_template.config.get(
-                "summary", {"type": "concise"}
-            )
+            config["summary"] = effective_config.get("summary", {"type": "concise"})
             # Pass org/workspace context for tool resolution
             config["organization_id"] = (
                 str(self.eval_template.organization.id)
@@ -2494,25 +2546,23 @@ class EvaluationRunner:
             )
 
         elif eval_type_id == "CustomPromptEvaluator":
-            config["provider"] = self.eval_template.config.get("provider")
-            config["rule_prompt"] = self.eval_template.config.get("rule_prompt")
-            config["system_prompt"] = self.eval_template.config.get("system_prompt")
+            config["provider"] = effective_config.get("provider")
+            config["rule_prompt"] = effective_config.get("rule_prompt")
+            config["system_prompt"] = effective_config.get("system_prompt")
             # If choice_scores are defined, force choices mode
-            raw_output = self.eval_template.config.get("output")
+            raw_output = effective_config.get("output")
             if self.eval_template.choice_scores and raw_output != "Pass/Fail":
                 config["output_type"] = "choices"
             else:
                 config["output_type"] = raw_output
             # Multi-message and few-shot support
-            if self.eval_template.config.get("messages"):
-                config["messages"] = self.eval_template.config.get("messages")
-            if self.eval_template.config.get("few_shot_examples"):
-                config["few_shot_examples"] = self.eval_template.config.get(
-                    "few_shot_examples"
-                )
+            if effective_config.get("messages"):
+                config["messages"] = effective_config.get("messages")
+            if effective_config.get("few_shot_examples"):
+                config["few_shot_examples"] = effective_config.get("few_shot_examples")
 
             # Resolve model — prefer runtime model over stored config
-            raw_model = model or self.eval_template.config.get("model")
+            raw_model = model or effective_config.get("model")
             futureagi_models = {
                 ModelChoices.TURING_LARGE.value,
                 ModelChoices.TURING_SMALL.value,
@@ -2531,10 +2581,8 @@ class EvaluationRunner:
                 )
 
             # Pass agent config flags to evaluator
-            config["check_internet"] = self.eval_template.config.get(
-                "check_internet", False
-            )
-            config["multi_choice"] = self.eval_template.config.get("multi_choice")
+            config["check_internet"] = effective_config.get("check_internet", False)
+            config["multi_choice"] = effective_config.get("multi_choice")
             # Derive choices from choice_scores if not set on template
             config["choices"] = self.eval_template.choices or (
                 list(self.eval_template.choice_scores.keys())
@@ -2572,6 +2620,7 @@ class EvaluationRunner:
 
     def _prepare_futureagi_config(self, config, model=ModelChoices.TURING_LARGE.value):
         """Prepare configuration for FutureAGI evaluation"""
+        effective_config = self._get_effective_eval_config()
         config["api_key"] = None
         if self.user_eval_metric:
             config["knowledge_base_id"] = (
@@ -2588,26 +2637,21 @@ class EvaluationRunner:
 
         if (
             self.eval_template
-            and self.eval_template.config.get("eval_type_id")
-            == "DeterministicEvaluator"
+            and effective_config.get("eval_type_id") == "DeterministicEvaluator"
         ):
             if "rule_prompt" not in config:
                 config["choices"] = self.eval_template.choices
                 config["rule_prompt"] = self.eval_template.criteria
                 config["multi_choice"] = self.eval_template.multi_choice
-                config["custom_eval"] = self.eval_template.config.get(
-                    "custom_eval", False
-                )
+                config["custom_eval"] = effective_config.get("custom_eval", False)
 
             config["model_type"] = model
 
             # Pass param_modalities and required_keys for validation
-            if "param_modalities" in self.eval_template.config:
-                config["param_modalities"] = self.eval_template.config[
-                    "param_modalities"
-                ]
-            if "required_keys" in self.eval_template.config:
-                config["required_keys"] = self.eval_template.config["required_keys"]
+            if "param_modalities" in effective_config:
+                config["param_modalities"] = effective_config["param_modalities"]
+            if "required_keys" in effective_config:
+                config["required_keys"] = effective_config["required_keys"]
 
         if config.get("criteria"):
             self.criteria = config.pop("criteria")


### PR DESCRIPTION
## Summary

Fixes the custom-eval versioning bug where dataset drawer edits could add a new prompt variable and mapping, but leave `required_keys` stale in the saved config/version snapshot. In that state, usage logs correctly recorded the new input value, but the actual `AgentEvaluator` prompt renderer only rendered the old key set and passed an unresolved placeholder such as `{{order_json}}` to the evaluator.

**What this PR ships:**

1. **Prompt-variable sync helper for custom eval configs.** `model_hub.utils.eval_prompt_variables` extracts Jinja variables from `rule_prompt`, `system_prompt`, `criteria`, and chat `messages`, then syncs mapped/allowed prompt variables into `config.required_keys` while preserving existing order.

2. **Dataset drawer save path now persists corrected `required_keys`.** `EditAndRunUserEvalView` normalizes the incoming runtime config, syncs prompt variables against the submitted mapping, and validates against the corrected required key list before saving `UserEvalMetric.config`.

3. **Version creation snapshots corrected `required_keys`.** `maybe_pin_new_version` now derives the active mapping from the request or existing metric config and syncs prompt variables into the snapshot before dedup/version creation. New versions created from drawer edits now store prompt, mapping, and `required_keys` in lockstep.

4. **Runner-side recovery for already-stale versions.** `EvaluationRunner` reads an effective config by overlaying the resolved pinned version snapshot over the live template config, then recovers user-owned `AgentEvaluator` / `CustomPromptEvaluator` prompt variables at runtime when the row input already contains that key. This keeps historical broken snapshots runnable without a risky DB rewrite.

5. **Regression coverage for both failure modes.** Tests cover the drawer/version creation path that previously snapshotted `required_keys=["json"]` despite a prompt containing `{{order_json}}`, and the runner path that must recover stale pinned snapshots so placeholders are rendered before evaluator execution.

**What this PR deliberately does NOT do:**

- **No data migration/backfill.** New saves and new versions are corrected in DB going forward; existing stale snapshots are made safe at runtime. A backfill can still be added later as cleanup, but it is not required to stop evaluation failures.
- **No frontend changes.** The drawer can keep sending the same shape; backend save/version/runtime paths now enforce the invariant.
- **No mapping contract change.** Column-to-variable mapping remains unchanged. The fix is only about keeping `required_keys` aligned with prompt variables that already have mapped values.

## Changes

**Backend** (4 files):

| File | Change |
| --- | --- |
| `model_hub/utils/eval_prompt_variables.py` *(new)* | Extracts prompt variables from eval prompt fields/messages and syncs mapped/allowed variables into `required_keys`. |
| `model_hub/services/eval_version_pinning.py` | Syncs prompt variables into the version snapshot before dedup and `EvalTemplateVersion` creation. |
| `model_hub/views/develop_dataset.py` | Syncs normalized drawer config before mapping validation and before saving `UserEvalMetric.config`. |
| `model_hub/views/eval_runner.py` | Uses resolved version snapshots as effective runtime config and recovers stale user-eval `required_keys` from prompt variables plus incoming row keys. |

**Tests** (1 file):

| File | Change |
| --- | --- |
| `model_hub/tests/test_eval_versioning.py` | Adds regression tests for drawer-version snapshot sync and runner recovery from stale pinned snapshots. |

## Linked Issues

Closes TH-6835.

Related to #1319 follow-up validation of eval usage/versioned custom eval execution.

## Type of Change

- [x] 🐛 Bug fix

## How This Was Tested


###Before:


https://github.com/user-attachments/assets/ebda1bf5-fdb3-4387-814c-3642cbf7b2d9



###After :


https://github.com/user-attachments/assets/28ee6a42-c2ba-4df9-8312-0e9734d29849



### Static checks

```text
$ git diff --check
# passed with no output
```

```text
$ python3 -m py_compile futureagi/model_hub/views/eval_runner.py futureagi/model_hub/views/develop_dataset.py futureagi/model_hub/services/eval_version_pinning.py futureagi/model_hub/utils/eval_prompt_variables.py futureagi/model_hub/tests/test_eval_versioning.py
# passed with no output
```

### Targeted regression tests

```text
$ docker exec backend python -m pytest model_hub/tests/test_eval_versioning.py -k "prompt_edit_syncs_required_keys_from_mapping or runner_map_fields_uses_pinned_snapshot_required_keys" -q
⚠️  CH25 schema apply skipped during pytest_configure: Error HTTPConnectionPool(host='localhost', port=8123): Max retries exceeded ...
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
django: version: 5.1.8, settings: tfc.settings.test (from ini)
rootdir: /app/backend
configfile: pytest.ini
plugins: django-4.12.0, langsmith-0.4.3, anyio-4.9.0
collected 77 items / 75 deselected / 2 selected

model_hub/tests/test_eval_versioning.py ..                               [100%]

======================= 2 passed, 75 deselected in 1.65s =======================
```

### Broader eval-focused backend pass

```text
$ docker exec backend sh -lc 'python -m pytest $(find model_hub/tests -maxdepth 1 -type f \( -name "*eval*.py" -o -name "*evaluation*.py" \) | sort) model_hub/system_evals/tests/test_validators.py -q'
⚠️  CH25 schema apply skipped during pytest_configure: Error HTTPConnectionPool(host='localhost', port=8123): Max retries exceeded ...
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
django: version: 5.1.8, settings: tfc.settings.test (from ini)
rootdir: /app/backend
configfile: pytest.ini
plugins: django-4.12.0, langsmith-0.4.3, anyio-4.9.0
collected 696 items / 139 deselected / 557 selected
...
=================================== FAILURES ===================================
__________ test_eval_template_bulk_delete_soft_deletes_eval_settings ___________
model_hub/tests/test_eval_playground_contracts.py:660: in test_eval_template_bulk_delete_soft_deletes_eval_settings
    assert setting.deleted is True
E   assert False is True
E    +  where False = <EvalSettings: EvalSettings object (7)>.deleted
...
=========================== short test summary info ============================
FAILED model_hub/tests/test_eval_playground_contracts.py::test_eval_template_bulk_delete_soft_deletes_eval_settings
=========== 1 failed, 556 passed, 139 deselected in 65.19s (0:01:05) ===========
```

### Standalone reproduction of the one broader-suite failure

```text
$ docker exec backend python -m pytest model_hub/tests/test_eval_playground_contracts.py::test_eval_template_bulk_delete_soft_deletes_eval_settings -q
⚠️  CH25 schema apply skipped during pytest_configure: Error HTTPConnectionPool(host='localhost', port=8123): Max retries exceeded ...
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
django: version: 5.1.8, settings: tfc.settings.test (from ini)
rootdir: /app/backend
configfile: pytest.ini
plugins: django-4.12.0, langsmith-0.4.3, anyio-4.9.0
collected 1 item

model_hub/tests/test_eval_playground_contracts.py F                      [100%]

=================================== FAILURES ===================================
__________ test_eval_template_bulk_delete_soft_deletes_eval_settings ___________
model_hub/tests/test_eval_playground_contracts.py:660: in test_eval_template_bulk_delete_soft_deletes_eval_settings
    assert setting.deleted is True
E   assert False is True
E    +  where False = <EvalSettings: EvalSettings object (8)>.deleted
...
=========================== short test summary info ============================
FAILED model_hub/tests/test_eval_playground_contracts.py::test_eval_template_bulk_delete_soft_deletes_eval_settings
============================== 1 failed in 7.81s ===============================
```

### Notes

- The repeated CH25 warning is from ClickHouse schema setup in this local/container environment and did not block the selected Django tests.
- `black` / `isort` are not installed in the backend container, so container format checks could not be run there; import/order changes were kept minimal and manually reviewed.
- The one deterministic broader-suite failure is outside this PR's touched required-keys/versioning paths. It asserts eval-template bulk delete should soft-delete `EvalSettings`, but `EvalSettings.deleted` remains `False`.

