### PR TITLE
fix(frontend): send snake_case eval template id when duplicating

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
@@ -55,7 +55,7 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
   const onDuplicate = (data) => {
     const payload = {
       name: data.name,
-      evalTemplateId: evalId,
+      eval_template_id: evalId,
     };
     mutate(payload);
   };


### PR DESCRIPTION
## Summary\n- send eval_template_id when duplicating an evaluation template\n- align the frontend payload with the backend contract and prevent 400 responses\n\n## Validation\n- git diff --check\n- frontend ESLint/Vitest not run because dependencies are not installed in this fresh worktree\n\nFixes #1768