### PR TITLE
feat(tracing): import Cekura chat transcripts

### DIFF
--- a/futureagi/integrations/transformers/cekura_transformer.py
+++ b/futureagi/integrations/transformers/cekura_transformer.py
@@ -1,0 +1,236 @@
+"""Transform Cekura chat-test transcripts into FutureAGI trace records."""
+
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any
+
+from integrations.transformers.base import BaseTraceTransformer, register_transformer
+
+
+class CekuraTransformer(BaseTraceTransformer):
+    """Map a Cekura run and its transcript to the common trace shape.
+
+    Cekura can deliver transcript fields in either snake_case or camelCase.
+    The importer deliberately accepts both forms, while producing stable,
+    namespaced span IDs so webhook retries update rows instead of duplicating
+    them or colliding with spans from another source.
+    """
+
+    def transform_trace(
+        self, raw_trace: dict[str, Any], project_id: str
+    ) -> dict[str, Any]:
+        run_id = self._run_id(raw_trace)
+        metadata = raw_trace.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {"original_metadata": metadata}
+        metadata = {**metadata, "integration_source": "cekura"}
+
+        tags = raw_trace.get("tags") or []
+        if not isinstance(tags, list):
+            tags = [str(tags)]
+        if "cekura" not in tags:
+            tags.append("cekura")
+
+        return {
+            "external_id": run_id,
+            "project_id": project_id,
+            "name": (
+                raw_trace.get("name")
+                or raw_trace.get("test_name")
+                or raw_trace.get("testName")
+                or raw_trace.get("scenario_name")
+                or raw_trace.get("scenarioName")
+                or "Cekura chat test"
+            ),
+            "input": raw_trace.get("input"),
+            "output": raw_trace.get("output"),
+            "metadata": metadata,
+            "tags": tags,
+            "user_id": raw_trace.get("user_id") or raw_trace.get("userId"),
+            "session_id": raw_trace.get("session_id") or raw_trace.get("sessionId"),
+        }
+
+    def transform_observations(
+        self, raw_trace: dict[str, Any], trace_id: str, project_id: str
+    ) -> list[dict[str, Any]]:
+        run_id = self._run_id(raw_trace)
+        observations: list[dict[str, Any]] = []
+        for turn_index, turn in enumerate(self._turns(raw_trace)):
+            if not isinstance(turn, dict):
+                continue
+
+            turn_id = self._span_id(
+                "turn", run_id, self._source_id(turn, turn_index)
+            )
+            start_time = self._timestamp(
+                turn.get("start_time")
+                or turn.get("startTime")
+                or turn.get("timestamp")
+            )
+            end_time = self._timestamp(turn.get("end_time") or turn.get("endTime"))
+            role = turn.get("role") or turn.get("speaker") or "unknown"
+            content = turn.get("content", turn.get("message", turn.get("text")))
+            turn_input = turn.get("input")
+            turn_output = turn.get("output") or turn.get("response")
+            if turn_input is None and role in ("user", "customer", "system"):
+                turn_input = {"role": role, "content": content}
+            if turn_output is None and role in ("assistant", "agent", "bot"):
+                turn_output = {"role": role, "content": content}
+
+            observations.append(
+                {
+                    "id": turn_id,
+                    "trace_id": trace_id,
+                    "project_id": project_id,
+                    "parent_span_id": None,
+                    "observation_type": "conversation",
+                    "name": turn.get("name") or f"{str(role).title()} turn",
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "input": turn_input,
+                    "output": turn_output,
+                    "metadata": turn.get("metadata") or {},
+                    "model": "",
+                    "provider": "",
+                    "model_parameters": {},
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "latency_ms": self._latency_ms(turn, start_time, end_time),
+                    "cost": 0,
+                    "status": self._status(turn.get("status")),
+                    "span_attributes": {"fi.span.kind": "CONVERSATION"},
+                    "eval_attributes": {"fi.span.kind": "CONVERSATION"},
+                }
+            )
+
+            for tool_index, tool in enumerate(self._tools(turn)):
+                if not isinstance(tool, dict):
+                    continue
+                tool_start = self._timestamp(
+                    tool.get("start_time")
+                    or tool.get("startTime")
+                    or tool.get("timestamp")
+                )
+                tool_end = self._timestamp(tool.get("end_time") or tool.get("endTime"))
+                tool_id = self._span_id(
+                    "tool",
+                    run_id,
+                    f"{self._source_id(turn, turn_index)}:"
+                    f"{self._source_id(tool, tool_index)}",
+                )
+                tool_input = (
+                    tool.get("input")
+                    or tool.get("arguments")
+                    or tool.get("parameters")
+                )
+                tool_output = (
+                    tool.get("output") or tool.get("result") or tool.get("response")
+                )
+                observations.append(
+                    {
+                        "id": tool_id,
+                        "trace_id": trace_id,
+                        "project_id": project_id,
+                        "parent_span_id": turn_id,
+                        "observation_type": "tool",
+                        "name": tool.get("name") or tool.get("tool_name") or "Tool call",
+                        "start_time": tool_start,
+                        "end_time": tool_end,
+                        "input": tool_input,
+                        "output": tool_output,
+                        "metadata": tool.get("metadata") or {},
+                        "model": "",
+                        "provider": "",
+                        "model_parameters": {},
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                        "latency_ms": self._latency_ms(tool, tool_start, tool_end),
+                        "cost": 0,
+                        "status": self._status(tool.get("status")),
+                        "span_attributes": {"fi.span.kind": "TOOL"},
+                        "eval_attributes": {"fi.span.kind": "TOOL"},
+                    }
+                )
+        return observations
+
+    def transform_scores(self, raw_trace: dict[str, Any], trace_id: str) -> list[dict]:
+        """Scores belong to the separate Cekura evaluation ingestion feature."""
+        return []
+
+    @staticmethod
+    def _turns(raw_trace: dict[str, Any]) -> list[Any]:
+        transcript = (
+            raw_trace.get("turns")
+            or raw_trace.get("transcript")
+            or raw_trace.get("conversation")
+            or []
+        )
+        if isinstance(transcript, dict):
+            transcript = transcript.get("turns") or transcript.get("messages") or []
+        return transcript if isinstance(transcript, list) else []
+
+    @staticmethod
+    def _tools(turn: dict[str, Any]) -> list[Any]:
+        tools = turn.get("tool_calls") or turn.get("toolCalls") or turn.get("tools") or []
+        return tools if isinstance(tools, list) else []
+
+    @staticmethod
+    def _source_id(value: dict[str, Any], index: int) -> str:
+        return str(
+            value.get("id") or value.get("turn_id") or value.get("turnId") or index
+        )
+
+    @staticmethod
+    def _span_id(kind: str, run_id: str, source_id: str) -> str:
+        digest = sha256(f"{run_id}:{source_id}".encode()).hexdigest()[:40]
+        return f"cekura-{kind}-{digest}"
+
+    @staticmethod
+    def _run_id(raw_trace: dict[str, Any]) -> str:
+        run_id = raw_trace.get("id") or raw_trace.get("run_id") or raw_trace.get("runId")
+        if not run_id:
+            raise ValueError("Cekura run missing required 'id' field")
+        run_id = str(run_id)
+        if len(run_id) > 255:
+            raise ValueError("Cekura run id exceeds 255 characters")
+        return run_id
+
+    @staticmethod
+    def _timestamp(value: Any) -> datetime | None:
+        if value is None or value == "":
+            return None
+        if isinstance(value, (int, float)):
+            if value > 10_000_000_000:
+                value /= 1000
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return value if isinstance(value, datetime) else None
+
+    @staticmethod
+    def _latency_ms(
+        raw: dict[str, Any], start: datetime | None, end: datetime | None
+    ) -> int:
+        value = (
+            raw.get("latency_ms")
+            or raw.get("latencyMs")
+            or raw.get("duration_ms")
+            or raw.get("durationMs")
+        )
+        if value is not None:
+            return int(value)
+        if start and end:
+            return int((end - start).total_seconds() * 1000)
+        return 0
+
+    @staticmethod
+    def _status(status: Any) -> str:
+        return "ERROR" if str(status).lower() in {"error", "failed", "failure"} else "OK"
+
+
+register_transformer("cekura", CekuraTransformer())

--- a/futureagi/tfc/urls.py
+++ b/futureagi/tfc/urls.py
@@ -33,6 +33,7 @@ from tfc.views.health import (
 )
 from tfc.views.socket import CallWebsocketView
 from tracer.views.clickhouse_health import ClickHouseHealthView
+from tracer.views.cekura_ingestion import CekuraIngestionView
 from tracer.views.langfuse_ingestion import LangfuseIngestionView
 from tracer.views.otlp import OTLPHealthView, OTLPTraceView
 from tracer.views.span_attributes import (
@@ -93,6 +94,11 @@ urlpatterns = [
         "api/public/ingestion",
         LangfuseIngestionView.as_view(),
         name="api-public-ingestion",
+    ),
+    path(
+        "api/public/cekura/ingestion",
+        CekuraIngestionView.as_view(),
+        name="api-public-cekura-ingestion",
     ),
     path("integrations/", include("integrations.urls")),
     path("agentcc/", include("agentcc.urls")),

--- a/futureagi/tracer/tests/test_cekura_ingestion.py
+++ b/futureagi/tracer/tests/test_cekura_ingestion.py
@@ -1,0 +1,118 @@
+"""Tests for Cekura transcript transformation and ingestion."""
+
+import pytest
+
+from integrations.transformers.cekura_transformer import CekuraTransformer
+from model_hub.models.ai_model import AIModel
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+
+
+@pytest.fixture
+def cekura_run():
+    return {
+        "id": "cekura-run-42",
+        "testName": "Refund flow",
+        "metadata": {"suite": "regression"},
+        "turns": [
+            {
+                "id": "turn-user-1",
+                "role": "user",
+                "content": "I need a refund",
+                "timestamp": "2026-07-18T10:00:00Z",
+            },
+            {
+                "id": "turn-agent-1",
+                "role": "assistant",
+                "content": "Let me look that up.",
+                "timestamp": "2026-07-18T10:00:01Z",
+                "toolCalls": [
+                    {
+                        "id": "lookup-order",
+                        "name": "lookup_order",
+                        "arguments": {"order_id": "123"},
+                        "result": {"eligible": True},
+                        "status": "completed",
+                    }
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_transformer_creates_turns_and_nested_tool_spans(cekura_run):
+    transformer = CekuraTransformer()
+
+    trace = transformer.transform_trace(cekura_run, "project-1")
+    spans = transformer.transform_observations(cekura_run, "trace-1", "project-1")
+
+    assert trace["external_id"] == "cekura-run-42"
+    assert trace["metadata"]["integration_source"] == "cekura"
+    assert "cekura" in trace["tags"]
+    assert [span["observation_type"] for span in spans] == [
+        "conversation",
+        "conversation",
+        "tool",
+    ]
+    assert spans[2]["parent_span_id"] == spans[1]["id"]
+    assert spans[0]["id"].startswith("cekura-turn-")
+    assert spans[2]["id"].startswith("cekura-tool-")
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_ingestion_upserts_trace_and_spans(auth_client, organization, workspace, cekura_run):
+    project = Project.objects.create(
+        name="Cekura traces",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+    payload = {"project_id": str(project.id), "run": cekura_run}
+
+    first = auth_client.post("/api/public/cekura/ingestion", payload, format="json")
+    assert first.status_code == 201
+    assert first.data == {"created": True, "spans_ingested": 3}
+
+    cekura_run["turns"][1]["content"] = "Your order is eligible for a refund."
+    second = auth_client.post("/api/public/cekura/ingestion", payload, format="json")
+    assert second.status_code == 200
+    assert second.data == {"created": False, "spans_ingested": 3}
+
+    trace = Trace.objects.get(project=project, external_id="cekura-run-42")
+    spans = ObservationSpan.objects.filter(trace=trace)
+    assert spans.count() == 4  # deterministic synthetic root + 2 turns + 1 tool
+
+    root = spans.get(id="root-cekura-run-42")
+    agent_turn = spans.get(name="Assistant turn")
+    tool = spans.get(name="lookup_order")
+    assert agent_turn.parent_span_id == root.id
+    assert tool.parent_span_id == agent_turn.id
+    assert agent_turn.output == {
+        "role": "assistant",
+        "content": "Your order is eligible for a refund.",
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_ingestion_rejects_a_run_without_a_stable_id(auth_client, organization, workspace):
+    project = Project.objects.create(
+        name="Cekura invalid run",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+
+    response = auth_client.post(
+        "/api/public/cekura/ingestion",
+        {"project_id": str(project.id), "run": {"turns": []}},
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert Trace.objects.filter(project=project).count() == 0

--- a/futureagi/tracer/views/cekura_ingestion.py
+++ b/futureagi/tracer/views/cekura_ingestion.py
@@ -1,0 +1,68 @@
+"""Authenticated Cekura chat-test transcript ingestion endpoint."""
+
+import structlog
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from accounts.authentication import APIKeyAuthentication
+from integrations.transformers.cekura_transformer import CekuraTransformer
+from tracer.models.project import Project
+from tracer.utils.langfuse_upsert import upsert_langfuse_trace
+
+logger = structlog.get_logger(__name__)
+_transformer = CekuraTransformer()
+
+
+class CekuraIngestionView(APIView):
+    """Import one Cekura chat-test run into a selected observe project.
+
+    Cekura callers authenticate with the project owner's FutureAGI API key.
+    The payload must contain ``project_id`` and either an ``id``/``run_id`` at
+    its root or inside a ``run`` object.  ``turns``/``transcript`` is optional.
+    """
+
+    parser_classes = [JSONParser]
+    authentication_classes = [APIKeyAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        project_id = request.data.get("project_id")
+        if not project_id:
+            return Response({"detail": "project_id is required."}, status=400)
+
+        org = getattr(request, "organization", None) or request.user.organization
+        project = Project.no_workspace_objects.filter(
+            id=project_id, organization=org, trace_type="observe", deleted=False
+        ).first()
+        if not project:
+            return Response({"detail": "Observe project not found."}, status=404)
+
+        workspace = getattr(request, "workspace", None)
+        if workspace and project.workspace_id and project.workspace_id != workspace.id:
+            return Response({"detail": "Project is outside the active workspace."}, status=404)
+
+        run = request.data.get("run", request.data)
+        if not isinstance(run, dict):
+            return Response({"detail": "run must be an object."}, status=400)
+
+        try:
+            created, spans_count, _ = upsert_langfuse_trace(
+                assembled_trace=run,
+                transformer=_transformer,
+                project_id=str(project.id),
+                org=org,
+                workspace=project.workspace,
+                org_id=org.id,
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=400)
+        except Exception:
+            logger.exception("cekura_ingestion_failed", project_id=str(project.id))
+            return Response({"detail": "Unable to import Cekura run."}, status=500)
+
+        return Response(
+            {"created": created, "spans_ingested": spans_count},
+            status=201 if created else 200,
+        )


### PR DESCRIPTION
## Summary
- add an authenticated Cekura transcript ingestion endpoint
- transform conversation turns into observation spans and nest tool calls under their turn
- reuse the shared external-ID upsert path for trace/span idempotency
- add focused transformer and endpoint/upsert tests

## Validation
- Python compileall syntax validation passed for the transformer, endpoint, and test module.
- git diff --check passed.

Closes #1582