### PR TITLE
fix(persona): Behavioural Settings should require at least one selection

### DIFF
--- a/frontend/src/sections/persona/PersonaCreateEdit/__tests__/common.test.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/__tests__/common.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { PersonCreateValidationSchema } from "../common";
+
+// A fully valid, single-language persona payload. Individual tests override
+// one field to isolate the behavioural-settings requirement.
+const validPersona = (overrides = {}) => ({
+  multilingual: false,
+  language: "en",
+  simulationType: "text",
+  name: "Test Persona",
+  description: "A test persona",
+  gender: [],
+  ageGroup: [],
+  location: [],
+  profession: [],
+  personality: [{ value: "friendly" }],
+  communicationStyle: ["formal"],
+  accent: [],
+  customProperties: [],
+  additionalInstruction: null,
+  ...overrides,
+});
+
+describe("PersonCreateValidationSchema behavioural settings", () => {
+  it("rejects a persona with no personality selected", () => {
+    const result = PersonCreateValidationSchema.safeParse(
+      validPersona({ personality: [] }),
+    );
+
+    // Pre-fix this parsed successfully (empty array transformed to null).
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error.issues)).toContain(
+      "Select at least one personality",
+    );
+  });
+
+  it("rejects a persona with no communication style selected", () => {
+    const result = PersonCreateValidationSchema.safeParse(
+      validPersona({ communicationStyle: [] }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error.issues)).toContain(
+      "Select at least one communication style",
+    );
+  });
+
+  it("accepts a persona with at least one personality and communication style", () => {
+    const result = PersonCreateValidationSchema.safeParse(validPersona());
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -373,10 +373,12 @@ const PersonCreateBaseValidationSchema = z.object({
   profession: z.array(z.string()).transform((val) => (val.length ? val : null)),
   personality: z
     .array(z.object({ value: z.string() }))
-    .transform((val) => (val.length ? val?.map((item) => item.value) : null)),
+    .min(1, "Select at least one personality")
+    .transform((val) => val.map((item) => item.value)),
   communicationStyle: z
     .array(z.string())
-    .transform((val) => (val.length ? val : null)),
+    .min(1, "Select at least one communication style")
+    .transform((val) => val),
   accent: z.array(z.string()).transform((val) => (val.length ? val : null)),
   conversationSpeed: z
     .array(z.object({ value: z.string() }))


### PR DESCRIPTION
Fixes #1523

The zod schema for both personality and communicationStyle was silently
transforming empty arrays to null instead of blocking form submission.
This meant a persona could be saved with nothing selected in Behavioural
Settings.

Before:
  personality: z.array(...).transform((val) => val.length ? ... : null)
  communicationStyle: z.array(...).transform((val) => val.length ? val : null)

Fix: add .min(1) before the transform so zod raises a validation error
when nothing is selected, matching the intent of the UI section.

Changes:
- frontend/src/sections/persona/PersonaCreateEdit/common.js