### PR TITLE
fix: validate mirror rule target_provider references configured providers

### DIFF
--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -1058,6 +1058,14 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	for _, rule := range c.Routing.Mirror.Rules {
+		if rule.TargetProvider != "" {
+			if _, ok := c.Providers[rule.TargetProvider]; !ok {
+				return fmt.Errorf("mirror rule for model %q: target_provider %q not found in configured providers", rule.SourceModel, rule.TargetProvider)
+			}
+		}
+	}
+
 	validLevels := map[string]bool{"debug": true, "info": true, "warn": true, "error": true}
 	if !validLevels[strings.ToLower(c.Logging.Level)] {
 		return fmt.Errorf("logging.level must be one of debug, info, warn, error; got %q", c.Logging.Level)

--- a/agentcc-gateway/internal/config/config_test.go
+++ b/agentcc-gateway/internal/config/config_test.go
@@ -73,6 +73,26 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "mirror rule unknown target provider",
+			modify: func(c *Config) {
+				c.Providers["p1"] = ProviderConfig{BaseURL: "http://localhost", APIFormat: "openai"}
+				c.Routing.Mirror.Rules = []MirrorRule{
+					{SourceModel: "gpt-4o", TargetProvider: "nonexistent", SampleRate: 1.0},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "mirror rule valid target provider",
+			modify: func(c *Config) {
+				c.Providers["p1"] = ProviderConfig{BaseURL: "http://localhost", APIFormat: "openai"}
+				c.Routing.Mirror.Rules = []MirrorRule{
+					{SourceModel: "gpt-4o", TargetProvider: "p1", SampleRate: 1.0},
+				}
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What
Add startup validation in config.Validate() to check that mirror rule target_provider values reference actual configured providers. This prevents silent runtime failures when users configure custom OpenAI-compatible upstreams with typos in mirror rule provider names. Previously, a mistyped target_provider would only log a warning at runtime during ExecuteAsync; now the gateway fails fast at startup with a clear error message.

This directly addresses the validation gap described in issue #1746: users registering arbitrary OpenAI-compatible upstreams for shadow/mirror testing now get immediate feedback if their mirror rule references a non-existent provider.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #1746