### PR TITLE
fix(logging): keep privacy marker on emitted record

### DIFF
--- a/agentcc-gateway/internal/plugins/logging/logging.go
+++ b/agentcc-gateway/internal/plugins/logging/logging.go
@@ -86,10 +86,10 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 	// Apply redaction: org redactor (with org patterns) takes priority over global.
 	if orgRedactor != nil && orgRedactor.ShouldRedact() && record.RequestBody != nil {
 		record = redactRecord(record, orgRedactor, mode)
-		rc.SetMetadata("privacy_redacted", "true")
+		markPrivacyRedacted(&record)
 	} else if p.redactor != nil && p.redactor.ShouldRedact() && record.RequestBody != nil {
 		record = redactRecord(record, p.redactor, mode)
-		rc.SetMetadata("privacy_redacted", "true")
+		markPrivacyRedacted(&record)
 	}
 
 	p.emitter.Emit(record)
@@ -99,6 +99,15 @@ func (p *Plugin) ProcessResponse(_ context.Context, rc *models.RequestContext) p
 	}
 
 	return pipeline.ResultContinue()
+}
+
+// markPrivacyRedacted annotates the emitted snapshot without mutating the
+// request context shared with parallel post-response plugins.
+func markPrivacyRedacted(record *TraceRecord) {
+	if record.Metadata == nil {
+		record.Metadata = make(map[string]string)
+	}
+	record.Metadata["privacy_redacted"] = "true"
 }
 
 // getOrgRedactor returns a per-org privacy redactor if the org has privacy config.

--- a/agentcc-gateway/internal/plugins/logging/logging_test.go
+++ b/agentcc-gateway/internal/plugins/logging/logging_test.go
@@ -647,6 +647,15 @@ func TestProcessResponse_EmitsRecord(t *testing.T) {
 	}
 }
 
+func TestMarkPrivacyRedactedAnnotatesRecordOnly(t *testing.T) {
+	record := TraceRecord{}
+	markPrivacyRedacted(&record)
+
+	if got := record.Metadata["privacy_redacted"]; got != "true" {
+		t.Fatalf("privacy_redacted = %q, want %q", got, "true")
+	}
+}
+
 func TestProcessResponse_Disabled(t *testing.T) {
 	handler, cleanup := installCapturingLogger()
 	defer cleanup()


### PR DESCRIPTION
## Summary\n- attach privacy_redacted=true to the emitted trace snapshot\n- stop mutating shared RequestContext metadata in the parallel post-response plugin\n- add a focused marker regression test\n\n## Validation\n- git diff --check\n- Go tests not run: Go toolchain is unavailable in this environment\n\nFixes #1750