### PR TITLE
fix(merge-guard): read push tip via github.event.after, not .commits[].sha

### DIFF
--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -21,20 +21,20 @@ jobs:
         id: detect
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Push-event tip SHA. (push payload commits use .id, not .sha; only the
+          # tip can be a squash of a dev->main PR, so we check just that commit.)
+          HEAD_SHA: ${{ github.event.after }}
         run: |
           set -eu
-          violation=""
-          for sha in $(jq -r '.commits[].sha' "$GITHUB_EVENT_PATH"); do
-            parents=$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha" --jq '.parents | length')
-            [ "$parents" -ge 2 ] && continue
-            pr_json=$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/pulls" --jq \
-              '[.[] | select(.base.ref == "main" and .head.ref == "dev" and .merged_at != null and .merge_commit_sha == "'"$sha"'")][0] // empty')
-            if [ -n "$pr_json" ]; then
-              violation="$(printf '%s' "$pr_json" | jq -r '.number')"
-              break
-            fi
-          done
-          echo "pr=${violation}" >> "$GITHUB_OUTPUT"
+          case "$HEAD_SHA" in 0000000000000000000000000000000000000000) echo "pr=" >> "$GITHUB_OUTPUT"; exit 0 ;; esac
+          parents=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA" --jq '.parents | length')
+          if [ "$parents" -ge 2 ]; then
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+            --jq '[.[] | select(.base.ref == "main" and .head.ref == "dev" and .merged_at != null and .merge_commit_sha == env.HEAD_SHA)][0].number // empty')
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
       - name: Send Slack alert
         if: steps.detect.outputs.pr != ''
         continue-on-error: true


### PR DESCRIPTION
**Hotfix** — merge-guard failed on the #1741 merge ([run](https://github.com/future-agi/future-agi/actions/runs/30353747692)) with `gh: No commit found for SHA: null`.

**Cause:** push-event commit objects expose the SHA as `.id`, not `.sha`, so `jq '.commits[].sha'` returned `null` for every commit and `gh api .../commits/null` 422'd. Latent since authoring — first executed when merge-guard reached `main` via #1741.

**Fix:** check only the push tip (`github.event.after`, passed via `env:` — injection-safe; matched in jq through `env.HEAD_SHA`), which is the only commit that can be a squashed dev→main PR. A proper merge commit (≥2 parents) short-circuits — so this exact #1741-style merge now passes. actionlint clean.

Twin to dev follows. Non-blocking (not yet a required check), but it should stop failing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)