### PR TITLE
[TH-7111] Fix compare & single-version prompt variable display

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -574,6 +574,7 @@ const WorkbenchProvider = ({ children }) => {
       skipLatestLoadOnce.current = false;
       return;
     }
+    const loadedVersion = selectedVersions?.[0]?.version;
     setPromptName(data?.name);
     setSelectedVersions([
       {
@@ -591,7 +592,15 @@ const WorkbenchProvider = ({ children }) => {
       setCurrentTab("Playground");
     }
 
-    if (data?.prompt_config?.[0]?.messages && !prompts?.[0]?.prompts.length) {
+    // Load messages when the editor is empty or the fetched version differs from the
+    // one already loaded. Guarding only on empty `prompts` left stale content from
+    // another version in the editor after a switch; reloading on every `data` refetch
+    // (rename/commit/tag invalidations) would clobber the current same-version editor.
+    const isVersionSwitch = loadedVersion !== data?.version;
+    if (
+      data?.prompt_config?.[0]?.messages &&
+      (!prompts?.[0]?.prompts.length || isVersionSwitch)
+    ) {
       const newPrompts = data?.prompt_config?.[0]?.messages?.map((prompt) => ({
         ...prompt,
         id: getRandomId(),
@@ -1441,6 +1450,7 @@ const WorkbenchProvider = ({ children }) => {
     const newPlaceholders = [];
     const newResults = [];
     const newModelConfigs = [];
+    const addedVariableData = {};
 
     newCompareVersions.forEach((eachCompareVersions) => {
       newVersions.push({
@@ -1456,6 +1466,10 @@ const WorkbenchProvider = ({ children }) => {
         prompts: eachCompareVersions.prompt_config_snapshot.messages,
         id: getRandomId(),
       });
+
+      if (eachCompareVersions?.variable_names) {
+        Object.assign(addedVariableData, eachCompareVersions.variable_names);
+      }
 
       const placeholderArray =
         eachCompareVersions.prompt_config_snapshot.placeholders || [];
@@ -1485,6 +1499,8 @@ const WorkbenchProvider = ({ children }) => {
     setPlaceholders((e) => [e[0], ...newPlaceholders]);
     setModelConfig((e) => [e[0], ...newModelConfigs]);
     setResults((e) => [e[0], ...newResults]);
+    // Merge added versions' variables into the shared panel; base (index 0) wins on conflicts.
+    setVariableData((prev) => ({ ...addedVariableData, ...prev }));
   };
 
   const removeFromCompare = (index) => {


### PR DESCRIPTION
**Ticket:** [TH-7111](https://linear.app/future-agi/issue/TH-7111/compare-view-variables-show-missingred-when-added-second-version-has) — Fixes [TH-7111](https://linear.app/future-agi/issue/TH-7111/compare-view-variables-show-missingred-when-added-second-version-has)

## What was the bug

Two related defects in prompt variable display in the workbench:

1. **Compare view** — when the base/first version has no variables and a second version *with* variables is added to the comparison, that version's variables render as **missing (red)**. Reversing the order (variable version first) does not reproduce it.
2. **Single-version view** — landing on a prompt could show a **different version's content** in the editor (e.g. v2's label but v1's `{{ONE}}`/`{{TWO}}` text), so variables that the version doesn't actually have appeared, and they showed red because the variable data belonged to the real (default) version.

## What changes have been done

* `frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx`
  * `applyCompare` — collect each added version's `variable_names` and merge them into the shared `variableData` (base version wins on key conflicts).
  * Initial/default-version load effect — load the fetched version's messages when the editor is empty **or** the loaded version differs from the fetched one, instead of only when the editor is empty.

## Why the changes

* **Compare:** the shared `variableData` was seeded only from the base version, and `applyCompare` never registered an added version's variables. The red/green highlight (`placeEditBolt`) marks a variable valid only when its name is a populated key in `variableData`, so the added version's variables were always flagged missing. The per-version run payload is unaffected — `getVariables` re-filters `variableData` against each version's own template, so merged keys never leak to versions that don't use them.
* **Single-version load:** the load guard `!prompts?.[0]?.prompts.length` only refreshed messages when the editor was empty, so stale content from another version stayed put while the label/variable data switched to the default version. Keying the reload on a version switch loads the correct content on a real switch while preserving the editor (and cursor/focus) on same-version data refetches (rename/commit/tag invalidations).

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Base version has no variables; add a second version with `{{ONE}}` to compare | Second version's variables render normally (not red); run button enabled |
| 2 | Reverse order (variable version as base) | No regression — still correct |
| 3 | Run both compare versions | Each version's payload carries only its own variables |
| 4 | Land on a prompt whose default version differs from stale editor content | Editor shows the default version's real content |
| 5 | Edit the default version, then rename / commit / assign a tag | Editor content, cursor and focus preserved (no revert) |
| 6 | Compare → remove a version (collapse to single) | Remaining version's content preserved |

## How to reproduce (original bug)

1. Open a prompt version with **no** variables as the base.
2. Open History → Compare → add a version that **has** variables.
3. Observe the added version's variables showing as missing/red.

## Commands

```bash
cd frontend
yarn test:run src/sections/workbench
yarn lint
```

## Videos and screenshots

https://github.com/user-attachments/assets/62e0562e-09a9-4da5-ae05-5620c2508557