### PR TITLE
fix(graphs): refetch when filters are active

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/GraphSection.jsx
@@ -158,7 +158,9 @@ const GraphSection = ({
         req_data_config: selectedGraphConfig,
         project_id: observeId,
       }),
-    enabled: selectedTab === "trace" && Boolean(selectedGraphConfig?.id),
+    enabled:
+      selectedTab === "trace" &&
+      (Boolean(selectedGraphConfig?.id) || combinedFilters.length > 0),
     select: (data) => data.data?.result,
   });
 
@@ -186,7 +188,9 @@ const GraphSection = ({
         req_data_config: selectedGraphConfig,
         project_id: observeId,
       }),
-    enabled: selectedTab === "spans" && Boolean(selectedGraphConfig?.id),
+    enabled:
+      selectedTab === "spans" &&
+      (Boolean(selectedGraphConfig?.id) || combinedFilters.length > 0),
     select: (data) => data.data?.result,
   });
 


### PR DESCRIPTION
## Summary
- enable trace graph queries when combined filters are present without a graph config
- apply the same behavior to span graph queries
- preserve selected graph config behavior and leave PrimaryGraph untouched

## Verification
- git diff --check
- frontend ESLint unavailable because dependencies are not installed in this worktree

Closes #1482