### PR TITLE
fix: PG-native eval-config discovery for voice endpoints

### DIFF
--- a/futureagi/tracer/tests/test_helper_eval_configs.py
+++ b/futureagi/tracer/tests/test_helper_eval_configs.py
@@ -1,0 +1,40 @@
+"""Tests for get_project_eval_configs — PG-native eval-config discovery."""
+import pytest
+
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.project import Project
+from tracer.utils.helper import get_project_eval_configs
+
+
+@pytest.mark.django_db
+def test_returns_non_deleted_configs_for_project(project, eval_template):
+    keep = CustomEvalConfig.objects.create(
+        project=project, eval_template=eval_template, name="keep"
+    )
+    CustomEvalConfig.objects.create(
+        project=project, eval_template=eval_template, name="gone", deleted=True
+    )
+
+    configs, ids = get_project_eval_configs(project.id)
+
+    assert [c.id for c in configs] == [keep.id]
+    assert ids == [str(keep.id)]
+
+
+@pytest.mark.django_db
+def test_excludes_other_projects_and_empty_case(project, eval_template):
+    other_project = Project.objects.create(
+        name="Other Project",
+        organization=project.organization,
+        workspace=project.workspace,
+        model_type=project.model_type,
+        trace_type="experiment",
+    )
+    CustomEvalConfig.objects.create(
+        project=other_project, eval_template=eval_template, name="foreign"
+    )
+
+    configs, ids = get_project_eval_configs(project.id)
+
+    assert configs == []
+    assert ids == []

--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -419,6 +419,22 @@ def eval_output_type_for_config(config: CustomEvalConfig) -> str | None:
     return (getattr(template, "config", None) or {}).get("output")
 
 
+def get_project_eval_configs(
+    project_id,
+) -> tuple[list[CustomEvalConfig], list[str]]:
+    """Non-deleted eval configs for a project, read from PG (no ClickHouse).
+
+    Replaces the CH ``dictGet('trace_dict',...)`` discovery scan on the voice
+    endpoints. Uses the ``(project, created_at)`` index. Returns
+    ``(eval_configs, eval_config_ids)``.
+    """
+    qs = CustomEvalConfig.objects.filter(
+        project_id=project_id, deleted=False
+    ).select_related("eval_template")
+    configs = list(qs)
+    return configs, [str(c.id) for c in configs]
+
+
 def _validate_span_attribute_filter(column_id, filter_config):
     """Enforce the SPAN_ATTRIBUTE type/op/value contract; raise on mismatch."""
     ftype = (filter_config.get("filter_type") or "").lower()

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -99,6 +99,7 @@ from tracer.utils.helper import (
     flatten_eval_score_into_entry,
     get_annotation_labels_for_project,
     get_default_trace_config,
+    get_project_eval_configs,
     select_eval_score,
     update_column_config_based_on_eval_config,
     update_span_column_config_based_on_annotations,
@@ -2814,29 +2815,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 if not processed_log.get("message_count"):
                     processed_log["message_count"] = len(stored)
 
-        # Fetch ALL non-deleted eval configs for the project so the drawer
-        # renders the same set of evals as the list columns. Missing scores
-        # become placeholder entries with `output=None`.
-        # Eval configs with results for this project's traces. CH25-safe: resolve
-        # via the CH eval table + trace_dict (PG `tracer_trace` is dropped),
-        # mirroring the trace-list path so the drawer shows the same eval set.
-        eval_table, eval_nd = eval_logger_source()
-        cfg_result = analytics.execute_ch_query(
-            "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            f"FROM {eval_table} FINAL "
-            f"WHERE {eval_nd} "
-            "AND dictGet('trace_dict', 'project_id', trace_id) = toUUID(%(pid)s)",
-            {"pid": str(project_id)},
-            timeout_ms=30000,
-        )
-        cfg_ids = [r.get("cid", "") for r in cfg_result.data if r.get("cid")]
-        if cfg_ids:
-            eval_configs = CustomEvalConfig.objects.filter(
-                id__in=cfg_ids, deleted=False
-            ).select_related("eval_template")
-        else:
-            eval_configs = []
-        eval_config_ids = [str(c.id) for c in eval_configs]
+        # All non-deleted eval configs for the project so the drawer renders
+        # the same set of evals as the list columns; missing scores become
+        # placeholder entries with `output=None`. Read from PG (indexed) —
+        # replaces the unbounded CH dictGet discovery scan.
+        eval_configs, eval_config_ids = get_project_eval_configs(project_id)
 
         eval_outputs = {}
         trace_evals: dict[str, Any] = {}
@@ -3739,26 +3722,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         page_size = validated_data.get("page_size", 30)
         page_number = page - 1  # Convert 1-based to 0-based
 
-        # Get eval config IDs from CH (fast) instead of PG EvalLogger scan
-        eval_config_ids = []
-        eval_table, eval_nd = eval_logger_source()
-        ch_result = analytics.execute_ch_query(
-            "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            f"FROM {eval_table} FINAL "
-            f"WHERE {eval_nd} "
-            "AND dictGet('trace_dict', 'project_id', "
-            "trace_id) = toUUID(%(pid)s)",
-            {"pid": str(project_id)},
-            timeout_ms=30000,
-        )
-        ch_ids = [r.get("cid", "") for r in ch_result.data if r.get("cid")]
-        if ch_ids:
-            eval_configs = CustomEvalConfig.objects.filter(
-                id__in=ch_ids, deleted=False
-            ).select_related("eval_template")
-            eval_config_ids = [str(c.id) for c in eval_configs]
-        else:
-            eval_configs = []
+        # Eval configs for the project, from PG (indexed) — replaces the
+        # unbounded CH dictGet discovery scan.
+        eval_configs, eval_config_ids = get_project_eval_configs(project_id)
 
         # Get annotation labels that have actual annotations/scores for this project
         annotation_labels = get_annotation_labels_for_project(project_id)


### PR DESCRIPTION
## Summary

`list_voice_calls` and `voice_call_detail` began every request with a discovery query that scanned the **entire, cross-tenant `tracer_eval_logger` table** just to decide which eval configs to render as columns:

```sql
SELECT DISTINCT custom_eval_config_id FROM tracer_eval_logger FINAL
WHERE ... AND dictGet('trace_dict','project_id', trace_id) = toUUID(:pid)
```

The eval-logger table has no `project_id` column, so the `dictGet` filter can't prune and forces a **full-table scan on every list/detail load** — a cost that grows with total platform eval volume. This PR replaces that scan with an indexed Postgres lookup.

## Linked issues

Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Eval-config discovery moved from ClickHouse to Postgres**

- New helper `get_project_eval_configs(project_id) -> (eval_configs, eval_config_ids)` in `tracer/utils/helper.py` — returns the project's non-deleted `CustomEvalConfig`s via the existing `(project, created_at)` index.
- `voice_call_detail` (`_voice_call_detail_clickhouse`) and `list_voice_calls` (`_list_voice_calls_clickhouse`) now call the helper instead of the `dictGet` CH scan. Downstream `build_eval_query` / column-config logic is unchanged.

---

## 2) Why the changes were done

- **Technical:** the discovery query full-scans the global `tracer_eval_logger` table (no `project_id` column → `dictGet` defeats index pruning), on every list/detail request, and gets slower as platform eval volume grows. `CustomEvalConfig` already carries a `project` FK indexed on `(project, created_at)`, so the same set is a cheap indexed PG lookup.
- **Architecture:** keeps eval-config discovery in Postgres (its source of truth) and removes a hot-path ClickHouse round-trip.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_helper_eval_configs.py`** — unit tests for the new helper

- `test_returns_non_deleted_configs_for_project` — returns the project's configs, excludes soft-deleted ones
- `test_excludes_other_projects_and_empty_case` — excludes other projects' configs; empty result for a project with none

> Run result: **2 passed**. Endpoint behaviour validated against prod data (local CH test DB is a pre-existing infra gap, unrelated to this change).

---

## 4) How to run / test

```bash
cd futureagi
bin/test tracer/tests/test_helper_eval_configs.py -v
```

---

## 6) Edge cases & considerations

- **Behaviour change:** discovery now returns **all non-deleted eval configs configured for the project** — a superset of the old "configs that have >=1 result". A configured-but-not-yet-run config now appears as an (empty) column instead of showing up only after its first result lands. Deleted configs stay hidden (both paths filter `deleted=False`).

---

## 8) Architectural / important decisions

- **PG over CH for discovery:** eval configs are always project-scoped with an indexed `project` FK, so "which configs apply to this project" belongs in Postgres — no need to scan ClickHouse scores to answer it.

## Checklist

- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
