### PR TITLE
feat(traces): expose agent playground action

### DIFF
--- a/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
+++ b/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
@@ -70,11 +70,11 @@ const ACTION_ITEMS = [
     icon: "mdi:pencil-box-outline",
     spanTypes: ["llm"],
   },
-  // {
-  //   id: "playground",
-  //   label: "Iterate in agent playground",
-  //   icon: "mdi:gamepad-variant-outline",
-  // },
+  {
+    id: "playground",
+    label: "Iterate in agent playground",
+    icon: "mdi:gamepad-variant-outline",
+  },
   { id: "tags", label: "Add Tags", icon: "mdi:tag-outline" },
   { id: "annotate", label: "Annotate", icon: "mdi:comment-text-outline" },
   { id: "queue", label: "Add to annotation queue", icon: "mdi:playlist-plus" },


### PR DESCRIPTION
## Summary
- expose the existing Iterate in agent playground action in the live trace Actions menu
- reuse the existing createGraphFromTrace handler and loading/error behavior
- leave other trace actions unchanged

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1573