### PR TITLE
Restrict code-executor port binding to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
   code-executor:
     image: futureagi/code-executor:${CODE_EXECUTOR_VERSION:-latest}
     ports:
-      - "${CODE_EXECUTOR_PORT:-8060}:8060"
+      - "127.0.0.1:${CODE_EXECUTOR_PORT:-8060}:8060"
     privileged: true
     deploy:
       resources:


### PR DESCRIPTION
`code-executor` was published on all interfaces (0.0.0.0:8060) while
every datastore in the same file binds to 127.0.0.1. INSTALLATION.md
documents the executor as "internal only by default" — this makes the
implementation match the documented intent.

Adds the `127.0.0.1:` prefix, identical to postgres, redis, minio, and
temporal. Inter-container traffic is unaffected (containers communicate
via the compose network by service name, not the published host port).