### PR TITLE
fix(cors): fail closed instead of wildcard + credentials by default

### DIFF
--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -71,6 +71,19 @@ def _split_env(name: str, default: str = "") -> list[str]:
     return [x.strip() for x in raw.split(",") if x.strip()]
 
 
+def _cors_policy(
+    is_local: bool, explicit: list[str], frontend_hosts: tuple[str, ...]
+) -> tuple[bool, list[str]]:
+    """(CORS_ALLOW_ALL_ORIGINS, CORS_ALLOWED_ORIGINS): wildcard only for local/test with no
+    allowlist; otherwise the explicit origins plus the first-party frontend hosts."""
+    if is_local and not explicit:
+        return True, []
+    origins = list(explicit)
+    for host in (h.strip().rstrip("/") for h in frontend_hosts if h.strip()):
+        origins += [host] if "://" in host else [f"https://{host}", f"http://{host}"]
+    return False, list(dict.fromkeys(origins))
+
+
 def _bounded_env_int(
     name: str,
     default: int,
@@ -172,15 +185,21 @@ DEBUG = os.getenv("DEBUG", "True" if _IS_LOCAL else "False").lower() in (
 ALLOWED_HOSTS = _split_env("ALLOWED_HOSTS", "*")
 
 # ── CORS (django-cors-headers) ────────────────────────────────────────────
-# Default: permissive — any browser origin can hit the API. Production
-# self-hosters should set CORS_ALLOWED_ORIGINS (comma-separated) to flip
-# CORS_ALLOW_ALL_ORIGINS off when explicit origins are configured.
-_cors_origins = _split_env("CORS_ALLOWED_ORIGINS")
-if _cors_origins:
-    CORS_ALLOW_ALL_ORIGINS = False
-    CORS_ALLOWED_ORIGINS = _cors_origins
-else:
-    CORS_ALLOW_ALL_ORIGINS = True
+# Fail closed outside local/test: credentialed CORS is never paired with a
+# wildcard origin. The allowlist is CORS_ALLOWED_ORIGINS plus the first-party
+# frontend hosts (APP_URL / FRONTEND_URL), so a self-hosted stack needs no config.
+CORS_ALLOW_ALL_ORIGINS, CORS_ALLOWED_ORIGINS = _cors_policy(
+    _IS_LOCAL,
+    _split_env("CORS_ALLOWED_ORIGINS"),
+    (os.getenv("APP_URL", ""), os.getenv("FRONTEND_URL", "")),
+)
+if not _IS_LOCAL and not CORS_ALLOWED_ORIGINS:
+    import sys as _sys
+
+    _sys.stderr.write(
+        "[WARN] CORS is disabled: set CORS_ALLOWED_ORIGINS (or APP_URL / "
+        "FRONTEND_URL) to allow browser access in a non-local environment.\n"
+    )
 # Legacy alias (django-cors-headers pre-4.0)
 CORS_ORIGIN_ALLOW_ALL = CORS_ALLOW_ALL_ORIGINS
 

--- a/futureagi/tfc/tests/test_cors_settings.py
+++ b/futureagi/tfc/tests/test_cors_settings.py
@@ -1,0 +1,19 @@
+"""Regression tests for the CORS origin policy (issue #1133)."""
+
+from tfc.settings.settings import _cors_policy
+
+
+def test_the_wildcard_is_local_only():
+    assert _cors_policy(True, [], ("", "")) == (True, [])
+    # #1133: outside local/test an empty allowlist fails closed instead of wildcarding.
+    assert _cors_policy(False, [], ("", "")) == (False, [])
+
+
+def test_frontend_hosts_back_the_allowlist():
+    # Self-hosted default (APP_URL set, no explicit list) works without the wildcard.
+    localhost = ["https://localhost:3031", "http://localhost:3031"]
+    assert _cors_policy(False, [], ("localhost:3031", "")) == (False, localhost)
+    # Full origins pass through; duplicates collapse.
+    explicit, hosts = ["https://a.example"], ("https://b.example/", "a.example")
+    expected = ["https://a.example", "https://b.example", "http://a.example"]
+    assert _cors_policy(False, explicit, hosts) == (False, expected)


### PR DESCRIPTION
## Summary

The Django API defaulted to `CORS_ALLOW_ALL_ORIGINS = True` whenever `CORS_ALLOWED_ORIGINS` was unset, while `CORS_ALLOW_CREDENTIALS = True`. That combination lets **any** website make authenticated cross-origin requests to the API and read the responses — and it was the default for every non-local deployment (the backend is also published on a host port by compose).

This changes the default to **fail closed** outside local/test without breaking the self-hosted frontend: only `local`/`test` keeps the permissive wildcard; every other environment gets `CORS_ALLOW_ALL_ORIGINS = False` and an explicit allowlist built from `CORS_ALLOWED_ORIGINS` **plus** the first-party frontend hosts derived from `APP_URL` / `FRONTEND_URL` — the same vars that already back `CSRF_TRUSTED_ORIGINS` and OAuth callbacks. A default self-hosted stack keeps working with no new config; anyone already setting `CORS_ALLOWED_ORIGINS` is unaffected; a non-local deployment with neither set now refuses browser access and says so on stderr at startup.

The policy is a small `_cors_policy` helper next to `_split_env` in `settings.py`. (An earlier revision had it in a separate module; folded in to keep this a small fix per CONTRIBUTION_POLICY rule 1.)

## Linked issues

Closes #1133

## AI use

AI use: Claude Code (Claude Fable 5.1) produced the patch and tests under my direction; the checks below were run in my local environment.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## E2E coverage

E2E: exempt (backend-internal)

## How was this tested?

Regression tests for the helper (`futureagi/tfc/tests/test_cors_settings.py`):

```
$ .venv/bin/python -m pytest tfc/tests/test_cors_settings.py -q
collected 2 items
tfc/tests/test_cors_settings.py ..                                       [100%]
============================== 2 passed in 0.03s ===============================
```

The real settings module, imported under each deployment shape (`ENV_TYPE=production SECRET_KEY=x`; CORS-related vars unset unless listed):

| Shape | `CORS_ALLOW_ALL_ORIGINS` | `CORS_ALLOWED_ORIGINS` |
|---|---|---|
| local dev, nothing set | `True` | `[]` — dev unchanged |
| self-host prod, `APP_URL=localhost:3031` | `False` | `['https://localhost:3031', 'http://localhost:3031']` |
| cloud prod, `CORS_ALLOWED_ORIGINS=https://app.example.com` + `APP_URL=https://app.futureagi.com` | `False` | `['https://app.example.com', 'https://app.futureagi.com']` |
| prod, nothing set | `False` | `[]`, plus `[WARN] CORS is disabled: set CORS_ALLOWED_ORIGINS (or APP_URL / FRONTEND_URL) to allow browser access in a non-local environment.` |

Fails-without / passes-with — the "prod, nothing set" import against `dev`'s `settings.py` vs this branch:

```
BEFORE: CORS_ALLOW_ALL_ORIGINS = True  | CORS_ALLOWED_ORIGINS = <undefined> | CORS_ALLOW_CREDENTIALS = True
AFTER:  CORS_ALLOW_ALL_ORIGINS = False | CORS_ALLOWED_ORIGINS = []          | CORS_ALLOW_CREDENTIALS = True
```

SDK trace ingestion and the gateway are server-to-server, so CORS (a browser-only mechanism) does not affect them. `black`/`isort`/`flake8` pass on the changed hunks (black's two complaints elsewhere in `settings.py` pre-exist on `dev` and are left alone). I did not run the full `make check-all` locally (heavy backend dependency tree); CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
