### PR TITLE
fix(annotations): exempt default queues from the annotation-queue plan quota [TH-6882]

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -604,7 +604,7 @@ class TestCreateQueue:
             resp = create_queue(auth_client, name="Denied Cross Workspace Queue")
 
         assert resp.status_code == status.HTTP_402_PAYMENT_REQUIRED
-        assert "2 existing queues" in resp.data["error"]["message"]
+        assert "2 user-created queues" in resp.data["error"]["message"]
         assert "1 in the current workspace" in resp.data["error"]["message"]
         assert "1 in other workspaces" in resp.data["error"]["message"]
         assert resp.data["error"]["detail"]["current_usage"] == 2
@@ -614,61 +614,18 @@ class TestCreateQueue:
             name="Denied Cross Workspace Queue"
         ).exists()
 
-    def test_get_or_create_default_checks_queue_plan_limit(
+    def test_get_or_create_default_create_branch_exempt_from_plan_limit(
         self, auth_client, organization, workspace
     ):
+        """Opening Add Label must never 402: a default queue is auto-provisioned
+        plumbing, so its create path is exempt from the plan quota even at the
+        cap (where check_ee_can_create would otherwise deny)."""
         project = Project.objects.create(
-            name="Default Queue Limit Project",
+            name="Default Queue Exempt Project",
             organization=organization,
             workspace=workspace,
             model_type="GenerativeLLM",
             trace_type="observe",
-        )
-
-        with (
-            patch("tfc.ee_gating.is_oss", return_value=False),
-            patch("tfc.ee_gating.check_ee_can_create") as check_can_create,
-        ):
-            resp = auth_client.post(
-                f"{QUEUE_URL}get-or-create-default/",
-                {"project_id": str(project.id)},
-                format="json",
-            )
-
-        assert resp.status_code == status.HTTP_200_OK, resp.data
-        check_can_create.assert_called_once_with(
-            EEResource.ANNOTATION_QUEUES,
-            org_id=str(organization.id),
-            current_count=0,
-        )
-
-    def test_get_or_create_default_limit_message_explains_org_queue_count(
-        self, auth_client, organization, user, workspace
-    ):
-        other_workspace = Workspace.objects.create(
-            name="Other Default Queue Workspace",
-            organization=organization,
-            is_active=True,
-            created_by=user,
-        )
-        project = Project.objects.create(
-            name="Default Queue Limit Message Project",
-            organization=organization,
-            workspace=workspace,
-            model_type="GenerativeLLM",
-            trace_type="observe",
-        )
-        AnnotationQueue.objects.create(
-            name="Current Workspace Queue",
-            organization=organization,
-            workspace=workspace,
-            created_by=user,
-        )
-        AnnotationQueue.objects.create(
-            name="Other Workspace Queue",
-            organization=organization,
-            workspace=other_workspace,
-            created_by=user,
         )
 
         with (
@@ -677,15 +634,15 @@ class TestCreateQueue:
                 "tfc.ee_gating.check_ee_can_create",
                 side_effect=FeatureUnavailable(
                     EEResource.ANNOTATION_QUEUES.value,
-                    detail="You've reached the 2 annotation queues limit",
+                    detail="You've reached the 3 annotation queues limit",
                     code="ENTITLEMENT_LIMIT",
                     metadata={
                         "resource": EEResource.ANNOTATION_QUEUES.value,
-                        "current_usage": 2,
-                        "limit": 2,
+                        "current_usage": 3,
+                        "limit": 3,
                     },
                 ),
-            ),
+            ) as check_can_create,
         ):
             resp = auth_client.post(
                 f"{QUEUE_URL}get-or-create-default/",
@@ -693,16 +650,103 @@ class TestCreateQueue:
                 format="json",
             )
 
-        assert resp.status_code == status.HTTP_402_PAYMENT_REQUIRED
-        assert "2 existing queues" in resp.data["error"]["message"]
-        assert "1 in the current workspace" in resp.data["error"]["message"]
-        assert "1 in other workspaces" in resp.data["error"]["message"]
-        assert resp.data["error"]["detail"]["current_usage"] == 2
-        assert resp.data["error"]["detail"]["workspace_usage"] == 1
-        assert resp.data["error"]["detail"]["other_workspace_usage"] == 1
-        assert not AnnotationQueue.objects.filter(
-            name__startswith="Default - Default Queue Limit Message Project"
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["result"]["action"] == "created"
+        check_can_create.assert_not_called()
+        assert AnnotationQueue.objects.filter(
+            project=project, is_default=True, deleted=False
         ).exists()
+
+    def test_get_or_create_default_restore_branch_exempt_from_plan_limit(
+        self, auth_client, organization, workspace, user
+    ):
+        """Un-archiving a scope's default queue is also exempt: the restore
+        branch must not resurrect the silent-402 at the cap."""
+        project = Project.objects.create(
+            name="Default Queue Restore Exempt Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        archived = AnnotationQueue.objects.create(
+            name="Default - Default Queue Restore Exempt Project",
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            organization=organization,
+            workspace=workspace,
+            project=project,
+            created_by=user,
+            is_default=True,
+        )
+        archived.delete()  # soft-archive (flips deleted=True)
+
+        with (
+            patch("tfc.ee_gating.is_oss", return_value=False),
+            patch(
+                "tfc.ee_gating.check_ee_can_create",
+                side_effect=FeatureUnavailable(
+                    EEResource.ANNOTATION_QUEUES.value,
+                    detail="You've reached the 3 annotation queues limit",
+                    code="ENTITLEMENT_LIMIT",
+                    metadata={
+                        "resource": EEResource.ANNOTATION_QUEUES.value,
+                        "current_usage": 3,
+                        "limit": 3,
+                    },
+                ),
+            ) as check_can_create,
+        ):
+            resp = auth_client.post(
+                f"{QUEUE_URL}get-or-create-default/",
+                {"project_id": str(project.id)},
+                format="json",
+            )
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert resp.data["result"]["action"] == "restored"
+        assert resp.data["result"]["queue"]["id"] == str(archived.id)
+        check_can_create.assert_not_called()
+
+    def test_default_queues_excluded_from_create_count(
+        self, auth_client, organization, user, workspace
+    ):
+        """Auto-provisioned default queues don't consume the plan quota, so a
+        real-queue create counts only user-created queues (the blast radius:
+        without this, N default queues would silently exhaust the org's cap)."""
+        AnnotationQueue.objects.create(
+            name="Existing Real Queue",
+            organization=organization,
+            created_by=user,
+        )
+        project = Project.objects.create(
+            name="Default Count Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        AnnotationQueue.objects.create(
+            name="Default - Default Count Project",
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            organization=organization,
+            workspace=workspace,
+            project=project,
+            created_by=user,
+            is_default=True,
+        )
+
+        with (
+            patch("tfc.ee_gating.is_oss", return_value=False),
+            patch("tfc.ee_gating.check_ee_can_create") as check_can_create,
+        ):
+            resp = create_queue(auth_client, name="Plan Counted Real Queue")
+
+        assert resp.status_code == status.HTTP_201_CREATED, resp.data
+        check_can_create.assert_called_once_with(
+            EEResource.ANNOTATION_QUEUES,
+            org_id=str(organization.id),
+            current_count=1,  # the default queue is not counted
+        )
 
     def test_get_or_create_default_gives_requester_full_manager_access(
         self, auth_client, organization, workspace, user

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -2766,7 +2766,9 @@ def _is_review_workspace_request(
 
 
 def _workspace_visible_queue_count(org, workspace):
-    queryset = AnnotationQueue.no_workspace_objects.filter(organization=org)
+    queryset = AnnotationQueue.no_workspace_objects.filter(
+        organization=org, is_default=False
+    )
     if not workspace:
         return queryset.count()
     if getattr(workspace, "is_default", False):
@@ -2792,11 +2794,14 @@ def _check_annotation_queue_create_limit(org, workspace=None):
     if is_oss():
         return
 
-    # Queue pricing limits are org-level entitlements. Do not use the default
-    # manager here because it applies the current workspace context and would
-    # under-count queues that exist in other workspaces in the same org.
+    # Queue pricing limits are org-level entitlements. Use the workspace-agnostic
+    # manager so queues in sibling workspaces are still counted, and exclude
+    # auto-provisioned default queues: they are plumbing for the quick add-label
+    # flow (one per scope), not deliberate user artefacts, so they do not consume
+    # the plan quota.
     current_count = AnnotationQueue.no_workspace_objects.filter(
         organization=org,
+        is_default=False,
     ).count()
     try:
         check_ee_can_create(
@@ -2814,7 +2819,7 @@ def _check_annotation_queue_create_limit(org, workspace=None):
             limit_text = f"{limit} " if limit is not None else ""
             detail = (
                 f"You've reached the {limit_text}annotation queues limit across "
-                f"this organization ({current_count} existing queues; "
+                f"this organization ({current_count} user-created queues; "
                 f"{workspace_count} in the current workspace and "
                 f"{metadata['other_workspace_usage']} in other workspaces). "
                 "Archive unused queues in another workspace or upgrade your plan."
@@ -3904,6 +3909,11 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         ).first()
         action = "fetched"
         if not queue:
+            # Default queues are auto-provisioned plumbing for the quick
+            # add-label flow — one per scope, bounded by the unique index — not
+            # deliberate user queues, so they are exempt from the plan quota.
+            # Do NOT gate this path on the create limit: at the cap it would 402
+            # and the add-label button would silently do nothing.
             archived = (
                 AnnotationQueue.all_objects.filter(
                     **lookup, is_default=True, deleted=True, organization=org
@@ -3912,16 +3922,10 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 .first()
             )
             if archived:
-                _check_annotation_queue_create_limit(
-                    org, getattr(request, "workspace", None)
-                )
                 _restore_archived_default_queue(archived)
                 queue = archived
                 action = "restored"
             else:
-                _check_annotation_queue_create_limit(
-                    org, getattr(request, "workspace", None)
-                )
                 queue = AnnotationQueue.objects.create(
                     is_default=True,
                     name=f"Default - {getattr(entity, 'name', None) or getattr(entity, 'agent_name', str(entity))}",


### PR DESCRIPTION
## TH-6882 — "Add Label" silently fails org-wide once the queue quota is full

**This isn't a perf bug — the feature is just off at the cap.** Opening **Add Label** on any trace/dataset/eval calls `POST /model-hub/annotation-queues/get-or-create-default/`, which auto-provisions (or un-archives) a `Default - <scope>` queue. That create ran the plan-limit check, so **auto-created default queues consumed the customer's queue quota**. At the cap it returned **402 `ENTITLEMENT_LIMIT`**, and the button did nothing.

Proven on us2 at its untouched 3/3 state: the click → **402 (433 ms)**. Archive one queue → same click, same trace → **200 (420 ms)**, then add-label 770 ms. The only variable was the quota.

**Blast radius:** each scope needs its own default queue, so a 3-queue plan could annotate from **at most 3 scopes**, and every Add Label stole from the user's real-queue budget. Worse, a `0-real / 3-default` org could not create its *first* real queue.

## Fix

**Principle:** `is_default=True` queues are auto-provisioned plumbing (one per scope, bounded by the unique index), not deliberate user artefacts — so they are **fully exempt from the plan quota, both enforcement and counting.**

| Change | Where |
|---|---|
| `get-or-create-default` no longer runs the create-limit check on **either** the create-new or the restore-archived branch → opening Add Label can never 402 | `views/annotation_queues.py` `get_or_create_default` |
| The plan-limit count **excludes** `is_default` queues, so accumulated default machinery can't exhaust the org's real-queue budget | `_check_annotation_queue_create_limit` + `_workspace_visible_queue_count` |
| 402 message "existing queues" → "user-created queues" (the count now excludes defaults, so the old wording undercounted vs. the queue table) | same |

After this, `_check_annotation_queue_create_limit` has exactly **one** caller — the real-queue `create` path. This matches `resolve_default_queue_for_source` (the scores path), which **already** creates/un-archives default queues with no limit check — so the change makes an already-half-open gate coherent rather than inventing a new policy. The check itself landed in an unrelated omnibus "queue export" commit, not a deliberate pricing decision.

## ⚠️ Pricing call to ack

Datasets are **unlimited on every plan** (`ee/billing.yaml`), and every dataset gets a default queue. After this change, default queues are **unmetered and unbounded** — a free-plan org can mint unlimited *functional* queues by creating datasets and hitting Add Label. This is almost certainly the right trade (the current behavior makes free-plan annotation unusable), but per the OSS/EE standard it's a pricing decision that should be **acked, not silently made**. Flagging for the pricing owner.

Also: removing the check from the default path also removes the `limit == 0 → "not available on your plan"` plan-availability gate from that path. No plan configures annotation queues to `0` today, so this is a no-op in practice (YAGNI), noted for completeness.

## Not FE, not perf
- The FE **already surfaces** the error (`useGetOrCreateDefaultQueue.onError` → snackbar). The "FE swallows it" note from the original audit is stale — no FE change needed.
- No perf test: this is a functional/quota bug (the 402 is fast). No latency to guard.
- **No migration:** `is_default` already exists; view-logic only.

## Tests (`test_annotation_queues_api.py`)
Rewrote the two tests that asserted the default path *enforces* the limit into the new contract, and added the blast-radius guard:
- `test_get_or_create_default_create_branch_exempt_from_plan_limit` — patches `check_ee_can_create` to **deny**, asserts the create branch returns **200** and the check is not called.
- `test_get_or_create_default_restore_branch_exempt_from_plan_limit` — same, for the un-archive branch (200 + `action: restored`).
- `test_default_queues_excluded_from_create_count` — 1 real + 1 default queue → real-queue create sees `current_count=1` (default not counted).
- Updated the cross-workspace message assertion to "user-created queues".

**Fails-on-revert verified empirically:** with the view change stashed, the exemption tests go red (402 ≠ 200), the count test goes red (2 ≠ 1), and the message test goes red — every line is load-bearing. Full file green: **61 passed**. (The 5 failures in `test_annotation_api_contract.py` are a pre-existing missing-`swagger.json` in the dev container — unrelated; this change touches no serializer or endpoint signature.)

## Reviews
- **Pre-code architect (fable):** GO on the core fix; verified all call sites, that `no_workspace_objects` filters `deleted`, no EE-side double-count, and that the `ee/usage` `is_default` fixtures are Workspaces not queues. It also surfaced the `resolve_default_queue_for_source` precedent and the datasets-unlimited pricing caveat above.

## Follow-up (deliberately out of scope)
The `restore` action still has no limit check — the archive→restore cap-bypass for **real** queues is a separate pre-existing bug (a *tightening*, unlike this *loosening*; needs its own FE check on the archived-tab Restore button). To be filed as its own ticket rather than bundled here.

