### PR TITLE
fix(evals): make variable mapping optional in eval tasks when trace/session context is passed (TH-7079)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -2020,6 +2020,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             settings only. */}
         {source !== "composite" &&
           !sourceReady &&
+          !hasDataInjection &&
           !testError &&
           !testPassed && (
             <Typography
@@ -2195,7 +2196,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 : `Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) before ${actionLabel}.`;
           }
 
-          if (!addDisabled && source !== "composite" && !sourceReady) {
+          if (
+            !addDisabled &&
+            source !== "composite" &&
+            !sourceReady &&
+            !hasDataInjection
+          ) {
             addDisabled = true;
             addDisabledReason = `Map all variables before ${actionLabel}.`;
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -651,7 +651,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       (evalType === "code"
         ? code.trim()
         : instructions.trim() && !needsTemplateVariable) &&
-      (source === "composite" || sourceReady);
+      (source === "composite" || sourceReady || hasDataInjection);
 
   const getDisabledReason = () => {
     if (!name.trim()) return "Name is required";
@@ -1318,7 +1318,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
             </Typography>
           </Box>
         )}
-        {!sourceReady && !testError && !testPassed && (
+        {!sourceReady && !hasDataInjection && !testError && !testPassed && (
           <Typography
             variant="caption"
             color="text.secondary"

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -401,7 +401,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       }
     }
 
-    if (!sourceReady && source !== "composite") {
+    if (!sourceReady && source !== "composite" && !hasDataInjection) {
       next.mapping = "Map all variables before saving";
     }
 

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -880,14 +880,15 @@ const TracingTestMode = React.forwardRef(
       });
     }, [variables, fieldNames]);
 
-    // Mapping is always required; a sample row only when not using data injection.
+    // With data injection the trace/session context supplies the values, so
+    // mapping is optional; otherwise require all variables mapped + a sample row.
     useEffect(() => {
       if (!onReadyChange) return;
       const allMapped =
         variables.length === 0 ||
         variables.every((v) => mapping[v] && String(mapping[v]).length > 0);
       const hasRow = !!currentRow;
-      const ready = hasDataInjection ? allMapped : allMapped && hasRow;
+      const ready = hasDataInjection || (allMapped && hasRow);
       onReadyChange(ready, mapping);
     }, [variables, mapping, currentRow, hasDataInjection, onReadyChange]);
 


### PR DESCRIPTION
## Bug / Context

In eval **tasks**, variable mapping was mandatory even when the task already passes trace/session/span **context**. Per [TH-7079](https://linear.app/future-agi/issue/TH-7079), when context is injected the eval can resolve its values from that context, so forcing the user to map every variable is unnecessary friction.

Scoped to **agent evals only** — `AgentEvaluator` is the sole evaluator that actually consumes injected `span_context` / `trace_context` / `session_context` at runtime. LLM/code evals ignore that context, so relaxing mapping for them would silently render `{{variables}}` empty and produce misleading scores.

## Changes

Mapping is now **optional whenever `hasDataInjection` is true** (`evalType === "agent" && (source === "task" || source === "tracing") && a non-`variables_only` context option is selected). The mapping UI stays — any partial mapping the user does enter is still saved.

- **`TracingTestMode.jsx`** — readiness now `ready = hasDataInjection || (allMapped && hasRow)` (was `hasDataInjection ? allMapped : allMapped && hasRow`), so injected context no longer requires every variable mapped.
- **`EvalPickerConfigFull.jsx`** — added `!hasDataInjection` escape to the "Add / Update Evaluation" disable gate and to the "Map all variables…" caption (mirrors the existing Test-button escape).
- **`EvalPickerCreateNew.jsx`** — same escape on the create-new-eval flow: `validate()`, `canSave`, and the caption, so the two flows behave identically.

## Why

The `+context` selection injects the span/trace/session data the eval needs, so the per-variable mapping requirement is redundant in that case. Keeping it agent-only matches the only runtime path that can execute mapping-free.

## Test-case scenarios

- **Agent eval + task/tracing + context selected + variables unmapped** → "Add / Update Evaluation" button **enabled**, "Map all variables…" caption **gone**.
- **Remove the context** (variables-only) → gate **returns** (button disabled, caption shown).
- **Non-agent eval (LLM/code)** with context → gate **returns** (scoped correctly).
- **No data injection** → behavior **identical** to before (`false || (allMapped && hasRow)` ≡ old `allMapped && hasRow`).
- Partial mapping the user enters is still carried into the saved config payload.

## How to reproduce

1. Tasks → **Create Task** (`/dashboard/tasks/create`).
2. Configure an **Agent** eval with a `+context` chip (e.g. a Spans task auto-adds `span_context`) and at least one `{{variable}}` in the instructions.
3. Leave the **Variable Mapping** empty.
4. The bottom **"Add / Update Evaluation"** button is enabled with no "Map all variables…" caption. (The top-right "Save version" button was never mapping-gated.)

## Commands

```bash
yarn lint     # 0 errors on the three touched files
yarn test:run # existing suites unaffected
```

## Videos / Screenshots


https://github.com/user-attachments/assets/2e38cfd1-357f-4ea8-b3f3-4409ba6d4e0d

