### PR TITLE
fix(huggingface): load options for existing datasets

### DIFF
--- a/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceDetailDrawer.jsx
@@ -20,17 +20,17 @@ const HuggingFaceDetailDrawer = ({
 }) => {
   useEffect(() => {
     if (!show) return;
-    if (show && showNameField && huggingFaceDetail?.name) {
-      const defaultValues = { name: huggingFaceDetail.name };
-      if (subsetOptions?.length > 0) {
-        defaultValues.huggingface_dataset_config = subsetOptions[0].value;
-      }
-      if (splitOptions?.length > 0) {
-        defaultValues.huggingface_dataset_split = splitOptions[0].value;
-      }
-      defaultValues.num_rows = 1;
-      reset(defaultValues);
+    const defaultValues = { num_rows: 1 };
+    if (showNameField && huggingFaceDetail?.name) {
+      defaultValues.name = huggingFaceDetail.name;
     }
+    if (subsetOptions?.length > 0) {
+      defaultValues.huggingface_dataset_config = subsetOptions[0].value;
+    }
+    if (splitOptions?.length > 0) {
+      defaultValues.huggingface_dataset_split = splitOptions[0].value;
+    }
+    reset(defaultValues);
   }, [
     show,
     showNameField,


### PR DESCRIPTION
## Summary
- initialize Hugging Face subset and split selections whenever options load
- keep num_rows defaulting to 1 in every drawer mode
- keep name initialization gated to create-new-dataset mode

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1500