### PR TITLE
fix(frontend): keep RequestBody textarea transparent over highlight backdrop

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -315,6 +315,10 @@ const RequestBody = ({
 
   const inputPadding = multiline ? "8px" : "8.5px 12px";
 
+  // The textarea must stay transparent so the highlight backdrop shows through —
+  // a caller-supplied background belongs on the wrapper instead.
+  const { backgroundColor: sxBackgroundColor, ...textareaSx } = sx || {};
+
   return (
     <Box
       sx={{
@@ -338,7 +342,7 @@ const RequestBody = ({
       <div
         style={{
           position: "relative",
-          backgroundColor: theme.palette.background.default,
+          backgroundColor: sxBackgroundColor || theme.palette.background.default,
           borderRadius: "8px",
         }}
       >
@@ -393,7 +397,7 @@ const RequestBody = ({
             backgroundColor: "transparent",
             position: "relative",
             verticalAlign: "top",
-            ...sx,
+            ...textareaSx,
           }}
           onKeyDown={onKeyDown}
         />


### PR DESCRIPTION
## Summary

The per-column description field in the "Create Synthetic data" wizard (step 3,
"Add description") showed nothing but a blinking caret — typed text and the
`{{variable}}` highlighting were both invisible.

`RequestBody` is a transparent-text textarea layered over a syntax-highlighting
backdrop div. The textarea sets `backgroundColor: "transparent"` so the backdrop
shows through, but the caller-supplied `sx` was spread onto the same style object
afterwards and won. `CreateDescriptions` passes
`backgroundColor: theme.palette.background.paper`, so the textarea became opaque
and painted over the backdrop, hiding the only visible copy of the text.

This routes `sx.backgroundColor` to the outer wrapper div (where an opaque
background was clearly the intent) and spreads the rest of `sx` onto the textarea
as before. `CreateDescriptions` is unchanged.

## Linked issues

Closes #1586

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Not yet verified locally — `node_modules` is not installed in this checkout, so
`yarn check-all` has not been run against the change.

Reviewer verification needed:
1. Dataset → Create Synthetic Data → fill "Add details", add a column.
2. Step 3 "Add description", type text including `{{`-referenced columns.
3. Text and `{{variable}}` highlighting render, in both light and dark theme.
4. Confirm the API-call request body editor (`AddColumnApiCall`, `AddFieldInput`)
   is unchanged — neither passes `sx`, so they fall back to
   `theme.palette.background.default` exactly as before.

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `yarn check-all` passes locally
- [x] I've updated the documentation where relevant (n/a)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA

No test added: the fix is inline style routing, and a jsdom assertion on computed styles would test the mock rather than the stacking behaviour that actually broke. Say the word if you want one anyway — reviewers often want the box ticked regardless.