### PR TITLE
fix(clickhouse): tracer_eval_logger timestamps DateTime64(3) → (6) for PeerDB CDC

### DIFF
--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -346,11 +346,16 @@ CREATE TABLE IF NOT EXISTS tracer_eval_logger (
 
     -- Soft-delete
     deleted UInt8 DEFAULT 0,
-    deleted_at Nullable(DateTime64(3)),
+    deleted_at Nullable(DateTime64(6)),
 
     -- Timestamps
-    created_at DateTime64(3),
-    updated_at DateTime64(3),
+    -- DateTime64(6) REQUIRED: PeerDB (v0.36.x) normalize writes epoch-micros
+    -- regardless of destination precision. With DateTime64(3) every synced row
+    -- landed ~year 58356 (1000x off), exploding the toYYYYMM partition key so
+    -- ReplacingMergeTree FINAL never deduped (2026-07-18 us2 incident). All
+    -- other PeerDB-mirrored tables already use (6).
+    created_at DateTime64(6),
+    updated_at DateTime64(6),
 
     -- PeerDB CDC meta-columns
     _peerdb_synced_at DateTime64(6),


### PR DESCRIPTION
Linear: [TH-7059](https://linear.app/future-agi/issue/TH-7059)

## Summary

Corrects the ClickHouse DDL for `tracer_eval_logger`: the timestamp columns (`created_at`, `updated_at`, `deleted_at`) are changed from **`DateTime64(3)` → `DateTime64(6)`**. At millisecond precision, PeerDB-replicated rows landed with timestamps ~34,000 years in the future, which broke partitioning and de-duplication for the whole table.

## What changed

`futureagi/tracer/services/clickhouse/schema.py` — in the `tracer_eval_logger` `CREATE TABLE`:

- `created_at`  `DateTime64(3)` → `DateTime64(6)`
- `updated_at`  `DateTime64(3)` → `DateTime64(6)`
- `deleted_at`  `Nullable(DateTime64(3))` → `Nullable(DateTime64(6))`

(+ an inline comment recording why, so it is not "simplified" back later.)

## Why

PeerDB (v0.36.x) normalize writes timestamp values as **epoch microseconds regardless of the destination column's declared precision**. When the column is `DateTime64(3)` (milliseconds), ClickHouse interprets those microsecond integers as milliseconds — a **1000× overshoot** — so every CDC-synced row landed around **year 58356**.

Two concrete breakages followed:

1. **Partitioning exploded.** The table is `PARTITION BY toYYYYMM(created_at)`. Corrupt future dates created a partition per bogus month, wrecking merge/query efficiency.
2. **De-duplication silently failed.** It is a `ReplacingMergeTree`, so `SELECT ... FINAL` must collapse multiple versions of a row. The corrupt partition/sort placement meant duplicate versions never merged — row counts drifted above the source and `FINAL` reads returned stale/duplicated rows.

Every other PeerDB-mirrored table in this file already declares `DateTime64(6)`; `tracer_eval_logger` was the lone `(3)` outlier, which is why only it exhibited the fault.

## How it affects the system

`tracer_eval_logger` in ClickHouse backs **eval-config discovery** and the **Eval Metrics** query path (`CH25_EVAL_LOGGER_TABLE`). Correct timestamps here mean correct partition pruning, correct `FINAL` de-duplication, and accurate eval analytics.

### Upgrades (positive)

- **CDC rows land with correct timestamps** → sane `toYYYYMM` partitions, healthy merges, and working `ReplacingMergeTree FINAL` de-duplication.
- **Eval Metrics / eval-config reads become accurate** (no stale duplicates, no exploded partition scan cost).
- **Consistency** — aligns `tracer_eval_logger` with every other mirrored table (all `(6)`), removing a latent trap for any future deploy/region that applies this DDL with PeerDB.
- **Higher timestamp fidelity** (microsecond) at negligible cost — `DateTime64(6)` is the same 8-byte physical width as `(3)`.

### Downgrades / risks (honest)

- **Not a live migration.** `CREATE TABLE IF NOT EXISTS` will **not** alter an existing `(3)` table on boot — and `created_at` is the partition key, which ClickHouse forbids `ALTER`-ing in place. Any environment that already created the `(3)` table needs a one-time **table swap** (create a `(6)` table + `EXCHANGE TABLES` + re-mirror). This was already done on us2 on 2026-07-18; other CH-direct/PeerDB stacks (e.g. EU) must do the same before relying on this table.
- **Fresh deploys only benefit automatically** — the fix is correct-by-construction for any environment created from this DDL going forward; pre-existing ones require the manual swap above.
- **Blast radius is limited to `tracer_eval_logger`** — no other table, query, or Postgres schema is touched. The four other legacy-chain DDL blocks in this file are still `(3)` but are never created on GCP; they should be aligned separately if any stack activates them under PeerDB.

## Validation (performed live on us2, 2026-07-18)

- Recreated the table at `DateTime64(6)` via `EXCHANGE TABLES` and re-mirrored: **1,470,026 rows, exact parity with Postgres, 0 corrupted timestamps**, date range a sane 2025-02 → 2026-07.
- Live CDC probe: a source `UPDATE` was delivered within ~20s and correctly collapsed by `FINAL`.

> Companion PR (deployment repo): pins the PeerDB CDC mirrors to a single ClickHouse replica and restores the `tracer_eval_logger` mirror. Both are required for a healthy eval_logger feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
