### PR TITLE
feat(dataset): show supported image upload formats

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImageZoom.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImageZoom.jsx
@@ -285,6 +285,9 @@ const EditImageZoom = ({
                       <Typography variant="body2" color="text.secondary">
                         Click to upload an image
                       </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        Supported formats: JPEG, PNG, WebP, BMP, TIFF
+                      </Typography>
                     </Box>
                   </Box>
                   <Box

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
@@ -385,6 +385,9 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                   <Typography variant="body2" color="text.secondary">
                     Click or drag images here to upload
                   </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Supported formats: JPEG, PNG, WebP, BMP, TIFF
+                  </Typography>
                 </Box>
               </Box>
             </Box>


### PR DESCRIPTION
## Summary
- show supported image formats in the multi-image upload empty state
- show the same caption in the single-image upload empty state
- leave MIME accept lists, validation, and rejection handling unchanged

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1498