### PR TITLE
feat: guard experiment CSV downloads

### DIFF
--- a/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx
@@ -1,24 +1,92 @@
-import { Button } from "@mui/material";
-import React from "react";
+import { Box, Button, CircularProgress } from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import React, { useRef, useState } from "react";
+import { useParams } from "react-router";
+import { enqueueSnackbar } from "src/components/snackbar";
+import axios, { endpoints } from "src/utils/axios";
 import { useExperimentDetailContext } from "../experiment-context";
 import { trackEvent, Events } from "src/utils/Mixpanel";
 import Iconify from "src/components/iconify";
 
 const ExperimentBarSummaryRightSection = () => {
+  const { experimentId } = useParams();
+  const canDownloadExperiment = Boolean(experimentId);
+  const downloadInFlightRef = useRef(false);
+  const [isDownloading, setIsDownloading] = useState(false);
   const { setChooseWinnerOpen } = useExperimentDetailContext();
 
+  const { mutate: downloadExperiment } = useMutation({
+    mutationFn: () =>
+      axios.get(endpoints.develop.experiment.downloadExperiment(experimentId), {
+        responseType: "blob",
+      }),
+    onMutate: () => {
+      setIsDownloading(true);
+    },
+    onSuccess: (response) => {
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `experiment-${experimentId}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      enqueueSnackbar("Experiment downloaded successfully", {
+        variant: "success",
+      });
+    },
+    onError: () => {
+      enqueueSnackbar("Failed to download experiment", {
+        variant: "error",
+      });
+    },
+    onSettled: () => {
+      downloadInFlightRef.current = false;
+      setIsDownloading(false);
+    },
+    meta: { errorHandled: true },
+  });
+
+  const handleDownload = () => {
+    if (!experimentId || downloadInFlightRef.current) return;
+
+    downloadInFlightRef.current = true;
+    trackEvent(Events.expDownloadClicked);
+    downloadExperiment();
+  };
+
   return (
-    <Button
-      variant="contained"
-      color="primary"
-      startIcon={<Iconify icon="mdi:crown-outline" />}
-      onClick={() => {
-        trackEvent(Events.expWinnerClick);
-        setChooseWinnerOpen(true);
-      }}
-    >
-      Choose winner
-    </Button>
+    <Box display="flex" alignItems="center" gap={1.5}>
+      {canDownloadExperiment && (
+        <Button
+          variant="outlined"
+          startIcon={
+            isDownloading ? (
+              <CircularProgress color="inherit" size={16} />
+            ) : (
+              <Iconify icon="material-symbols:download" />
+            )
+          }
+          disabled={isDownloading}
+          onClick={handleDownload}
+        >
+          {isDownloading ? "Downloading…" : "Download CSV"}
+        </Button>
+      )}
+      <Button
+        variant="contained"
+        color="primary"
+        startIcon={<Iconify icon="mdi:crown-outline" />}
+        onClick={() => {
+          trackEvent(Events.expWinnerClick);
+          setChooseWinnerOpen(true);
+        }}
+      >
+        Choose winner
+      </Button>
+    </Box>
   );
 };
 

--- a/frontend/src/sections/experiment-detail/ExperimentBarRightSection/__tests__/ExperimentBarSummaryRightSection.test.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentBarRightSection/__tests__/ExperimentBarSummaryRightSection.test.jsx
@@ -1,0 +1,261 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ExperimentBarSummaryRightSection from "../ExperimentBarSummaryRightSection";
+
+const mockGet = vi.fn();
+const mockTrackEvent = vi.fn();
+const mockEnqueueSnackbar = vi.fn();
+const mockSetChooseWinnerOpen = vi.fn();
+let anchorClick;
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: (...args) => mockGet(...args),
+  },
+  endpoints: {
+    develop: {
+      experiment: {
+        downloadExperiment: (experimentId) =>
+          `/model-hub/experiments/v2/${experimentId}/download/`,
+      },
+    },
+  },
+}));
+
+vi.mock("src/utils/Mixpanel", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    trackEvent: (...args) => mockTrackEvent(...args),
+  };
+});
+
+vi.mock("src/components/snackbar", () => ({
+  enqueueSnackbar: (...args) => mockEnqueueSnackbar(...args),
+}));
+
+vi.mock("src/sections/experiment-detail/experiment-context", () => ({
+  useExperimentDetailContext: () => ({
+    setChooseWinnerOpen: mockSetChooseWinnerOpen,
+  }),
+}));
+
+function renderComponent({
+  initialEntry = "/dashboard/develop/experiment/exp-123/summary",
+  routePath = "/dashboard/develop/experiment/:experimentId/summary",
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path={routePath}
+            element={<ExperimentBarSummaryRightSection />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExperimentBarSummaryRightSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    vi.stubGlobal("URL", {
+      ...window.URL,
+      createObjectURL: vi.fn(() => "blob:experiment-csv"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  it("renders Download CSV before the unchanged Choose winner action", () => {
+    renderComponent();
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveAccessibleName("Download CSV");
+    expect(buttons[1]).toHaveAccessibleName("Choose winner");
+  });
+
+  it("hides Download CSV on the individual experiment summary route", () => {
+    renderComponent({
+      initialEntry:
+        "/dashboard/develop/individual-experiment/ind-123/summary",
+      routePath:
+        "/dashboard/develop/individual-experiment/:individualExperimentId/summary",
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Download CSV" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Choose winner" }),
+    ).toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("tracks and starts the experiment CSV request once while disabled", async () => {
+    let resolveDownload;
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDownload = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderComponent();
+
+    const downloadButton = screen.getByRole("button", { name: "Download CSV" });
+    await user.click(downloadButton);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("Experiment_download_clicked");
+    expect(mockGet).toHaveBeenCalledWith(
+      "/model-hub/experiments/v2/exp-123/download/",
+      { responseType: "blob" },
+    );
+    expect(
+      screen.getByRole("button", { name: "Downloading…" }),
+    ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Downloading…" }));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    resolveDownload({ data: "experiment,data" });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Download CSV" })).toBeEnabled();
+    });
+  });
+
+  it("accepts one same-turn activation and releases the guard after success", async () => {
+    let resolveDownload;
+    mockGet
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveDownload = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ data: "second,download" });
+    renderComponent();
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download CSV",
+    });
+    act(() => {
+      downloadButton.click();
+      downloadButton.click();
+    });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+    resolveDownload({ data: "first,download" });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Download CSV" })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download CSV" }));
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the atomic guard after a failed request", async () => {
+    let rejectDownload;
+    mockGet
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve, reject) => {
+            rejectDownload = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ data: "retry,download" });
+    renderComponent();
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download CSV",
+    });
+    act(() => {
+      downloadButton.click();
+      downloadButton.click();
+    });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+    rejectDownload(new Error("network unavailable"));
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        "Failed to download experiment",
+        { variant: "error" },
+      );
+      expect(screen.getByRole("button", { name: "Download CSV" })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download CSV" }));
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("downloads the response with the experiment filename and reports success", async () => {
+    mockGet.mockResolvedValue({ data: "experiment,data" });
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole("button", { name: "Download CSV" }));
+
+    await waitFor(() => expect(anchorClick).toHaveBeenCalledTimes(1));
+    const link = anchorClick.mock.instances[0];
+    expect(link.download).toBe("experiment-exp-123.csv");
+    expect(link.href).toBe("blob:experiment-csv");
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(
+      "blob:experiment-csv",
+    );
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      "Experiment downloaded successfully",
+      { variant: "success" },
+    );
+  });
+
+  it("reports a failed request and restores the download action", async () => {
+    mockGet.mockRejectedValue(new Error("network unavailable"));
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole("button", { name: "Download CSV" }));
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        "Failed to download experiment",
+        { variant: "error" },
+      );
+    });
+    expect(screen.getByRole("button", { name: "Download CSV" })).toBeEnabled();
+  });
+
+  it("keeps the Choose winner behavior unchanged", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByRole("button", { name: "Choose winner" }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "Dataset_experiment_winner_clicked",
+    );
+    expect(mockSetChooseWinnerOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/utils/Mixpanel/EventNames.js
+++ b/frontend/src/utils/Mixpanel/EventNames.js
@@ -254,6 +254,7 @@ export const Events = {
   expRowDeleted: "Dataset_experiment_row_deleted",
   expRowReRunClick: "Dataset_experiment_row_re-run_clicked",
   expRowReRunSuccess: "Dataset_experiment_row_re-run_successful",
+  expDownloadClicked: "Experiment_download_clicked",
   expWinnerClick: "Dataset_experiment_winner_clicked",
   expWinnerSelect: "Dataset_experiment_winner_selected",
 


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

Adds CSV download support to the aggregate experiment Summary view, including download progress, success and error feedback, and the `Experiment_download_clicked` analytics event. The download action is hidden on individual-experiment Summary routes, and a synchronous in-flight guard prevents duplicate requests and analytics events from same-turn activations while allowing retries after success or failure.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #1459 

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

- `npm test -- --run src/sections/experiment-detail/ExperimentBarRightSection/__tests__/ExperimentBarSummaryRightSection.test.jsx` — 8/8 tests passed.
- `npx eslint src/sections/experiment-detail/ExperimentBarRightSection/ExperimentBarSummaryRightSection.jsx src/sections/experiment-detail/ExperimentBarRightSection/__tests__/ExperimentBarSummaryRightSection.test.jsx src/utils/Mixpanel/EventNames.js` — passed.
- Direct Vite production build with the local frontend binary on `PATH` — passed.
- Full frontend test suite — the scoped tests passed; remaining failures matched documented baseline/infrastructure failures outside this change.
- Playwright browser validation confirmed:
  - a normal double-click produces one request and one download;
  - same-turn `click(); click();` produces one request, one download, and one analytics event;
  - success and error paths show one snackbar and restore the download action;
  - individual-experiment Summary routes show no Download CSV action and issue no download request;
  - Choose Winner behavior remains unchanged.

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

1.  <img width="1440" height="1000" alt="01-summary-default" src="https://github.com/user-attachments/assets/08c1a27e-1afd-4a89-b241-86eb30099217" />
2.  <img width="1440" height="1000" alt="02-download-pending" src="https://github.com/user-attachments/assets/fc73bd09-9084-4d19-9d2b-4bf4dffc347e" />
3.  <img width="1440" height="1000" alt="03-download-success" src="https://github.com/user-attachments/assets/2719758a-d9d6-432c-8fe3-665c89180019" />
4.  <img width="1440" height="1000" alt="04-download-error" src="https://github.com/user-attachments/assets/5cd5aac6-1dee-4f57-8e6c-3dcd431c5a26" />
5.  <img width="1440" height="1000" alt="05-choose-winner" src="https://github.com/user-attachments/assets/58c577ce-0889-4622-89ea-6c63cd57fe77" />


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
