### PR TITLE
fix: keep strong references to PromptStreamConsumer background tasks

### DIFF
--- a/futureagi/model_hub/utils/kb_helpers.py
+++ b/futureagi/model_hub/utils/kb_helpers.py
@@ -5,6 +5,7 @@ This module contains shared utility functions for KB operations,
 used by both views and tasks.
 """
 
+import asyncio
 import os
 import time
 
@@ -21,7 +22,7 @@ logger = structlog.get_logger(__name__)
 # Strong references to fire-and-forget workflow cancellations. The event loop
 # only keeps weak references, so an unreferenced ensure_future() task can be
 # garbage-collected before the cancellation reaches Temporal.
-_pending_cancellations = set()
+_pending_cancellations: set["asyncio.Future[None]"] = set()
 
 
 def is_kb_deleted_or_cancelled(kb_id):
@@ -182,8 +183,6 @@ def cancel_kb_ingestion_workflow(kb_id):
     1. Mark KB as DELETING - this signals background tasks to stop
     2. Cancel the Temporal workflow
     """
-    import asyncio
-
     # Step 1: Mark KB as DELETING to signal background tasks to stop
     try:
         KnowledgeBaseFile.objects.filter(id=kb_id).update(

--- a/futureagi/model_hub/utils/kb_helpers.py
+++ b/futureagi/model_hub/utils/kb_helpers.py
@@ -18,6 +18,11 @@ from tfc.utils.storage_client import get_object_url, get_storage_client
 
 logger = structlog.get_logger(__name__)
 
+# Strong references to fire-and-forget workflow cancellations. The event loop
+# only keeps weak references, so an unreferenced ensure_future() task can be
+# garbage-collected before the cancellation reaches Temporal.
+_pending_cancellations = set()
+
 
 def is_kb_deleted_or_cancelled(kb_id):
     """
@@ -206,7 +211,9 @@ def cancel_kb_ingestion_workflow(kb_id):
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():
-            asyncio.ensure_future(_cancel())
+            task = asyncio.ensure_future(_cancel())
+            _pending_cancellations.add(task)
+            task.add_done_callback(_pending_cancellations.discard)
         else:
             asyncio.run(_cancel())
     except RuntimeError:

--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -44,6 +44,31 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         self.session_uuid = None
         self.organization_id = None
         self.workspace_id = None
+        # Strong references to in-flight execution tasks. The event loop only
+        # keeps weak references, so a bare create_task() result can be
+        # garbage-collected mid-run, silently freezing the client's stream
+        # right after execution_started.
+        self._background_tasks = set()
+
+    def _spawn(self, coro):
+        """Run coro as a background task, holding a strong reference until done."""
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._on_background_task_done)
+        return task
+
+    def _on_background_task_done(self, task):
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            # The execute_* coroutines report their own errors to the client;
+            # anything reaching here escaped those handlers.
+            logger.error(
+                f"Background task failed unexpectedly: session={self.session_uuid}",
+                exc_info=exc,
+            )
 
     async def connect(self):
         self.user = self.scope.get("user")
@@ -75,6 +100,13 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         logger.info(
             f"PromptStream connection closed: session={self.session_uuid}, code={close_code}"
         )
+        # Stop in-flight executions — with the socket gone there is nowhere
+        # to stream results, so letting them run only wastes LLM calls.
+        pending = [task for task in self._background_tasks if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def receive_json(self, content):
         message_type = content.get("type")
@@ -117,7 +149,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(self.execute_template_async(content, template_id))
+        self._spawn(self.execute_template_async(content, template_id))
 
     async def execute_template_async(self, content, template_id):
         try:
@@ -221,7 +253,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(
+        self._spawn(
             self.execute_improve_prompt_async(payload, payload.get("improve_id"))
         )
 
@@ -312,7 +344,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(self.execute_generate_prompt_async(payload, generation_id))
+        self._spawn(self.execute_generate_prompt_async(payload, generation_id))
 
     async def execute_generate_prompt_async(self, content, generation_id):
         try:

--- a/futureagi/sockets/tests/test_prompt_stream_consumer.py
+++ b/futureagi/sockets/tests/test_prompt_stream_consumer.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for PromptStreamConsumer background-task lifecycle.
+
+Regression tests for GH-819: the three streaming entry points used bare
+asyncio.create_task() without retaining a reference, so the event loop's
+weak reference was the only one and tasks could be garbage-collected
+mid-run — freezing the client's stream right after execution_started.
+
+Tests cover:
+- Spawned tasks are tracked with a strong reference until completion
+- Completed tasks are removed from the tracking set
+- Each streaming handler (run_template, improve_prompt, generate_prompt)
+  tracks its execution task
+- disconnect() cancels still-pending tasks
+- Task exceptions escaping the executors do not crash the done-callback
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sockets.prompt_stream_consumer import PromptStreamConsumer
+
+
+def _make_consumer():
+    """Create a consumer instance with mocked I/O and identity."""
+    consumer = PromptStreamConsumer()
+    consumer.scope = {"type": "websocket", "query_string": b""}
+    consumer.session_uuid = "session-123"
+    consumer.organization_id = "org-123"
+    consumer.user = MagicMock(id="user-123")
+    consumer.accept = AsyncMock()
+    consumer.close = AsyncMock()
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestBackgroundTaskTracking:
+    """Tests for _spawn() strong-reference tracking."""
+
+    async def test_spawn_keeps_strong_reference_until_done(self):
+        """Spawned tasks must stay referenced while running."""
+        consumer = _make_consumer()
+        release = asyncio.Event()
+
+        async def work():
+            await release.wait()
+
+        task = consumer._spawn(work())
+
+        assert task in consumer._background_tasks
+
+        release.set()
+        await task
+
+        assert task not in consumer._background_tasks
+
+    async def test_spawn_discards_task_on_exception(self):
+        """A task failing with an escaped exception is still discarded."""
+        consumer = _make_consumer()
+
+        async def boom():
+            raise RuntimeError("escaped the executor")
+
+        task = consumer._spawn(boom())
+        await asyncio.gather(task, return_exceptions=True)
+        # Let the done-callback run.
+        await asyncio.sleep(0)
+
+        assert task not in consumer._background_tasks
+
+    async def test_disconnect_cancels_pending_tasks(self):
+        """disconnect() must cancel in-flight executions."""
+        consumer = _make_consumer()
+
+        async def never_finishes():
+            await asyncio.Event().wait()
+
+        task = consumer._spawn(never_finishes())
+
+        await consumer.disconnect(1000)
+
+        assert task.cancelled()
+        assert not consumer._background_tasks
+
+    async def test_disconnect_with_no_tasks_is_noop(self):
+        """disconnect() must not fail when nothing is running."""
+        consumer = _make_consumer()
+        await consumer.disconnect(1000)
+        assert not consumer._background_tasks
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandlersTrackTasks:
+    """Each streaming handler must track its execution task."""
+
+    @patch.object(
+        PromptStreamConsumer, "execute_template_async", new_callable=AsyncMock
+    )
+    @patch.object(
+        PromptStreamConsumer, "validate_template_access", new_callable=AsyncMock
+    )
+    async def test_run_template_tracks_task(self, mock_validate, mock_execute):
+        mock_validate.return_value = True
+        consumer = _make_consumer()
+
+        await consumer.handle_run_template(
+            {"type": "run_template", "template_id": "tpl-1", "version": "1"}
+        )
+
+        assert len(consumer._background_tasks) == 1
+        await asyncio.gather(*consumer._background_tasks)
+        mock_execute.assert_awaited_once()
+        assert not consumer._background_tasks
+
+    @patch.object(
+        PromptStreamConsumer, "execute_improve_prompt_async", new_callable=AsyncMock
+    )
+    @patch(
+        "sockets.prompt_stream_consumer.replace_ids_with_column_name_async",
+        new_callable=AsyncMock,
+    )
+    async def test_improve_prompt_tracks_task(self, mock_replace, mock_execute):
+        mock_replace.side_effect = lambda prompt: prompt
+        consumer = _make_consumer()
+
+        await consumer.handle_improve_prompt(
+            {
+                "type": "improve_prompt",
+                "existing_prompt": "prompt text",
+                "improvement_requirements": "make it better",
+            }
+        )
+
+        assert len(consumer._background_tasks) == 1
+        await asyncio.gather(*consumer._background_tasks)
+        mock_execute.assert_awaited_once()
+        assert not consumer._background_tasks
+
+    @patch.object(
+        PromptStreamConsumer, "execute_generate_prompt_async", new_callable=AsyncMock
+    )
+    async def test_generate_prompt_tracks_task(self, mock_execute):
+        consumer = _make_consumer()
+
+        await consumer.handle_generate_prompt(
+            {"type": "generate_prompt", "statement": "write a prompt"}
+        )
+
+        assert len(consumer._background_tasks) == 1
+        await asyncio.gather(*consumer._background_tasks)
+        mock_execute.assert_awaited_once()
+        assert not consumer._background_tasks


### PR DESCRIPTION
## Summary

The three streaming entry points in `PromptStreamConsumer` (`run_template`,
`improve_prompt`, `generate_prompt`) spawn their execution coroutines with a
bare `asyncio.create_task()` and discard the returned task. The event loop
holds only weak references to tasks, so an otherwise-unreferenced task can be
garbage-collected mid-run — the client receives `execution_started` and the
stream then silently freezes with no error, intermittently and load-dependently.

This PR tracks spawned tasks in a consumer-held set (released via a
done-callback), mirroring the existing pattern in `simulation_consumer.py`, and
cancels any still-pending tasks on disconnect so orphaned LLM executions stop
instead of streaming into a closed socket. The fire-and-forget Temporal
workflow cancellation in `model_hub/utils/kb_helpers.py` (flagged in the same
issue) gets the same reference-keeping.

## Linked issues

Closes #819

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Added `sockets/tests/test_prompt_stream_consumer.py` with 7 regression
  tests: tasks are strongly referenced while running, released on completion
  and on escaped exceptions, cancelled by `disconnect()`, and all three
  handlers track their execution task.
- `pytest sockets/tests/` — 18 passed (7 new + 11 existing).
- `black` and `isort` clean on the changed files; `mypy` introduces no new
  errors against the baseline.
- Note: I ran the test suite and scoped lint/type checks directly rather than
  the full `make check-all`, as I didn't have the Docker test services
  available locally. Deferring the DB-backed portion of the suite to CI.

## Screenshots / recordings (if UI)

N/A — backend only.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally (see testing note above)
- [x] I've updated the documentation where relevant (no docs affected)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
