### PR TITLE
feat(annotations): add Select All and Select None to bulk assign dialog

### DIFF
--- a/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
@@ -754,6 +754,28 @@ export default function QueueDetailView() {
         <DialogTitle>Assign Selected Items</DialogTitle>
         <DialogContent>
           <Stack spacing={0.5} sx={{ mt: 1 }}>
+            {queueAnnotators.length > 0 && (
+              <Stack direction="row" spacing={1} sx={{ mb: 0.5 }}>
+                <Button
+                  size="small"
+                  disabled={isAssigningItems}
+                  onClick={() =>
+                    setBulkAssignUserIds(
+                      new Set(queueAnnotators.map((a) => String(a.user_id))),
+                    )
+                  }
+                >
+                  Select All
+                </Button>
+                <Button
+                  size="small"
+                  disabled={isAssigningItems}
+                  onClick={() => setBulkAssignUserIds(new Set())}
+                >
+                  Select None
+                </Button>
+              </Stack>
+            )}
             {queueAnnotators.map((annotator) => {
               const uid = String(annotator.user_id);
               return (


### PR DESCRIPTION
Fixes #1502

The bulk assignment dialog in annotation queues only had individual
checkboxes with no way to quickly select or clear all annotators at
once. With large teams this made bulk assignment slow.

Fix: added Select All and Select None buttons above the annotator list.
Select All sets all annotator IDs into the checked set in one click.
Select None clears it. Both buttons are disabled while assignment is in
progress to prevent race conditions.

Changes:
- frontend/src/sections/annotations/queues/view/queue-detail-view.jsx