### PR TITLE
fix(frontend): keep automation rule row heights consistent

### DIFF
--- a/frontend/src/sections/annotations/queues/view/__tests__/automation-rules-tab.test.jsx
+++ b/frontend/src/sections/annotations/queues/view/__tests__/automation-rules-tab.test.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "src/utils/test-utils";
+import AutomationRulesTab from "../automation-rules-tab";
+
+const { capturedProps } = vi.hoisted(() => ({ capturedProps: {} }));
+
+vi.mock("ag-grid-react", () => {
+  const MockAgGridReact = React.forwardRef((props, _ref) => {
+    Object.assign(capturedProps, props);
+    return null;
+  });
+  MockAgGridReact.displayName = "AgGridReactMock";
+  return { AgGridReact: MockAgGridReact };
+});
+
+vi.mock("src/api/annotation-queues/annotation-queues", () => ({
+  useAutomationRules: () => ({ data: [], isLoading: false }),
+  useUpdateAutomationRule: () => ({ mutate: vi.fn() }),
+  useDeleteAutomationRule: () => ({ mutate: vi.fn() }),
+  useEvaluateRule: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("src/components/custom-dialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: () => null,
+}));
+
+vi.mock("src/hooks/use-ag-theme", () => ({
+  useAgThemeWith: () => ({}),
+}));
+
+vi.mock("src/theme/ag-theme", () => ({
+  AG_THEME_OVERRIDES: { noHeaderBorder: {} },
+}));
+
+vi.mock("src/utils/format-time", () => ({
+  fDateTime: () => "",
+}));
+
+vi.mock("src/styles/clean-data-table.css", () => ({}));
+
+vi.mock("../create-rule-dialog", () => ({
+  default: () => null,
+  TRIGGER_FREQUENCY_OPTIONS: [],
+}));
+
+vi.mock("../edit-rule-dialog", () => ({
+  default: () => null,
+}));
+
+describe("AutomationRulesTab", () => {
+  beforeEach(() => {
+    Object.keys(capturedProps).forEach((key) => delete capturedProps[key]);
+  });
+
+  it("keeps every automation-rule row at the same height", () => {
+    render(<AutomationRulesTab queueId="queue-1" queue={{}} />);
+
+    expect(capturedProps.getRowHeight).toEqual(expect.any(Function));
+    expect(
+      [
+        { data: { id: "rule-1", name: "Short" } },
+        { data: { id: "rule-2", name: "A longer rule name" } },
+      ].map(capturedProps.getRowHeight),
+    ).toEqual([52, 52]);
+  });
+});

--- a/frontend/src/sections/annotations/queues/view/__tests__/automation-rules-tab.test.jsx
+++ b/frontend/src/sections/annotations/queues/view/__tests__/automation-rules-tab.test.jsx
@@ -8,7 +8,18 @@ const { capturedProps } = vi.hoisted(() => ({ capturedProps: {} }));
 vi.mock("ag-grid-react", () => {
   const MockAgGridReact = React.forwardRef((props, _ref) => {
     Object.assign(capturedProps, props);
-    return null;
+    return (
+      <div className="ag-layout-auto-height">
+        <div
+          className="ag-center-cols-viewport"
+          data-testid="automation-rules-grid-viewport"
+        />
+        <div
+          className="ag-center-cols-container"
+          data-testid="automation-rules-grid-container"
+        />
+      </div>
+    );
   });
   MockAgGridReact.displayName = "AgGridReactMock";
   return { AgGridReact: MockAgGridReact };
@@ -57,15 +68,19 @@ describe("AutomationRulesTab", () => {
     Object.keys(capturedProps).forEach((key) => delete capturedProps[key]);
   });
 
-  it("keeps every automation-rule row at the same height", () => {
-    render(<AutomationRulesTab queueId="queue-1" queue={{}} />);
+  it("keeps the auto-height grid body aligned with its fixed-height rows", () => {
+    const { getByTestId } = render(
+      <AutomationRulesTab queueId="queue-1" queue={{}} />,
+    );
 
-    expect(capturedProps.getRowHeight).toEqual(expect.any(Function));
+    expect(capturedProps.rowHeight).toBe(52);
+    expect(capturedProps.getRowHeight).toBeUndefined();
     expect(
-      [
-        { data: { id: "rule-1", name: "Short" } },
-        { data: { id: "rule-2", name: "A longer rule name" } },
-      ].map(capturedProps.getRowHeight),
-    ).toEqual([52, 52]);
+      getComputedStyle(getByTestId("automation-rules-grid-viewport")).minHeight,
+    ).toBe("52px");
+    expect(
+      getComputedStyle(getByTestId("automation-rules-grid-container"))
+        .minHeight,
+    ).toBe("52px");
   });
 });

--- a/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
@@ -42,6 +42,8 @@ const SKELETON_ROWS = Array.from({ length: 3 }, (_, i) => ({
   _skeleton: true,
 }));
 
+const AUTOMATION_RULE_ROW_HEIGHT = 52;
+
 // ---------------------------------------------------------------------------
 // Cell renderers
 // ---------------------------------------------------------------------------
@@ -282,6 +284,7 @@ export default function AutomationRulesTab({ queueId, queue }) {
   }, []);
 
   const getRowId = useCallback((params) => params.data?.id, []);
+  const getRowHeight = useCallback(() => AUTOMATION_RULE_ROW_HEIGHT, []);
 
   const CustomNoRowsOverlay = useCallback(
     () => (
@@ -370,7 +373,8 @@ export default function AutomationRulesTab({ queueId, queue }) {
             columnDefs={columnDefs}
             defaultColDef={defaultColDef}
             context={gridContext}
-            rowHeight={52}
+            rowHeight={AUTOMATION_RULE_ROW_HEIGHT}
+            getRowHeight={getRowHeight}
             headerHeight={42}
             pagination={false}
             animateRows={false}

--- a/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
@@ -43,6 +43,12 @@ const SKELETON_ROWS = Array.from({ length: 3 }, (_, i) => ({
 }));
 
 const AUTOMATION_RULE_ROW_HEIGHT = 52;
+const AUTOMATION_RULES_GRID_SX = {
+  "& .ag-layout-auto-height .ag-center-cols-viewport, & .ag-layout-auto-height .ag-center-cols-container":
+    {
+      minHeight: `${AUTOMATION_RULE_ROW_HEIGHT}px`,
+    },
+};
 
 // ---------------------------------------------------------------------------
 // Cell renderers
@@ -284,7 +290,6 @@ export default function AutomationRulesTab({ queueId, queue }) {
   }, []);
 
   const getRowId = useCallback((params) => params.data?.id, []);
-  const getRowHeight = useCallback(() => AUTOMATION_RULE_ROW_HEIGHT, []);
 
   const CustomNoRowsOverlay = useCallback(
     () => (
@@ -364,7 +369,7 @@ export default function AutomationRulesTab({ queueId, queue }) {
       )}
 
       {(!isError || rulesList.length > 0) && (
-        <Box>
+        <Box sx={AUTOMATION_RULES_GRID_SX}>
           <AgGridReact
             ref={gridRef}
             theme={agTheme}
@@ -374,7 +379,6 @@ export default function AutomationRulesTab({ queueId, queue }) {
             defaultColDef={defaultColDef}
             context={gridContext}
             rowHeight={AUTOMATION_RULE_ROW_HEIGHT}
-            getRowHeight={getRowHeight}
             headerHeight={42}
             pagination={false}
             animateRows={false}


### PR DESCRIPTION
## Summary

- Keep Automation Rules rows at the existing fixed 52px height.
- Override the AG Grid auto-height 150px minimum body height within this table so trailing body space does not look like an enlarged final row.
- Remove the redundant getRowHeight callback and add focused regression coverage for the scoped minimum height.

## Validation

- yarn test:run src/sections/annotations/queues/view/__tests__/automation-rules-tab.test.jsx --reporter=dot
- eslint on the two changed files
- prettier --check on the two changed files
- git diff --check

Fixes #1578