### PR TITLE
fix(tasks): scope eval drawer preview to the task time window (TH-6635)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -127,6 +127,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     isEditMode,
     requiredColumnId,
     onFiltersChange,
+    sourceTimeWindow,
     filterForm: localFilterForm,
   } = useEvalPickerContext();
   const normalizedEvalData = useMemo(
@@ -200,8 +201,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     name: "filters",
   });
   const localApiFilters = useMemo(
-    () => buildApiFilterArray(localFormFilters),
-    [localFormFilters],
+    () =>
+      buildApiFilterArray(
+        localFormFilters,
+        sourceTimeWindow?.startDate,
+        sourceTimeWindow?.endDate,
+      ),
+    [localFormFilters, sourceTimeWindow?.startDate, sourceTimeWindow?.endDate],
   );
 
   const handleSourceReadyChange = useCallback((ready, mapping) => {

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "src/utils/test-utils";
+
+import EvalPickerProvider from "./context/EvalPickerProvider";
+import EvalPickerConfigFull from "./EvalPickerConfigFull";
+
+const { capturedProps } = vi.hoisted(() => ({
+  capturedProps: { tracing: null },
+}));
+
+vi.mock("src/sections/evals/components/TracingTestMode", () => {
+  const M = React.forwardRef((props, _ref) => {
+    capturedProps.tracing = props;
+    return <div data-testid="tracing-test-mode" />;
+  });
+  M.displayName = "TracingTestModeMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/DatasetTestMode", () => {
+  const M = React.forwardRef(() => <div />);
+  M.displayName = "DatasetTestModeMock";
+  return { default: M, JsonValueTree: () => <div /> };
+});
+
+vi.mock("src/sections/evals/components/SimulationTestMode", () => {
+  const M = React.forwardRef(() => <div />);
+  M.displayName = "SimulationTestModeMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/CreateSimulationPreviewMode", () => {
+  const M = React.forwardRef(() => <div />);
+  M.displayName = "CreateSimulationPreviewModeMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/TestPlayground", () => {
+  const M = React.forwardRef(() => <div />);
+  M.displayName = "TestPlaygroundMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/ModelSelector", () => ({
+  default: () => <div />,
+  FAGI_MODEL_VALUES: new Set(),
+}));
+
+vi.mock("src/sections/evals/components/InstructionEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/LLMPromptEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/CodeEvalEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/OutputTypeConfig", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/FewShotExamples", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/tasks/components/TaskFilterBar", () => ({
+  default: () => <div />,
+}));
+
+// Transitive import of the real TaskLivePreview (needed for the real
+// buildApiFilterArray); its module-scope localStorage read breaks under
+// the test environment.
+vi.mock("src/sections/evals/components/EvalResultDisplay", () => ({
+  default: () => <div />,
+}));
+
+// Hook mocks must return referentially stable values — a fresh object per
+// call re-triggers every downstream useMemo/useEffect and loops the render.
+const {
+  stableEvalDetail,
+  stableUpdateEval,
+  stableVersions,
+  stableCreateVersion,
+  stableCompositeDetail,
+  stableUnionKeys,
+} = vi.hoisted(() => ({
+  stableEvalDetail: {
+    data: {
+      id: "tpl-1",
+      name: "toxicity",
+      eval_type: "llm",
+      output_type: "pass_fail",
+      config: {},
+    },
+    isLoading: false,
+    isError: false,
+  },
+  stableUpdateEval: { mutate: () => {}, mutateAsync: async () => ({}) },
+  stableVersions: { data: { versions: [] } },
+  stableCreateVersion: { mutateAsync: async () => ({}) },
+  stableCompositeDetail: { data: null },
+  stableUnionKeys: [],
+}));
+
+vi.mock("src/sections/evals/hooks/useEvalDetail", () => ({
+  useEvalDetail: () => stableEvalDetail,
+  useUpdateEval: () => stableUpdateEval,
+}));
+
+vi.mock("src/sections/evals/hooks/useEvalVersions", () => ({
+  useEvalVersions: () => stableVersions,
+  useCreateEvalVersion: () => stableCreateVersion,
+}));
+
+vi.mock("src/sections/evals/hooks/useCompositeEval", () => ({
+  useCompositeDetail: () => stableCompositeDetail,
+}));
+
+vi.mock("src/sections/evals/hooks/useCompositeChildrenKeys", () => ({
+  useCompositeChildrenUnionKeys: () => stableUnionKeys,
+}));
+
+vi.mock("src/hooks/useDeploymentMode", () => ({
+  useDeploymentMode: () => ({ isOSS: false }),
+}));
+
+vi.mock("notistack", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    enqueueSnackbar: vi.fn(),
+    useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+  };
+});
+
+const TIME_WINDOW = {
+  startDate: "2025-05-18T13:37:41.000Z",
+  endDate: "2026-05-18T18:29:59.000Z",
+};
+
+const renderConfigFull = ({ sourceTimeWindow } = {}) =>
+  render(
+    <EvalPickerProvider
+      source="task"
+      sourceId="project-1"
+      sourceRowType="traces"
+      sourceColumns={[]}
+      existingEvals={[]}
+      onEvalAdded={() => {}}
+      onClose={() => {}}
+      sourceTimeWindow={sourceTimeWindow}
+    >
+      <EvalPickerConfigFull
+        evalData={{ id: "tpl-1", templateId: "tpl-1", name: "toxicity" }}
+        onBack={() => {}}
+        onSave={() => {}}
+        isSaving={false}
+      />
+    </EvalPickerProvider>,
+  );
+
+describe("EvalPickerConfigFull — task preview time window", () => {
+  beforeEach(() => {
+    capturedProps.tracing = null;
+  });
+
+  it("passes the task's time window to TracingTestMode as a created_at filter", () => {
+    renderConfigFull({ sourceTimeWindow: TIME_WINDOW });
+
+    expect(capturedProps.tracing).not.toBeNull();
+    const createdAt = (capturedProps.tracing.localFilters || []).find(
+      (f) => f.column_id === "created_at",
+    );
+    // Without this filter the backend defaults to a 30-day lookback and the
+    // drawer previews empty for tasks whose data is older than that.
+    expect(createdAt).toEqual({
+      column_id: "created_at",
+      filter_config: {
+        filter_type: "datetime",
+        filter_op: "between",
+        filter_value: [TIME_WINDOW.startDate, TIME_WINDOW.endDate],
+      },
+    });
+  });
+
+  it("omits the created_at filter when no time window is provided", () => {
+    renderConfigFull();
+
+    expect(capturedProps.tracing).not.toBeNull();
+    expect(
+      (capturedProps.tracing.localFilters || []).some(
+        (f) => f.column_id === "created_at",
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -122,6 +122,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     setSelectedEval,
     setStep,
     onFiltersChange,
+    sourceTimeWindow,
     filterForm: localFilterForm,
   } = useEvalPickerContext();
   const { enqueueSnackbar } = useSnackbar();
@@ -164,8 +165,13 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     name: "filters",
   });
   const localApiFilters = useMemo(
-    () => buildApiFilterArray(localFormFilters),
-    [localFormFilters],
+    () =>
+      buildApiFilterArray(
+        localFormFilters,
+        sourceTimeWindow?.startDate,
+        sourceTimeWindow?.endDate,
+      ),
+    [localFormFilters, sourceTimeWindow?.startDate, sourceTimeWindow?.endDate],
   );
 
   // Composite eval state (only used when evalType === "composite")

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
@@ -75,8 +75,20 @@ vi.mock("src/sections/tasks/components/TaskFilterBar", () => ({
   default: () => <div />,
 }));
 
-vi.mock("src/sections/tasks/components/TaskLivePreview", () => ({
-  buildApiFilterArray: () => [],
+// Real buildApiFilterArray so the task time-window test exercises the
+// actual created_at filter construction.
+vi.mock(
+  "src/sections/tasks/components/TaskLivePreview",
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return { buildApiFilterArray: actual.buildApiFilterArray };
+  },
+);
+
+// Transitive import of the real TaskLivePreview; its module-scope
+// localStorage read breaks under the test environment.
+vi.mock("src/sections/evals/components/EvalResultDisplay", () => ({
+  default: () => <div />,
 }));
 
 vi.mock("src/sections/evals/hooks/useCreateEval", () => ({
@@ -104,11 +116,15 @@ vi.mock("src/hooks/useDeploymentMode", () => ({
   useDeploymentMode: () => ({ isOSS: false }),
 }));
 
-vi.mock("notistack", () => ({
-  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
-}));
+vi.mock("notistack", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+  };
+});
 
-const renderWithSource = (source) =>
+const renderWithSource = (source, providerProps = {}) =>
   render(
     <EvalPickerProvider
       source={source}
@@ -117,6 +133,7 @@ const renderWithSource = (source) =>
       existingEvals={[]}
       onEvalAdded={() => {}}
       onClose={() => {}}
+      {...providerProps}
     >
       <EvalPickerCreateNew onBack={() => {}} onSave={() => {}} />
     </EvalPickerProvider>,
@@ -145,5 +162,30 @@ describe("EvalPickerCreateNew — onReadyChange wiring (TH-5013 regression)", ()
     renderWithSource("dataset");
     expect(capturedProps.dataset).not.toBeNull();
     expect(typeof capturedProps.dataset.onReadyChange).toBe("function");
+  });
+});
+
+describe("EvalPickerCreateNew — task preview time window", () => {
+  beforeEach(() => {
+    capturedProps.tracing = null;
+  });
+
+  it("passes the task's time window to TracingTestMode as a created_at filter", () => {
+    const timeWindow = {
+      startDate: "2025-05-18T13:37:41.000Z",
+      endDate: "2026-05-18T18:29:59.000Z",
+    };
+    renderWithSource("task", { sourceTimeWindow: timeWindow });
+
+    expect(capturedProps.tracing).not.toBeNull();
+    const createdAt = (capturedProps.tracing.localFilters || []).find(
+      (f) => f.column_id === "created_at",
+    );
+    // Without this filter the backend defaults to a 30-day lookback and the
+    // drawer previews empty for tasks whose data is older than that.
+    expect(createdAt?.filter_config?.filter_value).toEqual([
+      timeWindow.startDate,
+      timeWindow.endDate,
+    ]);
   });
 });

--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -282,6 +282,10 @@ const EvalPickerDrawer = ({
   keepOpenAfterSave = false,
   sourceFilters = null,
   onFiltersChange = null,
+  // { startDate, endDate } the source's preview rows are scoped to. Without
+  // an explicit created_at filter the backend defaults to a 30-day lookback,
+  // so previews for older data come back empty.
+  sourceTimeWindow = null,
 }) => {
   const [currentStep, setCurrentStep] = useState("list");
 
@@ -334,6 +338,7 @@ const EvalPickerDrawer = ({
         keepOpenAfterSave={keepOpenAfterSave}
         sourceFilters={sourceFilters}
         onFiltersChange={onFiltersChange}
+        sourceTimeWindow={sourceTimeWindow}
       >
         <EvalPickerContent onStepChange={setCurrentStep} />
       </EvalPickerProvider>
@@ -361,6 +366,10 @@ EvalPickerDrawer.propTypes = {
   keepOpenAfterSave: PropTypes.bool,
   sourceFilters: PropTypes.array,
   onFiltersChange: PropTypes.func,
+  sourceTimeWindow: PropTypes.shape({
+    startDate: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    endDate: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  }),
 };
 
 export default EvalPickerDrawer;

--- a/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
+++ b/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
@@ -39,6 +39,7 @@ const EvalPickerProvider = ({
   keepOpenAfterSave = false,
   sourceFilters = null,
   onFiltersChange = null,
+  sourceTimeWindow = null,
 }) => {
   const [step, setStep] = useState(initialEval ? "config" : "list");
   const [selectedEval, setSelectedEvalState] = useState(
@@ -99,6 +100,7 @@ const EvalPickerProvider = ({
         keepOpenAfterSave,
         sourceFilters,
         onFiltersChange,
+        sourceTimeWindow,
         filterForm,
       }}
     >
@@ -125,6 +127,10 @@ EvalPickerProvider.propTypes = {
   keepOpenAfterSave: PropTypes.bool,
   sourceFilters: PropTypes.array,
   onFiltersChange: PropTypes.func,
+  sourceTimeWindow: PropTypes.shape({
+    startDate: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    endDate: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  }),
 };
 
 export default EvalPickerProvider;

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -304,6 +304,8 @@ const TaskConfigPanel = ({
   const project = useWatch({ control, name: "project" });
   const rowType = useWatch({ control, name: "rowType" }) || "spans";
   const taskFilters = useWatch({ control, name: "filters" });
+  const startDate = useWatch({ control, name: "startDate" });
+  const endDate = useWatch({ control, name: "endDate" });
   const isProjectSelected = !!project;
   // row_type is immutable after task creation — the dispatcher, the
   // target_type on every EvalLogger row, and the dedup index are all
@@ -799,6 +801,7 @@ const TaskConfigPanel = ({
         onFiltersChange={(f) =>
           setValue("filters", f || [], { shouldDirty: true })
         }
+        sourceTimeWindow={{ startDate, endDate }}
       />
 
       <ModalWrapper


### PR DESCRIPTION
## Why

Editing or adding an evaluation on an existing task showed **"No trace data found — Add trace to this project before running a test"** in the Add/Edit Evaluation drawer, even though the task's main Live Preview showed matching rows (TH-6635, reported on pre-eval-revamp tasks on dev).

Root cause: the drawer's variable-mapping preview sent the task's filters **without** the task's `startDate`/`endDate`. With no `created_at` filter in the request, the backend's `parse_time_range` (`tracer/services/clickhouse/query_builders/base.py`) applies its default **now − 30 days** lookback. Any task whose matching data is older than 30 days previews empty, so variables can't be mapped. Proven by replaying the drawer's exact request against dev: without the date filter → `total_rows: 0`; with the task's window added → `total_rows: 40`.

This also means the drawer was never previewing the task's actual scope — even for recent data it sampled "last 30 days" rather than the configured window.

## What

Thread the task form's time window through to the drawer's preview query:

- `TaskConfigPanel.jsx` — watch `startDate`/`endDate` from the task form and pass `sourceTimeWindow` to `EvalPickerDrawer`.
- `EvalPickerDrawer.jsx` / `EvalPickerProvider.jsx` — new optional `sourceTimeWindow` prop, exposed via the eval-picker context.
- `EvalPickerConfigFull.jsx` (Add/Edit eval — the reported path) and `EvalPickerCreateNew.jsx` (Create New Eval) — pass the window into `buildApiFilterArray`, exactly as `TaskLivePreview` already does for the main preview.

Out of scope / unchanged: other drawer hosts (dataset, simulation, tracing, eval-detail Test Playground) pass no window and keep today's behavior; `buildApiFilterArray` already no-ops on absent dates. The window only scopes the preview request — it is not written into the task's saved filters.

## Tests

**New**
- `EvalPickerConfigFull.test.jsx` (new file, 2 tests)
  - *passes the task's time window to TracingTestMode as a created_at filter* — renders the config step with `sourceTimeWindow` in context and asserts `TracingTestMode` receives a `created_at between [start, end]` entry in `localFilters`. This is the exact regression: it *fails* with the fix reverted (verified).
  - *omits the created_at filter when no time window is provided* — guards the other drawer hosts: absent window ⇒ no date filter injected.
- `EvalPickerCreateNew.test.jsx` — added *passes the task's time window to TracingTestMode as a created_at filter* for the Create New Eval path; the file's `TaskLivePreview` mock now passes through the real `buildApiFilterArray` so the test exercises the actual filter construction rather than a stub.

**Existing**
- All 6 EvalPicker suites pass: 49 tests (includes the TH-5013 `onReadyChange` regression suite untouched by this change).
- Note: `TracingTestMode.test.jsx` fails locally **on clean dev** (module-scope `localStorage` read in a transitive import crashes under Node's stub localStorage; unrelated to this change, passes in CI).

## Commands

```bash
cd frontend
npx vitest run src/sections/common/EvalPicker/
npx eslint src/sections/common/EvalPicker/ src/sections/tasks/components/TaskConfigPanel.jsx
```

## How I tested locally

1. Opened a task create page (project with spans, 12-month window) on the local stack.
2. Opened **Add Evaluation** → picked an eval → config step.
3. Observed the drawer's row-list request now includes the task's window and returns rows:

Before (dev, task 2bd163f5, drawer request — no date filter):
```
GET /tracer/trace/list_traces_of_session/?...&filters=[{"column_id":"node_type",...}]
→ {"result":{"metadata":{"total_rows":0}}}
```
Same request with the task's window (what the drawer sends after this fix):
```
GET /tracer/trace/list_traces_of_session/?...&filters=[{"column_id":"node_type",...},{"column_id":"created_at","filter_config":{"filter_type":"datetime","filter_op":"between","filter_value":["2025-05-18T13:37:41.000Z","2026-05-18T18:29:59.000Z"]}}]
→ {"result":{"metadata":{"total_rows":40}}}
```
Local drawer request after the fix (matches the main Live Preview exactly):
```
GET /tracer/observation-span/list_spans_observe/?...&filters=[{"column_id":"created_at","filter_config":{"filter_type":"datetime","filter_op":"between","filter_value":["2025-07-15T07:23:35.000Z","2026-07-15T18:29:59.000Z"]}}]
→ 200, rows returned
```

Test run:
```
✓ src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx (2 tests) 476ms
✓ src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx (4 tests) 482ms
Test Files  6 passed (6)
     Tests  49 passed (49)
```
Lint: 0 errors (5 pre-existing warnings on untouched lines).

## Architectural rationale

The window rides the existing eval-picker context (`sourceFilters` → now also `sourceTimeWindow`) rather than being baked into `sourceFilters` itself: `sourceFilters` seeds the drawer's *editable* filter form and round-trips into the task's saved filters via `onFiltersChange`, so injecting a `created_at` row there would surface a phantom filter chip in the UI and persist it on save. Keeping it as a separate context value reuses `buildApiFilterArray`'s existing date handling (no new filter-construction path to drift from `TaskLivePreview`) and stays additive for every non-task drawer host.

Fixes TH-6635