### PR TITLE
fix: trim leading/trailing whitespace on form name/description fields

### DIFF
--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -76,7 +76,7 @@ export const createAgentDefinitionSchema = (options) => {
     .object({
       // Basic Information
       agentType: z.string().min(1, "Agent type is required"),
-      agentName: z.string().min(1, "Agent name is required"),
+      agentName: z.string().trim().min(1, "Agent name is required"),
       languages: z
         .array(z.string())
         .min(1, "At least one language is required"),
@@ -105,12 +105,12 @@ export const createAgentDefinitionSchema = (options) => {
         .optional(),
 
       // Behaviour
-      description: z.string().min(1, "Description is required"),
+      description: z.string().trim().min(1, "Description is required"),
       knowledgeBase: z.string().optional(),
       countryCode: z.string().optional(),
       contactNumber: z.string().optional(),
       inbound: z.boolean(),
-      commitMessage: z.string().min(1, "Commit message is required"),
+      commitMessage: z.string().trim().min(1, "Commit message is required"),
       model: z.string().optional(),
       modelDetails: z.any().optional().nullable(),
 

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -365,8 +365,8 @@ export const getPersonaDefaultValues = (editPersona) => {
 
 const PersonCreateBaseValidationSchema = z.object({
   simulationType: z.enum(["voice", "text"]),
-  name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().min(1, "Description is required"),
   gender: z.array(z.string()).transform((val) => (val.length ? val : null)),
   ageGroup: z.array(z.string()).transform((val) => (val.length ? val : null)),
   location: z.array(z.string()).transform((val) => (val.length ? val : null)),

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -64,8 +64,8 @@ const CreateScenarioDefaultSchema = {
     .default("agent_definition"),
   sourceId: z.string().min(1, "Source is required"),
   sourceLabel: z.string().optional(), // Used for auto-generating scenario name, not sent to API
-  name: z.string().min(1, "Name is required"),
-  description: z.string().optional(),
+  name: z.string().trim().min(1, "Name is required"),
+  description: z.string().trim().optional(),
   agentDefinitionId: z.string().optional(),
   agentDefinitionVersionId: z.string().optional(),
   promptTemplateId: z.string().optional(),


### PR DESCRIPTION
Adds .trim() to zod schemas for name and description fields in persona, scenario, and agent definition forms. Prevents blank-looking names (e.g. " test ") from being saved and rejects all-whitespace values. Closes #1389