### PR TITLE
fix(agentic_eval): stop classifying .mp4 video URLs as images

### DIFF
--- a/futureagi/agentic_eval/core/utils/llm_payloads.py
+++ b/futureagi/agentic_eval/core/utils/llm_payloads.py
@@ -381,7 +381,7 @@ def build_user_message(content: Sequence[ContentBlock]) -> Message:
 _SUPPORTED_MEDIA = {"image", "images", "audio", "pdf"}
 
 _IMAGE_EXT_PAT = re.compile(
-    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff|mp4)(\?|$)",
+    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff)(\?|$)",
     re.IGNORECASE,
 )
 

--- a/futureagi/agentic_eval/core/utils/tests/test_llm_payloads_media_detection.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_llm_payloads_media_detection.py
@@ -1,0 +1,32 @@
+"""Tests for Stage-1 media-extension detection in llm_payloads.
+
+`_IMAGE_EXT_PAT` drives the fast-path modality guess in
+``detect_and_build_media_blocks``: a URL matching it is routed straight to
+the image content builder (which downloads the bytes and validates them with
+Pillow). Only genuine still-image extensions belong here — a video URL that
+matches would be forced down the image path and crash on Pillow validation.
+"""
+
+import pytest
+
+from agentic_eval.core.utils.llm_payloads import _IMAGE_EXT_PAT
+
+IMAGE_EXTS = ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "tiff"]
+VIDEO_EXTS = ["mp4", "mov", "avi", "webm", "mkv"]
+
+
+@pytest.mark.parametrize("ext", IMAGE_EXTS)
+def test_image_url_is_classified_as_image(ext):
+    assert _IMAGE_EXT_PAT.search(f"https://cdn.example.com/asset.{ext}")
+
+
+@pytest.mark.parametrize("ext", IMAGE_EXTS)
+def test_image_url_with_query_string_is_classified_as_image(ext):
+    assert _IMAGE_EXT_PAT.search(f"https://cdn.example.com/asset.{ext}?v=2")
+
+
+@pytest.mark.parametrize("ext", VIDEO_EXTS)
+def test_video_url_is_not_classified_as_image(ext):
+    # A video URL must not match the image extension pattern, otherwise it is
+    # routed to the image builder and crashes on Pillow validation.
+    assert _IMAGE_EXT_PAT.search(f"https://cdn.example.com/clip.{ext}") is None


### PR DESCRIPTION
## Summary

`_IMAGE_EXT_PAT` (the Stage-1 fast-path in `detect_and_build_media_blocks`) listed `mp4` — a **video** extension — among still-image extensions. Any `.mp4` URL was therefore classified as `"image"` and sent to `build_media_content_block`, which downloads the bytes and validates them with Pillow (`img.verify()`). Pillow can't decode a video, so it raised and the eval crashed with `MediaNotAccessibleError`.

There is no video modality (`_SUPPORTED_MEDIA = {"image", "images", "audio", "pdf"}`), so this was a misclassification. Removing `mp4` lets video URLs fall through to Stage-2 content sniffing like any other non-image URL.

```diff
-    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff|mp4)(\?|$)",
+    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff)(\?|$)",
```

## Linked issues

Closes #1673

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Added `agentic_eval/core/utils/tests/test_llm_payloads_media_detection.py`:
- image extensions (png/jpg/jpeg/gif/webp/svg/bmp/tiff, incl. `?query` suffix) still classify as image;
- video extensions (mp4/mov/avi/webm/mkv) do **not**.

TDD red → green on the real module:

**RED — before the fix** (`mp4` still in the pattern):
```
core/utils/tests/test_llm_payloads_media_detection.py::test_video_url_is_not_classified_as_image[mp4] FAILED
E   AssertionError: assert <re.Match object; span=(0, 32),
    match='https://cdn.example.com/clip.mp4'> is None
E    +  where ... = re.compile('https?://\\S+\\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff|mp4)(\\?|$)',
                                 re.IGNORECASE).search('https://cdn.example.com/clip.mp4')
========================= 1 failed, 20 passed in 0.27s =========================
```

**GREEN — after removing `mp4`:**
```
# new test file
========================= 21 passed in 0.33s =========================

# full agentic_eval/core/utils/tests/ suite (no regressions)
========================= 79 passed in 0.44s =========================
```

`flake8` is clean on the new test file.

> Note: I ran the targeted `pytest` (real module, `tfc.utils.storage` stubbed since it is the only unrelated import and is never exercised by the regex under test) plus `flake8`, not the full Docker `make check-all` stack. Happy to run anything else a maintainer would like.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
