### PR TITLE
fix(agentic_eval): correct Spearman rho for tied and constant inputs

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3573,19 +3573,36 @@ def _parse_number_list(val):
     return [float(val)]
 
 
+def _pearson_r(x, y):
+    """
+    Compute the Pearson correlation coefficient between two equal-length lists.
+
+    Args:
+        x (List[float]): First series.
+        y (List[float]): Second series.
+
+    Returns:
+        float | None: The coefficient, or None if either series has zero variance
+            (the correlation is undefined there rather than zero).
+    """
+    n = len(x)
+    mx, my = sum(x) / n, sum(y) / n
+    ss_x = sum((xi - mx) ** 2 for xi in x)
+    ss_y = sum((yi - my) ** 2 for yi in y)
+    if ss_x == 0 or ss_y == 0:
+        return None
+    return sum((xi - mx) * (yi - my) for xi, yi in zip(x, y)) / (ss_x * ss_y) ** 0.5
+
+
 def calculate_pearson_correlation(output, expected, **kwargs):
     """Compute Pearson correlation coefficient between two sets of values."""
     x = _parse_number_list(output)
     y = _parse_number_list(expected)
     if len(x) != len(y) or len(x) < 2:
         return {"result": 0.0, "reason": f"Invalid input: {len(x)} vs {len(y)} values (need >=2)"}
-    n = len(x)
-    mx, my = sum(x) / n, sum(y) / n
-    ss_x = sum((xi - mx) ** 2 for xi in x)
-    ss_y = sum((yi - my) ** 2 for yi in y)
-    if ss_x == 0 or ss_y == 0:
+    r = _pearson_r(x, y)
+    if r is None:
         return {"result": 0.0, "reason": "Zero variance in one or both inputs"}
-    r = sum((xi - mx) * (yi - my) for xi, yi in zip(x, y)) / (ss_x * ss_y) ** 0.5
     score = (r + 1) / 2  # Normalize from [-1,1] to [0,1]
     return {"result": score, "reason": f"Pearson r={r:.4f}, normalized={score:.4f}"}
 
@@ -3612,9 +3629,14 @@ def calculate_spearman_correlation(output, expected, **kwargs):
             i = j + 1
         return ranks
 
+    # Spearman's rho is Pearson's r over the ranks. The 1 - 6*sum(d^2)/(n(n^2-1))
+    # shortcut is an algebraic simplification that only holds when both rank
+    # vectors are permutations of 1..n; with tied values _rank returns midranks,
+    # which breaks that assumption and yields a wrong (sometimes sign-flipped) rho.
     rx, ry = _rank(x), _rank(y)
-    d_sq = sum((rxi - ryi) ** 2 for rxi, ryi in zip(rx, ry))
-    rho = 1 - (6 * d_sq) / (n * (n ** 2 - 1))
+    rho = _pearson_r(rx, ry)
+    if rho is None:
+        return {"result": 0.0, "reason": "Zero variance in one or both inputs"}
     score = (rho + 1) / 2
     return {"result": score, "reason": f"Spearman rho={rho:.4f}, normalized={score:.4f}"}
 

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Ensure Django is configured before importing the evaluator functions.
+
+``functions.py``'s import chain reaches Django models, so the app registry must
+be populated before collection. When these tests run inside the backend's own
+settings (Docker, ``bin/test``), Django is already configured and this module
+does nothing. Standalone, it configures the minimum app set those imports need,
+so the deterministic evaluators stay unit-testable without the full stack.
+"""
+
+import sys
+from pathlib import Path
+
+# futureagi/ — the backend root, so that `agentic_eval` and `tfc` are importable.
+_BACKEND_ROOT = Path(__file__).resolve().parents[5]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={},
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "accounts",
+            "model_hub",
+            "tracer",
+        ],
+        REST_FRAMEWORK={},
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_correlation_evaluators.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_correlation_evaluators.py
@@ -1,0 +1,170 @@
+"""
+Regression tests for the rank/linear correlation evaluators.
+
+``calculate_spearman_correlation`` computed rho with the
+``1 - 6*sum(d^2)/(n*(n^2-1))`` shortcut. That identity is an algebraic
+simplification of Pearson-over-ranks that holds only when both rank vectors are
+permutations of 1..n. ``_rank`` correctly assigns midranks to tied values —
+which breaks the assumption — so any input containing ties produced a wrong rho,
+roughly 10% of the time with the sign inverted. Ties dominate this evaluator's
+realistic inputs: Likert responses, 1-5 judge scores, star ratings, ordinal
+labels.
+
+The same shortcut had no zero-variance guard, so a constant series (a collapsed
+model emitting the same value on every row) scored a perfect 1.0 — the exact
+failure the metric is run to catch, inverted into a pass.
+
+Both are fixed by computing rho as Pearson's r over the midranks, which is the
+definition the shortcut was standing in for. Expected values below come from
+``scipy.stats.spearmanr`` / ``pearsonr``; they are inlined rather than imported
+so the suite carries no test-only dependency.
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_pearson_correlation,
+    calculate_spearman_correlation,
+)
+
+
+def _rho(result):
+    """Recover raw rho from the normalized [0,1] score at full precision."""
+    return result["result"] * 2 - 1
+
+
+class TestSpearmanWithTies:
+    """Tied values must not break rho. Reference: scipy.stats.spearmanr."""
+
+    @pytest.mark.parametrize(
+        "x, y, expected_rho",
+        [
+            # A perfect inverse relationship, previously reported as no correlation.
+            ([2, 1, 1, 1, 1], [1, 2, 2, 2, 2], -1.0),
+            # Previously returned +0.1250 — the wrong sign.
+            ([2, 2, 3, 3, 2], [2, 3, 2, 2, 2], -0.4082482904638631),
+            # Previously returned 0.1571 for genuinely uncorrelated series.
+            ([1, 1, 2, 2, 3, 3], [1, 2, 1, 2, 1, 2], 0.0),
+            # Likert-style ratings, the common real-world shape.
+            ([5, 4, 4, 3, 5, 2], [5, 5, 4, 3, 4, 1], 0.7575757575757573),
+        ],
+    )
+    def test_tied_inputs_match_scipy(self, x, y, expected_rho):
+        assert _rho(calculate_spearman_correlation(x, y)) == pytest.approx(
+            expected_rho, abs=1e-9
+        )
+
+    def test_sign_is_not_inverted(self):
+        """The starkest case: a perfect inverse must read as strongly negative."""
+        assert (
+            _rho(calculate_spearman_correlation([2, 1, 1, 1, 1], [1, 2, 2, 2, 2])) < 0
+        )
+
+    def test_rho_stays_within_bounds_on_tied_input(self):
+        for x, y in [
+            ([1, 1, 2], [2, 2, 1]),
+            ([3, 3, 3, 1], [1, 2, 2, 2]),
+            ([1, 2, 2, 2, 3], [3, 2, 2, 1, 1]),
+        ]:
+            assert -1.0 <= _rho(calculate_spearman_correlation(x, y)) <= 1.0
+
+
+class TestSpearmanZeroVariance:
+    """A constant series has undefined correlation; it must not score as perfect."""
+
+    @pytest.mark.parametrize(
+        "x, y",
+        [
+            ([1, 1, 1], [5, 5, 5]),  # previously 1.0 — a maximum score
+            ([5, 5, 5, 5, 5], [1, 2, 3, 4, 5]),  # previously 0.75
+            ([1, 2, 3], [5, 5, 5]),
+        ],
+    )
+    def test_constant_series_is_not_a_perfect_score(self, x, y):
+        result = calculate_spearman_correlation(x, y)
+        assert result["result"] == 0.0
+        assert "Zero variance" in result["reason"]
+
+    def test_matches_the_pearson_sibling_convention(self):
+        """Both correlation evaluators should answer zero variance the same way."""
+        assert calculate_spearman_correlation([1, 1, 1], [5, 5, 5]) == (
+            calculate_pearson_correlation([1, 1, 1], [5, 5, 5])
+        )
+
+
+class TestSpearmanUntiedBehaviourPreserved:
+    """Untied input already matched scipy exactly and must not shift."""
+
+    @pytest.mark.parametrize(
+        "x, y, expected_rho",
+        [
+            ([1, 2, 3, 4, 5], [1, 2, 3, 4, 5], 1.0),
+            ([1, 2, 3, 4, 5], [5, 4, 3, 2, 1], -1.0),
+            ([1, 2, 3, 4, 5], [2, 1, 4, 3, 5], 0.7999999999999999),
+            ([10, 20, 30], [30, 10, 20], -0.5),
+        ],
+    )
+    def test_untied_inputs_still_match_scipy(self, x, y, expected_rho):
+        assert _rho(calculate_spearman_correlation(x, y)) == pytest.approx(
+            expected_rho, abs=1e-9
+        )
+
+    def test_monotone_nonlinear_is_still_a_perfect_rank_correlation(self):
+        """Spearman's whole point: monotone but nonlinear reads as 1.0."""
+        assert _rho(
+            calculate_spearman_correlation([1, 2, 3, 4], [1, 4, 9, 16])
+        ) == pytest.approx(1.0, abs=1e-9)
+
+
+class TestCorrelationInputHandling:
+    """Behaviour that predates the fix and must be preserved."""
+
+    @pytest.mark.parametrize(
+        "x, y",
+        [([1, 2], [1, 2, 3]), ([1], [2]), ([], [])],
+    )
+    def test_mismatched_or_too_short_inputs_are_rejected(self, x, y):
+        for fn in (calculate_spearman_correlation, calculate_pearson_correlation):
+            result = fn(x, y)
+            assert result["result"] == 0.0
+            assert "Invalid input" in result["reason"]
+
+    @pytest.mark.parametrize(
+        "series", ["1,2,3,4,5", "[1, 2, 3, 4, 5]", [1, 2, 3, 4, 5]]
+    )
+    def test_csv_json_and_list_inputs_are_all_accepted(self, series):
+        assert _rho(calculate_spearman_correlation(series, series)) == pytest.approx(
+            1.0
+        )
+
+    def test_reason_string_still_reports_rho_and_normalized_score(self):
+        reason = calculate_spearman_correlation([1, 2, 3], [1, 2, 3])["reason"]
+        assert "rho=" in reason and "normalized=" in reason
+
+
+class TestPearsonUnchanged:
+    """_pearson_r was extracted from this function; its behaviour must not move."""
+
+    @pytest.mark.parametrize(
+        "x, y, expected_r",
+        [
+            ([1, 2, 3, 4], [2, 4, 6, 8], 1.0),
+            ([1, 2, 3, 4], [8, 6, 4, 2], -1.0),
+            ([1, 2, 3, 4], [2, 4, 6, 9], 0.9943767126843689),
+        ],
+    )
+    def test_pearson_matches_scipy(self, x, y, expected_r):
+        assert _rho(calculate_pearson_correlation(x, y)) == pytest.approx(
+            expected_r, abs=1e-9
+        )
+
+    def test_pearson_zero_variance_still_guarded(self):
+        result = calculate_pearson_correlation([1, 1, 1], [5, 5, 5])
+        assert result["result"] == 0.0
+        assert "Zero variance in one or both inputs" == result["reason"]
+
+    def test_pearson_reason_string_unchanged(self):
+        assert (
+            "Pearson r="
+            in calculate_pearson_correlation([1, 2, 3], [1, 2, 3])["reason"]
+        )


### PR DESCRIPTION
Fixes the `calculate_spearman_correlation` defect from #1610 (Tier 3). Two symptoms, one root cause, one fix.

## What was wrong

`_rank` correctly assigns midranks to tied values — I verified it's identical to `scipy.rankdata(method='average')`. The bug is what happens next: rho is computed with the `1 - 6*sum(d^2)/(n*(n^2-1))` shortcut, which is an algebraic simplification of Pearson-over-ranks that **only holds when both rank vectors are permutations of 1..n**. Midranks break that assumption.

```python
F.calculate_spearman_correlation([2,1,1,1,1], [1,2,2,2,2])   # rho  0.0000  | scipy -1.0
F.calculate_spearman_correlation([2,2,3,3,2], [2,3,2,2,2])   # rho +0.1250  | scipy -0.4082
```

The first is a *perfect inverse relationship* reported as no correlation whatsoever. The second has the sign flipped. Ties aren't an edge case for this evaluator — they're the normal shape of its input: Likert responses, 1–5 judge scores, star ratings, ordinal labels.

The same expression had no zero-variance guard, unlike its Pearson sibling three lines up:

```python
F.calculate_spearman_correlation([1,1,1], [5,5,5])          # 1.0  <- MAXIMUM score | scipy nan
F.calculate_spearman_correlation([5,5,5,5,5], [1,2,3,4,5])  # 0.75                  | scipy nan
F.calculate_pearson_correlation([1,1,1], [5,5,5])           # 0.0  'Zero variance…' <- sibling gets it right
```

A collapsed model emitting the same value on every row scores a **perfect 1.0**. That's the exact failure this metric is run to catch, inverted into a pass that silently clears a CI gate. `[1,2,3]` vs `[5,5,5]` → 0.75 rules out an "identical inputs → perfect score" reading: the inputs aren't identical, the correlation is simply fabricated.

## The fix

Spearman's rho *is* Pearson's r over the ranks — that's the definition the shortcut was standing in for. So the Pearson body is extracted into a `_pearson_r` helper and reused, which resolves both symptoms at once: ties are handled correctly because Pearson makes no permutation assumption, and Spearman inherits the zero-variance guard Pearson already had. The two evaluators now answer that case identically, which is asserted in the tests.

I extracted the helper rather than duplicating the formula so the two can't drift apart again — that drift is what this issue is.

## Verification

Fuzzed against `scipy.stats.spearmanr` / `pearsonr`:

| Case | Result |
|---|---|
| 5,000 random **tied** inputs | **0 mismatches**, max abs error `3.33e-16` |
| 3,000 random **untied** inputs (path must not move) | **0 mismatches** |
| 3,000 random inputs through `calculate_pearson_correlation` (refactor must be behaviour-preserving) | **0 mismatches** |
| zero-variance cases (scipy `nan`) | all 79 agreed |

The untied result matters as much as the tied one: it's what shows this is a strict improvement rather than a behaviour change. Untied input was already exact and still is, bit for bit.

## Tests

- **9 of 27 fail on the unfixed code** (the ties, the sign flip, the zero-variance passes)
- The other 18 pin behaviour that was already correct: untied inputs, monotone-nonlinear → 1.0, CSV/JSON/list parsing, length validation, reason-string format, and the whole Pearson surface

Expected values are inlined from scipy rather than imported, so the suite carries no test-only dependency. Every one was cross-checked against scipy before committing (three of my hand-derived values were wrong — worth knowing if you ever inline more).

```
27 passed
```

## Notes

- `tests/conftest.py` is byte-identical to the one in #1611, so if both land the add/add merges cleanly. These two PRs are otherwise independent and can merge in either order.
- Same collection caveat as #1611 — nothing collects `agentic_eval`'s tests today (#1610). To run:
  ```bash
  cd futureagi/agentic_eval
  pytest core_evals/fi_evals/function/tests/ --confcutdir=core_evals/fi_evals/function/tests
  ```
- Formatted only my own lines; `functions.py` isn't Black-clean (#1066) and reformatting it would produce a ~900-line diff.
