### PR TITLE
fix: model logo, prompt-sim run refresh, and dataset eval navigation

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -79,7 +79,7 @@ const ViewDetailsCellRenderer = (props) => {
         ...node?.data?.data?.description,
         evalName: node?.data?.data?.eval_name,
         metadata: metadata,
-        evalMetricId: data?.data?.column?.col?.sourceId,
+        evalMetricId: data?.data?.column?.col?.source_id,
       });
     }
   };
@@ -354,12 +354,12 @@ const DatapointDrawerChild = () => {
 
       return {
         ...currentField,
+        eval_name: column?.headerName,
         metadata: enhancedColumn?.metadata,
-        evalMetricId: column?.col?.sourceId,
+        evalMetricId: column?.col?.source_id,
       };
-    } else {
-      return null;
     }
+    return null;
   });
   const evalValueInfos = evalOpen?.value_infos
   const evalCellValue = evalOpen?.cell_value 
@@ -467,7 +467,7 @@ const DatapointDrawerChild = () => {
         });
         if (evalOpen) {
           const column = allColumns.find(
-            (i) => i?.col?.sourceId === evalOpen?.evalMetricId,
+            (i) => i?.col?.source_id === evalOpen?.evalMetricId,
           );
 
           setEvalOpen({
@@ -501,7 +501,7 @@ const DatapointDrawerChild = () => {
             });
             if (evalOpen) {
               const column = allColumns.find(
-                (i) => i?.col?.sourceId === evalOpen?.evalMetricId,
+                (i) => i?.col?.source_id === evalOpen?.evalMetricId,
               );
               setEvalOpen({
                 ...evalOpen,
@@ -553,7 +553,7 @@ const DatapointDrawerChild = () => {
           });
           if (evalOpen) {
             const column = allColumns.find(
-              (i) => i?.col?.sourceId === evalOpen?.evalMetricId,
+              (i) => i?.col?.source_id === evalOpen?.evalMetricId,
             );
             setEvalOpen({
               ...evalOpen,
@@ -575,7 +575,7 @@ const DatapointDrawerChild = () => {
       });
       if (evalOpen) {
         const column = allColumns.find(
-          (i) => i?.col?.sourceId === evalOpen?.evalMetricId,
+          (i) => i?.col?.source_id === evalOpen?.evalMetricId,
         );
         setEvalOpen({
           ...evalOpen,
@@ -982,7 +982,7 @@ const DatapointDrawerChild = () => {
                       // column / metric.
                       const evalColumn =
                         allColumns.find(
-                          (c) => c?.col?.sourceId === evalOpen?.evalMetricId,
+                          (c) => c?.col?.source_id === evalOpen?.evalMetricId,
                         )?.col ?? column?.col;
                       setAddEvaluationFeeback({
                         ...evalColumn,

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/NewModelRenderWithParamsTool.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/NewModelRenderWithParamsTool.jsx
@@ -194,7 +194,7 @@ const NewModelRenderWithParamsTool = ({
           >
             <Image
               ratio="1/1"
-              src={selectedModel?.logoUrl}
+              src={selectedModel?.logoUrl ?? selectedModel?.logo_url}
               alt={selectedModel?.model_name}
               flexShrink={0}
               style={{

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -72,7 +72,7 @@ const TestRunHeader = () => {
       axios.post(
         endpoint,
         isPromptSimulation
-          ? undefined
+          ? {}
           : {
               select_all: false,
               scenario_ids: selectedScenarios,

--- a/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
@@ -55,6 +55,7 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
     scenarioIds: [],
     versionId: "",
   });
+  const [isStarting, setIsStarting] = useState(false);
 
   // Fetch available scenarios using existing hook
   const {
@@ -166,15 +167,37 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
         },
       );
     },
-    onSuccess: (response) => {
-      enqueueSnackbar("Simulation created successfully", {
-        variant: "success",
-      });
+    onSuccess: async (response) => {
+      const simulationId = response?.data?.result?.id;
       // Invalidate the simulations list cache to trigger a refresh
       queryClient.invalidateQueries({
         queryKey: ["run-tests", "prompt", promptTemplateId],
       });
-      onSuccess?.(response?.data?.result?.id);
+        if (simulationId) {
+        setIsStarting(true);
+        try {
+          await axios.post(
+            endpoints.promptSimulation.execute(promptTemplateId, simulationId),
+            {},
+          );
+          enqueueSnackbar("Simulation created and execution started", {
+            variant: "success",
+          });
+        } catch (error) {
+          enqueueSnackbar(
+            error?.response?.data?.error ||
+              "Simulation created, but failed to start execution",
+            { variant: "warning" },
+          );
+        } finally {
+          setIsStarting(false);
+        }
+      } else {
+        enqueueSnackbar("Simulation created successfully", {
+          variant: "success",
+        });
+      }
+      onSuccess?.(simulationId);
     },
     onError: (error) => {
       enqueueSnackbar(
@@ -469,12 +492,15 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
           onClick={handleSubmit}
           disabled={
             isCreating ||
+            isStarting ||
             !formData.name.trim() ||
             !formData.versionId ||
             formData.scenarioIds.length === 0
           }
           startIcon={
-            isCreating && <CircularProgress size={16} color="inherit" />
+            (isCreating || isStarting) && (
+              <CircularProgress size={16} color="inherit" />
+            )
           }
           sx={{
             backgroundColor: "primary.main",
@@ -483,7 +509,11 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
             },
           }}
         >
-          {isCreating ? "Creating..." : "Create Simulation"}
+          {isCreating
+            ? "Creating..."
+            : isStarting
+              ? "Starting..."
+              : "Create Simulation"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/EmptyExecutionsState.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/EmptyExecutionsState.jsx
@@ -22,6 +22,7 @@ const EmptyExecutionsState = () => {
     mutationFn: async () => {
       return axios.post(
         endpoints.promptSimulation.execute(promptTemplateId, simulation?.id),
+        {},
       );
     },
     onSuccess: () => {

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
@@ -198,6 +198,7 @@ const SimulationDetailHeader = ({ onBack }) => {
     mutationFn: async () => {
       return axios.post(
         endpoints.promptSimulation.execute(promptTemplateId, simulation?.id),
+        {},
       );
     },
     onSuccess: () => {

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/context/SimulationDetailProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/context/SimulationDetailProvider.jsx
@@ -58,11 +58,15 @@ export const SimulationDetailProvider = ({ simulationId, children }) => {
   }, []);
 
   const refreshGrid = useCallback(() => {
+
+    queryClient.invalidateQueries({
+      queryKey: ["simulation-executions-grid", simulationId],
+    });
     queryClient.invalidateQueries({
       queryKey: ["simulation-executions", simulationId],
     });
     if (gridApiRef.current) {
-      gridApiRef.current.refreshServerSide();
+      gridApiRef?.current?.refreshServerSide();
     }
   }, [queryClient, simulationId]);
 


### PR DESCRIPTION
## Summary

Three independent frontend bug fixes, one commit each:

1. **Model logo missing in experiment setup** — GPT models (e.g. `gpt-4o-mini`) showed no logo.
2. **Prompt simulation: 2nd run visible only after refresh** — a newly started execution didn't appear in the grid until a manual reload; also the execute API was failing on a missing payload; and creating a simulation didn't auto-start the first run.
3. **Dataset eval detail not refreshed on row navigation** — after opening an eval and using the up/down (next/prev) buttons, the eval panel kept showing the first datapoint's data.

## Why / problem

All three trace back to the same class of issue introduced by the snake_case payload migration (the axios snake→camel response interceptor was removed): a few call sites still read camelCase keys, and one server-side grid refresh targeted the wrong query key.

- **Logo:** the model render read only `selectedModel.logoUrl`; payloads now provide `logo_url`, so the value was `undefined`.
- **Simulation:**
  - The execute endpoint was called with no request body (`undefined`), which the API rejects.
  - After starting a run, `refreshGrid` invalidated `["simulation-executions", …]`, but the AG Grid server-side datasource caches its pages under `["simulation-executions-grid", …]` via `queryClient.fetchQuery`. With the global 5s `staleTime`, `refreshServerSide()` re-ran `getRows` but got a still-fresh cached page, so the new run was hidden until a hard refresh.
  - Creating a simulation did not kick off the first execution.
- **Eval navigation:** the grid column object exposes the eval identifier as `source_id` (snake) but does **not** add a `sourceId` (camel) alias. The datapoint drawer read `col.sourceId`, so `evalMetricId` was `undefined` and the navigation lookup `col.sourceId === evalMetricId` resolved to `undefined === undefined`, matching the **first/wrong** column and merging the wrong cell into the open eval panel.

## What changed

**Commit 1 — `fix(experiment): fall back to snake_case logo_url for model logo`**
- `NewModelRenderWithParamsTool.jsx`: `src={selectedModel?.logoUrl ?? selectedModel?.logo_url}`.

**Commit 2 — `fix(simulation): auto-run on create, send execute payload, refresh grid`**
- `CreateSimulationModal.jsx`: after create succeeds, POST `execute` (with `{}` body) for the new simulation, then navigate; added a `Starting…` button state.
- `SimulationDetailHeader.jsx`, `EmptyExecutionsState.jsx`, `TestRunHeader.jsx`: send `{}` as the execute payload.
- `SimulationDetailProvider.jsx`: `refreshGrid` now invalidates the grid's own key `["simulation-executions-grid", simulationId]` (and the context key) before refreshing the server-side grid.

**Commit 3 — `fix(dataset-eval): sync eval detail with datapoint on next/prev navigation`**
- `DatapointDrawerV2.jsx`: use `source_id` for the `evalMetricId` assignment and all navigation/feedback lookups; set `eval_name` on open so the panel header shows the correct eval name.

## Tests

Manual test-case tables per commit (video repros attached in the linked Linear tickets):

### Commit 1 — Logo (TH-6972)
| # | Steps | Expected |
|---|-------|----------|
| 1 | Set up an experiment, add a GPT model (e.g. `gpt-4o-mini`) | Model logo renders next to the name |
| 2 | Add a non-GPT model whose payload uses `logoUrl` | Logo still renders (camel fallback preserved) |
| 3 | Model with no logo at all | No broken image; graceful empty |

### Commit 2 — Simulation (TH-6990)
| # | Steps | Expected |
|---|-------|----------|
| 1 | Create a chat simulation from the modal | Simulation is created **and** the first execution starts; detail view opens with a run in progress |
| 2 | In an already-loaded detail view, click **Run** | The new execution row appears at the top without a manual refresh |
| 3 | Start a 2nd run within ~5s of the previous fetch | New run still appears (previously hidden by the 5s stale cache) |
| 4 | Trigger execute where the backend would reject a missing body | Request now sends `{}` and succeeds |
| 5 | Backend rejects execute after create | Simulation still created; warning toast; detail view opens on the empty/run state |

### Commit 3 — Eval navigation (TH-6930)
| # | Steps | Expected |
|---|-------|----------|
| 1 | Open a datapoint via an eval cell → eval panel opens | Panel shows that eval's score + explanation |
| 2 | Use up/down (K/J) to navigate rows | Eval panel updates to the **current** datapoint's eval data |
| 3 | Navigate past the loaded page boundary (triggers fetch) | Eval panel still tracks the datapoint |
| 4 | Open the drawer from a non-eval (input) cell | Eval panel stays closed (no default eval) |
| 5 | Click another eval's **View Detail** | Panel switches to that eval; navigation keeps syncing it |

## Commands

- [ ] `yarn lint` (all four touched files lint clean)

## Backwards compatibility

No API contract changes. The logo and eval changes read snake_case with camel fallback where relevant; the execute `{}` body is accepted by the existing endpoint.

## Manual verification

Verified against the repro videos in the three Linear tickets. See the per-commit tables above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code lints clean (eslint)
- [x] Self-reviewed the diff
- [x] One focused commit per issue

## Backout

Revert any of the three commits independently — they touch disjoint files and are not interdependent.

## Linear

Closes TH-6972
Closes TH-6990
Closes TH-6930
