### PR TITLE
[TH-6928] Fix HuggingFace import: dataset count key + selected-chip dark-mode styling

### DIFF
--- a/frontend/src/sections/huggingface/HuggingFaceView.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceView.jsx
@@ -83,7 +83,6 @@ const HuggingFaceView = () => {
   const [tempRowCount, setTempRowCount] = useState([0, 1000000000]);
   const [mainFilter, setMainFilter] = useState("Main");
   const [selectedTask, setSelectedTask] = useState(null);
-  const [, setTotalDatasets] = useState(0);
 
   // Add pagination state
   const [page, setPage] = useState(1); // Initialize page state here
@@ -267,12 +266,6 @@ const HuggingFaceView = () => {
         },
       );
     },
-    select: (data) => {
-      if (huggingFaceList?.data?.result?.totalDatasets !== undefined) {
-        setTotalDatasets(huggingFaceList?.data?.result?.totalDatasets);
-      }
-      return data;
-    },
   });
 
   // Modify the filtered datasets to include pagination
@@ -283,11 +276,11 @@ const HuggingFaceView = () => {
   const MAX_PAGES = 100; // Define maximum number of pages
 
   const totalPages = useMemo(() => {
-    const total = huggingFaceList?.data?.result?.totalDatasets || 0;
+    const total = huggingFaceList?.data?.result?.total_datasets || 0;
     const calculatedPages = Math.ceil(total / itemsPerPage);
     // Limit to maximum 100 pages
     return Math.min(MAX_PAGES, Math.max(1, calculatedPages));
-  }, [huggingFaceList?.data?.result?.totalDatasets, itemsPerPage]);
+  }, [huggingFaceList?.data?.result?.total_datasets, itemsPerPage]);
 
   const {
     mutate: createHuggingFaceDataset,
@@ -1010,7 +1003,7 @@ const HuggingFaceView = () => {
             >
               <Typography fontSize="12px" color="text.secondary">
                 <b style={{ fontSize: "14px" }}>Total Datasets : </b>
-                {huggingFaceList?.data?.result?.totalDatasets || 0}
+                {huggingFaceList?.data?.result?.total_datasets || 0}
               </Typography>
 
               {/* Sort controls */}
@@ -1076,21 +1069,17 @@ const HuggingFaceView = () => {
                     <Iconify icon="eva:close-fill" width={16} height={16} />
                   }
                   sx={{
-                    backgroundColor:
-                      theme.palette.mode === "light"
-                        ? "primary.main"
-                        : "primary.light",
-                    color:
-                      theme.palette.mode === "light"
-                        ? "common.white"
-                        : "primary.dark",
+                    backgroundColor: "primary.main",
+                    color: "primary.contrastText",
                     borderRadius: "4px",
+                    fontWeight: 500,
+                    "& .MuiChip-deleteIcon": {
+                      color: "primary.contrastText",
+                      opacity: 0.7,
+                      "&:hover": { color: "primary.contrastText", opacity: 1 },
+                    },
                     "&:hover": {
-                      backgroundColor:
-                        theme.palette.mode === "light"
-                          ? theme.palette.primary.dark
-                          : theme.palette.primary.light,
-                      opacity: theme.palette.mode === "light" ? 1 : 0.8,
+                      backgroundColor: "primary.dark",
                       cursor: "default",
                     },
                   }}
@@ -1205,7 +1194,7 @@ const HuggingFaceView = () => {
             page={page}
             totalPages={isLoadingHuggingFaceList ? 1 : totalPages}
             onPageChange={handlePageChange}
-            totalItems={huggingFaceList?.data?.result?.totalDatasets || 0}
+            totalItems={huggingFaceList?.data?.result?.total_datasets || 0}
             itemsPerPage={itemsPerPage}
             isLoading={isLoadingHuggingFaceList}
           />


### PR DESCRIPTION
**Ticket:** [TH-6928](https://linear.app/future-agi/issue/TH-6928/hugging-face-import-dataset-count-category-selection-visibility-and) — Fixes TH-6928

## What was the bug
On the HuggingFace import screen (`/dashboard/huggingface`):
1. **Total datasets showed `0`** even though datasets were available.
2. Selecting categories (3D / Audio / Images) never updated the count — stayed `0`.
3. Selected category chips had **poor active-state styling** (washed-out, barely legible in dark mode).
4. Pagination showed the invalid **"1 of 0"**.

## Root cause
The list endpoint returns the count as **`total_datasets`** (snake_case), but the UI read **`totalDatasets`** (camelCase) → always `undefined` → `|| 0` everywhere. That single key mismatch caused bugs 1, 2 and 4 (the count is what drives category-filtered totals and pagination). Confirmed at runtime: the backend returned `total_datasets: 696244`, updating correctly per filter (`32030`, `165`, `610`…), while the camelCase read was `undefined`.

Bug 3 was a separate dark-mode styling issue: selected chips used a pale `primary.light` background with dark text, which washed out.

## What changes have been done
- `src/sections/huggingface/HuggingFaceView.jsx`
  - Read `result.total_datasets` (not `totalDatasets`) at all four sites: `totalPages` memo + its dep, the "Total Datasets" render, and pagination `totalItems`.
  - Removed dead code: a `useState` whose value was never read and a `select` callback that read a stale closure with the wrong key and wrote that discarded setter (its condition was never even true).
  - Selected filter chips now use a solid `primary.main` background with white (`primary.contrastText`) text in both themes, plus an explicitly-colored delete icon — clear, legible active state in dark mode.

## Why the changes
- The FE/BE key must match; the backend contract (`HuggingFaceDatasetListResponseResultSerializer.total_datasets`) and its tests confirm snake_case.
- I audited every other response key in the flow (list rows, dataset detail, subset/split config) against the backend serializers — `total_datasets` was the only mismatch; everything else already matches.

## Test cases — what each scenario covers
| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open HuggingFace import | Total Datasets shows a real number, not 0 |
| 2 | Apply 3D / Audio / Image filters | Count updates to the filtered total |
| 3 | Selected chips (dark mode) | Solid purple bg + white text + visible × — clearly legible |
| 4 | Pagination | Valid "1 of N" (no "1 of 0") |

## How to reproduce (original bug)
1. Open **Import Dataset → Hugging Face** (`/dashboard/huggingface`).
2. Observe **Total Datasets : 0** despite datasets loading.
3. Apply a category filter — count stays 0.
4. Note pagination shows "1 of 0" and selected chips are washed out in dark mode.

## Commands
```bash
# from frontend/
yarn lint
```

## Videos and screenshots

https://github.com/user-attachments/assets/cd5d1041-e77b-4928-8702-c43cfb38a143

