### PR TITLE
fix(annotations): align queue pager buttons with keyboard navigation (TH-6799)

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -1313,11 +1313,11 @@ export default function AnnotateWorkspaceView() {
     isChangingCompletedVisibility,
   ]);
 
-  // Once the navigated-to item's detail finishes loading, drop the direction
-  // so the arrow returns and background refetches don't keep the spinner up.
+  // Keyed on currentItemId too: navigating to a cached item never toggles
+  // detailFetching, so on that alone navDirection would stay stale.
   useEffect(() => {
     if (!detailFetching) setNavDirection(null);
-  }, [detailFetching]);
+  }, [detailFetching, currentItemId]);
 
   const canNavigatePrev =
     historyIndex > 0 || Boolean(detailNavigation.prevItemId);

--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -439,6 +439,10 @@ export default function AnnotateWorkspaceView() {
   // Reviewers/managers default to a comparison view. When a single annotator
   // is selected, request that annotator only so values never merge into one
   // editable form.
+  // Detail's next/prev item IDs gate the pager buttons; keep them over the same
+  // set the keyboard walks (completed items are navigable in View submissions).
+  const detailIncludeCompleted =
+    isReviewWorkspaceMode && !requiresReview ? true : includeCompletedItems;
   const {
     data: detail,
     isLoading: detailLoading,
@@ -447,7 +451,7 @@ export default function AnnotateWorkspaceView() {
     refetch: refetchAnnotateDetail,
   } = useAnnotateDetail(queueId, currentItemId, {
     annotatorId: scopedAnnotatorId,
-    includeCompleted: includeCompletedItems,
+    includeCompleted: detailIncludeCompleted,
     viewMode: isReviewWorkspaceMode ? "review" : undefined,
     reviewStatus:
       isReviewWorkspaceMode && requiresReview ? "pending_review" : undefined,
@@ -465,14 +469,14 @@ export default function AnnotateWorkspaceView() {
         itemId: currentItemId || null,
         annotatorId: scopedAnnotatorId || null,
         mode: workspaceMode,
-        includeCompleted: includeCompletedItems,
+        includeCompleted: detailIncludeCompleted,
         params: navigationModeParams,
       }),
     [
       currentItemId,
       scopedAnnotatorId,
       workspaceMode,
-      includeCompletedItems,
+      detailIncludeCompleted,
       navigationModeParams,
     ],
   );
@@ -1166,12 +1170,16 @@ export default function AnnotateWorkspaceView() {
   }, [navigate, queueId, confirmDiscardUnsaved]);
 
   const [isFetchingPrev, setIsFetchingPrev] = useState(false);
+  // Direction of the in-flight navigation, so the footer can show the spinner
+  // in place of the arrow being navigated toward while its detail loads.
+  const [navDirection, setNavDirection] = useState(null);
 
   const handlePrev = useCallback(async () => {
     if (isChangingCompletedVisibility) return;
     if (!confirmDiscardUnsaved("You have unsaved changes. Load another item?"))
       return;
     if (historyIndex > 0) {
+      setNavDirection("prev");
       dispatch({ type: "prev" });
       return;
     }
@@ -1185,6 +1193,7 @@ export default function AnnotateWorkspaceView() {
       const prevItem =
         res?.data?.data?.item || res?.data?.result?.item || res?.data?.item;
       if (prevItem?.id) {
+        setNavDirection("prev");
         dispatch({ type: "init", id: prevItem.id });
       }
     } catch (err) {
@@ -1224,11 +1233,13 @@ export default function AnnotateWorkspaceView() {
       return;
     // If there are forward items in history, navigate to them
     if (historyIndex < itemHistory.length - 1) {
+      setNavDirection("next");
       dispatch({ type: "next" });
       return;
     }
 
     if (detailNavigation.nextItemId) {
+      setNavDirection("next");
       dispatch({ type: "push", id: detailNavigation.nextItemId });
       return;
     }
@@ -1246,6 +1257,7 @@ export default function AnnotateWorkspaceView() {
       const nextItem =
         res?.data?.data?.item || res?.data?.result?.item || res?.data?.item;
       if (nextItem?.id) {
+        setNavDirection("next");
         dispatch({ type: "push", id: nextItem.id });
       }
     } catch (err) {
@@ -1301,12 +1313,34 @@ export default function AnnotateWorkspaceView() {
     isChangingCompletedVisibility,
   ]);
 
+  // Once the navigated-to item's detail finishes loading, drop the direction
+  // so the arrow returns and background refetches don't keep the spinner up.
+  useEffect(() => {
+    if (!detailFetching) setNavDirection(null);
+  }, [detailFetching]);
+
+  const canNavigatePrev =
+    historyIndex > 0 || Boolean(detailNavigation.prevItemId);
+  const canNavigateNext =
+    historyIndex < itemHistory.length - 1 ||
+    Boolean(detailNavigation.nextItemId);
+  const isLoadingPrevNav =
+    isFetchingPrev ||
+    isChangingCompletedVisibility ||
+    (detailFetching && navDirection === "prev");
+  const isLoadingNextNav =
+    isFetchingNext ||
+    isChangingCompletedVisibility ||
+    (detailFetching && navDirection === "next");
+
   useKeyboardShortcuts({
     onSubmit: handleKeyboardSubmit,
     onSkip: handleSkip,
     onPrev: handlePrev,
     onNext: handleNext,
     onEscape: handleBack,
+    canPrev: canNavigatePrev,
+    canNext: canNavigateNext,
   });
 
   const isInitialDetailLoading =
@@ -1782,13 +1816,10 @@ export default function AnnotateWorkspaceView() {
         total={footerProgress.total}
         onPrev={handlePrev}
         onNext={handleNext}
-        hasPrev={historyIndex > 0 || Boolean(detailNavigation.prevItemId)}
-        hasNext={
-          historyIndex < itemHistory.length - 1 ||
-          Boolean(detailNavigation.nextItemId)
-        }
-        isLoadingPrev={isFetchingPrev || isChangingCompletedVisibility}
-        isLoadingNext={isFetchingNext || isChangingCompletedVisibility}
+        hasPrev={canNavigatePrev}
+        hasNext={canNavigateNext}
+        isLoadingPrev={isLoadingPrevNav}
+        isLoadingNext={isLoadingNextNav}
       />
 
       <CollaborationDrawer

--- a/frontend/src/sections/annotations/queues/annotate/use-keyboard-shortcuts.js
+++ b/frontend/src/sections/annotations/queues/annotate/use-keyboard-shortcuts.js
@@ -48,18 +48,13 @@ export default function useKeyboardShortcuts({
           onSkip?.();
           break;
         case "ArrowLeft":
-          // Guard at the first item so the key can't trigger a pointless
-          // fetch that "loads and comes back" — matches the disabled button.
-          if (canPrev) {
-            e.preventDefault();
-            onPrev?.();
-          }
+          // Suppress native arrow scroll even at the boundary; only gate the nav.
+          e.preventDefault();
+          if (canPrev) onPrev?.();
           break;
         case "ArrowRight":
-          if (canNext) {
-            e.preventDefault();
-            onNext?.();
-          }
+          e.preventDefault();
+          if (canNext) onNext?.();
           break;
         case "Escape":
           e.preventDefault();

--- a/frontend/src/sections/annotations/queues/annotate/use-keyboard-shortcuts.js
+++ b/frontend/src/sections/annotations/queues/annotate/use-keyboard-shortcuts.js
@@ -24,6 +24,8 @@ export default function useKeyboardShortcuts({
   onPrev,
   onNext,
   onEscape,
+  canPrev = true,
+  canNext = true,
 }) {
   useEffect(() => {
     const handler = (e) => {
@@ -46,12 +48,18 @@ export default function useKeyboardShortcuts({
           onSkip?.();
           break;
         case "ArrowLeft":
-          e.preventDefault();
-          onPrev?.();
+          // Guard at the first item so the key can't trigger a pointless
+          // fetch that "loads and comes back" — matches the disabled button.
+          if (canPrev) {
+            e.preventDefault();
+            onPrev?.();
+          }
           break;
         case "ArrowRight":
-          e.preventDefault();
-          onNext?.();
+          if (canNext) {
+            e.preventDefault();
+            onNext?.();
+          }
           break;
         case "Escape":
           e.preventDefault();
@@ -64,5 +72,5 @@ export default function useKeyboardShortcuts({
 
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [onSubmit, onSkip, onPrev, onNext, onEscape]);
+  }, [onSubmit, onSkip, onPrev, onNext, onEscape, canPrev, canNext]);
 }


### PR DESCRIPTION
## Bug

In the annotation-queue workspace, the pager (◄ ► buttons + ← → keys) behaved inconsistently:

* In **View submissions**, the ◄ ► buttons greyed out / got stuck (couldn't page through completed items), while the arrow keys still worked — "mouse click does nothing, key bindings work."
* The arrow keys had **no boundary guard**, so pressing them on the first/last item fired a pointless fetch that "loaded and came back."
* Navigating showed a blank flash — no loading indicator on the pager arrows.

## Changes

* **Pager buttons walk the same item set as the keys.** The item-detail request now sends `include_completed` in View-submissions mode, so the backend's `next_item_id`/`prev_item_id` (which drive the buttons' enabled state) cover completed items — matching the set the keyboard's `/next` navigation already uses. Threaded the same value into the nav scope-key so the "is this up to date?" gate stays consistent.
* **Keyboard boundary guard.** `useKeyboardShortcuts` now takes `canPrev`/`canNext`; ← only navigates when there's a prev, → only when there's a next. `hasPrev`/`hasNext` were lifted into shared `canNavigatePrev`/`canNavigateNext` consts so buttons and keys use one source of truth.
* **Navigation loader.** A `navDirection` flag (set only right before an actual navigating dispatch) drives the footer to show the spinner in place of the arrow being navigated toward while the target item's detail loads.

## Why

The buttons' enabled state comes entirely from the detail response's `next_item_id`/`prev_item_id`, which the backend computes over whichever item set the request selects. View-submissions was sending `include_completed=false` — excluding exactly the completed items that mode exists to show — so the server returned no neighbours and the buttons disabled. The keyboard path used a different request (`navigationModeParams`, which already sent `include_completed=true`), so it kept working. The two paths simply disagreed on the item set; this aligns them.

## Test-case scenarios

* View submissions, first item: Prev disabled, Next works (mouse + keyboard).
* View submissions, middle item: both work.
* View submissions, last item: Next disabled, Prev works.
* Annotate mode / Review-required mode: navigation unchanged (still scoped to their own item sets).
* Arrow key at the first/last item: no-op (no "loads and comes back").
* Navigating: spinner shows on the arrow being moved toward, then clears when the item loads.

## How to reproduce (before fix)

1. Open an annotation queue with both completed and pending items as a reviewer+annotator.
2. Open an item and switch to **View submissions**.
3. Click ◄ / ► — nothing happens (buttons greyed). Press ← / → — it navigates.

## Commands

```bash
cd frontend
yarn lint
```

## Videos / Screenshots

https://github.com/user-attachments/assets/89a4588a-fd6a-44df-b62f-54c635533509