### PR TITLE
fix(voice): scope call detail to request org, play combined-only recordings, prefer rehosted Bland URL

### DIFF
--- a/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
@@ -20,11 +20,61 @@ const isUpdatedWithinTwoMinutes = (timestamp) => {
 };
 
 /**
+ * Single audio bar for a call that has exactly one mixed track. Keyed on the
+ * recording shape rather than the provider, so every provider that returns one
+ * URL renders identically.
+ */
+export const SingleTrackPlayer = ({ url }) => (
+  <Stack
+    height={50}
+    width="100%"
+    justifyContent="center"
+    alignItems="center"
+    direction="row"
+  >
+    <AudioPlaybackProvider>
+      <CustomAudioPlayer
+        audioData={{ url }}
+        customLoaderComponent={
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1.5,
+              width: "100%",
+            }}
+          >
+            <Iconify icon="svg-spinners:bars-scale" width={20} height={20} />
+            <Typography typography="s1" fontWeight="fontWeightMedium">
+              Painting sound waves...
+            </Typography>
+          </Box>
+        }
+      />
+    </AudioPlaybackProvider>
+    <AudioDownloadButton
+      audioUrls={{ mono: url, stereo: "", assistant: "", customer: "" }}
+      singleTrack
+      size="small"
+      sx={{
+        minWidth: "32px",
+        mr: 1,
+        borderRadius: 0.5,
+        bgcolor: "background.paper",
+      }}
+    />
+  </Stack>
+);
+
+SingleTrackPlayer.propTypes = {
+  url: PropTypes.string,
+};
+
+/**
  * Renders MultiTrackAudioPlayer using stereo channel splitting when a stereo
- * URL is available. Falls back to separate mono assistant/customer URLs.
- *
- * Stereo splitting ensures both waveforms share the same duration and timeline,
- * fixing the misaligned waveform issue caused by mono files with different lengths.
+ * URL is available. Falls back to separate mono assistant/customer URLs, and to
+ * the single-track bar when the call has only one mixed recording.
  */
 export const StereoMultiTrackPlayer = ({
   recordings,
@@ -57,44 +107,31 @@ export const StereoMultiTrackPlayer = ({
   const assistantUrl = useStereo ? stereoAssistant : recordings?.assistant;
   const customerUrl = useStereo ? stereoCustomer : recordings?.customer;
 
-  // Combined-only providers mix both speakers into one mono track and expose no
-  // stereo or per-channel audio to split, so there is nothing to lay out on two
-  // rows. Render the single mix instead of waiting on two channel tracks that
-  // never resolve — the player gates readiness on every track loading.
+  // One mono mix and nothing to split into channels: a two-row waveform can
+  // neither be filled nor tell the speakers apart, and the player only becomes
+  // ready once every track loads. Hand it to the single-track bar instead.
   const combinedOnly =
     !useStereo && !assistantUrl && !customerUrl && Boolean(recordings?.combined);
 
   const trackUrls = useMemo(
-    () =>
-      combinedOnly
-        ? [
-            {
-              url: recordings?.combined,
-              color: assistantColor,
-              name: "Call Audio",
-            },
-          ]
-        : [
-            {
-              url: customerUrl,
-              color: customerColor,
-              name: "Customer Audio",
-            },
-            {
-              url: assistantUrl,
-              color: assistantColor,
-              name: "Assistant Audio",
-            },
-          ],
-    [
-      combinedOnly,
-      recordings?.combined,
-      customerUrl,
-      assistantUrl,
-      customerColor,
-      assistantColor,
+    () => [
+      {
+        url: customerUrl,
+        color: customerColor,
+        name: "Customer Audio",
+      },
+      {
+        url: assistantUrl,
+        color: assistantColor,
+        name: "Assistant Audio",
+      },
     ],
+    [customerUrl, assistantUrl, customerColor, assistantColor],
   );
+
+  if (combinedOnly) {
+    return <SingleTrackPlayer url={recordings.combined} />;
+  }
 
   if (useStereo && stereoLoading) {
     return (
@@ -167,62 +204,6 @@ const AudioPlayerCustom = ({ data, onInstance }) => {
           <Typography typography="s2_1">
             No recording found - <i>{data?.ended_reason}</i>
           </Typography>
-        </Stack>
-      );
-    }
-
-    if (data?.call_metadata?.provider === "retell") {
-      return (
-        <Stack
-          height={50}
-          width="100%"
-          justifyContent="center"
-          alignItems="center"
-          direction="row"
-        >
-          <AudioPlaybackProvider>
-            <CustomAudioPlayer
-              audioData={{
-                url: data?.recording_url,
-              }}
-              customLoaderComponent={
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 1.5,
-                    width: "100%",
-                  }}
-                >
-                  <Iconify
-                    icon="svg-spinners:bars-scale"
-                    width={20}
-                    height={20}
-                  />
-                  <Typography typography="s1" fontWeight="fontWeightMedium">
-                    Painting sound waves...
-                  </Typography>
-                </Box>
-              }
-            />
-          </AudioPlaybackProvider>
-          <AudioDownloadButton
-            audioUrls={{
-              mono: data.recording_url,
-              stereo: "",
-              assistant: "",
-              customer: "",
-            }}
-            singleTrack
-            size="small"
-            sx={{
-              minWidth: "32px",
-              mr: 1,
-              borderRadius: 0.5,
-              bgcolor: "background.paper",
-            }}
-          />
         </Stack>
       );
     }

--- a/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom.jsx
@@ -56,20 +56,44 @@ export const StereoMultiTrackPlayer = ({
 
   const assistantUrl = useStereo ? stereoAssistant : recordings?.assistant;
   const customerUrl = useStereo ? stereoCustomer : recordings?.customer;
+
+  // Combined-only providers mix both speakers into one mono track and expose no
+  // stereo or per-channel audio to split, so there is nothing to lay out on two
+  // rows. Render the single mix instead of waiting on two channel tracks that
+  // never resolve — the player gates readiness on every track loading.
+  const combinedOnly =
+    !useStereo && !assistantUrl && !customerUrl && Boolean(recordings?.combined);
+
   const trackUrls = useMemo(
-    () => [
-      {
-        url: customerUrl,
-        color: customerColor,
-        name: "Customer Audio",
-      },
-      {
-        url: assistantUrl,
-        color: assistantColor,
-        name: "Assistant Audio",
-      },
+    () =>
+      combinedOnly
+        ? [
+            {
+              url: recordings?.combined,
+              color: assistantColor,
+              name: "Call Audio",
+            },
+          ]
+        : [
+            {
+              url: customerUrl,
+              color: customerColor,
+              name: "Customer Audio",
+            },
+            {
+              url: assistantUrl,
+              color: assistantColor,
+              name: "Assistant Audio",
+            },
+          ],
+    [
+      combinedOnly,
+      recordings?.combined,
+      customerUrl,
+      assistantUrl,
+      customerColor,
+      assistantColor,
     ],
-    [customerUrl, assistantUrl, customerColor, assistantColor],
   );
 
   if (useStereo && stereoLoading) {

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
@@ -26,7 +26,7 @@ vi.mock("src/components/multi-track-audio-player/MultiTrackAudioPlayer", () => (
   MemoizedBarsIcon: () => <span data-testid="bars" />,
 }));
 
-// eslint-disable-next-line import/first
+// Imported after the mocks above so the component picks them up.
 import { StereoMultiTrackPlayer } from "../AudioPlayerCustom";
 
 const COMBINED = "https://example.test/recording.wav";

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "src/utils/test-utils";
 
 const captured = { trackUrls: null };
+
+// Mutable so a case can hand back real split channels; hoisted because the
+// vi.mock factory below is lifted above this file's other statements.
+const { stereo } = vi.hoisted(() => ({
+  stereo: { assistantUrl: "", customerUrl: "", loading: false, error: null },
+}));
 
 vi.mock("src/components/iconify", () => ({
   default: ({ icon, ...props }) => (
@@ -10,12 +16,7 @@ vi.mock("src/components/iconify", () => ({
 }));
 
 vi.mock("src/hooks/use-stereo-channels", () => ({
-  default: () => ({
-    assistantUrl: "",
-    customerUrl: "",
-    loading: false,
-    error: null,
-  }),
+  default: () => stereo,
 }));
 
 vi.mock("src/components/multi-track-audio-player/MultiTrackAudioPlayer", () => ({
@@ -32,10 +33,39 @@ import { StereoMultiTrackPlayer } from "../AudioPlayerCustom";
 const COMBINED = "https://example.test/recording.wav";
 
 describe("StereoMultiTrackPlayer track selection", () => {
+  beforeEach(() => {
+    captured.trackUrls = null;
+    Object.assign(stereo, {
+      assistantUrl: "",
+      customerUrl: "",
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("splits a stereo recording into two channel tracks", () => {
+    Object.assign(stereo, {
+      assistantUrl: "blob:assistant",
+      customerUrl: "blob:customer",
+    });
+
+    render(
+      <StereoMultiTrackPlayer
+        recordings={{ stereo: "https://example.test/stereo.wav" }}
+        id="call-0"
+      />,
+    );
+
+    expect(captured.trackUrls).toHaveLength(2);
+    expect(captured.trackUrls.map((t) => t.url)).toEqual([
+      "blob:customer",
+      "blob:assistant",
+    ]);
+  });
+
   it("renders the single mix when a provider only exposes a combined recording", () => {
     // The player gates readiness on every track loading, so handing it two
     // undefined channel tracks leaves it painting waveforms forever.
-    captured.trackUrls = null;
     render(
       <StereoMultiTrackPlayer recordings={{ combined: COMBINED }} id="call-1" />,
     );
@@ -46,7 +76,6 @@ describe("StereoMultiTrackPlayer track selection", () => {
   });
 
   it("still splits into customer and assistant rows when channels exist", () => {
-    captured.trackUrls = null;
     render(
       <StereoMultiTrackPlayer
         recordings={{

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "src/utils/test-utils";
+
+const captured = { trackUrls: null };
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+vi.mock("src/hooks/use-stereo-channels", () => ({
+  default: () => ({
+    assistantUrl: "",
+    customerUrl: "",
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("src/components/multi-track-audio-player/MultiTrackAudioPlayer", () => ({
+  default: (props) => {
+    captured.trackUrls = props.trackUrls;
+    return <div data-testid="multi-track" />;
+  },
+  MemoizedBarsIcon: () => <span data-testid="bars" />,
+}));
+
+// eslint-disable-next-line import/first
+import { StereoMultiTrackPlayer } from "../AudioPlayerCustom";
+
+const COMBINED = "https://example.test/recording.wav";
+
+describe("StereoMultiTrackPlayer track selection", () => {
+  it("renders the single mix when a provider only exposes a combined recording", () => {
+    // The player gates readiness on every track loading, so handing it two
+    // undefined channel tracks leaves it painting waveforms forever.
+    captured.trackUrls = null;
+    render(
+      <StereoMultiTrackPlayer recordings={{ combined: COMBINED }} id="call-1" />,
+    );
+
+    expect(captured.trackUrls).toHaveLength(1);
+    expect(captured.trackUrls[0].url).toBe(COMBINED);
+    expect(captured.trackUrls.every((t) => Boolean(t.url))).toBe(true);
+  });
+
+  it("still splits into customer and assistant rows when channels exist", () => {
+    captured.trackUrls = null;
+    render(
+      <StereoMultiTrackPlayer
+        recordings={{
+          combined: COMBINED,
+          assistant: "https://example.test/assistant.wav",
+          customer: "https://example.test/customer.wav",
+        }}
+        id="call-2"
+      />,
+    );
+
+    expect(captured.trackUrls).toHaveLength(2);
+    expect(captured.trackUrls.map((t) => t.name)).toEqual([
+      "Customer Audio",
+      "Assistant Audio",
+    ]);
+  });
+});

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
@@ -143,4 +143,24 @@ describe("AudioPlayerCustom picks the renderer from the recording shape", () => 
       expect(captured.trackUrls).toBeNull();
     },
   );
+
+  it("routes a call that names no provider anywhere", () => {
+    // The observability detail payload carries `call_metadata: {}` and no
+    // top-level provider, so the recording shape is the only signal available.
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <AudioPlayerCustom
+          data={{
+            module: "project",
+            recording_available: true,
+            call_metadata: {},
+            recording: { mono: { combined_url: COMBINED } },
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(captured.singleUrl).toBe(COMBINED);
+    expect(captured.trackUrls).toBeNull();
+  });
 });

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/AudioPlayerCustom.test.jsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "src/utils/test-utils";
 
-const captured = { trackUrls: null };
+const captured = { trackUrls: null, singleUrl: null };
 
 // Mutable so a case can hand back real split channels; hoisted because the
 // vi.mock factory below is lifted above this file's other statements.
@@ -27,21 +28,46 @@ vi.mock("src/components/multi-track-audio-player/MultiTrackAudioPlayer", () => (
   MemoizedBarsIcon: () => <span data-testid="bars" />,
 }));
 
+vi.mock("src/components/custom-audio/CustomAudioPlayer", () => ({
+  default: (props) => {
+    captured.singleUrl = props.audioData?.url;
+    return <div data-testid="single-track" />;
+  },
+}));
+
+vi.mock(
+  "src/components/custom-audio/context-provider/AudioPlaybackContext",
+  () => ({
+    // eslint-disable-next-line react/prop-types
+    AudioPlaybackProvider: ({ children }) => <div>{children}</div>,
+  }),
+);
+
+// Path is resolved from the component under test, not from this file.
+vi.mock("src/sections/test-detail/AudioDownloadButton", () => ({
+  default: () => <span data-testid="download" />,
+}));
+
 // Imported after the mocks above so the component picks them up.
-import { StereoMultiTrackPlayer } from "../AudioPlayerCustom";
+import AudioPlayerCustom, {
+  StereoMultiTrackPlayer,
+} from "../AudioPlayerCustom";
 
 const COMBINED = "https://example.test/recording.wav";
 
-describe("StereoMultiTrackPlayer track selection", () => {
-  beforeEach(() => {
-    captured.trackUrls = null;
-    Object.assign(stereo, {
-      assistantUrl: "",
-      customerUrl: "",
-      loading: false,
-      error: null,
-    });
+const resetCaptured = () => {
+  captured.trackUrls = null;
+  captured.singleUrl = null;
+  Object.assign(stereo, {
+    assistantUrl: "",
+    customerUrl: "",
+    loading: false,
+    error: null,
   });
+};
+
+describe("StereoMultiTrackPlayer track selection", () => {
+  beforeEach(resetCaptured);
 
   it("splits a stereo recording into two channel tracks", () => {
     Object.assign(stereo, {
@@ -63,18 +89,6 @@ describe("StereoMultiTrackPlayer track selection", () => {
     ]);
   });
 
-  it("renders the single mix when a provider only exposes a combined recording", () => {
-    // The player gates readiness on every track loading, so handing it two
-    // undefined channel tracks leaves it painting waveforms forever.
-    render(
-      <StereoMultiTrackPlayer recordings={{ combined: COMBINED }} id="call-1" />,
-    );
-
-    expect(captured.trackUrls).toHaveLength(1);
-    expect(captured.trackUrls[0].url).toBe(COMBINED);
-    expect(captured.trackUrls.every((t) => Boolean(t.url))).toBe(true);
-  });
-
   it("still splits into customer and assistant rows when channels exist", () => {
     render(
       <StereoMultiTrackPlayer
@@ -93,4 +107,40 @@ describe("StereoMultiTrackPlayer track selection", () => {
       "Assistant Audio",
     ]);
   });
+
+  it("uses the single-track bar when only a combined mix exists", () => {
+    // A two-row waveform can neither be filled nor separate the speakers, and
+    // it never reports ready while a track URL is missing.
+    render(
+      <StereoMultiTrackPlayer recordings={{ combined: COMBINED }} id="call-1" />,
+    );
+
+    expect(captured.singleUrl).toBe(COMBINED);
+    expect(captured.trackUrls).toBeNull();
+  });
+});
+
+describe("AudioPlayerCustom picks the renderer from the recording shape", () => {
+  beforeEach(resetCaptured);
+
+  it.each(["retell", "bland"])(
+    "sends a single-URL %s call to the same single-track bar",
+    (provider) => {
+      render(
+        <QueryClientProvider client={new QueryClient()}>
+          <AudioPlayerCustom
+            data={{
+              module: "project",
+              recording_available: true,
+              call_metadata: { provider },
+              recording: { mono: { combined_url: COMBINED } },
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      expect(captured.singleUrl).toBe(COMBINED);
+      expect(captured.trackUrls).toBeNull();
+    },
+  );
 });

--- a/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
+++ b/futureagi/tracer/tests/test_pull_observability_bland_twilio.py
@@ -155,6 +155,27 @@ def test_bland_already_owned_recording_is_not_rehosted():
 
 
 @pytest.mark.unit
+def test_bland_prefers_rehosted_combined_over_raw_recording_url():
+    # The simulate path rehosts on its own and stores the durable URL under
+    # `recording.combined`, leaving Bland's raw `recording_url` beside it. The
+    # raw one is not browser-playable, so the flattened attribute must surface
+    # the durable copy. Bland itself never returns a `recording` key.
+    log = {
+        **BLAND_CALL,
+        "recording_url": _BLAND_RECORDING_URL,
+        "recording": {"combined": _DURABLE_BLAND_URL},
+    }
+    with patch("tracer.utils.bland.convert_audio_url_to_s3_sync") as mock_convert:
+        result = normalize_bland_data(log)
+
+    mock_convert.assert_not_called()
+    assert (
+        result["span_attributes"]["conversation.recording.mono.combined"]
+        == _DURABLE_BLAND_URL
+    )
+
+
+@pytest.mark.unit
 def test_bland_rehost_failure_preserves_source_and_does_not_raise():
     log = {**BLAND_CALL, "recording_url": _BLAND_RECORDING_URL}
     with patch(

--- a/futureagi/tracer/tests/test_voice_call_detail_org_scope.py
+++ b/futureagi/tracer/tests/test_voice_call_detail_org_scope.py
@@ -6,6 +6,11 @@ the user is currently acting in, injected from ``X-Organization-Id``), not the
 organization stored on the user row. A user whose active organization differs
 from their home organization owns projects the user-row check cannot see, and
 every lookup 404s — which strands the drawer on its list-row stub.
+
+Scope note: the test client injects ``request.organization`` straight from the
+header, so these cases pin the view's *scoping* behaviour only. That the header
+itself cannot name an organization the user has no membership in is enforced
+upstream in authentication and covered by ``accounts.tests.test_multi_org_auth``.
 """
 
 import uuid

--- a/futureagi/tracer/tests/test_voice_call_detail_org_scope.py
+++ b/futureagi/tracer/tests/test_voice_call_detail_org_scope.py
@@ -1,0 +1,106 @@
+"""Ownership scoping for the voice call detail endpoint.
+
+The endpoint resolves a trace's project from ClickHouse and then checks that the
+caller owns it. That check must use the *request-scoped* organization (the one
+the user is currently acting in, injected from ``X-Organization-Id``), not the
+organization stored on the user row. A user whose active organization differs
+from their home organization owns projects the user-row check cannot see, and
+every lookup 404s — which strands the drawer on its list-row stub.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.ai_model import AIModel
+from tracer.models.project import Project
+
+VOICE_CALL_DETAIL_URL = "/tracer/trace/voice_call_detail/"
+CH_QUERY_PATH = (
+    "tracer.services.clickhouse.query_service."
+    "AnalyticsQueryService.execute_ch_query"
+)
+
+
+def _make_org_project(user, label):
+    """An organization + workspace + project that is NOT the user's home org."""
+    suffix = uuid.uuid4().hex[:8]
+    org = Organization.objects.create(name=f"{label} Org {suffix}")
+    workspace = Workspace.no_workspace_objects.create(
+        name=f"{label} Workspace {suffix}",
+        organization=org,
+        is_default=True,
+        is_active=True,
+        created_by=user,
+    )
+    project = Project.objects.create(
+        name=f"{label} Project",
+        organization=org,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+        metadata={},
+        config=[],
+    )
+    return org, workspace, project
+
+
+def _ch_returning(project_id):
+    """Stub CH: resolve the trace to ``project_id``, then find no root span.
+
+    Only the first query (project resolution) matters here. The second returns
+    empty so the request stops right after the ownership gate with a distinct
+    message — that message is how the tests tell "ownership passed" apart from
+    "ownership rejected", without standing up a full span fixture.
+    """
+    calls = {"n": 0}
+
+    def fake(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return SimpleNamespace(data=[{"project_id": str(project_id)}])
+        return SimpleNamespace(data=[])
+
+    return fake
+
+
+@pytest.mark.django_db
+def test_detail_allows_project_in_active_org_not_user_home_org(
+    auth_client, user, monkeypatch
+):
+    # The user's home organization stays whatever the fixture made it; the
+    # request acts in a different organization that owns the project.
+    _, active_workspace, project = _make_org_project(user, "Active")
+    assert project.organization_id != user.organization_id
+    auth_client.set_workspace(active_workspace)
+    monkeypatch.setattr(CH_QUERY_PATH, _ch_returning(project.id))
+
+    response = auth_client.get(
+        VOICE_CALL_DETAIL_URL, {"trace_id": str(uuid.uuid4())}
+    )
+
+    # Ownership passed: the request reached the root-span lookup. Scoping the
+    # check to the user row instead would have stopped at "trace_id not found".
+    assert "trace_id not found" not in str(response.data)
+    assert "root span" in str(response.data)
+
+
+@pytest.mark.django_db
+def test_detail_still_rejects_project_in_unrelated_org(
+    auth_client, user, monkeypatch
+):
+    # Guard on the loosened check: acting in one organization must not grant
+    # access to a project owned by a different one.
+    _, active_workspace, _ = _make_org_project(user, "Active")
+    _, _, foreign_project = _make_org_project(user, "Foreign")
+    auth_client.set_workspace(active_workspace)
+    monkeypatch.setattr(CH_QUERY_PATH, _ch_returning(foreign_project.id))
+
+    response = auth_client.get(
+        VOICE_CALL_DETAIL_URL, {"trace_id": str(uuid.uuid4())}
+    )
+
+    assert "trace_id not found" in str(response.data)

--- a/futureagi/tracer/utils/bland.py
+++ b/futureagi/tracer/utils/bland.py
@@ -104,7 +104,13 @@ def _extract_eval_attributes(log: dict) -> dict:
 
 
 def _extract_recording(log: dict, eval_attributes: dict):
-    recording_url = log.get("recording_url")
+    # Bland only ever returns ``recording_url``, whose raw form serves no CORS
+    # headers and rejects range requests — usable server-side, not browser-
+    # playable. The simulate path rehosts to our storage and stores the durable
+    # URL under ``recording.combined``, so prefer that copy when it exists.
+    recording = log.get("recording")
+    combined = recording.get("combined") if isinstance(recording, dict) else None
+    recording_url = combined or log.get("recording_url")
     if recording_url:
         eval_attributes[_BLAND_COMBINED_RECORDING_KEY] = recording_url
 

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -2593,7 +2593,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             project_id = proj_result.data[0]["project_id"]
             if not Project.objects.filter(
                 id=project_id,
-                organization_id=request.user.organization_id,
+                organization=_get_request_organization(request),
             ).exists():
                 return self._gm.not_found("trace_id not found")
 
@@ -2702,7 +2702,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     _st.isoformat() if hasattr(_st, "isoformat") else str(_st)
                 )
         simulation_context = _simulation_context_for_voice_call(
-            organization_id=request.user.organization_id,
+            organization_id=getattr(_get_request_organization(request), "id", None),
             span_attributes=span_attrs,
             eval_attributes=eval_attrs,
             raw_log=raw_log,


### PR DESCRIPTION
Closes TH-7161.

## 1. Observe voice drawer returned nothing — wrong org source

`voice_call_detail` resolves a trace's project from ClickHouse, then checks ownership:

```python
organization_id=request.user.organization_id   # the user ROW's org
```

A user whose active organization (`X-Organization-Id`) differs from the one on their user row owns projects that check cannot see, so the endpoint 404s `trace_id not found`. The drawer then keeps the list-row stub seeded in `_list_voice_calls_clickhouse` — `{id, observation_type, parent_span_id}` — which is exactly the three attributes users were seeing, with no transcript and "No recording found".

The data was never missing. For the trace I debugged, CH held 38 span attributes, the transcript, and the rehosted recording.

Fixed by using the request-scoped organization via the module's existing `_get_request_organization` helper — the same thing `list_voice_calls` does 90 lines above (`trace.py:2498`).

`_simulation_context_for_voice_call` had the identical bug at `trace.py:2705`; with the wrong org its `CallExecution` lookups silently resolved to `{}`.

**Verified on dev** (`dev.api.futureagi.com`), same request before and after:

| | before | after |
|---|---|---|
| status | 404 | 200 |
| body | 174 B | 179 KB |
| transcript | — | `list[15]` |
| span attributes | 3 (stub) | 41 |
| recording | — | project-scoped S3 URL |

## 2. Combined-only recordings never played

`StereoMultiTrackPlayer` always built two tracks from the per-channel mono URLs (or the stereo split), and `MultiTrackAudioPlayer` gates readiness on *every* track loading:

```js
const isReady = ready === trackUrls.length;
```

A provider exposing only a combined mix handed it two `undefined` tracks, so the waveform painted forever and play stayed disabled.

This is not a backend population gap. Verified against live data: VAPI ships `stereoUrl` + `mono.assistantUrl` + `mono.customerUrl` (all present), while Bland's API returns only `recording_url` — no `recording` key at all. Bland mixes both speakers into one mono file with no channel separation, so there is nothing to lay out on two rows. Faking it by copying the combined URL into both channels would render two identical waveforms labelled "Customer" and "Assistant".

Now renders the single mix when that is all the call has, and keeps the two-row split whenever channels exist.

Also covers **Retell in the simulate drawer**, which is broken today for the same reason: `recording_multi_channel_url` is optional (`retell.py:266`), so a Retell call without it is combined-only. The existing single-track path is a hardcoded `provider === "retell"` special-case inside the `isProjectModule` branch — Observe only, never applied to simulate. This fix keys off the data instead of the provider name, so it covers both surfaces. I left the Retell special-case alone; it could likely be deleted as a follow-up, but that would change Retell's Observe UI from `CustomAudioPlayer` to the waveform player.

## 3. Bland attribute surfaced the raw provider URL

`conversation.recording.mono.combined` carried `https://api.bland.ai/v1/recordings/<id>` on the simulate path, while observe stored the rehosted S3 copy for the same call.

The raw URL is a public GET, so server-side consumers (evals) work — it is **not** an eval blocker. But it serves no CORS headers and returns 400 on a range request, so it is not browser-playable:

```
GET raw URL                    -> 200, audio/x-wav
GET raw URL + Origin + Range   -> 400, no access-control headers
```

The durable URL is already in the same payload — the simulate path rehosts and writes it to `recording.combined`, leaving `recording_url` beside it. `_extract_recording` now prefers it. Bland's API never returns a `recording` key (confirmed against the live API), so the observe ingest path is unchanged.

## Tests

- `test_voice_call_detail_org_scope.py` (new) — a project in the active org but not the user's home org resolves; **and** a project in an unrelated org is still rejected, so the loosened check did not become permissive.
- `test_bland_prefers_rehosted_combined_over_raw_recording_url` — added to the existing Bland suite.
- `AudioPlayerCustom.test.jsx` (new) — combined-only yields one populated track; per-channel still yields the two named rows.

Every new test was verified to **fail without its fix** by reverting each and re-running. 23 backend pass, 2 frontend pass.

## Verification notes

Backend fixes are live on dev and confirmed. The frontend fix is **not** — dev serves the FE from a separate deploy train, so item 2 needs a FE deploy to verify.

## Not a bug (investigated, no change)

`unknown-project` in simulate S3 keys. The observability provider for that agent was created at `17:48:22`; the calls ran at `17:10:52`. `agent_definition.observability_provider` was `None` at rehost time, so `project_id` was correctly `None`. The scoping code in `bland_service.py` is already right.


## Screenshots
<img width="2651" height="1567" alt="image" src="https://github.com/user-attachments/assets/370d5a64-04c7-4f42-bf12-2b125d2b0d42" />

Vapi: 
<img width="2960" height="1481" alt="image" src="https://github.com/user-attachments/assets/8f784f08-3d22-4025-a4a4-f63292f3de95" />


Voice Observability

<img width="2617" height="1617" alt="image" src="https://github.com/user-attachments/assets/1fe90aa8-ddc4-4e7c-b777-ae800e0257b4" />


<img width="2044" height="1583" alt="image" src="https://github.com/user-attachments/assets/dd09f7f9-8ffe-47d9-ad0f-061ea825da7e" />


