### PR TITLE
ci(release): lint PR titles and enforce migrations callout

### DIFF
--- a/.github/workflows/migrations-callout-check.yml
+++ b/.github/workflows/migrations-callout-check.yml
@@ -1,0 +1,53 @@
+# Release notes must carry the migrations warning when the release contains
+# schema migrations (RELEASE-PROCESS-PLAN.md §5.3). Runs only on release-please
+# bot PRs; compares last release tag..HEAD for new migration files and requires
+# the callout string in the PR body. Fail-closed: missing callout blocks merge.
+name: migrations-callout
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-please--')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect new migration files since last release
+        id: detect
+        run: |
+          set -eu
+          last_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*' origin/main 2>/dev/null || echo "")
+          if [ -z "$last_tag" ]; then
+            echo "No previous release tag; treating all migrations in diff as new"
+            range="origin/main"
+          else
+            range="$last_tag..origin/main"
+          fi
+          added=$(git diff --name-only --diff-filter=A "$range" -- 'futureagi/*/migrations/*.py' | grep -v '__init__' || true)
+          if [ -n "$added" ]; then
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+            printf 'New migrations:\n%s\n' "$added"
+          else
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Require callout in PR body
+        if: steps.detect.outputs.has_migrations == 'true'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -eu
+          if printf '%s' "$PR_BODY" | grep -qF 'Contains database migrations'; then
+            echo "Callout present."
+          else
+            echo "::error::This release adds schema migrations but the release notes lack the '⚠️ Contains database migrations' callout. Edit the release-please PR body to add it (see RELEASE-PROCESS-PLAN.md §5.3)."
+            exit 1
+          fi

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,35 @@
+# Conventional-commit PR titles feed release-please's notes; this makes the
+# format a merge gate. Skips bot PRs and the dev->main release PR (whose title
+# is a release name, not a commit).
+name: pr-title-lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [dev, main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor != 'release-please[bot]' &&
+      !(github.head_ref == 'dev' && github.base_ref == 'main')
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            perf
+            ci
+            revert
+          requireScope: false


### PR DESCRIPTION
## What changed

Adds two PR-governance GitHub Actions workflows to support the tag-driven release pipeline:

- **`.github/workflows/pr-title-lint.yml`** (`pr-title-lint`) — enforces conventional-commit PR titles on PRs into `dev` and `main` via `amannn/action-semantic-pull-request@v5`. Allowed types: `feat, fix, chore, docs, refactor, test, perf, ci, revert`; scope optional. Skips `release-please[bot]` PRs and the `dev`→`main` release PR (whose title is a release name, not a commit).
- **`.github/workflows/migrations-callout-check.yml`** (`migrations-callout`) — runs only on `release-please--*` bot PRs into `main`. Detects new schema migration files added since the last release tag and, if any exist, **fails closed** unless the PR body contains the `Contains database migrations` callout.

## Why

PR titles feed release-please's generated release notes, so their format needs to be a merge gate (RELEASE-PROCESS-PLAN.md §5.1). Release notes must also carry the migrations warning whenever a release ships schema migrations so operators are alerted (RELEASE-PROCESS-PLAN.md §5.3).

These produce two required-check candidates (`pr-title-lint`, `migrations-callout`) that humans wire into branch protection in Track G.

## How verified

- `actionlint` on both files — exit 0, no findings:
  ```
  $ actionlint -color .github/workflows/pr-title-lint.yml .github/workflows/migrations-callout-check.yml
  exit=0
  ```
- YAML well-formedness (`python3 -c "import yaml; yaml.safe_load(...)"`) — OK for both files.
- Migration-detection command exercised against real repo history; runs without error. No release tag reachable from `origin/main` (only `-dev` pre-release tags exist, which are not reachable), so it takes the documented "no previous release tag" fallback (`range=origin/main`) and exits 0. The glob `futureagi/*/migrations/*.py` matches 485 real migration files, confirming the path pattern is correct.

## Follow-ups

- Branch protection wiring (mark `pr-title-lint` and `migrations-callout` as required checks) is Track G / human.
- Minor: `git describe --match 'v[0-9]*'` would also match a `-dev` pre-release tag if one were ever reachable from `main`. Per the cross-repo tag contract, release-please only creates clean `vX.Y.Z` tags on `main`, so in practice the last reachable tag is always a real release. Flagging for awareness; left as specified in the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
