### PR TITLE
fix(simulate): chat simulations show voice-only metrics in analytics view

### DIFF
--- a/frontend/src/sections/test-detail/TestRunInsight.jsx
+++ b/frontend/src/sections/test-detail/TestRunInsight.jsx
@@ -13,6 +13,7 @@ import { useParams } from "react-router";
 import { camelCaseToTitleCase } from "src/utils/utils";
 import { extractKpis } from "./common";
 import TestRunInsightSkeletonCard from "./TestRunInsightSkeletonCard";
+import { AGENT_TYPES } from "src/sections/agents/constants";
 
 const TestRunInsight = () => {
   const { executionId } = useParams();
@@ -88,6 +89,8 @@ const TestRunInsight = () => {
     return extractKpis(kpis, kpis?.agent_type);
   }, [kpis]);
 
+  const isVoice = kpis?.agent_type === AGENT_TYPES.VOICE;
+
   const renderMetrics = () => {
     if (isPending) {
       return (
@@ -125,36 +128,44 @@ const TestRunInsight = () => {
           secondaryText={`(Connected Calls: ${systemMetrics?.connectedCalls})`}
           tooltipTitle="Mean customer satisfaction score across all completed calls"
         />
-        <TestRunInsightCard
-          title="Avg. Agent Latency (ms)"
-          value={systemMetrics?.avgAgentLatency}
-          suffix={"ms"}
-          tooltipTitle="Average time (ms) for the agent to start a response after the user finishes speaking"
-        />
+        {isVoice && (
+          <TestRunInsightCard
+            title="Avg. Agent Latency (ms)"
+            value={systemMetrics?.avgAgentLatency}
+            suffix={"ms"}
+            tooltipTitle="Average time (ms) for the agent to start a response after the user finishes speaking"
+          />
+        )}
         {/* <TestRunInsightCard
           title="Sim Interrupts"
           value={systemMetrics?.avgUserInterruptionCount}
         /> */}
-        <TestRunInsightCard
-          title="Agent WPM"
-          value={Math.round(systemMetrics?.avgBotWpm)}
-          tooltipTitle="Agent's average speaking rate, measuring conversational pace"
-        />
-        <TestRunInsightCard
-          title="Talk Ratio (A/S%)"
-          value={`${Math.round(systemMetrics?.agentTalkPercentage)}%/${Math.round(systemMetrics?.customerTalkPercentage)}%`}
-          tooltipTitle="Ratio of time the Agent (A) spoke versus the simulator (S) spoke"
-        />
+        {isVoice && (
+          <TestRunInsightCard
+            title="Agent WPM"
+            value={Math.round(systemMetrics?.avgBotWpm)}
+            tooltipTitle="Agent's average speaking rate, measuring conversational pace"
+          />
+        )}
+        {isVoice && (
+          <TestRunInsightCard
+            title="Talk Ratio (A/S%)"
+            value={`${Math.round(systemMetrics?.agentTalkPercentage)}%/${Math.round(systemMetrics?.customerTalkPercentage)}%`}
+            tooltipTitle="Ratio of time the Agent (A) spoke versus the simulator (S) spoke"
+          />
+        )}
         {/* <TestRunInsightCard
           title="Agent Interrupts"
           value={systemMetrics?.avgAiInterruptionCount}
         /> */}
-        <TestRunInsightCard
-          title="Agent Stop Latency (ms)"
-          value={systemMetrics?.avgStopTimeAfterInterruption}
-          suffix={"ms"}
-          tooltipTitle=" Average time (ms) the agent takes to react to, and stop speaking, when interrupted by the user"
-        />
+        {isVoice && (
+          <TestRunInsightCard
+            title="Agent Stop Latency (ms)"
+            value={systemMetrics?.avgStopTimeAfterInterruption}
+            suffix={"ms"}
+            tooltipTitle=" Average time (ms) the agent takes to react to, and stop speaking, when interrupted by the user"
+          />
+        )}
 
         {Object.entries(evalMetrics || {}).map(([key, value]) => (
           <TestRunInsightCard

--- a/frontend/src/sections/test-detail/__tests__/TestRunInsight.test.jsx
+++ b/frontend/src/sections/test-detail/__tests__/TestRunInsight.test.jsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import useKpis from "src/hooks/useKpis";
+import TestRunInsight from "../TestRunInsight";
+
+vi.mock("src/hooks/useKpis", () => ({ default: vi.fn() }));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useParams: () => ({ executionId: "exec-1" }) };
+});
+
+// Isolate the test from KPI parsing internals; the fix only gates which
+// cards render based on agent_type, not how the metrics are computed.
+vi.mock("../common", () => ({
+  extractKpis: () => ({
+    systemMetrics: {
+      totalCalls: 5,
+      avgAgentLatency: 50,
+      avgBotWpm: 120,
+      agentTalkPercentage: 60,
+      customerTalkPercentage: 40,
+      avgStopTimeAfterInterruption: 20,
+    },
+    evalMetrics: {},
+  }),
+}));
+
+const VOICE_ONLY_TITLES = [
+  "Avg. Agent Latency (ms)",
+  "Agent WPM",
+  "Talk Ratio (A/S%)",
+  "Agent Stop Latency (ms)",
+];
+
+const setAgentType = (agentType) =>
+  useKpis.mockReturnValue({
+    data: { agent_type: agentType },
+    isPending: false,
+  });
+
+describe("TestRunInsight voice-only metrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides voice-only metrics for a chat (text) simulation", () => {
+    setAgentType("text");
+    render(<TestRunInsight />);
+
+    // A non-voice card confirms the metrics section actually rendered.
+    expect(screen.getByText("Total calls")).toBeInTheDocument();
+
+    // The bug rendered these voice metrics for chat sims too.
+    for (const title of VOICE_ONLY_TITLES) {
+      expect(screen.queryByText(title)).not.toBeInTheDocument();
+    }
+  });
+
+  it("shows voice-only metrics for a voice simulation", () => {
+    setAgentType("voice");
+    render(<TestRunInsight />);
+
+    for (const title of VOICE_ONLY_TITLES) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1503

The analytics view (TestRunInsight) always rendered four voice-only
KPI cards regardless of simulation type:
- Avg. Agent Latency (ms)
- Agent WPM
- Talk Ratio (A/S%)
- Agent Stop Latency (ms)

These metrics come from voice pipeline data (transcriber latency, TTS
speaking rate, talk time ratios) and are meaningless for chat
simulations which have none of that. They were showing as empty/zero
cards on every chat test run analytics page.

Fix: derive isVoice from kpis.agent_type (already present in the API
response) and wrap all four voice-only cards in an isVoice guard.
Chat simulations now only show metrics that apply to them.

Changes:
- frontend/src/sections/test-detail/TestRunInsight.jsx