### PR TITLE
fix(insights): constrain yesterday date range

### DIFF
--- a/frontend/src/sections/model/journey/insights-date-selector.jsx
+++ b/frontend/src/sections/model/journey/insights-date-selector.jsx
@@ -20,6 +20,7 @@ export function getDateRange(range) {
       break;
     case "yesterday":
       fromDate.setDate(toDate.getDate() - 1);
+      toDate.setDate(toDate.getDate() - 1);
       break;
     case "7d":
       fromDate.setDate(toDate.getDate() - 6); // Subtract 6 days (7 days including today)


### PR DESCRIPTION
## Summary
- move both date range boundaries to the previous calendar day for the Yesterday preset
- preserve all other date presets and formatting

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1483