### PR TITLE
fix(tracer): fan out CREATE DICTIONARY via ON CLUSTER in replicated apply_schema

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/apply_schema.py
+++ b/futureagi/tracer/services/clickhouse/v2/apply_schema.py
@@ -32,6 +32,7 @@ Exit codes:
     2   drift detected without --force
     3   CH error during apply
 """
+
 from __future__ import annotations
 
 import argparse
@@ -39,13 +40,12 @@ import hashlib
 import os
 import sys
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
-import clickhouse_connect          # HTTP — easier to debug than native here
+import clickhouse_connect  # HTTP — easier to debug than native here
 import structlog
-
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Logging — structured, machine-parseable, never print()
@@ -64,9 +64,12 @@ log = structlog.get_logger("apply_schema")
 # CLI
 # ──────────────────────────────────────────────────────────────────────────────
 def build_argparser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     p.add_argument(
-        "--schema-dir", type=Path,
+        "--schema-dir",
+        type=Path,
         # Default is THIS module's schema dir (v2). Earlier the default pointed
         # to ../schema which resolved to the legacy CH 24.10 schema directory
         # — codex review P1 finding. Tests sweep the v2 dir explicitly so they
@@ -81,27 +84,48 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--ch-password", default=os.environ.get("CH_PASSWORD", ""))
     p.add_argument("--ch-database", default="default")
     p.add_argument("--status", action="store_true", help="Show applied versions, exit")
-    p.add_argument("--force", action="store_true",
-                   help="Apply even if hash drift detected (requires DECISIONS.md justification)")
-    p.add_argument("--files", nargs="+", default=None,
-                   help="Apply only these files (relative to --schema-dir). Default: all *.sql in order.")
-    p.add_argument("--replicated", action="store_true",
-                   help=("Rewrite engine declarations to their Replicated* variants and append "
-                         "ON CLUSTER to CREATE TABLE / CREATE MATERIALIZED VIEW. Use in production "
-                         "where tables are coordinated via ZooKeeper / ClickHouse Keeper. The local "
-                         "test rig (single-node, no Keeper) does NOT use this flag."))
-    p.add_argument("--cluster", default="default",
-                   help="Cluster name for --replicated (default 'default'). Must match the cluster "
-                        "name in remote_servers config on the prod CH cluster.")
-    p.add_argument("--zk-table-path-prefix", default="/clickhouse/tables/ch25",
-                   help=("ZooKeeper/Keeper path prefix for Replicated tables (default "
-                         "'/clickhouse/tables/ch25'). Each table gets "
-                         "<prefix>/{shard}/<table>. {shard} and {replica} are resolved by "
-                         "CH macros server-side. The '/ch25' segment namespaces v2 tables "
-                         "away from the legacy '/clickhouse/tables/{shard}/<table>' paths "
-                         "used by the existing CH 24.10 tables (per schema.py:760). Sharing "
-                         "the path would cause replica-metadata collisions on the same "
-                         "Keeper instance — codex review P0 finding."))
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Apply even if hash drift detected (requires DECISIONS.md justification)",
+    )
+    p.add_argument(
+        "--files",
+        nargs="+",
+        default=None,
+        help="Apply only these files (relative to --schema-dir). Default: all *.sql in order.",
+    )
+    p.add_argument(
+        "--replicated",
+        action="store_true",
+        help=(
+            "Rewrite engine declarations to their Replicated* variants and append "
+            "ON CLUSTER to CREATE TABLE / CREATE MATERIALIZED VIEW / CREATE DICTIONARY. "
+            "Use in production "
+            "where tables are coordinated via ZooKeeper / ClickHouse Keeper. The local "
+            "test rig (single-node, no Keeper) does NOT use this flag."
+        ),
+    )
+    p.add_argument(
+        "--cluster",
+        default="default",
+        help="Cluster name for --replicated (default 'default'). Must match the cluster "
+        "name in remote_servers config on the prod CH cluster.",
+    )
+    p.add_argument(
+        "--zk-table-path-prefix",
+        default="/clickhouse/tables/ch25",
+        help=(
+            "ZooKeeper/Keeper path prefix for Replicated tables (default "
+            "'/clickhouse/tables/ch25'). Each table gets "
+            "<prefix>/{shard}/<table>. {shard} and {replica} are resolved by "
+            "CH macros server-side. The '/ch25' segment namespaces v2 tables "
+            "away from the legacy '/clickhouse/tables/{shard}/<table>' paths "
+            "used by the existing CH 24.10 tables (per schema.py:760). Sharing "
+            "the path would cause replica-metadata collisions on the same "
+            "Keeper instance — codex review P0 finding."
+        ),
+    )
     return p
 
 
@@ -114,7 +138,7 @@ class SchemaFile:
     sha256: str
 
     @classmethod
-    def from_path(cls, p: Path) -> "SchemaFile":
+    def from_path(cls, p: Path) -> SchemaFile:
         return cls(path=p, sha256=hashlib.sha256(p.read_bytes()).hexdigest())
 
 
@@ -122,14 +146,20 @@ class SchemaFile:
 # can import them without pulling in clickhouse_connect.
 from tracer.services.clickhouse.v2.apply_schema_rewriter import (  # noqa: E402
     extract_table_name as _extract_table_name,
+)
+from tracer.services.clickhouse.v2.apply_schema_rewriter import (  # noqa: E402
     rewrite_for_replicated,
     split_statements,
 )
 
 
-def ensure_versions_table(client, *, replicated: bool = False,
-                          cluster: str = "default",
-                          zk_prefix: str = "/clickhouse/tables") -> None:
+def ensure_versions_table(
+    client,
+    *,
+    replicated: bool = False,
+    cluster: str = "default",
+    zk_prefix: str = "/clickhouse/tables",
+) -> None:
     """Create schema_versions if it doesn't exist. Bootstrap; not tracked itself.
 
     Uses unqualified table name so it lands in the connection's current database
@@ -142,8 +172,10 @@ def ensure_versions_table(client, *, replicated: bool = False,
     """
     on_cluster = f" ON CLUSTER '{cluster}'" if replicated else ""
     if replicated:
-        engine = (f"ReplicatedMergeTree('{zk_prefix}/{{shard}}/schema_versions', "
-                  f"'{{replica}}')")
+        engine = (
+            f"ReplicatedMergeTree('{zk_prefix}/{{shard}}/schema_versions', "
+            f"'{{replica}}')"
+        )
     else:
         engine = "MergeTree"
     client.command(f"""
@@ -185,13 +217,21 @@ def discover_files(schema_dir: Path, only: Iterable[str] | None) -> list[SchemaF
             log.error("missing_files", missing=[str(m) for m in missing])
             sys.exit(1)
     else:
-        files = sorted(p for p in schema_dir.glob("*.sql") if not p.name.startswith("_"))
+        files = sorted(
+            p for p in schema_dir.glob("*.sql") if not p.name.startswith("_")
+        )
     return [SchemaFile.from_path(p) for p in files]
 
 
-def apply_file(client, sf: SchemaFile, applied_by: str, *,
-               replicated: bool = False, cluster: str = "default",
-               zk_prefix: str = "/clickhouse/tables") -> int:
+def apply_file(
+    client,
+    sf: SchemaFile,
+    applied_by: str,
+    *,
+    replicated: bool = False,
+    cluster: str = "default",
+    zk_prefix: str = "/clickhouse/tables",
+) -> int:
     """Apply one file. Returns the number of statements executed.
 
     When `replicated=True`, each statement is passed through
@@ -203,25 +243,41 @@ def apply_file(client, sf: SchemaFile, applied_by: str, *,
     """
     sql = sf.path.read_text()
     statements = split_statements(sql)
-    log.info("apply_file_begin", file=sf.path.name, sha256=sf.sha256[:12],
-             statements=len(statements), replicated=replicated)
+    log.info(
+        "apply_file_begin",
+        file=sf.path.name,
+        sha256=sf.sha256[:12],
+        statements=len(statements),
+        replicated=replicated,
+    )
     for i, stmt in enumerate(statements, 1):
         if replicated:
             table_name = _extract_table_name(stmt)
             if table_name:
                 stmt = rewrite_for_replicated(
-                    stmt, table_name=table_name,
-                    cluster=cluster, zk_prefix=zk_prefix,
+                    stmt,
+                    table_name=table_name,
+                    cluster=cluster,
+                    zk_prefix=zk_prefix,
                 )
         first_line = stmt.splitlines()[0][:80]
-        log.info("apply_statement", file=sf.path.name, n=i, of=len(statements), preview=first_line)
+        log.info(
+            "apply_statement",
+            file=sf.path.name,
+            n=i,
+            of=len(statements),
+            preview=first_line,
+        )
         try:
             client.command(stmt)
         except Exception as e:
-            log.error("statement_failed",
-                      file=sf.path.name, n=i,
-                      statement_preview=stmt[:500],
-                      err=str(e))
+            log.error(
+                "statement_failed",
+                file=sf.path.name,
+                n=i,
+                statement_preview=stmt[:500],
+                err=str(e),
+            )
             raise
     # Record successful apply
     client.insert(
@@ -239,7 +295,9 @@ def apply_file(client, sf: SchemaFile, applied_by: str, *,
 def main(argv: list[str] | None = None) -> int:
     args = build_argparser().parse_args(argv)
 
-    log.info("connect", host=args.ch_host, port=args.ch_http_port, database=args.ch_database)
+    log.info(
+        "connect", host=args.ch_host, port=args.ch_http_port, database=args.ch_database
+    )
     client = clickhouse_connect.get_client(
         host=args.ch_host,
         port=args.ch_http_port,
@@ -295,11 +353,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if drift and not args.force:
         for sf, prior in drift:
-            log.error("drift_detected",
-                      file=sf.path.name,
-                      prior_sha=prior[:12],
-                      current_sha=sf.sha256[:12],
-                      hint="rerun with --force after writing a DECISIONS.md entry justifying the schema edit")
+            log.error(
+                "drift_detected",
+                file=sf.path.name,
+                prior_sha=prior[:12],
+                current_sha=sf.sha256[:12],
+                hint="rerun with --force after writing a DECISIONS.md entry justifying the schema edit",
+            )
         return 2
 
     if not to_apply:
@@ -307,16 +367,21 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.replicated:
-        log.info("replicated_mode",
-                 cluster=args.cluster, zk_prefix=args.zk_table_path_prefix,
-                 note="engines will be rewritten to Replicated* and ON CLUSTER appended")
+        log.info(
+            "replicated_mode",
+            cluster=args.cluster,
+            zk_prefix=args.zk_table_path_prefix,
+            note="engines will be rewritten to Replicated* and ON CLUSTER appended",
+        )
 
     total_stmts = 0
     t0 = time.time()
     for sf in to_apply:
         try:
             total_stmts += apply_file(
-                client, sf, user,
+                client,
+                sf,
+                user,
                 replicated=args.replicated,
                 cluster=args.cluster,
                 zk_prefix=args.zk_table_path_prefix,
@@ -324,10 +389,12 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as e:
             log.error("apply_aborted", file=sf.path.name, err=str(e))
             return 3
-    log.info("apply_complete",
-             files=len(to_apply),
-             statements=total_stmts,
-             elapsed_sec=round(time.time() - t0, 2))
+    log.info(
+        "apply_complete",
+        files=len(to_apply),
+        statements=total_stmts,
+        elapsed_sec=round(time.time() - t0, 2),
+    )
     return 0
 
 

--- a/futureagi/tracer/services/clickhouse/v2/apply_schema_rewriter.py
+++ b/futureagi/tracer/services/clickhouse/v2/apply_schema_rewriter.py
@@ -8,9 +8,11 @@ regression would create non-replicated tables in prod, causing silent
 split-brain across replicas. Sibling test file:
 `tracer/tests/test_ch25_apply_schema_replicated.py`.
 """
+
 from __future__ import annotations
 
 import re
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Statement splitter — extracted so the rewriter is self-contained.
@@ -27,7 +29,8 @@ def split_statements(sql: str) -> list[str]:
     out = []
     for part in parts:
         stripped = "\n".join(
-            line for line in part.splitlines()
+            line
+            for line in part.splitlines()
             if line.strip() and not line.strip().startswith("--")
         ).strip()
         if stripped:
@@ -54,6 +57,9 @@ def split_statements(sql: str) -> list[str]:
 # We also append ` ON CLUSTER '<cluster>' ` to:
 #   CREATE TABLE IF NOT EXISTS <name>
 #   CREATE MATERIALIZED VIEW IF NOT EXISTS <name> TO <target>
+#   CREATE DICTIONARY IF NOT EXISTS <name>      (dictionaries are node-local —
+#                                                without ON CLUSTER the DDL lands
+#                                                only on the connected replica)
 #   ALTER TABLE <name>                          (for projection adds in 007)
 
 # Object-name pattern: each segment can be bare, backtick-quoted, or
@@ -62,11 +68,18 @@ def split_statements(sql: str) -> list[str]:
 _SEGMENT = r"(?:`[^`]+`|\"[^\"]+\"|[A-Za-z_][A-Za-z0-9_]*)"
 _OBJECT_NAME = rf"(?P<obj>{_SEGMENT}(?:\.{_SEGMENT})?)"
 _CREATE_TABLE_RE = re.compile(
-    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?" + _OBJECT_NAME,
+    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    + _OBJECT_NAME,
     re.IGNORECASE,
 )
 _CREATE_MV_RE = re.compile(
-    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?" + _OBJECT_NAME,
+    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    + _OBJECT_NAME,
+    re.IGNORECASE,
+)
+_CREATE_DICTIONARY_RE = re.compile(
+    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?DICTIONARY\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    + _OBJECT_NAME,
     re.IGNORECASE,
 )
 _ALTER_TABLE_RE = re.compile(
@@ -87,6 +100,8 @@ def _object_name_from_match(m: re.Match) -> str:
     if len(raw) >= 2 and raw[0] in ("`", '"') and raw[-1] == raw[0]:
         raw = raw[1:-1]
     return raw
+
+
 # Match the ENGINE = clause. We support both multi-line and single-line
 # SQL — the leading group accepts a newline, a space, or the start of the
 # string so the rewriter doesn't miss inline statements.
@@ -102,11 +117,11 @@ _ENGINE_RE = re.compile(
 
 
 def extract_table_name(stmt: str) -> str | None:
-    """Return the table or MV name for an apply-time rewrite. Returns None
+    """Return the table, MV, or dictionary name for an apply-time rewrite. Returns None
     for statements that aren't subject to engine rewriting (INSERTs, DROPs, etc.).
     Handles bare identifiers, backtick/double-quoted, and <db>.<table> shapes.
     """
-    for rx in (_CREATE_TABLE_RE, _CREATE_MV_RE, _ALTER_TABLE_RE):
+    for rx in (_CREATE_TABLE_RE, _CREATE_MV_RE, _CREATE_DICTIONARY_RE, _ALTER_TABLE_RE):
         m = rx.match(stmt)
         if m:
             return _object_name_from_match(m)
@@ -128,8 +143,9 @@ class ReplicatedRewriteError(Exception):
 _KIND_REQUIRES_ENGINE = ("CREATE TABLE",)
 
 
-def rewrite_for_replicated(stmt: str, *, table_name: str, cluster: str,
-                           zk_prefix: str) -> str:
+def rewrite_for_replicated(
+    stmt: str, *, table_name: str, cluster: str, zk_prefix: str
+) -> str:
     """Apply the prod-mode rewrites to a single statement. Pure function;
     given the same inputs, always produces the same output (so schema
     hashing in the versions table stays deterministic per-mode).
@@ -145,13 +161,20 @@ def rewrite_for_replicated(stmt: str, *, table_name: str, cluster: str,
     if "ON CLUSTER" not in stmt.upper():
         # CREATE TABLE [IF NOT EXISTS] <name>
         stmt = _CREATE_TABLE_RE.sub(
-            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1)
+            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1
+        )
         # CREATE MATERIALIZED VIEW [IF NOT EXISTS] <name>
         stmt = _CREATE_MV_RE.sub(
-            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1)
+            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1
+        )
+        # CREATE DICTIONARY [IF NOT EXISTS] <name>
+        stmt = _CREATE_DICTIONARY_RE.sub(
+            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1
+        )
         # ALTER TABLE <name>
         stmt = _ALTER_TABLE_RE.sub(
-            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1)
+            lambda m: f"{m.group(0)} ON CLUSTER '{cluster}'", stmt, count=1
+        )
 
     # 2. Rewrite engine. Only one ENGINE = per statement in our schema files.
     def _swap(m: re.Match) -> str:

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -12,41 +12,56 @@ would create non-replicated tables in prod — silent split-brain across
 replicas. These tests cover the engines and statement shapes we care
 about; any new engine the schema starts using needs a test added here.
 """
+
 from __future__ import annotations
 
 import pytest
 
 from tracer.services.clickhouse.v2.apply_schema_rewriter import (
     ReplicatedRewriteError,
-    extract_table_name as _extract_table_name,
     rewrite_for_replicated,
     split_statements,
+)
+from tracer.services.clickhouse.v2.apply_schema_rewriter import (
+    extract_table_name as _extract_table_name,
 )
 
 
 def _rewrite(sql: str, table: str = "spans") -> str:
     """Convenience wrapper with prod-default cluster + zk_prefix."""
     return rewrite_for_replicated(
-        sql, table_name=table,
-        cluster="default", zk_prefix="/clickhouse/tables",
+        sql,
+        table_name=table,
+        cluster="default",
+        zk_prefix="/clickhouse/tables",
     )
 
 
 class TestExtractTableName:
-    @pytest.mark.parametrize("stmt, expected", [
-        ("CREATE TABLE IF NOT EXISTS spans (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE TABLE spans_v2_dead_letter (...) ENGINE = MergeTree", "spans_v2_dead_letter"),
-        ("CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv TO spans_per_session AS ...",
-         "spans_per_session_mv"),
-        ("CREATE MATERIALIZED VIEW eval_per_config_mv TO eval_per_config AS ...",
-         "eval_per_config_mv"),
-        ("ALTER TABLE spans ADD COLUMN foo String", "spans"),
-        ("ALTER TABLE spans_per_session MODIFY TTL ...", "spans_per_session"),
-        # Negative — statements we deliberately don't touch:
-        ("INSERT INTO spans VALUES (1)", None),
-        ("SELECT * FROM spans", None),
-        ("DROP TABLE spans", None),  # we don't rewrite DROPs — safety
-    ])
+    @pytest.mark.parametrize(
+        "stmt, expected",
+        [
+            ("CREATE TABLE IF NOT EXISTS spans (a UInt8) ENGINE = MergeTree", "spans"),
+            (
+                "CREATE TABLE spans_v2_dead_letter (...) ENGINE = MergeTree",
+                "spans_v2_dead_letter",
+            ),
+            (
+                "CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv TO spans_per_session AS ...",
+                "spans_per_session_mv",
+            ),
+            (
+                "CREATE MATERIALIZED VIEW eval_per_config_mv TO eval_per_config AS ...",
+                "eval_per_config_mv",
+            ),
+            ("ALTER TABLE spans ADD COLUMN foo String", "spans"),
+            ("ALTER TABLE spans_per_session MODIFY TTL ...", "spans_per_session"),
+            # Negative — statements we deliberately don't touch:
+            ("INSERT INTO spans VALUES (1)", None),
+            ("SELECT * FROM spans", None),
+            ("DROP TABLE spans", None),  # we don't rewrite DROPs — safety
+        ],
+    )
     def test_extracts_or_skips(self, stmt, expected):
         assert _extract_table_name(stmt) == expected
 
@@ -113,8 +128,10 @@ class TestOnClusterAttachment:
             "TO spans_per_session AS SELECT 1",
             table="spans_per_session_mv",
         )
-        assert ("CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv "
-                "ON CLUSTER 'default'") in out
+        assert (
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv "
+            "ON CLUSTER 'default'"
+        ) in out
 
     def test_alter_table_gets_on_cluster(self):
         out = _rewrite("ALTER TABLE spans ADD PROJECTION p (...)")
@@ -128,6 +145,71 @@ class TestOnClusterAttachment:
         # Engine still rewrites...
         assert "ReplicatedMergeTree" in out
         # ...but ON CLUSTER count stays at 1
+        assert out.upper().count("ON CLUSTER") == 1
+
+
+class TestDictionaryOnCluster:
+    """Dictionaries are node-local objects — a CREATE DICTIONARY without
+    ON CLUSTER lands only on the replica apply_schema connected to. This
+    shipped: us2 prod had `end_users_dict` / `trace_sessions_dict` on 1 of
+    3 replicas, so queries load-balanced to the other two failed Code 36.
+    """
+
+    @pytest.mark.parametrize(
+        "stmt, expected",
+        [
+            (
+                "CREATE DICTIONARY IF NOT EXISTS end_users_dict (a UInt8) PRIMARY KEY a "
+                "SOURCE(CLICKHOUSE(TABLE 'end_users')) LIFETIME(60) LAYOUT(FLAT())",
+                "end_users_dict",
+            ),
+            (
+                "CREATE OR REPLACE DICTIONARY trace_dict (a UInt8) PRIMARY KEY a "
+                "SOURCE(CLICKHOUSE(TABLE 'traces')) LIFETIME(60) LAYOUT(FLAT())",
+                "trace_dict",
+            ),
+            (
+                "CREATE DICTIONARY analytics.trace_dict (a UInt8) PRIMARY KEY a "
+                "SOURCE(CLICKHOUSE(TABLE 'traces')) LIFETIME(60) LAYOUT(FLAT())",
+                "trace_dict",
+            ),
+            ("DROP DICTIONARY trace_dict", None),
+            ("SYSTEM RELOAD DICTIONARY trace_dict", None),
+        ],
+    )
+    def test_extracts_or_skips(self, stmt, expected):
+        assert _extract_table_name(stmt) == expected
+
+    def test_create_dictionary_gets_on_cluster(self):
+        out = _rewrite(
+            "CREATE DICTIONARY IF NOT EXISTS end_users_dict\n"
+            "(\n    end_user_id UUID,\n    user_id String\n)\n"
+            "PRIMARY KEY end_user_id\n"
+            "SOURCE(CLICKHOUSE(TABLE 'end_users' WHERE 'is_deleted = 0'))\n"
+            "LIFETIME(MIN 60 MAX 120)\n"
+            "LAYOUT(COMPLEX_KEY_HASHED());",
+            table="end_users_dict",
+        )
+        assert (
+            "CREATE DICTIONARY IF NOT EXISTS end_users_dict ON CLUSTER 'default'" in out
+        )
+
+    def test_create_dictionary_without_engine_does_not_raise(self):
+        # Dictionaries have no ENGINE clause — the CREATE-TABLE fail-closed
+        # path must not fire on them.
+        out = _rewrite(
+            "CREATE DICTIONARY d (a UInt8) PRIMARY KEY a "
+            "SOURCE(CLICKHOUSE(TABLE 't')) LIFETIME(60) LAYOUT(FLAT())",
+            table="d",
+        )
+        assert out.upper().count("ON CLUSTER") == 1
+
+    def test_idempotent_on_already_clustered(self):
+        stmt = (
+            "CREATE DICTIONARY d ON CLUSTER 'shard1' (a UInt8) PRIMARY KEY a "
+            "SOURCE(CLICKHOUSE(TABLE 't')) LIFETIME(60) LAYOUT(FLAT())"
+        )
+        out = _rewrite(stmt, table="d")
         assert out.upper().count("ON CLUSTER") == 1
 
 
@@ -155,6 +237,7 @@ class TestAllShippedSchemas:
     @pytest.fixture
     def schema_files(self):
         import pathlib
+
         here = pathlib.Path(__file__).resolve().parents[1]
         schema_dir = here / "services" / "clickhouse" / "v2" / "schema"
         return sorted(schema_dir.glob("*.sql"))
@@ -188,6 +271,29 @@ class TestAllShippedSchemas:
                     continue
                 rewritten = _rewrite(stmt, table=name)
                 assert "ON CLUSTER" in rewritten
+
+    def test_every_create_dictionary_gets_on_cluster(self, schema_files):
+        # The gate for the us2 incident: 015/017/018 ship dictionaries, and
+        # every one of them must fan out to all replicas in prod mode.
+        import re
+
+        create_dict = re.compile(
+            r"\s*CREATE\s+(?:OR\s+REPLACE\s+)?DICTIONARY", re.IGNORECASE
+        )
+        seen = 0
+        for f in schema_files:
+            for stmt in split_statements(f.read_text()):
+                name = _extract_table_name(stmt)
+                if name is None:
+                    continue
+                if not create_dict.match(stmt):
+                    continue
+                seen += 1
+                rewritten = _rewrite(stmt, table=name)
+                assert "ON CLUSTER" in rewritten, (
+                    f"{f.name}: CREATE DICTIONARY for {name} missing ON CLUSTER."
+                )
+        assert seen >= 3, "expected the shipped dictionary DDLs to be swept"
 
     def test_every_alter_table_gets_on_cluster(self, schema_files):
         for f in schema_files:
@@ -235,8 +341,11 @@ class TestFailClosed:
                 "CREATE TABLE foo (a UInt8) ENGINE = CollapsingMergeTree(sign)",
                 table="foo",
             )
-        assert "CollapsingMergeTree" in str(exc.value) or "unrecognised" in str(exc.value).lower() \
+        assert (
+            "CollapsingMergeTree" in str(exc.value)
+            or "unrecognised" in str(exc.value).lower()
             or "recognised" in str(exc.value).lower()
+        )
 
     def test_create_with_no_engine_at_all_raises(self):
         # Defensive: a CREATE without ENGINE is invalid CH SQL anyway, but
@@ -255,15 +364,23 @@ class TestSchemaQualifiedNames:
     path, not the database qualifier.
     """
 
-    @pytest.mark.parametrize("stmt, expected", [
-        ("CREATE TABLE analytics.spans (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE TABLE `analytics`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE MATERIALIZED VIEW analytics.spans_mv TO analytics.spans AS SELECT 1",
-         "spans_mv"),
-        ("ALTER TABLE analytics.spans ADD COLUMN b UInt8", "spans"),
-        ("CREATE TABLE IF NOT EXISTS `default`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE OR REPLACE TABLE foo (a UInt8) ENGINE = MergeTree", "foo"),
-    ])
+    @pytest.mark.parametrize(
+        "stmt, expected",
+        [
+            ("CREATE TABLE analytics.spans (a UInt8) ENGINE = MergeTree", "spans"),
+            ("CREATE TABLE `analytics`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
+            (
+                "CREATE MATERIALIZED VIEW analytics.spans_mv TO analytics.spans AS SELECT 1",
+                "spans_mv",
+            ),
+            ("ALTER TABLE analytics.spans ADD COLUMN b UInt8", "spans"),
+            (
+                "CREATE TABLE IF NOT EXISTS `default`.`spans` (a UInt8) ENGINE = MergeTree",
+                "spans",
+            ),
+            ("CREATE OR REPLACE TABLE foo (a UInt8) ENGINE = MergeTree", "foo"),
+        ],
+    )
     def test_extracts_table_segment(self, stmt, expected):
         assert _extract_table_name(stmt) == expected
 
@@ -284,20 +401,48 @@ class TestGoldenOutputForShippedFiles:
     must update this test, making the change visible in review.
     """
 
-    @pytest.mark.parametrize("table, expected_engine_substr", [
-        ("spans", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/spans', '{replica}', _version, is_deleted)"),
-        ("spans_v2_dead_letter", "ReplicatedMergeTree('/clickhouse/tables/{shard}/spans_v2_dead_letter', '{replica}')"),
-        ("schema_versions", "ReplicatedMergeTree('/clickhouse/tables/{shard}/schema_versions', '{replica}')"),
-        ("backfill_checkpoints", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/backfill_checkpoints', '{replica}', _version)"),
-        ("spans_per_session", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_per_session', '{replica}')"),
-        ("eval_per_config", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/eval_per_config', '{replica}')"),
-        ("spans_hourly_rollup", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_hourly_rollup', '{replica}')"),
-        ("tracer_eval_logger_v2", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/tracer_eval_logger_v2', '{replica}', _version, is_deleted)"),
-    ])
+    @pytest.mark.parametrize(
+        "table, expected_engine_substr",
+        [
+            (
+                "spans",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/spans', '{replica}', _version, is_deleted)",
+            ),
+            (
+                "spans_v2_dead_letter",
+                "ReplicatedMergeTree('/clickhouse/tables/{shard}/spans_v2_dead_letter', '{replica}')",
+            ),
+            (
+                "schema_versions",
+                "ReplicatedMergeTree('/clickhouse/tables/{shard}/schema_versions', '{replica}')",
+            ),
+            (
+                "backfill_checkpoints",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/backfill_checkpoints', '{replica}', _version)",
+            ),
+            (
+                "spans_per_session",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_per_session', '{replica}')",
+            ),
+            (
+                "eval_per_config",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/eval_per_config', '{replica}')",
+            ),
+            (
+                "spans_hourly_rollup",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_hourly_rollup', '{replica}')",
+            ),
+            (
+                "tracer_eval_logger_v2",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/tracer_eval_logger_v2', '{replica}', _version, is_deleted)",
+            ),
+        ],
+    )
     def test_engine_substr_matches(self, table, expected_engine_substr):
         # Find the file that declares this table and assert the rewrite
         # produces the expected engine line.
         import pathlib
+
         here = pathlib.Path(__file__).resolve().parents[1]
         schema_dir = here / "services" / "clickhouse" / "v2" / "schema"
         for f in sorted(schema_dir.glob("*.sql")):


### PR DESCRIPTION
## Why

`us2` prod broke on `/tracer/trace/list_traces_of_session/` with:

```
Code: 36. DB::Exception: Dictionary (`end_users_dict`) not found
```

Investigation on the us2 ClickHouse cluster (3 replicas, Altinity operator) showed `end_users_dict` and `trace_sessions_dict` exist **only on replica 0**:

| Replica | `end_users_dict` | `trace_sessions_dict` | `trace_dict` |
|---|---|---|---|
| cluster-0-0 | ✅ | ✅ | ✅ |
| cluster-0-1 | ❌ | ❌ | ✅ |
| cluster-0-2 | ❌ | ❌ | ✅ |

Root cause: `apply_schema --replicated` appends `ON CLUSTER` only to `CREATE TABLE` / `CREATE MATERIALIZED VIEW` / `ALTER TABLE`. `CREATE DICTIONARY` was not in the rewrite list, and dictionaries are **node-local** objects — so the dictionary DDL from `015`/`017`/`018` landed only on whichever replica `apply_schema` connected to (replica 0, applied 2026-07-07). Any query load-balanced to replicas 1/2 that touches `end_users_dict`/`trace_sessions_dict` fails Code 36. `trace_dict` (015) survived only by accident: the legacy `schema.py` boot-hook also creates it and backend boots have hit every replica over time; the v2-only dictionaries have no such self-heal path.

## What

- `apply_schema_rewriter.py`: new `_CREATE_DICTIONARY_RE` matching `CREATE [OR REPLACE] DICTIONARY [IF NOT EXISTS] <name>` (bare / quoted / db-qualified names, same `_OBJECT_NAME` pattern as tables). It participates in `extract_table_name` (so `apply_file` enters the rewrite path) and gets `ON CLUSTER '<cluster>'` injected after the object name in `rewrite_for_replicated`. No engine rewrite applies — dictionaries have no `ENGINE =` clause, and the fail-closed check only guards `CREATE TABLE`, so dictionaries pass through it untouched.
- `apply_schema.py`: `--replicated` help text updated to mention `CREATE DICTIONARY`.
- Note: the pre-commit ruff format/fix hook reflowed pre-existing code in both files (argparse blocks, import ordering) — the behavioral change is only the dictionary rewrite path.

## Tests

New (in `tracer/tests/test_ch25_apply_schema_replicated.py`):
- `TestDictionaryOnCluster::test_extracts_or_skips` — `extract_table_name` returns the dictionary name for `CREATE DICTIONARY IF NOT EXISTS`, `CREATE OR REPLACE DICTIONARY`, and db-qualified forms; returns `None` for `DROP DICTIONARY` / `SYSTEM RELOAD DICTIONARY` (we never rewrite those).
- `TestDictionaryOnCluster::test_create_dictionary_gets_on_cluster` — the 017-shaped multi-line DDL gets `ON CLUSTER 'default'` immediately after the name.
- `TestDictionaryOnCluster::test_create_dictionary_without_engine_does_not_raise` — dictionaries have no ENGINE clause; the CREATE-TABLE fail-closed path must not fire on them.
- `TestDictionaryOnCluster::test_idempotent_on_already_clustered` — a hand-written `ON CLUSTER` is not duplicated.
- `TestAllShippedSchemas::test_every_create_dictionary_gets_on_cluster` — sweeps every shipped `v2/schema/*.sql` and asserts all dictionary DDLs (015 `trace_dict`, 017 `end_users_dict`, 018 `trace_sessions_dict`) fan out; asserts ≥3 were swept so the gate can't silently go dead.

Old: all 44 pre-existing rewriter tests unchanged and green (engine rewrites, ON CLUSTER attachment, fail-closed, qualified names, golden outputs).

## Commands

```bash
cd futureagi
uv run pytest tracer/tests/test_ch25_apply_schema_replicated.py -q
uv run ruff check tracer/services/clickhouse/v2/apply_schema.py tracer/services/clickhouse/v2/apply_schema_rewriter.py tracer/tests/test_ch25_apply_schema_replicated.py
```

## Local verification

Rewriter output for the three shipped dictionary DDLs (prod flags `--cluster cluster --zk-table-path-prefix /clickhouse/tables/ch25`):

```
CREATE OR REPLACE DICTIONARY trace_dict ON CLUSTER 'cluster'
CREATE DICTIONARY IF NOT EXISTS end_users_dict ON CLUSTER 'cluster'
CREATE DICTIONARY IF NOT EXISTS trace_sessions_dict ON CLUSTER 'cluster'
```

Test run:

```
49 passed in 0.29s
All checks passed!
```

TDD evidence — the new tests fail without the fix:

```
FAILED ...::TestDictionaryOnCluster::test_extracts_or_skips[...] 
assert None == 'end_users_dict'
```

## Ops note (not in this PR)

This PR prevents recurrence; us2 still needs the one-time heal: re-run the `CREATE DICTIONARY IF NOT EXISTS` DDLs from 017/018 (and 015's `CREATE OR REPLACE`) with `ON CLUSTER 'cluster'` so replicas 1/2 get the dictionaries. Idempotent on replica 0.

## Architectural rationale

The fix follows the existing single-source-of-truth design: schema files stay cluster-agnostic and the `--replicated` rewriter injects topology at apply time, so dev/test single-node rigs and prod replicated clusters share the same SQL. Extending the rewriter (rather than hand-writing `ON CLUSTER` into the .sql files) keeps that invariant — the shipped-schema sweep test also enforces that source files must NOT contain `ON CLUSTER`. `schema_versions` bookkeeping is unaffected: hashes record the original file content, so already-applied files stay no-ops and the us2 heal is a manual DDL, not a re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
