### PR TITLE
[TH-6853] Fix model detail not populating when creating prompt from template

### DIFF
--- a/frontend/src/components/custom-model-dropdown/CustomModelDropdown.jsx
+++ b/frontend/src/components/custom-model-dropdown/CustomModelDropdown.jsx
@@ -10,23 +10,7 @@ import KeysDrawer from "./KeysDrawer";
 import { ShowComponent } from "../show";
 import ModelButtonField from "./ModelButtonField";
 import AddCustomModal from "src/pages/dashboard/settings/AddCustomModal";
-
-const normalizeModelOption = (option) => {
-  if (!option || option?.value === "no") return option;
-  const modelName =
-    option.modelName ?? option.model_name ?? option.name ?? option.value ?? "";
-  return {
-    ...option,
-    modelName,
-    model_name: option.model_name ?? modelName,
-    providers: option.providers ?? option.provider ?? "",
-    isAvailable: option.isAvailable ?? option.is_available ?? false,
-    is_available: option.is_available ?? option.isAvailable ?? false,
-    logoUrl: option.logoUrl ?? option.logo_url ?? "",
-    logo_url: option.logo_url ?? option.logoUrl ?? "",
-    type: option.type ?? option.mode ?? option.model_type ?? "",
-  };
-};
+import { normalizeModelOption } from "./common";
 
 const CustomModelDropdown = ({
   isModalContainer = false,

--- a/frontend/src/components/custom-model-dropdown/common.js
+++ b/frontend/src/components/custom-model-dropdown/common.js
@@ -1,1 +1,25 @@
 export const LOGO_WITH_BLACK_BACKGROUND = ["openai", "cerebras", "ollama"];
+
+// model_detail objects exist in two shapes: the backend contract is snake_case
+// (models_list, prompt template snapshots) while dropdown-picked values carry
+// camelCase aliases. Fill both so every reader resolves regardless of source.
+export const normalizeModelOption = (option) => {
+  if (!option || option?.value === "no") return option;
+  const modelName =
+    option.modelName ?? option.model_name ?? option.name ?? option.value ?? "";
+  const type = option.type ?? option.mode ?? option.model_type;
+  return {
+    ...option,
+    modelName,
+    model_name: option.model_name ?? modelName,
+    providers: option.providers ?? option.provider ?? "",
+    isAvailable: option.isAvailable ?? option.is_available ?? false,
+    is_available: option.is_available ?? option.isAvailable ?? false,
+    logoUrl: option.logoUrl ?? option.logo_url ?? "",
+    logo_url: option.logo_url ?? option.logoUrl ?? "",
+    // Never fabricate `type`: the backend's modality filter treats a MISSING
+    // model_detail.type as "chat", but an empty string matches nothing —
+    // stamping "" here would drop resaved prompts from modality tabs.
+    ...(type !== undefined && { type }),
+  };
+};

--- a/frontend/src/sections/workbench/SelectedPromptTemplateDrawer.jsx
+++ b/frontend/src/sections/workbench/SelectedPromptTemplateDrawer.jsx
@@ -23,6 +23,7 @@ import { LoadingButton } from "@mui/lab";
 import { usePromptWorkbenchContext } from "./createPrompt/WorkbenchContext";
 import { getRandomId } from "src/utils/utils";
 import { ConfirmDialog } from "src/components/custom-dialog";
+import { normalizeModelOption } from "src/components/custom-model-dropdown/common";
 
 export const SelectedPromptTemplateDrawer = ({
   open,
@@ -74,8 +75,16 @@ export const SelectedPromptTemplateDrawer = ({
         ...rest,
         id: getRandomId(),
       })) || [];
-    const newModelConfig =
+    const snapshotConfiguration =
       data?.promptConfig?.prompt_config_snapshot?.configuration || {};
+    const newModelConfig = snapshotConfiguration.model_detail
+      ? {
+          ...snapshotConfiguration,
+          model_detail: normalizeModelOption(
+            snapshotConfiguration.model_detail,
+          ),
+        }
+      : snapshotConfiguration;
 
     // Create a copy of the existing prompts
     const updatedPrompts = [...prompts];

--- a/frontend/src/sections/workbench/createPrompt/common.js
+++ b/frontend/src/sections/workbench/createPrompt/common.js
@@ -1,5 +1,6 @@
 import { enqueueSnackbar } from "notistack";
 import { PromptRoles, WS_CLOSE_CODES } from "src/utils/constants";
+import { normalizeModelOption } from "src/components/custom-model-dropdown/common";
 import { extractVariables } from "./Playground/common";
 
 /**
@@ -219,6 +220,9 @@ export function normalizeConfigurationForLoad(configuration) {
     delete result[snake];
     delete result[camel];
     if (value !== undefined) result[camel] = value;
+  }
+  if (result.model_detail) {
+    result.model_detail = normalizeModelOption(result.model_detail);
   }
   return result;
 }


### PR DESCRIPTION
**Ticket:** [TH-6853](https://linear.app/future-agi/issue/TH-6853/creating-prompt-from-template-doesnt-populate-the-model-customaimodel) — Fixes [TH-6853](https://linear.app/future-agi/issue/TH-6853/creating-prompt-from-template-doesnt-populate-the-model-customaimodel)

## What was the bug

Creating a prompt from a template (use-template or import-into-existing) rendered the model selector without the provider logo and model params — only the raw model name showed. Backend-side run failures for retired models are tracked separately in the sub-issue [TH-6868](https://linear.app/future-agi/issue/TH-6868/sample-prompt-base-templates-reference-retired-models-gpt-5-audit-and).

## What changes have been done

* `src/components/custom-model-dropdown/common.js` — `normalizeModelOption` moved here (exported) so it can be shared; it now only sets `type` when the source object actually has `type`/`mode`/`model_type` instead of fabricating `""`
* `src/components/custom-model-dropdown/CustomModelDropdown.jsx` — imports the helper from `common.js` instead of defining it locally (pure relocation)
* `src/sections/workbench/createPrompt/common.js` — `normalizeConfigurationForLoad` now passes `configuration.model_detail` through the shared normalizer (covers all four load sites in `WorkbenchProvider`)
* `src/sections/workbench/SelectedPromptTemplateDrawer.jsx` — `handleImportPrompt` normalizes the snapshot's `model_detail` (this path bypasses `normalizeConfigurationForLoad`)

## Why the changes

* `model_detail` exists in two shapes: the backend contract is snake_case (`model_name`, `logo_url`, `is_available` — from `models_list` and template snapshots), while dropdown-picked values carry frontend-manufactured camelCase aliases (`logoUrl`, `isAvailable`)
* Renderers (`ModelButtonField.jsx`, `CustomModelDropdown.jsx`) read only the camelCase aliases, so backend-sourced snapshots fell back to the generic icon; normalizing at the load boundary gives every reader one canonical object
* `type` must never be fabricated as `""`: the backend modality filter (`prompt_template.py` `model_detail__type__isnull` fallback) and the agent-playground chat check (`llm_prompt.py:90`) both treat a *missing* key as "chat" — an empty string would drop resaved prompts from modality tabs and hard-fail agent-playground runs

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Create prompt from a template (use-template flow) | Model name, provider logo, and params all populate on the create page |
| 2 | Import a template into an existing prompt (drawer import mode) | Same — logo and params populate |
| 3 | Pick a model manually from the dropdown | Unchanged — logo and params render as before |
| 4 | Open an old prompt whose `model_detail` has no `type`, edit so autosave fires | Prompt still appears under the Chat modality tab in the prompts list |
| 5 | Plain prompt creation (no template) | Unaffected |

## How to reproduce (original bug)

1. Prompts → templates → open any sample template → **Use this template**
2. It redirects to the workbench create page
3. Model selector shows only the model name with a generic box icon — no provider logo, no params

## Commands

```bash
cd frontend && yarn dev
```

## Videos and screenshots

https://github.com/user-attachments/assets/2cfd0899-45e5-4e09-9561-4a36b661d9f6