### PR TITLE
fix(annotations): keep automation rule rows uniform

### DIFF
--- a/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/automation-rules-tab.jsx
@@ -333,6 +333,7 @@ export default function AutomationRulesTab({ queueId, queue }) {
           defaultColDef={defaultColDef}
           context={gridContext}
           rowHeight={52}
+          getRowHeight={() => 52}
           headerHeight={42}
           pagination={false}
           animateRows={false}


### PR DESCRIPTION
## Summary
- explicitly return the configured 52px height for every Automation Rules row
- prevent auto-height recalculation from producing inconsistent row sizes
- leave rule rendering and interaction behavior unchanged

## Verification
- git diff --check
- focused Vitest unavailable because frontend dependencies are not installed in this worktree

Closes #1578