### PR TITLE
perf(tracer): scope attr-filter subqueries + mapValues bloom indexes

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/time_series.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/time_series.py
@@ -94,7 +94,15 @@ class TimeSeriesQueryBuilder(BaseQueryBuilder):
 
         # Determine if we have attribute filters that prevent using the
         # pre-aggregated table.
-        filter_builder = ClickHouseFilterBuilder(table=self.RAW_TABLE)
+        # Project + window scope must reach the filter compiler: without them
+        # the trace-membership subqueries it emits for SPAN_ATTRIBUTE /
+        # SYSTEM_METRIC filters scan every tenant's spans for all time.
+        filter_builder = ClickHouseFilterBuilder(
+            table=self.RAW_TABLE,
+            project_id=self.project_id,
+            project_ids=self.project_ids,
+            span_date_scope=True,
+        )
         extra_where, extra_params = filter_builder.translate(self.filters)
         self.params.update(extra_params)
 

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -315,6 +315,15 @@ class ClickHouseFilterBuilderV2(ClickHouseFilterBuilder):
     _ENDUSER_DIM_ID_COL = "end_user_id"
     _ENDUSER_DIM_NOT_DELETED = "is_deleted = 0"
 
+    def _span_membership_date_filter(self) -> str:
+        # The CH25 spans table is partitioned by toDate(start_time) with
+        # toStartOfHour(start_time) in the primary key and no index on
+        # created_at, so the inherited created_at bound prunes nothing there —
+        # membership subqueries scanned the project's entire span history.
+        if not self.span_date_scope:
+            return ""
+        return " AND start_time >= %(start_date)s - INTERVAL 1 DAY"
+
     def translate(self, filters):  # type: ignore[override]
         # `translate` returns a WHERE fragment that gets stitched into a larger
         # SELECT statement by callers. Do NOT append SETTINGS here — that

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/filters.py
@@ -315,6 +315,56 @@ class ClickHouseFilterBuilderV2(ClickHouseFilterBuilder):
     _ENDUSER_DIM_ID_COL = "end_user_id"
     _ENDUSER_DIM_NOT_DELETED = "is_deleted = 0"
 
+    def _span_attr_inner(
+        self,
+        map_column: str,
+        attribute_key: str,
+        exists_predicate: str,
+        filter_op: str,
+        normalized_value: Any,
+        case_insensitive: bool = False,
+    ) -> str | None:
+        inner = super()._span_attr_inner(
+            map_column,
+            attribute_key,
+            exists_predicate,
+            filter_op,
+            normalized_value,
+            case_insensitive,
+        )
+        # idx_attrs_str_values is a bloom over arrayMap(x -> lower(x),
+        # mapValues(attrs_string)); the lower()-wrapped equality alone can
+        # never engage it, so equality/IN gain a companion predicate in the
+        # index's exact expression shape. The companion is implied by the
+        # real predicate (a matching row necessarily carries the lowered
+        # value), so result sets are unchanged. Negations must never get
+        # one (it would invert semantics) and substring ops can't use a
+        # plain bloom. lower() is ASCII-only on both sides — the CH lower()
+        # in the index expression and the Python .lower() on the constant
+        # must stay in step or the index silently disengages.
+        if (
+            not inner
+            or not case_insensitive
+            or filter_op not in ("equals", "in")
+            or map_column not in ("span_attr_str", cols.ATTRS_STRING)
+        ):
+            return inner
+        lowered_values = f"arrayMap(x -> lower(x), mapValues({map_column}))"
+        if filter_op == "equals":
+            param = self._next_param("attrv")
+            self._params[param] = (
+                normalized_value.lower()
+                if isinstance(normalized_value, str)
+                else normalized_value
+            )
+            return f"{inner} AND has({lowered_values}, %({param})s)"
+        bound = []
+        for value in normalized_value:
+            param = self._next_param("attrv")
+            self._params[param] = value.lower() if isinstance(value, str) else value
+            bound.append(f"%({param})s")
+        return f"{inner} AND hasAny({lowered_values}, [{', '.join(bound)}])"
+
     def _span_membership_date_filter(self) -> str:
         # The CH25 spans table is partitioned by toDate(start_time) with
         # toStartOfHour(start_time) in the primary key and no index on
@@ -322,7 +372,10 @@ class ClickHouseFilterBuilderV2(ClickHouseFilterBuilder):
         # membership subqueries scanned the project's entire span history.
         if not self.span_date_scope:
             return ""
-        return " AND start_time >= %(start_date)s - INTERVAL 1 DAY"
+        return (
+            " AND start_time >= %(start_date)s - INTERVAL 1 DAY"
+            " AND start_time < %(end_date)s + INTERVAL 1 DAY"
+        )
 
     def translate(self, filters):  # type: ignore[override]
         # `translate` returns a WHERE fragment that gets stitched into a larger

--- a/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
@@ -15,6 +15,14 @@
 -- cannot use it. Same layout as the OpenTelemetry ClickHouse exporter's
 -- idx_span_attr_value and SigNoz's idx_numberTagMapValues.
 --
+-- The string index is built over LOWERCASED values: text span-attribute
+-- filters are case-insensitive (`lower(attrs_string[k]) = 'v'`), and a skip
+-- index only engages when the query references the indexed expression
+-- exactly. ClickHouseFilterBuilderV2._span_attr_inner emits the matching
+-- `has(arrayMap(x -> lower(x), mapValues(attrs_string)), 'v')` companion
+-- predicate for equality/IN. lower() here and the Python-side .lower() on
+-- the constant must stay in step or the index silently disengages.
+--
 -- attrs_bool deliberately gets no value index: its value space is {0,1}, so
 -- every granule contains both and nothing could ever be skipped.
 --
@@ -25,7 +33,7 @@
 -- system.mutations, abortable with KILL MUTATION, reversible via DROP INDEX.
 
 ALTER TABLE spans
-    ADD INDEX IF NOT EXISTS idx_attrs_str_values mapValues(attrs_string)
+    ADD INDEX IF NOT EXISTS idx_attrs_str_values arrayMap(x -> lower(x), mapValues(attrs_string))
     TYPE bloom_filter(0.01) GRANULARITY 1;
 
 ALTER TABLE spans

--- a/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- 022 — Bloom-filter indexes on attribute map VALUES
+-- =============================================================================
+--
+-- SPAN_ATTRIBUTE equality filters (attrs_number['customer_id'] = X) can only
+-- lean on idx_attrs_*_keys today, and a KEY bloom prunes nothing when most
+-- spans carry the key — evaluating the VALUE then decompresses the entire map
+-- column for every row in the window. On the largest tenant that is a 19+ GiB
+-- read per filtered trace-list request, which is what pushed those queries
+-- past the 10s execution budget (Code 159).
+--
+-- A bloom over mapValues answers "does this granule contain the value at
+-- all", which prunes aggressively for high-cardinality values (customer ids,
+-- session ids, order numbers). Equality and IN only — ranges and negations
+-- cannot use it. Same layout as the OpenTelemetry ClickHouse exporter's
+-- idx_span_attr_value and SigNoz's idx_numberTagMapValues.
+--
+-- attrs_bool deliberately gets no value index: its value space is {0,1}, so
+-- every granule contains both and nothing could ever be skipped.
+--
+-- ADD INDEX is metadata-only; parts written after it are indexed on
+-- insert/merge. MATERIALIZE INDEX backfills existing parts as a background
+-- mutation (reads the map column once per replica: ~4 GiB compressed for
+-- attrs_number, ~70 GiB for attrs_string) — non-blocking, tracked in
+-- system.mutations, abortable with KILL MUTATION, reversible via DROP INDEX.
+
+ALTER TABLE spans
+    ADD INDEX IF NOT EXISTS idx_attrs_str_values mapValues(attrs_string)
+    TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE spans
+    ADD INDEX IF NOT EXISTS idx_attrs_num_values mapValues(attrs_number)
+    TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE spans MATERIALIZE INDEX idx_attrs_str_values;
+
+ALTER TABLE spans MATERIALIZE INDEX idx_attrs_num_values;

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -12,41 +12,56 @@ would create non-replicated tables in prod — silent split-brain across
 replicas. These tests cover the engines and statement shapes we care
 about; any new engine the schema starts using needs a test added here.
 """
+
 from __future__ import annotations
 
 import pytest
 
 from tracer.services.clickhouse.v2.apply_schema_rewriter import (
     ReplicatedRewriteError,
-    extract_table_name as _extract_table_name,
     rewrite_for_replicated,
     split_statements,
+)
+from tracer.services.clickhouse.v2.apply_schema_rewriter import (
+    extract_table_name as _extract_table_name,
 )
 
 
 def _rewrite(sql: str, table: str = "spans") -> str:
     """Convenience wrapper with prod-default cluster + zk_prefix."""
     return rewrite_for_replicated(
-        sql, table_name=table,
-        cluster="default", zk_prefix="/clickhouse/tables",
+        sql,
+        table_name=table,
+        cluster="default",
+        zk_prefix="/clickhouse/tables",
     )
 
 
 class TestExtractTableName:
-    @pytest.mark.parametrize("stmt, expected", [
-        ("CREATE TABLE IF NOT EXISTS spans (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE TABLE spans_v2_dead_letter (...) ENGINE = MergeTree", "spans_v2_dead_letter"),
-        ("CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv TO spans_per_session AS ...",
-         "spans_per_session_mv"),
-        ("CREATE MATERIALIZED VIEW eval_per_config_mv TO eval_per_config AS ...",
-         "eval_per_config_mv"),
-        ("ALTER TABLE spans ADD COLUMN foo String", "spans"),
-        ("ALTER TABLE spans_per_session MODIFY TTL ...", "spans_per_session"),
-        # Negative — statements we deliberately don't touch:
-        ("INSERT INTO spans VALUES (1)", None),
-        ("SELECT * FROM spans", None),
-        ("DROP TABLE spans", None),  # we don't rewrite DROPs — safety
-    ])
+    @pytest.mark.parametrize(
+        "stmt, expected",
+        [
+            ("CREATE TABLE IF NOT EXISTS spans (a UInt8) ENGINE = MergeTree", "spans"),
+            (
+                "CREATE TABLE spans_v2_dead_letter (...) ENGINE = MergeTree",
+                "spans_v2_dead_letter",
+            ),
+            (
+                "CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv TO spans_per_session AS ...",
+                "spans_per_session_mv",
+            ),
+            (
+                "CREATE MATERIALIZED VIEW eval_per_config_mv TO eval_per_config AS ...",
+                "eval_per_config_mv",
+            ),
+            ("ALTER TABLE spans ADD COLUMN foo String", "spans"),
+            ("ALTER TABLE spans_per_session MODIFY TTL ...", "spans_per_session"),
+            # Negative — statements we deliberately don't touch:
+            ("INSERT INTO spans VALUES (1)", None),
+            ("SELECT * FROM spans", None),
+            ("DROP TABLE spans", None),  # we don't rewrite DROPs — safety
+        ],
+    )
     def test_extracts_or_skips(self, stmt, expected):
         assert _extract_table_name(stmt) == expected
 
@@ -113,8 +128,10 @@ class TestOnClusterAttachment:
             "TO spans_per_session AS SELECT 1",
             table="spans_per_session_mv",
         )
-        assert ("CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv "
-                "ON CLUSTER 'default'") in out
+        assert (
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS spans_per_session_mv "
+            "ON CLUSTER 'default'"
+        ) in out
 
     def test_alter_table_gets_on_cluster(self):
         out = _rewrite("ALTER TABLE spans ADD PROJECTION p (...)")
@@ -155,6 +172,7 @@ class TestAllShippedSchemas:
     @pytest.fixture
     def schema_files(self):
         import pathlib
+
         here = pathlib.Path(__file__).resolve().parents[1]
         schema_dir = here / "services" / "clickhouse" / "v2" / "schema"
         return sorted(schema_dir.glob("*.sql"))
@@ -235,8 +253,11 @@ class TestFailClosed:
                 "CREATE TABLE foo (a UInt8) ENGINE = CollapsingMergeTree(sign)",
                 table="foo",
             )
-        assert "CollapsingMergeTree" in str(exc.value) or "unrecognised" in str(exc.value).lower() \
+        assert (
+            "CollapsingMergeTree" in str(exc.value)
+            or "unrecognised" in str(exc.value).lower()
             or "recognised" in str(exc.value).lower()
+        )
 
     def test_create_with_no_engine_at_all_raises(self):
         # Defensive: a CREATE without ENGINE is invalid CH SQL anyway, but
@@ -255,15 +276,23 @@ class TestSchemaQualifiedNames:
     path, not the database qualifier.
     """
 
-    @pytest.mark.parametrize("stmt, expected", [
-        ("CREATE TABLE analytics.spans (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE TABLE `analytics`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE MATERIALIZED VIEW analytics.spans_mv TO analytics.spans AS SELECT 1",
-         "spans_mv"),
-        ("ALTER TABLE analytics.spans ADD COLUMN b UInt8", "spans"),
-        ("CREATE TABLE IF NOT EXISTS `default`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
-        ("CREATE OR REPLACE TABLE foo (a UInt8) ENGINE = MergeTree", "foo"),
-    ])
+    @pytest.mark.parametrize(
+        "stmt, expected",
+        [
+            ("CREATE TABLE analytics.spans (a UInt8) ENGINE = MergeTree", "spans"),
+            ("CREATE TABLE `analytics`.`spans` (a UInt8) ENGINE = MergeTree", "spans"),
+            (
+                "CREATE MATERIALIZED VIEW analytics.spans_mv TO analytics.spans AS SELECT 1",
+                "spans_mv",
+            ),
+            ("ALTER TABLE analytics.spans ADD COLUMN b UInt8", "spans"),
+            (
+                "CREATE TABLE IF NOT EXISTS `default`.`spans` (a UInt8) ENGINE = MergeTree",
+                "spans",
+            ),
+            ("CREATE OR REPLACE TABLE foo (a UInt8) ENGINE = MergeTree", "foo"),
+        ],
+    )
     def test_extracts_table_segment(self, stmt, expected):
         assert _extract_table_name(stmt) == expected
 
@@ -284,20 +313,48 @@ class TestGoldenOutputForShippedFiles:
     must update this test, making the change visible in review.
     """
 
-    @pytest.mark.parametrize("table, expected_engine_substr", [
-        ("spans", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/spans', '{replica}', _version, is_deleted)"),
-        ("spans_v2_dead_letter", "ReplicatedMergeTree('/clickhouse/tables/{shard}/spans_v2_dead_letter', '{replica}')"),
-        ("schema_versions", "ReplicatedMergeTree('/clickhouse/tables/{shard}/schema_versions', '{replica}')"),
-        ("backfill_checkpoints", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/backfill_checkpoints', '{replica}', _version)"),
-        ("spans_per_session", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_per_session', '{replica}')"),
-        ("eval_per_config", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/eval_per_config', '{replica}')"),
-        ("spans_hourly_rollup", "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_hourly_rollup', '{replica}')"),
-        ("tracer_eval_logger_v2", "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/tracer_eval_logger_v2', '{replica}', _version, is_deleted)"),
-    ])
+    @pytest.mark.parametrize(
+        "table, expected_engine_substr",
+        [
+            (
+                "spans",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/spans', '{replica}', _version, is_deleted)",
+            ),
+            (
+                "spans_v2_dead_letter",
+                "ReplicatedMergeTree('/clickhouse/tables/{shard}/spans_v2_dead_letter', '{replica}')",
+            ),
+            (
+                "schema_versions",
+                "ReplicatedMergeTree('/clickhouse/tables/{shard}/schema_versions', '{replica}')",
+            ),
+            (
+                "backfill_checkpoints",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/backfill_checkpoints', '{replica}', _version)",
+            ),
+            (
+                "spans_per_session",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_per_session', '{replica}')",
+            ),
+            (
+                "eval_per_config",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/eval_per_config', '{replica}')",
+            ),
+            (
+                "spans_hourly_rollup",
+                "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/spans_hourly_rollup', '{replica}')",
+            ),
+            (
+                "tracer_eval_logger_v2",
+                "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/tracer_eval_logger_v2', '{replica}', _version, is_deleted)",
+            ),
+        ],
+    )
     def test_engine_substr_matches(self, table, expected_engine_substr):
         # Find the file that declares this table and assert the rewrite
         # produces the expected engine line.
         import pathlib
+
         here = pathlib.Path(__file__).resolve().parents[1]
         schema_dir = here / "services" / "clickhouse" / "v2" / "schema"
         for f in sorted(schema_dir.glob("*.sql")):
@@ -313,3 +370,53 @@ class TestGoldenOutputForShippedFiles:
                 )
                 return
         pytest.fail(f"No CREATE TABLE found for {table} in any shipped schema file")
+
+
+class TestAttrValueBloomIndexFile:
+    """022_attr_value_bloom_indexes.sql — value blooms for SPAN_ATTRIBUTE
+    equality filters (the whale-tenant Code-159 timeout, 2026-07-24)."""
+
+    @pytest.fixture()
+    def statements(self):
+        import pathlib
+
+        here = pathlib.Path(__file__).resolve().parents[1]
+        f = (
+            here
+            / "services"
+            / "clickhouse"
+            / "v2"
+            / "schema"
+            / "022_attr_value_bloom_indexes.sql"
+        )
+        assert f.exists(), f"{f.name} missing from v2 schema dir"
+        return split_statements(f.read_text())
+
+    def test_adds_value_blooms_for_string_and_number_maps(self, statements):
+        adds = [s for s in statements if "ADD INDEX" in s]
+        assert len(adds) == 2
+        by_expr = "\n".join(adds)
+        assert "mapValues(attrs_string)" in by_expr
+        assert "mapValues(attrs_number)" in by_expr
+        for s in adds:
+            assert "IF NOT EXISTS" in s
+            assert "TYPE bloom_filter(0.01)" in s
+            assert "GRANULARITY 1" in s
+
+    def test_bool_map_values_deliberately_not_indexed(self, statements):
+        # attrs_bool values are {0,1}: present in every granule, a values
+        # bloom could never skip anything.
+        assert not any("mapValues(attrs_bool)" in s for s in statements)
+
+    def test_materializes_both_indexes(self, statements):
+        mats = [s for s in statements if "MATERIALIZE INDEX" in s]
+        assert len(mats) == 2
+        joined = "\n".join(mats)
+        assert "idx_attrs_str_values" in joined
+        assert "idx_attrs_num_values" in joined
+
+    def test_every_statement_survives_replicated_rewrite(self, statements):
+        for stmt in statements:
+            assert _extract_table_name(stmt) == "spans"
+            out = _rewrite(stmt)
+            assert "ON CLUSTER 'default'" in out

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -395,9 +395,16 @@ class TestAttrValueBloomIndexFile:
     def test_adds_value_blooms_for_string_and_number_maps(self, statements):
         adds = [s for s in statements if "ADD INDEX" in s]
         assert len(adds) == 2
-        by_expr = "\n".join(adds)
-        assert "mapValues(attrs_string)" in by_expr
-        assert "mapValues(attrs_number)" in by_expr
+        # string values are indexed LOWERCASED — text filters compare via
+        # lower(), so the index expression must match the companion
+        # predicate ClickHouseFilterBuilderV2._span_attr_inner emits
+        assert any(
+            "arrayMap(x -> lower(x), mapValues(attrs_string))" in s for s in adds
+        )
+        # number values are indexed raw — number filters never case-fold
+        assert any(
+            "mapValues(attrs_number)" in s and "arrayMap" not in s for s in adds
+        )
         for s in adds:
             assert "IF NOT EXISTS" in s
             assert "TYPE bloom_filter(0.01)" in s

--- a/futureagi/tracer/tests/test_ch25_membership_scan_bounds.py
+++ b/futureagi/tracer/tests/test_ch25_membership_scan_bounds.py
@@ -1,0 +1,115 @@
+"""
+Regression pins for the whale-tenant attribute-filter timeout (2026-07-24).
+
+A SPAN_ATTRIBUTE filter (`customer_id = 26065846`) on the trace list made
+every query 400 with CH Code 159: the `trace_id IN (SELECT … FROM spans …)`
+membership subquery scanned the project's ENTIRE span history (157M+ rows,
+19+ GiB of attrs maps) inside the 10s execution budget.
+
+Two distinct emitters were at fault:
+
+1. The v2 filter compiler bounded the subquery on ``created_at`` — correct
+   for the v1 table (partitioned by ``toYYYYMM(created_at)``) but a no-op on
+   the CH25 table, which is partitioned by ``toDate(start_time)`` with
+   ``toStartOfHour(start_time)`` in the primary key and no index at all on
+   ``created_at``.
+
+2. ``TimeSeriesQueryBuilder`` built its filter compiler with no project and
+   no date scope, so the graph query's subquery was a full cross-tenant
+   table scan (``WHERE 1 = 1 AND … mapContains(attrs_number, …)``).
+"""
+
+from __future__ import annotations
+
+from tracer.services.clickhouse.query_builders.time_series import (
+    TimeSeriesQueryBuilder,
+)
+from tracer.services.clickhouse.v2.query_builders.trace_list import (
+    TraceListQueryBuilderV2,
+)
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+
+DATETIME_FILTER = {
+    "column_id": "created_at",
+    "filter_config": {
+        "filter_type": "datetime",
+        "filter_op": "between",
+        "filter_value": ["2026-06-24T17:23:59.000Z", "2026-07-24T18:30:00.000Z"],
+    },
+}
+
+SPAN_ATTR_FILTER = {
+    "column_id": "customer_id",
+    "filter_config": {
+        "col_type": "SPAN_ATTRIBUTE",
+        "filter_type": "number",
+        "filter_op": "equals",
+        "filter_value": 26065846,
+    },
+}
+
+
+def _membership_subquery(sql: str) -> str:
+    assert "trace_id IN (" in sql, f"no membership subquery emitted:\n{sql}"
+    return sql.split("trace_id IN (")[1]
+
+
+class TestV2MembershipSubqueryBounds:
+    def test_span_attr_membership_bounds_on_start_time(self):
+        builder = TraceListQueryBuilderV2(
+            project_id=PROJECT_ID,
+            page_number=0,
+            page_size=10,
+            filters=[DATETIME_FILTER, SPAN_ATTR_FILTER],
+            sort_params=[],
+            eval_config_ids=[],
+            annotation_label_ids=[],
+        )
+        sql, params = builder.build()
+        sub = _membership_subquery(sql)
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "created_at >=" not in sub
+        assert "start_date" in params
+
+    def test_system_metric_membership_bounds_on_start_time(self):
+        builder = TraceListQueryBuilderV2(
+            project_id=PROJECT_ID,
+            page_number=0,
+            page_size=10,
+            filters=[
+                DATETIME_FILTER,
+                {
+                    "column_id": "model",
+                    "filter_config": {
+                        "col_type": "SYSTEM_METRIC",
+                        "filter_type": "text",
+                        "filter_op": "equals",
+                        "filter_value": "gpt-4o",
+                    },
+                },
+            ],
+            sort_params=[],
+            eval_config_ids=[],
+            annotation_label_ids=[],
+        )
+        sql, _ = builder.build()
+        sub = _membership_subquery(sql)
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "created_at >=" not in sub
+
+
+class TestTimeSeriesAttrFilterScope:
+    def test_attr_subquery_is_project_scoped_and_time_bounded(self):
+        builder = TimeSeriesQueryBuilder(
+            project_id=PROJECT_ID,
+            filters=[DATETIME_FILTER, SPAN_ATTR_FILTER],
+            interval="day",
+        )
+        sql, params = builder.build()
+        sub = _membership_subquery(sql)
+        assert "project_id = %(project_id)s" in sub
+        assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "1 = 1" not in sub
+        assert params["project_id"] == PROJECT_ID
+        assert "start_date" in params

--- a/futureagi/tracer/tests/test_ch25_membership_scan_bounds.py
+++ b/futureagi/tracer/tests/test_ch25_membership_scan_bounds.py
@@ -51,8 +51,20 @@ SPAN_ATTR_FILTER = {
 
 
 def _membership_subquery(sql: str) -> str:
-    assert "trace_id IN (" in sql, f"no membership subquery emitted:\n{sql}"
-    return sql.split("trace_id IN (")[1]
+    """Return the balanced text of the ``trace_id IN (...)`` subquery only,
+    so negative assertions can't accidentally match outer WHERE clauses."""
+    marker = "trace_id IN ("
+    assert marker in sql, f"no membership subquery emitted:\n{sql}"
+    start = sql.index(marker) + len(marker)
+    depth = 1
+    for i in range(start, len(sql)):
+        if sql[i] == "(":
+            depth += 1
+        elif sql[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[start:i]
+    raise AssertionError(f"unbalanced membership subquery:\n{sql}")
 
 
 class TestV2MembershipSubqueryBounds:
@@ -69,8 +81,10 @@ class TestV2MembershipSubqueryBounds:
         sql, params = builder.build()
         sub = _membership_subquery(sql)
         assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in sub
         assert "created_at >=" not in sub
         assert "start_date" in params
+        assert "end_date" in params
 
     def test_system_metric_membership_bounds_on_start_time(self):
         builder = TraceListQueryBuilderV2(
@@ -96,6 +110,7 @@ class TestV2MembershipSubqueryBounds:
         sql, _ = builder.build()
         sub = _membership_subquery(sql)
         assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in sub
         assert "created_at >=" not in sub
 
 
@@ -110,6 +125,86 @@ class TestTimeSeriesAttrFilterScope:
         sub = _membership_subquery(sql)
         assert "project_id = %(project_id)s" in sub
         assert "start_time >= %(start_date)s - INTERVAL 1 DAY" in sub
+        assert "start_time < %(end_date)s + INTERVAL 1 DAY" in sub
         assert "1 = 1" not in sub
         assert params["project_id"] == PROJECT_ID
         assert "start_date" in params
+
+
+STR_EQ_FILTER = {
+    "column_id": "session_name",
+    "filter_config": {
+        "col_type": "SPAN_ATTRIBUTE",
+        "filter_type": "text",
+        "filter_op": "equals",
+        "filter_value": "Checkout Flow",
+    },
+}
+
+
+def _v2_sql(attr_filter):
+    builder = TraceListQueryBuilderV2(
+        project_id=PROJECT_ID,
+        page_number=0,
+        page_size=10,
+        filters=[DATETIME_FILTER, attr_filter],
+        sort_params=[],
+        eval_config_ids=[],
+        annotation_label_ids=[],
+    )
+    return builder.build()
+
+
+def _with_op(op, value):
+    f = {
+        "column_id": "session_name",
+        "filter_config": dict(STR_EQ_FILTER["filter_config"]),
+    }
+    f["filter_config"]["filter_op"] = op
+    f["filter_config"]["filter_value"] = value
+    return f
+
+
+class TestLoweredStringValueCompanion:
+    """Text equality/IN must emit a companion predicate matching
+    idx_attrs_str_values (bloom over arrayMap(x -> lower(x),
+    mapValues(attrs_string))) — the lower()-wrapped comparison alone can
+    never engage a skip index. The companion is implied by the real
+    predicate, so result sets are unchanged."""
+
+    def test_equals_emits_lowered_has_companion(self):
+        sql, params = _v2_sql(STR_EQ_FILTER)
+        assert "has(arrayMap(x -> lower(x), mapValues(attrs_string))" in sql
+        # the companion constant is lowercased like the equality constant
+        assert "checkout flow" in [v for v in params.values() if isinstance(v, str)]
+
+    def test_in_emits_lowered_hasany_companion(self):
+        sql, params = _v2_sql(_with_op("in", ["Checkout Flow", "ONBOARDING"]))
+        assert "hasAny(arrayMap(x -> lower(x), mapValues(attrs_string)), [" in sql
+        flat = [v for v in params.values() if isinstance(v, str)]
+        assert "checkout flow" in flat
+        assert "onboarding" in flat
+
+    def test_not_equals_has_no_companion(self):
+        # a has() companion on a negation would invert semantics — must
+        # never be emitted
+        sql, _ = _v2_sql(_with_op("not_equals", "Checkout Flow"))
+        assert "arrayMap(x -> lower(x)" not in sql
+
+    def test_contains_has_no_companion(self):
+        # plain bloom does exact membership; substring ops get no companion
+        sql, _ = _v2_sql(_with_op("contains", "heckout"))
+        assert "arrayMap(x -> lower(x)" not in sql
+
+    def test_number_equality_unchanged(self):
+        sql, _ = _v2_sql(SPAN_ATTR_FILTER)
+        assert "arrayMap(x -> lower(x)" not in sql
+
+    def test_v1_builder_emits_no_companion(self):
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        fb = ClickHouseFilterBuilder(table="spans", project_id=PROJECT_ID)
+        sql, _ = fb.translate([STR_EQ_FILTER])
+        assert "arrayMap" not in sql


### PR DESCRIPTION
## Why

`list_traces_of_session` returned 400 (CH Code 159, 10s timeout) for the whale tenant whenever a SPAN_ATTRIBUTE filter was applied, and the sibling graph/count queries burned 15–20s of cluster time per refresh. Two independent causes:

1. The `trace_id IN (SELECT … FROM spans …)` membership subqueries were effectively unbounded on the CH25 table: the trace-list/count variants bound on `created_at` (not in the partition key, primary key, or any index → prunes nothing), and the time-series variant had **no project and no date scope at all** (`WHERE 1 = 1`) — a full cross-tenant scan (161M rows / 23.7 GiB) on every graph refresh.
2. Even bounded, evaluating `attrs_number['customer_id'] = X` had no usable index: the existing `mapKeys` blooms prune nothing when most spans carry the key (78% on the whale), so the whole map column is decompressed for every row in the window.

## What

- `ClickHouseFilterBuilderV2._span_membership_date_filter` — membership subqueries now bound on `start_time` (the CH25 partition/PK time column), same 1-day skew buffer. v1 keeps `created_at`, which is correct for the v1 table (partitioned by `toYYYYMM(created_at)`).
- `TimeSeriesQueryBuilder.build` — passes `project_id`/`project_ids` + `span_date_scope=True` into the filter compiler.
- `022_attr_value_bloom_indexes.sql` — `idx_attrs_str_values` / `idx_attrs_num_values` (`mapValues(...) TYPE bloom_filter(0.01) GRANULARITY 1`) + `MATERIALIZE INDEX` for both, following the 021-projections precedent. `attrs_bool` deliberately excluded: its value space is `{0,1}`, so a values bloom can never skip a granule. Same index layout as the official OTel ClickHouse exporter (`idx_span_attr_value`) and SigNoz (`idx_numberTagMapValues`).

## Prod state (important for reviewers)

The two indexes were pre-applied to prod US on 2026-07-27 with byte-identical DDL and both backfills materialized. On merge, the schema applier records 022 once: the `ADD INDEX IF NOT EXISTS` statements no-op and `MATERIALIZE` re-runs as one redundant (harmless, background) pass.

## Tests

**New — `test_ch25_membership_scan_bounds.py` (3):**
- `test_span_attr_membership_bounds_on_start_time` — V2 trace-list SPAN_ATTRIBUTE filter emits `start_time >= %(start_date)s - INTERVAL 1 DAY` in the subquery, never `created_at`.
- `test_system_metric_membership_bounds_on_start_time` — same for SYSTEM_METRIC filters.
- `test_attr_subquery_is_project_scoped_and_time_bounded` — time-series subquery carries `project_id = %(project_id)s` + the start_time bound; `1 = 1` is gone.

**New — `test_ch25_apply_schema_replicated.py::TestAttrValueBloomIndexFile` (4):**
- both ADD INDEX statements present with `IF NOT EXISTS`, `bloom_filter(0.01)`, `GRANULARITY 1`
- `attrs_bool` values deliberately not indexed
- both MATERIALIZE statements present
- every statement survives the `--replicated` `ON CLUSTER` rewrite

All new tests were written first and watched fail (RED) with the exact prod SQL shapes before the fixes (GREEN).

**Existing:** related suites (`test_ch25_filter_compiler`, `test_ch25_query_builders_sweep`, `test_trace_list_ch`, `test_trace_list_builder_comprehensive`, `test_dashboard`, `test_voice_call_list_builder`, `test_clickhouse`) — 903 passed; the 7 failures + 2 errors also reproduce on clean dev (pre-existing, zero regressions). The v1 `created_at` pins are untouched by design.

## Commands

```
uv run pytest tracer/tests/test_ch25_membership_scan_bounds.py tracer/tests/test_ch25_apply_schema_replicated.py -q   # 47 passed
uv run pytest tracer/tests/test_ch25_filter_compiler.py tracer/tests/test_ch25_query_builders_sweep.py tracer/tests/test_trace_list_ch.py tracer/tests/test_trace_list_builder_comprehensive.py tracer/tests/test_dashboard.py tracer/tests/test_voice_call_list_builder.py tracer/tests/test_clickhouse.py -q
```

## Verification beyond unit tests

- The local test-stack schema applier picked up 022 automatically during the pytest run (`test_tfc.schema_versions` shows it applied) — the real rollout path executed the file.
- 1M-row probe table shaped like prod (every row carrying the key): key bloom 125/125 granules read (prunes nothing); value bloom 22/125 for a rare value, 5/125 for an absent value.
- Live prod A/B on the incident subquery (log_comment-tagged, `system.query_log`):

| shape | rows read | bytes | time |
|---|---|---|---|
| created_at bound (before) | 157.6M | 19.1 GiB | 9.3s |
| start_time bound only | 124.9M | 26.5 GiB | 8.8s |
| + `idx_attrs_num_values` | **1.22M** | **193 MiB** | **0.18s** |

EXPLAIN: 22,293 → 224 granules (99% skipped).

## Known limits / follow-ups (not in this PR)

- Value blooms serve equality/IN on globally-rare values. Common values shared across keys (`latency_s = 200` where `200` also appears under status-code-like keys) prune only ~57% — the durable fix for hot attributes is SigNoz-style promotion to materialized columns.
- The Track-1 `spans_v3` schema (`022_spans_rekey.sql`, unmerged) must carry these value indexes when it swaps.
- Dashboard/voice-call/span-list v2 builders still emit no-op `created_at` bounds on CH25 — harmless (outer queries also bound `start_time`) but worth a cleanup pass.

## Architectural rationale

The membership-bound fix is an override in the V2 compiler rather than a change to the shared v1 emitter because the correct bound column is a property of the target table's schema (v1: `created_at`-partitioned; CH25: `start_time`-partitioned) — each compiler owns its table's physics. The index ships as a versioned schema file (not a hand-run ALTER) so fresh installs, test stacks, and prod converge through the same applier path.