### PR TITLE
[TH-6926] Strip UI-only filter keys on voice add-items flow

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -1104,9 +1104,9 @@ export function buildReadOnlyColumnDefs(columnConfig) {
   return columnConfig
     .filter((col) => col.is_visible !== false)
     .map((col) => {
-      const colDataType = col.data_type
-      const colIsFrozen = col.is_frozen
-      const colOriginType = col.origin_type
+      const colDataType = col.data_type;
+      const colIsFrozen = col.is_frozen;
+      const colOriginType = col.origin_type;
       const enrichedCol = {
         ...col,
         dataType: colDataType,
@@ -1930,7 +1930,9 @@ function TraceSelector({
             project_id: projectId,
             page_number: pageNumber,
             page_size: TRACE_ROWS_LIMIT,
-            filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
+            filters: JSON.stringify(
+              stripUiFilterKeys(filtersRef.current || []),
+            ),
           };
           if (versionId) {
             apiParams.project_version_id = versionId;
@@ -2374,7 +2376,7 @@ function TraceSelector({
                 excludedIds: new Set(),
                 projectId,
                 projectVersionId: versionId || undefined,
-                filters: validatedFilters,
+                filters: stripUiFilterKeys(validatedFilters || []),
               });
             }}
           />
@@ -2385,7 +2387,9 @@ function TraceSelector({
             cellHeight="Short"
             params={{
               project_id: projectId,
-              filters: JSON.stringify(validatedFilters || []),
+              filters: JSON.stringify(
+                stripUiFilterKeys(validatedFilters || []),
+              ),
             }}
             onSelectionChanged={(traceIds) => {
               onSetSelection(traceIds);
@@ -2578,7 +2582,9 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             project_id: projectId,
             page_number: pageNumber,
             page_size: SPAN_ROWS_LIMIT,
-            filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
+            filters: JSON.stringify(
+              stripUiFilterKeys(filtersRef.current || []),
+            ),
           };
           if (versionId) {
             apiParams.project_version_id = versionId;
@@ -3142,7 +3148,9 @@ function SessionSelector({ onSetSelection, onSelectAll }) {
                     direction: sort,
                   })),
                 ),
-                filters: JSON.stringify(stripUiFilterKeys(filtersRef.current || [])),
+                filters: JSON.stringify(
+                  stripUiFilterKeys(filtersRef.current || []),
+                ),
               },
             },
           );


### PR DESCRIPTION
**Ticket:** [TH-6926](https://linear.app/future-agi/issue/TH-6926/add-items-from-traces-with-filters-voice-list-voice-calls-400s-on-any) — Fixes [TH-6926](https://linear.app/future-agi/issue/TH-6926/add-items-from-traces-with-filters-voice-list-voice-calls-400s-on-any)

## What was the bug

In the annotation **Add items from traces** flow for **Voice calls**, applying any filter chip made the list call fail ("error fetching").

`GET /tracer/trace/list_voice_calls/` returned:

```
HTTP 400 validation_error
"filters: 0: Unknown filter item keys: _meta, id"
```

The FE attaches UI-only bookkeeping keys (`id` = React row id, `_meta.parentProperty`) to each filter object and sent them verbatim. The backend filter-item serializer is strict and rejects unknown keys. Same class as [TH-6267](https://linear.app/future-agi/issue/TH-6267/trace-list-filters-fe-must-strip-ui-only-keys-id-meta-before-calling), whose scope did not cover the voice `list_voice_calls` path.

## What changes have been done

* `frontend/src/sections/annotations/queues/items/add-items-dialog.jsx` — in the voice branch of `TraceSelector`, wrap `validatedFilters` in `stripUiFilterKeys(...)` at both filter-send sites:
  * the `CallLogsGrid` params → `GET /tracer/trace/list_voice_calls/`
  * the cross-page **Select all** → bulk `add-items` POST filter

## Why the changes

* `stripUiFilterKeys` drops the UI-only `id`/`_meta` keys before the request, matching the existing non-voice paths in the same dialog (Trace / Span / Session) and the LLM Tracing page's `toBackendFilters`. The voice branch was the only caller still sending them raw.

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Voice project → Add items → apply any filter chip | Grid loads (200), no 400 |
| 2 | Same request via API with `_meta`/`id` stripped | 200 (verified against api-us2) |
| 3 | Same request via API with `_meta`/`id` present | 400 `Unknown filter item keys: _meta, id` (pre-fix behavior) |
| 4 | Non-voice Trace / Span / Session add-items | Unchanged (already stripped) |

## How to reproduce (original bug)

1. Open a voice/simulator project's annotation queue → **Add items from traces**.
2. Add any filter chip (system / eval / custom).
3. Grid shows "error fetching"; network shows `GET list_voice_calls` → **400** `Unknown filter item keys: _meta, id`.

## Commands

```bash
# Before fix — filter carries UI-only keys → 400
# {"column_id":"name",...,"_meta":{"parentProperty":""},"id":"z0n8d9114"}
#   -> HTTP 400  "filters: 0: Unknown filter item keys: _meta, id"

# After fix — same filter, id/_meta stripped → 200
# {"column_id":"name","display_name":"Trace Name","filter_config":{...}}
#   -> HTTP 200  count=13
```

## Videos and screenshots

https://github.com/user-attachments/assets/bf29af3a-6c61-4924-8e0b-fbd2c557240e