### PR TITLE
perf(fi-collector): route voice raw_log to attributes_extra overflow

### DIFF
--- a/fi-collector/pkg/adapter/adapter.go
+++ b/fi-collector/pkg/adapter/adapter.go
@@ -37,6 +37,7 @@ var overflowKeyPrefixes = []string{
 	"output.value",
 	"retrieval.documents",
 	"embedding.embeddings",
+	"raw_log",
 }
 
 // Float64-safe integer range. Larger ints get demoted to overflow rather

--- a/fi-collector/pkg/adapter/adapter_test.go
+++ b/fi-collector/pkg/adapter/adapter_test.go
@@ -29,6 +29,7 @@ func buildAttrs() pcommon.Map {
 	m.PutEmptyMap("nested").PutStr("k", "v")
 	m.PutStr("llm.prompt.0.role", "user")      // overflow prefix
 	m.PutStr("input.value", "Hi")              // overflow prefix
+	m.PutStr("raw_log", `{"id":"call_1"}`)     // overflow prefix (voice blob, string-typed)
 	return m
 }
 
@@ -81,6 +82,12 @@ func TestSplit(t *testing.T) {
 	}
 	if _, ok := of["input.value"]; !ok {
 		t.Errorf("input.value must overflow (caller reads from overflow to fill `input`)")
+	}
+	if _, ok := of["raw_log"]; !ok {
+		t.Errorf("raw_log must overflow (heavy voice blob kept off hot attrs_string reads)")
+	}
+	if _, ok := str["raw_log"]; ok {
+		t.Errorf("raw_log must NOT land in attrs_string")
 	}
 }
 


### PR DESCRIPTION
## Summary

Route the voice-call `raw_log` provider payload into the collector's `attributes_extra` JSON overflow instead of the `attrs_string` typed map. `raw_log` is a large per-call blob that only the detail/replay path needs; keeping it in `attrs_string` bloats every hot voice list/filter read that scans the string map. This moves it out so those reads stay lean.

## Linked issues

Fixed TH-7105
Linear: https://linear.app/future-agi/issue/TH-7105/route-voice-raw-log-to-attributes-extra-so-attrs-string-stays-lean

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [x] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Collector attribute routing (`fi-collector/pkg/adapter/adapter.go`)**

- Added `"raw_log"` to `overflowKeyPrefixes`, so `Split()` forces the key into the `attributes_extra` overflow even though it arrives string-typed (the backend `json.dumps`es the payload before OTLP export).
- Shape is unchanged for readers: stored as a single string leaf `{"raw_log": "<json>"}` — deliberately not expanded into nested JSON paths, to avoid CH25 typed-JSON path-cardinality growth.

**B. No read-side changes required**

- Voice detail/replay readers already merge `attributes_extra` + `attrs_string`, so `raw_log` resolves from either column. Existing rows (raw_log still in `attrs_string`) and new rows (raw_log in `attributes_extra`) both work — no dual-read code or historical backfill needed.

---

## 2) Why the changes were done

- **Product/UX:** faster voice call list / filters — the multi-MB raw payload no longer rides along on reads of the hot string map.
- **Technical:** routing was already type-based with a key-prefix allowlist (`llm.prompt`, `input.value`, …); `raw_log` is the same class of large, variable payload, so it belongs in the same overflow tier.
- **Architecture:** keeps `attrs_string` bounded to small display/filter fields; heavy blobs live in the overflow column that lean reads already skip.

---

## 3) Tests written + scenarios each covers

**`fi-collector/pkg/adapter/adapter_test.go`** — attribute split routing

- `TestSplit` — extended: asserts a string-typed `raw_log` lands in the overflow map and NOT in `attrs_string`.

---

## 4) How to run / test

```bash
cd fi-collector && go test ./...
```

Full `fi-collector` suite passes locally. Verified live: after rebuilding the collector, re-ingested voice spans have `raw_log` in `attributes_extra` and 0 in `attrs_string`.

### Notes

- Python mirror `_OVERFLOW_KEY_PREFIXES` (`tracer/services/clickhouse/v2/adapter.py`) is the deprecated backfill path and is intentionally left unchanged.
