### PR TITLE
fix(datasets): persist audio duration on cell edits

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 import pytest
 from rest_framework import status
@@ -229,6 +230,85 @@ def test_update_cell_value_api_accepts_canonical_payload(
     assert response.status_code == status.HTTP_200_OK
     cell.refresh_from_db()
     assert cell.value == "Gamma"
+
+
+@pytest.fixture
+def audio_filter_seed(organization, workspace):
+    dataset = Dataset.objects.create(
+        name="Audio filter dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    audio_col = Column.objects.create(
+        name="recording",
+        data_type=DataTypeChoices.AUDIO.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    row = Row.objects.create(dataset=dataset, order=1)
+    cell = Cell.objects.create(dataset=dataset, row=row, column=audio_col)
+    return dataset, row, audio_col, cell
+
+
+def test_update_audio_cell_persists_duration_for_numeric_filters(
+    auth_client, audio_filter_seed
+):
+    dataset, row, audio_col, cell = audio_filter_seed
+
+    with patch(
+        "model_hub.views.develop_dataset.upload_audio_to_s3_duration",
+        return_value=("https://cdn.example.test/audio.mp3", 12.04),
+    ):
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/update_cell_value/",
+            {
+                "row_id": str(row.id),
+                "column_id": str(audio_col.id),
+                "new_value": "data:audio/mpeg;base64,ZmFrZQ==",
+            },
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata == {"audio_duration_seconds": 12.04}
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 1)],
+        [audio_col],
+    ) == [row]
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "less_than", 5)],
+        [audio_col],
+    ) == []
+
+
+def test_clearing_audio_cell_removes_duration_but_preserves_other_metadata(
+    auth_client, audio_filter_seed
+):
+    dataset, row, audio_col, cell = audio_filter_seed
+    cell.value = "https://cdn.example.test/audio.mp3"
+    cell.column_metadata = {
+        "audio_duration_seconds": 12.04,
+        "source": "manual-edit",
+    }
+    cell.save(update_fields=["value", "column_metadata"])
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.value is None
+    assert cell.column_metadata == {"source": "manual-edit"}
 
 
 def test_dataset_row_data_api_rejects_legacy_filter_shape(

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -5340,6 +5340,10 @@ class UpdateCellValueView(APIView):
                 cell.value = None
                 cell.value_infos = json.dumps({})
                 cell.status = CellStatus.PASS.value
+                if column_data_type == DataTypeChoices.AUDIO.value:
+                    cleared_metadata = dict(cell.column_metadata or {})
+                    cleared_metadata.pop("audio_duration_seconds", None)
+                    cell.column_metadata = cleared_metadata
             elif column_data_type == DataTypeChoices.TEXT.value:
                 cell.value = str(new_value)
                 cell.value_infos = json.dumps({})
@@ -5479,14 +5483,20 @@ class UpdateCellValueView(APIView):
                         cell.value = None
                         cell.value_infos = json.dumps({})
                         cell.status = CellStatus.PASS.value
+                        cleared_metadata = dict(cell.column_metadata or {})
+                        cleared_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = cleared_metadata
                     else:
                         audio_key = f"audio/{dataset_id}/{uuid.uuid4()}"
+                        existing_metadata = dict(cell.column_metadata or {})
                         audio_url, duration = upload_audio_to_s3_duration(
                             new_value,
                             bucket_name="fi-customer-data-dev",
                             object_key=audio_key,
-                            duration_seconds=cell.column_metadata.get(
-                                "audio_duration_seconds"
+                            duration_seconds=(
+                                existing_metadata.get("audio_duration_seconds")
+                                if new_value == cell.value
+                                else None
                             ),
                         )
                         value_infos = (
@@ -5498,6 +5508,11 @@ class UpdateCellValueView(APIView):
                         cell.value_infos = json.dumps(value_infos)
                         cell.status = CellStatus.PASS.value
                         cell.value = audio_url
+                        if duration:
+                            existing_metadata["audio_duration_seconds"] = float(duration)
+                        else:
+                            existing_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = existing_metadata
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")


### PR DESCRIPTION
## Summary\n\n- persist computed audio duration metadata when editing an audio cell\n- merge metadata safely, reuse duration only for the unchanged URL, and clear stale duration metadata when audio is cleared\n- add endpoint/filter regression coverage for numeric duration filtering and metadata cleanup\n\nCloses #1767\n\n## Validation\n\n- git diff --check\n- python -m compileall -q futureagi/model_hub/views/develop_dataset.py futureagi/model_hub/tests/test_dataset_table_filters.py\n- Focused pytest could not start because the environment is missing djangorestframework.