### PR TITLE
fix(develop): keep composite eval dialog open across grid polling (TH-6834)

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
@@ -4,7 +4,7 @@ import {
   DialogTitle,
   IconButton,
 } from "@mui/material";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Iconify from "src/components/iconify";
 import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 import { useCompositeEvalStore } from "src/sections/develop-detail/states";
@@ -14,19 +14,32 @@ const CompositeEvalDialog = () => {
   const setCompositeEval = useCompositeEvalStore((s) => s.setCompositeEval);
   const open = Boolean(compositeEval);
 
+  // Retain the last composite so the content stays mounted through the
+  // Dialog's close transition; clearing it immediately would collapse the
+  // modal height to just the title before the fade-out finishes.
+  const [rendered, setRendered] = useState(compositeEval);
+  useEffect(() => {
+    if (compositeEval) setRendered(compositeEval);
+  }, [compositeEval]);
+
   const close = () => setCompositeEval(null);
 
-  const children = compositeEval?.children || [];
+  const children = rendered?.children || [];
 
   return (
-    <Dialog open={open} onClose={close} maxWidth="md" fullWidth>
+    <Dialog
+      open={open}
+      onClose={close}
+      maxWidth="md"
+      fullWidth
+      TransitionProps={{ onExited: () => setRendered(null) }}
+    >
       <DialogTitle
         sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          fontSize: "15px",
-          fontWeight: 600,
+          typography: "subtitle1",
         }}
       >
         Composite evaluation breakdown
@@ -35,14 +48,14 @@ const CompositeEvalDialog = () => {
         </IconButton>
       </DialogTitle>
       <DialogContent dividers sx={{ p: 0 }}>
-        {open && (
+        {rendered && (
           <CompositeResultView
             compositeResult={{
-              aggregation_enabled: compositeEval?.aggregation_enabled,
-              aggregation_function: compositeEval?.aggregation_function,
-              aggregate_score: compositeEval?.aggregate_score,
-              aggregate_pass: compositeEval?.aggregate_pass,
-              summary: compositeEval?.summary,
+              aggregation_enabled: rendered?.aggregation_enabled,
+              aggregation_function: rendered?.aggregation_function,
+              aggregate_score: rendered?.aggregate_score,
+              aggregate_pass: rendered?.aggregate_pass,
+              summary: rendered?.summary,
               children,
               total_children: children.length,
               completed_children: children.filter(

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
@@ -4,7 +4,7 @@ import {
   DialogTitle,
   IconButton,
 } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useRef } from "react";
 import Iconify from "src/components/iconify";
 import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 import { useCompositeEvalStore } from "src/sections/develop-detail/states";
@@ -14,26 +14,21 @@ const CompositeEvalDialog = () => {
   const setCompositeEval = useCompositeEvalStore((s) => s.setCompositeEval);
   const open = Boolean(compositeEval);
 
-  // Retain the last composite so the content stays mounted through the
-  // Dialog's close transition; clearing it immediately would collapse the
-  // modal height to just the title before the fade-out finishes.
-  const [rendered, setRendered] = useState(compositeEval);
-  useEffect(() => {
-    if (compositeEval) setRendered(compositeEval);
-  }, [compositeEval]);
+  // Keep the last composite available during the Dialog's close transition so
+  // the modal body doesn't collapse to just the title while it fades out. The
+  // ref is written during render (before it's read), so content is present on
+  // the very first paint on open; MUI unmounts the subtree itself once the exit
+  // transition finishes.
+  const lastEvalRef = useRef(null);
+  if (compositeEval) lastEvalRef.current = compositeEval;
+  const rendered = compositeEval ?? lastEvalRef.current;
 
   const close = () => setCompositeEval(null);
 
   const children = rendered?.children || [];
 
   return (
-    <Dialog
-      open={open}
-      onClose={close}
-      maxWidth="md"
-      fullWidth
-      TransitionProps={{ onExited: () => setRendered(null) }}
-    >
+    <Dialog open={open} onClose={close} maxWidth="md" fullWidth>
       <DialogTitle
         sx={{
           display: "flex",

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx
@@ -1,0 +1,61 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+} from "@mui/material";
+import React from "react";
+import Iconify from "src/components/iconify";
+import CompositeResultView from "src/sections/evals/components/CompositeResultView";
+import { useCompositeEvalStore } from "src/sections/develop-detail/states";
+
+const CompositeEvalDialog = () => {
+  const compositeEval = useCompositeEvalStore((s) => s.compositeEval);
+  const setCompositeEval = useCompositeEvalStore((s) => s.setCompositeEval);
+  const open = Boolean(compositeEval);
+
+  const close = () => setCompositeEval(null);
+
+  const children = compositeEval?.children || [];
+
+  return (
+    <Dialog open={open} onClose={close} maxWidth="md" fullWidth>
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: "15px",
+          fontWeight: 600,
+        }}
+      >
+        Composite evaluation breakdown
+        <IconButton size="small" onClick={close} aria-label="Close">
+          <Iconify icon="mdi:close" width={18} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0 }}>
+        {open && (
+          <CompositeResultView
+            compositeResult={{
+              aggregation_enabled: compositeEval?.aggregation_enabled,
+              aggregation_function: compositeEval?.aggregation_function,
+              aggregate_score: compositeEval?.aggregate_score,
+              aggregate_pass: compositeEval?.aggregate_pass,
+              summary: compositeEval?.summary,
+              children,
+              total_children: children.length,
+              completed_children: children.filter(
+                (c) => c?.status === "completed",
+              ).length,
+              failed_children: children.filter((c) => c?.status === "failed")
+                .length,
+            }}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CompositeEvalDialog;

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
@@ -1,16 +1,9 @@
-import {
-  Box,
-  Chip,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-} from "@mui/material";
+import { Box, Chip } from "@mui/material";
 import _ from "lodash";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React from "react";
 import Iconify from "src/components/iconify";
-import CompositeResultView from "src/sections/evals/components/CompositeResultView";
+import { useCompositeEvalStore } from "src/sections/develop-detail/states";
 import { interpolateColorBasedOnScore } from "src/utils/utils";
 import RenderMeta from "../RenderMeta";
 import EvaluateArrayCellRenderer from "./EvaluateArrayCellRenderer";
@@ -72,7 +65,7 @@ const EvaluateCell = ({
         parsedValueInfos.children.length > 0 &&
         parsedValueInfos.children[0]?.child_id),
   );
-  const [compositeDialogOpen, setCompositeDialogOpen] = useState(false);
+  const setCompositeEval = useCompositeEvalStore((s) => s.setCompositeEval);
 
   const compositeBadge = isComposite ? (
     <Chip
@@ -82,7 +75,7 @@ const EvaluateCell = ({
       onClick={(e) => {
         window.__compositeEvalClick = true;
         e.stopPropagation();
-        setCompositeDialogOpen(true);
+        setCompositeEval(parsedValueInfos);
       }}
       sx={{
         ml: 0.75,
@@ -93,53 +86,6 @@ const EvaluateCell = ({
         "& .MuiChip-icon": { marginLeft: "4px", marginRight: "-4px" },
       }}
     />
-  ) : null;
-
-  const compositeDialog = isComposite ? (
-    <Dialog
-      open={compositeDialogOpen}
-      onClose={() => setCompositeDialogOpen(false)}
-      maxWidth="md"
-      fullWidth
-    >
-      <DialogTitle
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          fontSize: "15px",
-          fontWeight: 600,
-        }}
-      >
-        Composite evaluation breakdown
-        <IconButton
-          size="small"
-          onClick={() => setCompositeDialogOpen(false)}
-          aria-label="Close"
-        >
-          <Iconify icon="mdi:close" width={18} />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent dividers sx={{ p: 0 }}>
-        <CompositeResultView
-          compositeResult={{
-            aggregation_enabled: parsedValueInfos?.aggregation_enabled,
-            aggregation_function: parsedValueInfos?.aggregation_function,
-            aggregate_score: parsedValueInfos?.aggregate_score,
-            aggregate_pass: parsedValueInfos?.aggregate_pass,
-            summary: parsedValueInfos?.summary,
-            children: parsedValueInfos?.children || [],
-            total_children: parsedValueInfos?.children?.length ?? 0,
-            completed_children: (parsedValueInfos?.children || []).filter(
-              (c) => c?.status === "completed",
-            ).length,
-            failed_children: (parsedValueInfos?.children || []).filter(
-              (c) => c?.status === "failed",
-            ).length,
-          }}
-        />
-      </DialogContent>
-    </Dialog>
   ) : null;
 
   if (output === OutputTypes.NUMERIC) {
@@ -185,27 +131,24 @@ const EvaluateCell = ({
         : interpolateColorBasedOnScore(1, 1)
       : "";
     return (
-      <>
-        <Box
-          sx={{
-            padding: 1,
-            backgroundColor: bgColor,
-            color: "text.secondary",
-            display: "flex",
-            height: "100%",
-            alignItems: "center",
-          }}
-        >
-          {_.capitalize(value)}
-          {compositeBadge}
-          <RenderMeta
-            originType={originType}
-            meta={meta}
-            showToken={!isFutureAgiEval}
-          />
-        </Box>
-        {compositeDialog}
-      </>
+      <Box
+        sx={{
+          padding: 1,
+          backgroundColor: bgColor,
+          color: "text.secondary",
+          display: "flex",
+          height: "100%",
+          alignItems: "center",
+        }}
+      >
+        {_.capitalize(value)}
+        {compositeBadge}
+        <RenderMeta
+          originType={originType}
+          meta={meta}
+          showToken={!isFutureAgiEval}
+        />
+      </Box>
     );
   }
   if (dataType === "float") {
@@ -251,27 +194,24 @@ const EvaluateCell = ({
       ? interpolateColorBasedOnScore(numericValue, 1)
       : "";
     return (
-      <>
-        <Box
-          sx={{
-            padding: 1,
-            backgroundColor: bgColor,
-            color: "text.primary",
-            display: "flex",
-            height: "100%",
-            alignItems: "center",
-          }}
-        >
-          {hasValue ? `${getScorePercentage(numericValue)}%` : ""}
-          {compositeBadge}
-          <RenderMeta
-            originType={originType}
-            meta={meta}
-            showToken={!isFutureAgiEval}
-          />
-        </Box>
-        {compositeDialog}
-      </>
+      <Box
+        sx={{
+          padding: 1,
+          backgroundColor: bgColor,
+          color: "text.primary",
+          display: "flex",
+          height: "100%",
+          alignItems: "center",
+        }}
+      >
+        {hasValue ? `${getScorePercentage(numericValue)}%` : ""}
+        {compositeBadge}
+        <RenderMeta
+          originType={originType}
+          meta={meta}
+          showToken={!isFutureAgiEval}
+        />
+      </Box>
     );
   }
 
@@ -287,29 +227,26 @@ const EvaluateCell = ({
   }
 
   return (
-    <>
-      <Box
-        sx={{
-          padding: "4px 8px",
-          whiteSpace: "pre-wrap",
-          lineHeight: "1.5",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          display: "-webkit-box",
-          WebkitLineClamp: "6",
-          WebkitBoxOrient: "vertical",
-        }}
-      >
-        {value}
-        {compositeBadge}
-        <RenderMeta
-          originType={originType}
-          meta={meta}
-          showToken={!isFutureAgiEval}
-        />
-      </Box>
-      {compositeDialog}
-    </>
+    <Box
+      sx={{
+        padding: "4px 8px",
+        whiteSpace: "pre-wrap",
+        lineHeight: "1.5",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        display: "-webkit-box",
+        WebkitLineClamp: "6",
+        WebkitBoxOrient: "vertical",
+      }}
+    >
+      {value}
+      {compositeBadge}
+      <RenderMeta
+        originType={originType}
+        meta={meta}
+        showToken={!isFutureAgiEval}
+      />
+    </Box>
   );
 };
 

--- a/frontend/src/sections/develop-detail/DataTab/CompareData.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/CompareData.jsx
@@ -26,6 +26,7 @@ import { useDeleteCompare } from "src/api/develop/dataset-compare";
 import { useDevelopDetailContext } from "src/pages/dashboard/Develop/Context/DevelopDetailContext";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import { APP_CONSTANTS } from "src/utils/constants";
+import CompositeEvalDialog from "src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog";
 
 // Define status types that require refreshing
 const RefreshStatus = [
@@ -609,6 +610,7 @@ const CompareData = ({
             position: "relative",
           }}
         >
+          <CompositeEvalDialog />
           <AgGridReact
             ref={gridApiRef}
             columnDefs={columnDefs}

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -71,6 +71,7 @@ import { useDevelopDatasetList } from "src/api/develop/develop-detail";
 import { useEvalsList } from "src/sections/common/EvaluationDrawer/getEvalsList";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import SingleImageViewerProvider from "../Common/SingleImageViewer/SingleImageViewerProvider";
+import CompositeEvalDialog from "src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog";
 import { MultiImageViewerProvider } from "../Common/MultiImageViewer";
 import DevelopFilterBox from "./DevelopFilters/DevelopFilterBox";
 import TopBanner from "./TopBanner";
@@ -1241,6 +1242,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
         <DevelopFilterBox />
         <MultiImageViewerProvider>
           <SingleImageViewerProvider>
+            <CompositeEvalDialog />
             {isData === true ? (
               <>
                 <TopBanner />

--- a/frontend/src/sections/develop-detail/states.jsx
+++ b/frontend/src/sections/develop-detail/states.jsx
@@ -253,6 +253,11 @@ export const useDevelopSearchStore = create((set) => ({
   setSearch: (value) => set(() => ({ search: value })),
 }));
 
+export const useCompositeEvalStore = create((set) => ({
+  compositeEval: null,
+  setCompositeEval: (value) => set(() => ({ compositeEval: value })),
+}));
+
 export const useDatapointDrawerStore = create((set) => ({
   datapoint: null,
   column: null,

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
@@ -42,6 +42,7 @@ import FormSearchField from "src/components/FormSearchField/FormSearchField";
 
 import { enqueueSnackbar } from "notistack";
 import SingleImageViewerProvider from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageViewerProvider";
+import CompositeEvalDialog from "src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog";
 import RenderCellRunningOptions from "./RenderCellRunningOptions";
 import { useRerunColumnInExperimentStoreShallow } from "./states";
 import { useGetExperimentDetails } from "src/hooks/useGetExperimentDetails";
@@ -965,6 +966,7 @@ function ExperimentDataView() {
         }}
       >
         <SingleImageViewerProvider>
+          <CompositeEvalDialog />
           <AgGridReact
             rowHeight={defaultRowHeightMapping["Short"]?.height}
             getRowHeight={getRowHeight}


### PR DESCRIPTION
## Summary
The composite evaluation breakdown dialog closed itself whenever the develop/experiment/compare grid polled for new data. This hoists the dialog out of the AG Grid cell so it survives grid refreshes.

## Why / problem
The dialog's open state lived in `useState` **inside** the `EvaluateCell` AG Grid cell renderer (`EvaluateCell.jsx`). AG Grid cell renderers are ephemeral — on a poll refresh the grid recreates the cell component instances, which resets that local `useState(false)` and unmounts the dialog. The Develop and Experiment grids poll every 5–10s via `setInterval` (applying serverSide transaction `update`s), and Compare uses `refreshServerSide()`; all three recreate cells, so the dialog closed mid-view.

Note: two of the grids already use a stable `getRowId` + transaction updates, and the dialog still closed — AG Grid recreates the React cell component regardless, so a `getRowId`/immutable-update "stopgap" does not fix this. The state has to live above the grid.

## What changed
- `sections/develop-detail/states.jsx`: new `useCompositeEvalStore` (`compositeEval` + `setCompositeEval`), matching the existing store pattern (`useDatapointDrawerStore`, etc.).
- `sections/common/DevelopCellRenderer/EvaluateCellRenderer/CompositeEvalDialog.jsx` (new): a single dialog that reads the store and renders `CompositeResultView`; open when `compositeEval` is set. Owns the result mapping that used to live in the cell.
- `sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx`: removed the local `useState` and inline `<Dialog>`; the chip now calls `setCompositeEval(parsedValueInfos)`. Kept the `window.__compositeEvalClick` guard so opening it still doesn't trigger the row drawer. Dropped now-unused imports and collapsed leftover fragments.
- Mounted `<CompositeEvalDialog />` once beside `AgGridReact` in the three grids that use this cell: `DevelopDataV2.jsx`, `ExperimentDataView.jsx`, `CompareData.jsx`.

Because the store captures the composite result at click time, the open dialog now stays put across polls (showing the row's state as of when it was opened) instead of closing.

## Tests
- [ ] Open a grid with composite-eval cells, click a "N children" chip → dialog opens.
- [ ] While a poll is in flight (grid processing/refreshing), the dialog stays open.
- [ ] Close via X / backdrop → stays closed through the next poll.
- [ ] Clicking a chip still does NOT open the row drawer.
- [ ] Verified across all three grids: main dataset, experiments, compare datasets.

## Commands
- `yarn lint` (0 errors on changed files)

## Backwards compatibility
No API or contract changes. Pure frontend behavior fix; the dialog contents and trigger are unchanged.

## Manual verification
- [ ] Open composite-eval dialog on a dataset that is actively processing/polling and confirm it no longer closes.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Self-reviewed the change
- [x] No lint errors introduced
- [ ] Manually verified the dialog-during-poll flow

## Backout
Revert this commit — restores the in-cell dialog (and the bug).

## Linear
Closes TH-6834
