### PR TITLE
fix(agentic_eval): correct Jaro transposition count

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -2191,7 +2191,8 @@ def calculate_jaro_winkler_similarity(output, expected, case_insensitive=True, p
             transpositions += 1
         k += 1
 
-    jaro = (matches / len1 + matches / len2 + (matches - transpositions / 2) / matches) / 3
+    transpositions //= 2
+    jaro = (matches / len1 + matches / len2 + (matches - transpositions) / matches) / 3
 
     # Winkler modification: boost for common prefix
     prefix = 0

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Ensure Django is configured before importing the evaluator functions.
+
+``functions.py``'s import chain reaches Django models, so the app registry must
+be populated before collection. When these tests run inside the backend's own
+settings (Docker, ``bin/test``), Django is already configured and this module
+does nothing. Standalone, it configures the minimum app set those imports need,
+so the deterministic evaluators stay unit-testable without the full stack.
+"""
+
+import sys
+from pathlib import Path
+
+# futureagi/ -- the backend root, so that `agentic_eval` and `tfc` are importable.
+_BACKEND_ROOT = Path(__file__).resolve().parents[5]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={},
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "accounts",
+            "model_hub",
+            "tracer",
+        ],
+        REST_FRAMEWORK={},
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_jaro_winkler_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_jaro_winkler_similarity.py
@@ -1,0 +1,48 @@
+"""Regression tests for the deterministic Jaro-Winkler evaluator."""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_jaro_winkler_similarity,
+)
+
+
+def test_odd_transposition_count_is_floored_before_jaro_formula():
+    """Jaro uses floor(mismatched matching characters / 2) transpositions."""
+    result = calculate_jaro_winkler_similarity(
+        "dadc",
+        "acdcabbc",
+        case_insensitive=False,
+    )
+
+    assert result["result"] == pytest.approx(0.5972222222222222)
+    assert "Jaro=0.5972" in result["reason"]
+
+
+@pytest.mark.parametrize(
+    ("output", "expected", "score"),
+    [
+        ("MARTHA", "MARHTA", 0.9611111111111111),
+        ("DIXON", "DICKSONX", 0.8133333333333332),
+    ],
+)
+def test_canonical_jaro_winkler_examples_stay_stable(output, expected, score):
+    result = calculate_jaro_winkler_similarity(
+        output,
+        expected,
+        case_insensitive=False,
+    )
+
+    assert result["result"] == pytest.approx(score)
+
+
+def test_exact_match_still_returns_perfect_score():
+    result = calculate_jaro_winkler_similarity("hello", "hello")
+
+    assert result == {"result": 1.0, "reason": "Jaro-Winkler: 1.0 (exact match)"}
+
+
+def test_empty_input_still_returns_zero_score():
+    result = calculate_jaro_winkler_similarity("", "hello")
+
+    assert result == {"result": 0.0, "reason": "Jaro-Winkler: 0.0 (empty string)"}


### PR DESCRIPTION
## Summary

Part of #1610.

Corrects `calculate_jaro_winkler_similarity` so the Jaro transposition term uses `floor(mismatched matching characters / 2)` before applying the formula.

Previously, odd transposition counts were divided directly by `2`, which deflated the score. For example, `dadc` vs `acdcabbc` now returns `0.5972`, matching the reference Jaro calculation, instead of `0.5417`. Canonical examples such as `MARTHA`/`MARHTA` and `DIXON`/`DICKSONX` remain unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update

## How was this tested?

- `.\.venv\Scripts\python.exe -m pytest futureagi\agentic_eval\core_evals\fi_evals\function\tests\test_jaro_winkler_similarity.py --confcutdir=futureagi\agentic_eval\core_evals\fi_evals\function\tests`
- `.\.venv\Scripts\python.exe -m py_compile futureagi\agentic_eval\core_evals\fi_evals\function\functions.py futureagi\agentic_eval\core_evals\fi_evals\function\tests\conftest.py futureagi\agentic_eval\core_evals\fi_evals\function\tests\test_jaro_winkler_similarity.py`
- `.\.venv\Scripts\python.exe -m ruff check futureagi\agentic_eval\core_evals\fi_evals\function\tests\conftest.py futureagi\agentic_eval\core_evals\fi_evals\function\tests\test_jaro_winkler_similarity.py --output-format concise`
- `git diff --cached --check`

Focused pytest result: `5 passed`.

## Checklist

- [x] My code follows the style guide for the added tests
- [x] I've added tests that prove my fix is effective
- [ ] Full project check suite passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII

## Notes

I kept the source change intentionally narrow to avoid reformatting the large evaluator file. The new test bootstrap mirrors the minimal Django setup needed to import deterministic evaluator functions in isolation.