### PR TITLE
feat(frontend): add project tag autocomplete

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceDetailDrawerV2.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceDetailDrawerV2.jsx
@@ -537,6 +537,7 @@ const VoiceDetailDrawerV2 = ({
           open={Boolean(tagsAnchorEl)}
           onClose={() => setTagsAnchorEl(null)}
           traceId={data.trace_id}
+          projectId={projectId}
           currentTags={data?.tags || data?.trace?.tags || []}
           onSuccess={() =>
             queryClient.invalidateQueries({ queryKey: ["voiceCallDetail"] })

--- a/frontend/src/components/traceDetail/AddTagsPopover.jsx
+++ b/frontend/src/components/traceDetail/AddTagsPopover.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
-import { Box, Popover, Stack, Typography } from "@mui/material";
+import { Popover, Stack, Typography } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "src/utils/axios";
 import { enqueueSnackbar } from "notistack";
-import { normalizeTags } from "./tagUtils";
+import { useDashboardFilterValues } from "src/hooks/useDashboards";
+import { hashColor, normalizeTags } from "./tagUtils";
 import TagChip from "./TagChip";
 import TagInput from "./TagInput";
 
@@ -14,6 +15,7 @@ const AddTagsPopover = ({
   onClose,
   traceId,
   spanId,
+  projectId,
   bulkItems,
   currentTags = [],
   onSuccess,
@@ -25,6 +27,38 @@ const AddTagsPopover = ({
     isBulk ? [] : normalizeTags(currentTags),
   );
   const queryClient = useQueryClient();
+
+  const { data: projectTagValues = [] } = useDashboardFilterValues({
+    metricName: "tag",
+    metricType: "system_metric",
+    projectIds: projectId ? [projectId] : [],
+    source: "traces",
+    enabled: Boolean(open && projectId),
+  });
+
+  const projectTags = useMemo(() => {
+    const seen = new Set();
+
+    return projectTagValues.reduce((result, option) => {
+      const rawName =
+        typeof option === "string"
+          ? option
+          : option?.name || option?.value || option?.label;
+      const name = String(rawName || "").trim();
+      const key = name.toLowerCase();
+      if (!name || seen.has(key)) return result;
+
+      seen.add(key);
+      result.push({
+        name,
+        color:
+          typeof option === "object" && option?.color
+            ? option.color
+            : hashColor(name),
+      });
+      return result;
+    }, []);
+  }, [projectTagValues]);
 
   React.useEffect(() => {
     if (open) setTags(isBulk ? [] : normalizeTags(currentTags));
@@ -143,6 +177,7 @@ const AddTagsPopover = ({
       <TagInput
         onAdd={handleAdd}
         existingNames={tags.map((t) => t.name)}
+        suggestions={projectTags}
         disabled={isPending}
       />
 
@@ -161,6 +196,7 @@ AddTagsPopover.propTypes = {
   onClose: PropTypes.func.isRequired,
   traceId: PropTypes.string,
   spanId: PropTypes.string,
+  projectId: PropTypes.string,
   bulkItems: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/frontend/src/components/traceDetail/TagInput.jsx
+++ b/frontend/src/components/traceDetail/TagInput.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import { Box, Stack } from "@mui/material";
 import Iconify from "src/components/iconify";
@@ -11,6 +11,7 @@ import { TAG_COLORS, hashColor } from "./tagUtils";
  *   onAdd          — called with { name, color } when user presses Enter
  *   onCancel       — called when user presses Escape or input blurs empty
  *   existingNames  — array of names to prevent duplicates
+ *   suggestions    — existing project tags to suggest while typing
  *   disabled       — disables input
  *   placeholder    — placeholder text
  *   autoFocus      — auto-focus on mount
@@ -20,6 +21,7 @@ const TagInput = ({
   onAdd,
   onCancel,
   existingNames = [],
+  suggestions = [],
   disabled = false,
   placeholder = "Add tag...",
   autoFocus = true,
@@ -28,13 +30,44 @@ const TagInput = ({
   const [value, setValue] = useState("");
   const [selectedColor, setSelectedColor] = useState(null);
 
+  const normalizedExistingNames = useMemo(
+    () => new Set(existingNames.map((name) => name.trim().toLowerCase())),
+    [existingNames],
+  );
+
+  const matchingSuggestions = useMemo(() => {
+    const query = value.trim().toLowerCase();
+    if (!query) return [];
+
+    return suggestions
+      .map((suggestion) =>
+        typeof suggestion === "string"
+          ? { name: suggestion, color: hashColor(suggestion) }
+          : suggestion,
+      )
+      .filter((suggestion) => {
+        const name = suggestion?.name?.trim();
+        return (
+          name &&
+          name.toLowerCase().includes(query) &&
+          !normalizedExistingNames.has(name.toLowerCase())
+        );
+      })
+      .slice(0, 8);
+  }, [normalizedExistingNames, suggestions, value]);
+
   const previewColor =
     selectedColor || (value.trim() ? hashColor(value.trim()) : TAG_COLORS[0]);
 
   const handleSubmit = useCallback(() => {
     const name = value.trim();
     if (!name) return;
-    if (existingNames.includes(name)) {
+    if (
+      existingNames.some(
+        (existingName) =>
+          existingName.trim().toLowerCase() === name.toLowerCase(),
+      )
+    ) {
       setValue("");
       return;
     }
@@ -43,17 +76,32 @@ const TagInput = ({
     setSelectedColor(null);
   }, [value, selectedColor, existingNames, onAdd]);
 
+  const handleSelectSuggestion = useCallback(
+    (suggestion) => {
+      const name = suggestion?.name?.trim();
+      if (!name) return;
+      onAdd({ name, color: suggestion.color || hashColor(name) });
+      setValue("");
+      setSelectedColor(null);
+    },
+    [onAdd],
+  );
+
   const handleKeyDown = useCallback(
     (e) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        handleSubmit();
+        if (matchingSuggestions.length > 0) {
+          handleSelectSuggestion(matchingSuggestions[0]);
+        } else {
+          handleSubmit();
+        }
       }
       if (e.key === "Escape") {
         onCancel?.();
       }
     },
-    [handleSubmit, onCancel],
+    [handleSelectSuggestion, handleSubmit, matchingSuggestions, onCancel],
   );
 
   const handleCycleColor = () => {
@@ -135,6 +183,51 @@ const TagInput = ({
         )}
       </Box>
 
+      {matchingSuggestions.length > 0 && (
+        <Box
+          role="listbox"
+          aria-label="Existing project tags"
+          sx={{
+            maxHeight: 160,
+            overflowY: "auto",
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: "4px",
+            py: 0.25,
+          }}
+        >
+          {matchingSuggestions.map((suggestion) => (
+            <Box
+              key={suggestion.name}
+              role="option"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => handleSelectSuggestion(suggestion)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 1,
+                py: 0.5,
+                cursor: "pointer",
+                fontSize,
+                "&:hover": { bgcolor: "action.hover" },
+              }}
+            >
+              <Box
+                sx={{
+                  width: dotSize,
+                  height: dotSize,
+                  borderRadius: "50%",
+                  bgcolor: suggestion.color || hashColor(suggestion.name),
+                  flexShrink: 0,
+                }}
+              />
+              <Box component="span">{suggestion.name}</Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
       {/* Color palette — shown when user is typing */}
       {value.trim() && (
         <Stack direction="row" gap="3px" sx={{ pl: 0.25 }}>
@@ -167,6 +260,15 @@ TagInput.propTypes = {
   onAdd: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   existingNames: PropTypes.arrayOf(PropTypes.string),
+  suggestions: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        color: PropTypes.string,
+      }),
+    ]),
+  ),
   disabled: PropTypes.bool,
   placeholder: PropTypes.string,
   autoFocus: PropTypes.bool,

--- a/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
+++ b/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
@@ -1484,6 +1484,7 @@ const TraceDetailDrawerV2 = ({
         onClose={() => setTagsAnchorEl(null)}
         traceId={traceId}
         spanId={selectedSpanId}
+        projectId={projectId}
         currentTags={
           selectedSpanData
             ? getSpan(selectedSpanData)?.tags || []

--- a/frontend/src/components/traceDetail/__tests__/AddTagsPopover.test.jsx
+++ b/frontend/src/components/traceDetail/__tests__/AddTagsPopover.test.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render } from "src/utils/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import AddTagsPopover from "../AddTagsPopover";
+import { hashColor } from "../tagUtils";
+
+const captured = vi.hoisted(() => ({
+  filterArgs: null,
+  inputProps: null,
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardFilterValues: (args) => {
+    captured.filterArgs = args;
+    return { data: ["Production", "Existing"] };
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: { patch: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("../TagChip", () => ({
+  default: () => null,
+}));
+
+vi.mock("../TagInput", () => {
+  const MockTagInput = (props) => {
+    captured.inputProps = props;
+    return null;
+  };
+  MockTagInput.displayName = "TagInputMock";
+  return { default: MockTagInput };
+});
+
+describe("AddTagsPopover project tag suggestions", () => {
+  it("loads project tags and passes normalized suggestions to TagInput", () => {
+    render(
+      <AddTagsPopover
+        anchorEl={document.body}
+        open
+        onClose={vi.fn()}
+        projectId="project-1"
+        traceId="trace-1"
+        currentTags={["Existing"]}
+      />,
+    );
+
+    expect(captured.filterArgs).toEqual({
+      metricName: "tag",
+      metricType: "system_metric",
+      projectIds: ["project-1"],
+      source: "traces",
+      enabled: true,
+    });
+    expect(captured.inputProps.existingNames).toEqual(["Existing"]);
+    expect(captured.inputProps.suggestions).toEqual([
+      { name: "Production", color: hashColor("Production") },
+      { name: "Existing", color: hashColor("Existing") },
+    ]);
+  });
+});

--- a/frontend/src/components/traceDetail/__tests__/TagInput.test.jsx
+++ b/frontend/src/components/traceDetail/__tests__/TagInput.test.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import TagInput from "../TagInput";
+
+vi.mock("src/components/iconify", () => ({
+  default: () => <span data-testid="iconify" />,
+}));
+
+const PROJECT_TAGS = [
+  { name: "Production", color: "#8B5CF6" },
+  { name: "Project Alpha", color: "#3B82F6" },
+  { name: "Existing", color: "#06B6D4" },
+];
+
+describe("TagInput project tag suggestions", () => {
+  it("shows matching suggestions and excludes tags already applied", () => {
+    render(
+      <TagInput
+        onAdd={vi.fn()}
+        existingNames={["existing"]}
+        suggestions={PROJECT_TAGS}
+        autoFocus={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Add tag..."), {
+      target: { value: "pro" },
+    });
+
+    expect(screen.getByRole("option", { name: "Production" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Project Alpha" })).toBeVisible();
+    expect(screen.queryByRole("option", { name: "Existing" })).toBeNull();
+  });
+
+  it("adds the exact selected tag and clears the input", () => {
+    const onAdd = vi.fn();
+    render(
+      <TagInput onAdd={onAdd} suggestions={PROJECT_TAGS} autoFocus={false} />,
+    );
+
+    const input = screen.getByPlaceholderText("Add tag...");
+    fireEvent.change(input, { target: { value: "prod" } });
+    fireEvent.click(screen.getByRole("option", { name: "Production" }));
+
+    expect(onAdd).toHaveBeenCalledWith(PROJECT_TAGS[0]);
+    expect(input).toHaveValue("");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -4264,6 +4264,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                   setTagsAnchorEl(null);
                   setTagsBulkItems([]);
                 }}
+                projectId={observeId}
                 bulkItems={tagsBulkItems}
               />
             </Suspense>


### PR DESCRIPTION
## Summary

- Load distinct project tags through the existing dashboard filter-values API.
- Add matching suggestions to the trace/span tag input and exclude tags already applied.
- Selecting a suggestion preserves the existing tag name and color; unmatched names can still be created.
- Pass the project scope through trace, voice, and bulk tag-entry flows.

## Validation

- `yarn test:run src/components/traceDetail/__tests__ --reporter=dot`
- `yarn eslint src/components/traceDetail/TagInput.jsx src/components/traceDetail/AddTagsPopover.jsx src/components/traceDetail/TraceDetailDrawerV2.jsx src/components/VoiceDetailDrawerV2/VoiceDetailDrawerV2.jsx src/sections/projects/LLMTracing/LLMTracingView.jsx src/components/traceDetail/__tests__/TagInput.test.jsx src/components/traceDetail/__tests__/AddTagsPopover.test.jsx`
- Prettier check on changed files
- `git diff --check`

No backend changes are required.

Fixes #1583