### PR TITLE
fix(dataset): preserve audio duration metadata

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from rest_framework import status
+from unittest.mock import patch
 
 from model_hub.models.choices import DataTypeChoices, SourceChoices
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
@@ -229,6 +230,57 @@ def test_update_cell_value_api_accepts_canonical_payload(
     assert response.status_code == status.HTTP_200_OK
     cell.refresh_from_db()
     assert cell.value == "Gamma"
+
+
+def test_update_audio_cell_persists_duration_for_filters(
+    auth_client, organization, workspace
+):
+    dataset = Dataset.objects.create(
+        name="Audio filter dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    audio_col = Column.objects.create(
+        name="recording",
+        data_type=DataTypeChoices.AUDIO.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    row = Row.objects.create(dataset=dataset, order=1)
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://example.com/old.mp3",
+        column_metadata={"existing": "keep"},
+    )
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_audio_to_s3_duration",
+        return_value=("https://example.com/new.mp3", 12.04),
+    ):
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/update_cell_value/",
+            {
+                "row_id": str(row.id),
+                "column_id": str(audio_col.id),
+                "new_value": "data:audio/mpeg;base64,ZmFrZQ==",
+            },
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.value == "https://example.com/new.mp3"
+    assert cell.column_metadata == {
+        "existing": "keep",
+        "audio_duration_seconds": 12.04,
+    }
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 1)],
+        [audio_col],
+    ) == [row]
 
 
 def test_dataset_row_data_api_rejects_legacy_filter_shape(

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -5340,6 +5340,10 @@ class UpdateCellValueView(APIView):
                 cell.value = None
                 cell.value_infos = json.dumps({})
                 cell.status = CellStatus.PASS.value
+                if column_data_type == DataTypeChoices.AUDIO.value:
+                    cleared_metadata = dict(cell.column_metadata or {})
+                    cleared_metadata.pop("audio_duration_seconds", None)
+                    cell.column_metadata = cleared_metadata
             elif column_data_type == DataTypeChoices.TEXT.value:
                 cell.value = str(new_value)
                 cell.value_infos = json.dumps({})
@@ -5479,14 +5483,21 @@ class UpdateCellValueView(APIView):
                         cell.value = None
                         cell.value_infos = json.dumps({})
                         cell.status = CellStatus.PASS.value
+                        cleared_metadata = dict(cell.column_metadata or {})
+                        cleared_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = cleared_metadata
                     else:
                         audio_key = f"audio/{dataset_id}/{uuid.uuid4()}"
+                        existing_metadata = dict(cell.column_metadata or {})
+                        previous_duration = existing_metadata.get(
+                            "audio_duration_seconds"
+                        )
                         audio_url, duration = upload_audio_to_s3_duration(
                             new_value,
                             bucket_name="fi-customer-data-dev",
                             object_key=audio_key,
-                            duration_seconds=cell.column_metadata.get(
-                                "audio_duration_seconds"
+                            duration_seconds=(
+                                previous_duration if new_value == cell.value else None
                             ),
                         )
                         value_infos = (
@@ -5498,6 +5509,11 @@ class UpdateCellValueView(APIView):
                         cell.value_infos = json.dumps(value_infos)
                         cell.status = CellStatus.PASS.value
                         cell.value = audio_url
+                        if duration:
+                            existing_metadata["audio_duration_seconds"] = float(duration)
+                        else:
+                            existing_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = existing_metadata
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")


### PR DESCRIPTION
## Summary\n- persist computed audio duration metadata when editing a dataset cell\n- preserve unrelated metadata and clear stale duration keys when audio is cleared\n- add a regression test covering duration filtering\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused Django test not run: this environment lacks djangorestframework\n\nFixes #1767