### PR TITLE
fix(model-hub): persist audio duration metadata

### DIFF
--- a/futureagi/model_hub/tests/test_dataset_table_filters.py
+++ b/futureagi/model_hub/tests/test_dataset_table_filters.py
@@ -231,6 +231,141 @@ def test_update_cell_value_api_accepts_canonical_payload(
     assert cell.value == "Gamma"
 
 
+@pytest.fixture
+def audio_dataset_seed(organization, workspace):
+    dataset = Dataset.objects.create(
+        name="Audio duration dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    audio_col = Column.objects.create(
+        name="recording",
+        data_type=DataTypeChoices.AUDIO.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    row = Row.objects.create(dataset=dataset, order=1)
+    cell = Cell.objects.create(
+        dataset=dataset,
+        row=row,
+        column=audio_col,
+        value=None,
+        column_metadata=None,
+    )
+    return dataset, row, audio_col, cell
+
+
+def test_update_audio_cell_persists_duration_for_numeric_filters(
+    auth_client, audio_dataset_seed, monkeypatch
+):
+    dataset, row, audio_col, cell = audio_dataset_seed
+    upload_calls = []
+
+    def fake_upload(_value, **kwargs):
+        upload_calls.append(kwargs)
+        return "https://storage.example/audio/recording.mp3", 12.04
+
+    monkeypatch.setattr(
+        "model_hub.views.develop_dataset.upload_audio_to_s3_duration",
+        fake_upload,
+    )
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "data:audio/mpeg;base64,AAAA",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata == {"audio_duration_seconds": 12.04}
+    assert upload_calls[0]["duration_seconds"] is None
+
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "greater_than", 1)],
+        [audio_col],
+    ) == [row]
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "less_than", 5)],
+        [audio_col],
+    ) == []
+    assert _apply(
+        dataset,
+        [_filter(audio_col.id, "number", "between", [10, 15])],
+        [audio_col],
+    ) == [row]
+
+
+def test_update_audio_cell_replaces_and_clears_duration_metadata(
+    auth_client, audio_dataset_seed, monkeypatch
+):
+    dataset, row, audio_col, cell = audio_dataset_seed
+    old_url = "https://storage.example/audio/old.mp3"
+    cell.value = old_url
+    cell.column_metadata = {"audio_duration_seconds": 12.04, "source": "upload"}
+    cell.save()
+    upload_calls = []
+
+    def fake_upload(_value, **kwargs):
+        upload_calls.append(kwargs)
+        return "https://storage.example/audio/new.mp3", 7.5
+
+    monkeypatch.setattr(
+        "model_hub.views.develop_dataset.upload_audio_to_s3_duration",
+        fake_upload,
+    )
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "data:audio/mpeg;base64,BBBB",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.column_metadata == {
+        "audio_duration_seconds": 7.5,
+        "source": "upload",
+    }
+    assert upload_calls[0]["duration_seconds"] is None
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": cell.value,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert upload_calls[1]["duration_seconds"] == 7.5
+
+    response = auth_client.post(
+        f"/model-hub/develops/{dataset.id}/update_cell_value/",
+        {
+            "row_id": str(row.id),
+            "column_id": str(audio_col.id),
+            "new_value": "",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    cell.refresh_from_db()
+    assert cell.value is None
+    assert cell.column_metadata == {"source": "upload"}
+
+
 def test_dataset_row_data_api_rejects_legacy_filter_shape(
     auth_client, dataset_filter_seed
 ):

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -5340,6 +5340,10 @@ class UpdateCellValueView(APIView):
                 cell.value = None
                 cell.value_infos = json.dumps({})
                 cell.status = CellStatus.PASS.value
+                if column_data_type == DataTypeChoices.AUDIO.value:
+                    cleared_metadata = dict(cell.column_metadata or {})
+                    cleared_metadata.pop("audio_duration_seconds", None)
+                    cell.column_metadata = cleared_metadata
             elif column_data_type == DataTypeChoices.TEXT.value:
                 cell.value = str(new_value)
                 cell.value_infos = json.dumps({})
@@ -5479,14 +5483,20 @@ class UpdateCellValueView(APIView):
                         cell.value = None
                         cell.value_infos = json.dumps({})
                         cell.status = CellStatus.PASS.value
+                        cleared_metadata = dict(cell.column_metadata or {})
+                        cleared_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = cleared_metadata
                     else:
                         audio_key = f"audio/{dataset_id}/{uuid.uuid4()}"
+                        existing_metadata = dict(cell.column_metadata or {})
                         audio_url, duration = upload_audio_to_s3_duration(
                             new_value,
                             bucket_name="fi-customer-data-dev",
                             object_key=audio_key,
-                            duration_seconds=cell.column_metadata.get(
-                                "audio_duration_seconds"
+                            duration_seconds=(
+                                existing_metadata.get("audio_duration_seconds")
+                                if new_value == cell.value
+                                else None
                             ),
                         )
                         value_infos = (
@@ -5498,6 +5508,13 @@ class UpdateCellValueView(APIView):
                         cell.value_infos = json.dumps(value_infos)
                         cell.status = CellStatus.PASS.value
                         cell.value = audio_url
+                        if duration:
+                            existing_metadata["audio_duration_seconds"] = float(
+                                duration
+                            )
+                        else:
+                            existing_metadata.pop("audio_duration_seconds", None)
+                        cell.column_metadata = existing_metadata
 
                 except Exception as e:
                     logger.error(f"ERROR: {e}")


### PR DESCRIPTION
## Summary

- persist computed audio duration metadata when editing dataset cells
- merge metadata and clear stale duration keys when audio is replaced or cleared
- reuse a cached duration only when the same stored audio URL is re-saved
- add endpoint and numeric-filter regression coverage

Fixes #1767

## Verification

- `python -m compileall -q futureagi/model_hub/views/develop_dataset.py futureagi/model_hub/tests/test_dataset_table_filters.py`
- `git diff --check`
- Focused pytest is currently blocked by the environment missing `rest_framework`.