### PR TITLE
feat(simulate): add Bland.ai as an inbound voice provider

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -111006,12 +111006,13 @@
                 },
                 "provider": {
                     "title": "Provider",
-                    "description": "Voice provider. One of: vapi, retell, eleven_labs, others.",
+                    "description": "Voice provider. One of: vapi, retell, eleven_labs, bland, others.",
                     "type": "string",
                     "enum": [
                         "vapi",
                         "retell",
                         "eleven_labs",
+                        "bland",
                         "others"
                     ],
                     "default": "vapi"
@@ -122939,7 +122940,8 @@
                     "type": "string",
                     "enum": [
                         "vapi",
-                        "retell"
+                        "retell",
+                        "bland"
                     ]
                 },
                 "api_key": {
@@ -122983,7 +122985,8 @@
                     "type": "string",
                     "enum": [
                         "vapi",
-                        "retell"
+                        "retell",
+                        "bland"
                     ]
                 },
                 "assistant_id": {

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -55937,12 +55937,13 @@ export const OPENAPI_CONTRACT = Object.freeze({
         },
         "provider": {
           "title": "Provider",
-          "description": "Voice provider. One of: vapi, retell, eleven_labs, others.",
+          "description": "Voice provider. One of: vapi, retell, eleven_labs, bland, others.",
           "type": "string",
           "enum": [
             "vapi",
             "retell",
             "eleven_labs",
+            "bland",
             "others"
           ],
           "default": "vapi"
@@ -73936,7 +73937,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "enum": [
             "vapi",
-            "retell"
+            "retell",
+            "bland"
           ]
         },
         "api_key": {
@@ -73962,7 +73964,8 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "type": "string",
           "enum": [
             "vapi",
-            "retell"
+            "retell",
+            "bland"
           ]
         },
         "assistant_id": {

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -14939,7 +14939,7 @@ export interface AgentDefinitionApi {
 }
 
 /**
- * Voice provider. One of: vapi, retell, eleven_labs, others.
+ * Voice provider. One of: vapi, retell, eleven_labs, bland, others.
  */
 export type FetchAssistantRequestApiProvider = typeof FetchAssistantRequestApiProvider[keyof typeof FetchAssistantRequestApiProvider];
 
@@ -14948,6 +14948,7 @@ export const FetchAssistantRequestApiProvider = {
   vapi: 'vapi',
   retell: 'retell',
   eleven_labs: 'eleven_labs',
+  bland: 'bland',
   others: 'others',
 } as const;
 
@@ -14957,7 +14958,7 @@ export interface FetchAssistantRequestApi {
   /** @minLength 1 */
   api_key: string;
   agent_id?: string;
-  /** Voice provider. One of: vapi, retell, eleven_labs, others. */
+  /** Voice provider. One of: vapi, retell, eleven_labs, bland, others. */
   provider?: FetchAssistantRequestApiProvider;
 }
 
@@ -19808,6 +19809,7 @@ export type VerifyApiKeyRequestApiProvider = typeof VerifyApiKeyRequestApiProvid
 export const VerifyApiKeyRequestApiProvider = {
   vapi: 'vapi',
   retell: 'retell',
+  bland: 'bland',
 } as const;
 
 export interface VerifyApiKeyRequestApi {
@@ -19828,6 +19830,7 @@ export type VerifyAssistantIdRequestApiProvider = typeof VerifyAssistantIdReques
 export const VerifyAssistantIdRequestApiProvider = {
   vapi: 'vapi',
   retell: 'retell',
+  bland: 'bland',
 } as const;
 
 export interface VerifyAssistantIdRequestApi {

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -28246,7 +28246,7 @@ export const SimulateApiAgentDefinitionOperationsFetchAssistantFromProviderBody 
   "assistant_id": zod.string().min(1),
   "api_key": zod.string().min(1),
   "agent_id": zod.string().uuid().optional(),
-  "provider": zod.enum(['vapi', 'retell', 'eleven_labs', 'others']).default(simulateApiAgentDefinitionOperationsFetchAssistantFromProviderBodyProviderDefault).describe('Voice provider. One of: vapi, retell, eleven_labs, others.')
+  "provider": zod.enum(['vapi', 'retell', 'eleven_labs', 'bland', 'others']).default(simulateApiAgentDefinitionOperationsFetchAssistantFromProviderBodyProviderDefault).describe('Voice provider. One of: vapi, retell, eleven_labs, bland, others.')
 })
 
 
@@ -37355,7 +37355,7 @@ export const TracerObservabilityProviderCreateBody = zod.object({
  * API endpoints for managing Observability Providers.
  */
 export const TracerObservabilityProviderVerifyApiKeyBody = zod.object({
-  "provider": zod.enum(['vapi', 'retell']),
+  "provider": zod.enum(['vapi', 'retell', 'bland']),
   "api_key": zod.string().optional(),
   "agent_id": zod.string().optional()
 })
@@ -37373,7 +37373,7 @@ export const TracerObservabilityProviderVerifyApiKeyResponse = zod.object({
  * API endpoints for managing Observability Providers.
  */
 export const TracerObservabilityProviderVerifyAssistantIdBody = zod.object({
-  "provider": zod.enum(['vapi', 'retell']),
+  "provider": zod.enum(['vapi', 'retell', 'bland']),
   "assistant_id": zod.string().optional(),
   "api_key": zod.string().optional(),
   "agent_id": zod.string().optional()

--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -133,14 +133,6 @@ const EditAgentDetails = ({
      */
     mutationFn: (data) =>
       axios.post(endpoints.agentDefinitions.fetchAssistantFromProvider, data),
-    onError: (error) => {
-      enqueueSnackbar({
-        message:
-          error?.message ||
-          "Syncing with the provider failed. Recheck the API key and ID.",
-        variant: "error",
-      });
-    },
     onSuccess: (data) => {
       const providerData = data?.data?.result;
       if (!agentName?.includes(providerData?.name)) {
@@ -199,7 +191,7 @@ const EditAgentDetails = ({
     };
   }, []);
 
-  const handleSyncWithProvider = () => {
+  const handleSyncWithProvider = async () => {
     if (!apiKey || !assistantId) {
       enqueueSnackbar({
         message: "Please add a valid API key and assistant ID",
@@ -207,15 +199,15 @@ const EditAgentDetails = ({
       });
       return;
     }
-    // The sync fetches config straight from the provider, so it must not depend
-    // on whole-form validity (contact number, etc.). The backend validates the
-    // key + id and returns an error if either is wrong.
-    mutate({
-      api_key: apiKey,
-      assistant_id: assistantId,
-      provider: provider,
-      agent_id: agentDefinitionId,
-    });
+    const isValid = await trigger(["apiKey", "assistantId"]);
+    if (isValid) {
+      mutate({
+        api_key: apiKey,
+        assistant_id: assistantId,
+        provider: provider,
+        agent_id: agentDefinitionId,
+      });
+    }
   };
 
   const canEnableObservability = Boolean(apiKey && assistantId);

--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -133,6 +133,14 @@ const EditAgentDetails = ({
      */
     mutationFn: (data) =>
       axios.post(endpoints.agentDefinitions.fetchAssistantFromProvider, data),
+    onError: (error) => {
+      enqueueSnackbar({
+        message:
+          error?.message ||
+          "Syncing with the provider failed. Recheck the API key and ID.",
+        variant: "error",
+      });
+    },
     onSuccess: (data) => {
       const providerData = data?.data?.result;
       if (!agentName?.includes(providerData?.name)) {
@@ -191,7 +199,7 @@ const EditAgentDetails = ({
     };
   }, []);
 
-  const handleSyncWithProvider = async () => {
+  const handleSyncWithProvider = () => {
     if (!apiKey || !assistantId) {
       enqueueSnackbar({
         message: "Please add a valid API key and assistant ID",
@@ -199,15 +207,15 @@ const EditAgentDetails = ({
       });
       return;
     }
-    const isValid = await trigger(["apiKey", "assistantId"]);
-    if (isValid) {
-      mutate({
-        api_key: apiKey,
-        assistant_id: assistantId,
-        provider: provider,
-        agent_id: agentDefinitionId,
-      });
-    }
+    // The sync fetches config straight from the provider, so it must not depend
+    // on whole-form validity (contact number, etc.). The backend validates the
+    // key + id and returns an error if either is wrong.
+    mutate({
+      api_key: apiKey,
+      assistant_id: assistantId,
+      provider: provider,
+      agent_id: agentDefinitionId,
+    });
   };
 
   const canEnableObservability = Boolean(apiKey && assistantId);

--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -370,6 +370,9 @@ const EditAgentDetails = ({
                   "livekit",
                   "livekit_bridge",
                 ];
+                // "bland" is intentionally excluded: its raw-authorization key
+                // is distinct from these Bearer providers, so switching into or
+                // out of Bland must clear the key rather than carry a stale one.
 
                 // Clear authenticationMethod only if switching to or from "others"
                 const isPrevMain = mainProviders.includes(selectedProvider);

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -358,6 +358,9 @@ export default function AgentVoiceForm() {
               "livekit",
               "livekit_bridge",
             ];
+            // "bland" is intentionally excluded: its raw-authorization key is
+            // distinct from these Bearer providers, so switching into or out of
+            // Bland must clear the key rather than carry a stale one.
 
             // Clear authenticationMethod only if switching to or from "others"
             const isPrevMain = mainProviders.includes(selectedProvider);

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -204,6 +204,7 @@ export default function AgentVoiceForm() {
   });
 
   const debounceTimeoutRef = useRef(null);
+  const prevSyncRef = useRef("");
 
   const debouncedMutate = useCallback(
     (data) => {
@@ -216,6 +217,33 @@ export default function AgentVoiceForm() {
     },
     [mutate],
   );
+
+  // Sync the provider agent (name + prompt) whenever the API key, assistant id,
+  // or provider settle — regardless of whether the values were typed, pasted,
+  // or restored on navigation. The per-field onChange only fired on live
+  // keystrokes in one field, so pasted/prefilled values never synced. LiveKit
+  // has its own validation flow; "others" brings its own endpoint — both skip.
+  useEffect(() => {
+    if (
+      !selectedProvider ||
+      selectedProvider === "others" ||
+      isLiveKitProvider(selectedProvider)
+    ) {
+      return;
+    }
+    if (!apiKey || !assistantId) return;
+
+    const syncKey = `${selectedProvider}|${apiKey}|${assistantId}`;
+    if (syncKey === prevSyncRef.current) return;
+    prevSyncRef.current = syncKey;
+
+    clearErrors("assistantId");
+    debouncedMutate({
+      api_key: apiKey,
+      assistant_id: assistantId,
+      provider: selectedProvider,
+    });
+  }, [apiKey, assistantId, selectedProvider, debouncedMutate, clearErrors]);
 
   const canEnableObservability = Boolean(apiKey && assistantId);
   const keysRequired = inbound === false;
@@ -403,17 +431,7 @@ export default function AgentVoiceForm() {
             required={observabilityEnabled || keysRequired}
             size="small"
             fullWidth
-            onChange={(e) => {
-              trigger("apiKey");
-              const value = e.target.value;
-              if (assistantId && value && selectedProvider) {
-                debouncedMutate({
-                  api_key: value,
-                  assistant_id: assistantId,
-                  provider: selectedProvider,
-                });
-              }
-            }}
+            onChange={() => trigger("apiKey")}
           />
           <FormTextFieldV2
             control={control}
@@ -429,17 +447,7 @@ export default function AgentVoiceForm() {
               },
             }}
             size="small"
-            onChange={(e) => {
-              trigger("assistantId");
-              const value = e.target.value;
-              if (apiKey && value && selectedProvider) {
-                debouncedMutate({
-                  api_key: apiKey,
-                  assistant_id: value,
-                  provider: selectedProvider,
-                });
-              }
-            }}
+            onChange={() => trigger("assistantId")}
             helperText={getVapiFetch()}
           />
           <Box

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -204,7 +204,6 @@ export default function AgentVoiceForm() {
   });
 
   const debounceTimeoutRef = useRef(null);
-  const prevSyncRef = useRef("");
 
   const debouncedMutate = useCallback(
     (data) => {
@@ -217,33 +216,6 @@ export default function AgentVoiceForm() {
     },
     [mutate],
   );
-
-  // Sync the provider agent (name + prompt) whenever the API key, assistant id,
-  // or provider settle — regardless of whether the values were typed, pasted,
-  // or restored on navigation. The per-field onChange only fired on live
-  // keystrokes in one field, so pasted/prefilled values never synced. LiveKit
-  // has its own validation flow; "others" brings its own endpoint — both skip.
-  useEffect(() => {
-    if (
-      !selectedProvider ||
-      selectedProvider === "others" ||
-      isLiveKitProvider(selectedProvider)
-    ) {
-      return;
-    }
-    if (!apiKey || !assistantId) return;
-
-    const syncKey = `${selectedProvider}|${apiKey}|${assistantId}`;
-    if (syncKey === prevSyncRef.current) return;
-    prevSyncRef.current = syncKey;
-
-    clearErrors("assistantId");
-    debouncedMutate({
-      api_key: apiKey,
-      assistant_id: assistantId,
-      provider: selectedProvider,
-    });
-  }, [apiKey, assistantId, selectedProvider, debouncedMutate, clearErrors]);
 
   const canEnableObservability = Boolean(apiKey && assistantId);
   const keysRequired = inbound === false;
@@ -434,7 +406,17 @@ export default function AgentVoiceForm() {
             required={observabilityEnabled || keysRequired}
             size="small"
             fullWidth
-            onChange={() => trigger("apiKey")}
+            onChange={(e) => {
+              trigger("apiKey");
+              const value = e.target.value;
+              if (assistantId && value && selectedProvider) {
+                debouncedMutate({
+                  api_key: value,
+                  assistant_id: assistantId,
+                  provider: selectedProvider,
+                });
+              }
+            }}
           />
           <FormTextFieldV2
             control={control}
@@ -450,7 +432,17 @@ export default function AgentVoiceForm() {
               },
             }}
             size="small"
-            onChange={() => trigger("assistantId")}
+            onChange={(e) => {
+              trigger("assistantId");
+              const value = e.target.value;
+              if (apiKey && value && selectedProvider) {
+                debouncedMutate({
+                  api_key: apiKey,
+                  assistant_id: value,
+                  provider: selectedProvider,
+                });
+              }
+            }}
             helperText={getVapiFetch()}
           />
           <Box

--- a/frontend/src/sections/agents/constants.js
+++ b/frontend/src/sections/agents/constants.js
@@ -255,8 +255,10 @@ export const LIVEKIT_STEPS = [
   },
 ];
 
-// Bland uses a Conversational Pathway as the "assistant"; its pathway ID goes
-// in the Assistant ID field. Exact dashboard menu paths may need verification.
+// Bland uses a Conversational Pathway as the "assistant": the pathway ID goes
+// in the Assistant ID field, and the API key is sent as a raw authorization
+// header (no Bearer prefix). Copy references Bland's stable product nouns only,
+// not exact dashboard menu labels, so the steps don't drift with UI changes.
 export const BLAND_STEPS = [
   {
     label: "1. Log in to",
@@ -265,14 +267,14 @@ export const BLAND_STEPS = [
   },
   {
     label:
-      "2. Open Settings → 'API Keys' and copy your API key — it is used as the authorization header.",
+      "2. Copy your Bland API key from your account settings — it is sent as the raw authorization header (no 'Bearer' prefix).",
   },
   {
-    label: "3. Go to 'Conversational Pathways' and open the pathway your agent runs.",
+    label: "3. Open the Conversational Pathway your agent runs.",
   },
   {
     label:
-      "4. Click 'Copy ID' on the pathway and paste it into the Assistant ID field (Bland uses the pathway ID as the assistant).",
+      "4. Copy the pathway's ID and paste it into the Assistant ID field — Bland uses the pathway ID as the assistant.",
   },
   {
     label:

--- a/frontend/src/sections/agents/constants.js
+++ b/frontend/src/sections/agents/constants.js
@@ -96,6 +96,7 @@ export const AGENT_TYPES = {
 export const VOICE_CHAT_PROVIDERS = [
   { label: "Vapi", value: "vapi" },
   { label: "Retell", value: "retell" },
+  { label: "Bland.ai", value: "bland" },
   // Hidden until LiveKit server stability is restored.
   // { label: "LiveKit", value: "livekit_bridge" },
   // { label: "ElevenLabs", value: "elevenlabs" },
@@ -127,6 +128,7 @@ export const AUTH_METHODS_BY_PROVIDER = {
   vapi: AUTH_METHODS,
   retell: AUTH_METHODS,
   elevenlabs: AUTH_METHODS,
+  bland: AUTH_METHODS,
   others: OTHER_AUTH_METHODS,
 };
 
@@ -253,10 +255,36 @@ export const LIVEKIT_STEPS = [
   },
 ];
 
+// Bland uses a Conversational Pathway as the "assistant"; its pathway ID goes
+// in the Assistant ID field. Exact dashboard menu paths may need verification.
+export const BLAND_STEPS = [
+  {
+    label: "1. Log in to",
+    linkText: "Bland.ai",
+    link: "https://app.bland.ai",
+  },
+  {
+    label:
+      "2. Open Settings → 'API Keys' and copy your API key — it is used as the authorization header.",
+  },
+  {
+    label: "3. Go to 'Conversational Pathways' and open the pathway your agent runs.",
+  },
+  {
+    label:
+      "4. Click 'Copy ID' on the pathway and paste it into the Assistant ID field (Bland uses the pathway ID as the assistant).",
+  },
+  {
+    label:
+      "5. Set a Contact Number — Bland has no web connector, so a phone number is required to simulate a Bland agent. For inbound tests, use a Bland number attached to that pathway that can receive calls.",
+  },
+];
+
 export const PROVIDER_STEPS_MAPPER = {
   vapi: VAPI_STEPS,
   retell: RETELL_STEPS,
   elevenlabs: ELEVENLABS_STEPS,
+  bland: BLAND_STEPS,
   livekit: LIVEKIT_STEPS,
   livekit_bridge: LIVEKIT_STEPS,
 };

--- a/futureagi/simulate/serializers/agent_definition.py
+++ b/futureagi/simulate/serializers/agent_definition.py
@@ -59,6 +59,7 @@ class AgentDefinitionOperationSerializer(serializers.Serializer):
             ProviderChoices.VAPI,
             ProviderChoices.RETELL,
             ProviderChoices.ELEVEN_LABS,
+            ProviderChoices.BLAND,
             ProviderChoices.OTHERS,
         ],
         default=ProviderChoices.VAPI,

--- a/futureagi/simulate/serializers/requests/agent_definition.py
+++ b/futureagi/simulate/serializers/requests/agent_definition.py
@@ -440,8 +440,9 @@ class FetchAssistantRequestSerializer(serializers.Serializer):
             ProviderChoices.VAPI,
             ProviderChoices.RETELL,
             ProviderChoices.ELEVEN_LABS,
+            ProviderChoices.BLAND,
             ProviderChoices.OTHERS,
         ],
         default=ProviderChoices.VAPI,
-        help_text="Voice provider. One of: vapi, retell, eleven_labs, others.",
+        help_text="Voice provider. One of: vapi, retell, eleven_labs, bland, others.",
     )

--- a/futureagi/simulate/tests/test_agent_definition_api.py
+++ b/futureagi/simulate/tests/test_agent_definition_api.py
@@ -708,6 +708,47 @@ class TestFetchAssistantFromProvider:
         assert data["result"]["name"] == "Support Bot"
         assert data["result"]["prompt"] == "You are a helpful assistant."
 
+    def test_valid_bland_request(self, auth_client):
+        # Bland's "assistant" is a Conversational Pathway (a node graph); the
+        # synced prompt assembles the description and each node's prompt/text.
+        mock_pathway = {
+            "name": "Hours Pathway",
+            "description": "Store hours agent",
+            "nodes": [
+                {"data": {"prompt": "You are the front-desk agent. Opens 9 AM."}},
+                {"data": {"text": "Thank the caller and say goodbye."}},
+            ],
+        }
+        with patch("simulate.views.agent_definition.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = mock_pathway
+            mock_resp.raise_for_status.return_value = None
+            mock_get.return_value = mock_resp
+
+            response = auth_client.post(
+                self.URL,
+                {
+                    "assistant_id": "2fdd4db9-5e81-4422-b11c-168f0182d4fc",
+                    "api_key": "org_key",
+                    "provider": "bland",
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["status"] is True
+        assert data["result"]["name"] == "Hours Pathway"
+        prompt = data["result"]["prompt"]
+        assert "Store hours agent" in prompt
+        assert "front-desk agent" in prompt
+        assert "say goodbye" in prompt
+        # Fetched the pathway by id with Bland's raw authorization header.
+        assert mock_get.call_args[0][0].endswith(
+            "/v1/pathway/2fdd4db9-5e81-4422-b11c-168f0182d4fc"
+        )
+        assert mock_get.call_args[1]["headers"]["authorization"] == "org_key"
+
     def test_invalid_credentials(self, auth_client):
         with (
             patch("tfc.ee_gating.check_ee_feature", return_value=None),

--- a/futureagi/simulate/tests/test_agent_definition_serializers.py
+++ b/futureagi/simulate/tests/test_agent_definition_serializers.py
@@ -76,6 +76,14 @@ class TestAgentDefinitionCreateRequestSerializer:
         serializer = AgentDefinitionCreateRequestSerializer(data=_text_agent_payload())
         assert serializer.is_valid(), serializer.errors
 
+    def test_valid_bland_inbound_voice_agent(self):
+        # Bland has no web bridge, so an inbound Bland agent is reached over the
+        # phone path — a contact_number is the only provider-specific requirement.
+        serializer = AgentDefinitionCreateRequestSerializer(
+            data=_voice_agent_payload(provider="bland")
+        )
+        assert serializer.is_valid(), serializer.errors
+
     def test_missing_agent_name(self):
         data = _voice_agent_payload()
         del data["agent_name"]
@@ -344,6 +352,17 @@ class TestFetchAssistantRequestSerializer:
         )
         assert not serializer.is_valid()
         assert "provider" in serializer.errors
+
+    def test_bland_provider_accepted(self):
+        # Bland is a supported voice provider; assistant_id carries the pathway id.
+        serializer = FetchAssistantRequestSerializer(
+            data={
+                "assistant_id": "a0f0d4ed-f5f5-4f16-b3f9-22166594d7a7",
+                "api_key": "bland_key_123",
+                "provider": "bland",
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
 
 
 # ============================================================================

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -2,6 +2,7 @@ import json
 import re
 from datetime import datetime
 
+import requests
 import structlog
 from django.db import models, transaction
 from django.utils import timezone
@@ -56,8 +57,12 @@ from tfc.utils.base_viewset import BaseModelViewSetMixin
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.pagination import ExtendedPageNumberPagination
+from tracer.constants.external_endpoints import ObservabilityRoutes
 from tracer.models.observability_provider import ProviderChoices
 from tracer.models.replay_session import ReplaySession
+from tracer.services.observability_providers import (
+    OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+)
 from tracer.utils.observability_provider import create_observability_provider
 from tracer.utils.otel import ResourceLimitError
 from tracer.utils.replay_session import link_agent_to_replay_session
@@ -577,6 +582,30 @@ class AgentDefinitionOperationsViewSet(BaseModelViewSetMixin, ModelViewSet):
                 response_engine_json = json.loads(response_engine_raw)
                 name = assistant_json.get("agent_name")
                 prompt = response_engine_json.get("general_prompt")
+
+            elif provider == ProviderChoices.BLAND:
+                # Bland's "assistant" is a Conversational Pathway, fetched by id.
+                resp = requests.get(
+                    f"{ObservabilityRoutes.BLAND_PATHWAY_URL.value}/{assistant_id}",
+                    headers={"authorization": api_key},
+                    timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+                )
+                resp.raise_for_status()
+                pathway = resp.json()
+                name = pathway.get("name") or ""
+                # Pathways are node graphs, not a single prompt — surface the
+                # description and each node's prompt so the synced agent carries
+                # the pathway's behaviour.
+                node_texts = [
+                    (node.get("data") or {}).get("prompt")
+                    or (node.get("data") or {}).get("text")
+                    for node in pathway.get("nodes", [])
+                ]
+                prompt = "\n\n".join(
+                    text
+                    for text in [pathway.get("description"), *node_texts]
+                    if text
+                )
 
             response_data = {
                 "assistant_id": assistant_id,

--- a/futureagi/tracer/constants/external_endpoints.py
+++ b/futureagi/tracer/constants/external_endpoints.py
@@ -6,6 +6,7 @@ class ObservabilityRoutes(str, Enum):
     RETELL_LIST_CALLS_URL = "https://api.retellai.com/v2/list-calls"
     ELEVEN_LABS_CONVERSATIONS_URL = "https://api.elevenlabs.io/v1/convai/conversations"
     BLAND_CALLS_URL = "https://api.bland.ai/v1/calls"
+    BLAND_ME_URL = "https://api.bland.ai/v1/me"
     # {account_sid} interpolated at fetch time (Twilio's API is account-scoped).
     TWILIO_CALLS_URL = "https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Calls.json"
 
@@ -13,3 +14,5 @@ class ObservabilityRoutes(str, Enum):
     VAPI_ASSISTANT_URL = "https://api.vapi.ai/assistant"
     RETELL_GET_ASSISTANT_URL = "https://api.retellai.com/get-agent"
     RETELL_LIST_ASSISTANTS_URL = "https://api.retellai.com/list-agents"
+    # Bland's "assistant" is a Conversational Pathway (id appended at call time).
+    BLAND_PATHWAY_URL = "https://api.bland.ai/v1/pathway"

--- a/futureagi/tracer/serializers/observability_provider.py
+++ b/futureagi/tracer/serializers/observability_provider.py
@@ -3,7 +3,11 @@ from rest_framework import serializers
 from tracer.models.observability_provider import ObservabilityProvider, ProviderChoices
 
 # Providers whose api-key / assistant verification is actually implemented.
-VERIFIABLE_PROVIDERS = [ProviderChoices.VAPI.value, ProviderChoices.RETELL.value]
+VERIFIABLE_PROVIDERS = [
+    ProviderChoices.VAPI.value,
+    ProviderChoices.RETELL.value,
+    ProviderChoices.BLAND.value,
+]
 
 
 class ObservabilityProviderSerializer(serializers.ModelSerializer):

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -32,6 +32,15 @@ class ObservabilityService:
             api_endpoint = (
                 f"{ObservabilityRoutes.RETELL_LIST_ASSISTANTS_URL.value}?limit=1"
             )
+        elif provider == ProviderChoices.BLAND:
+            # Bland validates via its read-only account endpoint and takes the
+            # raw key in the authorization header (no Bearer prefix).
+            response = requests.get(
+                ObservabilityRoutes.BLAND_ME_URL.value,
+                headers={"authorization": api_key},
+                timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            )
+            return response.status_code
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
         headers = {"Authorization": f"Bearer {api_key}"}
@@ -55,6 +64,14 @@ class ObservabilityService:
             endpoint = (
                 f"{ObservabilityRoutes.RETELL_GET_ASSISTANT_URL.value}/{assistant_id}"
             )
+        elif provider == ProviderChoices.BLAND:
+            # Bland's "assistant" is a pathway; the raw key goes in authorization.
+            response = requests.get(
+                f"{ObservabilityRoutes.BLAND_PATHWAY_URL.value}/{assistant_id}",
+                headers={"authorization": api_key},
+                timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            )
+            return response.status_code
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
 

--- a/futureagi/tracer/tests/test_observability_provider_api.py
+++ b/futureagi/tracer/tests/test_observability_provider_api.py
@@ -496,15 +496,15 @@ def retell_signature(payload, api_key):
 @pytest.mark.parametrize(
     "provider",
     [
-        ProviderChoices.BLAND,
         ProviderChoices.TWILIO,
         ProviderChoices.OTHERS,
         ProviderChoices.ELEVEN_LABS,
     ],
 )
 def test_verify_request_serializer_rejects_unsupported_providers(serializer_cls, provider):
-    """The verify request schema only advertises VAPI/RETELL, so an unsupported
-    provider is rejected at validation (discoverable to clients), not at runtime."""
+    """The verify request schema only advertises VAPI/RETELL/BLAND, so an
+    unsupported provider is rejected at validation (discoverable to clients),
+    not at runtime."""
     import tracer.serializers.observability_provider as ser
 
     s = getattr(ser, serializer_cls)(
@@ -518,7 +518,10 @@ def test_verify_request_serializer_rejects_unsupported_providers(serializer_cls,
     "serializer_cls",
     ["VerifyApiKeyRequestSerializer", "VerifyAssistantIdRequestSerializer"],
 )
-@pytest.mark.parametrize("provider", [ProviderChoices.VAPI, ProviderChoices.RETELL])
+@pytest.mark.parametrize(
+    "provider",
+    [ProviderChoices.VAPI, ProviderChoices.RETELL, ProviderChoices.BLAND],
+)
 def test_verify_request_serializer_accepts_supported_providers(serializer_cls, provider):
     import tracer.serializers.observability_provider as ser
 

--- a/futureagi/tracer/tests/test_observability_providers.py
+++ b/futureagi/tracer/tests/test_observability_providers.py
@@ -127,6 +127,61 @@ class TestVerifyApiKey:
             timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
         )
 
+    @patch("tracer.services.observability_providers.requests.get")
+    def test_bland_verification_hits_me_endpoint_with_raw_auth(self, mock_requests_get):
+        # Bland takes the raw key in `authorization` (NO "Bearer " prefix) and
+        # validates against its read-only /v1/me endpoint.
+        from tracer.constants.external_endpoints import ObservabilityRoutes
+        from tracer.services.observability_providers import (
+            OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            ObservabilityService,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
+        result = ObservabilityService.verify_api_key(
+            ProviderChoices.BLAND,
+            "org_bland_key",
+        )
+
+        assert result == 200
+        mock_requests_get.assert_called_once_with(
+            ObservabilityRoutes.BLAND_ME_URL.value,
+            headers={"authorization": "org_bland_key"},
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+        )
+
+    @patch("tracer.services.observability_providers.requests.get")
+    def test_bland_assistant_verification_hits_pathway_with_raw_auth(
+        self, mock_requests_get
+    ):
+        # Bland's "assistant" is a pathway; verify GETs /v1/pathway/{id} with the
+        # raw authorization header.
+        from tracer.constants.external_endpoints import ObservabilityRoutes
+        from tracer.services.observability_providers import (
+            OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            ObservabilityService,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
+        result = ObservabilityService.verify_assistant_id(
+            ProviderChoices.BLAND,
+            "2fdd4db9-5e81-4422-b11c-168f0182d4fc",
+            "org_bland_key",
+        )
+
+        assert result == 200
+        mock_requests_get.assert_called_once_with(
+            f"{ObservabilityRoutes.BLAND_PATHWAY_URL.value}/2fdd4db9-5e81-4422-b11c-168f0182d4fc",
+            headers={"authorization": "org_bland_key"},
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+        )
+
 
 class TestFetchVapiLogs:
     """Tests for _fetch_vapi_logs method."""

--- a/futureagi/tracer/views/observability_provider.py
+++ b/futureagi/tracer/views/observability_provider.py
@@ -207,8 +207,12 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
                     msg = "Could not resolve the api key. Please recheck the same"
                     return self._gm.bad_request(msg)
 
-            # Only VAPI/RETELL support key verification; reject the rest clearly.
-            if provider in (ProviderChoices.VAPI, ProviderChoices.RETELL):
+            # VAPI/RETELL/BLAND support key verification; reject the rest clearly.
+            if provider in (
+                ProviderChoices.VAPI,
+                ProviderChoices.RETELL,
+                ProviderChoices.BLAND,
+            ):
                 status_code = ObservabilityService.verify_api_key(
                     provider=provider,
                     api_key=api_key,
@@ -248,8 +252,12 @@ class ObservabilityProviderViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSe
                     msg = "Could not resolve the api key. Please recheck the same"
                     return self._gm.bad_request(msg)
 
-            # Only VAPI/RETELL have an assistant model to verify against.
-            if provider in (ProviderChoices.VAPI, ProviderChoices.RETELL):
+            # VAPI/RETELL/BLAND have an assistant/pathway to verify against.
+            if provider in (
+                ProviderChoices.VAPI,
+                ProviderChoices.RETELL,
+                ProviderChoices.BLAND,
+            ):
                 status_code = ObservabilityService.verify_assistant_id(
                     provider=provider,
                     assistant_id=assistant_id,


### PR DESCRIPTION
## Summary

Adds **Bland.ai as an inbound voice provider**: a user can register their own inbound voice agent — hosted on Bland as a **Conversational Pathway** — as an agent definition / observability provider, so its production calls can be verified, fetched, ingested, and simulated. This is a **control-plane + frontend** change only; **no data-plane / Temporal code** (inbound Bland flows through the existing VAPI-simulator path). It has **no ee-repo component** and no file overlap with the two outbound Bland PRs.

Bland's model differs from VAPI/Retell: its "assistant" is a **pathway** (a node graph), fetched by id, and it authenticates with a **raw `authorization: <key>` header** (no `Bearer`). Both quirks are handled below.

---

## What a reviewer should verify first

1. **Contract fidelity** — the DRF serializer change and the four generated contract files must correspond exactly (a drifted contract silently breaks the FE and fails `backend-contracts` CI).
2. **Enum consistency** — `bland` must be accepted at *every* gate (serializer choices, provider verify/fetch, FE constants, generated contract), or the FE request interceptor rejects it client-side.
3. **The bundled `_process_vapi_logs` change** — see the ⚠️ callout below; it is **unrelated to Bland** and deserves its own scrutiny.

---

## File-by-file

### Backend — provider verification & fetch

**`tracer/constants/external_endpoints.py`** — add two Bland routes:
- `BLAND_PATHWAY_URL = "https://api.bland.ai/v1/pathway"` (assistant/pathway fetch; id appended at call time)
- `BLAND_ME_URL = "https://api.bland.ai/v1/me"` (read-only account endpoint used for api-key verification)

**`tracer/services/observability_providers.py`** — `ObservabilityService`:
- `verify_api_key`: for Bland, GET `/v1/me` with the raw `authorization` header, return the status code. (VAPI/Retell use `Bearer`; Bland deliberately does not.)
- `verify_assistant_id`: for Bland, GET `/v1/pathway/{id}` with the raw header.
- Both use the shared `OBSERVABILITY_VERIFY_TIMEOUT_SECONDS` (30s).

**`tracer/serializers/observability_provider.py`** — add `BLAND` to `VERIFIABLE_PROVIDERS`, so validation permits verification for Bland (and still 400s clearly for providers with no verify path).

**`tracer/views/observability_provider.py`** — extend the two `if provider in (VAPI, RETELL)` gates (verify-key and verify-assistant endpoints) to include `BLAND`. Non-verifiable providers still get a clean rejection; non-200 → "Invalid API key"; exceptions → logged + 400 (fail-closed on purpose).

### Backend — agent-definition sync (fetch pathway → agent)

**`simulate/serializers/agent_definition.py`** & **`simulate/serializers/requests/agent_definition.py`** — add `ProviderChoices.BLAND` to the provider `ChoiceField` (operations serializer + `FetchAssistantRequestSerializer`), and update the `help_text` (which is the source of the generated contract's enum + zod description).

**`simulate/views/agent_definition.py`** — `fetch_assistant_from_provider` gains a Bland branch: GET the pathway by id, then build the synced agent's `name` from `pathway.name` and its `prompt` by joining the pathway `description` + each node's `data.prompt`/`data.text` (pathways are node graphs, not a single prompt, so we surface the graph's behaviour). Uses `ObservabilityRoutes.BLAND_PATHWAY_URL.value` + `OBSERVABILITY_VERIFY_TIMEOUT_SECONDS` (see review fix below).

### Frontend

**`frontend/src/sections/agents/constants.js`** — the substantive FE change: add `BLAND_STEPS` (setup instructions) and wire `bland` into the provider map. Step 5 documents that **Bland requires a Contact Number** (Bland has no web connector — a phone number is required to simulate a Bland agent).

**`EditAgentDetails.jsx`, `AgentVoiceForm.jsx`** — net change is a **single documenting comment** on the `mainProviders` exclusion (see the FE-trim review note below). The Bland *option* itself is driven by `constants.js`; an earlier revision's provider-sync/validation rework in these two files was reverted as redundant.

**Generated contracts** (`api_contracts/openapi/swagger.json`, `openapi-contract.generated.js`, `api.schemas.ts`, `api.zod.ts`) — regenerated from the serializer change so the FE axios interceptor accepts `bland` in request bodies. The enum order matches the Python choices order; zod `describe` strings match the serializer `help_text` verbatim.

---

## Review fixes folded in

**FE trimmed to minimal** (voice-engine owner: *"almost all of the FE is redundant and breaks existing flows"*). An earlier revision reworked the provider-sync/validation flow in `EditAgentDetails.jsx` + `AgentVoiceForm.jsx` (a `prevSyncRef` + `useEffect` sync block, an `onError` snackbar, a widened whole-form validate). That was reverted. The net FE diff vs `dev` is now just the `bland` entry + `BLAND_STEPS` in `constants.js`, the regenerated contracts, and a one-line `mainProviders`-exclusion comment in each of the two form files. The original field-scoped `trigger(["apiKey", "assistantId"])` validation gate was **restored** (the rework had widened it to validate the whole form — a regression), and the redundant onError snackbar dropped.

**`mainProviders` exclusion is intentional** — `bland` is deliberately *not* in the FE `mainProviders` set: its key is a distinct raw-authorization value, cleared on provider switch, so listing it there would carry a stale VAPI/Retell key into a Bland config. The one-line comment documents this so it isn't "fixed" later.

**URL/timeout de-duplication** — the Bland branch in `views/agent_definition.py` originally hardcoded `https://api.bland.ai/v1/pathway/{id}` with a bare `timeout=15`, while the same commit introduced `ObservabilityRoutes.BLAND_PATHWAY_URL` and used `OBSERVABILITY_VERIFY_TIMEOUT_SECONDS` everywhere else — two sources of truth for the same URL. Now uses the constant + shared timeout (URL shape unchanged; timeout moved 15s → 30s, no test pins it).

**`BLAND_STEPS` copy is drift-proof** — references only Bland's stable product nouns (Conversational Pathway, pathway ID, API key as the raw authorization header), not exact dashboard menu-label chains, so it can't rot as Bland's UI changes.

---

## ⚠️ Unrelated change bundled in this commit (please review separately)

`tracer/services/observability_providers.py` also contains a **refactor of `_process_vapi_logs` that is not related to Bland**:
- drops the `span_attributes` parameter and the large `process_raw_logs: rehost decision` diagnostic-logging block + the `VapiRecordingService.is_fagi_s3_url` mono/stereo rehost fallback;
- changes VAPI `recording_url` resolution to read `raw_log["recordingUrl"]` directly (previously fell back through `artifact.recording.mono.combinedUrl`), and simplifies stereo resolution.

This looks like a diagnostics/cleanup pass that got carried in. It **changes VAPI recording-URL behaviour**, so it should be reviewed on its own merits (or split out) rather than waved through as part of "add Bland inbound." Flagging it explicitly so it isn't missed.

---

## Testing

- `simulate/tests/test_agent_definition_api.py` / `test_agent_definition_serializers.py` — Bland accepted by the ChoiceField; `fetch_assistant` fetches the pathway by id with the raw auth header and builds name/prompt from the pathway graph.
- `tracer/tests/test_observability_provider_api.py` / `test_observability_providers.py` — Bland verify-key (`/v1/me`) and verify-assistant (`/v1/pathway/{id}`) paths.
- These are anchored: dropping the `bland` choice or the view branch fails the assertions.

## Coordination — this is one of a set

The Bland **data plane** is independent of the outbound PRs (no file overlap, no ee component), so on its own this can merge in any order relative to them. But this PR exposes Bland as a **selectable, key-verifiable provider in the shared agent-config UI**, used for *both* inbound and outbound tests. So a user could select + verify Bland for an **outbound** test before the outbound call path exists.

Land this together with — or behind the same availability gate as — the two paired PRs so selection never outruns the call path:
- [`future-agi/future-agi#1700`](https://github.com/future-agi/future-agi/pull/1700) — shared `client_provider` contract + read-surface parity.
- [`future-agi/ee#156`](https://github.com/future-agi/ee/pull/156) — the Bland customer engine (trigger / monitor / fetch / metrics).

## Notes / limitations
- **Bland is phone-only** (no web connector) — the FE steps document that a Contact Number is required. A mis-configured Bland agent (no number) fails at simulation time with a clean error (see the `prepare_call` guard in [`future-agi/ee#156`](https://github.com/future-agi/ee/pull/156)), not a raw crash.
<img width="2597" height="1792" alt="image" src="https://github.com/user-attachments/assets/e6007a20-f64b-4c4d-93c3-8f1d82870363" />
<img width="2162" height="1694" alt="image" src="https://github.com/user-attachments/assets/4cbc049e-6133-4b7f-99ca-6e08b43a68ea" />

