### PR TITLE
fix(tfc): score multi-choice eval templates instead of reporting 100%

### DIFF
--- a/futureagi/tfc/tests/test_calculate_eval_average.py
+++ b/futureagi/tfc/tests/test_calculate_eval_average.py
@@ -1,0 +1,70 @@
+"""Tests for tfc.utils.functions.calculate_eval_average.
+
+For ``choices``/``reason`` eval templates the average is a weighted
+pass-rate: each log's selected choice is mapped through ``choices_map``
+(``pass`` -> 1, ``neutral`` -> 0.5, anything else -> 0) and averaged.
+
+Single-choice templates were scored this way, but multi-choice templates
+fell through to a branch that counted *every* log as a full success,
+forcing the displayed average to 100% no matter what the model actually
+selected. These tests pin the weighted behaviour for both shapes.
+"""
+
+import json
+from types import SimpleNamespace
+
+from tfc.constants.api_calls import APICallStatusChoices
+from tfc.utils.functions import calculate_eval_average
+
+SUCCESS = APICallStatusChoices.SUCCESS.value
+
+CHOICES_MAP = {"Excellent": "pass", "Okay": "neutral", "Poor": "fail"}
+
+
+def _template(*, multi_choice, output_type="choices", choices_map=CHOICES_MAP):
+    return SimpleNamespace(
+        config={"output": output_type, "choices_map": choices_map},
+        multi_choice=multi_choice,
+    )
+
+
+def _log(selected):
+    # api_logs entries carry the eval output as a JSON string under "config",
+    # with the selected choice(s) at output.output.
+    return {
+        "status": SUCCESS,
+        "config": json.dumps({"output": {"output": selected}}),
+    }
+
+
+def test_single_choice_pass_is_hundred():
+    avg = calculate_eval_average(_template(multi_choice=False), [_log(["Excellent"])])
+    assert avg == 100.0
+
+
+def test_single_choice_fail_is_zero():
+    avg = calculate_eval_average(_template(multi_choice=False), [_log(["Poor"])])
+    assert avg == 0.0
+
+
+def test_multi_choice_all_fail_is_not_hundred():
+    # Regression: this returned 100.0 because multi-choice logs were counted
+    # as blanket successes instead of being scored through choices_map.
+    avg = calculate_eval_average(_template(multi_choice=True), [_log(["Poor"])])
+    assert avg == 0.0
+
+
+def test_multi_choice_averages_selected_choices():
+    # ("Excellent"=1 + "Poor"=0) / 2 == 0.5 -> 50%.
+    avg = calculate_eval_average(
+        _template(multi_choice=True), [_log(["Excellent", "Poor"])]
+    )
+    assert avg == 50.0
+
+
+def test_multi_choice_mixed_logs_average():
+    # Log A: pass + neutral -> (1 + 0.5)/2 = 0.75 ; Log B: fail -> 0.0 ;
+    # overall (0.75 + 0.0)/2 = 0.375 -> 37.5%.
+    logs = [_log(["Excellent", "Okay"]), _log(["Poor"])]
+    avg = calculate_eval_average(_template(multi_choice=True), logs)
+    assert avg == 37.5

--- a/futureagi/tfc/utils/functions.py
+++ b/futureagi/tfc/utils/functions.py
@@ -686,6 +686,21 @@ def calculate_eval_average(eval_template, api_logs):
                                 valid_logs += 1
                             case _:
                                 valid_logs += 1
+                    elif choices_map and eval_template.multi_choice:
+                        # Multi-choice logs select several choices; score each
+                        # through choices_map and average the pass/neutral/fail
+                        # weight (mirrors _calculate_numeric_choices_average's
+                        # multi-choice path) instead of counting every log as a
+                        # blanket success, which forced the average to 100%.
+                        weights = {"pass": 1.0, "neutral": 0.5}
+                        selected = output.get("output") or []
+                        scores = [
+                            weights.get(choices_map.get(choice), 0.0)
+                            for choice in selected
+                        ]
+                        if scores:
+                            success_count += sum(scores) / len(scores)
+                            valid_logs += 1
                     else:
                         success_count += 1
                         valid_logs += 1


### PR DESCRIPTION
## Description

`calculate_eval_average()` in `tfc/utils/functions.py` computes the average shown on the eval-templates surface. For `choices` / `reason` output types, **multi-choice** templates always reported **100%**, regardless of the model's actual selections.

Single-choice templates are scored through `choices_map` (`pass` → 1, `neutral` → 0.5, anything else → 0). The multi-choice case fell through to a branch that counted **every** successful log as a full success:

```python
else:                       # multi_choice=True landed here
    success_count += 1      # every log counted as a full success
    valid_logs += 1
```

so `average = success_count / valid_logs * 100` was always `100%`.

This PR adds a multi-choice branch that scores each selected choice through `choices_map` and averages the pass/neutral/fail weight per log — mirroring the existing `_calculate_numeric_choices_average()` multi-choice path in the same file. The single-choice and reason-only (no `choices_map`) paths are left unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Proof (red → green)

New test `tfc/tests/test_calculate_eval_average.py` (5 cases). Two single-choice cases guard the unchanged behaviour; three multi-choice cases pin the fix.

**Before the fix** — multi-choice logs are scored, showing they were all forced to 100%:

```
tfc/tests/test_calculate_eval_average.py::test_single_choice_pass_is_hundred PASSED
tfc/tests/test_calculate_eval_average.py::test_single_choice_fail_is_zero PASSED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_all_fail_is_not_hundred FAILED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_averages_selected_choices FAILED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_mixed_logs_average FAILED

    assert avg == 0.0
E   assert 100.0 == 0.0        # all-fail multi-choice reported as 100%
3 failed, 2 passed
```

**After the fix:**

```
tfc/tests/test_calculate_eval_average.py::test_single_choice_pass_is_hundred PASSED
tfc/tests/test_calculate_eval_average.py::test_single_choice_fail_is_zero PASSED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_all_fail_is_not_hundred PASSED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_averages_selected_choices PASSED
tfc/tests/test_calculate_eval_average.py::test_multi_choice_mixed_logs_average PASSED
5 passed
```

`flake8` clean on both touched files.

> Note on how the tests were run: `calculate_eval_average()` is pure logic, but `tfc/utils/functions.py` imports several DB/ML modules at load time (numpy, ClickHouse client, `model_hub` models). To exercise the **real, unmodified** function without standing up Postgres/ClickHouse, I imported it with those load-time-only imports stubbed via `sys.modules` (none of them are touched by `calculate_eval_average`) and a minimal `settings.configure()` for the `TextChoices` enum. The function body under test is exactly what ships. Happy to adapt to the repo's preferred `make test` harness if you'd like it wired in differently.

## Checklist

### Testing

- [x] I have added tests that prove my fix is effective (red → green above)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have run `make test` successfully — the full Docker harness needs the complete service stack (Postgres/ClickHouse/Redis/MinIO); I verified the touched logic in isolation as described above instead.

### Code Quality

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code follows the project's style guidelines (`flake8` clean on touched files)

### Django-Specific

- [x] No model changes; no migrations required

### Security

- [x] My changes don't introduce security vulnerabilities
- [x] I have not committed any secrets or credentials

## Related Issues

Closes #1713
