### PR TITLE
fix(dashboards): canonicalize widget config casing

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_DECIMALS,
   escapeHtml,
   formatValueWithConfig,
+  fromAxisConfigPayload,
   getAutoDecimals,
   getSeriesAverage,
   getSuggestedUnitConfig,
@@ -96,7 +97,9 @@ export default function WidgetChart({ widget, globalDateRange }) {
   }, [rawQueryConfig, globalDateRange]);
   const chartConfig = widget.chart_config || {};
   const chartType = chartConfig.chart_type || "line";
-  const axisConfig = chartConfig.axis_config || null;
+  const axisConfig = chartConfig.axis_config
+    ? fromAxisConfigPayload(chartConfig.axis_config)
+    : null;
 
   const apexType = getApexType(chartType);
   const isStacked = chartType.startsWith("stacked_");

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -77,12 +77,14 @@ import {
   DEFAULT_DECIMALS,
   escapeHtml,
   formatValueWithConfig,
+  fromAxisConfigPayload,
   getAggColumnLabel,
   getAutoDecimals,
   getSeriesAverage,
   getSuggestedUnitConfig,
   getUnitRendering,
   getYAxisRangeWarning,
+  toAxisConfigPayload,
 } from "./widgetUtils";
 import {
   AGGREGATION_OPTIONS,
@@ -1368,13 +1370,14 @@ export default function WidgetEditorView() {
         setGranularity(qc.granularity || "day");
         setChartType(cc.chartType || cc.chart_type || "line");
         // Restore axis config if saved
-        const savedAxis = cc.axisConfig || cc.axis_config;
+        const savedAxis = cc.axis_config;
         if (savedAxis) {
+          const restoredAxis = fromAxisConfigPayload(savedAxis);
           setAxisConfig((prev) => ({
-            leftY: { ...prev.leftY, ...savedAxis.leftY },
-            rightY: { ...prev.rightY, ...savedAxis.rightY },
-            xAxis: { ...prev.xAxis, ...savedAxis.xAxis },
-            seriesAxis: savedAxis.seriesAxis || {},
+            leftY: { ...prev.leftY, ...restoredAxis.leftY },
+            rightY: { ...prev.rightY, ...restoredAxis.rightY },
+            xAxis: { ...prev.xAxis, ...restoredAxis.xAxis },
+            seriesAxis: restoredAxis.seriesAxis,
           }));
         }
         // Restore metrics with frontend type keys + source
@@ -2048,7 +2051,10 @@ export default function WidgetEditorView() {
       name: chartName.trim() || "Untitled widget",
       description: chartDescription,
       query_config: buildQueryConfig(),
-      chart_config: { chart_type: chartType, axis_config: axisConfig },
+      chart_config: {
+        chart_type: chartType,
+        axis_config: toAxisConfigPayload(axisConfig),
+      },
     };
 
     setSaveStatus("saving");
@@ -3038,7 +3044,7 @@ export default function WidgetEditorView() {
                   query_config: buildQueryConfig(),
                   chart_config: {
                     chart_type: chartType,
-                    axis_config: axisConfig,
+                    axis_config: toAxisConfigPayload(axisConfig),
                   },
                 };
                 createMutation

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -1,10 +1,44 @@
 import { describe, it, expect } from "vitest";
 import {
+  fromAxisConfigPayload,
   getAggColumnLabel,
   getYAxisRangeWarning,
   seriesHasDataPoints,
+  toAxisConfigPayload,
 } from "../widgetUtils";
 import { ALL_AGGREGATIONS } from "../constants";
+
+describe("axis config contract", () => {
+  const uiConfig = {
+    leftY: { prefixSuffix: "prefix", outOfBounds: "visible", unit: "ms" },
+    rightY: { prefixSuffix: "suffix", outOfBounds: "hidden" },
+    xAxis: { visible: true },
+    seriesAxis: { 0: "right" },
+  };
+
+  it("serializes UI state to the snake_case API contract", () => {
+    expect(toAxisConfigPayload(uiConfig)).toEqual({
+      left_y: {
+        prefix_suffix: "prefix",
+        out_of_bounds: "visible",
+        unit: "ms",
+      },
+      right_y: { prefix_suffix: "suffix", out_of_bounds: "hidden" },
+      x_axis: { visible: true },
+      series_axis: { 0: "right" },
+    });
+  });
+
+  it("restores the snake_case API contract to UI state", () => {
+    expect(fromAxisConfigPayload(toAxisConfigPayload(uiConfig))).toEqual(
+      uiConfig,
+    );
+  });
+
+  it("restores legacy camelCase axis configs during rollout", () => {
+    expect(fromAxisConfigPayload(uiConfig)).toEqual(uiConfig);
+  });
+});
 
 describe("seriesHasDataPoints", () => {
   it("returns false when series is empty", () => {

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -1,5 +1,49 @@
 export const DEFAULT_DECIMALS = 2;
 
+const toAxisPayload = ({ prefixSuffix, outOfBounds, ...axis } = {}) => ({
+  ...axis,
+  ...(prefixSuffix !== undefined && { prefix_suffix: prefixSuffix }),
+  ...(outOfBounds !== undefined && { out_of_bounds: outOfBounds }),
+});
+
+const fromAxisPayload = ({ prefix_suffix, out_of_bounds, ...axis } = {}) => ({
+  ...axis,
+  ...(prefix_suffix !== undefined && { prefixSuffix: prefix_suffix }),
+  ...(out_of_bounds !== undefined && { outOfBounds: out_of_bounds }),
+});
+
+export const toAxisConfigPayload = ({
+  leftY,
+  rightY,
+  xAxis,
+  seriesAxis,
+  ...config
+} = {}) => ({
+  ...config,
+  ...(leftY !== undefined && { left_y: toAxisPayload(leftY) }),
+  ...(rightY !== undefined && { right_y: toAxisPayload(rightY) }),
+  ...(xAxis !== undefined && { x_axis: xAxis }),
+  ...(seriesAxis !== undefined && { series_axis: seriesAxis }),
+});
+
+export const fromAxisConfigPayload = ({
+  left_y,
+  leftY,
+  right_y,
+  rightY,
+  x_axis,
+  xAxis,
+  series_axis,
+  seriesAxis,
+  ...config
+} = {}) => ({
+  ...config,
+  leftY: fromAxisPayload(left_y ?? leftY),
+  rightY: fromAxisPayload(right_y ?? rightY),
+  xAxis: x_axis ?? xAxis ?? {},
+  seriesAxis: series_axis ?? seriesAxis ?? {},
+});
+
 export const escapeHtml = (str) => {
   if (typeof str !== "string") return str;
   return str

--- a/futureagi/tracer/migrations/0094_canonicalize_dashboard_widget_configs.py
+++ b/futureagi/tracer/migrations/0094_canonicalize_dashboard_widget_configs.py
@@ -1,0 +1,124 @@
+from django.db import migrations
+
+
+QUERY_ITEM_KEY_ALIASES = {
+    "displayName": "display_name",
+}
+CHART_CONFIG_KEY_ALIASES = {
+    "chartType": "chart_type",
+    "axisConfig": "axis_config",
+}
+AXIS_CONFIG_KEY_ALIASES = {
+    "leftY": "left_y",
+    "rightY": "right_y",
+    "xAxis": "x_axis",
+    "seriesAxis": "series_axis",
+}
+AXIS_KEY_ALIASES = {
+    "prefixSuffix": "prefix_suffix",
+    "outOfBounds": "out_of_bounds",
+}
+
+
+def _move_alias_keys(value, aliases):
+    if not isinstance(value, dict):
+        return value, False
+
+    changed = False
+    next_value = dict(value)
+    for old_key, new_key in aliases.items():
+        if old_key not in next_value:
+            continue
+
+        old_value = next_value.pop(old_key)
+        if new_key not in next_value:
+            next_value[new_key] = old_value
+        elif isinstance(old_value, dict) and isinstance(next_value[new_key], dict):
+            next_value[new_key] = {**old_value, **next_value[new_key]}
+        changed = True
+
+    return next_value, changed
+
+
+def _canonicalize_query_config(query_config):
+    if not isinstance(query_config, dict):
+        return query_config, False
+
+    changed = False
+    next_config = dict(query_config)
+    for key in ("metrics", "breakdowns"):
+        items = next_config.get(key)
+        if not isinstance(items, list):
+            continue
+
+        next_items = []
+        items_changed = False
+        for item in items:
+            next_item, item_changed = _move_alias_keys(item, QUERY_ITEM_KEY_ALIASES)
+            next_items.append(next_item)
+            items_changed = items_changed or item_changed
+
+        if items_changed:
+            next_config[key] = next_items
+            changed = True
+
+    return next_config, changed
+
+
+def _canonicalize_chart_config(chart_config):
+    next_config, changed = _move_alias_keys(chart_config, CHART_CONFIG_KEY_ALIASES)
+    if not isinstance(next_config, dict):
+        return next_config, changed
+
+    axis_config = next_config.get("axis_config")
+    next_axis_config, axis_changed = _move_alias_keys(
+        axis_config, AXIS_CONFIG_KEY_ALIASES
+    )
+    changed = changed or axis_changed
+    if not isinstance(next_axis_config, dict):
+        return next_config, changed
+
+    for key in ("left_y", "right_y"):
+        next_axis, axis_value_changed = _move_alias_keys(
+            next_axis_config.get(key), AXIS_KEY_ALIASES
+        )
+        if axis_value_changed:
+            next_axis_config[key] = next_axis
+            changed = True
+
+    if changed:
+        next_config["axis_config"] = next_axis_config
+
+    return next_config, changed
+
+
+def forwards(apps, schema_editor):
+    DashboardWidget = apps.get_model("tracer", "DashboardWidget")
+    updated = 0
+
+    for widget in DashboardWidget.objects.iterator(chunk_size=500):
+        query_config, query_changed = _canonicalize_query_config(widget.query_config)
+        chart_config, chart_changed = _canonicalize_chart_config(widget.chart_config)
+        update_fields = []
+
+        if query_changed:
+            widget.query_config = query_config
+            update_fields.append("query_config")
+        if chart_changed:
+            widget.chart_config = chart_config
+            update_fields.append("chart_config")
+        if update_fields:
+            widget.save(update_fields=update_fields)
+            updated += 1
+
+    print(f"[canonicalize_dashboard_widget_configs] {updated} widgets updated")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0093_register_eval_task_search_attributes"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/futureagi/tracer/tests/test_dashboard_config_migration.py
+++ b/futureagi/tracer/tests/test_dashboard_config_migration.py
@@ -1,0 +1,106 @@
+import importlib
+
+
+migration = importlib.import_module(
+    "tracer.migrations.0094_canonicalize_dashboard_widget_configs"
+)
+
+
+def test_canonicalizes_known_dashboard_config_aliases():
+    query_config = {
+        "metrics": [{"name": "latency", "displayName": "Latency"}],
+        "breakdowns": [{"name": "status", "displayName": "Status"}],
+        "customCamelKey": "preserved",
+    }
+    chart_config = {
+        "chartType": "line",
+        "axisConfig": {
+            "leftY": {
+                "prefixSuffix": "prefix",
+                "outOfBounds": "visible",
+                "unit": "ms",
+            },
+            "rightY": {
+                "prefix_suffix": "suffix",
+                "out_of_bounds": "hidden",
+            },
+            "xAxis": {"visible": True},
+            "seriesAxis": {"0": "right"},
+        },
+    }
+
+    migrated_query, query_changed = migration._canonicalize_query_config(query_config)
+    migrated_chart, chart_changed = migration._canonicalize_chart_config(chart_config)
+
+    assert query_changed is True
+    assert migrated_query == {
+        "metrics": [{"name": "latency", "display_name": "Latency"}],
+        "breakdowns": [{"name": "status", "display_name": "Status"}],
+        "customCamelKey": "preserved",
+    }
+    assert chart_changed is True
+    assert migrated_chart == {
+        "chart_type": "line",
+        "axis_config": {
+            "left_y": {
+                "prefix_suffix": "prefix",
+                "out_of_bounds": "visible",
+                "unit": "ms",
+            },
+            "right_y": {
+                "prefix_suffix": "suffix",
+                "out_of_bounds": "hidden",
+            },
+            "x_axis": {"visible": True},
+            "series_axis": {"0": "right"},
+        },
+    }
+
+
+def test_preserves_canonical_values_when_aliases_coexist():
+    query_config = {
+        "metrics": [
+            {
+                "displayName": "Legacy latency",
+                "display_name": "Latency",
+            }
+        ]
+    }
+    chart_config = {
+        "axis_config": {
+            "leftY": {
+                "prefixSuffix": "prefix",
+                "unit": "ms",
+            },
+            "left_y": {
+                "prefix_suffix": "suffix",
+                "label": "Latency",
+            },
+        }
+    }
+
+    migrated_query, _ = migration._canonicalize_query_config(query_config)
+    migrated_chart, _ = migration._canonicalize_chart_config(chart_config)
+
+    assert migrated_query["metrics"] == [{"display_name": "Latency"}]
+    assert migrated_chart["axis_config"]["left_y"] == {
+        "prefix_suffix": "suffix",
+        "unit": "ms",
+        "label": "Latency",
+    }
+
+
+def test_canonicalization_is_idempotent():
+    query_config = {"metrics": [{"display_name": "Latency"}]}
+    chart_config = {
+        "chart_type": "line",
+        "axis_config": {
+            "left_y": {
+                "prefix_suffix": "prefix",
+                "out_of_bounds": "visible",
+            }
+        },
+    }
+
+    assert migration._canonicalize_query_config(query_config) == (query_config, False)
+    assert migration._canonicalize_chart_config(chart_config) == (chart_config, False)


### PR DESCRIPTION
## Summary

Canonicalizes persisted dashboard widget JSON to the backend's snake_case contract and prevents the frontend from writing camelCase axis configuration keys again. Existing widget query/chart configs are migrated in place, while React continues using camelCase internally through explicit boundary mappers.

## Linked issues

No linked ticket.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Persisted dashboard configuration**

- Added an idempotent data migration for known dashboard aliases such as `displayName`, `leftY`, `prefixSuffix`, and `outOfBounds`.
- Preserves canonical snake_case values when both forms coexist and merges mixed axis objects without rewriting unknown JSON keys.

**B. Frontend contract boundary**

- Serializes camelCase React axis state to snake_case before widget create, update, and duplicate requests.
- Restores canonical snake_case axis configuration into camelCase UI state for the editor and chart renderer.
- Retains centralized legacy camelCase read compatibility during rollout.

---

## 2) Why the changes were done

- **Product/UX:** Widgets with canonical snake_case configs must retain their saved axis formatting when reopened or rendered.
- **Technical:** Production contains mixed persisted casing, while new frontend writes were still storing nested camelCase axis fields inside otherwise snake_case JSON.
- **Architecture:** Casing conversion now happens once at the frontend boundary, and the migration targets only known contract fields rather than mutating arbitrary JSON keys.

---

## 3) Tests written + scenarios each covers

**`futureagi/tracer/tests/test_dashboard_config_migration.py`**

- Converts known query and chart aliases, including mixed nested axis shapes.
- Preserves canonical values when aliases coexist.
- Verifies canonicalization is idempotent and unknown camelCase keys are untouched.

**`frontend/src/sections/dashboards/__tests__/widgetUtils.test.js`**

- Serializes UI axis state to the snake_case API contract.
- Restores snake_case payloads to UI state.
- Reads legacy camelCase payloads during rollout.

> Verification: 3 backend migration assertions passed; frontend axis contract assertions passed in the backend container; migration graph check reported no model changes. The migration also normalized all 13 affected widgets in local PostgreSQL inside a transaction, with zero camelCase keys remaining before the transaction was rolled back.

---

## 4) How to run / test

```bash
# Backend migration assertions
python -m pytest tracer/tests/test_dashboard_config_migration.py -v

# Frontend helper tests
yarn test:run src/sections/dashboards/__tests__/widgetUtils.test.js

# Migration graph
python manage.py makemigrations --check --dry-run tracer
```

---

## 6) Edge cases & considerations

- Mixed configs with camelCase parent axis keys and snake_case child keys are normalized correctly.
- Existing snake_case values win when both aliases are present.
- Unknown JSON keys are not recursively renamed.
- The data migration is forward-only because reconstructing the previous mixed casing would be lossy.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [x] PR title follows Conventional Commits
- [x] No hardcoded secrets, URLs, or PII
