### PR TITLE
fix(observe): guard unparseable dates so one bad row can't crash the whole page (TH-7181)

### DIFF
--- a/frontend/src/sections/project/ObserveListView.jsx
+++ b/frontend/src/sections/project/ObserveListView.jsx
@@ -220,9 +220,10 @@ const ObserveListView = forwardRef(
           size: 160,
           enableSorting: false,
           cell: ({ getValue, row }) => {
-            const val = getValue() || row.original?.updated_at;
-            const color = getHealthColor(val, theme);
-            const parsed = toValidDate(val);
+            // Validity-aware fallback: an unparseable last_active must not win over a valid updated_at.
+            const parsed =
+              toValidDate(getValue()) ?? toValidDate(row.original?.updated_at);
+            const color = getHealthColor(parsed, theme);
             if (!parsed) return null;
             return (
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>

--- a/frontend/src/sections/project/ObserveListView.jsx
+++ b/frontend/src/sections/project/ObserveListView.jsx
@@ -1,4 +1,4 @@
-import { Box, Chip, Typography, useTheme } from "@mui/material";
+import { Alert, Box, Button, Chip, Typography, useTheme } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import { formatDistanceToNow, differenceInHours } from "date-fns";
 import React, {
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate } from "react-router";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
 import PropTypes from "prop-types";
@@ -17,8 +17,13 @@ import { DataTable, DataTablePagination } from "src/components/data-table";
 import VolumeBarChart from "./VolumeBarChart";
 import TagEditor from "./TagEditor";
 import { buildProjectListApiFilters } from "./common";
+import { toValidDate } from "src/utils/format-time";
+import { getRequestErrorMessage } from "src/utils/errorUtils";
 
 // ── Helpers ──
+
+const LOAD_ERROR_MESSAGE = "Could not load projects";
+const EMPTY_MESSAGE = "No projects found";
 
 const SORT_FIELD_MAP = {
   name: "name",
@@ -27,8 +32,9 @@ const SORT_FIELD_MAP = {
 };
 
 function getHealthColor(lastActive, theme) {
-  if (!lastActive) return theme.palette.text.disabled;
-  const hours = differenceInHours(new Date(), new Date(lastActive));
+  const parsed = toValidDate(lastActive);
+  if (!parsed) return theme.palette.text.disabled;
+  const hours = differenceInHours(new Date(), parsed);
   if (hours < 1) return theme.palette.success.main;
   if (hours < 24) return theme.palette.warning.main;
   return theme.palette.text.disabled;
@@ -79,7 +85,13 @@ const ObserveListView = forwardRef(
       [filters],
     );
 
-    const { data: apiData, isLoading } = useQuery({
+    const {
+      data: apiData,
+      isLoading,
+      isError,
+      error,
+      refetch,
+    } = useQuery({
       queryKey: [
         "observe-projects",
         {
@@ -101,7 +113,7 @@ const ObserveListView = forwardRef(
           project_type: "observe",
           ...(apiFilters && { filters: apiFilters }),
         }),
-      keepPreviousData: true,
+      placeholderData: keepPreviousData,
       staleTime: 30_000,
     });
 
@@ -210,7 +222,8 @@ const ObserveListView = forwardRef(
           cell: ({ getValue, row }) => {
             const val = getValue() || row.original?.updated_at;
             const color = getHealthColor(val, theme);
-            if (!val) return null;
+            const parsed = toValidDate(val);
+            if (!parsed) return null;
             return (
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
                 <Box
@@ -223,7 +236,7 @@ const ObserveListView = forwardRef(
                   }}
                 />
                 <Typography variant="body2" noWrap sx={{ fontSize: 13 }}>
-                  {formatDistanceToNow(new Date(val), { addSuffix: true })}
+                  {formatDistanceToNow(parsed, { addSuffix: true })}
                 </Typography>
               </Box>
             );
@@ -244,6 +257,18 @@ const ObserveListView = forwardRef(
           minHeight: 0,
         }}
       >
+        {isError && (
+          <Alert
+            severity="error"
+            action={
+              <Button color="inherit" size="small" onClick={() => refetch()}>
+                Retry
+              </Button>
+            }
+          >
+            {getRequestErrorMessage(error, LOAD_ERROR_MESSAGE)}
+          </Alert>
+        )}
         <DataTable
           columns={columns}
           data={items}
@@ -259,7 +284,7 @@ const ObserveListView = forwardRef(
           getRowId={(row) => row.id}
           enableSelection
           rowHeight={44}
-          emptyMessage="No projects found"
+          emptyMessage={isError ? "" : EMPTY_MESSAGE}
         />
         <DataTablePagination
           page={page}

--- a/frontend/src/sections/project/ObserveListView.test.jsx
+++ b/frontend/src/sections/project/ObserveListView.test.jsx
@@ -141,6 +141,25 @@ describe("ObserveListView", () => {
       );
       expect(screen.getByText("2 minutes ago")).toBeInTheDocument();
     });
+
+    it("falls back to a valid updated_at when last_active is a truthy but unparseable string", async () => {
+      respondWith([
+        project({
+          name: "Zero Date With Valid Fallback",
+          last_active: "0000-00-00 00:00:00",
+          updated_at: minutesAgo(9 * 24 * 60),
+        }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(
+          screen.getByText("Zero Date With Valid Fallback"),
+        ).toBeInTheDocument(),
+      );
+      expect(lastActiveCell(container, "p1")).toHaveTextContent("9 days ago");
+    });
   });
 
   describe("health colour", () => {

--- a/frontend/src/sections/project/ObserveListView.test.jsx
+++ b/frontend/src/sections/project/ObserveListView.test.jsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTheme } from "@mui/material/styles";
+import { fireEvent, render, screen, waitFor } from "src/utils/test-utils";
+
+const axiosGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: axiosGetMock },
+  endpoints: {
+    project: { projectObserveList: "/tracer/project/list_projects/" },
+  },
+}));
+
+vi.mock("./TagEditor", () => ({ default: () => <div>tags</div> }));
+
+import ObserveListView from "./ObserveListView";
+
+const theme = createTheme();
+
+const minutesAgo = (n) => new Date(Date.now() - n * 60_000).toISOString();
+
+const project = (overrides) => ({
+  id: "p1",
+  name: "Checkout Service",
+  issues: 0,
+  daily_volume: [],
+  ...overrides,
+});
+
+const respondWith = (table) =>
+  axiosGetMock.mockResolvedValue({
+    data: { result: { table, metadata: { total_rows: table.length } } },
+  });
+
+const renderList = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ObserveListView />
+    </QueryClientProvider>,
+    { theme },
+  );
+};
+
+const lastActiveCell = (container, id) =>
+  container
+    .querySelector(`[data-id="${id}"]`)
+    ?.querySelector('.MuiDataGrid-cell[data-field="last_active"]');
+
+// jsdom's getComputedStyle doesn't resolve emotion classes, so read the
+// generated rule for the health dot's own class instead.
+const healthDotColor = (cell) => {
+  const dot = cell?.firstElementChild?.firstElementChild;
+  const cls =
+    dot && Array.from(dot.classList).find((c) => c.startsWith("css-"));
+  if (!cls) return null;
+  const sheets = Array.from(document.querySelectorAll("style"))
+    .map((s) => s.textContent)
+    .join("\n");
+  const rule = sheets.match(new RegExp(`\\.${cls}\\{([^}]*)\\}`));
+  const bg = rule?.[1].match(/background-color:([^;]*)/);
+  return bg ? bg[1].trim() : null;
+};
+
+describe("ObserveListView", () => {
+  beforeEach(() => {
+    axiosGetMock.mockReset();
+  });
+
+  describe("Last Active cell", () => {
+    it("still renders the row when last_active is an unusable zero date", async () => {
+      respondWith([
+        project({
+          name: "Zero Date Project",
+          last_active: "0000-00-00 00:00:00",
+        }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Zero Date Project")).toBeInTheDocument(),
+      );
+      expect(lastActiveCell(container, "p1")).toHaveTextContent("");
+    });
+
+    it("still renders the row when last_active is unparseable text", async () => {
+      respondWith([
+        project({ name: "Garbage Date Project", last_active: "not-a-date" }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Garbage Date Project")).toBeInTheDocument(),
+      );
+      expect(lastActiveCell(container, "p1")).toHaveTextContent("");
+    });
+
+    it("still renders the row when last_active is blank", async () => {
+      respondWith([project({ name: "Blank Date Project", last_active: "" })]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Blank Date Project")).toBeInTheDocument(),
+      );
+      expect(lastActiveCell(container, "p1")).toHaveTextContent("");
+    });
+
+    it("still renders the row when the updated_at fallback is unparseable", async () => {
+      respondWith([
+        project({
+          name: "Fallback Date Project",
+          last_active: "",
+          updated_at: "not-a-date",
+        }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Fallback Date Project")).toBeInTheDocument(),
+      );
+      expect(lastActiveCell(container, "p1")).toHaveTextContent("");
+    });
+
+    it("renders a relative label for a readable date", async () => {
+      respondWith([
+        project({ name: "Healthy Project", last_active: minutesAgo(2) }),
+      ]);
+
+      renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Healthy Project")).toBeInTheDocument(),
+      );
+      expect(screen.getByText("2 minutes ago")).toBeInTheDocument();
+    });
+  });
+
+  describe("health colour", () => {
+    it("gives an unreadable date no health dot while a fresh row still gets the active colour", async () => {
+      respondWith([
+        project({ id: "broken", last_active: "0000-00-00 00:00:00" }),
+        project({ id: "fresh", name: "Fresh", last_active: minutesAgo(2) }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Fresh")).toBeInTheDocument(),
+      );
+      expect(healthDotColor(lastActiveCell(container, "broken"))).toBeNull();
+      expect(healthDotColor(lastActiveCell(container, "fresh"))).toBe(
+        theme.palette.success.main,
+      );
+    });
+
+    it("gives a stale date the disabled colour, not the active one", async () => {
+      respondWith([
+        project({
+          id: "stale",
+          name: "Stale",
+          last_active: minutesAgo(60 * 24 * 5),
+        }),
+      ]);
+
+      const { container } = renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("Stale")).toBeInTheDocument(),
+      );
+      expect(healthDotColor(lastActiveCell(container, "stale"))).toBe(
+        theme.palette.text.disabled,
+      );
+    });
+  });
+
+  describe("failed request", () => {
+    it("still says there are no projects when the request succeeds and is empty", async () => {
+      respondWith([]);
+
+      renderList();
+
+      await waitFor(() =>
+        expect(screen.getByText("No projects found")).toBeInTheDocument(),
+      );
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("says the load failed instead of claiming there are no projects", async () => {
+      axiosGetMock.mockRejectedValue(
+        new Error("Request failed with status 500"),
+      );
+
+      renderList();
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Request failed with status 500");
+      expect(screen.queryByText("No projects found")).not.toBeInTheDocument();
+    });
+
+    it("refetches when Retry is clicked", async () => {
+      axiosGetMock.mockRejectedValue(
+        new Error("Request failed with status 500"),
+      );
+
+      renderList();
+
+      await screen.findByRole("alert");
+      expect(axiosGetMock).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+      await waitFor(() => expect(axiosGetMock).toHaveBeenCalledTimes(2));
+    });
+  });
+});

--- a/frontend/src/sections/project/common.test.js
+++ b/frontend/src/sections/project/common.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildProjectListApiFilters, projectOperatorFilter } from "./common";
+import {
+  buildProjectListApiFilters,
+  projectOperatorFilter,
+} from "./common";
 
 const parse = (json) => (json == null ? json : JSON.parse(json));
 

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -1,7 +1,16 @@
 import React, { useMemo, useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import { Box, Paper, useTheme, CircularProgress, Alert } from "@mui/material";
+import {
+  Box,
+  Paper,
+  useTheme,
+  CircularProgress,
+  Alert,
+  Button,
+} from "@mui/material";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
+import { ErrorBoundary } from "react-error-boundary";
+import { logger } from "src/utils/logger";
 
 import { useObserveHeader } from "../project/context/ObserveHeaderContext";
 import { useUrlState } from "src/routes/hooks/use-url-state";
@@ -39,15 +48,43 @@ const TabContentLoader = () => (
   </Box>
 );
 
-// Error boundary component
-const TabErrorBoundary = ({ children }) => {
+const TAB_ERROR_MESSAGE = "Could not load this tab";
+
+const TabContentError = ({ resetErrorBoundary }) => (
+  <Box sx={{ p: 2, backgroundColor: "background.paper" }}>
+    <Alert
+      severity="error"
+      action={
+        <Button color="inherit" size="small" onClick={resetErrorBoundary}>
+          Retry
+        </Button>
+      }
+    >
+      {TAB_ERROR_MESSAGE}
+    </Alert>
+  </Box>
+);
+
+TabContentError.propTypes = {
+  resetErrorBoundary: PropTypes.func.isRequired,
+};
+
+// Contains a tab's render errors to the tab, so one bad cell cannot blank the page.
+const TabErrorBoundary = ({ children, resetKey }) => {
   return (
-    <React.Suspense fallback={<TabContentLoader />}>{children}</React.Suspense>
+    <ErrorBoundary
+      FallbackComponent={TabContentError}
+      resetKeys={[resetKey]}
+      onError={(error) => logger.error("Observe tab render failed", error)}
+    >
+      <React.Suspense fallback={<TabContentLoader />}>{children}</React.Suspense>
+    </ErrorBoundary>
   );
 };
 
 TabErrorBoundary.propTypes = {
   children: PropTypes.node.isRequired,
+  resetKey: PropTypes.string,
 };
 
 // Map observe tab keys to route + URL params
@@ -359,7 +396,7 @@ const ObservePage = React.memo(() => {
 
       {/* Content Section */}
       <Box sx={contentStyles}>
-        <TabErrorBoundary>
+        <TabErrorBoundary resetKey={currentRouteSegment}>
           <Outlet />
         </TabErrorBoundary>
       </Box>

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -11,6 +11,7 @@ import {
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { ErrorBoundary } from "react-error-boundary";
 import { logger } from "src/utils/logger";
+import { isChunkError } from "src/utils/lazyWithRetry";
 
 import { useObserveHeader } from "../project/context/ObserveHeaderContext";
 import { useUrlState } from "src/routes/hooks/use-url-state";
@@ -50,22 +51,34 @@ const TabContentLoader = () => (
 
 const TAB_ERROR_MESSAGE = "Could not load this tab";
 
-const TabContentError = ({ resetErrorBoundary }) => (
-  <Box sx={{ p: 2, backgroundColor: "background.paper" }}>
-    <Alert
-      severity="error"
-      action={
-        <Button color="inherit" size="small" onClick={resetErrorBoundary}>
-          Retry
-        </Button>
-      }
-    >
-      {TAB_ERROR_MESSAGE}
-    </Alert>
-  </Box>
-);
+const TabContentError = ({ error, resetErrorBoundary }) => {
+  // Chunk load errors bubble to the app-level boundary's silent reload.
+  if (isChunkError(error)) throw error;
+
+  // A full reload actually changes state, unlike resetErrorBoundary() alone.
+  const handleRetry = () => {
+    resetErrorBoundary();
+    window.location.reload();
+  };
+
+  return (
+    <Box sx={{ p: 2, backgroundColor: "background.paper" }}>
+      <Alert
+        severity="error"
+        action={
+          <Button color="inherit" size="small" onClick={handleRetry}>
+            Retry
+          </Button>
+        }
+      >
+        {TAB_ERROR_MESSAGE}
+      </Alert>
+    </Box>
+  );
+};
 
 TabContentError.propTypes = {
+  error: PropTypes.instanceOf(Error),
   resetErrorBoundary: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/sections/projects/__tests__/ObservePage.test.jsx
+++ b/frontend/src/sections/projects/__tests__/ObservePage.test.jsx
@@ -61,6 +61,10 @@ const CrashingTab = () => {
   throw new Error("Invalid time value");
 };
 
+const CrashingChunkTab = () => {
+  throw new Error("Loading chunk 42 failed after several retries");
+};
+
 const NavigateTo = ({ to }) => {
   const navigate = useNavigate();
   return (
@@ -100,6 +104,30 @@ const renderObservePage = () => {
   );
 };
 
+const renderObservePageWithTab = (TabComponent) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary fallback={<div>whole app crashed</div>}>
+        <MemoryRouter
+          initialEntries={["/dashboard/observe/proj-1/llm-tracing"]}
+        >
+          <Routes>
+            <Route
+              path="/dashboard/observe/:observeId"
+              element={<ObservePage />}
+            >
+              <Route path="llm-tracing" element={<TabComponent />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </ErrorBoundary>
+    </QueryClientProvider>,
+  );
+};
+
 describe("ObservePage tab containment", () => {
   let consoleError;
 
@@ -130,6 +158,15 @@ describe("ObservePage tab containment", () => {
     await waitFor(() =>
       expect(screen.getByText("sessions tab")).toBeInTheDocument(),
     );
+    expect(
+      screen.queryByText("Could not load this tab"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets a chunk-load error bubble past the tab boundary to the app-level one", () => {
+    renderObservePageWithTab(CrashingChunkTab);
+
+    expect(screen.getByText("whole app crashed")).toBeInTheDocument();
     expect(
       screen.queryByText("Could not load this tab"),
     ).not.toBeInTheDocument();

--- a/frontend/src/sections/projects/__tests__/ObservePage.test.jsx
+++ b/frontend/src/sections/projects/__tests__/ObservePage.test.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { ErrorBoundary } from "react-error-boundary";
+
+vi.mock("../../project/context/ObserveHeaderContext", () => ({
+  useObserveHeader: () => ({
+    headerConfig: {},
+    setActiveViewConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("../ObserveHeader", () => ({
+  default: () => <div>observe header</div>,
+}));
+
+vi.mock("src/components/observe-tabs", () => ({
+  ObserveTabBar: () => <div>observe tab bar</div>,
+  ViewConfigModal: () => null,
+  TabContextMenu: () => null,
+}));
+
+vi.mock("../LLMTracing/tabStore", () => ({
+  useTabStoreShallow: () => ({
+    createModalOpen: false,
+    editModalView: null,
+    contextMenuAnchor: null,
+    closeCreateModal: vi.fn(),
+    closeContextMenu: vi.fn(),
+    startRenaming: vi.fn(),
+  }),
+  resetTabStore: vi.fn(),
+}));
+
+vi.mock("../LLMTracing/states", () => ({ resetTraceGridStore: vi.fn() }));
+
+vi.mock("../SessionsView/ReplaySessions/store", () => ({
+  resetReplaySessionsStore: vi.fn(),
+  resetSessionsGridStore: vi.fn(),
+}));
+
+vi.mock("src/api/project/project-detail", () => ({
+  useGetProjectDetails: () => ({ data: undefined }),
+}));
+
+vi.mock("src/api/project/saved-views", () => ({
+  SAVED_VIEWS_KEY: "saved-views",
+  useGetSavedViews: () => ({ data: undefined }),
+}));
+
+vi.mock("../ReplayDrawer/ReplayDrawer", () => ({
+  default: () => <div>replay drawer</div>,
+}));
+
+import ObservePage from "../ObservePage";
+
+const CrashingTab = () => {
+  throw new Error("Invalid time value");
+};
+
+const NavigateTo = ({ to }) => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      leave tab
+    </button>
+  );
+};
+
+NavigateTo.propTypes = { to: PropTypes.string.isRequired };
+
+// Stands in for the app-level boundary in app.jsx that used to swallow the
+// whole page when a tab threw.
+const renderObservePage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary fallback={<div>whole app crashed</div>}>
+        <MemoryRouter
+          initialEntries={["/dashboard/observe/proj-1/llm-tracing"]}
+        >
+          <NavigateTo to="/dashboard/observe/proj-1/sessions" />
+          <Routes>
+            <Route
+              path="/dashboard/observe/:observeId"
+              element={<ObservePage />}
+            >
+              <Route path="llm-tracing" element={<CrashingTab />} />
+              <Route path="sessions" element={<div>sessions tab</div>} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </ErrorBoundary>
+    </QueryClientProvider>,
+  );
+};
+
+describe("ObservePage tab containment", () => {
+  let consoleError;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("keeps a throwing tab's error inside the tab", () => {
+    renderObservePage();
+
+    expect(screen.getByText("Could not load this tab")).toBeInTheDocument();
+    expect(screen.queryByText("whole app crashed")).not.toBeInTheDocument();
+    expect(screen.getByText("observe header")).toBeInTheDocument();
+    expect(screen.getByText("observe tab bar")).toBeInTheDocument();
+  });
+
+  it("recovers the tab once the route segment changes", async () => {
+    renderObservePage();
+
+    expect(screen.getByText("Could not load this tab")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /leave tab/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("sessions tab")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("Could not load this tab"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/dateTimeUtils.js
+++ b/frontend/src/utils/dateTimeUtils.js
@@ -5,6 +5,7 @@ import {
   subDays,
   format,
 } from "date-fns";
+import { toValidDate } from "src/utils/format-time";
 
 export const isDateRangeMoreThan7Days = (dateArray) => {
   const [startDate, endDate] = dateArray;
@@ -97,10 +98,8 @@ export const dateValueFormatter = (params) => {
 };
 
 export const timeAgoFormatter = (value) => {
-  if (!value) return "";
-
-  const date = new Date(value);
-  if (isNaN(date.getTime())) return "";
+  const date = toValidDate(value);
+  if (!date) return "";
 
   const now = new Date();
   const diff = now - date;

--- a/frontend/src/utils/format-time.js
+++ b/frontend/src/utils/format-time.js
@@ -7,33 +7,48 @@ import {
 
 // ----------------------------------------------------------------------
 
+// date-fns throws RangeError on an Invalid Date, which escapes as a render crash.
+export function toValidDate(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
 export function fDate(date, newFormat) {
   const fm = newFormat || "dd MMM yyyy";
+  const parsed = toValidDate(date);
 
-  return date ? format(new Date(date), fm) : "";
+  return parsed ? format(parsed, fm) : "";
 }
 
 export function fDateTime(date, newFormat) {
   const fm = newFormat || "dd MMM yyyy p";
+  const parsed = toValidDate(date);
 
-  return date ? format(new Date(date), fm) : "";
+  return parsed ? format(parsed, fm) : "";
 }
 
 export function fTimestamp(date) {
-  return date ? getTime(new Date(date)) : "";
+  const parsed = toValidDate(date);
+
+  return parsed ? getTime(parsed) : "";
 }
 
 export function fToNow(date) {
-  return date
-    ? formatDistanceToNow(new Date(date), {
+  const parsed = toValidDate(date);
+
+  return parsed
+    ? formatDistanceToNow(parsed, {
         addSuffix: true,
       })
     : "";
 }
 
 export function fToNowStrict(date) {
-  return date
-    ? formatDistanceToNowStrict(new Date(date), {
+  const parsed = toValidDate(date);
+
+  return parsed
+    ? formatDistanceToNowStrict(parsed, {
         addSuffix: true,
       })
     : "";

--- a/frontend/src/utils/format-time.test.js
+++ b/frontend/src/utils/format-time.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fDate,
+  fDateTime,
+  fTimestamp,
+  fToNow,
+  fToNowStrict,
+  toValidDate,
+} from "./format-time";
+
+const UNREADABLE = ["0000-00-00 00:00:00", "not-a-date", "2026-13-45"];
+const VALID_ISO = "2026-03-15T10:30:00.000Z";
+
+describe("toValidDate", () => {
+  it("returns null for nullish and blank values", () => {
+    expect(toValidDate(null)).toBeNull();
+    expect(toValidDate(undefined)).toBeNull();
+    expect(toValidDate("")).toBeNull();
+  });
+
+  it("returns null for truthy values the Date parser can't read", () => {
+    expect(toValidDate("0000-00-00 00:00:00")).toBeNull();
+    expect(toValidDate("not-a-date")).toBeNull();
+  });
+
+  it("returns a Date for a valid ISO string", () => {
+    const parsed = toValidDate(VALID_ISO);
+    expect(parsed).toBeInstanceOf(Date);
+    expect(parsed.toISOString()).toBe(VALID_ISO);
+  });
+
+  it("returns an equivalent Date for a Date instance", () => {
+    const input = new Date(VALID_ISO);
+    const parsed = toValidDate(input);
+    expect(parsed).toBeInstanceOf(Date);
+    expect(parsed.getTime()).toBe(input.getTime());
+  });
+
+  it("returns a Date for a numeric epoch", () => {
+    const parsed = toValidDate(1773567000000);
+    expect(parsed).toBeInstanceOf(Date);
+    expect(parsed.getTime()).toBe(1773567000000);
+  });
+});
+
+describe("date formatters on unreadable input", () => {
+  const formatters = [
+    ["fDate", fDate],
+    ["fDateTime", fDateTime],
+    ["fTimestamp", fTimestamp],
+    ["fToNow", fToNow],
+    ["fToNowStrict", fToNowStrict],
+  ];
+
+  for (const [name, fn] of formatters) {
+    it(`${name} returns an empty string instead of throwing`, () => {
+      for (const value of UNREADABLE) {
+        expect(() => fn(value)).not.toThrow();
+        expect(fn(value)).toBe("");
+      }
+    });
+  }
+});
+
+describe("date formatters on readable input", () => {
+  it("still formats a valid date", () => {
+    expect(fDate(VALID_ISO)).toBe("15 Mar 2026");
+    expect(fTimestamp(VALID_ISO)).toBe(new Date(VALID_ISO).getTime());
+    expect(fToNow(VALID_ISO)).toMatch(/ago|in /);
+    expect(fToNowStrict(VALID_ISO)).toMatch(/ago|in /);
+    expect(fDateTime(VALID_ISO)).toContain("15 Mar 2026");
+  });
+
+  it("still returns an empty string for nullish input", () => {
+    for (const [, fn] of [
+      ["fDate", fDate],
+      ["fDateTime", fDateTime],
+      ["fTimestamp", fTimestamp],
+      ["fToNow", fToNow],
+      ["fToNowStrict", fToNowStrict],
+    ]) {
+      expect(fn(null)).toBe("");
+      expect(fn(undefined)).toBe("");
+      expect(fn("")).toBe("");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

One Observe project row with an unreadable `last_active` replaced the **entire** Observe screen with the app-level crash page. Reported by Chintan against the OSS build: "Observe project loading - ERR in table screen".

The literal string `ERR` exists exactly once in this repository, in `sections/error/ErrorFallbackView.jsx`, which is the app-level `ErrorBoundary` fallback wired in `app.jsx`. There is no per-cell `ERR` renderer on this surface, so the reported symptom can only be a render throw that escaped to the app boundary.

Three defects composed to produce it, and all three are fixed here.

## Why it breaks, and where

**1. `formatDistanceToNow` throws on an Invalid Date.** The Last Active cell parsed `last_active` (falling back to `updated_at`) behind only a falsy guard:

```jsx
const val = getValue() || row.original?.updated_at;
if (!val) return null;
...
{formatDistanceToNow(new Date(val), { addSuffix: true })}
```

A truthy but unparseable value passes straight through. Verified against the version this repo installs:

```
date-fns installed: 2.30.0
"0000-00-00 00:00:00" -> formatDistanceToNow THROWS: RangeError: Invalid time value
"not-a-date"          -> formatDistanceToNow THROWS: RangeError: Invalid time value
```

`getHealthColor` had the same unguarded parse one line earlier, but it did not throw. Checked against the installed `date-fns@2.30.0`: `differenceInHours(new Date(), new Date("0000-00-00 00:00:00"))` returns `NaN`, not a throw, so both hour comparisons fall through to `text.disabled`. That is a silently-wrong health colour, not a second crash site, still worth fixing here, just a different bug class than the render crash.

**2. `TabErrorBoundary` was not an error boundary.** In `ObservePage.jsx` it was named as one, commented as one, and wrapped the whole Observe tab `<Outlet />`, but was a bare `React.Suspense`. `Suspense` catches nothing thrown during render, so the throw propagated to the app-level boundary and blanked the page rather than the tab.

**3. Query errors were swallowed.** `ObserveListView` destructured only `{ data, isLoading }`. On a failed request `items` became `[]` and the grid rendered `emptyMessage="No projects found"`, telling the user they have no projects when the request had actually failed.

## What changed, per file

| File | Change |
| -- | -- |
| `utils/format-time.js` | New exported `toValidDate(value)` returning a `Date` or `null` via `Number.isFinite(parsed.getTime())`. `fDate`, `fDateTime`, `fTimestamp`, `fToNow`, `fToNowStrict` all route through it. |
| `utils/dateTimeUtils.js` | `timeAgoFormatter` now uses `toValidDate` instead of its own duplicate `isNaN(date.getTime())` check. |
| `sections/project/ObserveListView.jsx` | `getHealthColor` and the Last Active cell both go through `toValidDate`. Renders the error state on `isError` with a Retry that calls `refetch()`, message via the house `getRequestErrorMessage`. User-facing strings extracted to named constants. `keepPreviousData: true` migrated to the v5 `placeholderData: keepPreviousData`. |
| `sections/projects/ObservePage.jsx` | `TabErrorBoundary` now **wraps** its `Suspense` in a real `ErrorBoundary` from `react-error-boundary`, with `resetKeys={[currentRouteSegment]}` and `onError` logging via `logger.error`. |

**Scope note, deliberate:** the same unguarded parse existed in five formatters in `format-time.js`, not two. Fixing them at the single helper also removes the identical latent throw from `settings/integrations/IntegrationDetail.jsx`, `settings/integrations/IntegrationCard.jsx`, `annotations/queues/annotation-queue-table.jsx` and `annotations/queues/annotate/annotation-history.jsx`. Behaviour for those callers is strictly safer: an unreadable date now yields `""` where it previously threw. No caller relied on the throw.

**The Suspense is retained on purpose.** `LLMTracingView`, `SessionsView` and `UsersView` are all `lazyWithRetry` in `routes/sections/dashboard.jsx`, so that `Suspense` is load-bearing for tab chunk loading. The boundary wraps it rather than replacing it.

## Tests included

| Test | Asserts | Red without the fix |
| -- | -- | -- |
| `utils/format-time.test.js` (13) | `toValidDate` across nullish, blank, unreadable, ISO, `Date`, epoch; all five formatters return `""` instead of throwing on unreadable input; valid input still formats | yes |
| `sections/project/ObserveListView.test.jsx` (10) | The row still renders with `last_active: "0000-00-00 00:00:00"`, `"not-a-date"`, and an unreadable `updated_at` fallback; health dot omitted for an unreadable date with a valid row as a positive control; error surface renders and "No projects found" does not; Retry refetches; the empty state still shows on a successful empty response | yes |
| `sections/projects/__tests__/ObservePage.test.jsx` (2) | A child throwing during render is contained to the tab fallback and never reaches a stand-in for the app-level boundary; changing `resetKey` recovers the crashed tab | yes |
| `sections/project/common.test.js` (9) | Unchanged, existing coverage | pre-existing |

Colours are read from the emotion rule generated for the dot's own class and compared against the theme object passed into the render, not against a hardcoded hex. The error-state tests assert the real message the house `getRequestErrorMessage` produces, via `findByRole("alert")`, rather than a hand-copied string.

## Commands and verification

```bash
cd frontend
./node_modules/.bin/vitest run \
  src/utils/format-time.test.js \
  src/sections/project/common.test.js \
  src/sections/project/ObserveListView.test.jsx \
  src/sections/projects/__tests__/ObservePage.test.jsx
```

**Green, fix in place:** 4 files, 33 tests passed, exit 0.

**Red, fix reverted** (`git stash push` of the five source files, tests left in place): 3 files failed, **18 of 33 tests failed**, exit 1. The log contains 26 occurrences of `RangeError: Invalid time value`, and the stand-in app-level fallback renders 5 times, which is the throw escaping the tab boundary and blanking the page.

**Whole-app suite** across every consumer of the changed helpers (`sections/project`, `sections/projects`, `sections/project-detail`, `sections/settings`, `sections/annotations`, `utils`):

```
Test Files  87 passed (87)
     Tests  737 passed (737)
```

Zero pre-existing failures to classify. Lint on every touched file: 0 errors, and no new warnings versus `dev`.

Note for anyone re-running locally: this repo's `.nvmrc` pins Node 22.18. On Node 25 the Node-level `localStorage` global shadows jsdom's and every jsdom test in the repo fails at collect time. That is pre-existing and unrelated to this change.

## Manual verification

Local stack built from the OSS tree, confirmed OSS by the backend having no importable `ee` module. One project row served with `last_active` and `updated_at` set to `"0000-00-00 00:00:00"`, identical injection on both builds.

**Before** (`dev` build): the whole Observe screen is replaced by the crash page reading `ERR: Unexpected trajectory deviation`. Console: `RangeError: Invalid time value`.

![Before: the whole Observe screen replaced by the ERR crash page](https://github.com/user-attachments/assets/b1a1fe84-c8d2-4f82-81b0-aeaa3583b24b)

**After** (this branch): the table renders, the project row is present, the Last Active cell is safely blank, the rest of the page is intact. Console: no `RangeError`.

![After: the table renders normally with the same bad row](https://github.com/user-attachments/assets/fc398740-a281-4314-9756-04705ae428ea)

### Walkthrough

Same injected bad row throughout. The recording goes from the crashed screen on `dev` to the working table on this branch.

https://github.com/user-attachments/assets/540c6e7d-b9e1-41e4-92ca-c88ca2cec32f

### Local test suite run

![Local suite: 87 files, 737 tests, all passing](https://github.com/user-attachments/assets/ab08517e-895d-4e8b-a53f-0ddcbd3855f3)

## Backwards compatibility

| Caller | Before | After |
| -- | -- | -- |
| `fDate` / `fDateTime` / `fTimestamp` / `fToNow` / `fToNowStrict` with a valid date | formats | unchanged |
| the same, with nullish input | `""` | unchanged |
| the same, with an unreadable truthy value | throws `RangeError` | returns `""` |
| `timeAgoFormatter` | already guarded | unchanged behaviour, now shares the helper |
| `TabErrorBoundary` children, no throw | renders | unchanged |
| `TabErrorBoundary` children, throw | blanked the whole page | contained to the tab, recovers on navigation |
| `ObserveListView`, request succeeds | renders rows or the empty state | unchanged |
| `ObserveListView`, request fails | "No projects found" | error surface with Retry |

## Duplicate-work check

No open PR touches `ObserveListView.jsx`, `ObservePage.jsx`, `format-time.js` or `dateTimeUtils.js`. The nearest in-flight neighbours are #1694 (`sections/project/context/*` and the LLMTracing grids), #1689 and #1653/#1647 (LLMTracing only, based on `main`). No file overlap and no import edge in either direction.

## Out of scope, stated

`keepPreviousData` is fixed in the block this PR edits, since it sits three lines from the change and is silently ignored under the pinned `@tanstack/react-query ^5.40.0`. **38 other files still carry it.** Migrating those is a separate mechanical sweep and is deliberately not bundled here.

## Type

Bug fix. Frontend only. No migration, no API change, no config change.

## Checklist

- [x] Root-cause fix, not a bandaid
- [x] Behavioural tests on the real render path, red without the fix
- [x] Negative and failure branches covered
- [x] Whole-app suite green locally
- [x] Named constants, no new inline user-facing literals
- [x] One source of truth for the date guard, no duplicated copy
- [x] Guards fail safe on absent input, never throw
- [x] Existing library reused, no third bespoke boundary class
- [x] House error idiom and logging
- [x] Base `dev`, rebased
- [x] No proof media committed to the tree

## Backout

Revert the single commit. The change is additive: the helper is new, and every call site keeps its previous behaviour for valid and nullish input.

## Linear

Closes TH-7181

