### PR TITLE
[TH-6898] Read-only Params/Tools in prompt version history

### DIFF
--- a/frontend/src/components/custom-model-options/CustomModelOptions.jsx
+++ b/frontend/src/components/custom-model-options/CustomModelOptions.jsx
@@ -22,6 +22,7 @@ const CustomModelOptions = ({
   modelConfig,
   disabledHover = false,
   disabledClick = false,
+  viewOnly = false,
   hoverPlacement = "bottom",
   isDirty,
   onClick = () => {},
@@ -56,6 +57,9 @@ const CustomModelOptions = ({
   }, [modelConfig]);
 
   const handleOpenDropdown = () => {
+    // View-only (e.g. version history): the button stays enabled so the
+    // read-only params hover renders, but clicking must not open the editor.
+    if (viewOnly) return;
     if (!openDropdown) {
       onClick?.();
       setValue("config", setToolValue());
@@ -130,9 +134,11 @@ const CustomModelOptions = ({
       >
         <IconButton
           disabled={disabledClick}
+          disableRipple={viewOnly}
           sx={{
             height: "24px",
             color: "text.primary",
+            ...(viewOnly && { cursor: "default" }),
             ...(isModalContainer
               ? {
                   borderRadius: "4px",
@@ -192,6 +198,7 @@ CustomModelOptions.propTypes = {
   modelConfig: PropTypes.object,
   disabledHover: PropTypes.bool,
   disabledClick: PropTypes.bool,
+  viewOnly: PropTypes.bool,
   hoverPlacement: PropTypes.string,
   isDirty: PropTypes.bool,
   onClick: PropTypes.func,

--- a/frontend/src/components/custom-model-options/CustomModelOptions.jsx
+++ b/frontend/src/components/custom-model-options/CustomModelOptions.jsx
@@ -57,8 +57,6 @@ const CustomModelOptions = ({
   }, [modelConfig]);
 
   const handleOpenDropdown = () => {
-    // View-only (e.g. version history): the button stays enabled so the
-    // read-only params hover renders, but clicking must not open the editor.
     if (viewOnly) return;
     if (!openDropdown) {
       onClick?.();

--- a/frontend/src/components/custom-model-options/ToolHoverState.jsx
+++ b/frontend/src/components/custom-model-options/ToolHoverState.jsx
@@ -1,28 +1,24 @@
 import React, { useMemo } from "react";
 import { alpha, Box, Divider, Typography } from "@mui/material";
 import PropTypes from "prop-types";
-import _ from "lodash";
 
-const EXCLUDED_KEYS = new Set([
-  "model",
-  "tools",
-  "toolChoice",
-  "modelDetail",
-  "modelType",
-  "outputFormat",
-  "responseFormat",
-  "booleans",
-  "dropdowns",
-  "id",
-]);
+import { buildParameterRows } from "./toolHoverState.utils";
 
 const CellStyle = ({ heading, value }) => {
   return (
-    <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "flex-start",
+        gap: 2,
+      }}
+    >
       <Typography
         variant="s3"
         fontWeight={"fontWeightMedium"}
         color="text.primary"
+        sx={{ flexShrink: 0 }}
       >
         {heading}
       </Typography>
@@ -30,6 +26,7 @@ const CellStyle = ({ heading, value }) => {
         variant="s3"
         fontWeight={"fontWeightRegular"}
         color="text.primary"
+        sx={{ textAlign: "right", wordBreak: "break-word", minWidth: 0 }}
       >
         {value}
       </Typography>
@@ -43,35 +40,7 @@ CellStyle.propTypes = {
 };
 
 const ToolHoverState = ({ config, disabledHover }) => {
-  const responseValue =
-    typeof config?.responseFormat === "string"
-      ? config?.responseFormat
-      : config?.responseFormat?.name;
-
-  const paramEntries = useMemo(() => {
-    if (!config) return [];
-    return Object.entries(config).filter(
-      ([key, value]) =>
-        !EXCLUDED_KEYS.has(key) &&
-        value !== null &&
-        value !== undefined &&
-        (typeof value === "number" || typeof value === "string"),
-    );
-  }, [config]);
-
-  const booleanEntries = useMemo(() => {
-    if (!config?.booleans || typeof config.booleans !== "object") return [];
-    return Object.entries(config.booleans).filter(
-      ([, value]) => value !== null && value !== undefined,
-    );
-  }, [config?.booleans]);
-
-  const dropdownEntries = useMemo(() => {
-    if (!config?.dropdowns || typeof config.dropdowns !== "object") return [];
-    return Object.entries(config.dropdowns).filter(
-      ([, value]) => value !== null && value !== undefined,
-    );
-  }, [config?.dropdowns]);
+  const rows = useMemo(() => buildParameterRows(config), [config]);
 
   if (disabledHover) {
     return "Parameters";
@@ -90,11 +59,7 @@ const ToolHoverState = ({ config, disabledHover }) => {
           `4px 4px 16px 0px ${alpha(theme.palette.common.black, 0.1)}`,
       }}
     >
-      <Box
-        sx={{
-          width: "100%",
-        }}
-      >
+      <Box sx={{ width: "100%" }}>
         <Typography
           variant="s3"
           fontWeight={"fontWeightSemiBold"}
@@ -104,27 +69,22 @@ const ToolHoverState = ({ config, disabledHover }) => {
         </Typography>
       </Box>
       <Divider />
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-        {paramEntries.map(([key, value]) => (
-          <CellStyle key={key} heading={`${_.startCase(key)}:`} value={value} />
-        ))}
-        {booleanEntries.map(([key, value]) => (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          maxHeight: 260,
+          overflowY: "auto",
+        }}
+      >
+        {rows.map(({ heading, value }, index) => (
           <CellStyle
-            key={key}
-            heading={`${_.startCase(key)}:`}
-            value={String(value)}
+            key={`${heading}-${index}`}
+            heading={`${heading}:`}
+            value={value}
           />
         ))}
-        {dropdownEntries.map(([key, value]) => (
-          <CellStyle
-            key={key}
-            heading={`${_.startCase(key)}:`}
-            value={_.startCase(String(value))}
-          />
-        ))}
-        {responseValue && (
-          <CellStyle heading="Response Type:" value={responseValue} />
-        )}
       </Box>
     </Box>
   );

--- a/frontend/src/components/custom-model-options/__tests__/toolHoverState.utils.test.js
+++ b/frontend/src/components/custom-model-options/__tests__/toolHoverState.utils.test.js
@@ -90,6 +90,17 @@ describe("buildParameterRows", () => {
     expect(valueOf(rows, "Size")).toBe("Auto");
   });
 
+  it("renders null booleans/dropdowns/sliders as '-' (consistent with scalars)", () => {
+    const rows = buildParameterRows({
+      booleans: { stream: null },
+      dropdowns: { size: null },
+      reasoning: { sliders: { budget: null } },
+    });
+    expect(valueOf(rows, "Stream")).toBe("-");
+    expect(valueOf(rows, "Size")).toBe("-");
+    expect(valueOf(rows, "Budget")).toBe("-");
+  });
+
   it("flattens the nested reasoning object", () => {
     const rows = buildParameterRows({
       reasoning: {

--- a/frontend/src/components/custom-model-options/__tests__/toolHoverState.utils.test.js
+++ b/frontend/src/components/custom-model-options/__tests__/toolHoverState.utils.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { buildParameterRows } from "../toolHoverState.utils";
+
+// Row lookup helper: find a row's value by its display heading.
+const valueOf = (rows, heading) =>
+  rows.find((r) => r.heading === heading)?.value;
+const headings = (rows) => rows.map((r) => r.heading);
+
+describe("buildParameterRows", () => {
+  it("returns [] for null/undefined/empty config", () => {
+    expect(buildParameterRows(null)).toEqual([]);
+    expect(buildParameterRows(undefined)).toEqual([]);
+    expect(buildParameterRows({})).toEqual([]);
+  });
+
+  it("renders null params as '-' and preserves 0", () => {
+    const rows = buildParameterRows({ temperature: null, top_p: 0 });
+    expect(valueOf(rows, "Temperature")).toBe("-");
+    expect(valueOf(rows, "Top P")).toBe(0);
+  });
+
+  it("drops empty-string values (e.g. unset tool_choice)", () => {
+    const rows = buildParameterRows({ tool_choice: "", temperature: 1 });
+    expect(headings(rows)).not.toContain("Tool Choice");
+    expect(valueOf(rows, "Temperature")).toBe(1);
+  });
+
+  it("shows tool_choice raw when set (scalars are not startCased)", () => {
+    const rows = buildParameterRows({ tool_choice: "auto" });
+    expect(valueOf(rows, "Tool Choice")).toBe("auto");
+  });
+
+  it("hides output_format for string output, shows response_format", () => {
+    const rows = buildParameterRows({
+      output_format: "string",
+      response_format: "text",
+    });
+    expect(headings(rows)).not.toContain("Output Format");
+    expect(valueOf(rows, "Response Format")).toBe("text");
+  });
+
+  it("shows output_format for non-string output, hides response_format", () => {
+    const rows = buildParameterRows({
+      output_format: "audio",
+      response_format: "text",
+    });
+    expect(valueOf(rows, "Output Format")).toBe("audio");
+    expect(headings(rows)).not.toContain("Response Format");
+  });
+
+  it("shows both formats when output_format is absent", () => {
+    const rows = buildParameterRows({ response_format: "text" });
+    expect(valueOf(rows, "Response Format")).toBe("text");
+  });
+
+  it("coerces an object response_format to a primitive (no React-child crash)", () => {
+    const rows = buildParameterRows({
+      output_format: "string",
+      response_format: { id: "abc", name: "MySchema" },
+    });
+    expect(valueOf(rows, "Response Format")).toBe("MySchema");
+  });
+
+  it("labels a custom-schema response_format (uuid) as 'Custom'", () => {
+    const rows = buildParameterRows({
+      output_format: "string",
+      response_format: "29edda1d-2e25-46af-870f-6b95a1381da8",
+    });
+    expect(valueOf(rows, "Response Format")).toBe("Custom");
+  });
+
+  it("excludes all structural keys", () => {
+    const rows = buildParameterRows({
+      model: "gpt-4o-mini",
+      model_detail: { type: "chat" },
+      tools: [{ id: "1" }],
+      providers: "openai",
+      id: "x",
+      temperature: 1,
+    });
+    expect(headings(rows)).toEqual(["Temperature"]);
+  });
+
+  it("flattens top-level booleans and dropdowns", () => {
+    const rows = buildParameterRows({
+      booleans: { stream: false },
+      dropdowns: { size: "auto" },
+    });
+    expect(valueOf(rows, "Stream")).toBe("false");
+    expect(valueOf(rows, "Size")).toBe("Auto");
+  });
+
+  it("flattens the nested reasoning object", () => {
+    const rows = buildParameterRows({
+      reasoning: {
+        sliders: {},
+        dropdowns: { reasoningEffort: "xhigh" },
+        showReasoningProcess: true,
+      },
+    });
+    expect(valueOf(rows, "Reasoning Effort")).toBe("Xhigh");
+    expect(valueOf(rows, "Show Reasoning Process")).toBe("true");
+  });
+
+  it("does not throw on malformed reasoning", () => {
+    expect(() => buildParameterRows({ reasoning: "oops" })).not.toThrow();
+    expect(() => buildParameterRows({ reasoning: [] })).not.toThrow();
+  });
+});

--- a/frontend/src/components/custom-model-options/toolHoverState.utils.js
+++ b/frontend/src/components/custom-model-options/toolHoverState.utils.js
@@ -1,0 +1,93 @@
+import _ from "lodash";
+
+// Structural keys that never represent a readable scalar param, so they are
+// skipped from the params list (their contents are handled separately).
+export const NON_PARAM_KEYS = new Set([
+  "model",
+  "model_detail",
+  "tools",
+  "providers",
+  "reasoning",
+  "booleans",
+  "dropdowns",
+  "id",
+]);
+
+const toRow = (key, value) => ({ heading: _.startCase(key), value });
+
+// Coerce to a renderable primitive: null/undefined -> "-", objects (e.g. a
+// response_format schema) -> their name/label, so nothing non-primitive
+// reaches React as a child.
+const toDisplayValue = (value) => {
+  if (value === null || value === undefined) return "-";
+  if (typeof value === "object") return value.name ?? value.label ?? "-";
+  return value;
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// A custom response schema is stored as its id; the schema name isn't in the
+// snapshot, so show a short label instead of the raw uuid.
+const formatResponseFormat = (value) =>
+  typeof value === "string" && UUID_RE.test(value) ? "Custom" : value;
+
+const getScalarRows = (config) => {
+  const outputFormat = config.output_format;
+  const hasOutputFormat = outputFormat !== null && outputFormat !== undefined;
+  const isStringOutput = outputFormat === "string";
+  const hideOutputFormat = hasOutputFormat && isStringOutput;
+  const hideResponseFormat = hasOutputFormat && !isStringOutput;
+
+  return Object.entries(config)
+    .filter(([key, value]) => {
+      if (NON_PARAM_KEYS.has(key)) return false;
+      if (key === "output_format") return !hideOutputFormat;
+      if (key === "response_format") return !hideResponseFormat;
+      if (value === null || value === undefined) return true;
+      if (typeof value !== "number" && typeof value !== "string") return false;
+      // Drop blank rows (e.g. an unset tool_choice on tool-less versions).
+      if (typeof value === "string" && value.trim() === "") return false;
+      return true;
+    })
+    .map(([key, value]) => {
+      let display = toDisplayValue(value);
+      if (key === "response_format") display = formatResponseFormat(display);
+      return toRow(key, display);
+    });
+};
+
+const getMapRows = (map, formatValue) =>
+  map && typeof map === "object"
+    ? Object.entries(map)
+        .filter(([, value]) => value !== null && value !== undefined)
+        .map(([key, value]) => toRow(key, formatValue(value)))
+    : [];
+
+// Reasoning is a nested object ({ sliders, dropdowns, showReasoningProcess }).
+const getReasoningRows = (reasoning) => {
+  if (!reasoning || typeof reasoning !== "object") return [];
+  const rows = [
+    ...getMapRows(reasoning.sliders, (value) => value ?? "-"),
+    ...getMapRows(reasoning.dropdowns, (value) => _.startCase(String(value))),
+  ];
+  const { showReasoningProcess } = reasoning;
+  if (showReasoningProcess !== null && showReasoningProcess !== undefined) {
+    rows.push({
+      heading: "Show Reasoning Process",
+      value: String(showReasoningProcess),
+    });
+  }
+  return rows;
+};
+
+// Full ordered row list for the params hover panel.
+export const buildParameterRows = (config) => {
+  if (!config) return [];
+  return [
+    ...getScalarRows(config),
+    ...getMapRows(config.booleans, String),
+    ...getMapRows(config.dropdowns, (value) => _.startCase(String(value))),
+    ...getReasoningRows(config.reasoning),
+  ];
+};

--- a/frontend/src/components/custom-model-options/toolHoverState.utils.js
+++ b/frontend/src/components/custom-model-options/toolHoverState.utils.js
@@ -59,16 +59,19 @@ const getScalarRows = (config) => {
 
 const getMapRows = (map, formatValue) =>
   map && typeof map === "object"
-    ? Object.entries(map)
-        .filter(([, value]) => value !== null && value !== undefined)
-        .map(([key, value]) => toRow(key, formatValue(value)))
+    ? Object.entries(map).map(([key, value]) =>
+        toRow(
+          key,
+          value === null || value === undefined ? "-" : formatValue(value),
+        ),
+      )
     : [];
 
 // Reasoning is a nested object ({ sliders, dropdowns, showReasoningProcess }).
 const getReasoningRows = (reasoning) => {
   if (!reasoning || typeof reasoning !== "object") return [];
   const rows = [
-    ...getMapRows(reasoning.sliders, (value) => value ?? "-"),
+    ...getMapRows(reasoning.sliders, (value) => value),
     ...getMapRows(reasoning.dropdowns, (value) => _.startCase(String(value))),
   ];
   const { showReasoningProcess } = reasoning;

--- a/frontend/src/components/custom-model-tools/ToolsHoverState.jsx
+++ b/frontend/src/components/custom-model-tools/ToolsHoverState.jsx
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const ToolsHoverState = ({ tools, disableHover }) => {
+  if (!tools || tools.length === 0) {
+    return "No tools";
+  }
   if (disableHover) {
     return "Tools";
   }

--- a/frontend/src/components/custom-model-tools/ToolsHoverState.jsx
+++ b/frontend/src/components/custom-model-tools/ToolsHoverState.jsx
@@ -3,11 +3,30 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const ToolsHoverState = ({ tools, disableHover }) => {
-  if (!tools || tools.length === 0) {
-    return "No tools";
-  }
   if (disableHover) {
     return "Tools";
+  }
+  if (!tools || tools.length === 0) {
+    return (
+      <Box
+        sx={{
+          marginTop: "-10px",
+          padding: "8px",
+          backgroundColor: "background.paper",
+          borderRadius: "8px",
+          boxShadow: (theme) =>
+            `4px 4px 16px 0px ${alpha(theme.palette.common.black, 0.1)}`,
+        }}
+      >
+        <Typography
+          variant="s3"
+          fontWeight={"fontWeightMedium"}
+          color="text.primary"
+        >
+          No tools
+        </Typography>
+      </Box>
+    );
   }
   return (
     <Box

--- a/frontend/src/components/custom-model-tools/index.jsx
+++ b/frontend/src/components/custom-model-tools/index.jsx
@@ -12,6 +12,7 @@ const CustomModelTools = ({
   tools,
   disableHover = false,
   disableClick = false,
+  viewOnly = false,
   hoverPlacement = "bottom",
   onClick = () => {},
   label,
@@ -23,6 +24,9 @@ const CustomModelTools = ({
   };
 
   const handleOpenDropdown = () => {
+    // View-only (e.g. version history): the button stays enabled so the
+    // read-only tools hover renders, but clicking must not open the editor.
+    if (viewOnly) return;
     if (!showModelTool) {
       onClick?.();
       setShowModelTool(true);
@@ -51,6 +55,7 @@ const CustomModelTools = ({
         <IconButton
           onClick={handleOpenDropdown}
           disabled={disableClick}
+          disableRipple={viewOnly}
           sx={{
             borderRadius: "4px",
             backgroundColor: "background.paper",
@@ -61,6 +66,7 @@ const CustomModelTools = ({
             width: label ? "auto" : "44px",
             marginTop: isModalContainer ? "-4px" : 0,
             color: "text.primary",
+            ...(viewOnly && { cursor: "default" }),
           }}
         >
           <SvgColor
@@ -115,6 +121,7 @@ CustomModelTools.propTypes = {
   tools: PropTypes.array,
   disableHover: PropTypes.bool,
   disableClick: PropTypes.bool,
+  viewOnly: PropTypes.bool,
   hoverPlacement: PropTypes.string,
   onClick: PropTypes.func,
   label: PropTypes.string,

--- a/frontend/src/components/custom-model-tools/index.jsx
+++ b/frontend/src/components/custom-model-tools/index.jsx
@@ -24,8 +24,6 @@ const CustomModelTools = ({
   };
 
   const handleOpenDropdown = () => {
-    // View-only (e.g. version history): the button stays enabled so the
-    // read-only tools hover renders, but clicking must not open the editor.
     if (viewOnly) return;
     if (!showModelTool) {
       onClick?.();

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionCard.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionCard.jsx
@@ -409,12 +409,12 @@ const VersionCard = ({
                 />
                 <CustomModelOptions
                   modelConfig={toolConfig}
-                  disabledClick
+                  viewOnly
                   hoverPlacement="bottom-end"
                 />
                 <CustomModelTools
                   tools={toolConfig?.tools || []}
-                  disableClick
+                  viewOnly
                   disableHover={
                     !toolConfig?.tools || toolConfig?.tools.length === 0
                   }

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionCard.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionCard.jsx
@@ -415,9 +415,7 @@ const VersionCard = ({
                 <CustomModelTools
                   tools={toolConfig?.tools || []}
                   viewOnly
-                  disableHover={
-                    !toolConfig?.tools || toolConfig?.tools.length === 0
-                  }
+                  disableHover={false}
                   hoverPlacement="bottom-end"
                 />
               </Box>


### PR DESCRIPTION
**Ticket:** [TH-6898](https://linear.app/future-agi/issue/TH-6898/params-button-is-disabled-in-the-prompt-workbench-history-tab) — Fixes TH-6898

## What was the bug
In the Prompt Workbench **History** drawer, the **Params** button was fully disabled, so historical versions' model params could not be viewed. The disabled button also suppressed hover, and the same pattern affected the **Tools** (wrench) button. While fixing this, the read-only params hover panel surfaced several display issues (default/null params hidden, blank rows, raw output/response format, missing reasoning, raw custom-schema UUID, cramped spacing).

## What changes have been done
- `custom-model-options/CustomModelOptions.jsx`, `custom-model-tools/index.jsx` — add a `viewOnly` mode: the button stays enabled (so the read-only hover fires) but clicking no longer opens the editor.
- `VersionHistory/VersionCard.jsx` — History Params/Tools now use `viewOnly` instead of `disabledClick`/`disableClick`.
- `custom-model-options/toolHoverState.utils.js` (new) — extract `buildParameterRows`: null params render `-`, blank rows dropped, output/response format shown mutually-exclusively, `reasoning` flattened, object values coerced, custom response schema (uuid) labelled `Custom`.
- `custom-model-options/ToolHoverState.jsx` — thin renderer over the util; add `maxHeight`/scroll and heading↔value spacing.
- `custom-model-tools/ToolsHoverState.jsx` — show `No tools` empty state on hover.
- `custom-model-options/__tests__/toolHoverState.utils.test.js` (new) — unit tests for `buildParameterRows`.

## Why the changes
- Disabling the button killed both click and hover; `viewOnly` keeps it interactive for the read-only hover while blocking edits — history should be viewable, not editable.
- The panel is a generic renderer over the snapshot config; the util centralises the display rules so behaviour is consistent and testable, and removes inline field-guessing (panel only ever receives the snake_case snapshot config).

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Hover Params on a history version | Read-only params panel opens; clicking does not open the editor |
| 2 | Hover Tools with tools present / absent | Shows tool list / `No tools` |
| 3 | Param left at model default (null) | Row shows `-` (e.g. `Temperature: -`) |
| 4 | `tool_choice` empty vs set | Hidden when empty; shows `auto` when set |
| 5 | Output format `string` vs `audio` | `string` → shows Response Format, hides Output Format; `audio` → reverse |
| 6 | Reasoning model version | Shows `Reasoning Effort` + `Show Reasoning Process` |
| 7 | Custom response schema | Shows `Response Format: Custom` (not the raw uuid), no overflow |

## How to reproduce (original bug)
1. Open a prompt in Workbench → **History**.
2. On any version card, try the **Params** button — it is disabled and params cannot be viewed.

## Commands
```bash
cd frontend
yarn vitest run src/components/custom-model-options/__tests__/toolHoverState.utils.test.js
```

## Videos and screenshots
<img width="1538" height="1035" alt="Screenshot 2026-07-16 at 1 24 06 PM" src="https://github.com/user-attachments/assets/13e77d19-a1d8-4aa6-b6c6-a6fc68cffe41" />
<img width="930" height="490" alt="Screenshot 2026-07-16 at 1 22 37 PM" src="https://github.com/user-attachments/assets/e624317a-cc32-462f-a0d2-9420e7d408f9" />
<img width="1031" height="758" alt="Screenshot 2026-07-16 at 1 22 24 PM" src="https://github.com/user-attachments/assets/e158fb23-62b8-48ca-96f7-4dda6332ee71" />
