### PR TITLE
fix(evals): preserve names containing reason suffix

### DIFF
--- a/futureagi/model_hub/tests/test_reason_column_names.py
+++ b/futureagi/model_hub/tests/test_reason_column_names.py
@@ -1,0 +1,7 @@
+from model_hub.utils.eval_reasons import eval_name_from_reason_column
+
+
+def test_eval_name_from_reason_column_removes_only_trailing_suffix():
+    assert eval_name_from_reason_column("no-reason-check-reason") == "no-reason-check"
+    assert eval_name_from_reason_column("gives-reason-reason") == "gives-reason"
+    assert eval_name_from_reason_column("plain-eval") == "plain-eval"

--- a/futureagi/model_hub/utils/eval_reasons.py
+++ b/futureagi/model_hub/utils/eval_reasons.py
@@ -15,6 +15,11 @@ except ImportError:
 from model_hub.models.choices import EvalExplanationSummaryStatus, SourceChoices
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.evals_metric import UserEvalMetric
+
+
+def eval_name_from_reason_column(column_name: str) -> str:
+    """Remove only the reason suffix from a generated reason-column name."""
+    return column_name.removesuffix("-reason")
 from tfc.temporal import temporal_activity
 
 logger = structlog.get_logger(__name__)
@@ -59,7 +64,7 @@ def get_eval_reasons(
 
     # Process reason columns
     for column in reason_columns:
-        eval_name = column.name.split("-reason")[0]
+        eval_name = eval_name_from_reason_column(column.name)
         # Extract user_eval_metric_id from source_id (format: "prefix-sourceid-id")
         user_eval_metric_id = None
         if column.source_id and "-sourceid-" in str(column.source_id):

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -40,6 +40,7 @@ from model_hub.models.experiments import (
     ExperimentsTable,
 )
 from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+from model_hub.utils.eval_reasons import eval_name_from_reason_column
 from model_hub.serializers.contracts import (
     MODEL_HUB_ERROR_RESPONSES,
     DatasetRowDiffRequestSerializer,
@@ -1147,7 +1148,7 @@ class DatasetExperimentsView(APIView):
                             "name": (
                                 column.name
                                 if "-reason" not in column.name
-                                else column.name.split("-reason")[0]
+                                else eval_name_from_reason_column(column.name)
                             ),
                             "data_type": (
                                 column.data_type


### PR DESCRIPTION
## Summary\n- strip only the trailing -reason suffix from generated reason columns\n- share the parsing helper across reason summaries and experiment responses\n- add regression coverage for eval names containing -reason\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused Django test not run: this environment lacks djangorestframework\n\nFixes #1721