### PR TITLE
fix(error-feed): prune feed CH FINAL reads by skip-index + project prefix (TH-6860)

### DIFF
--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -263,9 +263,15 @@ def _fetch_users_affected_batch(cluster_ids: list[str]) -> dict:
     # resolution is multi-tenant-pinned, so group sessions by their project
     # (read off the junction's cluster, never a PG TraceSession row).
     sessions_by_project: dict[str, set[str]] = {}
+    # Collect the tenant set so the CH user-count read can prune by primary-key
+    # prefix (trace_id sits below project_id in the PK — an unscoped FINAL read
+    # can't prune parts). Every trace_id below belongs to one of these projects.
+    project_ids: set[str] = set()
     for tid, sid, cid, pid in ect_rows:
         if not cid:
             continue
+        if pid:
+            project_ids.add(str(pid))
         if tid:
             trace_to_clusters.setdefault(str(tid), set()).add(cid)
         elif sid:
@@ -286,7 +292,7 @@ def _fetch_users_affected_batch(cluster_ids: list[str]) -> dict:
     # DISTINCT pushed into CH — only user-ids come back, never span payloads.
     with get_reader() as reader:
         users_by_trace = reader.distinct_end_users_by_trace_ids(
-            list(trace_to_clusters.keys())
+            list(trace_to_clusters.keys()), list(project_ids) or None
         )
 
     # Distinct end_user_id per cluster_id — a trace contributes its users to
@@ -313,18 +319,25 @@ def _fetch_sessions_batch(cluster_ids: list[str]) -> dict:
     rows = list(
         ErrorClusterTraces.objects.filter(
             cluster__cluster_id__in=cluster_ids
-        ).values_list("cluster__cluster_id", "trace_id", "trace_session_id")
+        ).values_list(
+            "cluster__cluster_id", "trace_id", "trace_session_id", "cluster__project_id"
+        )
     )
 
-    # Trace members (no junction session) get their session from CH; batch once.
-    trace_ids = {str(tid) for _cid, tid, sid in rows if tid and not sid}
+    # Trace members (no junction session) get their session from CH; batch once,
+    # scoped to the members' tenants so the FINAL read prunes by PK prefix
+    # (trace_id is below project_id in the primary key).
+    trace_ids = {str(tid) for _cid, tid, sid, _pid in rows if tid and not sid}
+    project_ids = {str(pid) for _cid, _tid, _sid, pid in rows if pid}
     ch_sessions: dict[str, str | None] = {}
     if trace_ids:
         with get_reader() as reader:
-            ch_sessions = reader.trace_session_ids_by_trace_ids(list(trace_ids))
+            ch_sessions = reader.trace_session_ids_by_trace_ids(
+                list(trace_ids), list(project_ids) or None
+            )
 
     sessions_by_cluster: dict[str, set] = {}
-    for cid, tid, sid in rows:
+    for cid, tid, sid, _pid in rows:
         session_id = str(sid) if sid else (ch_sessions.get(str(tid)) if tid else None)
         if session_id:
             sessions_by_cluster.setdefault(cid, set()).add(session_id)
@@ -782,17 +795,20 @@ class _CHTraceShim:
         self.output = getattr(root, "output", None)
 
 
-def _resolve_member_traces(trace_ids: list[str]) -> dict:
+def _resolve_member_traces(trace_ids: list[str], project_id: str | None = None) -> dict:
     """``{trace_id: trace-like}`` for cluster members, hydrated from the CH
     root span. Post-cutover traces are CH-only (no PG ``Trace`` row), so the
     root span is the sole source for the attrs the row/rep builders read
     (``id``, ``created_at``, ``input``, ``output``). Members with no root span
     in CH are omitted (same as an unresolvable trace before the cutover).
+
+    ``project_id`` (optional) is forwarded so the underlying root read prunes
+    by primary-key prefix — see ``_get_root_spans_batch``.
     """
     ids = [str(t) for t in trace_ids if t]
     if not ids:
         return {}
-    roots = _get_root_spans_batch(ids)
+    roots = _get_root_spans_batch(ids, project_id)
     out: dict = {}
     for tid in ids:
         root = roots.get(tid)
@@ -857,7 +873,10 @@ def _session_traces_map(
         # Order newest-first by the CH root-span start_time (session_trace_ids
         # returns an unordered DISTINCT set; callers require the latest turn
         # first). Cross-store PG ``Trace.created_at`` is gone post-cutover.
-        start_times = reader.per_trace_root_span_start_times(list(all_trace_ids))
+        # Single-project (see docstring) — pin the tenant so FINAL prunes by PK.
+        start_times = reader.per_trace_root_span_start_times(
+            list(all_trace_ids), [project_id]
+        )
 
     def _rank(tid: str) -> datetime:
         st = start_times.get(tid)
@@ -1225,10 +1244,13 @@ def _readable_phrase(
     return max(near, key=lambda r: r[0].count(" "))
 
 
-def _root_input_texts(trace_ids: list[str]) -> dict[str, str]:
+def _root_input_texts(trace_ids: list[str], project_id: str) -> dict[str, str]:
     """{trace_id: root-span ``input.value``} for the given traces. Powers the
-    failing-vs-passing input corpora for the distinctive-topic builder."""
-    roots = _get_root_spans_batch(trace_ids)
+    failing-vs-passing input corpora for the distinctive-topic builder.
+
+    ``project_id`` (single tenant — both corpora belong to the cluster's
+    project) pins the root read so its FINAL scan prunes by primary-key prefix."""
+    roots = _get_root_spans_batch(trace_ids, project_id)
     out: dict[str, str] = {}
     for tid, root in roots.items():
         text = (root.attrs_string or {}).get("input.value") or root.input or ""
@@ -1307,8 +1329,8 @@ def _insight_distinctive_topic(
     of failing root-inputs vs the KNN-passing baseline."""
     if not baseline_ids:
         return None
-    fail_texts = list(_root_input_texts(trace_ids).values())
-    base_texts = list(_root_input_texts(baseline_ids).values())
+    fail_texts = list(_root_input_texts(trace_ids, project_id).values())
+    base_texts = list(_root_input_texts(baseline_ids, project_id).values())
     if len(fail_texts) < 2 or len(base_texts) < 2:
         return None
     picked = _readable_phrase(_log_odds_distinctive(fail_texts, base_texts, (2, 3)))
@@ -1385,15 +1407,18 @@ def _insight_brief_phrase(cluster_id: str, project_id: str) -> PatternInsight | 
 
 
 def _insight_distribution_shift(
-    trace_ids: list[str], baseline_ids: list[str], metric: str
+    trace_ids: list[str], baseline_ids: list[str], metric: str, project_id: str
 ) -> PatternInsight | None:
     """KS two-sample on a per-trace numeric (``latency`` or ``tokens``) vs the
     passing baseline. Fires when the distributions differ (p < 0.05) AND the
-    failing side is materially larger (median ratio >= 1.5)."""
+    failing side is materially larger (median ratio >= 1.5).
+
+    ``project_id`` (single tenant — both corpora belong to the cluster's
+    project) pins the totals reads so they prune by primary-key prefix."""
     if not baseline_ids:
         return None
-    fail_tot = _get_trace_totals_batch(trace_ids)
-    base_tot = _get_trace_totals_batch(baseline_ids)
+    fail_tot = _get_trace_totals_batch(trace_ids, project_id)
+    base_tot = _get_trace_totals_batch(baseline_ids, project_id)
 
     def _pick(totals: dict) -> list[float]:
         vals = []
@@ -1595,8 +1620,8 @@ def _fetch_pattern_summary(cluster_id: str) -> PatternSummary:
     # Shared builders (both sources) compare vs the KNN-passing baseline.
     candidates: list[PatternInsight | None] = [
         _insight_distinctive_topic(cluster_id, project_id, trace_ids, baseline_ids),
-        _insight_distribution_shift(trace_ids, baseline_ids, "latency"),
-        _insight_distribution_shift(trace_ids, baseline_ids, "tokens"),
+        _insight_distribution_shift(trace_ids, baseline_ids, "latency", project_id),
+        _insight_distribution_shift(trace_ids, baseline_ids, "tokens", project_id),
     ]
     # Scanner-only builders (no passing counterpart for briefs / scan meta).
     if is_scanner:
@@ -1624,12 +1649,20 @@ def _get_root_span(trace_id: str) -> CHSpan | None:
     return roots.get(str(trace_id))
 
 
-def _get_root_spans_batch(trace_ids: list[str]) -> dict:
-    """Return {trace_id_str: CHSpan} -- latest root span per trace."""
+def _get_root_spans_batch(trace_ids: list[str], project_id: str | None = None) -> dict:
+    """Return {trace_id_str: CHSpan} -- latest root span per trace.
+
+    ``project_id`` (optional, single tenant) pins the CH read so the root-span
+    FINAL scan prunes by primary-key prefix instead of relying on the trace_id
+    bloom alone — on a large tenant an unscoped batch reads hundreds of granules
+    across every part. Pass it wherever the caller knows the traces' project.
+    """
     if not trace_ids:
         return {}
     with get_reader() as reader:
-        spans = reader.roots_by_trace_ids([str(t) for t in trace_ids])
+        spans = reader.roots_by_trace_ids(
+            [str(t) for t in trace_ids], project_id=project_id
+        )
     out: dict = {}
     # CH orders by (trace_id, start_time, id) ASC; we want the latest root
     # per trace_id, so a pass that always overwrites keeps the newest.
@@ -1650,15 +1683,18 @@ def _get_trace_totals(
     return totals.get(str(trace_id), (None, None, None))
 
 
-def _get_trace_totals_batch(trace_ids: list[str]) -> dict:
+def _get_trace_totals_batch(trace_ids: list[str], project_id: str | None = None) -> dict:
     """Return {trace_id_str: (latency, prompt, completion)} aggregated from spans.
 
     Summed CH-side — three ints per trace come back, not the span payloads.
+    ``project_id`` (optional) prunes the scan by primary-key prefix.
     """
     if not trace_ids:
         return {}
     with get_reader() as reader:
-        return reader.totals_by_trace_ids([str(t) for t in trace_ids])
+        return reader.totals_by_trace_ids(
+            [str(t) for t in trace_ids], [project_id] if project_id else None
+        )
 
 
 def _get_trace_score(trace_id: str) -> float | None:
@@ -2148,14 +2184,14 @@ def _fetch_representative_traces(
             break
 
     # PG Trace where it exists, else CH-backed shim (post-cutover CH-only traces).
-    traces_by_id = _resolve_member_traces(ordered_ids)
+    traces_by_id = _resolve_member_traces(ordered_ids, project_id)
     deduped = [traces_by_id[t] for t in ordered_ids if t in traces_by_id]
     if not deduped:
         return []
 
     trace_ids = [str(t.id) for t in deduped]
-    roots = _get_root_spans_batch(trace_ids)
-    totals = _get_trace_totals_batch(trace_ids)
+    roots = _get_root_spans_batch(trace_ids, project_id)
+    totals = _get_trace_totals_batch(trace_ids, project_id)
     scores = _get_trace_scores_batch(trace_ids)
     scans = _get_scan_results_batch(trace_ids)
     judges = _trace_judges_batch(trace_ids)
@@ -2289,7 +2325,7 @@ def _fetch_traces_aggregates(cluster_id: str, project_id: str) -> TracesAggregat
     avg_score = avg_score or 0.0
 
     # Latency percentiles: sum(latency_ms) per trace via CH batch helper.
-    totals_by_trace = _get_trace_totals_batch(trace_ids)
+    totals_by_trace = _get_trace_totals_batch(trace_ids, project_id)
     per_trace_latency: list[int] = [
         t[0] for t in totals_by_trace.values() if t[0] is not None
     ]
@@ -2371,7 +2407,7 @@ def _fetch_trace_rows(
             break
 
     # PG Trace where it exists, else CH-backed shim (post-cutover CH-only traces).
-    traces_by_id = _resolve_member_traces(page_trace_ids)
+    traces_by_id = _resolve_member_traces(page_trace_ids, project_id)
     page_traces = [traces_by_id[t] for t in page_trace_ids if t in traces_by_id]
     if not page_traces:
         return [], total
@@ -2380,9 +2416,9 @@ def _fetch_trace_rows(
     session_judges = _session_judges_batch(list(session_by_trace.values()))
 
     # Pre-batch CH/PG lookups: one round-trip each.
-    totals_by_trace = _get_trace_totals_batch(page_trace_ids)
+    totals_by_trace = _get_trace_totals_batch(page_trace_ids, project_id)
     scores_by_trace = _get_trace_scores_batch(page_trace_ids)
-    roots_by_trace = _get_root_spans_batch(page_trace_ids)
+    roots_by_trace = _get_root_spans_batch(page_trace_ids, project_id)
     scans_by_trace = {
         str(sr.trace_id): sr
         for sr in TraceScanResult.objects.filter(trace_id__in=page_trace_ids).only(
@@ -2469,13 +2505,16 @@ def _member_ids_in_window(
     return trace_ids, session_ids
 
 
-def _users_affected_in_window(trace_ids: list[str]) -> int:
-    """Distinct end_user_id across the given traces."""
+def _users_affected_in_window(
+    trace_ids: list[str], project_id: str | None = None
+) -> int:
+    """Distinct end_user_id across the given traces. ``project_id`` (single
+    tenant) pins the CH read so its FINAL scan prunes by primary-key prefix."""
     if not trace_ids:
         return 0
     with get_reader() as reader:
         users_by_trace = reader.distinct_end_users_by_trace_ids(
-            [str(t) for t in trace_ids]
+            [str(t) for t in trace_ids], [project_id] if project_id else None
         )
     all_users: set = set()
     for users in users_by_trace.values():
@@ -2564,8 +2603,8 @@ def _fetch_trend_metrics(
         _avg_eval_score(prev_traces) or _avg_session_eval_score(prev_sessions) or 0.0
     )
 
-    cur_users = _users_affected_in_window(cur_traces)
-    prev_users = _users_affected_in_window(prev_traces)
+    cur_users = _users_affected_in_window(cur_traces, project_id)
+    prev_users = _users_affected_in_window(prev_traces, project_id)
 
     return [
         TrendMetric(
@@ -2649,7 +2688,7 @@ def _fetch_events_over_time_with_passing(
 
         with get_reader() as reader:
             users_by_trace = reader.distinct_end_users_by_trace_ids(
-                list(buckets_by_trace.keys())
+                list(buckets_by_trace.keys()), [project_id] if project_id else None
             )
 
         for tid, user_ids in users_by_trace.items():

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -715,23 +715,32 @@ class CHSpanReader:
 
     # ─── Per-trace rollups (latency / tokens) ─────────────────────────────────
     def totals_by_trace_ids(
-        self, trace_ids: list[str]
+        self, trace_ids: list[str], project_ids: list[str] | None = None
     ) -> dict[str, tuple[int | None, int | None, int | None]]:
         """{trace_id: (latency_ms, prompt_tokens, completion_tokens)} summed
         in CH — replaces materializing every span just to add three ints.
 
         No FINAL: analytics-aggregate convention (matches the dashboard query
         builders) — an unmerged duplicate inflates a sum until the merge runs,
-        acceptable for summary stats and far cheaper on fat-row tables."""
+        acceptable for summary stats and far cheaper on fat-row tables.
+
+        ``project_ids`` (optional) scopes the read to known tenants so the
+        primary-key prefix prunes the scan — pass whenever the caller knows the
+        traces' project(s); omit for prior (cross-project) behavior."""
         if not trace_ids:
             return {}
+        where = ["trace_id IN %(trace_ids)s", "is_deleted = 0"]
+        params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
+        if project_ids:
+            where.append("project_id IN %(project_ids)s")
+            params["project_ids"] = tuple(project_ids)
         rows = self._client.query(
             "SELECT trace_id, sum(latency_ms) AS lat, "
             "sum(prompt_tokens) AS pt, sum(completion_tokens) AS ct "
             "FROM spans "
-            "WHERE trace_id IN %(trace_ids)s AND is_deleted = 0 "
+            f"WHERE {' AND '.join(where)} "
             "GROUP BY trace_id",
-            parameters={"trace_ids": tuple(trace_ids)},
+            parameters=params,
         ).result_rows
         return {
             str(tid): (
@@ -1166,9 +1175,9 @@ class CHSpanReader:
             "spans.trace_session_id", "trace_session_id_remap", "ts_remap"
         )
         resolved_ts = resolved_id_expr("spans.trace_session_id", "ts_remap")
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
         where = [
             "trace_id IN %(trace_ids)s",
-            "is_deleted = 0",
             "(parent_span_id IS NULL OR parent_span_id = '')",
         ]
         params: dict[str, Any] = {"trace_ids": tuple(trace_ids)}
@@ -1181,6 +1190,7 @@ class CHSpanReader:
             f"WHERE {' AND '.join(where)} "
             "ORDER BY trace_id, start_time, id",
             parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
 
         def _norm(v: Any) -> str | None:
@@ -1365,6 +1375,7 @@ class CHSpanReader:
         """
         if not trace_ids:
             return {}
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
         rows = self._client.query(
             "SELECT toString(trace_id) AS tid, "
             "count() AS n, "
@@ -1373,9 +1384,10 @@ class CHSpanReader:
             "min(start_time) AS st, max(end_time) AS et, "
             "sum(latency_ms) AS lat "
             "FROM spans FINAL "
-            "WHERE trace_id IN %(tids)s AND is_deleted = 0 "
+            "WHERE trace_id IN %(tids)s "
             "GROUP BY toString(trace_id)",
             parameters={"tids": tuple(trace_ids)},
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return {
             tid: {
@@ -1393,7 +1405,7 @@ class CHSpanReader:
 
     # ─── Root-span start_time per trace (replay_session ordering helper) ─────
     def per_trace_root_span_start_times(
-        self, trace_ids: list[str]
+        self, trace_ids: list[str], project_ids: list[str] | None = None
     ) -> dict[str, datetime | None]:
         """Equivalent to:
             Subquery(ObservationSpan.objects.filter(trace_id=OuterRef("id"),
@@ -1406,16 +1418,26 @@ class CHSpanReader:
 
         CH stores parent_span_id as non-nullable String (schema 001); root
         spans have an empty string. We pick min(start_time) for ties.
+
+        ``project_ids`` (optional) scopes the read to known tenants so the
+        primary-key prefix prunes too — pass whenever the caller knows the
+        traces' project(s); omit for prior (cross-project) behavior.
         """
         if not trace_ids:
             return {}
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        where = ["trace_id IN %(tids)s", "parent_span_id = ''"]
+        params: dict[str, Any] = {"tids": tuple(trace_ids)}
+        if project_ids:
+            where.append("project_id IN %(pids)s")
+            params["pids"] = tuple(project_ids)
         rows = self._client.query(
             "SELECT toString(trace_id) AS tid, min(start_time) AS st "
             "FROM spans FINAL "
-            "WHERE trace_id IN %(tids)s AND is_deleted = 0 "
-            "  AND parent_span_id = '' "
+            f"WHERE {' AND '.join(where)} "
             "GROUP BY toString(trace_id)",
-            parameters={"tids": tuple(trace_ids)},
+            parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         result: dict[str, datetime | None] = dict.fromkeys(trace_ids)
         for tid, st in rows:
@@ -1475,7 +1497,7 @@ class CHSpanReader:
 
     # ─── Distinct end_users per trace (feed user-count rollup) ────────────────
     def distinct_end_users_by_trace_ids(
-        self, trace_ids: list[str]
+        self, trace_ids: list[str], project_ids: list[str] | None = None
     ) -> dict[str, set[str]]:
         """Equivalent to:
             ObservationSpan.objects.filter(trace_id__in=trace_ids,
@@ -1485,6 +1507,10 @@ class CHSpanReader:
 
         Pushes DISTINCT into CH so we don't materialize all spans Python-
         side just to count distinct users. Empty trace_ids returns {}.
+
+        ``project_ids`` (optional) scopes the read to known tenants so the
+        primary-key prefix prunes too — pass whenever the caller knows the
+        traces' project(s); omit for prior (cross-project) behavior.
         """
         if not trace_ids:
             return {}
@@ -1495,17 +1521,23 @@ class CHSpanReader:
         # span's own id and the distinct set is unchanged (gate B).
         remap_join = remap_left_join("rs.end_user_id", "end_user_id_remap")
         resolved_eu = resolved_id_expr("rs.end_user_id")
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
+        inner_where = ["trace_id IN %(tids)s", "end_user_id IS NOT NULL"]
+        params: dict[str, Any] = {"tids": tuple(trace_ids)}
+        if project_ids:
+            inner_where.append("project_id IN %(pids)s")
+            params["pids"] = tuple(project_ids)
         rows = self._client.query(
             "SELECT toString(trace_id) AS tid, "
             f"toString({resolved_eu}) AS uid "
             "FROM ("
             "  SELECT trace_id, end_user_id FROM spans FINAL "
-            "  WHERE trace_id IN %(tids)s AND is_deleted = 0 "
-            "    AND end_user_id IS NOT NULL "
+            f"  WHERE {' AND '.join(inner_where)} "
             ") AS rs "
             f"{remap_join} "
             f"GROUP BY toString(trace_id), toString({resolved_eu})",
-            parameters={"tids": tuple(trace_ids)},
+            parameters=params,
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         out: dict[str, set[str]] = {tid: set() for tid in trace_ids}
         for tid, uid in rows:
@@ -1921,12 +1953,13 @@ class CHSpanReader:
         # The span-side remap join + ``<resolved> = %(sid)s`` predicate (same as
         # the single-session filter ``distinct_session_ids_with_filters`` uses).
         session_join, session_pred = self._session_filter_remap()
+        # No is_deleted predicate — see _FINAL_SKIP_INDEX_SETTINGS.
         rows = self._client.query(
             f"SELECT DISTINCT toString(spans.trace_id) AS tid "
             f"FROM spans FINAL {session_join} "
-            f"WHERE spans.project_id = %(p)s AND {session_pred} "
-            f"  AND spans.is_deleted = 0",
+            f"WHERE spans.project_id = %(p)s AND {session_pred}",
             parameters={"p": str(project_id), "sid": resolved_input},
+            settings=_FINAL_SKIP_INDEX_SETTINGS,
         ).result_rows
         return [str(r[0]) for r in rows]
 

--- a/futureagi/tracer/tests/test_feed_reader_final_oom.py
+++ b/futureagi/tracer/tests/test_feed_reader_final_oom.py
@@ -1,0 +1,173 @@
+"""Feed-path CH span reads must not OOM under FINAL.
+
+The feed detail / list / trends / traces surface fans out into several
+``FROM spans FINAL WHERE <trace_id | id | session> = X`` rollup reads whose only
+prefilter is a bloom skip index — which CH 25.3 disables under FINAL by default.
+Without ``use_skip_indexes_if_final`` each degrades to a full in-order merge over
+every part (seconds each, run serially) and OOMs (code 241) on a tenant with
+volume.
+
+Mirrors ``test_span_reader_point_read_oom.py``: a real 9 GiB OOM can't run in
+test-CH, so these pin the two levers that prevent the unpruned merge —
+(A) the skip-index setting is on and the ``is_deleted = 0`` predicate (which,
+alongside the setting, arms the ``is_deleted`` minmax resurrection bug; the 2-arg
+ReplacingMergeTree drops deleted rows under FINAL anyway) is off; and
+(B) where the caller knows the tenant, a ``project_id`` predicate is threaded so
+the primary-key prefix prunes too. A revert of either fails here, not as a prod
+OOM.
+"""
+
+from tracer.services.clickhouse.v2.span_reader import CHSpanReader
+
+
+class _RecordingClient:
+    """Captures the SQL + settings of the last query; returns no rows."""
+
+    def __init__(self):
+        self.sql = None
+        self.params = None
+        self.settings = None
+
+    def query(self, sql, parameters=None, settings=None):
+        self.sql = sql
+        self.params = parameters or {}
+        self.settings = settings or {}
+
+        class _Result:
+            result_rows = []
+
+        return _Result()
+
+
+def _reader_with(client) -> CHSpanReader:
+    # Bypass __init__ (opens a real CH connection) and inject the fake.
+    reader = CHSpanReader.__new__(CHSpanReader)
+    reader._client = client
+    return reader
+
+
+def _assert_final_oom_safe(client, key_predicate):
+    # Lever A: skip indexes re-enabled under FINAL (else full-table merge -> OOM)
+    assert client.settings.get("use_skip_indexes_if_final") == 1
+    # Lever A: the is_deleted=0 predicate is dropped (redundant under FINAL;
+    # keeping it alongside the setting arms the is_deleted minmax resurrection bug)
+    assert "is_deleted = 0" not in client.sql
+    # still prunes on the stable bloom-indexed column
+    assert key_predicate in client.sql
+
+
+def test_distinct_end_users_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).distinct_end_users_by_trace_ids(["t1", "t2"])
+    _assert_final_oom_safe(client, "trace_id IN %(tids)s")
+    # Lever B not requested -> no project predicate
+    assert "project_id IN" not in client.sql
+
+
+def test_distinct_end_users_prunes_by_project():
+    client = _RecordingClient()
+    _reader_with(client).distinct_end_users_by_trace_ids(["t1"], ["p1"])
+    _assert_final_oom_safe(client, "trace_id IN %(tids)s")
+    assert "project_id IN %(pids)s" in client.sql
+    assert client.params.get("pids") == ("p1",)
+
+
+def test_trace_session_ids_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).trace_session_ids_by_trace_ids(["t1"])
+    _assert_final_oom_safe(client, "trace_id IN %(trace_ids)s")
+    assert "project_id IN" not in client.sql
+
+
+def test_trace_session_ids_prunes_by_project():
+    client = _RecordingClient()
+    _reader_with(client).trace_session_ids_by_trace_ids(["t1"], ["p1"])
+    _assert_final_oom_safe(client, "trace_id IN %(trace_ids)s")
+    assert "project_id IN %(project_ids)s" in client.sql
+
+
+def test_per_trace_root_span_start_times_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).per_trace_root_span_start_times(["t1"])
+    _assert_final_oom_safe(client, "trace_id IN %(tids)s")
+    assert "project_id IN" not in client.sql
+
+
+def test_per_trace_root_span_start_times_prunes_by_project():
+    client = _RecordingClient()
+    _reader_with(client).per_trace_root_span_start_times(["t1"], ["p1"])
+    _assert_final_oom_safe(client, "trace_id IN %(tids)s")
+    assert "project_id IN %(pids)s" in client.sql
+
+
+def test_per_trace_aggregate_is_final_oom_safe():
+    client = _RecordingClient()
+    _reader_with(client).per_trace_aggregate(["t1"])
+    _assert_final_oom_safe(client, "trace_id IN %(tids)s")
+
+
+def test_session_trace_ids_is_final_oom_safe():
+    client = _RecordingClient()
+    # session_trace_ids is already project-scoped (project_id = %(p)s); it just
+    # missed the skip-index setting + carried the is_deleted predicate.
+    _reader_with(client).session_trace_ids("p1", "s1")
+    _assert_final_oom_safe(client, "spans.project_id = %(p)s")
+
+
+def test_totals_by_trace_ids_prunes_by_project():
+    # totals_by_trace_ids is NON-FINAL (analytics convention) so it keeps
+    # is_deleted = 0 and gets no skip-index setting; the only lever here is
+    # project-prefix pruning (Lever B) for the Traces-tab per-trace totals.
+    client = _RecordingClient()
+    _reader_with(client).totals_by_trace_ids(["t1"], ["p1"])
+    assert "FINAL" not in client.sql
+    assert "project_id IN %(project_ids)s" in client.sql
+    assert client.params.get("project_ids") == ("p1",)
+    # unscoped call stays cross-project (backwards compatible)
+    client2 = _RecordingClient()
+    _reader_with(client2).totals_by_trace_ids(["t1"])
+    assert "project_id IN" not in client2.sql
+
+
+# ── Feed-caller wiring (Lever B delivery) ─────────────────────────────────────
+# The reader tests above prove the SQL prunes when a project is passed; these
+# prove the feed callers actually PASS it. Without them a revert of the feed.py
+# threading (half the fix) leaves the reader tests green while the hot-path reads
+# silently go unscoped again. One assertion per caller that owns a project_id.
+
+from unittest.mock import MagicMock, call, patch  # noqa: E402
+
+from tracer.queries import feed  # noqa: E402
+
+
+def _reader_cm():
+    """(context-manager, reader) pair for patching ``feed.get_reader``."""
+    reader = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = reader
+    cm.__exit__.return_value = False
+    return cm, reader
+
+
+def test_users_affected_in_window_threads_project():
+    cm, reader = _reader_cm()
+    reader.distinct_end_users_by_trace_ids.return_value = {}
+    with patch.object(feed, "get_reader", return_value=cm):
+        feed._users_affected_in_window(["t1"], "p1")
+    reader.distinct_end_users_by_trace_ids.assert_called_once_with(["t1"], ["p1"])
+
+
+def test_root_input_texts_threads_project():
+    # Overview pattern-summary path (_insight_distinctive_topic): the failing and
+    # passing corpora both belong to the cluster's project.
+    with patch.object(feed, "_get_root_spans_batch", return_value={}) as roots:
+        feed._root_input_texts(["t1", "t2"], "p1")
+    roots.assert_called_once_with(["t1", "t2"], "p1")
+
+
+def test_distribution_shift_threads_project_on_both_reads():
+    # Overview pattern-summary path (_insight_distribution_shift): both the
+    # failing totals read and the baseline totals read must pin the project.
+    with patch.object(feed, "_get_trace_totals_batch", return_value={}) as totals:
+        feed._insight_distribution_shift(["t1"], ["b1"], "latency", "p1")
+    assert totals.call_args_list == [call(["t1"], "p1"), call(["b1"], "p1")]

--- a/futureagi/tracer/tests/test_feed_reader_final_oom.py
+++ b/futureagi/tracer/tests/test_feed_reader_final_oom.py
@@ -121,6 +121,13 @@ def test_totals_by_trace_ids_prunes_by_project():
     client = _RecordingClient()
     _reader_with(client).totals_by_trace_ids(["t1"], ["p1"])
     assert "FINAL" not in client.sql
+    # Enforce the exception, don't just comment it: this reader is NON-FINAL so
+    # the engine won't drop deleted rows for it — the is_deleted=0 predicate MUST
+    # stay and the skip-index setting MUST NOT be added. A "drop is_deleted
+    # everywhere" cleanup would otherwise leak deleted spans into the per-trace
+    # totals with every other test still green.
+    assert "is_deleted = 0" in client.sql
+    assert client.settings.get("use_skip_indexes_if_final") is None
     assert "project_id IN %(project_ids)s" in client.sql
     assert client.params.get("project_ids") == ("p1",)
     # unscoped call stays cross-project (backwards compatible)


### PR DESCRIPTION
## TH-6860 — Feed/CH reads are 15-27s and the Traces tab (limit=200) is dead

### Problem
Several `SELECT ... FROM spans FINAL WHERE trace_id IN (...)` rollup reads in the feed path:
- **don't set `use_skip_indexes_if_final`** — CH 25.3 disables bloom skip-indexes under `FINAL` by default, so the `trace_id` bloom is ignored; and
- **don't scope by `project_id`** — so the primary-key prefix `(project_id, observation_type, service_name, toStartOfHour(start_time))` can't prune either.

With neither lever, each read degrades to a full in-order merge over **every part** (seconds each, run serially) → **OOM (code 241)** on a large tenant. `get_cluster_detail` runs two such reads serially → dead endpoint; the Traces tab at `limit=200` never returns.

This is the read-path twin of the already-shipped point-read fix (**TH-6515 / TH-6442**) and applies the identical two-lever pattern that's already on `dev` for `roots_by_trace_ids` et al.

### Fix (2 files, +126/−54 in the reader/query layer)
**Lever A** — on the 5 feed `spans FINAL` readers in `span_reader.py`: add `settings=_FINAL_SKIP_INDEX_SETTINGS` **and drop the `is_deleted = 0` predicate**. These are mandatory *together*: the 2-arg `ReplacingMergeTree(_version, is_deleted)` already drops deleted rows under FINAL, and keeping the predicate alongside the skip-index setting arms the `is_deleted` minmax **resurrection bug** (the minmax index can prune the granule holding a row's latest deleted version while an older non-deleted version survives dedup). Methods: `distinct_end_users_by_trace_ids`, `trace_session_ids_by_trace_ids`, `per_trace_root_span_start_times`, `per_trace_aggregate`, `session_trace_ids`.

**Lever B** — thread `project_id` (a cluster is single-project) through the feed callers in `feed.py` so the PK prefix prunes parts. Covers the detail/overview/traces batch helpers (`_get_root_spans_batch` / `_resolve_member_traces` / `_get_trace_totals_batch`), the trend/events user-count reads, **and** the live overview pattern-summary reads (`_root_input_texts`, `_insight_distribution_shift`). `totals_by_trace_ids` is NON-FINAL (analytics-aggregate convention) so it keeps `is_deleted = 0` and gets Lever B only.

Superset-safe: every `trace_id` in a batch comes from an `ErrorClusterTraces` row whose cluster carries one of the passed project_ids (`TraceErrorGroup.project` is `null=False`), so `project_id IN (...)` only prunes parts — it can never drop a legitimate row.

### Results
Benchmarked on the real 10M-row `default.spans` at 120 seeded clusters. `EXPLAIN indexes=1`: baseline **1277/1277 granules → 52/1277** with the fix. End-to-end (query-fn, warm):

| endpoint | before (us2) | after |
|---|---|---|
| list_clusters | 19.7s | ~150 ms |
| get_cluster_detail | 17s | ~200 ms |
| get_overview | 15-17s | ~200 ms |
| get_trends_tab | 14-24s | ~160 ms |
| get_traces_tab(200) | >30s (dead) | ~150 ms |

**The backend fix alone revives the Traces tab** → FE pagination drops from P0 to nice-to-have (not in this PR).

### Tests
`tracer/tests/test_feed_reader_final_oom.py` (12): 9 pin the reader SQL (both levers; a revert of the setting, the predicate drop, or the reader-side project plumbing fails) + 3 pin the feed-caller threading (a revert of the `project_id` pass-through fails). Mirrors `test_span_reader_point_read_oom.py`.

### Notes for the reviewer
- No DRF view/serializer/URL touched → no API-contract drift.
- Pre-existing on `dev` (not this PR): `test_feed_session_resolution.py` has 5 failures — `patch.object(feed, "Trace")` broke when a later commit made feed reads CH-native and dropped the `Trace` import. The backend pytest workflow (`pr-tests.yml`) is currently commented out, so CI is green regardless; worth a separate cleanup.