### PR TITLE
fix(gateway): keep redaction metadata on trace records

### DIFF
--- a/agentcc-gateway/internal/plugins/logging/logging.go
+++ b/agentcc-gateway/internal/plugins/logging/logging.go
@@ -84,12 +84,19 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 	orgRedactor := p.getOrgRedactor(rc)
 
 	// Apply redaction: org redactor (with org patterns) takes priority over global.
+	redacted := false
 	if orgRedactor != nil && orgRedactor.ShouldRedact() && record.RequestBody != nil {
 		record = redactRecord(record, orgRedactor, mode)
-		rc.SetMetadata("privacy_redacted", "true")
+		redacted = true
 	} else if p.redactor != nil && p.redactor.ShouldRedact() && record.RequestBody != nil {
 		record = redactRecord(record, p.redactor, mode)
-		rc.SetMetadata("privacy_redacted", "true")
+		redacted = true
+	}
+	if redacted {
+		if record.Metadata == nil {
+			record.Metadata = make(map[string]string, 1)
+		}
+		record.Metadata["privacy_redacted"] = "true"
 	}
 
 	p.emitter.Emit(record)

--- a/agentcc-gateway/internal/plugins/logging/logging_test.go
+++ b/agentcc-gateway/internal/plugins/logging/logging_test.go
@@ -141,6 +141,38 @@ func TestPlugin_ProcessRequest_Noop(t *testing.T) {
 	}
 }
 
+func TestProcessResponse_RedactionMetadataStaysWithRecord(t *testing.T) {
+	emitter := &TraceEmitter{ch: make(chan TraceRecord, 1)}
+	p := &Plugin{
+		cfg: config.RequestLoggingConfig{
+			Enabled:       true,
+			IncludeBodies: true,
+		},
+		emitter:  emitter,
+		redactor: privacy.New(privacy.ModeFull, nil),
+	}
+
+	rc := newRC()
+	rc.Request = &models.ChatCompletionRequest{
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"secret"`)},
+		},
+	}
+
+	result := p.ProcessResponse(context.Background(), rc)
+	if result.Action != pipeline.Continue {
+		t.Fatalf("ProcessResponse Action = %v, want Continue", result.Action)
+	}
+
+	record := <-emitter.ch
+	if got := record.Metadata["privacy_redacted"]; got != "true" {
+		t.Errorf("record privacy_redacted = %q, want %q", got, "true")
+	}
+	if _, ok := rc.Metadata["privacy_redacted"]; ok {
+		t.Error("ProcessResponse mutated shared request metadata")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Record construction
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a gateway logging race and observability gap when privacy redaction is enabled. The logging plugin now records `privacy_redacted=true` on the emitted trace record itself instead of mutating the shared request context during parallel response processing.

## Linked issues

Closes #1750
Linear: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Chore / refactor
- [ ] Performance improvement
- [ ] Test-only change

## 1) What changes were done

**A. Trace redaction metadata**

- Tracks whether request-body redaction was applied.
- Adds `privacy_redacted=true` to the emitted `TraceRecord` metadata.
- Avoids writing to `RequestContext.Metadata` from the parallel post-processing hook.

**B. Regression coverage**

- Adds a focused test that verifies the marker is present on the emitted record.
- Verifies the shared request metadata remains unchanged.

## 2) Why the changes were done

- **Observability:** downstream trace consumers should be able to tell when stored content was redacted.
- **Concurrency:** the logging plugin declares parallel post-processing, so it should not mutate request-scoped metadata that other observer plugins may read concurrently.
- **Scope:** the change stays within the logging plugin and preserves existing redaction behavior.

## 3) Tests written + scenarios each covers

**`agentcc-gateway/internal/plugins/logging/logging_test.go`**

- `TestProcessResponse_RedactionMetadataStaysWithRecord` verifies the emitted marker and confirms the request context is not mutated.

Run results:

- `go test ./internal/plugins/logging -count=10` passed
- `go vet ./internal/plugins/logging` passed

## 4) How to run / test

```bash
cd agentcc-gateway
go test ./internal/plugins/logging -count=10
go vet ./internal/plugins/logging
```

## 6) Edge cases & considerations

- Handles both organization-specific and global redactors.
- Initializes record metadata when it is absent.
- Leaves metadata unchanged when no redaction occurs.

## 7) Pre-existing issues (NOT introduced by this PR)

The broader gateway suite has an unrelated existing failure in `internal/a2a` (`TestTaskStoreCleanup`); the focused logging package tests and vet pass.

## 8) Architectural / important decisions

- **Record ownership:** redaction metadata belongs to the emitted trace record because it describes that record's stored content.
- **Parallel safety:** the logging observer keeps its post-processing side-effect limited to its own record before emission.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [x] Documentation is not required for this internal fix
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status