### PR TITLE
fix(tracer): normalize legacy eval-task filter casing to canonical snake_case (TH-7118)

### DIFF
--- a/futureagi/tracer/migrations/0094_normalize_eval_task_filter_casing.py
+++ b/futureagi/tracer/migrations/0094_normalize_eval_task_filter_casing.py
@@ -1,0 +1,125 @@
+"""Normalize ``tracer_eval_task.filters`` items to the canonical snake_case
+contract.
+
+Legacy frontends persisted attribute filter items in camelCase
+(``columnId`` / ``filterConfig.filterOp`` …), and API writers could still store
+either casing or the legacy ``span_attributes_filters`` key. Current readers
+are canonical-first: ``formatTaskFilters`` on the FE renders snake_case only,
+and the reconciler's row resolver
+(``tracer/selectors/eval_tasks/row_resolver.py``) reads only the ``filters``
+key — so legacy rows display blank filters and, for legacy-key rows, run
+unfiltered.
+
+Rewrites each stored filter item to snake_case keys (``column_id`` /
+``filter_config`` / ``filter_type`` / ``filter_op`` / ``filter_value`` /
+``col_type``) and folds ``span_attributes_filters`` items into ``filters``.
+Values are never touched, unknown keys are converted by the same camel→snake
+rule, and re-running is a no-op. Rows are written with ``QuerySet.update`` so
+``updated_at`` is preserved. Forward-only: a casing normalization has no
+meaningful reverse.
+"""
+
+import logging
+import re
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+_CAMEL_RE = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def _snake(key):
+    return _CAMEL_RE.sub(r"\1_\2", key).lower()
+
+
+def _normalize_dict(value):
+    """Snake-case every key of ``value`` (one level), returning (dict, changed).
+
+    When both casings of a key are present, the snake_case entry wins and the
+    camelCase duplicate is dropped.
+    """
+    changed = False
+    out = {}
+    for key, val in value.items():
+        new_key = _snake(key)
+        if new_key != key:
+            changed = True
+            if new_key in value:
+                continue
+        out[new_key] = val
+    return out, changed
+
+
+def _normalize_item(item):
+    if not isinstance(item, dict):
+        return item, False
+    out, changed = _normalize_dict(item)
+    config = out.get("filter_config")
+    if isinstance(config, dict):
+        new_config, config_changed = _normalize_dict(config)
+        if config_changed:
+            out["filter_config"] = new_config
+            changed = True
+    return (out if changed else item), changed
+
+
+def normalize_task_filters(filters):
+    """Return (normalized_filters, changed) for one task's ``filters`` dict."""
+    items = filters.get("filters")
+    legacy = filters.get("span_attributes_filters")
+    if not isinstance(items, list):
+        items = []
+    changed = False
+    if isinstance(legacy, list) and legacy:
+        items = items + legacy
+        changed = True
+    normalized = []
+    for item in items:
+        new_item, item_changed = _normalize_item(item)
+        changed = changed or item_changed
+        normalized.append(new_item)
+    if not changed:
+        return filters, False
+    out = {k: v for k, v in filters.items() if k != "span_attributes_filters"}
+    out["filters"] = normalized
+    return out, True
+
+
+def forwards(apps, schema_editor):
+    EvalTask = apps.get_model("tracer", "EvalTask")
+    stats = {"scanned": 0, "updated": 0, "failed": 0}
+    # _base_manager: plain manager in both the historical and live registries —
+    # covers soft-deleted rows and skips workspace-context filtering.
+    for task in EvalTask._base_manager.exclude(filters__isnull=True).iterator(
+        chunk_size=500
+    ):
+        stats["scanned"] += 1
+        try:
+            if not isinstance(task.filters, dict):
+                continue
+            new_filters, changed = normalize_task_filters(task.filters)
+            if not changed:
+                continue
+            EvalTask._base_manager.filter(pk=task.pk).update(filters=new_filters)
+            stats["updated"] += 1
+        except Exception as e:
+            stats["failed"] += 1
+            logger.exception(
+                f"[normalize_eval_task_filter_casing] EvalTask id={task.pk} "
+                f"failed: {e}"
+            )
+    print(
+        f"[normalize_eval_task_filter_casing] scanned {stats['scanned']}, "
+        f"updated {stats['updated']}, {stats['failed']} rows skipped due to errors"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0093_register_eval_task_search_attributes"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/futureagi/tracer/serializers/filters.py
+++ b/futureagi/tracer/serializers/filters.py
@@ -517,10 +517,11 @@ class EvalTaskFiltersField(serializers.JSONField):
                     f"{key} must be a list of non-empty strings."
                 )
 
-        if "span_attributes_filters" in value:
-            value["span_attributes_filters"] = FilterListField().run_validation(
-                value["span_attributes_filters"]
-            )
+        for filter_list_key in ("filters", "span_attributes_filters"):
+            if filter_list_key in value:
+                value[filter_list_key] = FilterListField().run_validation(
+                    value[filter_list_key]
+                )
 
         return value
 

--- a/futureagi/tracer/tests/test_normalize_eval_task_filters.py
+++ b/futureagi/tracer/tests/test_normalize_eval_task_filters.py
@@ -1,0 +1,142 @@
+"""
+Tests for the ``0094_normalize_eval_task_filter_casing`` data migration and
+the write-side enforcement of the canonical ``filters`` item contract.
+
+  * camelCase items are rewritten to snake_case keys; values untouched.
+  * ``span_attributes_filters`` items fold into ``filters`` and the key drops.
+  * Already-canonical tasks are untouched; re-running is a no-op and
+    ``updated_at`` is never bumped.
+  * Malformed ``filters`` payloads are skipped without crashing.
+  * ``EvalTaskFiltersField`` now rejects camelCase items under ``filters``.
+"""
+
+import importlib
+
+import pytest
+from django.apps import apps as django_apps
+from rest_framework import serializers
+
+import model_hub.tasks  # noqa: F401
+from tracer.models.eval_task import EvalTask, RunType
+from tracer.serializers.filters import eval_task_filters_field
+
+migration = importlib.import_module(
+    "tracer.migrations.0094_normalize_eval_task_filter_casing"
+)
+
+CAMEL_ITEM = {
+    "columnId": "ended_reason",
+    "filterConfig": {
+        "colType": "SPAN_ATTRIBUTE",
+        "filterOp": "not_in",
+        "filterType": "text",
+        "filterValue": ["voicemail", "silence-timed-out"],
+    },
+}
+
+SNAKE_ITEM = {
+    "column_id": "ended_reason",
+    "filter_config": {
+        "col_type": "SPAN_ATTRIBUTE",
+        "filter_op": "not_in",
+        "filter_type": "text",
+        "filter_value": ["voicemail", "silence-timed-out"],
+    },
+}
+
+
+def _make_task(project, filters):
+    return EvalTask.objects.create(
+        project=project,
+        name="Casing test",
+        filters=filters,
+        run_type=RunType.HISTORICAL,
+    )
+
+
+def _run_migration():
+    migration.forwards(django_apps, None)
+
+
+@pytest.mark.django_db
+class TestForwards:
+    def test_camel_case_items_become_snake_case(self, project):
+        task = _make_task(
+            project,
+            {
+                "project_id": str(project.id),
+                "date_range": ["2026-06-02", "2026-07-02"],
+                "filters": [CAMEL_ITEM],
+            },
+        )
+        _run_migration()
+        task.refresh_from_db()
+        assert task.filters["filters"] == [SNAKE_ITEM]
+        assert task.filters["project_id"] == str(project.id)
+        assert task.filters["date_range"] == ["2026-06-02", "2026-07-02"]
+
+    def test_span_attributes_filters_fold_into_filters(self, project):
+        task = _make_task(
+            project, {"span_attributes_filters": [CAMEL_ITEM], "filters": []}
+        )
+        _run_migration()
+        task.refresh_from_db()
+        assert task.filters["filters"] == [SNAKE_ITEM]
+        assert "span_attributes_filters" not in task.filters
+
+    def test_canonical_task_untouched_and_rerun_is_noop(self, project):
+        canonical = {"project_id": str(project.id), "filters": [SNAKE_ITEM]}
+        task = _make_task(project, canonical)
+        original_updated_at = task.updated_at
+        _run_migration()
+        _run_migration()
+        task.refresh_from_db()
+        assert task.filters == canonical
+        assert task.updated_at == original_updated_at
+
+    def test_updated_at_preserved_on_rewrite(self, project):
+        task = _make_task(project, {"filters": [CAMEL_ITEM]})
+        original_updated_at = task.updated_at
+        _run_migration()
+        task.refresh_from_db()
+        assert task.filters["filters"] == [SNAKE_ITEM]
+        assert task.updated_at == original_updated_at
+
+    def test_mixed_casing_snake_wins(self, project):
+        task = _make_task(project, {"filters": [{**CAMEL_ITEM, "column_id": "kept"}]})
+        _run_migration()
+        task.refresh_from_db()
+        item = task.filters["filters"][0]
+        assert item["column_id"] == "kept"
+        assert "columnId" not in item
+
+    def test_malformed_filters_are_skipped(self, project):
+        malformed = [
+            _make_task(project, {"filters": "not-a-list"}),
+            _make_task(project, {"": ["junk"]}),
+            _make_task(project, {"filters": [None, "junk", 3]}),
+        ]
+        _run_migration()
+        for task in malformed:
+            before = task.filters
+            task.refresh_from_db()
+            assert task.filters == before
+
+    def test_deleted_tasks_are_normalized(self, project):
+        task = _make_task(project, {"filters": [CAMEL_ITEM]})
+        EvalTask.all_objects.filter(id=task.id).update(deleted=True)
+        _run_migration()
+        task = EvalTask.all_objects.get(id=task.id)
+        assert task.filters["filters"] == [SNAKE_ITEM]
+
+
+class TestEvalTaskFiltersFieldContract:
+    def test_snake_case_filters_accepted(self):
+        field = eval_task_filters_field()
+        value = field.run_validation({"filters": [SNAKE_ITEM]})
+        assert value["filters"] == [SNAKE_ITEM]
+
+    def test_camel_case_filters_rejected(self):
+        field = eval_task_filters_field()
+        with pytest.raises(serializers.ValidationError):
+            field.run_validation({"filters": [CAMEL_ITEM]})


### PR DESCRIPTION
## Why

Filters saved on older eval tasks don't render on the task detail page (TH-7118). Investigated on us2 with task `869f53b2-88e4-43eb-a931-100399a6599e` ("Ghosted - Prod - Future AGI Validated - 90D Historical"): the data is intact in PG and served correctly by `get_eval_details` — the drop is a casing contract mismatch.

Older prod frontends persisted attribute filter items in **camelCase** (`columnId` / `filterConfig.filterOp` …). The FE writer switched to snake_case (`279e62428`, 2026-06-12) and the reader followed (`6b7f32814`, TH-6523) — but stored rows were never converted, so `formatTaskFilters` maps legacy items to `propertyId: undefined` and the detail page renders no filters. The root enabler on the BE: `EvalTaskFiltersField` validated items under the legacy `span_attributes_filters` key only — items under the canonical `filters` key were **persisted verbatim with no validation**.

Scale on prod: US PG has 542 tasks, **35 with camelCase items** (incl. both Ghosted tasks); EU has 12 tasks, **5 camelCase**.

## What changed

1. **`tracer/migrations/0094_normalize_eval_task_filter_casing.py`** — forward-only data migration (`RunPython(forwards, noop)`):
   - Rewrites each stored filter item to snake_case keys (`column_id` / `filter_config` / `filter_type` / `filter_op` / `filter_value` / `col_type`); values untouched; generic camel→snake for unknown keys; when both casings coexist, snake_case wins.
   - Folds legacy `span_attributes_filters` items into the canonical `filters` key — the reconciler's row resolver (`tracer/selectors/eval_tasks/row_resolver.py`) reads only `filters`, so legacy-key rows would otherwise run **unfiltered**.
   - Idempotent; writes only changed rows via `QuerySet.update` (preserves `updated_at`); uses `_base_manager` so soft-deleted rows and rows outside workspace context are covered; per-row try/except so one bad row can't abort the pass.
2. **`tracer/serializers/filters.py`** — `EvalTaskFiltersField` now runs the `filters` key through the same strict `FilterListField` used for `span_attributes_filters`. Non-canonical items get a 400 instead of persisting silently — this is what makes the migration a one-time fix rather than a recurring one.

Deliberately **not** touched: the read-side dual-case tolerance in the CH filter compiler (`query_builders/filters.py:650`) stays — other deployments may migrate later than we deploy.

## Tests

**New (`tracer/tests/test_normalize_eval_task_filters.py`) — 9 tests:**

| Test | Scenario |
|---|---|
| `test_camel_case_items_become_snake_case` | Happy path: camelCase items rewritten, values + `project_id`/`date_range` untouched |
| `test_span_attributes_filters_fold_into_filters` | Legacy key folds into `filters`, key dropped |
| `test_canonical_task_untouched_and_rerun_is_noop` | Idempotency/re-run: canonical rows unchanged, `updated_at` not bumped across two runs |
| `test_updated_at_preserved_on_rewrite` | Rewrite path also preserves `updated_at` (QuerySet.update, not save) |
| `test_mixed_casing_snake_wins` | Item carrying both casings keeps the snake_case value, drops the camel duplicate |
| `test_malformed_filters_are_skipped` | Invalid input: non-list `filters`, empty-string keys, non-dict items — untouched, no crash |
| `test_deleted_tasks_are_normalized` | Soft-deleted rows are covered (`_base_manager`) |
| `test_snake_case_filters_accepted` | Contract: canonical payload passes the serializer |
| `test_camel_case_filters_rejected` | Contract: camelCase payload now 400s |

**Existing suites:** `test_eval_task.py`, `test_filter_serializer_contracts.py`, `test_filter_api_contract.py`, `test_eval_task_filter_dispatch.py` → 145 passed. 3 failures in `test_eval_task_filter_dispatch.py` (annotator Exists clauses) **pre-exist on origin/dev** — verified by stashing this change and re-running.

## Commands

```bash
cd futureagi
uv run pytest tracer/tests/test_normalize_eval_task_filters.py -q               # 9 passed
uv run pytest tracer/tests/test_normalize_eval_task_filters.py -q --create-db   # 9 passed — proves 0094 applies inside migrate on a fresh DB
uv run pytest tracer/tests/test_eval_task.py tracer/tests/test_filter_serializer_contracts.py \
  tracer/tests/test_filter_api_contract.py tracer/tests/test_eval_task_filter_dispatch.py -q
```

## Local verification against real prod data

Copied 10 real filter JSONs from us2 (read-only) and ran the migration's `normalize_task_filters` on them locally: 7 camelCase tasks transform with **only key names changing** (covered `not_in` list, numeric `greater_than`, scalar `not_contains`), 3 already-canonical tasks return `changed: False`, and a second pass on every output is asserted to be a no-op.

```
task 869f53b2-88e4-43eb-a931-100399a6599e  ('Ghosted - Prod - Future AGI Validated - 90D Historical')
changed: True
-      "columnId": "ended_reason",
-      "filterConfig": {
-        "colType": "SPAN_ATTRIBUTE",
-        "filterOp": "not_in",
+      "column_id": "ended_reason",
+      "filter_config": {
+        "col_type": "SPAN_ATTRIBUTE",
+        "filter_op": "not_in",
...
second pass: no-op (idempotent) OK

task 798139be-3d31-4f32-b158-f2674904ff74  ('Ongoing Evals')
changed: False
  -> no-op, stored JSON already canonical
```

```
$ uv run pytest tracer/tests/test_normalize_eval_task_filters.py -q --create-db
9 passed in 93.30s (0:01:33)
```

## Migration risk assessment

- Table is human-created config: 542 rows US / 12 EU, ~200-byte JSONs. One streamed scan (`iterator(chunk_size=500)`), 35 + 5 single-row PK updates — sub-second inside the normal `migrate` transaction. No locks beyond the updated rows, no schema change, `tracer_eval_logger`/ClickHouse untouched.
- Forward-only by design: a casing normalization has no meaningful reverse; backwards is `RunPython.noop` so rollback of neighbouring migrations isn't blocked.
- `EvalLogger.config_hash` does **not** include task filters (`services/eval_tasks/config_hash.py`), and the CH compiler already accepted both casings — so the reconciler's desired-row set is byte-identical before/after: no requeues, no re-runs, no eval churn.

## Architectural rationale

- **Migration over management command**: the fix must run exactly once per environment in lockstep with the serializer tightening — `migrate` gives that ordering for free on every deploy, including fresh stacks.
- **Reject over silently normalizing camelCase on write**: matches the repo's stated contract pattern (`FilterItemField`: "callers send the canonical snake_case filter contract or get a validation error") and surfaces a misbehaving client instead of hiding it. Without the guard, one main-built FE rollback (main's writer is still camelCase today) would silently re-poison the data post-migration.
- **Casing tolerance stays read-side only**: readers keep accepting both during the transition window; the write boundary is where the contract is enforced.
