### PR TITLE
fix(share): clarify direct-link close action

### DIFF
--- a/frontend/src/components/Share/Share.jsx
+++ b/frontend/src/components/Share/Share.jsx
@@ -78,6 +78,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
         >
           {body}
         </Typography>
+        <Typography variant="caption" color="text.secondary" display="block">
+          Note: This creates a direct link without access control.
+        </Typography>
 
         <Box display="flex" alignItems="center" gap={theme.spacing(1)} mt={2}>
           <Box flex={8}>
@@ -152,9 +155,9 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
             Cancel
           </Button>
           <Button
-            aria-label="finish-share-project"
-            variant="contained"
-            color="primary"
+            aria-label="close-share-project"
+            variant="outlined"
+            color="inherit"
             onClick={onClose}
             sx={{
               flex: 1,
@@ -162,7 +165,7 @@ const Share = ({ open, title = "Share as link", body, onClose }) => {
               fontSize: "13px",
             }}
           >
-            Done
+            Close
           </Button>
         </Box>
       </DialogActions>


### PR DESCRIPTION
## Summary
- rename the terminal Share action from Done to Close
- use neutral outlined styling and the close-share-project aria label
- explain that this legacy direct link has no access control
- preserve copy, cancel, and component props

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1501