### PR TITLE
fix(simulations): reset scenario page on search

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -223,6 +223,12 @@ const CreateRunTestPage = ({ open, onClose }) => {
     pageSize: 10,
   });
 
+  useEffect(() => {
+    setScenariosPagination((current) =>
+      current.page === 1 ? current : { ...current, page: 1 },
+    );
+  }, [debouncedSearch]);
+
   // Fetch scenarios with pagination
   const {
     data: scenariosData,


### PR DESCRIPTION
## Summary
- reset Choose Scenarios pagination to page 1 when debounced search changes
- cover both entering and clearing a search term
- preserve existing page-size and page-navigation behavior

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1485