### PR TITLE
fix(accounts): make the login password check unconditional (TH-5712)

### DIFF
--- a/futureagi/accounts/tests/test_login_error_codes.py
+++ b/futureagi/accounts/tests/test_login_error_codes.py
@@ -21,7 +21,7 @@ import pytest
 from django.core.cache import cache
 from django.http import HttpResponse
 from django.test import RequestFactory
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.test import APIClient
 
 # ---------------------------------------------------------------------------
@@ -98,6 +98,48 @@ class TestInvalidCredentialsErrorCode:
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
         result = _result(resp)
         assert result["error_code"] == "LOGIN_INVALID_CREDENTIALS"
+
+    @pytest.mark.parametrize(
+        "payload_password",
+        [None, "", "   "],
+        ids=["omitted", "empty", "whitespace"],
+    )
+    def test_contract_rejects_missing_password(
+        self, api_client, user, payload_password
+    ):
+        """LoginRequestSerializer is the first gate: no token on a blank password."""
+        payload = {"email": user.email}
+        if payload_password is not None:
+            payload["password"] = payload_password
+
+        resp = api_client.post("/accounts/token/", payload, format="json")
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "access" not in resp.content.decode()
+
+    def test_password_check_fails_closed_without_the_contract(self, api_client, user):
+        """The view must reject a blank password on its own.
+
+        The serializer normally rejects it first, so this drives the view with a
+        contract that permits blank, the state the view would face if the
+        contract ever loosened. Red when the check is guarded by a truthiness
+        test on the password, green when it is unconditional.
+        """
+        from accounts.serializers.contracts import LoginRequestSerializer
+
+        permissive = serializers.CharField(required=False, allow_blank=True, default="")
+        with patch.dict(
+            LoginRequestSerializer._declared_fields,
+            {"password": permissive},
+        ):
+            resp = api_client.post(
+                "/accounts/token/", {"email": user.email}, format="json"
+            )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        result = _result(resp)
+        assert result["error_code"] == "LOGIN_INVALID_CREDENTIALS"
+        assert "access" not in resp.content.decode()
 
     def test_nonexistent_email_preserves_legacy_error_string(self, api_client, db):
         resp = _login(api_client, "nobody@futureagi.com", "anypass")

--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -247,7 +247,7 @@ class CustomTokenObtainPairView(TokenObtainPairView):
 
             # --- Password check (must come before any token issuance) ---
             password_entered = validated_data["password"]
-            if password_entered and not check_password(password_entered, user.password):
+            if not check_password(password_entered, user.password):
                 failed_attempts += 1
                 cache.set(
                     attempts_key, failed_attempts, settings.FAILED_ATTEMPTS_TIMEOUT


### PR DESCRIPTION
## 1. Summary

The login password check in `CustomTokenObtainPairView` was guarded by a
truthiness test on the submitted password:

```python
password_entered = validated_data["password"]
if password_entered and not check_password(password_entered, user.password):
```

A falsy `password_entered` makes the whole condition `False`, so verification is
skipped and the request falls through to token issuance. The check is meant to
be the last gate before tokens are minted, and it fails open instead of closed.

This makes it unconditional:

```python
if not check_password(password_entered, user.password):
```

**Reachability, stated plainly:** this is defense in depth, not a live hole.
`LoginRequestSerializer.password` is a plain `serializers.CharField()`, so DRF's
defaults (`required=True`, `allow_blank=False`, `trim_whitespace=True`) already
reject an omitted, empty, or whitespace-only password with a 400 before the view
body runs. I verified all four vectors against unpatched `dev` and every one is
a 400 with no token issued. So nothing is currently exploitable in production.

What is wrong is that the view depends on a sibling serializer contract to stay
safe. If that contract is ever loosened (`required=False`, `allow_blank=True`,
or a new caller reaching this view through another serializer), the view issues
tokens on the email alone. Section 4's test demonstrates exactly that, and it is
red on today's code.

This supersedes #792, which carried the same intent against `main`.

## 2. Why the changes are done

TH-5712 was filed against this line. The original PR (#792) targeted `main` and
bundled three unrelated things: gateway config tests that have since merged as
part of #946, and `docker-compose` changes that make `AGENTCC_INTERNAL_API_KEY`
hard-required, which #799 supersedes with a better split (dev optional, prod
overlay required, so an empty `.env` still boots).

Stripping it back to the one line that is still unique, and moving it onto `dev`
where it belongs, is what makes it reviewable. #792 has sat with zero reviews for
52 days, and its shape is a large part of why.

## 3. What changed

| File | Change |
| --- | --- |
| `futureagi/accounts/views/user.py` | Drop the `password_entered and` guard so the `check_password` call always runs |
| `futureagi/accounts/tests/test_login_error_codes.py` | 4 tests added into the existing `TestInvalidCredentialsErrorCode` class |

One line of production code. No migration, no contract change, no client-visible
behavior change on any input that is reachable today.

## 4. Tests included

Folded into the existing `TestInvalidCredentialsErrorCode` class rather than a
new file.

**`test_password_check_fails_closed_without_the_contract`** is the behavioral
one. It patches `LoginRequestSerializer._declared_fields["password"]` to a
permissive `CharField(required=False, allow_blank=True, default="")`, posts to
the real `/accounts/token/` endpoint with no password, and asserts a 400
`LOGIN_INVALID_CREDENTIALS` with no `access` token in the body.

- Without the fix: **200, tokens issued** (`assert 200 == 400`)
- With the fix: **400 LOGIN_INVALID_CREDENTIALS**

**`test_contract_rejects_missing_password`** (parametrized: omitted, empty,
whitespace) pins the serializer gate itself, so if someone loosens the contract
later, that test fails and points at this one.

## 5. Commands to run the tests

```bash
cd futureagi

# the touched file
pytest accounts/tests/test_login_error_codes.py -q

# the behavioral test on its own
pytest accounts/tests/test_login_error_codes.py -q \
  -k test_password_check_fails_closed_without_the_contract

# whole-app siblings
pytest accounts/tests/ -q
pytest tfc/tests/test_accounts_api_contract_debt.py \
       model_hub/tests/test_annotation_workflow_api.py -q
```

## 6. Video

Not applicable. Backend-only change with no UI surface.

## 7. Screenshot of test suite run

![pytest run: login tests green, new test red without the fix, accounts/ suite at dev parity](https://github.com/user-attachments/assets/98260b60-714f-4ffa-a5e5-a2865a3fdaf7)

`accounts/tests/` reports 8 failed / 1119 passed / 73 errors on this branch.
Clean `origin/dev` reports the **same** 8 failures and 73 errors
(`test_config_endpoint.py` and `test_e2e_role_and_removal.py`), both pre-existing
and unrelated to login. No regression introduced.

## 8. Backwards compatibility

No behavior change on any input reachable today, because the serializer already
rejects every input whose handling this changes. Every existing login test in
`accounts/tests/` passes unchanged, including the wrong-password, blocked-account,
deactivated-account, 2FA, passkey, and TOTP paths.

## 9. Manual verification (UI)

Not applicable. No UI surface. Verified at the API level against the real
endpoint via the tests in section 4.

## 10. Type of change

Bug fix (security hardening). Non-breaking.

## 11. Checklist

- [x] Targets `dev`
- [x] Behavioral test on the real call path, red without the fix
- [x] Whole-app sibling suites run, no new failures vs `origin/dev`
- [x] No new dependencies, no migration, no config change
- [x] No dead code left behind
- [x] Linear updated

## 12. Backout / rollback

Revert the single commit. There is no migration and no state change, so revert
is complete and instant.

## 13. Linear

TH-5712 (Require password on login, enable gateway auth), child of TH-5709
(OSS Security Hardening).

The gateway half of TH-5712 already shipped as #946. This PR closes the login
half. #792 is superseded and will be closed.
