### PR TITLE
refactor(dataset-optimization): pass scoring fields into shell EvalTemplate paths and repair /stop/

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_optimization.py
+++ b/futureagi/model_hub/tests/test_dataset_optimization.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from rest_framework import status
 
@@ -538,3 +540,206 @@ def test_retrieve_table_row_shape_for_trial_without_baseline(
     assert metric_id in row["eval_scores"]
     assert row["eval_scores"][metric_id]["score"] == 0.75
     assert row["eval_scores"][metric_id]["percentage_change"] is None
+
+
+# ==================== Serializer: _prepare_dataset_execution_data ====================
+#
+# The dataset-optimization Temporal serializer feeds an execution_data dict
+# to the downstream shell EvalTemplate reconstructor. These tests drive the
+# serializer end to end with real DB rows and assert the five columnar keys
+# it must now emit for each eval template output type. Without these keys
+# the downstream shell's ``output_type_normalized`` is ``None`` and the
+# scorer falls back to ``percentage`` for every row.
+
+
+def _make_template(organization, workspace, name, output_type_normalized, choice_scores=None, pass_threshold=0.5):
+    return EvalTemplate.objects.create(
+        name=name,
+        organization=organization,
+        workspace=workspace,
+        criteria="Evaluate {{output}}",
+        model="gpt-4o-mini",
+        output_type_normalized=output_type_normalized,
+        choice_scores=choice_scores,
+        pass_threshold=pass_threshold,
+        config={
+            "output": "choices" if output_type_normalized != "pass_fail" else "Pass/Fail",
+            "required_keys": ["output"],
+            "eval_type_id": "AgentEvaluator",
+        },
+    )
+
+
+def _make_user_eval_metric(organization, workspace, dataset, template):
+    return UserEvalMetric.no_workspace_objects.create(
+        name=f"{template.name}_metric",
+        organization=organization,
+        workspace=workspace,
+        template=template,
+        dataset=dataset,
+        config={"mapping": {"output": "output"}, "config": {}},
+        model="gpt-4o-mini",
+    )
+
+
+@pytest.mark.django_db
+def test_serializer_emits_scoring_fields_for_pass_fail_template(
+    organization, workspace, dataset, output_column
+):
+    from tfc.temporal.dataset_optimization.activities import (
+        _prepare_dataset_execution_data,
+    )
+
+    template = _make_template(
+        organization, workspace, "esc_pass_fail_tpl", "pass_fail",
+        choice_scores=None, pass_threshold=0.7,
+    )
+    uem = _make_user_eval_metric(organization, workspace, dataset, template)
+
+    result = _prepare_dataset_execution_data(
+        output_column, dataset, [uem], initial_prompt="hello {{Prompt Output}}"
+    )
+    # No dataset rows so no call_executions, but eval_configs is populated
+    # only when at least one row exists; we check the emitted call_executions
+    # after adding a row below.
+
+    from model_hub.models.develop_dataset import Row, Cell
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=output_column, row=row, value="Passed")
+
+    result = _prepare_dataset_execution_data(
+        output_column, dataset, [uem], initial_prompt="hello {{Prompt Output}}"
+    )
+    assert len(result["call_executions"]) == 1
+    evals = result["call_executions"][0]["evaluations"]
+    assert len(evals) == 1
+    ev = evals[0]
+    assert ev["output_type_normalized"] == "pass_fail"
+    assert ev["choice_scores"] is None
+    assert ev["pass_threshold"] == 0.7
+    assert ev["eval_config_id"] == str(uem.id)
+    assert ev["eval_name"] == uem.name
+
+
+@pytest.mark.django_db
+def test_serializer_emits_scoring_fields_for_deterministic_with_choice_scores(
+    organization, workspace, dataset, output_column
+):
+    from tfc.temporal.dataset_optimization.activities import (
+        _prepare_dataset_execution_data,
+    )
+    from model_hub.models.develop_dataset import Row, Cell
+
+    template = _make_template(
+        organization, workspace, "det_choice_tpl", "deterministic",
+        choice_scores={"Good": 1.0, "Neutral": 0.5, "Bad": 0.0},
+    )
+    uem = _make_user_eval_metric(organization, workspace, dataset, template)
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=output_column, row=row, value="Good")
+
+    result = _prepare_dataset_execution_data(
+        output_column, dataset, [uem], initial_prompt="hello {{Prompt Output}}"
+    )
+    ev = result["call_executions"][0]["evaluations"][0]
+    assert ev["output_type_normalized"] == "deterministic"
+    assert ev["choice_scores"] == {"Good": 1.0, "Neutral": 0.5, "Bad": 0.0}
+
+
+@pytest.mark.django_db
+def test_serializer_emits_scoring_fields_for_percentage_no_choice_scores(
+    organization, workspace, dataset, output_column
+):
+    from tfc.temporal.dataset_optimization.activities import (
+        _prepare_dataset_execution_data,
+    )
+    from model_hub.models.develop_dataset import Row, Cell
+
+    template = _make_template(
+        organization, workspace, "pct_tpl", "percentage",
+    )
+    uem = _make_user_eval_metric(organization, workspace, dataset, template)
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=output_column, row=row, value="0.75")
+
+    result = _prepare_dataset_execution_data(
+        output_column, dataset, [uem], initial_prompt="hello {{Prompt Output}}"
+    )
+    ev = result["call_executions"][0]["evaluations"][0]
+    assert ev["output_type_normalized"] == "percentage"
+    assert ev["choice_scores"] is None
+
+
+@pytest.mark.django_db
+def test_serializer_preserves_pre_existing_keys(
+    organization, workspace, dataset, output_column
+):
+    from tfc.temporal.dataset_optimization.activities import (
+        _prepare_dataset_execution_data,
+    )
+    from model_hub.models.develop_dataset import Row, Cell
+
+    template = _make_template(
+        organization, workspace, "pre_existing_keys_tpl", "deterministic",
+    )
+    uem = _make_user_eval_metric(organization, workspace, dataset, template)
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=output_column, row=row, value="X")
+
+    result = _prepare_dataset_execution_data(
+        output_column, dataset, [uem], initial_prompt="hello {{Prompt Output}}"
+    )
+    ev = result["call_executions"][0]["evaluations"][0]
+    for key in (
+        "eval_template_id",
+        "eval_template_name",
+        "description",
+        "criteria",
+        "template_config",
+        "config",
+        "mapping",
+        "model",
+        "eval_type_id",
+        "output_type",
+        "required_keys",
+    ):
+        assert key in ev, f"pre-existing key {key!r} dropped"
+
+
+# ==================== /stop/ endpoint: select_for_update(of=("self",)) ====================
+#
+# Regression: before scoping the lock to the target table, the queryset
+# raised ``FOR UPDATE cannot be applied to the nullable side of an outer
+# join`` because ``get_queryset`` on the viewset joins across a nullable
+# workspace FK. These tests drive the endpoint end to end and assert that
+# a run in ``running`` status transitions to ``cancelled`` on POST /stop/.
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stop_endpoint_transitions_running_run_via_scoped_lock(
+    auth_client, output_column, user_eval_metric
+):
+    """Regression: before ``select_for_update(of=("self",))`` this endpoint
+    raised ``FOR UPDATE cannot be applied to the nullable side of an outer
+    join`` (Postgres) and returned 400 with a generic error. The workspace
+    fixture used here is the default one, which exercises the outer-join
+    branch of ``_request_workspace_filter``. Scoping the lock to the target
+    table lets the same request return 200 and transition the run to
+    ``cancelled``.
+    """
+    run = create_optimization_run(
+        output_column,
+        status=OptimizeDataset.StatusType.RUNNING,
+    )
+    run.user_eval_template_ids.add(user_eval_metric)
+
+    with patch(
+        "model_hub.views.dataset_optimization.cancel_dataset_optimization",
+        return_value=True,
+    ):
+        response = auth_client.post(f"/model-hub/dataset-optimization/{run.id}/stop/")
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["result"]["success"] is True
+    run.refresh_from_db()
+    assert run.status == OptimizeDataset.StatusType.CANCELLED

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -367,6 +367,76 @@ class TestAddUserEvalView:
             deleted=False,
         ).exists()
 
+    @pytest.mark.parametrize(
+        "output_type_normalized, choice_scores, pass_threshold",
+        [
+            ("pass_fail", None, 0.7),
+            ("deterministic", {"Good": 1.0, "Neutral": 0.5, "Bad": 0.0}, 0.5),
+            ("percentage", {"Good": 1.0, "Average": 0.7, "Bad": 0.0}, 0.5),
+            ("percentage", None, 0.5),
+            ("deterministic", None, 0.5),
+        ],
+        ids=[
+            "pass_fail",
+            "deterministic_with_choice_scores",
+            "percentage_with_choice_scores",
+            "percentage_no_choice_scores",
+            "deterministic_no_choice_scores",
+        ],
+    )
+    def test_add_user_eval_save_as_template_preserves_scoring_fields(
+        self,
+        auth_client,
+        dataset,
+        output_column,
+        valid_eval_config,
+        organization,
+        workspace,
+        output_type_normalized,
+        choice_scores,
+        pass_threshold,
+    ):
+        """The ``save_as_template=True`` branch clones the source template
+        into a new DB row. All three columnar scoring fields must propagate
+        so the clone can be scored via the same code path as the source.
+        """
+        cs_tag = "with-cs" if choice_scores else "no-cs"
+        source = EvalTemplate.objects.create(
+            name=f"src-{output_type_normalized}-{cs_tag}",
+            organization=organization,
+            workspace=workspace,
+            criteria="Evaluate {{output}}",
+            model="gpt-4o-mini",
+            output_type_normalized=output_type_normalized,
+            choice_scores=choice_scores,
+            pass_threshold=pass_threshold,
+            config={
+                "output": "Pass/Fail" if output_type_normalized == "pass_fail" else "choices",
+                "required_keys": ["output"],
+                "eval_type_id": "AgentEvaluator",
+            },
+        )
+        clone_name = f"clone-{output_type_normalized}-{cs_tag}"
+        payload = {
+            "name": clone_name,
+            "template_id": str(source.id),
+            "config": valid_eval_config,
+            "save_as_template": True,
+            "run": False,
+        }
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/add_user_eval/",
+            payload,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        clone = EvalTemplate.objects.get(name=clone_name, organization=organization)
+        assert clone.output_type_normalized == output_type_normalized
+        assert clone.choice_scores == choice_scores
+        assert clone.pass_threshold == pass_threshold
+
 
 # ==================== StartEvalsProcess Tests ====================
 

--- a/futureagi/model_hub/views/dataset_optimization.py
+++ b/futureagi/model_hub/views/dataset_optimization.py
@@ -303,7 +303,7 @@ class DatasetOptimizationViewSet(BaseModelViewSetMixin, ModelViewSet):
             # holding a DB connection and row lock during the external network call.
             with transaction.atomic():
                 instance = self.get_object()
-                instance = OptimizeDataset.objects.select_for_update().get(
+                instance = OptimizeDataset.objects.select_for_update(of=("self",)).get(
                     pk=instance.pk,
                     deleted=False,
                 )

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7972,6 +7972,9 @@ class EditAndRunUserEvalView(APIView):
                         choices=template.choices,
                         multi_choice=template.multi_choice,
                         error_localizer_enabled=template.error_localizer_enabled,
+                        output_type_normalized=template.output_type_normalized,
+                        choice_scores=template.choice_scores,
+                        pass_threshold=template.pass_threshold,
                     )
                     new_config = template.config
                     runtime_config = normalize_eval_runtime_config(
@@ -8308,6 +8311,9 @@ class AddUserEvalView(CreateAPIView):
                         choices=template.choices,
                         multi_choice=template.multi_choice,
                         error_localizer_enabled=template.error_localizer_enabled,
+                        output_type_normalized=template.output_type_normalized,
+                        choice_scores=template.choice_scores,
+                        pass_threshold=template.pass_threshold,
                     )
                     new_config = template.config
                     runtime_config = normalize_eval_runtime_config(
@@ -14305,6 +14311,9 @@ class AddCompareExperimentEvalView(APIView):
                     criteria=template.criteria,
                     choices=template.choices,
                     multi_choice=template.multi_choice,
+                    output_type_normalized=template.output_type_normalized,
+                    choice_scores=template.choice_scores,
+                    pass_threshold=template.pass_threshold,
                 )
                 new_config = template.config
                 try:

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -3396,6 +3396,9 @@ class AddExperimentEvalView(APIView):
                     multi_choice=template.multi_choice,
                     organization=organization,
                     owner=OwnerChoices.USER.value,
+                    output_type_normalized=template.output_type_normalized,
+                    choice_scores=template.choice_scores,
+                    pass_threshold=template.pass_threshold,
                 )
                 new_config = template.config
                 runtime_config = normalize_eval_runtime_config(

--- a/futureagi/tfc/temporal/dataset_optimization/activities.py
+++ b/futureagi/tfc/temporal/dataset_optimization/activities.py
@@ -661,6 +661,11 @@ def _prepare_dataset_execution_data(column, dataset, user_eval_metrics, initial_
                 "eval_type_id": template_config.get("eval_type_id"),
                 "output_type": template_config.get("output"),
                 "required_keys": template_config.get("required_keys"),
+                "output_type_normalized": eval_template.output_type_normalized,
+                "choice_scores": eval_template.choice_scores,
+                "pass_threshold": eval_template.pass_threshold,
+                "eval_config_id": str(user_eval_metric.id),
+                "eval_name": user_eval_metric.name or eval_template.name,
             }
         )
 


### PR DESCRIPTION
## 1. Why the changes are made

Two independent surfaces were dropping the columnar scoring fields on an `EvalTemplate`, and one endpoint was locked behind a Postgres error.

Dataset-optimization serializer. `_prepare_dataset_execution_data` in `tfc/temporal/dataset_optimization/activities.py` builds an eval-config dict that is later hydrated into an unsaved `EvalTemplate` shell by the downstream consumer. The serializer was emitting only a subset of the DB row, so the shell carried `output_type_normalized = None`, `choice_scores = None`, `pass_threshold = None` even when the source row was populated. Downstream `score_eval_output` reads `output_type_normalized`; when it is `None` the call falls back to `"percentage"`. Under that fallback, a template whose LLM output is a plain label (e.g. `"Passed"` from a `pass_fail` template, `"excellent"` or `['neutral']` from a `deterministic` template) is not numerically scorable and every row returns `default_score`. Templates whose raw output was already numeric or a dict carrying a `score` key kept scoring correctly under the same fallback, so this manifested as a per-template regression rather than a global one.

Clone endpoints. Three clone endpoints in `model_hub/views/develop_dataset.py` and one in `model_hub/views/experiments.py` create a new `EvalTemplate` row by copying an existing template. The same three columnar fields were absent from the copy, so cloning a `pass_fail` or `deterministic` template silently produced a clone that could no longer be scored via `score_eval_output`.

Stop endpoint. `POST /model-hub/dataset-optimization/{id}/stop/` returned 400 with `FOR UPDATE cannot be applied to the nullable side of an outer join`. The `select_for_update()` call in the view was locking across an implicit outer join through a nullable FK; Postgres rejects the lock in that shape.

## 2. What changes have been made

### Backend

| File | Change |
| --- | --- |
| `tfc/temporal/dataset_optimization/activities.py:669` | Serializer emits five additional keys per eval_config: `output_type_normalized`, `choice_scores`, `pass_threshold`, `eval_config_id`, `eval_name`. Pre-existing keys (`eval_template_id`, `eval_template_name`, `description`, `criteria`, `template_config`, `config`, `mapping`, `model`, `eval_type_id`, `output_type`, `required_keys`) are preserved verbatim. |
| `model_hub/views/dataset_optimization.py:306` | `.select_for_update()` scoped to the target table via `of=("self",)` so the lock does not span the outer join. Transaction boundary, atomic block and downstream `mark_as_cancelled()` call are unchanged. |
| `model_hub/views/develop_dataset.py:7975` | `EditAndRunUserEvalView` clone: propagate `output_type_normalized`, `choice_scores`, `pass_threshold` from source template. Existing copied fields (`choices`, `multi_choice`, `error_localizer_enabled`, etc.) unchanged. |
| `model_hub/views/develop_dataset.py:8314` | `AddUserEvalView` clone: same three fields propagated; other copied fields unchanged. |
| `model_hub/views/develop_dataset.py:14314` | `AddCompareExperimentEvalView` clone: same three fields propagated; other copied fields unchanged. |
| `model_hub/views/experiments.py:3399` | `AddExperimentEvalView` clone: same three fields propagated; other copied fields unchanged. |

## 3. What all tests are being written

Ten tests added across two existing test files, plus a live docker run for end-to-end confirmation.

| File | New tests |
| --- | --- |
| `model_hub/tests/test_dataset_optimization.py` | 4 serializer tests + 1 `/stop/` endpoint test |
| `model_hub/tests/test_evaluation_api.py` | 5 parametrized clone-endpoint tests inside the existing `TestAddUserEvalView` class |

## 4. What all test scenarios does each test cover

| Test | Scenario |
| --- | --- |
| `test_serializer_emits_scoring_fields_for_pass_fail_template` | Serializer keeps `output_type_normalized="pass_fail"`, `pass_threshold=0.7`, `choice_scores=None` on the emitted eval_config dict when the source template is `pass_fail`. |
| `test_serializer_emits_scoring_fields_for_deterministic_with_choice_scores` | Serializer keeps `output_type_normalized="deterministic"` and the full `choice_scores` label map on the emitted dict. |
| `test_serializer_emits_scoring_fields_for_percentage_no_choice_scores` | Serializer keeps `output_type_normalized="percentage"` and `choice_scores=None` on the emitted dict for a numeric-only template. |
| `test_serializer_preserves_pre_existing_keys` | The 11 pre-existing eval_config dict keys are not renamed or dropped by the additive change. |
| `test_stop_endpoint_transitions_running_run_via_scoped_lock` | `POST /model-hub/dataset-optimization/{id}/stop/` on a RUNNING run returns 200 and transitions the run to CANCELLED via `mark_as_cancelled()`; before the PR the same request returned 400 with `FOR UPDATE cannot be applied to the nullable side of an outer join`. |
| `test_add_user_eval_save_as_template_preserves_scoring_fields[pass_fail]` | Cloning a `pass_fail` template via `save_as_template=True` preserves `output_type_normalized="pass_fail"`, `pass_threshold=0.7`, `choice_scores=None` on the new DB row. |
| `test_add_user_eval_save_as_template_preserves_scoring_fields[deterministic_with_choice_scores]` | Cloning a `deterministic` template with a populated `choice_scores` map preserves the map verbatim on the clone. |
| `test_add_user_eval_save_as_template_preserves_scoring_fields[percentage_with_choice_scores]` | Cloning a `percentage` template with a populated `choice_scores` map preserves both `output_type_normalized="percentage"` and the map on the clone. |
| `test_add_user_eval_save_as_template_preserves_scoring_fields[percentage_no_choice_scores]` | Cloning a `percentage` template with `choice_scores=None` preserves both on the clone. |
| `test_add_user_eval_save_as_template_preserves_scoring_fields[deterministic_no_choice_scores]` | Cloning a `deterministic` template with `choice_scores=None` preserves both on the clone (documents the template-config gap that keeps `tone` / `politeness_level` at 0.5 downstream, which is intentional and not addressed by this PR). |

## 5. Commands to run these tests

```
docker exec futureagi-test-test-db-1 sh -c 'exit 0'  # confirm bin/test up services are running
DJANGO_SETTINGS_MODULE=tfc.settings.test .venv/bin/pytest \
  model_hub/tests/test_dataset_optimization.py \
  model_hub/tests/test_evaluation_api.py::TestAddUserEvalView::test_add_user_eval_save_as_template_preserves_scoring_fields \
  -v --no-header
```

Actual output (all 10 new tests + pre-existing test_dataset_optimization tests):

```
model_hub/tests/test_dataset_optimization.py::test_serializer_emits_scoring_fields_for_pass_fail_template PASSED
model_hub/tests/test_dataset_optimization.py::test_serializer_emits_scoring_fields_for_deterministic_with_choice_scores PASSED
model_hub/tests/test_dataset_optimization.py::test_serializer_emits_scoring_fields_for_percentage_no_choice_scores PASSED
model_hub/tests/test_dataset_optimization.py::test_serializer_preserves_pre_existing_keys PASSED
model_hub/tests/test_dataset_optimization.py::test_stop_endpoint_transitions_running_run_via_scoped_lock PASSED
model_hub/tests/test_evaluation_api.py::...[pass_fail] PASSED
model_hub/tests/test_evaluation_api.py::...[deterministic_with_choice_scores] PASSED
model_hub/tests/test_evaluation_api.py::...[percentage_with_choice_scores] PASSED
model_hub/tests/test_evaluation_api.py::...[percentage_no_choice_scores] PASSED
model_hub/tests/test_evaluation_api.py::...[deterministic_no_choice_scores] PASSED
```

## 6. Steps to test the specific pr changes on local/dev

Prerequisites: boot the local docker stack, confirm `postgres`, `temporal`, `temporal-worker-dev`, `backend` are all `Up`.

Step 1. Attach seven templates covering all three normalized output types to the develop dataset in your workspace: `customer_agent_single_choice`, `customer_agent_multi_choices`, `customer_agent_score_with_choices`, `customer_agent_human_escalation`, `customer_agent_context_retention`, `tone`, `politeness_level`.

Step 2. Confirm the DB carries scoring config for each. Rows where `output_type_normalized IS NULL` OR (`output_type_normalized = 'deterministic'` AND `choice_scores IS NULL`) will not score under `score_eval_output` on any code path; those are template-config gaps and out of scope for this PR.

```
docker exec postgres psql -U user -d tfc -c \
  "SELECT name, output_type_normalized, choice_scores IS NOT NULL AS has_choice_scores
   FROM model_hub_evaltemplate
   WHERE name IN ('customer_agent_single_choice','customer_agent_multi_choices','customer_agent_score_with_choices','customer_agent_human_escalation','customer_agent_context_retention','tone','politeness_level')
   ORDER BY name;"
```

Actual output on the reference workspace:

```
               name                | output_type_normalized | has_choice_scores
-----------------------------------+------------------------+-------------------
 customer_agent_context_retention  | percentage             | f
 customer_agent_human_escalation   | pass_fail              | f
 customer_agent_multi_choices      | deterministic          | t
 customer_agent_score_with_choices | percentage             | t
 customer_agent_single_choice      | deterministic          | t
 politeness_level                  | deterministic          | f
 tone                              | deterministic          | f
(7 rows)
```

Step 3. Trigger a GEPA optimization from the FE against the develop dataset column. Capture the `run_id` from the URL.

Step 4. Tail the temporal worker while the run progresses.

```
docker logs temporal-worker-dev --follow
```

Step 5. Wait for the baseline trial to complete, then confirm the per-eval score distribution matches the raw LLM output for each template.

```
docker exec postgres psql -U user -d tfc -c \
  "SELECT em.name AS eval_name, ie.score
   FROM dataset_optimization_item_evaluation ie
   JOIN model_hub_userevalmetric em ON ie.eval_metric_id = em.id
   JOIN dataset_optimization_trial_item ti ON ie.trial_item_id = ti.id
   JOIN dataset_optimization_trial t ON ti.trial_id = t.id
   WHERE t.optimization_run_id = '<run_id>' AND t.is_baseline = TRUE
   ORDER BY em.name, ti.row_id;"
```

Actual output for `run_id = 33c5cbf1-bd19-4256-98da-a8873af391f3` (five inputs per template, seven templates, 35 rows total):

```
                     eval_name                      | score
----------------------------------------------------+-------
 customer_agent_cont_optimization_16_jul_2026_13_58 |     1
 customer_agent_cont_optimization_16_jul_2026_13_58 |     1
 customer_agent_cont_optimization_16_jul_2026_13_58 |     0
 customer_agent_cont_optimization_16_jul_2026_13_58 |     1
 customer_agent_cont_optimization_16_jul_2026_13_58 |     1
 customer_agent_huma_optimization_16_jul_2026_13_57 |     1
 customer_agent_huma_optimization_16_jul_2026_13_57 |     1
 customer_agent_huma_optimization_16_jul_2026_13_57 |     1
 customer_agent_huma_optimization_16_jul_2026_13_57 |     1
 customer_agent_huma_optimization_16_jul_2026_13_57 |     1
 customer_agent_mult_optimization_16_jul_2026_13_56 | 0.875
 customer_agent_mult_optimization_16_jul_2026_13_56 | 0.875
 customer_agent_mult_optimization_16_jul_2026_13_56 | 0.875
 customer_agent_mult_optimization_16_jul_2026_13_56 | 0.875
 customer_agent_mult_optimization_16_jul_2026_13_56 | 0.875
 customer_agent_scor_optimization_16_jul_2026_13_57 |     1
 customer_agent_scor_optimization_16_jul_2026_13_57 |     1
 customer_agent_scor_optimization_16_jul_2026_13_57 |     1
 customer_agent_scor_optimization_16_jul_2026_13_57 |     0
 customer_agent_scor_optimization_16_jul_2026_13_57 |     0
 customer_agent_sing_optimization_16_jul_2026_13_56 |     1
 customer_agent_sing_optimization_16_jul_2026_13_56 |     1
 customer_agent_sing_optimization_16_jul_2026_13_56 |     1
 customer_agent_sing_optimization_16_jul_2026_13_56 |     1
 customer_agent_sing_optimization_16_jul_2026_13_56 |     0
 politeness_level_optimization_16_jul_2026_13_58    |   0.5
 politeness_level_optimization_16_jul_2026_13_58    |   0.5
 politeness_level_optimization_16_jul_2026_13_58    |   0.5
 politeness_level_optimization_16_jul_2026_13_58    |   0.5
 politeness_level_optimization_16_jul_2026_13_58    |   0.5
 tone_optimization_16_jul_2026_13_57                |   0.5
 tone_optimization_16_jul_2026_13_57                |   0.5
 tone_optimization_16_jul_2026_13_57                |   0.5
 tone_optimization_16_jul_2026_13_57                |   0.5
 tone_optimization_16_jul_2026_13_57                |   0.5
(35 rows)
```

Notes on the distribution: `human_escalation` returns 1.0 for `"Passed"` outputs (routed through `pass_fail`, not the `percentage` fallback). `single_choice` and `multi_choices` return values drawn from their `choice_scores` map. `context_retention` and `score_with_choices` return the numeric score from the eval. `tone` and `politeness_level` remain at 0.5 because their DB rows have `choice_scores = NULL` under `output_type_normalized = 'deterministic'`; template config, not this PR.

Step 6. Confirm trial `average_score` matches the mean of the 35 per-item, per-eval scores above.

```
docker exec postgres psql -U user -d tfc -c \
  "SELECT trial_number, is_baseline, average_score
   FROM dataset_optimization_trial
   WHERE optimization_run_id = '<run_id>'
   ORDER BY trial_number;"
```

Actual output on the reference run:

```
 trial_number | is_baseline |   average_score
--------------+-------------+--------------------
            0 | t           |              0.725
            1 | f           | 0.7821428571428571
            2 | f           | 0.7345238095238095
            3 | f           | 0.5892857142857143
(4 rows)
```

Baseline check: sum of the 35 scores above equals 25.375; 25.375 / 35 = 0.725, matching the persisted `average_score` on the baseline trial. GEPA candidate trials 1-3 diverge from the baseline (0.7821, 0.7345, 0.5893).

Step 7. Exercise the stop endpoint. Before this PR, `POST /model-hub/dataset-optimization/{id}/stop/` returned 400 with `Error stopping dataset optimization: FOR UPDATE cannot be applied to the nullable side of an outer join` in the backend logs. Verified on `run_id = d8269caa-703b-409b-b30d-5b6fbf2ec242` before the fix.

## 7. Screenshots

Live GEPA run (baseline trial and three candidate trials, seven eval templates, five row inputs).

<img width="3326" height="2136" alt="image" src="https://github.com/user-attachments/assets/dc465ba2-8ddd-4792-b3fb-372fe8e5e25b" />

## 8. Why the specific architectural decisions

Snapshot on the wire versus DB fetch on the receiver. The consumer of this serialized dict could hydrate the shell by fetching the `EvalTemplate` row from Postgres by id. Snapshotting the columnar scoring fields into the serialized dict keeps the consumer's data flow unchanged, avoids a per-eval-per-row DB roundtrip inside the worker loop, and matches the pattern used for the other columnar fields already propagated (`model`, `criteria`, `required_keys`). If the consumer later switches to a DB fetch, the snapshotted fields degrade to no-ops rather than blockers.

`select_for_update(of=("self",))` versus dropping the lock. The lock guards against a concurrent stop double-cancelling the workflow. Scoping the lock to the target row preserves that guarantee without pulling the outer join into the lock, which Postgres rejects.

## Linear

Fix TH-6996
