### PR TITLE
fix(frontend): preserve date-only dataset values

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import CustomTooltip from "src/components/tooltip";
 import RenderMeta from "../RenderMeta";
 import GenerateDiffText from "../../GenerateDiffText";
@@ -15,7 +15,12 @@ const DatetimeCellRenderer = ({
 }) => {
   const isValueArray = Array.isArray(value);
   const isBlankValue = value === null || value === undefined || value === "";
-  const isValidDate = !isBlankValue && !isNaN(new Date(value).getTime());
+  const hasTimeComponent =
+    typeof value === "string" && /(?:T|\s)\d{1,2}:\d{2}/.test(value);
+  const isIsoDateOnly =
+    typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+  const parsedDate = isIsoDateOnly ? parseISO(value) : new Date(value);
+  const isValidDate = !isBlankValue && !isNaN(parsedDate.getTime());
 
   return (
     <CustomTooltip
@@ -31,7 +36,10 @@ const DatetimeCellRenderer = ({
         {isValueArray ? (
           <GenerateDiffText cellText={value} />
         ) : isValidDate ? (
-          format(new Date(value), "dd/MM/yyyy HH:mm")
+          format(
+            parsedDate,
+            hasTimeComponent ? "dd/MM/yyyy HH:mm" : "dd/MM/yyyy",
+          )
         ) : isBlankValue ? (
           ""
         ) : (

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import { format } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "src/utils/test-utils";
 import DatetimeCellRenderer from "../DatetimeCellRenderer";
@@ -36,6 +37,31 @@ describe("DatetimeCellRenderer", () => {
     render(<DatetimeCellRenderer value="not-a-date" {...rendererProps} />);
 
     expect(screen.getByText("Invalid Date")).toBeInTheDocument();
+  });
+
+  it("renders date-only values without inventing a midnight time", () => {
+    render(<DatetimeCellRenderer value="2026-01-29" {...rendererProps} />);
+
+    expect(screen.getByText("29/01/2026")).toBeInTheDocument();
+    expect(screen.queryByText(/00:00/)).not.toBeInTheDocument();
+  });
+
+  it("preserves an explicit time component", () => {
+    const value = "2026-01-29T14:30:00Z";
+    render(<DatetimeCellRenderer value={value} {...rendererProps} />);
+
+    expect(
+      screen.getByText(format(new Date(value), "dd/MM/yyyy HH:mm")),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves an explicitly supplied midnight", () => {
+    const value = "2026-01-29T00:00:00Z";
+    render(<DatetimeCellRenderer value={value} {...rendererProps} />);
+
+    expect(
+      screen.getByText(format(new Date(value), "dd/MM/yyyy HH:mm")),
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- render date-only ISO values without adding a fabricated `00:00` time
- preserve explicit time components, including genuine midnight timestamps
- add regression coverage for date-only, timed, and explicit-midnight values

Fixes #1766

## Verification

- `vitest run src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx --reporter=dot --pool=threads --poolOptions.threads.singleThread=true` (8 passed)
- ESLint on both changed files
- Prettier `--check` on both changed files
- `git diff --check`