### PR TITLE
fix(observe): eliminate duplicate API calls in LLM-tracing & sessions (TH-7106)

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -4643,7 +4643,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                       [
                         PROJECT_SOURCE.PROTOTYPE,
                         PROJECT_SOURCE.OBSERVE,
-                      ].includes(projectSource) && selectedTab === "trace"
+                      ].includes(projectSource) &&
+                      selectedTab === "trace" &&
+                      selectedGraph === "compare"
                     }
                   />
                 </Suspense>
@@ -4744,7 +4746,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                       [
                         PROJECT_SOURCE.PROTOTYPE,
                         PROJECT_SOURCE.OBSERVE,
-                      ].includes(projectSource) && selectedTab === "spans"
+                      ].includes(projectSource) &&
+                      selectedTab === "spans" &&
+                      selectedGraph === "compare"
                     }
                   />
                 </Suspense>
@@ -4823,7 +4827,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 ref={compareCallLogsGridRef}
                 module="project"
                 id={observeId}
-                enabled={projectSource === PROJECT_SOURCE.SIMULATOR}
+                enabled={
+                  projectSource === PROJECT_SOURCE.SIMULATOR &&
+                  selectedGraph === "compare"
+                }
                 cellHeight={cellHeight}
                 columnVisibility={columns["compare-trace"]}
                 onColumnsChange={(next) =>

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -635,12 +635,11 @@ export function useTraceFilterProperties(
   { enabled = true, isSimulator = false, sourceScope = null } = {},
 ) {
   return useQuery({
-    queryKey: [
-      "trace-filter-properties-v2",
-      projectId,
-      isSimulator,
-      sourceScope,
-    ],
+    // Key on projectId only: isSimulator/sourceScope don't change the request
+    // (params are always {project_ids, per_eval_config}); they only affect the
+    // per-observer `select`. Keying on them spawned duplicate identical fetches
+    // (e.g. isSimulator flipping false→true once project detail resolves).
+    queryKey: ["trace-filter-properties-v2", projectId],
     enabled: enabled && Boolean(projectId),
     queryFn: async () => {
       const params = {};

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -635,10 +635,8 @@ export function useTraceFilterProperties(
   { enabled = true, isSimulator = false, sourceScope = null } = {},
 ) {
   return useQuery({
-    // Key on projectId only: isSimulator/sourceScope don't change the request
-    // (params are always {project_ids, per_eval_config}); they only affect the
-    // per-observer `select`. Keying on them spawned duplicate identical fetches
-    // (e.g. isSimulator flipping false→true once project detail resolves).
+    // Key on projectId only — isSimulator/sourceScope affect only the
+    // per-observer `select`, not the request, so keying on them duplicated fetches.
     queryKey: ["trace-filter-properties-v2", projectId],
     enabled: enabled && Boolean(projectId),
     queryFn: async () => {

--- a/frontend/src/sections/projects/ObserveHeader.jsx
+++ b/frontend/src/sections/projects/ObserveHeader.jsx
@@ -586,7 +586,6 @@ const ObserveHeader = ({
                   queryClient.invalidateQueries({
                     queryKey: ["observe-projects"],
                   });
-                  queryClient.invalidateQueries({ queryKey: ["callLogs"] });
                   // Dispatch a custom event that the grid can listen to
                   window.dispatchEvent(new CustomEvent("observe-refresh"));
                 }}

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -236,14 +236,15 @@ const SessionGrid = React.forwardRef(
                 ...(dateInterval && { interval: dateInterval }),
               });
 
-              // Use prefetched data if available, otherwise fetch
+              // Await the in-flight prefetch promise if present, else fetch —
+              // dedupes a concurrent getRows for the same page.
               const cached = prefetchCache.current.get(pageNumber);
               prefetchCache.current.delete(pageNumber);
-              const results =
-                cached ||
-                (await axios.get(endpoints.project.projectSessionList(), {
-                  params: buildParams(pageNumber),
-                }));
+              const results = cached
+                ? await cached
+                : await axios.get(endpoints.project.projectSessionList(), {
+                    params: buildParams(pageNumber),
+                  });
               const res = results?.data?.result;
               const newCols = normalizeConfigKeys(res?.config);
 
@@ -337,16 +338,17 @@ const SessionGrid = React.forwardRef(
                 rowCount: lastRow,
               });
 
-              // Prefetch next page so scroll feels instant
+              // Prefetch next page so scroll feels instant. Cache the promise
+              // (not the resolved value) so a concurrent getRows dedupes.
               if (!isLastPage) {
-                axios
-                  .get(endpoints.project.projectSessionList(), {
-                    params: buildParams(pageNumber + 1),
-                  })
-                  .then((res) => {
-                    prefetchCache.current.set(pageNumber + 1, res);
-                  })
-                  .catch(() => {});
+                const prefetch = axios.get(
+                  endpoints.project.projectSessionList(),
+                  { params: buildParams(pageNumber + 1) },
+                );
+                prefetchCache.current.set(pageNumber + 1, prefetch);
+                prefetch.catch(() => {
+                  prefetchCache.current.delete(pageNumber + 1);
+                });
               }
             } catch (error) {
               const message =


### PR DESCRIPTION
## Bug
In Observe (LLM-tracing & sessions), several APIs were called 2+ times on load / refresh — `list_voice_calls`, `list_traces_of_session`, `list_spans_observe`, `list_sessions`, and `/tracer/dashboard/metrics`.

## Changes
- **TraceFilterPanel** — key `useTraceFilterProperties` on `projectId` only. `isSimulator`/`sourceScope` are used only in the per-observer `select`, not in the request (params are always `{project_ids, per_eval_config}`); keying on them spawned duplicate `dashboard/metrics` fetches (notably when `isSimulator` flips `false→true` after project-detail resolves).
- **Compare grids (CallLogsGrid / TraceGrid / SpanGrid)** — gate their `enabled` on `selectedGraph === "compare"`. The hidden compare grids had the same `enabled` as their primary twins (missing the `selectedGraph` check), so they fetched `list_voice_calls` / `list_traces_of_session` / `list_spans_observe` alongside the visible primary. Switching into compare re-triggers the fetch via the existing `filterRequestKey` / datasource path.
- **ObserveHeader** — remove the redundant `["callLogs"]` invalidation in the refresh button. `refreshData()` (→ `refreshPrimary`) already invalidates it, so a single click was double-firing. The canonical path is shared by manual + auto refresh, so both still work.
- **Session-grid** — cache the in-flight prefetch **promise** (not the resolved value). Previously the cache was populated in `.then()`, so a concurrent `getRows` for the next page raced the cache and re-fetched it (page fetched twice). Now `getRows` awaits the cached promise.

## Why
Each was a real duplicate network request (confirmed via request-logging), adding avoidable load on heavily-used Observe views.

## Test-case scenarios
- Voice project → LLM-tracing (traces tab), compare off → `list_voice_calls` fires **once**.
- Observe/trace project → `list_traces_of_session` fires once; spans tab → `list_spans_observe` once.
- Header refresh button (voice) → `list_voice_calls` fires once (was twice).
- Sessions view → each page fetched once, incl. while scrolling; prefetch-for-instant-scroll preserved.
- Enter compare mode → the compare grid loads on demand (brief load instead of the previous eager hidden fetch).

## How to reproduce (before fix)
Open `…/observe/<projectId>/llm-tracing?viewMode="graph"&tab=traces` (and the sessions tab) with DevTools → Network; the listed endpoints fire twice.

## Commands
`yarn lint` — pre-commit lint-staged passed.

## Videos / Screenshots

https://github.com/user-attachments/assets/acff23ac-c40d-4908-8b41-ed1fadff45d1

