### PR TITLE
fix: resolve voice provider (gen_ai.system fallback) instead of 400 on openai label

### DIFF
--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -831,9 +831,24 @@ class ObservabilityService:
                 "call_metadata": sim_meta,
             }
 
-        if provider == ProviderChoices.VAPI:
-            processed = ObservabilityService._process_vapi_logs(raw_log, span_attributes)
-        elif provider == ProviderChoices.RETELL:
+        # The `provider` hot column can carry the LLM provider (e.g. 'openai')
+        # for a voice span whose assistant runs an OpenAI model — the collector
+        # ranks gen_ai.provider.name above gen_ai.system. Resolve the real voice
+        # provider: prefer gen_ai.system, then default to vapi (the dominant
+        # provider) rather than 400 the whole voice list on an unrecognized label.
+        voice_providers = {
+            ProviderChoices.VAPI,
+            ProviderChoices.RETELL,
+            ProviderChoices.ELEVEN_LABS,
+            ProviderChoices.BLAND,
+            ProviderChoices.TWILIO,
+        }
+        if provider not in voice_providers:
+            provider = (span_attributes or {}).get("gen_ai.system") or provider
+        if provider not in voice_providers:
+            provider = ProviderChoices.VAPI
+
+        if provider == ProviderChoices.RETELL:
             processed = ObservabilityService._process_retell_logs(raw_log)
         elif provider == ProviderChoices.ELEVEN_LABS:
             processed = ObservabilityService._process_eleven_labs_raw(raw_log)
@@ -841,8 +856,8 @@ class ObservabilityService:
             processed = ObservabilityService._process_bland_raw(raw_log)
         elif provider == ProviderChoices.TWILIO:
             processed = ObservabilityService._process_twilio_raw(raw_log)
-        else:
-            raise ValueError(f"Invalid choice for provider: {provider}")
+        else:  # VAPI, and the default for any still-unrecognized label
+            processed = ObservabilityService._process_vapi_logs(raw_log, span_attributes)
 
         if span_attributes:
             from tracer.utils.vapi_recording import VapiRecordingService


### PR DESCRIPTION
## Summary

Hotfix to production. New voice calls in prod fail: the call detail view stays empty and the API returns `validation_error: Invalid choice for provider: openai`.

The `provider` hot column can carry the assistant's **LLM** provider (e.g. `openai`) instead of the **voice** provider, because the collector ranks `gen_ai.provider.name` above `gen_ai.system`. The read path (`process_raw_logs`) had no case for `openai` and raised, 400ing the whole voice list/detail. This resolves the real voice provider — prefer `gen_ai.system`, then default to `vapi` — so an unrecognized label never 400s.

This is the same fix as #1717 (targeting `dev`), raised against `main` for immediate production rollout.

## Linked issues

Closes #
Linear: https://linear.app/future-agi/issue/TH-7135

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Voice provider resolution in the read path**

- `ObservabilityService.process_raw_logs` no longer raises `ValueError` on an unrecognized provider label.
- When `provider` is not a known voice provider, it falls back to `span_attributes["gen_ai.system"]`, then defaults to `vapi` (the dominant provider).
- Purely read-path (Django) change; no collector or schema change.

## 2) Why the changes were done

- **Product/UX:** unblocks new voice calls in prod whose assistant runs an OpenAI model — detail view and voice list were fully broken (empty + 400).
- **Technical:** the collector's Django-parity alias table put `gen_ai.provider.name` (LLM vendor) first, so the hot column now carries `openai`. Recovering via `gen_ai.system` (still `vapi`) is the minimal, safe read-side fix.

## 6) Edge cases & considerations

- Unknown/other labels: still default to `vapi` rather than erroring.
- Non-voice/legacy rows unaffected — known voice providers take the existing branches.

## 8) Architectural / important decisions

- **Read-path fix over collector fix:** fastest safe path to unblock prod. The underlying collector column semantics (LLM vs voice provider collision) are tracked separately.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linear issue is linked
- [ ] No API surface change (no contract regen needed)
