### PR TITLE
chore(test): expand OSS test suite coverage

### DIFF
--- a/futureagi/agentcc/tests/test_api.py
+++ b/futureagi/agentcc/tests/test_api.py
@@ -338,6 +338,244 @@ class TestAgentccGatewayAPI:
         assert no_mcp.status_code == status.HTTP_400_BAD_REQUEST
         mock_client.mcp_test_tool.assert_not_called()
 
+    def test_retrieve_gateway_unauthenticated(self, api_client, gateway_id):
+        response = api_client.get(f"/agentcc/gateways/{gateway_id}/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_get_providers_unauthenticated(self, api_client, gateway_id):
+        response = api_client.get(f"/agentcc/gateways/{gateway_id}/providers/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_get_providers_when_gateway_client_unreachable(
+        self, auth_client, gateway_id
+    ):
+        from agentcc.services.gateway_client import GatewayClientError
+
+        with patch("agentcc.views.gateway.get_gateway_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.list_providers.side_effect = GatewayClientError("down")
+            mock_get.return_value = mock_client
+
+            response = auth_client.get(
+                f"/agentcc/gateways/{gateway_id}/providers/"
+            )
+        # The endpoint handles unreachable upstream gracefully; either falls
+        # back to the DB-only view (200) or returns a bad_request (400).
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_reload_happy_path_pushes_current_config(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        # Seed an active org config so _push_current_config has something to push.
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=True
+        )
+        response = auth_client.post(f"/agentcc/gateways/{gateway_id}/reload/")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["result"]["gateway_synced"] is True
+
+    def test_reload_unauthenticated(self, api_client, gateway_id):
+        response = api_client.post(f"/agentcc/gateways/{gateway_id}/reload/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=False)
+    def test_reload_when_gateway_unreachable_reports_warning(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=True
+        )
+        response = auth_client.post(f"/agentcc/gateways/{gateway_id}/reload/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"]["gateway_synced"] is False
+        assert "gateway_warning" in response.json()["result"]
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_update_provider_standalone_creates_credential(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/update-provider/",
+            {
+                "name": "standalone-openai",
+                "config": {
+                    "api_key": "sk-standalone",
+                    "display_name": "Standalone OpenAI",
+                    "api_format": "openai",
+                    "models": ["gpt-4o"],
+                    "default_timeout": 20,
+                    "max_concurrent": 4,
+                    "conn_pool_size": 6,
+                    "base_url": "https://api.openai.com/v1",
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert AgentccProviderCredential.no_workspace_objects.filter(
+            organization=organization,
+            provider_name="standalone-openai",
+            deleted=False,
+        ).exists()
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_remove_provider_standalone_soft_deletes(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=organization,
+            provider_name="to-remove",
+            display_name="To Remove",
+            encrypted_credentials=b"placeholder",
+            api_format="openai",
+        )
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/remove-provider/",
+            {"name": "to-remove"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        cred.refresh_from_db()
+        assert cred.deleted is True
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_update_config_patches_active_row_and_bumps_version(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization,
+            version=1,
+            is_active=True,
+            routing={"strategy": "round_robin"},
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/update-config/",
+            {"cache": {"enabled": True, "default_ttl": 60}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        result = response.json()["result"]
+        assert result["version"] == 2  # bump
+        assert result["gateway_synced"] is True
+        mock_push.assert_called_once()
+
+        new_active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=organization, is_active=True, deleted=False
+        )
+        # Patched field applied, untouched field preserved.
+        assert new_active.cache == {"enabled": True, "default_ttl": 60}
+        assert new_active.routing == {"strategy": "round_robin"}
+        assert new_active.version == 2
+
+    def test_update_config_rejects_unknown_field(
+        self, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=True
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/update-config/",
+            {"not_a_real_field": {"x": 1}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_set_budget_writes_level_and_bumps_version(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=True, budgets={}
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/set-budget/",
+            {
+                "level": "organization",
+                "config": {"limit_usd": 100, "action_mode": "hard"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        result = response.json()["result"]
+        assert result["budget"] == "organization"
+        assert result["action"] == "set"
+        assert result["gateway_synced"] is True
+
+        new_active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=organization, is_active=True, deleted=False
+        )
+        # Budget should be present under the "organization" level in some form.
+        assert new_active.budgets  # not empty
+        assert new_active.version == 2
+
+    def test_set_budget_rejects_missing_fields(
+        self, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=True
+        )
+
+        # Empty body: reject_unknown_fields=True, so validator rejects.
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/set-budget/",
+            {},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_remove_budget_strips_level_and_bumps_version(
+        self, mock_push, auth_client, gateway_id, organization
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization,
+            version=1,
+            is_active=True,
+            budgets={
+                "organization": {"limit_usd": 100, "action_mode": "hard"},
+                "user": {"limit_usd": 20, "action_mode": "warn"},
+            },
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/remove-budget/",
+            {"level": "organization"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        result = response.json()["result"]
+        assert result["budget"] == "organization"
+        assert result["action"] == "removed"
+
+        new_active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=organization, is_active=True, deleted=False
+        )
+        assert "organization" not in new_active.budgets
+        assert "user" in new_active.budgets  # other levels preserved
+        assert new_active.version == 2
+
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -713,6 +951,182 @@ class TestAgentccAPIKeyAPI:
         key.refresh_from_db()
         assert key.status == AgentccAPIKey.ACTIVE
 
+    def test_retrieve_api_key_returns_key_metadata(
+        self, auth_client, organization, workspace
+    ):
+        key = AgentccAPIKey.objects.create(
+            gateway_key_id="gw-retrieve",
+            key_prefix="pk-retrieve",
+            name="retrieve-me",
+            organization=organization,
+            workspace=workspace,
+        )
+
+        response = auth_client.get(f"/agentcc/api-keys/{key.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["result"]
+        assert data["id"] == str(key.id)
+        assert data["name"] == "retrieve-me"
+        assert data["gateway_key_id"] == "gw-retrieve"
+        # Raw key is never rehydrated on retrieve; only the prefix survives.
+        assert "key" not in data
+        assert data["key_prefix"] == "pk-retrieve"
+
+    def test_retrieve_api_key_unauthenticated(self, api_client, organization, workspace):
+        key = AgentccAPIKey.objects.create(
+            gateway_key_id="gw-retrieve-unauth",
+            name="unauth",
+            organization=organization,
+            workspace=workspace,
+        )
+
+        response = api_client.get(f"/agentcc/api-keys/{key.id}/")
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    def test_destroy_api_key_removes_row(
+        self, auth_client, organization, workspace
+    ):
+        key = AgentccAPIKey.objects.create(
+            gateway_key_id="gw-destroy",
+            name="destroy-me",
+            organization=organization,
+            workspace=workspace,
+        )
+
+        response = auth_client.delete(f"/agentcc/api-keys/{key.id}/")
+
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        )
+        # DELETE either soft-deletes (deleted=True) or hard-deletes; either way
+        # the key must not appear on a subsequent list call.
+        list_response = auth_client.get("/agentcc/api-keys/")
+        ids = {item["id"] for item in list_response.json()["result"]}
+        assert str(key.id) not in ids
+
+    @patch("agentcc.views.api_key.auth_bridge")
+    def test_sync_api_keys_calls_bridge_sync_keys(
+        self, mock_bridge, auth_client, organization
+    ):
+        mock_bridge.sync_keys.return_value = 3
+
+        response = auth_client.post("/agentcc/api-keys/sync/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"] == {"synced": 3}
+        mock_bridge.sync_keys.assert_called_once()
+        # Sync is scoped to the active-request organization.
+        assert (
+            mock_bridge.sync_keys.call_args.kwargs["org"].id == organization.id
+        )
+
+    def test_sync_api_keys_unauthenticated(self, api_client):
+        response = api_client.post("/agentcc/api-keys/sync/")
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    def test_list_api_keys_cross_tenant_isolation(
+        self, auth_client, api_client, organization, workspace, user
+    ):
+        from accounts.models.organization import Organization
+
+        # Seed a key belonging to the current org and one to a foreign org.
+        AgentccAPIKey.objects.create(
+            gateway_key_id="gw-mine",
+            name="mine",
+            organization=organization,
+            workspace=workspace,
+        )
+        foreign_org = Organization.objects.create(name="API Key Foreign Org")
+        AgentccAPIKey.no_workspace_objects.create(
+            gateway_key_id="gw-not-mine",
+            name="not-mine",
+            organization=foreign_org,
+            workspace=None,
+        )
+
+        response = auth_client.get("/agentcc/api-keys/")
+        assert response.status_code == status.HTTP_200_OK
+        ids = {row["gateway_key_id"] for row in response.json()["result"]}
+        assert "gw-mine" in ids
+        assert "gw-not-mine" not in ids
+
+    @patch("agentcc.views.api_key.auth_bridge")
+    def test_put_api_key_cross_tenant_returns_404(
+        self, mock_bridge, auth_client, user, organization
+    ):
+        from accounts.models.organization import Organization
+
+        foreign_org = Organization.objects.create(name="PUT Foreign Org")
+        foreign_key = AgentccAPIKey.no_workspace_objects.create(
+            gateway_key_id="gw-foreign",
+            name="foreign",
+            organization=foreign_org,
+            workspace=None,
+        )
+
+        response = auth_client.put(
+            f"/agentcc/api-keys/{foreign_key.id}/",
+            {"name": "hijacked"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_bridge.update_key.assert_not_called()
+
+    def test_patch_api_key_updates_name(
+        self, auth_client, organization, workspace
+    ):
+        key = AgentccAPIKey.objects.create(
+            gateway_key_id="gw-patch",
+            name="before",
+            organization=organization,
+            workspace=workspace,
+        )
+        with patch("agentcc.views.api_key.auth_bridge") as mock_bridge:
+            def _update(api_key, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(api_key, k, v)
+                api_key.save(update_fields=[*kwargs.keys(), "updated_at"])
+                return api_key
+
+            mock_bridge.update_key.side_effect = _update
+            response = auth_client.patch(
+                f"/agentcc/api-keys/{key.id}/",
+                {"name": "after"},
+                format="json",
+            )
+        assert response.status_code == status.HTTP_200_OK
+        key.refresh_from_db()
+        assert key.name == "after"
+
+    def test_revoke_api_key_idempotence(
+        self, auth_client, organization, workspace
+    ):
+        # Revoking an already-revoked key returns 200 and stays revoked;
+        # auth_bridge.revoke_key is what enforces the state transition, so
+        # the endpoint just re-runs the same flow.
+        key = AgentccAPIKey.objects.create(
+            gateway_key_id="gw-revoke-twice",
+            name="revoke-twice",
+            status=AgentccAPIKey.REVOKED,
+            organization=organization,
+            workspace=workspace,
+        )
+        with patch("agentcc.views.api_key.auth_bridge") as mock_bridge:
+            mock_bridge.revoke_key.return_value = (key, False)
+            response = auth_client.post(f"/agentcc/api-keys/{key.id}/revoke/")
+
+        assert response.status_code == status.HTTP_200_OK
+        key.refresh_from_db()
+        assert key.status == AgentccAPIKey.REVOKED
+
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -821,6 +1235,22 @@ class TestAgentccRequestLogAPI:
 
     def test_list_request_logs_unauthenticated(self, api_client):
         response = api_client.get("/agentcc/request-logs/")
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    def test_retrieve_request_log_unknown_id_returns_404(self, auth_client):
+        # A random UUID that does not belong to any log row.
+        import uuid
+
+        response = auth_client.get(f"/agentcc/request-logs/{uuid.uuid4()}/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_retrieve_request_log_unauthenticated(self, api_client):
+        import uuid
+
+        response = api_client.get(f"/agentcc/request-logs/{uuid.uuid4()}/")
         assert response.status_code in [
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,

--- a/futureagi/agentcc/tests/test_api.py
+++ b/futureagi/agentcc/tests/test_api.py
@@ -359,18 +359,14 @@ class TestAgentccGatewayAPI:
 
         with patch("agentcc.views.gateway.get_gateway_client") as mock_get:
             mock_client = MagicMock()
-            mock_client.list_providers.side_effect = GatewayClientError("down")
+            mock_client.provider_health.side_effect = GatewayClientError("down")
             mock_get.return_value = mock_client
 
             response = auth_client.get(
                 f"/agentcc/gateways/{gateway_id}/providers/"
             )
-        # The endpoint handles unreachable upstream gracefully; either falls
-        # back to the DB-only view (200) or returns a bad_request (400).
-        assert response.status_code in (
-            status.HTTP_200_OK,
-            status.HTTP_400_BAD_REQUEST,
-        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["result"] == {"providers": []}
 
     @patch("agentcc.views.gateway.push_org_config", return_value=True)
     def test_reload_happy_path_pushes_current_config(
@@ -1109,9 +1105,6 @@ class TestAgentccAPIKeyAPI:
     def test_revoke_api_key_idempotence(
         self, auth_client, organization, workspace
     ):
-        # Revoking an already-revoked key returns 200 and stays revoked;
-        # auth_bridge.revoke_key is what enforces the state transition, so
-        # the endpoint just re-runs the same flow.
         key = AgentccAPIKey.objects.create(
             gateway_key_id="gw-revoke-twice",
             name="revoke-twice",
@@ -1124,8 +1117,8 @@ class TestAgentccAPIKeyAPI:
             response = auth_client.post(f"/agentcc/api-keys/{key.id}/revoke/")
 
         assert response.status_code == status.HTTP_200_OK
-        key.refresh_from_db()
-        assert key.status == AgentccAPIKey.REVOKED
+        mock_bridge.revoke_key.assert_called_once_with(key)
+        assert response.json()["result"]["status"] == AgentccAPIKey.REVOKED
 
 
 @pytest.mark.integration

--- a/futureagi/agentcc/tests/test_gateway_mcp_and_analytics_guardrail_api.py
+++ b/futureagi/agentcc/tests/test_gateway_mcp_and_analytics_guardrail_api.py
@@ -1,0 +1,265 @@
+"""Coverage for the gateway MCP sub-actions and the analytics guardrail endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentcc.models.org_config import AgentccOrgConfig
+
+
+@pytest.fixture
+def gateway_id():
+    return "default"
+
+
+def _seed_mcp_config(user, servers=None):
+    return AgentccOrgConfig.no_workspace_objects.create(
+        organization=user.organization,
+        version=1,
+        is_active=True,
+        mcp={"servers": servers or {"server-a": {"url": "http://mcp"}}},
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGatewayMCPStatus:
+    def test_mcp_status_returns_disabled_when_no_servers(
+        self, auth_client, gateway_id, user
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=user.organization,
+            version=1,
+            is_active=True,
+            mcp={},
+        )
+
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-status/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"]["enabled"] is False
+
+    @patch("agentcc.views.gateway.get_gateway_client")
+    def test_mcp_status_filters_to_configured_servers(
+        self, mock_get_client, auth_client, gateway_id, user
+    ):
+        _seed_mcp_config(user, servers={"server-a": {"url": "http://mcp"}})
+        mock_client = MagicMock()
+        mock_client.mcp_status.return_value = {
+            "enabled": True,
+            "sessions": 1,
+            "tools": 5,
+            "resources": 2,
+            "prompts": 1,
+            "servers": [
+                {"id": "server-a", "status": "connected"},
+                {"id": "server-b", "status": "connected"},  # not in org config
+            ],
+        }
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-status/"
+        )
+        assert response.status_code == 200
+        server_ids = {s["id"] for s in response.json()["result"]["servers"]}
+        assert server_ids == {"server-a"}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGatewayMCPTools:
+    def test_mcp_tools_empty_when_no_configured_servers(
+        self, auth_client, gateway_id, user
+    ):
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-tools/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"] == []
+
+    @patch("agentcc.views.gateway.get_gateway_client")
+    def test_mcp_tools_filters_to_configured_servers(
+        self, mock_get_client, auth_client, gateway_id, user
+    ):
+        _seed_mcp_config(user, servers={"server-a": {"url": "http://mcp"}})
+        mock_client = MagicMock()
+        mock_client.mcp_tools.return_value = [
+            {"name": "tool-1", "server": "server-a"},
+            {"name": "tool-2", "server": "server-b"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-tools/"
+        )
+        assert response.status_code == 200
+        names = {t["name"] for t in response.json()["result"]}
+        assert names == {"tool-1"}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGatewayMCPUpdates:
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_update_mcp_server_writes_config(
+        self, mock_push, auth_client, gateway_id, user
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=user.organization, version=1, is_active=True
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/update-mcp-server/",
+            {
+                "server_id": "server-a",
+                "config": {"url": "http://mcp/server-a", "enabled": True},
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=user.organization, is_active=True, deleted=False
+        )
+        assert "server-a" in (active.mcp or {}).get("servers", {})
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_remove_mcp_server_strips_server(
+        self, mock_push, auth_client, gateway_id, user
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=user.organization,
+            version=1,
+            is_active=True,
+            mcp={"servers": {"server-a": {"url": "http://mcp"}}},
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/remove-mcp-server/",
+            {"server_id": "server-a"},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=user.organization, is_active=True, deleted=False
+        )
+        assert "server-a" not in (active.mcp or {}).get("servers", {})
+
+    @patch("agentcc.views.gateway.push_org_config", return_value=True)
+    def test_update_mcp_guardrails_writes_config(
+        self, mock_push, auth_client, gateway_id, user
+    ):
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=user.organization, version=1, is_active=True
+        )
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/update-mcp-guardrails/",
+            {"config": {"scan_tool_names": True}},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=user.organization, is_active=True, deleted=False
+        )
+        assert (active.mcp or {}).get("guardrails") == {"scan_tool_names": True}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGatewayMCPTest:
+    @patch("agentcc.views.gateway.get_gateway_client")
+    def test_test_mcp_tool_happy(
+        self, mock_get_client, auth_client, gateway_id, user
+    ):
+        _seed_mcp_config(user, servers={"server-a": {"url": "http://mcp"}})
+        mock_client = MagicMock()
+        mock_client.mcp_test_tool.return_value = {"ok": True, "result": "hi"}
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/test-mcp-tool/",
+            {"name": "tool-1", "arguments": {"x": 1}},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        mock_client.mcp_test_tool.assert_called_once()
+
+    def test_test_mcp_tool_rejects_missing_tool_name(
+        self, auth_client, gateway_id
+    ):
+        response = auth_client.post(
+            f"/agentcc/gateways/{gateway_id}/test-mcp-tool/",
+            {},
+            format="json",
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGatewayMCPReadonly:
+    @patch("agentcc.views.gateway.get_gateway_client")
+    def test_mcp_resources_returns_list(
+        self, mock_get_client, auth_client, gateway_id, user
+    ):
+        _seed_mcp_config(user, servers={"server-a": {"url": "http://mcp"}})
+        mock_client = MagicMock()
+        mock_client.mcp_resources.return_value = [
+            {"uri": "res://a", "server": "server-a"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-resources/"
+        )
+        assert response.status_code == 200
+
+    @patch("agentcc.views.gateway.get_gateway_client")
+    def test_mcp_prompts_returns_list(
+        self, mock_get_client, auth_client, gateway_id, user
+    ):
+        _seed_mcp_config(user, servers={"server-a": {"url": "http://mcp"}})
+        mock_client = MagicMock()
+        mock_client.mcp_prompts.return_value = [
+            {"name": "prompt-1", "server": "server-a"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.get(
+            f"/agentcc/gateways/{gateway_id}/mcp-prompts/"
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAnalyticsGuardrail:
+    def test_guardrail_overview_pins_kpi_keys(self, auth_client):
+        response = auth_client.get("/agentcc/analytics/guardrail-overview/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        # Pin the KPI keys the FE renders; if the helper drops one, this
+        # test flips red instead of the FE rendering blank cards.
+        assert isinstance(result, dict)
+        assert "total_requests" in result
+
+    def test_guardrail_rules_pins_top_level_shape(self, auth_client):
+        response = auth_client.get("/agentcc/analytics/guardrail-rules/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        # get_guardrail_rules returns a dict aggregate; a list would indicate
+        # a shape regression the FE cannot parse.
+        assert isinstance(result, dict)
+
+    def test_guardrail_trends_pins_series_keys(self, auth_client):
+        response = auth_client.get("/agentcc/analytics/guardrail-trends/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        assert isinstance(result, dict)
+        assert "granularity" in result and "series" in result
+
+    def test_guardrail_overview_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/analytics/guardrail-overview/")
+        assert response.status_code in (401, 403)

--- a/futureagi/agentcc/tests/test_guardrail_endpoints_api.py
+++ b/futureagi/agentcc/tests/test_guardrail_endpoints_api.py
@@ -1,0 +1,287 @@
+"""Coverage for the guardrail-policies, guardrail-configs helpers, blocklists, and guardrail-feedback endpoints."""
+
+import pytest
+
+from agentcc.models.blocklist import AgentccBlocklist
+from agentcc.models.guardrail_feedback import AgentccGuardrailFeedback
+from agentcc.models.guardrail_policy import AgentccGuardrailPolicy
+from agentcc.models.request_log import AgentccRequestLog
+
+
+def _make_policy(user, name="policy-a", **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "name": name,
+        "scope": "global",
+        "checks": [{"name": "pii-detector", "action": "block"}],
+        "mode": "enforce",
+        "is_active": True,
+    }
+    kwargs.update(overrides)
+    return AgentccGuardrailPolicy.objects.create(**kwargs)
+
+
+def _make_blocklist(user, name="block-a", words=None, **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "name": name,
+        "words": words or ["forbidden"],
+    }
+    kwargs.update(overrides)
+    return AgentccBlocklist.objects.create(**kwargs)
+
+
+def _make_request_log(user, request_id="req-a"):
+    return AgentccRequestLog.objects.create(
+        organization=user.organization,
+        request_id=request_id,
+        model="gpt-4o",
+        provider="openai",
+    )
+
+
+def _make_feedback(user, request_log, check_name="pii-detector", feedback="correct"):
+    return AgentccGuardrailFeedback.objects.create(
+        organization=user.organization,
+        request_log=request_log,
+        check_name=check_name,
+        feedback=feedback,
+        created_by=user,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGuardrailPolicyCRUD:
+    def test_list_returns_policies(self, auth_client, user):
+        _make_policy(user, name="alpha")
+        _make_policy(user, name="beta")
+
+        response = auth_client.get("/agentcc/guardrail-policies/")
+        assert response.status_code == 200
+        names = {row["name"] for row in response.json()["result"]}
+        assert {"alpha", "beta"} <= names
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/guardrail-policies/")
+        assert response.status_code in (401, 403)
+
+    def test_retrieve_returns_policy(self, auth_client, user):
+        policy = _make_policy(user, name="retrieve-me")
+        response = auth_client.get(
+            f"/agentcc/guardrail-policies/{policy.id}/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(policy.id)
+
+    def test_create_writes_and_scopes_to_org(self, auth_client, user):
+        response = auth_client.post(
+            "/agentcc/guardrail-policies/",
+            {
+                "name": "new-policy",
+                "scope": "global",
+                "checks": [{"name": "injection-detector", "action": "block"}],
+                "mode": "enforce",
+                "is_active": True,
+            },
+            format="json",
+        )
+        assert response.status_code in (200, 201), response.json()
+        row = AgentccGuardrailPolicy.objects.get(name="new-policy")
+        assert row.organization == user.organization
+
+    def test_patch_updates_mode(self, auth_client, user):
+        policy = _make_policy(user, name="patch-me", mode="enforce")
+        response = auth_client.patch(
+            f"/agentcc/guardrail-policies/{policy.id}/",
+            {"mode": "monitor"},
+            format="json",
+        )
+        assert response.status_code == 200
+        policy.refresh_from_db()
+        assert policy.mode == "monitor"
+
+    def test_destroy_soft_deletes_policy(self, auth_client, user):
+        policy = _make_policy(user, name="destroy-me")
+        response = auth_client.delete(
+            f"/agentcc/guardrail-policies/{policy.id}/"
+        )
+        assert response.status_code in (200, 204)
+        policy.refresh_from_db()
+        assert policy.deleted is True
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGuardrailPolicySync:
+    def test_sync_endpoint_returns_ok(self, auth_client, user):
+        _make_policy(user, name="synceable", is_active=True)
+        response = auth_client.post("/agentcc/guardrail-policies/sync/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        assert result["synced"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGuardrailConfigHelpers:
+    def test_pii_entities_returns_list(self, auth_client):
+        response = auth_client.get("/agentcc/guardrail-configs/pii-entities/")
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert isinstance(rows, list) and len(rows) > 0
+
+    def test_topics_returns_list(self, auth_client):
+        response = auth_client.get("/agentcc/guardrail-configs/topics/")
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert isinstance(rows, list)
+
+    def test_validate_cel_accepts_valid_expression(self, auth_client):
+        response = auth_client.post(
+            "/agentcc/guardrail-configs/validate-cel/",
+            {"expression": "1 == 1"},
+            format="json",
+        )
+        # Returns 200 with a JSON body reporting validity; the shape may
+        # be {"valid": true} or {"is_valid": true}.
+        assert response.status_code == 200
+
+    def test_validate_cel_rejects_missing_expression(self, auth_client):
+        response = auth_client.post(
+            "/agentcc/guardrail-configs/validate-cel/",
+            {},
+            format="json",
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestBlocklistRemaining:
+    def test_list_returns_blocklists(self, auth_client, user):
+        _make_blocklist(user, name="list-a")
+        _make_blocklist(user, name="list-b")
+
+        response = auth_client.get("/agentcc/blocklists/")
+        assert response.status_code == 200
+        names = {row["name"] for row in response.json()["result"]}
+        assert {"list-a", "list-b"} <= names
+
+    def test_retrieve_returns_blocklist(self, auth_client, user):
+        block = _make_blocklist(user, name="retrieve")
+        response = auth_client.get(f"/agentcc/blocklists/{block.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(block.id)
+
+    def test_put_updates_words(self, auth_client, user):
+        block = _make_blocklist(user, name="put", words=["old"])
+        response = auth_client.put(
+            f"/agentcc/blocklists/{block.id}/",
+            {"name": "put", "words": ["new-one", "new-two"]},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        block.refresh_from_db()
+        assert set(block.words) == {"new-one", "new-two"}
+
+    def test_patch_updates_description(self, auth_client, user):
+        block = _make_blocklist(user, name="patch")
+        response = auth_client.patch(
+            f"/agentcc/blocklists/{block.id}/",
+            {"description": "now with a description"},
+            format="json",
+        )
+        assert response.status_code == 200
+        block.refresh_from_db()
+        assert block.description == "now with a description"
+
+    def test_remove_words_strips_specified_words(self, auth_client, user):
+        block = _make_blocklist(
+            user, name="remove", words=["keep-1", "drop-me", "keep-2"]
+        )
+        response = auth_client.post(
+            f"/agentcc/blocklists/{block.id}/remove-words/",
+            {"words": ["drop-me"]},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        block.refresh_from_db()
+        assert "drop-me" not in block.words
+        assert "keep-1" in block.words
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGuardrailFeedbackCRUD:
+    def test_list_returns_feedback(self, auth_client, user):
+        log = _make_request_log(user)
+        _make_feedback(user, log, check_name="pii-detector")
+        _make_feedback(user, log, check_name="injection-detector")
+
+        response = auth_client.get("/agentcc/guardrail-feedback/")
+        assert response.status_code == 200
+        assert len(response.json()["result"]) >= 2
+
+    def test_retrieve_returns_feedback(self, auth_client, user):
+        log = _make_request_log(user)
+        fb = _make_feedback(user, log)
+
+        response = auth_client.get(
+            f"/agentcc/guardrail-feedback/{fb.id}/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(fb.id)
+
+    def test_create_writes_feedback(self, auth_client, user):
+        log = _make_request_log(user, request_id="req-create-fb")
+        response = auth_client.post(
+            "/agentcc/guardrail-feedback/",
+            {
+                "request_log": str(log.id),
+                "check_name": "pii-detector",
+                "feedback": "false_positive",
+                "comment": "false positive",
+            },
+            format="json",
+        )
+        assert response.status_code in (200, 201), response.json()
+        assert AgentccGuardrailFeedback.objects.filter(
+            request_log=log, check_name="pii-detector"
+        ).exists()
+
+    def test_patch_updates_comment(self, auth_client, user):
+        log = _make_request_log(user)
+        fb = _make_feedback(user, log)
+
+        response = auth_client.patch(
+            f"/agentcc/guardrail-feedback/{fb.id}/",
+            {"comment": "reviewed and confirmed"},
+            format="json",
+        )
+        assert response.status_code == 200
+        fb.refresh_from_db()
+        assert fb.comment == "reviewed and confirmed"
+
+    def test_destroy_soft_deletes_feedback(self, auth_client, user):
+        log = _make_request_log(user)
+        fb = _make_feedback(user, log)
+
+        response = auth_client.delete(
+            f"/agentcc/guardrail-feedback/{fb.id}/"
+        )
+        assert response.status_code in (200, 204)
+        fb.refresh_from_db()
+        assert fb.deleted is True
+
+    def test_summary_aggregates_by_check(self, auth_client, user):
+        log = _make_request_log(user)
+        _make_feedback(user, log, check_name="pii-detector", feedback="correct")
+        _make_feedback(user, log, check_name="pii-detector", feedback="false_positive")
+
+        response = auth_client.get("/agentcc/guardrail-feedback/summary/")
+        assert response.status_code == 200
+        # Response shape is a dict of aggregations; assert the endpoint
+        # returns 200 with a dict body rather than pinning the exact keys.
+        result = response.json()["result"]
+        assert isinstance(result, (dict, list))

--- a/futureagi/agentcc/tests/test_name_validation_api.py
+++ b/futureagi/agentcc/tests/test_name_validation_api.py
@@ -53,6 +53,7 @@ class TestAgentccSafeNameValidationAPI:
         assert NAME_ERROR in response.json()["result"]
         mock_bridge.update_key.assert_not_called()
 
+    @pytest.mark.requires_ee
     def test_create_webhook_rejects_xss_name(self, auth_client):
         response = auth_client.post(
             "/agentcc/webhooks/",

--- a/futureagi/agentcc/tests/test_org_config_api.py
+++ b/futureagi/agentcc/tests/test_org_config_api.py
@@ -1,0 +1,256 @@
+"""Coverage for the /agentcc/org-configs/ ViewSet endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+from accounts.models.organization import Organization
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.workspace import Workspace, WorkspaceMembership
+from agentcc.models.org_config import AgentccOrgConfig
+from conftest import WorkspaceAwareAPIClient
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+
+
+@pytest.fixture
+def secondary_org_context(user):
+    org_b = Organization.objects.create(name="OrgConfig Peer Org")
+    membership = OrganizationMembership.no_workspace_objects.create(
+        user=user,
+        organization=org_b,
+        role=OrganizationRoles.OWNER,
+        level=Level.OWNER,
+        is_active=True,
+    )
+    workspace_b = Workspace.objects.create(
+        name="OrgConfig Peer Workspace",
+        organization=org_b,
+        is_default=True,
+        is_active=True,
+        created_by=user,
+    )
+    WorkspaceMembership.objects.create(
+        workspace=workspace_b,
+        user=user,
+        role=OrganizationRoles.WORKSPACE_ADMIN,
+        level=Level.WORKSPACE_ADMIN,
+        organization_membership=membership,
+        is_active=True,
+    )
+    return org_b, workspace_b
+
+
+@pytest.fixture
+def secondary_org_client(user, secondary_org_context):
+    _, workspace_b = secondary_org_context
+    client = WorkspaceAwareAPIClient()
+    client.force_authenticate(user=user)
+    client.set_workspace(workspace_b)
+    yield client
+    client.stop_workspace_injection()
+
+
+def _make_config(organization, version=1, is_active=True, **overrides):
+    defaults = {
+        "organization": organization,
+        "version": version,
+        "is_active": is_active,
+    }
+    defaults.update(overrides)
+    return AgentccOrgConfig.no_workspace_objects.create(**defaults)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigList:
+    def test_list_returns_versions_for_active_org(self, auth_client, user):
+        _make_config(user.organization, version=1, is_active=False)
+        _make_config(user.organization, version=2, is_active=True)
+
+        response = auth_client.get("/agentcc/org-configs/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        # Both versions should be returned; the ViewSet orders by -version.
+        versions = [row["version"] for row in result]
+        assert versions == sorted(versions, reverse=True)
+        assert 1 in versions and 2 in versions
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/org-configs/")
+        assert response.status_code in (401, 403)
+
+    def test_list_isolates_per_org(
+        self, user, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        _make_config(user.organization, version=1)
+        _make_config(org_b, version=1)
+
+        response = secondary_org_client.get("/agentcc/org-configs/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        assert len(result) == 1
+        assert result[0]["organization"] == str(org_b.id)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigRetrieve:
+    def test_retrieve_returns_config(self, auth_client, user):
+        config = _make_config(user.organization, version=1)
+        response = auth_client.get(f"/agentcc/org-configs/{config.id}/")
+        assert response.status_code == 200
+        data = response.json()["result"]
+        assert data["id"] == str(config.id)
+        assert data["version"] == 1
+
+    def test_retrieve_cross_tenant_returns_404(
+        self, user, secondary_org_context, secondary_org_client
+    ):
+        # Config lives in org A; client is scoped to org B.
+        config = _make_config(user.organization, version=1)
+        response = secondary_org_client.get(f"/agentcc/org-configs/{config.id}/")
+        assert response.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigCreate:
+    @patch(
+        "agentcc.views.org_config.AgentccOrgConfigViewSet._push_config_to_gateway",
+        return_value=True,
+    )
+    def test_create_new_version_deactivates_prior(self, mock_push, auth_client, user):
+        prior = _make_config(user.organization, version=1, is_active=True)
+
+        response = auth_client.post(
+            "/agentcc/org-configs/",
+            {"routing": {"strategy": "round_robin"}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        prior.refresh_from_db()
+        assert prior.is_active is False
+        # New row is active with version 2.
+        new_active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=user.organization, is_active=True, deleted=False
+        )
+        assert new_active.version == 2
+        assert new_active.routing == {"strategy": "round_robin"}
+        mock_push.assert_called_once()
+
+    @patch(
+        "agentcc.views.org_config.AgentccOrgConfigViewSet._push_config_to_gateway",
+        return_value=True,
+    )
+    def test_create_unknown_fields_are_silently_ignored(
+        self, mock_push, auth_client, user
+    ):
+        # Unknown fields silently dropped (write serializer does not opt into reject_unknown_fields).
+        response = auth_client.post(
+            "/agentcc/org-configs/",
+            {"not_a_real_field": {"x": 1}, "cache": {"enabled": True}},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        new_active = AgentccOrgConfig.no_workspace_objects.get(
+            organization=user.organization, is_active=True, deleted=False
+        )
+        # normalize_cache_config backfills defaults; pin enabled=True only.
+        assert new_active.cache.get("enabled") is True
+        # Unknown key is dropped, not written into any slot.
+        assert "not_a_real_field" not in {
+            f.name for f in AgentccOrgConfig._meta.get_fields()
+        }
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigImmutable:
+    def test_put_returns_400_because_immutable(self, auth_client, user):
+        config = _make_config(user.organization, version=1)
+        response = auth_client.put(
+            f"/agentcc/org-configs/{config.id}/",
+            {"routing": {"strategy": "round_robin"}},
+            format="json",
+        )
+        assert response.status_code == 400
+        assert "immutable" in response.json()["message"].lower()
+
+    def test_patch_returns_400_because_immutable(self, auth_client, user):
+        config = _make_config(user.organization, version=1)
+        response = auth_client.patch(
+            f"/agentcc/org-configs/{config.id}/",
+            {"routing": {"strategy": "round_robin"}},
+            format="json",
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigActivate:
+    @patch(
+        "agentcc.views.org_config.AgentccOrgConfigViewSet._push_config_to_gateway",
+        return_value=True,
+    )
+    def test_activate_swaps_active_and_pushes(self, mock_push, auth_client, user):
+        old_active = _make_config(user.organization, version=1, is_active=True)
+        new_version = _make_config(user.organization, version=2, is_active=False)
+
+        response = auth_client.post(
+            f"/agentcc/org-configs/{new_version.id}/activate/"
+        )
+
+        assert response.status_code == 200, response.json()
+        old_active.refresh_from_db()
+        new_version.refresh_from_db()
+        assert old_active.is_active is False
+        assert new_version.is_active is True
+        assert response.json()["result"]["gateway_synced"] is True
+        mock_push.assert_called_once()
+
+    def test_activate_on_already_active_is_idempotent(self, auth_client, user):
+        active = _make_config(user.organization, version=1, is_active=True)
+
+        response = auth_client.post(f"/agentcc/org-configs/{active.id}/activate/")
+        assert response.status_code == 200
+        # Idempotent path returns the current config without touching the DB.
+        active.refresh_from_db()
+        assert active.is_active is True
+
+    def test_activate_cross_tenant_returns_404(
+        self, user, secondary_org_context, secondary_org_client
+    ):
+        config = _make_config(user.organization, version=1, is_active=False)
+        response = secondary_org_client.post(
+            f"/agentcc/org-configs/{config.id}/activate/"
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestOrgConfigActive:
+    def test_active_returns_current_config(self, auth_client, user):
+        _make_config(user.organization, version=1, is_active=False)
+        active = _make_config(user.organization, version=2, is_active=True)
+
+        response = auth_client.get("/agentcc/org-configs/active/")
+        assert response.status_code == 200
+        data = response.json()["result"]
+        assert data is not None
+        assert data["id"] == str(active.id)
+        assert data["version"] == 2
+
+    def test_active_returns_none_when_no_config(self, auth_client, user):
+        # No config seeded for this org.
+        response = auth_client.get("/agentcc/org-configs/active/")
+        assert response.status_code == 200
+        assert response.json()["result"] is None
+
+    def test_active_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/org-configs/active/")
+        assert response.status_code in (401, 403)

--- a/futureagi/agentcc/tests/test_org_config_bulk.py
+++ b/futureagi/agentcc/tests/test_org_config_bulk.py
@@ -1,0 +1,111 @@
+"""Bulk org-config sync endpoint: admin-token gating and envelope shape."""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import Organization
+from agentcc.models.org_config import AgentccOrgConfig
+
+ADMIN_TOKEN = "agentcc-admin-secret"
+
+
+@pytest.fixture(autouse=True)
+def _set_agentcc_admin_token():
+    with patch("agentcc.permissions.AGENTCC_ADMIN_TOKEN", ADMIN_TOKEN):
+        yield
+
+
+@pytest.fixture
+def admin_client():
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {ADMIN_TOKEN}")
+    return client
+
+
+def _make_active_config(organization, version=1, **overrides):
+    defaults = {
+        "organization": organization,
+        "version": version,
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    return AgentccOrgConfig.no_workspace_objects.create(**defaults)
+
+
+class TestOrgConfigBulk:
+    def test_unauthenticated_returns_403(self, db):
+        response = APIClient().get("/agentcc/org-configs/bulk/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_wrong_token_returns_403(self, db):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Bearer wrong-token")
+        response = client.get("/agentcc/org-configs/bulk/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_empty_response_when_no_active_configs(self, admin_client, db):
+        response = admin_client.get("/agentcc/org-configs/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] is True
+        assert response.json()["result"] == {}
+
+    def test_returns_configs_keyed_by_org_id(self, admin_client, organization):
+        _make_active_config(organization)
+
+        response = admin_client.get("/agentcc/org-configs/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+
+        result = response.json()["result"]
+        # Envelope shape: dict keyed by str(org_id) with a dict value.
+        assert str(organization.id) in result
+        assert isinstance(result[str(organization.id)], dict)
+
+    def test_multi_org_configs_all_returned(self, admin_client, organization, db):
+        _make_active_config(organization)
+        org_b = Organization.objects.create(name="Bulk Sync Peer Org")
+        _make_active_config(org_b)
+
+        result = admin_client.get("/agentcc/org-configs/bulk/").json()["result"]
+
+        assert str(organization.id) in result
+        assert str(org_b.id) in result
+        assert len(result) == 2
+
+    def test_inactive_versions_excluded(self, admin_client, organization):
+        # Only the active row should be shipped; older inactive versions are
+        # history and must not leak into the gateway payload.
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization, version=1, is_active=False
+        )
+        _make_active_config(organization, version=2)
+
+        result = admin_client.get("/agentcc/org-configs/bulk/").json()["result"]
+
+        # Exactly one entry for this org: the active version.
+        assert str(organization.id) in result
+        # The endpoint filters by is_active=True at the ORM level; assert we
+        # get exactly one row per org (not two).
+        assert (
+            AgentccOrgConfig.no_workspace_objects.filter(
+                organization=organization
+            ).count()
+            == 2
+        )
+        # But bulk sync returns exactly one key per org.
+        assert list(result.keys()).count(str(organization.id)) == 1
+
+    def test_soft_deleted_configs_excluded(self, admin_client, organization, db):
+        # Soft-deleted rows are still present in the DB but must be filtered
+        # out of the bulk payload the gateway pulls.
+        AgentccOrgConfig.no_workspace_objects.create(
+            organization=organization,
+            version=1,
+            is_active=True,
+            deleted=True,
+        )
+
+        result = admin_client.get("/agentcc/org-configs/bulk/").json()["result"]
+        assert str(organization.id) not in result

--- a/futureagi/agentcc/tests/test_org_config_bulk.py
+++ b/futureagi/agentcc/tests/test_org_config_bulk.py
@@ -78,24 +78,20 @@ class TestOrgConfigBulk:
         # Only the active row should be shipped; older inactive versions are
         # history and must not leak into the gateway payload.
         AgentccOrgConfig.no_workspace_objects.create(
-            organization=organization, version=1, is_active=False
+            organization=organization,
+            version=1,
+            is_active=False,
+            routing={"strategy": "old"},
         )
-        _make_active_config(organization, version=2)
+        _make_active_config(
+            organization,
+            version=2,
+            routing={"strategy": "active"},
+        )
 
         result = admin_client.get("/agentcc/org-configs/bulk/").json()["result"]
 
-        # Exactly one entry for this org: the active version.
-        assert str(organization.id) in result
-        # The endpoint filters by is_active=True at the ORM level; assert we
-        # get exactly one row per org (not two).
-        assert (
-            AgentccOrgConfig.no_workspace_objects.filter(
-                organization=organization
-            ).count()
-            == 2
-        )
-        # But bulk sync returns exactly one key per org.
-        assert list(result.keys()).count(str(organization.id)) == 1
+        assert result[str(organization.id)]["routing"] == {"strategy": "active"}
 
     def test_soft_deleted_configs_excluded(self, admin_client, organization, db):
         # Soft-deleted rows are still present in the DB but must be filtered

--- a/futureagi/agentcc/tests/test_org_context_agentcc_api.py
+++ b/futureagi/agentcc/tests/test_org_context_agentcc_api.py
@@ -74,6 +74,7 @@ class TestAgentccRequestOrganizationContext:
         assert session.organization_id == org_b.id
         assert session.organization_id != user.organization_id
 
+    @pytest.mark.requires_ee
     def test_webhook_create_uses_active_request_organization(
         self, user, secondary_org_context, secondary_org_client
     ):
@@ -242,6 +243,7 @@ class TestAgentccRequestOrganizationContext:
         assert policy.deleted is True
         assert policy.deleted_at is not None
 
+    @pytest.mark.requires_ee
     def test_email_alert_create_uses_active_request_organization(
         self, user, secondary_org_context, secondary_org_client
     ):
@@ -264,6 +266,7 @@ class TestAgentccRequestOrganizationContext:
         assert alert.organization_id == org_b.id
         assert alert.organization_id != user.organization_id
 
+    @pytest.mark.requires_ee
     def test_email_alert_update_preserves_existing_secret_when_omitted(
         self, user, secondary_org_context, secondary_org_client, settings
     ):

--- a/futureagi/agentcc/tests/test_org_context_agentcc_api.py
+++ b/futureagi/agentcc/tests/test_org_context_agentcc_api.py
@@ -266,31 +266,25 @@ class TestAgentccRequestOrganizationContext:
         assert alert.organization_id == org_b.id
         assert alert.organization_id != user.organization_id
 
-    @pytest.mark.requires_ee
     def test_email_alert_update_preserves_existing_secret_when_omitted(
         self, user, secondary_org_context, secondary_org_client, settings
     ):
         settings.INTEGRATION_ENCRYPTION_KEY = Fernet.generate_key().decode()
+        org_b, _ = secondary_org_context
 
-        create_response = secondary_org_client.post(
-            "/agentcc/email-alerts/",
-            {
-                "name": "secondary_alert_secret",
-                "recipients": ["alerts@example.com"],
-                "events": ["budget.exceeded"],
-                "provider": "sendgrid",
-                "provider_config": {
-                    "api_key": "sg.original-secret",
-                    "from_email": "old@example.com",
-                },
-            },
-            format="json",
+        alert = AgentccEmailAlert.no_workspace_objects.create(
+            organization=org_b,
+            name="secondary_alert_secret",
+            recipients=["alerts@example.com"],
+            events=["budget.exceeded"],
+            provider="sendgrid",
+            encrypted_config=CredentialManager.encrypt(
+                {"api_key": "sg.original-secret", "from_email": "old@example.com"}
+            ),
         )
-        assert create_response.status_code == 200, create_response.json()
-        alert_id = create_response.json()["result"]["id"]
 
         update_response = secondary_org_client.patch(
-            f"/agentcc/email-alerts/{alert_id}/",
+            f"/agentcc/email-alerts/{alert.id}/",
             {
                 "provider_config": {"from_email": "new@example.com"},
                 "cooldown_minutes": 10,
@@ -299,7 +293,7 @@ class TestAgentccRequestOrganizationContext:
         )
 
         assert update_response.status_code == 200, update_response.json()
-        alert = AgentccEmailAlert.no_workspace_objects.get(id=alert_id)
+        alert.refresh_from_db()
         config = CredentialManager.decrypt(bytes(alert.encrypted_config))
         assert config["api_key"] == "sg.original-secret"
         assert config["from_email"] == "new@example.com"

--- a/futureagi/agentcc/tests/test_provider_credential_api.py
+++ b/futureagi/agentcc/tests/test_provider_credential_api.py
@@ -174,3 +174,194 @@ class TestAgentccProviderCredentialOrganizationIsolation:
         assert response.status_code == 400, response.json()
         assert "could not be decrypted" in response.json()["message"]
         mock_fetch.assert_not_called()
+
+    def test_retrieve_returns_metadata_without_decrypted_credentials(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=org_b,
+            provider_name="openai",
+            display_name="Org B OpenAI",
+            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-org-b"}),
+            api_format="openai",
+        )
+
+        response = secondary_org_client.get(
+            f"/agentcc/provider-credentials/{cred.id}/"
+        )
+
+        assert response.status_code == 200, response.json()
+        data = response.json()["result"]
+        assert data["provider_name"] == "openai"
+        assert data["display_name"] == "Org B OpenAI"
+        # Encrypted-credential bytes must not appear in the response.
+        assert "encrypted_credentials" not in data
+        # Credentials field is masked (present but value redacted); the
+        # plaintext api_key must never appear on the wire.
+        creds = data.get("credentials") or {}
+        assert creds.get("api_key") in (None, "****", "")
+        assert "sk-org-b" not in str(data)
+
+    def test_retrieve_cross_tenant_returns_404(
+        self, user, secondary_org_context, secondary_org_client
+    ):
+        # Credential belongs to org A; secondary_org_client is scoped to org B.
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=user.organization,
+            provider_name="openai",
+            display_name="Org A OpenAI",
+            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-org-a"}),
+            api_format="openai",
+        )
+
+        response = secondary_org_client.get(
+            f"/agentcc/provider-credentials/{cred.id}/"
+        )
+        assert response.status_code == 404
+
+    def test_update_writes_safe_fields_and_pushes_config(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=org_b,
+            provider_name="openai",
+            display_name="Old Display",
+            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-untouched"}),
+            api_format="openai",
+            models_list=["gpt-4o-mini"],
+        )
+
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ) as mock_push:
+            response = secondary_org_client.put(
+                f"/agentcc/provider-credentials/{cred.id}/",
+                {
+                    "provider_name": "openai",
+                    "display_name": "New Display",
+                    "models_list": ["gpt-4o"],
+                    "api_format": "openai",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        # PUT falls through to DRF's default UpdateModelMixin (no override in
+        # the view) so the payload comes back raw; PATCH is overridden to
+        # wrap via _gm.success_response. Accept both shapes.
+        data = body.get("result", body)
+        assert data["display_name"] == "New Display"
+
+        cred.refresh_from_db()
+        assert cred.display_name == "New Display"
+        assert cred.models_list == ["gpt-4o"]
+        # Current behavior: PUT does not push to the gateway because the
+        # view only overrides create/partial_update/destroy/rotate. PATCH
+        # (below) is the client path that fans out to the gateway. If PUT
+        # is ever overridden to push, this assertion should flip.
+        assert mock_push.call_count == 0
+
+    def test_patch_updates_single_field_leaving_others_intact(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=org_b,
+            provider_name="openai",
+            display_name="Original Display",
+            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-org-b"}),
+            api_format="openai",
+            default_timeout_seconds=30,
+            max_concurrent=5,
+        )
+
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ):
+            response = secondary_org_client.patch(
+                f"/agentcc/provider-credentials/{cred.id}/",
+                {"default_timeout_seconds": 45},
+                format="json",
+            )
+
+        assert response.status_code == 200, response.json()
+        cred.refresh_from_db()
+        assert cred.default_timeout_seconds == 45
+        assert cred.max_concurrent == 5  # untouched
+        assert cred.display_name == "Original Display"  # untouched
+
+    def test_destroy_soft_deletes_and_pushes_config(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        cred = AgentccProviderCredential.no_workspace_objects.create(
+            organization=org_b,
+            provider_name="anthropic",
+            display_name="To Delete",
+            encrypted_credentials=CredentialManager.encrypt({"api_key": "sk-x"}),
+            api_format="anthropic",
+        )
+
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ) as mock_push:
+            response = secondary_org_client.delete(
+                f"/agentcc/provider-credentials/{cred.id}/"
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["result"]["deleted"] is True
+        assert response.json()["result"]["gateway_synced"] is True
+        mock_push.assert_called_once()
+
+        cred.refresh_from_db()
+        # Soft-delete, not hard-delete.
+        assert cred.deleted is True
+        assert cred.deleted_at is not None
+        # List should now exclude it.
+        list_response = secondary_org_client.get("/agentcc/provider-credentials/")
+        list_ids = {item["id"] for item in list_response.json()["result"]}
+        assert str(cred.id) not in list_ids
+
+    def test_list_unauthenticated(self, api_client, db):
+        response = api_client.get("/agentcc/provider-credentials/")
+        assert response.status_code in (401, 403)
+
+    def test_create_encrypts_credentials_before_persisting(
+        self, secondary_org_context, secondary_org_client
+    ):
+        org_b, _ = secondary_org_context
+        raw_api_key = "sk-plaintext-must-not-appear-at-rest"
+
+        with patch(
+            "agentcc.views.provider_credential.AgentccProviderCredentialViewSet._push_config_to_gateway",
+            return_value=True,
+        ):
+            response = secondary_org_client.post(
+                "/agentcc/provider-credentials/",
+                {
+                    "provider_name": "openai",
+                    "display_name": "Org B OpenAI",
+                    "credentials": {"api_key": raw_api_key},
+                    "api_format": "openai",
+                },
+                format="json",
+            )
+        assert response.status_code == 201, response.json()
+
+        cred = AgentccProviderCredential.no_workspace_objects.get(
+            provider_name="openai", organization=org_b, deleted=False
+        )
+        # The raw api_key must not sit in the DB in plaintext, either as
+        # the encrypted-credentials bytes or anywhere else.
+        assert raw_api_key.encode() not in cred.encrypted_credentials
+        # But CredentialManager.decrypt should yield the original.
+        assert CredentialManager.decrypt(cred.encrypted_credentials) == {
+            "api_key": raw_api_key
+        }

--- a/futureagi/agentcc/tests/test_routing_policy_api.py
+++ b/futureagi/agentcc/tests/test_routing_policy_api.py
@@ -1,0 +1,164 @@
+"""Coverage for the /agentcc/routing-policies/ endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentcc.models.routing_policy import AgentccRoutingPolicy
+
+
+def _make_policy(user, name="fastest", is_active=True, version=1, **overrides):
+    # AgentccRoutingPolicy has no workspace field; it is org-scoped only.
+    kwargs = {
+        "organization": user.organization,
+        "created_by": user,
+        "name": name,
+        "version": version,
+        "is_active": is_active,
+        "config": {"strategy": "fastest"},
+    }
+    kwargs.update(overrides)
+    return AgentccRoutingPolicy.objects.create(**kwargs)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyList:
+    def test_list_returns_all_versions(self, auth_client, user):
+        _make_policy(user, name="chatty", version=1, is_active=False)
+        _make_policy(user, name="chatty", version=2, is_active=True)
+        _make_policy(user, name="prompty", version=1, is_active=True)
+
+        response = auth_client.get("/agentcc/routing-policies/")
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert len(rows) == 3
+
+    def test_list_active_only_filter(self, auth_client, user):
+        _make_policy(user, name="chatty", version=1, is_active=False)
+        _make_policy(user, name="chatty", version=2, is_active=True)
+
+        response = auth_client.get(
+            "/agentcc/routing-policies/?active_only=true"
+        )
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert len(rows) == 1
+        assert rows[0]["version"] == 2
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/routing-policies/")
+        assert response.status_code in (401, 403)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyRetrieve:
+    def test_retrieve_returns_policy(self, auth_client, user):
+        policy = _make_policy(user, name="lookup-me")
+        response = auth_client.get(
+            f"/agentcc/routing-policies/{policy.id}/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(policy.id)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyCreate:
+    @patch(
+        "agentcc.views.routing_policy.AgentccRoutingPolicyViewSet._sync_routing_to_gateway",
+        return_value=True,
+    )
+    def test_create_new_version_deactivates_prior(
+        self, mock_sync, auth_client, user
+    ):
+        prior = _make_policy(user, name="fastest", version=1, is_active=True)
+
+        response = auth_client.post(
+            "/agentcc/routing-policies/",
+            {"name": "fastest", "config": {"strategy": "fastest"}},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        prior.refresh_from_db()
+        assert prior.is_active is False
+        new_row = AgentccRoutingPolicy.no_workspace_objects.get(
+            organization=user.organization,
+            name="fastest",
+            is_active=True,
+            deleted=False,
+        )
+        assert new_row.version == 2
+        mock_sync.assert_called_once()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyImmutable:
+    def test_put_returns_400(self, auth_client, user):
+        policy = _make_policy(user, name="frozen")
+        response = auth_client.put(
+            f"/agentcc/routing-policies/{policy.id}/",
+            {"name": "frozen", "config": {"strategy": "round_robin"}},
+            format="json",
+        )
+        assert response.status_code == 400
+        assert "versioned" in response.json()["message"].lower()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyDestroy:
+    @patch(
+        "agentcc.views.routing_policy.AgentccRoutingPolicyViewSet._sync_routing_to_gateway",
+        return_value=True,
+    )
+    def test_destroy_soft_deletes_and_syncs(self, mock_sync, auth_client, user):
+        policy = _make_policy(user, name="to-delete")
+        response = auth_client.delete(
+            f"/agentcc/routing-policies/{policy.id}/"
+        )
+        assert response.status_code == 200
+        assert response.json()["result"]["deleted"] is True
+        mock_sync.assert_called_once()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicyActivate:
+    @patch(
+        "agentcc.views.routing_policy.AgentccRoutingPolicyViewSet._sync_routing_to_gateway",
+        return_value=True,
+    )
+    def test_activate_swaps_active_within_same_name(
+        self, mock_sync, auth_client, user
+    ):
+        v1 = _make_policy(user, name="fastest", version=1, is_active=True)
+        v2 = _make_policy(user, name="fastest", version=2, is_active=False)
+
+        response = auth_client.post(
+            f"/agentcc/routing-policies/{v2.id}/activate/"
+        )
+        assert response.status_code == 200, response.json()
+        v1.refresh_from_db()
+        v2.refresh_from_db()
+        assert v1.is_active is False
+        assert v2.is_active is True
+        mock_sync.assert_called_once()
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRoutingPolicySync:
+    @patch(
+        "agentcc.views.routing_policy.AgentccRoutingPolicyViewSet._sync_routing_to_gateway",
+        return_value=True,
+    )
+    def test_sync_triggers_gateway_push(self, mock_sync, auth_client, user):
+        _make_policy(user, name="fastest", is_active=True)
+        response = auth_client.post("/agentcc/routing-policies/sync/")
+        assert response.status_code == 200
+        assert response.json()["result"]["synced"] is True
+        mock_sync.assert_called_once()

--- a/futureagi/agentcc/tests/test_session_crud_api.py
+++ b/futureagi/agentcc/tests/test_session_crud_api.py
@@ -1,0 +1,115 @@
+"""CRUD + close-action coverage for /agentcc/sessions/."""
+
+import pytest
+
+from agentcc.models.session import AgentccSession
+
+
+def _make_session(user, workspace, session_id="sess-a", **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "workspace": workspace,
+        "session_id": session_id,
+        "name": session_id,
+        "status": "active",
+    }
+    kwargs.update(overrides)
+    return AgentccSession.objects.create(**kwargs)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccSessionListPlain:
+    def test_list_returns_sessions_for_active_workspace(
+        self, auth_client, user, workspace
+    ):
+        _make_session(user, workspace, session_id="sess-list-a")
+        _make_session(user, workspace, session_id="sess-list-b")
+
+        response = auth_client.get("/agentcc/sessions/")
+        assert response.status_code == 200
+        body = response.json()
+        rows = body.get("result", body.get("results", []))
+        ids = {row["session_id"] for row in rows}
+        assert {"sess-list-a", "sess-list-b"} <= ids
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/sessions/")
+        assert response.status_code in (401, 403)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccSessionUpdate:
+    def test_put_updates_status(self, auth_client, user, workspace):
+        session = _make_session(user, workspace, session_id="sess-put")
+
+        response = auth_client.put(
+            f"/agentcc/sessions/{session.id}/",
+            {
+                "session_id": "sess-put",
+                "name": "renamed",
+                "status": "closed",
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        session.refresh_from_db()
+        assert session.status == "closed"
+        assert session.name == "renamed"
+
+    def test_patch_partial_update(self, auth_client, user, workspace):
+        session = _make_session(user, workspace, session_id="sess-patch")
+
+        response = auth_client.patch(
+            f"/agentcc/sessions/{session.id}/",
+            {"metadata": {"tag": "loaded"}},
+            format="json",
+        )
+        assert response.status_code == 200
+        session.refresh_from_db()
+        assert session.metadata == {"tag": "loaded"}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccSessionDestroy:
+    def test_destroy_soft_deletes_session(self, auth_client, user, workspace):
+        session = _make_session(user, workspace, session_id="sess-del")
+
+        response = auth_client.delete(f"/agentcc/sessions/{session.id}/")
+        assert response.status_code in (200, 204)
+
+        # Subsequent list must not surface the deleted row.
+        list_response = auth_client.get("/agentcc/sessions/")
+        assert list_response.status_code == 200
+        body = list_response.json()
+        rows = body.get("result", body.get("results", []))
+        ids = {row["session_id"] for row in rows}
+        assert "sess-del" not in ids
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccSessionClose:
+    def test_close_transitions_active_to_closed(
+        self, auth_client, user, workspace
+    ):
+        session = _make_session(user, workspace, session_id="sess-close")
+        assert session.status == "active"
+
+        response = auth_client.post(f"/agentcc/sessions/{session.id}/close/")
+        assert response.status_code == 200, response.json()
+        session.refresh_from_db()
+        assert session.status == "closed"
+
+    def test_close_twice_is_idempotent(self, auth_client, user, workspace):
+        session = _make_session(
+            user, workspace, session_id="sess-close-twice", status="closed"
+        )
+
+        response = auth_client.post(f"/agentcc/sessions/{session.id}/close/")
+        # Endpoint returns 200 whether already closed or freshly closed.
+        assert response.status_code == 200
+        session.refresh_from_db()
+        assert session.status == "closed"

--- a/futureagi/agentcc/tests/test_shadow_experiments_api.py
+++ b/futureagi/agentcc/tests/test_shadow_experiments_api.py
@@ -1,0 +1,258 @@
+"""Coverage for the /agentcc/shadow-experiments/ and /agentcc/shadow-results/ endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentcc.models.shadow_experiment import AgentccShadowExperiment
+from agentcc.models.shadow_result import AgentccShadowResult
+
+
+def _make_experiment(user, name="test-exp", status=None, **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "workspace": None,
+        "created_by": user,
+        "name": name,
+        "source_model": "gpt-4o",
+        "shadow_model": "claude-3-5-sonnet",
+        "shadow_provider": "anthropic",
+        "sample_rate": 0.1,
+    }
+    if status is not None:
+        kwargs["status"] = status
+    kwargs.update(overrides)
+    return AgentccShadowExperiment.no_workspace_objects.create(**kwargs)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestShadowExperimentCRUD:
+    def test_list_returns_experiments(self, auth_client, user):
+        _make_experiment(user, name="exp-a")
+        _make_experiment(user, name="exp-b")
+
+        response = auth_client.get("/agentcc/shadow-experiments/")
+        assert response.status_code == 200
+        result = response.json()["result"]
+        names = {row["name"] for row in result}
+        assert {"exp-a", "exp-b"} <= names
+
+    def test_list_filter_by_status(self, auth_client, user):
+        _make_experiment(
+            user, name="active-one", status=AgentccShadowExperiment.STATUS_ACTIVE
+        )
+        _make_experiment(
+            user, name="paused-one", status=AgentccShadowExperiment.STATUS_PAUSED
+        )
+
+        response = auth_client.get(
+            "/agentcc/shadow-experiments/?status=paused"
+        )
+        assert response.status_code == 200
+        names = {row["name"] for row in response.json()["result"]}
+        assert names == {"paused-one"}
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/shadow-experiments/")
+        assert response.status_code in (401, 403)
+
+    @pytest.mark.requires_ee
+    def test_create_writes_and_scopes_to_active_org(self, auth_client, user):
+        response = auth_client.post(
+            "/agentcc/shadow-experiments/",
+            {
+                "name": "brand-new-exp",
+                "source_model": "gpt-4o",
+                "shadow_model": "claude-3-5-sonnet",
+                "shadow_provider": "anthropic",
+                "sample_rate": 0.25,
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        row = AgentccShadowExperiment.no_workspace_objects.get(name="brand-new-exp")
+        assert row.organization == user.organization
+        assert row.created_by == user
+        assert row.sample_rate == 0.25
+
+    def test_retrieve_returns_experiment(self, auth_client, user):
+        exp = _make_experiment(user, name="retrieve-me")
+        response = auth_client.get(f"/agentcc/shadow-experiments/{exp.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(exp.id)
+
+    def test_partial_update_writes_field(self, auth_client, user):
+        exp = _make_experiment(user, name="orig-name")
+        response = auth_client.patch(
+            f"/agentcc/shadow-experiments/{exp.id}/",
+            {"description": "now with a description"},
+            format="json",
+        )
+        assert response.status_code == 200
+        exp.refresh_from_db()
+        assert exp.description == "now with a description"
+
+    def test_destroy_soft_deletes_experiment_and_results(self, auth_client, user):
+        exp = _make_experiment(user, name="to-delete")
+        # Attach a result row so we can verify the cascade.
+        result = AgentccShadowResult.no_workspace_objects.create(
+            experiment=exp,
+            organization=user.organization,
+            workspace=None,
+            source_model="gpt-4o",
+            shadow_model="claude-3-5-sonnet",
+        )
+
+        response = auth_client.delete(f"/agentcc/shadow-experiments/{exp.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["deleted"] is True
+
+        exp.refresh_from_db()
+        assert exp.deleted is True
+        assert exp.deleted_at is not None
+        # Results are cascade-soft-deleted (raw SQL check bypasses any
+        # manager-level deleted filter).
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT deleted FROM agentcc_shadow_result WHERE id = %s",
+                [str(result.id)],
+            )
+            row = cursor.fetchone()
+        assert row is not None and row[0] is True
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestShadowExperimentLifecycle:
+    @patch(
+        "agentcc.views.shadow_experiments.AgentccShadowExperimentViewSet._push_org_config",
+        return_value=True,
+    )
+    def test_pause_transitions_active_to_paused(self, mock_push, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_ACTIVE)
+        response = auth_client.patch(f"/agentcc/shadow-experiments/{exp.id}/pause/")
+        assert response.status_code == 200, response.json()
+        exp.refresh_from_db()
+        assert exp.status == AgentccShadowExperiment.STATUS_PAUSED
+        mock_push.assert_called_once()
+
+    def test_pause_rejects_non_active(self, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_PAUSED)
+        response = auth_client.patch(f"/agentcc/shadow-experiments/{exp.id}/pause/")
+        assert response.status_code == 400
+        assert "active" in response.json()["message"].lower()
+
+    @patch(
+        "agentcc.views.shadow_experiments.AgentccShadowExperimentViewSet._push_org_config",
+        return_value=True,
+    )
+    def test_resume_transitions_paused_to_active(self, mock_push, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_PAUSED)
+        response = auth_client.patch(f"/agentcc/shadow-experiments/{exp.id}/resume/")
+        assert response.status_code == 200, response.json()
+        exp.refresh_from_db()
+        assert exp.status == AgentccShadowExperiment.STATUS_ACTIVE
+
+    def test_resume_rejects_non_paused(self, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_ACTIVE)
+        response = auth_client.patch(f"/agentcc/shadow-experiments/{exp.id}/resume/")
+        assert response.status_code == 400
+
+    @patch(
+        "agentcc.views.shadow_experiments.AgentccShadowExperimentViewSet._push_org_config",
+        return_value=True,
+    )
+    def test_complete_terminates_experiment(self, mock_push, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_ACTIVE)
+        response = auth_client.patch(
+            f"/agentcc/shadow-experiments/{exp.id}/complete/"
+        )
+        assert response.status_code == 200, response.json()
+        exp.refresh_from_db()
+        assert exp.status == AgentccShadowExperiment.STATUS_COMPLETED
+
+    def test_complete_rejects_already_completed(self, auth_client, user):
+        exp = _make_experiment(user, status=AgentccShadowExperiment.STATUS_COMPLETED)
+        response = auth_client.patch(
+            f"/agentcc/shadow-experiments/{exp.id}/complete/"
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestShadowExperimentStats:
+    def test_stats_aggregates_over_results(self, auth_client, user):
+        exp = _make_experiment(user)
+        for source_ms, shadow_ms in [(100, 150), (200, 250), (300, 400)]:
+            AgentccShadowResult.no_workspace_objects.create(
+                experiment=exp,
+                organization=user.organization,
+                workspace=None,
+                source_model="gpt-4o",
+                shadow_model="claude-3-5-sonnet",
+                source_latency_ms=source_ms,
+                shadow_latency_ms=shadow_ms,
+                source_status_code=200,
+                shadow_status_code=200,
+            )
+
+        response = auth_client.get(f"/agentcc/shadow-experiments/{exp.id}/stats/")
+        assert response.status_code == 200
+        stats = response.json()["result"]
+        assert stats["total_comparisons"] == 3
+        assert stats["avg_source_latency_ms"] == 200.0
+        assert stats["avg_shadow_latency_ms"] == pytest.approx(266.7, rel=1e-2)
+
+    def test_stats_empty_returns_zeroed_shape(self, auth_client, user):
+        exp = _make_experiment(user)
+        response = auth_client.get(f"/agentcc/shadow-experiments/{exp.id}/stats/")
+        assert response.status_code == 200
+        stats = response.json()["result"]
+        assert stats["total_comparisons"] == 0
+        assert stats["latency_delta_pct"] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestShadowResultReadOnly:
+    def test_list_returns_results_for_org(self, auth_client, user):
+        exp = _make_experiment(user)
+        AgentccShadowResult.no_workspace_objects.create(
+            experiment=exp,
+            organization=user.organization,
+            workspace=None,
+            source_model="gpt-4o",
+            shadow_model="claude-3-5-sonnet",
+        )
+
+        response = auth_client.get("/agentcc/shadow-results/")
+        assert response.status_code == 200
+        body = response.json()
+        # DRF pagination wraps results under "results"; the unpaginated
+        # branch wraps under _gm.success_response's "result" key. Accept
+        # both shapes.
+        rows = (
+            body.get("result")
+            if "result" in body
+            else body.get("results", [])
+        )
+        assert isinstance(rows, list)
+        assert len(rows) >= 1
+
+    def test_retrieve_returns_result(self, auth_client, user):
+        exp = _make_experiment(user)
+        row = AgentccShadowResult.no_workspace_objects.create(
+            experiment=exp,
+            organization=user.organization,
+            workspace=None,
+            source_model="gpt-4o",
+            shadow_model="claude-3-5-sonnet",
+        )
+
+        response = auth_client.get(f"/agentcc/shadow-results/{row.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(row.id)

--- a/futureagi/agentcc/tests/test_webhook_outbound_api.py
+++ b/futureagi/agentcc/tests/test_webhook_outbound_api.py
@@ -1,0 +1,220 @@
+"""Coverage for the /agentcc/webhooks/ and /agentcc/webhook-events/ endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentcc.models.webhook import AgentccWebhook, AgentccWebhookEvent
+
+
+def _make_webhook(user, name="hook", **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "name": name,
+        "url": "https://example.com/webhook",
+        "events": ["request.completed"],
+    }
+    kwargs.update(overrides)
+    return AgentccWebhook.objects.create(**kwargs)
+
+
+def _make_event(webhook, user, status=None, **overrides):
+    kwargs = {
+        "organization": user.organization,
+        "webhook": webhook,
+        "event_type": "request.completed",
+        "payload": {"foo": "bar"},
+    }
+    if status is not None:
+        kwargs["status"] = status
+    kwargs.update(overrides)
+    return AgentccWebhookEvent.objects.create(**kwargs)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccWebhookCRUD:
+    def test_list_returns_webhooks(self, auth_client, user):
+        _make_webhook(user, name="hook-a")
+        _make_webhook(user, name="hook-b")
+
+        response = auth_client.get("/agentcc/webhooks/")
+        assert response.status_code == 200
+        names = {row["name"] for row in response.json()["result"]}
+        assert {"hook-a", "hook-b"} <= names
+
+    def test_list_unauthenticated(self, api_client):
+        response = api_client.get("/agentcc/webhooks/")
+        assert response.status_code in (401, 403)
+
+    def test_retrieve_returns_webhook(self, auth_client, user):
+        webhook = _make_webhook(user, name="lookup-me")
+        response = auth_client.get(f"/agentcc/webhooks/{webhook.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(webhook.id)
+
+    def test_update_writes_fields(self, auth_client, user):
+        webhook = _make_webhook(user, name="mutate-me")
+
+        response = auth_client.put(
+            f"/agentcc/webhooks/{webhook.id}/",
+            {
+                "name": "renamed",
+                "url": "https://example.com/renamed",
+                "events": ["error.occurred"],
+            },
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        webhook.refresh_from_db()
+        assert webhook.name == "renamed"
+        assert webhook.url == "https://example.com/renamed"
+        assert webhook.events == ["error.occurred"]
+
+    def test_partial_update_writes_single_field(self, auth_client, user):
+        webhook = _make_webhook(user, name="partial")
+        response = auth_client.patch(
+            f"/agentcc/webhooks/{webhook.id}/",
+            {"description": "now with a description"},
+            format="json",
+        )
+        assert response.status_code == 200
+        webhook.refresh_from_db()
+        assert webhook.description == "now with a description"
+
+    def test_destroy_soft_deletes_webhook(self, auth_client, user):
+        webhook = _make_webhook(user, name="to-delete")
+        response = auth_client.delete(f"/agentcc/webhooks/{webhook.id}/")
+        assert response.status_code == 200
+        webhook.refresh_from_db()
+        assert webhook.deleted is True
+        assert webhook.deleted_at is not None
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccWebhookTest:
+    @patch("agentcc.views.webhook_outbound.build_ssrf_safe_session")
+    @patch("agentcc.views.webhook_outbound.ensure_public_http_url")
+    def test_test_send_success_records_delivered_event(
+        self, mock_ensure_url, mock_session_builder, auth_client, user
+    ):
+        webhook = _make_webhook(user, name="test-send")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        session = MagicMock()
+        session.post.return_value = mock_response
+        mock_session_builder.return_value = session
+
+        response = auth_client.post(f"/agentcc/webhooks/{webhook.id}/test/")
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["result"]["status_code"] == 200
+        assert response.json()["result"]["success"] is True
+
+        # An event row is written for the test delivery.
+        event = AgentccWebhookEvent.objects.get(
+            webhook=webhook, event_type="test"
+        )
+        assert event.status == AgentccWebhookEvent.DELIVERED
+        assert event.last_response_code == 200
+
+    @patch("agentcc.views.webhook_outbound.build_ssrf_safe_session")
+    @patch("agentcc.views.webhook_outbound.ensure_public_http_url")
+    def test_test_send_upstream_error_records_failed_event(
+        self, mock_ensure_url, mock_session_builder, auth_client, user
+    ):
+        from requests import RequestException
+
+        webhook = _make_webhook(user, name="test-fail")
+        session = MagicMock()
+        session.post.side_effect = RequestException("connection refused")
+        mock_session_builder.return_value = session
+
+        response = auth_client.post(f"/agentcc/webhooks/{webhook.id}/test/")
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["result"]["success"] is False
+        assert "connection refused" in response.json()["result"]["error"]
+
+        event = AgentccWebhookEvent.objects.get(
+            webhook=webhook, event_type="test"
+        )
+        assert event.status == AgentccWebhookEvent.FAILED
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestAgentccWebhookEvent:
+    def test_list_returns_events(self, auth_client, user):
+        webhook = _make_webhook(user)
+        _make_event(webhook, user)
+        _make_event(webhook, user)
+
+        response = auth_client.get("/agentcc/webhook-events/")
+        assert response.status_code == 200
+        assert len(response.json()["result"]) >= 2
+
+    def test_list_filter_by_status(self, auth_client, user):
+        webhook = _make_webhook(user)
+        _make_event(webhook, user, status=AgentccWebhookEvent.DELIVERED)
+        _make_event(webhook, user, status=AgentccWebhookEvent.FAILED)
+
+        response = auth_client.get(
+            "/agentcc/webhook-events/?status=failed"
+        )
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert len(rows) == 1
+        assert rows[0]["status"] == "failed"
+
+    def test_list_filter_by_webhook_id(self, auth_client, user):
+        w1 = _make_webhook(user, name="hook-1")
+        w2 = _make_webhook(user, name="hook-2")
+        _make_event(w1, user)
+        _make_event(w2, user)
+
+        response = auth_client.get(
+            f"/agentcc/webhook-events/?webhook_id={w1.id}"
+        )
+        assert response.status_code == 200
+        rows = response.json()["result"]
+        assert len(rows) == 1
+
+    def test_retrieve_returns_event(self, auth_client, user):
+        webhook = _make_webhook(user)
+        event = _make_event(webhook, user)
+
+        response = auth_client.get(f"/agentcc/webhook-events/{event.id}/")
+        assert response.status_code == 200
+        assert response.json()["result"]["id"] == str(event.id)
+
+    def test_retry_resets_failed_event_to_pending(self, auth_client, user):
+        webhook = _make_webhook(user)
+        event = _make_event(
+            webhook,
+            user,
+            status=AgentccWebhookEvent.FAILED,
+            attempts=3,
+            last_error="boom",
+        )
+
+        response = auth_client.post(
+            f"/agentcc/webhook-events/{event.id}/retry/"
+        )
+        assert response.status_code == 200
+        event.refresh_from_db()
+        assert event.status == AgentccWebhookEvent.PENDING
+        assert event.attempts == 0
+        assert event.last_error == ""
+
+    def test_retry_rejects_already_delivered(self, auth_client, user):
+        webhook = _make_webhook(user)
+        event = _make_event(
+            webhook, user, status=AgentccWebhookEvent.DELIVERED
+        )
+
+        response = auth_client.post(
+            f"/agentcc/webhook-events/{event.id}/retry/"
+        )
+        assert response.status_code == 400

--- a/futureagi/agentcc/tests/test_webhook_outbound_api.py
+++ b/futureagi/agentcc/tests/test_webhook_outbound_api.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agentcc.models.webhook import AgentccWebhook, AgentccWebhookEvent
+from agentcc.services.url_safety import WEBHOOK_PRIVATE_URL_ERROR
 
 
 def _make_webhook(user, name="hook", **overrides):
@@ -94,6 +95,18 @@ class TestAgentccWebhookCRUD:
 @pytest.mark.integration
 @pytest.mark.api
 class TestAgentccWebhookTest:
+    @patch("agentcc.views.webhook_outbound.build_ssrf_safe_session")
+    def test_test_send_rejects_private_url(
+        self, mock_session_builder, auth_client, user
+    ):
+        webhook = _make_webhook(user, url="http://169.254.169.254/")
+
+        response = auth_client.post(f"/agentcc/webhooks/{webhook.id}/test/")
+
+        assert response.status_code == 400, response.json()
+        assert response.json()["result"] == WEBHOOK_PRIVATE_URL_ERROR
+        mock_session_builder.assert_not_called()
+
     @patch("agentcc.views.webhook_outbound.build_ssrf_safe_session")
     @patch("agentcc.views.webhook_outbound.ensure_public_http_url")
     def test_test_send_success_records_delivered_event(

--- a/futureagi/agentcc/views/api_key.py
+++ b/futureagi/agentcc/views/api_key.py
@@ -1,4 +1,5 @@
 import structlog
+from django.http import Http404
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
@@ -130,6 +131,8 @@ class AgentccAPIKeyViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
             api_key = auth_bridge.update_key(api_key, **serializer.validated_data)
             return self._gm.success_response(AgentccAPIKeySerializer(api_key).data)
 
+        except Http404:
+            return self._gm.not_found("API key not found")
         except GatewayClientError as e:
             logger.exception("api_key_update_gateway_error", error=str(e))
             return self._gm.bad_request(f"Gateway error: {e}")

--- a/futureagi/agentcc/views/org_config.py
+++ b/futureagi/agentcc/views/org_config.py
@@ -3,6 +3,7 @@ import copy
 import structlog
 from django.db import transaction
 from django.db.models import Max
+from django.http import Http404
 from django.utils import timezone
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -236,6 +237,8 @@ class AgentccOrgConfigViewSet(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
             if not synced:
                 data["gateway_warning"] = _GATEWAY_SYNC_WARNING
             return self._gm.success_response(data)
+        except Http404:
+            return self._gm.not_found("Org config not found")
         except Exception as e:
             logger.exception("org_config_activate_error", error=str(e))
             return self._gm.bad_request(str(e))


### PR DESCRIPTION
## Why

The agentcc Python test suite green with `ee/` present (217/217) fails with `ee/` removed (213/217): the four failures are on POST endpoints that the ee-only entitlement layer 402s in the OSS lane. At the same time, a fresh endpoint-coverage sweep against `agentcc/urls.py` marks 92 of 149 registered endpoints as NONE, including seventeen P0. This PR:

1. Marks the four ee-gated tests + one new gated test with `@pytest.mark.requires_ee` so both lanes agree.
2. Adds tests for every P0-NONE endpoint and upgrades every THIN P0 endpoint with the negative it was missing (unauth, cross-tenant, upstream-unreachable).
3. Fixes two bugs the new cross-tenant tests surface: `views/api_key.py::partial_update` and `views/org_config.py::activate` swallow `Http404` in their generic `except Exception` and return 400 instead of 404.

The `requires_ee` marker + auto-skip machinery is already registered in `futureagi/conftest.py` on the base branch (`fix/th-7080-simulate-oss-suite-green`), so this PR reuses it rather than reintroducing it.

## What changed

Fourteen files. Twelve test files (ten new, two extended); two view files with a three-line each `except Http404` addition.

### Backend

| File | Change | What is preserved unchanged |
|---|---|---|
| `agentcc/views/api_key.py` | Import `Http404`; add `except Http404: return self._gm.not_found("API key not found")` before the existing `except GatewayClientError` in `partial_update` (`api_key.py:134-135`). | Existing `GatewayClientError` and `Exception` handlers, `success_response` return, `serializer.validated_data` and `auth_bridge.update_key` call, `except GatewayClientError` log-and-return-400 semantics. |
| `agentcc/views/org_config.py` | Import `Http404`; add `except Http404: return self._gm.not_found("Org config not found")` before the existing `except Exception` in `activate` (`org_config.py:240-241`). | Existing `except Exception` handler, the transactional deactivate + activate + `_push_config_to_gateway(org.id, instance)` sequence, `gateway_synced` and `gateway_warning` keys in the response. |

Both fixes match the app pattern: `agentcc/views/{blocklist,custom_property,email_alert,gateway,guardrail_feedback,guardrail_policy,org_config,provider_credential,request_log,routing_policy,session,shadow_experiments,webhook_outbound}.py` return `self._gm.not_found("<Resource> not found")` at 23 other sites already.

### Tests

New:

| File | New tests | Scope |
|---|---|---|
| `agentcc/tests/test_org_config_bulk.py` | 7 | `GET /agentcc/org-configs/bulk/` admin-token gating, envelope keyed by str(org_id), inactive-version + soft-deleted exclusion. |
| `agentcc/tests/test_org_config_api.py` | 15 | `AgentccOrgConfigViewSet` list, retrieve, create with version bump, PUT + PATCH 400 (immutable), activate, active-action, cross-tenant 404. |
| `agentcc/tests/test_shadow_experiments_api.py` | 17 | `AgentccShadowExperimentViewSet` + `AgentccShadowResultViewSet` CRUD, pause / resume / complete state transitions, stats aggregation. |
| `agentcc/tests/test_routing_policy_api.py` | 9 | `AgentccRoutingPolicyViewSet` list, retrieve, create with version bump, PUT 400, destroy, activate, sync. |
| `agentcc/tests/test_webhook_outbound_api.py` | 14 | `AgentccWebhookViewSet` CRUD + test-send success and failure, `AgentccWebhookEventViewSet` list / filter / retry. |
| `agentcc/tests/test_session_crud_api.py` | 7 | `AgentccSessionViewSet` list + unauth, PUT, PATCH, DELETE, close active-to-closed + idempotent-when-closed. |
| `agentcc/tests/test_guardrail_endpoints_api.py` | 22 | `AgentccGuardrailPolicyViewSet` CRUD + sync, `AgentccGuardrailConfigViewSet` helpers, `AgentccBlocklistViewSet` remaining CRUD + remove-words, `AgentccGuardrailFeedbackViewSet` CRUD + summary. |
| `agentcc/tests/test_gateway_mcp_and_analytics_guardrail_api.py` | 15 | Gateway MCP sub-actions (`mcp-status`, `mcp-tools`, `update-mcp-server`, `remove-mcp-server`, `update-mcp-guardrails`, `test-mcp-tool`, `mcp-resources`, `mcp-prompts`) + `AgentccAnalyticsViewSet` guardrail read endpoints. |

Extended:

| File | New tests | Scope |
|---|---|---|
| `agentcc/tests/test_api.py` | 24 | `TestAgentccAPIKeyAPI`: retrieve, retrieve-unauth, destroy, sync, sync-unauth, list cross-tenant, PUT cross-tenant, PATCH happy, revoke idempotent (9). `TestAgentccGatewayAPI`: retrieve-unauth, providers-unauth, providers-when-unreachable, reload happy, reload-unauth, reload-unreachable, update-provider standalone, remove-provider standalone, update-config + unknown-field, set-budget + missing-fields, remove-budget (13). `TestAgentccRequestLogAPI`: retrieve 404 on unknown id + unauth (2). |
| `agentcc/tests/test_provider_credential_api.py` | 7 | Retrieve masked credentials, retrieve cross-tenant 404, PUT safe-fields (documents that PUT currently does not push to the gateway), PATCH single-field, destroy soft-delete, list-unauth, create encrypts credentials at rest. |
| `agentcc/tests/test_name_validation_api.py` | 0 | Adds `@pytest.mark.requires_ee` on `test_create_webhook_rejects_xss_name` (endpoint is ee-gated). |
| `agentcc/tests/test_org_context_agentcc_api.py` | 0 | Adds `@pytest.mark.requires_ee` on `test_webhook_create_uses_active_request_organization`, `test_email_alert_create_uses_active_request_organization`, `test_email_alert_update_preserves_existing_secret_when_omitted` (all target create endpoints that the ee-only entitlement layer gates). |

Total: 137 new tests, 5 marker additions.

## Test scenarios

Every new test class asserts one specific behavior; each row below is one test.

### Bulk sync

| Test | Failure mode it pins |
|---|---|
| `test_unauthenticated_returns_403` | Anon call to `/org-configs/bulk/` returns 403 (not 200 with data). |
| `test_wrong_token_returns_403` | Bearer with wrong secret returns 403. |
| `test_empty_response_when_no_active_configs` | Zero-orgs case returns `result: {}`. |
| `test_returns_configs_keyed_by_org_id` | Envelope shape: dict keyed by `str(org_id)`, value is a dict. |
| `test_multi_org_configs_all_returned` | Two active orgs both surface in one call. |
| `test_inactive_versions_excluded` | Only the `is_active=True` row for an org is shipped. |
| `test_soft_deleted_configs_excluded` | `deleted=True` rows do not leak to the gateway. |

### Org config CRUD

| Test | Failure mode it pins |
|---|---|
| `test_list_returns_versions_for_active_org` | Versions ordered `-version` and both surface. |
| `test_list_unauthenticated` | Anon returns 401/403. |
| `test_list_isolates_per_org` | Cross-org list does not surface a foreign row. |
| `test_retrieve_returns_config` | 200 with id + version. |
| `test_retrieve_cross_tenant_returns_404` | Foreign-org id returns 404. |
| `test_create_new_version_deactivates_prior` | New create deactivates the prior active row, bumps version, calls `_push_config_to_gateway`. |
| `test_create_unknown_fields_are_silently_ignored` | Pins current serializer behavior: unknown fields dropped, valid slots persisted. |
| `test_put_returns_400_because_immutable` | PUT returns 400 with "immutable" in the message. |
| `test_patch_returns_400_because_immutable` | PATCH same. |
| `test_activate_swaps_active_and_pushes` | Activate old version deactivates current, activates target, calls push. |
| `test_activate_on_already_active_is_idempotent` | No-op when already active. |
| `test_activate_cross_tenant_returns_404` | **Load-bearing for view fix.** Without the `except Http404` block, this test returns 400 instead of 404. |
| `test_active_returns_current_config` | `/active/` returns the current is_active=True row. |
| `test_active_returns_none_when_no_config` | `/active/` returns `result: None` on empty org. |
| `test_active_unauthenticated` | Anon returns 401/403. |

### API keys

| Test | Failure mode it pins |
|---|---|
| `test_retrieve_api_key_returns_key_metadata` | Retrieve returns id, name, gateway_key_id, key_prefix; never rehydrates the raw key. |
| `test_retrieve_api_key_unauthenticated` | Anon 401/403. |
| `test_destroy_api_key_removes_row` | DELETE hides the row on a subsequent list. |
| `test_sync_api_keys_calls_bridge_sync_keys` | POST `/sync/` calls `auth_bridge.sync_keys(org=active_org)` and returns `{"synced": count}`. |
| `test_sync_api_keys_unauthenticated` | Anon 401/403. |
| `test_list_api_keys_cross_tenant_isolation` | Foreign-org keys do not surface. |
| `test_put_api_key_cross_tenant_returns_404` | **Load-bearing for view fix.** Without the `except Http404` block, this returns 400. |
| `test_patch_api_key_updates_name` | PATCH updates a single field via the bridge. |
| `test_revoke_api_key_idempotence` | Revoke on already-revoked key returns 200 and stays revoked. |

### Gateway ViewSet mutations

| Test | Failure mode it pins |
|---|---|
| `test_retrieve_gateway_unauthenticated` | Anon 401/403. |
| `test_get_providers_unauthenticated` | Anon 401/403. |
| `test_get_providers_when_gateway_client_unreachable` | Endpoint does not 500 on `GatewayClientError`; returns 200 or 400. |
| `test_reload_happy_path_pushes_current_config` | Calls `push_org_config` and returns `gateway_synced=True`. |
| `test_reload_unauthenticated` | Anon 401/403. |
| `test_reload_when_gateway_unreachable_reports_warning` | Push returns False, endpoint returns 200 with `gateway_warning`. |
| `test_update_provider_standalone_creates_credential` | POST `/update-provider/` writes an AgentccProviderCredential. |
| `test_remove_provider_standalone_soft_deletes` | POST `/remove-provider/` sets `deleted=True`. |
| `test_update_config_patches_active_row_and_bumps_version` | update-config applies a JSON patch, bumps version, mocks push. |
| `test_update_config_rejects_unknown_field` | 400 on unknown top-level field. |
| `test_set_budget_writes_level_and_bumps_version` | set-budget writes the level and bumps version. |
| `test_set_budget_rejects_missing_fields` | 400 on empty body. |
| `test_remove_budget_strips_level_and_bumps_version` | Named level is stripped; sibling levels preserved. |

### Provider credentials

| Test | Failure mode it pins |
|---|---|
| `test_retrieve_returns_metadata_without_decrypted_credentials` | Plaintext api_key never on the wire; response contains masked or absent credentials. |
| `test_retrieve_cross_tenant_returns_404` | Foreign-org credential id returns 404. |
| `test_update_writes_safe_fields_and_pushes_config` | PUT updates the safe fields; documents that PUT does not call `_push_config_to_gateway` (only PATCH does). |
| `test_patch_updates_single_field_leaving_others_intact` | Single-field PATCH does not touch siblings. |
| `test_destroy_soft_deletes_and_pushes_config` | destroy sets `deleted=True` and calls push. |
| `test_list_unauthenticated` | Anon 401/403. |
| `test_create_encrypts_credentials_before_persisting` | Raw api_key is not present in `encrypted_credentials`; `CredentialManager.decrypt` yields it back. |

### Shadow experiments

| Test | Failure mode it pins |
|---|---|
| `test_list_returns_experiments` | 200 with rows keyed by name. |
| `test_list_filter_by_status` | `?status=paused` filters correctly. |
| `test_list_unauthenticated` | Anon 401/403. |
| `test_create_writes_and_scopes_to_active_org` | POST scopes the experiment to the caller's org and user. `@pytest.mark.requires_ee` because the create endpoint is gated on the OSS lane. |
| `test_retrieve_returns_experiment` | 200 with id. |
| `test_partial_update_writes_field` | PATCH writes a field. |
| `test_destroy_soft_deletes_experiment_and_results` | destroy cascades soft-delete to results (raw SQL check). |
| `test_pause_transitions_active_to_paused` | Active-only guard; calls `_push_org_config`. |
| `test_pause_rejects_non_active` | 400 on non-active. |
| `test_resume_transitions_paused_to_active` | Paused-only guard. |
| `test_resume_rejects_non_paused` | 400 on non-paused. |
| `test_complete_terminates_experiment` | Any-to-completed transition. |
| `test_complete_rejects_already_completed` | 400 on already-completed. |
| `test_stats_aggregates_over_results` | avg_source_latency, avg_shadow_latency, total_comparisons. |
| `test_stats_empty_returns_zeroed_shape` | Zero-result case returns zeros, `latency_delta_pct == 0`. |
| `test_list_returns_results_for_org` | shadow-results list accepts both paginated and wrapped shapes. |
| `test_retrieve_returns_result` | 200 with id. |

### Routing policies

| Test | Failure mode it pins |
|---|---|
| `test_list_returns_all_versions` | Both versions surface. |
| `test_list_active_only_filter` | `?active_only=true` filters correctly. |
| `test_list_unauthenticated` | Anon 401/403. |
| `test_retrieve_returns_policy` | 200 with id. |
| `test_create_new_version_deactivates_prior` | Create deactivates prior same-name active, bumps version, calls `_sync_routing_to_gateway`. |
| `test_put_returns_400` | PUT returns 400 with "versioned" in the message. |
| `test_destroy_soft_deletes_and_syncs` | destroy + sync. |
| `test_activate_swaps_active_within_same_name` | Activate old swaps within same policy name. |
| `test_sync_triggers_gateway_push` | POST `/sync/` calls `_sync_routing_to_gateway` and returns 200. |

### Outbound webhooks + events

| Test | Failure mode it pins |
|---|---|
| `test_list_returns_webhooks` | 200 with rows. |
| `test_list_unauthenticated` | Anon 401/403. |
| `test_retrieve_returns_webhook` | 200 with id. |
| `test_update_writes_fields` | PUT writes name / url / events. |
| `test_partial_update_writes_single_field` | PATCH single field. |
| `test_destroy_soft_deletes_webhook` | destroy sets deleted=True. |
| `test_test_send_success_records_delivered_event` | Success writes AgentccWebhookEvent with status=DELIVERED, last_response_code=200. `ensure_public_http_url` and `build_ssrf_safe_session` are patched. |
| `test_test_send_upstream_error_records_failed_event` | `RequestException` writes status=FAILED with the error message. |
| `test_list_returns_events` | 200 with rows. |
| `test_list_filter_by_status` | `?status=failed` filters. |
| `test_list_filter_by_webhook_id` | `?webhook_id=` filters. |
| `test_retrieve_returns_event` | 200 with id. |
| `test_retry_resets_failed_event_to_pending` | Failed event flips to PENDING, attempts=0, last_error="". |
| `test_retry_rejects_already_delivered` | 400 on DELIVERED. |

### Sessions CRUD

| Test | Failure mode it pins |
|---|---|
| `test_list_returns_sessions_for_active_workspace` | List returns seeded rows (accepts both paginated and wrapped shapes). |
| `test_list_unauthenticated` | Anon 401/403. |
| `test_put_updates_status` | PUT writes status and name. |
| `test_patch_partial_update` | PATCH writes metadata dict. |
| `test_destroy_soft_deletes_session` | DELETE hides the row on subsequent list. |
| `test_close_transitions_active_to_closed` | POST `/close/` flips status. |
| `test_close_twice_is_idempotent` | Second close on closed session returns 200. |

### Guardrail cluster

Twenty-two tests across four classes (`TestGuardrailPolicyCRUD`, `TestGuardrailPolicySync`, `TestGuardrailConfigHelpers`, `TestBlocklistRemaining`, `TestGuardrailFeedbackCRUD`). Each pins one endpoint's behavior: list, retrieve, create, PATCH, destroy, sync-endpoint returns 200 with `result.synced is True`, `pii-entities` / `topics` / `validate-cel` helpers, blocklist PUT / PATCH / remove-words strips specified words, feedback create / retrieve / patch-comment / destroy soft-delete / summary aggregation. Full list in the file at `agentcc/tests/test_guardrail_endpoints_api.py`.

### MCP + analytics guardrail

| Test | Failure mode it pins |
|---|---|
| `test_mcp_status_returns_disabled_when_no_servers` | Empty MCP config returns `enabled=False`. |
| `test_mcp_status_filters_to_configured_servers` | Gateway server list filtered to org-config server ids. |
| `test_mcp_tools_empty_when_no_configured_servers` | Zero-servers returns `result: []`. |
| `test_mcp_tools_filters_to_configured_servers` | Tool list filtered by server id. |
| `test_update_mcp_server_writes_config` | POST writes `mcp.servers.<id>`. |
| `test_remove_mcp_server_strips_server` | DELETE strips the server id. |
| `test_update_mcp_guardrails_writes_config` | POST writes `mcp.guardrails` (asserts 200 + written keys, not `in (200, 400)`). |
| `test_test_mcp_tool_happy` | Calls `mcp_test_tool(name, arguments)`. |
| `test_test_mcp_tool_rejects_missing_tool_name` | 400 on missing name. |
| `test_mcp_resources_returns_list` | 200 with list. |
| `test_mcp_prompts_returns_list` | 200 with list. |
| `test_guardrail_overview_pins_kpi_keys` | Response contains `total_requests`. |
| `test_guardrail_rules_pins_top_level_shape` | Response is a dict. |
| `test_guardrail_trends_pins_series_keys` | Response contains `granularity` and `series`. |
| `test_guardrail_overview_unauthenticated` | Anon 401/403. |

### Bug-fix load-bearing verification

Both view fixes were checked by removing the `except Http404` block and re-running the target test:

```
# api_key.py fix removed → test_put_api_key_cross_tenant_returns_404 FAILED
# org_config.py fix removed → test_activate_cross_tenant_returns_404 FAILED
```

## Commands

From `futureagi/`:

```bash
# EE lane (ee/ present)
bin/test app agentcc --no-services

# OSS lane (ee/ absent)
mv ee ee_ && bin/test app agentcc --no-services ; mv ee_ ee
```

## Steps to test locally

1. Check out the branch: `git fetch origin fix/th-7140-green-agentcc-suite-oss && git checkout fix/th-7140-green-agentcc-suite-oss`.
2. Confirm `futureagi/ee` exists on disk.
3. From `futureagi/`, run `bin/test app agentcc --no-services`. Expect `354 passed`.
4. Rename `ee`: `mv ee ee_`.
5. Re-run `bin/test app agentcc --no-services`. Expect `349 passed, 5 skipped`. The five `SKIPPED` entries are the tests marked `@pytest.mark.requires_ee`.
6. Restore: `mv ee_ ee`.
7. Verify the two bug fixes are load-bearing: edit `agentcc/views/api_key.py` to remove the `except Http404` block, re-run `bin/test app agentcc --no-services -k test_put_api_key_cross_tenant_returns_404`. Expect FAILED. Restore the block. Repeat for `agentcc/views/org_config.py` and `test_activate_cross_tenant_returns_404`.

## Screenshots

### with ee:
<img width="1692" height="1316" alt="image" src="https://github.com/user-attachments/assets/44ae99f7-2881-4933-bb77-5b98826fb749" />

### without ee:
<img width="1686" height="1320" alt="image" src="https://github.com/user-attachments/assets/b876391d-2817-45c4-bb15-c5269c6c7cc7" />


## Behavior callouts

- `views/api_key.py::partial_update`: cross-tenant PUT / PATCH used to return 400 with `str(Http404)` in the message; now returns 404 with `"API key not found"` in `_gm.not_found` shape. Downstream callers that inspected the 400 body must retarget the 404 branch. This aligns with the app's 23 other 404 sites.
- `views/org_config.py::activate`: same shape change on cross-tenant activate. 400 → 404, message `"Org config not found"`.
- No other endpoint's status code changes.

## Architectural decisions

1. **Reuse root conftest's `requires_ee` machinery instead of a local bypass.** The base branch registers the marker at `futureagi/conftest.py`; local bypass fixtures would drift and mock the gate in tests that never touch it. Standard 04 (OSS / EE boundary): one typed boundary per domain, honored via a marker, not per-test mocks.
2. **404 via `_gm.not_found("<Resource> not found")`, not `raise Http404`.** The app's own convention across ~22 other view sites: consistent wire shape (`{"status": false, "result": "..."}`) instead of DRF's default `{"detail": "Not found."}`. Standard 03 (thin views): keep the routing decision in one place.
3. **Extend `test_api.py` in place for API keys and gateway; new files for resources without an existing test file.** Standard 01 (minimal-code): honor "keep tests for a feature in one place"; do not fork a new file when the existing class already covers the resource.
4. **Requires-ee marker on the five gated tests, not a per-view mock.** The three create endpoints under this marker are gated in production too; skipping in OSS matches production semantics rather than hiding it behind a local bypass.

## Out of scope

Each item has a rationale for deferral:

- **P1 group backfills**: guardrail policies remainder, email alerts (P2), custom properties remainder. Deferred to a follow-up so this PR keeps to P0-NONE + THIN-P0-upgrade + the two bug fixes.
- **The Http404-swallow pattern in the other `except Exception` sites in agentcc views.** Grep for `agentcc/views/*.py` shows the same pattern in additional actions; only the two sites currently reachable by a cross-tenant test are fixed. Others are pre-existing pain, not introduced by this PR.

## Linear

Fix TH-7140




