### PR TITLE
fix(develop): preserve synthetic description highlight layer

### DIFF
--- a/frontend/src/sections/develop/AddRowDrawer/CreateDescriptions.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/CreateDescriptions.jsx
@@ -1,4 +1,4 @@
-import { Box, Typography, useTheme } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 import { useWatch } from "react-hook-form";
@@ -7,7 +7,6 @@ import CustomTooltip from "src/components/tooltip";
 import RequestBody from "src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody";
 
 const CreateDescriptions = ({ fields, control }) => {
-  const theme = useTheme();
   const columns = useWatch({
     name: "columns",
     control,
@@ -128,7 +127,6 @@ const CreateDescriptions = ({ fields, control }) => {
                   }
                   showHelper={false}
                   sx={{
-                    backgroundColor: theme.palette.background.paper,
                     borderRadius: "4px",
                   }}
                 />

--- a/frontend/src/sections/develop/AddRowDrawer/__tests__/CreateDescriptions.test.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/__tests__/CreateDescriptions.test.jsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import CreateDescriptions from "../CreateDescriptions";
+
+const mockRequestBody = vi.fn();
+
+vi.mock("react-hook-form", async () => {
+  const actual = await vi.importActual("react-hook-form");
+  return {
+    ...actual,
+    useWatch: vi.fn(() => [{ name: "Question" }]),
+  };
+});
+
+vi.mock(
+  "src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody",
+  () => ({
+    default: (props) => {
+      mockRequestBody(props);
+      return <div data-testid="request-body" />;
+    },
+  }),
+);
+
+vi.mock("src/components/iconify", () => ({
+  default: () => <span data-testid="iconify" />,
+}));
+
+vi.mock("src/components/tooltip", () => ({
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+describe("CreateDescriptions", () => {
+  it("does not pass an opaque background color to the shared RequestBody textarea", () => {
+    render(
+      <CreateDescriptions
+        control={{}}
+        fields={[
+          {
+            data_type: "text",
+            property: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Column 1:")).toBeInTheDocument();
+    expect(mockRequestBody).toHaveBeenCalledTimes(1);
+    expect(mockRequestBody.mock.calls[0][0].sx).toEqual({
+      borderRadius: "4px",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1586

## What changed
- Remove the opaque `backgroundColor` override from the synthetic-description `RequestBody` caller so it cannot cover the shared highlight layer.
- Add a focused regression test that verifies this caller passes only the border-radius style.

## Scope
This branch is based on the latest `dev` and contains one commit affecting two files. Current `dev` already includes the shared `RequestBody` layering hardening from #1105; this change keeps the synthetic-description caller from overriding that behavior.

## Verification
- `yarn test:run src/sections/develop/AddRowDrawer/__tests__/CreateDescriptions.test.jsx`
- ESLint on both changed files
- Prettier check on both changed files
- Production Vite build