### PR TITLE
fix(personas): require location on persona forms

### DIFF
--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
@@ -92,6 +92,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 control={control}
                 fieldName="location"
                 label="Location"
+                required
                 fullWidth
                 placeholder="United States"
                 size="small"

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -365,7 +365,10 @@ const PersonCreateBaseValidationSchema = z.object({
   description: z.string().min(1, "Description is required"),
   gender: z.array(z.string()).transform((val) => (val.length ? val : null)),
   ageGroup: z.array(z.string()).transform((val) => (val.length ? val : null)),
-  location: z.array(z.string()).transform((val) => (val.length ? val : null)),
+  location: z
+    .array(z.string())
+    .min(1, "Location is required")
+    .transform((val) => (val.length ? val : null)),
   profession: z.array(z.string()).transform((val) => (val.length ? val : null)),
   personality: z
     .array(z.object({ value: z.string() }))


### PR DESCRIPTION
## Summary
- require at least one location in the shared persona create/edit schema
- mark the Location selector as required in the persona form
- preserve the existing selected-value transformation

## Verification
- git diff --check
- frontend ESLint could not run because dependencies are not installed in this worktree

Closes #1526