### PR TITLE
chore: free disk space before frontend release build to avoid ENOSPC (main)

### DIFF
--- a/.github/workflows/release-frontend.yml
+++ b/.github/workflows/release-frontend.yml
@@ -30,6 +30,18 @@ jobs:
     environment: production
 
     steps:
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # Reclaim ~20-30 GB by removing preinstalled tooling this build doesn't use.
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Cherry-pick of #1633 onto `main`, following the standard cherry-pick-to-main pattern used for other release-workflow fixes (see #1605 → #1606, #1572 → #1587).

The manual `Release frontend` workflow started failing with `System.IO.IOException: No space left on device` while the runner was writing its own diagnostic log. Standard `ubuntu-latest` runners ship with ~30 GB of preinstalled tooling (Android SDK, .NET, Haskell, large-packages, cached language toolchains) that leaves only ~14 GB free — not enough headroom for a multi-arch (`linux/amd64` + `linux/arm64`) Docker build plus the registry buildcache pull. The `future-agi/ee` release workflow hit the same failure recently and was fixed by adding `jlumbroso/free-disk-space@main` as the first job step (see `future-agi/ee/.github/workflows/release-image.yml`); this PR applies the exact same fix to `release-frontend.yml`. `docker-images` and `swap-storage` are intentionally kept — Docker base images are used by buildx, and swap is a safety net against transient memory spikes. None of the removed tooling is referenced by any step in this workflow, since the build runs entirely inside buildx and never invokes Android/.NET/Haskell/etc. on the host.

## Linked issues

Cherry-pick of #1633 (targeting `dev`). Linear: N/A (raised in Slack by Atharva).

## Type of change

- [x] 🧹 Chore / refactor (no user-visible change)

## Test plan

- [ ] Trigger `Release frontend` from the Actions tab against `main` with a test version tag and confirm the run completes without ENOSPC
- [ ] Verify `futureagi/frontend:<version>`, `:<minor>`, `:latest` are published on Docker Hub for both `linux/amd64` and `linux/arm64`
- [ ] Confirm total job duration is comparable to previous successful runs (free-disk-space step adds ~1 min)

## Checklist

- [x] PR description explains **what** and **why**
- [x] PR title follows Conventional Commits
- [x] Change is scoped to a single workflow file
- [x] No hardcoded secrets, URLs, or PII
- [x] Mirrors the validated fix from `future-agi/ee` release workflow
- [x] Clean cherry-pick of #1633