### PR TITLE
fix(persona): Location field is not required in persona creation form

### DIFF
--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
@@ -97,6 +97,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 multiple={multiple}
                 checkbox={multiple}
                 selectAll
+                required
               />
               <FormSearchSelectFieldControl
                 control={control}

--- a/frontend/src/sections/persona/PersonaCreateEdit/__tests__/PersonaBasicInfo.test.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/__tests__/PersonaBasicInfo.test.jsx
@@ -1,0 +1,51 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import { render, screen } from "src/utils/test-utils";
+import PersonaBasicInfo from "../PersonaBasicInfo";
+
+const Wrapper = ({ children }) => {
+  const methods = useForm({
+    defaultValues: {
+      name: "",
+      description: "",
+      gender: [],
+      ageGroup: [],
+      location: [],
+      profession: [],
+    },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+const fieldLabel = (text) =>
+  screen.getByText(new RegExp(`^${text}`), { selector: "label" });
+
+describe("PersonaBasicInfo required fields", () => {
+  it("marks the Location field as required", () => {
+    render(
+      <Wrapper>
+        <PersonaBasicInfo viewOptions={{}} />
+      </Wrapper>,
+    );
+
+    // The bug left Location optional; the fix adds `required`, which MUI
+    // renders as an asterisk on the field label.
+    expect(
+      fieldLabel("Location").querySelector(".MuiFormLabel-asterisk"),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves genuinely optional sibling fields (Gender) unmarked", () => {
+    render(
+      <Wrapper>
+        <PersonaBasicInfo viewOptions={{}} />
+      </Wrapper>,
+    );
+
+    expect(
+      fieldLabel("Gender").querySelector(".MuiFormLabel-asterisk"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1526

The Location field in the persona creation form had no required
validation. Name and Description both have required: true on their
FormTextFieldV2 controls and z.string().min(1) in the zod schema, but
Location was missing the required prop on its FormSearchSelectFieldControl.

Fix: add required to the Location field so the form blocks submission
when no location is selected, consistent with the other mandatory fields.

Changes:
- frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx