### PR TITLE
fix(agentic_eval): stop duplicate retrievals from inflating AP past 1.0

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -3749,8 +3749,15 @@ def calculate_mean_average_precision(reference, hypothesis, **kwargs):
             gt_set = set(str(x) for x in gt)
             hits = 0
             sum_prec = 0.0
+            seen_relevant = set()
             for rank, item in enumerate(ret, 1):
-                if str(item) in gt_set:
+                # Binary relevance credits each relevant item at most once, as in
+                # ndcg_at_k. Re-retrieving the same item must not add a hit: the
+                # denominator counts distinct items, so counting occurrences in the
+                # numerator lets AP exceed its 1.0 upper bound.
+                key = str(item)
+                if key in gt_set and key not in seen_relevant:
+                    seen_relevant.add(key)
                     hits += 1
                     sum_prec += hits / rank
             ap = sum_prec / len(gt_set) if gt_set else 0.0
@@ -3763,8 +3770,12 @@ def calculate_mean_average_precision(reference, hypothesis, **kwargs):
         return {"result": 0.0, "reason": "Empty ground truth"}
     hits = 0
     sum_prec = 0.0
+    seen_relevant = set()
     for rank, item in enumerate(retrieved, 1):
-        if str(item) in gt_set:
+        # See the nested-query loop above: each relevant item is credited once.
+        key = str(item)
+        if key in gt_set and key not in seen_relevant:
+            seen_relevant.add(key)
             hits += 1
             sum_prec += hits / rank
     ap = sum_prec / len(gt_set)

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Ensure Django is configured before importing the evaluator functions.
+
+``functions.py``'s import chain reaches Django models, so the app registry must
+be populated before collection. When these tests run inside the backend's own
+settings (Docker, ``bin/test``), Django is already configured and this module
+does nothing. Standalone, it configures the minimum app set those imports need,
+so the deterministic evaluators stay unit-testable without the full stack.
+"""
+
+import sys
+from pathlib import Path
+
+# futureagi/ — the backend root, so that `agentic_eval` and `tfc` are importable.
+_BACKEND_ROOT = Path(__file__).resolve().parents[5]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={},
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "accounts",
+            "model_hub",
+            "tracer",
+        ],
+        REST_FRAMEWORK={},
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_retrieval_evaluators.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_retrieval_evaluators.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for Average Precision / MAP with duplicate retrieved items.
+
+``calculate_mean_average_precision`` incremented ``hits`` on every occurrence of
+a relevant item while dividing by ``len(gt_set)`` — a count of *distinct* items.
+Mixing the two conventions let AP exceed its 1.0 upper bound:
+
+    gt=["chunk_7"], retrieved=["chunk_7", "chunk_7", "chunk_3"]  ->  AP 2.0
+    gt=["a"],       retrieved=["a"] * 5                          ->  AP 5.0
+
+AP is bounded [0, 1] under every convention: the numerator can credit at most
+|R| distinct documents and the denominator is |R|. Duplicate retrievals are
+exactly what MAP is run to catch (hybrid retrievers, multi-query fan-out,
+overlapping chunk windows), and ``mean_average_precision.yaml`` renders the
+score as a percentage against ``pass_threshold: 0.5`` — so a duplicate-heavy
+retriever displayed as 200% and unconditionally passed its own gate.
+
+The sibling evaluators in this module were already correct on the same input
+(``ndcg_at_k`` 1.0, ``precision_at_k`` 0.333, ``recall_at_k`` 1.0); MAP was the
+only outlier. ``ndcg_at_k`` even carries the rule in a comment — "Repeated
+retrieval of the same relevant item must not increase DCG" — and the fix applies
+that same ``seen`` guard here.
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_mean_average_precision,
+    ndcg_at_k,
+)
+
+
+class TestAveragePrecisionIsBounded:
+    """AP is a bounded [0,1] quantity regardless of what the retriever returns."""
+
+    @pytest.mark.parametrize(
+        "ground_truth, retrieved",
+        [
+            (["chunk_7"], ["chunk_7", "chunk_7", "chunk_3"]),  # previously 2.0
+            (["a"], ["a"] * 5),  # previously 5.0
+            (["a", "b"], ["a", "a", "b", "b"]),
+            (["a"], ["a", "a"]),
+        ],
+    )
+    def test_duplicates_never_push_ap_above_one(self, ground_truth, retrieved):
+        assert (
+            calculate_mean_average_precision(ground_truth, retrieved)["result"] <= 1.0
+        )
+
+    def test_a_repeated_perfect_hit_scores_exactly_one(self):
+        result = calculate_mean_average_precision(
+            ["chunk_7"], ["chunk_7", "chunk_7", "chunk_3"]
+        )
+        assert result["result"] == pytest.approx(1.0)
+
+    def test_reason_counts_distinct_relevant_items_not_occurrences(self):
+        """Previously reported '2 relevant' when one distinct relevant doc existed."""
+        reason = calculate_mean_average_precision(
+            ["chunk_7"], ["chunk_7", "chunk_7", "chunk_3"]
+        )["reason"]
+        assert "1 relevant" in reason
+
+    def test_agrees_with_the_ndcg_sibling_on_duplicate_input(self):
+        """Both are binary-relevance metrics; a repeat must not credit either."""
+        gt, ret = ["chunk_7"], ["chunk_7", "chunk_7", "chunk_3"]
+        assert calculate_mean_average_precision(gt, ret)["result"] == pytest.approx(
+            float(ndcg_at_k(gt, ret)["result"])
+        )
+
+    def test_duplicates_do_not_beat_a_clean_ranking(self):
+        """Padding a result list with repeats must never improve the score."""
+        clean = calculate_mean_average_precision(["a", "b"], ["a", "b"])["result"]
+        padded = calculate_mean_average_precision(["a", "b"], ["a", "a", "b", "b"])[
+            "result"
+        ]
+        assert padded <= clean
+
+
+class TestNestedMultiQuery:
+    """The nested (per-query) path has the same loop and the same defect."""
+
+    def test_duplicates_in_one_query_do_not_inflate_map(self):
+        result = calculate_mean_average_precision(
+            [["a"], ["b"]], [["a", "a"], ["x", "b"]]
+        )
+        assert result["result"] <= 1.0
+        # Query 1 is a perfect hit (1.0); query 2 finds 'b' at rank 2 (0.5).
+        assert result["result"] == pytest.approx(0.75)
+
+    def test_nested_reason_still_reports_query_count(self):
+        reason = calculate_mean_average_precision([["a"], ["b"]], [["a"], ["b"]])[
+            "reason"
+        ]
+        assert "2 queries" in reason
+
+
+class TestBehaviourPreserved:
+    """Duplicate-free input already scored correctly and must not move."""
+
+    @pytest.mark.parametrize(
+        "ground_truth, retrieved, expected_ap",
+        [
+            (["a"], ["a"], 1.0),
+            (["a", "b"], ["a", "b"], 1.0),
+            (
+                ["a", "b"],
+                ["b", "a"],
+                1.0,
+            ),  # AP is order-insensitive when all hit at top
+            (["a", "b"], ["x", "a", "y", "b"], 0.5),
+            (["a"], ["x", "y", "a"], 1.0 / 3),
+            (["a"], ["x", "y"], 0.0),
+        ],
+    )
+    def test_duplicate_free_scores_are_unchanged(
+        self, ground_truth, retrieved, expected_ap
+    ):
+        assert calculate_mean_average_precision(ground_truth, retrieved)[
+            "result"
+        ] == pytest.approx(expected_ap)
+
+    def test_earlier_hits_still_score_higher(self):
+        """AP's core property: rank position matters."""
+        early = calculate_mean_average_precision(["a"], ["a", "x", "y"])["result"]
+        late = calculate_mean_average_precision(["a"], ["x", "y", "a"])["result"]
+        assert early > late
+
+    def test_missing_ground_truth_is_still_rejected(self):
+        result = calculate_mean_average_precision([], ["a"])
+        assert result["result"] == 0.0
+        assert "Empty ground truth" in result["reason"]
+
+    def test_irrelevant_duplicates_are_still_ignored(self):
+        """Repeating a non-relevant item must not change the score either."""
+        assert calculate_mean_average_precision(["a"], ["z", "z", "a"])[
+            "result"
+        ] == pytest.approx(1.0 / 3)


### PR DESCRIPTION
Fixes the `calculate_mean_average_precision` defect from #1610 (Tier 2).

## What was wrong

`hits` incremented on every *occurrence* of a relevant item, while the denominator stayed `len(gt_set)` — a count of *distinct* items. Mixing the two conventions lets AP exceed its upper bound:

```python
F.calculate_mean_average_precision(["chunk_7"], ["chunk_7","chunk_7","chunk_3"])  # AP = 2.0
F.calculate_mean_average_precision(["a"], ["a"]*5)                                # AP = 5.0  (linear in dupes)
```

AP is bounded [0,1] under **every** convention — the numerator can credit at most |R| distinct documents and the denominator is |R|. So this isn't a convention disagreement; there's no reading under which 2.0 is right.

The strongest evidence it's unintended is internal: the sibling evaluators are all correct on that exact input, and `ndcg_at_k` even carries the rule in a comment.

```python
F.ndcg_at_k(["chunk_7"], ["chunk_7","chunk_7","chunk_3"])         # 1.0     <- correct
F.precision_at_k(["chunk_7"], ["chunk_7","chunk_7","chunk_3"])    # 0.333   <- correct
F.recall_at_k(["chunk_7"], ["chunk_7","chunk_7","chunk_3"])       # 1.0     <- correct
```

```python
# ndcg_at_k, line 750
# Binary relevance should credit each relevant item at most once.
# Repeated retrieval of the same relevant item must not increase DCG.
if item in relevant_set and item not in seen_relevant:
```

MAP was the only outlier in its own family.

## Why it matters

Duplicate chunks aren't unusual input — they're precisely what MAP is run to catch: hybrid retrievers merging result sets, multi-query fan-out, overlapping chunk windows. And `mean_average_precision.yaml` declares `output_type_normalized: percentage` with `pass_threshold: 0.5`, so a duplicate-heavy retriever rendered as **200%** and unconditionally passed its own gate. The failure mode is a retriever that's silently degrading while its eval reports a new high score.

The `reason` string was wrong too: `'AP: 2.0000 (2 relevant in 3 retrieved)'` when exactly one distinct relevant document exists.

## The fix

Applies `ndcg_at_k`'s existing `seen_relevant` guard to both of MAP's loops — the nested per-query one and the single-query one. Each relevant item is credited at most once, which makes the numerator's convention match the denominator's.

## Verification

| Case | Result |
|---|---|
| 5,000 random inputs (with duplicates) | AP **> 1.0 in 0 cases**; max observed exactly 1.0000 |
| 3,000 duplicate-free inputs vs. previous behaviour | **0 divergences** |

The second row is the important one: duplicate-free rankings scored correctly before and are bit-identical now. This only changes results that were previously outside the metric's range.

Spot-checks preserved: rank sensitivity (`["a","x","y"]` > `["x","y","a"]`), interleaved 0.5, miss 0.0, empty-ground-truth guard, and the nested multi-query path (`[["a"],["b"]]` vs `[["a","a"],["x","b"]]` → 0.75 = mean(1.0, 0.5), previously 1.25).

## Tests

- **9 of 19 fail on the unfixed code**
- The other 10 pin behaviour that was already correct, including rank sensitivity, order handling, the empty-ground-truth guard, and that irrelevant duplicates stay ignored
- One test asserts MAP and `ndcg_at_k` now agree on duplicate input, so the family can't drift apart again

```
19 passed
```

## Notes

- `tests/conftest.py` is byte-identical to #1611 / #1612 — add/add merges cleanly, and the three PRs are independent in any order.
- Same collection caveat as the others (#1610): nothing collects `agentic_eval`'s tests today. To run:
  ```bash
  cd futureagi/agentic_eval
  pytest core_evals/fi_evals/function/tests/ --confcutdir=core_evals/fi_evals/function/tests
  ```
- `mean_average_precision.yaml` duplicates this logic and has the same defect. I left it alone — #1610's point is that the two implementations shouldn't exist separately, and I didn't want to entrench the split by patching both. Happy to sync it if you'd rather have it fixed now.
