### PR TITLE
perf(tracer): bound CH span scans on the hot list APIs + fix eval-attributes memory-guard failures

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -334,6 +334,10 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         """Fetch input/output + typed attr maps for a page of span IDs."""
         if not span_ids:
             return "", {}
+        if "start_date" not in self.params or "end_date" not in self.params:
+            start_date, end_date = self.parse_time_range(self.filters)
+            self.params["start_date"] = start_date
+            self.params["end_date"] = end_date
         params = {**self.params, "content_span_ids": tuple(span_ids)}
         query = f"""
         SELECT id, input, output, attributes_extra,
@@ -343,6 +347,8 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         PREWHERE id IN %(content_span_ids)s
         WHERE {self.project_filter_sql()} AND is_deleted = 0
+          AND start_time >= %(start_date)s - INTERVAL 1 DAY
+          AND start_time < %(end_date)s + INTERVAL 1 DAY
         """
         return query, params
 

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -23,8 +23,10 @@ from tracer.services.clickhouse.query_builders.eval_status import (
 )
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 
-# TODO: switch this to "start_time" once we create an index on that column .
-TIME_FILTER_COLUMN = "created_at"  # Options: "created_at" | "start_time"
+# On the v2 schema (PARTITION BY toDate(start_time), PK on toStartOfHour(
+# start_time)) start_time prunes partitions and the PK; created_at prunes
+# nothing and scans the whole project.
+TIME_FILTER_COLUMN = "start_time"  # Options: "created_at" | "start_time"
 
 
 class TraceListQueryBuilder(BaseQueryBuilder):
@@ -107,6 +109,24 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         self.annotation_label_ids = annotation_label_ids or []
         self.start_date: datetime | None = None
         self.end_date: datetime | None = None
+
+    def _span_time_window(
+        self, params: dict[str, Any], column: str = "start_time"
+    ) -> str:
+        """Bound a page-scoped span probe to the request window ± 1 day.
+
+        Page trace_ids come from the windowed page scan; every span of an
+        in-window trace starts within the window ± max trace duration (prod
+        max ≈ 5h « 1d). Empty when no build() ran (standalone callers).
+        """
+        if self.start_date is None:
+            return ""
+        params["start_date"] = self.start_date
+        params["end_date"] = self.end_date
+        return (
+            f"AND {column} >= %(start_date)s - INTERVAL 1 DAY\n"
+            f"          AND {column} < %(end_date)s + INTERVAL 1 DAY"
+        )
 
     # ------------------------------------------------------------------
     # Phase 1: Paginated trace list
@@ -207,24 +227,6 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         # Heavy columns are fetched in build_content_query() for just the
         # returned trace_ids — avoids OOM on large tables.
         #
-        # `created_at` is the partition/sort key (`PARTITION BY
-        # toYYYYMM(created_at)`, `ORDER BY (project_id, toDate(created_at),
-        # trace_id, id)`). Adding a **lower bound only** on `created_at`
-        # lets CH prune old partitions — without it, the existing
-        # `start_time` filter alone triggers a full project scan because
-        # `start_time` isn't indexed. `start_time` remains the semantic
-        # bound so user-visible timestamps are respected exactly.
-        #
-        # NO UPPER BOUND on `created_at`: prod data shows 0.5% of rows
-        # arrive >7 days late (SDK buffering, backfills, manual uploads);
-        # an upper bound would silently drop them. A 1-day buffer on the
-        # lower bound tolerates clock skew. This delivers 100% of the
-        # pruning benefit (upper bound tested: zero additional win since
-        # no row has `created_at` in the future).
-        #
-        # On a 3.5M-span project, 7d page-1 drops from 663ms/3.5M rows
-        # to 256ms/306K rows (~2.5x faster, 91% less I/O).
-        #
         # PERF: no `LIMIT 1 BY trace_id`. That clause deduped multi-root /
         # duplicate-version traces, but forced CH to read + full-sort EVERY
         # root span in the window before applying ORDER BY … LIMIT —
@@ -240,7 +242,6 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND (parent_span_id IS NULL OR parent_span_id = '')
-          AND created_at >= %(start_date)s - INTERVAL 1 DAY
           AND {TIME_FILTER_COLUMN} >= %(start_date)s
           AND {TIME_FILTER_COLUMN} < %(end_date)s
           {pv_fragment}
@@ -290,7 +291,6 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND (parent_span_id IS NULL OR parent_span_id = '')
-          AND created_at >= %(start_date)s - INTERVAL 1 DAY
           AND {TIME_FILTER_COLUMN} >= %(start_date)s
           AND {TIME_FILTER_COLUMN} < %(end_date)s
           {pv_fragment}
@@ -314,6 +314,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             "content_trace_ids": tuple(trace_ids),
         }
 
+        span_window = self._span_time_window(params)
         query = f"""
         SELECT
             trace_id,
@@ -330,6 +331,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         WHERE {self.project_filter_sql()}
           AND is_deleted = 0
           AND (parent_span_id IS NULL OR parent_span_id = '')
+          {span_window}
         LIMIT 1 BY trace_id
         """
         return query, params
@@ -346,6 +348,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             return "", {}
 
         params = {**self.params, "attr_trace_ids": tuple(trace_ids)}
+        span_window = self._span_time_window(params)
         query = f"""
         SELECT
             trace_id,
@@ -356,6 +359,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
           AND is_deleted = 0
           AND attributes_extra != '{{}}'
           AND attributes_extra != ''
+          {span_window}
         """
         return query, params
 
@@ -396,17 +400,11 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             search_fragment = "AND trace_name ILIKE %(search)s"
             params["search"] = f"%{self.search}%"
 
-        # See comment in build() — lower-bound-only `created_at` filter
-        # prunes old partitions. Drops 7d count from 716ms/3.5M rows to
-        # 255ms/306K rows on a 3.5M-span project, without dropping any
-        # rows that legitimately match the user's `start_time` window.
-
         query = f"""
         SELECT uniq(trace_id) AS total
         FROM {self.TABLE}
         {self.project_where()}
           AND (parent_span_id IS NULL OR parent_span_id = '')
-          AND created_at >= %(start_date)s - INTERVAL 1 DAY
           AND {TIME_FILTER_COLUMN} >= %(start_date)s
           AND {TIME_FILTER_COLUMN} < %(end_date)s
           {pv_fragment}
@@ -603,6 +601,9 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             "trace_ids": tuple(trace_ids),
             "label_ids": tuple(annotation_label_ids),
         }
+        # Bound only the spans (sp) join side; the score (s) side keeps no
+        # upper bound so annotations created after the window still resolve.
+        sp_window = self._span_time_window(params, column="sp.start_time")
 
         query = f"""
         SELECT
@@ -619,6 +620,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         LEFT JOIN {self.TABLE} AS sp
           ON sp.id = s.observation_span_id
          AND sp._peerdb_is_deleted = 0
+         {sp_window}
         WHERE s._peerdb_is_deleted = 0
           AND s.deleted = false
           AND if(
@@ -646,6 +648,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             **self.params,
             "user_trace_ids": tuple(trace_ids),
         }
+        span_window = self._span_time_window(params)
 
         query = f"""
         SELECT trace_id, user_id
@@ -659,6 +662,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
               AND _peerdb_is_deleted = 0
               AND end_user_id IS NOT NULL
               AND end_user_id != toUUID('00000000-0000-0000-0000-000000000000')
+              {span_window}
             GROUP BY trace_id
         )
         WHERE user_id != ''

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -9,6 +9,7 @@ endpoints assume CH is reachable; if it's down, the request fails loudly.
 
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
@@ -319,15 +320,38 @@ class AnalyticsQueryService:
         return [row["config_id"] for row in result.data]
 
     def get_span_trace_map(
-        self, trace_ids: list[str], timeout_ms: int = 10000
+        self,
+        trace_ids: list[str],
+        project_id: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        timeout_ms: int = 10000,
     ) -> dict[str, str]:
-        """Map span id -> trace id for spans in the given traces (CH-native)."""
+        """Map span id -> trace id for spans in the given traces (CH-native).
+
+        ``project_id`` prunes the scan to the partition/PK prefix; the
+        ``start_date``/``end_date`` window (widened one day each side to cover a
+        trace's full duration) prunes partitions. Without them the query is a
+        full-table scan.
+        """
         if not trace_ids:
             return {}
+        params: dict[str, Any] = {"trace_ids": trace_ids}
+        where = ["trace_id IN %(trace_ids)s", "is_deleted = 0"]
+        if project_id is not None:
+            params["project_id"] = project_id
+            where.append("project_id = %(project_id)s")
+        if start_date is not None and end_date is not None:
+            params["start_date"] = start_date
+            params["end_date"] = end_date
+            where.append(
+                "start_time >= %(start_date)s - INTERVAL 1 DAY "
+                "AND start_time < %(end_date)s + INTERVAL 1 DAY"
+            )
         result = self.execute_ch_query(
             "SELECT toString(id) AS span_id, toString(trace_id) AS trace_id "
-            "FROM spans WHERE trace_id IN %(trace_ids)s AND is_deleted = 0",
-            {"trace_ids": trace_ids},
+            f"FROM spans WHERE {' AND '.join(where)}",
+            params,
             timeout_ms=timeout_ms,
         )
         return {r["span_id"]: r["trace_id"] for r in result.data}

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -139,7 +139,6 @@ class AnalyticsQueryService:
             params["recent_days"] = int(recent_days)
             recent_filter = "AND start_time >= now() - toIntervalDay(%(recent_days)s)"
 
-        inner_order = "ORDER BY start_time DESC" if recent_days is not None else ""
         outer_select = "SELECT key, argMax(type, cnt) AS type"
         if include_counts:
             outer_select += ", sum(cnt) AS count"
@@ -150,33 +149,30 @@ class AnalyticsQueryService:
         query = f"""
             {outer_select} FROM (
                 SELECT key, 'string' AS type, count() AS cnt FROM (
-                    SELECT attrs_string FROM spans
+                    SELECT attrs_string.keys AS ks FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
-                    {inner_order}
                     LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_string) AS key
+                ) ARRAY JOIN ks AS key
                 GROUP BY key
                 UNION ALL
                 SELECT key, 'number' AS type, count() AS cnt FROM (
-                    SELECT attrs_number FROM spans
+                    SELECT attrs_number.keys AS ks FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
-                    {inner_order}
                     LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_number) AS key
+                ) ARRAY JOIN ks AS key
                 GROUP BY key
                 UNION ALL
                 SELECT key, 'boolean' AS type, count() AS cnt FROM (
-                    SELECT attrs_bool FROM spans
+                    SELECT attrs_bool.keys AS ks FROM spans
                     WHERE project_id IN %(project_ids)s
                       AND is_deleted = 0
                       {recent_filter}
-                    {inner_order}
                     LIMIT 10000
-                ) ARRAY JOIN mapKeys(attrs_bool) AS key
+                ) ARRAY JOIN ks AS key
                 GROUP BY key
             )
             GROUP BY key

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -311,10 +311,14 @@ class TestSpanAttributeKeysPartitionPruning:
     """The recent-window discovery query must prune by the partition key.
 
     ``spans`` is partitioned by ``toDate(start_time)``; ``created_at`` is
-    neither the partition key nor in the sort key. Windowing/ordering by
-    ``created_at`` defeats partition pruning and scans the whole project
-    (measured ~23x over-read at 100k spans -> Code: 159 timeouts). Pin that
-    the query windows and orders by ``start_time`` instead.
+    neither the partition key nor in the sort key. Windowing by ``created_at``
+    defeats partition pruning and scans the whole project. Pin that the query
+    windows by ``start_time`` and does NOT order by it: ``start_time`` sits
+    behind ``observation_type``/``service_name`` in the sort key, so an ordered
+    top-N reads the whole window (materializing the fat ``attrs_*`` maps) before
+    ``LIMIT`` applies -> Code 396 / Code 159 on high-volume projects. Without the
+    ORDER BY, ``project_id`` leading the sort key lets ``LIMIT 10000`` bound the
+    scan. Also pin that only the Map ``.keys`` subcolumn is read (never values).
     """
 
     def _capture_sql(self, monkeypatch, *, recent_days=7) -> str:
@@ -337,11 +341,29 @@ class TestSpanAttributeKeysPartitionPruning:
         )
         return captured["query"]
 
-    def test_windows_and_orders_by_start_time(self, monkeypatch):
+    def test_windows_by_start_time_without_recency_order(self, monkeypatch):
         sql = self._capture_sql(monkeypatch, recent_days=7)
         # start_time is the partition key -> CH can prune to the window.
         assert "start_time >= now() - toIntervalDay" in sql
-        assert "ORDER BY start_time DESC" in sql
+        # The recency ORDER BY is dropped so LIMIT 10000 bounds the scan.
+        assert "ORDER BY start_time" not in sql
+
+    def test_reads_keys_subcolumn_not_whole_map(self, monkeypatch):
+        sql = self._capture_sql(monkeypatch, recent_days=7)
+        # keys-only endpoint -> read the Map .keys subcolumn, never the
+        # (200-380 KB) map values via mapKeys().
+        assert "attrs_string.keys" in sql
+        assert "attrs_number.keys" in sql
+        assert "attrs_bool.keys" in sql
+        assert "mapKeys(" not in sql
+
+    def test_preserves_limit_and_type_labels(self, monkeypatch):
+        sql = self._capture_sql(monkeypatch, recent_days=7)
+        # The per-map LIMIT and type labels are unchanged by the fix.
+        assert "LIMIT 10000" in sql
+        assert "'string'" in sql
+        assert "'number'" in sql
+        assert "'boolean'" in sql
 
     def test_does_not_window_or_order_by_created_at(self, monkeypatch):
         sql = self._capture_sql(monkeypatch, recent_days=7)

--- a/futureagi/tracer/tests/test_span_list_builder_comprehensive.py
+++ b/futureagi/tracer/tests/test_span_list_builder_comprehensive.py
@@ -264,6 +264,13 @@ class TestBuildContentQuery:
         assert "is_deleted = 0" in sql
         assert params["content_span_ids"] == ("s1", "s2")
 
+    def test_bounds_start_time_window(self):
+        sql, params = _make_builder().build_content_query(span_ids=["s1"])
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sql
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in sql
+        assert params["start_date"] is not None
+        assert params["end_date"] is not None
+
 
 # --------------------------------------------------------------------------- #
 # build_eval_query() — Phase 2

--- a/futureagi/tracer/tests/test_trace.py
+++ b/futureagi/tracer/tests/test_trace.py
@@ -5,7 +5,6 @@ Tests for /tracer/trace/ endpoints.
 """
 
 import uuid
-from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -58,7 +57,6 @@ class TestTraceRetrieveAPI:
         assert response.status_code == status.HTTP_200_OK
         data = get_result(response)
         # Spans may be in various locations in the response
-        spans = data.get("observation_spans", data.get("spans", []))
         # API may return spans elsewhere or spans may not be included inline
         # Just verify the response contains trace data
         trace_data = data.get("trace", data)
@@ -656,6 +654,68 @@ def test_get_span_trace_map_selects_from_spans(monkeypatch):
     assert "trace_id IN %(trace_ids)s" in captured["query"]
     assert "is_deleted = 0" in captured["query"]
     assert captured["params"] == {"trace_ids": ["t1"]}
+    assert "project_id" not in captured["query"]
+    assert "start_time" not in captured["query"]
+
+
+def _capture_span_trace_map_query(monkeypatch, **kwargs):
+    from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+    captured = {}
+
+    def fake_exec(self, query, params=None, timeout_ms=5000):
+        captured["query"] = query
+        captured["params"] = params
+
+        class R:
+            data = []
+
+        return R()
+
+    monkeypatch.setattr(AnalyticsQueryService, "execute_ch_query", fake_exec)
+    AnalyticsQueryService().get_span_trace_map(["t1"], **kwargs)
+    return captured
+
+
+def test_get_span_trace_map_scopes_project_id_only(monkeypatch):
+    captured = _capture_span_trace_map_query(monkeypatch, project_id="p1")
+
+    assert "trace_id IN %(trace_ids)s" in captured["query"]
+    assert "project_id = %(project_id)s" in captured["query"]
+    assert "start_time" not in captured["query"]
+    assert captured["params"] == {"trace_ids": ["t1"], "project_id": "p1"}
+
+
+def test_get_span_trace_map_bounds_start_time_window(monkeypatch):
+    from datetime import datetime
+
+    start = datetime(2026, 7, 1)
+    end = datetime(2026, 7, 8)
+    captured = _capture_span_trace_map_query(
+        monkeypatch, project_id="p1", start_date=start, end_date=end
+    )
+
+    assert "trace_id IN %(trace_ids)s" in captured["query"]
+    assert "project_id = %(project_id)s" in captured["query"]
+    assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in captured["query"]
+    assert "start_time < %(end_date)s + INTERVAL 1 DAY" in captured["query"]
+    assert captured["params"] == {
+        "trace_ids": ["t1"],
+        "project_id": "p1",
+        "start_date": start,
+        "end_date": end,
+    }
+
+
+def test_get_span_trace_map_window_needs_both_bounds(monkeypatch):
+    from datetime import datetime
+
+    captured = _capture_span_trace_map_query(
+        monkeypatch, project_id="p1", start_date=datetime(2026, 7, 1)
+    )
+
+    assert "start_time" not in captured["query"]
+    assert captured["params"] == {"trace_ids": ["t1"], "project_id": "p1"}
 
 
 def test_build_annotation_map_pg_has_no_observation_span_join(monkeypatch):

--- a/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
+++ b/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
@@ -86,6 +86,20 @@ class TestBuildContentQuery:
         assert "project_id IN %(project_ids)s" in query
         assert params["project_ids"] == tuple(pids)
 
+    def test_start_time_window_after_build(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        builder.build()
+        query, params = builder.build_content_query(trace_ids)
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in query
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in query
+        assert params["start_date"] == builder.start_date
+        assert params["end_date"] == builder.end_date
+
+    def test_no_window_standalone(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, _ = builder.build_content_query(trace_ids)
+        assert "start_time" not in query
+
 
 # ---------------------------------------------------------------------------
 # build_span_attributes_query
@@ -128,6 +142,19 @@ class TestBuildSpanAttributesQuery:
         assert "project_id = %(project_id)s" in query
         assert "is_deleted = 0" in query
         assert "_peerdb_is_deleted" not in query
+
+    def test_start_time_window_after_build(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        builder.build()
+        query, params = builder.build_span_attributes_query(trace_ids)
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in query
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in query
+        assert params["start_date"] == builder.start_date
+
+    def test_no_window_standalone(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, _ = builder.build_span_attributes_query(trace_ids)
+        assert "start_time" not in query
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +222,19 @@ class TestBuildUserIdQuery:
         assert "00000000-0000-0000-0000-000000000000" in query
         assert "GROUP BY trace_id" in query
         assert "user_id != ''" in query
+
+    def test_start_time_window_after_build(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        builder.build()
+        query, params = builder.build_user_id_query(trace_ids)
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in query
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in query
+        assert params["start_date"] == builder.start_date
+
+    def test_no_window_standalone(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, _ = builder.build_user_id_query(trace_ids)
+        assert "start_time" not in query
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +330,37 @@ class TestBuildAnnotationQuery:
         assert "s._peerdb_is_deleted = 0" in query
         assert "s.deleted = false" in query
         assert "sp._peerdb_is_deleted = 0" in query
+
+    def test_spans_join_side_bounded_on_start_time(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        builder.build()
+        query, params = builder.build_annotation_query(trace_ids, ["l1"])
+        # The spans-JOIN side is bounded on the sp alias so it prunes the
+        # scan of every page trace's spans.
+        assert "sp.start_time >= %(start_date)s - INTERVAL 1 DAY" in query
+        assert "sp.start_time < %(end_date)s + INTERVAL 1 DAY" in query
+        assert params["start_date"] == builder.start_date
+
+    def test_trailing_score_not_dropped(self, project_id, trace_ids):
+        """A score/annotation can be created arbitrarily later than the span
+        it targets. The score (s) side must therefore carry no time predicate
+        at all, so a row whose created_at falls after the window end still
+        resolves; only the spans (sp) join side is time-bounded."""
+        builder = TraceListQueryBuilder(project_id=project_id)
+        builder.build()
+        query, _ = builder.build_annotation_query(trace_ids, ["l1"])
+        # spans side bounded ...
+        assert "sp.start_time <" in query
+        # ... but the score side has no created_at bound of any kind, so a
+        # late-created score is never filtered out by time.
+        assert "s.created_at" not in query
+        assert "s.start_time" not in query
+
+    def test_no_window_standalone(self, project_id, trace_ids):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, params = builder.build_annotation_query(trace_ids, ["l1"])
+        assert "start_time" not in query
+        assert set(params.keys()) == {"trace_ids", "label_ids"}
 
 
 # ---------------------------------------------------------------------------
@@ -409,11 +480,13 @@ class TestBuildCountQuery:
         assert "trace_name ILIKE %(search)s" in query
         assert params["search"] == "%boom%"
 
-    def test_created_at_lower_bound_pruning(self, project_id):
+    def test_start_time_window_no_created_at_skew(self, project_id):
         builder = TraceListQueryBuilder(project_id=project_id)
         builder.build()
         query, _ = builder.build_count_query()
-        assert "created_at >= %(start_date)s - INTERVAL 1 DAY" in query
+        assert "start_time >= %(start_date)s" in query
+        assert "start_time < %(end_date)s" in query
+        assert "created_at" not in query
 
     def test_multi_project_scoping(self):
         pids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -422,6 +495,28 @@ class TestBuildCountQuery:
         query, params = builder.build_count_query()
         assert "project_id IN %(project_ids)s" in query
         assert params["project_ids"] == tuple(pids)
+
+
+# ---------------------------------------------------------------------------
+# Outer window bounds on start_time (Card A / T0 + T1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOuterWindowStartTime:
+    def test_build_bounds_start_time_no_created_at(self, project_id):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, _ = builder.build()
+        assert "start_time >= %(start_date)s" in query
+        assert "start_time < %(end_date)s" in query
+        assert "created_at" not in query
+
+    def test_id_query_bounds_start_time_no_created_at(self, project_id):
+        builder = TraceListQueryBuilder(project_id=project_id)
+        query, _ = builder.build_id_query()
+        assert "start_time >= %(start_date)s" in query
+        assert "start_time < %(end_date)s" in query
+        assert "created_at" not in query
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/tracer/tests/test_traces_of_session_pagination.py
+++ b/futureagi/tracer/tests/test_traces_of_session_pagination.py
@@ -103,3 +103,112 @@ class TestTracesOfSessionPagination:
         assert len(payload["table"]) == page_size
         # total_rows comes from the (correct) uniq() count, unchanged by the trim.
         assert payload["metadata"]["total_rows"] == total
+
+    def test_span_trace_map_skipped_without_annotation_labels(self):
+        """No annotation labels -> the annotation map is a guaranteed no-op,
+        so the span->trace map query must not run at all."""
+        view = self._make_view()
+        request = self._make_request(page_size=5)
+        trace_rows = [{"trace_id": str(uuid.uuid4())} for _ in range(3)]
+        analytics = self._routing_analytics(trace_rows=trace_rows, total=3)
+
+        with (
+            mock.patch("tracer.views.trace.CustomEvalConfig") as mock_cfg,
+            mock.patch(
+                "tracer.views.trace.get_annotation_labels_for_project",
+                return_value=[],
+            ),
+            mock.patch(
+                "tracer.views.trace._build_annotation_map_from_scores",
+                return_value={},
+            ),
+        ):
+            mock_cfg.objects.filter.return_value.select_related.return_value = []
+            status, _ = view._list_traces_of_session_clickhouse(
+                request,
+                project_id=str(uuid.uuid4()),
+                validated_data={"filters": [], "page_number": 0, "page_size": 5},
+                analytics=analytics,
+                org_project_ids=None,
+                org=request.organization,
+            )
+
+        assert status == "ok"
+        analytics.get_span_trace_map.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_span_trace_map_runs_with_annotation_labels(self):
+        """With labels present the span->trace map runs, scoped to project + window."""
+        view = self._make_view()
+        request = self._make_request(page_size=5)
+        trace_rows = [{"trace_id": str(uuid.uuid4())} for _ in range(3)]
+        analytics = self._routing_analytics(trace_rows=trace_rows, total=3)
+        label = mock.Mock()
+        label.id = uuid.uuid4()
+        label.type = "text"
+        label.name = "Quality"
+        label.settings = {}
+        project_id = str(uuid.uuid4())
+
+        with (
+            mock.patch("tracer.views.trace.CustomEvalConfig") as mock_cfg,
+            mock.patch(
+                "tracer.views.trace.get_annotation_labels_for_project",
+                return_value=[label],
+            ),
+            mock.patch(
+                "tracer.views.trace._build_annotation_map_from_scores",
+                return_value={},
+            ),
+        ):
+            mock_cfg.objects.filter.return_value.select_related.return_value = []
+            status, _ = view._list_traces_of_session_clickhouse(
+                request,
+                project_id=project_id,
+                validated_data={"filters": [], "page_number": 0, "page_size": 5},
+                analytics=analytics,
+                org_project_ids=None,
+                org=request.organization,
+            )
+
+        assert status == "ok"
+        analytics.get_span_trace_map.assert_called_once()
+        assert analytics.get_span_trace_map.call_args.kwargs["project_id"] == project_id
+
+    def test_content_shortfall_logs_buffer_warning(self):
+        """Fewer content rows than page traces -> the window-buffer warning fires."""
+        view = self._make_view()
+        request = self._make_request(page_size=5)
+        trace_rows = [{"trace_id": str(uuid.uuid4())} for _ in range(3)]
+        analytics = self._routing_analytics(trace_rows=trace_rows, total=3)
+
+        with (
+            mock.patch("tracer.views.trace.CustomEvalConfig") as mock_cfg,
+            mock.patch(
+                "tracer.views.trace.get_annotation_labels_for_project",
+                return_value=[],
+            ),
+            mock.patch(
+                "tracer.views.trace._build_annotation_map_from_scores",
+                return_value={},
+            ),
+            mock.patch("tracer.views.trace.logger") as mock_logger,
+        ):
+            mock_cfg.objects.filter.return_value.select_related.return_value = []
+            status, _ = view._list_traces_of_session_clickhouse(
+                request,
+                project_id=str(uuid.uuid4()),
+                validated_data={"filters": [], "page_number": 0, "page_size": 5},
+                analytics=analytics,
+                org_project_ids=None,
+                org=request.organization,
+            )
+
+        assert status == "ok"
+        warning_events = [
+            c.args[0] for c in mock_logger.warning.call_args_list if c.args
+        ]
+        assert (
+            "trace content enrichment returned fewer traces than requested"
+            in warning_events
+        )

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3556,6 +3556,17 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     content_query, content_params, timeout_ms=10000
                 )
                 content_rows = content_result.data
+                # Every in-window trace has a root span, so a shortfall means
+                # spans fell outside the 1-day window buffer (a trace running
+                # longer than the buffer, clock skew, or backfilled
+                # timestamps) and enrichment silently dropped them.
+                if len(content_rows) < len(trace_ids):
+                    logger.warning(
+                        "trace content enrichment returned fewer traces than requested",
+                        returned=len(content_rows),
+                        requested=len(trace_ids),
+                        project_id=str(project_id) if project_id else None,
+                    )
         content_map = merge_content_rows(
             result.data,
             content_rows,
@@ -3609,7 +3620,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 start_date=builder.params.get("start_date"),
                 end_date=builder.params.get("end_date"),
             )
-            if trace_ids
+            if trace_ids and annotation_label_ids
             else {}
         )
         annotation_map = _build_annotation_map_from_scores(

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -70,7 +70,6 @@ from tracer.serializers.trace import (
     UsersQuerySerializer,
     UsersResponseSerializer,
 )
-from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.graph_dispatch import (
     fetch_annotation_graph_ch,
     fetch_eval_graph_ch,
@@ -82,9 +81,6 @@ from tracer.services.clickhouse.query_builders import (
 )
 from tracer.services.clickhouse.query_builders.base import NIL_UUID
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
-from tracer.services.clickhouse.v2.query_builders.user_list import (
-    UserListQueryBuilderV2,
-)
 from tracer.services.clickhouse.v2.span_selectors import (
     flatten_span_attributes_into_entry,
     merge_content_rows,
@@ -571,13 +567,22 @@ def _simulation_context_for_voice_call(
 
 
 def _build_annotation_map_from_scores(
-    trace_ids, annotation_label_ids, label_types, span_trace_map=None
+    trace_ids,
+    annotation_label_ids,
+    label_types,
+    span_trace_map=None,
+    project_id=None,
+    start_date=None,
+    end_date=None,
 ):
     """Fetch annotation values from PG Score table and build annotation_map.
 
     Always reads from PG to guarantee read-after-write consistency —
     annotations are written to PG first and CDC replication to ClickHouse
     may lag, causing newly created annotations to be invisible.
+
+    ``project_id``/``start_date``/``end_date`` scope the span->trace CH
+    lookup when this builds the map itself (span_trace_map not supplied).
 
     Returns:
         Dict mapping trace_id -> label_id -> structured annotation data
@@ -588,7 +593,12 @@ def _build_annotation_map_from_scores(
     if span_trace_map is None:
         from tracer.services.clickhouse.query_service import AnalyticsQueryService
 
-        span_trace_map = AnalyticsQueryService().get_span_trace_map(trace_ids)
+        span_trace_map = AnalyticsQueryService().get_span_trace_map(
+            trace_ids,
+            project_id=project_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
     return _build_annotation_map_from_scores_pg(
         trace_ids, annotation_label_ids, label_types, span_trace_map
     )
@@ -3589,7 +3599,19 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 )
 
         # Phase 3: Annotations — PG values, span->trace resolved via CH.
-        span_trace_map = analytics.get_span_trace_map(trace_ids) if trace_ids else {}
+        # In org-scoped mode the page spans multiple projects, so scope the
+        # map on the window only (a single project_id would drop other
+        # projects' spans).
+        span_trace_map = (
+            analytics.get_span_trace_map(
+                trace_ids,
+                project_id=None if org_scope else str(project_id),
+                start_date=builder.params.get("start_date"),
+                end_date=builder.params.get("end_date"),
+            )
+            if trace_ids
+            else {}
+        )
         annotation_map = _build_annotation_map_from_scores(
             trace_ids, annotation_label_ids, label_types, span_trace_map
         )
@@ -3876,7 +3898,12 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         # Phase 3: Annotations — fetch from PG Score (unified annotation system)
         annotation_map = _build_annotation_map_from_scores(
-            trace_ids, annotation_label_ids, label_types
+            trace_ids,
+            annotation_label_ids,
+            label_types,
+            project_id=str(project_id),
+            start_date=builder.params.get("start_date"),
+            end_date=builder.params.get("end_date"),
         )
 
         # Phase 4 (child spans) removed — observation_span is a detail-only field.
@@ -4242,7 +4269,12 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         # Phase 3: Annotations — fetch from PG Score (unified annotation system)
         annotation_map = _build_annotation_map_from_scores(
-            trace_ids, annotation_label_ids, label_types
+            trace_ids,
+            annotation_label_ids,
+            label_types,
+            project_id=str(project_id),
+            start_date=builder.params.get("start_date"),
+            end_date=builder.params.get("end_date"),
         )
 
         user_id_map = builder.resolve_user_ids(trace_ids, analytics)


### PR DESCRIPTION
## Why

Three prod pain points on the two hottest tracer list APIs plus the eval-attributes picker, all traced per-request via Loki request-id joins + `system.query_log` on us2 (2026-07-23):

- A single `list_traces_of_session` page load on the largest tenant took **10.0 s**, dominated by CH queries that scan far beyond the requested window (page scan read 121.6M rows for 300 results; the span→trace map read 183.3M rows — the whole table, every tenant — per page load).
- `list_spans_observe` enrichment reads scanned project-lifetime granules for page-scoped id lookups.
- `get_eval_attributes_list` failed **100% of requests on the largest tenant** (CH Code 396 TOO_MANY_ROWS_OR_BYTES ×106/week + Code 159 timeouts ×10/week): an `ORDER BY start_time DESC` the sort key cannot serve forced materializing every span's 200–380 KB attribute maps before a `LIMIT 10000` that consequently bounded nothing.

Every fix here was A/B-measured on live prod data before implementation (read-only, result-set equality verified). Full evidence: `internal-docs/ch-query-optimization/QUICK_WINS_PLAN.md` + `EVAL_ATTRS_INVESTIGATION.md`.

## What

Three commits, no schema changes, no API contract changes:

1. **`31e0ad09f` trace-list window + enrichment bounds** — the outer page/id/count window binds `start_time` (the v2 partition + PK column) instead of `created_at` (unindexed on v2, pruned nothing); the dead `created_at` skew line is dropped. The four page-scoped enrichment queries (content, span-attributes, user_id, annotation-join spans side) gain a `start_time ∈ [start−1d, end+1d)` window. The annotation query bounds only its spans JOIN side, in the ON clause (preserves LEFT JOIN rows for trace-level annotations); the score side keeps no upper time bound so late-created annotations still resolve.
2. **`30a1c6ea3` span→trace map + span-list content scoping** — `get_span_trace_map` gains optional `project_id` + `start_time` window params, threaded from all four caller paths (org-scoped listing passes the window without a project id — a single id would drop sibling projects' spans). Span-list `build_content_query` gains the same window.
3. **`d4c47ab52` eval-attributes memory-guard fix** — drop the unservable recency sort (the `LIMIT 10000` now bounds the scan, since `project_id` leads the sort key) and read the Map `.keys` subcolumns instead of whole maps (the endpoint returns keys only).

## Measured impact (prod A/B, whale tenant, identical result sets in every pair)

| Query | Before | After |
|---|---|---|
| Trace-list page scan | 2,826 ms / 121.6M rows | 500 ms / 24.0M rows (5.7×) |
| span→trace map | 1,040 ms / 183.3M rows | 174 ms / 35.2M rows (6×) |
| Span-list content fetch | 15.4M rows / 495 MiB | 3.3M rows / 208 MiB (4.6× I/O) |
| Eval-attributes keys | 24,548 ms / 97.1M rows / 5.9 GB mem | **63 ms / 825K rows / 51 MB (~390×)** |

## Tests

**New (18):**
- `test_trace_list_builder_comprehensive.py` (+11): outer window on `start_time` with no `created_at` skew (build/id/count); window present on content/span-attrs/user_id after `build()` and absent standalone; annotation spans-side bounded in ON clause; `test_trailing_score_not_dropped` — structurally proves a score created after the window end cannot be filtered (no time predicate on the score side).
- `test_trace.py` (+3): `get_span_trace_map` shapes — project-only scoping; full window (both bounds, parameterized ids); window requires both dates; unbounded call byte-identical.
- `test_span_list_builder_comprehensive.py` (+1): content-query window bounds + param binding.
- `test_eval_attributes_list.py` (+2, 1 inverted): `.keys` subcolumn present / `mapKeys(` absent; `LIMIT 10000` + type labels preserved; the old `orders_by_start_time` assertion inverted to `without_recency_order`.

**Existing suites kept green (evidence below):** trace view/API suites, trace-list + span-list builder suites, observation-span API suite, eval-attributes `@integration @api` tests (run the new `.keys` SQL against live test CH and assert real keys), span-attribute lookups, pagination.

## Test commands

```bash
docker compose -f docker-compose.test.yml -p futureagi-test up -d
cd futureagi
uv run pytest tracer/tests/test_trace.py tracer/tests/test_trace_list_builder_comprehensive.py \
  tracer/tests/test_trace_list_ch.py tracer/tests/test_span_list_builder_comprehensive.py \
  tracer/tests/test_observation_span.py tracer/tests/test_eval_attributes_list.py \
  tracer/services/clickhouse/tests/test_span_attribute_lookups.py \
  tracer/tests/test_traces_of_session_pagination.py -q
```

## Test output

```
======================= 280 passed, 5 xpassed in 21.70s ========================
```
(5 xpassed are pre-existing on dev; verified identical before these changes.)

## Local verification steps

1. Bring up the test stack and run the command above (all suites green).
2. Optional live check: point a local backend at a seeded CH, load the traces page with a 7-day window, and confirm in `system.query_log` that the page-scan shape carries `start_time >=/<` bounds and no `created_at` predicate, and the span-map shape carries `project_id` + `start_time` bounds.

## Behavioral notes / rationale

- **Date-window semantics** (commit 1): the window now means "when the trace ran" (`start_time`) rather than "when we ingested it" (`created_at`) — the product decision recorded in `V2_SCHEMA_OPTIMIZATION.md` §S3.3, pulled into this hotfix deliberately. ~0.5% late-ingested rows appear in the window they ran. FE date filters labeled `created_at` keep working (`parse_time_range` folds both labels into the same window).
- **Eval-attributes sample order** (commit 3): the 10k-row key sample is now sort-key-ordered rather than most-recent. Flagged to product; at a 100% failure rate the trade is strictly favorable.
- **±1-day buffer safety**: any span of an in-window trace starts within the trace's lifetime of the window; measured prod max trace duration ≈ 5 h (zero traces > 1 day across 7.9M).
- **Overlap with `perf/ch-v2-schema-opt`**: commit 1's window retarget re-implements that branch's C2 minimally; reconciliation at merge is expected and accepted (this is the hotfix track).
- Deliberately untouched: the span-list page scan (already window-pruned; its residual cost is top-N-over-window, fixed only by the upcoming schema re-key) and `list_attributes_for_trace` (returns values, separate ticket — see EVAL_ATTRS_INVESTIGATION.md §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
