### PR TITLE
fix(evals): allow renaming dataset evaluation instances

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1264,7 +1264,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           size="small"
           placeholder="e.g. toxicity-check, my-custom-eval"
           value={evalName}
-          disabled={isEditMode} // Name is not editable in edit mode — it's the name of the UserEvalMetric instance, not the template
           onChange={(e) => {
             // Sanitise: lowercase, replace spaces with hyphens, only allow a-z 0-9 _ -
             const raw = e.target.value
@@ -1274,13 +1273,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          error={!isEditMode && evalName.length >= 51}
+          error={evalName.length >= 51}
           helperText={
-            isEditMode
-              ? undefined
-              : evalName.length >= 51
-                ? "Name can't be longer than 50 characters"
-                : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
+            evalName.length >= 51
+              ? "Name can't be longer than 50 characters"
+              : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }
           FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -35,6 +35,7 @@ from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.evals_metric import (
     CompositeEvalChild,
     EvalTemplate,
+    EvalTemplateVersion,
     UserEvalMetric,
 )
 from tfc.middleware.workspace_context import set_workspace_context
@@ -1684,6 +1685,122 @@ class TestEditAndRunUserEvalView:
         assert response.status_code == status.HTTP_200_OK
         user_eval_metric.refresh_from_db()
         assert user_eval_metric.name == "updated-eval"
+        assert not Column.objects.filter(
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+            dataset=dataset,
+            deleted=False,
+        ).exists()
+
+    def test_edit_and_run_user_eval_renames_existing_columns(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """A dataset eval rename updates its value and both grid headers."""
+        eval_column = Column.objects.create(
+            name="Test Evaluation",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+        )
+        reason_column = Column.objects.create(
+            name="Test Evaluation-reason",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION_REASON.value,
+            source_id=f"{eval_column.id}-sourceid-{user_eval_metric.id}",
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "renamed-evaluation",
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        eval_column.refresh_from_db()
+        reason_column.refresh_from_db()
+        assert user_eval_metric.name == "renamed-evaluation"
+        assert eval_column.name == "renamed-evaluation"
+        assert reason_column.name == "renamed-evaluation-reason"
+
+    def test_edit_and_run_user_eval_rejects_invalid_rename_before_writes(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """Invalid names fail before versioning or the metric can be changed."""
+        original_name = user_eval_metric.name
+        version_count = EvalTemplateVersion.objects.filter(
+            eval_template=user_eval_metric.template
+        ).count()
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "My Eval!",
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == original_name
+        assert EvalTemplateVersion.objects.filter(
+            eval_template=user_eval_metric.template
+        ).count() == version_count
+
+    def test_edit_and_run_user_eval_rejects_duplicate_name(
+        self,
+        auth_client,
+        dataset,
+        user_eval_metric,
+        organization,
+        workspace,
+    ):
+        """A dataset cannot contain two active eval instances with one name."""
+        UserEvalMetric.objects.create(
+            name="taken-evaluation",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=user_eval_metric.template,
+            status=StatusType.NOT_STARTED.value,
+            config={},
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "taken-evaluation",
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
+
+    def test_edit_and_run_user_eval_blank_name_is_noop(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """An empty optional name leaves the existing instance name intact."""
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "",
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "Test Evaluation"
 
     def test_edit_and_run_user_eval_without_name(
         self, auth_client, dataset, user_eval_metric, output_column

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -1664,7 +1664,7 @@ class TestEditAndRunUserEvalView:
     ):
         """Test successfully editing and running a user evaluation."""
         payload = {
-            "name": "Updated Eval",
+            "name": "updated-eval",
             "output_column_id": str(output_column.id),
             "config": {
                 "model": "gpt-4",
@@ -1682,6 +1682,8 @@ class TestEditAndRunUserEvalView:
             )
 
         assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "updated-eval"
 
     def test_edit_and_run_user_eval_without_name(
         self, auth_client, dataset, user_eval_metric, output_column

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7919,6 +7919,34 @@ class EditAndRunUserEvalView(APIView):
                         f"{get_error_message('COLUMN_DELETED')} {eval_metric.name}"
                     )
 
+                # Validate a requested instance rename before any writes occur.
+                # Returning from transaction.atomic() commits, so invalid names
+                # must be rejected before version/column work starts.
+                new_name = None
+                if not save_as_template:
+                    requested_name = (request_data.get("name") or "").strip()
+                    if requested_name and requested_name != eval_metric.name:
+                        from model_hub.utils.eval_validators import validate_eval_name
+
+                        try:
+                            new_name = validate_eval_name(requested_name)
+                        except ValueError as e:
+                            return self._gm.bad_request(str(e))
+
+                        if (
+                            UserEvalMetric.objects.filter(
+                                name=new_name,
+                                organization=eval_metric.organization,
+                                dataset_id=eval_metric.dataset_id,
+                                deleted=False,
+                            )
+                            .exclude(id=eval_metric.id)
+                            .exists()
+                        ):
+                            return self._gm.bad_request(
+                                get_error_message("EVAL_NAME_EXISTS")
+                            )
+
                 if save_as_template:
                     template = eval_metric.template
 
@@ -8208,6 +8236,21 @@ class EditAndRunUserEvalView(APIView):
                             deleted=False,
                         ).update(status=CellStatus.RUNNING.value)
 
+                if new_name:
+                    eval_metric.name = new_name
+                    if not experiment_id:
+                        Column.objects.filter(
+                            source=SourceChoices.EVALUATION.value,
+                            source_id=str(eval_metric.id),
+                            dataset=eval_metric.dataset,
+                            deleted=False,
+                        ).update(name=new_name)
+                        Column.objects.filter(
+                            source=SourceChoices.EVALUATION_REASON.value,
+                            source_id__endswith=f"-sourceid-{eval_metric.id}",
+                            dataset=eval_metric.dataset,
+                            deleted=False,
+                        ).update(name=f"{new_name}-reason")
                 eval_metric.save()
                 return self._gm.success_response(
                     "Column evaluation updated and queued for processing"


### PR DESCRIPTION
## Summary

- allow editing the name of an existing dataset evaluation instance
- validate renames before version or column writes and reject duplicates within a dataset
- keep evaluation and reason-column headers in sync with the renamed instance
- add API regression coverage for successful, blank, duplicate, invalid, and existing-column paths

## Root cause

The frontend disabled the name field whenever the evaluation picker was in edit mode, while the edit endpoint ignored `name` for the existing `UserEvalMetric`. This left the persisted instance name and its grid headers stale even though the UI displayed the field as part of the form.

The endpoint now validates an optional rename before entering write-heavy version and column reconciliation, checks active names within the dataset, updates the metric, and renames existing dataset-scoped evaluation/reason columns without changing experiment-scoped column naming.

## Validation

- `python -m compileall -q futureagi/model_hub/tests/test_evaluation_api.py futureagi/model_hub/views/develop_dataset.py`
- `git diff --check`
- The focused pytest command could not start in this checkout because Django REST Framework is not installed (`ModuleNotFoundError: No module named 'rest_framework'`).

Fixes #1769
