### PR TITLE
perf(annotations): remove the queue-count cartesian, the items-list N+1, and the duplicate trace reads

### DIFF
--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -1789,6 +1789,12 @@ class AnnotateDetailSerializer(serializers.Serializer):
         labels = instance["labels"]
         annotations = instance["annotations"]
         progress = instance["progress"]
+        # Same page cache the view built, under the key ``get_source_preview``
+        # already uses. content and preview resolve the SAME tracer source, so
+        # without it they each did their own CH point-read (TH-7104).
+        ch_cache = self.context.get("ch_source_cache")
+        if ch_cache is None:
+            ch_cache = CollectorSourceCache.for_items([item])
 
         return {
             "item": {
@@ -1826,8 +1832,8 @@ class AnnotateDetailSerializer(serializers.Serializer):
                         "user"
                     )
                 ],
-                "source_content": resolve_source_content(item),
-                "source_preview": resolve_source_preview(item),
+                "source_content": resolve_source_content(item, ch_cache=ch_cache),
+                "source_preview": resolve_source_preview(item, ch_cache=ch_cache),
                 "review_notes": item.review_notes,
                 "reviewed_by_name": (
                     item.reviewed_by.name if item.reviewed_by else None

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -548,6 +548,11 @@ class QueueItemSerializer(serializers.ModelSerializer):
         }.get(status, status)
 
     def get_comment_count(self, obj):
+        # Annotated by QueueItemViewSet.get_queryset; the query is the fallback
+        # for callers that serialize an item they fetched themselves.
+        annotated = getattr(obj, "annotated_comment_count", None)
+        if annotated is not None:
+            return annotated
         return QueueItemReviewComment.objects.filter(
             queue_item=obj,
             action=QueueItemReviewComment.ACTION_COMMENT,
@@ -555,6 +560,9 @@ class QueueItemSerializer(serializers.ModelSerializer):
         ).count()
 
     def get_open_feedback_count(self, obj):
+        annotated = getattr(obj, "annotated_open_feedback_count", None)
+        if annotated is not None:
+            return annotated
         return QueueItemReviewThread.objects.filter(
             queue_item=obj,
             blocking=True,

--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -36,7 +36,7 @@ from model_hub.models.choices import (
     QueueItemStatus,
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
-from model_hub.views.annotation_queues import _queue_count_subquery
+from model_hub.views.annotation_queues import _related_count_subquery
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 from tfc.ee_gating import EEResource, FeatureUnavailable
@@ -353,7 +353,11 @@ class TestListQueues:
             try:
                 return (
                     AnnotationQueue.no_workspace_objects.filter(pk=queue.pk)
-                    .annotate(item_count=_queue_count_subquery(QueueItem))
+                    .annotate(
+                        item_count=_related_count_subquery(
+                            QueueItem.no_workspace_objects, "queue"
+                        )
+                    )
                     .first()
                     .item_count
                 )

--- a/futureagi/model_hub/tests/test_annotation_queues_api.py
+++ b/futureagi/model_hub/tests/test_annotation_queues_api.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
 from accounts.models.organization_membership import OrganizationMembership
@@ -25,9 +27,16 @@ from model_hub.models.annotation_queues import (
     AnnotationQueue,
     AnnotationQueueAnnotator,
     AnnotationQueueLabel,
+    QueueItem,
 )
-from model_hub.models.choices import AnnotationQueueStatusChoices, AnnotatorRole
+from model_hub.models.choices import (
+    AnnotationQueueStatusChoices,
+    AnnotatorRole,
+    QueueItemSourceType,
+    QueueItemStatus,
+)
 from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.views.annotation_queues import _queue_count_subquery
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 from tfc.ee_gating import EEResource, FeatureUnavailable
@@ -210,6 +219,156 @@ class TestListQueues:
         assert resp.status_code == status.HTTP_200_OK
         result = resp.data["results"][0]
         assert "label_count" in result
+
+    def test_include_counts_does_not_join_multivalued_relations(
+        self, auth_client, organization, workspace, user
+    ):
+        """TH-7104: the counts must come from subqueries, not joins.
+
+        Counting labels, annotators and items in one GROUP BY joins three
+        multi-valued relations, so the row the aggregate runs over is their
+        cartesian product — a voice queue's item count multiplied by every
+        label and annotator. The COUNT(DISTINCT)s still return the right
+        numbers, which is why correctness alone can't catch a regression
+        here: the cost is the shape. Assert the shape.
+        """
+        create_queue(auth_client, name="Join Guard")
+        queue = AnnotationQueue.objects.get(name="Join Guard")
+        for i in range(3):
+            label = AnnotationsLabels.objects.create(
+                name=f"join-guard-label-{i}",
+                type="categorical",
+                organization=organization,
+                workspace=workspace,
+                settings={
+                    "options": [{"label": "A"}, {"label": "B"}],
+                    "multi_choice": False,
+                    "rule_prompt": "",
+                    "auto_annotate": False,
+                    "strategy": None,
+                },
+            )
+            AnnotationQueueLabel.objects.create(queue=queue, label=label, order=i)
+        for i in range(2):
+            member = User.objects.create_user(
+                email=f"join-guard-{i}@example.com",
+                password="pw",
+                name=f"Join Guard {i}",
+                organization=organization,
+            )
+            AnnotationQueueAnnotator.objects.create(queue=queue, user=member)
+        for i in range(4):
+            QueueItem.objects.create(
+                queue=queue,
+                source_type=QueueItemSourceType.TRACE.value,
+                trace_id=uuid.uuid4(),
+                organization=organization,
+                workspace=workspace,
+                status=(
+                    QueueItemStatus.COMPLETED.value
+                    if i < 2
+                    else QueueItemStatus.PENDING.value
+                ),
+            )
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = auth_client.get(QUEUE_URL, {"include_counts": "true"})
+
+        assert resp.status_code == status.HTTP_200_OK
+        row = next(r for r in resp.data["results"] if r["name"] == "Join Guard")
+        # creator is auto-added as an annotator alongside the 2 created here
+        assert (row["label_count"], row["item_count"], row["completed_count"]) == (
+            4,
+            4,
+            2,
+        )
+        assert row["annotator_count"] == 3
+
+        listing = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "label_count" in q["sql"] and "item_count" in q["sql"]
+        ]
+        assert listing, "did not capture the annotated queue-list query"
+        for sql in listing:
+            assert 'JOIN "model_hub_queueitem"' not in sql, (
+                "include_counts joined model_hub_queueitem into the list query — "
+                "that multiplies every queue row by its item count before the "
+                "aggregate runs (TH-7104). Count via a correlated subquery.\n" + sql
+            )
+
+    def test_include_counts_ignores_ambient_workspace_context(
+        self, organization, workspace, user
+    ):
+        """Counts must not shrink to the caller's workspace.
+
+        ``BaseModelManager`` folds the thread-local workspace into every
+        queryset, and ``QueueItem`` has a ``workspace`` FK — so counting
+        through ``QueueItem.objects`` would drop items belonging to another
+        workspace (or to none), which the joined ``Count()`` never did.
+
+        The API test client deliberately leaves that thread-local unset
+        (see conftest.WorkspaceAwareAPIClient), and so does manage.py — which
+        is exactly why this class of bug survives both the suite and manual
+        benchmarking. Set it explicitly here or the test proves nothing.
+        """
+        from tfc.middleware.workspace_context import (
+            clear_workspace_context,
+            set_workspace_context,
+        )
+
+        other_ws = Workspace.objects.create(
+            name="th7104-other-ws",
+            organization=organization,
+            is_default=False,
+            created_by=user,
+        )
+        queue = AnnotationQueue.objects.create(
+            name="th7104-ws-scope",
+            organization=organization,
+            workspace=workspace,
+            created_by=user,
+        )
+        # one item per workspace-shape the manager filter discriminates on
+        items = [
+            QueueItem.objects.create(
+                queue=queue,
+                source_type=QueueItemSourceType.TRACE.value,
+                trace_id=uuid.uuid4(),
+                organization=organization,
+                workspace=ws,
+                status=QueueItemStatus.PENDING.value,
+            )
+            for ws in (workspace, other_ws, None)
+        ]
+        # a post_save signal backfills workspace from the ambient context, so the
+        # third item only stays NULL if we blank it with an UPDATE afterwards
+        QueueItem.all_objects.filter(pk=items[-1].pk).update(workspace=None)
+
+        def count_under(ws):
+            # no_workspace_objects on the OUTER query too: all_objects applies the
+            # same ambient filter and would hide the queue itself.
+            if ws is not None:
+                set_workspace_context(workspace=ws, organization=organization)
+            try:
+                return (
+                    AnnotationQueue.no_workspace_objects.filter(pk=queue.pk)
+                    .annotate(item_count=_queue_count_subquery(QueueItem))
+                    .first()
+                    .item_count
+                )
+            finally:
+                clear_workspace_context()
+
+        unscoped = count_under(None)
+        scoped = count_under(other_ws)
+
+        assert unscoped == 3
+        assert scoped == 3, (
+            "item_count changed with the ambient workspace context "
+            f"({scoped} vs {unscoped}). The count subquery is going through a "
+            "workspace-filtering manager; use no_workspace_objects (TH-7104)."
+        )
 
     def test_combined_filters(self, auth_client):
         """TC-5: Combined status + search."""
@@ -403,9 +562,7 @@ class TestCreateQueue:
 
     def test_create_queue_without_label_ids_returns_400(self, auth_client):
         """A queue requires >=1 label; omitting label_ids is rejected."""
-        resp = auth_client.post(
-            QUEUE_URL, {"name": "No Label Queue"}, format="json"
-        )
+        resp = auth_client.post(QUEUE_URL, {"name": "No Label Queue"}, format="json")
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
         assert resp.data["type"] == "validation_error"
         assert resp.data["code"] == "invalid"
@@ -818,9 +975,7 @@ class TestUpdateQueue:
         API/SDK caller that toggles labels off via PATCH-with-empty gets 400.
         """
         label_id = create_label_for_queue(auth_client, name="L1")
-        create_queue(
-            auth_client, name="Empty Update Queue", label_ids=[str(label_id)]
-        )
+        create_queue(auth_client, name="Empty Update Queue", label_ids=[str(label_id)])
         queue_id = get_queue_id(auth_client, "Empty Update Queue")
         resp = auth_client.patch(
             queue_detail_url(queue_id),

--- a/futureagi/model_hub/tests/test_queue_items_api.py
+++ b/futureagi/model_hub/tests/test_queue_items_api.py
@@ -63,8 +63,6 @@ def demote_queue_creator_to_annotator(queue_id, user):
 # ---------------------------------------------------------------------------
 
 
-
-
 @pytest.fixture
 def queue(auth_client):
     """Create a queue and return its ID."""
@@ -763,3 +761,49 @@ class TestQueueItemModelValidation:
         )
         with pytest.raises(ValidationError):
             item.full_clean()
+
+
+class TestItemsListQueryCount:
+    """TH-7104: rendering the items list must not query per row."""
+
+    def test_query_count_does_not_grow_with_page_size(
+        self, auth_client, queue, organization, workspace
+    ):
+        """comment_count / open_feedback_count used to be a .count() each, per
+        item — so a page cost 2N+12 queries and ?limit=1000 cost 2012. They are
+        annotated onto the queryset now, which makes the cost flat.
+
+        Asserting flatness rather than an absolute number: the constant is
+        incidental, the scaling is the contract.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        for i in range(30):
+            QueueItem.objects.create(
+                queue_id=queue,
+                source_type="trace",
+                trace_id=uuid.uuid4(),
+                organization=organization,
+                workspace=workspace,
+                order=i,
+            )
+
+        def count_queries(limit):
+            url = f"{items_url(queue)}?limit={limit}&page=1"
+            auth_client.get(url)  # warm: auth/session lookups are one-offs
+            with CaptureQueriesContext(connection) as ctx:
+                resp = auth_client.get(url)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data["results"]) == limit
+            return len(ctx.captured_queries)
+
+        small = count_queries(5)
+        large = count_queries(25)
+
+        assert large == small, (
+            f"items list ran {small} queries for 5 items and {large} for 25 — "
+            f"{(large - small) / 20:.1f} extra queries per row. Something in the "
+            "serializer is querying per item instead of reading an annotation "
+            "(TH-7104)."
+        )

--- a/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
+++ b/futureagi/model_hub/tests/test_voice_annotation_regressions_e2e.py
@@ -3,6 +3,7 @@ import io
 import json
 import uuid
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 from django.utils import timezone
@@ -12,7 +13,6 @@ from accounts.models.user import User
 from model_hub.models.ai_model import AIModel
 from model_hub.models.annotation_queues import (
     AnnotationQueue,
-    AnnotationQueueAnnotator,
     AnnotationQueueLabel,
     QueueItem,
     QueueItemNote,
@@ -32,6 +32,11 @@ from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.evals_metric import EvalTemplate
 from model_hub.models.score import Score
+from model_hub.utils.annotation_queue_helpers import (
+    canonical_score_value,
+    eval_metrics_from_call_execution,
+    eval_output_value,
+)
 from simulate.models.agent_definition import AgentDefinition
 from simulate.models.run_test import RunTest
 from simulate.models.scenario_graph import ScenarioGraph
@@ -217,8 +222,7 @@ def _annotate_detail_url(queue, item):
 
 def _submit_url(queue, item):
     return (
-        f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/"
-        "annotations/submit/"
+        f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/annotations/submit/"
     )
 
 
@@ -2028,14 +2032,6 @@ class TestVoiceAnnotationRegressionE2E:
 
 # Unit tests for call_execution-side annotation queue export helpers
 
-from types import SimpleNamespace
-
-from model_hub.utils.annotation_queue_helpers import (
-    canonical_score_value,
-    eval_metrics_from_call_execution,
-    eval_output_value,
-)
-
 
 def _label(type_value):
     return SimpleNamespace(type=type_value, id="lbl-1")
@@ -2043,24 +2039,36 @@ def _label(type_value):
 
 class TestCanonicalScoreValue:
     def test_text_label_extracts_text_key(self):
-        assert canonical_score_value(
-            _label(AnnotationTypeChoices.TEXT.value), {"text": "hello"}
-        ) == "hello"
+        assert (
+            canonical_score_value(
+                _label(AnnotationTypeChoices.TEXT.value), {"text": "hello"}
+            )
+            == "hello"
+        )
 
     def test_numeric_label_extracts_value_key(self):
-        assert canonical_score_value(
-            _label(AnnotationTypeChoices.NUMERIC.value), {"value": 7}
-        ) == 7
+        assert (
+            canonical_score_value(
+                _label(AnnotationTypeChoices.NUMERIC.value), {"value": 7}
+            )
+            == 7
+        )
 
     def test_star_label_extracts_rating_key(self):
-        assert canonical_score_value(
-            _label(AnnotationTypeChoices.STAR.value), {"rating": 4}
-        ) == 4
+        assert (
+            canonical_score_value(
+                _label(AnnotationTypeChoices.STAR.value), {"rating": 4}
+            )
+            == 4
+        )
 
     def test_thumbs_label_extracts_value_key(self):
-        assert canonical_score_value(
-            _label(AnnotationTypeChoices.THUMBS_UP_DOWN.value), {"value": "up"}
-        ) == "up"
+        assert (
+            canonical_score_value(
+                _label(AnnotationTypeChoices.THUMBS_UP_DOWN.value), {"value": "up"}
+            )
+            == "up"
+        )
 
     def test_categorical_label_extracts_selected_key(self):
         assert canonical_score_value(
@@ -2068,10 +2076,15 @@ class TestCanonicalScoreValue:
         ) == ["a", "b"]
 
     def test_none_raw_returns_none(self):
-        assert canonical_score_value(_label(AnnotationTypeChoices.STAR.value), None) is None
+        assert (
+            canonical_score_value(_label(AnnotationTypeChoices.STAR.value), None)
+            is None
+        )
 
     def test_scalar_raw_passes_through(self):
-        assert canonical_score_value(_label(AnnotationTypeChoices.NUMERIC.value), 5) == 5
+        assert (
+            canonical_score_value(_label(AnnotationTypeChoices.NUMERIC.value), 5) == 5
+        )
 
     def test_missing_label_returns_raw_dict(self):
         assert canonical_score_value(None, {"value": 1}) == {"value": 1}
@@ -2332,4 +2345,148 @@ class TestQueueExportQueryCount:
             f"running per-item; the Prefetch is missing or _call_transcript_turns "
             f"is bypassing the prefetched attribute.\n"
             + "\n".join(q["sql"][:200] for q in ctx_3.captured_queries)
+        )
+
+
+class TestAnnotateDetailClickHouseReads:
+    """TH-7104: opening a voice item must not re-read the same trace from CH."""
+
+    def test_annotate_detail_reads_trace_root_once_scoped_to_project(
+        self,
+        auth_client,
+        organization,
+        workspace,
+        user,
+        observe_project,
+        observe_trace,
+        root_conversation_span,
+        thumbs_label,
+    ):
+        """One CH root-span read per open, pruned to the item's project.
+
+        The notes target, the rendered content and the preview all resolve the
+        SAME tracer source. Each used to do its own point-read, and none of
+        them passed the item's denormalized ``project_id``, so a voice item
+        cost three unscoped ``spans FINAL`` reads across the whole
+        multi-tenant table.
+        """
+        from tracer.services.clickhouse.v2 import span_reader
+
+        queue = _queue(
+            "TH-7104 CH read guard",
+            organization,
+            workspace,
+            user,
+            project=observe_project,
+        )
+        AnnotationQueueLabel.objects.create(queue=queue, label=thumbs_label)
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=observe_trace,
+            project=observe_project,
+            organization=organization,
+            workspace=workspace,
+            status=QueueItemStatus.PENDING.value,
+        )
+
+        calls = []
+        original = span_reader.CHSpanReader.roots_by_trace_ids
+
+        def recording(self, trace_ids, **kwargs):
+            calls.append(kwargs.get("project_id"))
+            return original(self, trace_ids, **kwargs)
+
+        span_reader.CHSpanReader.roots_by_trace_ids = recording
+        try:
+            resp = auth_client.get(_annotate_detail_url(queue, item))
+        finally:
+            span_reader.CHSpanReader.roots_by_trace_ids = original
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        detail = resp.data["result"]
+        # the read still has to produce the content the workspace renders
+        assert detail["item"]["source_content"]["type"] == "trace"
+        assert detail["item"]["source_preview"]["type"] == "trace"
+        assert detail["span_notes_source_id"] == root_conversation_span.id
+
+        assert len(calls) == 1, (
+            f"annotate-detail made {len(calls)} ClickHouse root-span reads for "
+            "one trace; content, preview and the notes target must share one "
+            "cached read (TH-7104)."
+        )
+        assert calls[0] == str(observe_project.id), (
+            "the root-span read was not scoped to the item's project, so it "
+            "cannot prune the spans PK prefix and scans every tenant "
+            f"(TH-7104). project_id passed: {calls[0]!r}"
+        )
+
+    def test_annotate_detail_reads_a_span_item_once(
+        self,
+        auth_client,
+        organization,
+        workspace,
+        user,
+        observe_project,
+        root_conversation_span,
+        thumbs_label,
+    ):
+        """The heavy path: an observation_span item must be read once, not thrice.
+
+        A span read carries the full column set including ``attributes_extra``,
+        which on a real voice conversation root is tens of MB. Measured on dev:
+        73 MiB and 203 MiB of ClickHouse memory per read, against 5.5 KiB for a
+        lean trace-root read. Tripling that is the expensive shape, so it gets
+        its own guard rather than riding on the trace test.
+        """
+        from tracer.services.clickhouse.v2 import span_reader
+
+        queue = _queue(
+            "TH-7104 span read guard",
+            organization,
+            workspace,
+            user,
+            project=observe_project,
+        )
+        AnnotationQueueLabel.objects.create(queue=queue, label=thumbs_label)
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+            observation_span=root_conversation_span,
+            project=observe_project,
+            organization=organization,
+            workspace=workspace,
+            status=QueueItemStatus.PENDING.value,
+        )
+
+        calls = []
+        orig_list = span_reader.CHSpanReader.list_by_ids
+        orig_get = span_reader.CHSpanReader.get
+
+        def rec_list(self, span_ids, **kwargs):
+            calls.append(("list_by_ids", kwargs.get("project_id")))
+            return orig_list(self, span_ids, **kwargs)
+
+        def rec_get(self, span_id, **kwargs):
+            calls.append(("get", kwargs.get("project_id")))
+            return orig_get(self, span_id, **kwargs)
+
+        span_reader.CHSpanReader.list_by_ids = rec_list
+        span_reader.CHSpanReader.get = rec_get
+        try:
+            resp = auth_client.get(_annotate_detail_url(queue, item))
+        finally:
+            span_reader.CHSpanReader.list_by_ids = orig_list
+            span_reader.CHSpanReader.get = orig_get
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        detail = resp.data["result"]
+        assert detail["item"]["source_content"]["type"] == "observation_span"
+        assert detail["item"]["source_preview"]["type"] == "observation_span"
+        assert detail["span_notes_source_id"] == root_conversation_span.id
+
+        assert len(calls) == 1, (
+            f"annotate-detail made {len(calls)} ClickHouse span reads "
+            f"({[c[0] for c in calls]}) for one item; the notes target, content "
+            "and preview must share one cached read (TH-7104)."
         )

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -9,7 +9,16 @@ from decimal import Decimal, InvalidOperation
 import structlog
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Count, Exists, Max, OuterRef, Prefetch, Q
+from django.db.models import (
+    Count,
+    Exists,
+    Max,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Value,
+)
 from django.db.models.functions import Coalesce, Lower, TruncDate
 from django.utils import timezone
 from drf_yasg.utils import swagger_auto_schema
@@ -1282,14 +1291,26 @@ def _reopen_items_missing_required_labels(queue):
     )
 
 
-def _span_notes_target_for_queue_item(item):
+def _span_notes_target_for_queue_item(item, *, ch_cache=None):
     """Return the span that stores whole-item notes for queue annotation.
 
     CH-native: span-source items resolve the span from CH by its soft id;
     trace-source items pick the trace's root span from CH (lean) — preference
     order ``observation_type="conversation"`` root (voice) → first root span →
     ``None``. Downstream only reads ``.id``. Never query PG (tables are dropped).
+
+    ``ch_cache`` (opt-in :class:`CollectorSourceCache`): reads the already-resolved
+    source off the page/item cache — same root-pick rule, so the same span — instead
+    of its own unscoped CH point-read. Callers that resolve the item's source anyway
+    should pass it; the bare read stays for callers that don't.
     """
+    if ch_cache is not None:
+        if item.source_type == "observation_span":
+            return ch_cache.span(item.observation_span_id)
+        if item.source_type == "trace":
+            return ch_cache.trace_root(item.trace_id)
+        return None
+
     from tracer.services.clickhouse.v2 import get_reader
 
     if item.source_type == "observation_span" and item.observation_span_id:
@@ -2873,6 +2894,34 @@ def _review_workflow_entitlement_denial(request):
     return None
 
 
+def _queue_count_subquery(model, **filters):
+    """Live rows of *model* for the outer queue, as a correlated scalar subquery.
+
+    One indexed aggregate per count on the child's ``queue_id`` — never a join
+    the outer GROUP BY has to de-duplicate.
+
+    ``no_workspace_objects``, NOT ``objects``: ``BaseModelManager`` folds the
+    ambient thread-local workspace into every queryset it builds, and ``QueueItem``
+    carries a ``workspace`` FK. Through ``objects`` these counts would silently
+    shrink to the request's workspace — a semantics change the joined ``Count()``
+    they replace never had — and would drag a correlated ``accounts_workspace``
+    join into each of the four subqueries per row. The queue is already
+    workspace-scoped by ``get_queryset``; its item count is a property of the
+    queue, not of who is looking at it.
+    """
+    return Coalesce(
+        Subquery(
+            model.no_workspace_objects.filter(
+                queue=OuterRef("pk"), deleted=False, **filters
+            )
+            .values("queue")
+            .annotate(count=Count("id"))
+            .values("count")[:1]
+        ),
+        Value(0),
+    )
+
+
 class AnnotationQueuePagination(ExtendedPageNumberPagination):
     def get_page_size(self, request):
         if self.page_size_query_param in request.query_params:
@@ -2955,41 +3004,18 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             queryset = queryset.filter(name__icontains=search)
 
         if include_counts:
+            # Correlated subqueries, NOT Count() over joins. Counting three
+            # multi-valued relations in one GROUP BY multiplies them into a
+            # labels x annotators x items cartesian the COUNT(DISTINCT)s then
+            # have to sort back down — a voice queue's item count is the
+            # multiplier, so the page spills to disk and takes seconds
+            # (TH-7104). Each subquery is an indexed aggregate on queue_id.
             queryset = queryset.annotate(
-                label_count=Coalesce(
-                    Count(
-                        "queue_labels",
-                        filter=Q(queue_labels__deleted=False),
-                        distinct=True,
-                    ),
-                    0,
-                ),
-                annotator_count=Coalesce(
-                    Count(
-                        "queue_annotators",
-                        filter=Q(queue_annotators__deleted=False),
-                        distinct=True,
-                    ),
-                    0,
-                ),
-                item_count=Coalesce(
-                    Count(
-                        "items",
-                        filter=Q(items__deleted=False),
-                        distinct=True,
-                    ),
-                    0,
-                ),
-                completed_count=Coalesce(
-                    Count(
-                        "items",
-                        filter=Q(
-                            items__deleted=False,
-                            items__status="completed",
-                        ),
-                        distinct=True,
-                    ),
-                    0,
+                label_count=_queue_count_subquery(AnnotationQueueLabel),
+                annotator_count=_queue_count_subquery(AnnotationQueueAnnotator),
+                item_count=_queue_count_subquery(QueueItem),
+                completed_count=_queue_count_subquery(
+                    QueueItem, status=QueueItemStatus.COMPLETED.value
                 ),
             )
 
@@ -5958,10 +5984,17 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             is_reviewer=is_reviewer,
         )
 
+        # One CH read for the whole workspace. The notes target, the rendered
+        # content and the preview all resolve the SAME tracer source, and each
+        # used to do its own point-read — three unscoped `spans FINAL` scans per
+        # open on a voice trace (TH-7104). The cache reads once, pruned to the
+        # item's denormalized project_id, and the serializer reuses it.
+        ch_cache = CollectorSourceCache.for_items([item])
+
         existing_notes = ""
         span_notes = []
         span_notes_source_id = None
-        span_notes_target = _span_notes_target_for_queue_item(item)
+        span_notes_target = _span_notes_target_for_queue_item(item, ch_cache=ch_cache)
         if span_notes_target is not None:
             span_notes_source_id = span_notes_target.id
         span_notes = _item_note_payloads(
@@ -6093,7 +6126,9 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             "prev_item_id": str(prev_item) if prev_item else None,
         }
 
-        serializer = AnnotateDetailSerializer(data, context={"request": request})
+        serializer = AnnotateDetailSerializer(
+            data, context={"request": request, "ch_source_cache": ch_cache}
+        )
         return self._gm.success_response(serializer.data)
 
     @validated_request(

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -2894,27 +2894,29 @@ def _review_workflow_entitlement_denial(request):
     return None
 
 
-def _queue_count_subquery(model, **filters):
-    """Live rows of *model* for the outer queue, as a correlated scalar subquery.
+def _related_count_subquery(manager, fk_field, **filters):
+    """Live rows of *manager* pointing at the outer row, as a correlated scalar
+    subquery: one indexed aggregate on ``fk_field``, never a join the outer
+    GROUP BY has to de-duplicate, and never a query per rendered row.
 
-    One indexed aggregate per count on the child's ``queue_id`` — never a join
-    the outer GROUP BY has to de-duplicate.
+    The CALLER picks the manager, because the correct one differs by call site
+    and the difference is invisible in tests:
 
-    ``no_workspace_objects``, NOT ``objects``: ``BaseModelManager`` folds the
-    ambient thread-local workspace into every queryset it builds, and ``QueueItem``
-    carries a ``workspace`` FK. Through ``objects`` these counts would silently
-    shrink to the request's workspace — a semantics change the joined ``Count()``
-    they replace never had — and would drag a correlated ``accounts_workspace``
-    join into each of the four subqueries per row. The queue is already
-    workspace-scoped by ``get_queryset``; its item count is a property of the
-    queue, not of who is looking at it.
+    * ``no_workspace_objects`` reproduces a joined ``Count()`` — a JOIN carries
+      no workspace predicate, so the aggregate it replaces never had one.
+    * ``objects`` reproduces a per-object ``Model.objects.filter(...).count()``
+      — ``BaseModelManager`` folds the ambient thread-local workspace in, so
+      that count always did have one.
+
+    Picking the wrong one changes counts only under a non-default workspace,
+    which neither the API test client nor ``manage.py`` ever sets — so it will
+    not fail a test, it will just be wrong in production.
     """
+    lookups = {fk_field: OuterRef("pk"), "deleted": False, **filters}
     return Coalesce(
         Subquery(
-            model.no_workspace_objects.filter(
-                queue=OuterRef("pk"), deleted=False, **filters
-            )
-            .values("queue")
+            manager.filter(**lookups)
+            .values(fk_field)
             .annotate(count=Count("id"))
             .values("count")[:1]
         ),
@@ -3011,11 +3013,19 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             # multiplier, so the page spills to disk and takes seconds
             # (TH-7104). Each subquery is an indexed aggregate on queue_id.
             queryset = queryset.annotate(
-                label_count=_queue_count_subquery(AnnotationQueueLabel),
-                annotator_count=_queue_count_subquery(AnnotationQueueAnnotator),
-                item_count=_queue_count_subquery(QueueItem),
-                completed_count=_queue_count_subquery(
-                    QueueItem, status=QueueItemStatus.COMPLETED.value
+                label_count=_related_count_subquery(
+                    AnnotationQueueLabel.no_workspace_objects, "queue"
+                ),
+                annotator_count=_related_count_subquery(
+                    AnnotationQueueAnnotator.no_workspace_objects, "queue"
+                ),
+                item_count=_related_count_subquery(
+                    QueueItem.no_workspace_objects, "queue"
+                ),
+                completed_count=_related_count_subquery(
+                    QueueItem.no_workspace_objects,
+                    "queue",
+                    status=QueueItemStatus.COMPLETED.value,
                 ),
             )
 
@@ -4655,6 +4665,28 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                         deleted=False
                     ).select_related("user"),
                     to_attr="active_assignments",
+                ),
+            )
+            # comment_count / open_feedback_count were a .count() per rendered
+            # item — two extra queries per row, so a page cost 2N+12 queries and
+            # ?limit=1000 cost 2012 (TH-7104). Annotated here they cost nothing
+            # extra. ``objects``, not ``no_workspace_objects``: the per-object
+            # counts these replace went through the workspace-filtering manager,
+            # so keeping it preserves their semantics exactly.
+            .annotate(
+                annotated_comment_count=_related_count_subquery(
+                    QueueItemReviewComment.objects,
+                    "queue_item",
+                    action=QueueItemReviewComment.ACTION_COMMENT,
+                ),
+                annotated_open_feedback_count=_related_count_subquery(
+                    QueueItemReviewThread.objects,
+                    "queue_item",
+                    blocking=True,
+                    status__in=[
+                        QueueItemReviewThread.STATUS_OPEN,
+                        QueueItemReviewThread.STATUS_REOPENED,
+                    ],
                 ),
             )
         )


### PR DESCRIPTION
## Summary

Annotation queue APIs are slow for voice projects because a voice queue's item count is what scales, and three separate endpoints scaled badly with it. The queue list built a `labels × annotators × items` cartesian to compute four counts. The items list ran two extra queries per rendered row. Opening one item read the same ClickHouse span three times. All three are fixed with no change to any response body.

Measured at realistic data shape (4 labels × 3 annotators, taken from actual dev data): queue list **1753 ms → 30 ms**, items list **212 → 12 queries** at `?limit=100`, annotate-detail **3 → 1** ClickHouse reads.

## Linked issues

Closes #
Linear: https://linear.app/future-agi/issue/TH-7104/annotation-queues-apis-are-slow-for-voice-projects

## Type of change

- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Queue list — `?include_counts=true` no longer builds a cartesian**

- `label_count`, `annotator_count`, `item_count`, `completed_count` were four `Count(..., distinct=True)` over three multi-valued relations in one `GROUP BY`. Postgres materialises `labels × annotators × items` rows per queue and then sorts them back down for the `DISTINCT`s.
- They are correlated scalar subqueries now, following the existing pattern at `model_hub/views/develop_dataset.py:1770`.
- `deleted=False` moves into the subquery `WHERE`. The old JOINs carried no `deleted` predicate, so soft-removed items kept multiplying forever — a queue never got cheaper when a user cleaned it up.
- No response shape change; the four fields are byte-identical.

**B. Items list — counts are annotated instead of queried per row**

- `comment_count` and `open_feedback_count` were each a `.count()` inside a `SerializerMethodField`, i.e. two extra queries per rendered item.
- Both are annotated onto the queryset in `QueueItemViewSet.get_queryset()`. The serializer reads the annotation and keeps the per-object query as a fallback, mirroring how `get_assigned_users` already handles its prefetch, so callers that serialize an item they fetched themselves still get a correct count.

**C. annotate-detail — one ClickHouse read instead of three**

- The notes target, `source_content` and `source_preview` each resolved the *same* tracer source with its own CH point-read.
- They now share one `CollectorSourceCache.for_items([item])` — the abstraction the list and export paths already use. `_span_notes_target_for_queue_item` gained an optional `ch_cache=` kwarg; the bare read stays for the submit path.

**D. Shared helper**

- `_related_count_subquery(manager, fk_field, **filters)` backs all six counts across A and B.

---

## 2) Why the changes were done

- **Product/UX:** the queue list and the annotation workspace are the two screens an annotator sits in all day. On a voice project both were multi-second.

- **Technical — why subqueries over the alternatives.** An index cannot help; the cost is a cartesian, not a scan. Denormalised counter columns would be two sources of truth. A post-pagination "3 flat queries mapped in Python" variant is marginally fewer index scans but needs `list()`/`paginate_queryset` overrides and leaves the counts unavailable to any future filter or ordering. Django 5.1 strips annotations from the paginator's `COUNT(*)`, and ordering is a plain `-created_at`, so the subqueries only execute for the rows on the page.

- **Architecture — the helper takes the manager from the caller, and that is deliberate.** `BaseModelManager` folds the ambient thread-local workspace into every queryset it builds, and `QueueItem`, `QueueItemReviewComment` and `QueueItemReviewThread` all carry a `workspace` FK. The correct manager therefore differs by call site:
  - **A** passes `no_workspace_objects`, because it replaces a joined `Count()` and a JOIN never carried a workspace predicate.
  - **B** passes `objects`, because it replaces a per-object `Model.objects.filter().count()` which always did.

  Both preserve their own prior semantics exactly. This is worth a reviewer's attention because getting either backwards changes counts **only under a non-default workspace** — and neither the API test client (`conftest.WorkspaceAwareAPIClient` deliberately leaves the thread-local unset) nor `manage.py` ever sets it. It would not fail a test; it would just be wrong in production. Hence the choice is explicit at each call site rather than hidden in the helper, and `test_include_counts_ignores_ambient_workspace_context` sets the thread-local by hand to pin it.

---

## 3) Tests written + scenarios each covers

Every test below was confirmed to **fail against the pre-fix code** before being trusted.

**`test_annotation_queues_api.py`** — queue list counting

- `test_include_counts_does_not_join_multivalued_relations` — asserts the emitted SQL contains no JOIN onto `model_hub_queueitem`. Correctness alone cannot catch a regression here: the old form returned the *right* numbers, the cost was the plan shape. Fails pre-fix on the JOIN assertion.
- `test_include_counts_ignores_ambient_workspace_context` — sets the workspace thread-local explicitly and asserts counts do not change. Fails pre-fix with `assert 2 == 3`.

**`test_queue_items_api.py`** — items list query scaling

- `test_query_count_does_not_grow_with_page_size` — compares query count at `limit=5` and `limit=25` and asserts they are equal. Asserts *flatness* rather than an absolute number: the constant is incidental, the scaling is the contract. Fails pre-fix with `assert 55 == 15` — "2.0 extra queries per row".

**`test_voice_annotation_regressions_e2e.py`** — ClickHouse read dedupe

- `test_annotate_detail_reads_trace_root_once_scoped_to_project` — a `trace` item must produce exactly one root-span read. Fails pre-fix with `assert 3 == 1`.
- `test_annotate_detail_reads_a_span_item_once` — an `observation_span` item must produce exactly one span read. This is the expensive path: a span read carries the full column set including `attributes_extra`, which on a real voice conversation root is tens of MB. Fails pre-fix with `['get', 'get', 'get']`.

> Run result: **507 passed** across the model_hub annotation suites. Six failures in that selection are pre-existing and fail identically on a clean `origin/dev` tree (`test_th5123_voice_call_detail_returns_simulation_path_context`, `test_text_label_surfaces_corpus_stats`, and four in `test_team_a_annotations_full_matrix.py`). Ruff check + format clean on all changed files.

---

## 4) How to run / test

```bash
cd futureagi

DJANGO_SETTINGS_MODULE=tfc.settings.test uv run --python 3.13 python -m pytest \
  model_hub/tests/test_annotation_queues_api.py \
  model_hub/tests/test_queue_items_api.py \
  model_hub/tests/test_voice_annotation_regressions_e2e.py -q -p no:randomly
```

No contract regeneration needed — no serializer field was added, removed or retyped.

---

## Benchmark method and numbers

Both code paths were run in one process against the same Postgres with arms interleaved per iteration and medians reported, so drift cannot land on one arm only. Seeded at **4 labels × 3 annotators**, which is the shape dev actually shows (2-6 labels, 1-3 annotators) rather than a guess.

**Queue list, org-wide page of 10.** Run both with and without the ambient workspace thread-local set, because production auth sets it and the test client does not:

| | before | after |
|---|---|---|
| contextvar unset | 1898 ms | 30.0 ms |
| contextvar set (what production runs) | 1753 ms | 30.3 ms |

**Per-queue scaling:**

| items | join rows | before | after |
|---|---|---|---|
| 1,000 | 12,000 | 8.7 ms | 2.0 ms |
| 4,000 | 48,000 | 46.8 ms | 3.1 ms |
| 16,000 | 192,000 | 174.2 ms | 4.1 ms |
| 64,000 | 768,000 | 1120.1 ms | 32.1 ms |

`EXPLAIN ANALYZE` on a 32k-item queue, before: `Sort Method: external merge  Disk: 276384kB`, 3984 ms. After: index scan, 14 ms.

**Items list, queries per request** at 64k items — before / after by page size: 1 → 14/12, 5 → 22/12, 25 → 62/12, 100 → **212/12**.

**ClickHouse**, measured on dev (`spans`: 832k rows, 15 GiB, fat real voice rows):

| read shape | bytes read | p50 | CH memory |
|---|---|---|---|
| heavy (`observation_span` item) | 73.13 MiB | 166 ms | 203 MiB |
| lean (`trace` item) | 5.52 KiB | 15 ms | 93 KiB |

Three of those become one. The saving is therefore large for `observation_span` items and modest for `trace` items.

### One correction, stated plainly

An earlier version of this analysis claimed the per-item CH reads were unscoped full-table scans and that passing `project_id` was the win. **That was wrong.** Measured on dev, scoped and unscoped reads are identical (31 rows, 5.79 KiB, ~21 ms) because `idx_trace_id` is a `bloom_filter(0.001)` that already prunes — and this was not a rigged test, that trace's project holds 260 of 832,000 spans. The real win in C is purely the 3 → 1 dedupe. The scoping is retained because it is the convention the batch paths already follow and bloom false positives scale with granule count, but it is not load-bearing here.

Relatedly: dev's largest org totals only ~44k join rows, so dev cannot reproduce the reported 2-3 s. The Postgres mechanism is proven strictly linear in join rows and the fix is sound regardless, but the absolute prod figure remains extrapolated from local seeding.

---

## Follow-ups not in this PR

- `ExtendedPageNumberPagination` has no `max_page_size`. Much less dangerous now (12 queries instead of 2012) but `?limit=50000` still materialises 50k rows.
- `queue analytics` grows 22 ms → 646 ms as a queue goes 1k → 64k items. Untouched here, and it is now the slowest thing on that page.
- `AnnotationsLabelsViewSet` with `include_usage_count=true` has the same cartesian shape (`annotations × scores` per label). Currently benign — dev shows 1,866 total join rows because the M2M is sparsely populated — but it will bite once labels accumulate both.
