### PR TITLE
fix(experiments): honor picker version pin in create/edit flow (TH-6979)

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -561,7 +561,10 @@ const CreateRunTestPage = ({ open, onClose }) => {
             evalConfig.name ||
             evalConfig.evalTemplateName ||
             "Unnamed Evaluation",
-          template_id: evalConfig.templateId || evalConfig.id?.split("_")[0], // Extract original template ID
+          template_id:
+            evalConfig.template_id ||
+            evalConfig.templateId ||
+            evalConfig.id?.split("_")[0],
           mapping: evalConfig.config?.mapping || {},
           config: evalConfig.config || {},
           error_localizer: evalConfig?.errorLocalizer,
@@ -643,14 +646,15 @@ const CreateRunTestPage = ({ open, onClose }) => {
 
   const toLegacyEvalShape = (evalConfig, versionedName) => {
     const serialized = serializeEvalConfig(evalConfig);
+    const templateId = evalConfig.template_id;
     return {
-      evalId: `${evalConfig.templateId}_${Date.now()}_${Math.random()
+      evalId: `${templateId}_${Date.now()}_${Math.random()
         .toString(36)
         .slice(2, 8)}`,
-      templateId: evalConfig.templateId,
+      templateId,
       name: versionedName,
-      evalTemplateName: evalConfig.evalTemplate?.name || evalConfig.name,
-      description: evalConfig.evalTemplate?.description || "",
+      evalTemplateName: evalConfig.eval_template?.name || evalConfig.name,
+      description: evalConfig.eval_template?.description || "",
       type: "user_built",
       mapping: evalConfig.mapping || {},
       config: {
@@ -659,20 +663,20 @@ const CreateRunTestPage = ({ open, onClose }) => {
         ...(evalConfig.instructions != null && {
           instructions: evalConfig.instructions,
         }),
-        ...(evalConfig.passThreshold != null && {
-          pass_threshold: evalConfig.passThreshold,
+        ...(evalConfig.pass_threshold != null && {
+          pass_threshold: evalConfig.pass_threshold,
         }),
-        ...(evalConfig.choiceScores &&
-          Object.keys(evalConfig.choiceScores).length > 0 && {
-            choice_scores: evalConfig.choiceScores,
+        ...(evalConfig.choice_scores &&
+          Object.keys(evalConfig.choice_scores).length > 0 && {
+            choice_scores: evalConfig.choice_scores,
           }),
       },
       model: evalConfig.model,
       evalRequiredKeys:
-        evalConfig.evalTemplate?.required_keys ||
-        evalConfig.evalTemplate?.requiredKeys ||
+        evalConfig.eval_template?.required_keys ||
+        evalConfig.eval_template?.requiredKeys ||
         [],
-      evalTemplateTags: evalConfig.evalTemplate?.tags || [],
+      evalTemplateTags: evalConfig.eval_template?.tags || [],
       errorLocalizer: !!evalConfig.error_localizer_enabled,
     };
   };
@@ -689,7 +693,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
       const versionedName = getVersionedEvalName(
         evalConfig.name,
         updated,
-        evalConfig.templateId,
+        evalConfig.template_id,
       );
       return [...updated, toLegacyEvalShape(evalConfig, versionedName)];
     });

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
@@ -173,17 +173,17 @@ const EvalPickerConfig = ({ evalData, onBack, onSave, isSaving }) => {
 
   const handleSave = useCallback(() => {
     const templateId =
-      evalData?.templateId || evalData?.template_id || evalData?.id;
+      evalData?.template_id || evalData?.templateId || evalData?.id;
     const evalConfig = {
-      templateId,
-      evalTemplateId: templateId,
+      template_id: templateId,
+      eval_template_id: templateId,
       name: evalName,
       model,
       mapping,
-      evalTemplate: normalizedEvalData,
-      evalType: normalizedEvalData?.evalType,
-      templateType: normalizedEvalData?.templateType,
-      outputType: normalizedEvalData?.outputType,
+      eval_template: normalizedEvalData,
+      eval_type: normalizedEvalData?.evalType,
+      template_type: normalizedEvalData?.templateType,
+      output_type: normalizedEvalData?.outputType,
       config: normalizedEvalData?.config,
     };
     onSave(evalConfig);

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -135,7 +135,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     [evalData],
   );
   const templateId =
-    evalData?.templateId || evalData?.template_id || evalData?.id;
+    evalData?.template_id || evalData?.id;
   // ── Data (same hooks as EvalDetailPage) ──
   const { data: fullEval, isLoading, isError } = useEvalDetail(templateId);
   const normalizedFullEval = useMemo(
@@ -177,14 +177,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [dataReady, setDataReady] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   useEffect(() => {
-    const pinned =
-      evalData?.pinned_version_id ?? evalData?.pinnedVersionId ?? null;
+    const pinned = evalData?.pinned_version_id ?? null;
     if (pinned && !selectedVersionId && !isDirty) {
       setSelectedVersionId(pinned);
     }
   }, [
     evalData?.pinned_version_id,
-    evalData?.pinnedVersionId,
     selectedVersionId,
     isDirty,
   ]);
@@ -981,9 +979,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     const tools = build_tools_payload(connectorIds);
 
     const templateType =
-      fullEval?.template_type ||
-      fullEval?.templateType ||
-      evalData?.template_type;
+      fullEval?.template_type || evalData?.template_type;
 
     const resolvedConfig = buildEvalTemplateConfig({
       baseConfig: fullEval?.config || evalData?.config || {},
@@ -1000,15 +996,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       templateFormat,
     });
 
-    // When the picker was opened in edit mode (initialEval came from a
-    // saved-evals row or the column-menu Edit Eval action), evalData
-    // carries `userEvalId` — the existing UserEvalMetric id. The host
-    // (EvaluationDrawer) reads this to route to /edit_and_run_user_eval
-    // instead of /add_user_eval, preventing duplicate bindings.
-    const userEvalId = evalData?.userEvalId;
+    const userEvalId = evalData?.user_eval_id;
 
-    // In edit mode: evalData.name is the saved instance name — skip
-    // fullEval.name (template name) so it never overwrites the instance name.
     const resolvedName =
       source === "composite"
         ? fullEval?.name || evalData?.name || evalName
@@ -1017,21 +1006,17 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           : evalName || fullEval?.name || evalData?.name;
 
     if (templateType === "composite") {
-      // Composite metrics don't carry prompt/model/output-type/choice-score
-      // state — those live on each child template. Emit only the fields
-      // the host needs to create a UserEvalMetric plus the per-binding
-      // weight overrides.
       onSave({
-        templateId,
-        evalTemplateId: templateId,
-        userEvalId,
+        template_id: templateId,
+        eval_template_id: templateId,
+        user_eval_id: userEvalId,
         name: resolvedName,
         mapping: sourceMapping,
-        evalTemplate: fullEval || evalData,
-        evalType,
-        templateType,
+        eval_template: fullEval || evalData,
+        eval_type: evalType,
+        template_type: templateType,
         config: fullEval?.config || evalData?.config,
-        versionId: selectedVersionId,
+        version_id: selectedVersionId,
         data_injection: dataInjection,
         error_localizer_enabled: errorLocalizerEnabled,
         composite_weight_overrides: compositeChildWeights,
@@ -1040,30 +1025,24 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     }
 
     onSave({
-      templateId,
-      evalTemplateId: templateId,
-      userEvalId,
+      template_id: templateId,
+      eval_template_id: templateId,
+      user_eval_id: userEvalId,
       name: resolvedName,
       model,
       mapping: sourceMapping,
-      evalTemplate: fullEval || evalData,
-      evalType,
-      templateType,
-      outputType,
+      eval_template: fullEval || evalData,
+      eval_type: evalType,
+      template_type: templateType,
+      output_type: outputType,
       config: resolvedConfig,
-      versionId: selectedVersionId,
+      version_id: selectedVersionId,
       instructions,
       messages,
       pass_threshold: passThreshold,
       choice_scores: choiceScores,
       multi_choice: multiChoice,
-      // Code-eval static params (function_params_schema inputs, e.g.
-      // min_words / max_words). Persisted so the backend writes them onto
-      // UserEvalMetric.config.params and future runs can read them via
-      // kwargs. Empty object is fine — backend treats it the same as
-      // "no static params" (eval body then reads kwargs.get(...) → None).
       params: evalType === "code" ? codeParams : {},
-      // Runtime overrides — these become config.run_config on the backend.
       agent_mode: agentMode,
       check_internet: useInternet,
       summary:

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -134,11 +134,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     () => normalizeEvalPickerEval(evalData),
     [evalData],
   );
-  const templateId =
-    evalData?.template_id ||
-    evalData?.templateId ||
-    normalizedEvalData?.templateId ||
-    evalData?.id;
+  const templateId = evalData?.template_id || evalData?.id;
   // ── Data (same hooks as EvalDetailPage) ──
   const { data: fullEval, isLoading, isError } = useEvalDetail(templateId);
   const normalizedFullEval = useMemo(
@@ -150,14 +146,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const updateEval = useUpdateEval(templateId);
   const createVersion = useCreateEvalVersion(templateId);
 
-  const initialPinnedVersionId =
-    normalizedEvalData?.pinnedVersionId ??
-    evalData?.pinned_version_id ??
-    null;
-
   // ── Editable state (mirrors EvalDetailPage) ──
   const [selectedVersionId, setSelectedVersionId] = useState(
-    initialPinnedVersionId,
+    evalData?.pinned_version_id ?? null,
   );
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState("");
@@ -185,19 +176,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [dataReady, setDataReady] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   useEffect(() => {
-    const pinned =
-      normalizedEvalData?.pinnedVersionId ??
-      evalData?.pinned_version_id ??
-      null;
+    const pinned = evalData?.pinned_version_id ?? null;
     if (pinned && !selectedVersionId && !isDirty) {
       setSelectedVersionId(pinned);
     }
-  }, [
-    normalizedEvalData?.pinnedVersionId,
-    evalData?.pinned_version_id,
-    selectedVersionId,
-    isDirty,
-  ]);
+  }, [evalData?.pinned_version_id, selectedVersionId, isDirty]);
   const [isTesting, setIsTesting] = useState(false);
   const [testPassed, setTestPassed] = useState(false);
   const [testError, setTestError] = useState(null);
@@ -991,9 +974,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     const tools = build_tools_payload(connectorIds);
 
     const templateType =
-      fullEval?.template_type ||
-      evalData?.template_type ||
-      normalizedEvalData?.templateType;
+      fullEval?.template_type || evalData?.template_type;
 
     const resolvedConfig = buildEvalTemplateConfig({
       baseConfig: fullEval?.config || evalData?.config || {},
@@ -1010,10 +991,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       templateFormat,
     });
 
-    const userEvalId =
-      evalData?.user_eval_id ??
-      evalData?.userEvalId ??
-      normalizedEvalData?.userEvalId;
+    const userEvalId = evalData?.user_eval_id;
 
     const resolvedName =
       source === "composite"

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -135,7 +135,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     [evalData],
   );
   const templateId =
-    evalData?.template_id || evalData?.id;
+    evalData?.template_id ||
+    evalData?.templateId ||
+    normalizedEvalData?.templateId ||
+    evalData?.id;
   // ── Data (same hooks as EvalDetailPage) ──
   const { data: fullEval, isLoading, isError } = useEvalDetail(templateId);
   const normalizedFullEval = useMemo(
@@ -147,9 +150,14 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const updateEval = useUpdateEval(templateId);
   const createVersion = useCreateEvalVersion(templateId);
 
+  const initialPinnedVersionId =
+    normalizedEvalData?.pinnedVersionId ??
+    evalData?.pinned_version_id ??
+    null;
+
   // ── Editable state (mirrors EvalDetailPage) ──
   const [selectedVersionId, setSelectedVersionId] = useState(
-    evalData?.pinned_version_id ?? null,
+    initialPinnedVersionId,
   );
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState("");
@@ -177,11 +185,15 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [dataReady, setDataReady] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
   useEffect(() => {
-    const pinned = evalData?.pinned_version_id ?? null;
+    const pinned =
+      normalizedEvalData?.pinnedVersionId ??
+      evalData?.pinned_version_id ??
+      null;
     if (pinned && !selectedVersionId && !isDirty) {
       setSelectedVersionId(pinned);
     }
   }, [
+    normalizedEvalData?.pinnedVersionId,
     evalData?.pinned_version_id,
     selectedVersionId,
     isDirty,
@@ -979,7 +991,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     const tools = build_tools_payload(connectorIds);
 
     const templateType =
-      fullEval?.template_type || evalData?.template_type;
+      fullEval?.template_type ||
+      evalData?.template_type ||
+      normalizedEvalData?.templateType;
 
     const resolvedConfig = buildEvalTemplateConfig({
       baseConfig: fullEval?.config || evalData?.config || {},
@@ -996,7 +1010,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       templateFormat,
     });
 
-    const userEvalId = evalData?.user_eval_id;
+    const userEvalId =
+      evalData?.user_eval_id ??
+      evalData?.userEvalId ??
+      normalizedEvalData?.userEvalId;
 
     const resolvedName =
       source === "composite"

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -155,7 +155,7 @@ const renderConfigFull = ({ sourceTimeWindow } = {}) =>
       sourceTimeWindow={sourceTimeWindow}
     >
       <EvalPickerConfigFull
-        evalData={{ id: "tpl-1", templateId: "tpl-1", name: "toxicity" }}
+        evalData={{ id: "tpl-1", template_id: "tpl-1", name: "toxicity" }}
         onBack={() => {}}
         onSave={() => {}}
         isSaving={false}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -514,18 +514,14 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (source === "task" && onFiltersChange) {
         onFiltersChange(localFilterForm.getValues("filters") || []);
       }
-      // Now add to the current context. data_injection (seeded from
-      // sourceRowType) is forwarded so the consumer's serializeEvalConfig
-      // captures it inside config.run_config — same shape an existing
-      // eval would emit through EvalPickerConfigFull.
       onSave({
-        templateId: draftId,
-        evalTemplateId: draftId,
+        template_id: draftId,
+        eval_template_id: draftId,
         name: name.trim(),
         model,
         mapping: sourceMapping,
-        evalType,
-        outputType,
+        eval_type: evalType,
+        output_type: outputType,
         instructions,
         data_injection:
           evalType === "agent"
@@ -600,11 +596,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       setSelectedEval({
         id: result?.id,
         name: name.trim(),
-        templateType: "composite",
-        evalType: result?.eval_type || "llm",
-        outputType:
+        template_type: "composite",
+        eval_type: result?.eval_type || "llm",
+        output_type:
           compositeChildAxis === "percentage" ? "percentage" : "pass_fail",
-        // EvalPickerConfigFull seeds its mapping panel from this.
         mapping: sourceMapping,
       });
       setStep("config");

--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -16,7 +16,6 @@ import { useEvalPickerContext } from "./context/EvalPickerContext";
 import EvalPickerList from "./EvalPickerList";
 import EvalPickerConfigFull from "./EvalPickerConfigFull";
 import EvalPickerCreateNew from "./EvalPickerCreateNew";
-import { normalizeEvalPickerEval } from "./evalPickerValue";
 
 const STEP_TITLES = {
   list: "Select Evaluation",
@@ -54,7 +53,7 @@ const EvalPickerContent = ({ onStepChange }) => {
       if (skipConfig) {
         setIsSaving(true);
         try {
-          await onEvalAdded?.(normalizeEvalPickerEval(evalData));
+          await onEvalAdded?.(evalData);
           onClose?.();
         } catch {
           // Parent handles error display
@@ -212,7 +211,6 @@ const EvalPickerContent = ({ onStepChange }) => {
           {step === "config" && selectedEval && (
             <EvalPickerConfigFull
               key={
-                selectedEval?.templateId ||
                 selectedEval?.template_id ||
                 selectedEval?.id
               }
@@ -321,12 +319,7 @@ const EvalPickerDrawer = ({
       }}
     >
       <EvalPickerProvider
-        key={
-          initialEval?.user_eval_id ||
-          initialEval?.userEvalId ||
-          initialEval?.id ||
-          "new"
-        }
+        key={initialEval?.user_eval_id || initialEval?.id || "new"}
         source={source}
         sourceId={sourceId}
         sourceRowType={sourceRowType}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -321,7 +321,12 @@ const EvalPickerDrawer = ({
       }}
     >
       <EvalPickerProvider
-        key={initialEval?.userEvalId || initialEval?.id || "new"}
+        key={
+          initialEval?.user_eval_id ||
+          initialEval?.userEvalId ||
+          initialEval?.id ||
+          "new"
+        }
         source={source}
         sourceId={sourceId}
         sourceRowType={sourceRowType}

--- a/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
+++ b/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useForm } from "react-hook-form";
 import { EvalPickerContext } from "./EvalPickerContext";
-import { normalizeEvalPickerEval } from "../evalPickerValue";
 
 const EvalPickerProvider = ({
   children,
@@ -42,9 +41,7 @@ const EvalPickerProvider = ({
   sourceTimeWindow = null,
 }) => {
   const [step, setStep] = useState(initialEval ? "config" : "list");
-  const [selectedEval, setSelectedEvalState] = useState(
-    normalizeEvalPickerEval(initialEval),
-  );
+  const [selectedEval, setSelectedEvalState] = useState(initialEval);
   // True when the drawer was opened in edit mode (initialEval was provided).
   // In edit mode the back button closes the drawer instead of going to list.
   const isEditMode = !!initialEval;
@@ -53,13 +50,13 @@ const EvalPickerProvider = ({
   // jump to config with that eval pre-selected.
   useEffect(() => {
     if (initialEval) {
-      setSelectedEvalState(normalizeEvalPickerEval(initialEval));
+      setSelectedEvalState(initialEval);
       setStep("config");
     }
   }, [initialEval]);
 
   const setSelectedEval = useCallback((evalData) => {
-    setSelectedEvalState(normalizeEvalPickerEval(evalData));
+    setSelectedEvalState(evalData);
   }, []);
 
   const handleReset = useCallback(() => {

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -104,6 +104,55 @@ export const buildEvalTemplateConfig = ({
   return nextConfig;
 };
 
+// Build the nested `{ mapping, config, run_config, params }` payload the
+// experiment endpoints expect (matches the shape EvaluationDrawer sends to
+// /edit_and_run_user_eval). Kept here so both the creation wizard and the
+// Manage-Evaluations drawer emit an identical shape — otherwise runtime
+// overrides picked in the drawer (agent_mode, tools, summary, …) never
+// reach `UserEvalMetric.config.run_config` and the pinned version snapshot
+// ends up equal to the template default.
+export const buildExperimentEvalRuntimePayload = (evalConfig, mapping) => {
+  const isComposite = evalConfig.templateType === "composite";
+  const templateConfig =
+    evalConfig.config || evalConfig.evalTemplate?.config || {};
+  const runConfig = {};
+  if (!isComposite) {
+    if (evalConfig.model) runConfig.model = evalConfig.model;
+    if (evalConfig.agent_mode) runConfig.agent_mode = evalConfig.agent_mode;
+    if (evalConfig.check_internet !== undefined)
+      runConfig.check_internet = !!evalConfig.check_internet;
+    if (evalConfig.summary) runConfig.summary = evalConfig.summary;
+    if (evalConfig.knowledge_base_id)
+      runConfig.knowledge_base_id = evalConfig.knowledge_base_id;
+    if (evalConfig.knowledge_bases)
+      runConfig.knowledge_bases = evalConfig.knowledge_bases;
+    if (evalConfig.tools) runConfig.tools = evalConfig.tools;
+    if (evalConfig.pass_threshold !== undefined)
+      runConfig.pass_threshold = evalConfig.pass_threshold;
+    if (
+      evalConfig.choice_scores &&
+      Object.keys(evalConfig.choice_scores).length
+    )
+      runConfig.choice_scores = evalConfig.choice_scores;
+    if (evalConfig.multi_choice !== undefined)
+      runConfig.multi_choice = !!evalConfig.multi_choice;
+  }
+  if (evalConfig.data_injection)
+    runConfig.data_injection = evalConfig.data_injection;
+  if (evalConfig.error_localizer_enabled !== undefined)
+    runConfig.error_localizer_enabled = !!evalConfig.error_localizer_enabled;
+  const evalParams =
+    evalConfig.params && typeof evalConfig.params === "object"
+      ? evalConfig.params
+      : {};
+  return {
+    mapping,
+    config: isComposite ? {} : templateConfig,
+    ...(Object.keys(evalParams).length ? { params: evalParams } : {}),
+    ...(Object.keys(runConfig).length ? { run_config: runConfig } : {}),
+  };
+};
+
 export const buildCompositeSourceModeProps = ({
   isComposite,
   fullEval,

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -104,17 +104,10 @@ export const buildEvalTemplateConfig = ({
   return nextConfig;
 };
 
-// Build the nested `{ mapping, config, run_config, params }` payload the
-// experiment endpoints expect (matches the shape EvaluationDrawer sends to
-// /edit_and_run_user_eval). Kept here so both the creation wizard and the
-// Manage-Evaluations drawer emit an identical shape — otherwise runtime
-// overrides picked in the drawer (agent_mode, tools, summary, …) never
-// reach `UserEvalMetric.config.run_config` and the pinned version snapshot
-// ends up equal to the template default.
 export const buildExperimentEvalRuntimePayload = (evalConfig, mapping) => {
-  const isComposite = evalConfig.templateType === "composite";
+  const isComposite = evalConfig.template_type === "composite";
   const templateConfig =
-    evalConfig.config || evalConfig.evalTemplate?.config || {};
+    evalConfig.config || evalConfig.eval_template?.config || {};
   const runConfig = {};
   if (!isComposite) {
     if (evalConfig.model) runConfig.model = evalConfig.model;

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCompositeSourceModeProps,
   buildDataInjection,
+  buildExperimentEvalRuntimePayload,
   contextOptionsForRowType,
   extractCodeEvaluateParams,
   getSourceModeVariables,
@@ -321,5 +322,78 @@ describe("getSourceModeVariables", () => {
         compositeUnionKeys: ["child_input", "child_output"],
       }),
     ).toEqual(["child_input", "child_output"]);
+  });
+});
+
+// TH-6979: guard the shared payload builder used by both experiment
+// drawers so runtime overrides + composite handling don't regress.
+describe("buildExperimentEvalRuntimePayload", () => {
+  it("wraps single-eval config with mapping + run_config + params", () => {
+    const mapping = { output: "col-uuid" };
+    const payload = buildExperimentEvalRuntimePayload(
+      {
+        templateType: "single",
+        config: { rule_prompt: "hi", output: "Pass/Fail" },
+        model: "turing_large",
+        agent_mode: "agent",
+        summary: { type: "concise" },
+        tools: [{ id: "t1" }],
+        knowledge_bases: ["kb-1"],
+        pass_threshold: 0.7,
+        multi_choice: false,
+        data_injection: { variables_only: true },
+        error_localizer_enabled: true,
+        params: { min_words: 3 },
+      },
+      mapping,
+    );
+
+    expect(payload.mapping).toEqual(mapping);
+    expect(payload.config).toEqual({
+      rule_prompt: "hi",
+      output: "Pass/Fail",
+    });
+    expect(payload.params).toEqual({ min_words: 3 });
+    expect(payload.run_config).toEqual({
+      model: "turing_large",
+      agent_mode: "agent",
+      summary: { type: "concise" },
+      knowledge_bases: ["kb-1"],
+      tools: [{ id: "t1" }],
+      pass_threshold: 0.7,
+      multi_choice: false,
+      data_injection: { variables_only: true },
+      error_localizer_enabled: true,
+    });
+  });
+
+  it("omits run_config / params when the picker didn't emit any override", () => {
+    const payload = buildExperimentEvalRuntimePayload(
+      { templateType: "single", config: { rule_prompt: "hi" } },
+      { output: "col-uuid" },
+    );
+    expect(payload).toEqual({
+      mapping: { output: "col-uuid" },
+      config: { rule_prompt: "hi" },
+    });
+  });
+
+  it("blanks the config for composite templates and skips per-child overrides", () => {
+    const payload = buildExperimentEvalRuntimePayload(
+      {
+        templateType: "composite",
+        config: { rule_prompt: "should-not-flow-through" },
+        model: "should-not-flow-through",
+        agent_mode: "should-not-flow-through",
+        data_injection: { variables_only: true },
+      },
+      { output: "col-uuid" },
+    );
+    expect(payload.config).toEqual({});
+    // Composite bindings only allow data_injection + error_localizer_enabled
+    // through, not the per-child single-eval knobs.
+    expect(payload.run_config).toEqual({
+      data_injection: { variables_only: true },
+    });
   });
 });

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -325,14 +325,12 @@ describe("getSourceModeVariables", () => {
   });
 });
 
-// TH-6979: guard the shared payload builder used by both experiment
-// drawers so runtime overrides + composite handling don't regress.
 describe("buildExperimentEvalRuntimePayload", () => {
   it("wraps single-eval config with mapping + run_config + params", () => {
     const mapping = { output: "col-uuid" };
     const payload = buildExperimentEvalRuntimePayload(
       {
-        templateType: "single",
+        template_type: "single",
         config: { rule_prompt: "hi", output: "Pass/Fail" },
         model: "turing_large",
         agent_mode: "agent",
@@ -369,7 +367,7 @@ describe("buildExperimentEvalRuntimePayload", () => {
 
   it("omits run_config / params when the picker didn't emit any override", () => {
     const payload = buildExperimentEvalRuntimePayload(
-      { templateType: "single", config: { rule_prompt: "hi" } },
+      { template_type: "single", config: { rule_prompt: "hi" } },
       { output: "col-uuid" },
     );
     expect(payload).toEqual({
@@ -381,7 +379,7 @@ describe("buildExperimentEvalRuntimePayload", () => {
   it("blanks the config for composite templates and skips per-child overrides", () => {
     const payload = buildExperimentEvalRuntimePayload(
       {
-        templateType: "composite",
+        template_type: "composite",
         config: { rule_prompt: "should-not-flow-through" },
         model: "should-not-flow-through",
         agent_mode: "should-not-flow-through",
@@ -390,8 +388,6 @@ describe("buildExperimentEvalRuntimePayload", () => {
       { output: "col-uuid" },
     );
     expect(payload.config).toEqual({});
-    // Composite bindings only allow data_injection + error_localizer_enabled
-    // through, not the per-child single-eval knobs.
     expect(payload.run_config).toEqual({
       data_injection: { variables_only: true },
     });

--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
@@ -24,22 +24,11 @@ export function normalizeOldEndpointEval(e) {
         : "llm");
   const created_by_name =
     e.created_by_name || (owner === "system" ? "System" : "User");
-  const templateId = e.template_id || e.eval_template_id || e.id;
+  const template_id = e.template_id || e.eval_template_id || e.id;
   return {
-    // IMPORTANT: the picker's config/detail flow operates on eval
-    // TEMPLATE ids, not user-eval binding ids. Old getEvalsList
-    // returns both (`id` = user eval, `template_id` = template). Use
-    // templateId as the canonical row id so opening the config drawer
-    // fetches the correct eval detail and renders the right type.
-    id: templateId,
-    templateId,
-    // Only already-attached UserEvalMetric rows carry a distinct
-    // `template_id` from the backend; catalog rows (preset / custom
-    // templates) return `id = template.id` with no `template_id`.
-    // Forwarding `e.id` on catalog rows would cause EvaluationDrawer
-    // to route "Add" clicks to /edit_and_run_user_eval/<template_id>
-    // and 404 with "Eval not found" (TH-4533).
-    userEvalId: e.template_id ? e.id : undefined,
+    id: template_id,
+    template_id,
+    user_eval_id: e.template_id ? e.id : undefined,
     name: e.name || e.eval_template_name,
     template_type: e.template_type || "single",
     eval_type,
@@ -151,18 +140,12 @@ export function useEvalPickerData({
   const items = useMemo(() => {
     if (!rawData) return [];
     if (isUsingOldEndpoint) {
-      // Old endpoint: { evals: [...] }. See `normalizeOldEndpointEval` above
-      // for the field-mapping contract — backend returns snake_case and we
-      // preserve it as snake_case (TH-6125 regression).
       const evals = rawData?.evals || [];
       return evals.map(normalizeOldEndpointEval);
     }
-    // New endpoint already returns normalized items; still ensure the
-    // picker has a stable templateId alias for edit/config flows.
     return (rawData?.items || []).map((item) => ({
       ...item,
-      templateId:
-        item.templateId || item.template_id || item.eval_template_id || item.id,
+      template_id: item.template_id || item.eval_template_id || item.id,
     }));
   }, [rawData, isUsingOldEndpoint]);
 

--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.test.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.test.js
@@ -38,7 +38,7 @@ describe("normalizeOldEndpointEval", () => {
     expect(out.created_by_name).toBe("User");
   });
 
-  it("uses template_id as the canonical id; sets userEvalId only on attached rows", () => {
+  it("uses template_id as the canonical id; sets user_eval_id only on attached rows", () => {
     // Catalog row — no template_id; id IS the template id.
     const catalog = normalizeOldEndpointEval({
       id: "tpl-1",
@@ -46,8 +46,8 @@ describe("normalizeOldEndpointEval", () => {
       type: "futureagi_built",
     });
     expect(catalog.id).toBe("tpl-1");
-    expect(catalog.templateId).toBe("tpl-1");
-    expect(catalog.userEvalId).toBeUndefined();
+    expect(catalog.template_id).toBe("tpl-1");
+    expect(catalog.user_eval_id).toBeUndefined();
 
     // Attached UserEvalMetric row — separate template_id and id.
     const attached = normalizeOldEndpointEval({
@@ -56,8 +56,8 @@ describe("normalizeOldEndpointEval", () => {
       name: "my eval",
     });
     expect(attached.id).toBe("tpl-1");
-    expect(attached.templateId).toBe("tpl-1");
-    expect(attached.userEvalId).toBe("uem-1");
+    expect(attached.template_id).toBe("tpl-1");
+    expect(attached.user_eval_id).toBe("uem-1");
   });
 
   it("derives eval_type from tags when eval_type is missing", () => {
@@ -128,8 +128,8 @@ describe("normalizeOldEndpointEval", () => {
     const out = normalizeOldEndpointEval(OLD_ENDPOINT_FIXTURE);
     expect(out).toMatchObject({
       id: "tpl-7",
-      templateId: "tpl-7",
-      userEvalId: "uem-42",
+      template_id: "tpl-7",
+      user_eval_id: "uem-42",
       name: "customer_agent_clarification_seeking",
       template_type: "single",
       eval_type: "agent",
@@ -145,6 +145,8 @@ describe("normalizeOldEndpointEval", () => {
       model: "gpt-4o-mini",
     });
     for (const camel of [
+      "templateId",
+      "userEvalId",
       "templateType",
       "evalType",
       "outputType",

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
@@ -1,11 +1,3 @@
-// Translate the camelCase output of EvalPickerConfigFull.handleAdd into the
-// snake_case payload accepted by simulate/run-tests/eval-configs/update and
-// the simulate add endpoint. RUN_CONFIG_KEYS mirrors the BE's
-//
-// Runtime overrides are emitted only in `config.run_config.*`, which is the
-// backend contract consumed by normalize_eval_runtime_config and the simulation
-// runner. Edit-reopen flows should read from that canonical location instead
-// of depending on duplicate top-level payload keys.
 const RUN_CONFIG_KEYS = [
   "model",
   "agent_mode",
@@ -28,13 +20,12 @@ export function serializeEvalConfig(evalConfig) {
     runConfig.error_localizer_enabled = !!evalConfig.error_localizer_enabled;
   }
   return {
-    template_id: evalConfig.templateId,
+    template_id: evalConfig.template_id,
     name: evalConfig.name,
     model: evalConfig.model,
     mapping: evalConfig.mapping || {},
     config: {
       ...(evalConfig.config || {}),
-      // BE looks up function-param values at `config.params` (normalize_eval_runtime_config).
       ...(evalConfig.params !== undefined && { params: evalConfig.params }),
       run_config: {
         ...(evalConfig.config?.run_config || {}),

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.test.js
@@ -4,7 +4,7 @@ import { serializeEvalConfig } from "./serializeEvalConfig";
 describe("serializeEvalConfig", () => {
   it("emits runtime overrides only inside config.run_config", () => {
     const payload = serializeEvalConfig({
-      templateId: "template-1",
+      template_id: "template-1",
       name: "quality_check",
       model: "turing_large",
       mapping: { output: "answer" },
@@ -49,7 +49,7 @@ describe("serializeEvalConfig", () => {
 
     expect(
       serializeEvalConfig({
-        templateId: "template-1",
+        template_id: "template-1",
         name: "quality_check",
         filters,
       }).filters,

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -323,7 +323,7 @@ const EditTaskDrawerV2Content = ({
   // Handle adding eval from the new picker
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
-      const tplId = evalConfig.templateId || evalConfig.template_id;
+      const tplId = evalConfig.template_id;
       const existingId = evalConfig.id;
       // Use serializeEvalConfig so function-params land at config.params.
       const serialized = serializeEvalConfig(evalConfig);
@@ -338,7 +338,7 @@ const EditTaskDrawerV2Content = ({
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
               config: serialized.config,
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
+              error_localizer: evalConfig.error_localizer_enabled || false,
             },
           );
           id = resp?.result?.id ?? existingId;
@@ -353,7 +353,7 @@ const EditTaskDrawerV2Content = ({
               mapping: evalConfig.mapping,
               config: serialized.config,
               filters: getNewTaskFilters(formValues, observeId, true).filters,
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
+              error_localizer: evalConfig.error_localizer_enabled || false,
             },
           );
           id = resp?.result?.id;

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
@@ -282,7 +282,7 @@ const NewTaskDrawerV2 = ({
   // Handle adding eval from the new picker
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
-      const tplId = evalConfig.templateId || evalConfig.template_id;
+      const tplId = evalConfig.template_id;
       const existingId = evalConfig.id;
       // Use serializeEvalConfig so function-params land at config.params.
       const serialized = serializeEvalConfig(evalConfig);
@@ -297,7 +297,7 @@ const NewTaskDrawerV2 = ({
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
               config: serialized.config,
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
+              error_localizer: evalConfig.error_localizer_enabled || false,
             },
           );
           id = resp?.result?.id ?? existingId;
@@ -311,7 +311,7 @@ const NewTaskDrawerV2 = ({
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
               config: serialized.config,
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
+              error_localizer: evalConfig.error_localizer_enabled || false,
             },
           );
           id = resp?.result?.id;

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -78,16 +78,9 @@ const EvaluationDrawerChild = ({
   // When editing an existing eval, pre-select it so the picker opens at config step
   const [editingEval, setEditingEval] = useState(null);
 
-  // Route a saved-eval row into the EvalPicker in edit mode. Shared between
-  // the saved-eval list "Edit" button and the column-menu "Edit Eval" entry.
-  //
-  // `name` is deliberately the saved user-eval *instance* name (not the
-  // template name) so the edit form pre-fills the instance's current name —
-  // users can then rename the binding. EvalPickerConfigFull's isEditMode
-  // branch reads this via evalData.name.
   const openEditForSavedEval = useCallback(
     (evalItem) => {
-      const tplId = evalItem.templateId || evalItem.template_id;
+      const tplId = evalItem.template_id || evalItem.templateId;
       if (!tplId) {
         enqueueSnackbar("Cannot edit: template ID not found. Try refreshing.", {
           variant: "warning",
@@ -96,38 +89,24 @@ const EvaluationDrawerChild = ({
       }
       setEditingEval({
         ...evalItem,
-        // id is what EvalPickerConfigFull passes to useEvalDetail(templateId)
         id: tplId,
+        template_id: tplId,
         name: evalItem.name,
-        evalType: evalItem.eval_type,
-        // Pre-populate the config screen so it renders before the detail
-        // API responds. Read run_config from the stored config blob (where
-        // the backend persists it) and fall back to a top-level run_config
-        // field for callers that pre-shape evalItem differently.
+        eval_type: evalItem.eval_type,
         config: {
           required_keys: evalItem.eval_required_keys || [],
           ...(evalItem.config?.run_config || evalItem.run_config || {}),
-          // Multi-turn LLM evals persist the full message chain on the
-          // template config, not under run_config — forward it so the
-          // picker pre-populates with every turn (not just System) before
-          // the detail API response merges the canonical value in.
           ...(evalItem.config?.messages
             ? { messages: evalItem.config.messages }
             : {}),
-          // Map the UserEvalMetric.error_localizer BooleanField to the key
-          // EvalPickerConfigFull expects so the toggle shows the saved state.
           ...(evalItem.error_localizer !== undefined
             ? { error_localizer_enabled: evalItem.error_localizer }
             : {}),
         },
         mapping: evalItem.mapping || {},
-        outputType: evalItem.output_type,
-        // Existing UserEvalMetric id — handleAdd routes via editEval
-        // endpoint instead of addEval to avoid duplicate bindings.
-        // The column-menu path matches via user_eval_id/userEvalId, so
-        // evalItem.id may not be the user-eval id — normalize here.
-        userEvalId: evalItem.user_eval_id ?? evalItem.userEvalId ?? evalItem.id,
-        pinned_version_id: evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
+        output_type: evalItem.output_type,
+        user_eval_id: evalItem.user_eval_id ?? evalItem.id,
+        pinned_version_id: evalItem.pinned_version_id,
       });
       setEvalPickerOpen(true);
     },
@@ -567,11 +546,6 @@ const EvaluationDrawerChild = ({
         source={module || "dataset"}
         sourceId={id || ""}
         sourceColumns={allColumns || []}
-        // Experiment evals reference two values that don't exist as real
-        // dataset cells — the prompt/agent output and the full prompt chain.
-        // Surface them as virtual columns in the variable-mapping dropdown
-        // so users can map eval inputs to them (mirrors the legacy
-        // ManageExperimentEvalsDrawer.experimentVirtualColumns).
         extraColumns={
           module === "experiment"
             ? [
@@ -590,18 +564,10 @@ const EvaluationDrawerChild = ({
           const { handleRun } = actionButtonConfig;
           if (!handleRun) return;
 
-          // Backend `UserEvalSerializer` (model_hub/serializers/eval_runner.py)
-          // expects `template_id` (snake_case), not `eval_template`. It also
-          // stores runtime overrides under config.run_config — everything the
-          // EvalPicker lets the user customize (model / mode / summary / etc.)
-          // should be forwarded so eval_runner can apply it at run time.
-          const isComposite = evalConfig.templateType === "composite";
+          const isComposite = evalConfig.template_type === "composite";
 
           const runConfig = {};
           if (!isComposite) {
-            // Single-eval runtime overrides. Composite children each
-            // carry their own model/mode/tools — none of this applies
-            // at the composite binding level.
             if (evalConfig.model) runConfig.model = evalConfig.model;
             if (evalConfig.agent_mode)
               runConfig.agent_mode = evalConfig.agent_mode;
@@ -623,33 +589,21 @@ const EvaluationDrawerChild = ({
             if (evalConfig.multi_choice !== undefined)
               runConfig.multi_choice = !!evalConfig.multi_choice;
           }
-          // Data injection applies to both single and composite — the
-          // backend resolves it at row-evaluation time.
           if (evalConfig.data_injection)
             runConfig.data_injection = evalConfig.data_injection;
-          // Error localizer toggle was previously dropped between
-          // EvalPickerConfigFull and the backend. It now flows through
-          // for both single and composite bindings.
           if (evalConfig.error_localizer_enabled !== undefined)
             runConfig.error_localizer_enabled =
               !!evalConfig.error_localizer_enabled;
 
-          // Code-eval static params (function_params_schema values).
-          // `EvalPickerConfigFull.handleSave` hands them back on
-          // evalConfig.params; forward to `config.params` so the backend
-          // persists them on UserEvalMetric.config.params and each row's
-          // evaluate() call receives them via **kwargs at run time.
           const evalParams =
             evalConfig.params && typeof evalConfig.params === "object"
               ? evalConfig.params
               : {};
 
-          // Build the payload — workbench endpoint expects a different
-          // shape than the dataset/task/experiment endpoints.
           let payload;
           if ((module || "dataset") === "workbench") {
             payload = {
-              id: evalConfig.templateId,
+              id: evalConfig.template_id,
               name: evalConfig.name,
               mapping: evalConfig.mapping || {},
               model: isComposite ? undefined : evalConfig.model,
@@ -666,16 +620,9 @@ const EvaluationDrawerChild = ({
           } else {
             payload = {
               name: evalConfig.name,
-              template_id: evalConfig.templateId,
+              template_id: evalConfig.template_id,
               model: isComposite ? undefined : evalConfig.model,
-              // In the optimization context the optimizer runs evals itself —
-              // skip the full-dataset run so adding an eval is near-instant.
-              // Dataset adds are also save-only now: the user runs evals
-              // manually from the dataset grid rather than auto-running on
-              // add, which would otherwise queue work the user didn't ask for.
               run: module !== "run-optimization" && module !== "dataset",
-              // Mirror the workbench path: surface error_localizer at the top
-              // level so EditAndRunUserEvalView can update eval_metric.error_localizer.
               error_localizer: runConfig.error_localizer_enabled ?? false,
               config: {
                 mapping: evalConfig.mapping || {},
@@ -687,42 +634,27 @@ const EvaluationDrawerChild = ({
                   ? { run_config: runConfig }
                   : {}),
               },
-              ...(isComposite && evalConfig.compositeWeightOverrides
-                ? {
-                    composite_weight_overrides:
-                      evalConfig.compositeWeightOverrides,
-                  }
-                : {}),
               ...(isComposite && evalConfig.composite_weight_overrides
                 ? {
                     composite_weight_overrides:
                       evalConfig.composite_weight_overrides,
                   }
                 : {}),
-              ...(evalConfig.versionId
-                ? { pinned_version_id: evalConfig.versionId }
+              ...(evalConfig.version_id
+                ? { pinned_version_id: evalConfig.version_id }
                 : {}),
             };
           }
-          // Edit branch: POST directly to /edit_and_run_user_eval/{id} so the
-          // existing UserEvalMetric is updated in place rather than duplicated
-          // by /add_user_eval (dataset) or /experiments/<id>/add-eval/
-          // (experiment). For experiment scope, the backend keys by
-          // source_id=experiment_id, so we attach experiment_id to the body
-          // — same pattern as the rest of the per-eval endpoints.
-          // Workbench + task modules keep their own create-or-update routes.
           const effectiveModule = module || "dataset";
           if (
-            evalConfig?.userEvalId &&
+            evalConfig?.user_eval_id &&
             (effectiveModule === "dataset" ||
               effectiveModule === "run-optimization" ||
               effectiveModule === "experiment")
           ) {
             try {
-              // `id` in this drawer is always the datasetId for dataset /
-              // experiment flows (experiment evals still live under a dataset).
               await axios.post(
-                endpoints.develop.eval.editEval(id, evalConfig.userEvalId),
+                endpoints.develop.eval.editEval(id, evalConfig.user_eval_id),
                 {
                   ...payload,
                   ...(effectiveModule === "experiment" && experimentId
@@ -733,10 +665,9 @@ const EvaluationDrawerChild = ({
               queryClient.invalidateQueries({
                 queryKey: getUserEvalListKey(module, id),
               });
-              // Invalidate version cache so reopening shows the new version
-              if (evalConfig.templateId) {
+              if (evalConfig.template_id) {
                 queryClient.invalidateQueries({
-                  queryKey: ["evals", "versions", evalConfig.templateId],
+                  queryKey: ["evals", "versions", evalConfig.template_id],
                 });
               }
               if (effectiveModule === "run-optimization") {
@@ -755,20 +686,13 @@ const EvaluationDrawerChild = ({
               setEvalPickerOpen(false);
               setVisibleSection("list");
             } catch (err) {
-              // Let EvalPickerDrawer's handleSaveEval catch keep the
-              // drawer open on failure.
               throw err;
             }
             return;
           }
-          // Non-dataset edit: forward user_eval_id in the payload so the
-          // module-specific endpoint can route to its own update path if
-          // it supports one.
-          if (evalConfig?.userEvalId) {
-            payload.user_eval_id = evalConfig.userEvalId;
+          if (evalConfig?.user_eval_id) {
+            payload.user_eval_id = evalConfig.user_eval_id;
           }
-          // await so errors propagate to EvalPickerDrawer's handleSaveEval
-          // catch block — keeps the drawer open on failure.
           await handleRun(payload, () => {
             setEvalPickerOpen(false);
             setVisibleSection("list");

--- a/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
+++ b/frontend/src/sections/develop-detail/Evaluation/EditEvaluation.jsx
@@ -104,7 +104,6 @@ const EditEvaluation = ({
     },
   });
 
-  // Build initialEval in the shape EvalPickerDrawer / EvalPickerConfigFull expects
   const initialEval = useMemo(() => {
     if (!evalConfig) return null;
     const tplId =
@@ -114,14 +113,10 @@ const EditEvaluation = ({
     if (!tplId) return null;
     return {
       id: tplId,
-      // Use the saved user eval instance name (not the template name) so the
-      // edit form pre-fills with the correct name and the edit endpoint
-      // receives the right value.
+      template_id: tplId,
       name: evalConfig.name,
-      evalType: evalConfig.eval_type || evalConfig.evalType,
-      // API returns saved model as selected_model; fall back to model field
+      eval_type: evalConfig.eval_type || evalConfig.evalType,
       model: evalConfig.selected_model || evalConfig.model,
-      // run_config may be top-level, camelCase, or nested under config
       run_config:
         evalConfig.run_config ||
         evalConfig.runConfig ||
@@ -139,26 +134,25 @@ const EditEvaluation = ({
           {}),
       },
       mapping: evalConfig.mapping || evalConfig.config?.mapping || {},
-      outputType: evalConfig.output_type || evalConfig.outputType,
-      userEvalId: evalConfig.id,
+      output_type: evalConfig.output_type || evalConfig.outputType,
+      user_eval_id: evalConfig.id,
     };
   }, [evalConfig]);
 
   const handleEvalAdded = async (cfg) => {
-    // Build run_config from EvalPickerConfigFull output
     const runConfig = {};
     if (cfg.model) runConfig.model = cfg.model;
-    if (cfg.agentMode) runConfig.agent_mode = cfg.agentMode;
-    if (cfg.checkInternet !== undefined)
-      runConfig.check_internet = !!cfg.checkInternet;
+    if (cfg.agent_mode) runConfig.agent_mode = cfg.agent_mode;
+    if (cfg.check_internet !== undefined)
+      runConfig.check_internet = !!cfg.check_internet;
     if (cfg.summary) runConfig.summary = cfg.summary;
-    if (cfg.dataInjection) runConfig.data_injection = cfg.dataInjection;
-    if (cfg.knowledgeBases) runConfig.knowledge_bases = cfg.knowledgeBases;
+    if (cfg.data_injection) runConfig.data_injection = cfg.data_injection;
+    if (cfg.knowledge_bases) runConfig.knowledge_bases = cfg.knowledge_bases;
     if (cfg.tools) runConfig.tools = cfg.tools;
-    if (cfg.passThreshold !== undefined)
-      runConfig.pass_threshold = cfg.passThreshold;
-    if (cfg.choiceScores && Object.keys(cfg.choiceScores).length)
-      runConfig.choice_scores = cfg.choiceScores;
+    if (cfg.pass_threshold !== undefined)
+      runConfig.pass_threshold = cfg.pass_threshold;
+    if (cfg.choice_scores && Object.keys(cfg.choice_scores).length)
+      runConfig.choice_scores = cfg.choice_scores;
 
     const payload = {
       run: false,

--- a/frontend/src/sections/develop-detail/Experiment/RunExperiment.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/RunExperiment.jsx
@@ -439,6 +439,7 @@ const RunExperimentForm = ({
               control={control}
               errors={errors}
               isEditingExperiment={Boolean(selectedExperiment)}
+              experimentId={selectedExperiment}
             />
           </ShowComponent>
 

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -14,21 +14,26 @@ import PropTypes from "prop-types";
 import SvgColor from "src/components/svg-color";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import { useFieldArray, useWatch } from "react-hook-form";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
 import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import { buildExperimentEvalRuntimePayload } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
 import { getVersionedEvalName } from "src/components/run-tests/common";
 import { ShowComponent } from "src/components/show";
 import { isUUID } from "src/utils/utils";
+import { transformUserEvalMetricsForApi } from "../schema";
 
 const EvaluationStepExperimentCreation = ({
   control,
   allColumns,
   errors,
   isEditingExperiment = false,
+  experimentId = null,
 }) => {
+  const queryClient = useQueryClient();
   const selectedColumn = useWatch({ control, name: "columnId" });
   const { dataset: datasetParam } = useParams();
   const [searchParam] = useSearchParams();
@@ -65,6 +70,42 @@ const EvaluationStepExperimentCreation = ({
     remove,
     update,
   } = useFieldArray({ control, name: "userEvalMetrics" });
+
+  // In the Edit-Experiment wizard, every Update-Evaluation click should
+  // persist immediately — the batched save at "Run Experiment" isn't
+  // enough because the picker's version selection can't round-trip
+  // without a server PUT. Mirrors `ManageExperimentEvalsDrawer` semantics.
+  const canSaveInline = isEditingExperiment && Boolean(experimentId);
+  const { mutate: saveEvalsInline } = useMutation({
+    mutationFn: (nextEvals) =>
+      axios.put(endpoints.develop.experiment.update(experimentId), {
+        user_eval_metrics: transformUserEvalMetricsForApi(nextEvals, true),
+      }),
+    onSuccess: async (resp) => {
+      // Sync form state to the server-authoritative pin + any new
+      // version rows the BE just created. Falls back to a refetch when
+      // the response body doesn't carry the fresh eval list.
+      const fresh = resp?.data?.result?.user_eval_metrics;
+      if (Array.isArray(fresh)) {
+        replaceEvals(
+          fresh.map((item) => ({
+            ...item,
+            evalId: item.id,
+            actualEvalCreatedId: item.id,
+            templateId: item.template_id,
+          })),
+        );
+      }
+      await queryClient.refetchQueries({
+        queryKey: ["experiment", experimentId],
+      });
+    },
+    onError: (error) => {
+      enqueueSnackbar(error?.message || "Failed to save evaluation", {
+        variant: "error",
+      });
+    },
+  });
   useEffect(() => {
     if (
       userEvalList &&
@@ -98,14 +139,10 @@ const EvaluationStepExperimentCreation = ({
       translatedMapping[variable] = col?.field || colName;
     }
 
-    // Merge full template config with the mapping so the backend knows
-    // how to execute the eval (eval_type_id, rule_prompt, output, etc.)
-    const templateConfig =
-      evalConfig.config || evalConfig.evalTemplate?.config || {};
-    const fullConfig = {
-      ...templateConfig,
-      mapping: translatedMapping,
-    };
+    const fullConfig = buildExperimentEvalRuntimePayload(
+      evalConfig,
+      translatedMapping,
+    );
 
     const evalEntry = {
       evalId: evalConfig.templateId,
@@ -118,14 +155,19 @@ const EvaluationStepExperimentCreation = ({
       templateType: evalConfig.templateType,
       requiredKeys:
         evalConfig.evalTemplate?.requiredKeys ||
-        templateConfig.requiredKeys ||
+        evalConfig.config?.requiredKeys ||
         [],
+      // Carry the version dropdown pick through form state → schema
+      // transform → POST body so the backend can pin it as the dedup
+      // baseline (see `_create_eval_metrics_inline`).
+      pinned_version_id: evalConfig.versionId ?? null,
       ...(evalConfig.templateType === "composite" &&
       evalConfig.compositeWeightOverrides
         ? { compositeWeightOverrides: evalConfig.compositeWeightOverrides }
         : {}),
     };
 
+    let nextEvals;
     if (editingEval) {
       // Edit mode: replace the existing field in place, keep the same name.
       const idx = evalFields.findIndex((f) => {
@@ -133,11 +175,15 @@ const EvaluationStepExperimentCreation = ({
         return fid === editingEval.userEvalId;
       });
       if (idx !== -1) {
-        update(idx, {
+        const merged = {
           ...evalFields[idx],
           ...evalEntry,
           name: evalConfig.name,
-        });
+        };
+        update(idx, merged);
+        nextEvals = evalFields.map((f, i) => (i === idx ? merged : f));
+      } else {
+        nextEvals = evalFields;
       }
     } else {
       // Add mode: append with versioned name to avoid duplicates.
@@ -146,8 +192,14 @@ const EvaluationStepExperimentCreation = ({
         evalFields,
         evalConfig.templateId,
       );
-      append({ ...evalEntry, name: versionedName });
+      const created = { ...evalEntry, name: versionedName };
+      append(created);
+      nextEvals = [...evalFields, created];
     }
+    // Persist immediately when we're inside the Edit-Experiment wizard so
+    // the picker's version pick and config edits land in DB without
+    // waiting for Run Experiment.
+    if (canSaveInline) saveEvalsInline(nextEvals);
     setEditingEval(null);
     setOpenEvaluationDialog(false);
   };
@@ -176,6 +228,10 @@ const EvaluationStepExperimentCreation = ({
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
+      // Seed the version dropdown from the last pinned pick so reopening
+      // preserves the user's choice instead of falling back to default.
+      pinned_version_id:
+        evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
       compositeWeightOverrides:
         evalItem.compositeWeightOverrides ||
         evalItem.composite_weight_overrides,
@@ -479,4 +535,5 @@ EvaluationStepExperimentCreation.propTypes = {
   allColumns: PropTypes.array,
   errors: PropTypes.object,
   isEditingExperiment: PropTypes.bool,
+  experimentId: PropTypes.string,
 };

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -71,10 +71,6 @@ const EvaluationStepExperimentCreation = ({
     update,
   } = useFieldArray({ control, name: "userEvalMetrics" });
 
-  // In the Edit-Experiment wizard, every Update-Evaluation click should
-  // persist immediately — the batched save at "Run Experiment" isn't
-  // enough because the picker's version selection can't round-trip
-  // without a server PUT. Mirrors `ManageExperimentEvalsDrawer` semantics.
   const canSaveInline = isEditingExperiment && Boolean(experimentId);
   const { mutate: saveEvalsInline } = useMutation({
     mutationFn: (nextEvals) =>
@@ -82,9 +78,6 @@ const EvaluationStepExperimentCreation = ({
         user_eval_metrics: transformUserEvalMetricsForApi(nextEvals, true),
       }),
     onSuccess: async (resp) => {
-      // Sync form state to the server-authoritative pin + any new
-      // version rows the BE just created. Falls back to a refetch when
-      // the response body doesn't carry the fresh eval list.
       const fresh = resp?.data?.result?.user_eval_metrics;
       if (Array.isArray(fresh)) {
         replaceEvals(
@@ -92,7 +85,7 @@ const EvaluationStepExperimentCreation = ({
             ...item,
             evalId: item.id,
             actualEvalCreatedId: item.id,
-            templateId: item.template_id,
+            template_id: item.template_id,
           })),
         );
       }
@@ -126,9 +119,6 @@ const EvaluationStepExperimentCreation = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userEvalList, replaceEvals]);
   const handleAddEvaluation = (evalConfig) => {
-    // Build mapping: DatasetTestMode returns { variable: "column_name" }.
-    // The backend expects { variable: "column_uuid" }.
-    // Translate using updatedEvalColumns.
     const rawMapping = evalConfig.mapping || {};
     const translatedMapping = {};
     for (const [variable, colName] of Object.entries(rawMapping)) {
@@ -145,34 +135,36 @@ const EvaluationStepExperimentCreation = ({
     );
 
     const evalEntry = {
-      evalId: evalConfig.templateId,
+      evalId: evalConfig.template_id,
       evalTemplateName: evalConfig.name,
-      templateId: evalConfig.templateId,
+      template_id: evalConfig.template_id,
+      templateId: evalConfig.template_id,
       mapping: translatedMapping,
       model: evalConfig.model,
       config: fullConfig,
-      templateDetails: evalConfig.evalTemplate,
-      templateType: evalConfig.templateType,
+      templateDetails: evalConfig.eval_template,
+      template_type: evalConfig.template_type,
+      templateType: evalConfig.template_type,
       requiredKeys:
-        evalConfig.evalTemplate?.requiredKeys ||
+        evalConfig.eval_template?.required_keys ||
+        evalConfig.eval_template?.requiredKeys ||
+        evalConfig.config?.required_keys ||
         evalConfig.config?.requiredKeys ||
         [],
-      // Carry the version dropdown pick through form state → schema
-      // transform → POST body so the backend can pin it as the dedup
-      // baseline (see `_create_eval_metrics_inline`).
-      pinned_version_id: evalConfig.versionId ?? null,
-      ...(evalConfig.templateType === "composite" &&
-      evalConfig.compositeWeightOverrides
-        ? { compositeWeightOverrides: evalConfig.compositeWeightOverrides }
+      pinned_version_id: evalConfig.version_id,
+      ...(evalConfig.template_type === "composite" &&
+      evalConfig.composite_weight_overrides
+        ? {
+            composite_weight_overrides: evalConfig.composite_weight_overrides,
+          }
         : {}),
     };
 
     let nextEvals;
     if (editingEval) {
-      // Edit mode: replace the existing field in place, keep the same name.
       const idx = evalFields.findIndex((f) => {
         const fid = f.actualEvalCreatedId || f.evalId || f.id;
-        return fid === editingEval.userEvalId;
+        return fid === editingEval.user_eval_id;
       });
       if (idx !== -1) {
         const merged = {
@@ -186,19 +178,15 @@ const EvaluationStepExperimentCreation = ({
         nextEvals = evalFields;
       }
     } else {
-      // Add mode: append with versioned name to avoid duplicates.
       const versionedName = getVersionedEvalName(
         evalConfig.name,
         evalFields,
-        evalConfig.templateId,
+        evalConfig.template_id,
       );
       const created = { ...evalEntry, name: versionedName };
       append(created);
       nextEvals = [...evalFields, created];
     }
-    // Persist immediately when we're inside the Edit-Experiment wizard so
-    // the picker's version pick and config edits land in DB without
-    // waiting for Run Experiment.
     if (canSaveInline) saveEvalsInline(nextEvals);
     setEditingEval(null);
     setOpenEvaluationDialog(false);
@@ -211,30 +199,26 @@ const EvaluationStepExperimentCreation = ({
 
   const handleEditEval = (evalItem) => {
     const tplId =
-      evalItem.templateId ||
       evalItem.template_id ||
-      evalItem.evalTemplateId ||
+      evalItem.templateId ||
       evalItem.eval_template_id ||
+      evalItem.evalTemplateId ||
       evalItem.evalId ||
       evalItem.id;
     setEditingEval({
       id: tplId,
-      // During creation the eval only has a local field id; during editing
-      // it may carry a backend-assigned id (actualEvalCreatedId).
-      userEvalId:
+      template_id: tplId,
+      user_eval_id:
         evalItem.actualEvalCreatedId || evalItem.evalId || evalItem.id,
       name: evalItem.name || evalItem.evalTemplateName,
-      templateType: evalItem.templateType || evalItem.template_type,
+      template_type: evalItem.template_type || evalItem.templateType,
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
-      // Seed the version dropdown from the last pinned pick so reopening
-      // preserves the user's choice instead of falling back to default.
-      pinned_version_id:
-        evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
-      compositeWeightOverrides:
-        evalItem.compositeWeightOverrides ||
-        evalItem.composite_weight_overrides,
+      pinned_version_id: evalItem.pinned_version_id,
+      composite_weight_overrides:
+        evalItem.composite_weight_overrides ||
+        evalItem.compositeWeightOverrides,
     });
     setOpenEvaluationDialog(true);
   };

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -24,7 +24,7 @@ import { buildExperimentEvalRuntimePayload } from "src/sections/common/EvalPicke
 import { getVersionedEvalName } from "src/components/run-tests/common";
 import { ShowComponent } from "src/components/show";
 import { isUUID } from "src/utils/utils";
-import { transformUserEvalMetricsForApi } from "../schema";
+import { transformUserEvalMetricsForApi } from "../utils";
 
 const EvaluationStepExperimentCreation = ({
   control,

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -77,16 +77,42 @@ const EvaluationStepExperimentCreation = ({
       axios.put(endpoints.develop.experiment.update(experimentId), {
         user_eval_metrics: transformUserEvalMetricsForApi(nextEvals, true),
       }),
-    onSuccess: async (resp) => {
+    onSuccess: async (resp, nextEvals) => {
       const fresh = resp?.data?.result?.user_eval_metrics;
       if (Array.isArray(fresh)) {
+        const prevById = new Map(
+          (nextEvals || []).map((e) => [
+            String(e.actualEvalCreatedId || e.id || ""),
+            e,
+          ]),
+        );
         replaceEvals(
-          fresh.map((item) => ({
-            ...item,
-            evalId: item.id,
-            actualEvalCreatedId: item.id,
-            template_id: item.template_id,
-          })),
+          fresh.map((item) => {
+            const prev =
+              prevById.get(String(item.id)) ||
+              (nextEvals || []).find(
+                (e) =>
+                  String(e.template_id || e.templateId) ===
+                    String(item.template_id) && e.name === item.name,
+              );
+            return {
+              ...prev,
+              ...item,
+              evalId: item.id,
+              actualEvalCreatedId: item.id,
+              template_id: item.template_id,
+              templateId: item.template_id,
+              template_type: prev?.template_type || prev?.templateType,
+              templateType: prev?.template_type || prev?.templateType,
+              requiredKeys: prev?.requiredKeys,
+              templateDetails: prev?.templateDetails || item.template_details,
+              composite_weight_overrides:
+                prev?.composite_weight_overrides ??
+                item.composite_weight_overrides,
+              mapping: prev?.mapping || item.config?.mapping,
+              pinned_version_id: item.pinned_version_id,
+            };
+          }),
         );
       }
       await queryClient.refetchQueries({

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -92,8 +92,8 @@ const EvaluationStepExperimentCreation = ({
               prevById.get(String(item.id)) ||
               (nextEvals || []).find(
                 (e) =>
-                  String(e.template_id || e.templateId) ===
-                    String(item.template_id) && e.name === item.name,
+                  String(e.template_id) === String(item.template_id) &&
+                  e.name === item.name,
               );
             return {
               ...prev,
@@ -101,11 +101,9 @@ const EvaluationStepExperimentCreation = ({
               evalId: item.id,
               actualEvalCreatedId: item.id,
               template_id: item.template_id,
-              templateId: item.template_id,
-              template_type: prev?.template_type || prev?.templateType,
-              templateType: prev?.template_type || prev?.templateType,
-              requiredKeys: prev?.requiredKeys,
-              templateDetails: prev?.templateDetails || item.template_details,
+              template_type: prev?.template_type,
+              required_keys: prev?.required_keys,
+              template_details: prev?.template_details || item.template_details,
               composite_weight_overrides:
                 prev?.composite_weight_overrides ??
                 item.composite_weight_overrides,
@@ -162,20 +160,16 @@ const EvaluationStepExperimentCreation = ({
 
     const evalEntry = {
       evalId: evalConfig.template_id,
-      evalTemplateName: evalConfig.name,
+      name: evalConfig.name,
       template_id: evalConfig.template_id,
-      templateId: evalConfig.template_id,
       mapping: translatedMapping,
       model: evalConfig.model,
       config: fullConfig,
-      templateDetails: evalConfig.eval_template,
+      template_details: evalConfig.eval_template,
       template_type: evalConfig.template_type,
-      templateType: evalConfig.template_type,
-      requiredKeys:
+      required_keys:
         evalConfig.eval_template?.required_keys ||
-        evalConfig.eval_template?.requiredKeys ||
         evalConfig.config?.required_keys ||
-        evalConfig.config?.requiredKeys ||
         [],
       pinned_version_id: evalConfig.version_id,
       ...(evalConfig.template_type === "composite" &&
@@ -226,9 +220,7 @@ const EvaluationStepExperimentCreation = ({
   const handleEditEval = (evalItem) => {
     const tplId =
       evalItem.template_id ||
-      evalItem.templateId ||
       evalItem.eval_template_id ||
-      evalItem.evalTemplateId ||
       evalItem.evalId ||
       evalItem.id;
     setEditingEval({
@@ -236,15 +228,13 @@ const EvaluationStepExperimentCreation = ({
       template_id: tplId,
       user_eval_id:
         evalItem.actualEvalCreatedId || evalItem.evalId || evalItem.id,
-      name: evalItem.name || evalItem.evalTemplateName,
-      template_type: evalItem.template_type || evalItem.templateType,
+      name: evalItem.name,
+      template_type: evalItem.template_type,
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
       pinned_version_id: evalItem.pinned_version_id,
-      composite_weight_overrides:
-        evalItem.composite_weight_overrides ||
-        evalItem.compositeWeightOverrides,
+      composite_weight_overrides: evalItem.composite_weight_overrides,
     });
     setOpenEvaluationDialog(true);
   };

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -13,6 +13,31 @@ import axios, { endpoints } from "src/utils/axios";
 import { isUUID } from "src/utils/utils";
 import { promptConfigTransform } from "./utils";
 
+// Translate a `userEvalMetrics` field-array into the snake_case shape the
+// `user_eval_metrics` PUT/POST body expects. Extracted so the Edit-Experiment
+// wizard can fire an incremental PUT on every Update-Evaluation click
+// without re-running the full Zod schema.
+export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
+  (userEvalMetrics ?? []).map((evalItem) => ({
+    ...(isEditing &&
+      evalItem?.actualEvalCreatedId &&
+      isUUID(evalItem?.actualEvalCreatedId) && {
+        id: evalItem?.actualEvalCreatedId,
+      }),
+    template_id:
+      evalItem?.templateDetails?.id ||
+      evalItem.templateId ||
+      evalItem.template_id ||
+      evalItem.id,
+    name: evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
+    config: evalItem.config,
+    model: evalItem.model,
+    error_localizer: evalItem.errorLocalizer ?? evalItem.error_localizer,
+    kb_id: evalItem.kbId || evalItem.kb_id || null,
+    pinned_version_id:
+      evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
+  }));
+
 const getMessageValidationSchema = () =>
   z
     .object({
@@ -445,24 +470,10 @@ export const getNewExperimentValidationSchema = (
         data.outputFormat,
         isEditing,
       ),
-      userEvalMetrics: (data.userEvalMetrics ?? []).map((evalItem) => ({
-        ...(isEditing &&
-          evalItem?.actualEvalCreatedId &&
-          isUUID(evalItem?.actualEvalCreatedId) && {
-            id: evalItem?.actualEvalCreatedId,
-          }),
-        template_id:
-          evalItem?.templateDetails?.id ||
-          evalItem.templateId ||
-          evalItem.template_id ||
-          evalItem.id,
-        name:
-          evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
-        config: evalItem.config,
-        model: evalItem.model,
-        error_localizer: evalItem.errorLocalizer ?? evalItem.error_localizer,
-        kb_id: evalItem.kbId || evalItem.kb_id || null,
-      })),
+      userEvalMetrics: transformUserEvalMetricsForApi(
+        data.userEvalMetrics,
+        isEditing,
+      ),
     }));
 
 export const getExperimentValidationSchema = (allColumns) =>

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -13,10 +13,6 @@ import axios, { endpoints } from "src/utils/axios";
 import { isUUID } from "src/utils/utils";
 import { promptConfigTransform } from "./utils";
 
-// Translate a `userEvalMetrics` field-array into the snake_case shape the
-// `user_eval_metrics` PUT/POST body expects. Extracted so the Edit-Experiment
-// wizard can fire an incremental PUT on every Update-Evaluation click
-// without re-running the full Zod schema.
 export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
   (userEvalMetrics ?? []).map((evalItem) => ({
     ...(isEditing &&
@@ -25,17 +21,19 @@ export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
         id: evalItem?.actualEvalCreatedId,
       }),
     template_id:
+      evalItem.template_id ||
       evalItem?.templateDetails?.id ||
       evalItem.templateId ||
-      evalItem.template_id ||
       evalItem.id,
     name: evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
     config: evalItem.config,
     model: evalItem.model,
     error_localizer: evalItem.errorLocalizer ?? evalItem.error_localizer,
     kb_id: evalItem.kbId || evalItem.kb_id || null,
-    pinned_version_id:
-      evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
+    pinned_version_id: evalItem.pinned_version_id,
+    ...(evalItem.composite_weight_overrides
+      ? { composite_weight_overrides: evalItem.composite_weight_overrides }
+      : {}),
   }));
 
 const getMessageValidationSchema = () =>

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -10,30 +10,10 @@ import {
 } from "../RunPrompt/common";
 import { normalizeForComparison } from "src/sections/workbench/createPrompt/Playground/common";
 import axios, { endpoints } from "src/utils/axios";
-import { isUUID } from "src/utils/utils";
-import { promptConfigTransform } from "./utils";
-
-export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
-  (userEvalMetrics ?? []).map((evalItem) => ({
-    ...(isEditing &&
-      evalItem?.actualEvalCreatedId &&
-      isUUID(evalItem?.actualEvalCreatedId) && {
-        id: evalItem?.actualEvalCreatedId,
-      }),
-    template_id:
-      evalItem.template_id ||
-      evalItem?.template_details?.id ||
-      evalItem.id,
-    name: evalItem.name || "Unnamed Evaluation",
-    config: evalItem.config,
-    model: evalItem.model,
-    error_localizer: evalItem.error_localizer,
-    kb_id: evalItem.kb_id || null,
-    pinned_version_id: evalItem.pinned_version_id,
-    ...(evalItem.composite_weight_overrides
-      ? { composite_weight_overrides: evalItem.composite_weight_overrides }
-      : {}),
-  }));
+import {
+  promptConfigTransform,
+  transformUserEvalMetricsForApi,
+} from "./utils";
 
 const getMessageValidationSchema = () =>
   z

--- a/frontend/src/sections/develop-detail/Experiment/schema.js
+++ b/frontend/src/sections/develop-detail/Experiment/schema.js
@@ -22,14 +22,13 @@ export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
       }),
     template_id:
       evalItem.template_id ||
-      evalItem?.templateDetails?.id ||
-      evalItem.templateId ||
+      evalItem?.template_details?.id ||
       evalItem.id,
-    name: evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
+    name: evalItem.name || "Unnamed Evaluation",
     config: evalItem.config,
     model: evalItem.model,
-    error_localizer: evalItem.errorLocalizer ?? evalItem.error_localizer,
-    kb_id: evalItem.kbId || evalItem.kb_id || null,
+    error_localizer: evalItem.error_localizer,
+    kb_id: evalItem.kb_id || null,
     pinned_version_id: evalItem.pinned_version_id,
     ...(evalItem.composite_weight_overrides
       ? { composite_weight_overrides: evalItem.composite_weight_overrides }

--- a/frontend/src/sections/develop-detail/Experiment/utils.js
+++ b/frontend/src/sections/develop-detail/Experiment/utils.js
@@ -738,3 +738,23 @@ export const promptConfigTransform = (
 
   return [];
 };
+
+export const transformUserEvalMetricsForApi = (userEvalMetrics, isEditing) =>
+  (userEvalMetrics ?? []).map((evalItem) => ({
+    ...(isEditing &&
+      evalItem?.actualEvalCreatedId &&
+      isUUID(evalItem?.actualEvalCreatedId) && {
+        id: evalItem?.actualEvalCreatedId,
+      }),
+    template_id:
+      evalItem.template_id || evalItem?.template_details?.id || evalItem.id,
+    name: evalItem.name || "Unnamed Evaluation",
+    config: evalItem.config,
+    model: evalItem.model,
+    error_localizer: evalItem.error_localizer,
+    kb_id: evalItem.kb_id || null,
+    pinned_version_id: evalItem.pinned_version_id,
+    ...(evalItem.composite_weight_overrides
+      ? { composite_weight_overrides: evalItem.composite_weight_overrides }
+      : {}),
+  }));

--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -109,16 +109,9 @@ const CompositeDetailPanel = ({
     setPendingAxis(null);
   };
 
-  // Accepts both shapes:
-  //   - skipConfig=true raw eval metadata: { id, name, evalType, ... }
-  //   - skipConfig=false EvalPickerConfigFull payload:
-  //     { templateId, evalTemplateId, name, evalType, mapping,
-  //       versionId, ... }
-  // The latter is sent when the user goes through the config screen
-  // for a child eval (playground + version + settings + mapping).
   const handleEvalAdded = (evalMeta) => {
     const childId =
-      evalMeta?.id || evalMeta?.templateId || evalMeta?.evalTemplateId;
+      evalMeta?.id || evalMeta?.template_id || evalMeta?.eval_template_id;
     if (!childId) return;
     if (childrenList.some((c) => c.child_id === childId)) {
       setPickerOpen(false);
@@ -138,18 +131,11 @@ const CompositeDetailPanel = ({
         child_id: childId,
         child_name: evalMeta.name || childId,
         order: childrenList.length,
-        eval_type: evalMeta.evalType || evalMeta.eval_type || "llm",
+        eval_type: evalMeta.eval_type || "llm",
         weight: 1.0,
-        // Persist the per-child version the user pinned in the picker
-        // so the composite always invokes this exact version. Stored as
-        // `pinned_version_id` for the backend; the human-readable
-        // `pinned_version_number` is resolved server-side on fetch.
-        ...(evalMeta.versionId
-          ? { pinned_version_id: evalMeta.versionId }
+        ...(evalMeta.version_id
+          ? { pinned_version_id: evalMeta.version_id }
           : {}),
-        // Persist the per-child variable mapping the user just configured.
-        // Backend `composite_runner` uses it when resolving each child's
-        // variables against the dataset row at evaluation time.
         ...(evalMeta.mapping && Object.keys(evalMeta.mapping).length
           ? { mapping: evalMeta.mapping }
           : {}),

--- a/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
@@ -22,6 +22,7 @@ import { ShowComponent } from "src/components/show";
 import ConfirmRunEvaluations from "src/sections/common/EvaluationDrawer/ConfirmRunEvaluations";
 import { getVersionedEvalName } from "src/components/run-tests/common";
 import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import { buildExperimentEvalRuntimePayload } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
 
 const isUUID = (str) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(str);
@@ -38,6 +39,11 @@ const transformEvals = (evalList) =>
     model: evalItem.model,
     error_localizer: evalItem.errorLocalizer,
     kb_id: evalItem.kbId || null,
+    // Carry the version dropdown pick so the backend can pin it as the
+    // dedup baseline in `_diff_and_update_evals` /
+    // `_create_eval_metrics_inline`.
+    pinned_version_id:
+      evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
     // Forward composite per-binding weight overrides when the bound
     // template is a composite. The experiment runner's composite branch
     // (Phase C) reads this off `UserEvalMetric.composite_weight_overrides`
@@ -178,16 +184,15 @@ const ManageExperimentEvalsDrawer = ({
       translatedMapping[variable] = col?.field || colName;
     }
 
-    const templateConfig =
-      evalConfig.config || evalConfig.evalTemplate?.config || {};
-
     const builtEval = {
       templateId: evalConfig.templateId,
       evalTemplateName: evalConfig.name,
       model: evalConfig.model,
       mapping: translatedMapping,
-      config: { ...templateConfig, mapping: translatedMapping },
+      config: buildExperimentEvalRuntimePayload(evalConfig, translatedMapping),
       templateType: evalConfig.templateType,
+      // Carry the picker's version selection through to `transformEvals`.
+      pinned_version_id: evalConfig.versionId ?? null,
       ...(evalConfig.templateType === "composite" &&
       evalConfig.compositeWeightOverrides
         ? { compositeWeightOverrides: evalConfig.compositeWeightOverrides }
@@ -255,6 +260,11 @@ const ManageExperimentEvalsDrawer = ({
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
+      // Seed EvalPickerConfigFull's version dropdown with the currently
+      // pinned version so reopening after Update Evaluation renders the
+      // just-saved version rather than the template default.
+      pinned_version_id:
+        evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
       compositeWeightOverrides:
         evalItem.compositeWeightOverrides ||
         evalItem.composite_weight_overrides,

--- a/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
@@ -33,12 +33,12 @@ const transformEvals = (evalList) =>
       isUUID(evalItem?.actualEvalCreatedId) && {
         id: evalItem?.actualEvalCreatedId,
       }),
-    template_id: evalItem.template_id || evalItem.templateId || evalItem.id,
-    name: evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
+    template_id: evalItem.template_id || evalItem.id,
+    name: evalItem.name || "Unnamed Evaluation",
     config: evalItem.config,
     model: evalItem.model,
-    error_localizer: evalItem.errorLocalizer,
-    kb_id: evalItem.kbId || null,
+    error_localizer: evalItem.error_localizer,
+    kb_id: evalItem.kb_id || null,
     pinned_version_id: evalItem.pinned_version_id,
     ...(evalItem.composite_weight_overrides
       ? { composite_weight_overrides: evalItem.composite_weight_overrides }
@@ -168,13 +168,11 @@ const ManageExperimentEvalsDrawer = ({
 
     const builtEval = {
       template_id: evalConfig.template_id,
-      templateId: evalConfig.template_id,
-      evalTemplateName: evalConfig.name,
+      name: evalConfig.name,
       model: evalConfig.model,
       mapping: translatedMapping,
       config: buildExperimentEvalRuntimePayload(evalConfig, translatedMapping),
       template_type: evalConfig.template_type,
-      templateType: evalConfig.template_type,
       pinned_version_id: evalConfig.version_id,
       ...(evalConfig.template_type === "composite" &&
       evalConfig.composite_weight_overrides
@@ -228,23 +226,18 @@ const ManageExperimentEvalsDrawer = ({
 
   const handleEditEval = (evalItem) => {
     const tplId =
-      evalItem.template_id ||
-      evalItem.templateId ||
-      evalItem.eval_template_id ||
-      evalItem.evalTemplateId;
+      evalItem.template_id || evalItem.eval_template_id || evalItem.id;
     setEditingEval({
-      id: tplId || evalItem.id,
-      template_id: tplId || evalItem.id,
+      id: tplId,
+      template_id: tplId,
       user_eval_id: evalItem.actualEvalCreatedId || evalItem.id,
-      name: evalItem.name || evalItem.evalTemplateName,
-      template_type: evalItem.template_type || evalItem.templateType,
+      name: evalItem.name,
+      template_type: evalItem.template_type,
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
       pinned_version_id: evalItem.pinned_version_id,
-      composite_weight_overrides:
-        evalItem.composite_weight_overrides ||
-        evalItem.compositeWeightOverrides,
+      composite_weight_overrides: evalItem.composite_weight_overrides,
     });
     setOpenEvaluationDialog(true);
   };
@@ -464,8 +457,7 @@ const ManageExperimentEvalsDrawer = ({
                               <Typography variant="subtitle2">
                                 {evalItem.name}
                               </Typography>
-                              {(evalItem.templateType === "composite" ||
-                                evalItem.template_type === "composite") && (
+                              {evalItem.template_type === "composite" && (
                                 <Chip
                                   label="Composite"
                                   size="small"

--- a/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
@@ -260,11 +260,7 @@ const ManageExperimentEvalsDrawer = ({
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
-      // Seed EvalPickerConfigFull's version dropdown with the currently
-      // pinned version so reopening after Update Evaluation renders the
-      // just-saved version rather than the template default.
-      pinned_version_id:
-        evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
+      pinned_version_id: evalItem.pinned_version_id,
       compositeWeightOverrides:
         evalItem.compositeWeightOverrides ||
         evalItem.composite_weight_overrides,

--- a/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx
@@ -33,23 +33,15 @@ const transformEvals = (evalList) =>
       isUUID(evalItem?.actualEvalCreatedId) && {
         id: evalItem?.actualEvalCreatedId,
       }),
-    template_id: evalItem.templateId || evalItem.id,
+    template_id: evalItem.template_id || evalItem.templateId || evalItem.id,
     name: evalItem.name || evalItem.evalTemplateName || "Unnamed Evaluation",
     config: evalItem.config,
     model: evalItem.model,
     error_localizer: evalItem.errorLocalizer,
     kb_id: evalItem.kbId || null,
-    // Carry the version dropdown pick so the backend can pin it as the
-    // dedup baseline in `_diff_and_update_evals` /
-    // `_create_eval_metrics_inline`.
-    pinned_version_id:
-      evalItem.pinned_version_id ?? evalItem.pinnedVersionId ?? null,
-    // Forward composite per-binding weight overrides when the bound
-    // template is a composite. The experiment runner's composite branch
-    // (Phase C) reads this off `UserEvalMetric.composite_weight_overrides`
-    // and hands it to `CompositeEvaluationRunner` at run time.
-    ...(evalItem.compositeWeightOverrides
-      ? { composite_weight_overrides: evalItem.compositeWeightOverrides }
+    pinned_version_id: evalItem.pinned_version_id,
+    ...(evalItem.composite_weight_overrides
+      ? { composite_weight_overrides: evalItem.composite_weight_overrides }
       : {}),
   }));
 
@@ -105,15 +97,6 @@ const ManageExperimentEvalsDrawer = ({
     },
   });
 
-  // Use the dataset-level start_evals_process endpoint with experiment_id so
-  // experiment evals go through the same code path as dataset evals — the
-  // backend delegates to the experiment rerun workflow when experiment_id
-  // is present. Keeps the endpoint surface symmetric with get_evals_list,
-  // edit_and_run_user_eval, and stop_user_eval.
-  // Invalidate the caches that render eval state — covers the experiment
-  // detail view, experiment list grid, and the per-module eval lists keyed
-  // under both "develop" and "experiment" prefixes (get_evals_list uses the
-  // module-prefixed key defined in getEvalsList.jsx).
   const invalidateEvalCaches = () => {
     queryClient.invalidateQueries({ queryKey: ["experiment", experimentId] });
     queryClient.invalidateQueries({ queryKey: ["experiment-list"] });
@@ -173,7 +156,6 @@ const ManageExperimentEvalsDrawer = ({
   };
 
   const handleAddEvaluation = (evalConfig) => {
-    // Translate column names to UUIDs
     const rawMapping = evalConfig.mapping || {};
     const translatedMapping = {};
     for (const [variable, colName] of Object.entries(rawMapping)) {
@@ -185,39 +167,40 @@ const ManageExperimentEvalsDrawer = ({
     }
 
     const builtEval = {
-      templateId: evalConfig.templateId,
+      template_id: evalConfig.template_id,
+      templateId: evalConfig.template_id,
       evalTemplateName: evalConfig.name,
       model: evalConfig.model,
       mapping: translatedMapping,
       config: buildExperimentEvalRuntimePayload(evalConfig, translatedMapping),
-      templateType: evalConfig.templateType,
-      // Carry the picker's version selection through to `transformEvals`.
-      pinned_version_id: evalConfig.versionId ?? null,
-      ...(evalConfig.templateType === "composite" &&
-      evalConfig.compositeWeightOverrides
-        ? { compositeWeightOverrides: evalConfig.compositeWeightOverrides }
+      template_type: evalConfig.template_type,
+      templateType: evalConfig.template_type,
+      pinned_version_id: evalConfig.version_id,
+      ...(evalConfig.template_type === "composite" &&
+      evalConfig.composite_weight_overrides
+        ? {
+            composite_weight_overrides: evalConfig.composite_weight_overrides,
+          }
         : {}),
     };
 
     if (editingEval) {
-      // Edit mode: replace the existing eval in-place
       builtEval.name = evalConfig.name;
-      builtEval.actualEvalCreatedId = editingEval.userEvalId;
-      builtEval.id = editingEval.userEvalId;
+      builtEval.actualEvalCreatedId = editingEval.user_eval_id;
+      builtEval.id = editingEval.user_eval_id;
       setEvals((prev) => {
         const updated = prev.map((e) => {
           const eid = e.actualEvalCreatedId || e.evalId || e.id;
-          return eid === editingEval.userEvalId ? { ...e, ...builtEval } : e;
+          return eid === editingEval.user_eval_id ? { ...e, ...builtEval } : e;
         });
         updateExperiment(updated);
         return updated;
       });
     } else {
-      // Add mode: append with versioned name
       const versionedName = getVersionedEvalName(
         evalConfig.name,
         evals,
-        evalConfig.templateId,
+        evalConfig.template_id,
       );
       builtEval.name = versionedName;
       setEvals((prev) => {
@@ -244,26 +227,24 @@ const ManageExperimentEvalsDrawer = ({
   };
 
   const handleEditEval = (evalItem) => {
-    // The template ID comes from different field names depending on
-    // whether the eval was just added (templateId) or loaded from
-    // the backend (template_id / eval_template_id).
     const tplId =
-      evalItem.templateId ||
       evalItem.template_id ||
-      evalItem.evalTemplateId ||
-      evalItem.eval_template_id;
+      evalItem.templateId ||
+      evalItem.eval_template_id ||
+      evalItem.evalTemplateId;
     setEditingEval({
       id: tplId || evalItem.id,
-      userEvalId: evalItem.actualEvalCreatedId || evalItem.id,
+      template_id: tplId || evalItem.id,
+      user_eval_id: evalItem.actualEvalCreatedId || evalItem.id,
       name: evalItem.name || evalItem.evalTemplateName,
-      templateType: evalItem.templateType || evalItem.template_type,
+      template_type: evalItem.template_type || evalItem.templateType,
       mapping: evalItem.config?.mapping || evalItem.mapping,
       model: evalItem.model || evalItem.selected_model,
       run_config: evalItem.config,
       pinned_version_id: evalItem.pinned_version_id,
-      compositeWeightOverrides:
-        evalItem.compositeWeightOverrides ||
-        evalItem.composite_weight_overrides,
+      composite_weight_overrides:
+        evalItem.composite_weight_overrides ||
+        evalItem.compositeWeightOverrides,
     });
     setOpenEvaluationDialog(true);
   };

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -384,7 +384,7 @@ const TaskConfigPanel = ({
 
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
-      const tplId = evalConfig.templateId || evalConfig.template_id;
+      const tplId = evalConfig.template_id;
 
       // When editing, configuredEvals[editingIndex].id is always the CustomEvalConfig id
       // (set from POST response on first add, or from the API on task load)
@@ -402,7 +402,7 @@ const TaskConfigPanel = ({
           ...serialized.config,
           mapping: evalConfig.mapping || {},
         },
-        error_localizer: !!evalConfig.errorLocalizerEnabled,
+        error_localizer: !!evalConfig.error_localizer_enabled,
       };
 
       let finalEval = { ...evalConfig, template_id: tplId };

--- a/futureagi/model_hub/serializers/experiments.py
+++ b/futureagi/model_hub/serializers/experiments.py
@@ -393,6 +393,13 @@ class EvalMetricEntrySerializer(serializers.Serializer):
     composite_weight_overrides = serializers.JSONField(
         required=False, allow_null=True, default=None
     )
+    # Version dropdown pick from the eval picker. Used as the dedup baseline
+    # when pinning — mirrors `EditAndRunUserEvalView.post`'s explicit
+    # `pinned_version_id` handling so a user's version choice survives the
+    # experiment batched-save path.
+    pinned_version_id = serializers.UUIDField(
+        required=False, allow_null=True, default=None
+    )
 
 
 class _ExtraFieldsMixin:
@@ -858,6 +865,13 @@ class ExperimentDetailV2Serializer(serializers.ModelSerializer):
                 "model": m.model,
                 "error_localizer": m.error_localizer,
                 "kb_id": str(m.kb_id) if m.kb_id else None,
+                # Surface the pin so the FE picker can preselect the correct
+                # version when the drawer reopens. Without this the picker
+                # falls back to the template default and the user's last
+                # pinned version is silently swapped.
+                "pinned_version_id": (
+                    str(m.pinned_version_id) if m.pinned_version_id else None
+                ),
             }
             for m in metrics
         ]

--- a/futureagi/model_hub/serializers/experiments.py
+++ b/futureagi/model_hub/serializers/experiments.py
@@ -388,15 +388,9 @@ class EvalMetricEntrySerializer(serializers.Serializer):
     )
     error_localizer = serializers.BooleanField(required=False, default=False)
     kb_id = serializers.UUIDField(required=False, allow_null=True, default=None)
-    # Per-binding weight overrides for composite evals. Ignored for
-    # single-template metrics. See Phase 7 wiring plan.
     composite_weight_overrides = serializers.JSONField(
         required=False, allow_null=True, default=None
     )
-    # Version dropdown pick from the eval picker. Used as the dedup baseline
-    # when pinning — mirrors `EditAndRunUserEvalView.post`'s explicit
-    # `pinned_version_id` handling so a user's version choice survives the
-    # experiment batched-save path.
     pinned_version_id = serializers.UUIDField(
         required=False, allow_null=True, default=None
     )
@@ -865,10 +859,6 @@ class ExperimentDetailV2Serializer(serializers.ModelSerializer):
                 "model": m.model,
                 "error_localizer": m.error_localizer,
                 "kb_id": str(m.kb_id) if m.kb_id else None,
-                # Surface the pin so the FE picker can preselect the correct
-                # version when the drawer reopens. Without this the picker
-                # falls back to the template default and the user's last
-                # pinned version is silently swapped.
                 "pinned_version_id": (
                     str(m.pinned_version_id) if m.pinned_version_id else None
                 ),

--- a/futureagi/model_hub/tests/test_experiment_api.py
+++ b/futureagi/model_hub/tests/test_experiment_api.py
@@ -1591,6 +1591,195 @@ class TestExperimentInlineEvalMetrics:
             "expected": "expected_column",
         }
 
+    # ==================== TH-6979: pinned_version_id parity ====================
+
+    @pytest.fixture
+    def user_eval_template(self, db, organization, workspace):
+        from model_hub.models.choices import OwnerChoices
+
+        return EvalTemplate.objects.create(
+            name="th-6979-user-template",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            criteria="Check {{output}}",
+            model="turing_large",
+        )
+
+    def test_create_eval_metrics_inline_pins_v1_for_user_template(
+        self, experiment, dataset, organization, user, workspace, user_eval_template
+    ):
+        """Baseline: creation without an explicit pin still creates + pins V1
+        (parity with the dataset EditAndRunUserEvalView side)."""
+        from model_hub.models.evals_metric import EvalTemplateVersion
+        from model_hub.views.experiments import _create_eval_metrics_inline
+
+        metrics = _create_eval_metrics_inline(
+            eval_entries=[
+                {
+                    "name": "pinned-parity-v1",
+                    "template_id": user_eval_template.id,
+                    "config": {"mapping": {"output": "output_column"}},
+                    "model": "turing_small",
+                }
+            ],
+            experiment=experiment,
+            snapshot_dataset=dataset,
+            organization=organization,
+            user=user,
+            workspace=workspace,
+        )
+        m = metrics[0]
+        assert m.pinned_version_id is not None
+        v1 = EvalTemplateVersion.objects.get(id=m.pinned_version_id)
+        assert v1.version_number == 1
+        assert v1.is_default is True
+
+    def test_create_eval_metrics_inline_honors_explicit_pinned_version(
+        self, experiment, dataset, organization, user, workspace, user_eval_template
+    ):
+        """TH-6979 core: passing `pinned_version_id` on the entry re-baselines
+        the pin so `maybe_pin_new_version` dedups against the user's pick
+        instead of silently creating a new version."""
+        from model_hub.models.evals_metric import EvalTemplateVersion
+        from model_hub.views.experiments import _create_eval_metrics_inline
+
+        # Two pre-existing versions on the template. v1's snapshot mirrors
+        # what `maybe_pin_new_version` would build for the entry below so
+        # dedup can hit exactly (`template.config | inner | {"model": ...}`).
+        v1_snap = {"foo": "one", "model": user_eval_template.model}
+        v1 = EvalTemplateVersion.objects.create_version(
+            eval_template=user_eval_template,
+            config_snapshot=v1_snap,
+            model=user_eval_template.model,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        v2 = EvalTemplateVersion.objects.create_version(
+            eval_template=user_eval_template,
+            config_snapshot={"foo": "two", "model": user_eval_template.model},
+            model=user_eval_template.model,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        # Entry replays v1's snapshot exactly (so dedup fires) and asks
+        # the FE version pin to snap back to v1.
+        metrics = _create_eval_metrics_inline(
+            eval_entries=[
+                {
+                    "name": "pinned-parity-explicit",
+                    "template_id": user_eval_template.id,
+                    "config": {
+                        "mapping": {"output": "output_column"},
+                        "config": {"foo": "one"},
+                    },
+                    "model": user_eval_template.model,
+                    "pinned_version_id": str(v1.id),
+                }
+            ],
+            experiment=experiment,
+            snapshot_dataset=dataset,
+            organization=organization,
+            user=user,
+            workspace=workspace,
+        )
+        m = metrics[0]
+        # Dedup fired: pinned_version_id == v1, no v3 created.
+        assert str(m.pinned_version_id) == str(v1.id)
+        assert (
+            EvalTemplateVersion.objects.filter(eval_template=user_eval_template).count()
+            == 2
+        )
+        # v2 stays around and still exists; v1 is the pin.
+        assert EvalTemplateVersion.objects.filter(id=v2.id).exists()
+
+    def test_apply_pinned_version_baseline_rejects_foreign_template(
+        self, experiment, dataset, organization, user, workspace, user_eval_template
+    ):
+        """Guard: pin id belonging to a different template raises so the
+        wrapping view surfaces it as a 400 rather than silently ignoring."""
+        from model_hub.models.choices import OwnerChoices
+        from model_hub.models.evals_metric import EvalTemplateVersion
+        from model_hub.views.experiments import (
+            _apply_entry_pinned_version_baseline,
+        )
+
+        other_tpl = EvalTemplate.objects.create(
+            name="th-6979-other-template",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+        )
+        other_v1 = EvalTemplateVersion.objects.create_version(
+            eval_template=other_tpl,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        # Create a metric bound to user_eval_template but reference a version
+        # from other_tpl in the entry — this should error out.
+        metric = UserEvalMetric.objects.create(
+            name="th-6979-mismatch",
+            organization=organization,
+            workspace=workspace,
+            dataset=dataset,
+            template=user_eval_template,
+            config={"mapping": {"output": "output_column"}},
+            status=StatusType.EXPERIMENT_EVALUATION.value,
+            source_id=str(experiment.id),
+            user=user,
+        )
+        with pytest.raises(ValueError, match="not found for template"):
+            _apply_entry_pinned_version_baseline(
+                {"pinned_version_id": str(other_v1.id)}, metric
+            )
+
+    def test_has_eval_changed_detects_version_only_switch(
+        self, experiment, dataset, organization, user, workspace, user_eval_template
+    ):
+        """Switching versions without editing config still triggers re-run —
+        otherwise `_diff_and_update_evals` would skip the update branch and
+        the pin would never be re-applied."""
+        from model_hub.models.evals_metric import EvalTemplateVersion
+        from model_hub.views.experiments import _has_eval_changed
+
+        v1 = EvalTemplateVersion.objects.create_version(
+            eval_template=user_eval_template,
+            user=user, organization=organization, workspace=workspace,
+        )
+        v2 = EvalTemplateVersion.objects.create_version(
+            eval_template=user_eval_template,
+            user=user, organization=organization, workspace=workspace,
+        )
+        metric = UserEvalMetric.objects.create(
+            name="th-6979-switch",
+            organization=organization,
+            workspace=workspace,
+            dataset=dataset,
+            template=user_eval_template,
+            config={"mapping": {"output": "output_column"}, "config": {}},
+            status=StatusType.EXPERIMENT_EVALUATION.value,
+            source_id=str(experiment.id),
+            user=user,
+            pinned_version=v1,
+        )
+        entry = {
+            "id": str(metric.id),
+            "name": metric.name,
+            "template_id": str(user_eval_template.id),
+            "model": metric.model or "",
+            "kb_id": None,
+            "error_localizer": False,
+            "config": {"mapping": {"output": "output_column"}, "config": {}},
+            "pinned_version_id": str(v2.id),
+        }
+        assert (
+            _has_eval_changed(metric, entry, {"output": "output_column"}) is True
+        )
+
 
 @pytest.mark.django_db
 class TestExperimentComparisonWeights:

--- a/futureagi/model_hub/tests/test_experiment_api.py
+++ b/futureagi/model_hub/tests/test_experiment_api.py
@@ -1591,8 +1591,6 @@ class TestExperimentInlineEvalMetrics:
             "expected": "expected_column",
         }
 
-    # ==================== TH-6979: pinned_version_id parity ====================
-
     @pytest.fixture
     def user_eval_template(self, db, organization, workspace):
         from model_hub.models.choices import OwnerChoices
@@ -1609,8 +1607,6 @@ class TestExperimentInlineEvalMetrics:
     def test_create_eval_metrics_inline_pins_v1_for_user_template(
         self, experiment, dataset, organization, user, workspace, user_eval_template
     ):
-        """Baseline: creation without an explicit pin still creates + pins V1
-        (parity with the dataset EditAndRunUserEvalView side)."""
         from model_hub.models.evals_metric import EvalTemplateVersion
         from model_hub.views.experiments import _create_eval_metrics_inline
 
@@ -1638,15 +1634,9 @@ class TestExperimentInlineEvalMetrics:
     def test_create_eval_metrics_inline_honors_explicit_pinned_version(
         self, experiment, dataset, organization, user, workspace, user_eval_template
     ):
-        """TH-6979 core: passing `pinned_version_id` on the entry re-baselines
-        the pin so `maybe_pin_new_version` dedups against the user's pick
-        instead of silently creating a new version."""
         from model_hub.models.evals_metric import EvalTemplateVersion
         from model_hub.views.experiments import _create_eval_metrics_inline
 
-        # Two pre-existing versions on the template. v1's snapshot mirrors
-        # what `maybe_pin_new_version` would build for the entry below so
-        # dedup can hit exactly (`template.config | inner | {"model": ...}`).
         v1_snap = {"foo": "one", "model": user_eval_template.model}
         v1 = EvalTemplateVersion.objects.create_version(
             eval_template=user_eval_template,
@@ -1665,8 +1655,6 @@ class TestExperimentInlineEvalMetrics:
             workspace=workspace,
         )
 
-        # Entry replays v1's snapshot exactly (so dedup fires) and asks
-        # the FE version pin to snap back to v1.
         metrics = _create_eval_metrics_inline(
             eval_entries=[
                 {
@@ -1687,20 +1675,16 @@ class TestExperimentInlineEvalMetrics:
             workspace=workspace,
         )
         m = metrics[0]
-        # Dedup fired: pinned_version_id == v1, no v3 created.
         assert str(m.pinned_version_id) == str(v1.id)
         assert (
             EvalTemplateVersion.objects.filter(eval_template=user_eval_template).count()
             == 2
         )
-        # v2 stays around and still exists; v1 is the pin.
         assert EvalTemplateVersion.objects.filter(id=v2.id).exists()
 
     def test_apply_pinned_version_baseline_rejects_foreign_template(
         self, experiment, dataset, organization, user, workspace, user_eval_template
     ):
-        """Guard: pin id belonging to a different template raises so the
-        wrapping view surfaces it as a 400 rather than silently ignoring."""
         from model_hub.models.choices import OwnerChoices
         from model_hub.models.evals_metric import EvalTemplateVersion
         from model_hub.views.experiments import (
@@ -1719,8 +1703,6 @@ class TestExperimentInlineEvalMetrics:
             organization=organization,
             workspace=workspace,
         )
-        # Create a metric bound to user_eval_template but reference a version
-        # from other_tpl in the entry — this should error out.
         metric = UserEvalMetric.objects.create(
             name="th-6979-mismatch",
             organization=organization,
@@ -1740,9 +1722,6 @@ class TestExperimentInlineEvalMetrics:
     def test_has_eval_changed_detects_version_only_switch(
         self, experiment, dataset, organization, user, workspace, user_eval_template
     ):
-        """Switching versions without editing config still triggers re-run —
-        otherwise `_diff_and_update_evals` would skip the update branch and
-        the pin would never be re-applied."""
         from model_hub.models.evals_metric import EvalTemplateVersion
         from model_hub.views.experiments import _has_eval_changed
 

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -4522,6 +4522,63 @@ def _with_default_reason_column(config):
     return config
 
 
+def _apply_entry_pinned_version_baseline(entry, metric):
+    """Re-point `metric.pinned_version` to the version the FE picker chose,
+    so `maybe_pin_new_version` uses it as the dedup baseline.
+
+    Mirrors `EditAndRunUserEvalView.post` (`develop_dataset.py:8031-8045`):
+    picking a version with no other edits → snap matches → dedup keeps it
+    pinned; picking a version with edits → new version created off that
+    baseline. Raises ValueError if the id was supplied but doesn't belong
+    to the metric's template (the calling views translate this to a 400).
+    """
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    ver_id = entry.get("pinned_version_id")
+    if not ver_id:
+        return
+    ver = EvalTemplateVersion.objects.filter(
+        id=ver_id, eval_template=metric.template
+    ).first()
+    if not ver:
+        raise ValueError(
+            f"Selected eval version {ver_id} not found for template"
+        )
+    metric.pinned_version = ver
+
+
+def _pin_experiment_metric_version(metric, entry, user, organization, workspace):
+    """Create + pin the initial EvalTemplateVersion for an experiment eval.
+
+    Mirrors what the dataset "Edit Eval" path does via
+    `EditAndRunUserEvalView.post` → `maybe_pin_new_version`. Without this
+    call, experiment-scoped UserEvalMetric rows never get a version row
+    in `model_hub_eval_template_version` and `pinned_version_id` stays
+    NULL. The service dedupes: on subsequent updates whose snapshot
+    matches the current pin, no new row is created — same as dataset.
+
+    `entry["config"]` is already the `{ mapping, config, run_config }`
+    shape the service expects, so it's passed through unwrapped. Callers
+    that want to honor an explicit `pinned_version_id` on `entry` should
+    call `_apply_entry_pinned_version_baseline` first.
+    """
+    from model_hub.services.eval_version_pinning import maybe_pin_new_version
+
+    maybe_pin_new_version(
+        metric,
+        {
+            "config": entry.get("config") or {},
+            "model": entry.get("model") or metric.model or "",
+            "composite_weight_overrides": entry.get("composite_weight_overrides"),
+        },
+        user=user,
+        organization=organization,
+        workspace=workspace,
+    )
+    if metric.pinned_version_id:
+        metric.save(update_fields=["pinned_version"])
+
+
 def _create_eval_metrics_inline(
     eval_entries,
     experiment,
@@ -4581,6 +4638,13 @@ def _create_eval_metrics_inline(
             # Per-binding weight overrides for composite evals. Ignored
             # for single-template metrics. See Phase 7 wiring plan.
             composite_weight_overrides=entry.get("composite_weight_overrides"),
+        )
+        # Honor an explicit version pick before pinning so dedup keeps the
+        # chosen version when the user made no other edits (parity with
+        # EditAndRunUserEvalView).
+        _apply_entry_pinned_version_baseline(entry, metric)
+        _pin_experiment_metric_version(
+            metric, entry, user, organization, workspace
         )
         created.append(metric)
     return created
@@ -5100,6 +5164,11 @@ def _has_eval_changed(metric, entry, translated_mapping):
         return True
     if metric.name != entry.get("name", ""):
         return True
+    # Version-switch with no other edits still counts as a change — the
+    # drawer needs to re-pin and re-run against the newly-selected version.
+    entry_pin = entry.get("pinned_version_id")
+    if entry_pin and str(entry_pin) != str(metric.pinned_version_id or ""):
+        return True
     return False
 
 
@@ -5151,6 +5220,15 @@ def _diff_and_update_evals(
                 metric.error_localizer = entry.get("error_localizer", False)
                 metric.kb_id = entry.get("kb_id")
                 metric.save()
+                # Honor an explicit version pick before pinning so dedup can
+                # keep the chosen version pinned when only the version was
+                # switched (parity with EditAndRunUserEvalView).
+                _apply_entry_pinned_version_baseline(entry, metric)
+                # Pin a new version so drawer edits get versioned the same
+                # way dataset edits do. Dedupes internally.
+                _pin_experiment_metric_version(
+                    metric, entry, user, organization, workspace
+                )
                 rerun_ids.append(entry_id)
         else:
             # NEW metric — create and pre-create eval columns

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -4523,15 +4523,6 @@ def _with_default_reason_column(config):
 
 
 def _apply_entry_pinned_version_baseline(entry, metric):
-    """Re-point `metric.pinned_version` to the version the FE picker chose,
-    so `maybe_pin_new_version` uses it as the dedup baseline.
-
-    Mirrors `EditAndRunUserEvalView.post` (`develop_dataset.py:8031-8045`):
-    picking a version with no other edits → snap matches → dedup keeps it
-    pinned; picking a version with edits → new version created off that
-    baseline. Raises ValueError if the id was supplied but doesn't belong
-    to the metric's template (the calling views translate this to a 400).
-    """
     from model_hub.models.evals_metric import EvalTemplateVersion
 
     ver_id = entry.get("pinned_version_id")
@@ -4548,20 +4539,6 @@ def _apply_entry_pinned_version_baseline(entry, metric):
 
 
 def _pin_experiment_metric_version(metric, entry, user, organization, workspace):
-    """Create + pin the initial EvalTemplateVersion for an experiment eval.
-
-    Mirrors what the dataset "Edit Eval" path does via
-    `EditAndRunUserEvalView.post` → `maybe_pin_new_version`. Without this
-    call, experiment-scoped UserEvalMetric rows never get a version row
-    in `model_hub_eval_template_version` and `pinned_version_id` stays
-    NULL. The service dedupes: on subsequent updates whose snapshot
-    matches the current pin, no new row is created — same as dataset.
-
-    `entry["config"]` is already the `{ mapping, config, run_config }`
-    shape the service expects, so it's passed through unwrapped. Callers
-    that want to honor an explicit `pinned_version_id` on `entry` should
-    call `_apply_entry_pinned_version_baseline` first.
-    """
     from model_hub.services.eval_version_pinning import maybe_pin_new_version
 
     maybe_pin_new_version(
@@ -4635,13 +4612,8 @@ def _create_eval_metrics_inline(
             model=entry.get("model", ""),
             error_localizer=entry.get("error_localizer", False),
             kb_id=entry.get("kb_id"),
-            # Per-binding weight overrides for composite evals. Ignored
-            # for single-template metrics. See Phase 7 wiring plan.
             composite_weight_overrides=entry.get("composite_weight_overrides"),
         )
-        # Honor an explicit version pick before pinning so dedup keeps the
-        # chosen version when the user made no other edits (parity with
-        # EditAndRunUserEvalView).
         _apply_entry_pinned_version_baseline(entry, metric)
         _pin_experiment_metric_version(
             metric, entry, user, organization, workspace
@@ -5164,8 +5136,6 @@ def _has_eval_changed(metric, entry, translated_mapping):
         return True
     if metric.name != entry.get("name", ""):
         return True
-    # Version-switch with no other edits still counts as a change — the
-    # drawer needs to re-pin and re-run against the newly-selected version.
     entry_pin = entry.get("pinned_version_id")
     if entry_pin and str(entry_pin) != str(metric.pinned_version_id or ""):
         return True
@@ -5220,12 +5190,7 @@ def _diff_and_update_evals(
                 metric.error_localizer = entry.get("error_localizer", False)
                 metric.kb_id = entry.get("kb_id")
                 metric.save()
-                # Honor an explicit version pick before pinning so dedup can
-                # keep the chosen version pinned when only the version was
-                # switched (parity with EditAndRunUserEvalView).
                 _apply_entry_pinned_version_baseline(entry, metric)
-                # Pin a new version so drawer edits get versioned the same
-                # way dataset edits do. Dedupes internally.
                 _pin_experiment_metric_version(
                     metric, entry, user, organization, workspace
                 )


### PR DESCRIPTION
## Description

Selecting a specific eval version from the picker inside an experiment did not
survive save/reopen. The FE picker emitted `versionId` on save, but both the
experiment-creation wizard (`EvaluationStepExperimentCreation`) and the
Manage-Evaluations drawer (`ManageExperimentEvalsDrawer`) dropped it while
building the react-hook-form entry, `schema.js` never forwarded it in the PUT
body, and `EvalMetricEntrySerializer` didn't even declare the field — so the
BE never saw the pick. `_diff_and_update_evals` / `_create_eval_metrics_inline`
therefore always fell through to `_pin_experiment_metric_version` with no
baseline, `maybe_pin_new_version` created a fresh row every save, and
`is_default` silently moved to that new row. Reopening the picker then rendered
the template default because `ExperimentDetailV2Serializer.get_user_eval_metrics`
also omitted `pinned_version_id` from the GET. Compounding it, the wizard's
Update-Evaluation click was purely local — no network call until final "Run
Experiment" — so mid-flow edits (including the version pick) lived only in
form state.

This PR wires `pinned_version_id` end-to-end and mirrors the re-baseline dance
already implemented in `EditAndRunUserEvalView` for the dataset side, so the
user's picker version choice becomes the dedup baseline that
`maybe_pin_new_version` compares against. Config edits also get a proper
`{mapping, config, run_config, params}` shape via a shared helper so runtime
overrides (agent_mode, tools, summary, etc.) don't get dropped between the
picker and the pin service.

## File-by-file justification

**Backend**

- `model_hub/serializers/experiments.py`
  - `EvalMetricEntrySerializer` — new optional `pinned_version_id = UUIDField`
    so the wizard/drawer PUT/POST can express the user's picker pick without
    being rejected by `reject_unknown_fields=True`.
  - `ExperimentDetailV2Serializer.get_user_eval_metrics` — surfaces
    `pinned_version_id` on the GET response so the FE picker can preselect
    the correct version on reopen.

- `model_hub/views/experiments.py`
  - New `_apply_entry_pinned_version_baseline(entry, metric)` — resolves
    `entry["pinned_version_id"]` to an `EvalTemplateVersion` scoped to the
    metric's template and re-points `metric.pinned_version` before
    `_pin_experiment_metric_version` runs. Mirrors
    `EditAndRunUserEvalView.post`'s existing re-baseline branch; raises
    `ValueError` on template mismatch so the wrapping view returns 400.
  - `_create_eval_metrics_inline` and the "changed existing metric" branch of
    `_diff_and_update_evals` — both call the new helper immediately before
    `_pin_experiment_metric_version` so a user pick + no other edits dedups
    to the picked version instead of creating a stale copy.
  - `_has_eval_changed` — now returns `True` when `pinned_version_id` differs,
    so a version-only switch still routes through the update branch and gets
    queued for re-run.

**Frontend**

- `src/sections/common/EvalPicker/evalPickerConfigUtils.js`
  - New `buildExperimentEvalRuntimePayload(evalConfig, mapping)` — produces
    the nested `{ mapping, config, run_config, params }` shape the experiment
    endpoints expect, so runtime overrides (`agent_mode`, `tools`, `summary`,
    `check_internet`, `data_injection`, `error_localizer_enabled`, …)
    survive the trip from the picker to the backend snapshot. Composite
    templates get an empty inner config and only the composite-safe run_config
    keys.

- `src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx`
  - Uses the shared helper instead of the previous flat spread.
  - Stamps `pinned_version_id: evalConfig.versionId ?? null` on the react-
    hook-form entry.
  - `handleEditEval` forwards `pinned_version_id` into the picker seed so
    reopening restores the previously chosen version.
  - When `isEditingExperiment && experimentId`, fires an incremental
    `PUT /experiments/v2/{id}/` on every Update-Evaluation click and syncs
    the form state from the response — no need to click Run Experiment for
    the pin/config to persist and reflect.

- `src/sections/develop-detail/Experiment/RunExperiment.jsx`
  - Passes `experimentId={selectedExperiment}` to the eval step so the inline
    save mutation above knows which experiment to PUT to.

- `src/sections/develop-detail/Experiment/schema.js`
  - Extracted `transformUserEvalMetricsForApi(items, isEditing)` so the
    inline mutation reuses the same snake-case transform the final wizard
    submit does.
  - The transform now forwards `pinned_version_id` on the outgoing body.

- `src/sections/experiment-detail/ExperimentData/ManageExperimentEvalsDrawer.jsx`
  - Uses the shared helper, stamps `pinned_version_id` on `builtEval`, and
    seeds the picker on reopen via `handleEditEval`.
  - `transformEvals` forwards `pinned_version_id` in the PUT body.

## Tests

**Backend** — added 4 focused cases in
`model_hub/tests/test_experiment_api.py::TestExperimentInlineEvalMetrics`:

- `test_create_eval_metrics_inline_pins_v1_for_user_template`
- `test_create_eval_metrics_inline_honors_explicit_pinned_version` (dedup)
- `test_apply_pinned_version_baseline_rejects_foreign_template`
- `test_has_eval_changed_detects_version_only_switch`

**Frontend** — 3 new vitest cases in
`src/sections/common/EvalPicker/evalPickerConfigUtils.test.js` covering the
single-eval wrap, the no-override defaults, and the composite blanking.

## Test logs

Backend regression run (`test_experiment_api`, `test_experiment_serializers`,
`test_experiment_v2_api`, `test_experiment_detail_api`,
`test_experiment_comparison_api`, `test_experiment_feedback_contracts`,
`test_experiment_v2_feedback`, `test_eval_versioning`,
`test_eval_version_tracking`, `test_eval_usage_version_regressions`):

\`\`\`
collected 265 items / 9 deselected / 256 selected

model_hub/tests/test_experiment_api.py ................................. [ 12%]
...............................                                          [ 25%]
model_hub/tests/test_experiment_v2_api.py ............................   [ 35%]
model_hub/tests/test_experiment_detail_api.py ...                        [ 37%]
model_hub/tests/test_experiment_comparison_api.py .................      [ 43%]
model_hub/tests/test_experiment_feedback_contracts.py ..                 [ 44%]
model_hub/tests/test_experiment_v2_feedback.py ......................... [ 54%]
......................                                                   [ 62%]
model_hub/tests/test_eval_versioning.py ................................ [ 75%]
..................................                                       [ 88%]
model_hub/tests/test_eval_version_tracking.py .......                    [ 91%]
model_hub/tests/test_eval_usage_version_regressions.py ....              [ 92%]
model_hub/tests/test_experiment_serializers.py .............             [ 98%]
model_hub/tests/test_eval_version_tracking.py ....                       [ 99%]
model_hub/tests/test_eval_usage_version_regressions.py .                 [100%]

====================== 256 passed, 9 deselected in 21.08s ======================
\`\`\`

Frontend vitest for the touched util:

\`\`\`
 ✓ src/sections/common/EvalPicker/evalPickerConfigUtils.test.js (32 tests) 3ms

 Test Files  1 passed (1)
      Tests  32 passed (32)
\`\`\`

End-to-end curl round-trip against local backend (using an existing V2
experiment with a user-owned template that already had 28 versions):

- Pick V5 + send a differing `run_config` → new V29 created off V5 as
  baseline and pinned. Version count 28 → 29. GET returns
  `pinned_version_id = V29`.
- Idempotent replay of the same PUT → dedup fires, no new version.
  Version count stays 29, `pinned_version_id` unchanged.
- Pick V5 with V5's exact snapshot → dedup keeps V5 pinned. Version count
  stays 29. GET returns `pinned_version_id = V5`.
  
  

https://github.com/user-attachments/assets/b1c78bde-a1d2-4588-ae27-6eb57d0334be



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change

## Checklist

- [x] Self-review done
- [x] Comments added on non-obvious paths
- [x] Lint clean on touched FE files, \`ast.parse\` clean on touched BE files
- [x] Backend tests added and passing (4 new, 256 total)
- [x] Frontend tests added and passing (3 new, 32 in touched file)
- [x] End-to-end verified via curl against local dev backend

## Related Issues

Closes TH-6979