### PR TITLE
feat(evals): add model parameter configuration to LLM-as-a-Judge evaluation setup

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -172,6 +172,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
   const [errorLocalizerEnabled, setErrorLocalizerEnabled] = useState(false);
+  // Judge model generation parameters (temperature, max_tokens, top_p, …)
+  // in backend snake_case, or null when the user has set none. Null must
+  // never reach the save payload — partial/undefined values would land in
+  // run_config and override provider defaults with garbage.
+  const [modelParams, setModelParams] = useState(null);
   // Name for the UserEvalMetric — defaults to template name, user can customise
   const [evalName, setEvalName] = useState("");
   const [dataReady, setDataReady] = useState(false);
@@ -542,6 +547,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           evalData?.multi_choice ??
           evalData?.multiChoice,
         params: rawRunConfig.params ?? evalData?.params,
+        model_params:
+          rawRunConfig.model_params ??
+          rawRunConfig.modelParams ??
+          evalData?.model_params ??
+          evalData?.modelParams,
         // Multi-turn LLM evals store the full message chain on the template
         // config (fullEval.config.messages). Fall through every source so a
         // dataset / simulate / task / experiment scoped copy of a template
@@ -663,6 +673,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           fullEval.error_localizer_enabled ??
           false,
       );
+      // Saved judge model params (edit flow). Object check guards against
+      // legacy/corrupt values; Object.keys guards against `{}` masquerading
+      // as "params were set".
+      if (
+        config.model_params &&
+        typeof config.model_params === "object" &&
+        Object.keys(config.model_params).length > 0
+      ) {
+        setModelParams(config.model_params);
+      }
 
       // Edit mode: keep the saved name. Create mode: generate a unique name
       // from the template base name + source slug + date/time, e.g.
@@ -1066,6 +1086,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       // Runtime overrides — these become config.run_config on the backend.
       agent_mode: agentMode,
       check_internet: useInternet,
+      // Judge model generation params. Emitted only when the user applied
+      // values — a null/empty state must not put partial keys in run_config.
+      ...(modelParams && Object.keys(modelParams).length
+        ? { model_params: modelParams }
+        : {}),
       summary:
         summaryType === "custom"
           ? { type: "custom", custom: "" }
@@ -1101,6 +1126,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     connectorIds,
     knowledgeBaseIds,
     contextOptions,
+    modelParams,
     compositeChildWeights,
     errorLocalizerEnabled,
     hasValidPromptMessages,
@@ -1562,6 +1588,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     model={model}
                     onModelChange={(v) => {
                       setModel(v);
+                      setIsDirty(true);
+                    }}
+                    modelParams={modelParams}
+                    onModelParamsChange={(v) => {
+                      setModelParams(v);
                       setIsDirty(true);
                     }}
                     datasetColumns={datasetColumns}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -547,9 +547,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           evalData?.multi_choice ??
           evalData?.multiChoice,
         params: rawRunConfig.params ?? evalData?.params,
+        // rawRunConfig can be the backend's filtered run_config view
+        // (build_run_config_view), which strips keys it doesn't know —
+        // model_params included. The drawer's edit flow spreads the RAW
+        // config.run_config blob flat into evalData.config, so fall through
+        // to it the same way `messages` does below.
         model_params:
           rawRunConfig.model_params ??
           rawRunConfig.modelParams ??
+          evalData?.config?.model_params ??
+          evalData?.config?.modelParams ??
           evalData?.model_params ??
           evalData?.modelParams,
         // Multi-turn LLM evals store the full message chain on the template

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "src/utils/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "src/utils/test-utils";
 
 import EvalPickerProvider from "./context/EvalPickerProvider";
 import EvalPickerConfigFull from "./EvalPickerConfigFull";
 
 const { capturedProps } = vi.hoisted(() => ({
-  capturedProps: { tracing: null },
+  capturedProps: { tracing: null, llm: null },
 }));
 
 vi.mock("src/sections/evals/components/TracingTestMode", () => {
@@ -52,7 +52,10 @@ vi.mock("src/sections/evals/components/InstructionEditor", () => ({
 }));
 
 vi.mock("src/sections/evals/components/LLMPromptEditor", () => ({
-  default: () => <div />,
+  default: (props) => {
+    capturedProps.llm = props;
+    return <div data-testid="llm-prompt-editor" />;
+  },
 }));
 
 vi.mock("src/sections/evals/components/CodeEvalEditor", () => ({
@@ -142,7 +145,7 @@ const TIME_WINDOW = {
   endDate: "2026-05-18T18:29:59.000Z",
 };
 
-const renderConfigFull = ({ sourceTimeWindow } = {}) =>
+const renderConfigFull = ({ sourceTimeWindow, evalData, onSave } = {}) =>
   render(
     <EvalPickerProvider
       source="task"
@@ -155,9 +158,11 @@ const renderConfigFull = ({ sourceTimeWindow } = {}) =>
       sourceTimeWindow={sourceTimeWindow}
     >
       <EvalPickerConfigFull
-        evalData={{ id: "tpl-1", templateId: "tpl-1", name: "toxicity" }}
+        evalData={
+          evalData ?? { id: "tpl-1", templateId: "tpl-1", name: "toxicity" }
+        }
         onBack={() => {}}
-        onSave={() => {}}
+        onSave={onSave ?? (() => {})}
         isSaving={false}
       />
     </EvalPickerProvider>,
@@ -196,5 +201,96 @@ describe("EvalPickerConfigFull — task preview time window", () => {
         (f) => f.column_id === "created_at",
       ),
     ).toBe(false);
+  });
+});
+
+describe("EvalPickerConfigFull — judge model params (#1764)", () => {
+  beforeEach(() => {
+    capturedProps.tracing = null;
+    capturedProps.llm = null;
+    // Give the llm eval real prompt content + a variable so the
+    // Add Evaluation button's content gates pass.
+    stableEvalDetail.data.config = {
+      messages: [{ role: "system", content: "Judge {{input}} for toxicity" }],
+    };
+  });
+
+  afterEach(() => {
+    stableEvalDetail.data.config = {};
+  });
+
+  const clickAdd = () => {
+    // Source readiness is reported by the (mocked) test-mode panel.
+    act(() => {
+      capturedProps.tracing.onReadyChange(true, { input: "col-1" });
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add evaluation/i }));
+  };
+
+  it("omits model_params from the save payload when never touched", () => {
+    const onSave = vi.fn();
+    renderConfigFull({ onSave });
+
+    clickAdd();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0]).not.toHaveProperty("model_params");
+  });
+
+  it("carries applied model params into the save payload, preserving zero", () => {
+    const onSave = vi.fn();
+    renderConfigFull({ onSave });
+
+    expect(capturedProps.llm).not.toBeNull();
+    act(() => {
+      capturedProps.llm.onModelParamsChange({
+        temperature: 0,
+        max_tokens: 256,
+      });
+    });
+
+    clickAdd();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].model_params).toEqual({
+      temperature: 0,
+      max_tokens: 256,
+    });
+  });
+
+  it("clears model_params from the payload when the override is removed", () => {
+    const onSave = vi.fn();
+    renderConfigFull({ onSave });
+
+    act(() => {
+      capturedProps.llm.onModelParamsChange({ temperature: 0.2 });
+    });
+    act(() => {
+      capturedProps.llm.onModelParamsChange(null);
+    });
+
+    clickAdd();
+
+    expect(onSave.mock.calls[0][0]).not.toHaveProperty("model_params");
+  });
+
+  it("hydrates saved run_config.model_params in edit mode and re-emits on save", () => {
+    const onSave = vi.fn();
+    renderConfigFull({
+      onSave,
+      evalData: {
+        id: "tpl-1",
+        templateId: "tpl-1",
+        name: "toxicity",
+        run_config: { model_params: { temperature: 0 } },
+      },
+    });
+
+    // The editor receives the saved values (falsy zero included) …
+    expect(capturedProps.llm.modelParams).toEqual({ temperature: 0 });
+
+    // … and an untouched save round-trips them.
+    clickAdd();
+    expect(onSave.mock.calls[0][0].model_params).toEqual({ temperature: 0 });
   });
 });

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx
@@ -293,4 +293,38 @@ describe("EvalPickerConfigFull — judge model params (#1764)", () => {
     clickAdd();
     expect(onSave.mock.calls[0][0].model_params).toEqual({ temperature: 0 });
   });
+
+  it("hydrates model_params from the drawer edit shape (filtered run_config + flattened config)", () => {
+    // EvaluationDrawer.openEditForSavedEval hands the picker:
+    //  - evalData.run_config: the backend's build_run_config_view — a
+    //    FILTERED defaults view that strips unknown keys like model_params;
+    //  - evalData.config: required_keys + the RAW config.run_config blob
+    //    spread flat (this is where model_params actually survives).
+    const onSave = vi.fn();
+    renderConfigFull({
+      onSave,
+      evalData: {
+        id: "tpl-1",
+        templateId: "tpl-1",
+        name: "toxicity",
+        run_config: { agent_mode: "agent", pass_threshold: 0.5 },
+        config: {
+          required_keys: [],
+          agent_mode: "agent",
+          model_params: { temperature: 0, top_p: 0.9 },
+        },
+      },
+    });
+
+    expect(capturedProps.llm.modelParams).toEqual({
+      temperature: 0,
+      top_p: 0.9,
+    });
+
+    clickAdd();
+    expect(onSave.mock.calls[0][0].model_params).toEqual({
+      temperature: 0,
+      top_p: 0.9,
+    });
+  });
 });

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -19,6 +19,7 @@ import React, {
 import SvgColor from "../../../components/svg-color";
 import { LoadingButton } from "@mui/lab";
 import EvaluationsSelectionGrid from "./EvaluationsSelectionGrid";
+import { buildRunConfig } from "./buildRunConfig";
 import { useEvalsList, getUserEvalListKey } from "./getEvalsList";
 import SavedEvalsList from "./SavedEvalsList";
 import SavedEvalsSkeleton from "./SavedEvalsSkeleton";
@@ -597,42 +598,10 @@ const EvaluationDrawerChild = ({
           // should be forwarded so eval_runner can apply it at run time.
           const isComposite = evalConfig.templateType === "composite";
 
-          const runConfig = {};
-          if (!isComposite) {
-            // Single-eval runtime overrides. Composite children each
-            // carry their own model/mode/tools — none of this applies
-            // at the composite binding level.
-            if (evalConfig.model) runConfig.model = evalConfig.model;
-            if (evalConfig.agent_mode)
-              runConfig.agent_mode = evalConfig.agent_mode;
-            if (evalConfig.check_internet !== undefined)
-              runConfig.check_internet = !!evalConfig.check_internet;
-            if (evalConfig.summary) runConfig.summary = evalConfig.summary;
-            if (evalConfig.knowledge_base_id)
-              runConfig.knowledge_base_id = evalConfig.knowledge_base_id;
-            if (evalConfig.knowledge_bases)
-              runConfig.knowledge_bases = evalConfig.knowledge_bases;
-            if (evalConfig.tools) runConfig.tools = evalConfig.tools;
-            if (evalConfig.pass_threshold !== undefined)
-              runConfig.pass_threshold = evalConfig.pass_threshold;
-            if (
-              evalConfig.choice_scores &&
-              Object.keys(evalConfig.choice_scores).length
-            )
-              runConfig.choice_scores = evalConfig.choice_scores;
-            if (evalConfig.multi_choice !== undefined)
-              runConfig.multi_choice = !!evalConfig.multi_choice;
-          }
-          // Data injection applies to both single and composite — the
-          // backend resolves it at row-evaluation time.
-          if (evalConfig.data_injection)
-            runConfig.data_injection = evalConfig.data_injection;
-          // Error localizer toggle was previously dropped between
-          // EvalPickerConfigFull and the backend. It now flows through
-          // for both single and composite bindings.
-          if (evalConfig.error_localizer_enabled !== undefined)
-            runConfig.error_localizer_enabled =
-              !!evalConfig.error_localizer_enabled;
+          // Key whitelist extracted to buildRunConfig.js so it stays
+          // unit-tested — anything not forwarded there is silently dropped
+          // before the API call.
+          const runConfig = buildRunConfig(evalConfig, { isComposite });
 
           // Code-eval static params (function_params_schema values).
           // `EvalPickerConfigFull.handleSave` hands them back on

--- a/frontend/src/sections/common/EvaluationDrawer/buildRunConfig.js
+++ b/frontend/src/sections/common/EvaluationDrawer/buildRunConfig.js
@@ -1,0 +1,46 @@
+/**
+ * Build the `run_config` block persisted on UserEvalMetric.config from the
+ * EvalPicker's save payload. Extracted from EvaluationDrawer's handleAdd so
+ * the key whitelist is unit-testable — keys not forwarded here are silently
+ * dropped before the API call, which is exactly the class of bug this
+ * whitelist has a habit of producing.
+ *
+ * Composite bindings keep only the keys that apply at the binding level
+ * (children each carry their own model/mode/tools).
+ */
+export function buildRunConfig(evalConfig, { isComposite }) {
+  const runConfig = {};
+  if (!isComposite) {
+    if (evalConfig.model) runConfig.model = evalConfig.model;
+    if (evalConfig.agent_mode) runConfig.agent_mode = evalConfig.agent_mode;
+    if (evalConfig.check_internet !== undefined)
+      runConfig.check_internet = !!evalConfig.check_internet;
+    if (evalConfig.summary) runConfig.summary = evalConfig.summary;
+    if (evalConfig.knowledge_base_id)
+      runConfig.knowledge_base_id = evalConfig.knowledge_base_id;
+    if (evalConfig.knowledge_bases)
+      runConfig.knowledge_bases = evalConfig.knowledge_bases;
+    if (evalConfig.tools) runConfig.tools = evalConfig.tools;
+    if (evalConfig.pass_threshold !== undefined)
+      runConfig.pass_threshold = evalConfig.pass_threshold;
+    if (evalConfig.choice_scores && Object.keys(evalConfig.choice_scores).length)
+      runConfig.choice_scores = evalConfig.choice_scores;
+    if (evalConfig.multi_choice !== undefined)
+      runConfig.multi_choice = !!evalConfig.multi_choice;
+    // Judge model generation params (temperature / max_tokens / …). Only
+    // forwarded when non-empty so an untouched picker never writes partial
+    // values into run_config.
+    if (evalConfig.model_params && Object.keys(evalConfig.model_params).length)
+      runConfig.model_params = evalConfig.model_params;
+  }
+  // Data injection applies to both single and composite — the backend
+  // resolves it at row-evaluation time.
+  if (evalConfig.data_injection)
+    runConfig.data_injection = evalConfig.data_injection;
+  // Error localizer toggle was previously dropped between
+  // EvalPickerConfigFull and the backend. It now flows through for both
+  // single and composite bindings.
+  if (evalConfig.error_localizer_enabled !== undefined)
+    runConfig.error_localizer_enabled = !!evalConfig.error_localizer_enabled;
+  return runConfig;
+}

--- a/frontend/src/sections/common/EvaluationDrawer/buildRunConfig.test.js
+++ b/frontend/src/sections/common/EvaluationDrawer/buildRunConfig.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { buildRunConfig } from "./buildRunConfig";
+
+describe("buildRunConfig", () => {
+  it("forwards single-eval runtime overrides", () => {
+    const runConfig = buildRunConfig(
+      {
+        model: "turing_large",
+        agent_mode: "agent",
+        check_internet: true,
+        summary: { type: "concise" },
+        knowledge_bases: ["kb-1"],
+        tools: { web: true },
+        pass_threshold: 0.7,
+        choice_scores: { yes: 1 },
+        multi_choice: false,
+        data_injection: { variables_only: true },
+        error_localizer_enabled: true,
+      },
+      { isComposite: false },
+    );
+
+    expect(runConfig).toEqual({
+      model: "turing_large",
+      agent_mode: "agent",
+      check_internet: true,
+      summary: { type: "concise" },
+      knowledge_bases: ["kb-1"],
+      tools: { web: true },
+      pass_threshold: 0.7,
+      choice_scores: { yes: 1 },
+      multi_choice: false,
+      data_injection: { variables_only: true },
+      error_localizer_enabled: true,
+    });
+  });
+
+  it("keeps composite bindings free of single-eval overrides", () => {
+    const runConfig = buildRunConfig(
+      {
+        model: "turing_large",
+        agent_mode: "agent",
+        model_params: { temperature: 0 },
+        data_injection: { variables_only: true },
+      },
+      { isComposite: true },
+    );
+
+    expect(runConfig).toEqual({
+      data_injection: { variables_only: true },
+    });
+  });
+
+  it("forwards model_params when present, preserving zero values", () => {
+    const runConfig = buildRunConfig(
+      { model_params: { temperature: 0, max_tokens: 256 } },
+      { isComposite: false },
+    );
+
+    expect(runConfig.model_params).toEqual({ temperature: 0, max_tokens: 256 });
+  });
+
+  it("omits model_params when absent or empty", () => {
+    expect(buildRunConfig({}, { isComposite: false })).not.toHaveProperty(
+      "model_params",
+    );
+    expect(
+      buildRunConfig({ model_params: {} }, { isComposite: false }),
+    ).not.toHaveProperty("model_params");
+    expect(
+      buildRunConfig({ model_params: null }, { isComposite: false }),
+    ).not.toHaveProperty("model_params");
+  });
+
+  it("keeps falsy-but-meaningful values (pass_threshold 0, multi_choice false)", () => {
+    const runConfig = buildRunConfig(
+      { pass_threshold: 0, multi_choice: false, check_internet: false },
+      { isComposite: false },
+    );
+
+    expect(runConfig.pass_threshold).toBe(0);
+    expect(runConfig.multi_choice).toBe(false);
+    expect(runConfig.check_internet).toBe(false);
+  });
+});

--- a/frontend/src/sections/evals/components/EvalModelParams.jsx
+++ b/frontend/src/sections/evals/components/EvalModelParams.jsx
@@ -1,0 +1,108 @@
+import PropTypes from "prop-types";
+import React, { useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import CustomModelOptions from "src/components/custom-model-options/CustomModelOptions";
+import axios, { endpoints } from "src/utils/axios";
+import {
+  getModelParamValues,
+  transformModelParams,
+} from "src/sections/workbench/createPrompt/Playground/common";
+import {
+  normalizeConfigurationForLoad,
+  normalizeConfigurationForSave,
+} from "src/sections/workbench/createPrompt/common";
+
+/**
+ * Judge-model parameter popover for LLM-as-a-Judge eval config.
+ *
+ * Same params UI as the Prompt Workbench (CustomModelOptions), minus the
+ * workbench-only concerns: no prompt versions, no Mixpanel prompt events,
+ * and no responseFormat control — the judge pipeline owns the output
+ * contract, so exposing a format toggle here could break score parsing.
+ *
+ * Values only leave this component on Apply (`onChange`), never on
+ * close/cancel. `value` and the `onChange` payload use backend snake_case
+ * keys (temperature, max_tokens, top_p, …) — the same names
+ * run_prompt.py reads from run_config — while the form itself holds the
+ * camelCase slider ids `transformModelParams` produces.
+ */
+export default function EvalModelParams({
+  model,
+  value,
+  onChange,
+  disabled = false,
+}) {
+  const {
+    control,
+    getValues,
+    setValue,
+    reset,
+    formState: { isDirty },
+  } = useForm();
+
+  const { data, isError } = useQuery({
+    // The endpoint requires a provider but ignores it for model_type "llm"
+    // (get_model_parameters dispatches straight to get_llm_parameters), so
+    // a placeholder satisfies validation for BYOK and FAGI models alike.
+    queryKey: ["eval-model-params-defs", model],
+    queryFn: () =>
+      axios.get(endpoints.develop.modelParams, {
+        params: { model, provider: "default", model_type: "llm" },
+      }),
+    enabled: Boolean(model),
+    staleTime: 60000,
+  });
+
+  const transformed = useMemo(() => {
+    if (!data?.data?.result) return null;
+    const { responseFormat, ...params } = transformModelParams(
+      data.data.result,
+    );
+    return params;
+  }, [data]);
+
+  const seeded = useMemo(
+    () =>
+      getModelParamValues(
+        transformed || {},
+        normalizeConfigurationForLoad(value || {}) || {},
+      ),
+    [transformed, value],
+  );
+
+  useEffect(() => {
+    reset({ config: seeded });
+  }, [seeded, reset]);
+
+  const handleApply = () => {
+    const config = normalizeConfigurationForSave(getValues("config")) || {};
+    const applied = Object.fromEntries(
+      Object.entries(config).filter(([, v]) => v !== null && v !== undefined),
+    );
+    onChange(Object.keys(applied).length ? applied : null);
+  };
+
+  return (
+    <CustomModelOptions
+      isModalContainer
+      control={control}
+      handleApply={handleApply}
+      reset={reset}
+      setValue={setValue}
+      responseSchema={[]}
+      modelConfig={seeded}
+      isDirty={isDirty}
+      disabledHover
+      disabledClick={disabled || isError || !transformed}
+      modelParams={transformed}
+    />
+  );
+}
+
+EvalModelParams.propTypes = {
+  model: PropTypes.string,
+  value: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};

--- a/frontend/src/sections/evals/components/EvalModelParams.test.jsx
+++ b/frontend/src/sections/evals/components/EvalModelParams.test.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "src/utils/test-utils";
+
+import EvalModelParams from "./EvalModelParams";
+
+const { capturedProps } = vi.hoisted(() => ({ capturedProps: { cmo: null } }));
+
+vi.mock("src/components/custom-model-options/CustomModelOptions", () => ({
+  default: (props) => {
+    capturedProps.cmo = props;
+    return <div data-testid="custom-model-options" />;
+  },
+}));
+
+const { axiosGet } = vi.hoisted(() => ({ axiosGet: vi.fn() }));
+
+vi.mock("src/utils/axios", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: { ...actual.default, get: axiosGet },
+  };
+});
+
+// Same shape get_llm_parameters returns (sliders keyed by snake_case label);
+// transformModelParams turns labels into camelCase slider ids.
+const LLM_PARAM_DEFS = {
+  sliders: [
+    { label: "temperature", min: 0, max: 2, step: 0.1, default: null },
+    { label: "max_tokens", min: 1, max: 65536, step: 1, default: null },
+    { label: "top_p", min: 0, max: 1, step: 0.1, default: null },
+  ],
+  responseFormat: [{ value: "json" }, { value: "text" }],
+};
+
+const renderParams = (props = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EvalModelParams
+        model="turing_large"
+        value={null}
+        onChange={() => {}}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+describe("EvalModelParams", () => {
+  beforeEach(() => {
+    capturedProps.cmo = null;
+    axiosGet.mockReset();
+    axiosGet.mockResolvedValue({ data: { result: LLM_PARAM_DEFS } });
+  });
+
+  it("fetches llm definitions for the model and passes transformed sliders", async () => {
+    renderParams();
+
+    await waitFor(() => {
+      expect(capturedProps.cmo?.modelParams?.sliders?.length).toBe(3);
+    });
+
+    expect(axiosGet).toHaveBeenCalledWith(
+      expect.stringContaining("model_parameters"),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          model: "turing_large",
+          model_type: "llm",
+        }),
+      }),
+    );
+    const ids = capturedProps.cmo.modelParams.sliders.map((s) => s.id);
+    expect(ids).toEqual(["temperature", "maxTokens", "topP"]);
+    // Judge output parsing owns the response contract — never expose it here.
+    expect(capturedProps.cmo.modelParams.responseFormat).toBeUndefined();
+  });
+
+  it("applies edited values to onChange as snake_case without nullish keys", async () => {
+    const onChange = vi.fn();
+    renderParams({ onChange });
+
+    await waitFor(() => {
+      expect(capturedProps.cmo?.modelParams?.sliders?.length).toBe(3);
+    });
+
+    capturedProps.cmo.setValue("config", {
+      temperature: 0,
+      maxTokens: 256,
+      topP: null,
+    });
+    capturedProps.cmo.handleApply();
+
+    // temperature 0 preserved; topP null dropped; keys snake_cased.
+    expect(onChange).toHaveBeenCalledWith({ temperature: 0, max_tokens: 256 });
+  });
+
+  it("emits null when applying with no values set", async () => {
+    const onChange = vi.fn();
+    renderParams({ onChange });
+
+    await waitFor(() => {
+      expect(capturedProps.cmo?.modelParams?.sliders?.length).toBe(3);
+    });
+
+    capturedProps.cmo.setValue("config", {
+      temperature: null,
+      maxTokens: undefined,
+    });
+    capturedProps.cmo.handleApply();
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("seeds saved snake_case values back into the form, including zero", async () => {
+    renderParams({ value: { temperature: 0, max_tokens: 512 } });
+
+    await waitFor(() => {
+      expect(capturedProps.cmo?.modelConfig?.temperature).toBe(0);
+    });
+    expect(capturedProps.cmo.modelConfig.maxTokens).toBe(512);
+  });
+
+  it("disables the control when the definitions fetch fails", async () => {
+    axiosGet.mockRejectedValue(new Error("boom"));
+    const onChange = vi.fn();
+    renderParams({ onChange });
+
+    await waitFor(() => {
+      expect(capturedProps.cmo?.disabledClick).toBe(true);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/evals/components/LLMPromptEditor.jsx
+++ b/frontend/src/sections/evals/components/LLMPromptEditor.jsx
@@ -15,6 +15,7 @@ import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
 import { ShowComponent } from "src/components/show";
 import axios, { endpoints } from "src/utils/axios";
+import EvalModelParams from "./EvalModelParams";
 import MessageEditor from "./MessageEditor";
 
 const TEMPLATE_FORMATS = [
@@ -51,6 +52,8 @@ const LLMPromptEditor = ({
   modelSelectorDisabled,
   model,
   onModelChange,
+  modelParams,
+  onModelParamsChange,
 }) => {
   const [aiOpen, setAiOpen] = useState(false);
   const [aiPrompt, setAiPrompt] = useState("");
@@ -426,6 +429,16 @@ const LLMPromptEditor = ({
         aiBar={aiOpen ? aiBar : null}
         onFalconClick={() => setAiOpen(true)}
         aiOpen={aiOpen}
+        modelParamsSlot={
+          onModelParamsChange ? (
+            <EvalModelParams
+              model={model}
+              value={modelParams}
+              onChange={onModelParamsChange}
+              disabled={modelSelectorDisabled ?? disabled}
+            />
+          ) : null
+        }
       />
     </Box>
   );
@@ -438,6 +451,8 @@ LLMPromptEditor.propTypes = {
   onTemplateFormatChange: PropTypes.func,
   model: PropTypes.string,
   onModelChange: PropTypes.func,
+  modelParams: PropTypes.object,
+  onModelParamsChange: PropTypes.func,
   disabled: PropTypes.bool,
   modelSelectorDisabled: PropTypes.bool,
 };

--- a/frontend/src/sections/evals/components/MessageEditor.jsx
+++ b/frontend/src/sections/evals/components/MessageEditor.jsx
@@ -54,6 +54,9 @@ const MessageEditor = ({
   modelSelectorDisabled,
   model,
   onModelChange,
+  // Parent-rendered params control shown beside the model selector (same
+  // slot pattern as aiBar) — the eval picker uses it for judge model params.
+  modelParamsSlot,
   // Falcon AI: the parent renders the AI bar node (shown at the top of
   // the box when open) and passes the trigger handler for the bottom-bar
   // icon. aiOpen hides the trigger while the bar is open, matching agent.
@@ -299,7 +302,15 @@ const MessageEditor = ({
           }}
         >
           {onModelChange ? (
-            <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
               <ModelSelector
                 model={model}
                 onModelChange={onModelChange}
@@ -307,6 +318,7 @@ const MessageEditor = ({
                 showPlus={false}
                 disabled={modelSelectorDisabled ?? disabled}
               />
+              {modelParamsSlot}
             </Box>
           ) : (
             <Box sx={{ flex: 1 }} />
@@ -373,6 +385,7 @@ MessageEditor.propTypes = {
   datasetJsonSchemas: PropTypes.object,
   disabled: PropTypes.bool,
   modelSelectorDisabled: PropTypes.bool,
+  modelParamsSlot: PropTypes.node,
   aiBar: PropTypes.node,
   onFalconClick: PropTypes.func,
   aiOpen: PropTypes.bool,


### PR DESCRIPTION
## Summary

Adds judge-model generation-parameter configuration (temperature, max_tokens, top_p, penalties, reasoning effort where supported) to the LLM-as-a-Judge eval setup, using the same `CustomModelOptions` popover the Prompt Workbench already ships. Values persist under `run_config.model_params` on the `UserEvalMetric` and round-trip through the edit flow, so a judge can finally be pinned to temperature 0 and stay there.

## Linked issues

Closes #1764
Linear:

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

---

## 1) What changes were done

**A. Params control beside the judge model selector**

- New `EvalModelParams` (`frontend/src/sections/evals/components/EvalModelParams.jsx`): fetches slider definitions from the existing `GET /model-hub/api/model_parameters/`, shapes them with the workbench's `transformModelParams`/`getModelParamValues`, and renders the existing `CustomModelOptions` popover. Values leave the component only on Apply — Cancel/close never mutates state.
- Mounted in `MessageEditor`'s bottom bar next to `ModelSelector` via a new `modelParamsSlot` node prop (same slot pattern as the existing `aiBar`), threaded through `LLMPromptEditor`.

**B. State, payload and hydration in the eval picker**

- `EvalPickerConfigFull` gains `modelParams` state in the runtime-override block. It is emitted as `model_params` in the save payload **only when values were applied** — an untouched picker adds no key, so nothing partial/undefined ever reaches `run_config`.
- Edit-flow hydration falls through `run_config.model_params` → the drawer's flattened `evalData.config.model_params` (see decision 2 below) → top-level, tolerating snake_case and camelCase, using `??` throughout so `temperature: 0` survives.

**C. run_config whitelist made unit-testable**

- `EvaluationDrawer`'s inline `run_config` key whitelist is extracted to `buildRunConfig.js` (pure function) with `model_params` added for single-eval bindings. Keys missing from this whitelist are silently dropped before the API call — that mechanism is how these values got lost historically, so it now has direct test coverage.

No backend changes. The persisted shape uses the exact snake_case names `run_prompt.py` already reads (`temperature`, `max_tokens`, `top_p`, `presence_penalty`, `frequency_penalty`).

---

## 2) Why the changes were done

- **Product/UX:** A judge you cannot pin to a low temperature is a judge whose scores you cannot reproduce (issue #1764). The Prompt Workbench already exposes these controls, so judge runs and prompt runs against the same model are now configurable the same way.
- **Technical:** Reuses the proven `CustomModelOptions` stack rather than a new params UI. A thin eval-side wrapper was chosen over mounting the workbench's `ModelParamsContainer` directly because that container hard-requires eight workbench-only props (prompt versions, Mixpanel prompt events, PROMPTS-role permission gating) that don't exist on this surface.
- **Architecture:** The drawer's key whitelist moves from inline closure code to a pure, tested function; the params control mounts via a node slot so `MessageEditor` stays ignorant of eval-picker state.

---

## 3) Tests written + scenarios each covers

**`EvalModelParams.test.jsx`** — the popover wrapper in isolation

- `fetches llm definitions for the model and passes transformed sliders` — endpoint called with `model_type: "llm"`; camelCase slider ids; `responseFormat` deliberately stripped (judge pipeline owns the output contract)
- `applies edited values to onChange as snake_case without nullish keys` — `temperature: 0` preserved, nullish keys dropped, camelCase→snake_case at the boundary
- `emits null when applying with no values set` — all-default apply resolves to "no override"
- `seeds saved snake_case values back into the form, including zero`
- `disables the control when the definitions fetch fails`

**`EvalPickerConfigFull.test.jsx`** — save payload + hydration (new describe block)

- `omits model_params from the save payload when never touched` — regression guard for the no-partial-values requirement
- `carries applied model params into the save payload, preserving zero`
- `clears model_params from the payload when the override is removed`
- `hydrates saved run_config.model_params in edit mode and re-emits on save`
- `hydrates model_params from the drawer edit shape (filtered run_config + flattened config)` — covers the real `openEditForSavedEval` shape, where `evalData.run_config` is the backend's **filtered** `build_run_config_view` (which strips `model_params`) and the raw values only survive in the flattened `evalData.config`

**`buildRunConfig.test.js`** — the extracted whitelist

- forwards all existing single-eval overrides unchanged (characterization test for the extraction)
- keeps composite bindings free of single-eval overrides
- forwards `model_params` when present, preserving zero values
- omits `model_params` when absent, empty, or null
- keeps falsy-but-meaningful values (`pass_threshold: 0`, `multi_choice: false`)

> Run result: **17 passed** across the three suites above; full frontend `yarn check-all` (eslint + type-check + vitest) passes — **2454 tests across 290 files**, 0 failures.

---

## 4) How to run / test

### Frontend tests

```bash
cd frontend
yarn test:run src/sections/evals/components/EvalModelParams.test.jsx \
  src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx \
  src/sections/common/EvaluationDrawer/buildRunConfig.test.js
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Open a dataset → Evaluate → add an LLM-as-a-Judge template (e.g. toxicity) → the config screen's prompt editor now shows a params (tune) icon next to the model selector.
3. Open it, set temperature to 0 and max tokens to 256, Apply, save the eval.
4. In the network tab, the `add_user_eval` POST carries `config.run_config.model_params = {"temperature": 0, "max_tokens": 256}`.
5. Reload the page, edit the saved eval — the popover shows 0 / 256, not defaults.
6. Cancel-path: open the popover, change a slider, close without Apply, save — payload is unchanged.

---

## 6) Edge cases & considerations

- **`temperature: 0` (falsy zero):** `??` used across seed/hydrate/emit paths; covered by three tests.
- **Untouched picker:** no `model_params` key is emitted at any layer (picker payload, drawer whitelist), so existing evals save byte-identical to today.
- **Filtered list view:** the saved-evals list endpoint serves `run_config` through `build_run_config_view`, which strips unknown keys — hydration therefore falls through to the drawer's raw flattened `config` blob (same precedent as `messages` hydration).
- **Definitions fetch failure / model without params:** control renders disabled; no payload impact.
- **FAGI models (`turing_*`):** `get_llm_parameters` returns the standard LLM slider set for any model name, so the control works for built-in judges too. The endpoint requires a `provider` query param but ignores it for `model_type: "llm"` — the component sends a placeholder (commented in code).
- **Composite evals:** `model_params` is single-eval only; composite bindings remain untouched (tested).
- **responseFormat:** intentionally not exposed — the judge pipeline parses the output, so a user-set format toggle could break score parsing.

---

## 8) Architectural / important decisions

- **New thin wrapper over reusing `ModelParamsContainer`:** the workbench container requires prompt-workbench props (versions, Mixpanel prompt events, PROMPTS permission checks) that are wrong or meaningless here; the wrapper is ~100 lines and renders the same `CustomModelOptions`, which is what #1764's "Done when" asks for.
- **Nested `model_params` object (not flat keys in `run_config`):** keeps the override self-contained and mirrors how code-eval `params` already nests; inner keys use the snake_case names the backend's run-prompt path reads.
- **Whitelist extraction:** the silent-drop behaviour of `EvaluationDrawer`'s run_config assembly is the root mechanism behind "value lost on save" bugs; making it a pure tested function makes the next added key a one-line, tested change.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `yarn test:run` passes locally (frontend)
- [x] `yarn contracts:check` — N/A, no API surface change
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA (will sign when the bot prompts)
- [x] PR title follows Conventional Commits
- [ ] Linear issue — external contributor, no Linear access
