### PR TITLE
fix(develop): dedupe JSON response-format options across model dropdowns [TH-6960]

### DIFF
--- a/frontend/src/components/custom-model-options/ModelOptionsItems.jsx
+++ b/frontend/src/components/custom-model-options/ModelOptionsItems.jsx
@@ -14,6 +14,7 @@ import { BOOLEAN_VALUE_OPTIONS } from "../../utils/constants";
 import CustomAudioDialog from "src/sections/develop-detail/CustomAudioDialog";
 import CustomTooltip from "../tooltip";
 import SvgColor from "../svg-color";
+import { buildResponseFormatMenu } from "src/utils/responseFormat";
 
 const defaultMenus = [
   { value: "text", label: "Text" },
@@ -127,28 +128,15 @@ const ModelOptionsItems = ({
   const menuItems = useMemo(() => {
     // If responseFormat exists, use it + responseSchema
     if (responseFormat?.length || module === "workbench") {
-      const merged = [
-        ...(responseSchema?.map((item) => ({
-          label: item.name,
-          value: item.id,
-        })) ?? []),
-        ...(responseFormat?.map((item) => ({
-          label: item.value,
-          value: item.value,
-        })) ?? []),
-      ];
-
-      // Ensure uniqueness by value
-      const uniqueMenus = Array.from(
-        new Map(merged.map((item) => [item.value, item])).values(),
-      );
-
-      return uniqueMenus;
+      return buildResponseFormatMenu({
+        responseSchema,
+        modelResponseFormat: responseFormat,
+      });
     }
 
     // Otherwise, fallback to defaultMenus
     return [...defaultMenus];
-  }, [responseSchema, responseFormat]);
+  }, [responseSchema, responseFormat, module]);
 
   return (
     <Box

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/usePromptNodeQueries.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/usePromptNodeQueries.js
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import _ from "lodash";
 import axios, { endpoints } from "src/utils/axios";
 import { DEFAULT_RESPONSE_FORMAT_OPTIONS } from "src/sections/agent-playground/utils/constants";
+import { buildResponseFormatMenu } from "src/utils/responseFormat";
 
 /**
  * Custom hook for fetching data related to prompt node form
@@ -37,27 +37,15 @@ export function usePromptNodeQueries(watchedModel, watchedModelProvider) {
   });
 
   // Build menu items for response format dropdown
-  const responseFormatMenuItems = useMemo(() => {
-    const menus = [...DEFAULT_RESPONSE_FORMAT_OPTIONS];
-
-    // Add custom schemas from API
-    responseSchema?.forEach((item) => {
-      menus.push({ label: item.name, value: item.id });
-    });
-
-    // Add model-specific response formats
-    modelParams?.responseFormat?.forEach((item) => {
-      const exists = menus.some((m) => m.value === item.value);
-      if (!exists) {
-        menus.push({
-          label: _.startCase(item.value),
-          value: item.value,
-        });
-      }
-    });
-
-    return menus;
-  }, [responseSchema, modelParams?.responseFormat]);
+  const responseFormatMenuItems = useMemo(
+    () =>
+      buildResponseFormatMenu({
+        defaults: DEFAULT_RESPONSE_FORMAT_OPTIONS,
+        responseSchema,
+        modelResponseFormat: modelParams?.responseFormat,
+      }),
+    [responseSchema, modelParams?.responseFormat],
+  );
 
   return {
     responseSchema,

--- a/frontend/src/sections/develop-detail/Common/ModelOptions.jsx
+++ b/frontend/src/sections/develop-detail/Common/ModelOptions.jsx
@@ -15,6 +15,13 @@ import { generateNMarks } from "./common";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import { useController } from "react-hook-form";
 import CreateResponseSchema from "src/components/custom-model-options/CreateResponseSchema";
+import { buildResponseFormatMenu } from "src/utils/responseFormat";
+
+const DEFAULT_MENUS = [
+  { value: "text", label: "Text" },
+  { value: "json_object", label: "JSON" },
+  { value: "none", label: "None" },
+];
 
 const ModelOptions = ({
   responseSchema = [],
@@ -37,18 +44,10 @@ const ModelOptions = ({
     name: `${fieldNamePrefix}.responseFormat`,
     control,
   });
-  const defaultMenus = [
-    { value: "text", label: "Text" },
-    { value: "json_object", label: "JSON" },
-    { value: "none", label: "None" },
-  ];
-  const menuItems = useMemo(() => {
-    const menus = [...defaultMenus];
-    responseSchema.forEach((item) => {
-      menus.push({ label: item.name, value: item.id });
-    });
-    return menus;
-  }, [responseSchema]);
+  const menuItems = useMemo(
+    () => buildResponseFormatMenu({ defaults: DEFAULT_MENUS, responseSchema }),
+    [responseSchema],
+  );
   const renderInfo = () => {
     return (
       <Box

--- a/frontend/src/sections/develop-detail/Common/ModelOptionsState.jsx
+++ b/frontend/src/sections/develop-detail/Common/ModelOptionsState.jsx
@@ -28,8 +28,9 @@ import { BOOLEAN_VALUE_OPTIONS } from "../../../utils/constants";
 import { FormSearchSelectFieldState } from "../../../components/FromSearchSelectField";
 import CustomTooltip from "../../../components/tooltip";
 import SvgColor from "src/components/svg-color/svg-color";
+import { buildResponseFormatMenu } from "src/utils/responseFormat";
 
-const defaultMenus = [
+const DEFAULT_MENUS = [
   { value: "text", label: "Text" },
   { value: "json_object", label: "JSON" },
   { value: "none", label: "None" },
@@ -67,25 +68,15 @@ export default function ModelOptionsState({
     control,
   });
 
-  const menuItems = useMemo(() => {
-    const menus = [...defaultMenus];
-
-    responseSchema?.forEach((item) => {
-      menus.push({ label: item.name, value: item.id });
-    });
-
-    modelResponseFormat?.forEach((item) => {
-      const exists = menus.some((m) => m.value === item.value);
-      if (!exists) {
-        menus.push({
-          label: _.startCase(item.value),
-          value: item.value,
-        });
-      }
-    });
-
-    return menus;
-  }, [responseSchema, modelResponseFormat]);
+  const menuItems = useMemo(
+    () =>
+      buildResponseFormatMenu({
+        defaults: DEFAULT_MENUS,
+        responseSchema,
+        modelResponseFormat,
+      }),
+    [responseSchema, modelResponseFormat],
+  );
 
   const updateSliderParameter = (index, value) => {
     setModelParameters((prev) => ({

--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -82,6 +82,7 @@ import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { sanitizeContent } from "src/utils/utils";
 import { AudioPlaybackProvider } from "../../../components/custom-audio/context-provider/AudioPlaybackContext";
 import logger from "src/utils/logger";
+import { canonicalResponseFormat } from "src/utils/responseFormat";
 import { useCustomAudioDialog, useRunPromptStore } from "../states";
 import { useDevelopDetailContext } from "../Context/DevelopDetailContext";
 import { ShowComponent } from "../../../components/show";
@@ -1182,7 +1183,7 @@ export const RunPromptForm = React.forwardRef(
 
       setValue(
         "config.responseFormat",
-        importedConfig?.response_format ?? "text",
+        canonicalResponseFormat(importedConfig?.response_format ?? "text"),
       );
       setValue(
         "config.tools",

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { normalizeForComparison } from "src/sections/workbench/createPrompt/Playground/common";
 import { getRandomId } from "src/utils/utils";
+import { canonicalResponseFormat } from "src/utils/responseFormat";
 import { z } from "zod";
 
 function getIdFromObject(obj) {
@@ -128,11 +129,13 @@ export const transformDefaultData = (editConfigData, allColumns) => {
   const resolvedModelType =
     runPromptConfig?.model_type || runPromptConfig?.modelType;
 
+  // Prompts saved elsewhere store the backend's `json` spelling; map it onto
+  // the menu's `json_object` row.
   const rawResponseFormat = editConfigData?.response_format;
   const resolvedResponseFormat =
     typeof rawResponseFormat === "object"
       ? rawResponseFormat?.name ?? "text"
-      : rawResponseFormat ?? "text";
+      : canonicalResponseFormat(rawResponseFormat ?? "text");
 
   let voiceInputColumn = "";
   if (resolvedModelType === MODEL_TYPES.STT) {

--- a/frontend/src/utils/__tests__/responseFormat.test.js
+++ b/frontend/src/utils/__tests__/responseFormat.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildResponseFormatMenu,
+  canonicalResponseFormat,
+  responseFormatLabel,
+} from "../responseFormat";
+
+describe("canonicalResponseFormat", () => {
+  it("collapses json and json_object onto one key", () => {
+    expect(canonicalResponseFormat("json")).toBe("json_object");
+    expect(canonicalResponseFormat("json_object")).toBe("json_object");
+    expect(canonicalResponseFormat("JSON")).toBe("json_object");
+  });
+
+  it("leaves other formats untouched", () => {
+    expect(canonicalResponseFormat("text")).toBe("text");
+    expect(canonicalResponseFormat("none")).toBe("none");
+    expect(canonicalResponseFormat("json_schema")).toBe("json_schema");
+  });
+
+  it("passes through non-strings", () => {
+    expect(canonicalResponseFormat(undefined)).toBeUndefined();
+    const schema = { id: "abc" };
+    expect(canonicalResponseFormat(schema)).toBe(schema);
+  });
+});
+
+describe("responseFormatLabel", () => {
+  it("labels known formats", () => {
+    expect(responseFormatLabel("json")).toBe("JSON");
+    expect(responseFormatLabel("json_object")).toBe("JSON");
+    expect(responseFormatLabel("text")).toBe("Text");
+  });
+
+  it("start-cases unknown formats", () => {
+    expect(responseFormatLabel("structured_output")).toBe("Structured Output");
+  });
+});
+
+describe("buildResponseFormatMenu", () => {
+  const DEVELOP_DEFAULTS = [
+    { value: "text", label: "Text" },
+    { value: "json_object", label: "JSON" },
+    { value: "none", label: "None" },
+  ];
+
+  it("does not add a second JSON row when the backend advertises `json`", () => {
+    const menu = buildResponseFormatMenu({
+      defaults: DEVELOP_DEFAULTS,
+      modelResponseFormat: [{ value: "json" }, { value: "text" }],
+    });
+
+    expect(menu).toEqual(DEVELOP_DEFAULTS);
+  });
+
+  it("keeps the surface's own spelling when deduping", () => {
+    const menu = buildResponseFormatMenu({
+      defaults: [{ value: "json", label: "JSON" }],
+      modelResponseFormat: [{ value: "json_object" }],
+    });
+
+    expect(menu).toEqual([{ value: "json", label: "JSON" }]);
+  });
+
+  it("appends custom schemas between defaults and backend formats", () => {
+    const menu = buildResponseFormatMenu({
+      defaults: DEVELOP_DEFAULTS,
+      responseSchema: [{ id: "schema-id", name: "asdasd" }],
+      modelResponseFormat: [{ value: "json" }],
+    });
+
+    expect(menu).toEqual([
+      ...DEVELOP_DEFAULTS,
+      { label: "asdasd", value: "schema-id" },
+    ]);
+  });
+
+  it("keeps backend formats that are genuinely new", () => {
+    const menu = buildResponseFormatMenu({
+      defaults: DEVELOP_DEFAULTS,
+      modelResponseFormat: [{ value: "structured_output" }],
+    });
+
+    expect(menu).toContainEqual({
+      label: "Structured Output",
+      value: "structured_output",
+    });
+  });
+
+  it("builds a backend-only menu when no defaults are given", () => {
+    const menu = buildResponseFormatMenu({
+      modelResponseFormat: [{ value: "json" }, { value: "text" }],
+    });
+
+    expect(menu).toEqual([
+      { label: "JSON", value: "json" },
+      { label: "Text", value: "text" },
+    ]);
+  });
+});

--- a/frontend/src/utils/responseFormat.js
+++ b/frontend/src/utils/responseFormat.js
@@ -1,0 +1,48 @@
+import _ from "lodash";
+
+// `json` and `json_object` are two spellings of the same option: the run-prompt
+// backend advertises `json` while the develop UI stores `json_object`.
+// `json_schema` is deliberately excluded — it is a distinct format.
+const JSON_ALIASES = new Set(["json", "json_object"]);
+
+const FORMAT_LABELS = {
+  text: "Text",
+  json: "JSON",
+  json_object: "JSON",
+  none: "None",
+};
+
+export function canonicalResponseFormat(value) {
+  if (typeof value !== "string") return value;
+  const lowered = value.toLowerCase();
+  return JSON_ALIASES.has(lowered) ? "json_object" : value;
+}
+
+export function responseFormatLabel(value) {
+  if (typeof value !== "string") return value;
+  return FORMAT_LABELS[value.toLowerCase()] ?? _.startCase(value);
+}
+
+export function buildResponseFormatMenu({
+  defaults = [],
+  responseSchema = [],
+  modelResponseFormat = [],
+} = {}) {
+  const menus = [];
+  const seen = new Set();
+
+  const add = (item) => {
+    const key = canonicalResponseFormat(item.value);
+    if (seen.has(key)) return;
+    seen.add(key);
+    menus.push(item);
+  };
+
+  defaults.forEach(add);
+  responseSchema?.forEach((item) => add({ label: item.name, value: item.id }));
+  modelResponseFormat?.forEach((item) =>
+    add({ label: responseFormatLabel(item.value), value: item.value }),
+  );
+
+  return menus;
+}


### PR DESCRIPTION
**Ticket:** [TH-6960](https://linear.app/future-agi/issue/TH-6960/run-prompt-drawer-response-format-dropdown-shows-duplicate-json-option) — Closes TH-6960

## What was the bug

In the Develop Run Prompt drawer (`Model Options > Response Format`), the dropdown listed **two JSON entries**: `JSON` and `Json`.

Both map to the same `json_object` behaviour, so the user was given a meaningless choice between identical options.

The menu is built from two sources that spell JSON differently:

- the frontend hardcodes `{ value: "json_object", label: "JSON" }`
- `GET /model-hub/api/model_parameters/` advertises `{ "value": "json" }`

The dedup compared raw values (`"json_object" !== "json"`), so the backend entry was treated as new and appended with `_.startCase("json")`, rendering as `Json`.

The same hand-rolled menu exists on four surfaces with inconsistent hardcoded spellings, so the surfaces were free to keep drifting apart.

## What changes have been done

- `src/utils/responseFormat.js` — new shared helper: `canonicalResponseFormat`, `responseFormatLabel`, `buildResponseFormatMenu`. Builds the menu as defaults → custom schemas → backend formats, deduped on a canonical JSON key, first-wins, and owns its own labels
- `src/utils/__tests__/responseFormat.test.js` — unit tests for the dedup, aliasing and labelling
- `src/sections/develop-detail/Common/ModelOptionsState.jsx` — the reported surface, now builds its menu via the helper
- `src/sections/develop-detail/Common/ModelOptions.jsx` — same, via the helper
- `src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/usePromptNodeQueries.js` — same, via the helper
- `src/components/custom-model-options/ModelOptionsItems.jsx` — same, via the helper; keeps its backend-list-driven membership and its `module === "workbench"` branch
- `src/sections/develop-detail/RunPrompt/common.js` — hydrating a develop prompt maps a stored `json` onto the menu's `json_object` row
- `src/sections/develop-detail/RunPrompt/RunPrompt.jsx` — same mapping on the imported-config path

## Why the changes

- **Dedup on a canonical key, not the raw string.** `json` and `json_object` are one option with two spellings, so comparing raw values can never collapse them. `json_schema` is deliberately excluded from the alias set since it is a genuinely different format.
- **Each surface keeps the spelling it already persists.** Develop continues to store `json_object`, agent playground continues to store `json`. Nothing in this PR changes what is written. Standardising the stored value would break the agent playground engine, which matches the literal `"json"` when deciding whether to parse a node's output as JSON, and fails silently by handing downstream nodes a raw string.
- **Normalise on read for develop.** Prompts authored elsewhere store `json`. Once the duplicate row is gone, that value no longer matches a menu row, so hydrating maps it onto `json_object`. Without this the select would render empty for those prompts.
- **One shared builder.** Four copies of the same logic with three different hardcoded spellings is what allowed the drift in the first place.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Run Prompt dropdown, model whose backend list includes `json` | One JSON row. `Text, JSON, None` plus custom schemas, no trailing `Json` |
| 2 | Edit a column stored with the legacy `"json"` | `JSON` is selected, not blank |
| 3 | Edit a column using a custom schema | Schema stays selected, unchanged from before |
| 4 | Experiment model params popover | Labels read `JSON` / `Text` instead of raw lowercase, one JSON row |
| 5 | Agent playground prompt node | Menu unchanged, and the node still persists `"json"` |
| 6 | Backend advertises an unrecognised format | Still appended with its start-cased label |

Automated: 10 new unit tests, plus 706 existing tests passing across the touched areas.

## How to reproduce (original bug)

1. Open a Develop dataset, `?tab=data`
2. Click **Run Prompt**
3. Select an LLM model, for example `gpt-4.1` or `groq/llama-3.3-70b-versatile`
4. Click the gear icon on the model row to open **Model options**
5. Open the **Response Format** dropdown
6. Observe four entries: `Text`, `JSON`, `None`, `Json`

## Commands

```bash
# confirm the backend advertises the second spelling
curl '<host>/model-hub/api/model_parameters/?model=gpt-4.1&provider=openai&model_type=llm' \
  -H "Authorization: Bearer <token>"
# -> "responseFormat": [{"value": "json"}, {"value": "text"}]

cd frontend
yarn test:run src/utils/__tests__/responseFormat.test.js
```

## Videos and screenshots


https://github.com/user-attachments/assets/7de5c481-eca4-4138-9e67-a197a6cf1559

