### PR TITLE
feat(tracer): register eval-task Temporal search attributes via migration

### DIFF
--- a/futureagi/tfc/temporal/eval_tasks/registration.py
+++ b/futureagi/tfc/temporal/eval_tasks/registration.py
@@ -9,7 +9,11 @@ enums, which must not be pulled into the workflow sandbox. Used by the
 from __future__ import annotations
 
 from temporalio.api.enums.v1 import IndexedValueType
-from temporalio.api.operatorservice.v1 import AddSearchAttributesRequest
+from temporalio.api.operatorservice.v1 import (
+    AddSearchAttributesRequest,
+    ListSearchAttributesRequest,
+    RemoveSearchAttributesRequest,
+)
 from temporalio.service import RPCError, RPCStatusCode
 
 from tfc.temporal.eval_tasks.search_attributes import SEARCH_ATTRIBUTE_NAMES
@@ -18,19 +22,63 @@ from tfc.temporal.eval_tasks.search_attributes import SEARCH_ATTRIBUTE_NAMES
 async def register_search_attributes(client, namespace: str) -> bool:
     """Register the eval-task keyword Search Attributes on ``namespace``.
 
-    Idempotent: returns True if it registered them, False if they already
-    existed. Any other RPC error propagates.
+    Idempotent: only attributes missing from the namespace are added —
+    AddSearchAttributes rejects the whole batch with ALREADY_EXISTS if any
+    single name exists, so a partial prior registration would otherwise never
+    complete. Returns True if it added any, False if all already existed.
     """
+    existing = await client.operator_service.list_search_attributes(
+        ListSearchAttributesRequest(namespace=namespace)
+    )
+    missing = [
+        name
+        for name in SEARCH_ATTRIBUTE_NAMES
+        if name not in existing.custom_attributes
+    ]
+    if not missing:
+        return False
+
     request = AddSearchAttributesRequest(
         namespace=namespace,
         search_attributes=dict.fromkeys(
-            SEARCH_ATTRIBUTE_NAMES, IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+            missing, IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
         ),
     )
     try:
         await client.operator_service.add_search_attributes(request)
-        return True
     except RPCError as e:
-        if e.status == RPCStatusCode.ALREADY_EXISTS:
-            return False
-        raise
+        # Lost a race with a concurrent registration — the attributes exist.
+        if e.status != RPCStatusCode.ALREADY_EXISTS:
+            raise
+    return True
+
+
+async def remove_search_attributes(client, namespace: str) -> bool:
+    """Remove the eval-task Search Attributes from ``namespace``.
+
+    Idempotent: only attributes present on the namespace are removed. Returns
+    True if it removed any, False if none were registered.
+
+    Removing an attribute that running eval-task workflows still upsert wedges
+    their Workflow Tasks — only remove once those workflows are stopped.
+    """
+    existing = await client.operator_service.list_search_attributes(
+        ListSearchAttributesRequest(namespace=namespace)
+    )
+    present = [
+        name for name in SEARCH_ATTRIBUTE_NAMES if name in existing.custom_attributes
+    ]
+    if not present:
+        return False
+
+    try:
+        await client.operator_service.remove_search_attributes(
+            RemoveSearchAttributesRequest(
+                namespace=namespace, search_attributes=present
+            )
+        )
+    except RPCError as e:
+        # Lost a race with a concurrent removal — the attributes are gone.
+        if e.status != RPCStatusCode.NOT_FOUND:
+            raise
+    return True

--- a/futureagi/tracer/migrations/0093_register_eval_task_search_attributes.py
+++ b/futureagi/tracer/migrations/0093_register_eval_task_search_attributes.py
@@ -1,0 +1,122 @@
+"""Register the eval-task Temporal Search Attributes during `manage.py migrate`.
+
+The eval-task workflows upsert these attributes on start, and upserting an
+unregistered attribute wedges the Workflow Task forever — registration must
+happen before the workflows run. Baking it into `migrate` guarantees that
+ordering without a separate deploy step.
+
+Idempotent both ways: forwards adds only attributes missing from the
+namespace, backwards removes only those present, so re-running either
+direction is a no-op.
+
+Backwards caveat: removing an attribute that running eval-task workflows
+still upsert wedges their Workflow Tasks — only migrate backwards once those
+workflows are stopped.
+
+Skipping in test/CI:
+- If Temporal is unreachable (nothing listening on TEMPORAL_HOST) the step
+  warns and passes through — environments without Temporal are unaffected.
+  Run `python manage.py register_eval_task_search_attributes` there instead.
+- Set FI_SKIP_TEMPORAL_SA_MIGRATION=1 to skip explicitly.
+"""
+
+import asyncio
+import os
+
+from django.db import migrations
+
+CONNECT_TIMEOUT_SECONDS = 5
+
+
+def _skip_reason() -> str | None:
+    if os.getenv("FI_SKIP_TEMPORAL_SA_MIGRATION", "").lower() in ("1", "true", "yes"):
+        return "FI_SKIP_TEMPORAL_SA_MIGRATION=1"
+    try:
+        from temporalio.client import Client  # noqa: F401
+    except ImportError as e:
+        return f"temporalio not importable ({e})"
+    return None
+
+
+async def _connect():
+    """Return a connected client, or None (with a warning) if unreachable."""
+    from temporalio.client import Client
+
+    from tfc.temporal import TEMPORAL_HOST, TEMPORAL_NAMESPACE
+
+    try:
+        return await asyncio.wait_for(
+            Client.connect(TEMPORAL_HOST, namespace=TEMPORAL_NAMESPACE),
+            timeout=CONNECT_TIMEOUT_SECONDS,
+        )
+    except Exception as e:
+        print(
+            f"WARNING: Temporal unreachable at {TEMPORAL_HOST} ({e}). "
+            "Skipping search-attribute registration."
+        )
+        print(
+            "         Run `python manage.py register_eval_task_search_attributes` "
+            "once Temporal is up."
+        )
+        return None
+
+
+def forwards(apps, schema_editor):
+    reason = _skip_reason()
+    if reason:
+        print(f"{reason} — skipping Temporal search-attribute registration.")
+        return
+    asyncio.run(_register())
+
+
+def backwards(apps, schema_editor):
+    reason = _skip_reason()
+    if reason:
+        print(f"{reason} — skipping Temporal search-attribute removal.")
+        return
+    asyncio.run(_deregister())
+
+
+async def _register():
+    from tfc.temporal import TEMPORAL_NAMESPACE
+    from tfc.temporal.eval_tasks.registration import register_search_attributes
+    from tfc.temporal.eval_tasks.search_attributes import SEARCH_ATTRIBUTE_NAMES
+
+    client = await _connect()
+    if client is None:
+        return
+
+    registered = await register_search_attributes(client, TEMPORAL_NAMESPACE)
+    names = ", ".join(SEARCH_ATTRIBUTE_NAMES)
+    if registered:
+        print(f"Registered Temporal search attributes: {names}")
+    else:
+        print(f"Temporal search attributes already registered: {names}")
+
+
+async def _deregister():
+    from tfc.temporal import TEMPORAL_NAMESPACE
+    from tfc.temporal.eval_tasks.registration import remove_search_attributes
+    from tfc.temporal.eval_tasks.search_attributes import SEARCH_ATTRIBUTE_NAMES
+
+    client = await _connect()
+    if client is None:
+        return
+
+    removed = await remove_search_attributes(client, TEMPORAL_NAMESPACE)
+    names = ", ".join(SEARCH_ATTRIBUTE_NAMES)
+    if removed:
+        print(f"Removed Temporal search attributes: {names}")
+    else:
+        print(f"Temporal search attributes not registered, nothing to remove: {names}")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tracer", "0092_relax_external_eval_config_model_choices"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]


### PR DESCRIPTION
## Why

The eval-task Temporal workflows upsert four custom Search Attributes (`EvalTaskOrgId`, `EvalTaskProjectId`, `EvalTaskRunType`, `EvalTaskStatus`) on start. Upserting an attribute that isn't registered on the namespace wedges the Workflow Task forever. Registration currently depends on someone remembering to run `manage.py register_eval_task_search_attributes` before the workers pick up eval tasks — a deploy-ordering footgun. Baking registration into `manage.py migrate` makes it impossible to deploy the workflows against an unregistered namespace.

## What

1. **New data migration `tracer/0093_register_eval_task_search_attributes`** (follows the `0078_ch25_apply_schema` pattern for migrations touching external systems):
   - Forwards connects to Temporal (5s timeout) and runs the same `register_search_attributes` the management command uses.
   - Backwards deregisters the four attributes via the operator API (`RemoveSearchAttributes`).
   - Both directions warn-and-skip when Temporal is unreachable or `temporalio` isn't importable (test/CI environments), and honor `FI_SKIP_TEMPORAL_SA_MIGRATION=1` for explicit opt-out. Real RPC errors still fail the migration loudly.
2. **Hardened `tfc/temporal/eval_tasks/registration.py`**:
   - `register_search_attributes` was only idempotent for the all-or-nothing case: Temporal rejects the whole `AddSearchAttributes` batch with `ALREADY_EXISTS` if *any one* name already exists, so a partially-registered namespace (e.g. 2 of 4 attributes) would report "already registered" forever while the rest stayed missing. It now lists the namespace's attributes first and adds only the missing ones; `ALREADY_EXISTS` remains handled purely as a concurrent-registration race guard.
   - New `remove_search_attributes` mirror for the migration's backwards path — same list-first idempotency, removes only attributes actually present, treats `NOT_FOUND` as a lost race. Its docstring carries the operational hazard: removing an attribute that running workflows still upsert wedges their Workflow Tasks, so only migrate backwards after stopping them.

## Tests

No new pytest files — this is deploy/infra wiring, verified end-to-end against the test stack + a live local Temporal (see evidence below). Existing coverage that exercises the changed code:

- `tfc/temporal/eval_tasks/tests/test_observability.py` (6 e2e tests) — provisions an in-memory Temporal server via `register_search_attributes` and includes `test_registration_is_idempotent_and_lists_keys`, which now exercises the list-first path. All 6 pass.

### Per-scenario verification (manual, real Temporal)

| # | Scenario | Result |
|---|----------|--------|
| 1 | Fresh `migrate` on a namespace without the attributes | `Registered Temporal search attributes: EvalTaskOrgId, EvalTaskProjectId, EvalTaskRunType, EvalTaskStatus` |
| 2 | Re-run `migrate` forwards on an already-registered namespace | `Temporal search attributes already registered: …`, exit OK |
| 3 | `migrate` with Temporal down (`TEMPORAL_HOST=localhost:7999`) | `WARNING: Temporal unreachable … Skipping search-attribute registration.`, migrate still succeeds |
| 4 | `migrate tracer 0092` (backwards, attributes present) | `Removed Temporal search attributes: …` |
| 5 | Backwards again on the already-clean namespace | `Temporal search attributes not registered, nothing to remove: …`, exit OK |
| 6 | Forwards again after real removal | Re-registers cleanly (back to scenario 1 output) |

## Commands

```bash
cd futureagi
docker compose -f docker-compose.test.yml -p futureagi-test up -d
set -a && source .env.test.local && set +a

# full migrate (scenario 1)
DJANGO_SETTINGS_MODULE=tfc.settings.test uv run python manage.py migrate

# forwards/backwards round trip (scenarios 2, 4–6)
DJANGO_SETTINGS_MODULE=tfc.settings.test uv run python manage.py migrate tracer 0092
DJANGO_SETTINGS_MODULE=tfc.settings.test uv run python manage.py migrate tracer 0093

# unreachable-Temporal path (scenario 3)
TEMPORAL_HOST=localhost:7999 DJANGO_SETTINGS_MODULE=tfc.settings.test uv run python manage.py migrate tracer 0093

# existing e2e suite over the registration code
uv run pytest tfc/temporal/eval_tasks/tests/test_observability.py -p no:xdist -m e2e
```

## Local test steps

1. Bring up the test compose stack and have any Temporal reachable on `TEMPORAL_HOST` (dev compose default `localhost:7233`).
2. Run the commands above; each scenario's expected line is printed inline by the migration.
3. Optionally confirm namespace state directly: `temporal operator search-attribute list` (or via the Temporal UI list filter).

## Evidence

```text
  Applying tracer.0093_register_eval_task_search_attributes...Registered Temporal search attributes: EvalTaskOrgId, EvalTaskProjectId, EvalTaskRunType, EvalTaskStatus
 OK
  Applying tracer.0093_register_eval_task_search_attributes...Temporal search attributes already registered: EvalTaskOrgId, EvalTaskProjectId, EvalTaskRunType, EvalTaskStatus
 OK
  Applying tracer.0093_register_eval_task_search_attributes...WARNING: Temporal unreachable at localhost:7999 (Failed client connect: ... ConnectionRefused ...). Skipping search-attribute registration.
         Run `python manage.py register_eval_task_search_attributes` once Temporal is up.
 OK
  Unapplying tracer.0093_register_eval_task_search_attributes...Removed Temporal search attributes: EvalTaskOrgId, EvalTaskProjectId, EvalTaskRunType, EvalTaskStatus
 OK
  Unapplying tracer.0093_register_eval_task_search_attributes...Temporal search attributes not registered, nothing to remove: EvalTaskOrgId, EvalTaskProjectId, EvalTaskRunType, EvalTaskStatus
 OK

tfc/temporal/eval_tasks/tests/test_observability.py ......               [100%]
======================== 6 passed in 128.50s (0:02:08) =========================
```

## Architectural rationale

- **Migration over deploy script**: `migrate` is the one step every environment already runs before workers start, so it's the natural place to pin the "register before upsert" ordering — same reasoning as `tracer/0078` applying the CH schema. The management command remains for out-of-band use and stays the escape hatch when the migration skips.
- **List-first instead of catch-`ALREADY_EXISTS`**: batch add is not idempotent under partial registration; computing the missing set makes both directions converge from any starting state, which is exactly what a re-runnable migration needs.
- **Warn-and-skip on unreachable**: migrations run in CI/test databases where Temporal doesn't exist; failing `migrate` there would break every suite. The trade-off (a prod `migrate` during a Temporal blip silently skips) is mitigated by the loud warning and the idempotent management command in the deploy path.
- **Registration logic lives in `registration.py`, not the migration**: the command, the tests' `WorkflowEnvironment` provisioning, and the migration all share one implementation, so idempotency semantics can't drift between callers.
