### PR TITLE
feat(simulate): support Bland as an outbound customer provider

### DIFF
--- a/futureagi/simulate/semantics.py
+++ b/futureagi/simulate/semantics.py
@@ -28,6 +28,7 @@ SupportedProviders = {
     ProviderChoices.RETELL.value,
     ProviderChoices.ELEVEN_LABS.value,
     ProviderChoices.LIVEKIT.value,
+    ProviderChoices.BLAND.value,
     ProviderChoices.OTHERS.value,
 }
 

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -113,6 +113,7 @@ except ImportError:
 from simulate.temporal.activities.xl import (
     PATH_MISSING,
     TRANSCRIPT_DOT_ALIASES,
+    assert_recording_slot_available,
     build_simulation_context_map,
     stringify_leaf,
     walk_subject_path,
@@ -4851,6 +4852,14 @@ class TestExecutor:
                         ] = StatusType.FAILED.value
                         call_execution.save(update_fields=["eval_outputs"])
                         raise ValueError(error_message)
+
+            # A recording variable that resolved empty (e.g. stereo on a
+            # combined-only provider) fails here with an actionable message
+            # instead of an opaque "No input received" from the eval engine.
+            for map_key, map_value in mapping.items():
+                assert_recording_slot_available(
+                    map_key, map_value, updated_mapping.get(map_key), transcript_data
+                )
 
             # Prepare config
             config = eval_config.config.copy() if eval_config.config else {}

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -1510,6 +1510,18 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
             logger.info(f"Using customer_call_id: {customer_call_id}")
 
             customer_provider = snapshot.get("provider", ProviderChoices.VAPI)
+            from simulate.semantics import ToolCallingSupportedProviders
+
+            provider_value = getattr(customer_provider, "value", customer_provider)
+            if provider_value not in [p.value for p in ToolCallingSupportedProviders]:
+                # Only some providers have a tool-call adapter; gate here so an
+                # unsupported provider (e.g. Bland) skips cleanly instead of
+                # raising into the broad except and silently no-op'ing.
+                logger.info(
+                    f"Tool evaluation not supported for provider "
+                    f"'{provider_value}' (call {call_execution.id}), skipping"
+                )
+                return
             adapter = get_tool_call_adapter(customer_provider)
             messages = adapter.get_tool_call_transcript(
                 call_execution=call_execution,

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -506,6 +506,41 @@ TRANSCRIPT_DOT_ALIASES = {
     "call.agent_prompt": "agent_prompt",
 }
 
+# Recording variable sources (bare transcript_data keys + their dot-form
+# aliases). An eval variable bound to one of these that resolves empty gets an
+# actionable error instead of the eval engine's opaque "No input received".
+_RECORDING_KEYS = frozenset(
+    {"voice_recording", "stereo_recording", "assistant_recording", "customer_recording"}
+)
+_RECORDING_SOURCES = _RECORDING_KEYS | frozenset(
+    dot for dot, legacy in TRANSCRIPT_DOT_ALIASES.items() if legacy in _RECORDING_KEYS
+)
+
+
+def assert_recording_slot_available(
+    mapping_key, source_value, resolved_value, transcript_data
+):
+    """Raise an actionable error when an eval variable is mapped to a recording
+    the call has no audio for. Combined-only providers (e.g. Bland) produce no
+    stereo or per-channel track, so a stereo/assistant/customer mapping resolves
+    empty; without this the eval engine only reports an opaque "No input
+    received for '<var>'". Whole-conversation evals should map to
+    call.voice_recording (the combined recording).
+    """
+    if source_value not in _RECORDING_SOURCES or resolved_value:
+        return
+    available = sorted(k for k in _RECORDING_KEYS if transcript_data.get(k))
+    hint = (
+        f"Available recordings: {', '.join(available)}."
+        if available
+        else "This call has no recordings."
+    )
+    raise ValueError(
+        f"'{mapping_key}' is mapped to '{source_value}', but this call has no such "
+        f"recording — combined-only providers produce no stereo or per-channel "
+        f"audio. {hint} Map it to call.voice_recording."
+    )
+
 
 def build_simulation_context_map(call_execution, agent_version):
     """
@@ -897,6 +932,14 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                 eval_config.status = StatusType.FAILED.value
                 eval_config.save()
                 raise ValueError(error_message)
+
+        # A recording variable that resolved empty (e.g. stereo on a
+        # combined-only provider) fails here with an actionable message instead
+        # of an opaque "No input received" from the eval engine downstream.
+        for map_key, map_value in mapping.items():
+            assert_recording_slot_available(
+                map_key, map_value, updated_mapping.get(map_key), transcript_data
+            )
 
         # Prepare config and run evaluation
         config = eval_config.config.copy() if eval_config.config else {}

--- a/futureagi/simulate/temporal/types/activities.py
+++ b/futureagi/simulate/temporal/types/activities.py
@@ -371,6 +371,8 @@ class MonitorCallInput:
     provider_call_id: str
     call_type: str  # "inbound" or "outbound"
     provider: str
+    # Customer's provider (agent under test); selects the SIP-outbound poll path.
+    client_provider: str = "vapi"
     provider_config: dict[str, Any] = field(default_factory=dict)
     poll_interval_seconds: int = 20
     max_duration_seconds: int = 14400  # 4 hours
@@ -741,6 +743,11 @@ class InitiateCallInput:
     user_assistant_id: Optional[str] = None
     user_phone_number: Optional[str] = None  # User's phone to call from
 
+    # Customer's provider ("vapi"/"bland"/...) — the agent under test. Distinct
+    # from `provider` above, which is the system simulator. Selects the data
+    # plane for the SIP-outbound trigger.
+    client_provider: str = "vapi"
+
     # WebRTC bridge connection type (None = SIP, "web_vapi", "web_retell")
     connection_type: Optional[str] = None
 
@@ -834,6 +841,8 @@ class FetchAndPersistCallResultInput:
         str  # Provider name — use str to avoid Temporal str,Enum deserialization bug
     )
     call_type: str  # "inbound" or "outbound" — use str to avoid Temporal str,Enum deserialization bug
+    # Customer's provider (agent under test); selects the SIP-outbound fetch path.
+    client_provider: str = "vapi"
     duration_seconds: Optional[float] = None
     end_reason: Optional[str] = None
     provider_data: dict[str, Any] = field(default_factory=dict)

--- a/futureagi/simulate/temporal/types/activities.py
+++ b/futureagi/simulate/temporal/types/activities.py
@@ -929,6 +929,10 @@ class CalculateConversationMetricsInput:
     call_id: str
     is_outbound: bool = False
     provider: str = "livekit"
+    # When the customer's own account holds the call data (SIP outbound), this
+    # is the customer's provider and transcript reads dispatch to its engine.
+    # None for inbound/bridge calls, where the system provider owns the data.
+    client_provider: Optional[str] = None
 
 
 # =============================================================================

--- a/futureagi/simulate/temporal/utils/async_storage.py
+++ b/futureagi/simulate/temporal/utils/async_storage.py
@@ -237,6 +237,23 @@ async def _convert_audio_url_to_s3_async_with_size(
         return existing
 
     try:
+        # SSRF guard: a recording URL arrives inside a provider's API response,
+        # so validate its host resolves to a public address before we fetch it —
+        # a tampered/unexpected value must not reach an internal or cloud-metadata
+        # endpoint. Reuses the shared ssrf_guard classifier. Skips the
+        # authenticated-provider download (fixed host, no free-form URL) and our
+        # own storage (already returned above). Only the converter is guarded:
+        # the raw download_audio_from_url_async intentionally stays open because
+        # the LiveKit egress path fetches internal storage through it.
+        if audio_url and not vapi_authenticated:
+            import asyncio
+
+            from tfc.utils.ssrf_guard import assert_url_host_public
+
+            await asyncio.get_running_loop().run_in_executor(
+                None, assert_url_host_public, audio_url
+            )
+
         # Async download
         audio_bytes = await download_audio_from_url_async(
             audio_url,

--- a/futureagi/simulate/tests/test_eval_resolver_behavior.py
+++ b/futureagi/simulate/tests/test_eval_resolver_behavior.py
@@ -1362,3 +1362,66 @@ class TestComputedSerializerFieldsInContext:
         m = mock_run.call_args.kwargs["mappings"]
         assert m["a"] == "Customer called about order 123."
         assert m["b"] == ""  # scenario_columns subject fell back to {}
+
+
+@pytest.mark.django_db
+@patch("simulate.services.test_executor.close_old_connections", lambda: None)
+class TestRecordingSlotAvailability:
+    """An eval variable mapped to a recording the call has no audio for (e.g.
+    stereo / per-channel on a combined-only provider like Bland) fails with an
+    actionable message naming the available recordings, instead of the eval
+    engine's opaque 'No input received for <var>'."""
+
+    # Combined-only shape: only the mono combined recording exists.
+    _COMBINED_ONLY = {
+        "transcript": "agent: hi\ncustomer: hello",
+        "voice_recording": "s3://bucket/combined.mp3",
+        "assistant_recording": "",
+        "customer_recording": "",
+        "stereo_recording": "",
+        "user_chat_transcript": "",
+        "assistant_chat_transcript": "",
+    }
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_empty_stereo_slot_raises_actionable_error(
+        self, mock_run, run_test, call_execution, eval_template
+    ):
+        ec = _make_eval({"output": "call.stereo_recording"}, run_test, eval_template)
+
+        with pytest.raises(ValueError, match="combined-only"):
+            _run(ec, call_execution, dict(self._COMBINED_ONLY))
+
+        mock_run.assert_not_called()  # never reaches the eval engine
+        ec.refresh_from_db()
+        assert ec.status == StatusType.FAILED.value
+        call_execution.refresh_from_db()
+        reason = call_execution.eval_outputs[str(ec.id)]["reason"]
+        assert "call.voice_recording" in reason  # actionable hint for the FE
+
+    @patch("simulate.services.test_executor.run_eval_func")
+    def test_present_combined_recording_resolves_and_runs(
+        self, mock_run, run_test, call_execution, eval_template
+    ):
+        mock_run.return_value = _SUCCESS_STUB
+        ec = _make_eval({"output": "call.voice_recording"}, run_test, eval_template)
+
+        _run(ec, call_execution, dict(self._COMBINED_ONLY))
+
+        assert (
+            mock_run.call_args.kwargs["mappings"]["output"]
+            == "s3://bucket/combined.mp3"
+        )
+
+    @patch("simulate.temporal.activities.xl.close_old_connections", lambda: None)
+    def test_empty_stereo_slot_raises_on_xl_temporal_path(
+        self, run_test, call_execution, eval_template
+    ):
+        """Same guard on the temporal-activity path (two-sources-of-truth)."""
+        from model_hub.views.utils import evals as evals_mod
+
+        ec = _make_eval({"output": "call.stereo_recording"}, run_test, eval_template)
+        with patch.object(evals_mod, "run_eval_func") as mock_run:
+            with pytest.raises(ValueError, match="combined-only"):
+                _run_xl(ec, call_execution, dict(self._COMBINED_ONLY))
+            mock_run.assert_not_called()

--- a/futureagi/simulate/tests/test_session_comparison_utils.py
+++ b/futureagi/simulate/tests/test_session_comparison_utils.py
@@ -126,6 +126,78 @@ class TestFetchComparisonTranscripts:
 
 
 @pytest.mark.unit
+class TestNonVapiProviderComparison:
+    """Bland (and any provider whose raw payload isn't VAPI/Retell-shaped) must
+    compare via the persisted CallTranscript rows + model fields, not render
+    blank. Regression: the retell branch swallowed the empty-list case, and
+    metrics/duration were read only from a VAPI payload."""
+
+    @staticmethod
+    def _patch_call_transcript(rows):
+        # rows: list of (speaker_role, content)
+        transcript_rows = [
+            SimpleNamespace(speaker_role=r, content=c) for r, c in rows
+        ]
+
+        class _SpeakerRole:
+            ASSISTANT = "assistant"
+            USER = "user"
+
+        class _QuerySet:
+            def filter(self, **kwargs):
+                return self
+
+            def order_by(self, *args):
+                return transcript_rows
+
+            def count(self):
+                return len(transcript_rows)
+
+        return patch(
+            "simulate.models.test_execution.CallTranscript",
+            SimpleNamespace(objects=_QuerySet(), SpeakerRole=_SpeakerRole),
+        )
+
+    def test_bland_transcripts_come_from_call_transcript_rows(self):
+        call = SimpleNamespace(
+            provider_call_data={
+                "bland": {"transcripts": [{"user": "assistant", "text": "x"}]}
+            }
+        )
+        with self._patch_call_transcript(
+            [("assistant", "Hello"), ("user", "Hi there")]
+        ):
+            out = session_comparison._extract_transcripts_from_provider_call_data(
+                call
+            )
+        assert out == [
+            {"role": "assistant", "messages": ["Hello"]},
+            {"role": "user", "messages": ["Hi there"]},
+        ]
+
+    def test_bland_metrics_use_model_fields_and_call_transcript(self):
+        call = SimpleNamespace(
+            provider_call_data={"bland": {}},
+            duration_seconds=66,
+            avg_agent_latency_ms=None,
+            user_wpm=None,
+            bot_wpm=None,
+            talk_ratio=None,
+        )
+        with self._patch_call_transcript(
+            [("assistant", "a"), ("user", "b"), ("assistant", "c")]
+        ):
+            metrics = session_comparison._extract_metrics_from_provider_call_data(
+                call
+            )
+        assert metrics["duration"] == 66
+        assert metrics["total_turns"] == 3
+        # None per-turn metrics degrade to 0 for a provider with no timing.
+        assert metrics["avg_agent_latency_ms"] == 0
+        assert metrics["talk_ratio"] == 0
+
+
+@pytest.mark.unit
 class TestConvertTraceToChatMessages:
     def test_returns_empty_list_for_none_or_empty_input(self):
         assert session_comparison.convert_trace_to_chat_messages(None) == []

--- a/futureagi/simulate/tests/test_speaker_role_read_alignment.py
+++ b/futureagi/simulate/tests/test_speaker_role_read_alignment.py
@@ -260,6 +260,32 @@ class TestEvalTranscriptLabels:
             == "customer"
         )
 
+    def test_bland_outbound_labels_are_direct(self):
+        # Bland is a customer-only OUTBOUND provider, so the tested agent is on
+        # `assistant` (same convention as VAPI outbound).
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "assistant", provider=ProviderChoices.BLAND, is_outbound=True
+            )
+            == "agent"
+        )
+        assert (
+            SpeakerRoleResolver.get_eval_role_label(
+                "user", provider=ProviderChoices.BLAND, is_outbound=True
+            )
+            == "customer"
+        )
+
+    def test_bland_map_is_independent_of_vapi(self):
+        # Its own dict, not an alias — a future Bland payload change is edited on
+        # the Bland map without silently affecting VAPI.
+        assert (
+            SpeakerRoleResolver._BLAND_OUTBOUND is not SpeakerRoleResolver._VAPI_OUTBOUND
+        )
+        assert (
+            SpeakerRoleResolver._BLAND_INBOUND is not SpeakerRoleResolver._VAPI_INBOUND
+        )
+
     def test_system_role_is_never_conversational(self):
         """The persona system prompt must never appear in an eval input."""
         assert "system" not in SpeakerRoleResolver.get_conversational_roles()

--- a/futureagi/simulate/tests/test_temporal_activities.py
+++ b/futureagi/simulate/tests/test_temporal_activities.py
@@ -1376,6 +1376,22 @@ class TestRunSimulateEvaluationsActivity:
         assert call_execution.status == CallExecution.CallStatus.ANALYZING
 
 
+@pytest.mark.unit
+def test_tool_evaluation_gate_invariant_bland_has_no_adapter():
+    """Locks the invariant the tool-eval gate in _run_tool_evaluation_standalone
+    relies on: a provider absent from ToolCallingSupportedProviders (e.g. Bland)
+    has no tool-call adapter, so get_tool_call_adapter raises. The gate skips
+    such providers up front instead of letting that raise into the broad except
+    (which silently no-ops tool evaluation). If a Bland adapter is ever added
+    this fails — a reminder to also add Bland to the supported list."""
+    from ee.agenthub.tool_eval_agent.adapters import get_tool_call_adapter
+    from simulate.semantics import ToolCallingSupportedProviders
+
+    assert ProviderChoices.BLAND not in ToolCallingSupportedProviders
+    with pytest.raises(ValueError):
+        get_tool_call_adapter(ProviderChoices.BLAND)
+
+
 @pytest.mark.integration
 class TestRunToolCallEvaluationActivity:
     """Integration tests for run_tool_call_evaluation activity."""

--- a/futureagi/simulate/utils/session_comparison.py
+++ b/futureagi/simulate/utils/session_comparison.py
@@ -449,6 +449,10 @@ def _extract_metrics_from_provider_call_data(call_execution: CallExecution):
             duration = (end - start).total_seconds()
         except (ValueError, TypeError):
             pass
+    # Provider-agnostic fallback (Bland, etc.): duration_seconds is populated on
+    # the model for every provider during fetch, so comparison isn't VAPI-only.
+    if not duration:
+        duration = call_execution.duration_seconds or 0
 
     # Count turns from messages
     messages = vapi_data.get("messages", [])
@@ -457,6 +461,17 @@ def _extract_metrics_from_provider_call_data(call_execution: CallExecution):
         total_turns = sum(
             1 for m in messages if m.get("role") in ("user", "assistant", "bot")
         )
+    if not total_turns:
+        # CallTranscript rows are written for every provider.
+        from simulate.models.test_execution import CallTranscript
+
+        total_turns = CallTranscript.objects.filter(
+            call_execution=call_execution,
+            speaker_role__in=[
+                CallTranscript.SpeakerRole.USER,
+                CallTranscript.SpeakerRole.ASSISTANT,
+            ],
+        ).count()
 
     return {
         "duration": duration,
@@ -479,6 +494,31 @@ def fetch_voice_trace_comparison_metrics(
     comparison_metrics = _extract_metrics_from_provider_call_data(call_execution)
 
     return _build_metric_comparisons(base_metrics, comparison_metrics)
+
+
+def _transcripts_from_call_transcript_rows(call_execution: CallExecution):
+    """Provider-agnostic transcripts from the persisted CallTranscript rows.
+
+    These are written for every voice provider (VAPI, Bland, ...) and ordered by
+    start_time_ms, so a provider whose raw payload isn't VAPI/Retell-shaped
+    (e.g. Bland) still compares against a baseline instead of rendering blank.
+    """
+    from simulate.models.test_execution import CallTranscript
+
+    role_map = {
+        CallTranscript.SpeakerRole.ASSISTANT: "assistant",
+        CallTranscript.SpeakerRole.USER: "user",
+    }
+    transcripts = []
+    rows = CallTranscript.objects.filter(call_execution=call_execution).order_by(
+        "start_time_ms"
+    )
+    for row in rows:
+        display_role = role_map.get(row.speaker_role)
+        content = (row.content or "").strip()
+        if display_role and content:
+            transcripts.append({"role": display_role, "messages": [content]})
+    return transcripts
 
 
 def _extract_transcripts_from_provider_call_data(call_execution: CallExecution):
@@ -517,7 +557,10 @@ def _extract_transcripts_from_provider_call_data(call_execution: CallExecution):
         "transcript_with_tool_calls", []
     )
 
-    if isinstance(transcript, list):
+    # Guard on retell_data so a provider without a retell payload (e.g. Bland,
+    # whose empty transcript is still a list) falls through to the CallTranscript
+    # fallback instead of returning an empty list here.
+    if retell_data and isinstance(transcript, list):
         transcripts = []
         for entry in transcript:
             role = entry.get("role", "")
@@ -531,7 +574,8 @@ def _extract_transcripts_from_provider_call_data(call_execution: CallExecution):
                 )
         return transcripts
 
-    return []
+    # Provider-agnostic fallback (Bland, etc.): read the persisted transcript.
+    return _transcripts_from_call_transcript_rows(call_execution)
 
 
 def fetch_voice_trace_comparison_transcripts(

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -65,6 +65,13 @@ class SpeakerRoleResolver:
     }
     _LIVEKIT_OUTBOUND: dict[str, str] = _LIVEKIT_INBOUND
 
+    # Bland's stored transcript shape matches VAPI's role convention today, so it
+    # reuses the VAPI maps — but as its own named seam, so a future Bland payload
+    # change is a one-line map edit here, not an alias hunt. Bland is a
+    # customer-only outbound provider (inbound Bland flows through VAPI).
+    _BLAND_INBOUND: dict[str, str] = _VAPI_INBOUND
+    _BLAND_OUTBOUND: dict[str, str] = _VAPI_OUTBOUND
+
     @staticmethod
     def detect_provider(
         provider_call_data: dict[str, Any] | None,
@@ -82,10 +89,7 @@ class SpeakerRoleResolver:
         if provider_call_data.get(ProviderChoices.VAPI.value):
             return ProviderChoices.VAPI
         if provider_call_data.get(ProviderChoices.BLAND.value):
-            # Bland's stored transcript shape matches VAPI's outbound
-            # convention, so the VAPI role map applies. Handled explicitly to
-            # avoid the unknown-provider error below firing on every read.
-            return ProviderChoices.VAPI
+            return ProviderChoices.BLAND
         logger.error(
             "speaker_role_resolver_unknown_provider",
             provider_call_data_keys=list(provider_call_data.keys()),
@@ -128,6 +132,8 @@ class SpeakerRoleResolver:
             return cls._VAPI_OUTBOUND if is_outbound else cls._VAPI_INBOUND
         if provider == ProviderChoices.LIVEKIT:
             return cls._LIVEKIT_OUTBOUND if is_outbound else cls._LIVEKIT_INBOUND
+        if provider == ProviderChoices.BLAND:
+            return cls._BLAND_OUTBOUND if is_outbound else cls._BLAND_INBOUND
         logger.error(
             "speaker_role_resolver_unsupported_provider",
             provider=str(provider),

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -65,12 +65,23 @@ class SpeakerRoleResolver:
     }
     _LIVEKIT_OUTBOUND: dict[str, str] = _LIVEKIT_INBOUND
 
-    # Bland's stored transcript shape matches VAPI's role convention today, so it
-    # reuses the VAPI maps — but as its own named seam, so a future Bland payload
-    # change is a one-line map edit here, not an alias hunt. Bland is a
-    # customer-only outbound provider (inbound Bland flows through VAPI).
-    _BLAND_INBOUND: dict[str, str] = _VAPI_INBOUND
-    _BLAND_OUTBOUND: dict[str, str] = _VAPI_OUTBOUND
+    # Bland is a customer-only outbound provider (inbound Bland flows through
+    # VAPI). Its own maps — same values as VAPI today, but independent so a Bland
+    # payload change is edited here directly, not through a shared alias.
+    _BLAND_INBOUND: dict[str, str] = {
+        "bot": "simulator",
+        "assistant": "simulator",
+        "agent": "simulator",
+        "user": "tested_agent",
+        "customer": "tested_agent",
+    }
+    _BLAND_OUTBOUND: dict[str, str] = {
+        "bot": "tested_agent",
+        "assistant": "tested_agent",
+        "agent": "tested_agent",
+        "user": "simulator",
+        "customer": "simulator",
+    }
 
     @staticmethod
     def detect_provider(

--- a/futureagi/simulate/utils/speaker_roles.py
+++ b/futureagi/simulate/utils/speaker_roles.py
@@ -81,6 +81,11 @@ class SpeakerRoleResolver:
             return ProviderChoices.LIVEKIT
         if provider_call_data.get(ProviderChoices.VAPI.value):
             return ProviderChoices.VAPI
+        if provider_call_data.get(ProviderChoices.BLAND.value):
+            # Bland's stored transcript shape matches VAPI's outbound
+            # convention, so the VAPI role map applies. Handled explicitly to
+            # avoid the unknown-provider error below firing on every read.
+            return ProviderChoices.VAPI
         logger.error(
             "speaker_role_resolver_unknown_provider",
             provider_call_data_keys=list(provider_call_data.keys()),

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -3220,14 +3220,25 @@ class CallExecutionDetailView(APIView):
                     vapi_data, include_call_logs=False
                 )
             else:
-                # Fallback for other providers (retell etc.): ship the raw
-                # payload under `raw_log` so the Attributes tab at least
-                # renders the full object tree.
-                provider_data = next(
-                    (v for v in pcd.values() if isinstance(v, dict)), None
+                # Other providers (Bland, Retell, ElevenLabs, Twilio): reuse the
+                # same per-provider normalizer the ingest pipeline runs, so the
+                # Attributes tab renders flat eval attributes (call.duration,
+                # conversation.transcript.*, cost, ...) instead of a single
+                # collapsed raw_log tree. Falls back to raw_log if no normalizer
+                # matches the provider key.
+                from tracer.utils.observability_provider import (
+                    flatten_provider_call_attributes,
+                )
+
+                provider_key, provider_data = next(
+                    ((k, v) for k, v in pcd.items() if isinstance(v, dict)),
+                    (None, None),
                 )
                 if provider_data:
-                    response_data["attributes"] = {"raw_log": provider_data}
+                    attrs = flatten_provider_call_attributes(
+                        provider_key, provider_data
+                    )
+                    response_data["attributes"] = attrs or {"raw_log": provider_data}
 
             return Response(response_data, status=status.HTTP_200_OK)
 

--- a/futureagi/tfc/utils/ssrf_guard.py
+++ b/futureagi/tfc/utils/ssrf_guard.py
@@ -104,6 +104,23 @@ def _resolve_pinned_ip(host: str) -> str:
     return resolved_ips[0]
 
 
+def assert_url_host_public(url: str) -> None:
+    """Raise SsrfBlocked unless `url`'s host resolves entirely to public IPs.
+
+    A pre-flight guard for streaming/async callers that do their own fetch and
+    only need the reject, not safe_fetch's buffered body. Because the fetch
+    re-resolves at connect time this keeps a small DNS-rebinding TOCTOU gap that
+    safe_fetch closes — acceptable when the URL is provider-returned over
+    authenticated TLS (e.g. a recording URL inside a provider's API response).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SsrfBlocked(f"Unsupported URL scheme: '{parsed.scheme}'.")
+    if not parsed.hostname:
+        raise SsrfBlocked("Invalid URL: missing host.")
+    _resolve_pinned_ip(parsed.hostname)  # resolves + rejects every A/AAAA record
+
+
 def _open_pinned_pool(scheme, pinned_ip, host, port, timeout):
     if scheme == "https":
         return urllib3.HTTPSConnectionPool(

--- a/futureagi/tfc/utils/tests/test_storage_ssrf.py
+++ b/futureagi/tfc/utils/tests/test_storage_ssrf.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from PIL import Image
 
-from tfc.utils.ssrf_guard import SsrfBlocked, SsrfResponse
+from tfc.utils.ssrf_guard import SsrfBlocked, SsrfResponse, assert_url_host_public
 from tfc.utils.storage import (
     _ssrf_safe_get,
     convert_image_from_url_to_base64,
@@ -222,3 +222,58 @@ class TestIsOwnStorageUrl:
             "https://fi-customer-data.s3.attacker-amazonaws.com/x",
             "fi-customer-data",
         )
+
+
+# ---------------------------------------------------------------------------
+# assert_url_host_public — pre-flight guard reused by the async recording rehost
+# (simulate.temporal.utils.async_storage). Provider recording URLs come back
+# inside an API response, so the converter validates the host before fetching.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://127.0.0.1/secret",  # loopback
+        "http://10.0.0.5/internal",  # private
+        "http://100.64.0.1/cgnat",  # carrier-grade NAT
+        "http://[::1]/x",  # ipv6 loopback
+    ],
+)
+def test_assert_url_host_public_blocks_private_and_metadata(url):
+    with pytest.raises(SsrfBlocked):
+        assert_url_host_public(url)
+
+
+def test_assert_url_host_public_rejects_non_http_scheme():
+    with pytest.raises(SsrfBlocked):
+        assert_url_host_public("ftp://example.com/x")
+
+
+def test_assert_url_host_public_rejects_missing_host():
+    with pytest.raises(SsrfBlocked):
+        assert_url_host_public("http:///nohost")
+
+
+def test_assert_url_host_public_allows_public_ip_literal():
+    # 8.8.8.8 is public; getaddrinfo on a literal doesn't hit DNS, so this stays
+    # hermetic while proving a legit provider host is not rejected.
+    assert_url_host_public("https://8.8.8.8/recording.mp3")  # no raise
+
+
+async def test_recording_rehost_blocks_ssrf_url_and_fails_open():
+    """The converter must not fetch a recording URL that points at an internal
+    host: it blocks before the download and fails open to the original URL with
+    0 bytes (nothing rehosted, nothing metered), never calling the downloader."""
+    from simulate.temporal.utils import async_storage
+
+    blocked = "http://169.254.169.254/latest/meta-data/"
+    with patch.object(
+        async_storage, "_existing_rehosted_audio", return_value=None
+    ), patch.object(async_storage, "download_audio_from_url_async") as mock_dl:
+        s3_url, size = await async_storage.convert_audio_url_to_s3_async_with_size(
+            "call-1", blocked, "recording", provider="bland"
+        )
+
+    assert s3_url == blocked
+    assert size == 0
+    mock_dl.assert_not_called()

--- a/futureagi/tfc/utils/tests/test_storage_ssrf.py
+++ b/futureagi/tfc/utils/tests/test_storage_ssrf.py
@@ -260,6 +260,29 @@ def test_assert_url_host_public_allows_public_ip_literal():
     assert_url_host_public("https://8.8.8.8/recording.mp3")  # no raise
 
 
+def test_assert_url_host_public_allows_public_hostname():
+    # A normal provider hostname (e.g. a CDN) must pass. Mock the resolver so the
+    # test stays hermetic — no real DNS — while proving hostnames, not just IP
+    # literals, go through the guard.
+    with patch(
+        "tfc.utils.ssrf_guard.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ) as mock_resolve:
+        assert_url_host_public("https://recordings.example.com/rec.mp3")  # no raise
+    assert mock_resolve.call_args.args[0] == "recordings.example.com"
+
+
+def test_assert_url_host_public_blocks_hostname_resolving_to_private():
+    # The real SSRF threat: a public-looking hostname that resolves to an
+    # internal address. The guard must reject on the RESOLVED IP, not the name.
+    with patch(
+        "tfc.utils.ssrf_guard.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("10.0.0.5", 0))],
+    ):
+        with pytest.raises(SsrfBlocked):
+            assert_url_host_public("https://totally-legit.example.com/rec.mp3")
+
+
 async def test_recording_rehost_blocks_ssrf_url_and_fails_open():
     """The converter must not fetch a recording URL that points at an internal
     host: it blocks before the download and fails open to the original URL with

--- a/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
+++ b/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
@@ -61,6 +61,29 @@ def test_normalize_bland_data_shape():
 
 
 @pytest.mark.unit
+def test_flatten_provider_call_attributes_bland_returns_flat_span_attributes():
+    from tracer.utils.observability_provider import flatten_provider_call_attributes
+
+    attrs = flatten_provider_call_attributes(ProviderChoices.BLAND.value, BLAND_CALL)
+    # Flat eval attributes (raw_log + conversation/call.* keys), not a bare
+    # raw_log tree — this is what feeds the simulate call-detail Attributes tab.
+    assert attrs
+    assert attrs.get("raw_log") == BLAND_CALL
+
+
+@pytest.mark.unit
+def test_flatten_provider_call_attributes_unknown_or_vapi_returns_empty():
+    from tracer.utils.observability_provider import flatten_provider_call_attributes
+
+    # VAPI is handled by its caller (needs include_call_logs=False); an
+    # unrecognized provider key yields {} so callers can fall back to raw_log.
+    assert (
+        flatten_provider_call_attributes(ProviderChoices.VAPI.value, {"id": "x"}) == {}
+    )
+    assert flatten_provider_call_attributes("nonsense", {"a": 1}) == {}
+
+
+@pytest.mark.unit
 def test_normalize_bland_call_length_is_minutes():
     out = normalize_bland_data({**BLAND_CALL, "end_at": None, "call_length": 2.5})
     assert out["span_attributes"]["call.duration"] == 150

--- a/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
+++ b/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
@@ -91,6 +91,86 @@ def test_normalize_bland_call_length_is_minutes():
     assert (out["end_time"] - out["start_time"]).total_seconds() == 150
 
 
+_BLAND_RECORDING_URL = "https://bland-cdn.example.test/call-bl-123-recording.mp3"
+_DURABLE_BLAND_URL = (
+    "https://fi-customer-data.s3.amazonaws.com/call-recordings/project-1/"
+    "bland/bl-123/mono_combined.mp3"
+)
+
+
+@pytest.mark.unit
+def test_bland_rehosts_combined_recording_with_provider_and_project_scope():
+    log = {**BLAND_CALL, "recording_url": _BLAND_RECORDING_URL}
+    with patch(
+        "tracer.utils.bland.convert_audio_url_to_s3_sync",
+        return_value=(_DURABLE_BLAND_URL, 150),
+    ) as mock_convert:
+        result = normalize_bland_data(log, project_id="project-1")
+
+    attrs = result["span_attributes"]
+    assert attrs["conversation.recording.mono.combined"] == _DURABLE_BLAND_URL
+    assert result["rehost_uploads"] == {"mono_combined": 150}
+    assert result["rehost_bytes_uploaded"] == 150
+    kwargs = mock_convert.call_args.kwargs
+    assert kwargs["provider"] == "bland"
+    assert kwargs["url_type"] == "mono_combined"
+    assert kwargs["artifact_type"] == "mono_combined"
+    assert kwargs["project_id"] == "project-1"
+    assert kwargs["call_id"] == "bl-123"
+
+
+@pytest.mark.unit
+def test_bland_no_project_or_no_recording_skips_rehost():
+    with patch("tracer.utils.bland.convert_audio_url_to_s3_sync") as mock_convert:
+        no_project = normalize_bland_data(
+            {**BLAND_CALL, "recording_url": _BLAND_RECORDING_URL}
+        )
+        no_url = normalize_bland_data(
+            {**BLAND_CALL, "recording_url": None}, project_id="project-1"
+        )
+
+    mock_convert.assert_not_called()
+    assert no_project["rehost_uploads"] == {}
+    # Without a project_id the raw combined URL is still surfaced (the sim path
+    # rehosts separately) but not rehosted here.
+    assert (
+        no_project["span_attributes"]["conversation.recording.mono.combined"]
+        == _BLAND_RECORDING_URL
+    )
+    assert "conversation.recording.mono.combined" not in no_url["span_attributes"]
+
+
+@pytest.mark.unit
+def test_bland_already_owned_recording_is_not_rehosted():
+    log = {**BLAND_CALL, "recording_url": _DURABLE_BLAND_URL}
+    with patch("tracer.utils.bland.convert_audio_url_to_s3_sync") as mock_convert:
+        result = normalize_bland_data(log, project_id="project-1")
+
+    mock_convert.assert_not_called()
+    assert (
+        result["span_attributes"]["conversation.recording.mono.combined"]
+        == _DURABLE_BLAND_URL
+    )
+    assert result["rehost_uploads"] == {}
+
+
+@pytest.mark.unit
+def test_bland_rehost_failure_preserves_source_and_does_not_raise():
+    log = {**BLAND_CALL, "recording_url": _BLAND_RECORDING_URL}
+    with patch(
+        "tracer.utils.bland.convert_audio_url_to_s3_sync",
+        side_effect=RuntimeError("download failed"),
+    ):
+        result = normalize_bland_data(log, project_id="project-1")
+
+    # A rehost failure must not drop the span; the source URL is left for retry.
+    assert (
+        result["span_attributes"]["conversation.recording.mono.combined"]
+        == _BLAND_RECORDING_URL
+    )
+    assert result["rehost_uploads"] == {}
+
+
 @pytest.mark.unit
 def test_normalize_twilio_data_shape():
     out = normalize_twilio_data(TWILIO_CALL)

--- a/futureagi/tracer/utils/bland.py
+++ b/futureagi/tracer/utils/bland.py
@@ -2,21 +2,54 @@
 
 from datetime import UTC, datetime, timedelta
 
+from simulate.temporal.utils.async_storage import convert_audio_url_to_s3_sync
 from tracer.utils.otel import (
     CallAttributes,
     ConversationAttributes,
     MessageAttributes,
     SpanAttributes,
 )
+from tracer.utils.vapi_recording import VapiRecordingService
+
+# Bland returns a single combined (mono-mixed) recording — no channel
+# separation, so only the combined key is written (per-channel needs diarization).
+_BLAND_COMBINED_RECORDING_KEY = (
+    f"{ConversationAttributes.CONVERSATION_RECORDING}."
+    f"{ConversationAttributes.MONO_COMBINED}"
+)
 
 
-def normalize_bland_data(log: dict) -> dict:
+def normalize_bland_data(log: dict, *, project_id: str | None = None) -> dict:
     """Normalizes a single detailed Bland call into the standard log shape."""
     status_map = {"completed": "ok", "complete": "ok", "failed": "error", "error": "error"}
     raw_status = (log.get("status") or "") if isinstance(log.get("status"), str) else ""
     status = status_map.get(raw_status.lower(), "ok" if log.get("completed") else "unset")
 
     eval_attributes = _extract_eval_attributes(log)
+
+    # Observe ingest only (project_id set): rehost the combined recording to our
+    # storage via the shared converter — Bland's raw URL has cross-origin
+    # problems. The sim path rehosts separately, so gating on project_id avoids a
+    # double-rehost. Best-effort: a failure leaves the source URL in place so a
+    # later poll can retry, and must not drop the whole span.
+    rehost_uploads: dict[str, int] = {}
+    source_url = eval_attributes.get(_BLAND_COMBINED_RECORDING_KEY)
+    if project_id and source_url and not VapiRecordingService.is_fagi_s3_url(source_url):
+        try:
+            durable_url, artifact_bytes = convert_audio_url_to_s3_sync(
+                call_id=log.get("call_id") or log.get("c_id"),
+                audio_url=source_url,
+                url_type="mono_combined",
+                provider="bland",
+                artifact_type="mono_combined",
+                project_id=project_id,
+            )
+            if durable_url and durable_url != source_url:
+                eval_attributes[_BLAND_COMBINED_RECORDING_KEY] = durable_url
+                rehost_uploads = {"mono_combined": artifact_bytes}
+        except Exception:
+            pass
+
     start_time, end_time = _extract_timestamps(log)
     transcript = _transcript_messages(log)
 
@@ -42,6 +75,8 @@ def normalize_bland_data(log: dict) -> dict:
         "prompt_tokens": None,
         "completion_tokens": None,
         "total_tokens": None,
+        "rehost_bytes_uploaded": sum(rehost_uploads.values()),
+        "rehost_uploads": rehost_uploads,
     }
 
 
@@ -63,8 +98,15 @@ def _extract_eval_attributes(log: dict) -> dict:
         "raw_log": log,
     }
     _extract_transcript(log, eval_attributes)
+    _extract_recording(log, eval_attributes)
     _extract_common_call_fields(log, eval_attributes)
     return eval_attributes
+
+
+def _extract_recording(log: dict, eval_attributes: dict):
+    recording_url = log.get("recording_url")
+    if recording_url:
+        eval_attributes[_BLAND_COMBINED_RECORDING_KEY] = recording_url
 
 
 def _extract_transcript(log: dict, eval_attributes: dict):

--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -472,7 +472,9 @@ def process_and_store_logs(
             log, project_id=str(project.id)
         ),
         ProviderChoices.ELEVEN_LABS: normalize_eleven_labs_data,
-        ProviderChoices.BLAND: normalize_bland_data,
+        ProviderChoices.BLAND: lambda log: normalize_bland_data(
+            log, project_id=str(project.id)
+        ),
         ProviderChoices.TWILIO: normalize_twilio_data,
     }
 

--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -407,6 +407,35 @@ def _export_provider_call_to_collector(span, provider: str, provider_log_id: str
         )
 
 
+def flatten_provider_call_attributes(provider_key: str, payload: dict) -> dict:
+    """Flat eval attributes for one provider call payload — the same shape the
+    ingest pipeline stores on the span.
+
+    Lets callers (e.g. the simulate call-detail drawer) render flat keys like
+    ``call.duration`` / ``conversation.transcript.*`` / cost for non-VAPI
+    providers instead of a single collapsed ``raw_log`` tree. VAPI is handled by
+    its caller directly because it needs ``include_call_logs=False`` to skip a
+    blocking log fetch. Returns ``{}`` for an unknown provider or on any
+    normalizer error, so callers can fall back to raw_log.
+    """
+    normalizers = {
+        ProviderChoices.RETELL.value: normalize_retell_data,
+        ProviderChoices.ELEVEN_LABS.value: normalize_eleven_labs_data,
+        ProviderChoices.BLAND.value: normalize_bland_data,
+        ProviderChoices.TWILIO.value: normalize_twilio_data,
+    }
+    normalize_fn = normalizers.get(provider_key)
+    if normalize_fn is None or not isinstance(payload, dict):
+        return {}
+    try:
+        return normalize_fn(payload).get("span_attributes") or {}
+    except Exception:
+        logger.exception(
+            "flatten_provider_call_attributes failed", provider=provider_key
+        )
+        return {}
+
+
 def process_and_store_logs(
     logs: list,
     provider: ObservabilityProvider,


### PR DESCRIPTION
## Summary

Outer-repo companion for the ee Bland **outbound** data plane ([`future-agi/ee#156`](https://github.com/future-agi/ee/pull/156)). Two groups of changes:

1. **The cross-repo contract** — a `client_provider` field on the shared Temporal activity inputs so the outbound-SIP flow can route its trigger / monitor / fetch / **metrics** to a non-VAPI customer agent (Bland) instead of assuming VAPI. Tiny and additive; **must merge first** (see **Merge order**).
2. **Read-surface parity for non-VAPI providers** — the simulate-side fixes from the Fable hidden-bug audit, so a Bland (and Retell) call renders correctly in the call-detail Attributes tab, in session comparison, and in tool evaluation instead of silently degrading. These are shared, provider-agnostic fixes and belong in the outer repo, not in the ee engine PR.

---

## Background

In an outbound voice simulation the customer's own agent is dialed and our simulator converses with it. Under a VAPI **system** simulator, the *customer's* provider account is the data plane for the outbound leg (trigger + poll + fetch + metrics), and that data plane was hard-wired to VAPI. To support a Bland customer agent, the ee activities need to know *which* customer provider they're driving — so the call-execution activity inputs carry it. Those inputs are Temporal dataclasses that live in this repo, hence this companion PR. The read-surface code (below) similarly assumed VAPI's payload shape and lives here.

---

## Part 1 — the `client_provider` contract

**`simulate/temporal/types/activities.py`** — add `client_provider: str = "vapi"` to the four activity inputs the outbound flow uses:
- `InitiateCallInput` (trigger), `MonitorCallInput` (poll), `FetchAndPersistCallResultInput` (fetch), and `CalculateConversationMetricsInput` (the 5th-site metrics fix — the customer holds the call data, so metrics must read the customer engine).

Distinct from the existing `provider` field, which is the **system simulator** provider; `client_provider` is the **customer agent under test**. Defaults to `"vapi"`, so existing callers and old in-flight Temporal payloads keep routing to VAPI. Adding a *field* to an activity input is **replay-safe** — Temporal replay validates command sequence and type, not payload shape — so no `workflow.patched` gate is needed.

**`simulate/semantics.py`** — add `ProviderChoices.BLAND.value` to `SupportedProviders` (the set the `CallExecution.provider_call_data` JSONField validator gates keys on; the ee path writes `provider_call_data["bland"]`, which the validator would otherwise reject).

**`simulate/utils/speaker_roles.py`** — in `SpeakerRoleResolver.detect_provider`, give Bland its own speaker-role map seam (aliased to VAPI's convention, since Bland's stored transcript shape matches), so the `unknown_provider` error doesn't fire on every read of a Bland call.

---

## Part 2 — read-surface parity (Fable hidden-bug audit)

The first live outbound run exposed places where the simulate read surfaces assume VAPI's data shape and silently degrade for Bland (and, it turned out, Retell). Fixed here:

**Attributes tab — `simulate/views/run_test.py` + `tracer/utils/observability_provider.py`.** The call-detail Attributes tab only flattened a `"vapi"` payload (`_extract_eval_attributes`); every other provider fell back to a bare `raw_log` tree. New `flatten_provider_call_attributes(provider_key, payload)` reuses the **existing per-provider ingest normalizers** (`normalize_bland_data`, `normalize_retell_data`, …), so Bland / Retell / ElevenLabs get the same flat eval attributes (`call.duration`, `conversation.transcript.*`, cost, …). VAPI keeps its existing path (it needs `include_call_logs=False` to skip a blocking fetch). **Fixes Retell too.**

**Session comparison — `simulate/utils/session_comparison.py`.** `_extract_metrics_from_provider_call_data` read duration/turns only from a `"vapi"` payload, and `_extract_transcripts_from_provider_call_data` handled only VAPI/Retell shapes — so a Bland call compared as **blank** (0 duration, 0 turns, empty transcript). Both now fall back to provider-agnostic sources: the `duration_seconds` model field and the persisted `CallTranscript` rows (written for every provider). Also fixes the Retell empty-transcript edge the old `if isinstance(transcript, list)` branch swallowed.

**Tool evaluation — `simulate/temporal/activities/xl.py`.** `get_tool_call_adapter("bland")` raised `ValueError` into a broad `except` — silently no-op'ing tool eval for every Bland run. Now gated on `ToolCallingSupportedProviders` up front: an unsupported provider skips cleanly with a log line instead of raising into the swallow.

> **Not a scoring bug.** The eval pipeline reads `CallTranscript` + `SpeakerRoleResolver`, not the flat attributes — so the empty Attributes tab was UI/comparison-only, never a scored-metric regression. Confirmed during the audit.

---

## Also here: Bland recording playback on the Observe detail view

`normalize_bland_data` put the raw `recording_url` only in `metadata` and never wrote the canonical `conversation.recording.mono.combined` key the Observe player + `recording_available` derive from — so a *pulled* Bland call showed **no player** (unlike VAPI/Retell). And the raw Bland URL has the same cross-origin access problem the sim path already rehosts around, so aliasing it would ship a dead URL into the player.

- **`tracer/utils/bland.py`** now writes `conversation.recording.mono.combined` and, on the Observe ingest path (`project_id` set), **rehosts** the raw recording to durable storage via the shared `convert_audio_url_to_s3_sync` before writing the key — mirroring Retell's inline rehost.
- Gated on `project_id` so the simulation path (which rehosts separately) never double-rehosts; **best-effort** so a rehost failure leaves the source URL in place for a later retry instead of dropping the span. The returned `rehost_uploads` is metered like the other providers.
- **`tracer/utils/observability_provider.py`** — the BLAND normalizer dispatch passes `project_id` (mirrors the Retell dispatch).

> Bland exposes a **single combined** recording only (no channel separation), so only the combined key is written; real per-channel needs diarization. The same missing-canonical-key gap in ElevenLabs / Twilio and a provider-aware FE variable picker are tracked in TH-7153 (this closes item 1 of that ticket).

---

## Also here: SSRF host-guard on provider recording downloads

Folded into this outer PR (response to [`ee#156`](https://github.com/future-agi/ee/pull/156) finding #1) because it's a **shared** change and belongs with VAPI/Retell, not just Bland. The async recording rehost (`simulate/temporal/utils/async_storage.py`) handed a provider-returned `recording_url` straight to `download_audio_from_url_async` with **no host validation** — the one async audio fetch that skipped the SSRF guard the sync downloads enforce.

- New public **`assert_url_host_public(url)`** in `tfc/utils/ssrf_guard.py` — resolves the host and rejects any record that's private / loopback / link-local (incl. the `169.254.169.254` metadata endpoint) / CGNAT / reserved, via the same `_resolve_pinned_ip` classifier `safe_fetch` uses.
- Called in `_convert_audio_url_to_s3_async_with_size` **before the download, for provider URLs only** (`audio_url and not vapi_authenticated`); our own storage is already short-circuited by `_is_fagi_storage_url`.
- **Scoped to the converter, not the raw downloader** — `download_audio_from_url_async` is also called by the LiveKit egress path, which legitimately fetches an internal egress bucket (private IP in self-hosted); a blanket block there would break egress. The converter only ever sees provider URLs, so guarding it covers VAPI / Bland / Retell.
- Private-range block (not a host allow-list — recordings live on arbitrary CDN/S3 hosts); **fail-open** to the original URL, nothing metered. Residual DNS-rebinding TOCTOU documented on the helper.

---

## Testing

- **Contract / additive:** the `client_provider="vapi"` default means every existing VAPI / LiveKit / Retell path is unchanged.
- **Read-surface fixes:** `test_session_comparison_utils.py` (Bland transcripts/metrics via CallTranscript + model fields), `tracer/tests/test_pull_observability_bland_twilio.py` (`flatten_provider_call_attributes` returns flat attrs for Bland, `{}` for VAPI/unknown), `test_temporal_activities.py` (tool-eval gate invariant: Bland has no adapter → must be gated). Regression tests fail on the pre-fix behavior.
- **Recording rehost:** `tracer/tests/test_pull_observability_bland_twilio.py` — Bland rehosts the combined recording (provider/project scoped), skips when no project or no URL, skips an already-owned FAGI URL, and preserves the source on rehost failure.
- **SSRF:** `tfc/utils/tests/test_storage_ssrf.py` — blocks metadata/loopback/private/CGNAT/ipv6-loopback, rejects bad scheme / missing host, allows public host (mocked resolver), and a converter test asserting a metadata URL is blocked before download (fails open, 0 bytes).

> Pre-existing red: `simulate/tests/test_call_log_tasks.py` has a **stale assertion** from the ee restructure (the caller now passes `call_id`/`api_key` kwargs to `iter_call_logs`; the call path works, the test just needs the two kwargs). Being addressed separately.

## Risk

Low. Part 1 is purely additive behind a `"vapi"` default. Part 2 keeps every VAPI/Retell fast path intact and only adds provider-agnostic fallbacks for what previously degraded.

## ⚠️ Merge order

**Merge this before [`future-agi/ee#156`](https://github.com/future-agi/ee/pull/156).** The ee `CallExecutionWorkflow` passes `client_provider=` to the activity inputs (including `CalculateConversationMetricsInput`) on **every** execution (VAPI included). If ee deploys before this is on dev, every voice workflow throws `TypeError: unexpected keyword argument 'client_provider'` at input construction. This is the single cross-repo ordering dependency for the whole Bland-outbound change.
<img width="2005" height="1434" alt="image" src="https://github.com/user-attachments/assets/f0055516-616f-4769-85d0-e7267c4e0125" />

