### PR TITLE
 fix(install): rotate default PostgreSQL password instead of shipping…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ AGENTCC_GATEWAY_VERSION=
 SERVING_VERSION=
 CODE_EXECUTOR_VERSION=
 
+# ---- Datastore credentials ----
+# The self-hosted datastores fall back to a publicly-known password when this
+# is unset (docker-compose.yml: `${PG_PASSWORD:-futureagi}`). `./bin/install`
+# rotates the value below to a generated secret on first run — keep the
+# CHANGEME- prefix so that rotation actually fires. Never expose the default
+# on any network-reachable host.
+PG_PASSWORD=CHANGEME-run-bin-install-to-generate
+
 # ---- BYO LLM provider keys ----
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=


### PR DESCRIPTION
`docker-compose.yml:92` falls back to `${PG_PASSWORD:-futureagi}`, so a fresh
install runs with a publicly-known DB password. `bin/install:290` already calls
`rotate_placeholder PG_PASSWORD`, but the helper only rewrites lines matching
`^PG_PASSWORD=CHANGEME-`, and `.env.example` has no such line — so the rotation
is a silent no-op.

This adds the missing `PG_PASSWORD=CHANGEME-…` placeholder so the existing
rotation fires and each install gets a unique password. One line, no logic changes.