### PR TITLE
fix(query): avoid stale cached data via shorter staleTime + refetch on focus/mount (TH-6887)

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -84,12 +84,15 @@ const queryClient = new QueryClient({
   }),
   defaultOptions: {
     queries: {
-      // Data stays fresh for 30s — no refetch on remount/focus within this window
-      staleTime: 30 * 1000,
-      // Keep unused data in cache for 5 min (default)
-      gcTime: 5 * 60 * 1000,
-      // Don't refetch when browser tab regains focus
-      refetchOnWindowFocus: false,
+      // Data is fresh for 5s; after that remount/focus/reconnect refetch —
+      // the cached value is shown instantly, then updated in place
+      staleTime: 5 * 1000,
+      // Keep unused data in cache for 1 min
+      gcTime: 1 * 60 * 1000,
+      // Refetch when the tab regains focus, on remount, and on reconnect
+      refetchOnWindowFocus: true,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
       // Retry once on failure
       retry: 1,
     },


### PR DESCRIPTION
## Summary
Tunes the global React Query defaults so the UI stops serving stale cached data. Data is now considered fresh for only 5s, and refetches on remount, tab-focus, and reconnect.

## Why / problem
The app's data changes frequently, but the global query defaults (`staleTime: 30s`, `refetchOnWindowFocus: false`) meant a query stayed "fresh" for 30 seconds and never refetched on navigation or tab-refocus within that window — so users kept seeing cached values that were already out of date.

## What changed
`frontend/src/app.jsx` — `QueryClient` default `queries` options:
- `staleTime: 30 * 1000` → `5 * 1000` (data is fresh for 5s, then stale)
- `refetchOnWindowFocus: false` → `true`
- add `refetchOnMount: true`
- add `refetchOnReconnect: true`
- `gcTime: 5 * 60 * 1000` → `1 * 60 * 1000`

Cached values are still shown instantly on navigation, then updated in place once the background refetch resolves — no blank screens or spinner flashes.

## Tests
- [ ] Load a data view, navigate away and back after >5s → data refetches (fresh values shown).
- [ ] Switch browser tabs and return → data refetches on focus.
- [ ] Drop and restore the network → data refetches on reconnect.
- [ ] Rapidly navigate within 5s → cached data served without a refetch storm.

## Commands
- [ ] `yarn eslint src/app.jsx` — passes.

## Backwards compatibility
Global default only; any `useQuery` can still override `staleTime`/refetch options for views that need different behavior (e.g. a longer window for rarely-changing lookups, or `staleTime: 0` for real-time views). No API or data-model changes.

## Manual verification
- [ ] Verified lint passes on `src/app.jsx`.

## Type of change
- [x] Bug fix (stale data shown to users)
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] Lint passes on changed file
- [x] No new code comments beyond the corrected config comments
- [ ] Manually verified refetch behavior in the browser

## Backout
Revert commit `3b83680d7` — restores the previous 30s/`refetchOnWindowFocus: false` defaults. No migrations or config to unwind.

## Linear
Closes TH-6887
