### PR TITLE
fix(frontend): keep request body highlight visible

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -33,6 +33,7 @@ const RequestBody = ({
   sx = {},
 }) => {
   const theme = useTheme();
+  const { backgroundColor, ...textareaSx } = sx;
   const [showDropdown, setShowDropdown] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState({ x: 0, y: 0 });
   const inputRef = useRef(null);
@@ -342,7 +343,7 @@ const RequestBody = ({
       <div
         style={{
           position: "relative",
-          backgroundColor: theme.palette.background.default,
+          backgroundColor: backgroundColor || theme.palette.background.default,
           borderRadius: "8px",
         }}
       >
@@ -398,7 +399,7 @@ const RequestBody = ({
             backgroundColor: "transparent",
             position: "relative",
             verticalAlign: "top",
-            ...sx,
+            ...textareaSx,
           }}
           onKeyDown={onKeyDown}
         />


### PR DESCRIPTION
## Summary\n- keep caller backgrounds on the outer RequestBody backdrop\n- prevent sx.backgroundColor from covering the transparent textarea layer\n- preserve all other caller-provided textarea styles\n\n## Validation\n- targeted ESLint passes\n- git diff --check\n\nFixes #1586