### PR TITLE
[TH-7037] Scenarios grid + detail: expose Failed vs empty vs still-generating

### DIFF
--- a/frontend/src/api/scenarios/scenarios.js
+++ b/frontend/src/api/scenarios/scenarios.js
@@ -1,5 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
+import { isScenarioInProgress } from "src/utils/scenarioStatus";
 
 export const useGetScenarioDetail = (scenarioId, options = {}) => {
   return useQuery({
@@ -8,7 +9,7 @@ export const useGetScenarioDetail = (scenarioId, options = {}) => {
     select: (d) => d.data,
     enabled: !!scenarioId,
     refetchInterval: ({ state }) => {
-      return state?.data?.data?.status === "Processing" ? 5000 : false;
+      return isScenarioInProgress(state?.data?.data?.status) ? 5000 : false;
     },
     ...options,
   });

--- a/frontend/src/components/scenarios/CustomCellRenderers/ScenarioStatusCellRenderer.jsx
+++ b/frontend/src/components/scenarios/CustomCellRenderers/ScenarioStatusCellRenderer.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Chip } from "@mui/material";
+import {
+  isScenarioCompleted,
+  isScenarioFailed,
+  isScenarioInProgress,
+} from "src/utils/scenarioStatus";
+
+const ScenarioStatusChip = ({ status }) => {
+  let config;
+  if (isScenarioInProgress(status)) {
+    config = { label: "Processing", color: "warning" };
+  } else if (isScenarioCompleted(status)) {
+    config = { label: "Completed", color: "success" };
+  } else if (isScenarioFailed(status)) {
+    config = { label: "Failed", color: "error" };
+  }
+  if (!config) return null;
+
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={config.label}
+      color={config.color}
+    />
+  );
+};
+
+ScenarioStatusChip.propTypes = {
+  status: PropTypes.string,
+};
+
+export default ScenarioStatusChip;

--- a/frontend/src/pages/dashboard/scenarios/Scenarios.jsx
+++ b/frontend/src/pages/dashboard/scenarios/Scenarios.jsx
@@ -2,7 +2,7 @@
 import { Box, Button, Stack, Typography } from "@mui/material";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useNavigate } from "react-router-dom";
 
@@ -14,6 +14,8 @@ import DeleteScenarioDialog from "src/components/scenarios/DeleteScenarioDialog"
 import EditScenarioDialog from "src/components/scenarios/EditScenarioDialog";
 import ScenarioActionMenu from "src/components/scenarios/ScenariosActionMenu";
 import { getChipConfig } from "src/components/scenarios/CustomCellRenderers/ChipCellRenderer";
+import ScenarioStatusChip from "src/components/scenarios/CustomCellRenderers/ScenarioStatusCellRenderer";
+import { isScenarioInProgress } from "src/utils/scenarioStatus";
 
 import { useAuthContext } from "src/auth/hooks";
 import { useDebounce } from "src/hooks/use-debounce";
@@ -55,8 +57,15 @@ function ChipCell({ getValue }) {
   );
 }
 
-function CreatedAtCell({ getValue }) {
-  const value = getValue();
+function CreatedAtCell({ value }) {
+  const [, setTick] = useState(0);
+  // Re-render every minute so the relative "time ago" stays current even when
+  // the grid data itself hasn't changed.
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60000);
+    return () => clearInterval(id);
+  }, []);
+
   if (!value) {
     return (
       <Typography variant="body2" sx={{ fontSize: 13, color: "text.disabled" }}>
@@ -105,6 +114,13 @@ function Scenarios() {
       }),
     select: (d) => d.data,
     keepPreviousData: true,
+    refetchInterval: (query) => {
+      const results = query?.state?.data?.data?.results ?? [];
+      const hasInProgress = results.some((s) =>
+        isScenarioInProgress(s?.status),
+      );
+      return hasInProgress ? 5000 : false;
+    },
   });
 
   const items = useMemo(() => data?.results ?? [], [data]);
@@ -185,6 +201,14 @@ function Scenarios() {
         ),
       },
       {
+        id: "status",
+        accessorKey: "status",
+        header: "Status",
+        size: 140,
+        enableSorting: false,
+        cell: ({ getValue }) => <ScenarioStatusChip status={getValue()} />,
+      },
+      {
         id: "scenario_type",
         accessorKey: "scenario_type",
         header: "Scenario Type",
@@ -198,7 +222,7 @@ function Scenarios() {
         header: "Created At",
         size: 170,
         enableSorting: false,
-        cell: CreatedAtCell,
+        cell: ({ getValue }) => <CreatedAtCell value={getValue()} />,
       },
     ];
 

--- a/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/GraphPreview.jsx
@@ -18,6 +18,10 @@ import ModalWrapper from "src/components/ModalWrapper/ModalWrapper";
 import logger from "src/utils/logger";
 import { useAuthContext } from "src/auth/hooks";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
+import {
+  isScenarioFailed,
+  isScenarioInProgress,
+} from "src/utils/scenarioStatus";
 
 const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
   const { role } = useAuthContext();
@@ -28,7 +32,7 @@ const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
   const isLoading =
     scenario?.graph && Object.keys(scenario?.graph || {}).length > 0
       ? false
-      : scenario?.status === "Processing";
+      : isScenarioInProgress(scenario?.status);
   const { nodes, edges } = useMemo(() => {
     if (
       !scenario?.graph ||
@@ -150,7 +154,7 @@ const GraphPreview = ({ scenario, agentType, viewOnly = false }) => {
     );
   }
 
-  if (scenario?.status === "Failed") {
+  if (isScenarioFailed(scenario?.status)) {
     return (
       <Box
         sx={{

--- a/frontend/src/sections/scenarios/scenario-detail/PromptPreview.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/PromptPreview.jsx
@@ -9,12 +9,16 @@ import { getDatasetQueryOptions } from "src/api/develop/develop-detail";
 import { useQuery } from "@tanstack/react-query";
 import { useAuthContext } from "src/auth/hooks";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
+import {
+  isScenarioFailed,
+  isScenarioInProgress,
+} from "src/utils/scenarioStatus";
 
 const PromptPreview = ({ scenario }) => {
   const { role } = useAuthContext();
   const isWriteDisabled =
     !RolePermission.SIMULATION_AGENT[PERMISSIONS.UPDATE][role];
-  const { data: tableData, isPending: isLoadingTable } = useQuery(
+  const { data: tableData } = useQuery(
     getDatasetQueryOptions(scenario.dataset, 0, [], [], "", { enabled: false }),
   );
 
@@ -25,13 +29,13 @@ const PromptPreview = ({ scenario }) => {
     return allowedVariables;
   }, [tableData?.data?.result?.column_config]);
 
-  const isLoading =
-    isLoadingTable ||
-    (scenario?.prompts ? false : scenario?.status === "Processing");
+  const hasPrompts = Boolean(scenario?.prompts?.[0]?.content);
+  const isProcessing = !hasPrompts && isScenarioInProgress(scenario?.status);
+  const isFailed = !hasPrompts && isScenarioFailed(scenario?.status);
 
   const [open, setOpen] = useState(false);
 
-  if (isLoading) {
+  if (isProcessing) {
     return (
       <Box
         sx={{
@@ -51,6 +55,29 @@ const PromptPreview = ({ scenario }) => {
         <CircularProgress size={20} />
         <Typography typography="s1">
           We are processing the prompts...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isFailed) {
+    return (
+      <Box
+        sx={{
+          flex: 1,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 1,
+          overflow: "hidden",
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+        }}
+      >
+        <Typography typography="s1">
+          There was an error generating the prompt
         </Typography>
       </Box>
     );

--- a/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
@@ -15,6 +15,10 @@ import DevelopDetailProvider from "src/sections/develop-detail/DevelopDetailProv
 import AddRowScenario from "./AddRowScenario";
 import ScenarioDetailRightSection from "./ScenarioDetailRightSection";
 import AddColumnScenario from "./AddColumnScenario";
+import {
+  isScenarioFailed,
+  isScenarioInProgress,
+} from "src/utils/scenarioStatus";
 
 const MetaChip = ({ label, value, icon }) => (
   <Box
@@ -167,7 +171,7 @@ const ScenarioDatasetView = () => {
             height: "50%",
           }}
         >
-            <GraphPreview agentType={agentType} scenario={scenario} />
+          <GraphPreview agentType={agentType} scenario={scenario} />
           <PromptPreview scenario={scenario} />
         </Box>
         <Box
@@ -189,7 +193,7 @@ const ScenarioDatasetView = () => {
         </Box>
 
         <ShowComponent condition={!datasetId}>
-          <ShowComponent condition={scenario?.status === "Processing"}>
+          <ShowComponent condition={isScenarioInProgress(scenario?.status)}>
             <Box
               sx={{
                 display: "flex",
@@ -206,7 +210,7 @@ const ScenarioDatasetView = () => {
               </Typography>
             </Box>
           </ShowComponent>
-          <ShowComponent condition={scenario?.status === "Failed"}>
+          <ShowComponent condition={isScenarioFailed(scenario?.status)}>
             <Box
               sx={{
                 display: "flex",

--- a/frontend/src/utils/scenarioStatus.js
+++ b/frontend/src/utils/scenarioStatus.js
@@ -1,0 +1,22 @@
+export const SCENARIO_STATUS = {
+  PROCESSING: "Processing",
+  RUNNING: "Running",
+  COMPLETED: "Completed",
+  FAILED: "Failed",
+};
+
+export const SCENARIO_IN_PROGRESS_STATUSES = [
+  SCENARIO_STATUS.PROCESSING,
+  SCENARIO_STATUS.RUNNING,
+];
+
+const normalize = (status) => status?.toString().toLowerCase();
+
+export const isScenarioInProgress = (status) =>
+  SCENARIO_IN_PROGRESS_STATUSES.some((s) => normalize(s) === normalize(status));
+
+export const isScenarioFailed = (status) =>
+  normalize(status) === normalize(SCENARIO_STATUS.FAILED);
+
+export const isScenarioCompleted = (status) =>
+  normalize(status) === normalize(SCENARIO_STATUS.COMPLETED);


### PR DESCRIPTION
**Ticket:** [TH-7037](https://linear.app/future-agi/issue/TH-7037/scenarios-grid-detail-expose-failed-vs-empty-vs-still-generating) — Fixes [TH-7037](https://linear.app/future-agi/issue/TH-7037/scenarios-grid-detail-expose-failed-vs-empty-vs-still-generating)

## What was the bug

The scenarios grid had **no status column**. A scenario whose generation returned `Failed` rendered `0` under *No of Datapoints*, indistinguishable from one that was still generating or one that legitimately ended up empty — the only way to learn it failed was to open it.

On the detail page the states also **contradicted each other**: on a failed scenario the graph panel showed *"There was an error generating the scenario graph"* while the prompt panel simultaneously showed *"We are processing the prompts…"* — a stuck spinner that never resolved.

## What changes have been done

* `frontend/src/utils/scenarioStatus.js` **(new)** — single source of truth for `Scenarios.status`: `SCENARIO_STATUS`, `SCENARIO_IN_PROGRESS_STATUSES` (`Processing`, `Running`), and case-insensitive helpers `isScenarioInProgress` / `isScenarioFailed` / `isScenarioCompleted`.
* `frontend/src/components/scenarios/CustomCellRenderers/ScenarioStatusCellRenderer.jsx` **(new)** — MUI `Chip` mapping status → Processing / Completed / Failed (warning / success / error).
* `frontend/src/pages/dashboard/scenarios/Scenarios.jsx` — adds the **Status column**; adds **live polling** (5s) that runs only while a current-page row is in progress and stops once all are terminal; makes the *Created At* cell self-tick so the relative time stays current.
* `frontend/src/sections/scenarios/scenario-detail/PromptPreview.jsx` — fixes the stuck spinner (was gated on an `enabled:false` query that stays `isPending` forever); adds a **Failed** branch; `hasPrompts` now checks `prompts?.[0]?.content` instead of `Boolean(prompts)` (an empty array is truthy).
* `frontend/src/api/scenarios/scenarios.js`, `GraphPreview.jsx`, `ScenarioDatasetView.jsx` — route their `status` checks through the shared helpers so `Running` is handled consistently and a `Running` scenario's detail page auto-polls.

## Why the changes

* **Backend is the source of the states.** Both the list (`ScenarioResponseSerializer`) and detail (`views/scenarios.py` → `"status": scenario.status`) endpoints expose the same `Scenarios.status` / `StatusType` field. Runtime lifecycle is `Processing` → `Completed` / `Failed`, with `Running` as the model default — so all of those must be treated consistently on the FE.
* **Stuck prompt spinner** was a real bug: the dataset query is created with `enabled:false` (cache-only, for variable highlighting), so its `isPending` never resolves when the dataset isn't cached — the old `isLoading = isLoadingTable || …` pinned the spinner forever on failed/empty scenarios.
* **Shared constant** prevents the grid and the detail page from drifting on what "in progress" means (the review caught `Running` being handled in the grid but not the detail page).

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Grid row with `status: Failed` | Red **Failed** chip (no longer a bare `0`) |
| 2 | Grid row with `status: Processing`/`Running` | **Processing** chip; grid polls every 5s until terminal |
| 3 | Grid row with `status: Completed` | Green **Completed** chip; no polling |
| 4 | Grid left open \~1 min | *Created At* relative time advances without a refresh |
| 5 | Detail page, failed scenario | Graph + prompt panels both show the error — no "processing prompts" spinner |
| 6 | Detail page, processing/running scenario | Both panels show the generating spinner; detail auto-polls |

## How to reproduce (original bug)

1. Open **Simulate → Scenarios** with a scenario whose generation failed.
2. Grid shows `0` datapoints with no indication it failed.
3. Open it — the graph panel shows an error while the prompt panel spins on *"We are processing the prompts…"* indefinitely.

## Commands

```bash
cd frontend && yarn lint
```

## Videos and screenshots

https://github.com/user-attachments/assets/2721e451-3344-46f5-ba2f-de0bc152be09

https://github.com/user-attachments/assets/39e3eb3d-d732-4064-81a0-8bfa6fbee45b