### PR TITLE
[TH-7038] Block 0-datapoint scenarios from simulation runs

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -394,6 +394,14 @@ const CreateRunTestPage = ({ open, onClose }) => {
     if (!formData?.selectedScenarios?.length) return [];
     return scenarios.filter((s) => formData.selectedScenarios.includes(s.id));
   }, [scenarios, formData?.selectedScenarios]);
+  const runnableScenarioIds = useMemo(
+    () =>
+      (formData?.selectedScenarios || []).filter((id) => {
+        const s = scenarios.find((x) => x.id === id);
+        return !s || (s.dataset_rows || 0) > 0;
+      }),
+    [scenarios, formData?.selectedScenarios],
+  );
 
   const sourcePreviewData = useMemo(() => {
     const isText = formData?.agentType === AGENT_TYPES.CHAT;
@@ -503,7 +511,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
     mutationFn: (testId) =>
       axios.post(endpoints.runTests.runTest(testId), {
         select_all: false,
-        scenario_ids: formData?.selectedScenarios || [],
+        scenario_ids: runnableScenarioIds,
       }),
   });
 
@@ -574,7 +582,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
     const payload = {
       name: formData?.testName || "",
       description: formData?.description || "",
-      scenario_ids: formData?.selectedScenarios || [],
+      scenario_ids: runnableScenarioIds,
       agent_definition_id: formData.agentDefinitionId,
       agent_version: formData?.agentDefinitionVersionId,
       eval_config_ids: [], // Keep empty for existing eval configs
@@ -633,6 +641,10 @@ const CreateRunTestPage = ({ open, onClose }) => {
 
   const handleScenarioToggle = (scenarioId) => {
     const isSelected = formData.selectedScenarios.includes(scenarioId);
+    if (!isSelected) {
+      const scenario = scenarios.find((s) => s.id === scenarioId);
+      if (scenario && (scenario.dataset_rows || 0) === 0) return;
+    }
     setFormData({
       ...formData,
       selectedScenarios: isSelected
@@ -1122,98 +1134,126 @@ const CreateRunTestPage = ({ open, onClose }) => {
                 ) : (
                   <>
                     <List sx={{ width: "100%", bgcolor: "background.paper" }}>
-                      {filteredScenarios.map((scenario) => (
-                        <ListItem
-                          key={scenario.id}
-                          sx={{
-                            border: "1px solid",
-                            borderColor: formData.selectedScenarios.includes(
-                              scenario.id,
-                            )
-                              ? "primary.main"
-                              : "divider",
-                            borderRadius: 1,
-                            mb: 1.5,
-                            px: 2,
-                            py: 1.5,
-                            cursor: "pointer",
-                            "&:hover": {
-                              borderColor: "primary.lighter",
-                              bgcolor: alpha(
-                                theme.palette.primary["lighter"],
-                                0.12,
-                              ),
-                            },
-                          }}
-                          onClick={() => {
-                            handleScenarioToggle(scenario.id);
-                          }}
-                        >
-                          <ListItemIcon sx={{ minWidth: 40 }}>
-                            <Checkbox
-                              edge="start"
-                              checked={formData.selectedScenarios.includes(
-                                scenario.id,
-                              )}
-                              tabIndex={-1}
-                              disableRipple
-                            />
-                          </ListItemIcon>
-                          <ListItemText
-                            primary={
-                              <Typography
-                                variant="subtitle2"
-                                sx={{
-                                  display: "-webkit-box",
-                                  WebkitLineClamp: 1,
-                                  WebkitBoxOrient: "vertical",
-                                  overflow: "hidden",
-                                }}
-                              >
-                                {scenario.name}
-                              </Typography>
-                            }
-                            secondary={
-                              <Typography
-                                variant="body2"
-                                color="text.secondary"
-                                sx={{
-                                  display: "-webkit-box",
-                                  WebkitLineClamp: 2,
-                                  WebkitBoxOrient: "vertical",
-                                  overflow: "hidden",
-                                }}
-                              >
-                                {scenario.description ||
-                                  scenario.source ||
-                                  "No description available"}
-                              </Typography>
-                            }
-                          />
-                          <Box
-                            sx={{
-                              display: "flex",
-                              flexDirection: "column",
-                              alignItems: "flex-end",
-                              gap: 0.5,
-                            }}
+                      {filteredScenarios.map((scenario) => {
+                        const isEmpty = (scenario.dataset_rows || 0) === 0;
+                        return (
+                          <CustomTooltip
+                            key={scenario.id}
+                            show={isEmpty}
+                            arrow
+                            placement="top"
+                            size="small"
+                            title="This scenario has no datapoints to run against."
                           >
-                            {scenario.scenarioType === "dataset" && (
-                              <Chip
-                                label="Dataset"
-                                size="small"
-                                sx={{
-                                  height: "20px",
-                                  fontSize: "11px",
-                                }}
+                            <ListItem
+                              sx={{
+                                border: "1px solid",
+                                borderColor:
+                                  formData.selectedScenarios.includes(
+                                    scenario.id,
+                                  )
+                                    ? "primary.main"
+                                    : "divider",
+                                borderRadius: 1,
+                                mb: 1.5,
+                                px: 2,
+                                py: 1.5,
+                                cursor: isEmpty ? "not-allowed" : "pointer",
+                                opacity: isEmpty ? 0.5 : 1,
+                                "&:hover": isEmpty
+                                  ? {}
+                                  : {
+                                      borderColor: "primary.lighter",
+                                      bgcolor: alpha(
+                                        theme.palette.primary["lighter"],
+                                        0.12,
+                                      ),
+                                    },
+                              }}
+                              onClick={() => {
+                                if (!isEmpty) handleScenarioToggle(scenario.id);
+                              }}
+                            >
+                              <ListItemIcon sx={{ minWidth: 40 }}>
+                                <Checkbox
+                                  edge="start"
+                                  checked={formData.selectedScenarios.includes(
+                                    scenario.id,
+                                  )}
+                                  disabled={isEmpty}
+                                  tabIndex={-1}
+                                  disableRipple
+                                />
+                              </ListItemIcon>
+                              <ListItemText
+                                primary={
+                                  <Typography
+                                    variant="subtitle2"
+                                    sx={{
+                                      display: "-webkit-box",
+                                      WebkitLineClamp: 1,
+                                      WebkitBoxOrient: "vertical",
+                                      overflow: "hidden",
+                                    }}
+                                  >
+                                    {scenario.name}
+                                  </Typography>
+                                }
+                                secondary={
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    sx={{
+                                      display: "-webkit-box",
+                                      WebkitLineClamp: 2,
+                                      WebkitBoxOrient: "vertical",
+                                      overflow: "hidden",
+                                    }}
+                                  >
+                                    {scenario.description ||
+                                      scenario.source ||
+                                      "No description available"}
+                                  </Typography>
+                                }
                               />
-                            )}
-                            <Typography variant="body2" fontWeight={600}>
-                              {scenario.dataset_rows || 0}
-                            </Typography>
-                          </Box>
-                        </ListItem>
-                      ))}
+                              <Box
+                                sx={{
+                                  display: "flex",
+                                  flexDirection: "column",
+                                  alignItems: "flex-end",
+                                  gap: 0.5,
+                                }}
+                              >
+                                {scenario.scenarioType === "dataset" && (
+                                  <Chip
+                                    label="Dataset"
+                                    size="small"
+                                    sx={{
+                                      height: "20px",
+                                      fontSize: "11px",
+                                    }}
+                                  />
+                                )}
+                                {isEmpty ? (
+                                  <Chip
+                                    label="No datapoints"
+                                    size="small"
+                                    sx={{
+                                      height: "20px",
+                                      color: "text.disabled",
+                                      bgcolor: "action.hover",
+                                    }}
+                                  />
+                                ) : (
+                                  <Typography variant="body2" fontWeight={600}>
+                                    {scenario.dataset_rows}
+                                  </Typography>
+                                )}
+                              </Box>
+                            </ListItem>
+                          </CustomTooltip>
+                        );
+                      })}
                     </List>
 
                     {/* Pagination */}

--- a/frontend/src/sections/test/TestRuns/ScenarioPopover.jsx
+++ b/frontend/src/sections/test/TestRuns/ScenarioPopover.jsx
@@ -18,6 +18,7 @@ import { useScrollEnd } from "../../../hooks/use-scroll-end";
 import { useSelectedScenariosStore } from "./states";
 import { ShowComponent } from "../../../components/show";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
+import CustomTooltip from "src/components/tooltip";
 import { useUpdateTestRuns } from "src/api/tests/testRuns";
 import { useGetScenarioList } from "src/api/scenarios/scenarios";
 import { AGENT_TYPES } from "src/sections/agents/constants";
@@ -68,7 +69,12 @@ const ScenarioPopoverChild = ({ simulationType, testId: testIdProp }) => {
     useSelectedScenariosStore();
 
   const handleToggle = (value) => {
-    const newSelectedScenarios = selectedScenarios?.includes(value)
+    const isSelected = selectedScenarios?.includes(value);
+    if (!isSelected) {
+      const scenario = scenarios?.find((s) => s.id === value);
+      if (scenario && (scenario.dataset_rows || 0) === 0) return;
+    }
+    const newSelectedScenarios = isSelected
       ? selectedScenarios?.filter((id) => id !== value)
       : [...selectedScenarios, value];
     setSelectedScenarios(newSelectedScenarios);
@@ -111,39 +117,54 @@ const ScenarioPopoverChild = ({ simulationType, testId: testIdProp }) => {
           <ScenarioSkeletonItem />
         </ShowComponent>
         <ShowComponent condition={!isPending}>
-          {scenarios?.map(({ id, name, dataset_rows:datasetRows }) => {
+          {scenarios?.map(({ id, name, dataset_rows: datasetRows }) => {
             const labelId = `checkbox-list-label-${id}`;
             const isSelected = selectedScenarios?.includes(id);
+            const isEmpty = (datasetRows || 0) === 0;
+            const blockAdd = isEmpty && !isSelected;
 
             return (
-              <ListItem key={id} disablePadding>
-                <ListItemButton
-                  role={undefined}
-                  onClick={() => handleToggle(id)}
-                  dense
-                >
-                  <ListItemIcon>
-                    <Checkbox
-                      edge="start"
-                      checked={isSelected}
-                      tabIndex={-1}
-                      disableRipple
-                      inputProps={{ "aria-labelledby": labelId }}
-                      sx={{ padding: 0 }}
+              <CustomTooltip
+                key={id}
+                show={blockAdd}
+                arrow
+                placement="left"
+                title="This scenario has no datapoints to run against."
+                size="small"
+              >
+                <ListItem disablePadding>
+                  <ListItemButton
+                    role={undefined}
+                    onClick={() => handleToggle(id)}
+                    disabled={blockAdd}
+                    dense
+                  >
+                    <ListItemIcon>
+                      <Checkbox
+                        edge="start"
+                        checked={isSelected}
+                        disabled={blockAdd}
+                        tabIndex={-1}
+                        disableRipple
+                        inputProps={{ "aria-labelledby": labelId }}
+                        sx={{ padding: 0 }}
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      id={labelId}
+                      primary={name}
+                      secondary={
+                        isEmpty ? "No datapoints" : `${datasetRows} records`
+                      }
+                      primaryTypographyProps={{
+                        typography: "s2",
+                        fontWeight: "medium",
+                      }}
+                      secondaryTypographyProps={{ typography: "s2" }}
                     />
-                  </ListItemIcon>
-                  <ListItemText
-                    id={labelId}
-                    primary={name}
-                    secondary={`${datasetRows} records`}
-                    primaryTypographyProps={{
-                      typography: "s2",
-                      fontWeight: "medium",
-                    }}
-                    secondaryTypographyProps={{ typography: "s2" }}
-                  />
-                </ListItemButton>
-              </ListItem>
+                  </ListItemButton>
+                </ListItem>
+              </CustomTooltip>
             );
           })}
         </ShowComponent>

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -96,6 +96,9 @@ const TestRunHeader = () => {
     (s) =>
       selectedScenarioIds.has(s.id) && s.status !== SCENARIO_STATUS.COMPLETED,
   );
+  const hasEmptyScenario = scenarioDetails.some(
+    (s) => selectedScenarioIds.has(s.id) && (s.dataset_rows || 0) === 0,
+  );
   const agentType = isPromptSimulation
     ? AGENT_TYPES.CHAT
     : testData?.agent_definition_detail?.agent_type ??
@@ -236,6 +239,7 @@ const TestRunHeader = () => {
             show={
               isAgentDefinitionDeleted ||
               selectedScenarios.length === 0 ||
+              hasEmptyScenario ||
               hasIncompleteScenario
             }
             title={
@@ -243,7 +247,9 @@ const TestRunHeader = () => {
                 ? "Agent definition has been deleted. Please select a new agent definition to run simulation."
                 : selectedScenarios.length === 0
                   ? "Select atleast one scenario to run test"
-                  : "Some selected scenarios are not completed. Wait for them to finish or remove them from the selection."
+                  : hasEmptyScenario
+                    ? "Some selected scenarios have no datapoints. Remove them from the selection to run."
+                    : "Some selected scenarios are not completed. Wait for them to finish or remove them from the selection."
             }
             size="small"
             arrow
@@ -277,6 +283,7 @@ const TestRunHeader = () => {
                   ][role] ||
                   selectedScenarios.length === 0 ||
                   isAgentDefinitionDeleted ||
+                  hasEmptyScenario ||
                   hasIncompleteScenario
                 }
               >

--- a/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx
@@ -33,6 +33,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { getVersionLabel } from "src/utils/utils";
 import { format } from "date-fns";
 import { useGetScenarioList } from "src/api/scenarios/scenarios";
+import CustomTooltip from "src/components/tooltip";
 import { AGENT_TYPES } from "src/sections/agents/constants";
 import { usePromptVersions } from "../hooks/use-prompt-versions";
 
@@ -122,9 +123,19 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
     }
   }, [versions, formData.versionId]);
 
+  const selectableScenarios = useMemo(
+    () => scenarios.filter((s) => (s.dataset_rows || 0) > 0),
+    [scenarios],
+  );
+
   const handleScenarioToggle = (scenarioId) => {
     setFormData((prev) => {
-      const newScenarioIds = prev.scenarioIds.includes(scenarioId)
+      const isSelected = prev.scenarioIds.includes(scenarioId);
+      if (!isSelected) {
+        const scenario = scenarios.find((s) => s.id === scenarioId);
+        if (scenario && (scenario.dataset_rows || 0) === 0) return prev;
+      }
+      const newScenarioIds = isSelected
         ? prev.scenarioIds.filter((id) => id !== scenarioId)
         : [...prev.scenarioIds, scenarioId];
       return { ...prev, scenarioIds: newScenarioIds };
@@ -132,12 +143,12 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
   };
 
   const handleSelectAll = () => {
-    if (formData.scenarioIds.length === scenarios.length) {
+    if (formData.scenarioIds.length === selectableScenarios.length) {
       setFormData((prev) => ({ ...prev, scenarioIds: [] }));
     } else {
       setFormData((prev) => ({
         ...prev,
-        scenarioIds: scenarios.map((s) => s.id),
+        scenarioIds: selectableScenarios.map((s) => s.id),
       }));
     }
   };
@@ -173,7 +184,7 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
       queryClient.invalidateQueries({
         queryKey: ["run-tests", "prompt", promptTemplateId],
       });
-        if (simulationId) {
+      if (simulationId) {
         setIsStarting(true);
         try {
           await axios.post(
@@ -222,7 +233,11 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
       });
       return;
     }
-    createSimulation(formData);
+    const scenarioIds = formData.scenarioIds.filter((id) => {
+      const scenario = scenarios.find((s) => s.id === id);
+      return !scenario || (scenario.dataset_rows || 0) > 0;
+    });
+    createSimulation({ ...formData, scenarioIds });
   };
 
   return (
@@ -369,9 +384,9 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
                     />
                   </IconButton>
                 </Tooltip>
-                {scenarios.length > 0 && (
+                {selectableScenarios.length > 0 && (
                   <Button size="small" onClick={handleSelectAll}>
-                    {formData.scenarioIds.length === scenarios.length
+                    {formData.scenarioIds.length === selectableScenarios.length
                       ? "Deselect All"
                       : "Select All"}
                   </Button>
@@ -441,32 +456,51 @@ const CreateSimulationModal = ({ open, onClose, onSuccess }) => {
                     />
                   </ListItem>
                 ) : (
-                  scenarios.map((scenario) => (
-                    <ListItem key={scenario.id} disablePadding>
-                      <ListItemButton
-                        onClick={() => handleScenarioToggle(scenario.id)}
-                        dense
+                  scenarios.map((scenario) => {
+                    const isEmpty = (scenario.dataset_rows || 0) === 0;
+                    return (
+                      <CustomTooltip
+                        key={scenario.id}
+                        show={isEmpty}
+                        title="This scenario has no datapoints to run against."
+                        placement="left"
+                        arrow
+                        size="small"
                       >
-                        <ListItemIcon sx={{ minWidth: 36 }}>
-                          <Checkbox
-                            edge="start"
-                            checked={formData.scenarioIds.includes(scenario.id)}
-                            tabIndex={-1}
-                            disableRipple
-                            size="small"
-                          />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={scenario.name}
-                          secondary={
-                            scenario.description || scenario.scenarioType
-                          }
-                          primaryTypographyProps={{ variant: "body2" }}
-                          secondaryTypographyProps={{ variant: "caption" }}
-                        />
-                      </ListItemButton>
-                    </ListItem>
-                  ))
+                        <ListItem disablePadding>
+                          <ListItemButton
+                            onClick={() => handleScenarioToggle(scenario.id)}
+                            disabled={isEmpty}
+                            dense
+                          >
+                            <ListItemIcon sx={{ minWidth: 36 }}>
+                              <Checkbox
+                                edge="start"
+                                checked={formData.scenarioIds.includes(
+                                  scenario.id,
+                                )}
+                                disabled={isEmpty}
+                                tabIndex={-1}
+                                disableRipple
+                                size="small"
+                              />
+                            </ListItemIcon>
+                            <ListItemText
+                              primary={scenario.name}
+                              secondary={
+                                isEmpty
+                                  ? "No datapoints"
+                                  : scenario.description ||
+                                    scenario.scenarioType
+                              }
+                              primaryTypographyProps={{ variant: "body2" }}
+                              secondaryTypographyProps={{ variant: "caption" }}
+                            />
+                          </ListItemButton>
+                        </ListItem>
+                      </CustomTooltip>
+                    );
+                  })
                 )}
               </List>
             )}

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx
@@ -24,6 +24,7 @@ import { useParams } from "react-router";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "src/components/snackbar";
 import axios, { endpoints } from "src/utils/axios";
+import CustomTooltip from "src/components/tooltip";
 import { useSimulationDetailContext } from "./context/SimulationDetailContext";
 import VersionSelect from "./VersionSelect";
 import SimulationEvaluationDrawer from "./SimulationEvaluationDrawer";
@@ -227,6 +228,11 @@ const SimulationDetailHeader = ({ onBack }) => {
   const evals =
     simulation?.simulate_eval_configs_detail || simulation?.evals_detail || [];
 
+  const selectedScenarioIds = new Set(selectedScenarios || []);
+  const hasEmptyScenario = (simulation?.scenarios_detail || []).some(
+    (s) => selectedScenarioIds.has(s.id) && (s.dataset_rows || 0) === 0,
+  );
+
   return (
     <>
       <Box
@@ -357,22 +363,35 @@ const SimulationDetailHeader = ({ onBack }) => {
               </Button>
 
               {/* Run Button */}
-              <Button
-                variant="contained"
+              <CustomTooltip
+                show={hasEmptyScenario}
+                title="Some selected scenarios have no datapoints. Remove them from the selection to run."
                 size="small"
-                color="primary"
-                startIcon={
-                  isExecuting ? (
-                    <CircularProgress size={14} color="inherit" />
-                  ) : (
-                    <SvgColor src="/assets/icons/navbar/ic_get_started.svg" />
-                  )
-                }
-                onClick={() => executeSimulation()}
-                disabled={isExecuting || selectedScenarios.length === 0}
+                arrow
               >
-                {isExecuting ? "Starting..." : "Run Simulation"}
-              </Button>
+                <Box>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    color="primary"
+                    startIcon={
+                      isExecuting ? (
+                        <CircularProgress size={14} color="inherit" />
+                      ) : (
+                        <SvgColor src="/assets/icons/navbar/ic_get_started.svg" />
+                      )
+                    }
+                    onClick={() => executeSimulation()}
+                    disabled={
+                      isExecuting ||
+                      selectedScenarios.length === 0 ||
+                      hasEmptyScenario
+                    }
+                  >
+                    {isExecuting ? "Starting..." : "Run Simulation"}
+                  </Button>
+                </Box>
+              </CustomTooltip>
             </>
           )}
         </Box>


### PR DESCRIPTION
**Ticket:** [TH-7038](https://linear.app/future-agi/issue/TH-7038/simulation-create-block-0-datapoint-scenarios-from-selection-next) — Fixes TH-7038

## What was the bug
In the Simulation flows, scenarios with **0 datapoints** (backend `dataset_rows`) could be selected and run. On the default (Celery) backend this creates an empty "completed" run with zero calls; on the Temporal backend it creates one dataless phantom call per empty scenario. Either way the user gets a misleading junk run they never intended. Neither backend errors, so the frontend is the only place to give honest feedback.

## What changes have been done
- `frontend/src/components/run-tests/CreateRunTestPage.jsx` — Run Simulation wizard picker: 0-datapoint rows are disabled + dimmed with a "No datapoints" chip and tooltip; `handleScenarioToggle` blocks adding them; a `runnableScenarioIds` filter strips any empty id from the create/voice-execute payload.
- `frontend/src/sections/test/TestRuns/ScenarioPopover.jsx` — re-run picker: blocks adding an empty scenario (`blockAdd = isEmpty && !isSelected`) while still allowing an already-attached empty one to be removed; shows "No datapoints" + tooltip.
- `frontend/src/sections/test/TestRuns/TestRunHeader.jsx` — "Run New Simulation" button is disabled (with tooltip) when a selected scenario has 0 datapoints, mirroring the existing incomplete-scenario gate.
- `frontend/src/sections/workbench/createPrompt/Simulate/CreateSimulationModal.jsx` — workbench "Create Chat Simulation" picker: empty rows disabled + tooltip; "Select All" only picks scenarios with datapoints; submit filters empties from the payload.
- `frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationDetailHeader.jsx` — "Run Simulation" button is disabled (with tooltip) when an attached scenario has 0 datapoints.

## Why the changes
- A 0-datapoint scenario has nothing to run against, so any run it's part of is empty/phantom — a dead-end result. Blocking at selection (and gating the run buttons for pre-existing attachments) is the only honest UX since the backend silently "succeeds".
- Payload filters are a defensive net; they keep ids not on the loaded page (valid selections we can't inspect) and only drop known-empty ones, so no valid selection is ever dropped.
- Terminology uses the product's word "datapoints" (the scenario grid column is "No of Datapoints"), not backend terms like rows/dataset.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Wizard: scenario shows 0 datapoints | Row dimmed, checkbox disabled, "No datapoints" + tooltip; can't select |
| 2 | Wizard: select only non-empty scenarios → Next | Proceeds; payload has no empty ids |
| 3 | Re-run popover: empty scenario not yet selected | Disabled, can't add |
| 4 | Re-run popover: empty scenario already attached | Still removable; Run button disabled until removed |
| 5 | Workbench create: "Select All" with some empty scenarios | Only non-empty get selected |
| 6 | SimulationDetailHeader: sim has an attached 0-datapoint scenario | "Run Simulation" disabled with tooltip |

## How to reproduce (original bug)
1. Create a scenario whose dataset has 0 rows (or otherwise shows 0 datapoints).
2. Go to Run Simulation → Choose Scenarios, select that 0-datapoint scenario, click Next and run.
3. Observe an empty/"completed" run with no meaningful results.

## Videos and screenshots
<img width="709" height="788" alt="Screenshot 2026-07-17 at 2 25 20 PM" src="https://github.com/user-attachments/assets/974757ed-023b-44dd-8491-47d57f7af5c6" />
<img width="1866" height="1080" alt="Screenshot 2026-07-17 at 2 12 15 PM" src="https://github.com/user-attachments/assets/c5170ff3-0278-4c14-9ce4-71a948327f52" />
<img width="1783" height="1080" alt="Screenshot 2026-07-17 at 2 12 10 PM" src="https://github.com/user-attachments/assets/20f1a0c5-527f-4651-9385-489819011e61" />
<img width="1302" height="1080" alt="Screenshot 2026-07-17 at 2 04 07 PM" src="https://github.com/user-attachments/assets/2d73355f-560c-4980-863f-aef562497fe0" />

https://github.com/user-attachments/assets/96987bc1-d216-4ce1-b5a1-64b5101dd37b

