### PR TITLE
fix(ci): exempt release-please branches from branch-name check (twin)

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -17,7 +17,7 @@ jobs:
           BRANCH: ${{ github.head_ref }}
         run: |
           # Skip validation for release branches and dependabot
-          if [[ "$BRANCH" =~ ^(main|dev|release/.+|dependabot/.+)$ ]]; then
+          if [[ "$BRANCH" =~ ^(main|dev|release/.+|release-please--.+|dependabot/.+)$ ]]; then
             echo "✅ Skipping validation for $BRANCH"
             exit 0
           fi


### PR DESCRIPTION
Twin of the main PR targeting dev. Byte-identical one-line skip-list addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)