### PR TITLE
fix(tracer): prevent Users tab query timeout

### DIFF
--- a/futureagi/tracer/services/users_list_manager.py
+++ b/futureagi/tracer/services/users_list_manager.py
@@ -63,58 +63,54 @@ _CH_TIMEOUT_MS = 30000
 MAX_EXPORT_ROWS = 10_000
 
 
-def _users_attr_enrichment_query(project_id=None):
-    """Build the Observe-Users span-attribute enrichment query (DESIGN §3).
-
-    P3b step1.5 DUAL id-remap so a cross-cutover straddler's attributes unify
-    under the OLD curated id: resolve each span's ``end_user_id`` new→old via
-    ``end_user_id_remap``, then both filter AND re-project on the resolved id so
-    the caller buckets new-id spans under the old id. Resolve+filter lives in a
-    wrapped ``WHERE`` (not ``PREWHERE``, which can't see the joined column).
-
-    Returns ``(sql, params)``; the caller binds ``%(eu_ids)s``.
-    """
-    from tracer.services.clickhouse.v2.id_remap_sql import (
-        remap_left_join,
-        resolved_id_expr,
-    )
-
-    params: dict = {}
-    project_clause = ""
-    if project_id:
-        params["attr_pid"] = str(project_id)
-        project_clause = "AND project_id = toUUID(%(attr_pid)s)"
-
-    remap_join = remap_left_join("end_user_id", "end_user_id_remap")
-    resolved = resolved_id_expr("end_user_id")
-    sql = f"""
-    SELECT
-        resolved_end_user_id AS end_user_id,
-        attributes_extra,
-        attrs_string,
-        attrs_number
-    FROM (
-        SELECT
-            {resolved} AS resolved_end_user_id,
-            attributes_extra,
-            attrs_string,
-            attrs_number
-        FROM spans
-        {remap_join}
-        WHERE is_deleted = 0
-          {project_clause}
-          AND (
-            (attributes_extra != '{{}}' AND attributes_extra != '')
-            OR length(mapKeys(attrs_string)) > 0
-            OR length(mapKeys(attrs_number)) > 0
-          )
-    )
-    WHERE resolved_end_user_id IN %(eu_ids)s
-    """
+def _users_attr_id_map_query():
+    """Map stored span end-user IDs to the page's canonical user IDs."""
     from tracer.services.clickhouse.v2.query_builders.filters import (
         _append_v2_settings,
     )
 
+    sql = """
+    WITH relevant_new_ids AS (
+        SELECT DISTINCT new_id
+        FROM end_user_id_remap FINAL
+        WHERE old_id IN %(page_eu_ids)s OR new_id IN %(page_eu_ids)s
+    )
+    SELECT any_id, min(survivor_id) AS survivor_id
+    FROM (
+        SELECT
+            arrayJoin([old_id, new_id]) AS any_id,
+            argMin(old_id, toString(old_id)) OVER (
+                PARTITION BY new_id
+            ) AS survivor_id
+        FROM end_user_id_remap FINAL
+        WHERE new_id IN (SELECT new_id FROM relevant_new_ids)
+    )
+    GROUP BY any_id
+    """
+    return _append_v2_settings(sql), {}
+
+
+def _users_attr_enrichment_query(project_ids: list[str]):
+    """Fetch attributes through project and raw end-user index predicates."""
+    from tracer.services.clickhouse.v2.query_builders.filters import (
+        _append_v2_settings,
+    )
+
+    sql = """
+    SELECT
+        end_user_id,
+        attributes_extra,
+        attrs_string,
+        attrs_number
+    FROM spans
+    PREWHERE project_id IN %(attr_project_ids)s
+      AND is_deleted = 0
+      AND end_user_id IN %(attr_span_eu_ids)s
+    WHERE (attributes_extra != '{}' AND attributes_extra != '')
+       OR length(mapKeys(attrs_string)) > 0
+       OR length(mapKeys(attrs_number)) > 0
+    """
+    params = {"attr_project_ids": tuple(str(p) for p in project_ids)}
     return _append_v2_settings(sql), params
 
 
@@ -188,16 +184,42 @@ class UsersListManager:
             return
         try:
             analytics = AnalyticsQueryService()
-            attr_query, attr_params = _users_attr_enrichment_query(
-                project_id=self.project_id
+            canonical_ids = tuple(str(e) for e in end_user_ids)
+
+            map_query, map_params = _users_attr_id_map_query()
+            map_params["page_eu_ids"] = canonical_ids
+            map_result = analytics.execute_ch_query(
+                map_query, map_params, timeout_ms=5000
             )
-            attr_params["eu_ids"] = tuple(str(e) for e in end_user_ids)
+            page_id_set = set(canonical_ids)
+            mapped_page_ids: set[str] = set()
+            raw_to_canonical: dict[str, str] = {}
+            for row in map_result.data:
+                any_id = str(row.get("any_id", ""))
+                survivor_id = str(row.get("survivor_id", ""))
+                if not any_id or not survivor_id:
+                    continue
+                if any_id in page_id_set:
+                    mapped_page_ids.add(any_id)
+                if survivor_id in page_id_set:
+                    raw_to_canonical[any_id] = survivor_id
+            for canonical_id in canonical_ids:
+                if canonical_id not in mapped_page_ids:
+                    raw_to_canonical[canonical_id] = canonical_id
+            if not raw_to_canonical:
+                return
+
+            attr_query, attr_params = _users_attr_enrichment_query(
+                self.scoped_project_ids
+            )
+            attr_params["attr_span_eu_ids"] = tuple(raw_to_canonical)
             attr_result = analytics.execute_ch_query(
                 attr_query, attr_params, timeout_ms=_CH_TIMEOUT_MS
             )
             user_attrs: dict = {}
             for attr_row in attr_result.data:
-                uid = str(attr_row.get("end_user_id", ""))
+                raw_uid = str(attr_row.get("end_user_id", ""))
+                uid = raw_to_canonical.get(raw_uid, raw_uid)
                 raw = attr_row.get("attributes_extra", "{}")
                 try:
                     attrs = json.loads(raw) if isinstance(raw, str) else (raw or {})

--- a/futureagi/tracer/tests/test_users_export.py
+++ b/futureagi/tracer/tests/test_users_export.py
@@ -16,6 +16,8 @@ from tracer.services.users_list_manager import (
     MAX_EXPORT_ROWS,
     USERS_EXPORT_COLUMNS,
     UsersListManager,
+    _users_attr_enrichment_query,
+    _users_attr_id_map_query,
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.api]
@@ -471,6 +473,142 @@ class TestUserListQueryBuilderUnpaginated:
         assert "LIMIT %(max_rows)s" in query
         assert "count() OVER()" not in query
         assert params["max_rows"] == 10_000
+
+
+class TestUsersAttributeEnrichment:
+    def test_query_filters_by_scoped_projects_and_raw_end_user_ids(self):
+        project_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+
+        query, params = _users_attr_enrichment_query(project_ids)
+
+        assert "PREWHERE project_id IN %(attr_project_ids)s" in query
+        assert "end_user_id IN %(attr_span_eu_ids)s" in query
+        assert "idx_end_user_id" not in query
+        assert "end_user_id_remap" not in query
+        assert "resolved_end_user_id" not in query
+        assert "SETTINGS" in query
+        assert params["attr_project_ids"] == tuple(project_ids)
+
+    def test_id_map_query_limits_survivor_map_to_page_groups(self):
+        query, params = _users_attr_id_map_query()
+
+        assert "WITH relevant_new_ids AS" in query
+        assert "old_id IN %(page_eu_ids)s" in query
+        assert "new_id IN %(page_eu_ids)s" in query
+        assert "new_id IN (SELECT new_id FROM relevant_new_ids)" in query
+        assert "arrayJoin([old_id, new_id]) AS any_id" in query
+        assert "argMin(old_id, toString(old_id)) OVER" in query
+        assert "SETTINGS" in query
+        assert params == {}
+
+    def test_enrichment_merges_all_group_members_into_survivor(self):
+        project_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+        survivor_id = str(uuid.uuid4())
+        old_id = str(uuid.uuid4())
+        new_id = str(uuid.uuid4())
+        rows = [{"user_id": "u1", "end_user_id": survivor_id}]
+        manager = UsersListManager(
+            organization_id=str(uuid.uuid4()),
+            allowed_project_ids=project_ids,
+        )
+        remap_rows = [
+            {"any_id": survivor_id, "survivor_id": survivor_id},
+            {"any_id": old_id, "survivor_id": survivor_id},
+            {"any_id": new_id, "survivor_id": survivor_id},
+        ]
+        attribute_rows = [
+            {
+                "end_user_id": survivor_id,
+                "attributes_extra": "{}",
+                "attrs_string": {"customer.plan": "enterprise"},
+                "attrs_number": {},
+            },
+            {
+                "end_user_id": old_id,
+                "attributes_extra": "{}",
+                "attrs_string": {"customer.plan": "free"},
+                "attrs_number": {},
+            },
+            {
+                "end_user_id": new_id,
+                "attributes_extra": "{}",
+                "attrs_string": {"customer.plan": "pro"},
+                "attrs_number": {},
+            },
+        ]
+
+        with patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            side_effect=[_ch_stub(remap_rows), _ch_stub(attribute_rows)],
+        ) as execute:
+            manager._enrich_with_span_attributes(rows)
+
+        assert rows[0]["customer.plan"] == ["enterprise", "free", "pro"]
+        assert execute.call_count == 2
+        assert execute.call_args_list[0].args[1]["page_eu_ids"] == (
+            survivor_id,
+        )
+        attr_params = execute.call_args_list[1].args[1]
+        assert attr_params["attr_project_ids"] == tuple(project_ids)
+        assert set(attr_params["attr_span_eu_ids"]) == {
+            survivor_id,
+            old_id,
+            new_id,
+        }
+
+    def test_enrichment_keeps_unmapped_user_as_identity(self):
+        project_id = str(uuid.uuid4())
+        end_user_id = str(uuid.uuid4())
+        rows = [{"user_id": "u1", "end_user_id": end_user_id}]
+        manager = UsersListManager(
+            organization_id=str(uuid.uuid4()),
+            allowed_project_ids=[project_id],
+            project_id=project_id,
+        )
+        attribute_rows = [
+            {
+                "end_user_id": end_user_id,
+                "attributes_extra": '{"customer.region": "us"}',
+                "attrs_string": {},
+                "attrs_number": {},
+            }
+        ]
+
+        with patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            side_effect=[_ch_stub([]), _ch_stub(attribute_rows)],
+        ) as execute:
+            manager._enrich_with_span_attributes(rows)
+
+        assert rows[0]["customer.region"] == "us"
+        assert execute.call_args_list[1].args[1]["attr_span_eu_ids"] == (
+            end_user_id,
+        )
+
+    def test_enrichment_does_not_relabel_non_survivor_page_row(self):
+        project_id = str(uuid.uuid4())
+        page_end_user_id = str(uuid.uuid4())
+        survivor_id = str(uuid.uuid4())
+        rows = [{"user_id": "u1", "end_user_id": page_end_user_id}]
+        manager = UsersListManager(
+            organization_id=str(uuid.uuid4()),
+            allowed_project_ids=[project_id],
+            project_id=project_id,
+        )
+
+        with patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            return_value=_ch_stub(
+                [{"any_id": page_end_user_id, "survivor_id": survivor_id}]
+            ),
+        ) as execute:
+            manager._enrich_with_span_attributes(rows)
+
+        assert rows == [{"user_id": "u1", "end_user_id": page_end_user_id}]
+        assert execute.call_count == 1
 
 
 class TestUsersExportStreaming:


### PR DESCRIPTION
## Summary

Fixes the Observe Users tab 504 by removing the full remap join from span-attribute enrichment. The large `spans` read is now scoped by the workspace's projects and raw end-user IDs in `PREWHERE`, allowing ClickHouse to use project pruning and `idx_end_user_id` while preserving consolidated-user attribute behavior.

## Linked issues

Linear: https://linear.app/future-agi/issue/TH-6934/users-tab-is-completely-broken-returns-504-gateway-timeout

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [x] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Indexable span-attribute enrichment**

- Replaced the post-join `resolved_end_user_id` filter with project-scoped and raw-ID predicates in `PREWHERE`.
- Always applies the request's complete workspace project scope, including requests without an explicit project filter.
- Maps returned raw span IDs back to canonical page users before folding dynamic attributes.

**B. Page-scoped remap resolution**

- Resolves only consolidation groups related to users on the current page instead of materializing the complete survivor map.
- Preserves many-old-to-one-new consolidation, identity fallback for unmapped users, and non-survivor safety.
- Keeps enrichment fail-open behavior unchanged.

---

## 2) Why the changes were done

- **Product/UX:** The Users tab returned a 504 because secondary span-attribute enrichment exceeded ClickHouse's 30-second limit.
- **Technical:** Filtering on a joined/computed ID prevented ClickHouse from using `idx_end_user_id` and caused a large scan of wide span attribute columns.
- **Architecture:** Remap resolution remains a small preliminary read; the expensive `spans` read is now independent of the remap join and follows the table's existing access paths.

---

## 3) Tests written + scenarios each covers

**`futureagi/tracer/tests/test_users_export.py`** — Users query shape and attribute-enrichment behavior

- `test_query_filters_by_scoped_projects_and_raw_end_user_ids` — asserts project/raw-ID `PREWHERE` predicates and removal of the remap join.
- `test_id_map_query_limits_survivor_map_to_page_groups` — asserts survivor calculation is limited to relevant page groups.
- `test_enrichment_merges_all_group_members_into_survivor` — verifies attributes from old and new IDs merge into the survivor row.
- `test_enrichment_keeps_unmapped_user_as_identity` — verifies identity fallback for an unmapped user.
- `test_enrichment_does_not_relabel_non_survivor_page_row` — prevents attributes from being assigned to the wrong page row.

> Run result: **13 passed** across the focused manager/query suites. Python compilation, `git diff --check`, and IDE diagnostics are clean.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
set -a && source .env.test && set +a
.venv/bin/pytest \
  tracer/tests/test_users_export.py::TestUserListQueryBuilderUnpaginated \
  tracer/tests/test_users_export.py::TestUsersAttributeEnrichment \
  tracer/tests/test_users_export.py::TestUsersExportStreaming -v
```

### Production read-only verification

For the affected workspace, the optimized attribute read completed in approximately 103 ms and used `idx_end_user_id`. Its final pruning stage read 6 parts / 6 granules instead of the deployed query's broad scan. The page-scoped remap query produced mappings identical to the existing full survivor map while reducing peak memory from approximately 244 MB to 12 MB.

---

## 5) Screenshots / recordings

Not applicable; this is a backend query-plan fix with automated and live read-only verification.

---

## 6) Edge cases & considerations

- **Consolidated identities:** Attributes from every old/new member are merged under the canonical survivor.
- **Unmapped identities:** The page ID is used as an identity mapping.
- **Non-survivor page IDs:** The row is not relabeled or enriched under the wrong identity.
- **ClickHouse failure:** Secondary attribute enrichment remains fail-open, so the primary Users response can still succeed.
- **Projection selection:** Projection use remains cost-based; the query does not force a projection or require schema changes.

---

## 7) Pre-existing issues (NOT introduced by this PR)

The focused local run reports that CH25 schema setup cannot connect to ClickHouse at `.env.test`'s `localhost:18123`; the selected tests do not require that fixture and all 13 passed.

---

## 8) Architectural / important decisions

- **Resolve IDs before the wide span read:** This preserves remap semantics without placing a join between ClickHouse and its user-ID skip index.
- **No new MV or forced projection:** Existing rollups do not contain arbitrary dynamic attributes, and forcing a projection would make rollout dependent on projection shape across environments.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] Full `bin/test` suite passes locally — focused affected suites were run
- [ ] Frontend tests — not applicable; no frontend changes
- [ ] Contract verification — not applicable; no API contract change
- [x] Documentation is not required for this internal query-plan change
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA status is unchanged
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked
