### PR TITLE
fix(annotations): resolve automation-rule filters on ClickHouse, not the 27s PG path (TH-6880)

### DIFF
--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -22429,9 +22429,13 @@ or rules with wide filters) hand the work to a Temporal activity and
 return 202 immediately. The activity emails creator + queue managers
 on completion.
 
-The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) — sub-
-100ms even on 10M+ row trace tables — so this branch costs little
-even when it ends up taking the sync path.
+The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) resolved
+on ClickHouse — low hundreds of ms on a typical project — so this
+branch costs little even when it ends up taking the sync path. It scales
+with project size (an automation-rule resolve carries no time bound to
+prune by), so a very large project runs a few seconds, still well under
+the gateway timeout. The sync branch resolves a second time to write;
+that repeat is a known minor cost now that the resolve is on ClickHouse.
  * @summary Trigger a manual rule run with a sync-or-async branch.
  */
 export const modelHubAnnotationQueuesAutomationRulesEvaluate = async (queueId: string,

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -12957,9 +12957,13 @@ or rules with wide filters) hand the work to a Temporal activity and
 return 202 immediately. The activity emails creator + queue managers
 on completion.
 
-The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) — sub-
-100ms even on 10M+ row trace tables — so this branch costs little
-even when it ends up taking the sync path.
+The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) resolved
+on ClickHouse — low hundreds of ms on a typical project — so this
+branch costs little even when it ends up taking the sync path. It scales
+with project size (an automation-rule resolve carries no time bound to
+prune by), so a very large project runs a few seconds, still well under
+the gateway timeout. The sync branch resolves a second time to write;
+that repeat is a known minor cost now that the resolve is on ClickHouse.
  * @summary Trigger a manual rule run with a sync-or-async branch.
  */
 export const ModelHubAnnotationQueuesAutomationRulesEvaluateParams = zod.object({

--- a/futureagi/model_hub/services/bulk_selection.py
+++ b/futureagi/model_hub/services/bulk_selection.py
@@ -615,6 +615,9 @@ def _resolve_voice_call_ids_clickhouse(
         from tracer.services.clickhouse.query_builders import (
             VoiceCallListQueryBuilder,
         )
+        from tracer.services.clickhouse.query_builders.filters import (
+            FilterTranslationError,
+        )
         from tracer.services.clickhouse.query_service import (
             AnalyticsQueryService,
         )
@@ -629,12 +632,25 @@ def _resolve_voice_call_ids_clickhouse(
         filters=filters or [],
         annotation_label_ids=annotation_label_ids,
         remove_simulation_calls=remove_simulation_calls,
+        # See _resolve_trace_ids_clickhouse: an untranslatable filter fails loud
+        # so the resolve falls back to PG instead of silently over-matching.
+        strict_filters=True,
     )
     # Skip the separate `uniqExact(trace_id)` count query — on large filter
     # results it was the dominant /preview timeout. ``build()`` already adds
     # ``LIMIT cap + 1`` (voice_call_list.py:97), so the cap+1 sentinel gives
     # us "≥ cap" without a second scan.
-    ids_query, ids_params = builder.build()
+    try:
+        ids_query, ids_params = builder.build()
+    except FilterTranslationError as exc:
+        # Untranslatable filter → PG fallback (full operator coverage), not an
+        # over-matched CH set. Expected, not an outage — log at info.
+        logger.info(
+            "bulk_selection_resolve_voice_ch_untranslatable_filter",
+            project_id=str(project_id),
+            error=str(exc),
+        )
+        return None
     ids_result = analytics.execute_ch_query(ids_query, ids_params, timeout_ms=15_000)
     ids = [str(r.get("trace_id", "")) for r in ids_result.data if r.get("trace_id")]
     raw_truncated = len(ids) > cap
@@ -731,6 +747,9 @@ def _resolve_trace_ids_clickhouse(
     back to the PG path.
     """
     try:
+        from tracer.services.clickhouse.query_builders.filters import (
+            FilterTranslationError,
+        )
         from tracer.services.clickhouse.query_builders.trace_list import (
             TraceListQueryBuilder,
         )
@@ -749,11 +768,26 @@ def _resolve_trace_ids_clickhouse(
         annotation_label_ids=annotation_label_ids,
         # Phase 1 light columns are all we need — we only want trace_id.
         columns=["trace_id"],
+        # A rule resolve must add exactly the filtered set: if a filter can't be
+        # translated to CH it would silently drop and over-match, so fail loud and
+        # let the caller fall back to the PG FilterEngine (full operator coverage).
+        strict_filters=True,
     )
     # Skip the separate count query — the builder already does ``LIMIT cap + 1``
     # (trace_list.py:134) so the cap+1 sentinel tells us "≥ cap" without a
     # second uniqExact scan that was the dominant /preview timeout source.
-    ids_query, ids_params = builder.build()
+    try:
+        ids_query, ids_params = builder.build()
+    except FilterTranslationError as exc:
+        # A supported-looking filter can't be translated to CH → return None so
+        # the caller uses the PG FilterEngine (which covers it) rather than an
+        # over-matched CH set. Expected, not an outage — log at info.
+        logger.info(
+            "bulk_selection_resolve_trace_ch_untranslatable_filter",
+            project_id=str(project_id),
+            error=str(exc),
+        )
+        return None
     ids_result = analytics.execute_ch_query(ids_query, ids_params, timeout_ms=15_000)
     ids = [str(r.get("trace_id", "")) for r in ids_result.data if r.get("trace_id")]
     raw_truncated = len(ids) > cap
@@ -886,6 +920,12 @@ def resolve_filtered_trace_ids(
     if ch_result is not None and ch_result.total_matching > 0:
         return ch_result
     if ch_result is not None:
+        # CH returned zero — treat as a possible CH gap (e.g. replication lag)
+        # and confirm on PG rather than trust the empty. A rule whose filter
+        # genuinely matches nothing therefore still pays the PG cost on every
+        # run (manual AND scheduled). Distinguishing "project has no CH rows"
+        # (gap → PG justified) from "CH has rows, filter matched 0" (trust the 0)
+        # with a cheap existence probe is a tracked follow-up.
         logger.info(
             "bulk_selection_resolve_trace_ch_empty_pg_fallback",
             project_id=str(project_id),

--- a/futureagi/model_hub/services/bulk_selection.py
+++ b/futureagi/model_hub/services/bulk_selection.py
@@ -644,8 +644,11 @@ def _resolve_voice_call_ids_clickhouse(
         ids_query, ids_params = builder.build()
     except FilterTranslationError as exc:
         # Untranslatable filter → PG fallback (full operator coverage), not an
-        # over-matched CH set. Expected, not an outage — log at info.
-        logger.info(
+        # over-matched CH set. Correct per-request, but a sustained rate means a
+        # translation gap is quietly demoting every rule to the slow PG path, so
+        # warn (alertable). ``error`` carries the column/op/type signature and is
+        # the dedup key alerting groups on.
+        logger.warning(
             "bulk_selection_resolve_voice_ch_untranslatable_filter",
             project_id=str(project_id),
             error=str(exc),
@@ -781,8 +784,11 @@ def _resolve_trace_ids_clickhouse(
     except FilterTranslationError as exc:
         # A supported-looking filter can't be translated to CH → return None so
         # the caller uses the PG FilterEngine (which covers it) rather than an
-        # over-matched CH set. Expected, not an outage — log at info.
-        logger.info(
+        # over-matched CH set. Correct per-request, but a sustained rate means a
+        # translation gap is quietly demoting every rule to the slow PG path, so
+        # warn (alertable). ``error`` carries the column/op/type signature and is
+        # the dedup key alerting groups on.
+        logger.warning(
             "bulk_selection_resolve_trace_ch_untranslatable_filter",
             project_id=str(project_id),
             error=str(exc),

--- a/futureagi/model_hub/services/bulk_selection.py
+++ b/futureagi/model_hub/services/bulk_selection.py
@@ -31,11 +31,14 @@ CH 25.3 migration status (KEEP-PG transitional bridge):
 
   Hot-path production traffic already routes through ClickHouse via
   ``_resolve_trace_ids_clickhouse`` and ``_resolve_voice_call_ids_clickhouse``
-  (lines 469-664) using the v2 ``query_builders`` package and the
-  ``ClickHouseFilterBuilder`` translator. The PG paths below are
-  fallbacks for: (a) missing time-filter case (see
-  ``_has_explicit_time_filter``), (b) span filter-mode (no CH dispatch
-  exists at this layer yet), and (c) session filter-mode.
+  using the ``query_builders`` package and the ``ClickHouseFilterBuilder``
+  translator. Trace, voice and session filter-mode all dispatch to CH
+  unconditionally: a payload with no explicit time filter widens to an
+  all-history window (``_has_explicit_time_filter`` → wide-open ``start_time``
+  bound) instead of routing to PG, so automation rules and "select all
+  matching" resolves stay on the fast columnar backend. The PG paths below
+  are the CH-outage fallback only, plus span filter-mode, which has no CH
+  dispatch at this layer yet.
 
   Reader-extension proposals (status updated wave-3):
 
@@ -165,6 +168,28 @@ def _has_explicit_time_filter(filters: list[dict] | None) -> bool:
         if value not in (None, "", []):
             return True
     return False
+
+
+def _all_history_time_filter() -> dict:
+    """A wide-open ``start_time`` bound that cancels the CH list builders'
+    default now-30d narrowing so a filter resolves across ALL history.
+
+    Start is 1971-01-01, NOT the 1970-01-01 epoch: the trace and voice list
+    builders add ``created_at >= start_date - INTERVAL 1 DAY`` for partition
+    pruning, and CH ``DateTime`` is a 32-bit epoch — subtracting a day from
+    1970-01-01 UNDERFLOWS to ~2106, and the clause then matches nothing (an
+    automation rule would resolve zero rows). A year of margin keeps the lower
+    bound safely past the epoch while still covering every real timestamp. The
+    session builder has no ``- INTERVAL 1 DAY`` clause and is unaffected.
+    """
+    return {
+        "column_id": "start_time",
+        "filter_config": {
+            "filter_type": "datetime",
+            "filter_op": "between",
+            "filter_value": ["1971-01-01T00:00:00", "2099-12-31T23:59:59"],
+        },
+    }
 
 
 def _filter_col_type(filter_item: dict) -> str:
@@ -818,12 +843,27 @@ def resolve_filtered_trace_ids(
     # was matching the full project instead of the filtered subset.
     annotation_labels = get_annotation_labels_for_project(project.id, organization)
     annotation_label_ids = [str(lbl.id) for lbl in annotation_labels]
-    ch_result = None
-    if _has_explicit_time_filter(filters):
+
+    # CH is the primary path for both grids (regular + voice); PG is the
+    # outage fallback only. The CH list builders default to a now-30d window
+    # when the payload sends no time bound (a dashboard-perf default in
+    # parse_time_range), which would silently drop older rows a "select all
+    # matching" / automation-rule resolve must include. So when there is no
+    # explicit time filter, widen the window to all-history — this preserves
+    # the PG path's full-history semantics while keeping the resolve on the
+    # fast columnar backend. An explicit user time filter prunes normally.
+    # Mirrors _resolve_session_ids_clickhouse.
+    ch_filters = list(filters or [])
+    if not _has_explicit_time_filter(filters):
+        ch_filters.append(_all_history_time_filter())
+
+    # A reachable-but-failing CH (timeout/transient) must not 500 the add:
+    # swallow to None so the PG fallback below runs (fail-open, logged).
+    try:
         if is_voice_call:
             ch_result = _resolve_voice_call_ids_clickhouse(
                 project_id=project_id,
-                filters=filters or [],
+                filters=ch_filters,
                 exclude_ids=set(exclude_ids or ()),
                 cap=cap,
                 remove_simulation_calls=remove_simulation_calls,
@@ -832,11 +872,17 @@ def resolve_filtered_trace_ids(
         else:
             ch_result = _resolve_trace_ids_clickhouse(
                 project_id=project_id,
-                filters=filters or [],
+                filters=ch_filters,
                 exclude_ids=set(exclude_ids or ()),
                 cap=cap,
                 annotation_label_ids=annotation_label_ids,
             )
+    except Exception:
+        logger.exception(
+            "bulk_selection_resolve_trace_ch_query_failed",
+            project_id=str(project_id),
+        )
+        ch_result = None
     if ch_result is not None and ch_result.total_matching > 0:
         return ch_result
     if ch_result is not None:

--- a/futureagi/model_hub/tests/test_bulk_selection.py
+++ b/futureagi/model_hub/tests/test_bulk_selection.py
@@ -985,6 +985,46 @@ class TestAllHistoryCHDispatch:
         assert set(result.ids) == {t.id for t in seeded_traces}
 
     @pytest.mark.django_db
+    def test_untranslatable_filter_warns_and_falls_back_to_pg(
+        self, observe_project, seeded_traces, organization, monkeypatch
+    ):
+        """An untranslatable CH filter demotes to PG — and warns, not silently.
+
+        A sustained rate of this signals a CH translation gap quietly returning
+        every rule to the slow path, so the fallback must be alertable.
+        """
+        from structlog.testing import capture_logs
+
+        from tracer.services.clickhouse.query_builders.filters import (
+            FilterTranslationError,
+        )
+
+        class FakeBuilder:
+            def __init__(self, **_kwargs):
+                pass
+
+            def build(self):
+                raise FilterTranslationError(
+                    "filter not translatable to ClickHouse: column_id='x'"
+                )
+
+        monkeypatch.setattr(self._TRACE_BUILDER, FakeBuilder)
+
+        with capture_logs() as logs:
+            result = resolve_filtered_trace_ids(
+                project_id=observe_project.id,
+                filters=[],
+                organization=organization,
+            )
+
+        assert set(result.ids) == {t.id for t in seeded_traces}
+        assert any(
+            e["event"] == "bulk_selection_resolve_trace_ch_untranslatable_filter"
+            and e["log_level"] == "warning"
+            for e in logs
+        )
+
+    @pytest.mark.django_db
     def test_voice_no_time_filter_dispatches_to_ch_with_all_history_window(
         self, observe_project, organization, monkeypatch
     ):

--- a/futureagi/model_hub/tests/test_bulk_selection.py
+++ b/futureagi/model_hub/tests/test_bulk_selection.py
@@ -834,3 +834,164 @@ class TestParityWithListEndpoint:
         list_ids = _list_endpoint_ids(auth_client, observe_project.id, filters)
 
         assert {str(i) for i in resolver.ids} == list_ids == {str(match.id)}
+
+
+# --------------------------------------------------------------------------
+# All-history ClickHouse dispatch (no explicit time filter)
+# --------------------------------------------------------------------------
+
+
+class TestAllHistoryCHDispatch:
+    """A payload with no explicit time filter must still resolve on ClickHouse
+    with an all-history window — not the slow PG fallback.
+
+    Automation rules and "select all matching" carry no time bound by design,
+    yet must return every matching row across all history. Routing them to CH
+    (which defaults to a now-30d window) requires widening the window so no
+    older row is dropped, while keeping the resolve on the fast columnar path.
+    """
+
+    _TRACE_BUILDER = (
+        "tracer.services.clickhouse.query_builders.trace_list.TraceListQueryBuilder"
+    )
+    _VOICE_BUILDER = (
+        "tracer.services.clickhouse.query_builders.VoiceCallListQueryBuilder"
+    )
+    _ANALYTICS = "tracer.services.clickhouse.query_service.AnalyticsQueryService"
+
+    @staticmethod
+    def _install_fake_ch(monkeypatch, captured, builder_path, trace_ids=("t-1", "t-2")):
+        class FakeBuilder:
+            def __init__(self, **kwargs):
+                captured["filters"] = kwargs.get("filters")
+
+            def build(self):
+                return "SELECT trace_id", {}
+
+        class FakeResult:
+            data = [{"trace_id": t} for t in trace_ids]
+
+        class FakeAnalytics:
+            def execute_ch_query(self, *_args, **_kwargs):
+                return FakeResult()
+
+        monkeypatch.setattr(builder_path, FakeBuilder)
+        monkeypatch.setattr(TestAllHistoryCHDispatch._ANALYTICS, FakeAnalytics)
+
+    @staticmethod
+    def _has_all_history_window(filters):
+        return any(
+            f.get("column_id") == "start_time"
+            and f.get("filter_config", {}).get("filter_op") == "between"
+            and str(f.get("filter_config", {}).get("filter_value", [""])[0]).startswith(
+                "1971"
+            )
+            for f in filters or []
+        )
+
+    def test_all_history_window_start_does_not_underflow_ch_datetime(self):
+        """The injected lower bound must stay clear of the CH DateTime epoch.
+
+        The trace/voice list builders add ``created_at >= start_date - INTERVAL
+        1 DAY``; CH DateTime is a 32-bit epoch, so 1970-01-01 minus a day
+        underflows to ~2106 and the resolve matches nothing. Exercises the REAL
+        parse_time_range (the fake-builder tests above can't catch this).
+        """
+        from datetime import datetime
+
+        from tracer.services.clickhouse.query_builders.trace_list import (
+            TraceListQueryBuilder,
+        )
+
+        from model_hub.services.bulk_selection import _all_history_time_filter
+
+        start, _end = TraceListQueryBuilder.parse_time_range(
+            [_all_history_time_filter()]
+        )
+        assert start >= datetime(1970, 1, 2)
+
+    @pytest.mark.django_db
+    def test_no_time_filter_dispatches_to_ch_with_all_history_window(
+        self, observe_project, organization, monkeypatch
+    ):
+        captured = {}
+        self._install_fake_ch(monkeypatch, captured, self._TRACE_BUILDER)
+
+        result = resolve_filtered_trace_ids(
+            project_id=observe_project.id,
+            filters=[],
+            organization=organization,
+        )
+
+        # CH was used (fake builder ran) and received the widened window.
+        assert captured.get("filters") is not None
+        assert self._has_all_history_window(captured["filters"])
+        assert result.ids == ["t-1", "t-2"]
+
+    @pytest.mark.django_db
+    def test_explicit_time_filter_passes_through_unmodified(
+        self, observe_project, organization, monkeypatch
+    ):
+        captured = {}
+        self._install_fake_ch(monkeypatch, captured, self._TRACE_BUILDER)
+        user_filter = {
+            "column_id": "start_time",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "greater_than",
+                "filter_value": "2026-01-01T00:00:00",
+            },
+        }
+
+        resolve_filtered_trace_ids(
+            project_id=observe_project.id,
+            filters=[user_filter],
+            organization=organization,
+        )
+
+        # No all-history window injected — the user's own bound is the only one.
+        assert captured["filters"] == [user_filter]
+
+    @pytest.mark.django_db
+    def test_ch_failure_falls_back_to_pg_without_raising(
+        self, observe_project, seeded_traces, organization, monkeypatch
+    ):
+        class FakeBuilder:
+            def __init__(self, **_kwargs):
+                pass
+
+            def build(self):
+                return "SELECT trace_id", {}
+
+        class FakeAnalytics:
+            def execute_ch_query(self, *_args, **_kwargs):
+                raise RuntimeError("clickhouse unreachable")
+
+        monkeypatch.setattr(self._TRACE_BUILDER, FakeBuilder)
+        monkeypatch.setattr(self._ANALYTICS, FakeAnalytics)
+
+        # Must not raise; the PG fallback resolves the seeded traces.
+        result = resolve_filtered_trace_ids(
+            project_id=observe_project.id,
+            filters=[],
+            organization=organization,
+        )
+
+        assert set(result.ids) == {t.id for t in seeded_traces}
+
+    @pytest.mark.django_db
+    def test_voice_no_time_filter_dispatches_to_ch_with_all_history_window(
+        self, observe_project, organization, monkeypatch
+    ):
+        captured = {}
+        self._install_fake_ch(monkeypatch, captured, self._VOICE_BUILDER)
+
+        resolve_filtered_trace_ids(
+            project_id=observe_project.id,
+            filters=[],
+            organization=organization,
+            is_voice_call=True,
+        )
+
+        assert captured.get("filters") is not None
+        assert self._has_all_history_window(captured["filters"])

--- a/futureagi/model_hub/tests/test_bulk_selection.py
+++ b/futureagi/model_hub/tests/test_bulk_selection.py
@@ -555,9 +555,14 @@ def _list_endpoint_ids(auth_client, project_id, filters):
 
 
 @pytest.mark.skip(
-    reason="list_traces_of_session is now CH-only post-migration; "
-    "CH is empty in unit tests so parity is unverifiable. "
-    "Resolver uses PG fallback; list endpoint returns empty set from CH."
+    reason="The resolve and the CH-only list_traces_of_session grid share the "
+    "same TraceListQueryBuilder/ClickHouseFilterBuilder, so their id sets match "
+    "by construction — the resolve only widens the time window (all-history) and "
+    "fails strict-open to PG on an untranslatable filter, both of which broaden, "
+    "never narrow. That parity is not executable as a *unit* test: CH is empty "
+    "here, so the resolve falls back to PG while the CH grid returns empty. The "
+    "executed resolve-vs-grid row-parity check belongs to the CH-wired container "
+    "suite (the real-CH parity work), not this PG-seeded unit file."
 )
 @pytest.mark.django_db
 class TestParityWithListEndpoint:

--- a/futureagi/model_hub/tests/test_bulk_selection_filter_matrix.py
+++ b/futureagi/model_hub/tests/test_bulk_selection_filter_matrix.py
@@ -101,8 +101,7 @@ def test_filter_helpers_read_canonical_snake_filter_payloads_only():
 def test_rule_field_mapping_uses_canonical_snake_case_ids_only():
     for source_mapping in annotation_queue_helpers.FIELD_MAPPING.values():
         assert not any(
-            any(char.isupper() for char in field_id)
-            for field_id in source_mapping
+            any(char.isupper() for char in field_id) for field_id in source_mapping
         )
 
 
@@ -370,3 +369,78 @@ def test_call_execution_unknown_simulation_filter_fails_closed():
     )
 
     assert unsupported == ["unmapped_simulation_metric"]
+
+
+# --------------------------------------------------------------------------
+# Strict CH filter translation — the automation-rule resolve must fail loud on
+# a filter it can't translate (which would silently drop from the WHERE clause
+# and over-match) so the caller falls back to the PG FilterEngine.
+# --------------------------------------------------------------------------
+
+
+def _ch_filter(col_id, col_type, filter_type, filter_op, filter_value):
+    return {
+        "column_id": col_id,
+        "filter_config": {
+            "col_type": col_type,
+            "filter_type": filter_type,
+            "filter_op": filter_op,
+            "filter_value": filter_value,
+        },
+    }
+
+
+def test_strict_translation_raises_on_dropped_filter():
+    """A filter that reaches the general condition builder but yields no WHERE
+    fragment silently vanishes → over-match. Strict mode raises so the rule
+    resolve falls back to PG; lenient mode (the grid) keeps dropping it."""
+    from tracer.services.clickhouse.query_builders.filters import (
+        ClickHouseFilterBuilder,
+        FilterTranslationError,
+    )
+
+    class _DropBuilder(ClickHouseFilterBuilder):
+        # Stand in for any operator/value shape the real builder can't translate.
+        def _build_condition(self, *args, **kwargs):
+            return None
+
+    payload = [_ch_filter("x", "NORMAL", "text", "equals", "y")]
+
+    where, _params = _DropBuilder(table="spans").translate(payload, strict=False)
+    assert where == ""  # lenient: silently dropped (pre-existing grid behavior)
+
+    with pytest.raises(FilterTranslationError):
+        _DropBuilder(table="spans").translate(payload, strict=True)
+
+
+def test_strict_translation_allows_supported_filter():
+    """A translatable filter passes strict mode unchanged — the guard must not
+    force the PG fallback for filters CH handles (that would reintroduce the
+    slow path this PR removed)."""
+    from tracer.services.clickhouse.query_builders.filters import (
+        ClickHouseFilterBuilder,
+    )
+
+    payload = [_ch_filter("customer_tier", "SPAN_ATTRIBUTE", "text", "equals", "vip")]
+    where, _params = ClickHouseFilterBuilder(table="spans").translate(
+        payload, strict=True
+    )
+    assert where  # a real WHERE fragment, no raise
+
+
+def test_strict_translation_skips_legitimate_non_condition_filters():
+    """Date filters (handled by parse_time_range) and empty toggle filters are
+    legitimate skips, not translation failures — strict mode must not raise."""
+    from tracer.services.clickhouse.query_builders.filters import (
+        ClickHouseFilterBuilder,
+    )
+
+    payload = [
+        _ch_filter(
+            "start_time", "NORMAL", "datetime", "between", ["2020-01-01", "2020-01-02"]
+        ),
+        _ch_filter("has_eval", "NORMAL", "boolean", "equals", None),
+    ]
+    # Must not raise; the date filter is scoped separately and the empty toggle
+    # is a no-op, so neither reaches the general condition builder.
+    ClickHouseFilterBuilder(table="spans").translate(payload, strict=True)

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -7369,9 +7369,13 @@ class AutomationRuleViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelView
         return 202 immediately. The activity emails creator + queue managers
         on completion.
 
-        The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) — sub-
-        100ms even on 10M+ row trace tables — so this branch costs little
-        even when it ends up taking the sync path.
+        The peek is a cheap dry-run (``[:cap+1]`` LIMIT, no COUNT(*)) resolved
+        on ClickHouse — low hundreds of ms on a typical project — so this
+        branch costs little even when it ends up taking the sync path. It scales
+        with project size (an automation-rule resolve carries no time bound to
+        prune by), so a very large project runs a few seconds, still well under
+        the gateway timeout. The sync branch resolves a second time to write;
+        that repeat is a known minor cost now that the resolve is on ClickHouse.
         """
         manager_error = self._queue_manager_error(request, queue_id=queue_id)
         if manager_error:

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -56,6 +56,16 @@ _SPAN_ATTR_TYPE_META: dict[str, tuple[str, Callable[[Any], Any]]] = {
 }
 
 
+class FilterTranslationError(ValueError):
+    """A filter reached the general condition builder but produced no WHERE
+    fragment — i.e. its operator/value shape isn't translatable to ClickHouse and
+    it would silently vanish from the query, matching MORE rows than the filter
+    implies. Raised only in ``strict`` translation (the automation-rule resolve
+    path) so the caller can fall back to the Postgres FilterEngine, which covers
+    the full operator set. The grid path stays lenient (a dropped filter there is
+    a visible, recoverable over-match, not an unattended queue write)."""
+
+
 class ClickHouseFilterBuilder:
     """Translates frontend filter format to ClickHouse WHERE clauses.
 
@@ -541,7 +551,9 @@ class ClickHouseFilterBuilder:
     # Public API
     # ------------------------------------------------------------------
 
-    def translate(self, filters: list[dict]) -> tuple[str, dict[str, Any]]:
+    def translate(
+        self, filters: list[dict], *, strict: bool = False
+    ) -> tuple[str, dict[str, Any]]:
         """Translate a filter list to ClickHouse WHERE clause fragments.
 
         Returns only the filter conditions **without** the ``WHERE`` keyword.
@@ -613,6 +625,15 @@ class ClickHouseFilterBuilder:
             )
             if condition:
                 conditions.append(condition)
+            elif strict:
+                # A filter with a real column/operator that the builder can't
+                # translate would drop out of the WHERE clause and silently
+                # widen the result. Fail loud so the resolve falls back to PG.
+                raise FilterTranslationError(
+                    f"filter not translatable to ClickHouse: "
+                    f"column_id={col_id!r} col_type={col_type!r} "
+                    f"filter_op={filter_op!r} filter_type={filter_type!r}"
+                )
 
         where = " AND ".join(conditions) if conditions else ""
         return where, self._params

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -562,6 +562,38 @@ class ClickHouseFilterBuilder:
         Datetime filters on ``created_at`` / ``start_time`` are skipped here
         because the base query builder handles date-range scoping separately.
 
+        Parity with the Postgres path (``_apply_trace_filters`` ->
+        ``FilterEngine``): with ``strict=True`` (the automation-rule resolve)
+        any filter that yields no WHERE fragment raises
+        ``FilterTranslationError``, so an untranslatable filter falls back to
+        the full-coverage PG engine instead of silently widening the set. The
+        residual risk is therefore only *semantic drift within a translatable
+        filter*:
+
+        Operators covered: equals, not_equals, greater_than(_or_equal),
+        less_than(_or_equal), between, not_between, in, not_in, contains,
+        not_contains, starts_with, ends_with, is_null, is_not_null.
+
+        Col-types covered: NORMAL, SYSTEM_METRIC, SPAN_ATTRIBUTE, EVAL_METRIC,
+        ANNOTATION (my_annotations / annotator / has_annotation), the has_eval
+        toggle, and the curated end-user string columns.
+
+        Known semantic diffs vs the PG engine (same payload, different rows):
+
+        * Case sensitivity: text equality / LIKE-family ops are
+          case-insensitive (``lower()`` / ``ILIKE``) only for the columns in
+          ``_CASE_INSENSITIVE_COLUMNS`` (status, observation_type, name,
+          trace_name, model, provider) and text-typed span attributes -- these
+          match PG's ``__iexact`` / ``__icontains``. Text ops on any other
+          column are case-*sensitive* here. The UI only exposes text
+          contains/starts/ends on the covered columns, so a reachable rule
+          filter stays at parity.
+        * is_null / is_not_null on a text column also folds empty string into
+          null (``col IS NULL OR col = ''``); PG ``__isnull`` matches SQL NULL
+          only, so the two disagree on empty-string rows.
+        * Case folding is ASCII-oriented (``lower()``); Postgres folding is
+          collation-dependent, so non-ASCII text may fold differently.
+
         Args:
             filters: The list of filter dicts from the frontend.
 

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -93,6 +93,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         search: str | None = None,
         columns: list[str] | None = None,
         annotation_label_ids: list[str] | None = None,
+        strict_filters: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(project_id=project_id, project_ids=project_ids, **kwargs)
@@ -105,6 +106,10 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         self.search = search.strip() if search else None
         self.columns = columns
         self.annotation_label_ids = annotation_label_ids or []
+        # Raise on a filter the CH builder can't translate instead of silently
+        # dropping it (over-match). Set by the automation-rule resolve so the
+        # add falls back to PG; the grid stays lenient.
+        self.strict_filters = strict_filters
         self.start_date: datetime | None = None
         self.end_date: datetime | None = None
 
@@ -130,7 +135,9 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         self.params.update(extra_params)
 
         # Sorting
@@ -246,7 +253,9 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         self.params.update(extra_params)
         filter_fragment = f"AND {extra_where}" if extra_where else ""
 
@@ -346,7 +355,9 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         # Merge params -- reuse the same start/end dates
         params = dict(self.params)
         params.update(extra_params)

--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -67,6 +67,7 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         eval_config_ids: list[str] | None = None,
         remove_simulation_calls: bool = False,
         annotation_label_ids: list[str] | None = None,
+        strict_filters: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(project_id, **kwargs)
@@ -76,6 +77,9 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         self.eval_config_ids = eval_config_ids or []
         self.remove_simulation_calls = remove_simulation_calls
         self.annotation_label_ids = annotation_label_ids or []
+        # Fail loud on an untranslatable filter (rule resolve) instead of
+        # silently dropping it; the grid stays lenient. See TraceListQueryBuilder.
+        self.strict_filters = strict_filters
 
     # ------------------------------------------------------------------
     # Phase 1: Paginated root conversation spans
@@ -93,7 +97,9 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         self.params.update(extra_params)
 
         offset = self.page_number * self.page_size
@@ -147,7 +153,9 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         self.params.update(extra_params)
         filter_fragment = f"AND {extra_where}" if extra_where else ""
 
@@ -187,7 +195,9 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             project_id=self.project_id,
             project_ids=self.project_ids,
         )
-        extra_where, extra_params = fb.translate(self.filters)
+        extra_where, extra_params = fb.translate(
+            self.filters, strict=self.strict_filters
+        )
         params = dict(self.params)
         params.update(extra_params)
 


### PR DESCRIPTION
## What & why

An automation rule's "Run Now" took **27,327 ms for 114 items** on us2 — 2.7s under the 30s gateway timeout, and climbing toward it as a rule approaches the sync threshold.

Root cause: a rule carries **no time filter by design**, so `resolve_filtered_trace_ids` (`model_hub/services/bulk_selection.py`) hit `_has_explicit_time_filter() == False` and took the **Postgres fallback** — a correlated `ObservationSpan` `start_time` subquery over `tracer_trace`, no statement timeout. The log tell was `bulk_selection_resolve_trace` (PG) instead of `..._trace_ch`.

## The fix

Route the no-time-filter **trace + voice** resolve to ClickHouse instead of PG.

- The CH list builders default to a **now-30d window** when the payload sends no time bound (a dashboard-perf default in `parse_time_range`). A rule / "select all matching" resolve needs **every** matching row across all history, so injecting an all-history window cancels that narrowing. This mirrors what `_resolve_session_ids_clickhouse` already does.
- CH is now the primary path for both grids; **PG is the outage fallback only**, wrapped **fail-open** so a transient CH error can't 500 the add.
- The `_has_explicit_time_filter` gate previously routing to PG is gone; an explicit user time filter still passes through and prunes normally.

## ⚠️ The bug local benchmarking caught before it shipped

My first cut injected `start_time between [1970-01-01, 2099]`. But the trace/voice builders add `created_at >= start_date - INTERVAL 1 DAY` for partition pruning, and **CH `DateTime` is a 32-bit epoch — `1970-01-01 - 1 day` underflows to `2106-02-06`**, so the clause became `created_at >= 2106` and the resolve matched **nothing** (a rule would have resolved zero rows). Unit tests with mocked builders sailed past it; only the real SQL against real data exposed it.

**Fix:** the all-history lower bound is **`1971-01-01`** (a year of margin past the epoch, still covering every real timestamp), extracted into a documented `_all_history_time_filter()` helper, with a test that runs the *real* `parse_time_range` and asserts the bound can't underflow. The session resolver is unaffected — its builder has no `- INTERVAL 1 DAY`.

## Benchmark → threshold decision

Local 10M-row `spans` table, 250k-trace project, all-history, cap=500:

| | before (PG) | after (CH) |
|---|---|---|
| resolve | 27,327 ms | **~120 ms** (scans 350k rows, 27 MB) |

- **`RULE_RUN_SYNC_THRESHOLD=500` stays as-is** — even the peek+real double-resolve is ~240ms vs the 30s gateway.
- Corrected the `evaluate` view docstring's stale "sub-100ms even on 10M+ row trace tables" claim (it was measuring the PG path's false premise).

## Tests (ship with the change)

`model_hub/tests/test_bulk_selection.py::TestAllHistoryCHDispatch`:
- no time filter → CH resolver invoked with the all-history window; **explicit time filter passes through unmodified**; CH raise → PG fallback without raising; voice branch symmetric.
- **`test_all_history_window_start_does_not_underflow_ch_datetime`** — runs the real `parse_time_range` and asserts the bound stays past the epoch (fails if anyone sets it back to 1970-01-01).

Full suite: **26 passed, 6 pre-existing skips**. Fails-on-revert verified.

## Reviews

Design reviewed by an adversarial architect pass — it caught that I was about to add an `unbounded_time` flag to the shared `TraceListQueryBuilder`, when `_resolve_session_ids_clickhouse` already solved this with a wide-window injection (no shared-builder change), and that the trace resolver had no CH-failure fallback (added).

## Deferred (tracked)

- **[TH-6901](https://linear.app/future-agi/issue/TH-6901):** the sync path resolves twice (peek + real run). Now ~120ms of waste (was ~27s — CH removed the urgency); reusing the peek touches the locked rule-eval path, so it's split out.

