### PR TITLE
ci: add manual release workflow for fi-collector -> Docker Hub

### DIFF
--- a/.github/workflows/release-fi-collector.yml
+++ b/.github/workflows/release-fi-collector.yml
@@ -12,9 +12,11 @@ on:
         required: true
         type: string
       branch:
+        # fi-collector currently lives only on dev (not yet merged to main),
+        # so dev is the default until it lands there.
         description: "Branch to build from"
         required: true
-        default: "main"
+        default: "dev"
         type: choice
         options:
           - main

--- a/.github/workflows/release-fi-collector.yml
+++ b/.github/workflows/release-fi-collector.yml
@@ -1,0 +1,78 @@
+# Manual trigger only. Run from the Actions tab when ready to cut a fi-collector release.
+# Publishes futureagi/fi-collector:<version>, :<minor>, :latest.
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
+
+name: Release fi-collector
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to publish (e.g. v0.2.0)"
+        required: true
+        type: string
+      branch:
+        description: "Branch to build from"
+        required: true
+        default: "main"
+        type: choice
+        options:
+          - main
+          - dev
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build & push fi-collector
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          submodules: false
+
+      - name: Resolve version & minor
+        id: version
+        run: |
+          set -eu
+          v="${{ inputs.version }}"
+          if ! printf '%s' "$v" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$'; then
+            echo "::error::Version '$v' does not match expected vX.Y.Z[-suffix] form"
+            exit 1
+          fi
+          base="${v%%-*}"
+          minor="${base%.*}"
+          { echo "version=$v"; echo "minor=$minor"; } >> "$GITHUB_OUTPUT"
+          echo "Resolved: version=$v, minor=$minor"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./fi-collector
+          file: ./fi-collector/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            futureagi/fi-collector:${{ steps.version.outputs.version }}
+            futureagi/fi-collector:${{ steps.version.outputs.minor }}
+            futureagi/fi-collector:latest
+          cache-from: type=registry,ref=futureagi/fi-collector:buildcache
+          cache-to: type=registry,ref=futureagi/fi-collector:buildcache,mode=max


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-fi-collector.yml`, a manual (`workflow_dispatch`) release workflow mirroring `release-agentcc-gateway.yml`
- Builds `fi-collector/Dockerfile` for linux/amd64 + linux/arm64 and pushes `futureagi/fi-collector:<version>`, `:<minor>`, and `:latest` to Docker Hub, with a registry build cache
- Replaces the ad-hoc GCP Artifact Registry push (`us-east5-docker.pkg.dev/futureagiprimary/futureagi/fi-collector`)
- Branch input defaults to `dev` since fi-collector is not on `main` yet
- Reuses the existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets — no new secrets required

## Notes
- First push auto-creates the `futureagi/fi-collector` Docker Hub repo (org default visibility)
- Follow-up in the deployment repo: point `fiCollector.image.repository` at Docker Hub and add `imagePullSecrets` to the fi-collector deployment template
- A sibling PR targets `main` so the workflow appears in the Actions tab (workflow_dispatch requires the default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)