### PR TITLE
fix(evals): use snake_case eval_template_id in duplicate eval dialog

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
@@ -55,7 +55,7 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
   const onDuplicate = (data) => {
     const payload = {
       name: data.name,
-      evalTemplateId: evalId,
+      eval_template_id: evalId,
     };
     mutate(payload);
   };

--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DuplicateEvals from "./DuplicateEvals";
+
+const mockPost = vi.fn();
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    post: (...args) => mockPost(...args),
+  },
+  endpoints: {
+    develop: {
+      eval: {
+        duplicateEvalsTemplate: "/model-hub/duplicate-eval-template/",
+      },
+    },
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  open: true,
+  onClose: vi.fn(),
+  evalId: "11111111-1111-1111-1111-111111111111",
+  onSubmit: vi.fn(),
+};
+
+function renderComponent(props = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DuplicateEvals {...DEFAULT_PROPS} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DuplicateEvals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the dialog when open", () => {
+    renderComponent();
+    expect(screen.getByText("Duplicate evaluation")).toBeInTheDocument();
+  });
+
+  it("does not render the dialog when closed", () => {
+    renderComponent({ open: false });
+    expect(screen.queryByText("Duplicate evaluation")).not.toBeInTheDocument();
+  });
+
+  it("sends eval_template_id (snake_case) in the POST payload", async () => {
+    mockPost.mockResolvedValueOnce({
+      data: {
+        status: true,
+        result: {
+          message: "Evaluation template duplicated successfully",
+          eval_template_id: "22222222-2222-2222-2222-222222222222",
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    // Fill in the evaluation name.
+    const input = screen.getByPlaceholderText("Enter evaluation name");
+    await user.type(input, "my_copy");
+
+    // Submit the form.
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    // Verify the request was sent to the correct endpoint with snake_case keys.
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith(
+      "/model-hub/duplicate-eval-template/",
+      {
+        name: "my_copy",
+        eval_template_id: DEFAULT_PROPS.evalId,
+      },
+    );
+  });
+
+  it("calls onSubmit with the result on success", async () => {
+    const resultData = {
+      message: "Evaluation template duplicated successfully",
+      eval_template_id: "33333333-3333-3333-3333-333333333333",
+    };
+    mockPost.mockResolvedValueOnce({
+      data: { status: true, result: resultData },
+    });
+
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    renderComponent({ onSubmit });
+
+    const input = screen.getByPlaceholderText("Enter evaluation name");
+    await user.type(input, "my-copy");
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    // Wait for the mutation to resolve, then check the callback.
+    await vi.waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(resultData);
+    });
+  });
+
+  it("lowercases the name and replaces invalid characters", async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { status: true, result: { eval_template_id: "some-id" } },
+    });
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    const input = screen.getByPlaceholderText("Enter evaluation name");
+    await user.type(input, "My Special Eval!");
+
+    // The onChange handler should have transformed the value.
+    expect(input).toHaveValue("my_special_eval_");
+
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ name: "my_special_eval_" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The "Duplicate evaluation" dialog in the EvaluationDrawer always failed with a 400 because the request payload sent `evalTemplateId` (camelCase) while the backend serializer requires `eval_template_id` (snake_case). With `reject_unknown_fields=True`, a single mismatched key caused two independent validation failures: the camelCase key was rejected as unknown, and the required snake_case key was missing. This PR corrects the property name to match the backend contract.

## Linked issues

Closes #1768

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Fix request payload key in DuplicateEvals dialog**

- Changed `evalTemplateId` → `eval_template_id` in the payload built by `onDuplicate` (`frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx:58`).
- No API, serializer, model, or contract changes — the backend contract was already correct.

**B. Add behavioral test for DuplicateEvals dialog**

- Added `frontend/src/sections/common/EvaluationDrawer/__tests__/DuplicateEvals.test.jsx` with a regression test that verifies the POST payload uses `eval_template_id` (snake_case). If anyone accidentally changes it back to camelCase, this test will fail. Also covers dialog rendering, name transformation, and the success callback.

---

## 2) Why the changes were done

- **Product/UX:** clicking "Duplicate" on an evaluation in the EvaluationDrawer always failed silently. The snackbar never fired, and no copy was created. Every attempt was a 400.
- **Technical:** the backend `DuplicateEvalTemplateSerializer` declares `eval_template_id = serializers.UUIDField()` and the view enables `reject_unknown_fields=True`. The frontend sent the id under the JavaScript-conventional camelCase name, which the serializer could never see. The fix aligns the frontend key with the existing contract rather than relaxing backend validation — the contract is already enforced by the generated OpenAPI schema and used correctly by the sibling caller `useEvalDetail.js`.
- **Architecture:** no key-casing interceptor exists in the axios layer, and adding one for this single call would be a disproportionate change with cross-cutting risk. The one-key fix is the minimal, safest approach.

---

## 3) Tests written + scenarios each covers

**Frontend behavioral test:** `frontend/src/sections/common/EvaluationDrawer/__tests__/DuplicateEvals.test.jsx`

- Verifies the POST payload sends `eval_template_id` (snake_case) to match the backend serializer contract — reverting the fix would cause this test to fail.
- Covers dialog rendering, name transformation, and the success callback.

The backend also has regression coverage:

- `test_eval_create.py::TestDuplicateEvalTemplateAPI::test_duplicate_returns_eval_template_id` — verifies the endpoint accepts `eval_template_id` and returns 200.
- `test_legacy_eval_template_actions_api.py` — two additional calls exercising the same contract.
- `test_model_hub_api_contract_debt.py` — enforces `"DuplicateEvalTemplate"` as the request body schema.
- The generated TypeScript type `DuplicateEvalTemplateApi` requires `eval_template_id: string` at compile time.

> Run result: `yarn lint` clean on the changed files.

---

## 4) How to run / test

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Go to **Evaluations**, create an evaluation so one exists with `owner = USER`.
3. Open a dataset, add the evaluation via the column menu, then open the EvaluationDrawer.
4. Click the **duplicate icon** in that evaluation action buttons.
5. Type a name and submit — the request succeeds (200), and a copy appears in the list.

### Verify the fix with curl

```bash
# Before fix (simulated) — 400:
curl -X POST http://localhost:8000/model-hub/duplicate-eval-template/ \
  -H "Content-Type: application/json" \
  -d '{"name": "test", "evalTemplateId": "<uuid>"}'
# → 400 (unknown field + missing required field)

# After fix — 200:
curl -X POST http://localhost:8000/model-hub/duplicate-eval-template/ \
  -H "Content-Type: application/json" \
  -d '{"name": "test", "eval_template_id": "<uuid>"}'
# → 200
```

---

## 6) Edge cases & considerations

- **No extra keys in payload:** the payload still sends exactly `{ name, eval_template_id }`. Adding any extra key would re-trigger `reject_unknown_fields`.
- **Name transformation unchanged:** `handleNameTransformation` still lowercases the typed name and replaces non-`[a-z0-9-]` characters with `_`. This is existing behaviour and out of scope.
- **Duplicate name still fails correctly:** the backend name-uniqueness check (`separate_evals.py:6852-6858`) is untouched, so submitting an existing name still returns the "already exists" error.
- **Other org rejection preserved:** the org-scoped template lookup is unchanged, so cross-org duplication attempts still fail with the missing-template error.
- **Sibling caller already correct:** `useEvalDetail.js:60` (used by the Evaluations detail page) already sends `eval_template_id` and was never affected by this bug.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] `yarn lint` passes on the changed file
- [x] No API surface changed — `yarn contracts:check` not required
- [x] No hardcoded secrets, URLs, or PII
- [x] I will sign the CLA when prompted
- [x] PR title follows Conventional Commits
