### PR TITLE
fix(media): avoid treating videos as images

### DIFF
--- a/futureagi/agentic_eval/core/utils/llm_payloads.py
+++ b/futureagi/agentic_eval/core/utils/llm_payloads.py
@@ -381,7 +381,7 @@ def build_user_message(content: Sequence[ContentBlock]) -> Message:
 _SUPPORTED_MEDIA = {"image", "images", "audio", "pdf"}
 
 _IMAGE_EXT_PAT = re.compile(
-    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff|mp4)(\?|$)",
+    r"https?://\S+\.(png|jpg|jpeg|gif|webp|svg|bmp|tiff)(\?|$)",
     re.IGNORECASE,
 )
 

--- a/futureagi/agentic_eval/core/utils/tests/test_llm_payload_media_detection.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_llm_payload_media_detection.py
@@ -1,0 +1,6 @@
+from agentic_eval.core.utils.llm_payloads import _IMAGE_EXT_PAT
+
+
+def test_video_urls_are_not_fast_pathed_as_images():
+    assert _IMAGE_EXT_PAT.search("https://cdn.example.com/clip.mp4") is None
+    assert _IMAGE_EXT_PAT.search("https://cdn.example.com/photo.webp")


### PR DESCRIPTION
## Summary\n- remove the .mp4 extension from the image URL fast-path\n- let video URLs fall through to normal content-type detection\n- add a regression test preserving image extension matching\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused test blocked by missing structlog in this environment\n\nFixes #1673