### PR TITLE
feat(traces): add free-text search across trace content

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/FilterChips.jsx
+++ b/frontend/src/sections/projects/LLMTracing/FilterChips.jsx
@@ -75,6 +75,8 @@ const FilterChips = ({
   onAddFilter,
   onChipClick,
   fieldLabelMap,
+  searchTerm,
+  onRemoveSearch,
 }) => {
   const chips = useMemo(
     () =>
@@ -88,7 +90,7 @@ const FilterChips = ({
     [extraFilters, fieldLabelMap],
   );
 
-  if (chips.length === 0) return null;
+  if (chips.length === 0 && !searchTerm) return null;
 
   return (
     <Box
@@ -121,6 +123,13 @@ const FilterChips = ({
           overflow: "hidden",
         }}
       >
+        {searchTerm && (
+          <Chip
+            size="small"
+            onDelete={onRemoveSearch}
+            label={`Search contains “${searchTerm}”`}
+          />
+        )}
         {chips.map((chip) => (
           <Tooltip
             key={chip._idx}
@@ -318,6 +327,8 @@ FilterChips.propTypes = {
   // { [columnId]: { [value]: label } } — resolves chip display labels for
   // enum-like fields (e.g. Project UUID → project name).
   fieldLabelMap: PropTypes.object,
+  searchTerm: PropTypes.string,
+  onRemoveSearch: PropTypes.func,
 };
 
 export default React.memo(FilterChips);

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -688,6 +688,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   });
   const [openCustomColumn, setOpenCustomColumn] = useState(false);
   const [extraFilters, setExtraFiltersRaw] = useState([]);
+  const [traceSearch, setTraceSearch] = useState("");
   const [compareExtraFilters, setCompareExtraFiltersRaw] = useState([]);
   const [filterChipsSaved, setFilterChipsSaved] = useState(false);
   // Track which graph the filter panel targets in compare mode: "primary" | "compare"
@@ -2411,7 +2412,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             colId: c.id,
             hide: c.isVisible === false,
           }))
-        : activeGridApi?.getColumnState?.() ?? undefined;
+        : (activeGridApi?.getColumnState?.() ?? undefined);
     // Dedup colIds before persisting — the store-derived save path bypasses
     // AG Grid's own colId uniqueness.
     const seenColIds = new Set();
@@ -3144,6 +3145,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       {/* Active filter chips — in compare mode, only show Clear/Save at top (chips are inline on each graph) */}
       {!filterChipsSaved && !showCompare && (
         <FilterChips
+          searchTerm={traceSearch}
           extraFilters={extraFilters.map((f) => ({
             ...f,
             display_name:
@@ -3159,9 +3161,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             setExternalFilterAnchor(null);
             setExtraFilters((prev) => prev.filter((_, i) => i !== idx));
           }}
+          onRemoveSearch={() => setTraceSearch("")}
           onClearAll={() => {
             setExternalFilterAnchor(null);
             setExtraFilters([]);
+            setTraceSearch("");
             try {
               localStorage.removeItem(filtersStorageKey);
             } catch {
@@ -3665,6 +3669,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 setIsPrimaryFilterOpen(!isPrimaryFilterOpen);
               }}
               onApplyExtraFilters={setExtraFilters}
+              searchTerm={traceSearch}
+              onSearch={setTraceSearch}
               onClearExtraFilters={clearPrimaryExtraFilters}
               graphFilters={selectPanelGraphFilters(
                 filterTarget,
@@ -3794,8 +3800,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               selectedCount={
                 projectSource === PROJECT_SOURCE.SIMULATOR
                   ? simCallFilterSelectionMode
-                    ? simCallMeta.totalMatching ??
-                      simCallMeta.totalPages * simCallMeta.pageLimit
+                    ? (simCallMeta.totalMatching ??
+                      simCallMeta.totalPages * simCallMeta.pageLimit)
                     : selectedCallIds?.length || 0
                   : selectedTab === "trace"
                     ? allTracesSelected
@@ -4580,6 +4586,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               >
                 <Suspense fallback={<ComponentLoader />}>
                   <TraceGrid
+                    search={traceSearch}
                     columns={columns["primary-trace"]}
                     setColumns={(columns) =>
                       setSpecificColumns("primary-trace", columns)
@@ -4620,6 +4627,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               >
                 <Suspense fallback={<ComponentLoader />}>
                   <TraceGrid
+                    search={traceSearch}
                     columns={columns["compare-trace"]}
                     setColumns={(columns) =>
                       setSpecificColumns("compare-trace", columns)

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
-import { Badge, Button, MenuItem, Popover, Stack } from "@mui/material";
+import {
+  Badge,
+  Button,
+  MenuItem,
+  Popover,
+  Stack,
+  TextField,
+} from "@mui/material";
 import { startOfToday, startOfTomorrow, startOfYesterday, sub } from "date-fns";
 import Iconify from "src/components/iconify";
 import DisplayPanel from "./DisplayPanel";
@@ -36,6 +43,8 @@ const ObserveToolbar = ({
   dateFilter,
   setDateFilter,
   // Filter
+  searchTerm = "",
+  onSearch,
   hasActiveFilter,
   canSaveView,
   onSaveView,
@@ -111,11 +120,14 @@ const ObserveToolbar = ({
   const [panelFilters, setPanelFilters] = useState(null); // stores raw panel-format filters
   const [dateAnchor, setDateAnchor] = useState(null);
   const [customDateOpen, setCustomDateOpen] = useState(false);
+  const [searchInput, setSearchInput] = useState(searchTerm);
   const dateButtonRef = useRef(null);
   const setFilterButtonNode = useCallback((node) => {
     filterButtonRef.current = node;
     setFilterButtonEl(node);
   }, []);
+
+  useEffect(() => setSearchInput(searchTerm), [searchTerm]);
 
   const handleDateOptionChange = (option) => {
     setDateAnchor(null);
@@ -310,6 +322,22 @@ const ObserveToolbar = ({
 
   const toolbarContent = (
     <Stack direction="row" alignItems="center" gap={1}>
+      {!isCompareActive && mode === "traces" && (
+        <TextField
+          size="small"
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onSearch?.(searchInput.trim());
+          }}
+          placeholder="Search traces"
+          inputProps={{ "aria-label": "Search traces" }}
+          sx={{
+            width: 190,
+            "& .MuiInputBase-root": { height: 26, fontSize: 13 },
+          }}
+        />
+      )}
       {/* Date picker — hidden in compare mode (each graph has its own) */}
       {dateLabel && !isCompareActive && (
         <>
@@ -599,6 +627,8 @@ ObserveToolbar.propTypes = {
   excludeSimulationCalls: PropTypes.bool,
   onToggleSimulationCalls: PropTypes.func,
   onApplyExtraFilters: PropTypes.func,
+  searchTerm: PropTypes.string,
+  onSearch: PropTypes.func,
   onClearExtraFilters: PropTypes.func,
   onClearCompareExtraFilters: PropTypes.func,
   filterFields: PropTypes.array,

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -60,6 +60,7 @@ const TraceGrid = React.forwardRef(
       canonicalOrderRef,
       enabled = true,
       showErrors = false,
+      search = "",
     },
     gridRef,
   ) => {
@@ -109,6 +110,7 @@ const TraceGrid = React.forwardRef(
           extraFilters: extraFilters || EMPTY_EXTRA_FILTERS,
           metricFilters: metricFilters || [],
           hasEvalFilter,
+          search,
           dateInterval,
           projectId,
           enabled,
@@ -118,6 +120,7 @@ const TraceGrid = React.forwardRef(
         extraFilters,
         metricFilters,
         hasEvalFilter,
+        search,
         dateInterval,
         projectId,
         enabled,
@@ -235,6 +238,7 @@ const TraceGrid = React.forwardRef(
                   ]),
                 ),
                 ...(dateInterval && { interval: dateInterval }),
+                ...(search ? { search } : {}),
               });
 
               // Use prefetched data if available, otherwise fetch
@@ -641,6 +645,7 @@ TraceGrid.propTypes = {
   metricFilters: PropTypes.array,
   enabled: PropTypes.bool,
   showErrors: PropTypes.bool,
+  search: PropTypes.string,
 };
 
 export default TraceGrid;

--- a/futureagi/tracer/serializers/trace.py
+++ b/futureagi/tracer/serializers/trace.py
@@ -166,6 +166,7 @@ class TraceObserveListQuerySerializer(StrictInputSerializer):
         required=False, default=30, min_value=1, max_value=500
     )
     interval = serializers.CharField(required=False, allow_blank=True)
+    search = serializers.CharField(required=False, allow_blank=True)
 
 
 class TraceObserveListMetadataSerializer(serializers.Serializer):

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -185,10 +185,11 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             pv_fragment = "AND project_version_id = %(project_version_id)s"
             self.params["project_version_id"] = self.project_version_id
 
-        # Search filter on trace_name
+        # Free-text search spans the fields shown in the trace table. Keep the
+        # predicate in the root query so pagination and totals stay aligned.
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = "AND (trace_name ILIKE %(search)s OR input ILIKE %(search)s OR output ILIKE %(search)s)"
             self.params["search"] = f"%{self.search}%"
 
         # Configurable columns — only SELECT requested columns.
@@ -283,7 +284,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
 
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = "AND (trace_name ILIKE %(search)s OR input ILIKE %(search)s OR output ILIKE %(search)s)"
             self.params["search"] = f"%{self.search}%"
 
         query = f"""
@@ -397,7 +398,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         # Search filter (reuse from build())
         search_fragment = ""
         if self.search:
-            search_fragment = "AND trace_name ILIKE %(search)s"
+            search_fragment = "AND (trace_name ILIKE %(search)s OR input ILIKE %(search)s OR output ILIKE %(search)s)"
             params["search"] = f"%{self.search}%"
 
         query = f"""

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -2585,6 +2585,23 @@ class TestTraceListQueryBuilder:
         assert "uniq(trace_id)" in query
         assert "parent_span_id IS NULL" in query
 
+    def test_free_text_search_matches_name_and_content(self):
+        """Search must cover the trace name plus root input/output fields."""
+        from tracer.services.clickhouse.query_builders import TraceListQueryBuilder
+
+        builder = TraceListQueryBuilder(
+            project_id="test-project-id", search="timeout", page_size=10
+        )
+        query, params = builder.build()
+        assert "trace_name ILIKE %(search)s" in query
+        assert "input ILIKE %(search)s" in query
+        assert "output ILIKE %(search)s" in query
+        assert params["search"] == "%timeout%"
+
+        count_query, count_params = builder.build_count_query()
+        assert "input ILIKE %(search)s" in count_query
+        assert count_params["search"] == "%timeout%"
+
     def test_build_eval_query(self):
         """Phase-2 eval query should query tracer_eval_logger grouped by config."""
         from tracer.services.clickhouse.query_builders import TraceListQueryBuilder

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3436,6 +3436,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         org_scope = bool(org_project_ids)
         filters = list(validated_data.get("filters", []) or [])
+        search = validated_data.get("search") or None
         page_number = validated_data["page_number"]
         page_size = validated_data["page_size"]
         session_id = (
@@ -3523,6 +3524,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             page_size=page_size,
             eval_config_ids=eval_config_ids,
             annotation_label_ids=annotation_label_ids,
+            search=search,
         )
 
         # Phase 1: Paginated traces (light columns only — no input/output)


### PR DESCRIPTION
## Summary

- expose the existing ClickHouse trace-list search hook through the strict API serializer and view
- match free-text terms against trace name, root input, or root output while keeping count and pagination predicates aligned
- add a Search traces toolbar field with Enter-to-apply behavior and a removable active chip
- add a focused query-builder regression test

Closes #1579

## Verification

- python -m compileall -q passed for changed Python modules
- Prettier check passed for changed frontend files
- git diff --check passed
- Targeted pytest is blocked locally because rest_framework is not installed in the workspace