### PR TITLE
feat(annotations): add bulk assignee selection controls

### DIFF
--- a/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-detail-view.jsx
@@ -823,6 +823,41 @@ export default function QueueDetailView() {
       >
         <DialogTitle>Assign Selected Items</DialogTitle>
         <DialogContent>
+          {queueAnnotators.length > 1 && (
+            <Stack direction="row" spacing={1} sx={{ mt: 1, mb: 0.5 }}>
+              <Button
+                size="small"
+                disabled={isAssigningItems}
+                onClick={() => {
+                  const allSelected = queueAnnotators.every((annotator) =>
+                    bulkAssignUserIds.has(String(annotator.user_id)),
+                  );
+                  setBulkAssignUserIds(
+                    allSelected
+                      ? new Set()
+                      : new Set(
+                          queueAnnotators.map((annotator) =>
+                            String(annotator.user_id),
+                          ),
+                        ),
+                  );
+                }}
+              >
+                {queueAnnotators.every((annotator) =>
+                  bulkAssignUserIds.has(String(annotator.user_id)),
+                )
+                  ? "Deselect All"
+                  : "Select All"}
+              </Button>
+              <Button
+                size="small"
+                disabled={isAssigningItems}
+                onClick={() => setBulkAssignUserIds(new Set())}
+              >
+                Select None
+              </Button>
+            </Stack>
+          )}
           <Stack spacing={0.5} sx={{ mt: 1 }}>
             {queueAnnotators.map((annotator) => {
               const uid = String(annotator.user_id);


### PR DESCRIPTION
## Summary
- add Select All/Deselect All and Select None controls to bulk assignment
- show controls only when at least two annotators are available
- disable both controls while assignment is in progress
- preserve individual checkbox behavior

## Verification
- git diff --check
- focused Vitest unavailable because frontend dependencies are not installed in this worktree

Closes #1502