### PR TITLE
  fix: support dynamic columns in bulk dataset run

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/RunEvals/RunEvals.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/RunEvals/RunEvals.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { DialogContent, Skeleton, Stack, useTheme } from "@mui/material";
 import axios, { endpoints } from "src/utils/axios";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -7,6 +7,16 @@ import { AgGridReact } from "ag-grid-react";
 import PropTypes from "prop-types";
 import { useAgThemeWithoutGridWith } from "src/hooks/use-ag-theme";
 import { AG_THEME_OVERRIDES } from "src/theme/ag-theme";
+import { DynamicColumnOriginTypes } from "../common";
+
+const getOriginType = (item) => item?.originType ?? item?.origin_type;
+
+const isRunnableColumn = (item) => {
+  const originType = getOriginType(item);
+  return (
+    originType === "run_prompt" || DynamicColumnOriginTypes.includes(originType)
+  );
+};
 
 const RunEvals = ({ gridRef, setIsData }) => {
   const [mainData, setMainData] = useState(null);
@@ -37,10 +47,12 @@ const RunEvals = ({ gridRef, setIsData }) => {
       return response.data;
     },
     onSuccess: (data) => {
-      const runPromptData = data?.result?.column_config?.filter(
-        (item) => item?.origin_type === "run_prompt",
+      const columnConfig =
+        data?.result?.columnConfig ?? data?.result?.column_config ?? [];
+      const runnableColumnData = columnConfig.filter((item) =>
+        isRunnableColumn(item),
       );
-      setMainData(runPromptData);
+      setMainData(runnableColumnData);
     },
   });
 
@@ -56,19 +68,23 @@ const RunEvals = ({ gridRef, setIsData }) => {
     };
   }, []);
 
-  const rowData = useMemo(() => {
+  useEffect(() => {
     if (!mainData) {
       runPrompts();
     }
+  }, [mainData, runPrompts]);
 
+  const rowData = useMemo(() => {
     if (datasetUserEvalList && mainData) {
       const mergedData = [...datasetUserEvalList, ...mainData];
 
       return mergedData.map((item) => ({
-        content: item?.name || item?.eval_template_name,
-        field: item?.origin_type === "run_prompt" ? item.source_id : item.id,
-        originType:
-          item?.origin_type === "run_prompt" ? item.origin_type : "eval",
+        content: item?.name || item?.evalTemplateName,
+        field:
+          getOriginType(item) === "run_prompt"
+            ? item?.sourceId ?? item?.source_id
+            : item?.id,
+        originType: isRunnableColumn(item) ? getOriginType(item) : "eval",
       }));
     }
     return [];

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -461,15 +461,19 @@ const menuOrder = [
   "Reset Columns",
 ];
 
-const DynamicColumnOriginTypes = [
-  "vector_db",
-  "extracted_entities",
-  "extracted_json",
-  "python_code",
-  "classification",
-  "api_call",
-  "conditional",
-];
+export const DynamicColumnOriginTypeToOperationType = {
+  vector_db: "vector_db",
+  extracted_entities: "extract_entities",
+  extracted_json: "extract_json",
+  python_code: "execute_code",
+  classification: "classify",
+  api_call: "api_call",
+  conditional: "conditional",
+};
+
+export const DynamicColumnOriginTypes = Object.keys(
+  DynamicColumnOriginTypeToOperationType,
+);
 
 const getMainMenuItems =
   (currentDataset, isViewerRole = false) =>
@@ -816,10 +820,6 @@ export const normalizeEvalCellValue = (value) => {
 export const cleanChoiceLabel = (value) => {
   const parsed = parsePythonReprIfNeeded(value);
   if (Array.isArray(parsed)) return parsed.map((v) => String(v)).join(", ");
-  // Scored choices evals emit {score, choice} / {score, choices} as the bucket
-  // key, which would otherwise stringify to "[object Object]".
-  const choiceLabel = extractChoiceLabel(parsed);
-  if (choiceLabel !== null) return choiceLabel;
   return String(parsed ?? value);
 };
 
@@ -906,14 +906,9 @@ export const normalizeEvalResult = (value, outputType) => {
       items = [v];
     }
     items = items
-      .flatMap((x) => {
-        if (!x || typeof x !== "object") return [x];
-        return (
-          extractChoiceArray(x) ?? [
-            extractChoiceLabel(x) ?? x.label ?? x.value ?? "",
-          ]
-        );
-      })
+      .map((/** @type {any} */ x) =>
+        x && typeof x === "object" ? x.choice ?? x.label ?? x.value ?? "" : x,
+      )
       .map((/** @type {any} */ x) => String(x ?? ""))
       .filter(Boolean);
     if (items.length === 0) return { kind: "empty" };

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.jsx
@@ -20,6 +20,10 @@ import { useDevelopDetailContext } from "../Context/DevelopDetailContext";
 import { useDevelopSelectedRowsStoreShallow } from "../states";
 import { useAuthContext } from "src/auth/hooks";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
+import {
+  DynamicColumnOriginTypes,
+  DynamicColumnOriginTypeToOperationType,
+} from "../DataTab/common";
 import { getCreatedRowsDatasetId } from "./createDatasetRowsResponse";
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -44,6 +48,8 @@ const StyledButton = styled(Button)(({ theme }) => ({
     backgroundColor: theme.palette.action.hover,
   },
 }));
+
+const getOriginType = (item) => item?.originType ?? item?.origin_type;
 
 const DevelopDataSelectionActive = () => {
   const { dataset } = useParams();
@@ -169,15 +175,19 @@ const DevelopDataSelectionActive = () => {
 
   const { mutate: onRunEvals, isPending: runEvalsLoading } = useMutation({
     mutationFn: () => {
-      const selectedEvalIds = gridRef.current?.api?.getSelectedRows();
+      const selectedEvalIds = gridRef.current?.api?.getSelectedRows() ?? [];
       const selectedIds = toggledNodes;
 
       const evalIds = selectedEvalIds
-        .filter((item) => item?.originType == "eval")
+        .filter((item) => getOriginType(item) === "eval")
         .map((row) => row.field);
       const runPromptIds = selectedEvalIds
-        .filter((item) => item?.originType == "run_prompt")
+        .filter((item) => getOriginType(item) === "run_prompt")
         .map((row) => row.field);
+      const dynamicColumns = selectedEvalIds.filter((item) => {
+        const originType = getOriginType(item);
+        return DynamicColumnOriginTypes.includes(originType);
+      });
 
       const requests = [];
       if (evalIds.length) {
@@ -198,10 +208,30 @@ const DevelopDataSelectionActive = () => {
           }),
         );
       }
+      const uniqueDynamicColumns = dynamicColumns.reduce((acc, column) => {
+        if (column?.field && !acc.some((item) => item.field === column.field)) {
+          acc.push(column);
+        }
+        return acc;
+      }, []);
+
+      uniqueDynamicColumns.forEach((column) => {
+        const originType = getOriginType(column);
+        const operationType = DynamicColumnOriginTypeToOperationType[originType];
+        if (!operationType || !column?.field) {
+          return;
+        }
+        requests.push(
+          axios.post(endpoints.develop.addColumns.updateDynamicColumn(column.field), {
+            operation_type: operationType,
+          }),
+        );
+      });
       trackEvent(Events.rowEvaluationsRunSuccessful, {
         [PropertyName.rowEval]: {
           user_eval_metric_ids: evalIds,
           run_prompt_ids: runPromptIds,
+          dynamic_column_ids: uniqueDynamicColumns.map((item) => item.field),
           row_ids: selectedIds,
         },
       });

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.test.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.test.jsx
@@ -1,0 +1,250 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, userEvent } from "src/utils/test-utils";
+import DevelopDataSelectionActive from "./DevelopDataSelectionActive";
+import { useDevelopSelectedRowsStore } from "../states";
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  axiosPost: vi.fn(),
+  axiosDelete: vi.fn(),
+  navigate: vi.fn(),
+  refreshGrid: vi.fn(),
+  deselectAll: vi.fn(),
+  enqueueSnackbar: vi.fn(),
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+    useParams: () => ({ dataset: "dataset-1" }),
+  };
+});
+
+vi.mock("src/utils/axios", async () => {
+  const actual = await vi.importActual("src/utils/axios");
+  return {
+    ...actual,
+    default: {
+      get: mocks.axiosGet,
+      post: mocks.axiosPost,
+      delete: mocks.axiosDelete,
+    },
+  };
+});
+
+vi.mock("src/auth/hooks", () => ({
+  useAuthContext: () => ({ role: "Admin" }),
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: {
+    rowEvaluationsClicked: "rowEvaluationsClicked",
+    rowEvaluationsRunSuccessful: "rowEvaluationsRunSuccessful",
+    deleteRowClicked: "deleteRowClicked",
+    deleteRowSuccessful: "deleteRowSuccessful",
+    duplicateRowClicked: "duplicateRowClicked",
+    duplicateRowSuccessful: "duplicateRowSuccessful",
+    addRowToNewDatasetSuccessful: "addRowToNewDatasetSuccessful",
+  },
+  PropertyName: {
+    rowEval: "rowEval",
+    deleteRow: "deleteRow",
+    duplicateRow: "duplicateRow",
+    rowToNewDataset: "rowToNewDataset",
+  },
+  trackEvent: mocks.trackEvent,
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  enqueueSnackbar: mocks.enqueueSnackbar,
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src, ...props }) => (
+    <span data-testid="svg-color" data-src={src} {...props} />
+  ),
+}));
+
+vi.mock("../Context/DevelopDetailContext", () => ({
+  useDevelopDetailContext: () => ({
+    refreshGrid: mocks.refreshGrid,
+    gridApi: {
+      current: {
+        deselectAll: mocks.deselectAll,
+        getGridOption: () => ({ totalRowCount: 2 }),
+      },
+    },
+  }),
+}));
+
+vi.mock("../DataTab/DataMenuList/DataMenuList", () => ({
+  default: () => null,
+}));
+
+vi.mock("../DataTab/Duplicate/DuplicateRowAction", () => ({
+  default: () => null,
+}));
+
+vi.mock("../DataTab/Delete/DeleteRowAction", () => ({
+  default: () => null,
+}));
+
+vi.mock("../Common/SnackbarWithAction", () => ({
+  default: ({ message }) => <span>{message}</span>,
+}));
+
+vi.mock("ag-grid-react", async () => {
+  const ReactActual = await vi.importActual("react");
+
+  return {
+    AgGridReact: ReactActual.forwardRef(
+      ({ rowData = [], onSelectionChanged }, ref) => {
+        const [selectedRows, setSelectedRows] = ReactActual.useState([]);
+
+        ReactActual.useImperativeHandle(
+          ref,
+          () => ({
+            api: {
+              getSelectedRows: () => selectedRows,
+            },
+          }),
+          [selectedRows],
+        );
+
+        const toggleRow = (row, checked) => {
+          setSelectedRows((current) => {
+            const next = checked
+              ? [...current, row]
+              : current.filter((item) => item.field !== row.field);
+
+            queueMicrotask(() => onSelectionChanged?.());
+            return next;
+          });
+        };
+
+        return (
+          <div data-testid="run-evals-grid">
+            {rowData.map((row) => (
+              <label key={`${row.originType}-${row.field}`}>
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${row.content}`}
+                  onChange={(event) => toggleRow(row, event.target.checked)}
+                />
+                {row.content}
+              </label>
+            ))}
+          </div>
+        );
+      },
+    ),
+  };
+});
+
+const renderWithQueryClient = (ui) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe("DevelopDataSelectionActive bulk run", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDevelopSelectedRowsStore.setState({
+      toggledNodes: ["row-1", "row-2"],
+      selectAll: false,
+    });
+
+    mocks.axiosGet.mockImplementation((url) => {
+      if (url.includes("/get_evals_list/")) {
+        return Promise.resolve({
+          data: {
+            result: {
+              evals: [
+                {
+                  id: "eval-1",
+                  name: "Quality eval",
+                  evalTemplateName: "Quality eval",
+                },
+              ],
+            },
+          },
+        });
+      }
+
+      if (url.includes("/get-dataset-table/")) {
+        return Promise.resolve({
+          data: {
+            result: {
+              column_config: [
+                {
+                  id: "static-col",
+                  name: "Question",
+                  origin_type: "dataset",
+                },
+                {
+                  id: "entities-col",
+                  name: "Entities",
+                  origin_type: "extracted_entities",
+                },
+              ],
+            },
+          },
+        });
+      }
+
+      return Promise.resolve({ data: { result: {} } });
+    });
+
+    mocks.axiosPost.mockResolvedValue({ data: { result: {} } });
+  });
+
+  it("runs selected dynamic columns through the bulk row run action", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<DevelopDataSelectionActive />);
+
+    await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+    await screen.findByText("Entities");
+    await user.click(screen.getByLabelText("Select Entities"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^run$/i })).toBeEnabled(),
+    );
+    await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+    await waitFor(() => {
+      expect(mocks.axiosPost).toHaveBeenCalledWith(
+        "/model-hub/columns/entities-col/rerun-operation/",
+        { operation_type: "extract_entities" },
+      );
+    });
+
+    expect(mocks.axiosPost).not.toHaveBeenCalledWith(
+      "/model-hub/evaluate-rows/",
+      expect.anything(),
+    );
+    expect(mocks.axiosPost).not.toHaveBeenCalledWith(
+      "/model-hub/run-prompt-for-rows/",
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
 ## Summary

  This PR fixes the Data tab bulk Run action so dynamic/computed dataset columns are included in the "Run Evals & Prompts"  dialog. Previously only prompt and eval columns were shown, so newly added rows could not have dynamic columns computed
  from the bulk Run flow.

  The picker now includes supported dynamic column origin types, and the run dispatcher sends selected dynamic columns to
  the existing rerun-operation endpoint with the correct operation_type. Existing prompt and eval execution paths are
  unchanged.

  Dynamic column reruns still recompute the whole column because the current backend rerun-operation endpoint does not
  support row-scoped reruns.

  ## Linked issues

  Closes #1386

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation only
  - [ ] Chore / refactor (no user-visible change)
  - [ ] Performance improvement
  - [ ] Test-only change

  ## How was this tested?

  - Passed `git diff --check`
  - Passed targeted ESLint for changed files
  - Passed production Vite build with `node --max-old-space-size=8192 node_modules/vite/bin/vite.js build`

  ## Screenshots / recordings

  N/A