### PR TITLE
fix(eval): use removesuffix instead of split for -reason column name parsing

### DIFF
--- a/futureagi/model_hub/utils/eval_reasons.py
+++ b/futureagi/model_hub/utils/eval_reasons.py
@@ -59,7 +59,7 @@ def get_eval_reasons(
 
     # Process reason columns
     for column in reason_columns:
-        eval_name = column.name.split("-reason")[0]
+        eval_name = column.name.removesuffix("-reason")
         # Extract user_eval_metric_id from source_id (format: "prefix-sourceid-id")
         user_eval_metric_id = None
         if column.source_id and "-sourceid-" in str(column.source_id):

--- a/futureagi/model_hub/utils/tests/test_eval_reasons_parse.py
+++ b/futureagi/model_hub/utils/tests/test_eval_reasons_parse.py
@@ -1,0 +1,45 @@
+"""Tests for eval reason column name parsing (issue #1721).
+
+Verifies that eval names containing "-reason" are not truncated by
+the suffix-stripping logic.
+"""
+import pytest
+
+
+class TestReasonColumnParse:
+    """Issue #1721: split("-reason")[0] truncates eval names containing -reason."""
+
+    @pytest.mark.parametrize(
+        "column_name,expected",
+        [
+            # Standard case: eval name + "-reason" suffix
+            ("accuracy-reason", "accuracy"),
+            ("gpt4-accuracy-reason", "gpt4-accuracy"),
+            # Eval names that themselves contain "-reason"
+            ("no-reason-check-reason", "no-reason-check"),
+            ("gives-reason-reason", "gives-reason"),
+            # Names without the suffix (should be unchanged)
+            ("accuracy", "accuracy"),
+            ("gpt4-accuracy", "gpt4-accuracy"),
+        ],
+    )
+    def test_removesuffix_correctly_strips_trailing_reason(self, column_name, expected):
+        """removesuffix only strips the trailing -reason, not earlier occurrences."""
+        result = column_name.removesuffix("-reason")
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "column_name,expected",
+        [
+            ("no-reason-check-reason", "no-reason-check"),
+            ("gives-reason-reason", "gives-reason"),
+        ],
+    )
+    def test_split_truncates_names_containing_reason(self, column_name, expected):
+        """Demonstrates the bug: split('-reason')[0] truncates at the first match."""
+        # The OLD behavior (bug) would return the wrong result:
+        buggy_result = column_name.split("-reason")[0]
+        assert buggy_result != expected, (
+            f"Expected split to truncate '{column_name}' incorrectly, "
+            f"but got '{buggy_result}' (expected '{expected}')"
+        )

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -1147,7 +1147,7 @@ class DatasetExperimentsView(APIView):
                             "name": (
                                 column.name
                                 if "-reason" not in column.name
-                                else column.name.split("-reason")[0]
+                                else column.name.removesuffix("-reason")
                             ),
                             "data_type": (
                                 column.data_type


### PR DESCRIPTION
## Summary

Fixes #1721 — eval names containing "-reason" were truncated by `split("-reason")[0]`, which returns everything before the **first** match rather than stripping the trailing suffix.

**Before:**
```python
"no-reason-check-reason".split("-reason")[0]   # -> "no"   (should be "no-reason-check")
"gives-reason-reason".split("-reason")[0]      # -> "gives" (should be "gives-reason")
```

**After:**
```python
"no-reason-check-reason".removesuffix("-reason")  # -> "no-reason-check" ✓
"gives-reason-reason".removesuffix("-reason")     # -> "gives-reason" ✓
```

## Changes

| File | Change |
|------|--------|
| `model_hub/utils/eval_reasons.py:62` | `split("-reason")[0]` → `removesuffix("-reason")` |
| `model_hub/views/experiments.py:1150` | Same fix in the DatasetExperimentsView column name handler |
| `model_hub/utils/tests/test_eval_reasons_parse.py` | New parametrized tests covering standard names and names containing "-reason" |

## Why `removesuffix`?

The reason columns are created with `f"{name}-reason"` (see `get_eval_reasons`). `removesuffix` is the exact inverse of this construction — it only strips the trailing `-reason` suffix, regardless of whether the eval name itself contains `-reason`.

## Test Plan

- [x] Added parametrized tests for standard names (`accuracy-reason` → `accuracy`)
- [x] Added tests for names containing `-reason` (`no-reason-check-reason` → `no-reason-check`)
- [x] Verified the bug exists with `split` and is fixed with `removesuffix`
- [x] Non-reason column names are unchanged

## Checklist

- [x] PR description explains what and why
- [x] Tests added
- [x] Conventional commit format
- [x] Branch from dev
- [x] CLA ready to sign
