### PR TITLE
fix(error-feed): render agent-protocol frames in Analyze tab (TH-7108)

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
+++ b/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
@@ -117,6 +117,11 @@ function ensureSocket(token, workspaceId) {
       const convId = parsed?.data?.conversation_id;
       if (convId && handlers.has(convId)) {
         handlers.get(convId)(parsed);
+        return;
+      }
+    
+      if (!convId && handlers.size === 1) {
+        handlers.values().next().value(parsed);
       }
     };
   });
@@ -432,10 +437,102 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
   let reasoningSeq = 0;
   let firstFrameSeen = false; // delivery watchdog: did the run actually start?
 
+
+  let agentMsgId = null;
+  let agentAnswer = "";
+  const agentOpenCalls = new Map(); // call_id → step id
+  const ensureAgentMsg = () => {
+    if (agentMsgId) return;
+    agentMsgId = `agent-${conversationId}`;
+    patchThread(clusterId, (t) => ({
+      ...t,
+      status: null,
+      messages: [
+        ...t.messages,
+        {
+          id: agentMsgId,
+          type: MESSAGE_TYPE.SUBAGENT,
+          title: "Falcon",
+          status: STREAM_STATUS.STREAMING,
+          steps: [],
+          answer: null,
+        },
+      ],
+    }));
+  };
+
   const handler = (parsed) => {
     const { type, data } = parsed;
     if (!data) return;
     firstFrameSeen = true; // any frame proves the run actually started
+
+    // ── Agent/chat-protocol frames (see ensureAgentMsg above) ──────────────
+    if (type === "iteration_start") {
+      ensureAgentMsg();
+      return;
+    }
+    if (type === CHAT_FRAME.TOOL_CALL_START) {
+      ensureAgentMsg();
+      const stepId = `${agentMsgId}-${data.call_id}`;
+      agentOpenCalls.set(data.call_id, stepId);
+      patchThread(clusterId, (t) => ({
+        ...t,
+        messages: t.messages.map((m) =>
+          m.id === agentMsgId
+            ? {
+                ...m,
+                steps: [
+                  ...m.steps,
+                  {
+                    id: stepId,
+                    title: data.tool_description || data.tool_name,
+                    detail: "",
+                    status: STEP_STATUS.RUNNING,
+                  },
+                ],
+              }
+            : m,
+        ),
+      }));
+      return;
+    }
+    if (type === CHAT_FRAME.TOOL_CALL_RESULT) {
+      ensureAgentMsg();
+      const stepId = agentOpenCalls.get(data.call_id);
+      patchThread(clusterId, (t) => ({
+        ...t,
+        messages: t.messages.map((m) =>
+          m.id === agentMsgId
+            ? {
+                ...m,
+                steps: m.steps.map((s) =>
+                  s.id === stepId
+                    ? {
+                        ...s,
+                        status: STEP_STATUS.DONE,
+                        detail: truncate(data.result_summary, 90),
+                      }
+                    : s,
+                ),
+              }
+            : m,
+        ),
+      }));
+      agentOpenCalls.delete(data.call_id);
+      return;
+    }
+    if (type === CHAT_FRAME.TEXT_DELTA) {
+      ensureAgentMsg();
+      agentAnswer += data.delta || "";
+      patchThread(clusterId, (t) => ({
+        ...t,
+        status: null,
+        messages: t.messages.map((m) =>
+          m.id === agentMsgId ? { ...m, answer: agentAnswer } : m,
+        ),
+      }));
+      return;
+    }
 
     if (type === RCA_FRAME.STATUS) {
       // Setup progress ping (before the first LLM round-trip). Held on the
@@ -556,7 +653,16 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
     }
 
     if (type === RCA_FRAME.DONE) {
-      patchThread(clusterId, (t) => ({ ...t, runState: RUN_STATE.DONE }));
+      patchThread(clusterId, (t) => ({
+        ...t,
+        runState: RUN_STATE.DONE,
+        // Finalize the agent-protocol subagent block (if this run used it).
+        messages: agentMsgId
+          ? t.messages.map((m) =>
+              m.id === agentMsgId ? { ...m, status: STREAM_STATUS.DONE } : m,
+            )
+          : t.messages,
+      }));
       handlers.delete(conversationId);
       return;
     }


### PR DESCRIPTION
[TH-7108](https://linear.app/future-agi/issue/TH-7108/error-feed-fix-tab-analyze-this-cluster-never-generates-creates-empty)

## Summary

The Error Feed "Analyze this cluster" tab rendered **empty**. This is a frontend **stopgap** that makes the streamed response render; the **root cause is on the backend** (see Diagnosis) and still needs a fix.

## Diagnosis (root cause = backend)

What the frontend sends over `/ws/falcon-ai/` (after a `createConversation`):

```json
{ "type": "chat", "message": "/cluster-rca", "conversation_id": "<id>",
  "context": { "page": "error-feed", "entity_type": "error_cluster",
               "entity_id": "<clusterId>", "project_id": "<projectId>" } }
```

`/cluster-rca` is the Falcon **skill command** that should activate the cluster-RCA agent.

What the backend streams back (observed on the wire): `iteration_start`, `tool_call_result`, `text_delta`, `done` — the **standard Falcon agent protocol** — plus a generic answer (*"I couldn't find any recent traces with errors. Would…"*).

**So the backend is not activating the `/cluster-rca` skill** — it treats the command as a plain chat message and lets the default Falcon agent answer. The expected frames are `rca_status` / `rca_reasoning` / `rca_step_*` / `rca_synthesis`. The structured cluster analysis never runs.

**Backend follow-up needed:** is `/cluster-rca` still a registered Falcon skill, and does the `/ws/falcon-ai/` chat handler route that command to the RCA agent? If it was renamed/removed/gated, restore the routing (or publish the new contract).

## What changed (frontend only)

`frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js`:

- **Main run handler now understands the agent protocol.** Added branches for `iteration_start`, `tool_call_start`, `tool_call_result`, `text_delta`, rendering them into a `SUBAGENT` block (streamed answer + tool steps) — the same message shape the follow-up chat already uses and that `SubagentCard` already renders. Previously these types matched no branch, so every content frame was dropped and the thread stayed blank.
- **`done` finalizes** that subagent block (`STREAMING → DONE`).
- **Router fallback:** frames carrying `message_id` but no `conversation_id` were dropped by the dispatcher. When exactly one run is active on this dedicated socket, route to it instead of dropping.

Both protocols are now tolerated — the `rca_*` path is unchanged and still primary.

## Reviewer note

Because the FE is now protocol-tolerant, the tab will show the **generic chat answer** rather than a blank panel. That is intentionally a stopgap and can **mask** the backend regression — after the `/cluster-rca` skill is fixed, please verify the **`rca_*` structured synthesis** still renders (the agent-protocol branches are a fallback, not the primary render path).

## Test plan

- [ ] Open Error Feed → a cluster → **Analyze this cluster**: the streamed answer renders instead of an empty panel.
- [ ] Tool steps appear when the agent emits `tool_call_start` / `tool_call_result`.
- [ ] After the backend skill fix: `rca_*` frames still render the reasoning steps + synthesis card.
- [x] `eslint` clean on the changed file.

## Type of change

- [x] Bug fix (frontend stopgap)
- [ ] New feature
- [ ] Breaking change

## Linear

Closes TH-7108
