### PR TITLE
fix(annotations): batch export cell read + cap sync export size (TH-6876)

### DIFF
--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -10809,6 +10809,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "409": {
             "$ref": "#/definitions/ApiTextErrorResponse"
           },
+          "413": {
+            "$ref": "#/definitions/ApiTextErrorResponse"
+          },
           "500": {
             "$ref": "#/definitions/ApiTextErrorResponse"
           },

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -21696,6 +21696,11 @@ export type modelHubAnnotationQueuesExportAnnotationsResponse409 = {
   status: 409
 }
 
+export type modelHubAnnotationQueuesExportAnnotationsResponse413 = {
+  data: ApiTextErrorResponseApi
+  status: 413
+}
+
 export type modelHubAnnotationQueuesExportAnnotationsResponse500 = {
   data: ApiTextErrorResponseApi
   status: 500
@@ -21703,13 +21708,13 @@ export type modelHubAnnotationQueuesExportAnnotationsResponse500 = {
 
 export type modelHubAnnotationQueuesExportAnnotationsResponseDefault = {
   data: ManagementAPIErrorResponseApi
-  status: Exclude<HTTPStatusCodes, 200 | 400 | 403 | 404 | 409 | 500>
+  status: Exclude<HTTPStatusCodes, 200 | 400 | 403 | 404 | 409 | 413 | 500>
 }
 
 export type modelHubAnnotationQueuesExportAnnotationsResponseSuccess = (modelHubAnnotationQueuesExportAnnotationsResponse200) & {
   headers: Headers;
 };
-export type modelHubAnnotationQueuesExportAnnotationsResponseError = (modelHubAnnotationQueuesExportAnnotationsResponse400 | modelHubAnnotationQueuesExportAnnotationsResponse403 | modelHubAnnotationQueuesExportAnnotationsResponse404 | modelHubAnnotationQueuesExportAnnotationsResponse409 | modelHubAnnotationQueuesExportAnnotationsResponse500 | modelHubAnnotationQueuesExportAnnotationsResponseDefault) & {
+export type modelHubAnnotationQueuesExportAnnotationsResponseError = (modelHubAnnotationQueuesExportAnnotationsResponse400 | modelHubAnnotationQueuesExportAnnotationsResponse403 | modelHubAnnotationQueuesExportAnnotationsResponse404 | modelHubAnnotationQueuesExportAnnotationsResponse409 | modelHubAnnotationQueuesExportAnnotationsResponse413 | modelHubAnnotationQueuesExportAnnotationsResponse500 | modelHubAnnotationQueuesExportAnnotationsResponseDefault) & {
   headers: Headers;
 };
 

--- a/frontend/src/sections/annotations/queues/__tests__/queue-analytics-tab.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/queue-analytics-tab.test.jsx
@@ -13,11 +13,13 @@ const {
   mockCreateObjectURL,
   mockRevokeObjectURL,
   mockUseQueueAnalytics,
+  mockEnqueueSnackbar,
 } = vi.hoisted(() => ({
   mockAxiosGet: vi.fn(),
   mockCreateObjectURL: vi.fn(),
   mockRevokeObjectURL: vi.fn(),
   mockUseQueueAnalytics: vi.fn(),
+  mockEnqueueSnackbar: vi.fn(),
 }));
 
 vi.mock("src/components/iconify", () => ({
@@ -40,7 +42,7 @@ vi.mock("src/utils/axios", () => ({
 }));
 
 vi.mock("notistack", () => ({
-  enqueueSnackbar: vi.fn(),
+  enqueueSnackbar: mockEnqueueSnackbar,
 }));
 
 describe("QueueAnalyticsTab", () => {
@@ -48,6 +50,7 @@ describe("QueueAnalyticsTab", () => {
     mockAxiosGet.mockReset();
     mockCreateObjectURL.mockReset();
     mockRevokeObjectURL.mockReset();
+    mockEnqueueSnackbar.mockReset();
     mockCreateObjectURL.mockReturnValue("blob:queue-export");
     Object.defineProperty(URL, "createObjectURL", {
       configurable: true,
@@ -158,5 +161,51 @@ describe("QueueAnalyticsTab", () => {
     });
     expect(mockCreateObjectURL).toHaveBeenCalled();
     expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:queue-export");
+  });
+
+  it("surfaces the backend 413 cap message instead of the generic failure", async () => {
+    const user = userEvent.setup();
+    mockUseQueueAnalytics.mockReturnValue({
+      isLoading: false,
+      data: {
+        total: 1,
+        status_breakdown: {
+          pending: 0,
+          in_review: 0,
+          needs_changes: 0,
+          resubmitted: 0,
+          completed: 1,
+          skipped: 0,
+        },
+        throughput: { avg_per_day: 1, total_completed: 1, daily: [] },
+        annotator_performance: [],
+        label_distribution: {},
+      },
+    });
+    // The export uses responseType:"blob", so the 413 body arrives as a Blob —
+    // the handler must read and parse it to surface the server's cap message.
+    const capMessage =
+      "This export has 5,000 rows, over the 2,000-row cap. Narrow the queue.";
+    const payload = JSON.stringify({ result: capMessage, code: "export_too_large" });
+    const errorBody = new Blob([payload], { type: "application/json" });
+    // jsdom's Blob has no `.text()` (real browsers do); stub it so the Blob
+    // still passes `instanceof Blob` and reads back the browser way.
+    errorBody.text = async () => payload;
+    mockAxiosGet.mockRejectedValue({
+      response: { status: 413, data: errorBody },
+    });
+
+    render(<QueueAnalyticsTab queueId="queue-1" />);
+
+    await user.click(screen.getByRole("button", { name: /export csv/i }));
+
+    // Reverting the Blob-parsing branch to a bare `enqueueSnackbar("Export
+    // failed")` would surface the generic string and fail this assertion.
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(capMessage, {
+        variant: "error",
+      });
+    });
+    expect(mockCreateObjectURL).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/sections/annotations/queues/view/queue-analytics-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-analytics-tab.jsx
@@ -272,9 +272,20 @@ export default function QueueAnalyticsTab({ queueId }) {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
-    } catch {
+    } catch (err) {
       const { enqueueSnackbar } = await import("notistack");
-      enqueueSnackbar("Export failed", { variant: "error" });
+      let message = "Export failed";
+      // The request uses responseType:"blob", so an error body arrives as a Blob —
+      // read and parse it to surface the server's actionable message (e.g. the 413
+      // export_too_large cap) instead of a generic failure.
+      try {
+        const data = err?.response?.data;
+        const parsed = data instanceof Blob ? JSON.parse(await data.text()) : data;
+        message = parsed?.result || parsed?.message || message;
+      } catch {
+        // non-JSON / unreadable error body — keep the generic message
+      }
+      enqueueSnackbar(message, { variant: "error" });
     }
   };
 

--- a/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
+++ b/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
@@ -1,0 +1,267 @@
+"""Export batching + size-cap coverage for annotation queues.
+
+Regression guard for the export endpoint that timed out at the gateway: the
+dataset-row cell read must be batched (one ``row_id__in`` query, not a per-item
+N+1), and an oversize queue must be rejected up front instead of materializing
+and resolving the whole queue synchronously.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext, override_settings
+from rest_framework import status
+
+from model_hub.models.annotation_queues import (
+    AnnotationQueue,
+    AnnotationQueueAnnotator,
+    AnnotationQueueLabel,
+    FULL_ACCESS_QUEUE_ROLES,
+    QueueItem,
+)
+from model_hub.models.choices import (
+    AnnotationQueueStatusChoices,
+    AnnotatorRole,
+    DataTypeChoices,
+    DatasetSourceChoices,
+    QueueItemSourceType,
+    QueueItemStatus,
+    SourceChoices,
+    StatusType,
+)
+from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.utils.annotation_queue_helpers import (
+    dataset_cells_by_row,
+    resolve_source_content,
+)
+from tracer.models.project import Project
+
+EXPORT_URL = "/model-hub/annotation-queues/{queue_id}/export/"
+
+
+def _unwrap(data):
+    return data.get("result", data) if isinstance(data, dict) else data
+
+
+def _cell_queries(captured):
+    """SQL statements in *captured* that touch the cell table."""
+    return [q for q in captured.captured_queries if "model_hub_cell" in q["sql"]]
+
+
+def _build_dataset_queue(*, organization, workspace, user, n_rows, cells_per_row=3):
+    """Seed a queue whose items are ``n_rows`` distinct dataset rows, each with
+    ``cells_per_row`` cells. Returns the queue plus its rows for assertions."""
+    project = Project.objects.create(
+        name=f"export project {uuid.uuid4().hex[:8]}",
+        organization=organization,
+        workspace=workspace,
+        model_type="GenerativeLLM",
+        trace_type="observe",
+    )
+    dataset = Dataset.objects.create(
+        name=f"export dataset {uuid.uuid4().hex[:8]}",
+        source=DatasetSourceChoices.BUILD.value,
+        organization=organization,
+        workspace=workspace,
+        user=user,
+    )
+    columns = [
+        Column.objects.create(
+            name=f"col_{i}",
+            data_type=DataTypeChoices.TEXT.value,
+            dataset=dataset,
+            source=SourceChoices.OTHERS.value,
+            status=StatusType.COMPLETED.value,
+        )
+        for i in range(cells_per_row)
+    ]
+    label = AnnotationsLabels.objects.create(
+        name=f"export label {uuid.uuid4().hex[:8]}",
+        type="star",
+        settings={"no_of_stars": 5},
+        organization=organization,
+        workspace=workspace,
+    )
+    queue = AnnotationQueue.objects.create(
+        name=f"export queue {uuid.uuid4().hex[:8]}",
+        status=AnnotationQueueStatusChoices.ACTIVE.value,
+        organization=organization,
+        workspace=workspace,
+        project=project,
+        dataset=dataset,
+        created_by=user,
+    )
+    AnnotationQueueLabel.objects.create(queue=queue, label=label, order=0)
+    AnnotationQueueAnnotator.objects.update_or_create(
+        queue=queue,
+        user=user,
+        deleted=False,
+        defaults={
+            "role": AnnotatorRole.MANAGER.value,
+            "roles": FULL_ACCESS_QUEUE_ROLES,
+        },
+    )
+    rows = []
+    for order in range(n_rows):
+        row = Row.objects.create(dataset=dataset, order=order)
+        for i, col in enumerate(columns):
+            Cell.objects.create(
+                dataset=dataset, row=row, column=col, value=f"r{order}c{i}"
+            )
+        QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.DATASET_ROW.value,
+            dataset_row=row,
+            organization=organization,
+            workspace=workspace,
+            project=project,
+            status=QueueItemStatus.PENDING.value,
+            order=order,
+        )
+        rows.append(row)
+    return {"queue": queue, "dataset": dataset, "columns": columns, "rows": rows}
+
+
+@pytest.mark.django_db
+def test_export_json_batches_dataset_cells_no_n_plus_one(
+    auth_client, organization, workspace, user
+):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=5
+    )
+    with CaptureQueriesContext(connection) as cap:
+        resp = auth_client.get(
+            EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json"
+        )
+    assert resp.status_code == status.HTTP_200_OK, resp.data
+
+    # The whole export resolves every row's cells in a single batched read, not
+    # one query per item — this is the regression the endpoint's hang came from.
+    assert len(_cell_queries(cap)) == 1
+
+    result = _unwrap(resp.data)
+    assert len(result) == 5
+    by_order = {row["order"]: row for row in result}
+    assert by_order[0]["source"]["fields"] == {
+        "col_0": "r0c0",
+        "col_1": "r0c1",
+        "col_2": "r0c2",
+    }
+
+
+@pytest.mark.django_db
+def test_export_csv_batches_dataset_cells(auth_client, organization, workspace, user):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=3
+    )
+    with CaptureQueriesContext(connection) as cap:
+        resp = auth_client.get(
+            EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=csv"
+        )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["Content-Type"] == "text/csv"
+    assert len(_cell_queries(cap)) == 1
+    body = resp.content.decode()
+    # One header row + one line per item (no labels scored -> one row each).
+    assert body.count("dataset_row") == 3
+
+
+@pytest.mark.django_db
+@override_settings(ANNOTATION_EXPORT_SYNC_MAX=2)
+def test_export_rejects_oversize_queue_before_resolving(
+    auth_client, organization, workspace, user
+):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=3
+    )
+    with CaptureQueriesContext(connection) as cap:
+        resp = auth_client.get(
+            EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json"
+        )
+    assert resp.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    # Rejected up front: no cell resolution happened.
+    assert _cell_queries(cap) == []
+
+    # CSV hits the same guard (it is checked before the format branch).
+    resp_csv = auth_client.get(
+        EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=csv"
+    )
+    assert resp_csv.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+@pytest.mark.django_db
+@override_settings(ANNOTATION_EXPORT_SYNC_MAX=3)
+def test_export_at_cap_boundary_succeeds(
+    auth_client, organization, workspace, user
+):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=3
+    )
+    resp = auth_client.get(
+        EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json"
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(_unwrap(resp.data)) == 3
+
+
+@pytest.mark.django_db
+def test_dataset_cells_by_row_batches_and_preseeds(
+    organization, workspace, user
+):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=3
+    )
+    items = list(QueueItem.objects.filter(queue=seed["queue"]))
+    # A row with no cells must still appear in the map (pre-seeded) so it is a
+    # cache hit rather than a spurious per-item fallback query.
+    empty_row = Row.objects.create(dataset=seed["dataset"], order=99)
+    items.append(
+        QueueItem.objects.create(
+            queue=seed["queue"],
+            source_type=QueueItemSourceType.DATASET_ROW.value,
+            dataset_row=empty_row,
+            organization=organization,
+            workspace=workspace,
+        )
+    )
+
+    with CaptureQueriesContext(connection) as cap:
+        cache = dataset_cells_by_row(items)
+    assert len(_cell_queries(cap)) == 1
+
+    assert set(cache) == {str(r.id) for r in seed["rows"]} | {str(empty_row.id)}
+    assert cache[str(empty_row.id)] == []
+    assert len(cache[str(seed["rows"][0].id)]) == 3
+
+
+@pytest.mark.django_db
+def test_resolve_source_content_uses_cell_cache_then_falls_back(
+    organization, workspace, user
+):
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=1
+    )
+    item = QueueItem.objects.select_related("dataset_row__dataset").get(
+        queue=seed["queue"]
+    )
+    cache = dataset_cells_by_row([item])
+
+    # With the cache, no per-item cell query fires.
+    with CaptureQueriesContext(connection) as cap:
+        cached = resolve_source_content(item, cell_cache=cache)
+    assert _cell_queries(cap) == []
+
+    # Without it, the single-item caller keeps its own read (fallback unchanged).
+    with CaptureQueriesContext(connection) as cap:
+        fresh = resolve_source_content(item)
+    assert len(_cell_queries(cap)) == 1
+
+    assert cached["fields"] == fresh["fields"] == {
+        "col_0": "r0c0",
+        "col_1": "r0c1",
+        "col_2": "r0c2",
+    }

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -886,6 +886,33 @@ class CollectorSourceCache:
         return self._sessions.get(str(session_id)) if session_id else None
 
 
+def dataset_cells_by_row(items):
+    """Batch the dataset-row cell read for a render/export page: ``{row_id(str): [Cell]}``.
+
+    The Postgres companion to :class:`CollectorSourceCache`. ``resolve_source_content``
+    builds a dataset row's field map from its cells; run once per item that is an
+    unbatched ``Cell.objects.filter(row=…)`` — an N+1 across a list/export page. Build
+    this map once and pass it as ``cell_cache=`` so the page does a single ``row_id__in``
+    read. Every requested row_id is pre-seeded with ``[]``: a row with no cells is a
+    cache HIT (no fallback query); a row_id absent from the map was never batched, so
+    the caller falls back to its own per-row read (keys are ``str`` throughout to dodge
+    the UUID-vs-str lookup mismatch)."""
+    row_ids = [
+        str(item.dataset_row_id)
+        for item in items or []
+        if getattr(item, "source_type", None) == QueueItemSourceType.DATASET_ROW.value
+        and getattr(item, "dataset_row_id", None)
+    ]
+    if not row_ids:
+        return {}
+    from model_hub.models.develop_dataset import Cell
+
+    cells_by_row = {row_id: [] for row_id in row_ids}
+    for cell in Cell.objects.filter(row_id__in=row_ids).select_related("column"):
+        cells_by_row[str(cell.row_id)].append(cell)
+    return cells_by_row
+
+
 class _CHTraceSessionSource:
     """Duck-typed stand-in for a PG ``TraceSession`` resolved from CH. Carries only
     the attributes the annotation scope/store/render path reads off a session
@@ -1106,13 +1133,15 @@ def resolve_source_preview(item, *, ch_cache=None):
     return {"type": item.source_type, "error": "Could not resolve preview"}
 
 
-def resolve_source_content(item, *, ch_cache=None):
+def resolve_source_content(item, *, ch_cache=None, cell_cache=None):
     """Return full renderable content for a QueueItem's source (used in annotation view).
 
     Tracer sources (trace / observation_span / trace_session) are read CH-only.
     ``ch_cache`` (opt-in :class:`CollectorSourceCache`): when supplied, they read
-    from the page-batched map instead of a per-item CH point-read. Single-item
-    callers pass ``None`` and keep the per-item read."""
+    from the page-batched map instead of a per-item CH point-read. ``cell_cache``
+    (opt-in, from :func:`dataset_cells_by_row`): when supplied, a dataset row's cells
+    read from the page-batched map instead of a per-item ``Cell`` query. Single-item
+    callers pass ``None`` for both and keep the per-item reads."""
     try:
         if item.source_type == QueueItemSourceType.DATASET_ROW.value:
             row = item.dataset_row
@@ -1133,9 +1162,13 @@ def resolve_source_content(item, *, ch_cache=None):
             fields = {}
             field_types = {}
             try:
-                from model_hub.models.develop_dataset import Cell
+                row_key = str(row.id)
+                if cell_cache is not None and row_key in cell_cache:
+                    cells = cell_cache[row_key]
+                else:
+                    from model_hub.models.develop_dataset import Cell
 
-                cells = Cell.objects.filter(row=row).select_related("column")
+                    cells = Cell.objects.filter(row=row).select_related("column")
                 for cell in cells:
                     col_name = (
                         cell.column.name if cell.column else f"column_{cell.column_id}"

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -119,6 +119,7 @@ from model_hub.utils.annotation_queue_helpers import (
     auto_assign_items,
     calculate_agreement,
     canonical_score_value,
+    dataset_cells_by_row,
     eval_metrics_from_call_execution,
     eval_output_value,
     evaluate_rule,
@@ -159,6 +160,13 @@ ERROR_RESPONSES = {
 # path for selections exceeding this; until then, the endpoint errors with
 # ``selection_too_large`` so the UI can prompt the user to narrow the filter.
 MAX_SELECTION_CAP = 10_000
+
+# Synchronous export materializes and resolves full content for every item in one
+# HTTP request. Past this size it can't reliably finish under the gateway timeout,
+# and the ClickHouse content reads over very wide (voice) rows risk OOM-ing the
+# shared cluster, so cap it and let the caller narrow the set (a background export
+# lifts the ceiling). Conservative default; override via settings to tune in prod.
+EXPORT_SYNC_MAX_ITEMS = 1_000
 
 
 def _queue_item_export_prefetches():
@@ -3306,7 +3314,25 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         if status_filter:
             items_qs = items_qs.filter(status=status_filter)
 
-        items_list = list(items_qs.order_by("order", "created_at"))
+        # Fetch one past the cap so an oversize queue is caught before any of the
+        # expensive per-item batch reads below, and without materializing the whole
+        # queryset (the slice bounds the row count fetched).
+        export_max = getattr(
+            settings, "ANNOTATION_EXPORT_SYNC_MAX", EXPORT_SYNC_MAX_ITEMS
+        )
+        items_list = list(
+            items_qs.order_by("order", "created_at")[: export_max + 1]
+        )
+        if len(items_list) > export_max:
+            return self._gm.custom_error_response(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                result=(
+                    f"This queue has more than {export_max} items, which is too "
+                    "large to export in a single download. Filter to a smaller set "
+                    "of items and try again."
+                ),
+                code="export_too_large",
+            )
         queue_label_ids = list(
             queue.queue_labels.filter(deleted=False).values_list("label_id", flat=True)
         )
@@ -3314,10 +3340,13 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         item_notes_by_id = _latest_item_notes_for_queue_items(items_list)
         eval_metrics_by_item = _eval_metrics_for_queue_items(items_list)
         ch_source_cache = CollectorSourceCache.for_items(items_list)
+        cell_cache = dataset_cells_by_row(items_list)
 
         result = []
         for item in items_list:
-            content = resolve_source_content(item, ch_cache=ch_source_cache)
+            content = resolve_source_content(
+                item, ch_cache=ch_source_cache, cell_cache=cell_cache
+            )
             annotations = [
                 _serialize_score_for_export(score)
                 for score in scores_by_item.get(item.id, [])
@@ -3620,6 +3649,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             items_qs = items_qs.filter(status=status_filter)
         items_list = list(items_qs.order_by("order", "created_at"))
         ch_source_cache = CollectorSourceCache.for_items(items_list)
+        cell_cache = dataset_cells_by_row(items_list)
 
         export_field_defs = _build_annotation_queue_export_fields(
             queue, sample_items=items_list[:100]
@@ -3717,7 +3747,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         item_notes_by_id = _latest_item_notes_for_queue_items(items_list)
         eval_metrics_by_item = _eval_metrics_for_queue_items(items_list)
         for i, item in enumerate(items_list):
-            content = resolve_source_content(item, ch_cache=ch_source_cache)
+            content = resolve_source_content(
+                item, ch_cache=ch_source_cache, cell_cache=cell_cache
+            )
             scores = scores_by_item.get(item.id, [])
             annotations_metadata = {}
             for score in scores:

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -133,6 +133,7 @@ from model_hub.utils.utils import send_message_to_channel
 from simulate.models.test_execution import CallTranscript
 from simulate.utils.stored_transcript_roles import get_displayable_transcript_roles
 from tfc.utils.api_contracts import validated_request
+from tfc.utils.api_errors import ApiErrorCode
 from tfc.utils.api_serializers import (
     ApiSelectionTooLargeErrorSerializer,
     ApiTextErrorResponseSerializer,
@@ -3287,7 +3288,11 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @validated_request(
         query_serializer=QueueExportQuerySerializer,
-        responses={200: QueueExportAnnotationsResponseSerializer, **ERROR_RESPONSES},
+        responses={
+            200: QueueExportAnnotationsResponseSerializer,
+            413: ApiTextErrorResponseSerializer,
+            **ERROR_RESPONSES,
+        },
     )
     @action(detail=True, methods=["get"], url_path="export")
     def export_annotations(self, request, pk=None):
@@ -3331,7 +3336,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                     "large to export in a single download. Filter to a smaller set "
                     "of items and try again."
                 ),
-                code="export_too_large",
+                code=ApiErrorCode.EXPORT_TOO_LARGE.value,
             )
         queue_label_ids = list(
             queue.queue_labels.filter(deleted=False).values_list("label_id", flat=True)

--- a/futureagi/tfc/utils/api_errors.py
+++ b/futureagi/tfc/utils/api_errors.py
@@ -30,6 +30,7 @@ class ApiErrorCode(StrEnum):
     CONFLICT = "conflict"
     GONE = "gone"
     REQUEST_TOO_LARGE = "request_too_large"
+    EXPORT_TOO_LARGE = "export_too_large"
     RATE_LIMITED = "rate_limited"
     SERVER_ERROR = "server_error"
     SERVICE_UNAVAILABLE = "service_unavailable"


### PR DESCRIPTION
## TH-6876 — Export is broken (30s gateway timeout on a 118-item queue)

`GET /model-hub/annotation-queues/:id/export/` materialized and resolved full content for **every** item in one synchronous request. It timed out at the gateway on a **118-item** queue (surfacing in-browser as a bogus CORS error — the timeout response never reaches Django so carries no CORS header), and under Granian ASGI each hung export pinned a threadpool thread indefinitely.

Three compounding costs, three fixes:

1. **Unscoped ClickHouse read** — resolved for free by stacking on **TH-6864** (`CollectorSourceCache.for_items` now scopes reads by `project_id`). No code here.
2. **Per-item `Cell` N+1** for dataset-row items — `resolve_source_content` ran `Cell.objects.filter(row=row)` inside the loop. New `dataset_cells_by_row()` helper (the Postgres twin of `CollectorSourceCache`) does one `row_id__in` read, grouped and pre-seeded with `[]`, exposed via an opt-in `cell_cache=` param that mirrors `ch_cache`. Single-item callers pass nothing and are unchanged. Both export loops (`export_annotations` **and** `export_to_dataset`) use it.
3. **No ceiling** — added `EXPORT_SYNC_MAX_ITEMS` (default 1000, overridable via `ANNOTATION_EXPORT_SYNC_MAX`). `export_annotations` fetches `items_qs[:N+1]` and returns **413** (`export_too_large`) before any resolution — one query, race-free, no full materialization.

### Builds on TH-6864 (already merged)
The 118-item case only clears the timeout **with** 6864's scoped `for_items` reads. TH-6864 (#1565) merged to `dev` at 2026-07-15, so this targets `dev` directly and the diff is only the export changes.

### Deliberate scope
- **Async export is out of scope** — that's TH-6863 (returns 202 + a background job + download link). The cap is the honest stopgap until it lands; async removes the cap.
- **The cap value is a conservative reasoned default, not benchmarked.** The CH OOM risk (code 241) on huge queues is row **width** (fat voice spans), not row count, so a local table can't reproduce it and can't justify a higher number. Tune `ANNOTATION_EXPORT_SYNC_MAX` in prod once there's a real read.
- **`export_to_dataset` gets the batched cell read but not the cap** — known parity gap, kept out to keep this PR single-purpose (the reported bug is the GET `export`). Tracked as **TH-7029** (post-quota-exemption an oversize default queue exported via `/export-to-dataset/` is a plausible hang-shape).
- **No per-tenant request throttle** on this endpoint or its siblings — `REST_FRAMEWORK` (`tfc/settings/settings.py`) sets no `DEFAULT_THROTTLE_CLASSES`/`DEFAULT_THROTTLE_RATES` and the viewset declares none, so the cap bounds one request's size but not a tenant hammering max-size queues before 429 fires. The only rate-limiting in the codebase is auth-level (login / failed-auth IP blocking), which doesn't cover data endpoints. The rates need product/infra agreement, so it's tracked as **TH-7032** rather than silently defaulted here.

### Tests
`model_hub/tests/test_annotation_export_batch_cap.py` — 6 tests, all green: JSON + CSV each prove exactly **one** `model_hub_cell` query regardless of item count; the cap rejects an oversize queue *before* resolving (JSON + CSV); the at-cap boundary passes; `dataset_cells_by_row` batches and pre-seeds; `resolve_source_content` reads from the cache with zero cell queries and its no-cache fallback is unchanged. Blast-radius suites (`test_annotation_render_e2e`, `test_ch25_annotation_collector_source_resolution`) pass except 3 CH-native preview tests that fail identically on the clean base (CH is empty in the test env — pre-existing).

Closes TH-6876.


