### PR TITLE
fix(tracer): classify base64 audio values

### DIFF
--- a/futureagi/tracer/tests/test_helper_eval_configs.py
+++ b/futureagi/tracer/tests/test_helper_eval_configs.py
@@ -1,9 +1,10 @@
 """Tests for get_project_eval_configs — PG-native eval-config discovery."""
 import pytest
 
+from model_hub.models.choices import DataTypeChoices
 from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.project import Project
-from tracer.utils.helper import get_project_eval_configs
+from tracer.utils.helper import determine_value_type, get_project_eval_configs
 
 
 @pytest.mark.django_db
@@ -38,3 +39,12 @@ def test_excludes_other_projects_and_empty_case(project, eval_template):
 
     assert configs == []
     assert ids == []
+
+
+def test_determine_value_type_classifies_audio_data_urls():
+    assert (
+        determine_value_type("data:audio/wav;base64,AAAA")
+        == DataTypeChoices.AUDIO.value
+    )
+    assert determine_value_type("data:image/png;base64,AAAA") == DataTypeChoices.IMAGE.value
+    assert determine_value_type("plain text") == DataTypeChoices.TEXT.value

--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -237,6 +237,10 @@ def is_image(value: str) -> bool:
     return value.startswith(("data:image", "iVBORw0KGgo"))
 
 
+def is_audio(value: str) -> bool:
+    return value.startswith("data:audio")
+
+
 def determine_value_type(value):
     # Determine data type based on value
     if isinstance(value, bool):
@@ -258,6 +262,8 @@ def determine_value_type(value):
             return DataTypeChoices.DATETIME.value
         elif is_image(value):
             return DataTypeChoices.IMAGE.value
+        elif is_audio(value):
+            return DataTypeChoices.AUDIO.value
         return DataTypeChoices.TEXT.value
     else:
         return DataTypeChoices.OTHERS.value


### PR DESCRIPTION
## Summary\n- recognize data:audio/... values as audio columns\n- preserve existing image and text classification\n- add regression coverage for audio data URLs\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused Django test not run: this environment lacks djangorestframework\n\nFixes #1664