### PR TITLE
[TH-7112] Preserve newly-added eval-grid rows after running an evaluation

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
@@ -16,6 +16,7 @@ import {
   calculateRowHeight,
   CELL_STATE,
   isUnsavedRow,
+  mergeUnsavedRows,
 } from "../common";
 import { OriginTypes } from "src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 import axios, { endpoints } from "src/utils/axios";
@@ -576,12 +577,8 @@ const EvaluationData = () => {
   }, [evaluationData, processColumnConfig, hasDeletableRow, handleDeleteRow]);
 
   useEffect(() => {
-    setRows((prev) => {
-      const next = processRowData(evaluationData);
-      const unsavedTail = prev.slice(next.length).filter(isUnsavedRow);
-      if (!unsavedTail.length) return next;
-      return [...next, ...unsavedTail];
-    });
+    const next = processRowData(evaluationData);
+    setRows((prev) => mergeUnsavedRows(next, prev));
     return () => {
       if (addRowTimeoutRef.current) {
         clearTimeout(addRowTimeoutRef.current);

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx
@@ -576,7 +576,12 @@ const EvaluationData = () => {
   }, [evaluationData, processColumnConfig, hasDeletableRow, handleDeleteRow]);
 
   useEffect(() => {
-    setRows(processRowData(evaluationData));
+    setRows((prev) => {
+      const next = processRowData(evaluationData);
+      const unsavedTail = prev.slice(next.length).filter(isUnsavedRow);
+      if (!unsavedTail.length) return next;
+      return [...next, ...unsavedTail];
+    });
     return () => {
       if (addRowTimeoutRef.current) {
         clearTimeout(addRowTimeoutRef.current);

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/__tests__/common.test.js
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/__tests__/common.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isUnsavedRow, CELL_STATE } from "../common";
+import { isUnsavedRow, mergeUnsavedRows, CELL_STATE } from "../common";
 
 const E = CELL_STATE.EMPTY;
+
+const backendRow = (id) => ({ id, TOPIC: "backend", "Output-v2": "out" });
+const localRow = (id) => ({ id, _isLocal: true, TOPIC: E, "Output-v2": E });
 
 describe("isUnsavedRow", () => {
   it("is true for a locally-added row (flagged _isLocal)", () => {
@@ -34,5 +37,96 @@ describe("isUnsavedRow", () => {
   it("returns false for nullish input", () => {
     expect(isUnsavedRow(null)).toBe(false);
     expect(isUnsavedRow(undefined)).toBe(false);
+  });
+});
+
+describe("mergeUnsavedRows", () => {
+  it("Scenario 1 — added but unrun row survives an eval refetch", () => {
+    // Backend has rows 0-4; user added a local row "5" and hasn't run it.
+    const next = [0, 1, 2, 3, 4].map((i) => backendRow(`${i}`));
+    const prev = [...next, localRow("5")];
+
+    const merged = mergeUnsavedRows(next, prev);
+
+    expect(merged).toHaveLength(6);
+    expect(merged.at(-1)).toBe(prev.at(-1)); // same object, stable row identity
+  });
+
+  it("Scenario 2 — a run row that now persists in the backend isn't duplicated", () => {
+    // Local row "5" was run; the refetch now returns it as a backend row.
+    const next = [0, 1, 2, 3, 4, 5].map((i) => backendRow(`${i}`));
+    const prev = [
+      ...[0, 1, 2, 3, 4].map((i) => backendRow(`${i}`)),
+      localRow("5"),
+    ];
+
+    const merged = mergeUnsavedRows(next, prev);
+
+    expect(merged).toBe(next);
+    expect(merged.filter((r) => r.id === "5")).toHaveLength(1);
+  });
+
+  it("Scenario 3 — no unsaved rows: returns backend rows unchanged", () => {
+    const next = [0, 1, 2].map((i) => backendRow(`${i}`));
+    const prev = [0, 1, 2].map((i) => backendRow(`${i}`));
+
+    expect(mergeUnsavedRows(next, prev)).toBe(next);
+  });
+
+  it("partial persistence — first added row persists, second stays local", () => {
+    // Added "5" and "6"; only "5" was run, so the backend now returns 0-5.
+    const next = [0, 1, 2, 3, 4, 5].map((i) => backendRow(`${i}`));
+    const prev = [
+      ...[0, 1, 2, 3, 4].map((i) => backendRow(`${i}`)),
+      localRow("5"),
+      localRow("6"),
+    ];
+
+    const merged = mergeUnsavedRows(next, prev);
+
+    expect(merged.map((r) => r.id)).toEqual([
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+    ]);
+    expect(merged.at(-1)._isLocal).toBe(true);
+  });
+
+  it("returns next untouched when it holds id-less placeholder rows", () => {
+    // processRowData(undefined) returns 6 id-less placeholders; don't graft
+    // locals onto a grid whose rows can't be keyed.
+    const next = Array.from({ length: 6 }, () => ({
+      Variables: "",
+      Outputs: "",
+    }));
+    const prev = [backendRow("0"), localRow("1")];
+
+    expect(mergeUnsavedRows(next, prev)).toBe(next);
+  });
+
+  it("returns next for non-array or empty prev", () => {
+    const next = [backendRow("0")];
+    expect(mergeUnsavedRows(next, [])).toBe(next);
+    expect(mergeUnsavedRows(next, null)).toBe(next);
+    expect(mergeUnsavedRows(null, [localRow("0")])).toBe(null);
+  });
+
+  it("keeps a sparse-id local row when the backend count grows for another reason", () => {
+    // Local id "7" (from add-then-delete churn) must not be dropped just
+    // because the backend grew to 6 rows — its id isn't among them.
+    const next = [0, 1, 2, 3, 4, 5].map((i) => backendRow(`${i}`));
+    const prev = [
+      ...[0, 1, 2, 3, 4].map((i) => backendRow(`${i}`)),
+      localRow("7"),
+    ];
+
+    const merged = mergeUnsavedRows(next, prev);
+
+    expect(merged.map((r) => r.id)).toContain("7");
+    expect(merged).toHaveLength(7);
   });
 });

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/common.js
@@ -24,6 +24,16 @@ export const CELL_STATE = {
 // sniffing __EMPTY__ cells, which misfires after the row is run or compared.
 export const isUnsavedRow = (rowData) => !!rowData?._isLocal;
 
+export const mergeUnsavedRows = (next, prev) => {
+  if (!Array.isArray(next) || !Array.isArray(prev)) return next;
+  if (!next.every((row) => row?.id != null)) return next;
+  const nextIds = new Set(next.map((row) => row.id));
+  const unsaved = prev.filter(
+    (row) => isUnsavedRow(row) && row.id != null && !nextIds.has(row.id),
+  );
+  return unsaved.length ? [...next, ...unsaved] : next;
+};
+
 export const COLUMNIDS = {
   COMPARISON: "Comparison",
 };


### PR DESCRIPTION
**Ticket:** [TH-7112](https://linear.app/future-agi/issue/TH-7112/evaluation-grid-newly-added-rows-generated-prompt-output-disappears) — Fixes [TH-7112](https://linear.app/future-agi/issue/TH-7112/evaluation-grid-newly-added-rows-generated-prompt-output-disappears)

## What was the bug

In a prompt's **Evaluation** tab, a variable row added via **"+ Add row"** that hasn't been run yet **disappears** when you run an evaluation (on any row / Run All), instead of staying in the grid.

## What changes have been done

* `frontend/src/sections/workbench/createPrompt/Evaluation/EvaluationData/EvaluationData.jsx` — the grid-rebuild `useEffect` now preserves unsaved local rows across a refetch instead of rebuilding `rows` purely from backend data.

## Why the changes

* Running an eval invalidates the grid query → refetch → the effect ran `setRows(processRowData(evaluationData))`, which rebuilds the row list **only** from backend data.
* A row added with "+ Add row" is client-only (`_isLocal: true`) until its prompt is run and its variable persisted. Since the backend response doesn't contain it, the rebuild dropped it → the row vanished.
* Fix: backend rows are positional, so any row past the backend row count that is still unsaved (`isUnsavedRow`) is re-appended after the backend-derived rows. Preserved rows keep their original ids (already `≥` the backend range, so no collision and no re-key), which keeps AG Grid row identity stable — no remount, no orphaned per-row sockets.

## Test cases — what each scenario covers

<!-- linear:table-colwidths:266,266,266 -->
| \# | Scenario | Expected |
| -- | -- | -- |
| 1 | Add a row, **don't** run it, then run an eval on another row | New row stays visible |
| 2 | Add a row, run its prompt (variable persists), then run an eval | Row comes back from backend; no duplicate |
| 3 | No unsaved rows present, run an eval | Grid rebuilds from backend exactly as before (no behavior change) |

## How to reproduce (original bug)

1. Open a prompt's **Evaluation** tab.
2. Click **"+ Add row"** and enter a variable value — do **not** run the prompt.
3. Run an evaluation on any other row (or **Run All**).
4. Observe the newly-added row disappears.

## Videos and screenshots

https://github.com/user-attachments/assets/29b52028-d38b-403b-b759-06f8d68f01d1