### PR TITLE
perf(simulate): pre-fetch cells in scenario_rows generation (TH-6942)

### DIFF
--- a/futureagi/simulate/tasks/scenario_tasks.py
+++ b/futureagi/simulate/tasks/scenario_tasks.py
@@ -422,8 +422,6 @@ def generate_scenario_rows(
             f"Generated {len(cases)} cases, updating cells for {num_rows} rows..."
         )
 
-        # Pre-fetch every existing cell once instead of a `Cell.objects.get(...)`
-        # per (row, column) pair inside the double loop.
         target_row_ids = new_rows_id[: min(len(cases), num_rows)]
         existing_cells = {
             (str(cell.row_id), str(cell.column_id)): cell
@@ -460,7 +458,6 @@ def generate_scenario_rows(
                     cell.status = CellStatus.PASS.value
                     cells_to_update.append(cell)
                 else:
-                    # Fallback: row-creation didn't seed this cell.
                     cells_to_update.append(
                         Cell(
                             id=uuid.uuid4(),
@@ -509,8 +506,6 @@ def generate_scenario_rows(
                 ]
             )
 
-            # Pre-fetch cells to avoid a `.get()` per (row, column) inside the
-            # error path's double loop.
             existing_error_cells = Cell.objects.filter(
                 dataset=dataset,
                 column__in=total_columns,

--- a/futureagi/simulate/tasks/scenario_tasks.py
+++ b/futureagi/simulate/tasks/scenario_tasks.py
@@ -421,9 +421,23 @@ def generate_scenario_rows(
         logger.info(
             f"Generated {len(cases)} cases, updating cells for {num_rows} rows..."
         )
+
+        # Pre-fetch every existing cell once instead of a `Cell.objects.get(...)`
+        # per (row, column) pair inside the double loop.
+        target_row_ids = new_rows_id[: min(len(cases), num_rows)]
+        existing_cells = {
+            (str(cell.row_id), str(cell.column_id)): cell
+            for cell in Cell.objects.filter(
+                dataset=dataset,
+                column__in=total_columns,
+                row_id__in=target_row_ids,
+            )
+        }
+
         cells_to_update = []
         for i in range(min(len(cases), num_rows)):
             case = cases[i]
+            row_id = new_rows_id[i]
             for col in total_columns:
                 try:
                     col_lower = col.name.lower()
@@ -440,24 +454,19 @@ def generate_scenario_rows(
                 except Exception:
                     value = ""
 
-                # Get the cell (should already exist from row creation)
-                try:
-                    cell = Cell.objects.get(
-                        dataset=dataset,
-                        column=col,
-                        row_id=new_rows_id[i],
-                    )
+                cell = existing_cells.get((str(row_id), str(col.id)))
+                if cell is not None:
                     cell.value = value
                     cell.status = CellStatus.PASS.value
                     cells_to_update.append(cell)
-                except Cell.DoesNotExist:
-                    # Create if it doesn't exist (fallback)
+                else:
+                    # Fallback: row-creation didn't seed this cell.
                     cells_to_update.append(
                         Cell(
                             id=uuid.uuid4(),
                             dataset=dataset,
                             column=col,
-                            row_id=new_rows_id[i],
+                            row_id=row_id,
                             value=value,
                             status=CellStatus.PASS.value,
                         )
@@ -500,20 +509,17 @@ def generate_scenario_rows(
                 ]
             )
 
-            # Bulk update cells to failed status
+            # Pre-fetch cells to avoid a `.get()` per (row, column) inside the
+            # error path's double loop.
+            existing_error_cells = Cell.objects.filter(
+                dataset=dataset,
+                column__in=total_columns,
+                row_id__in=new_rows_id,
+            )
             cells_to_fail = []
-            for col in total_columns:
-                for row_id in new_rows_id:
-                    try:
-                        cell = Cell.objects.get(
-                            dataset=dataset,
-                            column=col,
-                            row_id=row_id,
-                        )
-                        cell.status = CellStatus.ERROR.value
-                        cells_to_fail.append(cell)
-                    except Cell.DoesNotExist:
-                        pass
+            for cell in existing_error_cells:
+                cell.status = CellStatus.ERROR.value
+                cells_to_fail.append(cell)
 
             # Bulk update all failed cells
             if cells_to_fail:

--- a/futureagi/simulate/tests/test_scenario_generation.py
+++ b/futureagi/simulate/tests/test_scenario_generation.py
@@ -1031,10 +1031,6 @@ class TestGenerateScenarioRowsPrefetch:
             agent.graph_generator.get_branches.return_value = []
             agent._generate_cases_for_branches.return_value = cases
 
-            # Cap well under O(num_rows * len(columns)) = 5 * len(columns).
-            # Pre-fix code fires one SELECT per (row, column) inside the loop;
-            # the prefetch collapses those into a single filter(). Reverting
-            # to the per-cell `.get()` blows this budget immediately.
             with django_assert_max_num_queries(20):
                 generate_scenario_rows(
                     dataset_id=scenario_dataset.id,

--- a/futureagi/simulate/tests/test_scenario_generation.py
+++ b/futureagi/simulate/tests/test_scenario_generation.py
@@ -16,7 +16,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.choices import (
+    CellStatus,
+    DatasetSourceChoices,
+    SourceChoices,
+    StatusType,
+)
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from simulate.models import AgentDefinition, Scenarios
 from simulate.models.simulator_agent import SimulatorAgent
@@ -816,3 +821,183 @@ class TestScenarioTypeVariations:
         # Verify relationship
         assert graph.scenario == scenario
         assert ScenarioGraph.objects.filter(scenario=scenario).exists()
+
+
+@pytest.mark.integration
+class TestGenerateScenarioRowsPrefetch:
+    """Tests for cell resolution in generate_scenario_rows."""
+
+    @staticmethod
+    def _make_scenario_and_graph(dataset, agent_definition, organization, workspace):
+        from simulate.models.scenario_graph import ScenarioGraph
+
+        scenario = Scenarios.objects.create(
+            name="Prefetch Test",
+            source="",
+            scenario_type=Scenarios.ScenarioTypes.GRAPH,
+            organization=organization,
+            workspace=workspace,
+            agent_definition=agent_definition,
+            dataset=dataset,
+        )
+        ScenarioGraph.objects.create(
+            name="Prefetch Graph",
+            scenario=scenario,
+            organization=organization,
+            graph_config={"nodes": [], "edges": []},
+        )
+        return scenario
+
+    @staticmethod
+    def _seed_rows(dataset, num_rows):
+        Row.objects.bulk_create(
+            [Row(dataset=dataset, order=i) for i in range(num_rows)]
+        )
+        return list(
+            Row.objects.filter(dataset=dataset).order_by("order").values_list("id", flat=True)
+        )
+
+    @staticmethod
+    def _seed_cells(dataset, columns, row_ids):
+        Cell.objects.bulk_create(
+            [
+                Cell(dataset=dataset, column=c, row_id=rid, value="")
+                for rid in row_ids
+                for c in columns
+            ]
+        )
+
+    @staticmethod
+    def _build_cases(num_rows, columns):
+        return [
+            {c.name.lower(): f"val_r{i}_c{c.name}" for c in columns}
+            for i in range(num_rows)
+        ]
+
+    def test_prefetch_updates_existing_cells(
+        self, db, scenario_dataset, agent_definition, organization, workspace
+    ):
+        from simulate.tasks.scenario_tasks import generate_scenario_rows
+
+        columns = list(Column.objects.filter(dataset=scenario_dataset))
+        row_ids = self._seed_rows(scenario_dataset, num_rows=3)
+        self._seed_cells(scenario_dataset, columns, row_ids)
+        scenario = self._make_scenario_and_graph(
+            scenario_dataset, agent_definition, organization, workspace
+        )
+        cases = self._build_cases(3, columns)
+
+        with patch(
+            "simulate.tasks.scenario_tasks.EnhancedScenariosAgent"
+        ) as mock_agent_cls, patch(
+            "simulate.tasks.scenario_tasks.close_old_connections"
+        ):
+            agent = mock_agent_cls.return_value
+            agent.graph_generator.get_branches.return_value = []
+            agent._generate_cases_for_branches.return_value = cases
+
+            generate_scenario_rows(
+                dataset_id=scenario_dataset.id,
+                scenario_id=scenario.id,
+                num_rows=3,
+                description="test",
+                new_rows_id=row_ids,
+            )
+
+        for i, rid in enumerate(row_ids):
+            for c in columns:
+                cell = Cell.objects.get(row_id=rid, column=c)
+                assert cell.value == f"val_r{i}_c{c.name}"
+                assert cell.status == CellStatus.PASS.value
+        assert Cell.objects.filter(dataset=scenario_dataset).count() == 3 * len(columns)
+
+    def test_error_path_marks_seeded_cells_error(
+        self, db, scenario_dataset, agent_definition, organization, workspace
+    ):
+        from simulate.tasks.scenario_tasks import generate_scenario_rows
+
+        columns = list(Column.objects.filter(dataset=scenario_dataset))
+        row_ids = self._seed_rows(scenario_dataset, num_rows=2)
+        self._seed_cells(scenario_dataset, columns, row_ids)
+        scenario = self._make_scenario_and_graph(
+            scenario_dataset, agent_definition, organization, workspace
+        )
+
+        with patch(
+            "simulate.tasks.scenario_tasks.EnhancedScenariosAgent"
+        ) as mock_agent_cls, patch(
+            "simulate.tasks.scenario_tasks.close_old_connections"
+        ):
+            agent = mock_agent_cls.return_value
+            agent.graph_generator.get_branches.return_value = []
+            agent._generate_cases_for_branches.return_value = []
+
+            with pytest.raises(ValueError):
+                generate_scenario_rows(
+                    dataset_id=scenario_dataset.id,
+                    scenario_id=scenario.id,
+                    num_rows=2,
+                    description="test",
+                    new_rows_id=row_ids,
+                )
+
+        cells = Cell.objects.filter(dataset=scenario_dataset)
+        assert cells.count() == 2 * len(columns)
+        assert set(cells.values_list("status", flat=True)) == {CellStatus.ERROR.value}
+        columns_qs = Column.objects.filter(dataset=scenario_dataset)
+        assert set(columns_qs.values_list("status", flat=True)) == {
+            StatusType.FAILED.value
+        }
+
+    def test_conversation_branch_reads_branch_name_fallback(
+        self, db, scenario_dataset, agent_definition, organization, workspace
+    ):
+        from simulate.tasks.scenario_tasks import generate_scenario_rows
+
+        conv_col = Column.objects.create(
+            dataset=scenario_dataset,
+            name="conversation_branch",
+            data_type="text",
+            source=SourceChoices.OTHERS.value,
+        )
+        scenario_dataset.column_order = [
+            *scenario_dataset.column_order,
+            str(conv_col.id),
+        ]
+        scenario_dataset.save()
+
+        columns = list(Column.objects.filter(dataset=scenario_dataset))
+        row_ids = self._seed_rows(scenario_dataset, num_rows=1)
+        self._seed_cells(scenario_dataset, columns, row_ids)
+        scenario = self._make_scenario_and_graph(
+            scenario_dataset, agent_definition, organization, workspace
+        )
+        cases = [
+            {
+                "persona": "p",
+                "situation": "s",
+                "outcome": "o",
+                "branch_name": "greeting-then-verify",
+            }
+        ]
+
+        with patch(
+            "simulate.tasks.scenario_tasks.EnhancedScenariosAgent"
+        ) as mock_agent_cls, patch(
+            "simulate.tasks.scenario_tasks.close_old_connections"
+        ):
+            agent = mock_agent_cls.return_value
+            agent.graph_generator.get_branches.return_value = []
+            agent._generate_cases_for_branches.return_value = cases
+
+            generate_scenario_rows(
+                dataset_id=scenario_dataset.id,
+                scenario_id=scenario.id,
+                num_rows=1,
+                description="test",
+                new_rows_id=row_ids,
+            )
+
+        conv_cell = Cell.objects.get(row_id=row_ids[0], column=conv_col)
+        assert conv_cell.value == "greeting-then-verify"
+        assert conv_cell.status == CellStatus.PASS.value

--- a/futureagi/simulate/tests/test_scenario_generation.py
+++ b/futureagi/simulate/tests/test_scenario_generation.py
@@ -1001,3 +1001,45 @@ class TestGenerateScenarioRowsPrefetch:
         conv_cell = Cell.objects.get(row_id=row_ids[0], column=conv_col)
         assert conv_cell.value == "greeting-then-verify"
         assert conv_cell.status == CellStatus.PASS.value
+
+    def test_cell_resolution_is_one_query_not_per_cell(
+        self,
+        db,
+        scenario_dataset,
+        agent_definition,
+        organization,
+        workspace,
+        django_assert_max_num_queries,
+    ):
+        from simulate.tasks.scenario_tasks import generate_scenario_rows
+
+        columns = list(Column.objects.filter(dataset=scenario_dataset))
+        num_rows = 5
+        row_ids = self._seed_rows(scenario_dataset, num_rows=num_rows)
+        self._seed_cells(scenario_dataset, columns, row_ids)
+        scenario = self._make_scenario_and_graph(
+            scenario_dataset, agent_definition, organization, workspace
+        )
+        cases = self._build_cases(num_rows, columns)
+
+        with patch(
+            "simulate.tasks.scenario_tasks.EnhancedScenariosAgent"
+        ) as mock_agent_cls, patch(
+            "simulate.tasks.scenario_tasks.close_old_connections"
+        ):
+            agent = mock_agent_cls.return_value
+            agent.graph_generator.get_branches.return_value = []
+            agent._generate_cases_for_branches.return_value = cases
+
+            # Cap well under O(num_rows * len(columns)) = 5 * len(columns).
+            # Pre-fix code fires one SELECT per (row, column) inside the loop;
+            # the prefetch collapses those into a single filter(). Reverting
+            # to the per-cell `.get()` blows this budget immediately.
+            with django_assert_max_num_queries(20):
+                generate_scenario_rows(
+                    dataset_id=scenario_dataset.id,
+                    scenario_id=scenario.id,
+                    num_rows=num_rows,
+                    description="test",
+                    new_rows_id=row_ids,
+                )


### PR DESCRIPTION
## 1. Why the changes are made

`simulate/tasks/scenario_tasks.py::generate_scenario_rows` at 421 to 473 (happy path) and 500 to 518 (error path) resolved existing cells via `Cell.objects.get(dataset=..., column=..., row_id=...)` inside a two-level loop over `cases * total_columns`. At `num_rows=20` with ~10 scenario columns per dataset that is 200 individual `SELECT`s against `model_hub_cell` before any batched write runs; the same anti-pattern is repeated in the error branch which is called on every failed generation.

The N+1 grows linearly with `num_rows * len(total_columns)`. Wall-clock is still dominated by upstream LLM case generation (already parallelized with a 15-worker thread pool), but every additional `SELECT` here compounds on top of that. The sibling helper `add_scenario_columns_task` in the same module already pre-fetches cells the same way this PR does; `generate_scenario_rows` is the outlier.

## 2. What changes have been made

### Backend

| File | Change |
| --- | --- |
| `futureagi/simulate/tasks/scenario_tasks.py:421-473` (happy path) | Pre-fetch every existing cell once via `Cell.objects.filter(dataset=X, column__in=total_columns, row_id__in=target_row_ids)`, project into `{(str(row_id), str(col_id)): cell}` dict, then look up per (row, col) inside the loop instead of `.get()`. Fallback create-branch (`Cell(id=uuid.uuid4(), dataset=..., column=..., row_id=..., value=..., status=PASS)`) preserved verbatim; `.status = CellStatus.PASS.value` and `cells_to_update.append(cell)` semantics preserved; the downstream `Cell.objects.bulk_update(cells_with_pk, ["value", "status"], batch_size=500)` and `Cell.objects.bulk_create(cells_without_pk, batch_size=500)` split at 478-486 preserved verbatim. |
| `futureagi/simulate/tasks/scenario_tasks.py:500-518` (error path) | Replace the `for col in total_columns: for row_id in new_rows_id: try Cell.objects.get(...); except DoesNotExist: pass` double loop with one `Cell.objects.filter(dataset=X, column__in=total_columns, row_id__in=new_rows_id)` iterated once. `cell.status = CellStatus.ERROR.value` and `cells_to_fail.append(cell)` semantics preserved; downstream `Cell.objects.bulk_update(cells_to_fail, ["status"], batch_size=500)` and `total_columns.update(status=StatusType.FAILED.value)` preserved verbatim. |
| `futureagi/simulate/tests/test_scenario_generation.py` | New `TestGenerateScenarioRowsPrefetch` class + 3 tests. Mocks only `EnhancedScenariosAgent` and `close_old_connections` at the module boundary via `unittest.mock.patch`; every model / manager / bulk write hits real Postgres via pytest-django's transactional DB fixture. |

## 3. Tests

New: three tests in the class above.

Existing regression scope: all 32 pre-existing tests in `simulate/tests/test_scenario_generation.py` (across `TestCellPersistence`, `TestScenarioGenerationVariations`, `TestScenarioTypeVariations`, `TestConvertPersonasToPropertyList`, `TestPersonaValidation`, `TestPersonaCycling`, `TestGeneratedDataStructure`, `TestLanguageBasedPersonaSelection`). All pass unchanged.

## 4. What each test covers

| Test | Scenario pinned | Failure mode caught |
| --- | --- | --- |
| `test_prefetch_updates_existing_cells` | Full `3 rows * N cols` cell grid pre-seeded; mocked LLM cases produce a distinct value per (row, col). | A regression that misses updating any cell in the grid, mis-maps a case value to the wrong column, leaves `status` at the default instead of `PASS`, or double-inserts (asserts final `Cell.objects.count() == 3 * N`). |
| `test_error_path_marks_seeded_cells_error` | Empty case list from `_generate_cases_for_branches` forces the `raise ValueError` at line 418, which the outer `except` handles by running the error-path prefetch. | A regression that flips only a subset of seeded cells to `ERROR`, leaves columns in `RUNNING` instead of `FAILED`, or drops the `raise` at line 529 that re-raises the original exception to the Temporal activity. |
| `test_conversation_branch_reads_branch_name_fallback` | Row where the mocked LLM emitted `branch_name` but omitted `conversation_branch`. | A regression that drops the `col_lower == "conversation_branch"` special case at lines 444 to 447 and falls back to the generic `case.get(col_lower, "")` (would yield `""` instead of `branch_name`'s value). |

## 5. Commands to run these tests

```
bin/test --no-services simulate/tests/test_scenario_generation.py -v
```

Runs all 35 tests in the file (3 new + 32 pre-existing). Expected wall-clock is under 15 seconds on a warm venv.

## 6. Steps to test the specific PR changes on local

Prerequisites: `backend`, `postgres`, `redis`, `temporal` up locally; venv active.

Step 1. Fetch the branch:

```
git fetch origin perf/th-6942-scenario-rows-prefetch-cells
git checkout perf/th-6942-scenario-rows-prefetch-cells
```

Step 2. Run the test file:

```
bin/test --no-services simulate/tests/test_scenario_generation.py -v
```

Step 3. Confirm the three new tests in output:

- `TestGenerateScenarioRowsPrefetch::test_prefetch_updates_existing_cells PASSED`
- `TestGenerateScenarioRowsPrefetch::test_error_path_marks_seeded_cells_error PASSED`
- `TestGenerateScenarioRowsPrefetch::test_conversation_branch_reads_branch_name_fallback PASSED`

Step 4. Confirm the aggregate line reads `35 passed`.

Step 5. Optional (manual, requires live LLM credentials). Trigger a scenario generation on any dataset with 10+ rows via `http://localhost:3031/dashboard/simulate/scenarios`. Watch Postgres connection metrics during the `generate_scenario_rows_activity` window; expect a flat count instead of stepping up `num_rows * len(total_columns)` times.

## 7. Screenshots

<img width="2064" height="702" alt="image" src="https://github.com/user-attachments/assets/2e1ee0c1-7d30-4871-b0be-be086806839f" />

<img width="3322" height="2142" alt="image" src="https://github.com/user-attachments/assets/98d0cf9d-3a7b-4086-b5ef-b37b573de0f1" />

## 8. Why the specific architectural decisions

- **Dict pre-fetch, not `select_related` on the loop.** `Cell` has FKs to `Dataset`, `Column`, and `Row`, but the loop body only reads `.value` and `.status` on the pre-existing cell and only writes `.value` and `.status`. A dict keyed by `(str(row_id), str(col_id))` is `O(1)` lookup with a single non-joined `SELECT`; no wasted eager joins.
- **Stringified UUID composite key.** `cell.row_id` and `cell.column_id` are UUID fields; `str(...)` on both sides of the lookup normalizes to the same key shape regardless of caller-supplied form (raw `UUID`, `str`, or `.pk`). Consistent with how the sibling `add_scenario_columns_task` composes its cell dict.
- **Fallback create branch preserved verbatim.** The pre-PR happy path also fell through to `Cell(id=uuid.uuid4(), ...)` when `.get()` raised `DoesNotExist`; the new dict-miss branch dispatches the exact same construct-and-append. No behavior change on the create side.
- **Error path drops the create-fallback deliberately.** The pre-PR error path swallowed `Cell.DoesNotExist` with `pass`. The new error path iterates the prefetched queryset, so cells not on disk are simply not seen. Same net outcome as `pass`, one fewer round-trip.
- **`bulk_update` / `bulk_create` partition preserved.** The existing `cells_with_pk` / `cells_without_pk` split at 478 to 479 is not touched. Batched-write semantics are unchanged.

## Linear

Closes TH-6942
