### PR TITLE
feat(kb): add Valkey as vector store backend for Knowledge Base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -452,14 +452,13 @@ services:
     restart: unless-stopped
 
   valkey:
-    image: valkey/valkey:8.1-alpine
-    command: valkey-server --appendonly yes --loadmodule /opt/valkey/lib/valkey-search.so
+    image: redis/redis-stack-server:latest
     ports:
       - "127.0.0.1:${VALKEY_PORT:-6389}:6379"
     volumes:
       - valkey-data:/data
     healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,6 +451,22 @@ services:
       retries: 5
     restart: unless-stopped
 
+  valkey:
+    image: valkey/valkey:8.1-alpine
+    command: valkey-server --appendonly yes --loadmodule /opt/valkey/lib/valkey-search.so
+    ports:
+      - "127.0.0.1:${VALKEY_PORT:-6389}:6379"
+    volumes:
+      - valkey-data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    profiles:
+      - valkey
+
   rabbitmq:
     image: rabbitmq:3-management
     environment:
@@ -723,6 +739,7 @@ volumes:
   postgres-data:
   clickhouse-data:
   redis-data:
+  valkey-data:
   rabbitmq-data:
   minio-data:
   peerdb-catalog-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -452,13 +452,13 @@ services:
     restart: unless-stopped
 
   valkey:
-    image: redis/redis-stack-server:latest
+    image: valkey/valkey-bundle:latest
     ports:
       - "127.0.0.1:${VALKEY_PORT:-6389}:6379"
     volumes:
       - valkey-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -153,7 +153,7 @@ CH_USE_REPLICATED_ENGINES=false   # true only if shard/replica macros are config
 # or Redis Stack.
 # VECTOR_DB_BACKEND=clickhouse     # "clickhouse" (default) or "valkey"
 # VALKEY_HOST=valkey               # Use 'valkey' for docker, 'localhost' for local
-# VALKEY_PORT=6379
+# VALKEY_PORT=6379                 # Container-to-container; host access uses 6389
 # VALKEY_PASSWORD=
 # VALKEY_DB=0
 # VALKEY_VECTOR_DIMS=768           # Must match your embedding model dimensions

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -156,6 +156,7 @@ CH_USE_REPLICATED_ENGINES=false   # true only if shard/replica macros are config
 # VALKEY_PORT=6379                 # Container-to-container; host access uses 6389
 # VALKEY_PASSWORD=
 # VALKEY_DB=0
+# VALKEY_SSL=false                 # Set to "true" for managed cloud (ElastiCache, MemoryDB, etc.)
 # VALKEY_VECTOR_DIMS=768           # Must match your embedding model dimensions
 
 # reCAPTCHA (enable + configure for public deployments)

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -145,6 +145,19 @@ CH_USE_REPLICATED_ENGINES=false   # true only if shard/replica macros are config
 # Memory limit for ClickHouse container (default: 2g, increase if OOM)
 # CLICKHOUSE_MEM_LIMIT=2g
 
+# -----------------------------------------------------------------------------
+# Valkey / Redis Vector Store (alternative to ClickHouse for KB embeddings)
+# -----------------------------------------------------------------------------
+# Set VECTOR_DB_BACKEND=valkey to use Valkey instead of ClickHouse for
+# knowledge base vector search. Requires Valkey 8+ with valkey-search module
+# or Redis Stack.
+# VECTOR_DB_BACKEND=clickhouse     # "clickhouse" (default) or "valkey"
+# VALKEY_HOST=valkey               # Use 'valkey' for docker, 'localhost' for local
+# VALKEY_PORT=6379
+# VALKEY_PASSWORD=
+# VALKEY_DB=0
+# VALKEY_VECTOR_DIMS=768           # Must match your embedding model dimensions
+
 # reCAPTCHA (enable + configure for public deployments)
 RECAPTCHA_ENABLED=false
 RECAPTCHA_SECRET_KEY=

--- a/futureagi/agentic_eval/core/database/__init__.py
+++ b/futureagi/agentic_eval/core/database/__init__.py
@@ -1,0 +1,25 @@
+"""
+Vector database backends for knowledge base and embedding storage.
+
+The active backend is controlled by the VECTOR_DB_BACKEND environment variable:
+  - "clickhouse" (default): Uses ClickHouse with cosineDistance
+  - "valkey": Uses Valkey with the vector search module (FT.*)
+"""
+
+import os
+
+
+def get_vector_db():
+    """
+    Factory function that returns the configured vector database instance.
+
+    Set VECTOR_DB_BACKEND=valkey to use Valkey; defaults to ClickHouse.
+    """
+    backend = os.getenv("VECTOR_DB_BACKEND", "clickhouse").lower()
+
+    if backend == "valkey":
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+        return ValkeyVectorDB()
+
+    from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
+    return ClickHouseVectorDB()

--- a/futureagi/agentic_eval/core/database/test_valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/test_valkey_vector.py
@@ -1,0 +1,406 @@
+"""
+Tests for ValkeyVectorDB.
+
+Unit tests use mocks; integration tests require VALKEY_TEST_ADDRESS to be set.
+
+Run unit tests:
+    pytest agentic_eval/core/database/test_valkey_vector.py -v -k "not integration"
+
+Run integration tests (requires Valkey with vector search module):
+    VALKEY_TEST_ADDRESS=localhost:6389 pytest agentic_eval/core/database/test_valkey_vector.py -v -k integration
+"""
+
+import json
+import os
+import struct
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestFloatListToBytes:
+    def test_basic_conversion(self):
+        from agentic_eval.core.database.valkey_vector import _float_list_to_bytes
+
+        vector = [1.0, 0.5, -1.0, 0.0]
+        result = _float_list_to_bytes(vector)
+        assert len(result) == 16
+        unpacked = struct.unpack("<4f", result)
+        assert unpacked == (1.0, 0.5, -1.0, 0.0)
+
+    def test_empty_vector(self):
+        from agentic_eval.core.database.valkey_vector import _float_list_to_bytes
+
+        result = _float_list_to_bytes([])
+        assert result == b""
+
+
+class TestEscapeTag:
+    def test_escapes_special_characters(self):
+        from agentic_eval.core.database.valkey_vector import _escape_tag
+
+        assert _escape_tag("hello world") == "hello\\ world"
+        assert "\\-" in _escape_tag("a-b")
+        assert _escape_tag("simple") == "simple"
+
+    def test_uuid(self):
+        from agentic_eval.core.database.valkey_vector import _escape_tag
+
+        test_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        escaped = _escape_tag(test_uuid)
+        assert "\\-" in escaped
+
+    def test_pipe_escaped(self):
+        from agentic_eval.core.database.valkey_vector import _escape_tag
+
+        assert _escape_tag("id1|id2") == "id1\\|id2"
+
+
+class TestValkeyVectorDBUnit:
+    """Unit tests with mocked redis client."""
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_init_connects(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=128)
+        mock_client.ping.assert_called_once()
+        assert db.dims == 128
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_create_table_creates_index(self, mock_redis_cls):
+        import redis as redis_pkg
+
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+        mock_client.execute_command.side_effect = [
+            redis_pkg.ResponseError("Unknown index name"),
+            "OK",
+        ]
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        db.create_table("test_table")
+
+        calls = mock_client.execute_command.call_args_list
+        assert calls[0][0][0] == "FT.INFO"
+        assert calls[1][0][0] == "FT.CREATE"
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_create_table_skips_if_exists(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+        mock_client.execute_command.return_value = ["some", "info"]
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        db.create_table("test_table")
+
+        assert mock_client.execute_command.call_count == 1
+        assert mock_client.execute_command.call_args[0][0] == "FT.INFO"
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_upsert_vector_stores_hash(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+        mock_client.execute_command.return_value = [0]
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        db._created_indices.add("idx:test_table")
+        result_id = db.upsert_vector(
+            "test_table",
+            "eval_1",
+            [0.1, 0.2, 0.3, 0.4],
+            {"key1": "val1", "key2": "val2"},
+            ["key1"],
+        )
+
+        assert result_id is not None
+        uuid.UUID(result_id)
+        mock_client.hset.assert_called_once()
+        call_args = mock_client.hset.call_args
+        mapping = call_args[1]["mapping"]
+        metadata_json = json.loads(mapping[b"metadata_json"].decode())
+        assert metadata_json == {"key1": "val1", "key2": "val2"}
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_bulk_upsert_uses_pipeline(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_pipe = MagicMock()
+        mock_client.pipeline.return_value = mock_pipe
+        mock_client.execute_command.return_value = [0]
+        mock_redis_cls.return_value = mock_client
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=3)
+        db._created_indices.add("idx:test_table")
+        ids = db.bulk_upsert_vectors(
+            "test_table",
+            "eval_1",
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+            [{"k": "v1"}, {"k": "v2"}],
+            ["k"],
+        )
+
+        assert len(ids) == 2
+        assert mock_pipe.hset.call_count == 2
+        mock_pipe.execute.assert_called()
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_fetch_vector_by_id(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+
+        vector_bytes = struct.pack("<4f", 0.1, 0.2, 0.3, 0.4)
+        metadata = {"key1": "val1", "key2": "val2"}
+        mock_client.hgetall.return_value = {
+            b"id": b"doc-123",
+            b"eval_id": b"eval-1",
+            b"metadata_json": json.dumps(metadata).encode(),
+            b"deleted": b"0",
+            b"vector": vector_bytes,
+        }
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        result = db.fetch_vector_by_id("test_table", "doc-123")
+
+        assert result is not None
+        assert result["id"] == "doc-123"
+        assert result["metadata"] == {"key1": "val1", "key2": "val2"}
+        assert len(result["vector"]) == 4
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_fetch_vector_by_id_deleted_returns_none(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+        mock_client.hgetall.return_value = {
+            b"id": b"doc-123",
+            b"deleted": b"1",
+        }
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        result = db.fetch_vector_by_id("test_table", "doc-123")
+        assert result is None
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_metadata_with_special_chars(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+        mock_client.execute_command.return_value = [0]
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        db._created_indices.add("idx:test_table")
+
+        metadata = {"text": "hello\x1fworld", "path": "a/b|c", "quote": 'she said "hi"'}
+        db.upsert_vector("test_table", "eval_1", [1, 0, 0, 0], metadata, ["text"])
+
+        call_args = mock_client.hset.call_args
+        mapping = call_args[1]["mapping"]
+        recovered = json.loads(mapping[b"metadata_json"].decode())
+        assert recovered == metadata
+
+    @patch("agentic_eval.core.database.valkey_vector.redis.Redis")
+    def test_close_does_not_set_none(self, mock_redis_cls):
+        mock_client = MagicMock()
+        mock_redis_cls.return_value = mock_client
+
+        from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+        db = ValkeyVectorDB(dims=4)
+        db.close()
+        mock_client.close.assert_called_once()
+
+
+@pytest.mark.skipif(
+    not os.getenv("VALKEY_TEST_ADDRESS"),
+    reason="VALKEY_TEST_ADDRESS not set; skipping Valkey integration test",
+)
+class TestValkeyVectorDBIntegration:
+    """Integration tests against a live Valkey instance with vector search."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        addr = os.getenv("VALKEY_TEST_ADDRESS", "localhost:6379")
+        host, port = addr.rsplit(":", 1)
+
+        with patch.dict(os.environ, {"VALKEY_HOST": host, "VALKEY_PORT": port, "VALKEY_PASSWORD": ""}):
+            from agentic_eval.core.database.valkey_vector import ValkeyVectorDB
+
+            self.db = ValkeyVectorDB(dims=4)
+            self.table_name = f"test_kb_{uuid.uuid4().hex[:8]}"
+            self.db.create_table(self.table_name)
+
+        yield
+
+        self.db.drop_table(self.table_name)
+        self.db.close()
+
+    def test_upsert_and_fetch(self):
+        doc_id = self.db.upsert_vector(
+            self.table_name,
+            "eval_1",
+            [0.5, 0.5, 0.5, 0.5],
+            {"chunk_text": "hello world", "file_id": "f1"},
+            ["chunk_text"],
+        )
+
+        result = self.db.fetch_vector_by_id(self.table_name, doc_id)
+        assert result is not None
+        assert result["metadata"]["chunk_text"] == "hello world"
+
+    def test_metadata_roundtrip_with_special_chars(self):
+        metadata = {"text": "line1\nline2", "path": "a/b/c", "json_like": '{"key": "val"}'}
+        doc_id = self.db.upsert_vector(
+            self.table_name,
+            "eval_1",
+            [1.0, 0.0, 0.0, 0.0],
+            metadata,
+            ["text"],
+        )
+        result = self.db.fetch_vector_by_id(self.table_name, doc_id)
+        assert result is not None
+        assert result["metadata"] == metadata
+
+    def test_similarity_search(self):
+        import time
+
+        self.db.upsert_vector(
+            self.table_name,
+            "eval_1",
+            [1.0, 0.0, 0.0, 0.0],
+            {"chunk_text": "doc A", "input_type": "text"},
+            ["chunk_text"],
+        )
+        self.db.upsert_vector(
+            self.table_name,
+            "eval_1",
+            [0.0, 1.0, 0.0, 0.0],
+            {"chunk_text": "doc B", "input_type": "text"},
+            ["chunk_text"],
+        )
+        time.sleep(1.5)
+
+        results = self.db.vector_similarity_search(
+            self.table_name,
+            [0.9, 0.1, 0.0, 0.0],
+            filter_by={"input_type": "text"},
+            eval_id="eval_1",
+            top_k=2,
+        )
+
+        assert len(results) >= 1
+        first_meta = results[0][2]
+        assert first_meta["chunk_text"] == "doc A"
+
+    def test_bulk_upsert(self):
+        ids = self.db.bulk_upsert_vectors(
+            self.table_name,
+            "eval_bulk",
+            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]],
+            [{"chunk_text": "c1", "input_type": "text"}, {"chunk_text": "c2", "input_type": "text"}],
+            ["chunk_text"],
+        )
+        assert len(ids) == 2
+        for doc_id in ids:
+            result = self.db.fetch_vector_by_id(self.table_name, doc_id)
+            assert result is not None
+
+    def test_bulk_upsert_marks_old_deleted(self):
+        import time
+
+        self.db.upsert_vector(
+            self.table_name,
+            "eval_dedup",
+            [1.0, 0.0, 0.0, 0.0],
+            {"item_id": "item1", "input_type": "text"},
+            ["item_id"],
+        )
+        time.sleep(0.5)
+
+        new_ids = self.db.bulk_upsert_vectors(
+            self.table_name,
+            "eval_dedup",
+            [[0.0, 1.0, 0.0, 0.0]],
+            [{"item_id": "item1", "input_type": "text"}],
+            ["item_id"],
+        )
+        time.sleep(1.5)
+
+        results = self.db.vector_similarity_search(
+            self.table_name,
+            [0.0, 1.0, 0.0, 0.0],
+            eval_id="eval_dedup",
+            top_k=10,
+        )
+        item_ids = [r[2].get("item_id") for r in results]
+        assert item_ids.count("item1") == 1
+
+    def test_threshold_search(self):
+        import time
+
+        self.db.upsert_vector(
+            self.table_name,
+            "eval_thr",
+            [1.0, 0.0, 0.0, 0.0],
+            {"chunk_text": "close", "input_type": "text"},
+            ["chunk_text"],
+        )
+        time.sleep(1.5)
+
+        results = self.db.vector_similarity_search_with_threshold(
+            self.table_name,
+            [1.0, 0.0, 0.0, 0.0],
+            dataset_id="eval_thr",
+            threshold=0.1,
+        )
+
+        assert results is not None
+        assert len(results) >= 1
+        assert results[0]["similarity"] <= 0.1
+
+    def test_delete_chunks_by_file(self):
+        import time
+
+        self.db.upsert_vector(
+            self.table_name,
+            "kb_1",
+            [1.0, 0.0, 0.0, 0.0],
+            {"file_id": "f1", "organization_id": "org1", "chunk_text": "hello"},
+            ["chunk_text"],
+        )
+        self.db.upsert_vector(
+            self.table_name,
+            "kb_1",
+            [0.0, 1.0, 0.0, 0.0],
+            {"file_id": "f2", "organization_id": "org1", "chunk_text": "world"},
+            ["chunk_text"],
+        )
+        time.sleep(1.5)
+
+        self.db.delete_chunks_by_file(self.table_name, "kb_1", "f1", "org1")
+        time.sleep(0.5)
+
+        results = self.db.vector_similarity_search(
+            self.table_name,
+            [1.0, 0.0, 0.0, 0.0],
+            eval_id="kb_1",
+            top_k=10,
+        )
+        file_ids = [r[2].get("file_id") for r in results]
+        assert "f1" not in file_ids
+        assert "f2" in file_ids

--- a/futureagi/agentic_eval/core/database/test_valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/test_valkey_vector.py
@@ -56,6 +56,12 @@ class TestEscapeTag:
 
         assert _escape_tag("id1|id2") == "id1\\|id2"
 
+    def test_backslash_escaped(self):
+        from agentic_eval.core.database.valkey_vector import _escape_tag
+
+        assert _escape_tag("path\\to\\file") == "path\\\\to\\\\file"
+        assert _escape_tag("no\\|inject") == "no\\\\\\|inject"
+
 
 class TestValkeyVectorDBUnit:
     """Unit tests with mocked redis client."""

--- a/futureagi/agentic_eval/core/database/valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/valkey_vector.py
@@ -74,7 +74,10 @@ class ValkeyVectorDB:
             socket_timeout=10,
             retry_on_timeout=True,
         )
-        self.client.ping()
+        try:
+            self.client.ping()
+        except redis.ConnectionError as e:
+            logger.warning("valkey: ping failed on init, will retry on first use", error=str(e))
         self._created_indices: set[str] = set()
 
     def _index_name(self, table_name: str) -> str:
@@ -195,46 +198,48 @@ class ValkeyVectorDB:
             filter_parts.append(f"@eval_id:{{{_escape_tag(str(eval_id))}}}")
 
         filter_query = " ".join(filter_parts)
-
-        try:
-            result = self.client.execute_command(
-                "FT.SEARCH", index_name, filter_query,
-                "LIMIT", "0", "10000",
-                "NOCONTENT",
-            )
-        except redis.ResponseError:
-            return
-
-        if not result or result[0] == 0:
-            return
-
+        prefix = self._key_prefix(table_name)
         keys_to_mark = []
-        count = result[0]
-        for i in range(1, min(count + 1, len(result))):
-            doc_key = result[i]
-            if isinstance(doc_key, bytes):
-                doc_key = doc_key.decode()
+        page_size = 500
+        offset = 0
 
-            data = self.client.hgetall(doc_key)
-            if not data or data.get(b"deleted", b"0") == b"1":
-                continue
+        while True:
+            try:
+                result = self.client.execute_command(
+                    "FT.SEARCH", index_name, filter_query,
+                    "LIMIT", str(offset), str(page_size),
+                )
+            except redis.ResponseError:
+                break
 
-            stored_meta = self._parse_metadata_from_field(data.get(b"metadata_json", b"{}"))
+            if not result or result[0] == 0:
+                break
 
-            match = True
-            for uk in unique_keys:
-                if stored_meta.get(uk) != str(metadata.get(uk, "")):
-                    match = False
-                    break
+            parsed = self._parse_raw_results(result)
+            if not parsed:
+                break
 
-            if match and exclude_keys:
-                for ek in exclude_keys:
-                    if ek in stored_meta:
+            for doc_id, fields in parsed:
+                stored_meta = self._parse_metadata_from_field(fields.get("metadata_json"))
+
+                match = True
+                for uk in unique_keys:
+                    if stored_meta.get(uk) != str(metadata.get(uk, "")):
                         match = False
                         break
 
-            if match:
-                keys_to_mark.append(doc_key)
+                if match and exclude_keys:
+                    for ek in exclude_keys:
+                        if ek in stored_meta:
+                            match = False
+                            break
+
+                if match:
+                    keys_to_mark.append(f"{prefix}{doc_id}")
+
+            if len(parsed) < page_size:
+                break
+            offset += page_size
 
         if keys_to_mark:
             pipe = self.client.pipeline(transaction=False)
@@ -315,6 +320,8 @@ class ValkeyVectorDB:
             if isinstance(eval_id, (list, tuple)):
                 id_filter = "|".join(_escape_tag(str(eid)) for eid in eval_id)
                 filter_parts.append(f"@id:{{{id_filter}}}")
+            else:
+                filter_parts.append(f"@id:{{{_escape_tag(str(eval_id))}}}")
 
         filter_query = " ".join(filter_parts) if filter_parts else "*"
         query = f"({filter_query})=>[KNN {top_k} @vector $BLOB AS distance]"
@@ -441,7 +448,7 @@ class ValkeyVectorDB:
                 doc_key = doc_key.decode()
             fields_flat = result[i + 1] if i + 1 < len(result) else []
             fields = {}
-            for j in range(0, len(fields_flat), 2):
+            for j in range(0, len(fields_flat) - 1, 2):
                 k = fields_flat[j]
                 v = fields_flat[j + 1]
                 if isinstance(k, bytes):
@@ -546,39 +553,50 @@ class ValkeyVectorDB:
             filter_parts.append(f"@eval_id:{{{_escape_tag(str(eval_id))}}}")
         filter_query = " ".join(filter_parts)
 
-        try:
-            result = self.client.execute_command(
-                "FT.SEARCH", index_name, filter_query,
-                "LIMIT", "0", "10000",
-            )
-        except redis.ResponseError:
-            return
-
-        if not result or result[0] == 0:
-            return
-
         unique_values_set = set()
         for metadata in metadata_list:
             key_tuple = tuple(str(metadata.get(uk, "")) for uk in unique_keys)
             unique_values_set.add(key_tuple)
 
+        prefix = self._key_prefix(table_name)
         keys_to_mark = []
-        parsed = self._parse_raw_results(result)
-        for doc_key_id, fields in parsed:
-            stored_meta = self._parse_metadata_from_field(fields.get("metadata_json"))
-            stored_tuple = tuple(stored_meta.get(uk, "") for uk in unique_keys)
+        page_size = 500
+        offset = 0
 
-            if stored_tuple in unique_values_set:
-                if exclude_keys:
-                    skip = False
-                    for ek in exclude_keys:
-                        if ek in stored_meta:
-                            skip = True
-                            break
-                    if skip:
-                        continue
-                prefix = self._key_prefix(table_name)
-                keys_to_mark.append(f"{prefix}{doc_key_id}")
+        while True:
+            try:
+                result = self.client.execute_command(
+                    "FT.SEARCH", index_name, filter_query,
+                    "LIMIT", str(offset), str(page_size),
+                )
+            except redis.ResponseError:
+                break
+
+            if not result or result[0] == 0:
+                break
+
+            parsed = self._parse_raw_results(result)
+            if not parsed:
+                break
+
+            for doc_key_id, fields in parsed:
+                stored_meta = self._parse_metadata_from_field(fields.get("metadata_json"))
+                stored_tuple = tuple(stored_meta.get(uk, "") for uk in unique_keys)
+
+                if stored_tuple in unique_values_set:
+                    if exclude_keys:
+                        skip = False
+                        for ek in exclude_keys:
+                            if ek in stored_meta:
+                                skip = True
+                                break
+                        if skip:
+                            continue
+                    keys_to_mark.append(f"{prefix}{doc_key_id}")
+
+            if len(parsed) < page_size:
+                break
+            offset += page_size
 
         if keys_to_mark:
             pipe = self.client.pipeline(transaction=False)
@@ -638,10 +656,14 @@ class ValkeyVectorDB:
         if not organization_id and not workspace_id:
             return total
 
-        result = self.client.execute_command(
-            "FT.SEARCH", index_name, filter_query,
-            "LIMIT", "0", str(total),
-        )
+        try:
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, filter_query,
+                "LIMIT", "0", str(total),
+            )
+        except redis.ResponseError:
+            return 0
+
         count = 0
         parsed = self._parse_raw_results(result)
         for _, fields in parsed:

--- a/futureagi/agentic_eval/core/database/valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/valkey_vector.py
@@ -1,0 +1,704 @@
+"""
+Valkey-backed vector database for the Knowledge Base.
+
+This module provides a ValkeyVectorDB class that implements the same interface as
+ClickHouseVectorDB, using Valkey's vector search module (FT.CREATE / FT.SEARCH)
+for similarity search over embeddings.
+
+Requires Valkey 8.0+ with the valkey-search module, or Redis Stack.
+"""
+
+import json
+import os
+import random
+import struct
+import uuid
+from datetime import datetime
+
+import redis
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def _float_list_to_bytes(vector: list[float]) -> bytes:
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def _escape_tag(value: str) -> str:
+    """Escape special characters for RediSearch TAG field queries."""
+    special = set(r' ,.<>{}[]"' + r"':;!@#$%^&*()-+=~/|")
+    escaped = []
+    for ch in value:
+        if ch in special:
+            escaped.append(f"\\{ch}")
+        else:
+            escaped.append(ch)
+    return "".join(escaped)
+
+
+class ValkeyVectorDB:
+    """
+    Vector database backed by Valkey with the vector search module.
+
+    Provides the same public interface as ClickHouseVectorDB so it can be used
+    as a drop-in replacement for knowledge base vector storage.
+
+    Thread safety: the underlying redis-py client uses a connection pool and is
+    safe for concurrent use from multiple threads. The close() method should only
+    be called after all operations are complete.
+
+    Environment variables:
+        VALKEY_HOST: Valkey server host (default: localhost)
+        VALKEY_PORT: Valkey server port (default: 6379)
+        VALKEY_PASSWORD: Valkey password (default: empty)
+        VALKEY_DB: Valkey database number (default: 0)
+        VALKEY_VECTOR_DIMS: Embedding vector dimensions (default: 768)
+    """
+
+    def __init__(self, dims: int | None = None):
+        host = os.getenv("VALKEY_HOST", "localhost")
+        port = int(os.getenv("VALKEY_PORT", "6379"))
+        password = os.getenv("VALKEY_PASSWORD", "")
+        db = int(os.getenv("VALKEY_DB", "0"))
+        self.dims = dims or int(os.getenv("VALKEY_VECTOR_DIMS", "768"))
+
+        self.client = redis.Redis(
+            host=host,
+            port=port,
+            password=password or None,
+            db=db,
+            decode_responses=False,
+            protocol=2,
+            socket_connect_timeout=5,
+            socket_timeout=10,
+            retry_on_timeout=True,
+        )
+        self.client.ping()
+        self._created_indices: set[str] = set()
+
+    def _index_name(self, table_name: str) -> str:
+        return f"idx:{table_name}"
+
+    def _key_prefix(self, table_name: str) -> str:
+        return f"{table_name}:"
+
+    def create_table(self, table_name: str) -> None:
+        index_name = self._index_name(table_name)
+        if index_name in self._created_indices:
+            return
+
+        try:
+            self.client.execute_command("FT.INFO", index_name)
+            self._created_indices.add(index_name)
+            return
+        except redis.ResponseError as e:
+            if "Unknown index name" not in str(e) and "Unknown Index name" not in str(e):
+                raise
+
+        prefix = self._key_prefix(table_name)
+        try:
+            self.client.execute_command(
+                "FT.CREATE", index_name,
+                "ON", "HASH",
+                "PREFIX", "1", prefix,
+                "SCHEMA",
+                "id", "TAG",
+                "eval_id", "TAG",
+                "metadata_json", "TEXT", "NOINDEX",
+                "deleted", "NUMERIC", "SORTABLE",
+                "vector", "VECTOR", "HNSW", "6",
+                "TYPE", "FLOAT32",
+                "DIM", str(self.dims),
+                "DISTANCE_METRIC", "COSINE",
+            )
+            logger.info("valkey vector index created", index=index_name, dims=self.dims)
+        except redis.ResponseError as e:
+            if "Index already exists" in str(e):
+                pass
+            else:
+                raise
+        self._created_indices.add(index_name)
+
+    def drop_table(self, table_name: str) -> None:
+        index_name = self._index_name(table_name)
+        try:
+            self.client.execute_command("FT.DROPINDEX", index_name, "DD")
+        except redis.ResponseError:
+            pass
+        self._created_indices.discard(index_name)
+
+    def get_or_create_collection(self, table_name: str) -> None:
+        self.create_table(table_name)
+
+    def _store_hash(
+        self,
+        table_name: str,
+        doc_id: str,
+        eval_id: str,
+        vector: list[float],
+        metadata: dict[str, str],
+        deleted: int = 0,
+    ) -> None:
+        key = f"{self._key_prefix(table_name)}{doc_id}"
+        metadata_json = json.dumps(metadata, ensure_ascii=False)
+        vector_bytes = _float_list_to_bytes(vector)
+
+        mapping = {
+            b"id": doc_id.encode(),
+            b"eval_id": eval_id.encode(),
+            b"metadata_json": metadata_json.encode("utf-8"),
+            b"deleted": str(deleted).encode(),
+            b"vector": vector_bytes,
+        }
+        self.client.hset(key, mapping=mapping)
+
+    def _parse_metadata_from_field(self, raw) -> dict[str, str]:
+        if not raw:
+            return {}
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    def upsert_vector(
+        self,
+        table_name: str,
+        eval_id: str,
+        vector: list[float],
+        metadata: dict[str, str],
+        unique_keys: list[str],
+        exclude_keys: list[str] | None = None,
+    ) -> str:
+        new_id = str(uuid.uuid4())
+
+        self._mark_deleted(table_name, eval_id, metadata, unique_keys, exclude_keys)
+        self._store_hash(table_name, new_id, eval_id, vector, metadata)
+
+        return new_id
+
+    def _mark_deleted(
+        self,
+        table_name: str,
+        eval_id: str,
+        metadata: dict[str, str],
+        unique_keys: list[str],
+        exclude_keys: list[str] | None = None,
+    ) -> None:
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        filter_parts = ["@deleted:[0 0]"]
+        if eval_id:
+            filter_parts.append(f"@eval_id:{{{_escape_tag(str(eval_id))}}}")
+
+        filter_query = " ".join(filter_parts)
+
+        try:
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, filter_query,
+                "LIMIT", "0", "10000",
+                "NOCONTENT",
+            )
+        except redis.ResponseError:
+            return
+
+        if not result or result[0] == 0:
+            return
+
+        keys_to_mark = []
+        count = result[0]
+        for i in range(1, min(count + 1, len(result))):
+            doc_key = result[i]
+            if isinstance(doc_key, bytes):
+                doc_key = doc_key.decode()
+
+            data = self.client.hgetall(doc_key)
+            if not data or data.get(b"deleted", b"0") == b"1":
+                continue
+
+            stored_meta = self._parse_metadata_from_field(data.get(b"metadata_json", b"{}"))
+
+            match = True
+            for uk in unique_keys:
+                if stored_meta.get(uk) != str(metadata.get(uk, "")):
+                    match = False
+                    break
+
+            if match and exclude_keys:
+                for ek in exclude_keys:
+                    if ek in stored_meta:
+                        match = False
+                        break
+
+            if match:
+                keys_to_mark.append(doc_key)
+
+        if keys_to_mark:
+            pipe = self.client.pipeline(transaction=False)
+            for key in keys_to_mark:
+                pipe.hset(key, b"deleted", b"1")
+            pipe.execute()
+
+    def fetch_vector_by_id(
+        self, table_name: str, id: str
+    ) -> dict[str, str | list[float] | dict[str, str]] | None:
+        key = f"{self._key_prefix(table_name)}{id}"
+        data = self.client.hgetall(key)
+        if not data:
+            return None
+        if data.get(b"deleted", b"0") == b"1":
+            return None
+
+        vector_bytes = data.get(b"vector", b"")
+        n_floats = len(vector_bytes) // 4
+        vector = list(struct.unpack(f"<{n_floats}f", vector_bytes))
+        metadata = self._parse_metadata_from_field(data.get(b"metadata_json", b"{}"))
+        return {"id": id, "vector": vector, "metadata": metadata}
+
+    def fetch_all_vectors(
+        self, table_name: str, filter_by: dict[str, str] | None = None
+    ) -> list[tuple[str, list[float], dict[str, str]]]:
+        if filter_by is None:
+            filter_by = {}
+
+        prefix = self._key_prefix(table_name)
+        results = []
+        cursor = 0
+        while True:
+            cursor, keys = self.client.scan(cursor, match=f"{prefix}*", count=500)
+            for key in keys:
+                data = self.client.hgetall(key)
+                if not data or data.get(b"deleted", b"0") == b"1":
+                    continue
+
+                metadata = self._parse_metadata_from_field(data.get(b"metadata_json", b"{}"))
+
+                if filter_by:
+                    skip = False
+                    for fk, fv in filter_by.items():
+                        if metadata.get(fk) != str(fv):
+                            skip = True
+                            break
+                    if skip:
+                        continue
+
+                vector_bytes = data.get(b"vector", b"")
+                n_floats = len(vector_bytes) // 4
+                vector = list(struct.unpack(f"<{n_floats}f", vector_bytes))
+                doc_id = data.get(b"id", b"").decode()
+                results.append((doc_id, vector, metadata))
+
+            if cursor == 0:
+                break
+        return results
+
+    def vector_similarity_search(
+        self,
+        table_name: str,
+        query_vector: list[float],
+        filter_by: dict[str, str] | None = None,
+        metadata_column_not_null: str | None = None,
+        eval_id: str | None = None,
+        top_k: int = 5,
+        syn_data_flag=False,
+    ):
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        filter_parts = ["@deleted:[0 0]"]
+        if eval_id and not syn_data_flag:
+            filter_parts.append(f"@eval_id:{{{_escape_tag(str(eval_id))}}}")
+        elif syn_data_flag and eval_id:
+            if isinstance(eval_id, (list, tuple)):
+                id_filter = "|".join(_escape_tag(str(eid)) for eid in eval_id)
+                filter_parts.append(f"@id:{{{id_filter}}}")
+
+        filter_query = " ".join(filter_parts) if filter_parts else "*"
+        query = f"({filter_query})=>[KNN {top_k} @vector $BLOB AS distance]"
+
+        blob = _float_list_to_bytes(query_vector)
+
+        try:
+            start_time = datetime.now()
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, query,
+                "PARAMS", "2", "BLOB", blob,
+                "SORTBY", "distance", "ASC",
+                "LIMIT", "0", str(top_k),
+                "DIALECT", "2",
+            )
+            elapsed = (datetime.now() - start_time).total_seconds()
+            logger.info(f"valkey similarity search took {elapsed:.2f}s")
+        except redis.ResponseError as e:
+            logger.error("valkey vector search error", error=str(e))
+            return []
+
+        return self._parse_search_results(result, filter_by, metadata_column_not_null, eval_id, syn_data_flag)
+
+    def vector_similarity_search_with_threshold(
+        self,
+        table_name: str,
+        query_vector: list[float],
+        filter_by: dict[str, str] | None = None,
+        metadata_column_not_null: str | None = None,
+        dataset_id: str | None = None,
+        top_k: int | None = None,
+        threshold: float = 0.75,
+    ):
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        search_k = top_k or 100
+
+        filter_parts = ["@deleted:[0 0]"]
+        if dataset_id:
+            filter_parts.append(f"@eval_id:{{{_escape_tag(str(dataset_id))}}}")
+
+        filter_query = " ".join(filter_parts) if filter_parts else "*"
+        query = f"({filter_query})=>[KNN {search_k} @vector $BLOB AS distance]"
+
+        blob = _float_list_to_bytes(query_vector)
+
+        try:
+            start_time = datetime.now()
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, query,
+                "PARAMS", "2", "BLOB", blob,
+                "SORTBY", "distance", "ASC",
+                "LIMIT", "0", str(search_k),
+                "DIALECT", "2",
+            )
+            elapsed = (datetime.now() - start_time).total_seconds()
+            logger.info(f"valkey threshold search took {elapsed:.2f}s")
+        except redis.ResponseError as e:
+            logger.error("valkey vector threshold search error", error=str(e))
+            return None
+
+        similarities = []
+        parsed = self._parse_raw_results(result)
+        for doc_id, fields in parsed:
+            distance = self._extract_float(fields.get("distance"), 1.0)
+            if distance > threshold:
+                continue
+
+            metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
+
+            if filter_by:
+                skip = False
+                for fk, fv in filter_by.items():
+                    if metadata.get(fk) != str(fv):
+                        skip = True
+                        break
+                if skip:
+                    continue
+
+            if metadata_column_not_null and not metadata.get(metadata_column_not_null):
+                continue
+
+            vector_bytes = fields.get("vector", b"")
+            n_floats = len(vector_bytes) // 4 if isinstance(vector_bytes, bytes) and vector_bytes else 0
+            vector = list(struct.unpack(f"<{n_floats}f", vector_bytes)) if n_floats else []
+
+            eval_id_raw = fields.get("eval_id", b"")
+            stored_dataset_id = eval_id_raw.decode() if isinstance(eval_id_raw, bytes) else str(eval_id_raw)
+
+            similarities.append({
+                "id": doc_id,
+                "dataset_id": stored_dataset_id,
+                "vector": vector,
+                "metadata": metadata,
+                "similarity": distance,
+            })
+
+        if top_k:
+            similarities = similarities[:top_k]
+
+        return similarities
+
+    def _extract_float(self, value, default: float = 0.0) -> float:
+        if value is None:
+            return default
+        if isinstance(value, bytes):
+            value = value.decode()
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return default
+
+    def _parse_raw_results(self, result) -> list[tuple[str, dict]]:
+        if not result or result[0] == 0:
+            return []
+
+        count = result[0]
+        parsed = []
+        i = 1
+        while i < len(result) and len(parsed) < count:
+            doc_key = result[i]
+            if isinstance(doc_key, bytes):
+                doc_key = doc_key.decode()
+            fields_flat = result[i + 1] if i + 1 < len(result) else []
+            fields = {}
+            for j in range(0, len(fields_flat), 2):
+                k = fields_flat[j]
+                v = fields_flat[j + 1]
+                if isinstance(k, bytes):
+                    k = k.decode()
+                fields[k] = v
+            doc_id = doc_key.split(":")[-1] if ":" in doc_key else doc_key
+            parsed.append((doc_id, fields))
+            i += 2
+
+        return parsed
+
+    def _parse_search_results(self, result, filter_by, metadata_column_not_null, eval_id, syn_data_flag):
+        parsed = self._parse_raw_results(result)
+        similarities = []
+
+        for doc_id, fields in parsed:
+            distance = self._extract_float(fields.get("distance"), 1.0)
+
+            metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
+
+            if filter_by:
+                skip = False
+                for fk, fv in filter_by.items():
+                    if metadata.get(fk) != str(fv):
+                        skip = True
+                        break
+                if skip:
+                    continue
+
+            if metadata_column_not_null and not metadata.get(metadata_column_not_null):
+                continue
+
+            stored_eval_id = fields.get("eval_id", b"")
+            if isinstance(stored_eval_id, bytes):
+                stored_eval_id = stored_eval_id.decode()
+
+            vector_bytes = fields.get("vector", b"")
+            if isinstance(vector_bytes, bytes) and vector_bytes:
+                n_floats = len(vector_bytes) // 4
+                vector = list(struct.unpack(f"<{n_floats}f", vector_bytes))
+            else:
+                vector = []
+
+            similarities.append((doc_id, vector, metadata, distance))
+
+        return similarities
+
+    def bulk_upsert_vectors(
+        self,
+        table_name: str,
+        eval_id: str,
+        vectors: list[list[float]],
+        metadata_list: list[dict[str, str]],
+        unique_keys: list[str],
+        exclude_keys: list[str] | None = None,
+    ) -> list[str]:
+        if len(vectors) != len(metadata_list):
+            raise ValueError("Number of vectors must match number of metadata dictionaries")
+
+        self._bulk_mark_deleted(table_name, eval_id, metadata_list, unique_keys, exclude_keys)
+
+        new_ids = [str(uuid.uuid4()) for _ in range(len(vectors))]
+
+        pipe = self.client.pipeline(transaction=False)
+        prefix = self._key_prefix(table_name)
+
+        for i, (vector, metadata) in enumerate(zip(vectors, metadata_list, strict=False)):
+            doc_id = new_ids[i]
+            key = f"{prefix}{doc_id}"
+            metadata_json = json.dumps(metadata, ensure_ascii=False)
+            vector_bytes = _float_list_to_bytes(vector)
+
+            mapping = {
+                b"id": doc_id.encode(),
+                b"eval_id": eval_id.encode(),
+                b"metadata_json": metadata_json.encode("utf-8"),
+                b"deleted": b"0",
+                b"vector": vector_bytes,
+            }
+            pipe.hset(key, mapping=mapping)
+
+        start_time = datetime.now()
+        pipe.execute()
+        elapsed = (datetime.now() - start_time).total_seconds()
+        logger.info(f"valkey bulk upsert took {elapsed:.2f}s", count=len(new_ids))
+
+        return new_ids
+
+    def _bulk_mark_deleted(
+        self,
+        table_name: str,
+        eval_id: str,
+        metadata_list: list[dict[str, str]],
+        unique_keys: list[str],
+        exclude_keys: list[str] | None = None,
+    ) -> None:
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        filter_parts = ["@deleted:[0 0]"]
+        if eval_id:
+            filter_parts.append(f"@eval_id:{{{_escape_tag(str(eval_id))}}}")
+        filter_query = " ".join(filter_parts)
+
+        try:
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, filter_query,
+                "LIMIT", "0", "10000",
+            )
+        except redis.ResponseError:
+            return
+
+        if not result or result[0] == 0:
+            return
+
+        unique_values_set = set()
+        for metadata in metadata_list:
+            key_tuple = tuple(str(metadata.get(uk, "")) for uk in unique_keys)
+            unique_values_set.add(key_tuple)
+
+        keys_to_mark = []
+        parsed = self._parse_raw_results(result)
+        for doc_key_id, fields in parsed:
+            stored_meta = self._parse_metadata_from_field(fields.get("metadata_json"))
+            stored_tuple = tuple(stored_meta.get(uk, "") for uk in unique_keys)
+
+            if stored_tuple in unique_values_set:
+                if exclude_keys:
+                    skip = False
+                    for ek in exclude_keys:
+                        if ek in stored_meta:
+                            skip = True
+                            break
+                    if skip:
+                        continue
+                prefix = self._key_prefix(table_name)
+                keys_to_mark.append(f"{prefix}{doc_key_id}")
+
+        if keys_to_mark:
+            pipe = self.client.pipeline(transaction=False)
+            for key in keys_to_mark:
+                pipe.hset(key, b"deleted", b"1")
+            pipe.execute()
+
+    def get_num_vectors(self, doc_ids: list[str], table_name: str):
+        prefix = self._key_prefix(table_name)
+        pipe = self.client.pipeline(transaction=False)
+        for doc_id in doc_ids:
+            pipe.exists(f"{prefix}{doc_id}")
+        results = pipe.execute()
+        count = sum(1 for r in results if r)
+        return [(count,)]
+
+    def get_random_examples(self, doc_ids: list[str], table_name: str, limit: int) -> list:
+        prefix = self._key_prefix(table_name)
+        shuffled = list(doc_ids)
+        random.shuffle(shuffled)
+
+        results = []
+        for doc_id in shuffled:
+            key = f"{prefix}{doc_id}"
+            data = self.client.hgetall(key)
+            if data and data.get(b"deleted", b"0") == b"0":
+                vector_bytes = data.get(b"vector", b"")
+                n_floats = len(vector_bytes) // 4
+                vector = list(struct.unpack(f"<{n_floats}f", vector_bytes)) if n_floats else []
+                metadata = self._parse_metadata_from_field(data.get(b"metadata_json", b"{}"))
+                eval_id = data.get(b"eval_id", b"").decode()
+                metadata_keys = list(metadata.keys())
+                metadata_values = list(metadata.values())
+                results.append((doc_id, eval_id, vector, metadata_keys, metadata_values, 0))
+            if len(results) >= limit:
+                break
+        return results
+
+    def get_feedback_count(
+        self, table_name: str, eval_id: str, organization_id: str | None = None, workspace_id: str | None = None
+    ) -> int:
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        filter_parts = ["@deleted:[0 0]", f"@eval_id:{{{_escape_tag(eval_id)}}}"]
+        filter_query = " ".join(filter_parts)
+
+        try:
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, filter_query,
+                "LIMIT", "0", "0",
+            )
+            total = result[0] if result else 0
+        except redis.ResponseError:
+            return 0
+
+        if not organization_id and not workspace_id:
+            return total
+
+        result = self.client.execute_command(
+            "FT.SEARCH", index_name, filter_query,
+            "LIMIT", "0", str(total),
+        )
+        count = 0
+        parsed = self._parse_raw_results(result)
+        for _, fields in parsed:
+            metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
+            if organization_id and metadata.get("organization_id") != str(organization_id):
+                continue
+            if workspace_id and metadata.get("workspace_id") != str(workspace_id):
+                continue
+            count += 1
+        return count
+
+    def delete_chunks_by_file(
+        self, table_name: str, kb_id: str, file_id: str, organization_id: str
+    ) -> None:
+        index_name = self._index_name(table_name)
+        self.create_table(table_name)
+
+        filter_parts = ["@deleted:[0 0]", f"@eval_id:{{{_escape_tag(kb_id)}}}"]
+        filter_query = " ".join(filter_parts)
+
+        try:
+            result = self.client.execute_command(
+                "FT.SEARCH", index_name, filter_query,
+                "LIMIT", "0", "10000",
+            )
+        except redis.ResponseError:
+            return
+
+        if not result or result[0] == 0:
+            return
+
+        keys_to_delete = []
+        prefix = self._key_prefix(table_name)
+        parsed = self._parse_raw_results(result)
+        for doc_id, fields in parsed:
+            metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
+            if metadata.get("file_id") == file_id and metadata.get("organization_id") == organization_id:
+                keys_to_delete.append(f"{prefix}{doc_id}")
+
+        if keys_to_delete:
+            pipe = self.client.pipeline(transaction=False)
+            for key in keys_to_delete:
+                pipe.delete(key)
+            pipe.execute()
+            logger.info(
+                "valkey deleted chunks",
+                kb_id=kb_id, file_id=file_id, count=len(keys_to_delete),
+            )
+
+    def table_exists(self, table_name: str) -> bool:
+        index_name = self._index_name(table_name)
+        try:
+            self.client.execute_command("FT.INFO", index_name)
+            return True
+        except redis.ResponseError:
+            return False
+
+    def close(self) -> None:
+        if hasattr(self, "client") and self.client is not None:
+            self.client.close()

--- a/futureagi/agentic_eval/core/database/valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/valkey_vector.py
@@ -96,11 +96,17 @@ class ValkeyVectorDB:
             self._created_indices.add(index_name)
             return
         except redis.ResponseError as e:
-            if "Unknown index name" not in str(e) and "Unknown Index name" not in str(e):
+            # Redis Stack says "Unknown index name"; valkey-search says
+            # "Index with name '...' not found". Treat both as "index missing".
+            msg = str(e).lower()
+            if "unknown index" not in msg and "not found" not in msg:
                 raise
 
         prefix = self._key_prefix(table_name)
         try:
+            # Only VECTOR, TAG, and NUMERIC field types are supported by
+            # valkey-search. metadata_json is stored in the hash but not
+            # indexed; FT.SEARCH returns all hash fields regardless.
             self.client.execute_command(
                 "FT.CREATE", index_name,
                 "ON", "HASH",
@@ -108,8 +114,7 @@ class ValkeyVectorDB:
                 "SCHEMA",
                 "id", "TAG",
                 "eval_id", "TAG",
-                "metadata_json", "TEXT", "NOINDEX",
-                "deleted", "NUMERIC", "SORTABLE",
+                "deleted", "NUMERIC",
                 "vector", "VECTOR", "HNSW", "6",
                 "TYPE", "FLOAT32",
                 "DIM", str(self.dims),
@@ -333,7 +338,6 @@ class ValkeyVectorDB:
             result = self.client.execute_command(
                 "FT.SEARCH", index_name, query,
                 "PARAMS", "2", "BLOB", blob,
-                "SORTBY", "distance", "ASC",
                 "LIMIT", "0", str(top_k),
                 "DIALECT", "2",
             )
@@ -374,7 +378,6 @@ class ValkeyVectorDB:
             result = self.client.execute_command(
                 "FT.SEARCH", index_name, query,
                 "PARAMS", "2", "BLOB", blob,
-                "SORTBY", "distance", "ASC",
                 "LIMIT", "0", str(search_k),
                 "DIALECT", "2",
             )

--- a/futureagi/agentic_eval/core/database/valkey_vector.py
+++ b/futureagi/agentic_eval/core/database/valkey_vector.py
@@ -27,6 +27,8 @@ def _float_list_to_bytes(vector: list[float]) -> bytes:
 
 def _escape_tag(value: str) -> str:
     """Escape special characters for RediSearch TAG field queries."""
+    # Escape backslash first to avoid double-escaping the escapes added below.
+    value = value.replace("\\", "\\\\")
     special = set(r' ,.<>{}[]"' + r"':;!@#$%^&*()-+=~/|")
     escaped = []
     for ch in value:
@@ -61,6 +63,7 @@ class ValkeyVectorDB:
         port = int(os.getenv("VALKEY_PORT", "6379"))
         password = os.getenv("VALKEY_PASSWORD", "")
         db = int(os.getenv("VALKEY_DB", "0"))
+        use_ssl = os.getenv("VALKEY_SSL", "false").lower() in ("1", "true", "yes")
         self.dims = dims or int(os.getenv("VALKEY_VECTOR_DIMS", "768"))
 
         self.client = redis.Redis(
@@ -68,6 +71,8 @@ class ValkeyVectorDB:
             port=port,
             password=password or None,
             db=db,
+            ssl=use_ssl,
+            ssl_cert_reqs="required" if use_ssl else None,
             decode_responses=False,
             protocol=2,
             socket_connect_timeout=5,
@@ -214,8 +219,12 @@ class ValkeyVectorDB:
                     "FT.SEARCH", index_name, filter_query,
                     "LIMIT", str(offset), str(page_size),
                 )
-            except redis.ResponseError:
-                break
+            except redis.ResponseError as e:
+                msg = str(e).lower()
+                if "not found" in msg or "unknown index" in msg:
+                    break
+                logger.warning("valkey _mark_deleted search error", error=str(e))
+                raise
 
             if not result or result[0] == 0:
                 break
@@ -572,8 +581,12 @@ class ValkeyVectorDB:
                     "FT.SEARCH", index_name, filter_query,
                     "LIMIT", str(offset), str(page_size),
                 )
-            except redis.ResponseError:
-                break
+            except redis.ResponseError as e:
+                msg = str(e).lower()
+                if "not found" in msg or "unknown index" in msg:
+                    break
+                logger.warning("valkey _bulk_mark_deleted search error", error=str(e))
+                raise
 
             if not result or result[0] == 0:
                 break
@@ -659,6 +672,12 @@ class ValkeyVectorDB:
         if not organization_id and not workspace_id:
             return total
 
+        if total > 5000:
+            logger.warning(
+                "valkey get_feedback_count: client-side filtering over large result set",
+                eval_id=eval_id, total=total,
+            )
+
         try:
             result = self.client.execute_command(
                 "FT.SEARCH", index_name, filter_query,
@@ -687,33 +706,45 @@ class ValkeyVectorDB:
         filter_parts = ["@deleted:[0 0]", f"@eval_id:{{{_escape_tag(kb_id)}}}"]
         filter_query = " ".join(filter_parts)
 
-        try:
-            result = self.client.execute_command(
-                "FT.SEARCH", index_name, filter_query,
-                "LIMIT", "0", "10000",
-            )
-        except redis.ResponseError:
-            return
-
-        if not result or result[0] == 0:
-            return
-
-        keys_to_delete = []
         prefix = self._key_prefix(table_name)
-        parsed = self._parse_raw_results(result)
-        for doc_id, fields in parsed:
-            metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
-            if metadata.get("file_id") == file_id and metadata.get("organization_id") == organization_id:
-                keys_to_delete.append(f"{prefix}{doc_id}")
+        keys_to_mark = []
+        page_size = 500
+        offset = 0
 
-        if keys_to_delete:
+        while True:
+            try:
+                result = self.client.execute_command(
+                    "FT.SEARCH", index_name, filter_query,
+                    "LIMIT", str(offset), str(page_size),
+                )
+            except redis.ResponseError as e:
+                logger.warning("valkey delete_chunks_by_file search error", error=str(e))
+                break
+
+            if not result or result[0] == 0:
+                break
+
+            parsed = self._parse_raw_results(result)
+            if not parsed:
+                break
+
+            for doc_id, fields in parsed:
+                metadata = self._parse_metadata_from_field(fields.get("metadata_json"))
+                if metadata.get("file_id") == file_id and metadata.get("organization_id") == organization_id:
+                    keys_to_mark.append(f"{prefix}{doc_id}")
+
+            if len(parsed) < page_size:
+                break
+            offset += page_size
+
+        if keys_to_mark:
             pipe = self.client.pipeline(transaction=False)
-            for key in keys_to_delete:
-                pipe.delete(key)
+            for key in keys_to_mark:
+                pipe.hset(key, b"deleted", b"1")
             pipe.execute()
             logger.info(
-                "valkey deleted chunks",
-                kb_id=kb_id, file_id=file_id, count=len(keys_to_delete),
+                "valkey soft-deleted chunks",
+                kb_id=kb_id, file_id=file_id, count=len(keys_to_mark),
             )
 
     def table_exists(self, table_name: str) -> bool:

--- a/futureagi/agentic_eval/core/embeddings/embedding_manager.py
+++ b/futureagi/agentic_eval/core/embeddings/embedding_manager.py
@@ -15,7 +15,7 @@ from django.db import close_old_connections
 from PIL import Image
 from tfc.telemetry import wrap_for_thread
 
-from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
+from agentic_eval.core.database import get_vector_db
 from agentic_eval.core.embeddings.serving_client import get_serving_client
 from agentic_eval.core.utils.functions import detect_input_type
 import structlog
@@ -231,7 +231,7 @@ model_manager = ModelManager()
 
 class EmbeddingManager:
     def __init__(self):
-        self.db_client = ClickHouseVectorDB()
+        self.db_client = get_vector_db()
         self.input_types = None
 
     def close(self):
@@ -249,6 +249,11 @@ class EmbeddingManager:
     def get_feedback_count(self, eval_id: str, organization_id: str = None, workspace_id: str = None) -> int:
         """Return the number of non-deleted feedback rows for a given eval_id."""
         try:
+            if hasattr(self.db_client, "get_feedback_count"):
+                return self.db_client.get_feedback_count(
+                    FEEDBACK_TABLE_NAME, eval_id, organization_id, workspace_id
+                )
+
             where = ["eval_id = %(eval_id)s", "deleted = 0"]
             params = {"eval_id": eval_id}
             if organization_id:
@@ -628,7 +633,7 @@ class EmbeddingManager:
         progress_callback=None,
     ):
         if table_name == FEEDBACK_TABLE_NAME:
-            db_client = ClickHouseVectorDB()
+            db_client = get_vector_db()
             db_client.create_table(table_name)
             vectors, metadata_list = self.data_formatter(
                 row_dict=metadatas,
@@ -661,7 +666,7 @@ class EmbeddingManager:
             def process_batch(batch):
                 # Per-row commits so partial progress survives mid-batch failures.
                 inserted_ids = []
-                db_client = ClickHouseVectorDB()
+                db_client = get_vector_db()
 
                 try:
                     db_client.create_table(table_name)
@@ -755,7 +760,7 @@ class EmbeddingManager:
         """
         try:
             # Create a new connection for this operation
-            db_client = ClickHouseVectorDB()
+            db_client = get_vector_db()
             try:
                 db_client.create_table(table_name)
                 new_ids = db_client.bulk_upsert_vectors(
@@ -1394,7 +1399,14 @@ class EmbeddingManager:
             organization_id (str): The organization ID to associate with the chunks
         """
         try:
-            # Check if table exists
+            if hasattr(self.db_client, "delete_chunks_by_file"):
+                self.db_client.delete_chunks_by_file(table_name, kb_id, file_id, organization_id)
+                logger.info(
+                    f"Successfully deleted chunks with eval_id {kb_id} and file_id {file_id} from table {table_name}"
+                )
+                return
+
+            # ClickHouse path
             check_query = f"EXISTS TABLE {table_name}"
             table_exists = self.db_client.client.execute(check_query)[0][0]
 
@@ -1404,7 +1416,6 @@ class EmbeddingManager:
                 )
                 return
 
-            # Construct and execute delete query using metadata.key and metadata.value
             delete_query = f"""
             ALTER TABLE {table_name}
             DELETE WHERE eval_id = '{kb_id}'


### PR DESCRIPTION
## Summary

- Add Valkey (with vector search module) as an alternative vector database backend for the Knowledge Base, alongside ClickHouse
- Backend selection via `VECTOR_DB_BACKEND` environment variable ("clickhouse" default, "valkey" option)
- Full interface parity with ClickHouseVectorDB: upsert, search, bulk operations, threshold search, chunk deletion

Part of #1608

## Changes

- `valkey_vector.py` — ValkeyVectorDB class using FT.CREATE/FT.SEARCH with HNSW indexing
- `__init__.py` — factory function `get_vector_db()` with lazy imports
- `test_valkey_vector.py` — 14 unit tests + 7 integration tests
- `embedding_manager.py` — updated to use factory, with backend-agnostic fallback for feedback count and chunk deletion
- `docker-compose.yml` — profile-gated `valkey` service
- `.env.example` — Valkey configuration documentation

## Test plan

- [x] Unit tests pass (14 tests, mocked redis client)
- [x] Integration tests pass against live Valkey with vector search (7 tests)
- [x] Verify upsert, fetch, similarity search, threshold search, bulk ops
- [x] Verify deduplication (bulk_upsert marks old entries as deleted)
- [x] Verify delete_chunks_by_file removes correct entries
- [x] Verify metadata roundtrip with special characters (JSON serialization)