### PR TITLE
[TH-6902][TH-7008] Fix empty KB picker + stuck 'Processing' on KB detail (snake_case)

### DIFF
--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   MenuItem,
   Popover,
+  Skeleton,
   TextField,
   Tooltip,
   Typography,
@@ -552,6 +553,25 @@ SummarySubmenu.propTypes = {
   onSelect: PropTypes.func.isRequired,
 };
 
+// ---------------------------------------------------------------------------
+// Skeleton rows for the Knowledge Base list — checkbox + label placeholders
+// that mirror each KB MenuItem while pages load.
+// ---------------------------------------------------------------------------
+function KBSkeletonRows({ count }) {
+  return Array.from({ length: count }).map((_, i) => (
+    <Box
+      key={`kb-skeleton-${i}`}
+      sx={{ display: "flex", alignItems: "center", gap: 1, px: 2, py: 0.75 }}
+    >
+      <Skeleton variant="rounded" width={18} height={18} />
+      <Skeleton
+        variant="text"
+        sx={{ flex: 1, fontSize: (theme) => theme.typography.s2_1.fontSize }}
+      />
+    </Box>
+  ));
+}
+
 // Main Component — [∞ Mode ▾] [model-name ▾] [+]
 // ---------------------------------------------------------------------------
 const ModelSelector = ({
@@ -647,6 +667,7 @@ const ModelSelector = ({
   };
 
   const [kbSearch, setKbSearch] = useState("");
+  const debouncedKbSearch = useDebounce(kbSearch.trim(), 400);
   const [keysDrawerModel, setKeysDrawerModel] = useState(null);
   const navigate = useNavigate();
   const { isOSS } = useDeploymentMode();
@@ -672,31 +693,43 @@ const ModelSelector = ({
     return Array.isArray(results) ? results : [];
   }, [connectorsData]);
 
-  // Fetch knowledge bases
-  const { data: kbData } = useInfiniteQuery({
-    queryKey: ["eval-knowledge-bases"],
-    queryFn: () => axios.get(endpoints.knowledge.list),
-    getNextPageParam: () => null,
-    initialPageParam: 1,
+  // Fetch knowledge bases (paginated /get/ endpoint, searched server-side).
+  // The API has no `next` cursor, so paginate off `total_rows`: request the
+  // next zero-indexed page while fewer rows are loaded than the total.
+  const {
+    data: kbData,
+    fetchNextPage: fetchNextKBPage,
+    hasNextPage: hasNextKBPage,
+    isFetchingNextPage: isFetchingNextKBPage,
+    isLoading: kbLoading,
+  } = useInfiniteQuery({
+    queryKey: ["eval-knowledge-bases", debouncedKbSearch],
+    queryFn: ({ pageParam }) =>
+      axios.get(endpoints.knowledge.list, {
+        params: {
+          search: debouncedKbSearch,
+          page_number: pageParam,
+          page_size: 25,
+        },
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce(
+        (n, p) => n + (p?.data?.result?.table_data?.length || 0),
+        0,
+      );
+      const total = lastPage?.data?.result?.total_rows || 0;
+      return loaded < total ? allPages.length : undefined;
+    },
+    initialPageParam: 0,
     staleTime: 60000,
   });
 
-  const knowledgeBases = useMemo(() => {
-    const page = kbData?.pages?.[0]?.data;
-    // API returns {status, result: {tableData: [...], totalRows}}
-    const items =
-      page?.result?.tableData || page?.results || page?.tableData || [];
-    return Array.isArray(items) ? items : [];
-  }, [kbData]);
-
-  const filteredKBs = useMemo(() => {
-    if (!kbSearch) return knowledgeBases;
-    return knowledgeBases.filter((kb) =>
-      (kb.name || kb.title || "")
-        .toLowerCase()
-        .includes(kbSearch.toLowerCase()),
-    );
-  }, [knowledgeBases, kbSearch]);
+  // API returns {status, result: {table_data: [...], total_rows}} per page.
+  const knowledgeBases = useMemo(
+    () =>
+      (kbData?.pages || []).flatMap((p) => p?.data?.result?.table_data || []),
+    [kbData],
+  );
 
   // Fetch BYOK models from API
   const {
@@ -1559,62 +1592,95 @@ const ModelSelector = ({
             )}
             {/* ══ Knowledge Base submenu ══ */}
             {plusSubmenu === "knowledge" && (
-              <Box sx={{ maxHeight: 350, overflowY: "auto" }}>
-                <Box sx={{ px: 1, pt: 0.5, pb: 0.5 }}>
-                  <TextField
-                    size="small"
-                    fullWidth
-                    autoFocus
-                    placeholder="Search knowledge bases..."
-                    value={kbSearch}
-                    onChange={(e) => setKbSearch(e.target.value)}
-                    InputProps={{
-                      startAdornment: (
-                        <Iconify
-                          icon="mdi:magnify"
-                          width={14}
-                          sx={{ mr: 0.5, color: "text.disabled" }}
-                        />
-                      ),
-                      sx: { fontSize: "12px", height: 28 },
-                    }}
-                  />
+              <Box
+                sx={{ width: 360, maxHeight: 360, overflowY: "auto" }}
+                onScroll={(e) => {
+                  const { scrollTop, scrollHeight, clientHeight } = e.target;
+                  if (
+                    scrollHeight - scrollTop - clientHeight < 50 &&
+                    hasNextKBPage &&
+                    !isFetchingNextKBPage
+                  ) {
+                    fetchNextKBPage();
+                  }
+                }}
+              >
+                <Box
+                  sx={{
+                    position: "sticky",
+                    top: 0,
+                    zIndex: 1,
+                    backgroundColor: "background.paper",
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <Box sx={{ px: 1, pt: 0.75, pb: 0.75 }}>
+                    <TextField
+                      size="small"
+                      fullWidth
+                      autoFocus
+                      placeholder="Search knowledge bases..."
+                      value={kbSearch}
+                      onChange={(e) => setKbSearch(e.target.value)}
+                      InputProps={{
+                        startAdornment: (
+                          <Iconify
+                            icon="mdi:magnify"
+                            width={14}
+                            sx={{ mr: 0.5, color: "text.disabled" }}
+                          />
+                        ),
+                        sx: {
+                          fontSize: (theme) => theme.typography.s2.fontSize,
+                          height: 30,
+                        },
+                      }}
+                    />
+                  </Box>
+
+                  {selectedKBs.length > 0 && (
+                    <Box
+                      sx={{
+                        px: 1.25,
+                        pb: 0.75,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                      }}
+                    >
+                      <Typography
+                        variant="s3"
+                        sx={{
+                          fontWeight: "fontWeightSemiBold",
+                          color: "text.secondary",
+                          letterSpacing: "0.02em",
+                        }}
+                      >
+                        {selectedKBs.length} selected
+                      </Typography>
+                      <Typography
+                        component="button"
+                        variant="s3"
+                        onClick={() => setSelectedKBs([])}
+                        sx={{
+                          fontWeight: "fontWeightSemiBold",
+                          color: "primary.main",
+                          background: "none",
+                          border: "none",
+                          p: 0,
+                          cursor: "pointer",
+                          "&:hover": { textDecoration: "underline" },
+                        }}
+                      >
+                        Clear all
+                      </Typography>
+                    </Box>
+                  )}
                 </Box>
 
-                {selectedKBs.length > 0 && (
-                  <Box
-                    sx={{
-                      px: 1,
-                      pb: 0.5,
-                      display: "flex",
-                      flexWrap: "wrap",
-                      gap: 0.5,
-                    }}
-                  >
-                    {selectedKBs.map((kbId) => {
-                      const kb = knowledgeBases.find(
-                        (k) => (k.id || k.pk) === kbId,
-                      );
-                      return (
-                        <Chip
-                          key={kbId}
-                          size="small"
-                          label={kb?.name || kb?.title || "KB"}
-                          onDelete={() =>
-                            setSelectedKBs((prev) =>
-                              prev.filter((x) => x !== kbId),
-                            )
-                          }
-                          deleteIcon={DELETE_ICON}
-                          sx={{ ...CHIP_STYLES, height: 20 }}
-                        />
-                      );
-                    })}
-                  </Box>
-                )}
-
-                {filteredKBs.length > 0 ? (
-                  filteredKBs.map((kb) => {
+                {knowledgeBases.length > 0 ? (
+                  knowledgeBases.map((kb) => {
                     const kbId = kb.id || kb.pk;
                     const kbName = kb.name || kb.title || "Untitled";
                     const isSelected = selectedKBs.includes(kbId);
@@ -1628,7 +1694,19 @@ const ModelSelector = ({
                               : [...prev, kbId],
                           )
                         }
-                        sx={{ borderRadius: "6px", py: 0.5, gap: 1 }}
+                        sx={{
+                          borderRadius: "6px",
+                          mx: 0.5,
+                          py: 0.5,
+                          gap: 1,
+                          ...(isSelected && {
+                            backgroundColor: (theme) =>
+                              alpha(
+                                theme.palette.primary.main,
+                                theme.palette.mode === "dark" ? 0.16 : 0.08,
+                              ),
+                          }),
+                        }}
                       >
                         <Iconify
                           icon={
@@ -1645,15 +1723,25 @@ const ModelSelector = ({
                           }}
                         />
                         <Typography
-                          variant="body2"
+                          variant="s2_1"
                           noWrap
-                          sx={{ fontSize: "13px", flex: 1 }}
+                          sx={{
+                            flex: 1,
+                            fontWeight: isSelected
+                              ? "fontWeightSemiBold"
+                              : "fontWeightRegular",
+                            color: isSelected
+                              ? "text.primary"
+                              : "text.secondary",
+                          }}
                         >
                           {kbName}
                         </Typography>
                       </MenuItem>
                     );
                   })
+                ) : kbLoading ? (
+                  <KBSkeletonRows count={6} />
                 ) : (
                   <Box sx={{ py: 2, px: 1.5, textAlign: "center" }}>
                     <Typography
@@ -1674,6 +1762,7 @@ const ModelSelector = ({
                     />
                   </Box>
                 )}
+                {isFetchingNextKBPage && <KBSkeletonRows count={3} />}
               </Box>
             )}
 

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -553,10 +553,6 @@ SummarySubmenu.propTypes = {
   onSelect: PropTypes.func.isRequired,
 };
 
-// ---------------------------------------------------------------------------
-// Skeleton rows for the Knowledge Base list — checkbox + label placeholders
-// that mirror each KB MenuItem while pages load.
-// ---------------------------------------------------------------------------
 function KBSkeletonRows({ count }) {
   return Array.from({ length: count }).map((_, i) => (
     <Box
@@ -693,9 +689,6 @@ const ModelSelector = ({
     return Array.isArray(results) ? results : [];
   }, [connectorsData]);
 
-  // Fetch knowledge bases (paginated /get/ endpoint, searched server-side).
-  // The API has no `next` cursor, so paginate off `total_rows`: request the
-  // next zero-indexed page while fewer rows are loaded than the total.
   const {
     data: kbData,
     fetchNextPage: fetchNextKBPage,
@@ -964,10 +957,10 @@ const ModelSelector = ({
                 Knowledge Bases
               </Typography>
               {selectedKBs.map((kbId) => {
-                const kb = knowledgeBases.find((k) => (k.id || k.pk) === kbId);
+                const kb = knowledgeBases.find((k) => k.id === kbId);
                 return (
                   <Typography key={kbId} sx={{ fontSize: "11px" }}>
-                    • {kb?.name || kb?.title || "KB"}
+                    • {kb?.name || "KB"}
                   </Typography>
                 );
               })}
@@ -1681,8 +1674,8 @@ const ModelSelector = ({
 
                 {knowledgeBases.length > 0 ? (
                   knowledgeBases.map((kb) => {
-                    const kbId = kb.id || kb.pk;
-                    const kbName = kb.name || kb.title || "Untitled";
+                    const kbId = kb.id;
+                    const kbName = kb.name;
                     const isSelected = selectedKBs.includes(kbId);
                     return (
                       <MenuItem

--- a/frontend/src/sections/knowledge-base/sheet-view/sheet-table-view.jsx
+++ b/frontend/src/sections/knowledge-base/sheet-view/sheet-table-view.jsx
@@ -50,7 +50,7 @@ const SheetTableView = forwardRef((props, ref) => {
           page_number: p,
         });
 
-        const rows = data?.result?.tableData ?? [];
+        const rows = data?.result?.table_data ?? [];
 
         const transaction = {
           update: rows,
@@ -61,7 +61,7 @@ const SheetTableView = forwardRef((props, ref) => {
         }
         setStatus({
           status: data?.result?.status,
-          status_count: data?.result?.statusCount,
+          status_count: data?.result?.status_count,
         });
       } catch (e) {
         logger.error("Failed to refresh rows", e);
@@ -161,27 +161,21 @@ const SheetTableView = forwardRef((props, ref) => {
             sort: sort,
           });
 
-          // setRowDataForRefresh(data?.result?.tableData)
-
-          const lastUpdated =
-            data?.result?.last_updated ?? data?.result?.lastUpdated;
+          const lastUpdated = data?.result?.last_updated;
           if (lastUpdated) {
             setLastUpdatedDate(lastUpdated);
           }
 
-          const totalRows =
-            data?.result?.total_rows ?? data?.result?.totalRows ?? 0;
+          const totalRows = data?.result?.total_rows ?? 0;
           setTotalRows(totalRows);
 
           if (data?.result?.status) {
             setStatus({
               status: data?.result?.status,
-              status_count:
-                data?.result?.status_count ?? data?.result?.statusCount,
+              status_count: data?.result?.status_count,
             });
           }
-          const rows =
-            data?.result?.table_data ?? data?.result?.tableData ?? [];
+          const rows = data?.result?.table_data ?? [];
 
           params.success({
             rowData: rows,


### PR DESCRIPTION
**Tickets:**
- [TH-6902](https://linear.app/future-agi/issue/TH-6902/list-of-added-and-completed-knowledge-bases-does-not-appear-in-the) — eval KB picker empty — Fixes TH-6902
- [TH-7008](https://linear.app/future-agi/issue/TH-7008/bugfix-knowledge-base-detail-page-stuck-on-processing-after-file) — KB detail stuck on "Processing" — Fixes TH-7008

## What was the bug
Both bugs come from the frontend reading **camelCase** keys the knowledge-base API never sends — the API is entirely snake_case.

1. **(TH-6902) Eval KB picker shows "No knowledge bases yet"** even with a completed KB. `ModelSelector.jsx` read `result.tableData`; the API returns `result.table_data`, so the list was always empty. The `useInfiniteQuery` was also never wired for pagination (`getNextPageParam` always `null`, no page params, no scroll handler), so it could only ever show the first page of a paginated endpoint.
2. **(TH-7008) KB detail chip stuck on "Processing"** after the file completed. `sheet-table-view.jsx`'s polling refresh read `result.tableData` / `result.statusCount`, so the final poll applied an **empty** AG Grid transaction — the row's status never flipped to "Completed", even though polling correctly stopped. A page refresh (different code path) showed the right state.

## What changes have been done
- `frontend/src/sections/knowledge-base/sheet-view/sheet-table-view.jsx`
  - `refreshRowsManual` now reads `result.table_data` / `result.status_count`.
  - Removed the dead `?? tableData` / `?? statusCount` camelCase fallbacks in the initial `getRows` load.
- `frontend/src/sections/evals/components/ModelSelector.jsx`
  - Read `result.table_data`.
  - Wired real **infinite scroll**: sends `page_number` / `page_size` (25), derives the next page from `total_rows` (endpoint has no cursor), flattens all pages, and fetches on scroll.
  - **Server-side debounced search** (replaces the old client-side filter that only searched loaded pages).
  - **Skeleton** loaders (initial + next-page) in place of spinners.
  - **Sticky header**: pinned search + a compact `N selected · Clear all` bar (replaces the sprawling chip pile); selected rows are tinted + bolded.
  - Typography pulled from theme tokens (`variant="s3"`, `fontWeight="fontWeightSemiBold"`, `theme.typography.sX.fontSize`) — no hardcoded `fontSize` / `fontWeight`.

## Why the changes
- The API response is snake_case (verified live against `/model-hub/knowledge-base/get/`, `/files/`, `/list/` — hand-built dicts, plain DRF `JSONRenderer`, no camelCase middleware). Reading camelCase silently yields `undefined` → empty data.
- The KB picker uses the paginated `/get/` endpoint (10–25/page), so it needs real pagination to reach every KB, not a single first-page fetch.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Create a KB, wait for processing to finish on the KB detail page | Chip flips to "Completed" live; no manual refresh needed |
| 2 | Open eval create → + → Knowledge Base with ≥1 completed KB | KB list is populated |
| 3 | Scroll the KB picker with >25 KBs | Skeleton rows appear, next page loads, until all `total_rows` shown |
| 4 | Type in the KB search | Debounced server-side query; matches across all KBs, resets pagination |
| 5 | Select several KBs | Header shows `N selected · Clear all`; stays one line; selected rows tinted/bolded |

## How to reproduce (original bug)
1. Create a knowledge base with a file and let it finish processing.
2. KB detail page: status chip stays "Processing" until you refresh the page.
3. Eval create → + → Knowledge Base: picker shows "No knowledge bases yet" despite the completed KB.

## Videos and screenshots
_UI change — screen recording of the KB picker (scroll + search + select) to be attached._
