### PR TITLE
fix(observe): align agent graph nodes by size

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -28,10 +28,10 @@ import {
   MarkerType,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import Dagre from "@dagrejs/dagre";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip";
 import FullscreenGraphDialog from "./FullscreenGraphDialog";
+import { layoutGraph } from "./agentGraphLayout";
 
 // ---------------------------------------------------------------------------
 // Node type → color + icon
@@ -433,36 +433,6 @@ const AgentNode = ({ data }) => {
 AgentNode.propTypes = { data: PropTypes.object };
 
 const nodeTypes = { agentNode: AgentNode };
-
-// ---------------------------------------------------------------------------
-// Dagre layout — direction-aware (LR for trace list, TB for trace detail)
-// ---------------------------------------------------------------------------
-const layoutGraph = (nodes, edges, direction = "LR") => {
-  const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
-  g.setGraph({
-    rankdir: direction,
-    ranksep: direction === "LR" ? 80 : 50,
-    nodesep: 25,
-  });
-
-  nodes.forEach((node) => {
-    const isSentinel = node.data?.type === "start" || node.data?.type === "end";
-    g.setNode(node.id, {
-      width: isSentinel ? 50 : 140,
-      height: isSentinel ? 32 : 44,
-    });
-  });
-  edges.forEach((edge) => {
-    g.setEdge(edge.source, edge.target);
-  });
-
-  Dagre.layout(g);
-
-  return nodes.map((node) => {
-    const pos = g.node(node.id);
-    return { ...node, position: { x: pos.x - 70, y: pos.y - 22 } };
-  });
-};
 
 // ---------------------------------------------------------------------------
 // Build React Flow nodes + edges from API data

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/agentGraphLayout.test.js
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/agentGraphLayout.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_GRAPH_NODE_SIZE, layoutGraph } from "../agentGraphLayout";
+
+const makeNode = (id, type = "agent") => ({
+  id,
+  data: { type },
+  position: { x: 0, y: 0 },
+});
+
+const findNode = (nodes, id) => nodes.find((node) => node.id === id);
+
+describe("layoutGraph", () => {
+  it("centers differently sized sentinel nodes on a vertical graph axis", () => {
+    const nodes = [
+      makeNode("start", "start"),
+      makeNode("agent"),
+      makeNode("end", "end"),
+    ];
+    const edges = [
+      { source: "start", target: "agent" },
+      { source: "agent", target: "end" },
+    ];
+
+    const layout = layoutGraph(nodes, edges, "TB");
+    const start = findNode(layout, "start");
+    const agent = findNode(layout, "agent");
+    const end = findNode(layout, "end");
+    const startCenter =
+      start.position.x + AGENT_GRAPH_NODE_SIZE.sentinel.width / 2;
+    const agentCenter =
+      agent.position.x + AGENT_GRAPH_NODE_SIZE.default.width / 2;
+    const endCenter = end.position.x + AGENT_GRAPH_NODE_SIZE.sentinel.width / 2;
+
+    expect(startCenter).toBe(agentCenter);
+    expect(endCenter).toBe(agentCenter);
+  });
+
+  it("leaves at least 60 pixels between sibling node rectangles", () => {
+    const nodes = [
+      makeNode("start", "start"),
+      makeNode("left"),
+      makeNode("right"),
+      makeNode("end", "end"),
+    ];
+    const edges = [
+      { source: "start", target: "left" },
+      { source: "start", target: "right" },
+      { source: "left", target: "end" },
+      { source: "right", target: "end" },
+    ];
+
+    const layout = layoutGraph(nodes, edges, "TB");
+    const left = findNode(layout, "left");
+    const right = findNode(layout, "right");
+    const horizontalGap =
+      Math.abs(right.position.x - left.position.x) -
+      AGENT_GRAPH_NODE_SIZE.default.width;
+
+    expect(horizontalGap).toBeGreaterThanOrEqual(60);
+  });
+
+  it("returns finite positions for a minimal graph", () => {
+    const layout = layoutGraph(
+      [makeNode("start", "start"), makeNode("end", "end")],
+      [{ source: "start", target: "end" }],
+      "TB",
+    );
+
+    for (const node of layout) {
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+    }
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/agentGraphLayout.js
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/agentGraphLayout.js
@@ -1,0 +1,38 @@
+import Dagre from "@dagrejs/dagre";
+
+export const AGENT_GRAPH_NODE_SIZE = {
+  default: { width: 140, height: 44 },
+  sentinel: { width: 50, height: 32 },
+};
+
+const isSentinelNode = (node) =>
+  node.data?.type === "start" || node.data?.type === "end";
+
+export const layoutGraph = (nodes, edges, direction = "LR") => {
+  const graph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({
+    rankdir: direction,
+    ranksep: direction === "LR" ? 80 : 50,
+    nodesep: 60,
+  });
+
+  nodes.forEach((node) => {
+    const size = isSentinelNode(node)
+      ? AGENT_GRAPH_NODE_SIZE.sentinel
+      : AGENT_GRAPH_NODE_SIZE.default;
+    graph.setNode(node.id, { ...size });
+  });
+  edges.forEach((edge) => {
+    graph.setEdge(edge.source, edge.target);
+  });
+
+  Dagre.layout(graph);
+
+  return nodes.map((node) => {
+    const { x, y, width, height } = graph.node(node.id);
+    return {
+      ...node,
+      position: { x: x - width / 2, y: y - height / 2 },
+    };
+  });
+};


### PR DESCRIPTION
## Summary

Fix the Observe trace-detail agent graph layout by converting Dagre center coordinates using each node's actual dimensions. Increase sibling separation so same-rank labels do not overlap, and extract the layout logic into a focused, testable module.

## Linked issues

Closes #1379

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- `yarn test:run src/sections/projects/LLMTracing/GraphSection/__tests__/agentGraphLayout.test.js`
- Targeted ESLint
- Targeted Prettier check
- `git diff --check`

## Screenshots / recordings (if UI)

Not included. The regression tests cover sentinel-node alignment, sibling spacing, and minimal graph positioning.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII