### PR TITLE
feat: materialize voice-call display fields at ingest (Phase 1)

### DIFF
--- a/futureagi/tracer/tests/test_vapi_process_raw_logs.py
+++ b/futureagi/tracer/tests/test_vapi_process_raw_logs.py
@@ -99,3 +99,312 @@ class TestProcessRawLogsOverlay:
         assert result["stereo_recording_url"] == span_attributes[
             "conversation.recording.stereo"
         ]
+
+
+class TestVapiDisplayFieldsParity:
+    """The normalizer's _extract_display_fields (ingest-time materialization)
+    must match _process_vapi_logs (read-path derivation) so the v2 typed-attr
+    read path stays in parity with legacy. Guards the intentional duplication."""
+
+    @staticmethod
+    def _sample():
+        return {
+            "id": "vapi-1",
+            "type": "inboundPhoneCall",
+            "status": "ended",
+            "startedAt": "2026-06-19T12:00:00.000Z",
+            "endedAt": "2026-06-19T12:01:00.000Z",
+            "createdAt": "2026-06-19T11:59:00.000Z",
+            "customer": {"number": "+15551230000"},
+            "phoneNumber": {"number": "+15559990000"},
+            "assistantId": "asst_9",
+            "summary": "Booked a demo",
+            "overallScore": 7,
+            "cost": 0.25,
+            # Assistant phone comes from variableValues.phoneNumber (string only).
+            "variableValues": {"phoneNumber": "+18005551234"},
+            "messages": [
+                {"role": "assistant", "message": "Hi", "duration": 2000,
+                 "secondsFromStart": 0, "time": 1700000000000},
+                {"role": "user", "message": "Hello", "duration": 1000,
+                 "secondsFromStart": 2, "time": 1700000002000},
+                {"role": "bot", "message": "Bye", "duration": 1000,
+                 "secondsFromStart": 3, "time": 1700000003000},
+            ],
+        }
+
+    def test_display_fields_match_process_raw_logs(self):
+        from tracer.utils.otel import CallAttributes
+        from tracer.utils.vapi import (
+            _extract_common_call_fields,
+            _extract_conversation,
+            _extract_metadata,
+            _extract_recording_urls,
+        )
+
+        # Distributed across the topical extract helpers (not one function).
+        attrs: dict = {}
+        sample = self._sample()
+        _extract_common_call_fields(sample, attrs)
+        _extract_metadata(sample, attrs)
+        _extract_conversation(sample, attrs)
+        _extract_recording_urls(sample, attrs)
+        # Separate copy — process_raw_logs mutates messages in place.
+        processed = ObservabilityService.process_raw_logs(
+            self._sample(), ProviderChoices.VAPI
+        )
+
+        assert attrs[CallAttributes.CUSTOMER_NAME] == processed["customer_name"]
+        assert attrs[CallAttributes.STATUS_DISPLAY] == processed["status"]
+        assert attrs[CallAttributes.CALL_TYPE] == processed["call_type"]
+        assert attrs[CallAttributes.SUMMARY] == processed["call_summary"]
+        assert attrs[CallAttributes.OVERALL_SCORE] == processed["overall_score"]
+        assert attrs[CallAttributes.ASSISTANT_ID] == processed["assistant_id"]
+        # assistant_phone intentionally diverges from legacy: from
+        # variableValues.phoneNumber (string), not the empty top-level field.
+        assert attrs[CallAttributes.ASSISTANT_PHONE_NUMBER] == "+18005551234"
+        assert attrs[CallAttributes.COST_CENTS] == processed["cost_cents"]
+        assert attrs[CallAttributes.MESSAGE_COUNT] == processed["message_count"]
+        assert (
+            attrs[CallAttributes.TRANSCRIPT_AVAILABLE]
+            == processed["transcript_available"]
+        )
+        assert attrs[CallAttributes.STARTED_AT] == processed["started_at"]
+        assert attrs[CallAttributes.CREATED_AT] == processed["created_at"]
+        # Talk-ratio breakdown parity.
+        tr = processed["talk_ratio"]
+        assert attrs[CallAttributes.TALK_SECONDS_USER] == tr["user"]
+        assert attrs[CallAttributes.TALK_SECONDS_BOT] == tr["bot"]
+        assert attrs[CallAttributes.TALK_PCT_USER] == tr["user_pct"]
+        assert attrs[CallAttributes.TALK_PCT_BOT] == tr["bot_pct"]
+
+
+class TestRetellDisplayFieldsParity:
+    """retell.py normalizer display fields must match _process_retell_logs."""
+
+    @staticmethod
+    def _sample():
+        return {
+            "call_id": "call_1",
+            "agent_id": "agent_9",
+            "agent_name": "Healthcare Check-In",
+            "call_status": "ended",
+            "direction": "inbound",
+            "to_number": "+12345162722",
+            "from_number": "+18568806998",
+            "start_timestamp": 1763541469420,
+            "end_timestamp": 1763541606176,
+            "recording_url": "https://x/recording.wav",
+            "recording_multi_channel_url": "https://x/multi.wav",
+            "call_cost": {
+                "combined_cost": 29.68,
+                "product_costs": [{"product": "tts", "unit_price": 0.1, "cost": 1.0}],
+            },
+            "call_analysis": {"call_summary": "Cindy confirmed the appointment."},
+            "disconnection_reason": "user_hangup",
+            "transcript_with_tool_calls": [
+                {"role": "agent", "content": "Hi", "words": [{"start": 2.0, "end": 5.0}]},
+                {"role": "user", "content": "Hello", "words": [{"start": 6.0, "end": 8.0}]},
+            ],
+        }
+
+    def test_display_fields_match_process_raw_logs(self):
+        from tracer.utils import retell as R
+        from tracer.utils.otel import CallAttributes
+
+        attrs: dict = {}
+        s = self._sample()
+        R._process_transcript(s, attrs)
+        R._extract_recording_urls(s, attrs)
+        R._extract_metadata(s, attrs)
+        R._extract_common_call_fields(s, attrs)
+        processed = ObservabilityService.process_raw_logs(
+            self._sample(), ProviderChoices.RETELL
+        )
+
+        assert attrs[CallAttributes.CUSTOMER_NAME] == processed["customer_name"]
+        assert attrs[CallAttributes.STATUS_DISPLAY] == processed["status"]
+        assert attrs[CallAttributes.CALL_TYPE] == processed["call_type"]
+        assert attrs[CallAttributes.SUMMARY] == processed["call_summary"]
+        assert attrs[CallAttributes.ASSISTANT_ID] == processed["assistant_id"]
+        assert (
+            attrs[CallAttributes.ASSISTANT_PHONE_NUMBER]
+            == processed["assistant_phone_number"]
+        )
+        assert attrs[CallAttributes.COST_CENTS] == processed["cost_cents"]
+        assert attrs[CallAttributes.MESSAGE_COUNT] == processed["message_count"]
+        assert (
+            attrs[CallAttributes.TRANSCRIPT_AVAILABLE]
+            == processed["transcript_available"]
+        )
+        assert attrs[CallAttributes.STARTED_AT] == processed["started_at"]
+        assert attrs[CallAttributes.ENDED_AT] == processed["ended_at"]
+        assert attrs[CallAttributes.RECORDING_AVAILABLE] == processed[
+            "recording_available"
+        ]
+        tr = processed["talk_ratio"]
+        assert attrs[CallAttributes.TALK_SECONDS_USER] == tr["user"]
+        assert attrs[CallAttributes.TALK_SECONDS_BOT] == tr["bot"]
+
+
+class TestSparseProviderDisplayFields:
+    """eleven_labs / bland / twilio normalizers materialize the list-display
+    fields (these providers set fewer fields than vapi/retell)."""
+
+    def test_eleven_labs(self):
+        from tracer.utils.eleven_labs import normalize_eleven_labs_data
+        from tracer.utils.otel import CallAttributes
+
+        attrs = normalize_eleven_labs_data(
+            {
+                "conversation_id": "conv_1",
+                "agent_id": "agent_x",
+                "status": "done",
+                "metadata": {"start_time_unix_secs": 1763541469, "cost": 42},
+                "transcript": [
+                    {"role": "agent", "message": "Hi"},
+                    {"role": "user", "message": "Hello"},
+                ],
+            }
+        )["span_attributes"]
+        assert attrs[CallAttributes.STATUS_DISPLAY] == "completed"
+        assert attrs[CallAttributes.COST_CENTS] == 42
+        assert attrs[CallAttributes.ASSISTANT_ID] == "agent_x"
+        assert attrs[CallAttributes.MESSAGE_COUNT] == 2
+        assert attrs[CallAttributes.TRANSCRIPT_AVAILABLE] is True
+        assert attrs[CallAttributes.RECORDING_AVAILABLE] is False
+        assert attrs[CallAttributes.STARTED_AT]
+
+    def test_bland(self):
+        from tracer.utils.bland import normalize_bland_data
+        from tracer.utils.otel import CallAttributes
+
+        attrs = normalize_bland_data(
+            {
+                "call_id": "c1",
+                "to": "+1",
+                "status": "completed",
+                "started_at": "2026-07-20T20:00:00Z",
+                "created_at": "2026-07-20T19:59:00Z",
+                "call_length": 2.5,
+                "price": 0.1,
+                "recording_url": "https://x/rec.wav",
+                "summary": "Done",
+                "transcripts": [
+                    {"user": "assistant", "text": "Hi"},
+                    {"user": "user", "text": "Hey"},
+                ],
+            }
+        )["span_attributes"]
+        assert attrs[CallAttributes.STATUS_DISPLAY] == "completed"
+        assert attrs[CallAttributes.COST_CENTS] == 0.1 * 100
+        assert attrs[CallAttributes.SUMMARY] == "Done"
+        assert attrs[CallAttributes.RECORDING_AVAILABLE] is True
+        assert attrs[CallAttributes.MESSAGE_COUNT] == 2
+        assert attrs[CallAttributes.TRANSCRIPT_AVAILABLE] is True
+
+    def test_twilio(self):
+        from tracer.utils.otel import CallAttributes
+        from tracer.utils.twilio_calls import normalize_twilio_data
+
+        attrs = normalize_twilio_data(
+            {
+                "sid": "CA1",
+                "to": "+1",
+                "status": "completed",
+                "direction": "inbound",
+                "start_time": "Tue, 20 Jul 2026 20:00:00 +0000",
+                "duration": "137",
+                "price": "-0.0085",
+            }
+        )["span_attributes"]
+        assert attrs[CallAttributes.STATUS_DISPLAY] == "completed"
+        assert attrs[CallAttributes.CALL_TYPE] == "inbound"
+        # Twilio reports price as a NEGATIVE dollar charge (e.g. "-0.0085");
+        # cost_cents is the magnitude converted to cents (abs × 100 = 0.85),
+        # mirroring _process_twilio_raw. Compared via the formula to dodge
+        # float-representation error.
+        assert attrs[CallAttributes.COST_CENTS] == abs(-0.0085) * 100
+        assert attrs[CallAttributes.RECORDING_AVAILABLE] is False
+        assert attrs[CallAttributes.MESSAGE_COUNT] == 0
+        assert attrs[CallAttributes.TRANSCRIPT_AVAILABLE] is False
+        assert attrs[CallAttributes.STARTED_AT]
+
+
+class TestNormalizerDisplayRobustness:
+    """The display-field additions must never raise when raw_log fields are
+    missing, None, or the wrong type (provider API shape drift)."""
+
+    def test_vapi_helpers_never_raise(self):
+        from tracer.utils import vapi as V
+        from tracer.utils.otel import CallAttributes
+
+        # Wrong types on the fields our additions read; existing-code fields kept
+        # well-formed (dicts/lists) so we isolate our additions.
+        bad = {
+            "customer": "not-a-dict",
+            "messages": [None, "x", {"role": "user", "duration": "abc"}],
+            "artifact": "not-a-dict",
+            "variableValues": "not-a-dict",
+            "cost": "not-a-number",
+            "phoneNumber": "not-a-dict",
+            "type": 123,
+            "status": None,
+        }
+        attrs: dict = {}
+        V._extract_common_call_fields(bad, attrs)
+        V._extract_metadata(bad, attrs)
+        V._extract_conversation(bad, attrs)
+        V._extract_recording_urls(bad, attrs)
+        assert CallAttributes.CUSTOMER_NAME not in attrs  # {} has no number
+        assert CallAttributes.COST_CENTS not in attrs  # str cost skipped
+        assert CallAttributes.ASSISTANT_PHONE_NUMBER not in attrs  # str vv skipped
+
+    def test_retell_helpers_never_raise(self):
+        from tracer.utils import retell as R
+        from tracer.utils.otel import CallAttributes
+
+        bads = [
+            {  # call_cost / call_analysis as non-dict; str timestamps; junk rows
+                "call_cost": "not-a-dict",
+                "call_analysis": "not-a-dict",
+                "start_timestamp": "not-a-number",
+                "end_timestamp": None,
+                "transcript_with_tool_calls": [None, "x", {"role": "user"}],
+                "direction": None,
+                "call_status": None,
+            },
+            {},  # everything absent — the del/pop path must be safe
+            {  # call_cost dict WITHOUT product_costs; string word timings
+                "call_cost": {"combined_cost": 1},
+                "transcript_with_tool_calls": [
+                    {"role": "user", "words": [{"start": "0", "end": "5"}]}
+                ],
+            },
+        ]
+        for bad in bads:
+            attrs: dict = {}
+            R._extract_common_call_fields(bad, attrs)
+            R._extract_metadata(bad, attrs)
+            R._process_transcript(bad, attrs)
+            R._extract_recording_urls(bad, attrs)
+            # Non-dict call_analysis / str timestamp → those keys must be skipped.
+            assert CallAttributes.STARTED_AT not in attrs or isinstance(
+                attrs.get(CallAttributes.STARTED_AT), str
+            )
+
+    def test_sparse_normalizers_never_raise(self):
+        from tracer.utils.bland import normalize_bland_data
+        from tracer.utils.eleven_labs import normalize_eleven_labs_data
+        from tracer.utils.twilio_calls import normalize_twilio_data
+
+        for fn in (
+            normalize_eleven_labs_data,
+            normalize_bland_data,
+            normalize_twilio_data,
+        ):
+            fn({})
+            fn({"status": None, "price": "abc", "metadata": None, "direction": None})
+            # metadata as a non-dict must not crash the get-chains
+            fn({"metadata": "oops", "status": 123, "price": {}})
+            fn({"metadata": {"charging": "oops"}})

--- a/futureagi/tracer/tests/test_vapi_recording_urls.py
+++ b/futureagi/tracer/tests/test_vapi_recording_urls.py
@@ -13,19 +13,22 @@ def test_string_artifact_does_not_crash():
     attrs = {}
     # Previously raised AttributeError: 'str' object has no attribute 'get'
     _extract_recording_urls({"artifact": "unexpected-string"}, attrs)
-    assert attrs == {}
+    # No recording URLs written; recording_available is materialized as False.
+    assert attrs == {"call.recording_available": False}
 
 
 def test_missing_artifact_does_not_crash():
     attrs = {}
     _extract_recording_urls({}, attrs)
-    assert attrs == {}
+    # No recording URLs written; recording_available is materialized as False.
+    assert attrs == {"call.recording_available": False}
 
 
 def test_none_artifact_does_not_crash():
     attrs = {}
     _extract_recording_urls({"artifact": None}, attrs)
-    assert attrs == {}
+    # No recording URLs written; recording_available is materialized as False.
+    assert attrs == {"call.recording_available": False}
 
 
 def test_well_formed_recording_still_extracted():

--- a/futureagi/tracer/utils/bland.py
+++ b/futureagi/tracer/utils/bland.py
@@ -21,7 +21,10 @@ def normalize_bland_data(log: dict) -> dict:
     transcript = _transcript_messages(log)
 
     price = log.get("price")
-    cost = float(price) if price not in (None, "") else None
+    try:
+        cost = float(price) if price not in (None, "") else None
+    except (TypeError, ValueError):
+        cost = None
 
     return {
         "id": log.get("call_id") or log.get("c_id"),
@@ -123,3 +126,24 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     eval_attributes[CallAttributes.USER_WPM] = None
     eval_attributes[CallAttributes.BOT_WPM] = None
     eval_attributes[CallAttributes.TALK_RATIO] = None
+
+    # Display fields for the voice-call list (mirror _process_bland_raw).
+    if status := log.get("status"):
+        eval_attributes[CallAttributes.STATUS_DISPLAY] = status
+    if started_at := (log.get("started_at") or log.get("created_at")):
+        eval_attributes[CallAttributes.STARTED_AT] = started_at
+    if created_at := (log.get("created_at") or log.get("started_at")):
+        eval_attributes[CallAttributes.CREATED_AT] = created_at
+    price = log.get("price")
+    if price not in (None, ""):
+        try:
+            eval_attributes[CallAttributes.COST_CENTS] = float(price) * 100
+        except (TypeError, ValueError):
+            pass
+    if summary := log.get("summary"):
+        eval_attributes[CallAttributes.SUMMARY] = summary
+    if error_message := log.get("error_message"):
+        eval_attributes[CallAttributes.ERROR_MESSAGE] = error_message
+    eval_attributes[CallAttributes.RECORDING_AVAILABLE] = bool(log.get("recording_url"))
+    eval_attributes[CallAttributes.MESSAGE_COUNT] = len(transcript)
+    eval_attributes[CallAttributes.TRANSCRIPT_AVAILABLE] = len(transcript) > 0

--- a/futureagi/tracer/utils/eleven_labs.py
+++ b/futureagi/tracer/utils/eleven_labs.py
@@ -8,6 +8,11 @@ from tracer.utils.otel import (
 )
 
 
+def _dict(value):
+    """Return value if it's a dict, else {} — defends against raw_log shape drift."""
+    return value if isinstance(value, dict) else {}
+
+
 def normalize_eleven_labs_data(log: dict) -> dict:
     """
     Normalizes a single log entry from ElevenLabs.
@@ -27,7 +32,7 @@ def normalize_eleven_labs_data(log: dict) -> dict:
         "id": log.get("conversation_id"),
         "start_time": start_time,
         "end_time": end_time,
-        "cost": log.get("metadata", {}).get("cost"),
+        "cost": _dict(log.get("metadata")).get("cost"),
         "status": status,
         "input": {"transcript": transcript} if transcript else {},
         "metadata": log.get("metadata"),
@@ -56,7 +61,7 @@ def _extract_llm_details(log: dict, eval_attributes: dict):
     """
     Extracts LLM details (model name, token counts) and adds them to eval_attributes.
     """
-    llm_usage = log.get("metadata", {}).get("charging", {}).get("llm_usage", {})
+    llm_usage = _dict(_dict(log.get("metadata")).get("charging")).get("llm_usage", {})
     if not llm_usage:
         return
 
@@ -99,12 +104,13 @@ def _extract_timestamps(log: dict) -> tuple:
     """
     Extracts start and end timestamps from an ElevenLabs log.
     """
+    metadata = _dict(log.get("metadata"))
     start_time = None
-    if start_time_unix := log.get("metadata", {}).get("start_time_unix_secs"):
+    if start_time_unix := metadata.get("start_time_unix_secs"):
         start_time = datetime.fromtimestamp(start_time_unix, tz=UTC)
 
     end_time = None
-    if start_time and (duration := log.get("metadata", {}).get("call_duration_secs")):
+    if start_time and (duration := metadata.get("call_duration_secs")):
         end_time = start_time + timedelta(seconds=duration)
 
     return start_time, end_time
@@ -116,13 +122,15 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     transcript = log.get("transcript", [])
     if isinstance(transcript, list):
         eval_attributes[CallAttributes.TOTAL_TURNS] = sum(
-            1 for msg in transcript if msg.get("role") in ("user", "agent")
+            1
+            for msg in transcript
+            if isinstance(msg, dict) and msg.get("role") in ("user", "agent")
         )
     else:
         eval_attributes[CallAttributes.TOTAL_TURNS] = 0
 
     # total_call_duration (seconds, int) — matches duration_seconds in API response
-    metadata = log.get("metadata", {}) or {}
+    metadata = _dict(log.get("metadata"))
     raw_duration = metadata.get("call_duration_secs")
     eval_attributes[CallAttributes.DURATION] = (
         int(raw_duration) if raw_duration is not None else None
@@ -138,3 +146,26 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     eval_attributes[CallAttributes.USER_WPM] = None
     eval_attributes[CallAttributes.BOT_WPM] = None
     eval_attributes[CallAttributes.TALK_RATIO] = None
+
+    # Display fields for the voice-call list (mirror _process_eleven_labs_raw).
+    status = log.get("status")
+    eval_attributes[CallAttributes.STATUS_DISPLAY] = (
+        "completed" if status in ("done", "ended") else status
+    )
+    start_unix = metadata.get("start_time_unix_secs")
+    if isinstance(start_unix, (int, float)):
+        started_at = datetime.fromtimestamp(start_unix, tz=UTC).isoformat()
+        eval_attributes[CallAttributes.STARTED_AT] = started_at
+        eval_attributes[CallAttributes.CREATED_AT] = started_at
+    if (cost := metadata.get("cost")) is not None:
+        eval_attributes[CallAttributes.COST_CENTS] = cost
+    if agent_id := log.get("agent_id"):
+        eval_attributes[CallAttributes.ASSISTANT_ID] = agent_id
+    msgs = [
+        m
+        for m in (transcript if isinstance(transcript, list) else [])
+        if isinstance(m, dict) and m.get("message")
+    ]
+    eval_attributes[CallAttributes.MESSAGE_COUNT] = len(msgs)
+    eval_attributes[CallAttributes.TRANSCRIPT_AVAILABLE] = len(msgs) > 0
+    eval_attributes[CallAttributes.RECORDING_AVAILABLE] = False

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -584,6 +584,28 @@ class CallAttributes:
     TALK_RATIO = "call.talk_ratio"
     """Ratio of bot talk time to user talk time."""
 
+    CUSTOMER_NAME = "call.customer_name"
+    STATUS_DISPLAY = "call.status_display"
+    CALL_TYPE = "call.type"
+    SUMMARY = "call.summary"
+    OVERALL_SCORE = "call.overall_score"
+    ASSISTANT_ID = "call.assistant_id"
+    ASSISTANT_PHONE_NUMBER = "call.assistant_phone_number"
+    ERROR_MESSAGE = "call.error_message"
+    COST_CENTS = "call.cost_cents"
+    MESSAGE_COUNT = "call.message_count"
+    TRANSCRIPT_AVAILABLE = "call.transcript_available"
+    RECORDING_AVAILABLE = "call.recording_available"
+    STARTED_AT = "call.started_at"
+    ENDED_AT = "call.ended_at"
+    CREATED_AT = "call.created_at"
+    RESPONSE_TIME_MS = "call.response_time_ms"
+    RESPONSE_TIME_SECONDS = "call.response_time_seconds"
+    TALK_SECONDS_USER = "call.talk_seconds.user"
+    TALK_SECONDS_BOT = "call.talk_seconds.bot"
+    TALK_PCT_USER = "call.talk_pct.user"
+    TALK_PCT_BOT = "call.talk_pct.bot"
+
 
 class OpenInferenceSpanKindValues(Enum):
     TOOL = "TOOL"

--- a/futureagi/tracer/utils/retell.py
+++ b/futureagi/tracer/utils/retell.py
@@ -132,32 +132,52 @@ def _extract_metadata(log: dict, eval_attributes: dict):
     )
 
     # Populating call cost
-    call_cost_object = log.get("call_cost", {})
+    call_cost_object = log.get("call_cost")
+    call_cost_object = call_cost_object if isinstance(call_cost_object, dict) else {}
     product_costs = call_cost_object.get("product_costs", [])
-    for i, cost in enumerate(product_costs):
-        call_cost_object[f"product_costs.{i}.product"] = cost.get("product")
-        call_cost_object[f"product_costs.{i}.unit_price"] = cost.get("unit_price")
-        call_cost_object[f"product_costs.{i}.cost"] = cost.get("cost")
-
-    del call_cost_object["product_costs"]
+    if isinstance(product_costs, list):
+        for i, cost in enumerate(product_costs):
+            if isinstance(cost, dict):
+                call_cost_object[f"product_costs.{i}.product"] = cost.get("product")
+                call_cost_object[f"product_costs.{i}.unit_price"] = cost.get(
+                    "unit_price"
+                )
+                call_cost_object[f"product_costs.{i}.cost"] = cost.get("cost")
+    call_cost_object.pop("product_costs", None)
 
     flattened_call_cost_object = flatten_dict(call_cost_object)
     eval_attributes.update(flattened_call_cost_object)
 
     # Populating llm token usages
     llm_token_usage_object = log.get("llm_token_usage")
-    if llm_token_usage_object:
+    if isinstance(llm_token_usage_object, dict):
         values = llm_token_usage_object.get("values")
-        for i, value in enumerate(values):
-            llm_token_usage_object[f"llm_token_usage.{i}"] = value
-
-        del log["llm_token_usage"]
+        if isinstance(values, list):
+            for i, value in enumerate(values):
+                llm_token_usage_object[f"llm_token_usage.{i}"] = value
+        log.pop("llm_token_usage", None)
         flattened_llm_token_usage_object = flatten_dict(llm_token_usage_object)
         eval_attributes.update(flattened_llm_token_usage_object)
 
     # Populating metadata
     eval_attributes["metadata"] = log.get("metadata", {})
     eval_attributes["latency"] = log.get("latency")
+
+    # Display fields for the voice-call list (mirror _process_retell_logs).
+    call_analysis = log.get("call_analysis")
+    call_summary = (
+        call_analysis.get("call_summary") if isinstance(call_analysis, dict) else None
+    )
+    if call_summary:
+        eval_attributes[CallAttributes.SUMMARY] = call_summary
+    if (overall_score := log.get("overallScore")) is not None:
+        eval_attributes[CallAttributes.OVERALL_SCORE] = overall_score
+    if agent_id := log.get("agent_id"):
+        eval_attributes[CallAttributes.ASSISTANT_ID] = agent_id
+    if from_number := log.get("from_number"):
+        eval_attributes[CallAttributes.ASSISTANT_PHONE_NUMBER] = from_number
+    if error_message := log.get("error_message"):
+        eval_attributes[CallAttributes.ERROR_MESSAGE] = error_message
 
 
 def _extract_eval_attributes(log: dict) -> dict:
@@ -176,18 +196,54 @@ def _extract_eval_attributes(log: dict) -> dict:
 def _process_transcript(log: dict, eval_attributes: dict):
     """Processes the transcript to extract conversation and tool call data."""
     transcript = log.get("transcript_with_tool_calls")
-    if not (transcript and isinstance(transcript, list)):
+    tlist = transcript if isinstance(transcript, list) else []
+    # Display fields for the voice-call list (mirror _process_retell_logs).
+    eval_attributes[CallAttributes.MESSAGE_COUNT] = len(tlist)
+    eval_attributes[CallAttributes.TRANSCRIPT_AVAILABLE] = len(tlist) > 0
+    if not tlist:
         return
 
     tool_call_index = 0
     eval_attributes["provider_transcript"] = []
     for i, msg in enumerate(transcript):
+        if not isinstance(msg, dict):
+            continue
         role = msg.get("role")
         if role == "tool_call_invocation":
             _process_tool_call(msg, eval_attributes, tool_call_index)
             tool_call_index += 1
         else:
             _process_conversation_message(msg, eval_attributes, i)
+
+    # Talk-ratio breakdown — per-message duration from word timings, by role.
+    # Defensive: tolerate non-dict rows / malformed word lists.
+    user_s = bot_s = 0.0
+    for msg in tlist:
+        if not isinstance(msg, dict):
+            continue
+        words = msg.get("words")
+        if not (isinstance(words, list) and words):
+            continue
+        first, last = words[0], words[-1]
+        if not (isinstance(first, dict) and isinstance(last, dict)):
+            continue
+        end, start = last.get("end"), first.get("start")
+        if not (isinstance(end, (int, float)) and isinstance(start, (int, float))):
+            continue
+        # Round per-message before summing to match _process_retell_logs.
+        dur = round(end - start, 2)
+        if dur <= 0:
+            continue
+        if msg.get("role") == "user":
+            user_s += dur
+        elif msg.get("role") in ("agent", "assistant", "bot"):
+            bot_s += dur
+    total_s = user_s + bot_s
+    if total_s > 0:
+        eval_attributes[CallAttributes.TALK_SECONDS_USER] = round(user_s, 1)
+        eval_attributes[CallAttributes.TALK_SECONDS_BOT] = round(bot_s, 1)
+        eval_attributes[CallAttributes.TALK_PCT_USER] = round((user_s / total_s) * 100)
+        eval_attributes[CallAttributes.TALK_PCT_BOT] = round((bot_s / total_s) * 100)
 
 
 def _process_tool_call(msg: dict, eval_attributes: dict, index: int):
@@ -232,14 +288,22 @@ def _process_conversation_message(msg: dict, eval_attributes: dict, index: int):
 
     if transcript_exists:
         words = msg.get("words")
-        seconds_from_start = words[0].get("start")
-        end_time = words[-1].get("end")
-        start_timedelta = timedelta(seconds=seconds_from_start)
-        end_timedelta = timedelta(seconds=end_time)
-        duration = end_timedelta - start_timedelta
+        first, last = words[0], words[-1]
+        seconds_from_start = first.get("start") if isinstance(first, dict) else None
+        end_time = last.get("end") if isinstance(last, dict) else None
+        if isinstance(seconds_from_start, (int, float)) and isinstance(
+            end_time, (int, float)
+        ):
+            duration = timedelta(seconds=end_time) - timedelta(
+                seconds=seconds_from_start
+            )
 
     duration = round(duration.total_seconds(), 2) if duration else None
-    seconds_from_start = round(seconds_from_start, 2) if seconds_from_start else None
+    seconds_from_start = (
+        round(seconds_from_start, 2)
+        if isinstance(seconds_from_start, (int, float))
+        else None
+    )
 
     eval_attributes[
         f"{ConversationAttributes.CONVERSATION_TRANSCRIPT}.{index}.{MessageAttributes.MESSAGE_DURATION}"
@@ -258,6 +322,7 @@ def _process_conversation_message(msg: dict, eval_attributes: dict, index: int):
 
 def _extract_recording_urls(log: dict, eval_attributes: dict):
     """Extracts recording URLs and adds them to eval_attributes."""
+    eval_attributes[CallAttributes.RECORDING_AVAILABLE] = bool(log.get("recording_url"))
     if recording_url := log.get("recording_url"):
         eval_attributes[
             f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.MONO_COMBINED}"
@@ -275,7 +340,9 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     transcript = log.get("transcript_with_tool_calls", [])
     if isinstance(transcript, list):
         eval_attributes[CallAttributes.TOTAL_TURNS] = sum(
-            1 for msg in transcript if msg.get("role") in ("user", "agent")
+            1
+            for msg in transcript
+            if isinstance(msg, dict) and msg.get("role") in ("user", "agent")
         )
     else:
         eval_attributes[CallAttributes.TOTAL_TURNS] = 0
@@ -308,3 +375,26 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     eval_attributes[CallAttributes.USER_WPM] = None
     eval_attributes[CallAttributes.BOT_WPM] = None
     eval_attributes[CallAttributes.TALK_RATIO] = None
+
+    # Display fields for the voice-call list (mirror _process_retell_logs).
+    if agent_name := log.get("agent_name"):
+        eval_attributes[CallAttributes.CUSTOMER_NAME] = agent_name
+    eval_attributes[CallAttributes.STATUS_DISPLAY] = (
+        "completed" if log.get("call_status") == "ended" else "in-progress"
+    )
+    if direction := log.get("direction"):
+        eval_attributes[CallAttributes.CALL_TYPE] = direction
+    call_cost = log.get("call_cost")
+    combined_cost = call_cost.get("combined_cost") if isinstance(call_cost, dict) else None
+    if combined_cost is not None:
+        eval_attributes[CallAttributes.COST_CENTS] = combined_cost
+    start_ts = log.get("start_timestamp")
+    if isinstance(start_ts, (int, float)):
+        started_at = datetime.fromtimestamp(start_ts / 1000, tz=UTC).isoformat()
+        eval_attributes[CallAttributes.STARTED_AT] = started_at
+        eval_attributes[CallAttributes.CREATED_AT] = started_at
+    end_ts = log.get("end_timestamp")
+    if isinstance(end_ts, (int, float)):
+        eval_attributes[CallAttributes.ENDED_AT] = datetime.fromtimestamp(
+            end_ts / 1000, tz=UTC
+        ).isoformat()

--- a/futureagi/tracer/utils/twilio_calls.py
+++ b/futureagi/tracer/utils/twilio_calls.py
@@ -19,14 +19,19 @@ def normalize_twilio_data(log: dict) -> dict:
         "no-answer": "error",
         "canceled": "error",
     }
-    status = status_map.get((log.get("status") or "").lower(), "unset")
+    raw_status = log.get("status")
+    raw_status = raw_status.lower() if isinstance(raw_status, str) else ""
+    status = status_map.get(raw_status, "unset")
 
     start_time = _parse_rfc2822(log.get("start_time"))
     end_time = _parse_rfc2822(log.get("end_time"))
 
     price = log.get("price")
     # Twilio reports price as a negative charge (e.g. "-0.0085"); store magnitude.
-    cost = abs(float(price)) if price not in (None, "") else None
+    try:
+        cost = abs(float(price)) if price not in (None, "") else None
+    except (TypeError, ValueError):
+        cost = None
 
     eval_attributes = {
         SpanAttributes.SPAN_KIND: "conversation",
@@ -39,6 +44,24 @@ def normalize_twilio_data(log: dict) -> dict:
         CallAttributes.BOT_WPM: None,
         CallAttributes.TALK_RATIO: None,
     }
+
+    # Display fields for the voice-call list (mirror _process_twilio_raw).
+    eval_attributes[CallAttributes.STATUS_DISPLAY] = log.get("status")
+    eval_attributes[CallAttributes.RECORDING_AVAILABLE] = False
+    eval_attributes[CallAttributes.MESSAGE_COUNT] = 0
+    eval_attributes[CallAttributes.TRANSCRIPT_AVAILABLE] = False
+    if direction := log.get("direction"):
+        eval_attributes[CallAttributes.CALL_TYPE] = direction
+    if start_time_raw := log.get("start_time"):
+        eval_attributes[CallAttributes.STARTED_AT] = start_time_raw
+        eval_attributes[CallAttributes.CREATED_AT] = start_time_raw
+    elif date_created := log.get("date_created"):
+        eval_attributes[CallAttributes.CREATED_AT] = date_created
+    if price not in (None, ""):
+        try:
+            eval_attributes[CallAttributes.COST_CENTS] = abs(float(price)) * 100
+        except (TypeError, ValueError):
+            pass
 
     return {
         "id": log.get("sid"),

--- a/futureagi/tracer/utils/vapi.py
+++ b/futureagi/tracer/utils/vapi.py
@@ -256,17 +256,31 @@ def _extract_llm_and_token_details(log: dict, eval_attributes: dict):
 def _extract_conversation(log: dict, eval_attributes: dict):
     """Extracts and flattens the conversation from the Vapi log."""
     messages = log.get("messages")
-    if not (messages and isinstance(messages, list)):
+    msg_list = messages if isinstance(messages, list) else []
+    eval_attributes[CallAttributes.MESSAGE_COUNT] = len(msg_list)
+    eval_attributes[CallAttributes.TRANSCRIPT_AVAILABLE] = len(msg_list) > 0
+    if not msg_list:
         return
 
     conversation_index = 0
+    user_talk_s = bot_talk_s = 0.0
     eval_attributes["provider_transcript"] = []
     for msg in messages:
+        if not isinstance(msg, dict):
+            continue
         role = msg.get("role")
         start_time = (
             msg.get("secondsFromStart") if msg.get("secondsFromStart") else None
         )
-        duration = msg.get("duration") / 1000 if msg.get("duration") else None
+        raw_duration = msg.get("duration")
+        duration = raw_duration / 1000 if isinstance(raw_duration, (int, float)) else None
+        if isinstance(duration, (int, float)):
+            # Round per-message before summing to match _process_vapi_logs.
+            d2 = round(duration, 2)
+            if role == "user":
+                user_talk_s += d2
+            elif role in ("bot", "assistant"):
+                bot_talk_s += d2
         if role in ["user", "assistant", "bot"]:
             # Normalize "bot" to "assistant" for consistent storage
             normalized_role = "assistant" if role == "bot" else role
@@ -288,6 +302,18 @@ def _extract_conversation(log: dict, eval_attributes: dict):
             )
             conversation_index += 1
 
+    # Talk-ratio breakdown for the list (mirror _process_vapi_logs).
+    total_talk_s = user_talk_s + bot_talk_s
+    if total_talk_s > 0:
+        eval_attributes[CallAttributes.TALK_SECONDS_USER] = round(user_talk_s, 1)
+        eval_attributes[CallAttributes.TALK_SECONDS_BOT] = round(bot_talk_s, 1)
+        eval_attributes[CallAttributes.TALK_PCT_USER] = round(
+            (user_talk_s / total_talk_s) * 100
+        )
+        eval_attributes[CallAttributes.TALK_PCT_BOT] = round(
+            (bot_talk_s / total_talk_s) * 100
+        )
+
 
 def _extract_metadata(log: dict, eval_attributes: dict):
     """
@@ -301,6 +327,27 @@ def _extract_metadata(log: dict, eval_attributes: dict):
     # Fetching call ended reason
     ended_reason = log.get("endedReason") if log.get("endedReason") else None
     eval_attributes["ended_reason"] = ended_reason
+
+    # Display fields for the voice-call list (mirror _process_vapi_logs).
+    if summary := log.get("summary"):
+        eval_attributes[CallAttributes.SUMMARY] = summary
+    if (overall_score := log.get("overallScore")) is not None:
+        eval_attributes[CallAttributes.OVERALL_SCORE] = overall_score
+    if assistant_id := log.get("assistantId"):
+        eval_attributes[CallAttributes.ASSISTANT_ID] = assistant_id
+    # Assistant phone: top-level `phoneNumber` is usually "" — read it from
+    # variableValues.phoneNumber, but only when it's a string (it's sometimes a
+    # nested dict that holds an unrelated number).
+    variable_values = log.get("variableValues")
+    vv_phone = (
+        variable_values.get("phoneNumber")
+        if isinstance(variable_values, dict)
+        else None
+    )
+    if isinstance(vv_phone, str) and vv_phone:
+        eval_attributes[CallAttributes.ASSISTANT_PHONE_NUMBER] = vv_phone
+    if error_message := log.get("errorMessage"):
+        eval_attributes[CallAttributes.ERROR_MESSAGE] = error_message
 
     # Fetching ids for filters
     eval_attributes["squad.id"] = log.get("squadId")
@@ -345,7 +392,8 @@ def _extract_metadata(log: dict, eval_attributes: dict):
     eval_attributes.update(flattened_cost_breakdown)
 
     # Fetching performance metrics
-    artifacts = log.get("artifact") or {}
+    artifacts = log.get("artifact")
+    artifacts = artifacts if isinstance(artifacts, dict) else {}
     performance_metrics = artifacts.get("performanceMetrics", {}).copy()
     if performance_metrics.get("turnLatencies") is not None:
         turn_latencies = performance_metrics.get("turnLatencies")
@@ -381,6 +429,13 @@ def _extract_recording_urls(log: dict, eval_attributes: dict):
     """Extracts recording URLs and adds them to eval_attributes."""
     artifact = log.get("artifact")
     recording = artifact.get("recording") if isinstance(artifact, dict) else None
+    # recording_available for the list — mirror _process_vapi_logs (combined mono
+    # url, with legacy recordingUrl fallback). Defensive on nested types.
+    mono = recording.get("mono") if isinstance(recording, dict) else None
+    combined = (
+        mono.get("combinedUrl") if isinstance(mono, dict) else None
+    ) or log.get("recordingUrl")
+    eval_attributes[CallAttributes.RECORDING_AVAILABLE] = bool(combined)
     if not (recording and isinstance(recording, dict)):
         return
 
@@ -425,7 +480,9 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
     messages = log.get("messages", [])
     if isinstance(messages, list):
         eval_attributes[CallAttributes.TOTAL_TURNS] = sum(
-            1 for msg in messages if msg.get("role") in ("user", "assistant", "bot")
+            1
+            for msg in messages
+            if isinstance(msg, dict) and msg.get("role") in ("user", "assistant", "bot")
         )
     else:
         eval_attributes[CallAttributes.TOTAL_TURNS] = 0
@@ -447,11 +504,37 @@ def _extract_common_call_fields(log: dict, eval_attributes: dict):
         eval_attributes[CallAttributes.DURATION] = None
 
     # participant_phone_number
-    customer = log.get("customer") or {}
-    eval_attributes[CallAttributes.PARTICIPANT_PHONE_NUMBER] = customer.get("number")
+    customer = log.get("customer")
+    eval_attributes[CallAttributes.PARTICIPANT_PHONE_NUMBER] = (
+        customer.get("number") if isinstance(customer, dict) else None
+    )
 
     # call_status (raw provider status)
     eval_attributes[CallAttributes.STATUS] = log.get("status")
+
+    # Display fields for the voice-call list (mirror _process_vapi_logs).
+    # Defensive: raw_log shapes vary — never assume a nested type.
+    customer = log.get("customer")
+    if isinstance(customer, dict) and customer.get("number"):
+        eval_attributes[CallAttributes.CUSTOMER_NAME] = customer["number"]
+    eval_attributes[CallAttributes.STATUS_DISPLAY] = (
+        "completed" if log.get("status") == "ended" else "in-progress"
+    )
+    eval_attributes[CallAttributes.CALL_TYPE] = (
+        "inbound" if log.get("type") == "inboundPhoneCall" else "outbound"
+    )
+    cost = log.get("cost")
+    if isinstance(cost, (int, float)) and cost:
+        eval_attributes[CallAttributes.COST_CENTS] = cost * 100
+    for key, src in (
+        (CallAttributes.STARTED_AT, "startedAt"),
+        (CallAttributes.ENDED_AT, "endedAt"),
+        (CallAttributes.CREATED_AT, "createdAt"),
+        (CallAttributes.RESPONSE_TIME_MS, "responseTimeMs"),
+        (CallAttributes.RESPONSE_TIME_SECONDS, "responseTimeSeconds"),
+    ):
+        if (val := log.get(src)) is not None:
+            eval_attributes[key] = val
 
 
 def _coerce_log_datetime(payload: dict) -> str | None:


### PR DESCRIPTION
## Summary

Phase 1 of the voice list/detail performance re-architecture. Voice-call **display fields** (customer, status, type, summary, cost, talk-ratio, timestamps, etc.) are now materialized as typed `call.*` attributes **at ingest**, inside each provider's normalizer. This lets the future v2 read path read typed attribute maps instead of parsing the `raw_log` blob per row. Purely additive — the legacy read path and all existing behavior are unchanged.

## Linked issues

Closes #
Fixed TH-7138

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (enables the v2 read path in later phases)

---

## 1) What changes were done

**A. Attribute-key contract (`tracer/utils/otel.py`)**

- Added ~21 `CallAttributes` constants for the voice-list display fields (`CUSTOMER_NAME`, `STATUS_DISPLAY`, `CALL_TYPE`, `SUMMARY`, `OVERALL_SCORE`, `ASSISTANT_ID`, `ASSISTANT_PHONE_NUMBER`, `ERROR_MESSAGE`, `COST_CENTS`, `MESSAGE_COUNT`, `TRANSCRIPT_AVAILABLE`, `RECORDING_AVAILABLE`, `STARTED_AT/ENDED_AT/CREATED_AT`, `RESPONSE_TIME_MS/SECONDS`, `TALK_SECONDS_USER/BOT`, `TALK_PCT_USER/BOT`).

**B. Per-provider normalizers materialize the fields (`vapi/retell/eleven_labs/bland/twilio_calls.py`)**

- Each provider writes the display fields into its **existing** topical extract helpers (`_extract_common_call_fields` / `_extract_metadata` / `_extract_conversation` / `_extract_recording_urls`), mirroring that provider's `_process_<provider>_logs` read-path logic so values match.
- Robustness guards (isinstance / try-except) so a changing raw_log shape never breaks ingestion.

**C. No read-path / API / collector change**

- The `call.*` keys already route to the collector's typed attribute maps — no Go change, no emit-path change. The legacy `process_raw_logs` read path is untouched.

---

## 2) Why the changes were done

- **Product/UX:** enables sub-second voice list/detail in later phases by removing per-row `raw_log` parsing.
- **Technical:** extraction belongs in the normalizers (their sole purpose); the v2 read path then reads typed maps. Distributed into existing helpers to avoid re-reading customer/messages/recording.
- **Architecture:** additive only — legacy stays as the fallback; the read-path rewrite is deferred to Phase 3/4.

---

## 3) Tests written + scenarios each covers

**`test_vapi_process_raw_logs.py`** — normalizer display-field parity + robustness

- `TestVapiDisplayFieldsParity` — vapi normalizer output matches `_process_vapi_logs` for the display fields
- `TestRetellDisplayFieldsParity` — same for retell
- `TestSparseProviderDisplayFields` — eleven_labs / bland / twilio (sparser, no talk-ratio / transcript)
- `TestNormalizerDisplayRobustness` — malformed / shape-shifted raw_log never raises

> Run result: parity + robustness suites pass locally.

---

## 4) How to run / test

```bash
cd futureagi && bin/test tracer/tests/test_vapi_process_raw_logs.py -v
```

---

Part of a 4-PR stack (Phase 1 → 4). This is Phase 1; Phase 2 (backfill) stacks on top.
