### PR TITLE
fix(simulation): aggregate test status from calls

### DIFF
--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2439,7 +2439,30 @@ class TestExecutionDetailView(APIView):
                 or str(col.get("id")) in eval_configs_map
             ]
             response_data["error_messages"] = error_messages
-            response_data["status"] = test_execution.status
+            call_status_order = [
+                CallExecution.CallStatus.PENDING,
+                CallExecution.CallStatus.REGISTERED,
+                CallExecution.CallStatus.ONGOING,
+                CallExecution.CallStatus.ANALYZING,
+                CallExecution.CallStatus.COMPLETED,
+                CallExecution.CallStatus.FAILED,
+                CallExecution.CallStatus.CANCELLED,
+            ]
+            call_statuses = list(
+                test_execution.calls.values_list("status", flat=True)
+            )
+            if call_statuses:
+                status_rank = {
+                    status: rank for rank, status in enumerate(call_status_order)
+                }
+                response_data["status"] = min(
+                    call_statuses,
+                    key=lambda call_status: status_rank.get(
+                        call_status, len(call_status_order)
+                    ),
+                )
+            else:
+                response_data["status"] = test_execution.status
             response_data["provider"] = (
                 test_execution.agent_definition.provider
                 if test_execution.agent_definition


### PR DESCRIPTION
## Summary
- compute test-execution detail status from related call statuses
- use the specified pending-to-cancelled lifecycle order for mixed calls
- fall back to the stored test-execution status when no calls exist
- leave the rest of the response unchanged

## Verification
- git diff --check
- python -m compileall -q futureagi/simulate/views/run_test.py
- focused Django tests unavailable in this environment

Closes #1524