### PR TITLE
fix(frontend): preserve date-only values without fake time

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
@@ -16,6 +16,8 @@ const DatetimeCellRenderer = ({
   const isValueArray = Array.isArray(value);
   const isBlankValue = value === null || value === undefined || value === "";
   const isValidDate = !isBlankValue && !isNaN(new Date(value).getTime());
+  const hasTimeComponent =
+    typeof value === "string" && /\d{1,2}:\d{2}/.test(value);
 
   return (
     <CustomTooltip
@@ -31,7 +33,7 @@ const DatetimeCellRenderer = ({
         {isValueArray ? (
           <GenerateDiffText cellText={value} />
         ) : isValidDate ? (
-          format(new Date(value), "dd/MM/yyyy HH:mm")
+          format(new Date(value), hasTimeComponent ? "dd/MM/yyyy HH:mm" : "dd/MM/yyyy")
         ) : isBlankValue ? (
           ""
         ) : (

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
@@ -37,6 +37,31 @@ describe("DatetimeCellRenderer", () => {
 
     expect(screen.getByText("Invalid Date")).toBeInTheDocument();
   });
+
+  it("does not invent a time for date-only values", () => {
+    render(<DatetimeCellRenderer value="2026-01-29" {...rendererProps} />);
+
+    expect(screen.getByText("29/01/2026")).toBeInTheDocument();
+    expect(screen.queryByText(/00:00/)).not.toBeInTheDocument();
+  });
+
+  it("preserves an explicit time, including midnight", () => {
+    const { rerender } = render(
+      <DatetimeCellRenderer
+        value="2026-01-29T14:30:00Z"
+        {...rendererProps}
+      />,
+    );
+    expect(screen.getByText(/29\/01\/2026 \d{2}:\d{2}/)).toBeInTheDocument();
+
+    rerender(
+      <DatetimeCellRenderer
+        value="2026-01-29T00:00:00Z"
+        {...rendererProps}
+      />,
+    );
+    expect(screen.getByText(/29\/01\/2026 \d{2}:\d{2}/)).toBeInTheDocument();
+  });
 });
 
 describe("JsonCellRenderer", () => {


### PR DESCRIPTION
## Summary\n\n- render date-only dataset values as dd/MM/yyyy without inventing midnight\n- preserve time formatting for values with an explicit time component, including real midnight\n- add regression coverage for date-only, timed, and existing invalid/blank cases\n\nFixes #1766\n\n## Verification\n\n- 
px vitest run src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx (7 passed)\n- targeted ESLint (pass)\n- git diff --check (pass)