### PR TITLE
fix: classify audio data URIs

### DIFF
--- a/futureagi/tracer/tests/test_value_type_helper.py
+++ b/futureagi/tracer/tests/test_value_type_helper.py
@@ -1,0 +1,14 @@
+from model_hub.models.choices import DataTypeChoices
+from tracer.utils.helper import determine_value_type
+
+
+def test_determine_value_type_recognizes_audio_data_uri():
+    value = "data:audio/wav;base64,UklGRg=="
+
+    assert determine_value_type(value) == DataTypeChoices.AUDIO.value
+
+
+def test_determine_value_type_preserves_image_data_uri_classification():
+    value = "data:image/webp;base64,UklGRg=="
+
+    assert determine_value_type(value) == DataTypeChoices.IMAGE.value

--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -236,6 +236,10 @@ def is_image(value: str) -> bool:
     return value.startswith(("data:image", "iVBORw0KGgo"))
 
 
+def is_audio(value: str) -> bool:
+    return value.startswith("data:audio/")
+
+
 def determine_value_type(value):
     # Determine data type based on value
     if isinstance(value, bool):
@@ -257,6 +261,8 @@ def determine_value_type(value):
             return DataTypeChoices.DATETIME.value
         elif is_image(value):
             return DataTypeChoices.IMAGE.value
+        elif is_audio(value):
+            return DataTypeChoices.AUDIO.value
         return DataTypeChoices.TEXT.value
     else:
         return DataTypeChoices.OTHERS.value


### PR DESCRIPTION
## Summary

Audio data URIs fell through the value classifier's text fallback despite the existing audio data type. This adds the missing `data:audio/` classification and focused coverage while preserving image classification.

## Linked issues

Closes #1664

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

The focused audio regression failed against the original helper and passed after the fix; the image classification guard also passes. Ruff passes for the new test, and the source file's existing Ruff/format findings are unchanged from baseline.

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
