### PR TITLE
[TH-6943] Disable Add to queue during root-span resolve

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -657,19 +657,24 @@ export default function AddItemsDialog({ open, onClose, queueId, queue }) {
         // annotator workspace's span-oriented UI (consistent with the
         // ``mappedIds`` branch above at lines 540-548).
         if (sourceType === "trace" && !isVoiceTraceSelection) {
-          const rootSpanMap = await fetchRootSpans(
-            ids,
-            selectedProjectId ? [selectedProjectId] : [],
-          );
-          const originalCount = ids.length;
-          ids = ids.map((traceId) => rootSpanMap[traceId]).filter(Boolean);
-          effectiveSourceType = "observation_span";
-          const droppedCount = originalCount - ids.length;
-          if (droppedCount > 0) {
-            enqueueSnackbar(
-              `${droppedCount} trace${droppedCount !== 1 ? "s" : ""} skipped — no root span found yet`,
-              { variant: "warning" },
+          setIsResolving(true);
+          try {
+            const rootSpanMap = await fetchRootSpans(
+              ids,
+              selectedProjectId ? [selectedProjectId] : [],
             );
+            const originalCount = ids.length;
+            ids = ids.map((traceId) => rootSpanMap[traceId]).filter(Boolean);
+            effectiveSourceType = "observation_span";
+            const droppedCount = originalCount - ids.length;
+            if (droppedCount > 0) {
+              enqueueSnackbar(
+                `${droppedCount} trace${droppedCount !== 1 ? "s" : ""} skipped — no root span found yet`,
+                { variant: "warning" },
+              );
+            }
+          } finally {
+            setIsResolving(false);
           }
         }
 


### PR DESCRIPTION
**Ticket:** [TH-6943](https://linear.app/future-agi/issue/TH-6943/add-items-button-stays-clickableloading-during-resolve-should-disable) — Fixes [TH-6943](https://linear.app/future-agi/issue/TH-6943/add-items-button-stays-clickableloading-during-resolve-should-disable)

## What was the bug

In the annotation-queue **Add items** drawer, when you manually select traces and click **Add to queue**, the button stayed clickable and un-spun while the root-span API (`fetchRootSpans` → `/tracer/observation-span/root-spans/`) was resolving. Only after that call finished — when the `addItems` mutation dispatched — did the button show its loading state. On a slow root-span read this made the button look active for seconds, and a second click could fire a duplicate resolve + add.

## What changes have been done

* `frontend/src/sections/annotations/queues/items/add-items-dialog.jsx` — wrapped the manual trace `fetchRootSpans` resolve in `setIsResolving(true)` / `finally setIsResolving(false)`.

## Why the changes

* The button's disabled/spinner state is driven by `isPending || isResolving`. On the manual-trace path, `isPending` (the mutation) isn't true yet during the resolve, and `isResolving` was never set — so both were false and the button stayed live. The selectAll-trace path already guards this exact call with `isResolving`; this brings the manual path in line. The `finally` guarantees the button recovers even if the resolve throws (error then surfaces via the existing outer catch toast).

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Manual-select traces, click Add to queue, slow root-span read | Button disables + shows spinner for the whole resolve, then stays loading through the add |
| 2 | Double-click Add during the resolve window | Second click is a no-op (button disabled) — no duplicate resolve/add |
| 3 | Root-span API errors mid-resolve | Button re-enables, error toast shows, nothing added |
| 4 | Manual-select spans / sessions / simulation | Unchanged — no root-span resolve; `isPending` covers button state |
| 5 | Select-all traces | Unchanged — already guarded by `isResolving` |

## How to reproduce (original bug)

1. Open an annotation queue → **Add items** → **From Traces**.
2. Pick a project and manually tick a few trace rows.
3. Click **Add to queue** (ideally where the root-span read is slow).
4. Observe: the button stays clickable and un-spun during the root-span call, only spinning once the add fires.

## Videos and screenshots

https://github.com/user-attachments/assets/6f78da40-3723-4999-886f-24dc145e1b66