### PR TITLE
[TH-6941/6939/6918] Add-items grid: quick filter, row-click nav, eval tooltip clamp

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -54,7 +54,9 @@ import {
   generateObserveTraceFilterDefinition,
   generateSpanObserveFilterDefinition,
   SPAN_DEFAULT_COLUMNS,
+  applyQuickFilters,
 } from "src/sections/projects/LLMTracing/common";
+import NumberQuickFilterPopover from "src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover";
 import DateRangePill, {
   dateFilterForOption,
 } from "src/sections/projects/LLMTracing/DateRangePill";
@@ -1795,6 +1797,7 @@ function TraceSelector({
   const [, setFilterDefinition] = useState([]);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
+  const [openQuickFilter, setOpenQuickFilter] = useState(null);
   const [gridApi, setGridApi] = useState(null);
   const gridRef = useRef(null);
   const filterButtonRef = useRef(null);
@@ -1996,6 +1999,13 @@ function TraceSelector({
       },
       suppressSizeToFit: false,
       sortable: false,
+      cellRendererParams: {
+        applyQuickFilters: applyQuickFilters(
+          setFilters,
+          setOpenQuickFilter,
+          setFilterOpen,
+        ),
+      },
     }),
     [],
   );
@@ -2259,6 +2269,8 @@ function TraceSelector({
           open={filterOpen}
           onClose={() => setFilterOpen(false)}
           projectId={projectId}
+          source="traces"
+          tab="trace"
           isSimulator={isVoiceProject}
           currentFilters={validatedMainFilters
             .filter((f) => f?.column_id)
@@ -2445,6 +2457,7 @@ function TraceSelector({
               rowModelType="serverSide"
               onGridReady={onGridReady}
               onSelectionChanged={onSelectionChanged}
+              context={{ disableCellNavigation: true }}
               getRowId={(d) => d?.data?.trace_id ?? d?.data?.traceId}
               animateRows={false}
               blockLoadDebounceMillis={300}
@@ -2453,6 +2466,14 @@ function TraceSelector({
           <StatusBar api={gridApi} />
         </Box>
       )}
+
+      <NumberQuickFilterPopover
+        open={Boolean(openQuickFilter)}
+        filterData={openQuickFilter}
+        onClose={() => setOpenQuickFilter(null)}
+        setFilters={setFilters}
+        setFilterOpen={setFilterOpen}
+      />
     </Box>
   );
 }
@@ -2481,6 +2502,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
   const [, setFilterDefinition] = useState([]);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
+  const [openQuickFilter, setOpenQuickFilter] = useState(null);
   const [gridApi, setGridApi] = useState(null);
   const gridRef = useRef(null);
   const filterButtonRef = useRef(null);
@@ -2649,6 +2671,13 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
       },
       suppressSizeToFit: false,
       sortable: false,
+      cellRendererParams: {
+        applyQuickFilters: applyQuickFilters(
+          setFilters,
+          setOpenQuickFilter,
+          setFilterOpen,
+        ),
+      },
     }),
     [],
   );
@@ -3016,6 +3045,7 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
               rowModelType="serverSide"
               onGridReady={onGridReady}
               onSelectionChanged={onSelectionChanged}
+              context={{ disableCellNavigation: true }}
               getRowId={(d) => d?.data?.span_id ?? d?.data?.spanId}
               animateRows={false}
               blockLoadDebounceMillis={300}
@@ -3024,6 +3054,14 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
           <StatusBar api={gridApi} />
         </Box>
       )}
+
+      <NumberQuickFilterPopover
+        open={Boolean(openQuickFilter)}
+        filterData={openQuickFilter}
+        onClose={() => setOpenQuickFilter(null)}
+        setFilters={setFilters}
+        setFilterOpen={setFilterOpen}
+      />
     </Box>
   );
 }

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
@@ -2,15 +2,10 @@ import PropTypes from "prop-types";
 
 const collapsedHeight = "150px";
 const expandedHeight = "300px";
-const lineClamp = 6;
 
 export const collapsedStyles = {
   maxHeight: collapsedHeight,
-  display: "-webkit-box",
-  WebkitLineClamp: lineClamp,
-  WebkitBoxOrient: "vertical",
-  overflowY: "hidden",
-  textOverflow: "ellipsis",
+  overflow: "hidden",
 };
 
 export const expandedStyles = {

--- a/frontend/src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx
@@ -149,6 +149,7 @@ const CustomTraceRenderer = (params) => {
       alignRight={alignRight}
       applyQuickFilters={params.applyQuickFilters}
       onCellClick={() => {
+        if (params.context?.disableCellNavigation) return;
         if (colId === CELL_TYPES.TRACE_ID) {
           handleTraceClick(traceIdFromCell);
         }


### PR DESCRIPTION
**Tickets:**
- [TH-6941](https://linear.app/future-agi/issue/TH-6941) — Fixes TH-6941 (quick filter not working in add-items traces table)
- [TH-6939](https://linear.app/future-agi/issue/TH-6939) — Fixes TH-6939 (row click in add-items trace table redirects to trace drawer)
- [TH-6918](https://linear.app/future-agi/issue/TH-6918) — Fixes TH-6918 (eval cell tooltip only shows "Show more" initially)

All three are FE fixes in the annotation **Add items** flow, under parent TH-6143.

## What was the bug

1. **TH-6941** — In the add-items **Traces** (and **Spans**) grid, the cell-hover quick-filter funnel did nothing. On top of that, once wired, Trace ID / Span ID couldn't be represented as filter fields because the panel was mounted without a `tab`, so they degraded to a generic "Property" row.
2. **TH-6939** — Clicking a trace/span **cell** in the add-items grid navigated the user to the LLM-tracing detail page/drawer. Rows in this picker should only select, never navigate.
3. **TH-6918** — The eval cell tooltip rendered a blank box with only a "Show more" button on first open; the full content appeared only after clicking. Caused by `-webkit-line-clamp` applied to block-level markdown, which collapses to nothing.

## What changes have been done

- `src/sections/annotations/queues/items/add-items-dialog.jsx`
  - Wired `applyQuickFilters(setFilters, setOpenQuickFilter, setFilterOpen)` into the trace & span grids' `cellRendererParams`, and render `NumberQuickFilterPopover` in each selector (TH-6941).
  - Passed `tab="trace"` + `source="traces"` to the Trace `TraceFilterPanel` (Span already had `tab="spans"`) so Trace ID / Span ID are first-class panel fields (TH-6941).
  - Added `context={{ disableCellNavigation: true }}` to the trace & span grids (TH-6939).
- `src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx`
  - Short-circuit `onCellClick` when `params.context?.disableCellNavigation` is set, before the Trace/Span-ID navigation handlers (TH-6939).
- `src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js`
  - `collapsedStyles` now uses `maxHeight` + `overflow: hidden` instead of `-webkit-line-clamp`/`-webkit-box`, so collapsed block markdown renders (TH-6918).

## Why the changes

- Quick filters share the single `filters` state with the panel, so chips and the panel stay one source of truth (`tab` makes the ID fields resolve correctly instead of "Property").
- Cell navigation is a shared renderer used by the real tracing page; gating it via grid `context` keeps that page's behavior intact while disabling it only in the picker.
- `-webkit-line-clamp` only clamps inline/`-webkit-box` content; on the block markdown container it produced an empty render — a height cap + overflow clamps without hiding everything.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Add items → Traces → hover a text cell (e.g. Trace Name) → click funnel | Filter applies, chip appears, list narrows; same row shows in the panel with the correct field label |
| 2 | Add items → Traces → quick-filter Trace ID | Applies + chip; panel shows it as **Trace ID**, not "Property" |
| 3 | Add items → Traces → open the filter panel manually | **Trace ID** is a selectable field in the dropdown |
| 4 | Add items → Spans → same as 1–3 | Trace ID + Span ID both selectable/quick-filterable |
| 5 | Add items → Traces/Spans → click a Trace ID / Span ID cell | No navigation; row selection only |
| 6 | Dataset eval cell → hover to open tooltip | Content renders immediately (collapsed), with "Show more" only when it overflows |

## How to reproduce (original bugs)

1. Open a queue → **Add items** → **Traces** tab.
2. Hover a cell → click the quick-filter funnel → nothing happens (TH-6941).
3. Click a Trace ID cell → redirected to the tracing detail page (TH-6939).
4. Dataset page → hover an eval cell tooltip → blank box with only "Show more" (TH-6918).

## Commands

```bash
yarn lint
```

## Videos and screenshots

_Placeholder — reference recordings are attached on the Linear tickets (TH-6941 / TH-6939 / TH-6918)._
