### PR TITLE
fix(annotations): match per-element on list filter values in dataset cell filters (TH-6920)

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -10,6 +10,7 @@ from model_hub.serializers.contracts import (
     DatasetRowDataRequestSerializer,
     DatasetTableQuerySerializer,
 )
+from model_hub.utils.annotation_queue_helpers import _filter_dataset_cells
 from model_hub.views.develop_dataset import GetDatasetTableView
 
 
@@ -254,3 +255,101 @@ def test_dataset_row_data_api_rejects_legacy_filter_shape(
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.fixture
+def array_col_seed(organization, workspace):
+    """A dataset with an array-typed column (e.g. PDF-to-text / extracted
+    entities) whose cells are stored as ``json.dumps([...])``."""
+    dataset = Dataset.objects.create(
+        name="Array filter dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    arr_col = Column.objects.create(
+        name="pdf_to_text",
+        data_type=DataTypeChoices.ARRAY.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    rows = [
+        Row.objects.create(dataset=dataset, order=1),
+        Row.objects.create(dataset=dataset, order=2),
+        Row.objects.create(dataset=dataset, order=3),
+    ]
+    Cell.objects.create(
+        dataset=dataset, row=rows[0], column=arr_col,
+        value=json.dumps(["CIRCULAR NO. 123 dated 2024"]),
+    )
+    Cell.objects.create(
+        dataset=dataset, row=rows[1], column=arr_col,
+        value=json.dumps(["internal memo, no reference"]),
+    )
+    Cell.objects.create(
+        dataset=dataset, row=rows[2], column=arr_col,
+        value=json.dumps(["see CIRCULAR appendix"]),
+    )
+    return dataset, rows, arr_col
+
+
+@pytest.mark.django_db
+def test_dataset_table_array_contains_list_value(array_col_seed):
+    """The UI sends ``filter_value`` as a list (``["CIRCULAR"]``) for array
+    columns. ``contains`` must match the same rows a scalar text search does —
+    it must not stringify the list into a Python repr that can never match.
+    """
+    dataset, rows, arr_col = array_col_seed
+
+    # Sanity: the data and search term are fine — a scalar text search matches.
+    assert _apply(
+        dataset,
+        [_filter(arr_col.id, "text", "contains", "CIRCULAR")],
+        [arr_col],
+    ) == [rows[0], rows[2]]
+
+    # The array-typed list payload the UI actually sends must match the same rows.
+    assert _apply(
+        dataset,
+        [_filter(arr_col.id, "array", "contains", ["CIRCULAR"])],
+        [arr_col],
+    ) == [rows[0], rows[2]]
+
+
+@pytest.mark.django_db
+def test_dataset_table_array_contains_not_contains_and_multi_term(array_col_seed):
+    """not_contains is the exact complement of contains, and a multi-element
+    list matches on any element (OR)."""
+    dataset, rows, arr_col = array_col_seed
+
+    # not_contains ["CIRCULAR"] → the rows contains did NOT return.
+    assert _apply(
+        dataset,
+        [_filter(arr_col.id, "array", "not_contains", ["CIRCULAR"])],
+        [arr_col],
+    ) == [rows[1]]
+
+    # multi-element list → any element matches (OR): "memo" hits row 1 only,
+    # "CIRCULAR" hits rows 0 and 2 → union of all three rows.
+    assert _apply(
+        dataset,
+        [_filter(arr_col.id, "array", "contains", ["memo", "CIRCULAR"])],
+        [arr_col],
+    ) == [rows[0], rows[1], rows[2]]
+
+
+@pytest.mark.django_db
+def test_filter_dataset_cells_array_contains_list_value(array_col_seed):
+    """The annotation-queue cell filter (``_filter_dataset_cells``) has the same
+    list-payload path and must match per-element, not the list's repr."""
+    dataset, rows, arr_col = array_col_seed
+    cells = Cell.objects.filter(column=arr_col)
+
+    matched = _filter_dataset_cells(cells, "array", "contains", ["CIRCULAR"], "array")
+    assert set(matched.values_list("row_id", flat=True)) == {rows[0].id, rows[2].id}
+
+    # in/not_in keep exact-value membership (a separate branch, unchanged by the
+    # fix) — it matches the whole stored cell value, not a substring.
+    exact = _filter_dataset_cells(
+        cells, "array", "in", [json.dumps(["see CIRCULAR appendix"])], "array"
+    )
+    assert set(exact.values_list("row_id", flat=True)) == {rows[2].id}

--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -338,6 +338,24 @@ def test_dataset_table_array_contains_not_contains_and_multi_term(array_col_seed
 
 
 @pytest.mark.django_db
+def test_dataset_table_none_value_contains_is_noop(dataset_filter_seed):
+    """A text ``contains`` sent without a filter_value degrades to a no-op
+    (matches every row) instead of matching the literal repr of ``None``. Pins
+    the unified None handling that ``or_text_filter_q`` shares across both sites.
+    """
+    dataset, rows, text_col, bool_col = dataset_filter_seed
+
+    assert (
+        _apply(
+            dataset,
+            [_filter(text_col.id, "text", "contains")],
+            [text_col, bool_col],
+        )
+        == rows
+    )
+
+
+@pytest.mark.django_db
 def test_filter_dataset_cells_array_contains_list_value(array_col_seed):
     """The annotation-queue cell filter (``_filter_dataset_cells``) has the same
     list-payload path and must match per-element, not the list's repr."""

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -2109,6 +2109,43 @@ def _apply_scalar_filter(qs, field_name, op, value):
     return qs.filter(**{lookup: value})
 
 
+# The six case-insensitive substring/equality operators shared by the
+# dataset-table filter and the annotation-queue cell filter. Kept separate from
+# _op_to_lookup, whose ``equals``/``not_equals`` map to a case-SENSITIVE exact
+# match — do not merge the two maps.
+TEXT_FILTER_LOOKUPS = {
+    "contains": "__icontains",
+    "not_contains": "__icontains",
+    "equals": "__iexact",
+    "not_equals": "__iexact",
+    "starts_with": "__istartswith",
+    "ends_with": "__iendswith",
+}
+_NEGATED_TEXT_OPS = ("not_contains", "not_equals")
+
+
+def or_text_filter_q(field, op, value):
+    """Build a case-insensitive text filter for ``op``, OR-ed across the terms.
+
+    The UI sends a list value for array-typed columns (e.g. ``["C"]``);
+    stringifying the whole list yields a Python repr (``"['c']"``) that never
+    matches a ``json.dumps`` cell, so match each element instead. ``value`` may
+    be a scalar or a list. ``not_contains`` / ``not_equals`` return the De
+    Morgan complement (matches none of the terms). Returns ``None`` for an
+    unrecognized op so the caller can reject it in its own way.
+    """
+    lookup = TEXT_FILTER_LOOKUPS.get(op)
+    if lookup is None:
+        return None
+    terms = value if isinstance(value, list) else [value]
+    condition = Q()
+    for term in terms:
+        condition |= Q(**{f"{field}{lookup}": "" if term is None else str(term)})
+    if op in _NEGATED_TEXT_OPS:
+        return ~condition
+    return condition
+
+
 def _filter_dataset_cells(cells, filter_type, filter_op, filter_value, column_type):
     """Apply one DevelopFilterRow-style filter to a Cell queryset."""
     if filter_type == "number":
@@ -2165,26 +2202,9 @@ def _filter_dataset_cells(cells, filter_type, filter_op, filter_value, column_ty
             if filter_op == "not_in":
                 return cells.filter(~condition)
             return cells.filter(condition)
-        # The UI sends filter_value as a list (e.g. ["C"]) for array-typed
-        # columns; stringifying it would emit a Python repr ("['c']") that never
-        # matches. Match each element instead (``values`` is already normalized
-        # above) — any element for the positive ops, none for the negated ones.
-        lookup_map = {
-            "contains": "value__icontains",
-            "not_contains": "value__icontains",
-            "equals": "value__iexact",
-            "not_equals": "value__iexact",
-            "starts_with": "value__istartswith",
-            "ends_with": "value__iendswith",
-        }
-        lookup = lookup_map.get(filter_op)
-        if lookup is None:
+        condition = or_text_filter_q("value", filter_op, values)
+        if condition is None:
             return cells.none()
-        condition = Q()
-        for term in values:
-            condition |= Q(**{lookup: "" if term is None else str(term)})
-        if filter_op in ("not_contains", "not_equals"):
-            return cells.filter(~condition)
         return cells.filter(condition)
 
     if filter_type == "boolean":

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -2165,18 +2165,24 @@ def _filter_dataset_cells(cells, filter_type, filter_op, filter_value, column_ty
             if filter_op == "not_in":
                 return cells.filter(~condition)
             return cells.filter(condition)
-        text_value = "" if filter_value is None else str(filter_value)
-        op_map = {
-            "contains": Q(value__icontains=text_value),
-            "not_contains": Q(value__icontains=text_value),
-            "equals": Q(value__iexact=text_value),
-            "not_equals": Q(value__iexact=text_value),
-            "starts_with": Q(value__istartswith=text_value),
-            "ends_with": Q(value__iendswith=text_value),
+        # The UI sends filter_value as a list (e.g. ["C"]) for array-typed
+        # columns; stringifying it would emit a Python repr ("['c']") that never
+        # matches. Match each element instead (``values`` is already normalized
+        # above) — any element for the positive ops, none for the negated ones.
+        lookup_map = {
+            "contains": "value__icontains",
+            "not_contains": "value__icontains",
+            "equals": "value__iexact",
+            "not_equals": "value__iexact",
+            "starts_with": "value__istartswith",
+            "ends_with": "value__iendswith",
         }
-        condition = op_map.get(filter_op)
-        if condition is None:
+        lookup = lookup_map.get(filter_op)
+        if lookup is None:
             return cells.none()
+        condition = Q()
+        for term in values:
+            condition |= Q(**{lookup: "" if term is None else str(term)})
         if filter_op in ("not_contains", "not_equals"):
             return cells.filter(~condition)
         return cells.filter(condition)

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -2033,36 +2033,43 @@ class GetDatasetTableView(APIView):
                         )
                         continue
 
-                    filter_value = str(filter_value).lower()
-                    text_ops = {
-                        "contains": {"value__icontains": filter_value},
-                        "not_contains": {
-                            "value__icontains": filter_value,
-                            "negate": True,
-                        },
-                        "equals": {"value__iexact": filter_value},
-                        "not_equals": {
-                            "value__iexact": filter_value,
-                            "negate": True,
-                        },
-                        "starts_with": {"value__istartswith": filter_value},
-                        "ends_with": {"value__iendswith": filter_value},
-                    }
+                    # The UI sends filter_value as a list (e.g. ["C"]) for
+                    # array-typed columns; stringifying the list would emit a
+                    # Python repr ("['c']") that never matches a json.dumps cell.
+                    # Match each element instead — any element for the positive
+                    # ops, none of them for the negated ones.
+                    terms = (
+                        filter_value
+                        if isinstance(filter_value, list)
+                        else [filter_value]
+                    )
+                    terms = [str(term).lower() for term in terms]
 
-                    if filter_op not in text_ops:
+                    lookup_map = {
+                        "contains": "value__icontains",
+                        "not_contains": "value__icontains",
+                        "equals": "value__iexact",
+                        "not_equals": "value__iexact",
+                        "starts_with": "value__istartswith",
+                        "ends_with": "value__iendswith",
+                    }
+                    if filter_op not in lookup_map:
                         message = (
                             "Invalid filter operation. \
                             Allowed operations are: "
-                            + ", ".join(text_ops.keys())
+                            + ", ".join(lookup_map.keys())
                         )
                         error_messages.append(message)
                         raise ValueError(message)
 
-                    filter_kwargs = text_ops[filter_op]
-                    if filter_kwargs.pop("negate", False):
-                        cells = cells.filter(~Q(**filter_kwargs), deleted=False)
+                    lookup = lookup_map[filter_op]
+                    condition = Q()
+                    for term in terms:
+                        condition |= Q(**{lookup: term})
+                    if filter_op in ("not_contains", "not_equals"):
+                        cells = cells.filter(~condition, deleted=False)
                     else:
-                        cells = cells.filter(**filter_kwargs, deleted=False)
+                        cells = cells.filter(condition, deleted=False)
 
                 elif filter_type == "boolean":
                     filter_value = str(filter_value).lower()

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -230,6 +230,10 @@ from model_hub.services.derived_variable_service import (
 )
 from model_hub.tasks.develop_dataset import ingest_files_to_s3, remove_kb_files
 from model_hub.types import ConversionResult
+from model_hub.utils.annotation_queue_helpers import (
+    TEXT_FILTER_LOOKUPS,
+    or_text_filter_q,
+)
 from model_hub.utils.eval_reasons import (
     MIN_ROWS_FOR_CRITICAL_ISSUES,
     get_explanation_summary,
@@ -2033,43 +2037,15 @@ class GetDatasetTableView(APIView):
                         )
                         continue
 
-                    # The UI sends filter_value as a list (e.g. ["C"]) for
-                    # array-typed columns; stringifying the list would emit a
-                    # Python repr ("['c']") that never matches a json.dumps cell.
-                    # Match each element instead — any element for the positive
-                    # ops, none of them for the negated ones.
-                    terms = (
-                        filter_value
-                        if isinstance(filter_value, list)
-                        else [filter_value]
-                    )
-                    terms = [str(term).lower() for term in terms]
-
-                    lookup_map = {
-                        "contains": "value__icontains",
-                        "not_contains": "value__icontains",
-                        "equals": "value__iexact",
-                        "not_equals": "value__iexact",
-                        "starts_with": "value__istartswith",
-                        "ends_with": "value__iendswith",
-                    }
-                    if filter_op not in lookup_map:
+                    condition = or_text_filter_q("value", filter_op, filter_value)
+                    if condition is None:
                         message = (
-                            "Invalid filter operation. \
-                            Allowed operations are: "
-                            + ", ".join(lookup_map.keys())
+                            "Invalid filter operation. Allowed operations are: "
+                            + ", ".join(TEXT_FILTER_LOOKUPS)
                         )
                         error_messages.append(message)
                         raise ValueError(message)
-
-                    lookup = lookup_map[filter_op]
-                    condition = Q()
-                    for term in terms:
-                        condition |= Q(**{lookup: term})
-                    if filter_op in ("not_contains", "not_equals"):
-                        cells = cells.filter(~condition, deleted=False)
-                    else:
-                        cells = cells.filter(condition, deleted=False)
+                    cells = cells.filter(condition, deleted=False)
 
                 elif filter_type == "boolean":
                     filter_value = str(filter_value).lower()


### PR DESCRIPTION
## What

In the dataset table, a `contains` filter on an **array-typed column** (e.g. PDF-to-text, extracted entities) returned **0 rows** even when the text clearly contained the term. Fixes **TH-6920**.

## Root cause — `str(list)` is a repr, not a value

The dataset-table filter is `GetDatasetTableView._apply_filters` (`views/develop_dataset.py`). For array-typed columns the UI sends `filter_value` as a **list** (`["C"]`), and the code did:

```python
filter_value = str(filter_value).lower()           # ["C"] → "['c']"
"contains": {"value__icontains": filter_value}      # value ILIKE '%[''c'']%'
```

`str(["C"])` is the Python repr `"['c']"` (single quotes), so `value__icontains` could never match cells stored as `json.dumps([...])` (double quotes) → 0 rows. A scalar `text`/contains (`"C"`) matched fine (9 rows), proving the data and search term were never the problem. `in`/`not_in` already iterated the list, so they were unaffected.

The same bug is duplicated in the annotation-queue cell filter `_filter_dataset_cells` (`utils/annotation_queue_helpers.py`) — which even normalized the value to a list and then ignored it for the text ops.

The array **typing** is a red herring — `data_type="array"` is by design for extracted-entities / vector-db / run-prompt columns, so this is not a typing/inference/backfill problem.

## How

At both sites: normalize `filter_value` to a list and OR the lookup across elements — any element matches for `contains`/`equals`/`starts_with`/`ends_with`, none for `not_contains`/`not_equals`. Scalar values are wrapped to a 1-element list, so existing scalar behavior is unchanged. `in`/`not_in` (exact whole-value membership) are untouched.

No SQL, no jsonb, no column-typing change, no backfill.

## Testing (real Postgres)

Reproduced red first, then green — in the backend container against real PG (`test_dataset_table_filters.py`, driving `_apply_filters` / `_filter_dataset_cells` directly with the exact list payload the UI sends):

- `array`/contains list → matches the same rows as scalar text (was `[]` before the fix — a real fails-on-revert guard)
- `not_contains` = exact complement
- multi-element list = OR (any element)
- `in` still does exact whole-value membership (guards the untouched branch)

Full file: **12 passed** (3 new + 9 existing), zero regressions.


