### PR TITLE
fix(accounts): rate-limit failed login attempts only, not every auth-page request (TH-7023)

### DIFF
--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -42,6 +42,17 @@ MAX_LOGIN_ATTEMPTS_PER_HOUR: int = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOU
 IP_BLOCK_DURATION: int = getattr(settings, "IP_BLOCK_DURATION", 3600)
 RATE_LIMIT_WINDOW_SECONDS: int = 3600
 
+# Exact route suffixes gated by the per-IP login limiter. A bare
+# endswith("login/") also swept up pages that carry no credentials
+# (e.g. /saml2_auth/login/, which just returns a redirect URL), so
+# unrelated traffic consumed the shared per-IP budget (TH-7023).
+RATE_LIMITED_AUTH_PATH_SUFFIXES = (
+    "/accounts/login/",
+    "/accounts/token/",
+    "/accounts/signup/",
+    "/admin/login/",
+)
+
 ANNOTATION_QUEUE_ROLE_SCOPED_WRITE_PATHS = (
     re.compile(
         r"/model-hub/annotation-queues/[^/]+/items/" r"(?:assign|bulk-review)/?$"
@@ -716,11 +727,7 @@ class AuthMonitoringMiddleware:
                 f"rate_limit_requests_{client_ip}", requests, RATE_LIMIT_WINDOW_SECONDS
             )
 
-        if (
-            request.path.endswith("login/")
-            or request.path.endswith("token/")
-            or request.path.endswith("signup/")
-        ):
+        if request.path.endswith(RATE_LIMITED_AUTH_PATH_SUFFIXES):
             # Check if IP is blocked
             if cache.get(f"blocked_ip_{client_ip}"):
                 return self._json_forbidden(
@@ -746,10 +753,31 @@ class AuthMonitoringMiddleware:
                     blocked=True,
                 )
 
-            requests.append(now)
-            cache.set(f"ip_requests_{client_ip}", requests, RATE_LIMIT_WINDOW_SECONDS)
+            response = self.get_response(request)
+
+            # Only failed credential submissions consume the budget. Counting
+            # every request (page views, CORS preflights, successful logins)
+            # let one office NAT exhaust the shared per-IP budget within
+            # minutes and lock out everyone behind it (TH-7023).
+            if self._is_failed_attempt(request, response):
+                requests.append(now)
+                cache.set(
+                    f"ip_requests_{client_ip}", requests, RATE_LIMIT_WINDOW_SECONDS
+                )
+
+            return response
 
         return self.get_response(request)
+
+    @staticmethod
+    def _is_failed_attempt(request, response) -> bool:
+        if request.method != "POST":
+            return False
+        if request.path.endswith("/admin/login/"):
+            # Django admin re-renders the form with 200 on bad credentials;
+            # success is a 302 redirect.
+            return response.status_code == 200
+        return response.status_code >= 400
 
 
 def generate_encrypted_message(key_value_pairs: dict) -> str:

--- a/futureagi/accounts/tests/test_login_error_codes.py
+++ b/futureagi/accounts/tests/test_login_error_codes.py
@@ -480,6 +480,7 @@ class TestMiddlewareIpBlockedRouting:
     def test_ip_rate_limited_error_code(self):
         """When IP requests hit the threshold, middleware returns LOGIN_IP_RATE_LIMITED."""
         from django.conf import settings
+
         from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
@@ -501,6 +502,7 @@ class TestMiddlewareIpBlockedRouting:
     def test_ip_rate_limit_keeps_requests_for_full_hour(self):
         """Requests older than 1000s but inside the 1h window still count."""
         from django.conf import settings
+
         from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
@@ -517,13 +519,17 @@ class TestMiddlewareIpBlockedRouting:
         assert body["result"]["error_code"] == "LOGIN_IP_RATE_LIMITED"
 
     def test_ip_request_cache_ttl_matches_full_window(self):
-        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
+        from accounts.authentication import (
+            RATE_LIMIT_WINDOW_SECONDS,
+            AuthMonitoringMiddleware,
+        )
 
-        middleware = self._middleware()
+        # Failed attempts (4xx) are the ones that consume budget.
+        middleware = AuthMonitoringMiddleware(lambda r: HttpResponse("no", status=400))
         with patch("accounts.authentication.cache.set", wraps=cache.set) as cache_set:
             resp = middleware(self._request("/api/accounts/token/"))
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         cache_set.assert_any_call(
             f"ip_requests_{self.TEST_IP}",
             ANY,
@@ -536,6 +542,89 @@ class TestMiddlewareIpBlockedRouting:
         resp = middleware(self._request("/api/accounts/token/"))
         # Passes through to the dummy lambda which returns 200
         assert resp.status_code == 200
+
+
+@pytest.mark.unit
+class TestMiddlewareFailedAttemptCounting:
+    """Only failed credential submissions consume the per-IP budget (TH-7023).
+
+    Successful logins, page views, and CORS preflights must not count —
+    otherwise one office NAT exhausts the shared budget and locks out
+    everyone behind it, including first-time users.
+    """
+
+    TEST_IP = "10.10.10.98"
+
+    def _middleware(self, status_code=200):
+        from accounts.authentication import AuthMonitoringMiddleware
+
+        return AuthMonitoringMiddleware(
+            lambda r: HttpResponse("resp", status=status_code)
+        )
+
+    def _request(self, path: str, method: str = "post"):
+        factory = RequestFactory()
+        req = getattr(factory, method)(path, content_type="application/json")
+        req.META["REMOTE_ADDR"] = self.TEST_IP
+        return req
+
+    def _attempt_count(self):
+        return len(cache.get(f"ip_requests_{self.TEST_IP}", []))
+
+    def test_successful_login_not_counted(self):
+        self._middleware(status_code=200)(self._request("/accounts/token/"))
+        assert self._attempt_count() == 0
+
+    def test_failed_login_counted(self):
+        self._middleware(status_code=400)(self._request("/accounts/token/"))
+        assert self._attempt_count() == 1
+
+    def test_get_page_view_not_counted(self):
+        self._middleware(status_code=200)(self._request("/admin/login/", "get"))
+        assert self._attempt_count() == 0
+
+    def test_cors_preflight_not_counted(self):
+        self._middleware(status_code=200)(self._request("/accounts/token/", "options"))
+        assert self._attempt_count() == 0
+
+    def test_admin_failed_post_counted(self):
+        # Django admin re-renders the form with 200 on bad credentials.
+        self._middleware(status_code=200)(self._request("/admin/login/"))
+        assert self._attempt_count() == 1
+
+    def test_admin_successful_post_not_counted(self):
+        # Successful admin login redirects.
+        self._middleware(status_code=302)(self._request("/admin/login/"))
+        assert self._attempt_count() == 0
+
+    def test_saml2_login_not_gated(self):
+        """/saml2_auth/login/ carries no credentials — not rate limited."""
+        cache.set(f"blocked_ip_{self.TEST_IP}", True, 3600)
+        resp = self._middleware(status_code=200)(
+            self._request("/saml2_auth/login/", "get")
+        )
+        assert resp.status_code == 200
+
+    def test_block_set_after_max_failed_attempts(self):
+        from django.conf import settings
+
+        max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
+        middleware = self._middleware(status_code=400)
+        for _ in range(max_attempts):
+            resp = middleware(self._request("/accounts/token/"))
+            assert resp.status_code == 400
+
+        # The next request — regardless of outcome — is rate limited.
+        resp = middleware(self._request("/accounts/token/"))
+        assert resp.status_code == 403
+        body = json.loads(resp.content)
+        assert body["result"]["error_code"] == "LOGIN_IP_RATE_LIMITED"
+
+        # And from then on the IP is blocked outright.
+        resp = middleware(self._request("/accounts/token/"))
+        assert resp.status_code == 403
+        body = json.loads(resp.content)
+        assert body["result"]["error_code"] == "LOGIN_IP_BLOCKED"
 
 
 @pytest.mark.unit
@@ -568,6 +657,7 @@ class TestMiddlewarePasswordResetRouting:
 
     def test_rate_limit_trigger_on_password_reset(self):
         from django.conf import settings
+
         from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
@@ -588,6 +678,7 @@ class TestMiddlewarePasswordResetRouting:
     def test_password_reset_rate_limit_keeps_requests_for_full_hour(self):
         """Requests older than 1000s but inside the 1h window still count."""
         from django.conf import settings
+
         from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)


### PR DESCRIPTION
## Problem

First-time users on us2 were greeted with `LOGIN_IP_BLOCKED`. The per-IP login limiter in `AuthMonitoringMiddleware` counted **every request** to any path ending in `login/`, `token/`, or `signup/` toward the 10/hour budget:

- successful logins (200s consumed budget),
- `/admin/login/` page loads (caught by accident via `endswith("login/")`),
- `/saml2_auth/login/` SSO URL fetches (GET-only, carries no credentials),
- CORS preflights.

A whole team behind one office NAT shares one budget, so it exhausted within minutes and everyone behind that IP — including people who had never attempted a login — got blocked for 1 hour. Verified live on us2 (2026-07-16): 3 office egress IPs at 10/10; `/accounts/token/` traffic showed 4×200 / 8×400 / 8×403, with the successes consuming budget.

## Change

- Gate exact route suffixes (`/accounts/token/`, `/accounts/login/`, `/accounts/signup/`, `/admin/login/`) instead of `endswith("login/")`. **Deliberate narrowing:** `/saml2_auth/login/` and `aws-marketplace/*` are no longer rate limited — neither accepts a brute-forceable credential.
- Count only **failed credential submissions**: POSTs with a 4xx response; for `/admin/login/`, a 200 form re-render (admin success is a 302 redirect). Page views, preflights, and successful logins no longer consume budget.
- Contract unchanged: `LOGIN_IP_BLOCKED` / `LOGIN_IP_RATE_LIMITED` error codes, the 10-failures/hour threshold, and the 1-hour block are all preserved.

## Tests

- 8 new unit tests (`TestMiddlewareFailedAttemptCounting`): success/failure/GET/OPTIONS counting, admin 200-vs-302 semantics, saml2 exemption, end-to-end block after max failed attempts.
- 1 existing test updated (`test_ip_request_cache_ttl_matches_full_window`) — it asserted the old count-on-success behavior.
- All 27 middleware unit tests pass locally.

Closes TH-7023

🤖 Generated with [Claude Code](https://claude.com/claude-code)