### PR TITLE
fix(personas): require behavioral settings

### DIFF
--- a/frontend/src/sections/persona/PersonaCreateEdit/OptionSelectors.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/OptionSelectors.jsx
@@ -12,6 +12,7 @@ const OptionSelectors = ({
   options,
   multiple = true,
   showClearButton = false,
+  error,
 }) => {
   const { control } = useFormContext();
   const { append, remove, fields } = useFieldArray({
@@ -107,6 +108,11 @@ const OptionSelectors = ({
           );
         })}
       </Box>
+      {error && (
+        <Typography color="error" typography="s1">
+          {error}
+        </Typography>
+      )}
     </Box>
   );
 };
@@ -118,6 +124,7 @@ OptionSelectors.propTypes = {
   options: PropTypes.array.isRequired,
   multiple: PropTypes.bool,
   showClearButton: PropTypes.bool,
+  error: PropTypes.string,
 };
 
 export default OptionSelectors;

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaBehaviouralSetting.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaBehaviouralSetting.jsx
@@ -23,7 +23,10 @@ const PersonaBehavioralSetting = ({
   showClearButton = false,
   type = AGENT_TYPES.VOICE,
 }) => {
-  const { control } = useFormContext();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext();
   return (
     <Box>
       <CustomPersonaAccordion disableGutters defaultExpanded>
@@ -43,6 +46,7 @@ const PersonaBehavioralSetting = ({
               options={PersonalityOptions}
               multiple={multiple}
               showClearButton={showClearButton}
+              error={errors.personality?.message}
             />
             <FormSearchSelectFieldControl
               control={control}

--- a/frontend/src/sections/persona/PersonaCreateEdit/common.js
+++ b/frontend/src/sections/persona/PersonaCreateEdit/common.js
@@ -431,6 +431,29 @@ export const PersonCreateValidationSchema = z
       ...PersonCreateBaseValidationSchema.shape,
     }),
   ])
+  .superRefine((data, ctx) => {
+    if (!data.personality?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["personality"],
+        message: "Personality is required",
+      });
+    }
+    if (!data.communicationStyle?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["communicationStyle"],
+        message: "Communication style is required",
+      });
+    }
+    if (data.simulationType === "voice" && !data.accent?.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["accent"],
+        message: "Accent is required for voice personas",
+      });
+    }
+  })
   .transform((data) => {
     return {
       ...data,

--- a/futureagi/simulate/serializers/persona.py
+++ b/futureagi/simulate/serializers/persona.py
@@ -96,7 +96,22 @@ class PersonaSerializer(serializers.ModelSerializer):
         """Custom validation"""
         # Note: organization and workspace are not in the serializer fields
         # They are handled automatically in the view layer from user context
-        # No validation needed here since they're set internally
+        errors = {}
+        for field, message in (
+            ("personality", "At least one personality trait is required."),
+            ("communication_style", "At least one communication style is required."),
+        ):
+            if field in attrs and not attrs[field]:
+                errors[field] = message
+        if "accent" in attrs:
+            simulation_type = attrs.get(
+                "simulation_type",
+                getattr(self.instance, "simulation_type", "voice"),
+            )
+            if simulation_type == "voice" and not attrs["accent"]:
+                errors["accent"] = "An accent is required for voice personas."
+        if errors:
+            raise serializers.ValidationError(errors)
         return attrs
 
     def get_simulation_type(self, obj):
@@ -551,6 +566,19 @@ class PersonaCreateSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         """Cross-field validation"""
+        errors = {}
+        for field, message in (
+            ("personality", "At least one personality trait is required."),
+            ("communication_style", "At least one communication style is required."),
+        ):
+            if not attrs.get(field):
+                errors[field] = message
+        simulation_type = attrs.get("simulation_type") or "voice"
+        if simulation_type == "voice" and not attrs.get("accent"):
+            errors["accent"] = "An accent is required for voice personas."
+        if errors:
+            raise serializers.ValidationError(errors)
+
         # If multilingual is True, languages must be non-empty
         multilingual = attrs.get("multilingual", False)
         languages = attrs.get("languages", [])


### PR DESCRIPTION
## Summary
- require personality and communication style selections in the persona form
- require accents for voice personas while leaving text personas unaffected
- surface field-specific frontend errors and enforce the same rules in create/update serializers
- preserve unrelated updates to existing personas with legacy empty settings

## Verification
- git diff --check
- python -m compileall -q futureagi/simulate/serializers/persona.py
- frontend/backend test dependencies unavailable in this worktree

Closes #1523