### PR TITLE
fix(oss): replace broken login/signup/reset flows with CLI setup modal [TH-7158]

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -48,10 +48,10 @@ For production, do not rely on local-only defaults. See [`deploy/README.md`](dep
 
 Useful flags:
 
-| Flag | What it does |
-|---|---|
+| Flag                   | What it does                                                     |
+| ---------------------- | ---------------------------------------------------------------- |
 | `--skip-user-creation` | Skip the first-user prompt. Run the `create_user` command later. |
-| `--no-up` | Bootstrap `.env` only; don't start the stack. |
+| `--no-up`              | Bootstrap `.env` only; don't start the stack.                    |
 
 When the backend logs `Application startup complete`, open:
 
@@ -98,15 +98,15 @@ docker compose up
 
 ## Prerequisites
 
-| Requirement | Minimum | Notes |
-|---|---|---|
-| Docker Engine | 24.0+ | Docker Desktop on Mac/Windows, or native Docker on Linux |
-| Docker Compose | v2.20+ | `docker compose version` should print v2.x |
-| RAM | 8 GB | 16 GB recommended (ClickHouse and the worker each hold ~1 GB) |
-| Disk | 20 GB free | Image pulls are ~3 GB; data grows from there |
-| CPU | 4 cores | — |
-| Platform | `privileged: true` supported | `code-executor` needs it — won't run on Fargate, Cloud Run, or some PaaS |
-| Architecture | `linux/amd64` | Prebuilt images ship amd64 only; see Apple Silicon note below |
+| Requirement    | Minimum                      | Notes                                                                    |
+| -------------- | ---------------------------- | ------------------------------------------------------------------------ |
+| Docker Engine  | 24.0+                        | Docker Desktop on Mac/Windows, or native Docker on Linux                 |
+| Docker Compose | v2.20+                       | `docker compose version` should print v2.x                               |
+| RAM            | 8 GB                         | 16 GB recommended (ClickHouse and the worker each hold ~1 GB)            |
+| Disk           | 20 GB free                   | Image pulls are ~3 GB; data grows from there                             |
+| CPU            | 4 cores                      | —                                                                        |
+| Platform       | `privileged: true` supported | `code-executor` needs it — won't run on Fargate, Cloud Run, or some PaaS |
+| Architecture   | `linux/amd64`                | Prebuilt images ship amd64 only; see Apple Silicon note below            |
 
 On Docker Desktop for Mac, give Docker at least **8 GB RAM** and **64 GB disk** under Settings → Resources. The defaults are often too small.
 
@@ -180,33 +180,34 @@ Every knob in the compose file has a sensible local default, so the stack boots 
 
 Only needed if you enable the corresponding feature:
 
-| Variable | Used by |
-|---|---|
-| `OPENAI_API_KEY` | Evaluations, agent loops, text simulation |
-| `ANTHROPIC_API_KEY` | Same as above |
-| `GOOGLE_API_KEY` | Gemini models |
-| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Bedrock models, S3 object storage |
-| `FUTURE_AGI_CLOUD_API_KEY` | Future AGI Cloud API features. Leave blank to run fully offline. |
+| Variable                                      | Used by                                                          |
+| --------------------------------------------- | ---------------------------------------------------------------- |
+| `OPENAI_API_KEY`                              | Evaluations, agent loops, text simulation                        |
+| `ANTHROPIC_API_KEY`                           | Same as above                                                    |
+| `GOOGLE_API_KEY`                              | Gemini models                                                    |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Bedrock models, S3 object storage                                |
+| `FUTURE_AGI_CLOUD_API_KEY`                    | Future AGI Cloud API features. Leave blank to run fully offline. |
 
 ### Ports reference
 
 All ports are configurable via `.env`. Defaults:
 
-| Service | Port | URL |
-|---|---|---|
-| Frontend | `3000` | <http://localhost:3000> |
-| Backend API | `8000` | <http://localhost:8000> |
-| Gateway (LLM proxy) | `8090` | internal only by default |
-| Model serving (embeddings) | `8080` | internal only by default |
-| Code executor | `8060` | internal only by default |
-| Postgres | `5432` | `127.0.0.1` — dev mode only: `0.0.0.0` |
-| ClickHouse HTTP | `8123` | same |
-| ClickHouse TCP | `9000` | same |
-| Redis | `6379` | same |
-| MinIO S3 API | `9000` | same |
-| MinIO console | `9001` | same |
-| Temporal gRPC | `7233` | same |
-| Temporal UI | `8085` | dev mode only |
+| Service                    | Port   | URL                                    |
+| -------------------------- | ------ | -------------------------------------- |
+| Frontend                   | `3000` | <http://localhost:3000>                |
+| Backend API                | `8000` | <http://localhost:8000>                |
+| Gateway (LLM proxy)        | `8090` | internal only by default               |
+| Model serving (embeddings) | `8080` | internal only by default               |
+| Code executor              | `8060` | internal only by default               |
+| Postgres                   | `5432` | `127.0.0.1` — dev mode only: `0.0.0.0` |
+| ClickHouse HTTP            | `8123` | same                                   |
+| ClickHouse TCP             | `9000` | same                                   |
+| Redis                      | `6379` | same                                   |
+| MinIO S3 API               | `9000` | same                                   |
+| MinIO console              | `9001` | same                                   |
+| Temporal gRPC              | `7233` | same                                   |
+| Temporal UI                | `8085` | dev mode only                          |
+
 To run two stacks side-by-side, copy `.env` to `.env.stackB`, change every port, and `docker compose --env-file .env.stackB -p stackb up`.
 
 ---
@@ -215,28 +216,28 @@ To run two stacks side-by-side, copy `.env` to `.env.stackB`, change every port,
 
 ### Application services
 
-| Service | Purpose |
-|---|---|
-| `frontend` | React SPA served by nginx. UI for traces, evals, datasets, playground. |
-| `backend` | Django API. Serves REST + gRPC + WebSockets. Reads/writes Postgres + ClickHouse + Redis + MinIO. |
-| `worker` | Single Temporal worker polling all queues. Replaced by six per-queue workers in dev mode. |
+| Service           | Purpose                                                                                                                |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `frontend`        | React SPA served by nginx. UI for traces, evals, datasets, playground.                                                 |
+| `backend`         | Django API. Serves REST + gRPC + WebSockets. Reads/writes Postgres + ClickHouse + Redis + MinIO.                       |
+| `worker`          | Single Temporal worker polling all queues. Replaced by six per-queue workers in dev mode.                              |
 | `agentcc-gateway` | Go-based LLM proxy. Routes calls to OpenAI, Anthropic, Gemini, Bedrock, Vertex. Handles retries, rate limits, logging. |
-| `serving` | Python service for embeddings and small model inference. |
-| `code-executor` | nsjail-sandboxed Python/JS code runner for evaluation code. **Requires `privileged: true`.** |
+| `serving`         | Python service for embeddings and small model inference.                                                               |
+| `code-executor`   | nsjail-sandboxed Python/JS code runner for evaluation code. **Requires `privileged: true`.**                           |
 
 ### Data stores
 
-| Service | Role |
-|---|---|
-| `postgres` | Primary transactional store (users, traces, datasets, evals, prompts, annotations). |
-| `clickhouse` | Analytics store for traces, spans, dashboards, and evaluation queries. |
-| `redis` | Cache, rate limits, Celery/Django cache, WebSocket pub/sub. |
-| `minio` | S3-compatible object storage (uploaded files, eval artifacts). In production, swap for real S3 by setting `S3_ENDPOINT_URL` to an AWS endpoint. **Note:** the backend uses `S3_ENDPOINT_URL` (internal Docker hostname) to talk to MinIO, but URLs returned to the browser use `MINIO_URL` (defaults to `http://localhost:9005`). If you access the UI from anywhere other than the host machine — e.g. another machine on your LAN, a remote VM, or a domain name — set `MINIO_URL` in `.env` to a URL the browser can reach (e.g. `http://your-host.example.com:9005`). |
+| Service      | Role                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `postgres`   | Primary transactional store (users, traces, datasets, evals, prompts, annotations).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `clickhouse` | Analytics store for traces, spans, dashboards, and evaluation queries.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `redis`      | Cache, rate limits, Celery/Django cache, WebSocket pub/sub.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `minio`      | S3-compatible object storage (uploaded files, eval artifacts). In production, swap for real S3 by setting `S3_ENDPOINT_URL` to an AWS endpoint. **Note:** the backend uses `S3_ENDPOINT_URL` (internal Docker hostname) to talk to MinIO, but URLs returned to the browser use `MINIO_URL` (defaults to `http://localhost:9005`). If you access the UI from anywhere other than the host machine — e.g. another machine on your LAN, a remote VM, or a domain name — set `MINIO_URL` in `.env` to a URL the browser can reach (e.g. `http://your-host.example.com:9005`). |
 
 ### Workflow engine
 
-| Service | Role |
-|---|---|
+| Service    | Role                                                            |
+| ---------- | --------------------------------------------------------------- |
 | `temporal` | Durable workflow server (auto-setup). Shares the main Postgres. |
 
 ## Configuring LLM providers
@@ -303,18 +304,27 @@ docker exec -it futureagi-backend-1 python manage.py shell
 ```
 
 ```python
-from django.contrib.auth.tokens import default_token_generator
+from django.utils import timezone
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
+from django.conf import settings
 from accounts.models import User
+from accounts.models.auth_token import AuthToken, AuthTokenType
+from accounts.authentication import generate_encrypted_message
 
 user = User.objects.get(email="user@example.com")
-uid = urlsafe_base64_encode(force_bytes(user.pk))
-token = default_token_generator.make_token(user)
-print(f"http://localhost:3000/auth/reset-password/{uid}/{token}/")
+access_token = AuthToken.objects.create(
+    user=user,
+    auth_type=AuthTokenType.ACCESS.value,
+    is_active=True,
+    last_used_at=timezone.now(),
+)
+token = generate_encrypted_message({"user_id": str(user.id), "id": str(access_token.id)})
+uidb64 = urlsafe_base64_encode(force_bytes(user.id))
+print(f"{settings.APP_URL or 'http://localhost:3000'}/auth/jwt/verify/{uidb64}/{token}")
 ```
 
-Share the printed URL with the user out-of-band (Slack, email, etc.).
+Share the printed URL with the user out-of-band (Slack, email, etc.). The link is valid for ~2 days. If your `APP_URL` has no scheme, prefix the URL with `http://` or `https://` when opening it.
 
 ---
 
@@ -322,9 +332,9 @@ Share the printed URL with the user out-of-band (Slack, email, etc.).
 
 The standard Compose stack runs the full OSS application path from published images:
 
-| Mode | Containers | What you get | When to use |
-|---|---|---|---|
-| **standard** | ~12 | Frontend, backend, worker, agentcc-gateway, serving, code-executor, postgres, clickhouse, redis, minio, rabbitmq, temporal | Local evaluation, team installs, and VM-based self-hosting. |
+| Mode         | Containers | What you get                                                                                                               | When to use                                                 |
+| ------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| **standard** | ~12        | Frontend, backend, worker, agentcc-gateway, serving, code-executor, postgres, clickhouse, redis, minio, rabbitmq, temporal | Local evaluation, team installs, and VM-based self-hosting. |
 
 Start it with:
 
@@ -380,37 +390,49 @@ MinIO can be mirrored to any S3 endpoint via `mc mirror`.
 ## Troubleshooting
 
 ### `Cannot connect to the Docker daemon`
+
 Docker isn't running. Start Docker Desktop (Mac/Windows) or `sudo systemctl start docker` (Linux).
 
 ### `ERROR: You don't have enough free space in /var/cache/apt/archives/`
+
 Docker Desktop's virtual disk is full. Either:
+
 - Settings → Resources → Disk image size — raise to 100 GB+.
 - Clean up: `docker system prune -af && docker builder prune -af`.
 
 ### `ports are not available: exposing port ... address already in use`
+
 Another process is using that port. Either kill it or override in `.env`:
+
 ```
 FRONTEND_PORT=3100
 BACKEND_PORT=8100
 ```
 
 ### Backend logs `FATAL: password authentication failed for user "futureagi"`
+
 You changed `PG_PASSWORD` after the volume was created. Postgres initializes the password on first boot only. Either:
+
 - Revert `PG_PASSWORD` to the original, or
 - Wipe and reinitialize: `docker compose down -v` (⚠ destroys all data).
 
 ### Frontend loads but API calls fail with CORS errors
+
 You're on a split-domain deployment without `VITE_HOST_API` set. Set it in `.env` (or your production env file) to your absolute backend URL and restart the frontend container:
+
 ```bash
 echo "VITE_HOST_API=https://api.example.com" >> .env
 docker compose up -d frontend
 ```
+
 The container's entrypoint regenerates `/config.js` on each start, so no rebuild is needed.
 
 ### `code-executor` crashes with `clone: Operation not permitted`
+
 The host kernel or container platform disallows `privileged: true` (Fargate, Cloud Run, some Kubernetes policies). Either run on a platform that allows privileged containers (EC2, GKE with privileged enabled, bare-metal) or disable code evaluation features.
 
 ### `temporal-server` keeps restarting
+
 Postgres connection is the usual cause. Check `docker compose logs postgres` for OOM. Raise Docker Desktop's RAM to 8 GB+.
 
 ---

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -63,7 +63,7 @@ When the backend logs `Application startup complete`, open:
 If you skipped the prompt at install time, create the admin account via the CLI:
 
 ```bash
-docker exec -it futureagi-backend-1 python manage.py create_user
+docker compose exec backend python manage.py create_user
 ```
 
 You will be prompted for your email, full name, and password. Then log in at <http://localhost:3000>.
@@ -71,7 +71,7 @@ You will be prompted for your email, full name, and password. Then log in at <ht
 To pass credentials non-interactively (useful for automated setups):
 
 ```bash
-docker exec futureagi-backend-1 python manage.py create_user \
+docker compose exec backend python manage.py create_user \
   --email you@example.com \
   --name "Your Name" \
   --password yourpassword
@@ -300,7 +300,7 @@ Restart the backend: `docker compose up -d --force-recreate backend worker`.
 If SMTP is not configured and a user needs a password reset, a shell admin can generate the reset link directly:
 
 ```bash
-docker exec -it futureagi-backend-1 python manage.py shell
+docker compose exec backend python manage.py shell
 ```
 
 ```python
@@ -324,7 +324,7 @@ uidb64 = urlsafe_base64_encode(force_bytes(user.id))
 print(f"{settings.APP_URL or 'http://localhost:3000'}/auth/jwt/verify/{uidb64}/{token}")
 ```
 
-Share the printed URL with the user out-of-band (Slack, email, etc.). The link is valid for ~2 days. If your `APP_URL` has no scheme, prefix the URL with `http://` or `https://` when opening it.
+Share the printed URL over a private channel. It **signs the user in as that account**, so treat it like a password and have them use it promptly. If your `APP_URL` has no scheme, prefix the URL with `http://` or `https://` when opening it.
 
 ---
 

--- a/frontend/src/auth/guard/index.js
+++ b/frontend/src/auth/guard/index.js
@@ -1,2 +1,3 @@
 export { default as AuthGuard } from "./auth-guard";
 export { default as GuestGuard } from "./guest-guard";
+export { default as OssRestrictedGuard } from "./oss-restricted-guard";

--- a/frontend/src/auth/guard/oss-restricted-guard.jsx
+++ b/frontend/src/auth/guard/oss-restricted-guard.jsx
@@ -1,0 +1,35 @@
+import PropTypes from "prop-types";
+import { Navigate } from "react-router-dom";
+
+import { paths } from "src/routes/paths";
+
+import { SplashScreen } from "src/components/loading-screen";
+import { useDeploymentMode } from "src/hooks/useDeploymentMode";
+
+// ----------------------------------------------------------------------
+
+// Redirects OSS-unavailable auth routes to login, opening the CLI-setup modal.
+export default function OssRestrictedGuard({ children, redirectHint }) {
+  const { isOSS, isLoading } = useDeploymentMode();
+
+  if (isLoading) return <SplashScreen />;
+
+  if (isOSS) {
+    return (
+      <Navigate
+        to={{
+          pathname: paths.auth.jwt.login,
+          search: redirectHint ? `?ossSetup=${redirectHint}` : "",
+        }}
+        replace
+      />
+    );
+  }
+
+  return children;
+}
+
+OssRestrictedGuard.propTypes = {
+  children: PropTypes.node,
+  redirectHint: PropTypes.oneOf(["create", "reset"]),
+};

--- a/frontend/src/auth/guard/oss-restricted-guard.jsx
+++ b/frontend/src/auth/guard/oss-restricted-guard.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 
 import { paths } from "src/routes/paths";
 
@@ -10,16 +10,21 @@ import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 
 // Redirects OSS-unavailable auth routes to login, opening the CLI-setup modal.
 export default function OssRestrictedGuard({ children, redirectHint }) {
-  const { isOSS, isLoading } = useDeploymentMode();
+  const { isOSS, isLoading, isSuccess } = useDeploymentMode();
+  const location = useLocation();
 
   if (isLoading) return <SplashScreen />;
 
-  if (isOSS) {
+  if (isSuccess && isOSS) {
+    // Carry the incoming query (e.g. returnTo, utm) and add the tab hint.
+    const params = new URLSearchParams(location.search);
+    if (redirectHint) params.set("ossSetup", redirectHint);
+    const search = params.toString();
     return (
       <Navigate
         to={{
           pathname: paths.auth.jwt.login,
-          search: redirectHint ? `?ossSetup=${redirectHint}` : "",
+          search: search ? `?${search}` : "",
         }}
         replace
       />

--- a/frontend/src/hooks/useDeploymentMode.js
+++ b/frontend/src/hooks/useDeploymentMode.js
@@ -13,7 +13,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { paths } from "src/routes/paths";
 
 export function useDeploymentMode() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isSuccess } = useQuery({
     queryKey: ["deployment-info"],
     queryFn: () => axios.get(endpoints.settings.v2.deploymentInfo),
     select: (res) => res.data?.result?.mode || "oss",
@@ -29,6 +29,7 @@ export function useDeploymentMode() {
     isOSS: mode === "oss",
     isEE: mode === "ee",
     isLoading,
+    isSuccess,
   };
 }
 

--- a/frontend/src/routes/sections/auth.jsx
+++ b/frontend/src/routes/sections/auth.jsx
@@ -5,7 +5,7 @@ import { Suspense } from "react";
 import lazyWithRetry from "src/utils/lazyWithRetry";
 import { Outlet } from "react-router-dom";
 
-import { AuthGuard, GuestGuard } from "src/auth/guard";
+import { AuthGuard, GuestGuard, OssRestrictedGuard } from "src/auth/guard";
 import AuthClassicLayout from "src/layouts/auth/classic";
 
 import { SplashScreen } from "src/components/loading-screen";
@@ -70,9 +70,11 @@ const authJwt = {
     {
       path: "forget-password",
       element: (
-        <AuthClassicLayout>
-          <ForgetPassword />
-        </AuthClassicLayout>
+        <OssRestrictedGuard redirectHint="reset">
+          <AuthClassicLayout>
+            <ForgetPassword />
+          </AuthClassicLayout>
+        </OssRestrictedGuard>
       ),
     },
     {
@@ -85,14 +87,20 @@ const authJwt = {
     },
     {
       path: "register",
-      element: <JwtRegisterPage />,
+      element: (
+        <OssRestrictedGuard redirectHint="create">
+          <JwtRegisterPage />
+        </OssRestrictedGuard>
+      ),
     },
     {
       path: "sso-sml",
       element: (
-        <AuthClassicLayout>
-          <SSOLogin />
-        </AuthClassicLayout>
+        <OssRestrictedGuard redirectHint="create">
+          <AuthClassicLayout>
+            <SSOLogin />
+          </AuthClassicLayout>
+        </OssRestrictedGuard>
       ),
     },
     {

--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -43,6 +43,7 @@ import {
 import RightSectionAuth from "./RightSectionAuth";
 import { isValidUtm } from "src/utils/utmUtils";
 import { usePostLoginPath } from "src/hooks/useDeploymentMode";
+import { OssSetupModal, useOssSetupModal } from "./oss-setup";
 
 // ----------------------------------------------------------------------
 
@@ -65,6 +66,13 @@ export default function JwtLoginView() {
   const { search } = useLocation();
   const { enqueueSnackbar } = useSnackbar();
   const { uuid, token } = useParams();
+
+  const ossSetup = useOssSetupModal({
+    enabled: !token,
+    autoOpenTab: searchParams.get("ossSetup"),
+  });
+  const showOssUi = ossSetup.isOSS && !ossSetup.isLoading;
+  const showSocial = !ossSetup.isOSS && !ossSetup.isLoading;
 
   const [inviteFailed, setInviteFailed] = useState(false);
 
@@ -560,10 +568,14 @@ export default function JwtLoginView() {
           color="primary"
           underline="always"
           href={paths.auth.jwt["forget-password"]}
-          onClick={() => {
+          onClick={(e) => {
             trackEvent(Events.forgotPasswordClicked, {
               [PropertyName.click]: true,
             });
+            if (showOssUi) {
+              e.preventDefault();
+              ossSetup.openReset();
+            }
           }}
         >
           Forgot Password
@@ -611,13 +623,15 @@ export default function JwtLoginView() {
         </Link>
         .
       </Typography>
-      <Divider>
-        <Typography variant="body2" sx={{ color: "text.disabled" }}>
-          or
-        </Typography>
-      </Divider>
+      {showSocial && (
+        <Divider>
+          <Typography variant="body2" sx={{ color: "text.disabled" }}>
+            or
+          </Typography>
+        </Divider>
+      )}
       <Stack spacing={1.5}>
-        {browserSupportsWebAuthn() && (
+        {showSocial && browserSupportsWebAuthn() && (
           <LoadingButton
             sx={{
               border: "1px solid",
@@ -638,24 +652,29 @@ export default function JwtLoginView() {
             </Typography>
           </LoadingButton>
         )}
-        <Button
-          sx={{
-            border: "1px solid",
-            borderColor: "divider",
-            borderRadius: 0.5,
+        {showSocial && (
+          <>
+            <Button
+              sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 0.5,
 
-            color: "text.primary",
-            height: 44,
-          }}
-          onClick={() => handleServiceProvider("google")}
-          startIcon={<Iconify icon="logos:google-icon" width={20} />}
-        >
-          <Typography fontWeight={"fontWeightMedium"} sx={{ fontSize: "15px" }}>
-            Continue with Google
-          </Typography>
-        </Button>
+                color: "text.primary",
+                height: 44,
+              }}
+              onClick={() => handleServiceProvider("google")}
+              startIcon={<Iconify icon="logos:google-icon" width={20} />}
+            >
+              <Typography
+                fontWeight={"fontWeightMedium"}
+                sx={{ fontSize: "15px" }}
+              >
+                Continue with Google
+              </Typography>
+            </Button>
 
-        {/* <Button
+            {/* <Button
         sx={{
           border: "1px solid",
           borderColor: "divider",
@@ -683,56 +702,56 @@ export default function JwtLoginView() {
           Continue with Microsoft
         </Typography>
       </Button> */}
-        <Button
-          sx={{
-            border: "1px solid",
-            borderColor: "divider",
-            borderRadius: 0.5,
+            <Button
+              sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 0.5,
 
-            height: 44,
-          }}
-          onClick={() => handleServiceProvider("github")}
-          startIcon={
-            <Iconify
-              icon="bi:github"
-              width={24}
-              sx={{ color: "text.primary" }}
-            />
-          }
-        >
-          <Typography
-            fontWeight={"fontWeightMedium"}
-            sx={{ fontSize: "15px", color: "text.primary" }}
-          >
-            Continue with Github
-          </Typography>
-        </Button>
-        <Button
-          sx={{
-            border: "1px solid",
-            borderColor: "divider",
-            borderRadius: 0.5,
+                height: 44,
+              }}
+              onClick={() => handleServiceProvider("github")}
+              startIcon={
+                <Iconify
+                  icon="bi:github"
+                  width={24}
+                  sx={{ color: "text.primary" }}
+                />
+              }
+            >
+              <Typography
+                fontWeight={"fontWeightMedium"}
+                sx={{ fontSize: "15px", color: "text.primary" }}
+              >
+                Continue with Github
+              </Typography>
+            </Button>
+            <Button
+              sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 0.5,
 
-            height: 44,
-            color: "text.primary",
-          }}
-          onClick={handleSsoLogin}
-          startIcon={
-            <SvgColor
-              sx={{ marginLeft: 2 }}
-              src="/assets/icons/ic_sso_saml.svg"
-            />
-          }
-        >
-          <Typography
-            fontWeight={"fontWeightMedium"}
-            sx={{ fontSize: "15px", marginRight: -1.5 }}
-          >
-            Continue with SSO/SAML
-          </Typography>
-        </Button>
-
-        {/* 🔹 New SAML/SSO Login Button */}
+                height: 44,
+                color: "text.primary",
+              }}
+              onClick={handleSsoLogin}
+              startIcon={
+                <SvgColor
+                  sx={{ marginLeft: 2 }}
+                  src="/assets/icons/ic_sso_saml.svg"
+                />
+              }
+            >
+              <Typography
+                fontWeight={"fontWeightMedium"}
+                sx={{ fontSize: "15px", marginRight: -1.5 }}
+              >
+                Continue with SSO/SAML
+              </Typography>
+            </Button>
+          </>
+        )}
 
         {/* ✅ Added Create Account Link */}
         <Typography
@@ -744,14 +763,34 @@ export default function JwtLoginView() {
           Don’t have an account?
           <Link
             variant="subtitle2"
-            component={RouterLink}
-            to={paths.auth.jwt.register + search}
+            component={showOssUi ? "button" : RouterLink}
+            type={showOssUi ? "button" : undefined}
+            to={showOssUi ? undefined : paths.auth.jwt.register + search}
+            onClick={(e) => {
+              if (showOssUi) {
+                e.preventDefault();
+                ossSetup.openCreate();
+              }
+            }}
             sx={{ color: "primary.main" }}
           >
             {" "}
             Sign up
           </Link>
         </Typography>
+
+        {showOssUi && (
+          <Link
+            component="button"
+            type="button"
+            variant="s2"
+            underline="hover"
+            onClick={ossSetup.openCreate}
+            sx={{ color: "text.secondary", alignSelf: "center" }}
+          >
+            Self-hosted? Set up via CLI
+          </Link>
+        )}
       </Stack>
     </Stack>
   );
@@ -822,6 +861,13 @@ export default function JwtLoginView() {
           </FormProvider>
         </Box>
       </Box>
+
+      <OssSetupModal
+        open={ossSetup.open}
+        onClose={ossSetup.onClose}
+        activeTab={ossSetup.activeTab}
+        onTabChange={ossSetup.setActiveTab}
+      />
 
       {/* Right Side - Image with Text Overlay */}
       <Box

--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -52,7 +52,7 @@ export default function JwtLoginView() {
   const postLoginPath = usePostLoginPath();
   const router = useRouter();
   const [errorMsg, setErrorMsg] = useState("");
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
   // Persist returnTo on a login action so it survives flows that drop the
   // URL param (OAuth round-trip, login → setup-org).
@@ -71,8 +71,25 @@ export default function JwtLoginView() {
     enabled: !token,
     autoOpenTab: searchParams.get("ossSetup"),
   });
-  const showOssUi = ossSetup.isOSS && !ossSetup.isLoading;
-  const showSocial = !ossSetup.isOSS && !ossSetup.isLoading;
+  // Only apply OSS treatment on a confirmed "oss" response; a failed
+  // deployment-info read falls back to the full login (social/SSO shown).
+  const confirmedOSS = ossSetup.isSuccess && ossSetup.isOSS;
+  const showOssUi = confirmedOSS;
+  const showSocial = !confirmedOSS;
+
+  // The hint has done its job once the modal opens on the right tab; strip it
+  // so a reload doesn't reopen the modal.
+  useEffect(() => {
+    if (searchParams.get("ossSetup")) {
+      setSearchParams(
+        (prev) => {
+          prev.delete("ossSetup");
+          return prev;
+        },
+        { replace: true },
+      );
+    }
+  }, [searchParams, setSearchParams]);
 
   const [inviteFailed, setInviteFailed] = useState(false);
 

--- a/frontend/src/sections/auth/jwt/oss-setup/CommandBlock.jsx
+++ b/frontend/src/sections/auth/jwt/oss-setup/CommandBlock.jsx
@@ -1,0 +1,70 @@
+import PropTypes from "prop-types";
+
+import Box from "@mui/material/Box";
+import Tooltip from "@mui/material/Tooltip";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+
+import Iconify from "src/components/iconify";
+import { useSnackbar } from "src/components/snackbar";
+import { copyToClipboard } from "src/utils/utils";
+
+const TERMINAL_BG = "#0D1117";
+
+export default function CommandBlock({ command }) {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(command);
+    enqueueSnackbar(ok ? "Copied to clipboard" : "Copy failed", {
+      variant: ok ? "success" : "error",
+    });
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        bgcolor: TERMINAL_BG,
+        borderRadius: 1,
+        py: 1.5,
+        pl: 2,
+        pr: 5,
+        overflowX: "auto",
+      }}
+    >
+      <Typography
+        component="pre"
+        variant="s2"
+        sx={{
+          m: 0,
+          fontFamily: "monospace",
+          whiteSpace: "pre",
+          color: "grey.300",
+        }}
+      >
+        {command}
+      </Typography>
+
+      <Tooltip title="Copy">
+        <IconButton
+          size="small"
+          onClick={handleCopy}
+          sx={{
+            position: "absolute",
+            top: (theme) => theme.spacing(0.5),
+            right: (theme) => theme.spacing(0.5),
+            color: "grey.500",
+            "&:hover": { color: "grey.100" },
+          }}
+        >
+          <Iconify icon="ph:copy" width={16} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}
+
+CommandBlock.propTypes = {
+  command: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/auth/jwt/oss-setup/OssSetupModal.jsx
+++ b/frontend/src/sections/auth/jwt/oss-setup/OssSetupModal.jsx
@@ -103,12 +103,13 @@ export default function OssSetupModal({
             <StepLabel>1. Open a Django shell:</StepLabel>
             <CommandBlock command={RESET_SHELL_CMD} />
 
-            <StepLabel>2. Generate a reset link:</StepLabel>
+            <StepLabel>2. Generate a sign-in link:</StepLabel>
             <CommandBlock command={RESET_PYTHON_SNIPPET} />
 
             <Typography variant="s1" color="text.secondary">
-              Open the printed link to set a new password (valid ~2 days), then
-              log in.
+              This prints a link that signs the user in. Treat it like a
+              password, share it privately, and open it promptly to set a new
+              password.
             </Typography>
           </Stack>
         )}

--- a/frontend/src/sections/auth/jwt/oss-setup/OssSetupModal.jsx
+++ b/frontend/src/sections/auth/jwt/oss-setup/OssSetupModal.jsx
@@ -1,0 +1,151 @@
+import PropTypes from "prop-types";
+
+import Tab from "@mui/material/Tab";
+import Link from "@mui/material/Link";
+import Tabs from "@mui/material/Tabs";
+import Stack from "@mui/material/Stack";
+import Dialog from "@mui/material/Dialog";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+
+import Iconify from "src/components/iconify";
+
+import CommandBlock from "./CommandBlock";
+import {
+  OSS_DOC_URL,
+  OSS_SETUP_TABS,
+  CREATE_USER_CMD,
+  RESET_SHELL_CMD,
+  RESET_PYTHON_SNIPPET,
+  CREATE_USER_CMD_NONINTERACTIVE,
+} from "./constants";
+
+function StepLabel({ children }) {
+  return (
+    <Typography
+      variant="s2"
+      fontWeight="fontWeightSemiBold"
+      color="text.primary"
+    >
+      {children}
+    </Typography>
+  );
+}
+
+StepLabel.propTypes = { children: PropTypes.node };
+
+export default function OssSetupModal({
+  open,
+  onClose,
+  activeTab,
+  onTabChange,
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack
+          direction="row"
+          alignItems="flex-start"
+          justifyContent="space-between"
+          spacing={2}
+        >
+          <Stack spacing={0.5}>
+            <Typography variant="m3" fontWeight="fontWeightSemiBold">
+              Set up your account
+            </Typography>
+            <Typography variant="s2" color="text.secondary">
+              Email and social sign-in aren&apos;t available in self-hosted
+              mode. Manage accounts from the CLI on the machine running
+              FutureAGI.
+            </Typography>
+          </Stack>
+          <IconButton
+            size="small"
+            onClick={onClose}
+            sx={{ mt: -0.5, mr: -0.5 }}
+          >
+            <Iconify icon="mdi:close" width={20} />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+
+      <Tabs
+        value={activeTab}
+        onChange={(_e, value) => onTabChange(value)}
+        sx={{ px: 3, borderBottom: 1, borderColor: "divider" }}
+      >
+        <Tab value={OSS_SETUP_TABS.CREATE} label="Create account" />
+        <Tab value={OSS_SETUP_TABS.RESET} label="Reset password" />
+      </Tabs>
+
+      <DialogContent sx={{ pt: 3 }}>
+        {activeTab === OSS_SETUP_TABS.CREATE && (
+          <Stack spacing={2}>
+            <StepLabel>Run this to create a user:</StepLabel>
+            <CommandBlock command={CREATE_USER_CMD} />
+
+            <Typography variant="s2" color="text.secondary">
+              Or create it non-interactively:
+            </Typography>
+            <CommandBlock command={CREATE_USER_CMD_NONINTERACTIVE} />
+
+            <Typography variant="s1" color="text.secondary">
+              Then close this and log in with those credentials.
+            </Typography>
+          </Stack>
+        )}
+
+        {activeTab === OSS_SETUP_TABS.RESET && (
+          <Stack spacing={2}>
+            <StepLabel>1. Open a Django shell:</StepLabel>
+            <CommandBlock command={RESET_SHELL_CMD} />
+
+            <StepLabel>2. Generate a reset link:</StepLabel>
+            <CommandBlock command={RESET_PYTHON_SNIPPET} />
+
+            <Typography variant="s1" color="text.secondary">
+              Open the printed link to set a new password (valid ~2 days), then
+              log in.
+            </Typography>
+          </Stack>
+        )}
+      </DialogContent>
+
+      <Divider />
+
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="flex-end"
+        sx={{ px: 3, py: 2 }}
+      >
+        <Link
+          href={OSS_DOC_URL[activeTab]}
+          target="_blank"
+          rel="noopener"
+          variant="s2"
+          underline="hover"
+        >
+          {activeTab === OSS_SETUP_TABS.RESET
+            ? "Password reset guide"
+            : "Account setup guide"}
+          <Iconify
+            icon="mdi:open-in-new"
+            width={14}
+            sx={{ ml: 0.5, verticalAlign: "middle" }}
+          />
+        </Link>
+      </Stack>
+    </Dialog>
+  );
+}
+
+OssSetupModal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  activeTab: PropTypes.string,
+  onTabChange: PropTypes.func,
+};

--- a/frontend/src/sections/auth/jwt/oss-setup/constants.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/constants.js
@@ -13,16 +13,14 @@ export const OSS_DOC_URL = {
   [OSS_SETUP_TABS.RESET]: `${INSTALL_GUIDE_BASE}#password-reset-without-email`,
 };
 
-const BACKEND_CONTAINER = "futureagi-backend-1";
+export const CREATE_USER_CMD = `docker compose exec backend python manage.py create_user`;
 
-export const CREATE_USER_CMD = `docker exec -it ${BACKEND_CONTAINER} python manage.py create_user`;
-
-export const CREATE_USER_CMD_NONINTERACTIVE = `docker exec ${BACKEND_CONTAINER} python manage.py create_user \\
+export const CREATE_USER_CMD_NONINTERACTIVE = `docker compose exec backend python manage.py create_user \\
   --email you@example.com \\
   --name "Your Name" \\
   --password yourpassword`;
 
-export const RESET_SHELL_CMD = `docker exec -it ${BACKEND_CONTAINER} python manage.py shell`;
+export const RESET_SHELL_CMD = `docker compose exec backend python manage.py shell`;
 
 export const RESET_PYTHON_SNIPPET = `from django.utils import timezone
 from django.utils.http import urlsafe_base64_encode

--- a/frontend/src/sections/auth/jwt/oss-setup/constants.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/constants.js
@@ -1,0 +1,44 @@
+export const OSS_SETUP_SEEN_KEY = "fai_oss_setup_seen";
+
+export const OSS_SETUP_TABS = {
+  CREATE: "create",
+  RESET: "reset",
+};
+
+const INSTALL_GUIDE_BASE =
+  "https://github.com/future-agi/future-agi/blob/main/INSTALLATION.md";
+
+export const OSS_DOC_URL = {
+  [OSS_SETUP_TABS.CREATE]: `${INSTALL_GUIDE_BASE}#create-your-first-account`,
+  [OSS_SETUP_TABS.RESET]: `${INSTALL_GUIDE_BASE}#password-reset-without-email`,
+};
+
+const BACKEND_CONTAINER = "futureagi-backend-1";
+
+export const CREATE_USER_CMD = `docker exec -it ${BACKEND_CONTAINER} python manage.py create_user`;
+
+export const CREATE_USER_CMD_NONINTERACTIVE = `docker exec ${BACKEND_CONTAINER} python manage.py create_user \\
+  --email you@example.com \\
+  --name "Your Name" \\
+  --password yourpassword`;
+
+export const RESET_SHELL_CMD = `docker exec -it ${BACKEND_CONTAINER} python manage.py shell`;
+
+export const RESET_PYTHON_SNIPPET = `from django.utils import timezone
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.conf import settings
+from accounts.models import User
+from accounts.models.auth_token import AuthToken, AuthTokenType
+from accounts.authentication import generate_encrypted_message
+
+user = User.objects.get(email="you@example.com")
+access_token = AuthToken.objects.create(
+    user=user,
+    auth_type=AuthTokenType.ACCESS.value,
+    is_active=True,
+    last_used_at=timezone.now(),
+)
+token = generate_encrypted_message({"user_id": str(user.id), "id": str(access_token.id)})
+uidb64 = urlsafe_base64_encode(force_bytes(user.id))
+print(f"{settings.APP_URL or 'http://localhost:3000'}/auth/jwt/verify/{uidb64}/{token}")`;

--- a/frontend/src/sections/auth/jwt/oss-setup/index.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/index.js
@@ -1,0 +1,3 @@
+export { default as OssSetupModal } from "./OssSetupModal";
+export { useOssSetupModal } from "./useOssSetupModal";
+export * from "./constants";

--- a/frontend/src/sections/auth/jwt/oss-setup/useOssSetupModal.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/useOssSetupModal.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+
+import { useBoolean } from "src/hooks/use-boolean";
+import { useDeploymentMode } from "src/hooks/useDeploymentMode";
+
+import { OSS_SETUP_SEEN_KEY, OSS_SETUP_TABS } from "./constants";
+
+export function useOssSetupModal({ enabled = true, autoOpenTab = null } = {}) {
+  const { isOSS, isLoading } = useDeploymentMode();
+  const open = useBoolean(false);
+  const [activeTab, setActiveTab] = useState(OSS_SETUP_TABS.CREATE);
+
+  const openCreate = () => {
+    setActiveTab(OSS_SETUP_TABS.CREATE);
+    open.onTrue();
+  };
+
+  const openReset = () => {
+    setActiveTab(OSS_SETUP_TABS.RESET);
+    open.onTrue();
+  };
+
+  useEffect(() => {
+    if (!enabled || isLoading || !isOSS) return;
+
+    const hint = Object.values(OSS_SETUP_TABS).includes(autoOpenTab)
+      ? autoOpenTab
+      : null;
+
+    // A hint always opens; otherwise auto-open only on the first OSS visit.
+    if (!hint) {
+      try {
+        if (localStorage.getItem(OSS_SETUP_SEEN_KEY)) return;
+        localStorage.setItem(OSS_SETUP_SEEN_KEY, "1");
+      } catch {
+        return;
+      }
+    } else {
+      try {
+        localStorage.setItem(OSS_SETUP_SEEN_KEY, "1");
+      } catch {
+        /* ignore */
+      }
+    }
+
+    if (hint === OSS_SETUP_TABS.RESET) openReset();
+    else openCreate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, isLoading, isOSS, autoOpenTab]);
+
+  return {
+    isOSS,
+    isLoading,
+    open: open.value,
+    activeTab,
+    setActiveTab,
+    onClose: open.onFalse,
+    openCreate,
+    openReset,
+  };
+}

--- a/frontend/src/sections/auth/jwt/oss-setup/useOssSetupModal.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/useOssSetupModal.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useBoolean } from "src/hooks/use-boolean";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
@@ -6,22 +6,23 @@ import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import { OSS_SETUP_SEEN_KEY, OSS_SETUP_TABS } from "./constants";
 
 export function useOssSetupModal({ enabled = true, autoOpenTab = null } = {}) {
-  const { isOSS, isLoading } = useDeploymentMode();
+  const { isOSS, isLoading, isSuccess } = useDeploymentMode();
   const open = useBoolean(false);
+  const openModal = open.onTrue;
   const [activeTab, setActiveTab] = useState(OSS_SETUP_TABS.CREATE);
 
-  const openCreate = () => {
+  const openCreate = useCallback(() => {
     setActiveTab(OSS_SETUP_TABS.CREATE);
-    open.onTrue();
-  };
+    openModal();
+  }, [openModal]);
 
-  const openReset = () => {
+  const openReset = useCallback(() => {
     setActiveTab(OSS_SETUP_TABS.RESET);
-    open.onTrue();
-  };
+    openModal();
+  }, [openModal]);
 
   useEffect(() => {
-    if (!enabled || isLoading || !isOSS) return;
+    if (!enabled || isLoading || !isSuccess || !isOSS) return;
 
     const hint = Object.values(OSS_SETUP_TABS).includes(autoOpenTab)
       ? autoOpenTab
@@ -45,12 +46,20 @@ export function useOssSetupModal({ enabled = true, autoOpenTab = null } = {}) {
 
     if (hint === OSS_SETUP_TABS.RESET) openReset();
     else openCreate();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, isLoading, isOSS, autoOpenTab]);
+  }, [
+    enabled,
+    isLoading,
+    isSuccess,
+    isOSS,
+    autoOpenTab,
+    openCreate,
+    openReset,
+  ]);
 
   return {
     isOSS,
     isLoading,
+    isSuccess,
     open: open.value,
     activeTab,
     setActiveTab,


### PR DESCRIPTION
## Bug
In OSS (self-hosted) mode the login page is broken: email login says a password was sent but no email arrives (no SMTP), "resend" errors with `[object Object]`, and Google sign-in fails with `missing required parameter: client_id`. None of these flows can work in OSS (no SMTP, no OAuth client, no enterprise IdP). [TH-7158]

## Changes
- **Keep** email/password login (works with CLI-created accounts).
- **CLI setup modal** (`src/sections/auth/jwt/oss-setup/`) with two tabs:
  - *Create account* — `manage.py create_user` commands.
  - *Reset password* — shell snippet that mints a `/auth/jwt/verify/...` reset link to share out-of-band.
  - Auto-opens once on first OSS visit (localStorage), plus a "Self-hosted? Set up via CLI" trigger under the form. Each tab deep-links to its own `INSTALLATION.md` section.
- **Hide** social/SSO buttons (Google / GitHub / SSO-SAML / Passkey) and the "or" divider in OSS.
- **Intercept** the Sign up and Forgot Password links in OSS → open the modal on the relevant tab (no navigation, no form submit).
- **Route guard** (`OssRestrictedGuard`) redirects direct visits to `/auth/jwt/register`, `/auth/jwt/forget-password`, `/auth/jwt/sso-sml` → login, opening the modal via an `?ossSetup=` hint.
- **Docs:** fix the `INSTALLATION.md` password-reset section (was a dead `/auth/reset-password/` URL + wrong `default_token_generator` token) to the verified encrypted-token + `/auth/jwt/verify/{uidb64}/{token}` recipe.

Everything is gated on `isOSS && !isLoading` — EE/cloud is byte-unchanged.

## Why
Users trying the OSS build hit a dead login. This replaces the non-functional email/OAuth/reset flows with their CLI equivalents (accounts are managed via CLI in OSS) instead of showing paths that silently fail.

## Test-case scenarios
- **OSS** — first visit auto-opens the modal (Create tab); dismissal persists across reloads.
- **OSS** — social/SSO buttons + "or" divider hidden; email/password login still works.
- **OSS** — Sign up → modal Create tab; Forgot Password → modal Reset tab (URL unchanged, form not submitted).
- **OSS** — direct `/auth/jwt/register`, `/auth/jwt/forget-password`, `/auth/jwt/sso-sml` → redirect to login with the modal open on the right tab.
- **OSS** — copy buttons work on `http://localhost`; the "Account setup guide" / "Password reset guide" links open the correct `INSTALLATION.md` section.
- **EE / cloud** — login page unchanged (social visible, links navigate normally, no modal, no redirect).

## How to reproduce (the bug)
1. Run the OSS stack (deployment-info returns `mode: oss`).
2. Open the login page → email login shows "password sent" but no email arrives; "resend" errors with `[object Object]`; Google shows `missing required parameter: client_id`.

## Commands
```
cd frontend && yarn lint && yarn test:run
```

## Verification
- `create_user` and the reset-link flow verified end-to-end on the local OSS stack — the confirm endpoint returns `200` and the password actually changes.
- Lint clean; frontend test suite green.

## Videos / screenshots
attached in ticket(video size too large)