### PR TITLE
feat(annotations): require all labels + block unassigned-item entry (TH-6885, TH-6886)

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/label-input.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-input.jsx
@@ -119,11 +119,9 @@ export default function LabelInput({
           sx={{ flex: 1, lineHeight: 1.3, transition: "color 0.15s" }}
         >
           {label.name}
-          {label.required && (
-            <Typography component="span" color="error.main" sx={{ ml: 0.25 }}>
-              *
-            </Typography>
-          )}
+          <Typography component="span" color="error.main" sx={{ ml: 0.25 }}>
+            *
+          </Typography>
           {hasError && (
             <Typography
               component="span"

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -510,9 +510,8 @@ const LabelPanel = forwardRef(function LabelPanel(
     // Read from ref to capture any values flushed above
     const currentValues = valuesRef.current;
 
-    // Check required labels have values
-    const missingRequired = labels.filter((ql) => {
-      if (!ql.required) return false;
+    // Every label must be annotated before submitting
+    const missingLabels = labels.filter((ql) => {
       const labelId = ql.label_id;
       const v = currentValues[labelId];
       if (v === null || v === undefined) return true;
@@ -526,13 +525,13 @@ const LabelPanel = forwardRef(function LabelPanel(
       return false;
     });
 
-    if (missingRequired.length > 0) {
-      const names = missingRequired.map((l) => l.name).join(", ");
-      enqueueSnackbar(`Required labels missing: ${names}`, {
+    if (missingLabels.length > 0) {
+      const names = missingLabels.map((l) => l.name).join(", ");
+      enqueueSnackbar(`Please annotate all labels: ${names}`, {
         variant: "warning",
       });
-      // Highlight the missing required labels
-      const errorSet = new Set(missingRequired.map((l) => l.label_id));
+      // Highlight the labels still missing a value
+      const errorSet = new Set(missingLabels.map((l) => l.label_id));
       setErrorLabels(errorSet);
       return;
     }

--- a/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
@@ -753,6 +753,20 @@ export default function QueueDetailView() {
               onSelectAll={handleSelectAll}
               onRemove={isManager ? handleRemove : undefined}
               onItemClick={(item) => {
+                const assignedUsers = item?.assigned_users || [];
+                const assignedToOther =
+                  queue?.auto_assign === false &&
+          
+                  !assignedUsers?.some(
+                    (a) => String(a.id) === currentUserId,
+                  );
+                if (assignedToOther && !canViewSubmissions && !isManager) {
+                  enqueueSnackbar(
+                    "You cannot annotate items that are not assigned to you",
+                    { variant: "warning" },
+                  );
+                  return;
+                }
                 if (
                   queue?.status === "active" ||
                   queue?.status === "completed"


### PR DESCRIPTION
## Summary
Two guards in the annotation queue annotate flow: every label must be filled before an annotation can be submitted (TH-6885), and annotators are stopped from opening items that aren't assigned to them (TH-6886).

## Why / problem
- **TH-6885:** Submission only validated labels explicitly flagged `required`, and that flag defaults to `false` on queue labels — so annotators could submit items with labels left blank (partial annotations).
- **TH-6886:** Clicking an item assigned to another annotator navigated into the annotate workspace before any assignment check, giving a confusing experience instead of clear feedback.

## What changed
- `label-panel.jsx` — `handleSubmit` now validates **all** labels (not just `required` ones); if any is empty it blocks submit, highlights the missing labels, and shows `Please annotate all labels: …`.
- `label-input.jsx` — the red `*` now renders on every label, since all labels are mandatory in the annotate flow.
- `queue-detail-view.jsx` — `onItemClick` now checks assignment before navigating: on a manual-assign queue, if the item is assigned to someone else and the viewer isn't a reviewer/manager, it shows `You cannot annotate items that are not assigned to you` and does not navigate.

## Tests
- [ ] Fill only some labels → **Submit & Next** is blocked, warning lists the empty labels, they highlight red, item stays put.
- [ ] Fill every label → submit succeeds and advances to the next item.
- [ ] Same behavior via `Cmd/Ctrl+Enter` keyboard submit.
- [ ] As a plain annotator, click an item assigned to someone else on a manual-assign queue → snackbar, no navigation.
- [ ] As the same annotator, click an item assigned to you → opens the workspace.
- [ ] As a reviewer/manager, click an item assigned to someone else → still opens (read-only/review), no snackbar.
- [ ] On an auto-assign queue, clicking any item opens normally.

## Commands
- [ ] `yarn eslint` on the three changed files — passes.

## Backwards compatibility
Frontend-only, additive UI validation. No API or data-model changes. Queues that already marked labels `required` behave the same (those labels were already enforced).

## Manual verification
- [ ] Verified lint passes on all three changed files.

## Type of change
- [x] New feature / behavior change (non-breaking)
- [ ] Bug fix
- [ ] Breaking change

## Checklist
- [x] Lint passes on changed files
- [x] No new comments added to code
- [ ] Manually verified in the annotate workspace

## Backout
Revert the two commits (`17c992e39`, `53b49bab3`) — no migrations or config to unwind.

## Linear
Closes TH-6885
Closes TH-6886
