### PR TITLE
fix(annotations): surface View session link from trace items (#1670)

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -1,8 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "src/utils/test-utils";
+import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
 import axios from "src/utils/axios";
 import ContentPanel from "../annotate/content-panel";
+
+// Per-test override for the trace-detail query. Default matches the
+// existing call sites (data: null, isLoading: false) so the original
+// tests stay green.
+const useGetTraceDetailMock = vi.hoisted(() =>
+  vi.fn(() => ({ data: null, isLoading: false })),
+);
+
+const navigateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("src/components/iconify", () => ({
   default: ({ icon, ...props }) => (
@@ -96,8 +105,16 @@ vi.mock("src/components/traceDetail/TraceDisplayPanel", () => ({
 }));
 
 vi.mock("src/api/project/trace-detail", () => ({
-  useGetTraceDetail: () => ({ data: null, isLoading: false }),
+  useGetTraceDetail: (...args) => useGetTraceDetailMock(...args),
 }));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 vi.mock("src/api/project/saved-views", () => ({
   useGetSavedViews: () => ({ data: { custom_views: [] } }),
@@ -202,5 +219,87 @@ describe("Annotation queue ContentPanel", () => {
       );
     });
     expect(screen.queryByTestId("voice-drawer")).not.toBeInTheDocument();
+  });
+});
+
+describe("Annotation queue ContentPanel — trace session link (#1670)", () => {
+  beforeEach(() => {
+    useGetTraceDetailMock.mockReturnValue({ data: null, isLoading: false });
+    navigateMock.mockReset();
+  });
+
+  const traceItem = {
+    source_type: "trace",
+    source_content: { trace_id: "trace-1" },
+  };
+
+  const renderPanel = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <ContentPanel item={traceItem} />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("does not render a View session chip when the trace has no session", async () => {
+    useGetTraceDetailMock.mockReturnValue({
+      data: { trace: { project: "proj-1" } },
+      isLoading: false,
+    });
+
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.queryByText("View session")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a View session chip when the trace belongs to a session", async () => {
+    useGetTraceDetailMock.mockReturnValue({
+      data: { trace: { project: "proj-1", session: "sess-42" } },
+      isLoading: false,
+    });
+
+    renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByText("View session")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to the observe sessions tab with the session id in the query string on click", async () => {
+    useGetTraceDetailMock.mockReturnValue({
+      data: { trace: { project: "proj-1", session: "sess-42" } },
+      isLoading: false,
+    });
+
+    renderPanel();
+
+    const chip = await waitFor(() => screen.getByText("View session"));
+    fireEvent.click(chip);
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/dashboard/observe/proj-1/sessions?session=sess-42",
+    );
+  });
+
+  it("URL-encodes the session id when navigating", async () => {
+    useGetTraceDetailMock.mockReturnValue({
+      data: { trace: { project: "proj-1", session: "sess with spaces" } },
+      isLoading: false,
+    });
+
+    renderPanel();
+
+    const chip = await waitFor(() => screen.getByText("View session"));
+    fireEvent.click(chip);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/dashboard/observe/proj-1/sessions?session=sess%20with%20spaces",
+    );
   });
 });

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from "react";
 import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -192,8 +193,17 @@ const READ_ONLY_TAB_TOOLTIP = "Open trace project to edit the view";
 
 function InlineTraceView({ traceId, spanId }) {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { data, isLoading } = useGetTraceDetail(traceId);
   const projectId = data?.trace?.project;
+  const sessionId = data?.trace?.session;
+
+  const handleViewSession = useCallback(() => {
+    if (!projectId || !sessionId) return;
+    navigate(
+      `/dashboard/observe/${projectId}/sessions?session=${encodeURIComponent(sessionId)}`,
+    );
+  }, [navigate, projectId, sessionId]);
 
   // Saved views — includes both traces-type custom views and imagine tabs.
   const { data: savedViewsData } = useGetSavedViews(projectId);
@@ -370,6 +380,34 @@ function InlineTraceView({ traceId, spanId }) {
         bgcolor: "background.paper",
       }}
     >
+      {/* Trace meta row — surfaces a "View session" link when the trace
+          belongs to a session. The session id is already on the trace
+          detail payload, so no extra fetch is needed. Clicking navigates
+          to the observe project's sessions tab with the session id in the
+          query string so SessionsView can preselect it. */}
+      {sessionId && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            px: 1.5,
+            py: 0.5,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <Chip
+            size="small"
+            variant="outlined"
+            clickable
+            icon={<Iconify icon="mdi:link-variant" width={14} />}
+            label="View session"
+            onClick={handleViewSession}
+          />
+        </Stack>
+      )}
+
       {/* Tabs toolbar — includes the "+ Imagine" button so users can pivot
           to an Imagine view from the annotate workspace. Saved views
           themselves stay read-only (no rename/edit here). */}


### PR DESCRIPTION
## Summary

Resolves #1670.

A trace selected from the annotation queue can belong to a session, but the
inline trace view in the annotation workspace gave annotators no way to
jump to that parent session — they had to leave the queue, open the
observe project, switch to the Sessions tab, and find the session
manually.

## Problem

`InlineTraceView` (the component used for `source_type === "trace"`
queue items) renders a `DrawerToolbar` (tabs + Imagine button) and the
trace tree / span detail, but never surfaces the trace's `session` id.
The session id is already on the trace-detail payload (`data.trace.session`
— see `TraceSerializer.session` in
`futureagi/tracer/serializers/trace.py`), so no backend change is
needed.

## Fix

In [`content-panel.jsx`](frontend/src/sections/annotations/queues/annotate/content-panel.jsx),
add a thin \"trace meta\" row above `DrawerToolbar` inside `InlineTraceView`.
When `data?.trace?.session` is truthy, render a clickable MUI `Chip`
labeled **\"View session\"**. Clicking calls `useNavigate()` to jump to
the observe project's Sessions tab, URL-encoding the session id in the
query string:

```text
/dashboard/observe/${projectId}/sessions?session=${sessionId}
```

The query param is **forward-compatible**: `SessionsView` does not yet
read it, so today the user lands on the Sessions tab and the param is a
no-op. A follow-up PR can wire `SessionsView` to preselect the drawer for
the given session id. This keeps the change minimal and the
backend/contract surface untouched.

## Files changed

- `frontend/src/sections/annotations/queues/annotate/content-panel.jsx`
  (+38) — `useNavigate` import, `sessionId` derivation, `handleViewSession`
  callback, conditional Chip row above `DrawerToolbar`.
- `frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx`
  (+103) — new `describe` block with 4 test cases; restructured the
  existing `useGetTraceDetail` mock to a `vi.hoisted` function so
  per-test overrides are possible.

## Verification

Local `vitest run` against the modified test file — all 6 tests pass
(2 pre-existing + 4 new):

```text
✓ Annotation queue ContentPanel > uses the voice drawer for voice call execution queue items
✓ Annotation queue ContentPanel > keeps chat call execution queue items on the chat detail layout
✓ Annotation queue ContentPanel — trace session link (#1670) > does not render a View session chip when the trace has no session
✓ Annotation queue ContentPanel — trace session link (#1670) > renders a View session chip when the trace belongs to a session
✓ Annotation queue ContentPanel — trace session link (#1670) > navigates to the observe sessions tab with the session id in the query string on click
✓ Annotation queue ContentPanel — trace session link (#1670) > URL-encodes the session id when navigating
```

## Why this is minimal

- No backend or API change — `session` is already on the trace-detail
  payload (`TraceSerializer.session` is a `PrimaryKeyRelatedField`).
- No `DrawerToolbar` change — the chip is a sibling, not a child, so
  the toolbar's tab/drag logic is untouched.
- No `SessionsView` change required for correctness — the query param
  is forward-compatible and silently ignored today.

## Checklist

- [x] `vitest run` passes locally against the modified test file
- [x] No Claude / Claude Code attribution in commit message, PR body,
      or comments
- [x] Branch `fix/1670-view-session-link-from-trace-item` based on
      `upstream/main` at `5d0491b1d`