### PR TITLE
fix(evals): preserve typed/pasted JSON in eval Test Data editor

### DIFF
--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -155,6 +155,10 @@ const CustomJsonInput = ({
       prev.length !== variables.length ||
       !prev.every((v, i) => v === variables[i]);
 
+    // Only reconcile when the variable set changes. On any other re-render
+    // (every keystroke, since jsonText is a dep) leave the user's text alone.
+    if (!varsChanged) return;
+
     let current;
     try {
       current = JSON.parse(jsonText || "{}");
@@ -175,16 +179,14 @@ const CustomJsonInput = ({
     let changed = false;
 
     // Drop a removed variable's empty field only — never a user's key.
-    if (varsChanged) {
-      for (const k of Object.keys(updated)) {
-        if (
-          !varSet.has(k) &&
-          prevSet.has(k) &&
-          (updated[k] === "" || updated[k] === null || updated[k] === undefined)
-        ) {
-          delete updated[k];
-          changed = true;
-        }
+    for (const k of Object.keys(updated)) {
+      if (
+        !varSet.has(k) &&
+        prevSet.has(k) &&
+        (updated[k] === "" || updated[k] === null || updated[k] === undefined)
+      ) {
+        delete updated[k];
+        changed = true;
       }
     }
 
@@ -215,18 +217,37 @@ const CustomJsonInput = ({
       try {
         const parsed = JSON.parse(text);
         setJsonError(null);
-        if (typeof parsed === "object" && !Array.isArray(parsed)) {
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
           Object.entries(parsed).forEach(([k, v]) => {
             const val =
               typeof v === "object" ? JSON.stringify(v) : String(v ?? "");
             onInputChange(k, val);
+          });
+          // Resolve each variable from its source — a direct key, or the
+          // key it's bound to in the mapping panel. Clear only when it has
+          // no source, so a deleted key's stale value isn't silently
+          // submitted while a mapped binding is left intact.
+          variables.forEach((v) => {
+            if (v in parsed) return;
+            const mapped = varMapping[v];
+            const val = mapped
+              ? mapped.split(".").reduce((obj, k) => obj?.[k], parsed)
+              : undefined;
+            onInputChange(
+              v,
+              val === undefined
+                ? ""
+                : typeof val === "object"
+                  ? JSON.stringify(val)
+                  : String(val ?? ""),
+            );
           });
         }
       } catch {
         setJsonError("Invalid JSON");
       }
     },
-    [onInputChange],
+    [onInputChange, variables, varMapping],
   );
 
   // Call AI

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -52,6 +52,9 @@ import {
 
 const SOURCE_TABS = ["Dataset", "Tracing", "Simulation", "Custom"];
 
+// Stable default so an omitted `requiredKeys` doesn't remint an array each render.
+const NO_REQUIRED_KEYS = [];
+
 const camelizeKey = (key = "") =>
   key.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
 
@@ -143,48 +146,67 @@ const CustomJsonInput = ({
     });
   }, [variables, jsonKeys]);
 
-  // Sync JSON keys with variables - add new ones, remove stale ones
+  // Sync the scaffold with the variables without clobbering what the user is typing.
+  const prevVarsRef = useRef(null);
   useEffect(() => {
-    // Parse current JSON
-    let current = {};
+    const prev = prevVarsRef.current;
+    const varsChanged =
+      prev === null ||
+      prev.length !== variables.length ||
+      !prev.every((v, i) => v === variables[i]);
+
+    let current;
     try {
-      current = JSON.parse(jsonText);
+      current = JSON.parse(jsonText || "{}");
     } catch {
-      /* keep empty */
+      return; // invalid / mid-edit — leave the user's text alone
+    }
+    if (
+      typeof current !== "object" ||
+      current === null ||
+      Array.isArray(current)
+    ) {
+      return;
     }
 
     const varSet = new Set(variables);
-
-    // Remove keys that are no longer in variables (only if their value is empty)
+    const prevSet = new Set(prev || []);
+    const updated = { ...current };
     let changed = false;
-    const updated = {};
-    for (const [k, v] of Object.entries(current)) {
-      if (!varSet.has(k) && (v === "" || v === null || v === undefined)) {
-        changed = true; // drop this stale key
-      } else {
-        updated[k] = v;
+
+    // Drop a removed variable's empty field only — never a user's key.
+    if (varsChanged) {
+      for (const k of Object.keys(updated)) {
+        if (
+          !varSet.has(k) &&
+          prevSet.has(k) &&
+          (updated[k] === "" || updated[k] === null || updated[k] === undefined)
+        ) {
+          delete updated[k];
+          changed = true;
+        }
       }
     }
 
-    // Add new variables that aren't already in the JSON
+    // Add any missing variable field.
     variables.forEach((v) => {
-      updated[v] = v in current ? current[v] : inputValues[v] || "";
-      if (!(v in current)) changed = true;
+      if (!(v in updated)) {
+        updated[v] = inputValues[v] || "";
+        changed = true;
+      }
     });
 
-    // Check if any old keys were removed
-    for (const key of Object.keys(current)) {
-      if (!varSet.has(key)) {
-        changed = true;
-        break;
-      }
-    }
+    prevVarsRef.current = variables;
 
     if (changed) {
-      const keys = Object.keys(updated);
-      setJsonText(keys.length > 0 ? JSON.stringify(updated, null, 2) : "{\n}");
+      setJsonText(
+        Object.keys(updated).length > 0
+          ? JSON.stringify(updated, null, 2)
+          : "{\n}",
+      );
+      setJsonError(null);
     }
-  }, [variables]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [variables, jsonText]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Parse JSON and update individual input values
   const handleJsonChange = useCallback(
@@ -638,7 +660,7 @@ const TestPlayground = React.forwardRef(
       evalName = "",
       evalType,
       model = "turing_large",
-      requiredKeys = [],
+      requiredKeys = NO_REQUIRED_KEYS,
       showVersions,
       onTestResult,
       onColumnsLoaded,
@@ -682,7 +704,7 @@ const TestPlayground = React.forwardRef(
 
     const { role } = useAuthContext();
     const canEditEvals = Boolean(
-      RolePermission.EVALS[PERMISSIONS.EDIT_CREATE_DELETE_EVALS]?.[role]
+      RolePermission.EVALS[PERMISSIONS.EDIT_CREATE_DELETE_EVALS]?.[role],
     );
 
     // Version hover menu state
@@ -698,8 +720,7 @@ const TestPlayground = React.forwardRef(
       if (!list.length) return;
       if (urlVersionParam) {
         const match = list.find(
-      ver =>
-            String(ver.version_number) === String(urlVersionParam),
+          (ver) => String(ver.version_number) === String(urlVersionParam),
         );
         if (match && match.id !== selectedVersionId) {
           setSelectedVersionId(match.id);
@@ -871,7 +892,6 @@ const TestPlayground = React.forwardRef(
       Simulation: false,
     });
 
-
     const handleDatasetReady = useCallback(
       (isReady, mapping) => {
         setTabReady((prev) =>
@@ -901,7 +921,7 @@ const TestPlayground = React.forwardRef(
       },
       [onReadyChange],
     );
-  useEffect(() => {
+    useEffect(() => {
       if (!onReadyChange) return;
       onReadyChange(!!tabReady[activeTab]);
     }, [activeTab, tabReady, onReadyChange]);

--- a/frontend/src/sections/evals/components/__tests__/CustomJsonInput.test.jsx
+++ b/frontend/src/sections/evals/components/__tests__/CustomJsonInput.test.jsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { render, screen } from "src/utils/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { CustomJsonInput } from "../TestPlayground";
+
+// Monaco doesn't run in jsdom — swap it for a plain textarea that mirrors the
+// value prop and forwards edits, so we can drive handleJsonChange directly.
+vi.mock("../CodeEditor", () => ({
+  default: ({ value, onChange }) => (
+    <textarea
+      data-testid="json-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+vi.mock("notistack", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+// Controlled harness so inputValues round-trips through onInputChange like the
+// real parent does.
+function Harness({ variables }) {
+  const [inputValues, setInputValues] = useState({});
+  return (
+    <CustomJsonInput
+      variables={variables}
+      inputValues={inputValues}
+      onInputChange={(k, v) => setInputValues((p) => ({ ...p, [k]: v }))}
+    />
+  );
+}
+
+Harness.propTypes = {
+  variables: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const editor = () => screen.getByTestId("json-editor");
+
+describe("CustomJsonInput — scaffold sync", () => {
+  it("does not rewrite the editor on a jsonText-only change that drops a variable key", () => {
+    render(<Harness variables={["conversation"]} />);
+    // Mount scaffolds the variable in.
+    expect(editor().value).toContain("conversation");
+
+    // User deletes the key; JSON stays valid, variable set unchanged.
+    fireEvent.change(editor(), { target: { value: "{}" } });
+
+    // The key must NOT be re-injected (the regression this fix removes).
+    expect(editor().value).toBe("{}");
+  });
+
+  it("back-fills a variable added while the JSON was invalid, once it parses again", () => {
+    const { rerender } = render(<Harness variables={["conversation"]} />);
+
+    // Make the JSON invalid mid-edit.
+    fireEvent.change(editor(), { target: { value: "{bad" } });
+    expect(editor().value).toBe("{bad");
+
+    // A new variable appears while the JSON can't be parsed — deferred.
+    rerender(<Harness variables={["conversation", "topic"]} />);
+    expect(editor().value).toBe("{bad");
+
+    // JSON becomes valid again → the deferred add replays.
+    fireEvent.change(editor(), { target: { value: '{"conversation":""}' } });
+    expect(editor().value).toContain("topic");
+  });
+});


### PR DESCRIPTION
## Bug

In the evaluation **Test Data** JSON editor (Custom test mode), typing or pasting was silently discarded — the editor cleared back to `{}` or a scaffold, and a stale "Invalid JSON" label could linger. This blocked pasting test data into any eval that uses variables.

## Root cause

The effect that keeps the JSON scaffold in sync with the instruction variables re-ran on nearly every render and rewrote the editor content — deleting empty keys and rebuilding the scaffold whenever the JSON was momentarily invalid (e.g. mid-paste). It couldn't tell a user's edit from a stale scaffold, so it clobbered live input.

## Changes

* Reconcile only when the **variable set actually changes** (content compare via a ref), so unrelated re-renders no longer rewrite the editor.
* **Never rewrite over invalid / mid-edit JSON** — leave the user's text alone.
* Delete a field **only** when its variable was removed **and** the field is still empty — never a user-authored key.
* Add a missing variable field, and back-fill it once the JSON is valid again.
* On a JSON edit, resolve each variable's value from its source — a matching key **or** its mapping-panel binding — and clear it only when it has no source, so a deleted key's stale value isn't silently submitted at run time while a mapping stays intact.
* Clear the "Invalid JSON" label when content is rewritten to valid JSON.
* Use a stable empty-array default for `requiredKeys` so an omitted prop doesn't remint an array each render (the source of the churn).

## Why

Stops the sync effect from fighting live user input while keeping its useful jobs: adding a field when a variable appears, and removing an empty one when a variable is deleted.

## Test scenarios

* Paste multi-line / nested JSON into Test Data → left exactly as pasted. The scaffold reconciles only on a variable-set change, so a paste — even one missing a variable key — is never rewritten or reserialized.
* Type a key with an empty value → no longer wiped.
* Add `{{var}}` in Instructions → Test Data auto-adds `"var": ""`.
* Remove `{{var}}` → its empty field is dropped; a field with a value is kept.
* Composite and code evals → fields add/remove correctly; no churn.

## How to reproduce (before this fix)

1. Create eval → Agents, add `{{conversation}}` in Instructions.
2. In Test Data (Custom), paste a multi-line conversation into the `"conversation"` value.
3. Before: the content vanishes / editor resets and "Invalid JSON" lingers. After: the content stays.

## Commands

* `yarn lint` — clean (0 errors)
* `yarn test:run src/sections/evals/components/__tests__/CustomJsonInput.test.jsx` — 2 passing (no-rewrite on key drop; back-fill after invalid → valid)

## Screenshots / video

https://github.com/user-attachments/assets/6e35ecb0-af3f-456d-b2a5-e23e376dc01b
