### PR TITLE
feat(annotations): add judge vs human agreement to annotation queues

### DIFF
--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -274,6 +274,9 @@ export const useUpdateAnnotationQueue = () => {
       queryClient.invalidateQueries({
         queryKey: annotationQueueKeys.detail(variables.id),
       });
+      queryClient.invalidateQueries({
+        queryKey: annotationQueueKeys.agreement(variables.id),
+      });
     },
     onError: (error) => {
       const msg = extractErrorMessage(error, "Failed to update queue");
@@ -1651,5 +1654,22 @@ export const useRemoveLabelFromQueue = () => {
         variant: "error",
       });
     },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Custom Eval Config list — used by QueueSettingsTab to link an evaluator
+// ---------------------------------------------------------------------------
+
+export const useCustomEvalConfigList = ({ projectId, ...options } = {}) => {
+  return useQuery({
+    queryKey: ["custom-eval-configs", projectId],
+    queryFn: () =>
+      axios.get("/tracer/custom-eval-config/list_custom_eval_configs/", {
+        params: projectId ? { project_id: projectId } : undefined,
+      }),
+    select: (d) => d.data?.result ?? d.data?.results ?? d.data ?? [],
+    staleTime: 1000 * 60 * 5,
+    ...options,
   });
 };

--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -380,6 +380,11 @@ export const useUpdateAnnotationQueueStatus = () => {
       queryClient.invalidateQueries({
         queryKey: annotationQueueKeys.detail(variables.id),
       });
+      // Judge-vs-human agreement only computes for COMPLETED queues — a
+      // status flip must re-fetch it or the tab keeps its stale empty-state.
+      queryClient.invalidateQueries({
+        queryKey: annotationQueueKeys.agreement(variables.id),
+      });
     },
     onError: (error) => {
       // Revert optimistic update on error

--- a/frontend/src/sections/annotations/queues/__tests__/create-queue-drawer.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/create-queue-drawer.test.jsx
@@ -20,6 +20,7 @@ vi.mock("src/api/annotation-queues/annotation-queues", () => ({
     mutate: mockUpdateStatus,
     isPending: false,
   }),
+  useCustomEvalConfigList: () => ({ data: [], isLoading: false }),
 }));
 
 vi.mock("src/components/iconify", () => ({

--- a/frontend/src/sections/annotations/queues/components/add-to-queue-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/components/add-to-queue-dialog.jsx
@@ -421,6 +421,7 @@ export default function AddToQueueDialog({
       <CreateQueueDrawer
         open={createDrawerOpen}
         onClose={() => setCreateDrawerOpen(false)}
+        projectId={projectId}
         onCreated={(queue) => {
           if (!queue?.id) return;
           const isFilterMode = selectionMode === "filter";

--- a/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
+++ b/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
@@ -62,7 +62,9 @@ const DEFAULT_VALUES = {
   label_ids: [],
   annotators: [],
   status: "draft",
-  custom_eval_config: null,
+  // Select options use value="" for "None", so the form state must too;
+  // null only appears in the submit payload (mapped in onSubmit).
+  custom_eval_config: "",
 };
 
 // ---------------------------------------------------------------------------
@@ -191,7 +193,7 @@ export default function CreateQueueDrawer({
         label_ids: qLabels,
         annotators: qAnnotators,
         status: editQueue.status || "draft",
-        custom_eval_config: editQueue.custom_eval_config || null,
+        custom_eval_config: editQueue.custom_eval_config || "",
       });
       setAdvancedOpen(false);
     } else if (open) {

--- a/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
+++ b/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
@@ -25,6 +25,7 @@ import {
   useCreateAnnotationQueue,
   useUpdateAnnotationQueue,
   useUpdateAnnotationQueueStatus,
+  useCustomEvalConfigList,
 } from "src/api/annotation-queues/annotation-queues";
 import LabelPicker from "./components/label-picker";
 import AnnotatorPicker from "./components/annotator-picker";
@@ -61,6 +62,7 @@ const DEFAULT_VALUES = {
   label_ids: [],
   annotators: [],
   status: "draft",
+  custom_eval_config: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -113,6 +115,7 @@ CreateQueueDrawer.propTypes = {
   onClose: PropTypes.func.isRequired,
   editQueue: PropTypes.object,
   onCreated: PropTypes.func,
+  projectId: PropTypes.string,
 };
 
 export default function CreateQueueDrawer({
@@ -120,6 +123,7 @@ export default function CreateQueueDrawer({
   onClose,
   editQueue,
   onCreated,
+  projectId,
 }) {
   const isEdit = editQueue && editQueue.id && !editQueue._isDuplicate;
   const { user } = useAuthContext();
@@ -142,6 +146,11 @@ export default function CreateQueueDrawer({
       opt.value === currentStatus ||
       (QUEUE_STATUS_TRANSITIONS[currentStatus] || []).includes(opt.value),
   );
+
+  const evaluatorProjectId = projectId || editQueue?.project;
+  const { data: evalConfigs = [] } = useCustomEvalConfigList({
+    projectId: evaluatorProjectId,
+  });
 
   const { control, handleSubmit, reset, setValue, watch, trigger } = useForm({
     defaultValues: DEFAULT_VALUES,
@@ -182,6 +191,7 @@ export default function CreateQueueDrawer({
         label_ids: qLabels,
         annotators: qAnnotators,
         status: editQueue.status || "draft",
+        custom_eval_config: editQueue.custom_eval_config || null,
       });
       setAdvancedOpen(false);
     } else if (open) {
@@ -222,6 +232,8 @@ export default function CreateQueueDrawer({
       annotator_roles: Object.fromEntries(
         formData.annotators.map((a) => [a.userId, a.roles || [a.role]]),
       ),
+      custom_eval_config: formData.custom_eval_config || null,
+      ...(evaluatorProjectId ? { project_id: evaluatorProjectId } : {}),
     };
 
     if (isEdit) {
@@ -380,6 +392,42 @@ export default function CreateQueueDrawer({
                     )}
                   />
                 )}
+
+                <Controller
+                  name="custom_eval_config"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      select
+                      size="small"
+                      label="Evaluator (Judge)"
+                      fullWidth
+                      helperText="Link an evaluator to compare judge scores against human labels in the Agreement tab"
+                      FormHelperTextProps={{ sx: { ml: 0 } }}
+                      sx={{ "& .MuiOutlinedInput-root": { borderRadius: 0.5 } }}
+                      SelectProps={{
+                        displayEmpty: true,
+                        renderValue: (value) => {
+                          if (!value) return "None";
+                          const selected = (evalConfigs || []).find(
+                            (ec) => ec.id === value,
+                          );
+                          return selected?.name || value;
+                        },
+                      }}
+                    >
+                      <MenuItem value="">
+                        <em>None</em>
+                      </MenuItem>
+                      {(evalConfigs || []).map((ec) => (
+                        <MenuItem key={ec.id} value={ec.id}>
+                          {ec.name}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
+                />
               </Stack>
             </Section>
 

--- a/frontend/src/sections/annotations/queues/view/__tests__/queue-agreement-tab.test.jsx
+++ b/frontend/src/sections/annotations/queues/view/__tests__/queue-agreement-tab.test.jsx
@@ -1,0 +1,155 @@
+import { describe, test, expect, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import QueueAgreementTab from "../queue-agreement-tab";
+
+// Mock the API hook so the component receives controlled data.
+vi.mock("src/api/annotation-queues/annotation-queues", () => ({
+  useQueueAgreement: vi.fn(),
+}));
+
+import { useQueueAgreement } from "src/api/annotation-queues/annotation-queues";
+
+function mockAgreement(overrides = {}) {
+  useQueueAgreement.mockReturnValue({
+    data: {
+      overall_agreement: 0.85,
+      labels: {},
+      annotator_pairs: [],
+      judge_vs_human: null,
+      ...overrides,
+    },
+    isLoading: false,
+  });
+}
+
+describe("QueueAgreementTab — judge vs human section", () => {
+  test("shows empty-state prompt when no evaluator is linked", () => {
+    mockAgreement();
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    expect(screen.getByText("Judge vs Human Agreement")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Link an evaluator to this queue to compare judge scores against human labels.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("renders judge-vs-human overall agreement when data is present", () => {
+    mockAgreement({
+      judge_vs_human: {
+        evaluator_name: "Safety Eval v2",
+        overall_agreement: 0.72,
+        total_comparisons: 45,
+        labels: {},
+      },
+    });
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    // The evaluator name is prefixed with "Evaluator: " in the Typography.
+    expect(screen.getByText("Evaluator: Safety Eval v2")).toBeInTheDocument();
+    // 72.0% appears as the Judge-Human Overall Agreement in <h2>.
+    expect(screen.getByText("72.0%")).toBeInTheDocument();
+  });
+
+  test("renders per-label agreement rows", () => {
+    mockAgreement({
+      judge_vs_human: {
+        evaluator_name: "Safety Eval v2",
+        overall_agreement: 0.67,
+        total_comparisons: 30,
+        labels: {
+          "label-1": {
+            label_name: "PII Leak",
+            label_type: "categorical",
+            judge_human_agreement: 0.68,
+            total_comparisons: 20,
+          },
+          "label-2": {
+            label_name: "Safe",
+            label_type: "categorical",
+            judge_human_agreement: 0.85,
+            total_comparisons: 10,
+          },
+        },
+      },
+    });
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    // Labels should appear in the table.
+    expect(screen.getByText("PII Leak")).toBeInTheDocument();
+    expect(screen.getByText("Safe")).toBeInTheDocument();
+    // Agreement percentages (overall_agreement is 0.85 -> "85.0%" in
+    // Overall card, and label-2 has 0.85 -> "85.0%" in the per-label
+    // table — so "85.0%" appears twice and "68.0%" once).
+    expect(screen.getByText("68.0%")).toBeInTheDocument();
+    expect(screen.getAllByText("85.0%").length).toBe(2);
+  });
+
+  test("shows N/A when overall agreement is null", () => {
+    mockAgreement({
+      judge_vs_human: {
+        evaluator_name: "Score Eval",
+        overall_agreement: null,
+        total_comparisons: 0,
+        labels: {},
+      },
+    });
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Not enough overlapping items with both judge scores and human labels to calculate agreement",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("shows N/A for label agreement when null", () => {
+    mockAgreement({
+      judge_vs_human: {
+        evaluator_name: "Safety Eval",
+        overall_agreement: null,
+        total_comparisons: 0,
+        labels: {
+          "label-1": {
+            label_name: "Toxicity",
+            label_type: "categorical",
+            judge_human_agreement: null,
+            total_comparisons: 0,
+          },
+        },
+      },
+    });
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    // The label name appears, but the agreement percentage shows N/A.
+    expect(screen.getByText("Toxicity")).toBeInTheDocument();
+    // "N/A" appears twice: once for overall and once for the label.
+    const naElements = screen.getAllByText("N/A");
+    expect(naElements.length).toBe(2);
+  });
+
+  test("does not render per-label table when labels are empty", () => {
+    mockAgreement({
+      judge_vs_human: {
+        evaluator_name: "Safety Eval",
+        overall_agreement: 0.5,
+        total_comparisons: 10,
+        labels: {},
+      },
+    });
+
+    render(<QueueAgreementTab queueId="q-1" />);
+
+    // The evaluator name is prefixed with "Evaluator: ".
+    expect(screen.getByText("Evaluator: Safety Eval")).toBeInTheDocument();
+    // Per-Label table headers should not appear.
+    expect(screen.queryByText("PII Leak")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
@@ -26,7 +26,7 @@ function formatPct(val) {
   return `${(val * 100).toFixed(1)}%`;
 }
 
-export default function QueueAgreementTab({ queueId }) {
+export default function QueueAgreementTab({ queueId, queue }) {
   const { data: agreement, isLoading } = useQueueAgreement(queueId);
 
   if (isLoading) {
@@ -237,10 +237,17 @@ export default function QueueAgreementTab({ queueId }) {
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             Judge vs Human Agreement
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Link an evaluator to this queue to compare judge scores against
-            human labels.
-          </Typography>
+          {queue && queue.custom_eval_config && queue.status !== "completed" ? (
+            <Typography variant="body2" color="text.secondary">
+              Mark the queue as completed to compare judge scores against human
+              labels.
+            </Typography>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              Link an evaluator to this queue to compare judge scores against
+              human labels.
+            </Typography>
+          )}
         </Box>
       )}
     </Box>
@@ -249,4 +256,8 @@ export default function QueueAgreementTab({ queueId }) {
 
 QueueAgreementTab.propTypes = {
   queueId: PropTypes.string.isRequired,
+  queue: PropTypes.shape({
+    custom_eval_config: PropTypes.string,
+    status: PropTypes.string,
+  }),
 };

--- a/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
@@ -237,11 +237,18 @@ export default function QueueAgreementTab({ queueId, queue }) {
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             Judge vs Human Agreement
           </Typography>
-          {queue && queue.custom_eval_config && queue.status !== "completed" ? (
-            <Typography variant="body2" color="text.secondary">
-              Mark the queue as completed to compare judge scores against human
-              labels.
-            </Typography>
+          {queue && queue.custom_eval_config ? (
+            queue.status !== "completed" ? (
+              <Typography variant="body2" color="text.secondary">
+                Mark the queue as completed to compare judge scores against
+                human labels.
+              </Typography>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No comparable data yet: judge scores and human labels have no
+                overlapping items to compare for this queue.
+              </Typography>
+            )
           ) : (
             <Typography variant="body2" color="text.secondary">
               Link an evaluator to this queue to compare judge scores against

--- a/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-agreement-tab.jsx
@@ -30,14 +30,13 @@ export default function QueueAgreementTab({ queueId }) {
   const { data: agreement, isLoading } = useQueueAgreement(queueId);
 
   if (isLoading) {
-    return (
-      <LoadingScreen variant="orbit" sx={{ minHeight: "50vh" }} />
-    );
+    return <LoadingScreen variant="orbit" sx={{ minHeight: "50vh" }} />;
   }
 
   if (!agreement) return null;
 
-  const { overall_agreement, labels, annotator_pairs } = agreement;
+  const { overall_agreement, labels, annotator_pairs, judge_vs_human } =
+    agreement;
   const overallAgreement = overall_agreement;
   const labelEntries = Object.entries(labels || {});
   const pairs = annotator_pairs || [];
@@ -148,6 +147,100 @@ export default function QueueAgreementTab({ queueId }) {
               </TableBody>
             </Table>
           </TableContainer>
+        </Box>
+      )}
+
+      {/* Judge vs Human Agreement */}
+      {judge_vs_human ? (
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Judge vs Human Agreement
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Evaluator: {judge_vs_human.evaluator_name}
+          </Typography>
+
+          {/* Overall */}
+          <Card sx={{ my: 2 }}>
+            <CardContent sx={{ textAlign: "center" }}>
+              <Typography variant="caption" color="text.secondary">
+                Overall Judge-Human Agreement
+              </Typography>
+              <Typography
+                variant="h2"
+                color={getAgreementColor(judge_vs_human.overall_agreement)}
+              >
+                {formatPct(judge_vs_human.overall_agreement)}
+              </Typography>
+              {judge_vs_human.overall_agreement == null && (
+                <Typography variant="body2" color="text.secondary">
+                  Not enough overlapping items with both judge scores and human
+                  labels to calculate agreement
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per-Label */}
+          {Object.keys(judge_vs_human.labels || {}).length > 0 && (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Label</TableCell>
+                    <TableCell>Type</TableCell>
+                    <TableCell align="right">Agreement</TableCell>
+                    <TableCell align="right">Comparisons</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {Object.entries(judge_vs_human.labels).map(([id, label]) => (
+                    <TableRow key={id}>
+                      <TableCell>{label.label_name}</TableCell>
+                      <TableCell>
+                        <Typography variant="caption">
+                          {label.label_type}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        {label.comparable === false ? (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            title="This label's type isn't comparable with the linked evaluator's output type"
+                          >
+                            N/A
+                          </Typography>
+                        ) : (
+                          <Typography
+                            color={getAgreementColor(
+                              label.judge_human_agreement,
+                            )}
+                            fontWeight={600}
+                          >
+                            {formatPct(label.judge_human_agreement)}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell align="right">
+                        {label.total_comparisons ?? 0}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Box>
+      ) : (
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Judge vs Human Agreement
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Link an evaluator to this queue to compare judge scores against
+            human labels.
+          </Typography>
         </Box>
       )}
     </Box>

--- a/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
@@ -543,7 +543,7 @@ export default function QueueDetailView() {
       )}
       {currentTab === "agreement" && (
         <Box sx={{ px: 3, overflow: "auto", flex: 1 }}>
-          <QueueAgreementTab queueId={queueId} />
+          <QueueAgreementTab queueId={queueId} queue={queue} />
         </Box>
       )}
       {currentTab === "rules" && (
@@ -756,10 +756,7 @@ export default function QueueDetailView() {
                 const assignedUsers = item?.assigned_users || [];
                 const assignedToOther =
                   queue?.auto_assign === false &&
-          
-                  !assignedUsers?.some(
-                    (a) => String(a.id) === currentUserId,
-                  );
+                  !assignedUsers?.some((a) => String(a.id) === currentUserId);
                 if (assignedToOther && !canViewSubmissions && !isManager) {
                   enqueueSnackbar(
                     "You cannot annotate items that are not assigned to you",

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -31,6 +31,7 @@ import {
   useHardDeleteAnnotationQueue,
   useUpdateAnnotationQueue,
   useUpdateAnnotationQueueStatus,
+  useCustomEvalConfigList,
 } from "src/api/annotation-queues/annotation-queues";
 import RHFTextField from "src/components/hook-form/rhf-text-field";
 import { RHFCheckbox } from "src/components/hook-form/rhf-checkbox";
@@ -90,7 +91,6 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
     useArchiveAnnotationQueue();
   const isPending = isUpdating || isStatusUpdating;
 
-
   const handleArchive = () => {
     navigate("/dashboard/annotations/queues");
     archiveQueue(queueId);
@@ -109,6 +109,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
       autoAssign: false,
       label_ids: [],
       annotators: [],
+      custom_eval_config: null,
     },
   });
 
@@ -119,6 +120,10 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
   const autoAssign = watch("autoAssign");
   const annotatorCount = annotators.filter(isQueueAnnotatorRole).length;
   const hasInitializedRef = useRef(false);
+
+  const { data: evalConfigs = [] } = useCustomEvalConfigList({
+    projectId: queue?.project,
+  });
 
   useEffect(() => {
     if (queue && !hasInitializedRef.current) {
@@ -142,6 +147,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
         autoAssign: queue.auto_assign ?? false,
         label_ids: qLabels,
         annotators: qAnnotators,
+        custom_eval_config: queue.custom_eval_config || null,
       });
     }
   }, [queue, reset]);
@@ -162,6 +168,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
       annotator_roles: Object.fromEntries(
         formData.annotators.map((a) => [a.userId, a.roles || [a.role]]),
       ),
+      custom_eval_config: formData.custom_eval_config || null,
     };
 
     const currentStatus = queue?.status || "draft";
@@ -281,6 +288,42 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
                       </TextField>
                     );
                   }}
+                />
+
+                <Controller
+                  name="custom_eval_config"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      select
+                      size="small"
+                      label="Evaluator (Judge)"
+                      fullWidth
+                      helperText="Link an evaluator to compare judge scores against human labels in the Agreement tab"
+                      FormHelperTextProps={{ sx: { ml: 0 } }}
+                      sx={{ "& .MuiOutlinedInput-root": { borderRadius: 0.5 } }}
+                      SelectProps={{
+                        displayEmpty: true,
+                        renderValue: (value) => {
+                          if (!value) return "None";
+                          const selected = (evalConfigs || []).find(
+                            (ec) => ec.id === value,
+                          );
+                          return selected?.name || value;
+                        },
+                      }}
+                    >
+                      <MenuItem value="">
+                        <em>None</em>
+                      </MenuItem>
+                      {(evalConfigs || []).map((ec) => (
+                        <MenuItem key={ec.id} value={ec.id}>
+                          {ec.name}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
                 />
               </Stack>
             </CardContent>

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -109,7 +109,9 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
       autoAssign: false,
       label_ids: [],
       annotators: [],
-      custom_eval_config: null,
+      // Select options use value="" for "None", so the form state must too;
+      // null only appears in the submit payload (mapped in onSubmit).
+      custom_eval_config: "",
     },
   });
 
@@ -147,7 +149,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
         autoAssign: queue.auto_assign ?? false,
         label_ids: qLabels,
         annotators: qAnnotators,
-        custom_eval_config: queue.custom_eval_config || null,
+        custom_eval_config: queue.custom_eval_config || "",
       });
     }
   }, [queue, reset]);

--- a/futureagi/model_hub/migrations/0130_add_queue_custom_eval_config.py
+++ b/futureagi/model_hub/migrations/0130_add_queue_custom_eval_config.py
@@ -1,0 +1,24 @@
+# Generated manually -- see issue #1667
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model_hub', '0122_backfill_queueitem_source_preview'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='annotationqueue',
+            name='custom_eval_config',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=models.SET_NULL,
+                related_name='annotation_queues',
+                to='tracer.customevalconfig',
+            ),
+        ),
+    ]

--- a/futureagi/model_hub/models/annotation_queues.py
+++ b/futureagi/model_hub/models/annotation_queues.py
@@ -141,6 +141,13 @@ class AnnotationQueue(BaseModel):
         null=True,
         blank=True,
     )
+    custom_eval_config = models.ForeignKey(
+        "tracer.CustomEvalConfig",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="annotation_queues",
+    )
     is_default = models.BooleanField(default=False)
     created_by = models.ForeignKey(
         User,

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -36,6 +36,7 @@ from model_hub.utils.annotation_queue_helpers import (
 )
 from tfc.utils.serializer_fields import JsonValueField
 from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.project import Project
 from tracer.serializers.filters import StrictInputSerializer, filter_list_field
 
 _ROLE_LIST_SCHEMA = serializers.ListField(child=serializers.CharField())
@@ -263,6 +264,10 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
         return organization, getattr(request, "workspace", None)
 
     def _queue_project_id(self):
+        resolved = self.context.get("_resolved_project")
+        if resolved is not None:
+            return str(resolved.pk)
+
         if self.instance and getattr(self.instance, "project_id", None):
             return str(self.instance.project_id)
 
@@ -356,7 +361,45 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
                     }
                 )
 
+        self._resolve_and_stash_project(attrs)
+
         return attrs
+
+    def _resolve_and_stash_project(self, attrs):
+        """Resolve ``project_id`` from the request body on create and stash the
+        validated ``Project`` for :meth:`validate_custom_eval_config` and
+        :meth:`create`.
+
+        ``project`` is a read-only serializer field (validated_data never
+        carries it), so without this resolution a fresh queue has no project
+        at validation time and the same-project evaluator guard would silently
+        pass on create. The lookup is org-scoped and rejects unknown ids with
+        a 400 — a bare ``.first()`` would let the queue silently drop its
+        project (or worse, a non-org-scoped one would let a client anchor the
+        queue onto another tenant's project).
+        """
+        if self.instance:
+            return  # update path: the guard reads instance.project_id
+
+        request = self.context.get("request")
+        request_data = getattr(request, "data", None) or {}
+        project_id = request_data.get("project_id")
+        if not project_id:
+            return
+
+        organization, _workspace = self._request_org_workspace()
+        try:
+            project = Project.objects.get(
+                id=project_id,
+                organization=organization,
+                deleted=False,
+            )
+        except (Project.DoesNotExist, ValueError, TypeError) as exc:
+            raise serializers.ValidationError(
+                {"project_id": "Project not found in your organization."}
+            ) from exc
+        self.context["_resolved_project"] = project
+        attrs["project"] = project
 
     def _viewer_membership(self, obj, user):
         if not user:
@@ -469,20 +512,11 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
         annotator_ids = validated_data.pop("annotator_ids", [])
         annotator_roles = validated_data.pop("annotator_roles", {})
 
-        # ``project`` is read-only (set by the view on save), but the
-        # cross-project evaluator guard in ``validate_custom_eval_config`` needs
-        # the queue's project during validation.  Resolve it from the request
-        # body so the guard can reject evaluators from other projects on create.
-        request = self.context.get("request")
-        project_id = None
-        if request:
-            project_id = getattr(request, "data", {}).get("project_id")
-        if project_id:
-            from tracer.models.project import Project
-
-            validated_data["project"] = Project.objects.filter(
-                id=project_id, deleted=False
-            ).first() or validated_data.get("project")
+        # ``project`` is read-only on the serializer; on create the org-scoped
+        # resolution happens in ``_resolve_and_stash_project`` (validate phase),
+        # which also stashes the instance so the same-project evaluator guard
+        # and this write use one validated ``Project``.
+        validated_data.setdefault("project", self.context.get("_resolved_project"))
 
         queue = AnnotationQueue(**validated_data)
         queue.save()

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -124,6 +124,26 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
         allow_null=True,
     )
 
+    def get_fields(self):
+        """Scope ``custom_eval_config`` to the caller's organization.
+
+        ``PrimaryKeyRelatedField.queryset`` only governs which PKs the field
+        will resolve (it never constrains what a client *may* submit); the
+        org/project check still lives in ``validate_custom_eval_config``. But
+        narrowing it here is defence-in-depth: a UUID from another org fails at
+        the field layer with a clear "does not exist" instead of reaching the
+        validator, and the field reads as org-scoped at definition time. The
+        ``objects.all()`` default stays as a fallback for non-request contexts
+        (e.g. OpenAPI schema generation) where no org is available.
+        """
+        fields = super().get_fields()
+        organization, _workspace = self._request_org_workspace()
+        if organization:
+            fields["custom_eval_config"].queryset = CustomEvalConfig.objects.filter(
+                project__organization=organization
+            )
+        return fields
+
     class Meta:
         model = AnnotationQueue
         fields = [

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -128,14 +128,16 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
     def get_fields(self):
         """Scope ``custom_eval_config`` to the caller's organization.
 
-        ``PrimaryKeyRelatedField.queryset`` only governs which PKs the field
-        will resolve (it never constrains what a client *may* submit); the
-        org/project check still lives in ``validate_custom_eval_config``. But
-        narrowing it here is defence-in-depth: a UUID from another org fails at
-        the field layer with a clear "does not exist" instead of reaching the
-        validator, and the field reads as org-scoped at definition time. The
-        ``objects.all()`` default stays as a fallback for non-request contexts
-        (e.g. OpenAPI schema generation) where no org is available.
+        ``PrimaryKeyRelatedField`` resolves submitted PKs against its
+        queryset (anything outside it fails validation with "does not
+        exist"), so narrowing it here already rejects cross-org UUIDs at
+        the field layer. The org/project checks in
+        ``validate_custom_eval_config`` stay as defence-in-depth (and cover
+        the non-request fallback path below), while this filter gives the
+        rejection a clear "does not exist" message and reads as org-scoped
+        at definition time. The ``objects.all()`` default is only used for
+        non-request contexts (e.g. OpenAPI schema generation) where no org
+        is available.
         """
         fields = super().get_fields()
         organization, _workspace = self._request_org_workspace()

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -35,6 +35,7 @@ from model_hub.utils.annotation_queue_helpers import (
     resolve_source_preview,
 )
 from tfc.utils.serializer_fields import JsonValueField
+from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.serializers.filters import StrictInputSerializer, filter_list_field
 
 _ROLE_LIST_SCHEMA = serializers.ListField(child=serializers.CharField())
@@ -117,6 +118,11 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
     viewer_roles = serializers.SerializerMethodField()
     viewer_role = serializers.SerializerMethodField()
     deleted = serializers.BooleanField(read_only=True)
+    custom_eval_config = serializers.PrimaryKeyRelatedField(
+        queryset=CustomEvalConfig.objects.all(),
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = AnnotationQueue
@@ -135,6 +141,7 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             "project",
             "dataset",
             "agent_definition",
+            "custom_eval_config",
             "is_default",
             "labels",
             "annotators",
@@ -209,6 +216,21 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             normalized[str(user_id)] = role_list
         return normalized
 
+    def validate_custom_eval_config(self, value):
+        if value is None:
+            return value
+        organization, _workspace = self._request_org_workspace()
+        if organization and value.project.organization_id != organization.id:
+            raise serializers.ValidationError(
+                "Evaluator does not belong to your organization."
+            )
+        queue_project_id = self._queue_project_id()
+        if queue_project_id and str(value.project_id) != queue_project_id:
+            raise serializers.ValidationError(
+                "Evaluator must belong to the same project as the queue."
+            )
+        return value
+
     def _request_org_workspace(self):
         request = self.context.get("request")
         if not request:
@@ -219,6 +241,20 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
             None,
         )
         return organization, getattr(request, "workspace", None)
+
+    def _queue_project_id(self):
+        if self.instance and getattr(self.instance, "project_id", None):
+            return str(self.instance.project_id)
+
+        request = self.context.get("request")
+        if not request:
+            return None
+
+        request_data = getattr(request, "data", None) or {}
+        project_id = request_data.get("project_id")
+        if project_id:
+            return str(project_id)
+        return None
 
     def _workspace_visibility_q(self, organization, workspace):
         if not workspace:
@@ -412,6 +448,22 @@ class AnnotationQueueSerializer(serializers.ModelSerializer):
         label_ids = validated_data.pop("label_ids", [])
         annotator_ids = validated_data.pop("annotator_ids", [])
         annotator_roles = validated_data.pop("annotator_roles", {})
+
+        # ``project`` is read-only (set by the view on save), but the
+        # cross-project evaluator guard in ``validate_custom_eval_config`` needs
+        # the queue's project during validation.  Resolve it from the request
+        # body so the guard can reject evaluators from other projects on create.
+        request = self.context.get("request")
+        project_id = None
+        if request:
+            project_id = getattr(request, "data", {}).get("project_id")
+        if project_id:
+            from tracer.models.project import Project
+
+            validated_data["project"] = Project.objects.filter(
+                id=project_id, deleted=False
+            ).first() or validated_data.get("project")
+
         queue = AnnotationQueue(**validated_data)
         queue.save()
 
@@ -1123,10 +1175,28 @@ class QueueAgreementAnnotatorPairSerializer(serializers.Serializer):
     total_comparisons = serializers.IntegerField()
 
 
+class QueueAgreementJudgeVsHumanLabelSerializer(serializers.Serializer):
+    label_name = serializers.CharField()
+    label_type = serializers.CharField()
+    judge_human_agreement = serializers.FloatField(allow_null=True)
+    total_comparisons = serializers.IntegerField()
+    comparable = serializers.BooleanField(default=True)
+
+
+class QueueAgreementJudgeVsHumanSerializer(serializers.Serializer):
+    evaluator_name = serializers.CharField()
+    overall_agreement = serializers.FloatField(allow_null=True)
+    total_comparisons = serializers.IntegerField()
+    labels = serializers.DictField(child=QueueAgreementJudgeVsHumanLabelSerializer())
+
+
 class QueueAgreementResultSerializer(serializers.Serializer):
     overall_agreement = serializers.FloatField(allow_null=True)
     labels = serializers.DictField(child=QueueAgreementLabelSerializer())
     annotator_pairs = QueueAgreementAnnotatorPairSerializer(many=True)
+    judge_vs_human = QueueAgreementJudgeVsHumanSerializer(
+        allow_null=True, required=False
+    )
 
 
 class QueueAgreementResponseSerializer(serializers.Serializer):

--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -20,6 +20,7 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
+from accounts.models.organization import Organization
 from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.user import User
 from accounts.models.workspace import Workspace, WorkspaceMembership
@@ -568,6 +569,65 @@ class TestCreateQueue:
         assert "project" in str(resp.data).lower()
         assert not AnnotationQueue.objects.filter(
             name="Project Scoped Queue",
+            organization=organization,
+        ).exists()
+
+    def test_create_rejects_cross_org_evaluator_at_field_layer(
+        self, auth_client, organization, workspace, user
+    ):
+        """A CustomEvalConfig belonging to a *different* organization must be
+        rejected at the ``custom_eval_config`` field layer (the org-scoped
+        queryset in ``AnnotationQueueSerializer.get_fields``), not only by the
+        ``validate_custom_eval_config`` project check. This guards against an
+        org A user binding an org B evaluator by its UUID.
+        """
+        other_org = Organization.objects.create(
+            name=f"Other Org {uuid.uuid4().hex[:8]}"
+        )
+        other_project = Project.objects.create(
+            name="Other Org Project",
+            organization=other_org,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        eval_template = EvalTemplate.objects.create(
+            name=f"Other Org Eval Template {uuid.uuid4().hex[:8]}",
+            organization=other_org,
+            output_type_normalized="pass_fail",
+        )
+        cross_org_config = CustomEvalConfig.objects.create(
+            name="Other Org Config",
+            project=other_project,
+            eval_template=eval_template,
+            config={},
+            mapping={},
+            filters={},
+        )
+
+        project = Project.objects.create(
+            name="Queue Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        label_id = create_label_for_queue(auth_client, name="Cross Org Label")
+
+        resp = auth_client.post(
+            QUEUE_URL,
+            {
+                "name": "Cross Org Eval Queue",
+                "project_id": str(project.id),
+                "label_ids": [str(label_id)],
+                "custom_eval_config": str(cross_org_config.id),
+            },
+            format="json",
+        )
+
+        # Rejected before the queue is persisted.
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert not AnnotationQueue.objects.filter(
+            name="Cross Org Eval Queue",
             organization=organization,
         ).exists()
 

--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -36,6 +36,7 @@ from model_hub.models.choices import (
     QueueItemStatus,
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.models.evals_metric import EvalTemplate
 from model_hub.views.annotation_queues import _related_count_subquery
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
@@ -44,6 +45,7 @@ from tfc.middleware.workspace_context import (
     clear_workspace_context,
     set_workspace_context,
 )
+from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.project import Project
 
 QUEUE_URL = "/model-hub/annotation-queues/"
@@ -516,6 +518,57 @@ class TestCreateQueue:
         assert not AnnotationQueue.objects.filter(
             name="Cross Workspace Label Queue",
             workspace=workspace,
+        ).exists()
+
+    def test_create_rejects_cross_project_evaluator(
+        self, auth_client, organization, workspace, user
+    ):
+        project = Project.objects.create(
+            name="Queue Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        other_project = Project.objects.create(
+            name="Evaluator Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        label_id = create_label_for_queue(auth_client, name="Project Queue Label")
+        eval_template = EvalTemplate.objects.create(
+            name=f"Queue Eval Template {uuid.uuid4().hex[:8]}",
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        custom_eval_config = CustomEvalConfig.objects.create(
+            name="Evaluator Project Config",
+            project=other_project,
+            eval_template=eval_template,
+            config={},
+            mapping={},
+            filters={},
+        )
+
+        resp = auth_client.post(
+            QUEUE_URL,
+            {
+                "name": "Project Scoped Queue",
+                "project_id": str(project.id),
+                "label_ids": [str(label_id)],
+                "custom_eval_config": str(custom_eval_config.id),
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "project" in str(resp.data).lower()
+        assert not AnnotationQueue.objects.filter(
+            name="Project Scoped Queue",
+            organization=organization,
         ).exists()
 
     def test_create_rejects_annotator_without_workspace_membership(

--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -572,6 +572,94 @@ class TestCreateQueue:
             organization=organization,
         ).exists()
 
+    def test_create_rejects_cross_org_project_id(
+        self, auth_client, organization, workspace, user
+    ):
+        """``project_id`` pointing at another organization's project must be
+        rejected with a 400 — the queue's project write is org-scoped, so a
+        bare UUID from another tenant can never anchor the queue (or,
+        combined with a matching eval config, defeat the same-project
+        evaluator guard)."""
+        other_org = Organization.objects.create(
+            name=f"Other Org {uuid.uuid4().hex[:8]}"
+        )
+        other_project = Project.objects.create(
+            name="Foreign Project",
+            organization=other_org,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        label_id = create_label_for_queue(auth_client, name="Cross Org Project Label")
+
+        resp = auth_client.post(
+            QUEUE_URL,
+            {
+                "name": "Cross Org Project Queue",
+                "project_id": str(other_project.id),
+                "label_ids": [str(label_id)],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert not AnnotationQueue.objects.filter(
+            name="Cross Org Project Queue",
+            organization=organization,
+        ).exists()
+
+    def test_create_rejects_unknown_project_id(
+        self, auth_client, organization, workspace, user
+    ):
+        """An unknown ``project_id`` must 400, not silently create a
+        project-less queue."""
+        label_id = create_label_for_queue(auth_client, name="Unknown Project Label")
+
+        resp = auth_client.post(
+            QUEUE_URL,
+            {
+                "name": "Unknown Project Queue",
+                "project_id": str(uuid.uuid4()),
+                "label_ids": [str(label_id)],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert not AnnotationQueue.objects.filter(
+            name="Unknown Project Queue",
+            organization=organization,
+        ).exists()
+
+    def test_create_with_project_in_org_succeeds(
+        self, auth_client, organization, workspace, user
+    ):
+        """The org-scoped resolution keeps the happy path working: a valid
+        same-org ``project_id`` creates the queue with that project."""
+        project = Project.objects.create(
+            name="Valid Queue Project",
+            organization=organization,
+            workspace=workspace,
+            model_type="GenerativeLLM",
+            trace_type="observe",
+        )
+        label_id = create_label_for_queue(auth_client, name="Valid Project Label")
+
+        resp = auth_client.post(
+            QUEUE_URL,
+            {
+                "name": "Valid Project Queue",
+                "project_id": str(project.id),
+                "label_ids": [str(label_id)],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_201_CREATED, resp.data
+        queue = AnnotationQueue.objects.get(
+            name="Valid Project Queue", organization=organization
+        )
+        assert str(queue.project_id) == str(project.id)
+
     def test_create_rejects_cross_org_evaluator_at_field_layer(
         self, auth_client, organization, workspace, user
     ):

--- a/futureagi/model_hub/tests/test_eval_group_contracts.py
+++ b/futureagi/model_hub/tests/test_eval_group_contracts.py
@@ -140,3 +140,15 @@ class TestEvalGroupMappingValues:
             )
 
         assert "hypothesis" in str(exc.value)
+
+    def test_none_mapping_returns_empty_without_crashing(self):
+        # A cleared/omitted mapping arrives as None from some call paths. The
+        # required-keys loop must not do ``key not in None``; it should return
+        # an empty mapping, mirroring the None early-return in
+        # ``CustomEvalConfigSerializer.validate_mapping``.
+        assert (
+            fetch_specific_mapping_for_specific_eval_template(
+                None, self._template(["hypothesis"], ["reference"])
+            )
+            == {}
+        )

--- a/futureagi/model_hub/tests/test_judge_human_agreement.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement.py
@@ -1,23 +1,36 @@
-"""Unit tests for ``_calculate_judge_human_agreement``.
+"""Unit tests for ``_calculate_judge_human_agreement`` and its helpers.
 
 Coverage:
-  - Returns ``None`` when the queue has no linked evaluator.
-  - Returns ``None`` when no trace/span-sourced items have overlapping data.
-  - Picks the latest ``EvalLogger`` row per span via Subquery.
-  - Skips error rows from ``EvalLogger``.
-  - Calculates overall and per-label agreement correctly.
-  - Handles pass_fail, percentage, and deterministic output types.
-  - Returns ``None`` for items without overlapping judge and human scores.
+  - ``_normalize_eval_output``: pass_fail / percentage / deterministic.
+  - ``_majority_value``: strict majority, ties, single value, order-independence.
+  - ``_normalize_human_score_value``: the three real shapes of a stored
+    ``Score.value`` — per-type dict, legacy bare scalar, and None/empty/garbage
+    (degrades to "not comparable" rather than crashing or false-agreeing).
+  - ``_calculate_judge_human_agreement``:
+      * returns None when no evaluator is linked / no span-sourced items;
+      * returns null agreement when judge and human scores don't overlap;
+      * computes per-label and overall agreement correctly;
+      * the latest-non-error eval Subquery is built with the right gates
+        (error=False, status=COMPLETED, skipped_reason__isnull, deleted=False).
+
+Note: the *execution* of the Subquery (real error-filtering and
+``-created_at`` ordering) is covered by the integration tests, which run
+against a real DB. These unit tests only assert the query *signature*, so a
+regression that drops a gate fails fast instead of silently passing.
 """
 
 import unittest
 from unittest.mock import MagicMock, patch
 
+from django.db.models import Subquery
+
 from model_hub.utils.annotation_queue_helpers import (
     _calculate_judge_human_agreement,
     _majority_value,
     _normalize_eval_output,
+    _normalize_human_score_value,
 )
+from tracer.models.observation_span import EvalEntryStatus
 
 
 class TestNormalizeEvalOutput(unittest.TestCase):
@@ -107,65 +120,97 @@ class TestMajorityValue(unittest.TestCase):
         ) == {"sel": ["A", "B"]}
 
 
+class TestNormalizeHumanScoreValue(unittest.TestCase):
+    """``_normalize_human_score_value`` must mirror the judge side so that
+    a stored ``Score.value`` compares equal to an ``_normalize_eval_output``
+    string. It also has to be defensive: the value is user/legacy data and
+    must never raise.
+
+    The first four tests cover the *comparable* shapes (per-type dict and
+    legacy bare scalar); the remaining tests cover every branch that must
+    degrade to "not comparable" (None) rather than crash or false-agree.
+    """
+
+    def test_categorical_dict_unwraps_single_choice(self):
+        assert (
+            _normalize_human_score_value(
+                {"selected": ["pass"]}, "categorical", "pass_fail"
+            )
+            == "pass"
+        )
+
+    def test_categorical_dict_multi_choice_sorts(self):
+        # Multiple selections stay order-independent via the sorted-list form,
+        # matching the judge side for deterministic output.
+        assert (
+            _normalize_human_score_value(
+                {"selected": ["B", "A"]}, "categorical", "deterministic"
+            )
+            == "['A', 'B']"
+        )
+
+    def test_numeric_percentage_rounds_to_two_decimals(self):
+        # Mirrors _normalize_eval_output's round(2) so the sides match.
+        assert (
+            _normalize_human_score_value({"value": 0.876}, "numeric", "percentage")
+            == "0.88"
+        )
+
+    def test_star_percentage_rounds(self):
+        assert (
+            _normalize_human_score_value({"rating": 4.0}, "star", "percentage") == "4.0"
+        )
+
+    def test_legacy_bare_scalar_passes_through(self):
+        # Old rows that stored a bare string stay comparable (backward compat).
+        assert (
+            _normalize_human_score_value("pass", "categorical", "pass_fail") == "pass"
+        )
+
+    def test_none_value_is_not_comparable(self):
+        assert _normalize_human_score_value(None, "categorical", "pass_fail") is None
+
+    def test_dict_missing_type_key_is_not_comparable(self):
+        # A categorical dict without "selected" cannot be unwrapped.
+        assert (
+            _normalize_human_score_value({"other": "x"}, "categorical", "pass_fail")
+            is None
+        )
+
+    def test_empty_selected_list_is_not_comparable(self):
+        # A categorical dict with an empty "selected" means no choice was
+        # made; it cannot be unwrapped into a comparable scalar.
+        assert (
+            _normalize_human_score_value({"selected": []}, "categorical", "pass_fail")
+            is None
+        )
+
+    def test_unknown_label_type_is_not_comparable(self):
+        # No mapping entry for the type → can't unwrap.
+        assert (
+            _normalize_human_score_value({"value": 5}, "unknown_type", "percentage")
+            is None
+        )
+
+    def test_non_numeric_percentage_is_not_comparable(self):
+        # A percentage judge needs a float; a string can't round.
+        assert (
+            _normalize_human_score_value({"value": "abc"}, "numeric", "percentage")
+            is None
+        )
+
+
 class TestCalculateJudgeHumanAgreement(unittest.TestCase):
-    """The function is called with a real or mocked ``AnnotationQueue``
-    instance. We mock the database queries so the tests stay fast and
-    deterministic."""
+    """The function is called with a mocked ``AnnotationQueue``. Database
+    queries are mocked so the tests stay fast and deterministic. Note: because
+    the Subquery is not executed under a MagicMock, tests that care about the
+    *latest non-error eval row* assert on the query signature rather than on a
+    result that the mock would fabricate (and that would false-pass)."""
 
     def test_returns_none_when_no_evaluator_linked(self):
         queue = MagicMock()
         queue.custom_eval_config_id = None
         assert _calculate_judge_human_agreement(queue) is None
-
-    def test_returns_none_when_output_type_is_none(self):
-        """When eval_template.output_type_normalized is None, bail early
-        because the normalisation codepath is undefined."""
-        queue = MagicMock()
-        queue.custom_eval_config_id = "eval-config-1"
-        queue.custom_eval_config.eval_template.output_type_normalized = None
-        queue.custom_eval_config.name = "Safety Eval"
-
-        assert _calculate_judge_human_agreement(queue) is None
-
-    @patch("tracer.models.observation_span.EvalLogger.objects")
-    @patch("model_hub.models.score.Score.objects")
-    def test_evaluator_name_falls_back_to_config_id_when_names_empty(
-        self, mock_score_objects, mock_eval_objects
-    ):
-        """When custom_eval_config.name is None and eval_template.name is
-        empty string, evaluator_name falls back to the config PK."""
-        queue = MagicMock()
-        queue.custom_eval_config_id = "eval-config-1"
-        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
-        queue.custom_eval_config.name = None
-        queue.custom_eval_config.eval_template.name = ""
-
-        queue.items.filter.return_value.values_list.return_value = [
-            ("item-1", "span-1"),
-        ]
-
-        mock_eval_objects.filter.return_value.values.return_value = [
-            {
-                "observation_span_id": "span-1",
-                "output_bool": True,
-                "output_float": None,
-                "output_str": None,
-                "output_str_list": [],
-            },
-        ]
-
-        mock_score_objects.filter.return_value.values.return_value = [
-            {
-                "queue_item_id": "item-1",
-                "label_id": "label-1",
-                "label__name": "Safety",
-                "label__type": "categorical",
-                "value": "pass",
-            },
-        ]
-
-        result = _calculate_judge_human_agreement(queue)
-        assert result["evaluator_name"] == "eval-config-1"
 
     @patch("tracer.models.observation_span.EvalLogger.objects")
     @patch("model_hub.models.score.Score.objects")
@@ -184,55 +229,76 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
 
     @patch("tracer.models.observation_span.EvalLogger.objects")
     @patch("model_hub.models.score.Score.objects")
-    def test_skips_error_eval_rows(self, mock_score_objects, mock_eval_objects):
-        """EvalLogger rows with error=True are excluded by the Subquery
-        filter, so only the span with a clean row contributes."""
+    def test_evaluator_name_falls_back_to_config_id(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """When custom_eval_config.name (None) and eval_template.name ("")
+        are both empty, evaluator_name falls back to the config PK so the UI
+        never renders a blank label. This single test covers both the None
+        and "" cases (both are falsy in the ``name or template.name or id``
+        chain)."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = None
+        queue.custom_eval_config.eval_template.name = ""
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+        mock_eval_objects.filter.return_value.values.return_value = []
+        mock_score_objects.filter.return_value.values.return_value = []
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["evaluator_name"] == "eval-config-1"
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_latest_eval_subquery_gates_on_error_and_status(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """The inner Subquery that selects the latest eval row per source must
+        be built with the right gates (error=False, status=COMPLETED,
+        skipped_reason__isnull=True, deleted=False, matching config id). Under
+        a MagicMock the Subquery is never executed, so we assert on the *call
+        signature*: dropping any gate from ``_latest_eval`` changes these
+        kwargs and fails the assertion. The actual filtering/ordering is
+        covered by the integration tests against a real DB."""
         queue = MagicMock()
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
         queue.custom_eval_config.name = "Safety Eval"
 
-        # values_list now returns (item_id, observation_span_id) tuples.
         queue.items.filter.return_value.values_list.return_value = [
             ("item-1", "span-1"),
-            ("item-2", "span-2"),
         ]
+        mock_eval_objects.filter.return_value.values.return_value = []
+        mock_score_objects.filter.return_value.values.return_value = []
 
-        # Only span-1 has a valid eval row; span-2 was error=True (excluded).
-        mock_eval_objects.filter.return_value.values.return_value = [
-            {
-                "observation_span_id": "span-1",
-                "output_bool": True,
-                "output_float": None,
-                "output_str": None,
-                "output_str_list": [],
-            },
+        _calculate_judge_human_agreement(queue)
+
+        # The inner latest-eval filter carries the gates; the outer filter only
+        # carries id=Subquery(...), observation_span_id__in, deleted=False.
+        inner = [
+            c.kwargs
+            for c in mock_eval_objects.filter.call_args_list
+            if c.kwargs.get("error") is False
         ]
+        assert inner, "expected an inner latest-eval filter gated on error=False"
+        gate = inner[0]
+        assert gate.get("error") is False
+        assert gate.get("status") == EvalEntryStatus.COMPLETED
+        assert gate.get("skipped_reason__isnull") is True
+        assert gate.get("deleted") is False
+        assert gate.get("custom_eval_config_id") == "eval-config-1"
 
-        # Human scores for both items.
-        mock_score_objects.filter.return_value.values.return_value = [
-            {
-                "queue_item_id": "item-1",
-                "label_id": "label-1",
-                "label__name": "Safety",
-                "label__type": "categorical",
-                "value": "pass",
-            },
-            {
-                "queue_item_id": "item-2",
-                "label_id": "label-1",
-                "label__name": "Safety",
-                "label__type": "categorical",
-                "value": "fail",
-            },
+        # The outer filter must wrap the inner one in a Subquery on id.
+        outer = [
+            c
+            for c in mock_eval_objects.filter.call_args_list
+            if any(isinstance(v, Subquery) for v in c.kwargs.values())
         ]
-
-        result = _calculate_judge_human_agreement(queue)
-
-        # span-2 had no (non-error) eval row → only item-1 contributes.
-        assert result["evaluator_name"] == "Safety Eval"
-        assert result["total_comparisons"] == 1
-        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
+        assert outer, "expected the outer eval-row filter to use a Subquery on id"
 
     @patch("tracer.models.observation_span.EvalLogger.objects")
     @patch("model_hub.models.score.Score.objects")
@@ -279,28 +345,28 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
                 "label_id": "label-1",
                 "label__name": "Label A",
                 "label__type": "categorical",
-                "value": "pass",
+                "value": {"selected": ["pass"]},
             },
             {
                 "queue_item_id": "item-1",
                 "label_id": "label-2",
                 "label__name": "Label B",
                 "label__type": "categorical",
-                "value": "fail",
+                "value": {"selected": ["fail"]},
             },
             {
                 "queue_item_id": "item-2",
                 "label_id": "label-1",
                 "label__name": "Label A",
                 "label__type": "categorical",
-                "value": "fail",
+                "value": {"selected": ["fail"]},
             },
             {
                 "queue_item_id": "item-2",
                 "label_id": "label-2",
                 "label__name": "Label B",
                 "label__type": "categorical",
-                "value": "pass",
+                "value": {"selected": ["pass"]},
             },
         ]
 
@@ -312,43 +378,6 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         assert result["labels"]["label-2"]["total_comparisons"] == 2
         assert result["overall_agreement"] == 0.5
         assert result["total_comparisons"] == 4
-
-    @patch("tracer.models.observation_span.EvalLogger.objects")
-    @patch("model_hub.models.score.Score.objects")
-    def test_uses_latest_eval_row_per_span(self, mock_score_objects, mock_eval_objects):
-        """The Subquery picks the latest EvalLogger row when a span has
-        multiple rows for the same config."""
-        queue = MagicMock()
-        queue.custom_eval_config_id = "eval-config-1"
-        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
-        queue.custom_eval_config.name = "Safety Eval"
-
-        queue.items.filter.return_value.values_list.return_value = [
-            ("item-1", "span-1"),
-        ]
-
-        mock_eval_objects.filter.return_value.values.return_value = [
-            {
-                "observation_span_id": "span-1",
-                "output_bool": True,
-                "output_float": None,
-                "output_str": None,
-                "output_str_list": [],
-            },
-        ]
-
-        mock_score_objects.filter.return_value.values.return_value = [
-            {
-                "queue_item_id": "item-1",
-                "label_id": "label-1",
-                "label__name": "Label A",
-                "label__type": "categorical",
-                "value": "pass",
-            },
-        ]
-
-        result = _calculate_judge_human_agreement(queue)
-        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
 
     @patch("tracer.models.observation_span.EvalLogger.objects")
     @patch("model_hub.models.score.Score.objects")
@@ -383,48 +412,55 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         assert result["total_comparisons"] == 0
         assert result["labels"] == {}
 
+
+class TestPercentageEndToEnd(unittest.TestCase):
+    """A percentage judge must agree with a human numeric dict value after
+    both sides round to two decimals. This exercises the full agreement path
+    (not just the normalize helper) for the percentage output type."""
+
     @patch("tracer.models.observation_span.EvalLogger.objects")
     @patch("model_hub.models.score.Score.objects")
-    def test_returns_none_when_output_type_missing(
+    def test_percentage_judge_agrees_with_numeric_dict(
         self, mock_score_objects, mock_eval_objects
     ):
-        """A linked evaluator without a normalized output type should short
-        circuit instead of returning a partial judge-vs-human payload."""
         queue = MagicMock()
         queue.custom_eval_config_id = "eval-config-1"
-        queue.custom_eval_config.eval_template.output_type_normalized = None
-        queue.custom_eval_config.name = "Missing Output Type Eval"
+        queue.custom_eval_config.eval_template.output_type_normalized = "percentage"
+        queue.custom_eval_config.name = "Score Eval"
 
         queue.items.filter.return_value.values_list.return_value = [
             ("item-1", "span-1"),
         ]
 
-        result = _calculate_judge_human_agreement(queue)
-
-        assert result is None
-        mock_eval_objects.filter.assert_not_called()
-        mock_score_objects.filter.assert_not_called()
-
-    @patch("tracer.models.observation_span.EvalLogger.objects")
-    @patch("model_hub.models.score.Score.objects")
-    def test_uses_config_id_as_final_evaluator_name_fallback(
-        self, mock_score_objects, mock_eval_objects
-    ):
-        """If both config.name and template.name are empty, the config id
-        keeps the UI from rendering a blank evaluator label."""
-        queue = MagicMock()
-        queue.custom_eval_config_id = "eval-config-1"
-        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
-        queue.custom_eval_config.name = ""
-        queue.custom_eval_config.eval_template.name = ""
-
-        queue.items.filter.return_value.values_list.return_value = [
-            ("item-1", "span-1"),
+        # Judge: 0.876 → "0.88"
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": None,
+                "output_float": 0.876,
+                "output_str": None,
+                "output_str_list": [],
+            },
         ]
 
-        mock_eval_objects.filter.return_value.values.return_value = []
-        mock_score_objects.filter.return_value.values.return_value = []
+        # Human: numeric dict {"value": 0.876} → unwraps + rounds → "0.88"
+        mock_score_objects.filter.return_value.values.return_value = [
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-1",
+                "label__name": "Label A",
+                "label__type": "numeric",
+                "value": {"value": 0.876},
+            },
+        ]
 
         result = _calculate_judge_human_agreement(queue)
+        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
+        assert result["overall_agreement"] == 1.0
+        assert result["total_comparisons"] == 1
 
-        assert result["evaluator_name"] == "eval-config-1"
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/futureagi/model_hub/tests/test_judge_human_agreement.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement.py
@@ -1,0 +1,430 @@
+"""Unit tests for ``_calculate_judge_human_agreement``.
+
+Coverage:
+  - Returns ``None`` when the queue has no linked evaluator.
+  - Returns ``None`` when no trace/span-sourced items have overlapping data.
+  - Picks the latest ``EvalLogger`` row per span via Subquery.
+  - Skips error rows from ``EvalLogger``.
+  - Calculates overall and per-label agreement correctly.
+  - Handles pass_fail, percentage, and deterministic output types.
+  - Returns ``None`` for items without overlapping judge and human scores.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from model_hub.utils.annotation_queue_helpers import (
+    _calculate_judge_human_agreement,
+    _majority_value,
+    _normalize_eval_output,
+)
+
+
+class TestNormalizeEvalOutput(unittest.TestCase):
+    def test_pass_fail_true(self):
+        assert _normalize_eval_output({"output_bool": True}, "pass_fail") == "pass"
+
+    def test_pass_fail_false(self):
+        assert _normalize_eval_output({"output_bool": False}, "pass_fail") == "fail"
+
+    def test_percentage_valid(self):
+        assert _normalize_eval_output({"output_float": 0.87654}, "percentage") == "0.88"
+
+    def test_percentage_none(self):
+        assert _normalize_eval_output({"output_float": None}, "percentage") is None
+
+    def test_deterministic_uses_str(self):
+        assert (
+            _normalize_eval_output({"output_str": "toxic"}, "deterministic") == "toxic"
+        )
+
+    def test_deterministic_fallbacks_to_str_list(self):
+        assert (
+            _normalize_eval_output(
+                {"output_str": None, "output_str_list": ["A"]},
+                "deterministic",
+            )
+            == "['A']"
+        )
+
+    def test_deterministic_str_list_is_sorted(self):
+        """str_list items are sorted before str() conversion so that
+        order differences don't cause false disagreements."""
+        assert (
+            _normalize_eval_output(
+                {"output_str": None, "output_str_list": ["B", "A", "C"]},
+                "deterministic",
+            )
+            == "['A', 'B', 'C']"
+        )
+
+    def test_pass_fail_none_bool_returns_none(self):
+        assert _normalize_eval_output({"output_bool": None}, "pass_fail") is None
+
+    def test_output_type_none_returns_none(self):
+        """When output_type is None the function bails early (returns None),
+        not the deterministic codepath — this mirrors the integration test
+        ``test_queue_with_null_output_type_returns_none`` which relies on the
+        caller short-circuiting to None for a linked evaluator whose
+        ``output_type_normalized`` is unset."""
+        assert _normalize_eval_output({"output_str": "abc"}, None) is None
+
+
+class TestMajorityValue(unittest.TestCase):
+    def test_returns_most_common(self):
+        assert _majority_value(["a", "b", "a"]) == "a"
+
+    def test_returns_none_for_empty(self):
+        assert _majority_value([]) is None
+
+    def test_handles_single_value(self):
+        assert _majority_value(["only"]) == "only"
+
+    def test_returns_none_on_tie(self):
+        # Two annotators disagree — no true majority.
+        assert _majority_value(["a", "b"]) is None
+
+    def test_returns_none_on_three_way_tie(self):
+        assert _majority_value(["a", "b", "c"]) is None
+
+    def test_strict_majority_wins(self):
+        # 2 "a" vs 1 "b" → "a" has a strict majority.
+        assert _majority_value(["a", "b", "a"]) == "a"
+
+    def test_equivalent_lists_are_not_ties(self):
+        """Lists with the same items in a different order are normalised
+        identically by _normalize_value and must not be reported as a tie."""
+        assert _majority_value([["A", "B"], ["B", "A"], ["A", "B"]]) == ["A", "B"]
+
+    def test_equivalent_dicts_are_not_ties(self):
+        """Dicts whose list-valued entries differ in order are normalised
+        identically by _normalize_value and must not be reported as a tie."""
+        assert _majority_value(
+            [
+                {"sel": ["A", "B"]},
+                {"sel": ["B", "A"]},
+            ]
+        ) == {"sel": ["A", "B"]}
+
+
+class TestCalculateJudgeHumanAgreement(unittest.TestCase):
+    """The function is called with a real or mocked ``AnnotationQueue``
+    instance. We mock the database queries so the tests stay fast and
+    deterministic."""
+
+    def test_returns_none_when_no_evaluator_linked(self):
+        queue = MagicMock()
+        queue.custom_eval_config_id = None
+        assert _calculate_judge_human_agreement(queue) is None
+
+    def test_returns_none_when_output_type_is_none(self):
+        """When eval_template.output_type_normalized is None, bail early
+        because the normalisation codepath is undefined."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = None
+        queue.custom_eval_config.name = "Safety Eval"
+
+        assert _calculate_judge_human_agreement(queue) is None
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_evaluator_name_falls_back_to_config_id_when_names_empty(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """When custom_eval_config.name is None and eval_template.name is
+        empty string, evaluator_name falls back to the config PK."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = None
+        queue.custom_eval_config.eval_template.name = ""
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": True,
+                "output_float": None,
+                "output_str": None,
+                "output_str_list": [],
+            },
+        ]
+
+        mock_score_objects.filter.return_value.values.return_value = [
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-1",
+                "label__name": "Safety",
+                "label__type": "categorical",
+                "value": "pass",
+            },
+        ]
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["evaluator_name"] == "eval-config-1"
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_returns_none_when_no_span_sourced_items(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = "Safety Eval"
+
+        # No observation_span-sourced items in the queue.
+        queue.items.filter.return_value.values_list.return_value = []
+
+        assert _calculate_judge_human_agreement(queue) is None
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_skips_error_eval_rows(self, mock_score_objects, mock_eval_objects):
+        """EvalLogger rows with error=True are excluded by the Subquery
+        filter, so only the span with a clean row contributes."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = "Safety Eval"
+
+        # values_list now returns (item_id, observation_span_id) tuples.
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+            ("item-2", "span-2"),
+        ]
+
+        # Only span-1 has a valid eval row; span-2 was error=True (excluded).
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": True,
+                "output_float": None,
+                "output_str": None,
+                "output_str_list": [],
+            },
+        ]
+
+        # Human scores for both items.
+        mock_score_objects.filter.return_value.values.return_value = [
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-1",
+                "label__name": "Safety",
+                "label__type": "categorical",
+                "value": "pass",
+            },
+            {
+                "queue_item_id": "item-2",
+                "label_id": "label-1",
+                "label__name": "Safety",
+                "label__type": "categorical",
+                "value": "fail",
+            },
+        ]
+
+        result = _calculate_judge_human_agreement(queue)
+
+        # span-2 had no (non-error) eval row → only item-1 contributes.
+        assert result["evaluator_name"] == "Safety Eval"
+        assert result["total_comparisons"] == 1
+        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_calculates_agreement_correctly(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """Two items, two labels. Judge agrees on label-1, disagrees on
+        label-2. Overall = 2/4 = 0.5."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = "Safety Eval"
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+            ("item-2", "span-2"),
+        ]
+
+        # Judge: pass on span-1, fail on span-2.
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": True,
+                "output_float": None,
+                "output_str": None,
+                "output_str_list": [],
+            },
+            {
+                "observation_span_id": "span-2",
+                "output_bool": False,
+                "output_float": None,
+                "output_str": None,
+                "output_str_list": [],
+            },
+        ]
+
+        # Human scores: each item has two labels, one annotator per label.
+        # label-1: item-1 says "pass" (agree), item-2 says "fail" (agree)
+        # label-2: item-1 says "fail" (judge:pass → disagree),
+        #          item-2 says "pass" (judge:fail → disagree)
+        mock_score_objects.filter.return_value.values.return_value = [
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-1",
+                "label__name": "Label A",
+                "label__type": "categorical",
+                "value": "pass",
+            },
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-2",
+                "label__name": "Label B",
+                "label__type": "categorical",
+                "value": "fail",
+            },
+            {
+                "queue_item_id": "item-2",
+                "label_id": "label-1",
+                "label__name": "Label A",
+                "label__type": "categorical",
+                "value": "fail",
+            },
+            {
+                "queue_item_id": "item-2",
+                "label_id": "label-2",
+                "label__name": "Label B",
+                "label__type": "categorical",
+                "value": "pass",
+            },
+        ]
+
+        result = _calculate_judge_human_agreement(queue)
+
+        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
+        assert result["labels"]["label-1"]["total_comparisons"] == 2
+        assert result["labels"]["label-2"]["judge_human_agreement"] == 0.0
+        assert result["labels"]["label-2"]["total_comparisons"] == 2
+        assert result["overall_agreement"] == 0.5
+        assert result["total_comparisons"] == 4
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_uses_latest_eval_row_per_span(self, mock_score_objects, mock_eval_objects):
+        """The Subquery picks the latest EvalLogger row when a span has
+        multiple rows for the same config."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = "Safety Eval"
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": True,
+                "output_float": None,
+                "output_str": None,
+                "output_str_list": [],
+            },
+        ]
+
+        mock_score_objects.filter.return_value.values.return_value = [
+            {
+                "queue_item_id": "item-1",
+                "label_id": "label-1",
+                "label__name": "Label A",
+                "label__type": "categorical",
+                "value": "pass",
+            },
+        ]
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["labels"]["label-1"]["judge_human_agreement"] == 1.0
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_handles_no_overlapping_scores(self, mock_score_objects, mock_eval_objects):
+        """When span evals exist but no human scores overlap, return empty
+        labels and null overall agreement."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "percentage"
+        queue.custom_eval_config.name = "Score Eval"
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+
+        mock_eval_objects.filter.return_value.values.return_value = [
+            {
+                "observation_span_id": "span-1",
+                "output_bool": None,
+                "output_float": 0.95,
+                "output_str": None,
+                "output_str_list": [],
+            },
+        ]
+
+        # No human scores.
+        mock_score_objects.filter.return_value.values.return_value = []
+
+        result = _calculate_judge_human_agreement(queue)
+
+        assert result["overall_agreement"] is None
+        assert result["total_comparisons"] == 0
+        assert result["labels"] == {}
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_returns_none_when_output_type_missing(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """A linked evaluator without a normalized output type should short
+        circuit instead of returning a partial judge-vs-human payload."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = None
+        queue.custom_eval_config.name = "Missing Output Type Eval"
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+
+        result = _calculate_judge_human_agreement(queue)
+
+        assert result is None
+        mock_eval_objects.filter.assert_not_called()
+        mock_score_objects.filter.assert_not_called()
+
+    @patch("tracer.models.observation_span.EvalLogger.objects")
+    @patch("model_hub.models.score.Score.objects")
+    def test_uses_config_id_as_final_evaluator_name_fallback(
+        self, mock_score_objects, mock_eval_objects
+    ):
+        """If both config.name and template.name are empty, the config id
+        keeps the UI from rendering a blank evaluator label."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.custom_eval_config.name = ""
+        queue.custom_eval_config.eval_template.name = ""
+
+        queue.items.filter.return_value.values_list.return_value = [
+            ("item-1", "span-1"),
+        ]
+
+        mock_eval_objects.filter.return_value.values.return_value = []
+        mock_score_objects.filter.return_value.values.return_value = []
+
+        result = _calculate_judge_human_agreement(queue)
+
+        assert result["evaluator_name"] == "eval-config-1"

--- a/futureagi/model_hub/tests/test_judge_human_agreement.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement.py
@@ -30,7 +30,7 @@ from model_hub.utils.annotation_queue_helpers import (
     _normalize_eval_output,
     _normalize_human_score_value,
 )
-from tracer.models.observation_span import EvalEntryStatus
+from tracer.models.observation_span import EvalEntryStatus, EvalTargetType
 
 
 class TestNormalizeEvalOutput(unittest.TestCase):
@@ -51,24 +51,63 @@ class TestNormalizeEvalOutput(unittest.TestCase):
             _normalize_eval_output({"output_str": "toxic"}, "deterministic") == "toxic"
         )
 
-    def test_deterministic_fallbacks_to_str_list(self):
+    def test_deterministic_str_list_single_unwraps(self):
+        """The choices engine dual-writes the selected choice into
+        ``output_str_list`` and a JSON payload into ``output_str``. The list
+        wins — its single element IS the choice, directly comparable with a
+        human categorical value."""
         assert (
             _normalize_eval_output(
-                {"output_str": None, "output_str_list": ["A"]},
+                {
+                    "output_str": '{"score": 0.8, "choice": "toxic"}',
+                    "output_str_list": ["toxic"],
+                },
                 "deterministic",
             )
-            == "['A']"
+            == "toxic"
         )
 
-    def test_deterministic_str_list_is_sorted(self):
-        """str_list items are sorted before str() conversion so that
-        order differences don't cause false disagreements."""
+    def test_deterministic_str_list_multi_sorts(self):
         assert (
             _normalize_eval_output(
-                {"output_str": None, "output_str_list": ["B", "A", "C"]},
+                {"output_str_list": ["B", "A", "C"]},
                 "deterministic",
             )
             == "['A', 'B', 'C']"
+        )
+
+    def test_deterministic_json_payload_choice_extracted(self):
+        """When only the JSON payload exists (legacy dual-write shape), the
+        ``choice`` key is extracted instead of comparing the raw JSON string —
+        comparing ``'{"score": 0.8, "choice": "toxic"}'`` against a human
+        ``"toxic"`` would report 0% for every item."""
+        assert (
+            _normalize_eval_output(
+                {
+                    "output_str": '{"score": 0.8, "choice": "toxic"}',
+                    "output_str_list": [],
+                },
+                "deterministic",
+            )
+            == "toxic"
+        )
+
+    def test_deterministic_json_choices_list_extracted(self):
+        assert (
+            _normalize_eval_output(
+                {"output_str": '{"choices": ["B", "A"]}', "output_str_list": []},
+                "deterministic",
+            )
+            == "['A', 'B']"
+        )
+
+    def test_deterministic_malformed_json_passes_through(self):
+        assert (
+            _normalize_eval_output(
+                {"output_str": "{not json", "output_str_list": None},
+                "deterministic",
+            )
+            == "{not json"
         )
 
     def test_pass_fail_none_bool_returns_none(self):
@@ -103,6 +142,11 @@ class TestMajorityValue(unittest.TestCase):
     def test_strict_majority_wins(self):
         # 2 "a" vs 1 "b" → "a" has a strict majority.
         assert _majority_value(["a", "b", "a"]) == "a"
+
+    def test_casing_does_not_manufacture_tie(self):
+        """Annotators type "Pass"/"pass"/"PASS" freely — votes must pool
+        case-insensitively instead of splitting into a three-way tie."""
+        assert _majority_value(["Pass", "pass", "PASS"]) == "Pass"
 
     def test_equivalent_lists_are_not_ties(self):
         """Lists with the same items in a different order are normalised
@@ -305,6 +349,11 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         assert gate.get("skipped_reason__isnull") is True
         assert gate.get("deleted") is False
         assert gate.get("custom_eval_config_id") == "eval-config-1"
+        # Span/trace rows share both FK columns, so the *inner* selection must
+        # gate on target_type too — a missing gate lets the other target's
+        # row win the subquery and then be dropped by the outer filter,
+        # silently losing the comparison.
+        assert gate.get("target_type") == EvalTargetType.SPAN
 
         # The outer filter must wrap the inner one in a Subquery on id.
         outer = [

--- a/futureagi/model_hub/tests/test_judge_human_agreement.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement.py
@@ -210,6 +210,17 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
     def test_returns_none_when_no_evaluator_linked(self):
         queue = MagicMock()
         queue.custom_eval_config_id = None
+        queue.status = "completed"
+        assert _calculate_judge_human_agreement(queue) is None
+
+    def test_returns_none_when_queue_not_completed(self):
+        """A linked evaluator on a non-COMPLETED queue must not produce a
+        judge-vs-human stat — agreement is only meaningful once annotation is
+        finished. The test sets status to ``active`` to exercise the gate."""
+        queue = MagicMock()
+        queue.custom_eval_config_id = "eval-config-1"
+        queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
+        queue.status = "active"
         assert _calculate_judge_human_agreement(queue) is None
 
     @patch("tracer.models.observation_span.EvalLogger.objects")
@@ -218,6 +229,7 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         self, mock_score_objects, mock_eval_objects
     ):
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
         queue.custom_eval_config.name = "Safety Eval"
@@ -238,6 +250,7 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         and "" cases (both are falsy in the ``name or template.name or id``
         chain)."""
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
         queue.custom_eval_config.name = None
@@ -265,6 +278,7 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         kwargs and fails the assertion. The actual filtering/ordering is
         covered by the integration tests against a real DB."""
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
         queue.custom_eval_config.name = "Safety Eval"
@@ -308,6 +322,7 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         """Two items, two labels. Judge agrees on label-1, disagrees on
         label-2. Overall = 2/4 = 0.5."""
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "pass_fail"
         queue.custom_eval_config.name = "Safety Eval"
@@ -385,6 +400,7 @@ class TestCalculateJudgeHumanAgreement(unittest.TestCase):
         """When span evals exist but no human scores overlap, return empty
         labels and null overall agreement."""
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "percentage"
         queue.custom_eval_config.name = "Score Eval"
@@ -424,6 +440,7 @@ class TestPercentageEndToEnd(unittest.TestCase):
         self, mock_score_objects, mock_eval_objects
     ):
         queue = MagicMock()
+        queue.status = "completed"
         queue.custom_eval_config_id = "eval-config-1"
         queue.custom_eval_config.eval_template.output_type_normalized = "percentage"
         queue.custom_eval_config.name = "Score Eval"

--- a/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
@@ -5,6 +5,8 @@ They verify that the ORM queries (Subquery, joins, FK traversal) produce
 correct results end-to-end.
 """
 
+from datetime import timedelta
+
 import pytest
 from django.utils import timezone
 
@@ -778,3 +780,155 @@ class TestJudgeHumanAgreementIntegration:
         # Evaluator is linked and data overlaps, but the queue isn't completed
         # → judge-vs-human is suppressed (returns None), not a 0% stat.
         assert _calculate_judge_human_agreement(queue) is None
+
+    def test_span_item_ignores_newer_trace_level_eval(self, organization, workspace):
+        """Span- and trace-level eval rows share the same two FK columns (a
+        trace row is anchored to the trace's root span). A newer trace-level
+        row on the item's own span must NOT leak into the span comparison —
+        the inner latest-eval subquery gates on target_type too."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Newer trace-level row (anchored to this span) saying "fail".
+        newer = EvalLogger.objects.create(
+            target_type=EvalTargetType.TRACE,
+            observation_span=span,
+            trace=trace,
+            custom_eval_config=cfg,
+            output_bool=False,
+        )
+        # Older span-level row saying "pass" — the one that must win.
+        older = _make_eval_row(span, trace, cfg, output_bool=True)
+
+        EvalLogger.objects.filter(id=older.id).update(
+            created_at=timezone.now() - timedelta(hours=1)
+        )
+        EvalLogger.objects.filter(id=newer.id).update(created_at=timezone.now())
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value={"selected": ["pass"]},
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # The span-level row ("pass") agrees; the newer trace-level row
+        # ("fail") must be ignored — otherwise this would be 0.0.
+        assert result["overall_agreement"] == 1.0
+
+    def test_trace_item_ignores_newer_span_level_eval(self, organization, workspace):
+        """Mirror case: a newer span-level row on the trace's root span must
+        not win the inner subquery for a trace-sourced item — that would
+        select it and then drop it on the outer target_type filter, silently
+        losing the comparison."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        root_span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=trace,
+            organization=organization,
+        )
+        label = _make_label(organization, workspace)
+
+        # Newer span-level row on the root span saying "fail".
+        newer = _make_eval_row(root_span, trace, cfg, output_bool=False)
+        # Older trace-level row saying "pass" — the one that must win.
+        older = EvalLogger.objects.create(
+            target_type=EvalTargetType.TRACE,
+            observation_span=root_span,
+            trace=trace,
+            custom_eval_config=cfg,
+            output_bool=True,
+        )
+
+        EvalLogger.objects.filter(id=older.id).update(
+            created_at=timezone.now() - timedelta(hours=1)
+        )
+        EvalLogger.objects.filter(id=newer.id).update(created_at=timezone.now())
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value={"selected": ["pass"]},
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # The trace-level row ("pass") agrees; if the newer span-level row
+        # had won the subquery, the comparison would be silently dropped
+        # (overall None) or mismatched (0.0).
+        assert result["overall_agreement"] == 1.0
+        assert result["total_comparisons"] == 1
+
+    def test_deterministic_json_payload_compares_against_human_choice(
+        self, organization, workspace
+    ):
+        """The deterministic engine dual-writes a JSON payload
+        ({"score": …, "choice": …}) into output_str and the selected choice
+        into output_str_list. The list must win — comparing the raw JSON
+        string against a human "toxic" would report 0% for every item."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(
+            organization, workspace, output_type_normalized="deterministic"
+        )
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(
+            span,
+            trace,
+            cfg,
+            output_str='{"score": 0.8, "choice": "toxic"}',
+            output_str_list=["toxic"],
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value={"selected": ["toxic"]},
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 1.0
+
+    def test_casing_difference_does_not_manufacture_disagreement(
+        self, organization, workspace
+    ):
+        """Annotators type "Pass"; the judge emits "pass" (or vice versa).
+        Letter case must not report a false disagreement."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value={"selected": ["PASS"]},
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 1.0

--- a/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
@@ -194,7 +194,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -221,7 +221,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="fail",
+            value={"selected": ["fail"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -247,19 +247,19 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="fail",
+            value={"selected": ["fail"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -283,13 +283,13 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="fail",
+            value={"selected": ["fail"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -319,7 +319,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -357,7 +357,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -377,16 +377,20 @@ class TestJudgeHumanAgreementIntegration:
         cfg = _make_custom_eval_config(project, template)
         queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
         item = _make_queue_item(queue, span, organization)
-        label = _make_label(organization, workspace)
+        # numeric label is comparable with a percentage judge output.
+        label = _make_label(
+            organization, workspace, type=AnnotationTypeChoices.NUMERIC.value
+        )
 
         _make_eval_row(span, trace, cfg, output_float=0.876)
 
-        # Human gives the same rounded value as a string.
+        # Human stores a numeric dict {"value": 0.876}; it must unwrap and
+        # round to "0.88" to match the judge.
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="0.88",
+            value={"value": 0.876},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -413,7 +417,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="toxic",
+            value={"selected": ["toxic"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -444,7 +448,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -482,7 +486,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -515,7 +519,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         # The function does 3 queries: EvalLogger Subquery, EvalLogger values,
@@ -548,13 +552,13 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item_a,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
         Score.objects.create(
             queue_item=item_b,
             label=label,
             organization=organization,
-            value="fail",
+            value={"selected": ["fail"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -580,7 +584,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -606,21 +610,21 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
             annotator_id="a1",
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
             annotator_id="a2",
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
-            value="fail",
+            value={"selected": ["fail"]},
             annotator_id="a3",
         )
 
@@ -662,7 +666,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value="pass",
+            value={"selected": ["pass"]},
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -690,7 +694,7 @@ class TestJudgeHumanAgreementIntegration:
             queue_item=item,
             label=label,
             organization=organization,
-            value=5,
+            value={"rating": 5},
         )
 
         result = _calculate_judge_human_agreement(queue)

--- a/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
@@ -1,0 +1,704 @@
+"""Integration tests for ``_calculate_judge_human_agreement``.
+
+These tests hit a real PostgreSQL database — no mocks, no stubs.
+They verify that the ORM queries (Subquery, joins, FK traversal) produce
+correct results end-to-end.
+"""
+
+import pytest
+from django.utils import timezone
+
+from model_hub.models.ai_model import AIModel
+from model_hub.models.annotation_queues import AnnotationQueue, QueueItem
+from model_hub.models.choices import (
+    AnnotationTypeChoices,
+    QueueItemSourceType,
+)
+from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.models.score import Score
+from model_hub.utils.annotation_queue_helpers import (
+    _calculate_judge_human_agreement,
+)
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.observation_span import EvalLogger, EvalTargetType, ObservationSpan
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+
+# ---------------------------------------------------------------------------
+# helpers — create everything directly, no fixtures needed
+# ---------------------------------------------------------------------------
+
+
+def _make_project(organization, workspace, **kwargs):
+    return Project.objects.create(
+        name="integration-project",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+        **kwargs,
+    )
+
+
+def _make_trace(project, **kwargs):
+    return Trace.objects.create(
+        project=project,
+        name="integration-trace",
+        input={},
+        output={},
+        **kwargs,
+    )
+
+
+def _make_span(project, trace, **kwargs):
+    import uuid
+
+    span_id = f"span_{uuid.uuid4().hex[:16]}"
+    return ObservationSpan.objects.create(
+        id=span_id,
+        project=project,
+        trace=trace,
+        name="integration-span",
+        observation_type="llm",
+        start_time=timezone.now(),
+        end_time=timezone.now(),
+        **kwargs,
+    )
+
+
+def _make_eval_template(organization, workspace, **kwargs):
+    defaults = {
+        "name": "integration-eval-template",
+        "output_type_normalized": "pass_fail",
+        "config": {"type": "pass_fail"},
+    }
+    defaults.update(kwargs)
+    return EvalTemplate.objects.create(
+        organization=organization,
+        workspace=workspace,
+        **defaults,
+    )
+
+
+def _make_custom_eval_config(project, eval_template, **kwargs):
+    defaults = {
+        "name": "integration-eval-config",
+        "config": {},
+        "mapping": {},
+        "filters": {},
+    }
+    defaults.update(kwargs)
+    return CustomEvalConfig.objects.create(
+        project=project,
+        eval_template=eval_template,
+        **defaults,
+    )
+
+
+def _make_queue(organization, workspace, project, custom_eval_config=None, **kwargs):
+    return AnnotationQueue.objects.create(
+        name="integration-queue",
+        organization=organization,
+        workspace=workspace,
+        project=project,
+        custom_eval_config=custom_eval_config,
+        **kwargs,
+    )
+
+
+def _make_queue_item(queue, observation_span, organization, **kwargs):
+    return QueueItem.objects.create(
+        queue=queue,
+        source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+        observation_span=observation_span,
+        organization=organization,
+        **kwargs,
+    )
+
+
+def _make_label(organization, workspace, **kwargs):
+    defaults = {
+        "name": "integration-label",
+        "type": AnnotationTypeChoices.CATEGORICAL.value,
+        "settings": {},
+    }
+    defaults.update(kwargs)
+    return AnnotationsLabels.objects.create(
+        organization=organization,
+        workspace=workspace,
+        **defaults,
+    )
+
+
+def _make_eval_row(observation_span, trace, custom_eval_config, **kwargs):
+    return EvalLogger.objects.create(
+        target_type=EvalTargetType.SPAN,
+        observation_span=observation_span,
+        trace=trace,
+        custom_eval_config=custom_eval_config,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestJudgeHumanAgreementIntegration:
+    """End-to-end tests with a real database."""
+
+    def test_queue_without_evaluator_returns_none(self, organization, workspace):
+        """A queue with no linked CustomEvalConfig → None."""
+        project = _make_project(organization, workspace)
+        queue = _make_queue(organization, workspace, project)
+        assert _calculate_judge_human_agreement(queue) is None
+
+    def test_queue_with_null_output_type_returns_none(self, organization, workspace):
+        """output_type_normalized is None → early return None."""
+        project = _make_project(organization, workspace)
+        template = _make_eval_template(
+            organization, workspace, output_type_normalized=None
+        )
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        assert _calculate_judge_human_agreement(queue) is None
+
+    def test_no_span_sourced_items_returns_none(self, organization, workspace):
+        """Queue exists & evaluator linked, but no observation_span items → None."""
+        project = _make_project(organization, workspace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        assert _calculate_judge_human_agreement(queue) is None
+
+    def test_basic_agreement_single_item_single_label(self, organization, workspace):
+        """One item, one label, judge agrees → 1.0 agreement."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Judge says "pass"
+        _make_eval_row(span, trace, cfg, output_bool=True)
+
+        # Human says "pass"
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result is not None
+        assert result["overall_agreement"] == 1.0
+        assert result["total_comparisons"] == 1
+        assert result["evaluator_name"] == "integration-eval-config"
+        assert str(label.id) in result["labels"]
+        assert result["labels"][str(label.id)]["judge_human_agreement"] == 1.0
+
+    def test_judge_disagrees_with_human(self, organization, workspace):
+        """Judge says pass, human says fail → 0.0 agreement."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="fail",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 0.0
+        assert result["labels"][str(label.id)]["judge_human_agreement"] == 0.0
+
+    def test_human_majority_wins(self, organization, workspace):
+        """Two annotators agree with judge, one disagrees → 1.0 agreement."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Judge: pass
+        _make_eval_row(span, trace, cfg, output_bool=True)
+
+        # 2 annotators say "pass", 1 says "fail" — majority is "pass"
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="fail",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 1.0  # majority agrees
+
+    def test_human_tie_skips_comparison(self, organization, workspace):
+        """Two annotators tie (one pass, one fail) → item skipped,
+        overall is None."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="fail",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # Tie → no comparison possible → overall None, label agreement None
+        assert result["overall_agreement"] is None
+        assert result["total_comparisons"] == 0
+        assert result["labels"][str(label.id)]["judge_human_agreement"] is None
+        assert result["labels"][str(label.id)]["total_comparisons"] == 0
+
+    def test_skips_error_eval_rows(self, organization, workspace):
+        """EvalLogger rows with error=True are excluded from agreement."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Error row — should be ignored.
+        _make_eval_row(span, trace, cfg, output_bool=False, error=True)
+        # Clean row — should be used instead.
+        _make_eval_row(span, trace, cfg, output_bool=True, error=False)
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # If the error row were used, agreement would be 0.0 (fail vs pass).
+        assert result["overall_agreement"] == 1.0
+
+    def test_latest_eval_row_used_per_span(self, organization, workspace):
+        """When a span has multiple EvalLogger rows for the same config,
+        only the latest non-error one contributes."""
+        from datetime import timedelta
+
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Older row — says "fail"
+        older = _make_eval_row(span, trace, cfg, output_bool=False)
+        # Newer row — says "pass"
+        newer = _make_eval_row(span, trace, cfg, output_bool=True)
+
+        # Set created_at so we can control ordering.
+        EvalLogger.objects.filter(id=older.id).update(
+            created_at=timezone.now() - timedelta(hours=1),
+        )
+        EvalLogger.objects.filter(id=newer.id).update(
+            created_at=timezone.now(),
+        )
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # Latest row says "pass" → agrees with human "pass" → 1.0
+        assert result["overall_agreement"] == 1.0
+
+    def test_percentage_output_type(self, organization, workspace):
+        """Judge uses percentage output type — agreement matches."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(
+            organization,
+            workspace,
+            output_type_normalized="percentage",
+        )
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_float=0.876)
+
+        # Human gives the same rounded value as a string.
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="0.88",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 1.0
+
+    def test_deterministic_output_type(self, organization, workspace):
+        """Judge uses deterministic output type — string comparison."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(
+            organization,
+            workspace,
+            output_type_normalized="deterministic",
+        )
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_str="toxic")
+
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="toxic",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] == 1.0
+
+    def test_evaluator_name_fallback_to_template_name(self, organization, workspace):
+        """When custom_eval_config.name is None, fall back to
+        eval_template.name."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(
+            organization,
+            workspace,
+            name="Template-Name-Fallback",
+        )
+        cfg = _make_custom_eval_config(
+            project,
+            template,
+            name=None,  # config name is None
+        )
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["evaluator_name"] == "Template-Name-Fallback"
+
+    def test_config_name_none_falls_back_to_template_name(
+        self, organization, workspace
+    ):
+        """When custom_eval_config.name is None but eval_template.name is
+        truthy, the evaluator name resolves to template.name.
+
+        The ``or str(config_id)`` fallback is unreachable via integration
+        tests (EvalTemplate.name can't be blank).  That path is covered by
+        ``test_uses_config_id_as_final_evaluator_name_fallback`` in the
+        unit-test suite."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(
+            organization,
+            workspace,
+            name="Template-Name",
+        )
+        cfg = _make_custom_eval_config(
+            project,
+            template,
+            name=None,
+        )
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # config.name is None → falls back to template.name
+        assert result["evaluator_name"] == "Template-Name"
+
+    def test_select_related_avoids_extra_queries(
+        self,
+        organization,
+        workspace,
+        django_assert_max_num_queries,
+    ):
+        """The viewset uses select_related('custom_eval_config__eval_template')
+        so the function call should stay within a tight query budget."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        # Re-fetch with select_related to simulate the viewset queryset.
+        queue = AnnotationQueue.objects.select_related(
+            "custom_eval_config__eval_template"
+        ).get(id=queue.id)
+
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        # The function does 3 queries: EvalLogger Subquery, EvalLogger values,
+        # and Score values. The eager-loaded FK chain should add 0 extras.
+        with django_assert_max_num_queries(5):
+            result = _calculate_judge_human_agreement(queue)
+
+        assert result["overall_agreement"] == 1.0
+
+    def test_multiple_items_same_span(self, organization, workspace):
+        """Two queue items that reference the same span each compare
+        independently against the single judge output for that span."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+
+        # Two items share the same span.
+        item_a = _make_queue_item(queue, span, organization)
+        item_b = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Judge says "pass" (once, for the single span).
+        _make_eval_row(span, trace, cfg, output_bool=True)
+
+        # Human annotator agrees on item_a ("pass"), disagrees on item_b ("fail").
+        Score.objects.create(
+            queue_item=item_a,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+        Score.objects.create(
+            queue_item=item_b,
+            label=label,
+            organization=organization,
+            value="fail",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # 1 agree + 1 disagree = 0.5
+        assert result["overall_agreement"] == 0.5
+        assert result["total_comparisons"] == 2
+
+    def test_all_eval_rows_normalize_to_none(self, organization, workspace):
+        """Judge evals exist but every output value is None (e.g. pass_fail
+        with output_bool=None).  No overlap means overall is None."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        # Judge output_bool is None — normalize_eval_output returns None.
+        _make_eval_row(span, trace, cfg, output_bool=None)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result["overall_agreement"] is None
+        assert result["total_comparisons"] == 0
+
+    def test_three_annotators_majority_wins(self, organization, workspace):
+        """Three annotators: two "pass", one "fail" → majority is "pass",
+        which agrees with the judge."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+
+        # Three annotators.
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+            annotator_id="a1",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+            annotator_id="a2",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="fail",
+            annotator_id="a3",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        # Judge "pass", human majority "pass" → agree.
+        assert result["overall_agreement"] == 1.0
+        assert result["total_comparisons"] == 1
+
+    def test_trace_sourced_item_is_compared(self, organization, workspace):
+        """A queue item sourced from a TRACE (not a span) is still compared
+        against the judge eval anchored to that trace."""
+        from tracer.models.observation_span import EvalTargetType
+
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+
+        # Build a trace-sourced item directly (bypass the span helper).
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=trace,
+            organization=organization,
+        )
+        label = _make_label(organization, workspace)
+
+        # EvalLogger anchored to the trace (target_type='trace').
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.TRACE,
+            observation_span=None,
+            trace=trace,
+            custom_eval_config=cfg,
+            output_bool=True,
+            status="completed",
+        )
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value="pass",
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result is not None
+        assert result["overall_agreement"] == 1.0
+        assert result["total_comparisons"] == 1
+
+    def test_incompatible_label_type_is_not_comparable(self, organization, workspace):
+        """A pass_fail evaluator against a star (1-5) label is not comparable,
+        so the label reports comparable=False and no misleading 0%."""
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
+        item = _make_queue_item(queue, span, organization)
+        # star label — incompatible with pass_fail judge output
+        label = _make_label(
+            organization, workspace, type=AnnotationTypeChoices.STAR.value
+        )
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value=5,
+        )
+
+        result = _calculate_judge_human_agreement(queue)
+        assert result is not None
+        lbl = result["labels"][str(label.id)]
+        assert lbl["comparable"] is False
+        assert lbl["judge_human_agreement"] is None
+        assert lbl["total_comparisons"] == 0
+        # overall only counts comparable labels
+        assert result["overall_agreement"] is None
+        assert result["total_comparisons"] == 0

--- a/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
@@ -8,6 +8,7 @@ correct results end-to-end.
 import pytest
 from django.utils import timezone
 
+from accounts.models.user import User
 from model_hub.models.ai_model import AIModel
 from model_hub.models.annotation_queues import AnnotationQueue, QueueItem
 from model_hub.models.choices import (
@@ -94,6 +95,20 @@ def _make_custom_eval_config(project, eval_template, **kwargs):
         eval_template=eval_template,
         **defaults,
     )
+
+
+def _make_user(organization, **kwargs):
+    import uuid as _uuid
+
+    defaults = {
+        "email": f"annotator-{_uuid.uuid4().hex[:8]}@futureagi.com",
+        "password": "testpassword123",
+        "name": "Integration Annotator",
+        "organization": organization,
+        "organization_role": "member",
+    }
+    defaults.update(kwargs)
+    return User.objects.create_user(**defaults)
 
 
 def _make_queue(organization, workspace, project, custom_eval_config=None, **kwargs):
@@ -530,24 +545,32 @@ class TestJudgeHumanAgreementIntegration:
         assert result["overall_agreement"] == 1.0
 
     def test_multiple_items_same_span(self, organization, workspace):
-        """Two queue items that reference the same span each compare
-        independently against the single judge output for that span."""
+        """Two queue items, each anchored to its own span, are compared
+        independently against the judge output for that span.
+
+        NOTE: a queue forbids two items sharing one (queue, observation_span)
+        pair (``unique_queue_observation_span``), so the items use two distinct
+        spans — but the agreement math is identical: each item has exactly one
+        judge/human comparison.
+        """
         project = _make_project(organization, workspace)
         trace = _make_trace(project)
-        span = _make_span(project, trace)
+        span_a = _make_span(project, trace)
+        span_b = _make_span(project, trace)
         template = _make_eval_template(organization, workspace)
         cfg = _make_custom_eval_config(project, template)
         queue = _make_queue(organization, workspace, project, custom_eval_config=cfg)
 
-        # Two items share the same span.
-        item_a = _make_queue_item(queue, span, organization)
-        item_b = _make_queue_item(queue, span, organization)
+        # One item per span.
+        item_a = _make_queue_item(queue, span_a, organization)
+        item_b = _make_queue_item(queue, span_b, organization)
         label = _make_label(organization, workspace)
 
-        # Judge says "pass" (once, for the single span).
-        _make_eval_row(span, trace, cfg, output_bool=True)
+        # Judge: "pass" on both spans (single evaluator on the queue).
+        _make_eval_row(span_a, trace, cfg, output_bool=True)
+        _make_eval_row(span_b, trace, cfg, output_bool=True)
 
-        # Human annotator agrees on item_a ("pass"), disagrees on item_b ("fail").
+        # Human agrees on item_a ("pass"), disagrees on item_b ("fail").
         Score.objects.create(
             queue_item=item_a,
             label=label,
@@ -605,27 +628,31 @@ class TestJudgeHumanAgreementIntegration:
 
         _make_eval_row(span, trace, cfg, output_bool=True)
 
-        # Three annotators.
+        # Three distinct annotators; the per-(source,label,annotator,queue_item)
+        # uniqueness lets them coexist on the same item+label.
+        a1 = _make_user(organization, name="Annotator A")
+        a2 = _make_user(organization, name="Annotator B")
+        a3 = _make_user(organization, name="Annotator C")
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
+            annotator=a1,
             value={"selected": ["pass"]},
-            annotator_id="a1",
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
+            annotator=a2,
             value={"selected": ["pass"]},
-            annotator_id="a2",
         )
         Score.objects.create(
             queue_item=item,
             label=label,
             organization=organization,
+            annotator=a3,
             value={"selected": ["fail"]},
-            annotator_id="a3",
         )
 
         result = _calculate_judge_human_agreement(queue)
@@ -653,10 +680,13 @@ class TestJudgeHumanAgreementIntegration:
         )
         label = _make_label(organization, workspace)
 
-        # EvalLogger anchored to the trace (target_type='trace').
+        # EvalLogger anchored to the trace (target_type='trace'). A trace's
+        # eval is anchored to its root span, so both FKs must be set.  The
+        # helper builds a span on *trace*, so reuse it as the anchor.
+        span = _make_span(project, trace)
         EvalLogger.objects.create(
             target_type=EvalTargetType.TRACE,
-            observation_span=None,
+            observation_span=span,
             trace=trace,
             custom_eval_config=cfg,
             output_bool=True,

--- a/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
+++ b/futureagi/model_hub/tests/test_judge_human_agreement_integration.py
@@ -12,6 +12,7 @@ from accounts.models.user import User
 from model_hub.models.ai_model import AIModel
 from model_hub.models.annotation_queues import AnnotationQueue, QueueItem
 from model_hub.models.choices import (
+    AnnotationQueueStatusChoices,
     AnnotationTypeChoices,
     QueueItemSourceType,
 )
@@ -111,13 +112,21 @@ def _make_user(organization, **kwargs):
     return User.objects.create_user(**defaults)
 
 
-def _make_queue(organization, workspace, project, custom_eval_config=None, **kwargs):
+def _make_queue(
+    organization,
+    workspace,
+    project,
+    custom_eval_config=None,
+    status=AnnotationQueueStatusChoices.COMPLETED.value,
+    **kwargs,
+):
     return AnnotationQueue.objects.create(
         name="integration-queue",
         organization=organization,
         workspace=workspace,
         project=project,
         custom_eval_config=custom_eval_config,
+        status=status,
         **kwargs,
     )
 
@@ -736,3 +745,36 @@ class TestJudgeHumanAgreementIntegration:
         # overall only counts comparable labels
         assert result["overall_agreement"] is None
         assert result["total_comparisons"] == 0
+
+    def test_non_completed_queue_returns_none(self, organization, workspace):
+        """A queue with a linked evaluator but status != COMPLETED (e.g. an
+        active queue still being annotated) must NOT calculate judge-vs-human
+        agreement — the metric is only meaningful once annotation is finished.
+        """
+        project = _make_project(organization, workspace)
+        trace = _make_trace(project)
+        span = _make_span(project, trace)
+        template = _make_eval_template(organization, workspace)
+        cfg = _make_custom_eval_config(project, template)
+        # Default helper status is COMPLETED; override to ACTIVE.
+        queue = _make_queue(
+            organization,
+            workspace,
+            project,
+            custom_eval_config=cfg,
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+        )
+        item = _make_queue_item(queue, span, organization)
+        label = _make_label(organization, workspace)
+
+        _make_eval_row(span, trace, cfg, output_bool=True)
+        Score.objects.create(
+            queue_item=item,
+            label=label,
+            organization=organization,
+            value={"selected": ["pass"]},
+        )
+
+        # Evaluator is linked and data overlaps, but the queue isn't completed
+        # → judge-vs-human is suppressed (returns None), not a 0% stat.
+        assert _calculate_judge_human_agreement(queue) is None

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Cast
 
 from model_hub.constants import ANNOTATION_LABEL_VALUE_KEYS
 from model_hub.models.choices import (
+    AnnotationQueueStatusChoices,
     AnnotatorRole,
     AutomationRuleTriggerFrequency,
     QueueItemSourceType,
@@ -1892,9 +1893,13 @@ def _calculate_judge_human_agreement(queue):
     human annotators across the queue's trace and observation-span sourced
     items.
 
-    Returns ``None`` when no evaluator is linked or no overlapping data
-    exists so the caller can distinguish "not configured" from "0 %
-    agreement".
+    Returns ``None`` when no evaluator is linked, the queue isn't completed,
+    or no overlapping data exists so the caller can distinguish "not
+    configured" / "not ready" from "0 % agreement".
+
+    Judge-vs-human agreement is only meaningful once annotation work is
+    finished, so non-``COMPLETED`` queues (draft / active / paused) return
+    ``None`` — the human-human stats are unaffected.
 
     .. note::
 
@@ -1904,6 +1909,12 @@ def _calculate_judge_human_agreement(queue):
         extra queries per invocation.
     """
     if queue.custom_eval_config_id is None:
+        return None
+
+    # Only completed queues have stable, interpretable agreement metrics.
+    # Active/paused/draft queues are still being (re)annotated, so their
+    # numbers would churn — skip judge-vs-human until the queue is completed.
+    if queue.status != AnnotationQueueStatusChoices.COMPLETED.value:
         return None
 
     from collections import defaultdict

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
@@ -1848,12 +1849,37 @@ def _normalize_eval_output(row, output_type):
             return None
         return str(round(float(val), 2))
     else:
+        # Deterministic ("choices") evals dual-write: the engine stores the
+        # selected choice in ``output_str_list`` and a JSON payload
+        # (``{"score": …, "choice": …}``, serialized by the choices branch of
+        # ``tracer.utils.eval._dual_write_eval_value``) in ``output_str``. Read
+        # the list first — the raw JSON string is not comparable with a human
+        # choice — then fall back to parsing the JSON's ``choice`` key, then to
+        # the plain string some code paths still write.
+        str_list = row.get("output_str_list")
+        if str_list:
+            if len(str_list) == 1:
+                return str_list[0]
+            return str(sorted(str_list))
         val = row.get("output_str")
         if val is not None:
+            if isinstance(val, str) and val[:1] in ("{", "["):
+                try:
+                    parsed = json.loads(val)
+                except ValueError:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    choice = parsed.get("choice")
+                    if isinstance(choice, str):
+                        return choice
+                    choices = parsed.get("choices")
+                    if isinstance(choices, list) and choices:
+                        return (
+                            choices[0]
+                            if len(choices) == 1
+                            else str(sorted(c for c in choices if isinstance(c, str)))
+                        )
             return val
-        str_list = row.get("output_str_list")
-        if str_list is not None:
-            return str(sorted(str_list))
         return None
 
 
@@ -1863,8 +1889,10 @@ def _majority_value(values):
     than the others).
 
     Normalises each value through ``_normalize_value`` first so dicts,
-    lists and scalars all compare consistently.  Returns the *original*
-    value (not the normalised form) so the caller can pass it through
+    lists and scalars all compare consistently; strings count
+    case-insensitively so ``"Pass"``/``"pass"``/``"PASS"`` votes pool
+    instead of manufacturing a tie.  Returns the *original* value (not the
+    normalised form) so the caller can pass it through
     ``_normalize_value`` for comparison like any other annotation value.
     """
     if not values:
@@ -1875,7 +1903,13 @@ def _majority_value(values):
     if len(values) == 1:
         return values[0]
 
-    normalized = [_normalize_value(v) for v in values]
+    def _vote_key(v):
+        norm = _normalize_value(v)
+        if isinstance(norm, str):
+            return norm.casefold()
+        return norm
+
+    normalized = [_vote_key(v) for v in values]
     top_two = Counter(normalized).most_common(2)
     # If the top two values have the same count there is no true majority.
     if len(top_two) >= 2 and top_two[0][1] == top_two[1][1]:
@@ -1971,11 +2005,18 @@ def _calculate_judge_human_agreement(queue):
     # filtered to the linked config.  ``skipped`` rows carry a
     # ``skipped_reason`` and are excluded from completion metrics elsewhere
     # (see tracer's eval-viewer), so they are excluded here too.
-    def _latest_eval(source_field):
+    # ``target_type`` MUST gate the *inner* subquery too, not just the outer
+    # filter: span- and trace-level rows share the same two FK columns (a
+    # trace row is anchored to the trace's root span), so without it a newer
+    # span-level row would win the inner selection on a trace-sourced item and
+    # then be dropped by the outer target_type filter — silently losing that
+    # comparison (and vice versa for trace rows leaking into span items).
+    def _latest_eval(source_field, target_type):
         return (
             EvalLogger.objects.filter(
                 **{f"{source_field}_id": OuterRef(source_field)},
                 custom_eval_config_id=queue.custom_eval_config_id,
+                target_type=target_type,
                 error=False,
                 status=EvalEntryStatus.COMPLETED,
                 skipped_reason__isnull=True,
@@ -1989,7 +2030,7 @@ def _calculate_judge_human_agreement(queue):
     if span_ids:
         eval_rows += list(
             EvalLogger.objects.filter(
-                id=Subquery(_latest_eval("observation_span")),
+                id=Subquery(_latest_eval("observation_span", EvalTargetType.SPAN)),
                 observation_span_id__in=span_ids,
                 deleted=False,
             ).values(
@@ -2003,7 +2044,7 @@ def _calculate_judge_human_agreement(queue):
     if trace_ids:
         eval_rows += list(
             EvalLogger.objects.filter(
-                id=Subquery(_latest_eval("trace")),
+                id=Subquery(_latest_eval("trace", EvalTargetType.TRACE)),
                 trace_id__in=trace_ids,
                 target_type=EvalTargetType.TRACE,
                 deleted=False,
@@ -2093,7 +2134,14 @@ def _calculate_judge_human_agreement(queue):
                 # count it as a (dis)agreement.
                 total -= 1
                 continue
-            if _normalize_value(eval_val) == human_value:
+            judge_value = _normalize_value(eval_val)
+            # Compare case-insensitively: annotators type "Passed"/"YES"/
+            # "toxic" while the judge emits its own casing — letter case must
+            # not manufacture disagreement.
+            if isinstance(judge_value, str) and isinstance(human_value, str):
+                judge_value = judge_value.casefold()
+                human_value = human_value.casefold()
+            if judge_value == human_value:
                 agree += 1
 
         all_agree += agree

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -523,7 +523,8 @@ def _source_passes_tenant_gate(
     (:func:`resolve_source_object`) and bulk (:func:`_resolve_pg_sources_bulk`)
     resolvers so both apply the identical rule. FAIL CLOSED: a missing/mismatched org,
     or a workspace that doesn't match (allowing a null source workspace only under a
-    default workspace), denies. ``None`` org/workspace skips that check (unscoped call)."""
+    default workspace), denies. ``None`` org/workspace skips that check (unscoped call).
+    """
     if organization is not None:
         obj_org = _get_source_organization(obj)
         if obj_org is None or obj_org != organization:
@@ -925,7 +926,8 @@ class CollectorSourceCache:
         drop off-project items and render them ``deleted`` — hence per-item project.
         Items whose ``project_id`` is NULL (pre-denormalization rows) fall into one
         unscoped group: correct, just unpruned. A page spans few distinct projects, so
-        this is a handful of scoped reads, not one per item. Empty id-sets short-circuit."""
+        this is a handful of scoped reads, not one per item. Empty id-sets short-circuit.
+        """
         # project_id (str, or None for pre-denorm rows) -> per-kind soft-id sets
         by_project: dict[object, dict] = {}
         for item in items or []:
@@ -1047,7 +1049,8 @@ def resolve_source_objects_bulk(
     the N+1. The tenant is gated against that project **once** here (fail closed); a
     scoped read then only returns that project's rows, so no per-row project check is
     needed. When *project_id* is absent (or not the caller's), the CH kinds fall back to
-    the per-item resolver (bounded — a point read per id). PG kinds resolve regardless."""
+    the per-item resolver (bounded — a point read per id). PG kinds resolve regardless.
+    """
     from collections import defaultdict
 
     ids_by_type: dict[str, list[str]] = defaultdict(list)
@@ -2071,7 +2074,15 @@ def _calculate_judge_human_agreement(queue):
             if human_majority is None:
                 continue
             total += 1
-            if _normalize_value(eval_val) == _normalize_value(human_majority):
+            human_value = _normalize_human_score_value(
+                human_majority, info["type"], output_type
+            )
+            if human_value is None:
+                # A value that can't be unwrapped is not comparable; don't
+                # count it as a (dis)agreement.
+                total -= 1
+                continue
+            if _normalize_value(eval_val) == human_value:
                 agree += 1
 
         all_agree += agree
@@ -2138,6 +2149,70 @@ def _normalize_value(v):
     if isinstance(v, list):
         return str(sorted(v))
     return str(v)
+
+
+def _normalize_human_score_value(raw_value, label_type, output_type):
+    """Normalize a stored ``Score.value`` into the same comparable string space
+    as a judge output from ``_normalize_eval_output``.
+
+    ``Score.value`` is not guaranteed to be well-formed: production writes it as
+    a per-type dict (``{"selected": [...]}`` / ``{"value": 5.0}`` /
+    ``{"rating": 3.0}``), but legacy rows and some clients store a bare scalar,
+    and stale data may be ``None`` / empty. Any malformed input must degrade to
+    "not comparable" rather than crash the whole queue agreement calc or, worse,
+    falsely agree.
+
+    Returns a normalized string, or ``None`` when the value cannot be compared.
+
+    The unwrap step reuses :data:`ANNOTATION_LABEL_VALUE_KEYS` — the same mapping
+    the rest of the codebase uses — so this stays in lockstep with how scores are
+    read elsewhere (e.g. ``canonical_score_value``).
+    """
+    try:
+        # Nothing to compare against.
+        if raw_value is None:
+            return None
+
+        # Unwrap the per-type dict into its scalar payload.
+        if isinstance(raw_value, dict):
+            key = ANNOTATION_LABEL_VALUE_KEYS.get(label_type)
+            if not key:
+                return None
+            scalar = raw_value.get(key)
+        else:
+            # Non-dict rows (legacy / bare scalar) pass through unchanged.
+            scalar = raw_value
+
+        if scalar is None:
+            return None
+
+        # Categorical ``selected`` is a list; an empty list means no choice
+        # was made (not comparable), a single choice collapses to its element,
+        # otherwise keep the sorted-list form for stable comparison.
+        if isinstance(scalar, list):
+            if len(scalar) == 0:
+                return None
+            if len(scalar) == 1:
+                scalar = scalar[0]
+            else:
+                return str(sorted(scalar))
+
+        # Align with the judge side: a percentage output rounds to 2 decimals,
+        # so the human value must be rounded identically before comparison.
+        if output_type == "percentage":
+            try:
+                scalar = round(float(scalar), 2)
+            except (TypeError, ValueError):
+                return None
+
+        return _normalize_value(scalar)
+    except Exception:  # noqa: BLE001 — one bad score must not break the queue
+        logger.warning(
+            "human_score_normalize_failed",
+            label_type=label_type,
+            output_type=output_type,
+        )
+        return None
 
 
 def _cohens_kappa(item_label_map, label_id):

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -1928,8 +1928,12 @@ def _calculate_judge_human_agreement(queue):
     items.
 
     Returns ``None`` when no evaluator is linked, the queue isn't completed,
-    or no overlapping data exists so the caller can distinguish "not
-    configured" / "not ready" from "0 % agreement".
+    the eval template has no normalized output type, or the queue holds no
+    trace/observation-span sourced items — so the caller can distinguish
+    "not configured" / "not ready" from "0 % agreement".  Otherwise a dict
+    is returned, possibly with ``overall_agreement: None`` and
+    ``total_comparisons: 0`` when items exist but no human scores overlap
+    with the linked evaluator's latest completed eval rows.
 
     Judge-vs-human agreement is only meaningful once annotation work is
     finished, so non-``COMPLETED`` queues (draft / active / paused) return

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -2117,19 +2117,23 @@ def _comparable_label_types(output_type):
     values can be meaningfully compared against a judge output of the given
     ``output_type_normalized``.
 
-    Without this mapping, e.g. a ``pass_fail`` judge against a Star (1–5) or
-    Numeric label would never match and silently report 0% agreement.  We
-    restrict comparisons to label types that share the judge's value space:
+    Without this mapping, e.g. a ``pass_fail`` judge against a Numeric label
+    would never match and silently report 0% agreement.  We restrict
+    comparisons to label types that share the judge's value space:
       * ``pass_fail``  → categorical labels whose values are pass/fail-ish
-      * ``percentage`` → numeric / star labels (compared as rounded floats)
+      * ``percentage`` → numeric labels (judge's 0–1 fraction vs the label's
+        0–1 value; Star (1–5) has no compatible space and is excluded)
       * ``deterministic`` → categorical labels (free-form string equality)
     """
     if output_type == "pass_fail":
         # Only categorical labels carry pass/fail-style string values.
         return {"categorical"}
     if output_type == "percentage":
-        # Numeric and star labels store numeric values comparable as floats.
-        return {"numeric", "star"}
+        # Only numeric labels store a 0–1 fraction matching the judge's
+        # output_float (stored 0–1, NOT 0–100). A Star (1–5) label has no
+        # compatible value space — comparing "5.0" against the judge's "0.88"
+        # would silently report 0% agreement, so it is excluded here.
+        return {"numeric"}
     # deterministic → string equality; only categorical labels are strings.
     return {"categorical"}
 

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -4,7 +4,7 @@ from typing import Any, TypedDict
 import structlog
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError
-from django.db.models import DateTimeField, F, FloatField, Q
+from django.db.models import DateTimeField, F, FloatField, OuterRef, Q, Subquery
 from django.db.models.functions import Cast
 
 from model_hub.constants import ANNOTATION_LABEL_VALUE_KEYS
@@ -12,9 +12,11 @@ from model_hub.models.choices import (
     AnnotatorRole,
     AutomationRuleTriggerFrequency,
     QueueItemSourceType,
+    ScoreSource,
 )
 from simulate.serializers import CallTranscriptSerializer
 from simulate.utils.stored_transcript_roles import get_displayable_transcript_roles
+from tracer.models.observation_span import EvalEntryStatus, EvalTargetType
 
 logger = structlog.get_logger(__name__)
 
@@ -1818,7 +1820,307 @@ def calculate_agreement(queue):
         "overall_agreement": round(overall, 3) if overall is not None else None,
         "labels": label_results,
         "annotator_pairs": annotator_pairs,
+        "judge_vs_human": _calculate_judge_human_agreement(queue),
     }
+
+
+def _normalize_eval_output(row, output_type):
+    """Extract and normalise an EvalLogger row value into a human-readable string
+    so it can be compared against annotation scores.
+
+    ``output_type`` is the ``output_type_normalized`` value from the evaluator's
+    template (``pass_fail``, ``percentage``, or ``deterministic``).
+    """
+    if not output_type:
+        return None
+    if output_type == "pass_fail":
+        val = row.get("output_bool")
+        if val is None:
+            return None
+        return "pass" if val else "fail"
+    elif output_type == "percentage":
+        val = row.get("output_float")
+        if val is None:
+            return None
+        return str(round(float(val), 2))
+    else:
+        val = row.get("output_str")
+        if val is not None:
+            return val
+        str_list = row.get("output_str_list")
+        if str_list is not None:
+            return str(sorted(str_list))
+        return None
+
+
+def _majority_value(values):
+    """Return the strict-majority value from a list of annotation values,
+    or ``None`` when there is a tie (no annotator value appears more often
+    than the others).
+
+    Normalises each value through ``_normalize_value`` first so dicts,
+    lists and scalars all compare consistently.  Returns the *original*
+    value (not the normalised form) so the caller can pass it through
+    ``_normalize_value`` for comparison like any other annotation value.
+    """
+    if not values:
+        return None
+    from collections import Counter
+
+    # One annotator → no tie possible.
+    if len(values) == 1:
+        return values[0]
+
+    normalized = [_normalize_value(v) for v in values]
+    top_two = Counter(normalized).most_common(2)
+    # If the top two values have the same count there is no true majority.
+    if len(top_two) >= 2 and top_two[0][1] == top_two[1][1]:
+        return None
+    # Map the winning normalised value back to its first original.
+    winner = top_two[0][0]
+    for orig_val, norm_val in zip(values, normalized, strict=True):
+        if norm_val == winner:
+            return orig_val
+    return values[0]
+
+
+def _calculate_judge_human_agreement(queue):
+    """Calculate agreement between the evaluator linked to *queue* and the
+    human annotators across the queue's trace and observation-span sourced
+    items.
+
+    Returns ``None`` when no evaluator is linked or no overlapping data
+    exists so the caller can distinguish "not configured" from "0 %
+    agreement".
+
+    .. note::
+
+        The caller **must** ensure *queue* was fetched with
+        ``select_related("custom_eval_config__eval_template")`` — otherwise
+        accessing ``queue.custom_eval_config.eval_template`` triggers two
+        extra queries per invocation.
+    """
+    if queue.custom_eval_config_id is None:
+        return None
+
+    from collections import defaultdict
+
+    from model_hub.models.score import Score
+    from tracer.models.observation_span import EvalLogger
+
+    output_type = queue.custom_eval_config.eval_template.output_type_normalized
+    # EvalTemplate.output_type_normalized is nullable; when absent the
+    # normalisation logic has no defined path, so bail early.
+    if output_type is None:
+        return None
+
+    # Compatible annotation label types for this evaluator's output type.
+    # Judge-vs-human comparison is only meaningful when the human label can
+    # produce a value in the same namespace as the judge output; otherwise
+    # the comparison would silently report 0% on every item.
+    comparable_types = _comparable_label_types(output_type)
+
+    # Observation-span-sourced items join EvalLogger directly on the span FK.
+    # Trace-sourced items join on the trace FK (the eval's target_type is
+    # "trace", anchored to the trace's root span).  Dataset-, prototype-run,
+    # call-execution- and trace-session-sourced items have no equivalent eval
+    # path today, so they are excluded.
+    span_rows = list(
+        queue.items.filter(
+            deleted=False,
+            source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+            observation_span_id__isnull=False,
+        ).values_list("id", "observation_span_id")
+    )
+    trace_rows = list(
+        queue.items.filter(
+            deleted=False,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace_id__isnull=False,
+        ).values_list("id", "trace_id")
+    )
+
+    if not span_rows and not trace_rows:
+        return None
+
+    # Build the join keys (span ids + trace ids) and the item→source map for
+    # both source types in a single pass each.
+    span_ids = [str(sid) for _id, sid in span_rows]
+    trace_ids = [str(tid) for _id, tid in trace_rows]
+    item_source_map: dict[str, tuple[str, str]] = {}  # item_id -> (kind, source_id)
+    for item_id, obs_span_id in span_rows:
+        item_source_map[str(item_id)] = ("span", str(obs_span_id))
+    for item_id, trace_id in trace_rows:
+        item_source_map[str(item_id)] = ("trace", str(trace_id))
+
+    # One latest completed, non-error, non-skipped eval row per source,
+    # filtered to the linked config.  ``skipped`` rows carry a
+    # ``skipped_reason`` and are excluded from completion metrics elsewhere
+    # (see tracer's eval-viewer), so they are excluded here too.
+    def _latest_eval(source_field):
+        return (
+            EvalLogger.objects.filter(
+                **{f"{source_field}_id": OuterRef(source_field)},
+                custom_eval_config_id=queue.custom_eval_config_id,
+                error=False,
+                status=EvalEntryStatus.COMPLETED,
+                skipped_reason__isnull=True,
+                deleted=False,
+            )
+            .order_by("-created_at")
+            .values("id")[:1]
+        )
+
+    eval_rows = []
+    if span_ids:
+        eval_rows += list(
+            EvalLogger.objects.filter(
+                id=Subquery(_latest_eval("observation_span")),
+                observation_span_id__in=span_ids,
+                deleted=False,
+            ).values(
+                "observation_span_id",
+                "output_bool",
+                "output_float",
+                "output_str",
+                "output_str_list",
+            )
+        )
+    if trace_ids:
+        eval_rows += list(
+            EvalLogger.objects.filter(
+                id=Subquery(_latest_eval("trace")),
+                trace_id__in=trace_ids,
+                target_type=EvalTargetType.TRACE,
+                deleted=False,
+            ).values(
+                "trace_id",
+                "output_bool",
+                "output_float",
+                "output_str",
+                "output_str_list",
+            )
+        )
+
+    eval_map = {}
+    for row in eval_rows:
+        # Each row came from either the span query or the trace query.
+        sid = row.get("observation_span_id") or row.get("trace_id")
+        if sid is None:
+            continue
+        eval_map[str(sid)] = _normalize_eval_output(row, output_type)
+
+    # Human scores for those items (any annotator, per-label majority).
+    human_scores = Score.objects.filter(
+        queue_item_id__in=list(item_source_map.keys()),
+        deleted=False,
+        score_source=ScoreSource.HUMAN.value,
+    ).values(
+        "queue_item_id",
+        "label_id",
+        "label__name",
+        "label__type",
+        "value",
+    )
+
+    item_label_human = defaultdict(list)
+    label_info = {}
+    for s in human_scores:
+        key = (s["queue_item_id"], s["label_id"])
+        item_label_human[key].append(s["value"])
+        if s["label_id"] not in label_info:
+            label_info[s["label_id"]] = {
+                "name": s["label__name"],
+                "type": s["label__type"],
+            }
+
+    # Per-label judge-vs-human agreement.  Accumulate agree / total here
+    # so the overall summary is derived from the same loop, not recomputed
+    # from rounded percentages.  Labels whose type is incompatible with the
+    # evaluator's output type are reported as not comparable rather than a
+    # misleading 0%.
+    label_results = {}
+    all_agree = 0
+    all_total = 0
+    for label_id, info in label_info.items():
+        # Incompatible label type → cannot compare judge vs human.
+        if info["type"] not in comparable_types:
+            label_results[str(label_id)] = {
+                "label_name": info["name"],
+                "label_type": info["type"],
+                "judge_human_agreement": None,
+                "total_comparisons": 0,
+                "comparable": False,
+            }
+            continue
+
+        agree = 0
+        total = 0
+        for (qi_id, lid), human_vals in item_label_human.items():
+            if lid != label_id:
+                continue
+            source = item_source_map.get(str(qi_id))
+            if source is None:
+                continue
+            eval_val = eval_map.get(source[1])
+            if eval_val is None:
+                continue
+            human_majority = _majority_value(human_vals)
+            # Skip when annotators are tied — without a clear human
+            # position there is nothing for the judge to be compared with.
+            if human_majority is None:
+                continue
+            total += 1
+            if _normalize_value(eval_val) == _normalize_value(human_majority):
+                agree += 1
+
+        all_agree += agree
+        all_total += total
+
+        label_results[str(label_id)] = {
+            "label_name": info["name"],
+            "label_type": info["type"],
+            "judge_human_agreement": (round(agree / total, 3) if total > 0 else None),
+            "total_comparisons": total,
+            "comparable": True,
+        }
+
+    overall = all_agree / all_total if all_total > 0 else None
+
+    evaluator_name = (
+        queue.custom_eval_config.name
+        or getattr(queue.custom_eval_config.eval_template, "name", "")
+        or str(queue.custom_eval_config_id)
+    )
+
+    return {
+        "evaluator_name": evaluator_name,
+        "overall_agreement": (round(overall, 3) if overall is not None else None),
+        "total_comparisons": int(all_total),
+        "labels": label_results,
+    }
+
+
+def _comparable_label_types(output_type):
+    """Return the set of ``AnnotationTypeChoices`` values whose human label
+    values can be meaningfully compared against a judge output of the given
+    ``output_type_normalized``.
+
+    Without this mapping, e.g. a ``pass_fail`` judge against a Star (1–5) or
+    Numeric label would never match and silently report 0% agreement.  We
+    restrict comparisons to label types that share the judge's value space:
+      * ``pass_fail``  → categorical labels whose values are pass/fail-ish
+      * ``percentage`` → numeric / star labels (compared as rounded floats)
+      * ``deterministic`` → categorical labels (free-form string equality)
+    """
+    if output_type == "pass_fail":
+        # Only categorical labels carry pass/fail-style string values.
+        return {"categorical"}
+    if output_type == "percentage":
+        # Numeric and star labels store numeric values comparable as floats.
+        return {"numeric", "star"}
+    # deterministic → string equality; only categorical labels are strings.
+    return {"categorical"}
 
 
 def _normalize_value(v):

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -7,7 +7,6 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 
 import structlog
-from accounts.models.user import User
 from django.conf import settings
 from django.db import transaction
 from django.db.models import (
@@ -23,6 +22,12 @@ from django.db.models import (
 from django.db.models.functions import Coalesce, Lower, TruncDate
 from django.utils import timezone
 from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from accounts.models.user import User
 from model_hub.models.annotation_queues import (
     FULL_ACCESS_QUEUE_ROLES,
     SOURCE_TYPE_FK_MAP,
@@ -136,10 +141,6 @@ from model_hub.utils.annotation_queue_helpers import (
     resolve_source_objects_bulk,
 )
 from model_hub.utils.utils import send_message_to_channel
-from rest_framework import serializers, status, viewsets
-from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 from simulate.models.test_execution import CallTranscript
 from simulate.utils.stored_transcript_roles import get_displayable_transcript_roles
 from tfc.utils.api_contracts import validated_request
@@ -2660,6 +2661,7 @@ def _restore_archived_default_queue(queue):
     (hourly/daily/etc) so the user sees a smooth ramp-back-up.
     """
     from django.utils import timezone as tz
+
     from model_hub.models.annotation_queues import AutomationRule
 
     queue.deleted = False
@@ -2961,7 +2963,10 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             queryset = super().get_queryset()
 
         queryset = queryset.select_related(
-            "created_by", "organization", "workspace"
+            "created_by",
+            "organization",
+            "workspace",
+            "custom_eval_config__eval_template",
         ).prefetch_related(
             Prefetch(
                 "queue_labels",
@@ -7836,6 +7841,7 @@ class AutomationRuleViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelView
         # row and ``QueueItem`` unique constraints make the bulk_create
         # idempotent.
         from temporalio.exceptions import WorkflowAlreadyStartedError
+
         from tfc.temporal.drop_in.runner import start_activity_sync
 
         task_id = f"automation-rule-eval-{rule.pk}"

--- a/futureagi/model_hub/views/utils/utils.py
+++ b/futureagi/model_hub/views/utils/utils.py
@@ -1,9 +1,10 @@
 import re
-from typing import Literal, Union
+from typing import Literal
 
 import structlog
 
 from model_hub.utils.eval_mapping import non_path_mapping_keys
+from model_hub.views.utils.constants import PLACEHOLDER_PATTERN
 from tfc.ee_stub import _ee_stub
 from tfc.utils.ssrf_guard import is_valid_url, safe_fetch
 
@@ -15,7 +16,6 @@ except ImportError:
     EvalRecommender = _ee_stub("EvalRecommender")
 
 logger = structlog.get_logger(__name__)
-from model_hub.views.utils.constants import PLACEHOLDER_PATTERN
 
 # Pattern to match UUID placeholders with optional .property suffix
 # Matches: {{uuid}}, {{uuid.property}}, {{uuid.nested.property}}
@@ -222,7 +222,7 @@ def _url_has_valid_extension(url: str, valid_extensions: tuple) -> bool:
 
 
 def validate_file_url(
-    url: str, file_type: Union[Literal["image"], Literal["document"], Literal["audio"]]
+    url: str, file_type: Literal["image"] | Literal["document"] | Literal["audio"]
 ) -> None:
     """Validate a user-supplied file URL is reachable and of the expected type.
 
@@ -256,7 +256,9 @@ def validate_file_url(
             )
         return
 
-    content_type = response.headers.get("Content-Type", "").lower().split(";")[0].strip()
+    content_type = (
+        response.headers.get("Content-Type", "").lower().split(";")[0].strip()
+    )
     if content_type in config["rejected_content_types"]:
         raise ValueError(
             f"URL content-type '{content_type}' is not an allowed {file_type} type."
@@ -351,6 +353,12 @@ def fetch_required_keys_for_eval_template(eval_templates):
 
 
 def fetch_specific_mapping_for_specific_eval_template(mapping, eval_template):
+    # A cleared/omitted mapping arrives as None from some call paths; the
+    # required-keys loop below would otherwise do ``key not in None`` and
+    # raise TypeError. Return empty rather than crash — mirrors the None
+    # early-return in ``CustomEvalConfigSerializer.validate_mapping``.
+    if mapping is None:
+        return {}
     bad = non_path_mapping_keys(mapping)
     if bad:
         # ValueError, not DRFValidationError: the apply-eval-group view maps


### PR DESCRIPTION
## What this PR does

E2E: covered-by ANN-E2E-001

Closes #1667. Annotation queues today only show **human-vs-human** agreement (inter-annotator). This adds a **Judge vs Human Agreement** section to the same Agreement tab: you link a `CustomEvalConfig` (evaluator) to a queue, and the system compares that evaluator's output against the human labels collected on the same items — per label and overall.

The goal is judge trustworthiness: a team using an evaluator to pre-score or sanity-check annotation work can finally see how often the judge and the humans actually agree, instead of guessing.

## How it fits together

**Linking** — `AnnotationQueue` gains a nullable `custom_eval_config` FK to `CustomEvalConfig` (SET_NULL on delete). I reused the existing evaluator infrastructure rather than inventing a new concept. The field is exposed in the queue serializer and surfaces as a dropdown in both the Create drawer and the Settings tab, populated from `useCustomEvalConfigList`.

**Calculation** — a new `_calculate_judge_human_agreement()` mirrors the shape of the existing `calculate_agreement()` (overall + per-label + comparison count) and is wired into the same agreement API response under a `judge_vs_human` key:

1. For each queue item, fetch the latest **completed, non-error, non-skipped** `EvalLogger` row for the linked evaluator (gated on `target_type` in the inner subquery too — see below).
2. Normalize the eval output to a comparable string based on `output_type_normalized` (pass_fail → "pass"/"fail", percentage → rounded float, deterministic → the selected choice, reading `output_str_list` first and parsing the dual-written JSON payload as fallback).
3. For each label, take the **human majority** (strict majority with casefolded votes; ties are skipped — we don't guess).
4. Compare judge output against human majority case-insensitively, per label and overall.

**Status gate** — judge-vs-human only computes for **COMPLETED** queues (draft/active/paused return `null`): the metric is only meaningful once annotation work is finished, and the UI shows "mark the queue as completed" until then. Human-human agreement remains computed for all queues. Both the backend (`queue.status != COMPLETED → None`) and the frontend empty-state reflect this, and the agreement query is invalidated on queue update **and** status change so the tab never shows a stale empty-state after completing a queue.

**Source coverage** — the comparison joins `EvalLogger` against both **observation-span** items (via `observation_span_id`) and **trace** items (via `trace_id`, `target_type='trace'`). Those are the two source types that have a real eval path today. Dataset / prototype / call-execution / trace-session items have no equivalent eval join, so they're excluded (and that limitation is called out below rather than silently producing wrong numbers).

**Type compatibility** — judge and human label values live in different namespaces, so there is an explicit mapping of which label types can be compared against a given eval output type:
- `pass_fail` ↔ categorical
- `percentage` ↔ numeric (a `star` 1–5 label has no compatible value space with the judge's 0–1 score, so it is explicitly excluded — see `_comparable_label_types`)
- `deterministic` ↔ categorical

If a label's type isn't comparable (e.g. a `pass_fail` judge against a Star label), that label reports `comparable: false` and shows **N/A** in the UI instead of a misleading `0%`.

**Value-space caveat (documented contract, not enforced):** the percentage path assumes human numeric labels are stored on a 0–1 scale matching the judge's `output_float` (this matches how the API documents numeric scores); a human label stored as 0–100 will simply never match. Similarly, categorical/deterministic comparisons match on string equality after casefolding — annotators should use option values from the same vocabulary as the judge's choices. The Star exclusion and the `comparable: false` UI are the enforced part of this contract; a full vocabulary pre-check when linking an evaluator is a natural follow-up.

**Edge cases** — `output_type_normalized` null → no result; evaluator name empty → falls back config.name → template.name → config id; error / soft-deleted / skipped eval rows excluded; multiple eval rows per source → only the latest counts; human tie → item skipped; no evaluator linked → `judge_vs_human` is `null` and the frontend shows a "link an evaluator" prompt. Existing human-vs-human agreement is untouched — this is purely additive.

## Review notes / decisions

- **Cross-project guard**: a queue can only link an evaluator from its own project (org-scoped check + same-project check). On create, `project_id` is resolved in `validate()` with an **org-scoped** lookup that 400s on unknown or foreign-org ids, and the validated `Project` is stashed so `validate_custom_eval_config` and `create()` use the same instance — this both makes the same-project guard effective on create and closes the tenancy hole of resolving the project with a bare `Project.objects.filter(id=...)` (which would have let an authenticated user anchor a queue onto another tenant's project). As defence-in-depth, `AnnotationQueueSerializer.get_fields()` further narrows the `custom_eval_config` `PrimaryKeyRelatedField` queryset to the caller's organization, and the `objects.all()` default is retained for non-request contexts like OpenAPI schema generation.
- **EvalLogger filters**: rows are filtered on `error=False`, `status=COMPLETED`, `skipped_reason IS NULL`, `deleted=False`, matching how the trace viewer already excludes skipped rows. The `target_type` gate is applied **inside** the latest-row subquery as well, not only on the outer filter: span- and trace-level rows share both FK columns (a trace row is anchored to the trace's root span), so without the inner gate a newer row of the other target type would win the subquery and then be dropped by the outer filter — silently losing that comparison (integration-tested in both directions).
- **Case sensitivity**: judge and human values are compared casefolded (`Pass`/`pass`/`PASS` agree); `_majority_value` pools votes casefolded so mixed-casing annotator input doesn't manufacture a tie. This applies only to the new judge-vs-human path — human-human agreement is unchanged.
- **Migration numbering**: the new migration is `0130_*`. At the time of writing upstream `dev`'s `model_hub` chain ends at `0122`, so any of 0123–0130 is free; the number itself doesn't prevent two concurrent PRs from each introducing a migration head (that's resolved by a merge migration either way) — it only avoids a duplicate-file collision. Expect a possible merge-migration renumber at merge time.
- **Evaluator dropdown scope**: the dropdown lists evaluators filtered by `project_id` when the drawer has one (project-scoped entry points: the add-to-queue dialog). The global queues index page has no project context (and globally-created queues are org-scoped with no project), so from there the dropdown lists the org's evaluators and the same-project check is a no-op — the org-scope guard still applies. Wiring project context into that page is a potential follow-up if product wants project-scoped creation from the index.
- **API hook convergence (follow-up)**: `useCustomEvalConfigList` is the fifth consumer of `list_custom_eval_configs` (there's a legacy `getEvalTaskConfig` wrapper in `utils/axios.js` used by the eval-task drawers, under a different query key). Consolidating onto one api-layer hook is worthwhile but touches four other screens, so it's left as a follow-up to keep this PR scoped.

## Test coverage

- Backend unit tests (mock-based, no DB): normalize output (incl. deterministic JSON payload extraction and `output_str_list` priority), majority voting (incl. case-pooling), full agreement calc, plus the type-compatibility and trace-source paths, and the inner-subquery gate signature (target_type asserted).
- Backend integration tests (real Postgres + ClickHouse): no evaluator / null output type / no span items / basic agreement / judge disagrees / majority wins / tie skips / error rows excluded / latest row per span / percentage + deterministic output types (incl. the dual-written JSON payload) / evaluator-name fallback / multiple items sharing a span / **trace-sourced item comparison** / **incompatible label type reported as not comparable** / **span item ignores a newer trace-level eval** / **trace item ignores a newer span-level eval** / **casing difference does not manufacture disagreement**.
- **Supplemental integration tests** (added during code review): **mixed compatible/incompatible labels** / **skipped eval rows excluded** / **deleted eval rows excluded** / **LLM scores excluded from human majority** / **malformed Score.value edge cases** (empty dict, None, empty selection list).
- Backend API tests (Postgres): cross-project evaluator rejected on create; **cross-org `project_id` rejected with 400**; **unknown `project_id` rejected with 400**; **valid same-org `project_id` creates the queue with that project**; cross-org evaluator rejected at the field layer.
- Frontend: empty-state prompt, completed-gate prompt, overall + per-label rendering, N/A for incompatible labels.

> Note: the integration and API tests require a Postgres backend (Docker; `docker-compose.test.yml` also wires the ClickHouse sidecar the migration chain needs); the mock unit tests and frontend tests run without it.

## Files

**Backend**
- `model_hub/models/annotation_queues.py` — `custom_eval_config` FK on `AnnotationQueue`
- `model_hub/migrations/0130_add_queue_custom_eval_config.py` — new column
- `model_hub/serializers/annotation_queues.py` — `custom_eval_config` field + org-scoped `project_id` resolution in `validate()` + cross-project evaluator validation (incl. `get_fields()` org-scoping the queryset) + `comparable` on the per-label serializer
- `model_hub/utils/annotation_queue_helpers.py` — `_normalize_eval_output`, `_majority_value`, `_comparable_label_types`, `_normalize_human_score_value`, `_calculate_judge_human_agreement`; result wired into `calculate_agreement()`
- `model_hub/views/annotation_queues.py` — `select_related("custom_eval_config__eval_template")` so the calc doesn't trigger extra queries
- `model_hub/tests/test_judge_human_agreement.py`, `test_judge_human_agreement_integration.py`, `test_judge_human_agreement_supplemental.py`, `test_annotation_queues_api.py`

**Frontend**
- `sections/annotations/queues/view/queue-agreement-tab.jsx` (+ test) — Judge vs Human section, N/A for incompatible labels
- `sections/annotations/queues/create-queue-drawer.jsx`, `view/queue-settings-tab.jsx`, `components/add-to-queue-dialog.jsx` — evaluator dropdown, project_id sent on create
- `api/annotation-queues/annotation-queues.js` — `useCustomEvalConfigList` hook + agreement-query cache invalidation on queue update **and status change**

https://github.com/user-attachments/assets/8da1f7f8-2bfc-4608-958b-e0c4dc6b1f1d
