### PR TITLE
fix(dataset): persist audio duration in column_metadata on cell update

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 import pytest
 from rest_framework import status
@@ -371,3 +372,274 @@ def test_filter_dataset_cells_array_contains_list_value(array_col_seed):
         cells, "array", "in", [json.dumps(["see CIRCULAR appendix"])], "array"
     )
     assert set(exact.values_list("row_id", flat=True)) == {rows[2].id}
+
+
+@pytest.fixture
+def audio_col_seed(organization, workspace):
+    """A dataset with an audio-typed column and a row for duration-filter tests."""
+    dataset = Dataset.objects.create(
+        name="Audio filter dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    audio_col = Column.objects.create(
+        name="recording",
+        data_type=DataTypeChoices.AUDIO.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    row = Row.objects.create(dataset=dataset, order=1)
+    return dataset, row, audio_col
+
+
+def test_audio_duration_filter_with_metadata(audio_col_seed):
+    """Duration filter reads from column_metadata__audio_duration_seconds."""
+    dataset, row, audio_col = audio_col_seed
+
+    Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/test.mp3",
+        column_metadata={"audio_duration_seconds": 12.04},
+    )
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 1)],
+        [audio_col],
+    )
+    assert matched == [row]
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 100)],
+        [audio_col],
+    )
+    assert matched == []
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "less_than", 5)],
+        [audio_col],
+    )
+    assert matched == []
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "between", [10, 15])],
+        [audio_col],
+    )
+    assert matched == [row]
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "between", [0, 5])],
+        [audio_col],
+    )
+    assert matched == []
+
+
+def test_audio_duration_filter_without_metadata_returns_empty(audio_col_seed):
+    """A cell with no audio_duration_seconds → NULL numeric_value → no matches."""
+    dataset, row, audio_col = audio_col_seed
+
+    Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/test.mp3",
+        column_metadata={},
+    )
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 1)],
+        [audio_col],
+    )
+    assert matched == []
+
+    matched = _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "less_than", 1000)],
+        [audio_col],
+    )
+    assert matched == []
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_stores_audio_duration(
+    mock_upload, auth_client, audio_col_seed
+):
+    """update_cell_value/ persists audio_duration_seconds in column_metadata."""
+    dataset, row, audio_col = audio_col_seed
+
+    mock_upload.return_value = (
+        "https://bucket/audio/new_upload.mp3",
+        12.5,
+    )
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="",
+        column_metadata={},
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/new_upload.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata == {"audio_duration_seconds": 12.5}
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_clears_audio_duration_on_empty(
+    mock_upload, auth_client, audio_col_seed
+):
+    """Clearing an audio cell removes audio_duration_seconds from column_metadata."""
+    dataset, row, audio_col = audio_col_seed
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/old.mp3",
+        column_metadata={"audio_duration_seconds": 12.04},
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.value is None
+    assert "audio_duration_seconds" not in (cell.column_metadata or {})
+    mock_upload.assert_not_called()
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_preserves_existing_metadata_keys(
+    mock_upload, auth_client, audio_col_seed
+):
+    """Non-audio keys in column_metadata survive an audio cell update."""
+    dataset, row, audio_col = audio_col_seed
+
+    mock_upload.return_value = (
+        "https://bucket/audio/new_upload.mp3",
+        8.0,
+    )
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="",
+        column_metadata={"embedding": True, "custom_key": "value"},
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/new_upload.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata["audio_duration_seconds"] == 8.0
+    assert cell.column_metadata["embedding"] is True
+    assert cell.column_metadata["custom_key"] == "value"
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_handles_none_column_metadata(
+    mock_upload, auth_client, audio_col_seed
+):
+    """A cell with column_metadata=None does not raise on update."""
+    dataset, row, audio_col = audio_col_seed
+
+    mock_upload.return_value = (
+        "https://bucket/audio/new_upload.mp3",
+        3.3,
+    )
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="",
+        column_metadata=None,
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/new_upload.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata == {"audio_duration_seconds": 3.3}
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_reuses_cached_duration_for_same_url(
+    mock_upload, auth_client, audio_col_seed
+):
+    """Re-saving the same URL passes cached duration so the file is not re-downloaded."""
+    dataset, row, audio_col = audio_col_seed
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/same.mp3",
+        column_metadata={"audio_duration_seconds": 9.99},
+    )
+
+    mock_upload.return_value = (
+        "https://bucket/audio/same.mp3",
+        9.99,
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/same.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    call_kwargs = mock_upload.call_args.kwargs
+    assert call_kwargs["duration_seconds"] == 9.99
+
+    cell.refresh_from_db()
+    assert cell.column_metadata["audio_duration_seconds"] == 9.99

--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 import pytest
 from rest_framework import status
 
-from model_hub.models.choices import DataTypeChoices, SourceChoices
+from model_hub.models.choices import (
+    CellStatus,
+    DataTypeChoices,
+    SourceChoices,
+)
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.serializers.contracts import (
     DatasetUpdateCellValueRequestSerializer,
@@ -643,3 +647,114 @@ def test_update_cell_value_reuses_cached_duration_for_same_url(
 
     cell.refresh_from_db()
     assert cell.column_metadata["audio_duration_seconds"] == 9.99
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_recomputes_duration_for_different_url(
+    mock_upload, auth_client, audio_col_seed
+):
+    """Replacing the audio recomputes the duration instead of reusing the cached one."""
+    dataset, row, audio_col = audio_col_seed
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/old.mp3",
+        column_metadata={"audio_duration_seconds": 12.5},
+    )
+
+    mock_upload.return_value = (
+        "https://bucket/audio/new.mp3",
+        4.0,
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/new.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    call_kwargs = mock_upload.call_args.kwargs
+    assert call_kwargs["duration_seconds"] is None
+
+    cell.refresh_from_db()
+    assert cell.value == "https://bucket/audio/new.mp3"
+    assert cell.column_metadata["audio_duration_seconds"] == 4.0
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_skips_metadata_write_for_falsy_duration(
+    mock_upload, auth_client, audio_col_seed
+):
+    """A 0 duration leaves no audio_duration_seconds key, matching the file-upload path."""
+    dataset, row, audio_col = audio_col_seed
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="",
+        column_metadata={"audio_duration_seconds": 12.5},
+    )
+
+    mock_upload.return_value = (
+        "https://bucket/audio/zero.mp3",
+        0,
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "https://bucket/audio/zero.mp3",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    cell.refresh_from_db()
+    assert "audio_duration_seconds" not in (cell.column_metadata or {})
+
+
+@patch("model_hub.views.develop_dataset.upload_audio_to_s3_duration")
+def test_update_cell_value_clears_cell_for_non_string_value(
+    mock_upload, auth_client, audio_col_seed
+):
+    """A non-string new_value with no file upload degrades to an empty cell, not an error."""
+    dataset, row, audio_col = audio_col_seed
+
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value="https://bucket/audio/old.mp3",
+        column_metadata={"audio_duration_seconds": 12.5},
+    )
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": 12345,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    mock_upload.assert_not_called()
+
+    cell.refresh_from_db()
+    assert cell.value is None
+    assert cell.status == CellStatus.PASS.value
+    assert "audio_duration_seconds" not in (cell.column_metadata or {})

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -5344,6 +5344,10 @@ class UpdateCellValueView(APIView):
                 cell.value = None
                 cell.value_infos = json.dumps({})
                 cell.status = CellStatus.PASS.value
+                if column_data_type == DataTypeChoices.AUDIO.value:
+                    cleared_metadata = dict(cell.column_metadata or {})
+                    cleared_metadata.pop("audio_duration_seconds", None)
+                    cell.column_metadata = cleared_metadata
             elif column_data_type == DataTypeChoices.TEXT.value:
                 cell.value = str(new_value)
                 cell.value_infos = json.dumps({})
@@ -5483,14 +5487,20 @@ class UpdateCellValueView(APIView):
                         cell.value = None
                         cell.value_infos = json.dumps({})
                         cell.status = CellStatus.PASS.value
+                        cleared_metadata = dict(cell.column_metadata or {})
+                        cleared_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = cleared_metadata
                     else:
                         audio_key = f"audio/{dataset_id}/{uuid.uuid4()}"
+                        existing_metadata = dict(cell.column_metadata or {})
                         audio_url, duration = upload_audio_to_s3_duration(
                             new_value,
                             bucket_name="fi-customer-data-dev",
                             object_key=audio_key,
-                            duration_seconds=cell.column_metadata.get(
-                                "audio_duration_seconds"
+                            duration_seconds=(
+                                existing_metadata.get("audio_duration_seconds")
+                                if new_value == cell.value
+                                else None
                             ),
                         )
                         value_infos = (
@@ -5502,6 +5512,13 @@ class UpdateCellValueView(APIView):
                         cell.value_infos = json.dumps(value_infos)
                         cell.status = CellStatus.PASS.value
                         cell.value = audio_url
+                        if duration:
+                            existing_metadata["audio_duration_seconds"] = float(
+                                duration
+                            )
+                        else:
+                            existing_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = existing_metadata
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")


### PR DESCRIPTION
## Summary

The `UpdateCellValueView` endpoint behind inline-editing a dataset audio cell computed the clip duration via `upload_audio_to_s3_duration()` but never wrote it back to `cell.column_metadata`. Every audio cell edited through the grid kept `column_metadata = {}`, so the duration filter — which reads `column_metadata__audio_duration_seconds` via `Cast(…, FloatField())` — always evaluated to NULL and returned zero rows for any numeric comparison.

## Linked issues

Closes #1767

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Core fix: write duration into `cell.column_metadata`** (`develop_dataset.py`, AUDIO branch)

- Replace `cell.column_metadata.get("audio_duration_seconds")` (unguarded, would `AttributeError` on `None`) with `dict(cell.column_metadata or {})`.
- Only pass the cached duration to `upload_audio_to_s3_duration` when `new_value == cell.value` (same URL, no re-download). Otherwise pass `None` so the helper recomputes.
- After upload, merge the duration into the existing metadata dict with `if duration:` — mirroring the file-upload reference path (`file_upload.py`), so a falsy (`0`/`None`) duration leaves no `audio_duration_seconds` key behind instead of writing a misleading zero.
- The inner empty-audio guard inside the AUDIO branch is **kept**: it catches the case where a truthy non-string `new_value` arrives without a multipart file (`_convert_to_base64` returns `None`), degrading gracefully to an empty PASS cell instead of a 400 ERROR.
- Both empty-value paths (the generic guard and the AUDIO-branch guard) pop `audio_duration_seconds` from `column_metadata`.

**B. Regression tests** (`test_dataset_table_filters.py`)

Three tests covering the risky behaviors flagged in review:

- `test_update_cell_value_recomputes_duration_for_different_url` — replacing the audio passes `duration_seconds=None` and overwrites the stored duration with the new clip's length (issue done-when; guards against the cached-duration passthrough ever being applied to a changed file).
- `test_update_cell_value_skips_metadata_write_for_falsy_duration` — a `0` duration writes no `audio_duration_seconds` key, matching the file-upload path.
- `test_update_cell_value_clears_cell_for_non_string_value` — a truthy non-string `new_value` with no file upload degrades to an empty PASS cell (200), not a 400 ERROR; locks in the inner empty guard.

---

## 2) Why the changes were done

- **Product/UX:** users editing audio cells from the dataset grid could never filter those cells by duration — every numeric operator returned zero rows.
- **Technical:** the reference implementation in the file-upload path (`file_upload.py:882–892`) already computes and persists the duration. The inline cell-edit path simply omitted the persist step.
- **Architecture:** the fix merges into `column_metadata` rather than replacing it, preserving any non-audio keys.

---

## 3) Tests written + scenarios each covers

### Test environment

- **Stack:** `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` with `PG_PORT=15432`
- **Test runner:** Django REST framework `APIClient` with `force_authenticate` (the Docker image bundles Django but not pytest)
- **Mock strategy:** `unittest.mock.patch` on `model_hub.views.develop_dataset.upload_audio_to_s3_duration`

### Unit tests (filter layer)

`test_audio_duration_filter_with_metadata` — seeds a cell with `column_metadata={"audio_duration_seconds": 12.04}` and exercises 5 filter operators (greater_than 1 → row returned; greater_than 100 → empty; less_than 5 → empty; between [10,15] → row returned; between [0,5] → empty).

`test_audio_duration_filter_without_metadata_returns_empty` — seeds a cell with `column_metadata={}` and confirms both greater_than and less_than return empty (NULL numeric_value matches nothing).

### Integration tests (API layer)

| Test | Seed state | Request payload | Assertions |
|------|-----------|----------------|------------|
| `test_update_cell_value_stores_audio_duration` | `value=""`, `column_metadata={}` | `{"new_value": "https://s3/audio/new.mp3"}` | 200, `column_metadata == {"audio_duration_seconds": 12.5}` |
| `test_update_cell_value_clears_audio_duration_on_empty` | `value="https://s3/audio/old.mp3"`, `column_metadata={"audio_duration_seconds": 12.04}` | `{"new_value": ""}` | 200, `cell.value is None`, `"audio_duration_seconds" not in column_metadata`, `mock.assert_not_called()` |
| `test_update_cell_value_preserves_existing_metadata_keys` | `column_metadata={"audio_duration_seconds": 7.0, "embedding": True}` | `{"new_value": "https://s3/audio/new3.mp3"}` | 200, `column_metadata["audio_duration_seconds"] == 8.0`, `column_metadata["embedding"] is True` |
| `test_update_cell_value_handles_none_column_metadata` | `value=""`, `column_metadata=None` (via `QuerySet.update()`) | `{"new_value": "https://s3/audio/new2.mp3"}` | 200, no `AttributeError`, `column_metadata == {"audio_duration_seconds": 3.3}` |
| `test_update_cell_value_reuses_cached_duration_for_same_url` | `value="https://s3/audio/same.mp3"`, `column_metadata={"audio_duration_seconds": 9.99}` | `{"new_value": "https://s3/audio/same.mp3"}` (same URL) | 200, `mock.call_args.kwargs["duration_seconds"] == 9.99`, `column_metadata["audio_duration_seconds"] == 9.99` |
| `test_update_cell_value_recomputes_duration_for_different_url` | `value="https://s3/audio/old.mp3"`, `column_metadata={"audio_duration_seconds": 12.5}` | `{"new_value": "https://s3/audio/new.mp3"}` (different URL) | 200, `mock.call_args.kwargs["duration_seconds"] is None`, `cell.value` updated, `column_metadata["audio_duration_seconds"] == 4.0` |
| `test_update_cell_value_skips_metadata_write_for_falsy_duration` | `column_metadata={"audio_duration_seconds": 12.5}` | `{"new_value": "https://s3/audio/zero.mp3"}`, mock returns `duration=0` | 200, `"audio_duration_seconds" not in column_metadata` |
| `test_update_cell_value_clears_cell_for_non_string_value` | `value="https://s3/audio/old.mp3"`, `column_metadata={"audio_duration_seconds": 12.5}` | `{"new_value": 12345}` (non-string, no file) | 200, `mock.assert_not_called()`, `cell.value is None`, `status == "pass"`, no duration key left |

Total: **10 tests** (2 filter-layer + 8 API-layer).

---

## 4) Deviations from the issue's suggested shape

- **Falsy duration:** the issue suggested `if duration:` and this PR follows it. An earlier iteration of this branch briefly used `duration is not None` (which would persist a parse-failure `0.0` from `get_audio_duration`'s last-resort fallback, diverging from the file-upload path); it was reverted to `if duration:` so both writer paths share the same semantics.
- **Inner empty-audio guard:** the issue asked to keep and extend it; this PR keeps it as-is (the generic guard already handles the common empty-string case, the inner guard handles the non-string/no-file case). Both pop `audio_duration_seconds`.

---

## 6) Edge cases & considerations

- **None column_metadata:** guarded with `dict(cell.column_metadata or {})` at every access point.
- **Falsy duration:** `0` or `None` pops the key rather than writing a misleading value — same as the file-upload reference path.
- **Cached duration only for same URL:** `duration_seconds` passes the existing value only when `new_value == cell.value`. Different URL passes `None` for recomputation (covered by test).
- **Non-string value without file:** degrades to an empty PASS cell via the inner empty guard (covered by test).
- **Annotation queue path:** read-only, no change needed.
- **Column-type conversion path** (`_convert_cell_to_audio`): explicitly out of scope per the issue.

## Checklist

- [x] My code follows the style guide
- [x] Tests added — 2 unit (filter layer) + 8 integration (API layer)
- [x] No API surface change
- [x] No hardcoded secrets, URLs, or PII
- [x] I will sign the CLA when prompted
- [x] PR title follows Conventional Commits
