### PR TITLE
fix(EvalPicker): live-extract {{variable}} from instructions in EvalPickerConfig

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
@@ -119,10 +119,23 @@ const EvalPickerConfig = ({ evalData, onBack, onSave, isSaving }) => {
     [evalData],
   );
 
-  // Extract required variables from eval template
+  // Extract required variables from eval template.
+  // Prefer live extraction from the instructions text (so newly added /
+  // removed `{{variable}}` placeholders show up immediately), falling
+  // back to the template's stored requiredKeys when there's no
+  // instructions text to parse. Mirrors the mustache-extraction branch
+  // in EvalPickerConfigFull.jsx.
   const variables = useMemo(() => {
-    const keys = normalizedEvalData?.requiredKeys || [];
-    return [...new Set(keys)];
+    const requiredKeys = normalizedEvalData?.requiredKeys || [];
+    const instructions = normalizedEvalData?.instructions || "";
+
+    const matches = instructions.match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [];
+    const templateVars = matches.map((m) =>
+      m.replace(/\{\{|\}\}/g, "").trim(),
+    );
+    if (templateVars.length > 0) return [...new Set(templateVars)];
+
+    return [...new Set(requiredKeys)];
   }, [normalizedEvalData]);
 
   // Column options for mapping dropdowns


### PR DESCRIPTION
## Summary
`EvalPickerConfig.jsx`'s variable-mapping list only read the eval template's stored `requiredKeys`, never the live `instructions` text, so newly added or removed `{{variable}}` placeholders never showed up in the Variable Mapping section. This adds the same live mustache (`{{variable}}`) extraction that `EvalPickerConfigFull.jsx` already uses, with `requiredKeys` as a fallback when there's no instructions text to parse.

## Linked issues
Closes #1525

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?
`EvalPickerConfig.jsx` isn't wired into any route (per the issue), so it can't be reached by clicking through the app. Tested by rendering the component standalone with an `evalData` object whose `requiredKeys` was empty but whose `instructions` contained a `{{newVar}}` placeholder, confirming:
- the new variable appears in the Variable Mapping section
- removing the placeholder from `instructions` drops it from the list
- `requiredKeys` still populate the list when `instructions` is empty (unchanged behavior)
- `EvalPickerConfigFull.jsx`'s own variable extraction was not modified and is unaffected

## Screenshots / recordings (if UI)
N/A - component has no live route to screenshot from; verified via standalone render (see above).

## Checklist
- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA