### PR TITLE
fix(ci): exempt release-please branches from branch-name check

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -17,7 +17,7 @@ jobs:
           BRANCH: ${{ github.head_ref }}
         run: |
           # Skip validation for release branches and dependabot
-          if [[ "$BRANCH" =~ ^(main|dev|release/.+|dependabot/.+)$ ]]; then
+          if [[ "$BRANCH" =~ ^(main|dev|release/.+|release-please--.+|dependabot/.+)$ ]]; then
             echo "✅ Skipping validation for $BRANCH"
             exit 0
           fi


### PR DESCRIPTION
The pre-existing `branch-name-check` fails on release-please's auto-generated branch `release-please--branches--main`, putting a red X on every release PR (currently #1817). Not a required check, so it doesn't block merges — but it's noise. One-line fix: add `release-please--.+` to the workflow's existing skip list (next to main/dev/release/dependabot). Resolves on #1817 the next time release-please refreshes its branch off main. Twin to dev follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)