### PR TITLE
fix(evals): score multi-choice outputs by mapping

### DIFF
--- a/futureagi/tfc/utils/functions.py
+++ b/futureagi/tfc/utils/functions.py
@@ -676,16 +676,23 @@ def calculate_eval_average(eval_template, api_logs):
                         continue
 
                 elif output_type in ["choices", "reason"]:
-                    if choices_map and not eval_template.multi_choice:
-                        match choices_map.get(output.get("output")[0]):
-                            case "pass":
-                                success_count += 1
-                                valid_logs += 1
-                            case "neutral":
-                                success_count += 0.5
-                                valid_logs += 1
-                            case _:
-                                valid_logs += 1
+                    selected_choices = output.get("output")
+                    if not isinstance(selected_choices, list):
+                        selected_choices = [selected_choices]
+
+                    if choices_map:
+                        if not eval_template.multi_choice:
+                            selected_choices = selected_choices[:1]
+
+                        weights = [
+                            {"pass": 1, "neutral": 0.5}.get(
+                                choices_map.get(choice), 0
+                            )
+                            for choice in selected_choices
+                        ]
+                        if weights:
+                            success_count += sum(weights) / len(weights)
+                        valid_logs += 1
                     else:
                         success_count += 1
                         valid_logs += 1

--- a/futureagi/tfc/utils/tests/test_functions_eval_average.py
+++ b/futureagi/tfc/utils/tests/test_functions_eval_average.py
@@ -1,0 +1,34 @@
+import json
+from types import SimpleNamespace
+
+from tfc.constants.api_calls import APICallStatusChoices
+from tfc.utils.functions import calculate_eval_average
+
+
+def _log(output):
+    return {
+        "status": APICallStatusChoices.SUCCESS.value,
+        "config": json.dumps({"output": {"output": output}}),
+    }
+
+
+def test_calculate_eval_average_weights_multi_choice_results():
+    template = SimpleNamespace(
+        config={
+            "output": "choices",
+            "choices_map": {"Excellent": "pass", "Okay": "neutral", "Poor": "fail"},
+        },
+        multi_choice=True,
+    )
+
+    # [Excellent, Poor] averages to 50%; [Poor] contributes 0%.
+    assert calculate_eval_average(template, [_log(["Excellent", "Poor"]), _log(["Poor"])]) == 25
+
+
+def test_calculate_eval_average_preserves_single_choice_scoring():
+    template = SimpleNamespace(
+        config={"output": "choices", "choices_map": {"Excellent": "pass", "Poor": "fail"}},
+        multi_choice=False,
+    )
+
+    assert calculate_eval_average(template, [_log(["Excellent"]), _log(["Poor"])]) == 50


### PR DESCRIPTION
## Summary\n- score multi-choice choice/reason outputs through choices_map\n- average selected pass/neutral/fail weights per log\n- preserve single-choice and no-map behavior\n- add regression coverage for multi- and single-choice averages\n\n## Validation\n- Python compileall passes\n- git diff --check passes\n- focused Django test not run: this environment lacks djangorestframework\n\nFixes #1713