### PR TITLE
fix(simulate): align chat initial message with per-turn simulator and bill actual LLM tokens

### DIFF
--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -201,7 +201,7 @@ def _generate_chat_initial_message(
             guidance_lines=len(guidance.split("\n")) if guidance else 0,
             hint_present=bool(hint),
         )
-        model_cfg = ModelConfigs.CLAUDE_4_5_SONNET_BEDROCK_ARN
+        model_cfg = ModelConfigs.VERTEX_GEMINI_2_5_PRO
         llm = LLM(
             model_name=model_cfg.model_name,
             temperature=0.7,  # Higher for more natural variation

--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -157,12 +157,11 @@ def _generate_chat_initial_message(
     situation: str,
     agent_name: str | None,
     initial_message_hint: str | None = None,
-) -> tuple[str | None, dict | None]:
+) -> tuple[str | None, float | None]:
     """
     Generate a realistic first customer message for chat using an LLM.
-    Returns (text, usage_metrics) or (None, None) on failure so callers can
-    fall back to the default initial message. usage_metrics carries the actual
-    prompt/completion token counts from the LLM invocation for billing rollup.
+    Returns (text, cost_usd) or (None, None) on failure so callers can fall
+    back to the default initial message; cost_usd is `LLM.cost['total_cost']`.
     """
     if not situation:
         return None, None
@@ -221,12 +220,8 @@ def _generate_chat_initial_message(
             logger.exception("chat_initial_message_llm_failed", error=text)
             return None, None
 
-        usage = getattr(llm, "token_usage", None) or {}
-        usage_metrics = {
-            "input_tokens": int(usage.get("prompt_tokens") or 0),
-            "output_tokens": int(usage.get("completion_tokens") or 0),
-        }
-        return (text or None, usage_metrics if text else None)
+        cost_usd = float((getattr(llm, "cost", None) or {}).get("total_cost") or 0.0)
+        return (text or None, cost_usd if text else None)
     except Exception as e:
         logger.exception("chat_initial_message_generation_failed", error=str(e))
         return None, None
@@ -234,7 +229,7 @@ def _generate_chat_initial_message(
 
 def get_chat_initial_message(
     call_execution: CallExecution,
-) -> tuple[str, str, dict | None]:
+) -> tuple[str, str, float | None]:
     """
     Resolve the initial customer message for a chat simulation.
 
@@ -244,15 +239,12 @@ def get_chat_initial_message(
     3) Hardcoded "Hi!"
 
     Returns:
-        (initial_message, source, usage_metrics) where source is one of:
+        (initial_message, source, cost_usd) where source is one of:
         - "llm_generated"
         - "provided_initial_message"
         - "default_hi"
-        usage_metrics is the LLM's actual `{input_tokens, output_tokens}` for
-        the "llm_generated" source and None otherwise. Callers roll it into
-        the billed `total_tokens` so the initial-message LLM call's cost is
-        included in customer billing (input tokens were previously dropped;
-        only the output text was counted via a heuristic estimator).
+        cost_usd is the LLM invocation's `LLM.cost['total_cost']` for the
+        "llm_generated" source and None otherwise.
     """
     call_metadata = call_execution.call_metadata or {}
     provided_initial_message = call_metadata.get("initial_message")
@@ -268,14 +260,14 @@ def get_chat_initial_message(
         else None
     )
 
-    generated, usage_metrics = _generate_chat_initial_message(
+    generated, cost_usd = _generate_chat_initial_message(
         persona=persona,
         situation=situation,
         agent_name=agent_name,
         initial_message_hint=provided_initial_message,
     )
     if generated:
-        return generated, "llm_generated", usage_metrics
+        return generated, "llm_generated", cost_usd
 
     if provided_initial_message and str(provided_initial_message).strip():
         return str(provided_initial_message).strip(), "provided_initial_message", None

--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -157,13 +157,15 @@ def _generate_chat_initial_message(
     situation: str,
     agent_name: str | None,
     initial_message_hint: str | None = None,
-) -> str | None:
+) -> tuple[str | None, dict | None]:
     """
     Generate a realistic first customer message for chat using an LLM.
-    Returns None on failure so callers can fall back to the default initial message.
+    Returns (text, usage_metrics) or (None, None) on failure so callers can
+    fall back to the default initial message. usage_metrics carries the actual
+    prompt/completion token counts from the LLM invocation for billing rollup.
     """
     if not situation:
-        return None
+        return None, None
 
     style = _extract_chat_style(persona or {})
     guidance = _build_chat_initial_message_guidance(persona or {}, style)
@@ -217,15 +219,22 @@ def _generate_chat_initial_message(
         # so the caller can fall back to a safe default without leaking error text to users.
         if "LLM call failed:" in text:
             logger.exception("chat_initial_message_llm_failed", error=text)
-            return None
+            return None, None
 
-        return text or None
+        usage = getattr(llm, "token_usage", None) or {}
+        usage_metrics = {
+            "input_tokens": int(usage.get("prompt_tokens") or 0),
+            "output_tokens": int(usage.get("completion_tokens") or 0),
+        }
+        return (text or None, usage_metrics if text else None)
     except Exception as e:
         logger.exception("chat_initial_message_generation_failed", error=str(e))
-        return None
+        return None, None
 
 
-def get_chat_initial_message(call_execution: CallExecution) -> tuple[str, str]:
+def get_chat_initial_message(
+    call_execution: CallExecution,
+) -> tuple[str, str, dict | None]:
     """
     Resolve the initial customer message for a chat simulation.
 
@@ -235,10 +244,15 @@ def get_chat_initial_message(call_execution: CallExecution) -> tuple[str, str]:
     3) Hardcoded "Hi!"
 
     Returns:
-        (initial_message, source) where source is one of:
+        (initial_message, source, usage_metrics) where source is one of:
         - "llm_generated"
         - "provided_initial_message"
         - "default_hi"
+        usage_metrics is the LLM's actual `{input_tokens, output_tokens}` for
+        the "llm_generated" source and None otherwise. Callers roll it into
+        the billed `total_tokens` so the initial-message LLM call's cost is
+        included in customer billing (input tokens were previously dropped;
+        only the output text was counted via a heuristic estimator).
     """
     call_metadata = call_execution.call_metadata or {}
     provided_initial_message = call_metadata.get("initial_message")
@@ -254,16 +268,16 @@ def get_chat_initial_message(call_execution: CallExecution) -> tuple[str, str]:
         else None
     )
 
-    generated = _generate_chat_initial_message(
+    generated, usage_metrics = _generate_chat_initial_message(
         persona=persona,
         situation=situation,
         agent_name=agent_name,
         initial_message_hint=provided_initial_message,
     )
     if generated:
-        return generated, "llm_generated"
+        return generated, "llm_generated", usage_metrics
 
     if provided_initial_message and str(provided_initial_message).strip():
-        return str(provided_initial_message).strip(), "provided_initial_message"
+        return str(provided_initial_message).strip(), "provided_initial_message", None
 
-    return "Hi!", "default_hi"
+    return "Hi!", "default_hi", None

--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -157,11 +157,12 @@ def _generate_chat_initial_message(
     situation: str,
     agent_name: str | None,
     initial_message_hint: str | None = None,
-) -> tuple[str | None, float | None]:
+) -> tuple[str | None, dict | None]:
     """
     Generate a realistic first customer message for chat using an LLM.
-    Returns (text, cost_usd) or (None, None) on failure so callers can fall
-    back to the default initial message; cost_usd is `LLM.cost['total_cost']`.
+    Returns (text, usage) or (None, None) on failure so callers can fall
+    back to the default initial message; `usage` carries `LLM.token_usage`
+    (`prompt_tokens` + `completion_tokens`) for billing rollup.
     """
     if not situation:
         return None, None
@@ -220,8 +221,12 @@ def _generate_chat_initial_message(
             logger.exception("chat_initial_message_llm_failed", error=text)
             return None, None
 
-        cost_usd = float((getattr(llm, "cost", None) or {}).get("total_cost") or 0.0)
-        return (text or None, cost_usd if text else None)
+        usage_src = getattr(llm, "token_usage", None) or {}
+        usage = {
+            "input_tokens": int(usage_src.get("prompt_tokens") or 0),
+            "output_tokens": int(usage_src.get("completion_tokens") or 0),
+        }
+        return (text or None, usage if text else None)
     except Exception as e:
         logger.exception("chat_initial_message_generation_failed", error=str(e))
         return None, None
@@ -229,7 +234,7 @@ def _generate_chat_initial_message(
 
 def get_chat_initial_message(
     call_execution: CallExecution,
-) -> tuple[str, str, float | None]:
+) -> tuple[str, str, dict | None]:
     """
     Resolve the initial customer message for a chat simulation.
 
@@ -239,12 +244,14 @@ def get_chat_initial_message(
     3) Hardcoded "Hi!"
 
     Returns:
-        (initial_message, source, cost_usd) where source is one of:
+        (initial_message, source, usage) where source is one of:
         - "llm_generated"
         - "provided_initial_message"
         - "default_hi"
-        cost_usd is the LLM invocation's `LLM.cost['total_cost']` for the
-        "llm_generated" source and None otherwise.
+        usage carries the LLM's `{input_tokens, output_tokens}` for the
+        "llm_generated" source (rolled into the per-call TEXT_CALL emit
+        so the persona-first-line spend joins the same `text_sim_tokens`
+        counter as every subsequent turn) and None otherwise.
     """
     call_metadata = call_execution.call_metadata or {}
     provided_initial_message = call_metadata.get("initial_message")
@@ -260,14 +267,14 @@ def get_chat_initial_message(
         else None
     )
 
-    generated, cost_usd = _generate_chat_initial_message(
+    generated, usage = _generate_chat_initial_message(
         persona=persona,
         situation=situation,
         agent_name=agent_name,
         initial_message_hint=provided_initial_message,
     )
     if generated:
-        return generated, "llm_generated", cost_usd
+        return generated, "llm_generated", usage
 
     if provided_initial_message and str(provided_initial_message).strip():
         return str(provided_initial_message).strip(), "provided_initial_message", None

--- a/futureagi/simulate/services/chat_sim.py
+++ b/futureagi/simulate/services/chat_sim.py
@@ -162,7 +162,7 @@ def initiate_chat(
                 )
 
         # Resolve the simulated customer's first message (LLM → provided initial_message → default).
-        initial_message, initial_message_source, initial_llm_cost_usd = (
+        initial_message, initial_message_source, initial_llm_usage = (
             get_chat_initial_message(call_execution)
         )
 
@@ -264,32 +264,35 @@ def initiate_chat(
             tokens=initial_tokens,
         )
 
-        if initial_llm_cost_usd and initial_llm_cost_usd > 0:
-            try:
-                from ee.usage.schemas.event_types import BillingEventType
-                from ee.usage.schemas.events import UsageEvent
-                from ee.usage.services.config import BillingConfig
-                from ee.usage.services.emitter import emit
+        if initial_llm_usage:
+            input_tokens = int(initial_llm_usage.get("input_tokens") or 0)
+            output_tokens = int(initial_llm_usage.get("output_tokens") or 0)
+            total_tokens = input_tokens + output_tokens
+            if total_tokens > 0:
+                try:
+                    from ee.usage.schemas.event_types import BillingEventType
+                    from ee.usage.schemas.events import UsageEvent
+                    from ee.usage.services.emitter import emit
 
-                credits = BillingConfig.get().calculate_ai_credits(initial_llm_cost_usd)
-                emit(
-                    UsageEvent(
-                        org_id=str(organization.id),
-                        event_type=BillingEventType.TEXT_CALL,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_chat_initial_message",
-                            "source_id": str(call_execution.id),
-                            "raw_cost_usd": str(initial_llm_cost_usd),
-                            "pricing_source": "llm.cost.total_cost",
-                        },
+                    emit(
+                        UsageEvent(
+                            org_id=str(organization.id),
+                            event_type=BillingEventType.TEXT_CALL,
+                            amount=total_tokens,
+                            properties={
+                                "source": "simulate_chat_initial_message",
+                                "source_id": str(call_execution.id),
+                                "input_tokens": input_tokens,
+                                "output_tokens": output_tokens,
+                                "total_tokens": total_tokens,
+                            },
+                        )
                     )
-                )
-            except Exception:
-                logger.exception(
-                    "chat_initial_message_bill_failed",
-                    call_execution_id=str(call_execution.id),
-                )
+                except Exception:
+                    logger.exception(
+                        "chat_initial_message_bill_failed",
+                        call_execution_id=str(call_execution.id),
+                    )
 
         ##check if test execution is pending
         if (

--- a/futureagi/simulate/services/chat_sim.py
+++ b/futureagi/simulate/services/chat_sim.py
@@ -162,8 +162,10 @@ def initiate_chat(
                 )
 
         # Resolve the simulated customer's first message (LLM → provided initial_message → default).
-        initial_message, initial_message_source = get_chat_initial_message(
-            call_execution
+        # usage_metrics carries the LLM invocation's actual prompt/completion tokens so we can
+        # roll them into the billed total_tokens; it is None when the source is not LLM-generated.
+        initial_message, initial_message_source, initial_llm_usage = (
+            get_chat_initial_message(call_execution)
         )
 
         # Create assistant using ChatServiceManager
@@ -225,14 +227,23 @@ def initiate_chat(
 
         message = ChatMessage(role=ChatRole.USER, content=initial_message)
 
-        # Calculate tokens for the initial message
+        # Calculate tokens for the initial message.
+        # Prefer the LLM invocation's actual prompt+completion token counts (so the
+        # persona-first-line LLM call is fully billed). Fall back to a heuristic
+        # estimate on the text when the message did not come from an LLM call
+        # (provided_initial_message / default_hi paths) or the LLM did not return
+        # usage.
         initial_msg_text = (
             initial_message
             if isinstance(initial_message, str)
             else str(initial_message)
         )
         initial_tokens = 0
-        if initial_msg_text:
+        if initial_llm_usage:
+            initial_tokens = int(initial_llm_usage.get("input_tokens") or 0) + int(
+                initial_llm_usage.get("output_tokens") or 0
+            )
+        elif initial_msg_text:
             try:
                 from ee.agenthub.traceerroragent.token_utils import (
                     estimate_tokens_text,

--- a/futureagi/simulate/services/chat_sim.py
+++ b/futureagi/simulate/services/chat_sim.py
@@ -162,9 +162,7 @@ def initiate_chat(
                 )
 
         # Resolve the simulated customer's first message (LLM → provided initial_message → default).
-        # usage_metrics carries the LLM invocation's actual prompt/completion tokens so we can
-        # roll them into the billed total_tokens; it is None when the source is not LLM-generated.
-        initial_message, initial_message_source, initial_llm_usage = (
+        initial_message, initial_message_source, initial_llm_cost_usd = (
             get_chat_initial_message(call_execution)
         )
 
@@ -227,23 +225,14 @@ def initiate_chat(
 
         message = ChatMessage(role=ChatRole.USER, content=initial_message)
 
-        # Calculate tokens for the initial message.
-        # Prefer the LLM invocation's actual prompt+completion token counts (so the
-        # persona-first-line LLM call is fully billed). Fall back to a heuristic
-        # estimate on the text when the message did not come from an LLM call
-        # (provided_initial_message / default_hi paths) or the LLM did not return
-        # usage.
+        # Calculate tokens for the initial message
         initial_msg_text = (
             initial_message
             if isinstance(initial_message, str)
             else str(initial_message)
         )
         initial_tokens = 0
-        if initial_llm_usage:
-            initial_tokens = int(initial_llm_usage.get("input_tokens") or 0) + int(
-                initial_llm_usage.get("output_tokens") or 0
-            )
-        elif initial_msg_text:
+        if initial_msg_text:
             try:
                 from ee.agenthub.traceerroragent.token_utils import (
                     estimate_tokens_text,
@@ -274,6 +263,33 @@ def initiate_chat(
             workspace=workspace,
             tokens=initial_tokens,
         )
+
+        if initial_llm_cost_usd and initial_llm_cost_usd > 0:
+            try:
+                from ee.usage.schemas.event_types import BillingEventType
+                from ee.usage.schemas.events import UsageEvent
+                from ee.usage.services.config import BillingConfig
+                from ee.usage.services.emitter import emit
+
+                credits = BillingConfig.get().calculate_ai_credits(initial_llm_cost_usd)
+                emit(
+                    UsageEvent(
+                        org_id=str(organization.id),
+                        event_type=BillingEventType.TEXT_CALL,
+                        amount=credits,
+                        properties={
+                            "source": "simulate_chat_initial_message",
+                            "source_id": str(call_execution.id),
+                            "raw_cost_usd": str(initial_llm_cost_usd),
+                            "pricing_source": "llm.cost.total_cost",
+                        },
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "chat_initial_message_bill_failed",
+                    call_execution_id=str(call_execution.id),
+                )
 
         ##check if test execution is pending
         if (


### PR DESCRIPTION
## 1. Why

The persona's first-line generation in a threads-based chat simulation went through `simulate/services/chat_initial_message.py:204` which was pinned to a Bedrock inference-profile SKU (`ModelConfigs.CLAUDE_4_5_SONNET_BEDROCK_ARN`). The deploy environment lacks Bedrock invoke permissions on that resource, so every call 403s and users see the hardcoded fallback opener instead of a persona-tailored one.

Every subsequent turn in the same feature already uses `VERTEX_GEMINI_2_5_PRO` via `generate_simulator_response` (`simulate/services/chat_constants.py:24`). Aligning the first-line model with the per-turn model removes the divergent code path.

## 2. What changed

| File | Change | Preserved |
|---|---|---|
| `futureagi/simulate/services/chat_initial_message.py` | Model switched at line 204 from `ModelConfigs.CLAUDE_4_5_SONNET_BEDROCK_ARN` to `ModelConfigs.VERTEX_GEMINI_2_5_PRO`. `_generate_chat_initial_message` now returns `(text, usage)` and `get_chat_initial_message` returns `(text, source, usage)` so the LLM invocation's actual `prompt_tokens` + `completion_tokens` counts flow to the caller. | The `LLM(...)` construction with `temperature=0.7`, `api_key=None`, the retry / exception path (still returns `None`s on failure), the selection order (LLM → provided → default). |
| `futureagi/simulate/services/chat_sim.py` | `initiate_chat` unpacks the new triple. When `usage` is populated, an additional `UsageEvent(BillingEventType.TEXT_CALL, amount=input_tokens + output_tokens, ...)` is emitted alongside the row insert so the persona-first-line spend rolls into the same `text_sim_tokens` counter as every subsequent turn. | The rest of `initiate_chat` — assistant creation, session creation, call-execution state transition, `notify_simulation_update`, `ChatMessageModel.objects.create` field layout; the existing per-turn TEXT_CALL emit. |

## 3. Behavior callouts

- Persona openers now come from Vertex Gemini 2.5 Pro. Both models produce a fine one-line opener; slight voice difference is expected.
- On any transient failure the caller falls back to the same hardcoded default opener as before; users never see an error.
- Cost per call drops from Bedrock Sonnet 4.5 ($3 / $15 per 1M in/out) to Vertex Gemini 2.5 Pro ($1.25 / $10 per 1M in/out).
- **Billing coverage restored** for the persona-first-line LLM call. Previously the LLM invocation's tokens were not counted in the per-call `total_tokens` aggregate that emits `UsageEvent(BillingEventType.TEXT_CALL, ...)`. Now a dedicated event with `amount=input_tokens + output_tokens` is emitted at `initiate_chat` time, matching the existing per-turn TEXT_CALL shape (feeds the same `text_sim_tokens` dimension per `billing.yaml`).
- Routing path unchanged: `LLM(api_key=None)` still tries the gateway first, falls back to litellm which uses pod-level `GOOGLE_APPLICATION_CREDENTIALS`. The credentials are already provisioned live — that's what makes every subsequent turn work.

## 4. Tests

Zero test churn:
- No mock consumers of `chat_initial_message.py` in `simulate/tests/`.
- Only real caller of `get_chat_initial_message` is `initiate_chat`; a stale import in `simulate/utils/chat_simulation.py` does not call the function.

Sanity import:

```
python -c "
from agentic_eval.core.utils.model_config import ModelConfigs
assert ModelConfigs.VERTEX_GEMINI_2_5_PRO.model_name == 'vertex_ai/gemini-2.5-pro'
print('ok')
"
```

## 5. Commands to run the tests

```
bin/test app simulate -k "chat" --no-services
```

<image: bin/test output showing chat suite green>

## 6. Steps to test on local

1. Boot the stack, sign in, open Simulate.
2. Kick off a chat-simulation call execution.
3. Verify the persona's opening line is generated (not the hardcoded fallback).
4. Inspect the request log for the initial call: `provider` should be `vertex_ai`, `model` should be `vertex_ai/gemini-2.5-pro`.
5. Confirm a `TEXT_CALL` usage event was emitted with `source: "simulate_chat_initial_message"` and `input_tokens`/`output_tokens` matching the LLM response.

<video: end-to-end chat simulation showing a persona-tailored opener>

## 7. Scope in / scope out

In-scope:
- Model switch on the one call site at `chat_initial_message.py:204`.
- Billing plumbing: an additional per-call `UsageEvent(TEXT_CALL, amount=tokens, source="simulate_chat_initial_message")` covering the persona-first-line LLM invocation.

Out-of-scope:
- Bedrock IAM permission changes. Even if we later re-add a Bedrock code path, that resource permission is a cloud-ops concern and does not gate this hotfix.
- Vertex Gemini 2.5 Pro vs a cheaper Gemini SKU. Kept parity with per-turn model so the persona voice stays consistent across the first line and every follow-up.
- Provided-initial-message / default-`Hi!` paths. These do not invoke an LLM at all, so there is nothing new to bill; they remain on the existing token-estimator path.

## 8. Design choices

- Chose `VERTEX_GEMINI_2_5_PRO` over any other Vertex/Gemini SKU because that is already the per-turn simulator model, so first-line and every-turn voice stay consistent.
- Kept the `temperature=0.7` override on the caller side; the temperature is deliberately higher than the class default to keep opener variety.
- Did NOT touch the graceful-fallback logic — on any exception the caller returns `(None, None, None)` and downstream uses a hardcoded safe default. That contract stays intact.
- Chose to emit a second `TEXT_CALL` event for the initial-message spend (rather than folding the tokens into the row's `tokens` field) so the initial-message row's `tokens` value keeps its "text length of the opener" semantic and downstream analytics that groups on `properties.source` can attribute the LLM cost distinctly.
- Metering failure is swallowed so a billing hiccup never breaks `initiate_chat`.

## Linear

Fix TH-7199
