### PR TITLE
fix(evals): derive provider from model in CustomPromptEvaluator, guard call_llm on None provider

### DIFF
--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -2086,10 +2086,11 @@ class LLM:
 
             # Handle API key scenarios
             if isinstance(self.api_key, dict):
-                payload["custom_llm_provider"] = provider
-                if provider == "bedrock" or provider.startswith("azure"):
+                provider_str = provider or ""
+                payload["custom_llm_provider"] = provider_str
+                if provider_str == "bedrock" or provider_str.startswith("azure"):
                     payload.update(self.api_key)
-                elif provider.startswith("vertex_ai"):
+                elif provider_str.startswith("vertex_ai"):
                     vertex_location = (
                         self.api_key.get("location")
                         if isinstance(self.api_key, dict)
@@ -2103,7 +2104,7 @@ class LLM:
                     payload["vertex_credentials"] = json.dumps(creds)
                     if vertex_location:
                         payload["vertex_location"] = vertex_location
-                elif provider == "openai":
+                elif provider_str == "openai":
                     if "key" in self.api_key:
                         api_key_dict = self.api_key.copy()
                         if "api_base" in api_key_dict:

--- a/futureagi/agentic_eval/core_evals/run_prompt/available_models.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/available_models.py
@@ -4119,27 +4119,6 @@ OSS_AVAILABLE_MODELS = [
         "notes": "GA multimodal embedding model; 8K input context. Replaces gemini-embedding-001 as recommended default.",
     },
     {
-        "model_name": "gemini/gemini-3-pro-preview",
-        "providers": "gemini",
-        "api_key_name": "GEMINI_API_KEY",
-        "mode": "chat",
-        "best_for": ["Gemini 3 flagship reasoning", "long-context multimodal analysis", "advanced coding"],
-        "use_case": [
-            "complex reasoning over large datasets",
-            "STEM problem solving",
-            "enterprise agent workflows",
-        ],
-        "cutoff": "04-2026",
-        "rate_limits": {
-            "requests_per_minute": 5,
-            "requests_per_day": 100,
-            "tokens_per_minute": 250000,
-        },
-        "latency": 120,
-        "pricing": {"input_per_1M_tokens": 2.0, "output_per_1M_tokens": 12.0},
-        "notes": "Preview tier. Base Gemini 3 Pro; 1M context, 64K max output.",
-    },
-    {
         "model_name": "gemini/gemini-3-flash-preview",
         "providers": "gemini",
         "api_key_name": "GEMINI_API_KEY",

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -391,6 +391,10 @@ def prepare_eval_config(
                 else None
             )
             config["api_key"] = _get_api_key(raw_model, org_id, ws_id)
+            if not config.get("provider"):
+                from model_hub.utils.llm_providers import get_provider_for_model
+
+                config["provider"] = get_provider_for_model(raw_model, org_id, ws_id)
 
         config["check_internet"] = eval_template.config.get("check_internet", False)
         config["multi_choice"] = eval_template.config.get("multi_choice")


### PR DESCRIPTION
## 1. Why

Two shipped together:

1. **LLM-as-Judge eval-playground crashed with `'NoneType' object has no attribute 'startswith'`** for any `vertex_ai/*` (and by extension `azure/*`) model on draft evals or templates without a saved `provider` in their config. Repro from local: create a new LLM-as-Judge eval, pick `vertex_ai/gemini-3-pro-preview` in the model dropdown, hit **Test Evaluation** → red banner.

2. **`gemini/gemini-3-pro-preview` was retired by Google upstream.** Direct call returns `NOT_FOUND` with the message "This model models/gemini-3-pro-preview is no longer available." Removing the OSS catalog entry so the FE dropdown stops surfacing a dead SKU.

## 2. What changed

| File | Change | Preserved |
|---|---|---|
| `futureagi/evaluations/engine/instance.py` | In `prepare_eval_config`'s `CustomPromptEvaluator` else-branch (non-Turing models), if `config["provider"]` is still None after reading from `eval_template.config`, derive it from `raw_model` via `model_hub.utils.llm_providers.get_provider_for_model`. | The pre-existing config read at line 346, the Turing branch that pins `provider="turing"`, api-key resolution. |
| `futureagi/agentic_eval/core/llm/llm.py` | Under the `isinstance(self.api_key, dict)` branch of `call_llm`, coalesce `provider` to `""` before the `.startswith("azure")` / `.startswith("vertex_ai")` checks, so any future None-provider caller falls through cleanly instead of raising `AttributeError`. | The `.startswith` comparisons themselves (still match `azure`, `vertex_ai`, `openai`), the payload construction, exception path. |
| `futureagi/agentic_eval/core_evals/run_prompt/available_models.py` | Removed the `gemini/gemini-3-pro-preview` catalog entry (Google retired the model upstream). | Every other entry, ordering, `_merge_model_catalog` behavior. |

## 3. Behavior callouts

- Root fix is in `instance.py` — provider is populated from the model when the config doesn't carry it. This solves the immediate crash.
- `llm.py` defensive edit is belt-and-suspenders — any other future caller that lands with `provider=None` gets a clean fall-through (custom_llm_provider empty string, no `.startswith` crash) instead of a stack trace bubbled to the FE.
- FE model dropdown no longer surfaces `gemini/gemini-3-pro-preview`. Any BYOK request that hardcodes that ID will still hit Google's 404 as before; nothing else changes.
- Zero behavior change for evals whose templates already have `provider` set — the new branch only runs when `config["provider"]` is falsy.

## 4. Tests

End-to-end verified by hitting the eval-playground endpoint after applying both patches to a live local backend.

### How it was tested

- **Endpoint**: `POST http://localhost:8000/model-hub/eval-playground/`
- **Eval type**: LLM-as-Judge (`CustomPromptEvaluator`)
- **Template**: `6db78cc1-dc71-4689-b2ff-ad5fdcb521bb` — a draft "is this toxic?" toxicity check with a single required key `{{input}}` and a Pass/Fail output.
- **Body**:
  ```json
  {"template_id":"6db78cc1-dc71-4689-b2ff-ad5fdcb521bb",
   "model":"<model_name>",
   "error_localizer":false,
   "config":{"mapping":{"input":"how are you?"}}}
  ```
- **Auth**: workspace bearer token; the Gemini direct + Vertex JSON credentials keys were saved in the workspace before the run.

### Per-model results

| Model | Result | Cost (USD) | Tokens (prompt / completion) |
|---|---|---|---|
| `gemini/gemini-3.6-flash` | ✅ Passed | $0.001507 | 345 / 132 |
| `gemini/gemini-3.5-flash` | ✅ Passed | $0.001768 | 345 / 139 |
| `gemini/gemini-3.5-flash-lite` | ✅ Passed | $0.000193 | 345 / 36 |
| `gemini/gemini-3.1-pro-preview` | ✅ Passed | $0.003078 | 345 / 199 |
| `gemini/gemini-3-flash-preview` | ✅ Passed | $0.000268 | 345 / 32 |
| `gemini/gemini-3.1-flash-lite` | ✅ Passed | $0.000317 | 345 / 154 |
| `vertex_ai/gemini-3.6-flash` | ✅ Passed | $0.001339 | 428 / 93 |
| `vertex_ai/gemini-3.5-flash` | ✅ Passed | $0.002055 | 428 / 157 |
| `vertex_ai/gemini-3.5-flash-lite` | ✅ Passed | $0.000230 | 428 / 41 |
| `vertex_ai/gemini-3.1-pro-preview` | ✅ Passed | $0.002800 | 428 / 162 |
| `vertex_ai/gemini-3-flash-preview` | ✅ Passed | $0.000306 | 420 / 32 |
| `vertex_ai/gemini-3.1-flash-lite` | ✅ Passed | $0.000335 | 428 / 152 |
| `claude-opus-5` | ⏭ Not tested | – | – |
| `claude-sonnet-5` | ⏭ Not tested | – | – |
| `claude-haiku-4-5` | ⏭ Not tested | – | – |
| `gemini/gemini-embedding-2` | ⏭ Not tested | – | – |
| `gemini/gemini-3.1-flash-image` | ⏭ Not tested | – | – |
| `gemini/gemini-2.5-flash-image` | ⏭ Not tested | – | – |
| `vertex_ai/gemini-3.1-flash-image` | ⏭ Not tested | – | – |
| `vertex_ai/gemini-2.5-flash-image` | ⏭ Not tested | – | – |
| `gemini/gemini-3-pro-preview` | 🗑 Removed in this PR | – | – |
| `vertex_ai/gemini-3-pro-preview` | ⚠ Still in ee catalog | – | – |

Skip reasons:
- **Claude 5 family** — Anthropic key not configured on the local workspace used for the sweep; not gating this PR since the routing / catalog wiring is identical to every other Anthropic entry and independent of this defensive change.
- **`gemini/gemini-embedding-2`** — embedding model; eval-playground's LLM-as-Judge path only accepts chat models. Needs a separate embedding-eval smoke test.
- **`gemini-3.1-flash-image`, `gemini-2.5-flash-image`, vertex_ai variants** — image-generation models; same reason as above (eval-playground rejects them by mode).
- **`gemini/gemini-3-pro-preview`** — removed in this PR (Google retired the model upstream, returned `NOT_FOUND`).
- **`vertex_ai/gemini-3-pro-preview`** — still present in `ee/prompts/additional_models.py` on ee/dev. This PR is scoped to the outer repo only; the ee-side removal is a follow-up (not opening one here).

## 5. Commands to run the tests

```bash
bin/test app model_hub -k "custom_prompt_evaluator or eval_playground" --no-services
```

For a live re-check of the fix against a running backend:

```bash
curl -sS -X POST "http://localhost:8000/model-hub/eval-playground/" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <workspace_token>" \
  -d '{"template_id":"<toxicity_template_uuid>",
       "model":"vertex_ai/gemini-3.6-flash",
       "error_localizer":false,
       "config":{"mapping":{"input":"how are you?"}}}'
```

<image: full-sweep terminal output showing 12/12 chat models passing after patch>

## 6. Steps to test on local

1. Check out this branch, restart the backend (`./dc.sh backend` from `future-agi/futureagi/`).
2. Open Evals → Create → LLM-as-Judge.
3. Save a Google API key (direct BYOK) or a Vertex JSON credentials blob in Settings → API Keys.
4. Pick any `vertex_ai/gemini-3.*` or `gemini/gemini-3.*` model from the dropdown.
5. Add Test Data matching the prompt template's variables.
6. Hit **Test Evaluation** → should return a Passed/Failed verdict + cost + metadata instead of the None-startswith crash.

<video: end-to-end LLM-as-Judge test with a vertex_ai model succeeding after the fix>

## 7. Scope in / scope out

In-scope:
- Provider-None defensive fix in `CustomPromptEvaluator` prep + `call_llm` payload builder.
- Removal of the retired `gemini/gemini-3-pro-preview` entry from the OSS catalog.

Out-of-scope:
- Companion `vertex_ai/gemini-3-pro-preview` removal on the ee repo. This PR is scoped to the outer repo only; the ee-side cleanup is a follow-up.
- Preview-tier Vertex model access — any GCP project without preview permissions still hits a 404 downstream. Provider-side, not gating.
- Other evaluator families (AgentEvaluator, DeterministicEvaluator) — their provider-resolution paths are unrelated.

## 8. Design choices

- Kept `instance.py` fix inside the existing else-branch rather than lifting it up so behavior stays identical for the Turing path (which pins `provider="turing"` explicitly).
- Chose a local `provider_str = provider or ""` variable in `llm.py` instead of mutating the caller-facing `provider` argument, so the log-tag `provider=` still reports what the caller actually passed (helps debugging the source of future None-provider callers).
- Bundled the `gemini-3-pro-preview` removal with this PR rather than filing a separate cleanup ticket because the two changes ship together on the same deployment window; the retirement was surfaced by the same test sweep.

## Linear

Fix TH-7200
