### PR TITLE
fix(simulation): hide interruption metrics for chat

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -157,8 +157,12 @@ const VoiceRightPanel = ({
       avgAgentLatencyMs: data?.avg_agent_latency_ms ?? data?.avg_agent_latency,
       userWpm: data?.user_wpm,
       botWpm: data?.bot_wpm,
-      userInterruptionCount: data?.user_interruption_count,
-      aiInterruptionCount: data?.ai_interruption_count,
+      ...(data?.simulation_call_type === "text"
+        ? {}
+        : {
+            userInterruptionCount: data?.user_interruption_count,
+            aiInterruptionCount: data?.ai_interruption_count,
+          }),
     };
 
     if (isSimulate) {


### PR DESCRIPTION
## Summary
- omit user/AI interruption metrics for text simulations
- preserve interruption metrics for voice simulations
- leave all other analytics KPIs and fallback behavior unchanged

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1503