### PR TITLE
chore(frontend): refetch on mount + tighten react-query staleTime to 10s

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -84,13 +84,10 @@ const queryClient = new QueryClient({
   }),
   defaultOptions: {
     queries: {
-      // Data stays fresh for 30s — no refetch on remount/focus within this window
-      staleTime: 30 * 1000,
-      // Keep unused data in cache for 5 min (default)
+      staleTime: 10 * 1000,
       gcTime: 5 * 60 * 1000,
-      // Don't refetch when browser tab regains focus
-      refetchOnWindowFocus: false,
-      // Retry once on failure
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
       retry: 1,
     },
   },


### PR DESCRIPTION
## Summary
Tune the global React Query defaults so screens show fresher data: drop `staleTime` from 30s to 10s and enable `refetchOnMount` and `refetchOnWindowFocus`.

## Why / problem
The previous defaults (introduced in an earlier perf pass) were optimized to minimize requests: `staleTime: 30s` + `refetchOnWindowFocus: false`. In practice that meant a remounted screen or a tab regaining focus kept serving cached data, so recent changes didn't show up promptly. For a fast-changing product we want fresher-on-navigation behavior.

## What changed
`frontend/src/app.jsx` — `QueryClient` `defaultOptions.queries`:
- `staleTime`: `30s` → `10s`
- `refetchOnMount: true` — a remounted screen refetches when data is stale (older than 10s)
- `refetchOnWindowFocus: true` — returning to the tab refetches stale queries
- `gcTime` (5min) and `retry: 1` unchanged

Net effect: data still de-dupes within a 10s window (no refetch storms), but navigation and tab-return pull fresh data once past that window.

## Tests
- [ ] Navigate away and back to a data screen after >10s → sees refreshed data.
- [ ] Rapid remount within 10s → served from cache, no refetch (no spinner storm).
- [ ] Switch to another tab and back after >10s → stale queries refetch.
- [ ] No regression in the polling grids (they drive their own setInterval refresh).

## Backwards compatibility
No API changes. Behavior-only change to client-side caching defaults; any query that sets its own `staleTime`/refetch options is unaffected.

## Type of change
- [x] Chore / tuning (non-breaking)

## Notes / follow-ups (not in this PR)
- `retry: 1` currently retries 4xx too; a follow-up could skip 4xx and only retry 5xx/network.
- With `refetchOnWindowFocus: true`, the global `queryCache.onError` toast can fire on background-refetch failures; a follow-up could suppress toasts when cached data already exists.
