### PR TITLE
fix(pagination): handle invalid page parameters

### DIFF
--- a/futureagi/common/tests/test_pagination.py
+++ b/futureagi/common/tests/test_pagination.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
+
+from common.utils.pagination import DEFAULT_PAGE_SIZE, paginate_queryset
+
+
+@pytest.mark.parametrize(
+    "params, expected_page_size, expected_page",
+    [
+        ({"page_number": "abc"}, DEFAULT_PAGE_SIZE, list(range(10))),
+        ({"page_size": "abc"}, DEFAULT_PAGE_SIZE, list(range(10))),
+        ({"page_size": "0"}, DEFAULT_PAGE_SIZE, list(range(10))),
+        ({"page_size": "-5"}, DEFAULT_PAGE_SIZE, list(range(10))),
+        ({"page_number": "2", "page_size": "5"}, 5, list(range(5, 10))),
+    ],
+)
+def test_paginate_queryset_handles_invalid_query_params(
+    params, expected_page_size, expected_page
+):
+    page, metadata = paginate_queryset(
+        list(range(12)), SimpleNamespace(query_params=params)
+    )
+
+    assert metadata["page_size"] == expected_page_size
+    assert metadata["total_count"] == 12
+    assert page == expected_page

--- a/futureagi/common/utils/pagination.py
+++ b/futureagi/common/utils/pagination.py
@@ -18,8 +18,17 @@ def paginate_queryset(queryset: QuerySet, request: Request) -> tuple[list, dict]
         request: DRF request whose ``query_params`` supply ``page_number``
             (default 1) and ``page_size`` (default 10).
     """
-    page_number = int(request.query_params.get("page_number", 1))
-    page_size = int(request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = int(request.query_params.get("page_number", 1))
+    except (TypeError, ValueError):
+        page_number = 1
+
+    try:
+        page_size = int(request.query_params.get("page_size", DEFAULT_PAGE_SIZE))
+    except (TypeError, ValueError):
+        page_size = DEFAULT_PAGE_SIZE
+    if page_size <= 0:
+        page_size = DEFAULT_PAGE_SIZE
 
     paginator = Paginator(queryset, page_size)
     page = paginator.get_page(page_number)


### PR DESCRIPTION
## Summary\n- fall back safely for non-numeric page and size parameters\n- use the default page size for zero or negative values\n- add parameterized regression coverage for malformed query params\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused Django test not run: this environment lacks djangorestframework\n\nFixes #1678