### PR TITLE
[TH-6833] Composite eval flow: direct-add children, carry mapping to config drawer, show child params, fix workbench mapping display

### DIFF
--- a/frontend/src/sections/common/EvalPicker/CompositeChildParams.jsx
+++ b/frontend/src/sections/common/EvalPicker/CompositeChildParams.jsx
@@ -1,0 +1,70 @@
+import { Box, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+
+const CompositeChildParams = ({ params }) => {
+  const entries = Object.entries(params || {});
+  if (entries.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        mt: 0.75,
+        pt: 0.75,
+        borderTop: "1px dashed",
+        borderColor: "divider",
+      }}
+    >
+      <Typography
+        variant="s3"
+        color="text.secondary"
+        sx={{
+          fontWeight: "fontWeightSemiBold",
+          display: "block",
+          mb: 0.25,
+        }}
+      >
+        Parameters
+      </Typography>
+      {entries.map(([key, value]) => (
+        <Box
+          key={key}
+          sx={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 1.5,
+          }}
+        >
+          <Typography variant="s3" color="text.secondary" noWrap>
+            {key}
+          </Typography>
+          <Typography
+            variant="s3"
+            sx={{
+              fontFamily: "monospace",
+              fontVariantNumeric: "tabular-nums",
+              textAlign: "right",
+              overflowWrap: "anywhere",
+            }}
+          >
+            {typeof value === "object" ? JSON.stringify(value) : String(value)}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+CompositeChildParams.propTypes = {
+  params: PropTypes.objectOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+      PropTypes.object,
+      PropTypes.array,
+    ]),
+  ),
+};
+
+export default CompositeChildParams;

--- a/frontend/src/sections/common/EvalPicker/CompositeChildParams.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/CompositeChildParams.test.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import CompositeChildParams from "./CompositeChildParams";
+
+describe("CompositeChildParams", () => {
+  it("renders nothing when params is undefined", () => {
+    const { container } = render(<CompositeChildParams />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when params is an empty object", () => {
+    const { container } = render(<CompositeChildParams params={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the Parameters label and one row per param", () => {
+    render(
+      <CompositeChildParams
+        params={{
+          gap_threshold_ms: "3000",
+          silence_threshold: 0.01,
+        }}
+      />,
+    );
+    expect(screen.getByText("Parameters")).toBeInTheDocument();
+    expect(screen.getByText("gap_threshold_ms")).toBeInTheDocument();
+    expect(screen.getByText("3000")).toBeInTheDocument();
+    expect(screen.getByText("silence_threshold")).toBeInTheDocument();
+    expect(screen.getByText("0.01")).toBeInTheDocument();
+  });
+
+  it("stringifies non-string scalar values", () => {
+    render(<CompositeChildParams params={{ enabled: true, count: 20 }} />);
+    expect(screen.getByText("true")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+  });
+
+  it("renders object and array values as JSON", () => {
+    render(
+      <CompositeChildParams
+        params={{
+          weights: { a: 1 },
+          labels: ["x", "y"],
+        }}
+      />,
+    );
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+    expect(screen.getByText('["x","y"]')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -56,6 +56,7 @@ import TestPlayground from "src/sections/evals/components/TestPlayground";
 import VersionBadge from "src/sections/evals/components/VersionBadge";
 import EvalTypeBadge from "src/sections/evals/components/EvalTypeBadge";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
+import CompositeChildParams from "./CompositeChildParams";
 import {
   getEvalCode,
   getEvalCodeLanguage,
@@ -65,7 +66,10 @@ import {
   normalizeEvalPickerEval,
 } from "./evalPickerValue";
 import { getEvalBaseName } from "src/sections/common/EvaluationDrawer/common";
-import { canonicalEntries, extractVariablesFromMessages } from "src/utils/utils";
+import {
+  canonicalEntries,
+  extractVariablesFromMessages,
+} from "src/utils/utils";
 import { format } from "date-fns";
 import {
   buildEvalTemplateConfig,
@@ -172,11 +176,17 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [dataReady, setDataReady] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   useEffect(() => {
-    const pinned = evalData?.pinned_version_id ?? evalData?.pinnedVersionId ?? null;
+    const pinned =
+      evalData?.pinned_version_id ?? evalData?.pinnedVersionId ?? null;
     if (pinned && !selectedVersionId && !isDirty) {
       setSelectedVersionId(pinned);
     }
-  }, [evalData?.pinned_version_id, evalData?.pinnedVersionId, selectedVersionId, isDirty]);
+  }, [
+    evalData?.pinned_version_id,
+    evalData?.pinnedVersionId,
+    selectedVersionId,
+    isDirty,
+  ]);
   const [isTesting, setIsTesting] = useState(false);
   const [testPassed, setTestPassed] = useState(false);
   const [testError, setTestError] = useState(null);
@@ -329,9 +339,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     const templateVars =
       evalType === "llm"
         ? extractVariablesFromMessages(instructions, messages, "mustache")
-        : (
-            (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || []
-          ).map((m) => m.replace(/\{\{|\}\}/g, "").trim());
+        : ((instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || []).map(
+            (m) => m.replace(/\{\{|\}\}/g, "").trim(),
+          );
     if (templateVars.length > 0) return [...new Set(templateVars)];
     // Fallback: stored required_keys (before instructions hydrate)
     if (requiredKeys.length > 0) return [...new Set(requiredKeys)];
@@ -450,7 +460,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     setIsDirty(false);
     setDataReady(true);
     initialLoadDone.current = true;
-  }, [selectedVersionId, versions, isDirty, fullEval, normalizedFullEval, normalizedEvalData, isEditMode, evalData]);
+  }, [
+    selectedVersionId,
+    versions,
+    isDirty,
+    fullEval,
+    normalizedFullEval,
+    normalizedEvalData,
+    isEditMode,
+    evalData,
+  ]);
 
   // ── Populate from eval detail (same logic as EvalDetailPage) ──
   const initialLoadDone = useRef(false);
@@ -1344,76 +1363,82 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                         <Box
                           key={child.child_id}
                           sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "space-between",
                             p: 1,
                             borderRadius: 1,
                             border: "1px solid",
                             borderColor: "divider",
                           }}
                         >
-                          <Box sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography
-                              variant="body2"
-                              fontWeight={600}
-                              noWrap
-                              sx={{ fontSize: "12px" }}
-                            >
-                              #{i + 1} {child.child_name}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              {child.eval_type || "llm"}
-                            </Typography>
-                          </Box>
                           <Box
                             sx={{
                               display: "flex",
                               alignItems: "center",
-                              gap: 0.5,
-                              flexShrink: 0,
+                              justifyContent: "space-between",
                             }}
                           >
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              sx={{ fontSize: "11px" }}
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              <Typography
+                                variant="body2"
+                                fontWeight={600}
+                                noWrap
+                                sx={{ fontSize: "12px" }}
+                              >
+                                #{i + 1} {child.child_name}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                              >
+                                {child.eval_type || "llm"}
+                              </Typography>
+                            </Box>
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                                flexShrink: 0,
+                              }}
                             >
-                              Weight
-                            </Typography>
-                            <input
-                              type="number"
-                              min="0"
-                              step="0.1"
-                              value={
-                                compositeChildWeights[child.child_id] ??
-                                child.weight ??
-                                1
-                              }
-                              onChange={(e) => {
-                                const v = parseFloat(e.target.value) || 0;
-                                setCompositeChildWeights((prev) => ({
-                                  ...prev,
-                                  [child.child_id]: v,
-                                }));
-                                setIsDirty(true);
-                              }}
-                              style={{
-                                width: 50,
-                                padding: "2px 6px",
-                                fontSize: "12px",
-                                borderRadius: 4,
-                                border:
-                                  "1px solid var(--mui-palette-divider, #444)",
-                                background: "transparent",
-                                color: "inherit",
-                                textAlign: "center",
-                              }}
-                            />
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: "11px" }}
+                              >
+                                Weight
+                              </Typography>
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.1"
+                                value={
+                                  compositeChildWeights[child.child_id] ??
+                                  child.weight ??
+                                  1
+                                }
+                                onChange={(e) => {
+                                  const v = parseFloat(e.target.value) || 0;
+                                  setCompositeChildWeights((prev) => ({
+                                    ...prev,
+                                    [child.child_id]: v,
+                                  }));
+                                  setIsDirty(true);
+                                }}
+                                style={{
+                                  width: 50,
+                                  padding: "2px 6px",
+                                  fontSize: "12px",
+                                  borderRadius: 4,
+                                  border:
+                                    "1px solid var(--mui-palette-divider, #444)",
+                                  background: "transparent",
+                                  color: "inherit",
+                                  textAlign: "center",
+                                }}
+                              />
+                            </Box>
                           </Box>
+                          <CompositeChildParams params={child.config?.params} />
                         </Box>
                       ))}
                     </Box>

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -280,8 +280,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const buildPayload = useCallback(
     () => ({
       eval_type: evalType,
-      instructions:
-        evalType === "code" ? undefined : instructions || undefined,
+      instructions: evalType === "code" ? undefined : instructions || undefined,
       code: evalType === "code" ? code : undefined,
       code_language: evalType === "code" ? codeLanguage : undefined,
       model,
@@ -599,6 +598,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         evalType: result?.eval_type || "llm",
         outputType:
           compositeChildAxis === "percentage" ? "percentage" : "pass_fail",
+        // EvalPickerConfigFull seeds its mapping panel from this.
+        mapping: sourceMapping,
       });
       setStep("config");
     } catch (error) {
@@ -623,6 +624,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     setSelectedEval,
     setStep,
     enqueueSnackbar,
+    sourceMapping,
   ]);
 
   const isComposite = mode === "composite";

--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -580,13 +580,9 @@ const CompositeDetailPanel = ({
           onClose={() => setPickerOpen(false)}
           onEvalAdded={handleEvalAdded}
           existingEvals={childrenList.map((c) => ({ id: c.child_id }))}
-          // Always step into the EvalPickerConfigFull screen — users
-          // need the version selector, scoring settings and (when a
-          // dataset is bound) the variable-mapping editor before the
-          // child is committed to the composite. The previous
-          // skipConfig=true bypassed all of that and added the child
-          // straight to the list with template defaults.
-          skipConfig={false}
+          // Add children directly with template defaults; mapping is
+          // resolved at composite level.
+          skipConfig
           source={pickerSource || (pickerSourceId ? "dataset" : "composite")}
           sourceId={pickerSourceId || ""}
           sourceRowType={pickerSourceRowType}

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1002,10 +1002,20 @@ const DatasetTestMode = React.forwardRef(
     }, [sourceColumns, isWorkbenchMode]);
 
     // Resolve UUID-based mapping values to display names (edit mode).
-    // Handles both plain UUIDs and "uuid.path" nested references.
+    // Handles plain UUIDs, "uuid.path" nested references, and workbench
+    // field identifiers (e.g. "input_prompt" → "model_input").
     const uuidResolutionDone = React.useRef(false);
     useEffect(() => {
-      if (!columns.length && !Object.keys(extraFieldToName).length) return;
+      const fieldToName = {};
+      Object.entries(sourceNameToField).forEach(([name, field]) => {
+        fieldToName[field] = name;
+      });
+      if (
+        !columns.length &&
+        !Object.keys(extraFieldToName).length &&
+        !Object.keys(fieldToName).length
+      )
+        return;
       if (uuidResolutionDone.current) return;
       const idToName = {};
       columns.forEach((c) => {
@@ -1029,12 +1039,15 @@ const DatasetTestMode = React.forwardRef(
           } else if (extraFieldToName[val]) {
             next[variable] = extraFieldToName[val];
             changed = true;
+          } else if (fieldToName[val]) {
+            next[variable] = fieldToName[val];
+            changed = true;
           }
         });
         if (changed) uuidResolutionDone.current = true;
         return changed ? next : prev;
       });
-    }, [columns, extraFieldToName, jsonSchemas]);
+    }, [columns, extraFieldToName, sourceNameToField, jsonSchemas]);
 
     // Prune stale mapping keys when variables list changes (instruction edits).
     useEffect(() => {


### PR DESCRIPTION
**Ticket:** [TH-6833](https://linear.app/future-agi/issue/TH-6833/composite-eval-flow-direct-add-child-evals-carry-variable-mapping-to) — Fixes TH-6833

## What was the bug

Four issues in the composite evaluation flow (Create New Evaluation → Composite):

1. Adding a child eval from the Select Evaluation catalog forced users through the full per-eval config screen, but nothing configured there survived — params showed empty back in the composite and the variable mapping never carried over.
2. Clicking **Create & Configure** dropped every variable mapping the user had just completed — the final config drawer opened with only the auto-mapped `output`, forcing a full re-map.
3. Per-child parameters (e.g. `gap_threshold_ms`) were invisible in the final config drawer even though they were saved correctly on the template (`child_configs`).
4. Workbench flow: mappings picked as display names (`model_input` / `model_output`) rendered in the final drawer as raw field identifiers (`input_prompt` / `output_prompt`) — values not present in the dropdown list. The same latent bug existed in the workbench edit-eval path.

## What changes have been done

- `frontend/src/sections/evals/components/CompositeDetailPanel.jsx` — nested child picker now passes `skipConfig`: catalog **Add** puts the eval straight into the Children list.
- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx` — `handleSaveAndAddComposite` carries `mapping: sourceMapping` in the `setSelectedEval` handoff so `EvalPickerConfigFull` seeds its mapping panel with the completed mappings.
- `frontend/src/sections/common/EvalPicker/CompositeChildParams.jsx` (new) — small read-only per-child Parameters component (theme `s3` typography, monospace values).
- `frontend/src/sections/common/EvalPicker/CompositeChildParams.test.jsx` (new) — unit tests for the component.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` — renders `CompositeChildParams` inside each Child Evaluator card in the composite section.
- `frontend/src/sections/evals/components/DatasetTestMode.jsx` — extended the existing mapping-normalization effect to reverse workbench field identifiers back to display names (`fieldToName` from `sourceNameToField`).

## Why the changes

- The config screen added friction with no lasting value for composite children: params were editable inline in the composite anyway, and mapping is resolved at composite level from the children's union `required_keys`.
- The Create & Configure handoff built `selectedEval` without the `mapping` field, while `EvalPickerConfigFull` seeds its panels from `evalData.mapping` (`initialMapping`) — the single-eval path already forwarded it; the composite path didn't.
- `EvalPickerConfigFull`'s Parameters section only renders the eval's own `functionParamsSchema`, which composites don't have — child params needed their own read-only surface.
- `DatasetTestMode` keeps its mapping keyed by display names but reports field identifiers upward; seeding the reported form back in without reverse translation showed out-of-list values. The effect already reverse-resolved dataset UUID ids — it just had no workbench branch.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Composite tab → + Add evaluation → **Add** on any eval | Eval lands in Children immediately (weight 1), drawer closes, no config screen |
| 2 | Re-open the catalog after adding | Added evals show disabled **Added** badge |
| 3 | Map variables on create page → **Create & Configure** | Final drawer opens with all mappings pre-filled, not just `output` |
| 4 | Child with params (e.g. `dead_air_detection`) in final drawer | Read-only Parameters block visible under the child card |
| 5 | Workbench: map `model_input` / `model_output` → Create & Configure | Final drawer dropdowns show display names; save payload keeps field identifiers |
| 6 | Single (non-composite) eval add from task panel | Config screen still opens as before (unchanged) |
| 7 | `CompositeChildParams` unit tests | Renders nothing when empty; label + row per param; scalars stringified; objects/arrays as JSON |

## Flows tested manually

| Flow | Entry point | Result |
|------|-------------|--------|
| Tasks | Task config panel → Create New Evaluation → Composite | ✅ |
| Evals pages | `/evaluations/create` and `/evaluations/:id` composite modes | ✅ |
| Dataset | Dataset eval drawer | ✅ |
| Run experiment | Experiment evals drawer | ✅ |
| Workbench | Workbench → Evaluation tab (incl. field-name display fix) | ✅ |

## How to reproduce (original bug)

1. Tasks → Create New Evaluation → Composite tab.
2. Add two child evals — note each Add routes through the full config screen (old behavior).
3. Map all variables in the right panel, click **Create & Configure**.
4. Final drawer shows only `output` mapped; child params not visible.
5. For issue 4: run the same flow from Workbench → Evaluation tab and observe `input_prompt` / `output_prompt` in the mapping dropdowns instead of `model_input` / `model_output`.

## Commands

```bash
cd frontend
yarn test:run src/sections/evals src/sections/common/EvalPicker   # 128 tests
```

## Videos and screenshots

https://github.com/user-attachments/assets/4daf5969-d9ef-413c-946b-b423e122d834

https://github.com/user-attachments/assets/bfc0e981-bd18-4eda-8a72-e322bf7672b4

https://github.com/user-attachments/assets/c14ad759-280d-4daf-aac3-ed6370dc6e08



