### PR TITLE
fix: retain prompt stream background tasks

### DIFF
--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -46,6 +46,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         super().__init__(*args, **kwargs)
         self.session_uuid = None
         self.workspace_id = None
+        self._background_tasks = set()
 
     async def connect(self):
         self.user = self.scope.get("user")
@@ -76,6 +77,12 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         logger.info(
             f"PromptStream connection closed: session={self.session_uuid}, code={close_code}"
         )
+        if self._background_tasks:
+            tasks = tuple(self._background_tasks)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._background_tasks.difference_update(tasks)
 
     async def receive_json(self, content):
         message_type = content.get("type")
@@ -92,6 +99,12 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             await self._send_ws_error(f"Unknown message type: {message_type}")
             return
         await handler(content)
+
+    def _create_background_task(self, coro):
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     # ------------------------------------------------------------------
     # Access resolution — the single gate.
@@ -264,7 +277,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(self.execute_template_async(content, template_id))
+        self._create_background_task(self.execute_template_async(content, template_id))
 
     async def execute_template_async(self, content, template_id):
         correlation = {"template_id": template_id}
@@ -344,7 +357,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(
+        self._create_background_task(
             self.execute_improve_prompt_async(payload, payload["improve_id"])
         )
 
@@ -407,7 +420,9 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(self.execute_generate_prompt_async(payload, generation_id))
+        self._create_background_task(
+            self.execute_generate_prompt_async(payload, generation_id)
+        )
 
     async def execute_generate_prompt_async(self, content, generation_id):
         correlation = {"generation_id": generation_id}

--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -103,8 +103,17 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
     def _create_background_task(self, coro):
         task = asyncio.create_task(coro)
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(self._on_background_task_done)
         return task
+
+    def _on_background_task_done(self, task):
+        self._background_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("PromptStream background task failed")
 
     # ------------------------------------------------------------------
     # Access resolution — the single gate.

--- a/futureagi/sockets/tests/test_prompt_stream_consumer.py
+++ b/futureagi/sockets/tests/test_prompt_stream_consumer.py
@@ -239,3 +239,84 @@ def test_execute_template_allows_null_workspace_template_in_same_org(monkeypatch
     # permission reasons).
     for call in consumer.close.await_args_list:
         assert call.kwargs.get("code") != WS_CLOSE_CODE_PERMISSION_DENIED
+
+
+# ---------------------------------------------------------------------------
+# Background prompt task retention
+# ---------------------------------------------------------------------------
+
+
+def test_start_handlers_retain_background_tasks_until_they_finish(monkeypatch):
+    async def run_case(handler_name, execute_name, content):
+        consumer = _make_consumer(workspace_id="ws-a")
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_execute(*args, **kwargs):
+            started.set()
+            await release.wait()
+
+        setattr(consumer, execute_name, fake_execute)
+        if handler_name == "handle_improve_prompt":
+            monkeypatch.setattr(
+                "sockets.prompt_stream_consumer.replace_ids_with_column_name_async",
+                AsyncMock(return_value=content["existing_prompt"]),
+            )
+
+        await getattr(consumer, handler_name)(content)
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert len(consumer._background_tasks) == 1
+        task = next(iter(consumer._background_tasks))
+        assert not task.done()
+
+        release.set()
+        await asyncio.wait_for(task, timeout=1)
+        assert not consumer._background_tasks
+
+    cases = [
+        (
+            "handle_run_template",
+            "execute_template_async",
+            {"template_id": "tmpl-1", "version": 1},
+        ),
+        (
+            "handle_improve_prompt",
+            "execute_improve_prompt_async",
+            {
+                "existing_prompt": "Summarize this",
+                "improvement_requirements": "Make it concise",
+            },
+        ),
+        (
+            "handle_generate_prompt",
+            "execute_generate_prompt_async",
+            {"statement": "Generate a support prompt"},
+        ),
+    ]
+
+    for handler_name, execute_name, content in cases:
+        asyncio.run(run_case(handler_name, execute_name, content))
+
+
+def test_disconnect_cancels_retained_background_tasks():
+    async def run():
+        consumer = _make_consumer(workspace_id="ws-a")
+        started = asyncio.Event()
+
+        async def fake_execute(*args, **kwargs):
+            started.set()
+            await asyncio.Event().wait()
+
+        consumer.execute_template_async = fake_execute
+
+        await consumer.handle_run_template({"template_id": "tmpl-1", "version": 1})
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task = next(iter(consumer._background_tasks))
+
+        await consumer.disconnect(1000)
+
+        assert task.cancelled()
+        assert not consumer._background_tasks
+
+    asyncio.run(run())

--- a/futureagi/sockets/tests/test_prompt_stream_consumer.py
+++ b/futureagi/sockets/tests/test_prompt_stream_consumer.py
@@ -320,3 +320,28 @@ def test_disconnect_cancels_retained_background_tasks():
         assert not consumer._background_tasks
 
     asyncio.run(run())
+
+
+def test_background_task_exception_is_logged_and_task_is_cleared(monkeypatch):
+    async def run():
+        consumer = _make_consumer(workspace_id="ws-a")
+        logged = asyncio.Event()
+        log_exception = MagicMock(side_effect=lambda *args, **kwargs: logged.set())
+
+        monkeypatch.setattr(
+            "sockets.prompt_stream_consumer.logger.exception",
+            log_exception,
+        )
+
+        async def fail():
+            raise RuntimeError("prompt runner exploded")
+
+        task = consumer._create_background_task(fail())
+
+        await asyncio.wait_for(logged.wait(), timeout=1)
+
+        assert task.done()
+        assert not consumer._background_tasks
+        log_exception.assert_called_once_with("PromptStream background task failed")
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Closes #819.

`PromptStreamConsumer` now keeps strong references to prompt execution tasks started from the WebSocket handlers and drops those references when tasks finish. It also cancels and awaits any still-running prompt tasks during `disconnect`, preventing silent prompt execution drops if the event loop garbage-collects an unreferenced task mid-run.

## Linked issues

Closes #819
Linear: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

---

## 1) What changes were done

**A. Prompt background task retention**

- Added a `_background_tasks` set on `PromptStreamConsumer`.
- Replaced bare `asyncio.create_task(...)` calls in `run_template`, `improve_prompt`, and `generate_prompt` handlers with a helper that stores the created task and discards it on completion.
- Cancel and await retained tasks on WebSocket disconnect.

---

## 2) Why the changes were done

- **Product/UX:** Prevents prompt streams from stalling silently when a background prompt execution task disappears before it finishes.
- **Technical:** `asyncio` only keeps weak references to tasks, so fire-and-forget tasks should be held strongly until completion.
- **Architecture:** The helper centralizes background task lifecycle management inside the consumer instead of duplicating retention logic across handlers.

---

## 3) Tests written + scenarios each covers

**`futureagi/sockets/tests/test_prompt_stream_consumer.py`** — PromptStreamConsumer access and task lifecycle behavior.

- `test_start_handlers_retain_background_tasks_until_they_finish` — covers all three start handlers and verifies the created task remains retained until it completes.
- `test_disconnect_cancels_retained_background_tasks` — verifies disconnect cancels and clears a still-running prompt task.
- `test_background_task_exception_is_logged_and_task_is_cleared` — verifies an unexpected exception escaping a retained background task is observed/logged and the task reference is cleared.

> Run result: focused pytest could not complete in this Windows venv because the existing consumer import chain requires the full backend/ML dependency stack. Static checks and an isolated async smoke test passed locally.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test sockets/tests/test_prompt_stream_consumer.py
```

Local checks run:

```bash
python -m py_compile futureagi/sockets/prompt_stream_consumer.py futureagi/sockets/tests/test_prompt_stream_consumer.py
python -m ruff check futureagi/sockets/prompt_stream_consumer.py futureagi/sockets/tests/test_prompt_stream_consumer.py --output-format concise
git diff --check
```

Also ran an isolated async smoke test that imports `PromptStreamConsumer` with external runner dependencies stubbed and verifies task retention/completion, disconnect cancellation, and exception logging for failed background tasks.

---

## 5) Screenshots / recordings

N/A — backend WebSocket lifecycle fix.

---

## 6) Edge cases & considerations

- Completed tasks are removed with `add_done_callback`, so the set does not retain finished work indefinitely.
- Disconnect snapshots the task set before cancellation so callbacks can safely discard tasks while cancellation is in progress.
- `asyncio.gather(..., return_exceptions=True)` prevents cancellation cleanup from surfacing task cancellation exceptions during disconnect.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Full focused pytest collection was blocked locally by missing optional/full-stack dependencies pulled through existing imports (`datasets` after other backend dependencies were installed). CI should have the project dependency set.

---

## 8) Architectural / important decisions

- **Central helper:** `_create_background_task` keeps task lifecycle handling in one place for the consumer.
- **Disconnect cleanup:** Pending prompt work is cancelled on WebSocket disconnect because the client can no longer receive streamed results from that consumer instance.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
