### PR TITLE
fix(observe): show processing status for dataset imports

### DIFF
--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddExistingDataset.jsx
@@ -260,10 +260,15 @@ const AddExistingDataset = ({
       axios.post(endpoints.project.addExistingDataset, payload),
     onSuccess: (res) => {
       if (res.data?.status) {
+        const isProcessing = res.data?.result?.status !== "completed";
+
         enqueueSnackbar(
           <>
-            <span>Data added successfully</span>
-            {/* {res.data.result.message} */}
+            <span>
+              {isProcessing
+                ? "Rows are being added to the dataset in the background, this can take a while for large selections."
+                : "Data added successfully"}
+            </span>
             <span
               onClick={() =>
                 navigate(`/dashboard/develop/${selectedDataset}?tab=data`, {
@@ -281,7 +286,7 @@ const AddExistingDataset = ({
               View Dataset
             </span>
           </>,
-          { variant: "success" },
+          { variant: isProcessing ? "info" : "success" },
         );
         handleclose();
         if (onSuccess) {

--- a/frontend/src/components/traceDetailDrawer/addToDataset/AddNewDataset.jsx
+++ b/frontend/src/components/traceDetailDrawer/addToDataset/AddNewDataset.jsx
@@ -111,15 +111,20 @@ const AddNewDataset = ({
         axios.post(endpoints.project.addNewDataset, payload),
 
       onSuccess: (res) => {
+        const result = res?.data?.result;
+        const datasetId = result?.dataset_id ?? result?.datasetId;
+        const isProcessing = result?.status !== "completed";
+
         enqueueSnackbar(
           <>
-            Datapoints added to newly created dataset
+            {isProcessing
+              ? "Dataset created. Rows are still being added in the background, this can take a while for large selections."
+              : "Datapoints added to newly created dataset"}
             <span
               onClick={() =>
-                navigate(
-                  `/dashboard/develop/${res?.data?.result?.dataset_id ?? res?.data?.result?.datasetId}?tab=data`,
-                  { state: { from: location.pathname } },
-                )
+                navigate(`/dashboard/develop/${datasetId}?tab=data`, {
+                  state: { from: location.pathname },
+                })
               }
               style={{
                 textDecoration: "underline",
@@ -132,7 +137,7 @@ const AddNewDataset = ({
               View Dataset
             </span>
           </>,
-          { variant: "success" },
+          { variant: isProcessing ? "info" : "success" },
         );
         handleclose();
         if (onSuccess) {


### PR DESCRIPTION
## Summary\n- reflect the API's processing status in add-to-new-dataset toasts\n- reflect the same status when adding traces to an existing dataset\n- preserve completed wording and dataset navigation links\n\n## Validation\n- targeted ESLint: 0 errors (4 pre-existing warnings in touched files)\n- git diff --check\n- component tests not added in this pass; behavior is isolated to the existing mutation success handlers\n\nFixes #1770