### PR TITLE
fix(evals): detect variables from instructions

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfig.jsx
@@ -122,7 +122,14 @@ const EvalPickerConfig = ({ evalData, onBack, onSave, isSaving }) => {
   // Extract required variables from eval template
   const variables = useMemo(() => {
     const keys = normalizedEvalData?.requiredKeys || [];
-    return [...new Set(keys)];
+    const instructions =
+      normalizedEvalData?.instructions ||
+      normalizedEvalData?.config?.rule_prompt ||
+      "";
+    const liveKeys = (instructions.match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [])
+      .map((match) => match.replace(/\{\{|\}\}/g, "").trim())
+      .filter(Boolean);
+    return [...new Set([...keys, ...liveKeys])];
   }, [normalizedEvalData]);
 
   // Column options for mapping dropdowns


### PR DESCRIPTION
## Summary
- merge stored required keys with live {{variable}} placeholders from instructions
- keep stored-key fallback behavior when instructions are absent
- leave the production EvalPickerConfigFull extraction path unchanged

## Verification
- git diff --check
- frontend tests unavailable because dependencies are not installed in this worktree

Closes #1525