### PR TITLE
fix(persona): require location on create and edit forms

### DIFF
--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
@@ -90,6 +90,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 control={control}
                 fieldName="location"
                 label="Location"
+                required
                 fullWidth
                 placeholder="United States"
                 size="small"

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -369,7 +369,10 @@ const PersonCreateBaseValidationSchema = z.object({
   description: z.string().min(1, "Description is required"),
   gender: z.array(z.string()).transform((val) => (val.length ? val : null)),
   ageGroup: z.array(z.string()).transform((val) => (val.length ? val : null)),
-  location: z.array(z.string()).transform((val) => (val.length ? val : null)),
+  location: z
+    .array(z.string())
+    .min(1, "Location is required")
+    .transform((val) => (val.length ? val : null)),
   profession: z.array(z.string()).transform((val) => (val.length ? val : null)),
   personality: z
     .array(z.object({ value: z.string() }))


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->
Enforced Location as a required field for persona creation and editing.

- Added .min(1, "Location is required") to the shared persona create/edit Zod
    validation schema.

- Added the required prop to the Location selector so it displays a required
  asterisk.

- Covers both Create persona and the Edit persona drawer.
- Preserves existing behavior for the Develop data double-click editor, which
  uses its own validation schema.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #1526

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->
<img width="1469" height="853" alt="Screenshot 2026-07-14 at 5 19 24 PM" src="https://github.com/user-attachments/assets/419d62f0-525e-4d64-a438-6bd8026dff0c" />
<img width="1473" height="852" alt="Screenshot 2026-07-14 at 5 18 52 PM" src="https://github.com/user-attachments/assets/0a21039d-7b7f-476b-ba08-e696b42d3e72" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
