### PR TITLE
feat(backfill): add resumable Vapi historical recording backfill

### DIFF
--- a/futureagi/simulate/management/commands/backfill_vapi_minimal.py
+++ b/futureagi/simulate/management/commands/backfill_vapi_minimal.py
@@ -4,13 +4,19 @@ import uuid
 
 from django.core.management.base import BaseCommand, CommandError
 
+from temporalio.common import WorkflowIDReusePolicy
+
 from tfc.temporal import start_workflow_sync
 from tfc.temporal.backfill.minimal_backfill import (
     VapiBackfillInput,
     VapiMinimalBackfillWorkflow,
     reconcile_backfill_sample,
 )
-from tfc.temporal.common.client import query_workflow_sync, signal_workflow_sync
+from tfc.temporal.common.client import (
+    cancel_workflow_sync,
+    query_workflow_sync,
+    signal_workflow_sync,
+)
 
 
 class Command(BaseCommand):
@@ -105,26 +111,48 @@ class Command(BaseCommand):
             raise CommandError(
                 "--run-id may contain only letters, digits, and underscores"
             )
-        for shard in range(options["shards"]):
-            workflow_id = (
-                f"vapi-backfill-{options['source']}-"
-                f"{options['project_id'] or 'all'}-{run_id}-{shard}"
-            )
-            start_workflow_sync(
-                VapiMinimalBackfillWorkflow,
-                VapiBackfillInput(
-                    source=options["source"],
-                    dry_run=options["dry_run"],
-                    limit=limit,
-                    project_id=options["project_id"],
-                    shards=options["shards"],
-                    shard=shard,
-                    batch_size=options["batch_size"],
-                    run_id=run_id,
-                    proof_gate=options["proof_gate"],
-                    min_records_per_second=options["min_records_per_second"],
-                ),
-                workflow_id=workflow_id,
-                task_queue="backfill",
-            )
-            self.stdout.write(self.style.SUCCESS(f"Started {workflow_id}"))
+        started: list[str] = []
+        try:
+            for shard in range(options["shards"]):
+                workflow_id = (
+                    f"vapi-backfill-{options['source']}-"
+                    f"{options['project_id'] or 'all'}-{run_id}-{shard}"
+                )
+                start_workflow_sync(
+                    VapiMinimalBackfillWorkflow,
+                    VapiBackfillInput(
+                        source=options["source"],
+                        dry_run=options["dry_run"],
+                        limit=limit,
+                        project_id=options["project_id"],
+                        shards=options["shards"],
+                        shard=shard,
+                        batch_size=options["batch_size"],
+                        run_id=run_id,
+                        proof_gate=options["proof_gate"],
+                        min_records_per_second=options["min_records_per_second"],
+                    ),
+                    workflow_id=workflow_id,
+                    task_queue="backfill",
+                    # Fail closed: never terminate an in-flight backfill by ID reuse.
+                    cancel_existing=False,
+                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                )
+                started.append(workflow_id)
+                self.stdout.write(self.style.SUCCESS(f"Started {workflow_id}"))
+        except Exception as exc:
+            for workflow_id in started:
+                try:
+                    cancel_workflow_sync(workflow_id)
+                except Exception as cancel_exc:
+                    self.stderr.write(
+                        self.style.WARNING(
+                            f"Failed to cancel {workflow_id} after partial start: {cancel_exc}"
+                        )
+                    )
+            if started:
+                raise CommandError(
+                    f"Multi-shard start failed after launching {len(started)} "
+                    f"workflow(s); cancelled: {', '.join(started)}. Error: {exc}"
+                ) from exc
+            raise

--- a/futureagi/simulate/management/commands/backfill_vapi_minimal.py
+++ b/futureagi/simulate/management/commands/backfill_vapi_minimal.py
@@ -1,0 +1,130 @@
+import os
+import re
+import uuid
+
+from django.core.management.base import BaseCommand, CommandError
+
+from tfc.temporal import start_workflow_sync
+from tfc.temporal.backfill.minimal_backfill import (
+    VapiBackfillInput,
+    VapiMinimalBackfillWorkflow,
+    reconcile_backfill_sample,
+)
+from tfc.temporal.common.client import query_workflow_sync, signal_workflow_sync
+
+
+class Command(BaseCommand):
+    requires_system_checks: list[str] = []
+    help = "Launch or control the historical Vapi recording backfill."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--action",
+            choices=("start", "status", "pause", "resume", "cancel", "reconcile"),
+            default="start",
+        )
+        parser.add_argument("--workflow-id")
+        parser.add_argument(
+            "--source", choices=("simulation", "observability"), default="simulation"
+        )
+        parser.add_argument("--project-id")
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--proof-gate", type=int, choices=(10, 100, 1000))
+        parser.add_argument("--limit", type=int)
+        parser.add_argument("--shards", type=int, default=1)
+        parser.add_argument("--batch-size", type=int, default=100)
+        parser.add_argument("--run-id")
+        parser.add_argument(
+            "--min-records-per-second",
+            type=float,
+            default=float(os.getenv("BACKFILL_MIN_RECORDS_PER_SECOND", "0")),
+        )
+
+    def handle(self, *args, **options):
+        if options["action"] == "reconcile":
+            # Observability without --project-id = safe map-only all-project scan.
+            # With --project-id = map + day-chunked attributes_extra counts.
+            report = reconcile_backfill_sample(
+                VapiBackfillInput(
+                    source=options["source"],
+                    project_id=options["project_id"],
+                )
+            )
+            self.stdout.write(str(report))
+            return
+
+        if options["action"] != "start":
+            workflow_id = options["workflow_id"]
+            if not workflow_id:
+                raise CommandError(
+                    "--workflow-id is required for status/pause/resume/cancel"
+                )
+            if options["action"] == "status":
+                self.stdout.write(str(query_workflow_sync(workflow_id, "status")))
+                return
+            delivered = signal_workflow_sync(workflow_id, options["action"])
+            if not delivered:
+                raise CommandError(f"Could not signal {workflow_id}")
+            self.stdout.write(
+                self.style.SUCCESS(f"Sent {options['action']} to {workflow_id}")
+            )
+            return
+
+        if options["shards"] < 1:
+            raise CommandError("--shards must be positive")
+        if not 1 <= options["batch_size"] <= 100:
+            raise CommandError("--batch-size must be between 1 and 100")
+        if options["limit"] is not None and options["limit"] < 1:
+            raise CommandError("--limit must be positive")
+        if options["source"] == "observability" and not options["project_id"]:
+            raise CommandError("--project-id is required for observability")
+        if options["project_id"]:
+            try:
+                uuid.UUID(options["project_id"])
+            except ValueError as exc:
+                raise CommandError("--project-id must be a UUID") from exc
+        if options["proof_gate"] and options["source"] != "observability":
+            raise CommandError("--proof-gate is only valid for observability")
+        if options["proof_gate"] and options["shards"] != 1:
+            raise CommandError(
+                "--proof-gate requires --shards 1 so its row count is exact"
+            )
+        if options["min_records_per_second"] < 0:
+            raise CommandError("--min-records-per-second cannot be negative")
+        if not os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND"):
+            self.stdout.write(
+                self.style.WARNING(
+                    "VAPI_API_RATE_LIMIT_PER_SECOND is unset; authenticated API fallback is disabled"
+                )
+            )
+        limit = options["proof_gate"] or options["limit"]
+        run_id = (
+            options["run_id"] or f"vapi_{options['source']}_{uuid.uuid4().hex[:12]}"
+        )
+        if not re.fullmatch(r"[A-Za-z0-9_]+", run_id):
+            raise CommandError(
+                "--run-id may contain only letters, digits, and underscores"
+            )
+        for shard in range(options["shards"]):
+            workflow_id = (
+                f"vapi-backfill-{options['source']}-"
+                f"{options['project_id'] or 'all'}-{run_id}-{shard}"
+            )
+            start_workflow_sync(
+                VapiMinimalBackfillWorkflow,
+                VapiBackfillInput(
+                    source=options["source"],
+                    dry_run=options["dry_run"],
+                    limit=limit,
+                    project_id=options["project_id"],
+                    shards=options["shards"],
+                    shard=shard,
+                    batch_size=options["batch_size"],
+                    run_id=run_id,
+                    proof_gate=options["proof_gate"],
+                    min_records_per_second=options["min_records_per_second"],
+                ),
+                workflow_id=workflow_id,
+                task_queue="backfill",
+            )
+            self.stdout.write(self.style.SUCCESS(f"Started {workflow_id}"))

--- a/futureagi/simulate/management/commands/backfill_vapi_minimal.py
+++ b/futureagi/simulate/management/commands/backfill_vapi_minimal.py
@@ -100,7 +100,8 @@ class Command(BaseCommand):
         if not os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND"):
             self.stdout.write(
                 self.style.WARNING(
-                    "VAPI_API_RATE_LIMIT_PER_SECOND is unset; authenticated API fallback is disabled"
+                    "VAPI_API_RATE_LIMIT_PER_SECOND is unset; "
+                    "authenticated API downloads will not be throttled"
                 )
             )
         limit = options["proof_gate"] or options["limit"]

--- a/futureagi/simulate/management/commands/start_vapi_backfill_worker.py
+++ b/futureagi/simulate/management/commands/start_vapi_backfill_worker.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+
+from tfc.temporal.backfill.start_backfill_worker import main
+
+
+class Command(BaseCommand):
+    requires_system_checks: list[str] = []
+    help = "Start the dedicated single-slot Vapi backfill Temporal worker."
+
+    def handle(self, *args, **options):
+        main()

--- a/futureagi/simulate/temporal/utils/async_storage.py
+++ b/futureagi/simulate/temporal/utils/async_storage.py
@@ -397,24 +397,19 @@ def convert_audio_url_to_s3_sync(
                 api_key=api_key,
             )
         else:
-            # Unauthenticated sync download via requests with size guard
-            response = requests.get(
-                audio_url, stream=True, timeout=DOWNLOAD_TIMEOUT
+            # Unauthenticated sync download via SSRF-safe fetch (hop revalidation).
+            from tfc.utils.ssrf_guard import safe_fetch
+
+            response = safe_fetch(
+                audio_url,
+                method="GET",
+                timeout=DOWNLOAD_TIMEOUT,
+                max_bytes=MAX_AUDIO_FILE_SIZE,
             )
             response.raise_for_status()
-
-            chunks = []
-            total_size = 0
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    chunks.append(chunk)
-                    total_size += len(chunk)
-                    if total_size > MAX_AUDIO_FILE_SIZE:
-                        raise ValueError(
-                            f"Audio file exceeds maximum size of "
-                            f"{MAX_AUDIO_FILE_SIZE / (1024 * 1024):.1f}MB"
-                        )
-            audio_bytes = b"".join(chunks)
+            audio_bytes = response.content or b""
+            if not audio_bytes:
+                raise ValueError("Empty audio body from direct URL")
 
         object_key = _rehost_object_key(
             object_key_base, _detected_audio_extension(audio_bytes)

--- a/futureagi/simulate/temporal/utils/async_storage.py
+++ b/futureagi/simulate/temporal/utils/async_storage.py
@@ -6,6 +6,7 @@ in high-concurrency scenarios.
 
 Uses httpx for async HTTP operations (already available in the project).
 """
+
 from typing import Optional
 
 import httpx
@@ -55,8 +56,7 @@ def _rehost_object_key_base(
     project_segment = str(project_id) if project_id else "unknown-project"
     provider_segment = str(provider).lower() if provider else "unknown-provider"
     return (
-        f"call-recordings/{project_segment}/{provider_segment}/"
-        f"{call_id}/{url_type}"
+        f"call-recordings/{project_segment}/{provider_segment}/" f"{call_id}/{url_type}"
     )
 
 
@@ -141,7 +141,9 @@ async def download_audio_from_url_async(
     """
     from tracer.utils.vapi_recording import VapiRecordingService
 
-    if VapiRecordingService.is_authenticated_download(provider, api_key, call_id, artifact_type):
+    if VapiRecordingService.is_authenticated_download(
+        provider, api_key, call_id, artifact_type
+    ):
         return await VapiRecordingService.download_artifact_async(
             call_id=call_id,
             artifact_type=artifact_type,
@@ -229,9 +231,7 @@ async def _convert_audio_url_to_s3_async_with_size(
     if _is_fagi_storage_url(audio_url):
         return audio_url, 0
 
-    object_key_base = _rehost_object_key_base(
-        call_id, url_type, project_id, provider
-    )
+    object_key_base = _rehost_object_key_base(call_id, url_type, project_id, provider)
     existing = _existing_rehosted_audio(object_key_base)
     if existing:
         return existing
@@ -382,9 +382,7 @@ def convert_audio_url_to_s3_sync(
     if _is_fagi_storage_url(audio_url):
         return audio_url, 0
 
-    object_key_base = _rehost_object_key_base(
-        call_id, url_type, project_id, provider
-    )
+    object_key_base = _rehost_object_key_base(call_id, url_type, project_id, provider)
     existing = _existing_rehosted_audio(object_key_base)
     if existing:
         return existing

--- a/futureagi/simulate/tests/test_async_storage_rehost_dedupe.py
+++ b/futureagi/simulate/tests/test_async_storage_rehost_dedupe.py
@@ -7,7 +7,8 @@ from simulate.temporal.utils.async_storage import convert_audio_url_to_s3_sync
 
 def _response(audio_bytes: bytes) -> Mock:
     response = Mock()
-    response.iter_content.return_value = [audio_bytes]
+    response.content = audio_bytes
+    response.raise_for_status = Mock()
     return response
 
 
@@ -38,7 +39,7 @@ def test_repeated_rehost_reuses_detected_format_object_and_stored_size():
         "tfc.utils.storage_client.get_object_url",
         side_effect=lambda _bucket, key: f"https://fi-customer-data.s3.amazonaws.com/{key}",
     ), patch(
-        "simulate.temporal.utils.async_storage.requests.get",
+        "tfc.utils.ssrf_guard.safe_fetch",
         return_value=_response(audio_bytes),
     ) as get, patch(
         "simulate.temporal.utils.async_storage._detected_audio_extension",
@@ -83,7 +84,7 @@ def test_rehost_storage_key_isolated_by_provider():
     ), patch(
         "tfc.utils.storage_client.get_storage_client", return_value=storage_client
     ), patch(
-        "simulate.temporal.utils.async_storage.requests.get",
+        "tfc.utils.ssrf_guard.safe_fetch",
         return_value=_response(b"recording"),
     ), patch(
         "simulate.temporal.utils.async_storage._detected_audio_extension",

--- a/futureagi/simulate/tests/test_backfill_vapi_minimal_command.py
+++ b/futureagi/simulate/tests/test_backfill_vapi_minimal_command.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -46,3 +48,76 @@ def test_reconcile_invokes_sample(mocker, capsys):
     call_command("backfill_vapi_minimal", action="reconcile", source="simulation")
     sample.assert_called_once()
     assert "call_execution" in capsys.readouterr().out
+
+
+def test_start_fail_closed_no_terminate(mocker):
+    from temporalio.common import WorkflowIDReusePolicy
+
+    start = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.start_workflow_sync",
+        return_value=SimpleNamespace(id="wf"),
+    )
+    call_command(
+        "backfill_vapi_minimal",
+        action="start",
+        source="simulation",
+        run_id="rerun_safe_1",
+        shards=1,
+        batch_size=1,
+        limit=1,
+    )
+    assert start.call_count == 1
+    kwargs = start.call_args.kwargs
+    assert kwargs["cancel_existing"] is False
+    assert kwargs["task_queue"] == "backfill"
+    assert (
+        kwargs["id_reuse_policy"]
+        is WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+    )
+
+
+def test_start_multi_shard_cancels_partial_on_failure(mocker):
+    calls = {"n": 0}
+
+    def start_side_effect(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("temporal down")
+        return SimpleNamespace(id=kwargs["workflow_id"])
+
+    start = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.start_workflow_sync",
+        side_effect=start_side_effect,
+    )
+    cancel = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.cancel_workflow_sync",
+        return_value=True,
+    )
+    with pytest.raises(CommandError, match="Multi-shard start failed"):
+        call_command(
+            "backfill_vapi_minimal",
+            action="start",
+            source="simulation",
+            run_id="partial_fail_1",
+            shards=3,
+            batch_size=1,
+            limit=1,
+        )
+    assert start.call_count == 2
+    assert cancel.call_count == 1
+
+
+def test_reconcile_passes_source_and_project(mocker):
+    sample = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.reconcile_backfill_sample",
+        return_value={"mode": "map_only_all_projects"},
+    )
+    call_command(
+        "backfill_vapi_minimal",
+        action="reconcile",
+        source="observability",
+        project_id="11111111-1111-1111-1111-111111111111",
+    )
+    inp = sample.call_args.args[0]
+    assert inp.source == "observability"
+    assert inp.project_id == "11111111-1111-1111-1111-111111111111"

--- a/futureagi/simulate/tests/test_backfill_vapi_minimal_command.py
+++ b/futureagi/simulate/tests/test_backfill_vapi_minimal_command.py
@@ -1,0 +1,48 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+def test_pause_requires_workflow_id():
+    with pytest.raises(CommandError, match="workflow-id"):
+        call_command("backfill_vapi_minimal", action="pause")
+
+
+def test_proof_gate_requires_single_shard():
+    with pytest.raises(CommandError, match="requires --shards 1"):
+        call_command(
+            "backfill_vapi_minimal",
+            source="observability",
+            project_id="11111111-1111-1111-1111-111111111111",
+            proof_gate=10,
+            shards=2,
+        )
+
+
+def test_pause_sends_signal(mocker):
+    signal = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.signal_workflow_sync",
+        return_value=True,
+    )
+    call_command("backfill_vapi_minimal", action="pause", workflow_id="wf-1")
+    signal.assert_called_once_with("wf-1", "pause")
+
+
+def test_status_queries_workflow(mocker, capsys):
+    query = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.query_workflow_sync",
+        return_value={"state": "running", "processed": 10},
+    )
+    call_command("backfill_vapi_minimal", action="status", workflow_id="wf-1")
+    query.assert_called_once_with("wf-1", "status")
+    assert "processed" in capsys.readouterr().out
+
+
+def test_reconcile_invokes_sample(mocker, capsys):
+    sample = mocker.patch(
+        "simulate.management.commands.backfill_vapi_minimal.reconcile_backfill_sample",
+        return_value={"call_execution": 3},
+    )
+    call_command("backfill_vapi_minimal", action="reconcile", source="simulation")
+    sample.assert_called_once()
+    assert "call_execution" in capsys.readouterr().out

--- a/futureagi/tfc/management/commands/start_temporal_worker.py
+++ b/futureagi/tfc/management/commands/start_temporal_worker.py
@@ -11,7 +11,7 @@ import signal
 import threading
 from typing import TYPE_CHECKING, List
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 if TYPE_CHECKING:
     from temporalio.worker import Worker
@@ -180,6 +180,12 @@ class Command(BaseCommand):
             # Map Celery-style queue names to Temporal queue names
             if task_queue in TASK_QUEUES:
                 task_queue = TASK_QUEUES[task_queue]
+            # Dedicated path may still target backfill alone; require slot=1 there.
+            if task_queue == "backfill" and max_concurrent_activities != 1:
+                raise CommandError(
+                    "backfill queue requires --max-concurrent-activities 1 "
+                    "(or use start_vapi_backfill_worker / start_backfill_worker)"
+                )
             queues_to_poll = [task_queue]
             workflows, activities = get_workflows_and_activities_for_queue(task_queue)
 
@@ -293,11 +299,21 @@ class Command(BaseCommand):
 
             def create_worker_kwargs(queue_name: str) -> dict:
                 """Create worker configuration for a specific queue."""
+                # One Worker per queue with that queue's own registration.
+                # backfill is forced to a single activity slot so all-queues can
+                # poll it without defeating the process-wide Vapi rate limiter.
+                q_workflows, q_activities = get_workflows_and_activities_for_queue(
+                    queue_name
+                )
+                activity_slots = (
+                    1 if queue_name == "backfill" else max_concurrent_activities
+                )
+
                 kwargs = {
                     "client": client,
                     "task_queue": queue_name,
-                    "workflows": workflows,
-                    "activities": activities,
+                    "workflows": q_workflows,
+                    "activities": q_activities,
                     "workflow_runner": UnsandboxedWorkflowRunner(),
                     "graceful_shutdown_timeout": timedelta(seconds=graceful_timeout),
                     "max_heartbeat_throttle_interval": timedelta(seconds=5),
@@ -314,11 +330,11 @@ class Command(BaseCommand):
                             maximum_slots=max_concurrent_workflow_tasks,
                         ),
                         activity_config=ResourceBasedSlotConfig(
-                            maximum_slots=max_concurrent_activities,
+                            maximum_slots=activity_slots,
                         ),
                     )
                 else:
-                    kwargs["max_concurrent_activities"] = max_concurrent_activities
+                    kwargs["max_concurrent_activities"] = activity_slots
                     kwargs["max_concurrent_workflow_tasks"] = (
                         max_concurrent_workflow_tasks
                     )

--- a/futureagi/tfc/management/commands/start_temporal_worker.py
+++ b/futureagi/tfc/management/commands/start_temporal_worker.py
@@ -180,11 +180,12 @@ class Command(BaseCommand):
             # Map Celery-style queue names to Temporal queue names
             if task_queue in TASK_QUEUES:
                 task_queue = TASK_QUEUES[task_queue]
-            # Dedicated path may still target backfill alone; require slot=1 there.
-            if task_queue == "backfill" and max_concurrent_activities != 1:
+            # backfill is dedicated-only: sync activities need activity_executor
+            # and a single process-wide Vapi rate-limit slot.
+            if task_queue == "backfill":
                 raise CommandError(
-                    "backfill queue requires --max-concurrent-activities 1 "
-                    "(or use start_vapi_backfill_worker / start_backfill_worker)"
+                    "backfill queue is not supported by start_temporal_worker; "
+                    "use start_vapi_backfill_worker / start_backfill_worker"
                 )
             queues_to_poll = [task_queue]
             workflows, activities = get_workflows_and_activities_for_queue(task_queue)
@@ -300,14 +301,10 @@ class Command(BaseCommand):
             def create_worker_kwargs(queue_name: str) -> dict:
                 """Create worker configuration for a specific queue."""
                 # One Worker per queue with that queue's own registration.
-                # backfill is forced to a single activity slot so all-queues can
-                # poll it without defeating the process-wide Vapi rate limiter.
                 q_workflows, q_activities = get_workflows_and_activities_for_queue(
                     queue_name
                 )
-                activity_slots = (
-                    1 if queue_name == "backfill" else max_concurrent_activities
-                )
+                activity_slots = max_concurrent_activities
 
                 kwargs = {
                     "client": client,

--- a/futureagi/tfc/temporal/backfill/minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/minimal_backfill.py
@@ -329,41 +329,83 @@ def _validate_storage_stat(stat: Any) -> None:
         raise RuntimeError(f"S3 HEAD validation failed ({content_type!r})")
 
 
-PUBLIC_VAPI_CDN_HOSTS = ("storage.vapi.ai",)
+def _valid_direct_audio(response: Any) -> tuple[bytes, str] | None:
+    """Accept a direct URL response only when the body is non-empty real audio.
 
-def _is_public_vapi_cdn(url: str) -> bool:
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    return host == "storage.vapi.ai" or host.endswith(".storage.vapi.ai")
+    storage.vapi.ai and other hosts can return 200 HTML/JSON error pages.
+    Reuse ``_detected_audio_extension`` (ffmpeg + supported format map) and
+    return the detected extension so ``_stored`` does not run ffmpeg again.
+    """
+    from simulate.temporal.utils.async_storage import _detected_audio_extension
+
+    content = getattr(response, "content", None) or b""
+    if not content:
+        return None
+    headers = getattr(response, "headers", None) or {}
+    content_type = str(headers.get("Content-Type") or headers.get("content-type") or "")
+    content_type = content_type.split(";", 1)[0].strip().lower()
+    # Explicit non-audio types lose before the expensive detector.
+    if content_type.startswith(("text/", "application/json", "application/xml")):
+        return None
+    try:
+        ext = _detected_audio_extension(content)
+    except Exception:
+        return None
+    return content, ext
 
 
-def _download(url: str, call_id: str, kind: str, api_key: str | None) -> bytes:
+def _raise_direct_fallback_disabled(direct_error: BaseException | None) -> None:
+    if isinstance(direct_error, Exception) and _is_retryable(direct_error):
+        raise direct_error
+    if direct_error is not None:
+        raise RuntimeError(
+            f"Direct URL failed and authenticated fallback is disabled: {direct_error}"
+        ) from direct_error
+    raise RuntimeError("Direct URL failed and authenticated fallback is disabled")
+
+
+def _download(
+    url: str,
+    call_id: str,
+    kind: str,
+    api_key_provider: Any | None = None,
+) -> tuple[bytes, str | None]:
+    """Direct-URL first with audio validation; API key only on authenticated fallback.
+
+    Returns ``(audio_bytes, detected_extension_or_None)``. Extension is set when
+    the direct URL path validated via ``_detected_audio_extension``; API fallback
+    leaves it None so ``_stored`` detects once on upload.
+    """
     import requests
 
     from tracer.utils.vapi_recording import VapiRecordingService
 
-    # CDN-only mode for public storage.vapi.ai / r2.dev URLs — never resolve API key
-    if _is_public_vapi_cdn(url):
-        response = requests.get(url, timeout=60, allow_redirects=True)
-        response.raise_for_status()
-        if not response.content:
-            raise RuntimeError("Empty CDN response")
-        return response.content
-
-    # Non-CDN URL: authenticated fallback only if key + rate limit configured
-    cdn_error: requests.RequestException | None = None
+    direct_error: BaseException | None = None
     try:
         response = requests.get(url, timeout=60, allow_redirects=True)
         response.raise_for_status()
-        if response.content:
-            return response.content
+        validated = _valid_direct_audio(response)
+        if validated is not None:
+            return validated
+        headers = getattr(response, "headers", None) or {}
+        content_type = str(
+            headers.get("Content-Type") or headers.get("content-type") or ""
+        )
+        direct_error = RuntimeError(
+            f"Direct URL response is not valid audio (content_type={content_type!r}, "
+            f"bytes={len(getattr(response, 'content', b'') or b'')})"
+        )
     except requests.RequestException as exc:
-        cdn_error = exc
+        direct_error = exc
 
     rate = int(os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND", "0") or "0")
-    if not api_key or rate <= 0:
-        if cdn_error is not None and _is_retryable(cdn_error):
-            raise cdn_error
-        raise RuntimeError("CDN failed and authenticated fallback is disabled")
+    if rate <= 0:
+        _raise_direct_fallback_disabled(direct_error)
+
+    # Only resolve credentials when authenticated fallback is actually enabled.
+    api_key = api_key_provider() if callable(api_key_provider) else None
+    if not api_key:
+        _raise_direct_fallback_disabled(direct_error)
 
     artifact = VapiRecordingService.artifact_for_url_type(kind)
     if not artifact:
@@ -372,11 +414,31 @@ def _download(url: str, call_id: str, kind: str, api_key: str | None) -> bytes:
     data = VapiRecordingService.download_artifact_sync(call_id, artifact, api_key)
     if not data:
         raise RuntimeError("Empty Vapi artifact")
-    return data
+    return data, None
+
+
+def _object_key_from_existing_url(base: str, url: str) -> str | None:
+    """Map a durable storage URL back to its object key without re-stat."""
+    from simulate.temporal.utils.async_storage import (
+        _REHOST_AUDIO_EXTENSIONS,
+        _rehost_object_key,
+    )
+
+    path = urllib.parse.urlparse(url).path.lstrip("/")
+    for ext in _REHOST_AUDIO_EXTENSIONS:
+        candidate = _rehost_object_key(base, ext)
+        if path == candidate or path.endswith("/" + candidate):
+            return candidate
+    return None
 
 
 def _stored(
-    project_id: str, call_id: str, kind: str, original: str, audio: bytes | None
+    project_id: str,
+    call_id: str,
+    kind: str,
+    original: str,
+    audio: bytes | None,
+    audio_ext: str | None = None,
 ) -> str:
     from simulate.temporal.utils.async_storage import (
         _detected_audio_extension,
@@ -393,34 +455,22 @@ def _stored(
     existing = _existing_rehosted_audio(base)
     if existing:
         url = existing[0]
-        storage = get_storage_client()
-        object_key = None
-        for ext in ("mp3", "wav", "ogg", "m4a", "aac", "flac", "wma", "aiff", "au"):
-            candidate = _rehost_object_key(base, ext)
-            try:
-                storage.stat_object(UPLOAD_BUCKET_NAME, candidate)
-                object_key = candidate
-                break
-            except Exception as exc:
-                if getattr(exc, "code", "") in {
-                    "NoSuchKey",
-                    "NoSuchObject",
-                    "NoSuchFile",
-                }:
-                    continue
-                raise
+        object_key = _object_key_from_existing_url(base, url)
         if not object_key:
-            raise RuntimeError("Existing S3 URL has no matching object")
+            raise RuntimeError("Existing S3 URL has no matching object key")
     else:
         if not audio:
             raise RuntimeError("Missing audio bytes")
-        object_key = _rehost_object_key(base, _detected_audio_extension(audio))
+        # Prefer extension carried from direct-URL validation (one ffmpeg).
+        ext = audio_ext or _detected_audio_extension(audio)
+        object_key = _rehost_object_key(base, ext)
         url = upload_audio_to_s3({"bytes": audio}, object_key=object_key)
     if url == original or not VapiRecordingService.is_fagi_s3_url(url):
         raise RuntimeError("Upload returned an invalid storage URL")
     stat = get_storage_client().stat_object(UPLOAD_BUCKET_NAME, object_key)
     _validate_storage_stat(stat)
     return url
+
 
 
 def _update_pg(row: Any, kind: str, old: str, new: str) -> bool:
@@ -617,7 +667,6 @@ def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult
                 continue
             try:
                 project_id = _project_id(row)
-                key = None if inp.dry_run else _api_key(row, project_id)
             except Exception as exc:
                 out.fatal += len(artifacts)
                 out.errors.append(
@@ -625,19 +674,30 @@ def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult
                 )
                 out.processed += 1
                 continue
+            api_key_provider = lambda row=row, project_id=project_id: _api_key(
+                row, project_id
+            )
             for kind, old in artifacts.items():
                 if inp.dry_run:
                     out.changed += 1
                     continue
                 try:
                     base = _rehost_object_key_base(call_id, kind, project_id, "vapi")
-                    audio = (
-                        None
-                        if _existing_rehosted_audio(base)
-                        else _download(old, call_id, kind, key)
-                    )
+                    audio = None
+                    audio_ext = None
+                    if not _existing_rehosted_audio(base):
+                        audio, audio_ext = _download(
+                            old, call_id, kind, api_key_provider
+                        )
                     try:
-                        new = _stored(project_id, call_id, kind, old, audio)
+                        new = _stored(
+                            project_id,
+                            call_id,
+                            kind,
+                            old,
+                            audio,
+                            audio_ext=audio_ext,
+                        )
                     finally:
                         # Drop recording bytes immediately — never hold batch audio in RAM.
                         audio = None
@@ -1140,14 +1200,27 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
                 base = _rehost_object_key_base(
                     str(call_id), kind, str(project_id), "vapi"
                 )
-                api_key = _api_key_for_attributes(attrs, str(project_id))
-                audio = (
-                    None
-                    if _existing_rehosted_audio(base)
-                    else _download(old, str(call_id), kind, api_key)
-                )
+                audio = None
+                audio_ext = None
+                if not _existing_rehosted_audio(base):
+                    # Resolve credentials only if authenticated Vapi API fallback runs.
+                    audio, audio_ext = _download(
+                        old,
+                        str(call_id),
+                        kind,
+                        lambda attrs=attrs, project_id=str(project_id): (
+                            _api_key_for_attributes(attrs, project_id)
+                        ),
+                    )
                 try:
-                    new = _stored(str(project_id), str(call_id), kind, old, audio)
+                    new = _stored(
+                        str(project_id),
+                        str(call_id),
+                        kind,
+                        old,
+                        audio,
+                        audio_ext=audio_ext,
+                    )
                 finally:
                     # Drop recording bytes immediately — never hold batch audio in RAM.
                     audio = None

--- a/futureagi/tfc/temporal/backfill/minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/minimal_backfill.py
@@ -1,0 +1,1600 @@
+"""Resumable Temporal backfill for historical Vapi recordings.
+
+Source URL state is the ledger. No billing, manifests, or auxiliary status tables.
+
+ClickHouse observability updates use ReplacingMergeTree version-bump inserts:
+- attrs Map columns via mapUpdate(s.map, patch_map) with patch-only staging
+- attributes_extra (String JSON after migration 013) via exact URL rewrite only
+  when the old URL is present in the text
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+
+PATHS = {
+    "mono_combined": (
+        ("artifact", "recording", "mono", "combinedUrl"),
+        ("recording", "combined"),
+    ),
+    "mono_customer": (
+        ("artifact", "recording", "mono", "customerUrl"),
+        ("recording", "customer"),
+    ),
+    "mono_assistant": (
+        ("artifact", "recording", "mono", "assistantUrl"),
+        ("recording", "assistant"),
+    ),
+    "stereo": (("artifact", "recording", "stereoUrl"), ("recording", "stereo")),
+}
+CH_KEYS = {
+    "mono_combined": ("conversation.recording.mono.combined", "recording_url"),
+    "mono_customer": ("conversation.recording.mono.customer",),
+    "mono_assistant": ("conversation.recording.mono.assistant",),
+    "stereo": ("conversation.recording.stereo", "stereo_recording_url"),
+}
+TOP_FIELD = {"mono_combined": "recording_url", "stereo": "stereo_recording_url"}
+VAPI_HOST_MARKERS = ("storage.vapi.ai", "api.vapi.ai", ".r2.dev")
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9_]+$")
+_API_RATE_LOCK = threading.Lock()
+_API_NEXT_REQUEST_AT = 0.0
+
+
+@dataclass
+class VapiBackfillInput:
+    source: str = "simulation"
+    dry_run: bool = False
+    limit: int | None = None
+    project_id: str | None = None
+    shards: int = 1
+    shard: int = 0
+    batch_size: int = 100
+    # ClickHouse keyset cursor
+    cursor_time: str | None = None
+    cursor_id: str | None = None
+    cursor_trace_id: str | None = None
+    # map = cheap attrs Map scan; extra = day-chunked attributes_extra-only scan
+    ch_scan_phase: str = "map"
+    cursor_day: str | None = None
+    # Independent simulation cursors (CE and Snapshot ID spaces differ)
+    ce_cursor_time: str | None = None
+    ce_cursor_id: str | None = None
+    snap_cursor_time: str | None = None
+    snap_cursor_id: str | None = None
+    run_id: str = "vapi_recording_backfill"
+    batch_seq: int = 0
+    proof_gate: int | None = None
+    min_records_per_second: float = 0.0
+    processed: int = 0
+    changed: int = 0
+    skipped: int = 0
+    fatal: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class VapiBackfillResult:
+    processed: int = 0
+    changed: int = 0
+    skipped: int = 0
+    fatal: int = 0
+    cursor_time: str | None = None
+    cursor_id: str | None = None
+    cursor_trace_id: str | None = None
+    ch_scan_phase: str = "map"
+    cursor_day: str | None = None
+    ce_cursor_time: str | None = None
+    ce_cursor_id: str | None = None
+    snap_cursor_time: str | None = None
+    snap_cursor_id: str | None = None
+    done: bool = True
+    errors: list[str] = field(default_factory=list)
+
+
+def _get(value: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = value
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _replace(value: dict[str, Any], path: tuple[str, ...], old: str, new: str) -> bool:
+    current: Any = value
+    for part in path[:-1]:
+        if not isinstance(current, dict):
+            return False
+        current = current.get(part)
+    if isinstance(current, dict) and current.get(path[-1]) == old:
+        current[path[-1]] = new
+        return True
+    return False
+
+
+def _is_vapi_url(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    host = (urllib.parse.urlparse(value).hostname or "").lower()
+    return host in {"storage.vapi.ai", "api.vapi.ai"} or host.endswith(".r2.dev")
+
+
+def _artifacts(payload: dict[str, Any] | None) -> tuple[str | None, dict[str, str]]:
+    vapi = (payload or {}).get("vapi")
+    if not isinstance(vapi, dict):
+        return None, {}
+    found = {}
+    for kind, paths in PATHS.items():
+        for path in paths:
+            url = _get(vapi, path)
+            if _is_vapi_url(url):
+                found[kind] = url
+                break
+    call_id = vapi.get("id") or vapi.get("callId")
+    return (str(call_id) if call_id else None), found
+
+
+def _extra_artifacts(raw: str) -> tuple[str | None, dict[str, str]]:
+    """Extract artifact URLs from historical raw Vapi JSON in attributes_extra."""
+    try:
+        root = json.loads(raw or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return None, {}
+    found: dict[str, str] = {}
+    call_id: str | None = None
+    key_to_kind = {
+        "combinedUrl": "mono_combined",
+        "customerUrl": "mono_customer",
+        "assistantUrl": "mono_assistant",
+        "stereoUrl": "stereo",
+    }
+
+    def walk(value: Any) -> None:
+        nonlocal call_id
+        if isinstance(value, dict):
+            if not call_id and ("artifact" in value or "recording" in value):
+                candidate = value.get("id") or value.get("callId")
+                if candidate:
+                    call_id = str(candidate)
+            for key, child in value.items():
+                kind = key_to_kind.get(key)
+                if kind and _is_vapi_url(child):
+                    found.setdefault(kind, child)
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    walk(root)
+    return call_id, found
+
+
+def _is_snapshot(row: Any) -> bool:
+    return row.__class__.__name__ == "CallExecutionSnapshot"
+
+
+def _call(row: Any) -> Any:
+    """Return the CallExecution-like object that owns identity fields."""
+    if _is_snapshot(row):
+        return row.call_execution
+    return row
+
+
+def _canonical_call_id(row: Any, nested_call_id: str | None) -> str | None:
+    """Full Vapi call ID only. Never use truncated snapshot.service_provider_call_id."""
+    if nested_call_id:
+        return nested_call_id
+    call = _call(row)
+    if call is None:
+        return None
+    value = getattr(call, "service_provider_call_id", None)
+    return str(value) if value else None
+
+
+def _row_artifacts(row: Any) -> tuple[str | None, dict[str, str]]:
+    nested_id, found = _artifacts(getattr(row, "provider_call_data", None))
+    if _is_vapi_url(getattr(row, "recording_url", None)):
+        found.setdefault("mono_combined", row.recording_url)
+    if _is_vapi_url(getattr(row, "stereo_recording_url", None)):
+        found.setdefault("stereo", row.stereo_recording_url)
+    return _canonical_call_id(row, nested_id), found
+
+
+def _project_id(row: Any) -> str:
+    call = _call(row)
+    if call is None:
+        raise ValueError(f"Snapshot {row.pk} has no parent CallExecution")
+    execution = call.test_execution
+    agent = execution.agent_definition or getattr(
+        execution.run_test, "agent_definition", None
+    )
+    provider = getattr(agent, "observability_provider", None) if agent else None
+    value = getattr(provider, "project_id", None)
+    if not value:
+        raise ValueError(f"No project_id for {row.pk}")
+    return str(value)
+
+
+def _api_key(row: Any, project_id: str) -> str | None:
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    call = _call(row)
+    if call is None:
+        return VapiRecordingService.get_api_key_for_project(project_id)
+    if (
+        str((call.call_metadata or {}).get("call_direction") or "").lower()
+        == "outbound"
+    ):
+        agent_id = call.test_execution.agent_definition_id or getattr(
+            call.test_execution.run_test, "agent_definition_id", None
+        )
+        return VapiRecordingService.get_api_key_for_agent_definition(agent_id)
+    return VapiRecordingService.get_api_key_for_project(project_id)
+
+
+def _wait_for_api_slot(rate: int) -> None:
+    """Process-wide limiter; dedicated worker must run one activity slot."""
+    global _API_NEXT_REQUEST_AT
+    with _API_RATE_LOCK:
+        now = time.monotonic()
+        delay = max(0.0, _API_NEXT_REQUEST_AT - now)
+        if delay:
+            time.sleep(delay)
+        _API_NEXT_REQUEST_AT = max(now, _API_NEXT_REQUEST_AT) + (1 / rate)
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Classify only transient provider/storage/network errors for activity retry."""
+    from tracer.utils.vapi_recording import (
+        VapiArtifactNotReadyError,
+        VapiAuthError,
+        VapiRateLimitError,
+    )
+
+    if isinstance(exc, VapiAuthError):
+        return False
+    if isinstance(exc, (VapiRateLimitError, VapiArtifactNotReadyError)):
+        return True
+    try:
+        import requests
+
+        if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
+            return True
+        if isinstance(exc, requests.HTTPError):
+            status = getattr(exc.response, "status_code", 0) or 0
+            return status == 429 or status >= 500
+    except ImportError:
+        pass
+    if getattr(exc, "code", "") in {
+        "SlowDown",
+        "InternalError",
+        "ServiceUnavailable",
+        "RequestTimeout",
+    }:
+        return True
+    status = getattr(getattr(exc, "response", None), "status_code", 0) or 0
+    if status in {401, 403, 404, 410}:
+        return False
+    if status == 429 or status >= 500:
+        return True
+    return type(exc).__name__ in {
+        "ReadTimeout",
+        "ConnectTimeout",
+        "ConnectError",
+        "NetworkError",
+        "SocketTimeout",
+        "ServiceUnavailable",
+    }
+
+
+def _ch_call_id(attrs: dict[str, str], extra_call_id: str | None = None) -> str | None:
+    """Resolve Vapi call identity from current and historical span attribute names."""
+    value = (
+        attrs.get("vapi.call_id")
+        or attrs.get("service_provider_call_id")
+        or attrs.get("call.id")
+        or attrs.get("gen_ai.voice.call_id")
+        or extra_call_id
+    )
+    return str(value) if value else None
+
+
+def _api_key_for_attributes(attrs: dict[str, str], project_id: str) -> str | None:
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    direction = (
+        attrs.get("call.direction") or attrs.get("call_direction") or ""
+    ).lower()
+    agent_id = attrs.get("agent_definition_id") or attrs.get("agent.id")
+    if direction == "outbound" and agent_id:
+        return VapiRecordingService.get_api_key_for_agent_definition(agent_id)
+    return VapiRecordingService.get_api_key_for_project(project_id)
+
+
+def _validate_storage_stat(stat: Any) -> None:
+    content_type = str(getattr(stat, "content_type", "") or "")
+    if int(getattr(stat, "size", 0) or 0) <= 0 or not content_type.startswith("audio/"):
+        raise RuntimeError(f"S3 HEAD validation failed ({content_type!r})")
+
+
+PUBLIC_VAPI_CDN_HOSTS = ("storage.vapi.ai",)
+
+def _is_public_vapi_cdn(url: str) -> bool:
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host == "storage.vapi.ai" or host.endswith(".storage.vapi.ai")
+
+
+def _download(url: str, call_id: str, kind: str, api_key: str | None) -> bytes:
+    import requests
+
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    # CDN-only mode for public storage.vapi.ai / r2.dev URLs — never resolve API key
+    if _is_public_vapi_cdn(url):
+        response = requests.get(url, timeout=60, allow_redirects=True)
+        response.raise_for_status()
+        if not response.content:
+            raise RuntimeError("Empty CDN response")
+        return response.content
+
+    # Non-CDN URL: authenticated fallback only if key + rate limit configured
+    cdn_error: requests.RequestException | None = None
+    try:
+        response = requests.get(url, timeout=60, allow_redirects=True)
+        response.raise_for_status()
+        if response.content:
+            return response.content
+    except requests.RequestException as exc:
+        cdn_error = exc
+
+    rate = int(os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND", "0") or "0")
+    if not api_key or rate <= 0:
+        if cdn_error is not None and _is_retryable(cdn_error):
+            raise cdn_error
+        raise RuntimeError("CDN failed and authenticated fallback is disabled")
+
+    artifact = VapiRecordingService.artifact_for_url_type(kind)
+    if not artifact:
+        raise ValueError(f"Unknown artifact type {kind}")
+    _wait_for_api_slot(rate)
+    data = VapiRecordingService.download_artifact_sync(call_id, artifact, api_key)
+    if not data:
+        raise RuntimeError("Empty Vapi artifact")
+    return data
+
+
+def _stored(
+    project_id: str, call_id: str, kind: str, original: str, audio: bytes | None
+) -> str:
+    from simulate.temporal.utils.async_storage import (
+        _detected_audio_extension,
+        _existing_rehosted_audio,
+        _rehost_object_key,
+        _rehost_object_key_base,
+    )
+    from tfc.settings.settings import UPLOAD_BUCKET_NAME
+    from tfc.utils.storage import upload_audio_to_s3
+    from tfc.utils.storage_client import get_storage_client
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    base = _rehost_object_key_base(call_id, kind, project_id, "vapi")
+    existing = _existing_rehosted_audio(base)
+    if existing:
+        url = existing[0]
+        storage = get_storage_client()
+        object_key = None
+        for ext in ("mp3", "wav", "ogg", "m4a", "aac", "flac", "wma", "aiff", "au"):
+            candidate = _rehost_object_key(base, ext)
+            try:
+                storage.stat_object(UPLOAD_BUCKET_NAME, candidate)
+                object_key = candidate
+                break
+            except Exception as exc:
+                if getattr(exc, "code", "") in {
+                    "NoSuchKey",
+                    "NoSuchObject",
+                    "NoSuchFile",
+                }:
+                    continue
+                raise
+        if not object_key:
+            raise RuntimeError("Existing S3 URL has no matching object")
+    else:
+        if not audio:
+            raise RuntimeError("Missing audio bytes")
+        object_key = _rehost_object_key(base, _detected_audio_extension(audio))
+        url = upload_audio_to_s3({"bytes": audio}, object_key=object_key)
+    if url == original or not VapiRecordingService.is_fagi_s3_url(url):
+        raise RuntimeError("Upload returned an invalid storage URL")
+    stat = get_storage_client().stat_object(UPLOAD_BUCKET_NAME, object_key)
+    _validate_storage_stat(stat)
+    return url
+
+
+def _update_pg(row: Any, kind: str, old: str, new: str) -> bool:
+    fields = []
+    field_name = TOP_FIELD.get(kind)
+    if field_name and getattr(row, field_name, None) == old:
+        setattr(row, field_name, new)
+        fields.append(field_name)
+    original = row.provider_call_data or {}
+    vapi = original.get("vapi")
+    if isinstance(vapi, dict):
+        vapi_copy = copy.deepcopy(vapi)
+        nested_changed = False
+        for path in PATHS[kind]:
+            nested_changed = _replace(vapi_copy, path, old, new) or nested_changed
+        if nested_changed:
+            payload = dict(original)
+            payload["vapi"] = vapi_copy
+            row.provider_call_data = payload
+            fields.append("provider_call_data")
+    if fields:
+        row.save(update_fields=list(dict.fromkeys(fields)))
+    return bool(fields)
+
+
+def _pg_pending_q():
+    from django.db.models import Q
+
+    pending = Q()
+    for marker in VAPI_HOST_MARKERS:
+        pending |= Q(recording_url__icontains=marker)
+        pending |= Q(stereo_recording_url__icontains=marker)
+        pending |= Q(provider_call_data__icontains=marker)
+    return pending
+
+
+def _pg_project_q(model_name: str, project_id: str):
+    from django.db.models import Q
+
+    prefix = "" if model_name == "CallExecution" else "call_execution__"
+    return Q(
+        **{
+            f"{prefix}test_execution__agent_definition__observability_provider__project_id": project_id
+        }
+    ) | Q(
+        **{
+            f"{prefix}test_execution__run_test__agent_definition__observability_provider__project_id": project_id
+        }
+    )
+
+
+def _pg_select_related(model_name: str) -> tuple[str, ...]:
+    if model_name == "CallExecution":
+        return (
+            "test_execution__agent_definition__observability_provider",
+            "test_execution__run_test__agent_definition__observability_provider",
+        )
+    return (
+        "call_execution__test_execution__agent_definition__observability_provider",
+        "call_execution__test_execution__run_test__agent_definition__observability_provider",
+        "call_execution",
+    )
+
+
+def _query_pg_table(
+    model: Any,
+    *,
+    cursor_time: str | None,
+    cursor_id: str | None,
+    project_id: str | None,
+    shards: int,
+    shard: int,
+    limit: int,
+) -> list[Any]:
+    from django.db.models import Q
+
+    if limit <= 0:
+        return []
+    cursor = Q()
+    if cursor_time and cursor_id:
+        cursor = Q(created_at__lt=cursor_time) | Q(
+            created_at=cursor_time, id__lt=cursor_id
+        )
+    qs = model.objects.filter(_pg_pending_q()).filter(cursor)
+    if project_id:
+        qs = qs.filter(_pg_project_q(model.__name__, project_id))
+    if shards > 1:
+        qs = qs.extra(
+            where=["MOD(ABS(hashtext(id::text)), %s) = %s"],
+            params=[shards, shard],
+        )
+    return list(
+        qs.select_related(*_pg_select_related(model.__name__)).order_by(
+            "-created_at", "-id"
+        )[:limit]
+    )
+
+
+def _pg_rows(inp: VapiBackfillInput) -> tuple[list[Any], dict[str, str | None]]:
+    """Return interleaved newest-first rows with independent per-table cursors."""
+    from simulate.models.test_execution import CallExecution, CallExecutionSnapshot
+
+    remaining = (
+        inp.batch_size
+        if inp.limit is None
+        else min(inp.batch_size, inp.limit - inp.processed)
+    )
+    if remaining <= 0:
+        return [], {
+            "ce_cursor_time": inp.ce_cursor_time,
+            "ce_cursor_id": inp.ce_cursor_id,
+            "snap_cursor_time": inp.snap_cursor_time,
+            "snap_cursor_id": inp.snap_cursor_id,
+        }
+
+    ce_rows = _query_pg_table(
+        CallExecution,
+        cursor_time=inp.ce_cursor_time,
+        cursor_id=inp.ce_cursor_id,
+        project_id=inp.project_id,
+        shards=inp.shards,
+        shard=inp.shard,
+        limit=remaining,
+    )
+    snap_rows = _query_pg_table(
+        CallExecutionSnapshot,
+        cursor_time=inp.snap_cursor_time,
+        cursor_id=inp.snap_cursor_id,
+        project_id=inp.project_id,
+        shards=inp.shards,
+        shard=inp.shard,
+        limit=remaining,
+    )
+
+    # Merge two already-sorted streams for true union top-N.
+    merged: list[Any] = []
+    i = j = 0
+    while len(merged) < remaining and (i < len(ce_rows) or j < len(snap_rows)):
+        take_ce = j >= len(snap_rows) or (
+            i < len(ce_rows)
+            and (ce_rows[i].created_at, ce_rows[i].id)
+            >= (snap_rows[j].created_at, snap_rows[j].id)
+        )
+        if take_ce:
+            merged.append(ce_rows[i])
+            i += 1
+        else:
+            merged.append(snap_rows[j])
+            j += 1
+
+    ce_cursor_time, ce_cursor_id = inp.ce_cursor_time, inp.ce_cursor_id
+    snap_cursor_time, snap_cursor_id = inp.snap_cursor_time, inp.snap_cursor_id
+    for row in merged:
+        if _is_snapshot(row):
+            snap_cursor_time, snap_cursor_id = row.created_at.isoformat(), str(row.id)
+        else:
+            ce_cursor_time, ce_cursor_id = row.created_at.isoformat(), str(row.id)
+
+    return merged, {
+        "ce_cursor_time": ce_cursor_time,
+        "ce_cursor_id": ce_cursor_id,
+        "snap_cursor_time": snap_cursor_time,
+        "snap_cursor_id": snap_cursor_id,
+    }
+
+
+@activity.defn(name="vapi-simulation-backfill-batch")
+def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult:
+    from django.db import close_old_connections
+
+    from simulate.temporal.utils.async_storage import (
+        _existing_rehosted_audio,
+        _rehost_object_key_base,
+    )
+
+    close_old_connections()
+    try:
+        rows, cursors = _pg_rows(inp)
+        out = VapiBackfillResult(done=not rows, **cursors)
+        if not rows:
+            return out
+        for row in rows:
+            call_id, artifacts = _row_artifacts(row)
+            if not artifacts:
+                out.skipped += 1
+                out.processed += 1
+                continue
+            if not call_id:
+                out.fatal += len(artifacts)
+                out.errors.append(
+                    f"{type(row).__name__}:{row.pk}: missing full Vapi call ID"
+                )
+                out.processed += 1
+                continue
+            try:
+                project_id = _project_id(row)
+                key = None if inp.dry_run else _api_key(row, project_id)
+            except Exception as exc:
+                out.fatal += len(artifacts)
+                out.errors.append(
+                    f"{type(row).__name__}:{row.pk}: identity resolution: {type(exc).__name__}: {exc}"
+                )
+                out.processed += 1
+                continue
+            for kind, old in artifacts.items():
+                if inp.dry_run:
+                    out.changed += 1
+                    continue
+                try:
+                    base = _rehost_object_key_base(call_id, kind, project_id, "vapi")
+                    audio = (
+                        None
+                        if _existing_rehosted_audio(base)
+                        else _download(old, call_id, kind, key)
+                    )
+                    try:
+                        new = _stored(project_id, call_id, kind, old, audio)
+                    finally:
+                        # Drop recording bytes immediately — never hold batch audio in RAM.
+                        audio = None
+                    if not _update_pg(row, kind, old, new):
+                        raise RuntimeError(
+                            "S3 object stored but source row was not updated"
+                        )
+                    out.changed += 1
+                except Exception as exc:
+                    if _is_retryable(exc):
+                        raise
+                    out.fatal += 1
+                    out.errors.append(
+                        f"{type(row).__name__}:{row.pk}:{kind}: {type(exc).__name__}: {exc}"
+                    )
+            out.processed += 1
+            activity.heartbeat(out.processed, out.changed, out.fatal)
+        remaining = (
+            inp.batch_size
+            if inp.limit is None
+            else min(inp.batch_size, inp.limit - inp.processed)
+        )
+        out.done = len(rows) < remaining
+        return out
+    finally:
+        close_old_connections()
+
+
+def _json_replace(raw: str, replacements: dict[str, str]) -> str:
+    """Exact URL replace inside String JSON.
+
+    Raises if rewrite is required but the payload is not valid JSON, so we never
+    write a half-broken attributes_extra (fail closed → original span kept).
+    """
+    try:
+        value = json.loads(raw or "{}")
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "attributes_extra contains a Vapi URL but is not valid JSON; "
+            "refusing to rewrite"
+        ) from exc
+
+    def walk(item: Any) -> Any:
+        if isinstance(item, str):
+            return replacements.get(item, item)
+        if isinstance(item, dict):
+            return {key: walk(val) for key, val in item.items()}
+        if isinstance(item, list):
+            return [walk(val) for val in item]
+        return item
+
+    return json.dumps(walk(value), separators=(",", ":"), ensure_ascii=False)
+
+
+def _mapping_table(run_id: str, shard: int) -> str:
+    if not RUN_ID_RE.fullmatch(run_id):
+        raise ValueError("invalid run_id")
+    if shard < 0:
+        raise ValueError("invalid shard")
+    return f"backfill_mapping_{run_id}_{shard}"
+
+
+def _ch_shape(ch: Any) -> tuple[str, str | None, str, str, str]:
+    from tracer.services.clickhouse.schema import detect_spans_table_shape
+
+    shape = detect_spans_table_shape(ch.execute)
+    if shape not in {"v1", "v2"}:
+        raise RuntimeError(f"Unsupported spans shape {shape}")
+    active = "attrs_string" if shape == "v2" else "span_attr_str"
+    columns = {
+        row[0]: row[1]
+        for row in ch.execute(
+            "SELECT name,type FROM system.columns WHERE database=currentDatabase() AND table='spans'"
+        )
+    }
+    if shape == "v2":
+        extra, version_col, deleted_col = "attributes_extra", "_version", "is_deleted"
+    else:
+        extra, version_col, deleted_col = (
+            "span_attributes_raw",
+            "_peerdb_version",
+            "_peerdb_is_deleted",
+        )
+    if active not in columns:
+        raise RuntimeError(f"spans missing active map column {active}")
+    return (
+        active,
+        (extra if extra in columns else None),
+        columns[active],
+        version_col,
+        deleted_col,
+    )
+
+
+def _ch_map_predicate(active: str) -> str:
+    """Pending Vapi/R2 URLs in the active string Map only (cheap, no wide JSON)."""
+    keys = [key for group in CH_KEYS.values() for key in group]
+    value = " OR ".join(
+        f"position({active}['{key}'], '{domain}') > 0"
+        for key in keys
+        for domain in VAPI_HOST_MARKERS
+    )
+    return f"({value})"
+
+
+def _ch_extra_predicate(extra: str) -> str:
+    """Pending Vapi/R2 host markers inside attributes_extra String JSON."""
+    value = " OR ".join(
+        f"position({extra}, '{domain}') > 0" for domain in VAPI_HOST_MARKERS
+    )
+    return f"({value})"
+
+
+def _ch_predicate(active: str, extra: str | None) -> str:
+    """Full pending predicate. Prefer map-only / day-chunked helpers for scans."""
+    map_clause = _ch_map_predicate(active)
+    if not extra:
+        return map_clause
+    return f"({map_clause} OR {_ch_extra_predicate(extra)})"
+
+
+def _ch_scan_settings(*, max_memory_bytes: int | None = None) -> dict[str, Any]:
+    """Conservative settings so cold attributes_extra scans do not OOM the server."""
+    memory = max_memory_bytes or int(
+        os.getenv("BACKFILL_CH_MAX_MEMORY_BYTES", str(2 * 1024**3))
+    )
+    return {
+        "max_execution_time": int(os.getenv("BACKFILL_CH_MAX_EXECUTION_SECONDS", "120")),
+        "max_memory_usage": memory,
+        "max_threads": int(os.getenv("BACKFILL_CH_MAX_THREADS", "2")),
+        # Prefer external spill over abort when possible.
+        "max_bytes_before_external_group_by": memory // 2,
+        "max_bytes_before_external_sort": memory // 2,
+    }
+
+
+def _ch_project_days(ch: Any, *, project_id: str, deleted_col: str) -> list[str]:
+    """Newest-first partition days for a project (partition key is toDate(start_time))."""
+    rows = ch.execute(
+        f"SELECT toString(toDate(start_time)) AS day "
+        f"FROM spans PREWHERE project_id=%(project)s "
+        f"WHERE {deleted_col}=0 "
+        f"GROUP BY day ORDER BY day DESC",
+        {"project": project_id},
+        settings=_ch_scan_settings(max_memory_bytes=512 * 1024**2),
+    )
+    return [str(row[0]) for row in rows]
+
+
+def _ch_count_map_pending(
+    ch: Any,
+    *,
+    active: str,
+    deleted_col: str,
+    project_id: str | None = None,
+) -> list[tuple[str, int]] | int:
+    """Map-only pending counts. Safe for all-project scans (no attributes_extra)."""
+    settings = _ch_scan_settings()
+    if project_id:
+        return int(
+            ch.execute(
+                f"SELECT count() FROM spans FINAL "
+                f"PREWHERE project_id=%(project)s "
+                f"WHERE {deleted_col}=0 AND {_ch_map_predicate(active)}",
+                {"project": project_id},
+                settings=settings,
+            )[0][0]
+        )
+    # All-project map scan: avoid FINAL here (OOM + is_deleted PREWHERE bug).
+    # Soft-deleted dupes are rare for historical Vapi URLs; reconcile is approximate.
+    rows = ch.execute(
+        f"SELECT toString(project_id), count() FROM spans "
+        f"WHERE {deleted_col}=0 AND {_ch_map_predicate(active)} "
+        f"GROUP BY project_id ORDER BY count() DESC",
+        settings=settings,
+    )
+    return [(str(project), int(count)) for project, count in rows]
+
+
+def _ch_count_extra_pending_day_chunked(
+    ch: Any,
+    *,
+    active: str,
+    extra: str,
+    deleted_col: str,
+    project_id: str,
+) -> int:
+    """Count extra-only pending spans one partition day at a time (avoids Code 241)."""
+    total = 0
+    settings = _ch_scan_settings()
+    for day in _ch_project_days(ch, project_id=project_id, deleted_col=deleted_col):
+        total += int(
+            ch.execute(
+                f"SELECT count() FROM spans FINAL "
+                f"PREWHERE project_id=%(project)s AND toDate(start_time)=toDate(%(day)s) "
+                f"WHERE {deleted_col}=0 "
+                f"AND NOT {_ch_map_predicate(active)} "
+                f"AND {_ch_extra_predicate(extra)}",
+                {"project": project_id, "day": day},
+                settings=settings,
+            )[0][0]
+        )
+    return total
+
+
+def _proof_light_select(
+    stored: list[str], active: str, extra: str | None, version_col: str
+) -> tuple[list[str], str]:
+    """Columns Python is allowed to pull for proof-gate (never input/output/etc.)."""
+    light = ["id", active, version_col]
+    if extra:
+        light.append(extra)
+    ignored = set(light)
+    others = [col for col in stored if col not in ignored]
+    # Hash remaining wide columns server-side so Python never materializes them.
+    other_hash = (
+        f"cityHash64(tuple({', '.join(others)}))" if others else "toUInt64(0)"
+    )
+    return light, other_hash
+
+
+def _proof_rows(
+    ch: Any,
+    *,
+    stored: list[str],
+    active: str,
+    extra: str | None,
+    version_col: str,
+    project_id: str,
+    span_ids: list[str],
+) -> dict[str, tuple[Any, ...]]:
+    """Load only id/map/extra/version + server-side hash of all other columns."""
+    if not span_ids:
+        return {}
+    light, other_hash = _proof_light_select(stored, active, extra, version_col)
+    rows = ch.execute(
+        f"SELECT {', '.join(light)}, {other_hash} AS other_hash "
+        f"FROM spans FINAL WHERE project_id=%(project)s AND id IN %(ids)s",
+        {"project": project_id, "ids": tuple(span_ids)},
+        settings={"max_execution_time": 120},
+    )
+    # row layout: light... + other_hash
+    return {str(row[0]): row for row in rows}
+
+
+def _assert_ch_gate_clear(ch: Any) -> None:
+    pending_mutations = ch.execute(
+        "SELECT count() FROM system.mutations WHERE database=currentDatabase() AND table='spans' AND is_done=0"
+    )[0][0]
+    if pending_mutations:
+        raise RuntimeError(
+            f"Proof gate blocked by {pending_mutations} pending spans mutations"
+        )
+    merge_count, max_elapsed = ch.execute(
+        "SELECT count(), coalesce(max(elapsed), 0) FROM system.merges WHERE database=currentDatabase() AND table='spans'"
+    )[0]
+    max_merges = int(os.getenv("BACKFILL_MAX_ACTIVE_MERGES", "20"))
+    max_merge_seconds = int(os.getenv("BACKFILL_MAX_MERGE_SECONDS", "300"))
+    if merge_count > max_merges or max_elapsed > max_merge_seconds:
+        raise RuntimeError(
+            f"Proof gate merge backlog exceeded: count={merge_count}, max_elapsed={max_elapsed}"
+        )
+
+
+def _verify_proof_gate(
+    *,
+    ch: Any,
+    stored: list[str],
+    active: str,
+    extra: str | None,
+    project_id: str,
+    before: dict[str, tuple[Any, ...]],
+    mappings: list[dict[str, Any]],
+    version_col: str = "_version",
+) -> None:
+    """Validate mapUpdate patches + optional attributes_extra exact rewrite.
+
+    Python only inspects light columns (id/map/extra/version). Unrelated wide
+    columns are compared via a server-side cityHash64 so we never OOM on
+    input/output/raw payloads.
+    """
+    _assert_ch_gate_clear(ch)
+    expected_ids = [item["span_id"] for item in mappings]
+    after = _proof_rows(
+        ch,
+        stored=stored,
+        active=active,
+        extra=extra,
+        version_col=version_col,
+        project_id=project_id,
+        span_ids=expected_ids,
+    )
+    expected = {item["span_id"]: item for item in mappings}
+    light, _ = _proof_light_select(stored, active, extra, version_col)
+    # layout: id, active, version, [extra], other_hash
+    idx_active = 1
+    idx_version = 2
+    idx_extra = 3 if extra else None
+    idx_hash = len(light)  # last
+    missing = [span_id for span_id in expected_ids if span_id not in after]
+    if missing:
+        raise RuntimeError(f"Proof gate lost spans: {missing[:5]}")
+    for span_id, item in expected.items():
+        new_row = after[span_id]
+        old_row = before.get(span_id)
+        if old_row is not None and old_row[idx_hash] != new_row[idx_hash]:
+            raise RuntimeError(
+                f"Proof gate changed unrelated wide columns on {span_id}"
+            )
+        new_map = dict(new_row[idx_active] or {})
+        patch = dict(item.get("patch_map") or {})
+        for key, value in patch.items():
+            if new_map.get(key) != value:
+                raise RuntimeError(f"Proof gate map patch miss on {span_id}:{key}")
+        if old_row is not None:
+            old_map = dict(old_row[idx_active] or {})
+            for key, value in old_map.items():
+                if key not in patch and new_map.get(key) != value:
+                    raise RuntimeError(
+                        f"Proof gate map clobbered unrelated key {key} on {span_id}"
+                    )
+        if extra and idx_extra is not None:
+            if int(item.get("extra_changed") or 0):
+                if new_row[idx_extra] != item["extra"]:
+                    raise RuntimeError(
+                        f"Proof gate attributes_extra mismatch on {span_id}"
+                    )
+            elif old_row is not None and new_row[idx_extra] != old_row[idx_extra]:
+                raise RuntimeError(
+                    f"Proof gate unexpectedly rewrote attributes_extra on {span_id}"
+                )
+        if int(new_row[idx_version]) < int(item["version"]):
+            raise RuntimeError(f"Proof gate version did not win on {span_id}")
+
+
+@activity.defn(name="vapi-observability-backfill-batch")
+def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult:
+    from simulate.temporal.utils.async_storage import (
+        _existing_rehosted_audio,
+        _rehost_object_key_base,
+    )
+    from tracer.services.clickhouse.client import get_clickhouse_client
+
+    if not inp.project_id:
+        raise ValueError("--project-id is required for observability")
+    if not RUN_ID_RE.fullmatch(inp.run_id):
+        raise ValueError("invalid run_id")
+    ch = get_clickhouse_client()
+    active, extra, map_type, version_col, deleted_col = _ch_shape(ch)
+    remaining = (
+        inp.batch_size
+        if inp.limit is None
+        else min(inp.batch_size, inp.limit - inp.processed)
+    )
+    if remaining <= 0:
+        return VapiBackfillResult(done=True, ch_scan_phase=inp.ch_scan_phase)
+
+    columns = ["id", "project_id", "trace_id", "start_time", version_col, active] + (
+        [extra] if extra else []
+    )
+    phase = inp.ch_scan_phase or "map"
+    cursor_day = inp.cursor_day
+    rows: list[tuple] = []
+    scan_settings = _ch_scan_settings()
+
+    def _keyset(params: dict[str, Any]) -> str:
+        if inp.cursor_time and inp.cursor_trace_id and inp.cursor_id and (
+            phase == "map" or cursor_day is not None
+        ):
+            # Only apply keyset when staying inside the same phase/day.
+            params.update(
+                time=inp.cursor_time, trace=inp.cursor_trace_id, id=inp.cursor_id
+            )
+            return "AND (start_time,trace_id,id) < (%(time)s,%(trace)s,%(id)s)"
+        return ""
+
+    if phase == "map":
+        params = {
+            "project": inp.project_id,
+            "shards": inp.shards,
+            "shard": inp.shard,
+            "limit": remaining,
+        }
+        cursor = _keyset(params)
+        # PREWHERE prunes deleted/project before evaluating Map values.
+        rows = ch.execute(
+            f"SELECT {','.join(columns)} FROM spans FINAL "
+            f"PREWHERE project_id=%(project)s "
+            f"WHERE {deleted_col}=0 "
+            f"AND cityHash64(trace_id) %% %(shards)s=%(shard)s "
+            f"AND {_ch_map_predicate(active)} {cursor} "
+            "ORDER BY start_time DESC,trace_id DESC,id DESC LIMIT %(limit)s",
+            params,
+            settings=scan_settings,
+        )
+        if not rows and extra:
+            phase = "extra"
+            cursor_day = None
+            # Clear map keyset so extra phase starts from newest day.
+            inp = VapiBackfillInput(
+                **{
+                    **inp.__dict__,
+                    "cursor_time": None,
+                    "cursor_id": None,
+                    "cursor_trace_id": None,
+                }
+            )
+
+    if phase == "extra" and extra and remaining > 0 and not rows:
+        days = _ch_project_days(
+            ch, project_id=inp.project_id, deleted_col=deleted_col
+        )
+        if cursor_day is not None:
+            # Resume from current day inclusive, then older days.
+            days = [day for day in days if day <= cursor_day]
+        for day in days:
+            params = {
+                "project": inp.project_id,
+                "shards": inp.shards,
+                "shard": inp.shard,
+                "limit": remaining,
+                "day": day,
+            }
+            # Fresh day → no keyset; same day resume → keyset.
+            use_keyset = cursor_day == day and inp.cursor_time
+            cursor = ""
+            if use_keyset and inp.cursor_trace_id and inp.cursor_id:
+                params.update(
+                    time=inp.cursor_time,
+                    trace=inp.cursor_trace_id,
+                    id=inp.cursor_id,
+                )
+                cursor = "AND (start_time,trace_id,id) < (%(time)s,%(trace)s,%(id)s)"
+            # Map-negative + extra-positive on a single partition day only.
+            day_rows = ch.execute(
+                f"SELECT {','.join(columns)} FROM spans FINAL "
+                f"PREWHERE project_id=%(project)s AND toDate(start_time)=toDate(%(day)s) "
+                f"WHERE {deleted_col}=0 "
+                f"AND cityHash64(trace_id) %% %(shards)s=%(shard)s "
+                f"AND NOT {_ch_map_predicate(active)} "
+                f"AND {_ch_extra_predicate(extra)} {cursor} "
+                "ORDER BY start_time DESC,trace_id DESC,id DESC LIMIT %(limit)s",
+                params,
+                settings=scan_settings,
+            )
+            if day_rows:
+                rows = day_rows
+                cursor_day = day
+                break
+            cursor_day = None  # exhausted this day
+            # Do not carry map/extra keyset across days.
+            inp = VapiBackfillInput(
+                **{
+                    **inp.__dict__,
+                    "cursor_time": None,
+                    "cursor_id": None,
+                    "cursor_trace_id": None,
+                }
+            )
+
+    out = VapiBackfillResult(
+        done=not rows,
+        ch_scan_phase=phase if rows else ("extra" if phase == "extra" else "map"),
+        cursor_day=cursor_day if rows else None,
+    )
+    if not rows:
+        # Finished map and (if present) all extra days.
+        out.done = True
+        out.ch_scan_phase = "extra" if extra else "map"
+        return out
+    out.cursor_id, out.cursor_trace_id, out.cursor_time = (
+        str(rows[-1][0]),
+        str(rows[-1][2]),
+        rows[-1][3].isoformat(),
+    )
+    out.ch_scan_phase = phase
+    out.cursor_day = cursor_day
+    mappings = []
+    for row in rows:
+        span_id, project_id, _, _, version, attrs = row[:6]
+        attrs, raw_extra = dict(attrs or {}), (row[6] if extra else "{}")
+        extra_call_id, extra_urls = _extra_artifacts(raw_extra)
+        call_id = _ch_call_id(attrs, extra_call_id)
+        replacements: dict[str, str] = {}
+        patch_map: dict[str, str] = {}
+        for kind, keys in CH_KEYS.items():
+            old = next(
+                (attrs[key] for key in keys if _is_vapi_url(attrs.get(key))), None
+            ) or extra_urls.get(kind)
+            if not old:
+                continue
+            if not call_id:
+                out.fatal += 1
+                out.errors.append(f"span:{span_id}:{kind}: missing Vapi call ID")
+                continue
+            if inp.dry_run:
+                out.changed += 1
+                continue
+            try:
+                base = _rehost_object_key_base(
+                    str(call_id), kind, str(project_id), "vapi"
+                )
+                api_key = _api_key_for_attributes(attrs, str(project_id))
+                audio = (
+                    None
+                    if _existing_rehosted_audio(base)
+                    else _download(old, str(call_id), kind, api_key)
+                )
+                try:
+                    new = _stored(str(project_id), str(call_id), kind, old, audio)
+                finally:
+                    # Drop recording bytes immediately — never hold batch audio in RAM.
+                    audio = None
+                replacements[old] = new
+                # Stage only changed Map keys; CH applies mapUpdate server-side.
+                for key_name in keys:
+                    if attrs.get(key_name) == old:
+                        patch_map[key_name] = new
+                out.changed += 1
+            except Exception as exc:
+                if _is_retryable(exc):
+                    raise
+                out.fatal += 1
+                out.errors.append(f"span:{span_id}:{kind}: {type(exc).__name__}: {exc}")
+        if replacements and not inp.dry_run:
+            raw_extra_text = raw_extra or "{}"
+            # attributes_extra is String JSON (migration 013). Rewrite only when
+            # an exact old URL appears in the text; otherwise keep s.extra.
+            extra_changed = any(old in raw_extra_text for old in replacements)
+            mappings.append(
+                {
+                    "batch_seq": inp.batch_seq,
+                    "span_id": str(span_id),
+                    "patch_map": patch_map,
+                    "extra": (
+                        _json_replace(raw_extra_text, replacements)
+                        if extra_changed
+                        else ""
+                    ),
+                    "extra_changed": 1 if extra_changed else 0,
+                    "version": max(time.time_ns(), int(version) + 1),
+                }
+            )
+        out.processed += 1
+        activity.heartbeat(out.processed, out.changed, out.fatal)
+    if mappings:
+        if inp.proof_gate:
+            _assert_ch_gate_clear(ch)
+        table = _mapping_table(inp.run_id, inp.shard)
+        # Patch-only staging: mapUpdate merges changed keys; extra is rewritten
+        # only when extra_changed=1 (String JSON, not typed JSON column).
+        ch.execute(
+            f"CREATE TABLE IF NOT EXISTS {table} ("
+            f"batch_seq UInt64, span_id String, patch_map {map_type}, "
+            f"extra String, extra_changed UInt8, version UInt64"
+            f") ENGINE=MergeTree ORDER BY (batch_seq,span_id) "
+            f"TTL toDateTime(intDiv(version,1000000000))+INTERVAL 90 DAY DELETE"
+        )
+        ch.insert(
+            table,
+            mappings,
+            [
+                "batch_seq",
+                "span_id",
+                "patch_map",
+                "extra",
+                "extra_changed",
+                "version",
+            ],
+        )
+        stored = [
+            row[0]
+            for row in ch.execute(
+                "SELECT name FROM system.columns WHERE database=currentDatabase() AND table='spans' AND default_kind NOT IN ('MATERIALIZED','ALIAS') ORDER BY position"
+            )
+        ]
+        before = (
+            _proof_rows(
+                ch,
+                stored=stored,
+                active=active,
+                extra=extra,
+                version_col=version_col,
+                project_id=inp.project_id,
+                span_ids=[item["span_id"] for item in mappings],
+            )
+            if inp.proof_gate
+            else {}
+        )
+        expressions = []
+        for col in stored:
+            if col == active:
+                # Official Map helper: keep existing keys, overwrite patch keys.
+                expressions.append(f"mapUpdate(s.{active}, m.patch_map) AS {col}")
+            elif extra and col == extra:
+                expressions.append(
+                    f"if(m.extra_changed = 1, m.extra, s.{extra}) AS {col}"
+                )
+            elif col == version_col:
+                expressions.append(f"m.version AS {col}")
+            else:
+                expressions.append(f"s.{col}")
+        ch.execute(
+            f"INSERT INTO spans ({','.join(stored)}) SELECT {','.join(expressions)} "
+            f"FROM spans AS s INNER JOIN {table} AS m "
+            f"ON s.id=m.span_id AND m.batch_seq=%(batch)s "
+            f"WHERE s.project_id=%(project)s AND s.{deleted_col}=0 "
+            f"ORDER BY s.id, s.{version_col} DESC "
+            f"LIMIT 1 BY s.id",
+            {"batch": inp.batch_seq, "project": inp.project_id},
+            settings={"max_execution_time": 120} if inp.proof_gate else None,
+        )
+        if inp.proof_gate:
+            _verify_proof_gate(
+                ch=ch,
+                stored=stored,
+                active=active,
+                extra=extra,
+                project_id=inp.project_id,
+                before=before,
+                mappings=mappings,
+                version_col=version_col,
+            )
+    # Map phase not exhausted until a short page AND extra phase is finished.
+    if phase == "map":
+        if len(rows) >= remaining:
+            out.done = False
+            out.ch_scan_phase = "map"
+        elif extra:
+            # Switch to day-chunked extra-only scan on the next activity call.
+            out.done = False
+            out.ch_scan_phase = "extra"
+            out.cursor_day = None
+            out.cursor_time = None
+            out.cursor_id = None
+            out.cursor_trace_id = None
+        else:
+            out.done = True
+    else:
+        # Extra phase: short page means try older days on next call via cursor_day.
+        if len(rows) >= remaining:
+            out.done = False
+            out.ch_scan_phase = "extra"
+            out.cursor_day = cursor_day
+        else:
+            # Exhausted this day; advance to older days on next call.
+            days = _ch_project_days(
+                ch, project_id=inp.project_id, deleted_col=deleted_col
+            )
+            older = [day for day in days if cursor_day is None or day < cursor_day]
+            if older:
+                out.done = False
+                out.ch_scan_phase = "extra"
+                out.cursor_day = older[0]
+                out.cursor_time = None
+                out.cursor_id = None
+                out.cursor_trace_id = None
+            else:
+                out.done = True
+                out.ch_scan_phase = "extra"
+    return out
+
+
+@activity.defn(name="vapi-drop-observability-mapping")
+def drop_observability_mapping(run_id: str, shard: int = 0) -> None:
+    from tracer.services.clickhouse.client import get_clickhouse_client
+
+    table = _mapping_table(run_id, shard)
+    get_clickhouse_client().execute(f"DROP TABLE IF EXISTS {table}")
+
+
+@activity.defn(name="vapi-backfill-reconcile-sample")
+def reconcile_backfill_sample(inp: VapiBackfillInput) -> dict[str, Any]:
+    """Report pending counts for operator reconciliation (no mutations).
+
+    Observability never cold-scans attributes_extra across a whole project:
+    - map_pending: cheap Map-only count (safe all-project)
+    - extra_pending: day-chunked count of extra-only rows (per project)
+    - spans_pending: map_pending + extra_pending
+    """
+    report: dict[str, Any] = {"source": inp.source, "project_id": inp.project_id}
+    if inp.source == "simulation":
+        from simulate.models.test_execution import CallExecution, CallExecutionSnapshot
+
+        for name, model in (
+            ("call_execution", CallExecution),
+            ("call_execution_snapshot", CallExecutionSnapshot),
+        ):
+            qs = model.objects.filter(_pg_pending_q())
+            if inp.project_id:
+                qs = qs.filter(_pg_project_q(model.__name__, inp.project_id))
+            report[name] = qs.count()
+        return report
+    from tracer.services.clickhouse.client import get_clickhouse_client
+
+    ch = get_clickhouse_client()
+    active, extra, _, _, deleted_col = _ch_shape(ch)
+    report["shape"] = {
+        "active": active,
+        "extra": extra,
+        "deleted": deleted_col,
+    }
+    if not inp.project_id:
+        # All-project: map-only only (attributes_extra full scan OOMs).
+        by_project = _ch_count_map_pending(
+            ch, active=active, deleted_col=deleted_col, project_id=None
+        )
+        assert isinstance(by_project, list)
+        report["mode"] = "map_only_all_projects"
+        report["projects"] = len(by_project)
+        report["map_pending_total"] = sum(count for _, count in by_project)
+        report["by_project"] = [
+            {"project_id": project, "map_pending": count} for project, count in by_project
+        ]
+        report["note"] = (
+            "extra_pending requires --project-id (day-chunked). "
+            "map_pending is the safe all-project baseline."
+        )
+        return report
+
+    map_pending = _ch_count_map_pending(
+        ch, active=active, deleted_col=deleted_col, project_id=inp.project_id
+    )
+    assert isinstance(map_pending, int)
+    report["mode"] = "map_plus_day_chunked_extra"
+    report["map_pending"] = map_pending
+    if extra:
+        extra_pending = _ch_count_extra_pending_day_chunked(
+            ch,
+            active=active,
+            extra=extra,
+            deleted_col=deleted_col,
+            project_id=inp.project_id,
+        )
+    else:
+        extra_pending = 0
+    report["extra_pending"] = extra_pending
+    report["spans_pending"] = map_pending + extra_pending
+    return report
+
+
+@workflow.defn(name="VapiMinimalBackfillWorkflow")
+class VapiMinimalBackfillWorkflow:
+    def __init__(self) -> None:
+        self.paused = False
+        self.cancelled = False
+        self.progress: dict[str, Any] = {"state": "starting"}
+
+    @workflow.signal
+    async def pause(self) -> None:
+        self.paused = True
+
+    @workflow.signal
+    async def resume(self) -> None:
+        self.paused = False
+
+    @workflow.signal
+    async def cancel(self) -> None:
+        # Soft-cancel: current activity drains, then workflow stops before the next batch.
+        self.cancelled = True
+
+    @workflow.query
+    def status(self) -> dict[str, Any]:
+        return {
+            **self.progress,
+            "paused": self.paused,
+            "cancelled": self.cancelled,
+        }
+
+    async def _cleanup(self, inp: VapiBackfillInput) -> None:
+        if inp.source == "observability" and not inp.dry_run:
+            await workflow.execute_activity(
+                drop_observability_mapping,
+                args=[inp.run_id, inp.shard],
+                task_queue="backfill",
+                start_to_close_timeout=timedelta(minutes=2),
+            )
+
+    @workflow.run
+    async def run(self, inp: VapiBackfillInput) -> VapiBackfillResult:
+        if inp.source not in {"simulation", "observability"}:
+            raise ValueError("invalid source")
+        state = inp
+        batches_in_history = 0
+        self.progress = {
+            "state": "running",
+            "processed": state.processed,
+            "changed": state.changed,
+            "skipped": state.skipped,
+            "fatal": state.fatal,
+            "batch_seq": state.batch_seq,
+            "shard": state.shard,
+            "note": "cancel is soft: in-flight batch may finish mutating",
+        }
+        while True:
+            await workflow.wait_condition(lambda: not self.paused or self.cancelled)
+            if self.cancelled:
+                await self._cleanup(state)
+                return VapiBackfillResult(
+                    processed=state.processed,
+                    changed=state.changed,
+                    skipped=state.skipped,
+                    fatal=state.fatal,
+                    errors=state.errors,
+                    cursor_time=state.cursor_time,
+                    cursor_id=state.cursor_id,
+                    cursor_trace_id=state.cursor_trace_id,
+                    ch_scan_phase=state.ch_scan_phase,
+                    cursor_day=state.cursor_day,
+                    ce_cursor_time=state.ce_cursor_time,
+                    ce_cursor_id=state.ce_cursor_id,
+                    snap_cursor_time=state.snap_cursor_time,
+                    snap_cursor_id=state.snap_cursor_id,
+                )
+            fn = (
+                vapi_simulation_backfill_batch
+                if state.source == "simulation"
+                else vapi_observability_backfill_batch
+            )
+            started_at = workflow.now()
+            batch = await workflow.execute_activity(
+                fn,
+                state,
+                task_queue="backfill",
+                start_to_close_timeout=timedelta(minutes=20),
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=2),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(minutes=2),
+                    maximum_attempts=5,
+                ),
+            )
+            elapsed = max((workflow.now() - started_at).total_seconds(), 0.001)
+            totals = {
+                "processed": state.processed + batch.processed,
+                "changed": state.changed + batch.changed,
+                "skipped": state.skipped + batch.skipped,
+                "fatal": state.fatal + batch.fatal,
+            }
+            errors = (state.errors + batch.errors)[-100:]
+            self.progress = {
+                **totals,
+                "batch_seq": state.batch_seq,
+                "errors": len(errors),
+                "records_per_second": batch.processed / elapsed,
+                "state": "running",
+                "shard": state.shard,
+                "ch_scan_phase": batch.ch_scan_phase,
+                "cursor_day": batch.cursor_day,
+                "note": "cancel is soft: in-flight batch may finish mutating",
+            }
+            reached_limit = (
+                state.limit is not None and totals["processed"] >= state.limit
+            )
+            if batch.done or reached_limit:
+                await self._cleanup(state)
+                if state.proof_gate and (
+                    totals["processed"] != state.proof_gate or totals["fatal"] > 0
+                ):
+                    raise RuntimeError(
+                        f"Proof gate failed: expected {state.proof_gate} rows, "
+                        f"processed={totals['processed']}, fatal={totals['fatal']}"
+                    )
+                return VapiBackfillResult(
+                    **totals,
+                    cursor_time=batch.cursor_time,
+                    cursor_id=batch.cursor_id,
+                    cursor_trace_id=batch.cursor_trace_id,
+                    ch_scan_phase=batch.ch_scan_phase,
+                    cursor_day=batch.cursor_day,
+                    ce_cursor_time=batch.ce_cursor_time,
+                    ce_cursor_id=batch.ce_cursor_id,
+                    snap_cursor_time=batch.snap_cursor_time,
+                    snap_cursor_id=batch.snap_cursor_id,
+                    errors=errors,
+                )
+            fatal_breach = batch.processed > 0 and batch.fatal / batch.processed > 0.05
+            throughput_breach = (
+                state.min_records_per_second > 0
+                and elapsed >= 60
+                and batch.processed / elapsed < state.min_records_per_second * 0.5
+            )
+            state = VapiBackfillInput(
+                **{
+                    **state.__dict__,
+                    **totals,
+                    "errors": errors,
+                    "cursor_time": batch.cursor_time,
+                    "cursor_id": batch.cursor_id,
+                    "cursor_trace_id": batch.cursor_trace_id,
+                    "ch_scan_phase": batch.ch_scan_phase,
+                    "cursor_day": batch.cursor_day,
+                    "ce_cursor_time": batch.ce_cursor_time,
+                    "ce_cursor_id": batch.ce_cursor_id,
+                    "snap_cursor_time": batch.snap_cursor_time,
+                    "snap_cursor_id": batch.snap_cursor_id,
+                    "batch_seq": state.batch_seq + 1,
+                }
+            )
+            if fatal_breach or throughput_breach:
+                self.paused = True
+                self.progress["state"] = "auto_paused"
+                self.progress["reason"] = (
+                    "fatal_rate_above_5_percent"
+                    if fatal_breach
+                    else "throughput_below_50_percent"
+                )
+                await workflow.wait_condition(lambda: not self.paused or self.cancelled)
+                if self.cancelled:
+                    await self._cleanup(state)
+                    return VapiBackfillResult(
+                        **totals,
+                        errors=errors,
+                        cursor_time=state.cursor_time,
+                        cursor_id=state.cursor_id,
+                        cursor_trace_id=state.cursor_trace_id,
+                        ch_scan_phase=state.ch_scan_phase,
+                        cursor_day=state.cursor_day,
+                        ce_cursor_time=state.ce_cursor_time,
+                        ce_cursor_id=state.ce_cursor_id,
+                        snap_cursor_time=state.snap_cursor_time,
+                        snap_cursor_id=state.snap_cursor_id,
+                    )
+            if self.paused or self.cancelled:
+                await workflow.wait_condition(lambda: not self.paused or self.cancelled)
+                if self.cancelled:
+                    await self._cleanup(state)
+                    return VapiBackfillResult(
+                        **totals,
+                        errors=errors,
+                        cursor_time=state.cursor_time,
+                        cursor_id=state.cursor_id,
+                        cursor_trace_id=state.cursor_trace_id,
+                        ch_scan_phase=state.ch_scan_phase,
+                        cursor_day=state.cursor_day,
+                        ce_cursor_time=state.ce_cursor_time,
+                        ce_cursor_id=state.ce_cursor_id,
+                        snap_cursor_time=state.snap_cursor_time,
+                        snap_cursor_id=state.snap_cursor_id,
+                    )
+            batches_in_history += 1
+            if (
+                batches_in_history >= 200
+                or workflow.info().is_continue_as_new_suggested()
+            ):
+                workflow.continue_as_new(state)
+
+
+def get_workflows() -> list[type]:
+    return [VapiMinimalBackfillWorkflow]
+
+
+def get_activities() -> list[Any]:
+    return [
+        vapi_simulation_backfill_batch,
+        vapi_observability_backfill_batch,
+        drop_observability_mapping,
+        reconcile_backfill_sample,
+    ]

--- a/futureagi/tfc/temporal/backfill/minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/minimal_backfill.py
@@ -227,21 +227,47 @@ def _project_id(row: Any) -> str:
     return str(value)
 
 
+def _system_vapi_api_key() -> str | None:
+    """FutureAGI system Vapi key (env) — same default as ``VapiService``."""
+    return os.getenv("VAPI_API_KEY") or None
+
+
+
+
 def _api_key(row: Any, project_id: str) -> str | None:
+    """Match live simulation key selection, with system key as backup.
+
+    - outbound → customer AgentDefinition, else system ``VAPI_API_KEY``, else project
+    - inbound / unknown → system ``VAPI_API_KEY`` first (FAGI-owned calls), else project
+    """
     from tracer.utils.vapi_recording import VapiRecordingService
 
+    system_key = _system_vapi_api_key()
+
     call = _call(row)
-    if call is None:
-        return VapiRecordingService.get_api_key_for_project(project_id)
-    if (
+    if call is not None and (
         str((call.call_metadata or {}).get("call_direction") or "").lower()
         == "outbound"
     ):
         agent_id = call.test_execution.agent_definition_id or getattr(
             call.test_execution.run_test, "agent_definition_id", None
         )
-        return VapiRecordingService.get_api_key_for_agent_definition(agent_id)
+        agent_key = VapiRecordingService.get_api_key_for_agent_definition(agent_id)
+        if agent_key:
+            return agent_key
+        if system_key:
+            return system_key
+        return VapiRecordingService.get_api_key_for_project(project_id)
+    # Inbound (and unknown): system first like VoiceServiceManager, then project.
+    if system_key:
+        return system_key
     return VapiRecordingService.get_api_key_for_project(project_id)
+
+
+
+
+
+
 
 
 def _wait_for_api_slot(rate: int) -> None:
@@ -312,6 +338,7 @@ def _ch_call_id(attrs: dict[str, str], extra_call_id: str | None = None) -> str 
 
 
 def _api_key_for_attributes(attrs: dict[str, str], project_id: str) -> str | None:
+    """Customer project/agent first; system ``VAPI_API_KEY`` always last backup."""
     from tracer.utils.vapi_recording import VapiRecordingService
 
     direction = (
@@ -319,8 +346,16 @@ def _api_key_for_attributes(attrs: dict[str, str], project_id: str) -> str | Non
     ).lower()
     agent_id = attrs.get("agent_definition_id") or attrs.get("agent.id")
     if direction == "outbound" and agent_id:
-        return VapiRecordingService.get_api_key_for_agent_definition(agent_id)
-    return VapiRecordingService.get_api_key_for_project(project_id)
+        agent_key = VapiRecordingService.get_api_key_for_agent_definition(agent_id)
+        if agent_key:
+            return agent_key
+    project_key = VapiRecordingService.get_api_key_for_project(project_id)
+    if project_key:
+        return project_key
+    return _system_vapi_api_key()
+
+
+
 
 
 def _validate_storage_stat(stat: Any) -> None:
@@ -354,14 +389,14 @@ def _valid_direct_audio(response: Any) -> tuple[bytes, str] | None:
     return content, ext
 
 
-def _raise_direct_fallback_disabled(direct_error: BaseException | None) -> None:
-    if isinstance(direct_error, Exception) and _is_retryable(direct_error):
-        raise direct_error
-    if direct_error is not None:
-        raise RuntimeError(
-            f"Direct URL failed and authenticated fallback is disabled: {direct_error}"
-        ) from direct_error
-    raise RuntimeError("Direct URL failed and authenticated fallback is disabled")
+def _raise_authenticated_download_failed(
+    error: BaseException | None, *, reason: str
+) -> None:
+    if isinstance(error, Exception) and _is_retryable(error):
+        raise error
+    if error is not None:
+        raise RuntimeError(f"{reason}: {error}") from error
+    raise RuntimeError(reason)
 
 
 def _download(
@@ -370,51 +405,76 @@ def _download(
     kind: str,
     api_key_provider: Any | None = None,
 ) -> tuple[bytes, str | None]:
-    """Direct-URL first with audio validation; API key only on authenticated fallback.
+    """Authenticated Vapi API first (live rehost), public URL only as last resort.
 
-    Returns ``(audio_bytes, detected_extension_or_None)``. Extension is set when
-    the direct URL path validated via ``_detected_audio_extension``; API fallback
-    leaves it None so ``_stored`` detects once on upload.
+    Public CDN hosts are expired; production path is API-key download via
+    ``VapiRecordingService.download_artifact_sync``, same as
+    ``convert_audio_url_to_s3_sync`` / live normalize rehost.
+
+    Returns ``(audio_bytes, detected_extension_or_None)``.
     """
-    import requests
-
+    from simulate.temporal.utils.async_storage import MAX_AUDIO_FILE_SIZE
+    from tfc.utils.ssrf_guard import safe_fetch
+    from tracer.models.observability_provider import ProviderChoices
     from tracer.utils.vapi_recording import VapiRecordingService
 
-    direct_error: BaseException | None = None
-    try:
-        response = requests.get(url, timeout=60, allow_redirects=True)
-        response.raise_for_status()
-        validated = _valid_direct_audio(response)
-        if validated is not None:
-            return validated
-        headers = getattr(response, "headers", None) or {}
-        content_type = str(
-            headers.get("Content-Type") or headers.get("content-type") or ""
-        )
-        direct_error = RuntimeError(
-            f"Direct URL response is not valid audio (content_type={content_type!r}, "
-            f"bytes={len(getattr(response, 'content', b'') or b'')})"
-        )
-    except requests.RequestException as exc:
-        direct_error = exc
-
-    rate = int(os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND", "0") or "0")
-    if rate <= 0:
-        _raise_direct_fallback_disabled(direct_error)
-
-    # Only resolve credentials when authenticated fallback is actually enabled.
-    api_key = api_key_provider() if callable(api_key_provider) else None
-    if not api_key:
-        _raise_direct_fallback_disabled(direct_error)
-
     artifact = VapiRecordingService.artifact_for_url_type(kind)
+    api_key = api_key_provider() if callable(api_key_provider) else None
+
+    # --- Preferred path: authenticated artifact API (live rehost parity) ---
+    if VapiRecordingService.is_authenticated_download(
+        ProviderChoices.VAPI, api_key, call_id, artifact
+    ):
+        rate = int(os.getenv("VAPI_API_RATE_LIMIT_PER_SECOND", "0") or "0")
+        if rate > 0:
+            _wait_for_api_slot(rate)
+        data = VapiRecordingService.download_artifact_sync(call_id, artifact, api_key)
+        if not data:
+            raise RuntimeError("Empty Vapi artifact")
+        return data, None
+
+    # --- Last resort: direct URL (legacy / non-Vapi hosts if any remain) ---
+    direct_error: BaseException | None = None
+    if url:
+        try:
+            response = safe_fetch(
+                url,
+                method="GET",
+                timeout=60,
+                max_bytes=MAX_AUDIO_FILE_SIZE,
+            )
+            response.raise_for_status()
+            validated = _valid_direct_audio(response)
+            if validated is not None:
+                return validated
+            headers = getattr(response, "headers", None) or {}
+            content_type = str(
+                headers.get("Content-Type") or headers.get("content-type") or ""
+            )
+            direct_error = RuntimeError(
+                f"Direct URL response is not valid audio (content_type={content_type!r}, "
+                f"bytes={len(getattr(response, 'content', b'') or b'')})"
+            )
+        except Exception as exc:
+            direct_error = exc
+
+    if not api_key:
+        _raise_authenticated_download_failed(
+            direct_error,
+            reason="Vapi API key unavailable and direct URL download failed",
+        )
     if not artifact:
         raise ValueError(f"Unknown artifact type {kind}")
-    _wait_for_api_slot(rate)
-    data = VapiRecordingService.download_artifact_sync(call_id, artifact, api_key)
-    if not data:
-        raise RuntimeError("Empty Vapi artifact")
-    return data, None
+    if not call_id:
+        raise ValueError("call_id is required for authenticated Vapi download")
+    _raise_authenticated_download_failed(
+        direct_error,
+        reason="Authenticated Vapi download prerequisites missing after direct URL failure",
+    )
+
+
+
+
 
 
 def _object_key_from_existing_url(base: str, url: str) -> str | None:
@@ -474,26 +534,44 @@ def _stored(
 
 
 def _update_pg(row: Any, kind: str, old: str, new: str) -> bool:
-    fields = []
-    field_name = TOP_FIELD.get(kind)
-    if field_name and getattr(row, field_name, None) == old:
-        setattr(row, field_name, new)
-        fields.append(field_name)
-    original = row.provider_call_data or {}
-    vapi = original.get("vapi")
-    if isinstance(vapi, dict):
-        vapi_copy = copy.deepcopy(vapi)
-        nested_changed = False
-        for path in PATHS[kind]:
-            nested_changed = _replace(vapi_copy, path, old, new) or nested_changed
-        if nested_changed:
-            payload = dict(original)
-            payload["vapi"] = vapi_copy
-            row.provider_call_data = payload
-            fields.append("provider_call_data")
-    if fields:
-        row.save(update_fields=list(dict.fromkeys(fields)))
-    return bool(fields)
+    """Rewrite recording URLs on a fresh locked row.
+
+    Re-reads under ``select_for_update`` so concurrent writers that deep-merge
+    ``provider_call_data`` (e.g. agent egress_id) are not clobbered by a stale
+    in-memory snapshot held across downloads.
+    """
+    from django.db import transaction
+
+    model = type(row)
+    with transaction.atomic():
+        locked = model.objects.select_for_update().get(pk=row.pk)
+        fields: list[str] = []
+        field_name = TOP_FIELD.get(kind)
+        if field_name and getattr(locked, field_name, None) == old:
+            setattr(locked, field_name, new)
+            fields.append(field_name)
+        original = locked.provider_call_data or {}
+        vapi = original.get("vapi")
+        if isinstance(vapi, dict):
+            vapi_copy = copy.deepcopy(vapi)
+            nested_changed = False
+            for path in PATHS[kind]:
+                nested_changed = _replace(vapi_copy, path, old, new) or nested_changed
+            if nested_changed:
+                payload = dict(original)
+                payload["vapi"] = vapi_copy
+                locked.provider_call_data = payload
+                fields.append("provider_call_data")
+        if not fields:
+            return False
+        locked.save(update_fields=list(dict.fromkeys(fields)))
+        # Keep the caller's in-memory row aligned for subsequent kinds.
+        if field_name and field_name in fields:
+            setattr(row, field_name, getattr(locked, field_name))
+        if "provider_call_data" in fields:
+            row.provider_call_data = locked.provider_call_data
+        return True
+
 
 
 def _pg_pending_q():
@@ -766,21 +844,21 @@ def _ch_shape(ch: Any) -> tuple[str, str | None, str, str, str]:
     shape = detect_spans_table_shape(ch.execute)
     if shape not in {"v1", "v2"}:
         raise RuntimeError(f"Unsupported spans shape {shape}")
-    active = "attrs_string" if shape == "v2" else "span_attr_str"
+    # v1 uses _peerdb_version counters. Stamping time.time_ns() would dominate
+    # later CDC and can resurrect soft-deleted rows. Prod is v2-only.
+    if shape == "v1":
+        raise RuntimeError(
+            "Vapi recording backfill requires spans v2 (_version); "
+            "refusing v1/_peerdb_version shape"
+        )
+    active = "attrs_string"
     columns = {
         row[0]: row[1]
         for row in ch.execute(
             "SELECT name,type FROM system.columns WHERE database=currentDatabase() AND table='spans'"
         )
     }
-    if shape == "v2":
-        extra, version_col, deleted_col = "attributes_extra", "_version", "is_deleted"
-    else:
-        extra, version_col, deleted_col = (
-            "span_attributes_raw",
-            "_peerdb_version",
-            "_peerdb_is_deleted",
-        )
+    extra, version_col, deleted_col = "attributes_extra", "_version", "is_deleted"
     if active not in columns:
         raise RuntimeError(f"spans missing active map column {active}")
     return (
@@ -790,6 +868,7 @@ def _ch_shape(ch: Any) -> tuple[str, str | None, str, str, str]:
         version_col,
         deleted_col,
     )
+
 
 
 def _ch_map_predicate(active: str) -> str:

--- a/futureagi/tfc/temporal/backfill/minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/minimal_backfill.py
@@ -17,6 +17,7 @@ import re
 import threading
 import time
 import urllib.parse
+import uuid
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
@@ -73,7 +74,9 @@ class VapiBackfillInput:
     ce_cursor_id: str | None = None
     snap_cursor_time: str | None = None
     snap_cursor_id: str | None = None
-    run_id: str = "vapi_recording_backfill"
+    run_id: str = field(
+        default_factory=lambda: f"vapi_recording_backfill_{uuid.uuid4().hex[:12]}"
+    )
     batch_seq: int = 0
     proof_gate: int | None = None
     min_records_per_second: float = 0.0
@@ -232,8 +235,6 @@ def _system_vapi_api_key() -> str | None:
     return os.getenv("VAPI_API_KEY") or None
 
 
-
-
 def _api_key(row: Any, project_id: str) -> str | None:
     """Match live simulation key selection, with system key as backup.
 
@@ -262,12 +263,6 @@ def _api_key(row: Any, project_id: str) -> str | None:
     if system_key:
         return system_key
     return VapiRecordingService.get_api_key_for_project(project_id)
-
-
-
-
-
-
 
 
 def _wait_for_api_slot(rate: int) -> None:
@@ -353,9 +348,6 @@ def _api_key_for_attributes(attrs: dict[str, str], project_id: str) -> str | Non
     if project_key:
         return project_key
     return _system_vapi_api_key()
-
-
-
 
 
 def _validate_storage_stat(stat: Any) -> None:
@@ -473,10 +465,6 @@ def _download(
     )
 
 
-
-
-
-
 def _object_key_from_existing_url(base: str, url: str) -> str | None:
     """Map a durable storage URL back to its object key without re-stat."""
     from simulate.temporal.utils.async_storage import (
@@ -532,7 +520,6 @@ def _stored(
     return url
 
 
-
 def _update_pg(row: Any, kind: str, old: str, new: str) -> bool:
     """Rewrite recording URLs on a fresh locked row.
 
@@ -571,7 +558,6 @@ def _update_pg(row: Any, kind: str, old: str, new: str) -> bool:
         if "provider_call_data" in fields:
             row.provider_call_data = locked.provider_call_data
         return True
-
 
 
 def _pg_pending_q():
@@ -756,8 +742,10 @@ def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult
                 row, project_id
             )
             for kind, old in artifacts.items():
+                activity.heartbeat(out.processed, out.changed, out.fatal)
                 if inp.dry_run:
                     out.changed += 1
+                    activity.heartbeat(out.processed, out.changed, out.fatal)
                     continue
                 try:
                     base = _rehost_object_key_base(call_id, kind, project_id, "vapi")
@@ -791,6 +779,7 @@ def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult
                     out.errors.append(
                         f"{type(row).__name__}:{row.pk}:{kind}: {type(exc).__name__}: {exc}"
                     )
+                activity.heartbeat(out.processed, out.changed, out.fatal)
             out.processed += 1
             activity.heartbeat(out.processed, out.changed, out.fatal)
         remaining = (
@@ -804,8 +793,8 @@ def vapi_simulation_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillResult
         close_old_connections()
 
 
-def _json_replace(raw: str, replacements: dict[str, str]) -> str:
-    """Exact URL replace inside String JSON.
+def _json_replace(raw: str, replacements: dict[str, str]) -> tuple[str, bool]:
+    """Replace exact URL values inside String JSON and report whether it changed.
 
     Raises if rewrite is required but the payload is not valid JSON, so we never
     write a half-broken attributes_extra (fail closed → original span kept).
@@ -818,16 +807,30 @@ def _json_replace(raw: str, replacements: dict[str, str]) -> str:
             "refusing to rewrite"
         ) from exc
 
-    def walk(item: Any) -> Any:
+    def walk(item: Any) -> tuple[Any, bool]:
         if isinstance(item, str):
-            return replacements.get(item, item)
+            replacement = replacements.get(item, item)
+            return replacement, replacement != item
         if isinstance(item, dict):
-            return {key: walk(val) for key, val in item.items()}
+            changed = False
+            rewritten = {}
+            for key, val in item.items():
+                rewritten_val, val_changed = walk(val)
+                rewritten[key] = rewritten_val
+                changed = val_changed or changed
+            return rewritten, changed
         if isinstance(item, list):
-            return [walk(val) for val in item]
-        return item
+            changed = False
+            rewritten = []
+            for val in item:
+                rewritten_val, val_changed = walk(val)
+                rewritten.append(rewritten_val)
+                changed = val_changed or changed
+            return rewritten, changed
+        return item, False
 
-    return json.dumps(walk(value), separators=(",", ":"), ensure_ascii=False)
+    rewritten, changed = walk(value)
+    return json.dumps(rewritten, separators=(",", ":"), ensure_ascii=False), changed
 
 
 def _mapping_table(run_id: str, shard: int) -> str:
@@ -870,7 +873,6 @@ def _ch_shape(ch: Any) -> tuple[str, str | None, str, str, str]:
     )
 
 
-
 def _ch_map_predicate(active: str) -> str:
     """Pending Vapi/R2 URLs in the active string Map only (cheap, no wide JSON)."""
     keys = [key for group in CH_KEYS.values() for key in group]
@@ -904,7 +906,9 @@ def _ch_scan_settings(*, max_memory_bytes: int | None = None) -> dict[str, Any]:
         os.getenv("BACKFILL_CH_MAX_MEMORY_BYTES", str(2 * 1024**3))
     )
     return {
-        "max_execution_time": int(os.getenv("BACKFILL_CH_MAX_EXECUTION_SECONDS", "120")),
+        "max_execution_time": int(
+            os.getenv("BACKFILL_CH_MAX_EXECUTION_SECONDS", "120")
+        ),
         "max_memory_usage": memory,
         "max_threads": int(os.getenv("BACKFILL_CH_MAX_THREADS", "2")),
         # Prefer external spill over abort when possible.
@@ -992,9 +996,7 @@ def _proof_light_select(
     ignored = set(light)
     others = [col for col in stored if col not in ignored]
     # Hash remaining wide columns server-side so Python never materializes them.
-    other_hash = (
-        f"cityHash64(tuple({', '.join(others)}))" if others else "toUInt64(0)"
-    )
+    other_hash = f"cityHash64(tuple({', '.join(others)}))" if others else "toUInt64(0)"
     return light, other_hash
 
 
@@ -1014,9 +1016,10 @@ def _proof_rows(
     light, other_hash = _proof_light_select(stored, active, extra, version_col)
     rows = ch.execute(
         f"SELECT {', '.join(light)}, {other_hash} AS other_hash "
-        f"FROM spans FINAL WHERE project_id=%(project)s AND id IN %(ids)s",
+        f"FROM spans FINAL "
+        f"PREWHERE project_id=%(project)s AND id IN %(ids)s",
         {"project": project_id, "ids": tuple(span_ids)},
-        settings={"max_execution_time": 120},
+        settings=_ch_scan_settings(),
     )
     # row layout: light... + other_hash
     return {str(row[0]): row for row in rows}
@@ -1143,8 +1146,11 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
     scan_settings = _ch_scan_settings()
 
     def _keyset(params: dict[str, Any]) -> str:
-        if inp.cursor_time and inp.cursor_trace_id and inp.cursor_id and (
-            phase == "map" or cursor_day is not None
+        if (
+            inp.cursor_time
+            and inp.cursor_trace_id
+            and inp.cursor_id
+            and (phase == "map" or cursor_day is not None)
         ):
             # Only apply keyset when staying inside the same phase/day.
             params.update(
@@ -1186,9 +1192,7 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
             )
 
     if phase == "extra" and extra and remaining > 0 and not rows:
-        days = _ch_project_days(
-            ch, project_id=inp.project_id, deleted_col=deleted_col
-        )
+        days = _ch_project_days(ch, project_id=inp.project_id, deleted_col=deleted_col)
         if cursor_day is not None:
             # Resume from current day inclusive, then older days.
             days = [day for day in days if day <= cursor_day]
@@ -1263,6 +1267,7 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
         replacements: dict[str, str] = {}
         patch_map: dict[str, str] = {}
         for kind, keys in CH_KEYS.items():
+            activity.heartbeat(out.processed, out.changed, out.fatal)
             old = next(
                 (attrs[key] for key in keys if _is_vapi_url(attrs.get(key))), None
             ) or extra_urls.get(kind)
@@ -1271,9 +1276,11 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
             if not call_id:
                 out.fatal += 1
                 out.errors.append(f"span:{span_id}:{kind}: missing Vapi call ID")
+                activity.heartbeat(out.processed, out.changed, out.fatal)
                 continue
             if inp.dry_run:
                 out.changed += 1
+                activity.heartbeat(out.processed, out.changed, out.fatal)
                 continue
             try:
                 base = _rehost_object_key_base(
@@ -1314,21 +1321,23 @@ def vapi_observability_backfill_batch(inp: VapiBackfillInput) -> VapiBackfillRes
                     raise
                 out.fatal += 1
                 out.errors.append(f"span:{span_id}:{kind}: {type(exc).__name__}: {exc}")
+            activity.heartbeat(out.processed, out.changed, out.fatal)
         if replacements and not inp.dry_run:
             raw_extra_text = raw_extra or "{}"
-            # attributes_extra is String JSON (migration 013). Rewrite only when
-            # an exact old URL appears in the text; otherwise keep s.extra.
-            extra_changed = any(old in raw_extra_text for old in replacements)
+            # attributes_extra is String JSON. Only rewrite exact URL values;
+            # URLs embedded in non-target strings remain unchanged.
+            rewritten_extra = ""
+            extra_changed = False
+            if any(old in raw_extra_text for old in replacements):
+                rewritten_extra, extra_changed = _json_replace(
+                    raw_extra_text, replacements
+                )
             mappings.append(
                 {
                     "batch_seq": inp.batch_seq,
                     "span_id": str(span_id),
                     "patch_map": patch_map,
-                    "extra": (
-                        _json_replace(raw_extra_text, replacements)
-                        if extra_changed
-                        else ""
-                    ),
+                    "extra": rewritten_extra if extra_changed else "",
                     "extra_changed": 1 if extra_changed else 0,
                     "version": max(time.time_ns(), int(version) + 1),
                 }
@@ -1502,7 +1511,8 @@ def reconcile_backfill_sample(inp: VapiBackfillInput) -> dict[str, Any]:
         report["projects"] = len(by_project)
         report["map_pending_total"] = sum(count for _, count in by_project)
         report["by_project"] = [
-            {"project_id": project, "map_pending": count} for project, count in by_project
+            {"project_id": project, "map_pending": count}
+            for project, count in by_project
         ]
         report["note"] = (
             "extra_pending requires --project-id (day-chunked). "

--- a/futureagi/tfc/temporal/backfill/start_backfill_worker.py
+++ b/futureagi/tfc/temporal/backfill/start_backfill_worker.py
@@ -1,0 +1,31 @@
+"""Dedicated, single-replica Temporal worker for the Vapi backfill queue."""
+
+import asyncio
+import os
+
+from temporalio.worker import UnsandboxedWorkflowRunner
+
+from tfc.temporal.common.worker import run_worker
+
+
+def main() -> None:
+    concurrency = int(os.getenv("BACKFILL_MAX_CONCURRENT_ACTIVITIES", "1"))
+    if concurrency != 1:
+        raise ValueError(
+            "BACKFILL_MAX_CONCURRENT_ACTIVITIES must be 1 so the process-wide Vapi rate limiter is global"
+        )
+    asyncio.run(
+        run_worker(
+            "backfill",
+            max_concurrent_activities=1,
+            max_concurrent_workflow_tasks=20,
+            # This temporary backfill keeps workflow and activity code in one module.
+            # The workflow itself uses only deterministic Temporal APIs, but sandbox
+            # validation would import Django/structlog through the activity side.
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
@@ -1,0 +1,474 @@
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from tfc.temporal.backfill.minimal_backfill import (
+    VapiMinimalBackfillWorkflow,
+    _artifacts,
+    _canonical_call_id,
+    _ch_call_id,
+    _ch_extra_predicate,
+    _ch_map_predicate,
+    _ch_predicate,
+    _ch_scan_settings,
+    _ch_shape,
+    _extra_artifacts,
+    _is_retryable,
+    _is_vapi_url,
+    _json_replace,
+    _mapping_table,
+    _row_artifacts,
+    _update_pg,
+    _validate_storage_stat,
+    _verify_proof_gate,
+    get_activities,
+    get_workflows,
+)
+
+
+def payload(url="https://storage.vapi.ai/call.wav"):
+    return {
+        "other": {"keep": True},
+        "vapi": {
+            "id": "call-1",
+            "artifact": {
+                "recording": {
+                    "mono": {
+                        "combinedUrl": url,
+                        "customerUrl": url + "?customer",
+                        "assistantUrl": url + "?assistant",
+                    },
+                    "stereoUrl": url + "?stereo",
+                }
+            },
+            "recording": {"combined": url},
+        },
+    }
+
+
+def test_extracts_all_four_artifacts_and_call_id():
+    call_id, found = _artifacts(payload())
+    assert call_id == "call-1"
+    assert set(found) == {"mono_combined", "mono_customer", "mono_assistant", "stereo"}
+
+
+def test_row_artifacts_includes_top_level_only_urls():
+    row = SimpleNamespace(
+        provider_call_data=None,
+        recording_url="https://storage.vapi.ai/only-top.wav",
+        stereo_recording_url=None,
+        service_provider_call_id="full-call-id-from-ce",
+        __class__=SimpleNamespace(__name__="CallExecution"),
+    )
+
+    # Patch class name check via real type-like object
+    class CallExecution:
+        pass
+
+    row = CallExecution()
+    row.provider_call_data = None
+    row.recording_url = "https://storage.vapi.ai/only-top.wav"
+    row.stereo_recording_url = None
+    row.service_provider_call_id = "full-call-id-from-ce"
+    call_id, found = _row_artifacts(row)
+    assert call_id == "full-call-id-from-ce"
+    assert found["mono_combined"].endswith("only-top.wav")
+
+
+def test_snapshot_never_uses_truncated_service_provider_call_id():
+    class CallExecution:
+        service_provider_call_id = "full-parent-call-id-abcdefghijklmnopqrstuvwxyz"
+
+    class CallExecutionSnapshot:
+        pass
+
+    snap = CallExecutionSnapshot()
+    snap.provider_call_data = {"vapi": {}}  # no nested id
+    snap.service_provider_call_id = "truncated-id"
+    snap.call_execution = CallExecution()
+    snap.recording_url = None
+    snap.stereo_recording_url = None
+    call_id = _canonical_call_id(snap, None)
+    assert call_id == "full-parent-call-id-abcdefghijklmnopqrstuvwxyz"
+    assert call_id != "truncated-id"
+
+
+def test_update_pg_replaces_all_exact_paths_and_preserves_unrelated_data():
+    old, new = (
+        "https://storage.vapi.ai/call.wav",
+        "https://fi-content.s3.amazonaws.com/call.mp3",
+    )
+    row = SimpleNamespace(
+        provider_call_data=payload(old), recording_url=old, stereo_recording_url=None
+    )
+    saved = []
+    row.save = lambda update_fields: saved.extend(update_fields)
+    assert _update_pg(row, "mono_combined", old, new)
+    assert row.recording_url == new
+    assert (
+        row.provider_call_data["vapi"]["artifact"]["recording"]["mono"]["combinedUrl"]
+        == new
+    )
+    assert row.provider_call_data["vapi"]["recording"]["combined"] == new
+    assert row.provider_call_data["other"] == {"keep": True}
+    assert set(saved) == {"recording_url", "provider_call_data"}
+
+
+def test_json_replace_only_changes_exact_urls():
+    old, new = "https://storage.vapi.ai/a.wav", "https://s3/a.wav"
+    value = _json_replace(
+        '{"nested":["https://storage.vapi.ai/a.wav","keep"]}', {old: new}
+    )
+    assert new in value and "keep" in value
+
+
+
+def test_json_replace_errors_on_invalid_json_when_rewrite_required():
+    import pytest
+    from tfc.temporal.backfill.minimal_backfill import _json_replace
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _json_replace('not-json https://storage.vapi.ai/x.wav', {
+            "https://storage.vapi.ai/x.wav": "https://s3.example/x.wav"
+        })
+
+def test_url_classification_and_registration_factories():
+    assert _is_vapi_url("https://storage.vapi.ai/a.wav")
+    assert not _is_vapi_url("https://example.com/a.wav")
+    assert len(get_workflows()) == 1
+    assert len(get_activities()) == 4
+
+
+def test_ch_call_id_prefers_vapi_normalizer_attribute():
+    assert _ch_call_id({"vapi.call_id": "call-from-vapi"}) == "call-from-vapi"
+    assert _ch_call_id({}, "call-from-extra") == "call-from-extra"
+
+
+def test_extracts_artifacts_from_attributes_extra():
+    call_id, found = _extra_artifacts(
+        '{"raw_log":{"id":"call-2","artifact":{"recording":{"mono":{"customerUrl":"https://storage.vapi.ai/customer.wav"}}}}}'
+    )
+    assert call_id == "call-2"
+    assert found == {"mono_customer": "https://storage.vapi.ai/customer.wav"}
+
+
+def test_destination_head_validation_rejects_empty_or_non_audio():
+    with pytest.raises(RuntimeError):
+        _validate_storage_stat(SimpleNamespace(size=0, content_type="audio/mpeg"))
+    with pytest.raises(RuntimeError):
+        _validate_storage_stat(SimpleNamespace(size=12, content_type="text/plain"))
+    _validate_storage_stat(SimpleNamespace(size=12, content_type="audio/wav"))
+
+
+def test_retry_classification_typed_vapi_errors():
+    from tracer.utils.vapi_recording import (
+        VapiArtifactNotReadyError,
+        VapiAuthError,
+        VapiRateLimitError,
+    )
+
+    assert _is_retryable(requests.Timeout())
+    assert _is_retryable(VapiRateLimitError("slow"))
+    assert _is_retryable(VapiArtifactNotReadyError("pending"))
+    assert not _is_retryable(VapiAuthError("nope"))
+    assert not _is_retryable(ValueError("bad source data"))
+    predicate = _ch_predicate("attrs_string", "attributes_extra")
+    assert "storage.vapi.ai" in predicate and "api.vapi.ai" in predicate
+    assert "position(attrs_string['recording_url'], 'vapi')" not in predicate
+    map_only = _ch_map_predicate("attrs_string")
+    assert "attributes_extra" not in map_only
+    assert "storage.vapi.ai" in map_only
+    extra_only = _ch_extra_predicate("attributes_extra")
+    assert "attrs_string" not in extra_only
+    assert "position(attributes_extra, 'storage.vapi.ai')" in extra_only
+    # Full predicate is map OR extra, never a bare cold full-table requirement.
+    assert map_only in predicate and "OR" in predicate
+    settings = _ch_scan_settings(max_memory_bytes=1024)
+    assert settings["max_memory_usage"] == 1024
+    assert settings["max_threads"] >= 1
+
+
+def test_mapping_table_is_shard_local():
+    assert _mapping_table("run1", 0) == "backfill_mapping_run1_0"
+    assert _mapping_table("run1", 3) == "backfill_mapping_run1_3"
+    assert _mapping_table("run1", 0) != _mapping_table("run1", 1)
+    with pytest.raises(ValueError):
+        _mapping_table("bad-id!", 0)
+
+
+@pytest.mark.asyncio
+async def test_workflow_signal_state_transitions():
+    flow = VapiMinimalBackfillWorkflow()
+    await flow.pause()
+    assert flow.paused
+    await flow.resume()
+    assert not flow.paused
+    await flow.cancel()
+    assert flow.cancelled
+    assert flow.status()["cancelled"] is True
+
+
+def test_proof_gate_detects_unrelated_column_change_and_missing_spans():
+    # light row: id, attrs_string, _version, attributes_extra, other_hash
+    stored = ["id", "attrs_string", "attributes_extra", "_version", "name", "input"]
+    mapping = {
+        "span_id": "s1",
+        "patch_map": {"recording_url": "s3"},
+        "extra": "{}",
+        "extra_changed": 0,
+        "version": 2,
+    }
+
+    class FakeCH:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def execute(self, query, params=None, settings=None):
+            if "system.mutations" in query:
+                return [(0,)]
+            if "system.merges" in query:
+                return [(0, 0)]
+            return self.rows
+
+    before = {
+        "s1": (
+            "s1",
+            {"recording_url": "old", "keep_me": "yes"},
+            1,
+            "{}",
+            111,  # other_hash
+        )
+    }
+    with pytest.raises(RuntimeError, match="unrelated wide columns"):
+        _verify_proof_gate(
+            ch=FakeCH(
+                [
+                    (
+                        "s1",
+                        {"recording_url": "s3", "keep_me": "yes"},
+                        2,
+                        "{}",
+                        999,  # hash changed => wide col clobber
+                    )
+                ]
+            ),
+            stored=stored,
+            active="attrs_string",
+            extra="attributes_extra",
+            project_id="p1",
+            before=before,
+            mappings=[mapping],
+        )
+    with pytest.raises(RuntimeError, match="lost spans"):
+        _verify_proof_gate(
+            ch=FakeCH([]),
+            stored=stored,
+            active="attrs_string",
+            extra="attributes_extra",
+            project_id="p1",
+            before=before,
+            mappings=[mapping],
+        )
+
+
+def test_proof_gate_accepts_mapupdate_patch_and_preserves_other_keys():
+    stored = ["id", "attrs_string", "attributes_extra", "_version", "name", "input"]
+    mapping = {
+        "span_id": "s1",
+        "patch_map": {"recording_url": "s3"},
+        "extra": '{"nested":"s3"}',
+        "extra_changed": 1,
+        "version": 2,
+    }
+
+    class FakeCH:
+        def execute(self, query, params=None, settings=None):
+            if "system.mutations" in query:
+                return [(0,)]
+            if "system.merges" in query:
+                return [(0, 0)]
+            # id, map, version, extra, other_hash
+            return [
+                (
+                    "s1",
+                    {"recording_url": "s3", "keep_me": "yes"},
+                    2,
+                    '{"nested":"s3"}',
+                    111,
+                )
+            ]
+
+    before = {
+        "s1": (
+            "s1",
+            {"recording_url": "old", "keep_me": "yes"},
+            1,
+            '{"nested":"old"}',
+            111,
+        )
+    }
+    _verify_proof_gate(
+        ch=FakeCH(),
+        stored=stored,
+        active="attrs_string",
+        extra="attributes_extra",
+        project_id="p1",
+        before=before,
+        mappings=[mapping],
+    )
+
+
+def test_proof_gate_detects_clobbered_unrelated_map_key():
+    stored = ["id", "attrs_string", "attributes_extra", "_version", "name", "input"]
+    mapping = {
+        "span_id": "s1",
+        "patch_map": {"recording_url": "s3"},
+        "extra": "",
+        "extra_changed": 0,
+        "version": 2,
+    }
+
+    class FakeCH:
+        def execute(self, query, params=None, settings=None):
+            if "system.mutations" in query:
+                return [(0,)]
+            if "system.merges" in query:
+                return [(0, 0)]
+            return [
+                (
+                    "s1",
+                    {"recording_url": "s3", "keep_me": "NOPE"},
+                    2,
+                    "{}",
+                    111,
+                )
+            ]
+
+    before = {
+        "s1": (
+            "s1",
+            {"recording_url": "old", "keep_me": "yes"},
+            1,
+            "{}",
+            111,
+        )
+    }
+    with pytest.raises(RuntimeError, match="clobbered unrelated key keep_me"):
+        _verify_proof_gate(
+            ch=FakeCH(),
+            stored=stored,
+            active="attrs_string",
+            extra="attributes_extra",
+            project_id="p1",
+            before=before,
+            mappings=[mapping],
+        )
+
+
+def test_proof_light_select_never_includes_wide_columns():
+    from tfc.temporal.backfill.minimal_backfill import _proof_light_select
+
+    light, hash_expr = _proof_light_select(
+        ["id", "attrs_string", "attributes_extra", "_version", "input", "output", "name"],
+        "attrs_string",
+        "attributes_extra",
+        "_version",
+    )
+    assert light == ["id", "attrs_string", "_version", "attributes_extra"]
+    assert "input" not in light and "output" not in light
+    assert "input" in hash_expr and "output" in hash_expr
+    assert "cityHash64" in hash_expr
+
+
+def test_dedicated_worker_rejects_multiple_activity_slots(monkeypatch):
+    from tfc.temporal.backfill.start_backfill_worker import main
+
+    monkeypatch.setenv("BACKFILL_MAX_CONCURRENT_ACTIVITIES", "2")
+    with pytest.raises(ValueError, match="must be 1"):
+        main()
+
+
+def test_clickhouse_shape_selects_v1_and_v2_columns(monkeypatch):
+    import tracer.services.clickhouse.schema as schema
+
+    class FakeCH:
+        def __init__(self, columns):
+            self.columns = columns
+
+        def execute(self, query, params=None, settings=None):
+            return list(self.columns.items())
+
+    monkeypatch.setattr(schema, "detect_spans_table_shape", lambda execute: "v1")
+    assert _ch_shape(
+        FakeCH({"span_attr_str": "Map(String,String)", "span_attributes_raw": "String"})
+    )[0:2] == ("span_attr_str", "span_attributes_raw")
+    monkeypatch.setattr(schema, "detect_spans_table_shape", lambda execute: "v2")
+    assert _ch_shape(
+        FakeCH({"attrs_string": "Map(String,String)", "attributes_extra": "String"})
+    )[0:2] == ("attrs_string", "attributes_extra")
+
+
+def test_reconcile_map_only_all_projects_and_day_chunked_extra(monkeypatch):
+    """Reconcile must never issue a project-wide attributes_extra cold scan."""
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    queries: list[str] = []
+
+    class FakeCH:
+        def execute(self, query, params=None, settings=None):
+            queries.append(query)
+            q = " ".join(query.split())
+            if "GROUP BY project_id" in q:
+                return [("p1", 10), ("p2", 5)]
+            if "toString(toDate(start_time))" in q or "GROUP BY day" in q:
+                return [("2026-07-01",), ("2026-06-30",)]
+            if "count()" in q and "toDate(start_time)" in q:
+                # day-chunked extra-only
+                return [(3 if params and params.get("day") == "2026-07-01" else 2,)]
+            if "count()" in q and "project_id=%(project)s" in q:
+                return [(7,)]
+            if "system.columns" in q:
+                return [
+                    ("attrs_string", "Map(String, String)"),
+                    ("attributes_extra", "String"),
+                    ("_version", "UInt64"),
+                    ("is_deleted", "UInt8"),
+                ]
+            return []
+
+    monkeypatch.setattr(
+        "tracer.services.clickhouse.client.get_clickhouse_client",
+        lambda: FakeCH(),
+    )
+    # Force shape without real CH.
+    monkeypatch.setattr(
+        mb,
+        "_ch_shape",
+        lambda ch: ("attrs_string", "attributes_extra", "Map(String, String)", "_version", "is_deleted"),
+    )
+
+    all_projects = mb.reconcile_backfill_sample(
+        mb.VapiBackfillInput(source="observability", project_id=None)
+    )
+    assert all_projects["mode"] == "map_only_all_projects"
+    assert all_projects["map_pending_total"] == 15
+    assert all_projects["projects"] == 2
+    # No query should scan attributes_extra without a day bound in all-project mode.
+    for q in queries:
+        if "attributes_extra" in q:
+            assert "toDate(start_time)" in q
+
+    queries.clear()
+    one = mb.reconcile_backfill_sample(
+        mb.VapiBackfillInput(
+            source="observability", project_id="11111111-1111-1111-1111-111111111111"
+        )
+    )
+    assert one["map_pending"] == 7
+    assert one["extra_pending"] == 5  # 3 + 2 day chunks
+    assert one["spans_pending"] == 12
+    # Extra counts must be day-scoped.
+    extra_queries = [q for q in queries if "attributes_extra" in q and "count()" in q]
+    assert extra_queries
+    assert all("toDate(start_time)" in q for q in extra_queries)

--- a/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
@@ -13,14 +13,17 @@ from tfc.temporal.backfill.minimal_backfill import (
     _ch_predicate,
     _ch_scan_settings,
     _ch_shape,
+    _download,
     _extra_artifacts,
     _is_retryable,
     _is_vapi_url,
     _json_replace,
     _mapping_table,
     _row_artifacts,
+    _stored,
     _update_pg,
     _validate_storage_stat,
+    _valid_direct_audio,
     _verify_proof_gate,
     get_activities,
     get_workflows,
@@ -472,3 +475,349 @@ def test_reconcile_map_only_all_projects_and_day_chunked_extra(monkeypatch):
     extra_queries = [q for q in queries if "attributes_extra" in q and "count()" in q]
     assert extra_queries
     assert all("toDate(start_time)" in q for q in extra_queries)
+
+
+def test_valid_direct_audio_uses_existing_detector(monkeypatch):
+    from simulate.temporal.utils import async_storage as storage_helpers
+
+    class HtmlResp:
+        content = b"<!doctype html><html>expired</html>"
+        headers = {"Content-Type": "text/html"}
+
+    class EmptyResp:
+        content = b""
+        headers = {"Content-Type": "audio/wav"}
+
+    class GoodResp:
+        content = b"fake-aac-or-wav-bytes-here"
+        headers = {"Content-Type": "audio/aac"}
+
+    assert _valid_direct_audio(HtmlResp()) is None
+    assert _valid_direct_audio(EmptyResp()) is None
+
+    # Detector accepts this body as a supported extension (aac/wav/etc.).
+    monkeypatch.setattr(
+        storage_helpers, "_detected_audio_extension", lambda content: "aac"
+    )
+    assert _valid_direct_audio(GoodResp()) == (GoodResp.content, "aac")
+
+    # Detector rejection (unsupported / non-audio) falls through.
+    monkeypatch.setattr(
+        storage_helpers,
+        "_detected_audio_extension",
+        lambda content: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    assert _valid_direct_audio(GoodResp()) is None
+
+
+def test_download_valid_direct_audio_never_resolves_api_key(monkeypatch):
+    import requests as requests_mod
+    from simulate.temporal.utils import async_storage as storage_helpers
+
+    class Resp:
+        content = b"ID3-or-aac-payload-bytes"
+        headers = {"Content-Type": "audio/mpeg"}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: Resp())
+    monkeypatch.setattr(
+        storage_helpers, "_detected_audio_extension", lambda content: "mp3"
+    )
+    called = {"n": 0}
+
+    def provider():
+        called["n"] += 1
+        raise AssertionError("api key must not be resolved on valid direct audio")
+
+    data, ext = _download(
+        "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+    )
+    assert data == b"ID3-or-aac-payload-bytes"
+    assert ext == "mp3"
+    assert called["n"] == 0
+
+
+def test_download_invalid_storage_vapi_html_uses_api_fallback(monkeypatch):
+    """storage.vapi.ai 200 HTML/error body must not count as audio."""
+    import requests as requests_mod
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    class HtmlResp:
+        content = b"<!doctype html><html>expired</html>"
+        headers = {"Content-Type": "text/html"}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: HtmlResp())
+    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "artifact_for_url_type",
+        staticmethod(lambda kind: "recording"),
+    )
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "download_artifact_sync",
+        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+    )
+    monkeypatch.setattr(
+        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+    )
+    called = {"n": 0}
+
+    def provider():
+        called["n"] += 1
+        return "secret-key"
+
+    data, ext = _download(
+        "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+    )
+    assert data == b"from-api"
+    assert ext is None
+    assert called["n"] == 1
+
+
+def test_download_empty_storage_vapi_body_uses_api_fallback(monkeypatch):
+    import requests as requests_mod
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    class EmptyResp:
+        content = b""
+        headers = {"Content-Type": "audio/wav"}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: EmptyResp())
+    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "artifact_for_url_type",
+        staticmethod(lambda kind: "recording"),
+    )
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "download_artifact_sync",
+        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+    )
+    monkeypatch.setattr(
+        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+    )
+    data, ext = _download(
+        "https://storage.vapi.ai/call.wav",
+        "call-1",
+        "mono_combined",
+        lambda: "secret",
+    )
+    assert data == b"from-api"
+    assert ext is None
+
+
+def test_download_private_r2_failure_uses_api_fallback_when_configured(monkeypatch):
+    """r2.dev is private; failed direct GET may use authenticated Vapi API only."""
+    import requests as requests_mod
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    def boom(*args, **kwargs):
+        err = requests_mod.HTTPError("forbidden")
+        err.response = SimpleNamespace(status_code=403)
+        raise err
+
+    monkeypatch.setattr(requests_mod, "get", boom)
+    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "artifact_for_url_type",
+        staticmethod(lambda kind: "recording"),
+    )
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "download_artifact_sync",
+        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+    )
+    monkeypatch.setattr(
+        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+    )
+    called = {"n": 0}
+
+    def provider():
+        called["n"] += 1
+        return "secret-key"
+
+    data, ext = _download(
+        "https://pub-abc.r2.dev/call.wav", "call-1", "mono_combined", provider
+    )
+    assert data == b"from-api"
+    assert ext is None
+    assert called["n"] == 1
+
+
+def test_download_cdn_failure_skips_key_when_rate_disabled(monkeypatch):
+    import requests as requests_mod
+
+    def boom(*args, **kwargs):
+        raise requests_mod.HTTPError("gone")
+
+    monkeypatch.setattr(requests_mod, "get", boom)
+    monkeypatch.delenv("VAPI_API_RATE_LIMIT_PER_SECOND", raising=False)
+    called = {"n": 0}
+
+    def provider():
+        called["n"] += 1
+        raise AssertionError("must not resolve key when rate limit unset")
+
+    with pytest.raises(RuntimeError, match="authenticated fallback is disabled"):
+        _download(
+            "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+        )
+    assert called["n"] == 0
+
+
+def test_download_cdn_failure_uses_api_fallback_when_configured(monkeypatch):
+    import requests as requests_mod
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    def boom(*args, **kwargs):
+        err = requests_mod.HTTPError("expired")
+        err.response = SimpleNamespace(status_code=403)
+        raise err
+
+    monkeypatch.setattr(requests_mod, "get", boom)
+    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "artifact_for_url_type",
+        staticmethod(lambda kind: "recording"),
+    )
+    monkeypatch.setattr(
+        VapiRecordingService,
+        "download_artifact_sync",
+        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+    )
+    monkeypatch.setattr(
+        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+    )
+    called = {"n": 0}
+
+    def provider():
+        called["n"] += 1
+        return "secret-key"
+
+    data, ext = _download(
+        "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+    )
+    assert data == b"from-api"
+    assert ext is None
+    assert called["n"] == 1
+
+
+def test_stored_resolves_existing_webm_without_restat(monkeypatch):
+    from simulate.temporal.utils import async_storage as storage_helpers
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    base = "call-recordings/p/vapi/call-1/mono_combined"
+    webm_url = "https://fi-content-dev.s3.amazonaws.com/" + base + ".webm"
+
+    monkeypatch.setattr(
+        storage_helpers,
+        "_existing_rehosted_audio",
+        lambda object_key_base: (webm_url, 12),
+    )
+    monkeypatch.setattr(
+        storage_helpers,
+        "_rehost_object_key_base",
+        lambda call_id, kind, project_id, provider: base,
+    )
+    monkeypatch.setattr(
+        storage_helpers,
+        "_rehost_object_key",
+        lambda object_key_base, extension: f"{object_key_base}.{extension}",
+    )
+
+    class Storage:
+        def stat_object(self, bucket, key):
+            # Final HEAD validation only — no extension probe loop.
+            assert key.endswith(".webm")
+            return SimpleNamespace(size=12, content_type="audio/webm")
+
+    monkeypatch.setattr(
+        "tfc.utils.storage_client.get_storage_client", lambda: Storage()
+    )
+    monkeypatch.setattr(
+        "tfc.settings.settings.UPLOAD_BUCKET_NAME", "fi-content-dev", raising=False
+    )
+    monkeypatch.setattr(
+        VapiRecordingService, "is_fagi_s3_url", staticmethod(lambda url: True)
+    )
+
+    url = _stored("p", "call-1", "mono_combined", "https://storage.vapi.ai/old.wav", None)
+    assert url == webm_url
+
+
+def test_stored_reuses_carried_audio_ext_without_redetection(monkeypatch):
+    from simulate.temporal.utils import async_storage as storage_helpers
+    from tracer.utils.vapi_recording import VapiRecordingService
+
+    base = "call-recordings/p/vapi/call-1/mono_combined"
+    detected = {"n": 0}
+
+    monkeypatch.setattr(
+        storage_helpers, "_existing_rehosted_audio", lambda object_key_base: None
+    )
+    monkeypatch.setattr(
+        storage_helpers,
+        "_rehost_object_key_base",
+        lambda call_id, kind, project_id, provider: base,
+    )
+    monkeypatch.setattr(
+        storage_helpers,
+        "_rehost_object_key",
+        lambda object_key_base, extension: f"{object_key_base}.{extension}",
+    )
+
+    def boom_detect(content):
+        detected["n"] += 1
+        raise AssertionError("must not re-detect when audio_ext is carried")
+
+    monkeypatch.setattr(storage_helpers, "_detected_audio_extension", boom_detect)
+    monkeypatch.setattr(
+        "tfc.utils.storage.upload_audio_to_s3",
+        lambda payload, object_key=None: f"https://fi-content-dev.s3.amazonaws.com/{object_key}",
+    )
+
+    class Storage:
+        def stat_object(self, bucket, key):
+            return SimpleNamespace(size=12, content_type="audio/aac")
+
+    monkeypatch.setattr(
+        "tfc.utils.storage_client.get_storage_client", lambda: Storage()
+    )
+    monkeypatch.setattr(
+        "tfc.settings.settings.UPLOAD_BUCKET_NAME", "fi-content-dev", raising=False
+    )
+    monkeypatch.setattr(
+        VapiRecordingService, "is_fagi_s3_url", staticmethod(lambda url: True)
+    )
+
+    url = _stored(
+        "p",
+        "call-1",
+        "mono_combined",
+        "https://storage.vapi.ai/old.wav",
+        b"aac-bytes",
+        audio_ext="aac",
+    )
+    assert url.endswith(".aac")
+    assert detected["n"] == 0
+
+
+def test_run_worker_rejects_backfill_multi_slot():
+    import asyncio
+
+    from tfc.temporal.common.worker import run_worker
+
+    with pytest.raises(ValueError, match="max_concurrent_activities=1"):
+        asyncio.run(run_worker("backfill", max_concurrent_activities=2, skip_otel_init=True))

--- a/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
@@ -97,16 +97,57 @@ def test_snapshot_never_uses_truncated_service_provider_call_id():
     assert call_id != "truncated-id"
 
 
-def test_update_pg_replaces_all_exact_paths_and_preserves_unrelated_data():
+def test_update_pg_replaces_all_exact_paths_and_preserves_unrelated_data(monkeypatch):
     old, new = (
         "https://storage.vapi.ai/call.wav",
         "https://fi-content.s3.amazonaws.com/call.mp3",
     )
-    row = SimpleNamespace(
-        provider_call_data=payload(old), recording_url=old, stereo_recording_url=None
+
+    class FakeQuerySet:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def select_for_update(self):
+            return self
+
+        def get(self, pk):
+            assert pk == self._obj.pk
+            return self._obj
+
+    class FakeManager:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def select_for_update(self):
+            return FakeQuerySet(self._obj)
+
+    class FakeRow:
+        objects = None
+
+        def __init__(self):
+            self.pk = 42
+            self.provider_call_data = payload(old)
+            self.recording_url = old
+            self.stereo_recording_url = None
+            self.saved = []
+
+        def save(self, update_fields=None):
+            self.saved.extend(update_fields or [])
+
+    row = FakeRow()
+    FakeRow.objects = FakeManager(row)
+
+    class _Atomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        "django.db.transaction.atomic",
+        lambda *a, **k: _Atomic(),
     )
-    saved = []
-    row.save = lambda update_fields: saved.extend(update_fields)
     assert _update_pg(row, "mono_combined", old, new)
     assert row.recording_url == new
     assert (
@@ -115,7 +156,8 @@ def test_update_pg_replaces_all_exact_paths_and_preserves_unrelated_data():
     )
     assert row.provider_call_data["vapi"]["recording"]["combined"] == new
     assert row.provider_call_data["other"] == {"keep": True}
-    assert set(saved) == {"recording_url", "provider_call_data"}
+    assert set(row.saved) == {"recording_url", "provider_call_data"}
+
 
 
 def test_json_replace_only_changes_exact_urls():
@@ -392,7 +434,7 @@ def test_dedicated_worker_rejects_multiple_activity_slots(monkeypatch):
         main()
 
 
-def test_clickhouse_shape_selects_v1_and_v2_columns(monkeypatch):
+def test_clickhouse_shape_requires_v2_and_refuses_v1(monkeypatch):
     import tracer.services.clickhouse.schema as schema
 
     class FakeCH:
@@ -403,13 +445,20 @@ def test_clickhouse_shape_selects_v1_and_v2_columns(monkeypatch):
             return list(self.columns.items())
 
     monkeypatch.setattr(schema, "detect_spans_table_shape", lambda execute: "v1")
-    assert _ch_shape(
-        FakeCH({"span_attr_str": "Map(String,String)", "span_attributes_raw": "String"})
-    )[0:2] == ("span_attr_str", "span_attributes_raw")
+    with pytest.raises(RuntimeError, match="requires spans v2"):
+        _ch_shape(
+            FakeCH(
+                {
+                    "span_attr_str": "Map(String,String)",
+                    "span_attributes_raw": "String",
+                }
+            )
+        )
     monkeypatch.setattr(schema, "detect_spans_table_shape", lambda execute: "v2")
     assert _ch_shape(
         FakeCH({"attrs_string": "Map(String,String)", "attributes_extra": "String"})
     )[0:2] == ("attrs_string", "attributes_extra")
+
 
 
 def test_reconcile_map_only_all_projects_and_day_chunked_extra(monkeypatch):
@@ -510,48 +559,14 @@ def test_valid_direct_audio_uses_existing_detector(monkeypatch):
     assert _valid_direct_audio(GoodResp()) is None
 
 
-def test_download_valid_direct_audio_never_resolves_api_key(monkeypatch):
-    import requests as requests_mod
-    from simulate.temporal.utils import async_storage as storage_helpers
-
-    class Resp:
-        content = b"ID3-or-aac-payload-bytes"
-        headers = {"Content-Type": "audio/mpeg"}
-
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: Resp())
-    monkeypatch.setattr(
-        storage_helpers, "_detected_audio_extension", lambda content: "mp3"
-    )
-    called = {"n": 0}
-
-    def provider():
-        called["n"] += 1
-        raise AssertionError("api key must not be resolved on valid direct audio")
-
-    data, ext = _download(
-        "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
-    )
-    assert data == b"ID3-or-aac-payload-bytes"
-    assert ext == "mp3"
-    assert called["n"] == 0
-
-
-def test_download_invalid_storage_vapi_html_uses_api_fallback(monkeypatch):
-    """storage.vapi.ai 200 HTML/error body must not count as audio."""
-    import requests as requests_mod
+def test_download_prefers_authenticated_api_when_key_present(monkeypatch):
+    """API-first: with key+call_id+artifact, never hit public CDN."""
     from tracer.utils.vapi_recording import VapiRecordingService
 
-    class HtmlResp:
-        content = b"<!doctype html><html>expired</html>"
-        headers = {"Content-Type": "text/html"}
+    def boom(*a, **k):
+        raise AssertionError("safe_fetch must not run when authenticated API works")
 
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: HtmlResp())
+    monkeypatch.setattr("tfc.utils.ssrf_guard.safe_fetch", boom)
     monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
     monkeypatch.setattr(
         VapiRecordingService,
@@ -580,19 +595,11 @@ def test_download_invalid_storage_vapi_html_uses_api_fallback(monkeypatch):
     assert called["n"] == 1
 
 
-def test_download_empty_storage_vapi_body_uses_api_fallback(monkeypatch):
-    import requests as requests_mod
+def test_download_api_works_without_rate_limit_env(monkeypatch):
+    """Rate limit env only throttles; it no longer gates API access."""
     from tracer.utils.vapi_recording import VapiRecordingService
 
-    class EmptyResp:
-        content = b""
-        headers = {"Content-Type": "audio/wav"}
-
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(requests_mod, "get", lambda *args, **kwargs: EmptyResp())
-    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    monkeypatch.delenv("VAPI_API_RATE_LIMIT_PER_SECOND", raising=False)
     monkeypatch.setattr(
         VapiRecordingService,
         "artifact_for_url_type",
@@ -603,115 +610,165 @@ def test_download_empty_storage_vapi_body_uses_api_fallback(monkeypatch):
         "download_artifact_sync",
         staticmethod(lambda call_id, artifact, api_key: b"from-api"),
     )
+    waited = {"n": 0}
     monkeypatch.setattr(
-        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot",
+        lambda rate: waited.__setitem__("n", waited["n"] + 1),
     )
     data, ext = _download(
-        "https://storage.vapi.ai/call.wav",
+        "https://storage.vapi.ai/dead.wav",
         "call-1",
         "mono_combined",
         lambda: "secret",
     )
     assert data == b"from-api"
     assert ext is None
+    assert waited["n"] == 0  # rate<=0 skips slot wait
 
 
-def test_download_private_r2_failure_uses_api_fallback_when_configured(monkeypatch):
-    """r2.dev is private; failed direct GET may use authenticated Vapi API only."""
-    import requests as requests_mod
-    from tracer.utils.vapi_recording import VapiRecordingService
+def test_download_falls_back_to_direct_url_when_no_api_key(monkeypatch):
+    from simulate.temporal.utils import async_storage as storage_helpers
+    from tfc.utils.ssrf_guard import SsrfResponse
 
-    def boom(*args, **kwargs):
-        err = requests_mod.HTTPError("forbidden")
-        err.response = SimpleNamespace(status_code=403)
-        raise err
-
-    monkeypatch.setattr(requests_mod, "get", boom)
-    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
     monkeypatch.setattr(
-        VapiRecordingService,
-        "artifact_for_url_type",
-        staticmethod(lambda kind: "recording"),
+        "tfc.utils.ssrf_guard.safe_fetch",
+        lambda *a, **k: SsrfResponse(
+            200,
+            {"Content-Type": "audio/mpeg"},
+            b"ID3-or-aac-payload-bytes",
+            "https://example.com/call.wav",
+        ),
     )
     monkeypatch.setattr(
-        VapiRecordingService,
-        "download_artifact_sync",
-        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+        storage_helpers, "_detected_audio_extension", lambda content: "mp3"
     )
-    monkeypatch.setattr(
-        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
-    )
-    called = {"n": 0}
-
-    def provider():
-        called["n"] += 1
-        return "secret-key"
-
     data, ext = _download(
-        "https://pub-abc.r2.dev/call.wav", "call-1", "mono_combined", provider
+        "https://example.com/call.wav", "call-1", "mono_combined", lambda: None
     )
-    assert data == b"from-api"
-    assert ext is None
-    assert called["n"] == 1
+    assert data == b"ID3-or-aac-payload-bytes"
+    assert ext == "mp3"
 
 
-def test_download_cdn_failure_skips_key_when_rate_disabled(monkeypatch):
-    import requests as requests_mod
+def test_download_fails_when_no_key_and_direct_url_dead(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("dns dead")
 
-    def boom(*args, **kwargs):
-        raise requests_mod.HTTPError("gone")
-
-    monkeypatch.setattr(requests_mod, "get", boom)
-    monkeypatch.delenv("VAPI_API_RATE_LIMIT_PER_SECOND", raising=False)
-    called = {"n": 0}
-
-    def provider():
-        called["n"] += 1
-        raise AssertionError("must not resolve key when rate limit unset")
-
-    with pytest.raises(RuntimeError, match="authenticated fallback is disabled"):
+    monkeypatch.setattr("tfc.utils.ssrf_guard.safe_fetch", boom)
+    with pytest.raises(RuntimeError, match="Vapi API key unavailable"):
         _download(
-            "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+            "https://storage.vapi.ai/call.wav",
+            "call-1",
+            "mono_combined",
+            lambda: None,
         )
-    assert called["n"] == 0
 
 
-def test_download_cdn_failure_uses_api_fallback_when_configured(monkeypatch):
-    import requests as requests_mod
-    from tracer.utils.vapi_recording import VapiRecordingService
+def test_api_key_inbound_uses_system_env_key(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
 
-    def boom(*args, **kwargs):
-        err = requests_mod.HTTPError("expired")
-        err.response = SimpleNamespace(status_code=403)
-        raise err
+    monkeypatch.setenv("VAPI_API_KEY", "system-fagi-key")
 
-    monkeypatch.setattr(requests_mod, "get", boom)
-    monkeypatch.setenv("VAPI_API_RATE_LIMIT_PER_SECOND", "5")
+    class TE:
+        agent_definition_id = None
+        run_test = None
+
+    class Call:
+        call_metadata = {"call_direction": "inbound"}
+        test_execution = TE()
+
+    class Row:
+        pass
+
+    row = Row()
+    monkeypatch.setattr(mb, "_call", lambda r: Call())
     monkeypatch.setattr(
-        VapiRecordingService,
-        "artifact_for_url_type",
-        staticmethod(lambda kind: "recording"),
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_project",
+        staticmethod(lambda pid: (_ for _ in ()).throw(AssertionError("project"))),
+    )
+    assert mb._api_key(row, "proj") == "system-fagi-key"
+
+
+
+def test_api_key_outbound_uses_agent_definition(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    monkeypatch.setenv("VAPI_API_KEY", "system-fagi-key")
+
+    class TE:
+        agent_definition_id = "agent-1"
+        run_test = None
+
+    class Call:
+        call_metadata = {"call_direction": "outbound"}
+        test_execution = TE()
+
+    class Row:
+        pass
+
+    row = Row()
+    monkeypatch.setattr(mb, "_call", lambda r: Call())
+    monkeypatch.setattr(
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_agent_definition",
+        staticmethod(lambda aid: f"agent-key-{aid}"),
+    )
+    assert mb._api_key(row, "proj") == "agent-key-agent-1"
+
+
+def test_api_key_outbound_falls_back_to_system_when_agent_missing(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    monkeypatch.setenv("VAPI_API_KEY", "system-fagi-key")
+
+    class TE:
+        agent_definition_id = "agent-1"
+        run_test = None
+
+    class Call:
+        call_metadata = {"call_direction": "outbound"}
+        test_execution = TE()
+
+    class Row:
+        pass
+
+    row = Row()
+    monkeypatch.setattr(mb, "_call", lambda r: Call())
+    monkeypatch.setattr(
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_agent_definition",
+        staticmethod(lambda aid: None),
     )
     monkeypatch.setattr(
-        VapiRecordingService,
-        "download_artifact_sync",
-        staticmethod(lambda call_id, artifact, api_key: b"from-api"),
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_project",
+        staticmethod(lambda pid: None),
     )
+    assert mb._api_key(row, "proj") == "system-fagi-key"
+
+
+def test_api_key_for_attributes_uses_project_customer_key(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    monkeypatch.delenv("VAPI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tfc.temporal.backfill.minimal_backfill._wait_for_api_slot", lambda rate: None
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_project",
+        staticmethod(lambda pid: f"proj-key-{pid}"),
     )
-    called = {"n": 0}
+    assert mb._api_key_for_attributes({}, "p1") == "proj-key-p1"
 
-    def provider():
-        called["n"] += 1
-        return "secret-key"
 
-    data, ext = _download(
-        "https://storage.vapi.ai/call.wav", "call-1", "mono_combined", provider
+def test_api_key_for_attributes_falls_back_to_system(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    monkeypatch.setenv("VAPI_API_KEY", "system-fagi-key")
+    monkeypatch.setattr(
+        "tracer.utils.vapi_recording.VapiRecordingService.get_api_key_for_project",
+        staticmethod(lambda pid: None),
     )
-    assert data == b"from-api"
-    assert ext is None
-    assert called["n"] == 1
+    assert mb._api_key_for_attributes({}, "p1") == "system-fagi-key"
+
+
+
+
+
+
 
 
 def test_stored_resolves_existing_webm_without_restat(monkeypatch):
@@ -821,3 +878,106 @@ def test_run_worker_rejects_backfill_multi_slot():
 
     with pytest.raises(ValueError, match="max_concurrent_activities=1"):
         asyncio.run(run_worker("backfill", max_concurrent_activities=2, skip_otel_init=True))
+
+
+def test_simulation_activity_skips_bad_artifact_and_continues(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    class Row:
+        pk = "row-1"
+        provider_call_data = {
+            "vapi": {
+                "id": "call-1",
+                "artifact": {
+                    "recording": {
+                        "mono": {
+                            "combinedUrl": "https://storage.vapi.ai/a.wav",
+                            "customerUrl": "https://storage.vapi.ai/b.wav",
+                        }
+                    }
+                },
+            }
+        }
+        recording_url = None
+        stereo_recording_url = None
+        service_provider_call_id = "call-1"
+
+    row = Row()
+
+    monkeypatch.setattr("django.db.close_old_connections", lambda: None)
+    monkeypatch.setattr(
+        mb,
+        "_pg_rows",
+        lambda inp: (
+            [row],
+            {
+                "ce_cursor_time": None,
+                "ce_cursor_id": None,
+                "snap_cursor_time": None,
+                "snap_cursor_id": None,
+            },
+        ),
+    )
+    monkeypatch.setattr(mb, "_project_id", lambda r: "proj-1")
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._existing_rehosted_audio",
+        lambda base: None,
+    )
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._rehost_object_key_base",
+        lambda *a, **k: "base",
+    )
+
+    def fake_download(url, call_id, kind, api_key_provider=None):
+        if kind == "mono_combined":
+            raise RuntimeError("bad-audio")
+        return b"ok-bytes", "wav"
+
+    monkeypatch.setattr(mb, "_download", fake_download)
+    monkeypatch.setattr(
+        mb,
+        "_stored",
+        lambda project_id, call_id, kind, original, audio, audio_ext=None: (
+            f"https://fi-content.s3.amazonaws.com/{kind}.wav"
+        ),
+    )
+    updated = []
+
+    def fake_update(row_obj, kind, old, new):
+        updated.append(kind)
+        return True
+
+    monkeypatch.setattr(mb, "_update_pg", fake_update)
+    # activity.heartbeat is no-op outside worker
+    monkeypatch.setattr(mb.activity, "heartbeat", lambda *a, **k: None)
+
+    out = mb.vapi_simulation_backfill_batch(
+        mb.VapiBackfillInput(source="simulation", batch_size=10, limit=10)
+    )
+    assert out.processed == 1
+    assert out.fatal == 1
+    assert out.changed == 1
+    assert updated == ["mono_customer"]
+    assert any("bad-audio" in e for e in out.errors)
+
+
+def test_get_all_queues_excludes_backfill(monkeypatch):
+    from tfc.temporal.common import registry as reg
+
+    monkeypatch.setattr(reg, "_ensure_workflows_registered", lambda: None)
+    monkeypatch.setattr(reg, "_ensure_activities_registered", lambda: None)
+    monkeypatch.setattr(
+        reg,
+        "_workflow_registry",
+        {"default": [object], "backfill": [object]},
+    )
+    monkeypatch.setattr(
+        reg,
+        "_activity_registry",
+        {"tasks_s": [object], "backfill": [object]},
+    )
+    queues = reg.get_all_queues()
+    assert "backfill" not in queues
+    assert "default" in queues
+    assert "tasks_s" in queues
+

--- a/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
+++ b/futureagi/tfc/temporal/backfill/test_minimal_backfill.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from tfc.temporal.backfill.minimal_backfill import (
+    VapiBackfillInput,
     VapiMinimalBackfillWorkflow,
     _artifacts,
     _canonical_call_id,
@@ -19,11 +20,12 @@ from tfc.temporal.backfill.minimal_backfill import (
     _is_vapi_url,
     _json_replace,
     _mapping_table,
+    _proof_rows,
     _row_artifacts,
     _stored,
     _update_pg,
-    _validate_storage_stat,
     _valid_direct_audio,
+    _validate_storage_stat,
     _verify_proof_gate,
     get_activities,
     get_workflows,
@@ -159,24 +161,39 @@ def test_update_pg_replaces_all_exact_paths_and_preserves_unrelated_data(monkeyp
     assert set(row.saved) == {"recording_url", "provider_call_data"}
 
 
-
 def test_json_replace_only_changes_exact_urls():
     old, new = "https://storage.vapi.ai/a.wav", "https://s3/a.wav"
-    value = _json_replace(
+    value, changed = _json_replace(
         '{"nested":["https://storage.vapi.ai/a.wav","keep"]}', {old: new}
     )
+    assert changed
     assert new in value and "keep" in value
 
 
+def test_json_replace_ignores_embedded_non_exact_urls():
+    old, new = "https://storage.vapi.ai/a.wav", "https://s3/a.wav"
+    raw = '{"raw_log":"prefix https://storage.vapi.ai/a.wav suffix"}'
+    value, changed = _json_replace(raw, {old: new})
+    assert not changed
+    assert old in value
+    assert new not in value
+
 
 def test_json_replace_errors_on_invalid_json_when_rewrite_required():
-    import pytest
-    from tfc.temporal.backfill.minimal_backfill import _json_replace
-
     with pytest.raises(ValueError, match="not valid JSON"):
-        _json_replace('not-json https://storage.vapi.ai/x.wav', {
-            "https://storage.vapi.ai/x.wav": "https://s3.example/x.wav"
-        })
+        _json_replace(
+            "not-json https://storage.vapi.ai/x.wav",
+            {"https://storage.vapi.ai/x.wav": "https://s3.example/x.wav"},
+        )
+
+
+def test_run_id_default_is_unique_per_input():
+    first = VapiBackfillInput()
+    second = VapiBackfillInput()
+    assert first.run_id != second.run_id
+    assert first.run_id.startswith("vapi_recording_backfill_")
+    assert second.run_id.startswith("vapi_recording_backfill_")
+
 
 def test_url_classification_and_registration_factories():
     assert _is_vapi_url("https://storage.vapi.ai/a.wav")
@@ -415,7 +432,15 @@ def test_proof_light_select_never_includes_wide_columns():
     from tfc.temporal.backfill.minimal_backfill import _proof_light_select
 
     light, hash_expr = _proof_light_select(
-        ["id", "attrs_string", "attributes_extra", "_version", "input", "output", "name"],
+        [
+            "id",
+            "attrs_string",
+            "attributes_extra",
+            "_version",
+            "input",
+            "output",
+            "name",
+        ],
         "attrs_string",
         "attributes_extra",
         "_version",
@@ -460,7 +485,6 @@ def test_clickhouse_shape_requires_v2_and_refuses_v1(monkeypatch):
     )[0:2] == ("attrs_string", "attributes_extra")
 
 
-
 def test_reconcile_map_only_all_projects_and_day_chunked_extra(monkeypatch):
     """Reconcile must never issue a project-wide attributes_extra cold scan."""
     from tfc.temporal.backfill import minimal_backfill as mb
@@ -497,7 +521,13 @@ def test_reconcile_map_only_all_projects_and_day_chunked_extra(monkeypatch):
     monkeypatch.setattr(
         mb,
         "_ch_shape",
-        lambda ch: ("attrs_string", "attributes_extra", "Map(String, String)", "_version", "is_deleted"),
+        lambda ch: (
+            "attrs_string",
+            "attributes_extra",
+            "Map(String, String)",
+            "_version",
+            "is_deleted",
+        ),
     )
 
     all_projects = mb.reconcile_backfill_sample(
@@ -688,7 +718,6 @@ def test_api_key_inbound_uses_system_env_key(monkeypatch):
     assert mb._api_key(row, "proj") == "system-fagi-key"
 
 
-
 def test_api_key_outbound_uses_agent_definition(monkeypatch):
     from tfc.temporal.backfill import minimal_backfill as mb
 
@@ -765,12 +794,6 @@ def test_api_key_for_attributes_falls_back_to_system(monkeypatch):
     assert mb._api_key_for_attributes({}, "p1") == "system-fagi-key"
 
 
-
-
-
-
-
-
 def test_stored_resolves_existing_webm_without_restat(monkeypatch):
     from simulate.temporal.utils import async_storage as storage_helpers
     from tracer.utils.vapi_recording import VapiRecordingService
@@ -810,7 +833,9 @@ def test_stored_resolves_existing_webm_without_restat(monkeypatch):
         VapiRecordingService, "is_fagi_s3_url", staticmethod(lambda url: True)
     )
 
-    url = _stored("p", "call-1", "mono_combined", "https://storage.vapi.ai/old.wav", None)
+    url = _stored(
+        "p", "call-1", "mono_combined", "https://storage.vapi.ai/old.wav", None
+    )
     assert url == webm_url
 
 
@@ -877,7 +902,9 @@ def test_run_worker_rejects_backfill_multi_slot():
     from tfc.temporal.common.worker import run_worker
 
     with pytest.raises(ValueError, match="max_concurrent_activities=1"):
-        asyncio.run(run_worker("backfill", max_concurrent_activities=2, skip_otel_init=True))
+        asyncio.run(
+            run_worker("backfill", max_concurrent_activities=2, skip_otel_init=True)
+        )
 
 
 def test_simulation_activity_skips_bad_artifact_and_continues(monkeypatch):
@@ -981,3 +1008,236 @@ def test_get_all_queues_excludes_backfill(monkeypatch):
     assert "default" in queues
     assert "tasks_s" in queues
 
+
+def test_simulation_activity_heartbeats_per_artifact(monkeypatch):
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    class Row:
+        pk = "row-1"
+        provider_call_data = {
+            "vapi": {
+                "id": "call-1",
+                "artifact": {
+                    "recording": {
+                        "mono": {
+                            "combinedUrl": "https://storage.vapi.ai/a.wav",
+                            "customerUrl": "https://storage.vapi.ai/b.wav",
+                        }
+                    }
+                },
+            }
+        }
+        recording_url = None
+        stereo_recording_url = None
+        service_provider_call_id = "call-1"
+
+    row = Row()
+    events: list[tuple[str, object]] = []
+
+    monkeypatch.setattr("django.db.close_old_connections", lambda: None)
+    monkeypatch.setattr(
+        mb,
+        "_pg_rows",
+        lambda inp: (
+            [row],
+            {
+                "ce_cursor_time": None,
+                "ce_cursor_id": None,
+                "snap_cursor_time": None,
+                "snap_cursor_id": None,
+            },
+        ),
+    )
+    monkeypatch.setattr(mb, "_project_id", lambda r: "proj-1")
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._existing_rehosted_audio",
+        lambda base: None,
+    )
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._rehost_object_key_base",
+        lambda *a, **k: "base",
+    )
+
+    def download(url, call_id, kind, api_key_provider=None):
+        events.append(("download", kind))
+        return b"ok", "wav"
+
+    def stored(project_id, call_id, kind, original, audio, audio_ext=None):
+        events.append(("stored", kind))
+        return f"https://fi-content.s3.amazonaws.com/{kind}.wav"
+
+    monkeypatch.setattr(mb, "_download", download)
+    monkeypatch.setattr(mb, "_stored", stored)
+    monkeypatch.setattr(mb, "_update_pg", lambda *a, **k: True)
+    monkeypatch.setattr(
+        mb.activity,
+        "heartbeat",
+        lambda *args, **kwargs: events.append(("heartbeat", args)),
+    )
+
+    out = mb.vapi_simulation_backfill_batch(
+        mb.VapiBackfillInput(source="simulation", batch_size=10, limit=10)
+    )
+    assert out.processed == 1
+    assert out.changed == 2
+    assert [event for event, _ in events] == [
+        "heartbeat",
+        "download",
+        "stored",
+        "heartbeat",
+        "heartbeat",
+        "download",
+        "stored",
+        "heartbeat",
+        "heartbeat",
+    ]
+    assert [value for event, value in events if event == "download"] == [
+        "mono_combined",
+        "mono_customer",
+    ]
+    assert [value for event, value in events if event == "stored"] == [
+        "mono_combined",
+        "mono_customer",
+    ]
+
+
+def test_proof_rows_uses_prewhere_and_scan_settings(monkeypatch):
+    captured = {}
+
+    class FakeCH:
+        def execute(self, query, params=None, settings=None):
+            captured["query"] = query
+            captured["params"] = params
+            captured["settings"] = settings
+            return [("s1", {"recording_url": "old"}, 1, "{}", 111)]
+
+    monkeypatch.setattr(
+        "tfc.temporal.backfill.minimal_backfill._ch_scan_settings",
+        lambda: {"max_memory_usage": 123, "max_threads": 1, "max_execution_time": 30},
+    )
+    rows = _proof_rows(
+        FakeCH(),
+        stored=["id", "attrs_string", "attributes_extra", "_version", "name"],
+        active="attrs_string",
+        extra="attributes_extra",
+        version_col="_version",
+        project_id="p1",
+        span_ids=["s1"],
+    )
+    assert "s1" in rows
+    assert "PREWHERE project_id=%(project)s AND id IN %(ids)s" in captured["query"]
+    assert captured["settings"]["max_memory_usage"] == 123
+    assert captured["params"]["project"] == "p1"
+
+
+def test_observability_activity_builds_mapping_and_mutation(monkeypatch):
+    from datetime import datetime, timezone
+
+    from tfc.temporal.backfill import minimal_backfill as mb
+
+    old = "https://storage.vapi.ai/call.wav"
+    new = "https://fi-content.s3.amazonaws.com/mono_combined.wav"
+    start = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    queries = []
+    inserts = []
+
+    class FakeCH:
+        def execute(self, query, params=None, settings=None):
+            queries.append((query, params, settings))
+            if query.startswith("SELECT id,project_id,trace_id"):
+                return [
+                    (
+                        "span-1",
+                        "proj-1",
+                        "trace-1",
+                        start,
+                        7,
+                        {"recording_url": old, "keep_me": "yes"},
+                        '{"recording_url":"%s","note":"keep"}' % old,
+                    )
+                ]
+            if "system.columns" in query and "default_kind" in query:
+                return [
+                    ("id",),
+                    ("project_id",),
+                    ("attrs_string",),
+                    ("attributes_extra",),
+                    ("_version",),
+                    ("name",),
+                ]
+            return []
+
+        def insert(self, table, rows, columns):
+            inserts.append((table, rows, columns))
+
+    monkeypatch.setattr(
+        "tracer.services.clickhouse.client.get_clickhouse_client", lambda: FakeCH()
+    )
+    monkeypatch.setattr(
+        mb,
+        "_ch_shape",
+        lambda ch: (
+            "attrs_string",
+            "attributes_extra",
+            "Map(String, String)",
+            "_version",
+            "is_deleted",
+        ),
+    )
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._existing_rehosted_audio",
+        lambda base: None,
+    )
+    monkeypatch.setattr(
+        "simulate.temporal.utils.async_storage._rehost_object_key_base",
+        lambda *a, **k: "base",
+    )
+    monkeypatch.setattr(
+        mb,
+        "_download",
+        lambda url, call_id, kind, api_key_provider=None: (b"ok", "wav"),
+    )
+    monkeypatch.setattr(
+        mb,
+        "_stored",
+        lambda project_id, call_id, kind, original, audio, audio_ext=None: (
+            new
+            if kind == "mono_combined"
+            else f"https://fi-content.s3.amazonaws.com/{kind}.wav"
+        ),
+    )
+    monkeypatch.setattr(mb, "_ch_call_id", lambda attrs, extra_call_id=None: "call-1")
+    monkeypatch.setattr(mb.activity, "heartbeat", lambda *a, **k: None)
+
+    out = mb.vapi_observability_backfill_batch(
+        mb.VapiBackfillInput(
+            source="observability",
+            project_id="proj-1",
+            batch_size=10,
+            limit=10,
+            run_id="obs_run_1",
+            batch_seq=3,
+        )
+    )
+
+    assert out.processed == 1
+    assert out.changed == 1
+    assert out.done is False
+    assert out.ch_scan_phase == "extra"
+    assert inserts
+    table, rows, columns = inserts[0]
+    assert table == "backfill_mapping_obs_run_1_0"
+    assert columns == [
+        "batch_seq",
+        "span_id",
+        "patch_map",
+        "extra",
+        "extra_changed",
+        "version",
+    ]
+    assert rows[0]["span_id"] == "span-1"
+    assert rows[0]["patch_map"]["recording_url"] == new
+    assert rows[0]["extra_changed"] == 1
+    assert new in rows[0]["extra"]
+    assert any("INSERT INTO spans" in q for q, _, _ in queries)
+    assert any("mapUpdate(s.attrs_string, m.patch_map)" in q for q, _, _ in queries)

--- a/futureagi/tfc/temporal/common/client.py
+++ b/futureagi/tfc/temporal/common/client.py
@@ -284,6 +284,18 @@ def signal_workflow_sync(workflow_id: str, signal: str, *args) -> bool:
     )
 
 
+async def query_workflow_async(workflow_id: str, query: str) -> Any:
+    """Query a running workflow."""
+    client = await get_client()
+    handle = client.get_workflow_handle(workflow_id)
+    return await handle.query(query)
+
+
+def query_workflow_sync(workflow_id: str, query: str) -> Any:
+    """Query a running workflow synchronously with OTel context propagation."""
+    return _run_async_in_sync_context(lambda: query_workflow_async(workflow_id, query))
+
+
 async def get_workflow_result_async(workflow_id: str, timeout: float = 3600) -> Any:
     """
     Wait for a workflow to complete and return its result.
@@ -343,6 +355,10 @@ __all__ = [
     "get_workflow_status_sync",
     "cancel_workflow_async",
     "cancel_workflow_sync",
+    "signal_workflow_async",
+    "signal_workflow_sync",
+    "query_workflow_async",
+    "query_workflow_sync",
     "get_workflow_result_async",
     "get_workflow_result_sync",
 ]

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -150,6 +150,22 @@ def _ensure_workflows_registered() -> None:
             "could_not_load_experiment_workflows", error=str(e)
         )
 
+    # Historical Vapi recording backfill (dedicated queue)
+    try:
+        from tfc.temporal.backfill.minimal_backfill import (
+            get_workflows as get_vapi_backfill_workflows,
+        )
+
+        register_for_queues(
+            queues=["backfill"], workflows=get_vapi_backfill_workflows()
+        )
+    except ImportError as e:
+        from tfc.logging.temporal import get_logger
+
+        get_logger(__name__).warning(
+            "could_not_load_vapi_backfill_workflows", error=str(e)
+        )
+
     # Agent prompt optimiser workflows (tasks_xl)
     try:
         from tfc.temporal.agent_prompt_optimiser import (
@@ -520,6 +536,19 @@ def _ensure_activities_registered() -> None:
         log.info("registered_agent_playground_activities")
     except ImportError as e:
         log.warning("could_not_load_agent_playground_activities", error=str(e))
+
+    # Historical Vapi recording backfill (dedicated queue)
+    try:
+        from tfc.temporal.backfill.minimal_backfill import (
+            get_activities as get_vapi_backfill_activities,
+        )
+
+        register_for_queues(
+            queues=["backfill"], activities=get_vapi_backfill_activities()
+        )
+        log.info("registered_vapi_backfill_activities")
+    except ImportError as e:
+        log.warning("could_not_load_vapi_backfill_activities", error=str(e))
 
     # Register simulate activities for tasks_xl, tasks_l, and tasks_s queues
     # (tasks_s needed for scheduled cleanup workflows)

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -854,7 +854,12 @@ def get_activities_for_queue(queue: str) -> list[Callable]:
 
 
 def get_all_queues() -> list[str]:
-    """Get all queues that have registered workflows or activities."""
+    """Get all queues that have registered workflows or activities.
+
+    Includes ``backfill``. Callers that poll multiple queues MUST force the
+    backfill worker to ``max_concurrent_activities=1`` (process-wide Vapi rate
+    limiter) while leaving other queues at their requested concurrency.
+    """
     _ensure_workflows_registered()
     _ensure_activities_registered()
     return list(set(list(_workflow_registry.keys()) + list(_activity_registry.keys())))

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -854,15 +854,19 @@ def get_activities_for_queue(queue: str) -> list[Callable]:
 
 
 def get_all_queues() -> list[str]:
-    """Get all queues that have registered workflows or activities.
+    """Get product queues that have registered workflows or activities.
 
-    Includes ``backfill``. Callers that poll multiple queues MUST force the
-    backfill worker to ``max_concurrent_activities=1`` (process-wide Vapi rate
-    limiter) while leaving other queues at their requested concurrency.
+    Excludes ``backfill``: that queue is opt-in via
+    ``start_vapi_backfill_worker`` / ``start_backfill_worker`` only. Multi-queue
+    workers must not poll it (sync activities need a dedicated executor, and the
+    Vapi rate limiter is process-local).
     """
     _ensure_workflows_registered()
     _ensure_activities_registered()
-    return list(set(list(_workflow_registry.keys()) + list(_activity_registry.keys())))
+    queues = set(list(_workflow_registry.keys()) + list(_activity_registry.keys()))
+    queues.discard("backfill")
+    return list(queues)
+
 
 
 def get_all_workflows() -> list[type]:

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -343,6 +343,7 @@ def _ensure_workflows_registered() -> None:
         from ee.voice.temporal.workflows.phone_number_dispatcher_workflow import (
             PhoneNumberDispatcherWorkflow,
         )
+
         from simulate.temporal.workflows.rerun_coordinator_workflow import (
             RerunCoordinatorWorkflow,
         )
@@ -866,7 +867,6 @@ def get_all_queues() -> list[str]:
     queues = set(list(_workflow_registry.keys()) + list(_activity_registry.keys()))
     queues.discard("backfill")
     return list(queues)
-
 
 
 def get_all_workflows() -> list[type]:

--- a/futureagi/tfc/temporal/common/worker.py
+++ b/futureagi/tfc/temporal/common/worker.py
@@ -9,7 +9,7 @@ import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from temporalio.worker import ResourceBasedSlotConfig, Worker, WorkerTuner
 
@@ -34,6 +34,7 @@ async def run_worker(
     target_memory_usage: Optional[float] = None,
     target_cpu_usage: Optional[float] = None,
     skip_otel_init: bool = False,
+    workflow_runner: Any | None = None,
 ) -> None:
     """
     Run a Temporal worker for the specified task queue.
@@ -162,6 +163,8 @@ async def run_worker(
         "max_heartbeat_throttle_interval": timedelta(seconds=5),
         "interceptors": [SentryInterceptor()],
     }
+    if workflow_runner is not None:
+        worker_kwargs["workflow_runner"] = workflow_runner
 
     if graceful_shutdown_timeout:
         worker_kwargs["graceful_shutdown_timeout"] = graceful_shutdown_timeout

--- a/futureagi/tfc/temporal/common/worker.py
+++ b/futureagi/tfc/temporal/common/worker.py
@@ -51,6 +51,11 @@ async def run_worker(
             Only used when target_memory_usage is set. Default: 1.0 (no CPU limit).
         skip_otel_init: Skip OTel initialization (caller already did it).
     """
+    if task_queue == "backfill" and max_concurrent_activities != 1:
+        raise ValueError(
+            "backfill queue requires max_concurrent_activities=1 "
+            "(process-wide Vapi rate limiter)"
+        )
     # Initialize OpenTelemetry FIRST (before any other imports)
     # This ensures all activities, DB queries, Redis, and HTTP calls are traced
     if not skip_otel_init:

--- a/futureagi/tracer/utils/vapi_recording.py
+++ b/futureagi/tracer/utils/vapi_recording.py
@@ -192,7 +192,15 @@ class VapiRecordingService:
             agent_def = None
         if agent_def is None:
             return None
-        return cls._api_key_from_agent_definition(agent_def)
+        try:
+            return cls._api_key_from_agent_definition(agent_def)
+        except Exception:
+            logger.exception(
+                "vapi_recording_service.get_api_key_provider_row_failed",
+                provider_id=str(getattr(provider, "id", None)),
+            )
+            return None
+
 
     @classmethod
     def _api_key_from_any_agent_on_project(
@@ -224,10 +232,18 @@ class VapiRecordingService:
         """Resolve Vapi api_key through the canonical ProviderCredentials chain."""
         from simulate.services.agent_definition import resolve_api_key_for_version
 
-        version = agent_def.active_version or agent_def.latest_version
-        if version is None:
+        try:
+            version = agent_def.active_version or agent_def.latest_version
+            if version is None:
+                return None
+            return resolve_api_key_for_version(version)
+        except Exception:
+            logger.exception(
+                "vapi_recording_service.get_api_key_agent_definition_decrypt_failed",
+                agent_definition_id=str(getattr(agent_def, "id", None)),
+            )
             return None
-        return resolve_api_key_for_version(version)
+
 
     @classmethod
     async def download_artifact_async(

--- a/futureagi/tracer/utils/vapi_recording.py
+++ b/futureagi/tracer/utils/vapi_recording.py
@@ -75,6 +75,7 @@ class VapiRecordingService:
         ).split(",")
         if b.strip()
     )
+
     @classmethod
     def build_artifact_url(cls, call_id: str, artifact_type: VapiArtifactType) -> str:
         """Build the authenticated endpoint URL for a call artifact."""
@@ -112,9 +113,7 @@ class VapiRecordingService:
 
         if not url:
             return False
-        return any(
-            is_own_storage_url(url, bucket) for bucket in cls._FAGI_S3_BUCKETS
-        )
+        return any(is_own_storage_url(url, bucket) for bucket in cls._FAGI_S3_BUCKETS)
 
     @classmethod
     def get_api_key_for_project(cls, project_id: Any) -> Optional[str]:
@@ -148,7 +147,9 @@ class VapiRecordingService:
             return None
 
     @classmethod
-    def get_api_key_for_agent_definition(cls, agent_definition_id: Any) -> Optional[str]:
+    def get_api_key_for_agent_definition(
+        cls, agent_definition_id: Any
+    ) -> Optional[str]:
         """Resolve the Vapi api_key for an AgentDefinition by id; None on failure."""
         if agent_definition_id is None:
             return None
@@ -167,6 +168,7 @@ class VapiRecordingService:
                 agent_definition_id=str(agent_definition_id),
             )
             return None
+
     @classmethod
     def _get_vapi_provider_for_project(cls, project_id: Any):
         from tracer.models.observability_provider import (
@@ -174,14 +176,11 @@ class VapiRecordingService:
             ProviderChoices,
         )
 
-        return (
-            ObservabilityProvider.objects.filter(
-                project_id=project_id,
-                provider=ProviderChoices.VAPI,
-                enabled=True,
-            )
-            .first()
-        )
+        return ObservabilityProvider.objects.filter(
+            project_id=project_id,
+            provider=ProviderChoices.VAPI,
+            enabled=True,
+        ).first()
 
     @classmethod
     def _api_key_from_provider_row(cls, provider) -> Optional[str]:
@@ -200,7 +199,6 @@ class VapiRecordingService:
                 provider_id=str(getattr(provider, "id", None)),
             )
             return None
-
 
     @classmethod
     def _api_key_from_any_agent_on_project(
@@ -243,7 +241,6 @@ class VapiRecordingService:
                 agent_definition_id=str(getattr(agent_def, "id", None)),
             )
             return None
-
 
     @classmethod
     async def download_artifact_async(
@@ -289,9 +286,7 @@ class VapiRecordingService:
         url = cls.build_artifact_url(call_id, artifact_type)
         headers = {"Authorization": f"Bearer {api_key}"}
 
-        with httpx.Client(
-            follow_redirects=True, timeout=timeout_seconds
-        ) as client:
+        with httpx.Client(follow_redirects=True, timeout=timeout_seconds) as client:
             try:
                 with client.stream("GET", url, headers=headers) as response:
                     cls._raise_for_artifact_response(response, call_id, artifact_type)
@@ -306,9 +301,7 @@ class VapiRecordingService:
                 raise
 
     @staticmethod
-    def _require_download_args(
-        call_id: str, artifact_type: str, api_key: str
-    ) -> None:
+    def _require_download_args(call_id: str, artifact_type: str, api_key: str) -> None:
         if not call_id:
             raise ValueError("call_id is required")
         if not artifact_type:
@@ -317,7 +310,9 @@ class VapiRecordingService:
             raise ValueError("api_key is required")
 
     @staticmethod
-    def _raise_for_artifact_response(response, call_id: str, artifact_type: str) -> None:
+    def _raise_for_artifact_response(
+        response, call_id: str, artifact_type: str
+    ) -> None:
         status = response.status_code
         if status in (401, 403):
             logger.warning(
@@ -437,8 +432,9 @@ class VapiRecordingService:
 
         # Multiple historical snapshots may share a provider call ID; update all.
         rows = list(
-            CallExecutionSnapshot.objects.filter(service_provider_call_id=call_id)
-            .only("id", "recording_url", "stereo_recording_url")
+            CallExecutionSnapshot.objects.filter(service_provider_call_id=call_id).only(
+                "id", "recording_url", "stereo_recording_url"
+            )
         )
         for row in rows:
             update_fields: list[str] = []
@@ -450,7 +446,6 @@ class VapiRecordingService:
                 update_fields.append("stereo_recording_url")
             if update_fields:
                 row.save(update_fields=update_fields)
-
 
     @classmethod
     def fetch_and_parse_call_logs(
@@ -510,9 +505,7 @@ class VapiRecordingService:
     ) -> Optional[bytes]:
         if call_id and api_key:
             try:
-                url = cls.build_artifact_url(
-                    call_id, VapiArtifactType.CALL_LOGS
-                )
+                url = cls.build_artifact_url(call_id, VapiArtifactType.CALL_LOGS)
                 headers = {"Authorization": f"Bearer {api_key}"}
                 response = requests.get(
                     url,


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `bin/test` (backend) or `yarn test:run` (frontend) passes locally
  • `yarn contracts:check` passes if API surface changed
-->

## Summary

Adds a resumable Temporal backfill that rehosts historical Vapi/CDN call recordings to durable S3 and rewrites the source URLs before those public links expire. Covers both simulation Postgres rows and observability ClickHouse spans, with a dedicated single-slot `backfill` worker so downloads stay rate-limited and ClickHouse mutations avoid wide-row OOMs.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. Also link the Linear issue. -->

Closes #
Linear:

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Temporal backfill workflow + activities**

- New `VapiMinimalBackfillWorkflow` on queue `backfill`
- Simulation path: scan pending CallExecution / Snapshot rows, rehost audio, update PG recording fields + nested `provider_call_data`
- Observability path: scan CH spans with Vapi/R2 recording map keys (and day-chunked `attributes_extra`), stage patch rows, `INSERT ... SELECT` with `mapUpdate` + optional exact extra rewrite, version bump without `FINAL` on the write side

**B. Operator CLI + dedicated worker**

- `manage.py backfill_vapi_minimal` for start/status/pause/resume/cancel/reconcile
- `manage.py start_vapi_backfill_worker` / `start_backfill_worker.py` with `BACKFILL_MAX_CONCURRENT_ACTIVITIES=1` and unsandboxed workflow runner (workflow+activity share one module)

**C. Temporal common wiring**

- Register backfill workflows/activities on the `backfill` queue
- Add `query_workflow_sync` for status queries
- Allow optional `workflow_runner` on `run_worker`

---

## 2) Why the changes were done

- **Product/UX:** Historical call recordings currently point at expiring Vapi/CDN URLs; playback and audit break when those links die.
- **Technical:** Source URL state is the ledger (no auxiliary status tables). Deterministic S3 keys + existence checks avoid re-upload. CH updates use patch-only staging and ordered latest-row selection to avoid materializing wide `attrs_string` rows with `FINAL` on write.
- **Architecture:** Isolated `backfill` queue keeps this off the main task workers and enforces a single global download slot.

---

## 3) Tests written + scenarios each covers

**`tfc/temporal/backfill/test_minimal_backfill.py`** — unit coverage for URL/artifact helpers, PG/CH batch logic, proof-gate checks, workflow signals

- artifact extraction / call-id canonicalization
- Vapi URL detection and JSON exact replace
- proof-gate map patch + unrelated column preservation
- workflow pause/resume/cancel state

**`simulate/tests/test_backfill_vapi_minimal_command.py`** — management command validation

- status requires `--workflow-id`
- proof-gate requires single shard
- pause/status/reconcile dispatch

> Run result: **48 passed** across these suites (`pytest tfc/temporal/backfill/test_minimal_backfill.py simulate/tests/test_backfill_vapi_minimal_command.py`).

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
source .venv/bin/activate
pytest tfc/temporal/backfill/test_minimal_backfill.py simulate/tests/test_backfill_vapi_minimal_command.py -q
```

### Manual / ops smoke (local)

```bash
# worker (concurrency must stay 1)
python manage.py start_vapi_backfill_worker

# simulation
python manage.py backfill_vapi_minimal --source simulation --limit 1 --shards 1 --batch-size 1
python manage.py backfill_vapi_minimal --source simulation --limit 10 --shards 1 --batch-size 10

# observability
python manage.py backfill_vapi_minimal --source observability --project-id <UUID> --limit 1 --shards 1 --batch-size 1
python manage.py backfill_vapi_minimal --source observability --project-id <UUID> --limit 10 --shards 1 --batch-size 10

# control
python manage.py backfill_vapi_minimal --action status --workflow-id <wf-id>
```

Verified locally against tunneled CH + PG:
- sim limit 1/10 completed; nested recording URLs rewritten to durable S3
- sim rerun on already-done rows: `changed=0`, all skipped, no re-upload
- obs limit 1/10 completed; CH latest `_version` points at S3
- obs rerun does not reselect already-rewritten spans (FINAL map pending filter)
- proof-gate path still OOMs on this CH host at batch 10 (`_proof_rows` wide hash) — normal mutation path is fine

### Frontend tests (if applicable)

```bash
# N/A — backend only
```

### Contract verification (if API surface changed)

```bash
# N/A — no public API contract change
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Open a previously backfilled call/span and confirm recording playback uses durable S3 URLs.
3. Confirm already-backfilled entities are not rewritten again on a second run.

---

## 5) Screenshots / recordings

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->
<!-- Include: test command output screenshot + UI testing screenshots/recordings -->

### Test output

<!-- Screenshot of the test run passing -->

### UI testing

<!-- Screenshot or video of the feature working in the browser -->

---

## 6) Edge cases & considerations

- Missing full Vapi call ID → fatal for that artifact, row continues
- Existing deterministic S3 object → skip download/upload and reuse URL
- CH write uses `ORDER BY id, _version DESC LIMIT 1 BY id` instead of write-side `FINAL` to avoid OOM
- `attributes_extra` rewritten only when the exact old URL text is present
- `raw_log` / non-target nested Vapi URLs intentionally not rewritten
- Proof-gate verification (`cityHash64` over wide/JSON columns) can OOM on memory-tight CH; prefer normal `--limit` canaries until proof-gate is slimmed
- Worker requires `BACKFILL_MAX_CONCURRENT_ACTIVITIES=1`
- Soft cancel: in-flight batch may finish mutating

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Local Django startup still attempts remote ClickHouse Cloud schema apply and can warn/timeout; unrelated to backfill runtime when `CH_*` points at the tunneled instance.

---

## 8) Architectural / important decisions

- **Source URLs are the ledger:** no auxiliary backfill status table; pending = still-Vapi recording fields.
- **Dedicated backfill queue + single activity slot:** keeps rate limiting global and isolates load from product workers.
- **Patch-only CH staging table:** small mapping rows joined server-side so Python never materializes wide span payloads for the mutation.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

