### PR TITLE
fix: Added fix for the enabled flag to allow to show the query when filters are present

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
@@ -186,7 +186,7 @@ const GraphSection = ({
         req_data_config: selectedGraphConfig,
         project_id: observeId,
       }),
-    enabled: selectedTab === "trace" && Boolean(selectedGraphConfig?.id),
+    enabled: selectedTab === "trace" && (Boolean(selectedGraphConfig?.id) || combinedFilters.length > 0),
     select: (data) => data.data?.result,
   });
 
@@ -216,7 +216,7 @@ const GraphSection = ({
         req_data_config: selectedGraphConfig,
         project_id: observeId,
       }),
-    enabled: selectedTab === "spans" && Boolean(selectedGraphConfig?.id),
+    enabled: selectedTab === "spans" && (Boolean(selectedGraphConfig?.id) || combinedFilters.length > 0),
     select: (data) => data.data?.result,
   });
 


### PR DESCRIPTION

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->
The enabled conditions on both graph queries in GraphSection.jsx require Boolean(selectedGraphConfig?.id), so when no graph config is selected the queries stay disabled and never refetch, even though combinedFilters (which already carries every filter and date-range change) is included in both queryKey arrays. We have added some more conditions to enable the graph quries when the combined filters are still present.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #
#1482

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->
Minimal Testing since it was mentioned in the description itself that in order to recreate the bug we need to render the file GraphSection.jsx on a standalone file.

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
