### PR TITLE
fix(evals): resolve inherited test failures (TH-5937)

### DIFF
--- a/futureagi/model_hub/tests/test_eval_playground_contracts.py
+++ b/futureagi/model_hub/tests/test_eval_playground_contracts.py
@@ -659,3 +659,29 @@ def test_eval_template_bulk_delete_soft_deletes_eval_settings(auth_client, user)
     assert template.deleted is True
     assert setting.deleted is True
     assert setting.deleted_at is not None
+
+
+@pytest.mark.django_db
+def test_eval_template_single_delete_soft_deletes_eval_settings(auth_client, user):
+    template = _create_code_eval_template(
+        user.organization, name="single-delete-cascades-settings"
+    )
+    setting = EvalSettings.objects.create(
+        eval_id=template.id,
+        user=user,
+        source="eval_playground",
+        column_config=[{"id": "column1", "name": "Evaluation ID"}],
+    )
+
+    response = auth_client.post(
+        "/model-hub/delete-eval-template/",
+        {"eval_template_id": str(template.id)},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    template.refresh_from_db()
+    setting.refresh_from_db()
+    assert template.deleted is True
+    assert setting.deleted is True
+    assert setting.deleted_at is not None

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -966,11 +966,12 @@ class EvaluationRunner:
         """
         cache_key = (id(getattr(self, "eval_template", None)),
                      id(getattr(self, "_resolved_version", None)))
+        cached = getattr(self, "_effective_config_cache", None)
         if (
-            self._effective_config_cache is not None
-            and self._effective_config_cache_key == cache_key
+            cached is not None
+            and getattr(self, "_effective_config_cache_key", None) == cache_key
         ):
-            return self._effective_config_cache
+            return cached
 
         template_config = getattr(self.eval_template, "config", None) or {}
         effective_config = (

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1819,12 +1819,13 @@ class EvalTemplateBulkDeleteView(APIView):
             from model_hub.models.develop_dataset import Cell, Column, Dataset
 
             with transaction.atomic():
+                delete_ts = timezone.now()
                 deleted_count = EvalTemplate.objects.filter(
                     id__in=req.template_ids,
                     organization=organization,
                     owner=OwnerChoices.USER.value,
                     deleted=False,
-                ).update(deleted=True, deleted_at=timezone.now())
+                ).update(deleted=True, deleted_at=delete_ts)
 
                 # Fetch all UserEvalMetrics bound to these templates
                 # Scoped to the requesting org to prevent cross-tenant cascade
@@ -1910,6 +1911,17 @@ class EvalTemplateBulkDeleteView(APIView):
                     UserEvalMetric.objects.filter(
                         id__in=[m[0] for m in metrics]
                     ).update(deleted=True, deleted_at=timezone.now())
+
+                # EvalSettings has no org field; gate through the exact templates deleted above.
+                EvalSettings.objects.filter(
+                    eval_id__in=EvalTemplate.all_objects.filter(
+                        id__in=req.template_ids,
+                        organization=organization,
+                        owner=OwnerChoices.USER.value,
+                        deleted_at=delete_ts,
+                    ).values_list("id", flat=True),
+                    deleted=False,
+                ).update(deleted=True, deleted_at=delete_ts)
 
             response = BulkDeleteResponse(deleted_count=deleted_count)
             return self._gm.success_response(response.model_dump())
@@ -6810,6 +6822,11 @@ class DeleteEvalTemplateView(APIView):
                     )
                 EvalLogger.objects.filter(
                     custom_eval_config__eval_template=eval_template
+                ).update(deleted=True, deleted_at=timezone.now())
+
+                # EvalSettings has no FK; cascade on the just-verified template id.
+                EvalSettings.objects.filter(
+                    eval_id=eval_template.id, deleted=False
                 ).update(deleted=True, deleted_at=timezone.now())
 
             return self._gm.success_response("Evaluation template Deleted successfully")

--- a/futureagi/tracer/tests/test_eval_task_aggregations.py
+++ b/futureagi/tracer/tests/test_eval_task_aggregations.py
@@ -9,6 +9,7 @@ rows (``observation_span_id IS NULL``) and picks the latest run when the
 same ``(span, eval_config)`` repeats.
 """
 
+import uuid
 from datetime import timedelta
 
 import pytest  # noqa: E402
@@ -87,6 +88,23 @@ def _row(*, span, cfg, task, **kwargs):
     )
 
 
+def _span(*, project, trace):
+    """Extra span for multi-row aggregation (eval_logger_live_span_uniq blocks stacking on one span)."""
+    return ObservationSpan.objects.create(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name="Aux Span",
+        observation_type="llm",
+        start_time=timezone.now() - timedelta(seconds=5),
+        end_time=timezone.now(),
+        input={},
+        output={},
+        model="gpt-4",
+        status="OK",
+    )
+
+
 # ── eval_aggregation ───────────────────────────────────────────────────
 
 
@@ -110,8 +128,11 @@ class TestEvalAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Faithfulness")
         task = _task(project=project)
-        for v in (0.4, 0.6, 0.8):
-            _row(span=observation_span, cfg=cfg, task=task, output_float=v)
+        spans = [observation_span] + [
+            _span(project=project, trace=observation_span.trace) for _ in range(2)
+        ]
+        for span, v in zip(spans, (0.4, 0.6, 0.8)):
+            _row(span=span, cfg=cfg, task=task, output_float=v)
 
         body = self._get(auth_client, task).json()["result"]
         agg = body["eval_aggregation"]["Faithfulness"]
@@ -129,8 +150,11 @@ class TestEvalAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Toxicity Check")
         task = _task(project=project)
-        for v in (True, True, True, False):
-            _row(span=observation_span, cfg=cfg, task=task, output_bool=v)
+        spans = [observation_span] + [
+            _span(project=project, trace=observation_span.trace) for _ in range(3)
+        ]
+        for span, v in zip(spans, (True, True, True, False)):
+            _row(span=span, cfg=cfg, task=task, output_bool=v)
 
         agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
             "Toxicity Check"
@@ -148,9 +172,12 @@ class TestEvalAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Sentiment")
         task = _task(project=project)
+        spans = [observation_span] + [
+            _span(project=project, trace=observation_span.trace) for _ in range(3)
+        ]
         # 4 rows: A, B, AC, A → A in 3/4, B in 1/4, C in 1/4
-        for lst in (["A"], ["B"], ["A", "C"], ["A"]):
-            _row(span=observation_span, cfg=cfg, task=task, output_str_list=lst)
+        for span, lst in zip(spans, (["A"], ["B"], ["A", "C"], ["A"])):
+            _row(span=span, cfg=cfg, task=task, output_str_list=lst)
 
         agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
             "Sentiment"
@@ -212,12 +239,14 @@ class TestEvalAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Faithfulness")
         task = _task(project=project)
+        span_b = _span(project=project, trace=observation_span.trace)
+        span_c = _span(project=project, trace=observation_span.trace)
         _row(span=observation_span, cfg=cfg, task=task, output_float=0.5)
-        _row(span=observation_span, cfg=cfg, task=task, output_float=0.5)
+        _row(span=span_b, cfg=cfg, task=task, output_float=0.5)
         # Adding an error row with a spurious output_float must not shift
         # the mean — the row is excluded entirely.
         _row(
-            span=observation_span,
+            span=span_c,
             cfg=cfg,
             task=task,
             error=True,
@@ -240,12 +269,12 @@ class TestEvalAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Toxicity")
         task = _task(project=project)
+        span_b = _span(project=project, trace=observation_span.trace)
         _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
-        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
-        # A soft-deleted False row would drop pass-rate to 66% if counted;
-        # excluding it keeps it at 100%.
+        _row(span=span_b, cfg=cfg, task=task, output_bool=True)
+        # Deleted row shares span_b; counted would drop pass-rate to 66%.
         _row(
-            span=observation_span,
+            span=span_b,
             cfg=cfg,
             task=task,
             output_bool=False,
@@ -408,6 +437,7 @@ class TestSpanAggregation:
     def test_latest_wins_when_same_span_eval_pair_has_multiple_rows(
         self, auth_client, project, organization, workspace, observation_span
     ):
+        # Re-run flow: soft-delete old, insert new (unique index blocks 2 live rows).
         tpl = _template(
             organization=organization,
             workspace=workspace,
@@ -415,14 +445,14 @@ class TestSpanAggregation:
         )
         cfg = _config(project=project, template=tpl, name="Faithfulness")
         task = _task(project=project)
-        older = _row(span=observation_span, cfg=cfg, task=task, output_float=0.1)
+        older = _row(
+            span=observation_span,
+            cfg=cfg,
+            task=task,
+            output_float=0.1,
+            deleted=True,
+        )
         newer = _row(span=observation_span, cfg=cfg, task=task, output_float=0.9)
-        # bump `older` further into the past so created_at ordering is
-        # deterministic regardless of intra-test timing.
-        from datetime import timedelta
-
-        from django.utils import timezone
-
         EvalLogger.objects.filter(id=older.id).update(
             created_at=timezone.now() - timedelta(hours=2)
         )


### PR DESCRIPTION
## Why

The 19-file sweep from TH-5937 surfaced 4 failures on \`dev\` at ticket-creation time. Rerunning that sweep against current \`dev\`:

- **3 of the 4 tracer failures are moot.** Their file \`tracer/tests/test_eval_task_runtime.py\` was deleted in the eval-task cutover (\`851aab38c\`); the code the tests exercised no longer exists.
- **1 original failure still applies**: bulk-delete of \`EvalTemplate\` never cascaded to \`EvalSettings\`. Test \`test_eval_template_bulk_delete_soft_deletes_eval_settings\` was asserting the intended contract.
- Rerunning the sweep surfaced **7 new inherited failures** that landed on \`dev\` after the ticket was filed: 6 in \`test_eval_task_aggregations.py\` (constraint added by \`f3b885e05\` rejects the tests' seeding pattern) and 1 stale attribute in \`test_eval_versioning.py\`.

This PR fixes the 1 remaining ticket failure plus the 7 inherited ones. Same file/scope surface as the ticket's sweep.

## What changed

### 1. \`EvalTemplate\` bulk-delete now cascades to \`EvalSettings\`
File: \`model_hub/views/separate_evals.py\`

- \`EvalSettings.eval_id\` is a UUID pointer (no FK / no auto-cascade); rows survive template deletion and the FE keeps rendering stale column configs.
- Cascade added inside the existing \`EvalTemplateBulkDeleteView.post\` transaction, matching the same view's inline-cascade style for \`Cell\`, \`Column\`, and \`UserEvalMetric\`.
- Signals are not the right layer here: \`QuerySet.update()\` bypasses signals by design, and the view already inlines its other cascades in the same transaction.
- Scoping: EvalSettings has no organization/workspace field, so the cascade is gated through a subquery on \`EvalTemplate.all_objects\` filtered by (a) IDs in the request, (b) caller's organization, (c) \`owner=USER\` (system templates cannot be swept), (d) \`deleted_at\` equal to the timestamp used by this transaction's UPDATE. This is stricter than \`req.template_ids\`: an attacker who sends cross-org or system-template IDs cannot cause EvalSettings soft-delete on those rows because the template-side gate blocks the update, so the subquery has no matching row and the cascade is a no-op.
- ORM cost: +1 UPDATE vs the original path; the subquery inlines the scope check so no extra SELECT roundtrip.

### 2. \`EvaluationRunner\` cache read is defensive
File: \`model_hub/views/eval_runner.py\`

- Two lines in \`_get_effective_eval_config\` were the only direct-attribute reads on \`self._effective_config_cache\` / \`self._effective_config_cache_key\` in a method that uses \`getattr\` everywhere else.
- Switching those two reads to \`getattr(self, ..., None)\` makes the method robust to partially-initialized instances (e.g. \`object.__new__(EvaluationRunner)\` in unit tests) without any behaviour change for normal, \`__init__\`-ed instances.

### 3. Six aggregation tests rewritten to respect the new uniqueness invariant
File: \`tracer/tests/test_eval_task_aggregations.py\`

- Constraint \`eval_logger_live_span_uniq\` (added in \`f3b885e05\`) enforces at most one live \`EvalLogger\` row per \`(eval_task_id, observation_span, custom_eval_config)\` when \`target_type='span'\`. The tests were seeding 2+ live rows on the same triple.
- Aggregation tests now spread rows across multiple spans via a new \`_span()\` factory (one live row per span, aggregation math unchanged).
- \`test_latest_wins_when_same_span_eval_pair_has_multiple_rows\` now soft-deletes the older row and inserts the newer as live \[matches the runtime flow the constraint expects\]; the aggregation's \`deleted=False\` filter plus \`ORDER BY -created_at\` still yields the newer value and the assertion is unchanged.

### 4. Sibling single-template delete gets the same \`EvalSettings\` cascade
File: \`model_hub/views/separate_evals.py\`, \`model_hub/tests/test_eval_playground_contracts.py\`

- \`DeleteEvalTemplateView.post\` (single-template delete) already cascades soft-delete to \`UserEvalMetric\`, \`PromptEvalConfig\`, \`CustomEvalConfig\`, \`InlineEval\`, \`ExternalEvalConfig\`, \`APICallLog\`, and \`EvalLogger\` inside its transaction, but was missing the same \`EvalSettings\` hole the bulk-delete view had. Deleting one template at a time left \`EvalSettings\` rows behind, producing the same stale-column-config problem in the FE.
- Cascade added directly on the just-verified \`eval_template.id\` (the enclosing \`EvalTemplate.objects.get\` already gates by org + \`owner=USER\` + \`deleted=False\`), so no subquery is needed here.
- New test \`test_eval_template_single_delete_soft_deletes_eval_settings\` mirrors the existing bulk-delete test, hits \`/model-hub/delete-eval-template/\`, and turns red if the cascade is reverted.

## Test results

24 pass across the 4 files that directly exercise this PR's fixes (two cascade tests, one runner-versioning test, and the aggregation file's 21 rewritten tests). The broader TH-5937 inherited-failure sweep is captured in the Test run screenshot below and confirms no other regression in the same surface.

```bash
bin/test --no-services \\
  model_hub/tests/test_eval_playground_contracts.py::test_eval_template_bulk_delete_soft_deletes_eval_settings \\
  model_hub/tests/test_eval_playground_contracts.py::test_eval_template_single_delete_soft_deletes_eval_settings \\
  model_hub/tests/test_eval_versioning.py::TestMaybePinNewVersion::test_runner_map_fields_uses_pinned_snapshot_required_keys \\
  tracer/tests/test_eval_task_aggregations.py
```

## Behaviour audit

- Read sites of \`EvalSettings\` (\`separate_evals.py:704\` in the column-config PATCH; \`:7082\`/\`:7086\` in \`get_column_data\`, called by \`GetAPICallLogView.get\` at \`:468\`) both use the default manager (\`deleted=False\` filter) and are only reachable when the template is live (upstream endpoints guard on \`EvalTemplate.DoesNotExist\`). No regression risk from either cascade path (bulk or single).
- \`unique_together = ("eval_id", "source", "user")\` on \`EvalSettings\` is a hard DB unique index. Because \`eval_id\` is a UUID and template IDs are never reused, a soft-deleted row cannot collide with a future insert.
- \`EvaluationRunner\` cache change is functionally identical for normal instances; only affects the \`AttributeError\` path (previously crashing) which now falls through to the compute path.

## Test run

Broader TH-5937 inherited-failure sweep (18 files; `test_eval_task_runtime.py` was dropped in the eval-task cutover `851aab38c` and no longer exists):

```bash
bin/test -v \\
    model_hub/tests/test_user_evaluation_tasks.py \\
    model_hub/tests/test_scoring.py \\
    model_hub/tests/test_eval_runner.py \\
    model_hub/tests/test_eval_runner_runtime_contracts.py \\
    model_hub/tests/test_eval_playground_contracts.py \\
    model_hub/tests/test_composite_eval.py \\
    model_hub/tests/test_eval_versioning.py \\
    model_hub/tests/test_function_params_surfaces.py \\
    simulate/tests/test_test_execution_api_contract.py \\
    simulate/tests/test_test_execution_detail_query_contract.py \\
    simulate/tests/test_run_test_activities.py \\
    simulate/tests/test_run_test_models.py \\
    simulate/tests/test_run_test_list_api.py \\
    simulate/tests/test_eval_config_contracts.py \\
    tracer/tests/test_eval_task_aggregations.py \\
    tracer/tests/test_has_eval_filter.py \\
    tracer/tests/test_trace_detail_helpers.py \\
    tracer/tests/test_trace_workspace_scope.py
```

<img width="1072" height="518" alt="image" src="https://github.com/user-attachments/assets/3c2e59b3-69e5-4de4-b768-cc84826fb9c5" />








