### PR TITLE
fix(annotations): gate annotate submit button on all labels answered (TH-6967)

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/annotate-components.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/annotate-components.test.jsx
@@ -842,6 +842,55 @@ describe("LabelPanel", () => {
     );
   });
 
+  it("enables submit only when every label is answered and re-disables on clear", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LabelPanel
+        labels={[
+          {
+            id: "ql-1",
+            label_id: "label-1",
+            name: "Content",
+            type: "thumbs_up_down",
+            settings: {},
+            allow_notes: false,
+          },
+          {
+            id: "ql-2",
+            label_id: "label-2",
+            name: "Latency",
+            type: "thumbs_up_down",
+            settings: {},
+            allow_notes: false,
+          },
+        ]}
+        annotations={[]}
+        onSubmit={vi.fn()}
+        queueId="queue-1"
+        itemId="item-1"
+        submitLabel="Submit for Review"
+      />,
+    );
+
+    const submit = () =>
+      screen.getByRole("button", { name: /submit for review/i });
+
+    expect(submit()).toBeDisabled();
+
+    // One of two labels answered → still disabled.
+    await user.click(screen.getAllByText("Yes")[0]);
+    expect(submit()).toBeDisabled();
+
+    // Both answered → enabled.
+    await user.click(screen.getAllByText("No")[1]);
+    expect(submit()).toBeEnabled();
+
+    // Clearing the first label re-disables it.
+    await user.click(screen.getAllByText("Yes")[0]);
+    expect(submit()).toBeDisabled();
+  });
+
   it("prefills and submits whole-item notes", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -28,6 +28,7 @@ import { alpha } from "@mui/material/styles";
 import { enqueueSnackbar } from "notistack";
 import Iconify from "src/components/iconify";
 import CellMarkdown from "src/sections/common/CellMarkdown";
+import { isLabelValueEmpty } from "src/sections/annotations/queues/utils/label-value";
 import { fDateTime, fToNowStrict } from "src/utils/format-time";
 import LabelInput from "./label-input";
 import AnnotationHistory from "./annotation-history";
@@ -511,19 +512,9 @@ const LabelPanel = forwardRef(function LabelPanel(
     const currentValues = valuesRef.current;
 
     // Every label must be annotated before submitting
-    const missingLabels = labels.filter((ql) => {
-      const labelId = ql.label_id;
-      const v = currentValues[labelId];
-      if (v === null || v === undefined) return true;
-      if (ql.type === "star" && !v.rating) return true;
-      if (ql.type === "categorical" && (!v.selected || v.selected.length === 0))
-        return true;
-      if (ql.type === "text" && !v.text?.trim()) return true;
-      if (ql.type === "thumbs_up_down" && !v.value) return true;
-      if (ql.type === "numeric" && (v.value === null || v.value === undefined))
-        return true;
-      return false;
-    });
+    const missingLabels = labels.filter((ql) =>
+      isLabelValueEmpty(ql.type, currentValues[ql.label_id]),
+    );
 
     if (missingLabels.length > 0) {
       const names = missingLabels.map((l) => l.name).join(", ");
@@ -565,9 +556,9 @@ const LabelPanel = forwardRef(function LabelPanel(
 
   useImperativeHandle(ref, () => ({ submit: handleSubmit }), [handleSubmit]);
 
-  const hasValues = Object.values(displayValues).some(
-    (v) => v !== null && v !== undefined && v !== "",
-  );
+  const allAnswered =
+    labels.length > 0 &&
+    labels.every((l) => !isLabelValueEmpty(l.type, displayValues[l.label_id]));
 
   // Keyboard navigation for labels (Tab/Shift+Tab + number keys + ? for help)
   useEffect(() => {
@@ -1259,7 +1250,7 @@ const LabelPanel = forwardRef(function LabelPanel(
                   },
                 }}
                 onClick={handleSubmit}
-                disabled={isPending || !hasValues}
+                disabled={isPending || !allAnswered}
                 startIcon={
                   isPending ? (
                     <CircularProgress size={16} color="inherit" />

--- a/frontend/src/sections/annotations/queues/utils/label-value.js
+++ b/frontend/src/sections/annotations/queues/utils/label-value.js
@@ -1,0 +1,21 @@
+import { isNil, isEmpty } from "lodash";
+
+// Values are per-type composites ({ rating }, { text }, ...); a cleared field
+// keeps the key with an empty inner value, so check inner emptiness per type.
+export const isLabelValueEmpty = (type, v) => {
+  if (isNil(v)) return true;
+  switch (type) {
+    case "star":
+      return !v.rating;
+    case "categorical":
+      return isEmpty(v.selected);
+    case "text":
+      return isEmpty(v.text?.trim());
+    case "thumbs_up_down":
+      return !v.value;
+    case "numeric":
+      return isNil(v.value);
+    default:
+      return false;
+  }
+};


### PR DESCRIPTION
### Bug
On the annotate queue "Annotate my answers" panel, the **Submit for Review** button became enabled as soon as *any one* label was filled, and it never went back to disabled when the field was cleared. It should enable only when *every* label is answered.

Linear: [TH-6967](https://linear.app/future-agi/issue/TH-6967)

### Changes
- Add `isLabelValueEmpty(type, value)` in `queues/utils/label-value.js` — per-type inner-emptiness check for the composite label values.
- Drive the submit-button gate from `labels.every(...!isLabelValueEmpty)` (replacing the shallow `hasValues` `.some()` check).
- Refactor the existing `missingLabels` submit-time guard in `label-panel.jsx` to reuse the same helper, so the button and the submit validation can't disagree.
- Add a regression test.

### Why
Each label's value is a per-type composite object (`{rating}`, `{text}`, `{selected}`, `{value}`). The old `hasValues` only checked `v !== null/undefined/""`, but an object is never any of those — so filling one field made it truthy forever, and clearing a widget (which writes an *empty* composite like `{rating:0}` / `{text:""}`) still read as "filled". The fix inspects the inner value per type.

### Test-case scenarios
- No labels answered → button disabled.
- One of several labels answered → button still disabled.
- All labels answered → button enabled.
- Clear a previously-answered label → button re-disabled.

### How to reproduce (before fix)
1. Open an item in an annotate queue with multiple required labels → "Annotate my answers".
2. Fill a single field → Submit button activates (should stay disabled).
3. Clear that field → Submit stays active (should disable again).

### Commands
```
yarn eslint src/sections/annotations/queues/annotate/label-panel.jsx src/sections/annotations/queues/utils/label-value.js
yarn test:run src/sections/annotations/queues/__tests__/annotate-components.test.jsx
```
Result: ESLint clean; **113/113 tests pass** (incl. the new regression test).

### Videos / screenshots

https://github.com/user-attachments/assets/0a4c28d9-68b2-458f-855b-6214afaa89a6


https://github.com/user-attachments/assets/c3cf10b2-d5c6-4af4-9663-9ddf746fc3f7

