### PR TITLE
fix(simulate): use normalized rehosted recording URLs

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
@@ -12,6 +12,7 @@ import {
 import Iconify from "src/components/iconify";
 import { fmtMs } from "src/utils/utils";
 import { computeCallMetrics, enrichTurns } from "./transcriptUtils";
+import { fmtWpm } from "./formatters";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Formatting helpers
@@ -119,11 +120,6 @@ KpiCell.propTypes = {
   value: PropTypes.node.isRequired,
   hint: PropTypes.string,
   tone: PropTypes.oneOf(["default", "success", "warn", "danger"]),
-};
-
-const fmtWpm = (n) => {
-  if (n == null || !Number.isFinite(n)) return "—";
-  return String(n);
 };
 
 const KpiStrip = ({ metrics, apiMetrics }) => {

--- a/frontend/src/components/VoiceDetailDrawerV2/__tests__/CallAnalyticsView.test.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/__tests__/CallAnalyticsView.test.jsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { fmtWpm } from "../formatters";
+
+describe("fmtWpm", () => {
+  it("rounds precise WPM metrics for display", () => {
+    expect(fmtWpm(259.30878424)).toBe("259");
+    expect(fmtWpm(176.81041613388277)).toBe("177");
+  });
+
+  it("preserves the empty metric placeholder", () => {
+    expect(fmtWpm(null)).toBe("—");
+  });
+});

--- a/frontend/src/components/VoiceDetailDrawerV2/formatters.js
+++ b/frontend/src/components/VoiceDetailDrawerV2/formatters.js
@@ -1,0 +1,4 @@
+export const fmtWpm = (n) => {
+  if (n == null || !Number.isFinite(n)) return "—";
+  return String(Math.round(n));
+};

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -4618,13 +4618,6 @@ class TestExecutor:
                     transcript_data["voice_recording"] = s3_url
                     recording_object["combined"] = s3_url
 
-                if recording_object:
-                    call_execution.provider_call_data.get(
-                        self.system_voice_provider.value
-                    )["recording"] = recording_object
-                    fields_to_update.append("provider_call_data")
-                    needs_save = True
-
             # Save the call_execution if any URLs were converted
             if needs_save:
                 call_execution.save(update_fields=fields_to_update)

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -317,7 +317,8 @@ def _build_transcript_data(call_execution):
                 if not isinstance(provider_data, dict):
                     continue
 
-                # Pre-stored S3 recording URLs
+                # Only consume normalized URLs. Raw artifact URLs may point to
+                # provider storage and must not leak into eval inputs.
                 recording = provider_data.get("recording", {})
                 if isinstance(recording, dict):
                     if (

--- a/futureagi/simulate/tests/test_speaker_role_read_alignment.py
+++ b/futureagi/simulate/tests/test_speaker_role_read_alignment.py
@@ -120,6 +120,24 @@ class TestGetRecordingsSwap:
         assert rec["assistant"] == "https://cdn/tested_agent.mp3"
         assert rec["customer"] == "https://cdn/simulator.mp3"
 
+    def test_vapi_normalized_recordings_are_available_to_eval_preview(self):
+        obj = _vapi_outbound_call()
+        obj.recording_url = None
+        obj.stereo_recording_url = None
+        obj.provider_call_data["vapi"]["recording"] = {
+            "combined": "https://s3/combined.mp3",
+            "customer": "https://s3/customer.mp3",
+            "assistant": "https://s3/assistant.mp3",
+            "stereo": "https://s3/stereo.mp3",
+        }
+
+        assert self._get_recordings(obj) == {
+            "combined": "https://s3/combined.mp3",
+            "stereo": "https://s3/stereo.mp3",
+            "customer": "https://s3/customer.mp3",
+            "assistant": "https://s3/assistant.mp3",
+        }
+
     def test_livekit_passthrough(self):
         obj = _livekit_inbound_call(
             recordings={


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `bin/test` (backend) or `yarn test:run` (frontend) passes locally
  • `yarn contracts:check` passes if API surface changed
-->

## Summary

Recording rehosting now keeps normalized S3 URLs in the provider payload used by simulation evaluation and Call Details. The EE service returns payload updates to the Temporal activity, which owns the final database save. The rose changes prevent evaluation reads from falling back to provider-hosted artifact URLs; the existing frontend change also displays WPM metrics as rounded whole numbers without changing stored precision.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. EE recording persistence**

- Rehosted Vapi recordings are written to the normalized provider payload.
- Artifact recording fields are synchronized to S3 URLs for provider-payload-based Call Details views; persisted tracing span attributes are handled separately in the follow-up backfill.
- The Temporal activity owns the final `CallExecution` save to avoid stale payload overwrites.

**B. Simulation evaluation reads**

- Evaluation preview and Temporal evaluation inputs consume only normalized recording URLs.
- The legacy recording-payload synchronization path no longer owns provider payload persistence.

**C. Frontend display**

- Call Analytics displays user and agent WPM as rounded whole numbers.
- Stored/API metric precision is unchanged.

---

## 2) Why the changes were done

- **Product/UX:** Assistant and customer recording mappings no longer resolve to inaccessible provider-hosted URLs, and WPM values are readable.
- **Technical:** S3 URLs are propagated through the active EE recording path and consumed from one normalized payload shape.
- **Architecture:** Provider payload persistence belongs to the active EE service and Temporal activity rather than the legacy synchronization path.

---

## 3) Tests written + scenarios each covers

**`ee/voice/tests/test_vapi_migration_wiring.py`** — Vapi recording rehosting and payload propagation.

- `test_passes_call_project_id_for_every_recording` — verifies normalized and artifact URLs receive S3 values.
- `test_rehosts_when_agent_has_no_api_key` — verifies nullable observability configuration and API-key behavior.
- `test_updates_stereo_artifact_without_mono_shape` — verifies partial artifact payload handling.

**`simulate/tests/test_speaker_role_read_alignment.py`** — normalized recording availability to eval preview.

- `test_vapi_normalized_recordings_are_available_to_eval_preview` — verifies assistant, customer, stereo, and combined normalized URLs.

**`frontend/src/components/VoiceDetailDrawerV2/__tests__/CallAnalyticsView.test.jsx`** — WPM display formatting.

- `fmtWpm` tests — verify rounding and the empty-value placeholder.

> Run result: **18 backend tests passed** across the focused EE and rose suites. Compilation and `git diff --check` passed.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
uv run pytest -q ee/voice/tests/test_vapi_migration_wiring.py
uv run pytest -q simulate/tests/test_speaker_role_read_alignment.py -k "normalized_recordings or vapi_outbound"
uv run python -m compileall -q ee/voice/services/types/voice.py ee/voice/services/vapi_service.py ee/voice/temporal/activities/voice_large.py simulate/services/test_executor.py
```

### Frontend tests (if applicable)

```bash
cd frontend
```

### Contract verification (if API surface changed)

Not applicable; no API contract changed.

### UI steps (manual)

1. Open a simulation call with rehosted recordings.
2. Open eval variable mapping and inspect assistant/customer recording values.
3. Open Call Analytics and verify WPM values display as whole numbers.

---

## 5) Screenshots / recordings

### No api key flow Inbound and User WPM and Agent WPM long float truncation

https://github.com/user-attachments/assets/4daccc60-69a6-4eba-9ab0-3eba21d6cc8d

### Attributes has S3 urls

https://github.com/user-attachments/assets/9d2cd505-eb83-4235-9af6-2322dd9910d6

### Evals Populating the recording

<img width="562" height="393" alt="image" src="https://github.com/user-attachments/assets/5eb6857b-4b37-46d4-a10c-639c32c4b926" />


### Tests related to agent definition
<img width="668" height="441" alt="image" src="https://github.com/user-attachments/assets/e7d2e05b-cd0d-45a7-87bd-78bb8e9ac2d1" />





---

## 6) Edge cases & considerations

- Missing observability provider: project ID is passed as `None` without aborting recording rehosting.
- Partial artifact payload: normalized URLs are still stored and stereo artifact synchronization works independently.
- Historical records containing only provider URLs are not rehosted during reads.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The local worktrees contain unrelated dirty files and the parent OSS checkout has pre-existing conflict markers; those files are not part of these PRs.
- The test environment may skip ClickHouse schema application when the local ClickHouse service is unavailable.

---

## 8) Architectural / important decisions

- **Single final save:** The EE service returns provider payload updates and the Temporal activity persists them with the other `CallExecution` fields, preventing stale object overwrites.
- **Normalized read contract:** Evaluation paths do not fall back to raw provider artifact URLs because those URLs are not customer-facing storage.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [x] `git diff --check` passes
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
