### PR TITLE
feat(tracer): add eval score distribution query

### DIFF
--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -125511,6 +125511,15 @@
                     ],
                     "default": "day"
                 },
+                "query_mode": {
+                    "title": "Query mode",
+                    "type": "string",
+                    "enum": [
+                        "time_series",
+                        "distribution"
+                    ],
+                    "default": "time_series"
+                },
                 "metrics": {
                     "type": "array",
                     "items": {
@@ -125607,7 +125616,6 @@
         },
         "DashboardQuerySeriesPoint": {
             "required": [
-                "timestamp",
                 "value"
             ],
             "type": "object",
@@ -125616,6 +125624,14 @@
                     "title": "Timestamp",
                     "type": "string",
                     "minLength": 1
+                },
+                "bucket_start": {
+                    "title": "Bucket start",
+                    "type": "number"
+                },
+                "bucket_end": {
+                    "title": "Bucket end",
+                    "type": "number"
                 },
                 "value": {
                     "title": "Value",

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -51860,6 +51860,12 @@ export const OPENAPI_CONTRACT = Object.freeze({
           enum: ["minute", "hour", "day", "week", "month"],
           default: "day",
         },
+        query_mode: {
+          title: "Query mode",
+          type: "string",
+          enum: ["time_series", "distribution"],
+          default: "time_series",
+        },
         metrics: {
           type: "array",
           items: {
@@ -102824,13 +102830,21 @@ export const OPENAPI_CONTRACT = Object.freeze({
       },
     },
     DashboardQuerySeriesPoint: {
-      required: ["timestamp", "value"],
+      required: ["value"],
       type: "object",
       properties: {
         timestamp: {
           title: "Timestamp",
           type: "string",
           minLength: 1,
+        },
+        bucket_start: {
+          title: "Bucket start",
+          type: "number",
+        },
+        bucket_end: {
+          title: "Bucket end",
+          type: "number",
         },
         value: {
           title: "Value",

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -20387,6 +20387,14 @@ export const DashboardQueryApiGranularity = {
   month: "month",
 } as const;
 
+export type DashboardQueryApiQueryMode =
+  (typeof DashboardQueryApiQueryMode)[keyof typeof DashboardQueryApiQueryMode];
+
+export const DashboardQueryApiQueryMode = {
+  time_series: "time_series",
+  distribution: "distribution",
+} as const;
+
 export type DashboardQueryApiFiltersItemFilterConfigAttributeValueTypesItem =
   (typeof DashboardQueryApiFiltersItemFilterConfigAttributeValueTypesItem)[keyof typeof DashboardQueryApiFiltersItemFilterConfigAttributeValueTypesItem];
 
@@ -20650,6 +20658,7 @@ export interface DashboardQueryApi {
   project_ids?: string[];
   time_range: DashboardTimeRangeApi;
   granularity?: DashboardQueryApiGranularity;
+  query_mode?: DashboardQueryApiQueryMode;
   metrics: DashboardMetricApi[];
   filters?: DashboardQueryApiFiltersItem[];
   breakdowns?: DashboardBreakdownApi[];
@@ -20683,7 +20692,9 @@ export const DashboardQueryMetricResultApiAggregation = {
 
 export interface DashboardQuerySeriesPointApi {
   /** @minLength 1 */
-  timestamp: string;
+  timestamp?: string;
+  bucket_start?: number;
+  bucket_end?: number;
   value: number;
 }
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -43984,6 +43984,7 @@ export const TracerDashboardQueryQueryParams = zod.object({
 export const tracerDashboardQueryBodyWorkflowDefault = `observability`;
 export const tracerDashboardQueryBodyProjectIdsDefault = [];
 export const tracerDashboardQueryBodyGranularityDefault = `day`;
+export const tracerDashboardQueryBodyQueryModeDefault = `time_series`;
 
 export const tracerDashboardQueryBodyMetricsItemSourceDefault = `traces`;
 export const tracerDashboardQueryBodyMetricsItemAggregationDefault = `avg`;
@@ -44015,6 +44016,9 @@ export const TracerDashboardQueryBody = zod.object({
   granularity: zod
     .enum(["minute", "hour", "day", "week", "month"])
     .default(tracerDashboardQueryBodyGranularityDefault),
+  query_mode: zod
+    .enum(["time_series", "distribution"])
+    .default(tracerDashboardQueryBodyQueryModeDefault),
   metrics: zod.array(
     zod.object({
       id: zod.string().optional(),
@@ -44311,7 +44315,9 @@ export const TracerDashboardQueryResponse = zod.object({
             name: zod.string(),
             data: zod.array(
               zod.object({
-                timestamp: zod.string().min(1),
+                timestamp: zod.string().min(1).optional(),
+                bucket_start: zod.number().optional(),
+                bucket_end: zod.number().optional(),
                 value: zod.number(),
               }),
             ),
@@ -44766,6 +44772,7 @@ export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigWorkflowDefault = 
 export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigProjectIdsDefault =
   [];
 export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigGranularityDefault = `day`;
+export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigQueryModeDefault = `time_series`;
 
 export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigMetricsItemSourceDefault = `traces`;
 export const tracerDashboardWidgetsPreviewQueryBodyQueryConfigMetricsItemAggregationDefault = `avg`;
@@ -44818,6 +44825,11 @@ export const TracerDashboardWidgetsPreviewQueryBody = zod.object({
       .enum(["minute", "hour", "day", "week", "month"])
       .default(
         tracerDashboardWidgetsPreviewQueryBodyQueryConfigGranularityDefault,
+      ),
+    query_mode: zod
+      .enum(["time_series", "distribution"])
+      .default(
+        tracerDashboardWidgetsPreviewQueryBodyQueryConfigQueryModeDefault,
       ),
     metrics: zod.array(
       zod.object({
@@ -45144,7 +45156,9 @@ export const TracerDashboardWidgetsPreviewQueryResponse = zod.object({
             name: zod.string(),
             data: zod.array(
               zod.object({
-                timestamp: zod.string().min(1),
+                timestamp: zod.string().min(1).optional(),
+                bucket_start: zod.number().optional(),
+                bucket_end: zod.number().optional(),
                 value: zod.number(),
               }),
             ),
@@ -45621,7 +45635,9 @@ export const TracerDashboardWidgetsExecuteQueryResponse = zod.object({
             name: zod.string(),
             data: zod.array(
               zod.object({
-                timestamp: zod.string().min(1),
+                timestamp: zod.string().min(1).optional(),
+                bucket_start: zod.number().optional(),
+                bucket_end: zod.number().optional(),
                 value: zod.number(),
               }),
             ),

--- a/futureagi/tracer/serializers/dashboard.py
+++ b/futureagi/tracer/serializers/dashboard.py
@@ -53,6 +53,7 @@ PROPERTY_CATALOG_METRIC_SOURCES = (
     "all",
 )
 DASHBOARD_GRANULARITIES = ("minute", "hour", "day", "week", "month")
+DASHBOARD_QUERY_MODES = ("time_series", "distribution")
 DASHBOARD_TIME_RANGE_PRESETS = (
     "30m",
     "6h",
@@ -310,6 +311,7 @@ class DashboardWidgetSerializer(serializers.ModelSerializer):
             "stacked_column",
             "bar",
             "stacked_bar",
+            "distribution",
             "pie",
             "table",
             "metric",
@@ -408,6 +410,9 @@ class DashboardQuerySerializer(StrictInputSerializer):
     granularity = serializers.ChoiceField(
         choices=DASHBOARD_GRANULARITIES, required=False, default="day"
     )
+    query_mode = serializers.ChoiceField(
+        choices=DASHBOARD_QUERY_MODES, required=False, default="time_series"
+    )
     metrics = DashboardMetricSerializer(many=True)
     filters = filter_list_field(required=False, default=list)
     breakdowns = DashboardBreakdownSerializer(many=True, required=False, default=list)
@@ -466,6 +471,49 @@ class DashboardQuerySerializer(StrictInputSerializer):
         ]
         dataset_workflow = attrs.get("workflow") == "dataset"
         simulation_workflow = attrs.get("workflow") == "simulation"
+
+        if attrs.get("query_mode") == "distribution":
+            if len(metrics) != 1:
+                raise serializers.ValidationError(
+                    {
+                        "metrics": (
+                            "Distribution queries require exactly one numeric eval metric."
+                        )
+                    }
+                )
+            metric = metrics[0]
+            if metric.get("type") != "eval_metric":
+                raise serializers.ValidationError(
+                    {"metrics": "Distribution queries only support eval metrics."}
+                )
+            if metric.get("source", "traces") not in ("traces", "both", "all"):
+                raise serializers.ValidationError(
+                    {
+                        "metrics": (
+                            "Distribution queries only support trace-sourced eval metrics."
+                        )
+                    }
+                )
+            output_type = str(
+                metric.get("output_type") or metric.get("outputType") or "SCORE"
+            ).upper()
+            if output_type not in ("SCORE", "NUMERIC"):
+                raise serializers.ValidationError(
+                    {
+                        "metrics": (
+                            "Distribution queries require a numeric score eval metric."
+                        )
+                    }
+                )
+            if metric.get("aggregation") != "count":
+                raise serializers.ValidationError(
+                    {"metrics": "Distribution queries use count aggregation."}
+                )
+            if attrs.get("breakdowns"):
+                raise serializers.ValidationError(
+                    {"breakdowns": "Distribution queries do not support breakdowns."}
+                )
+
         if (
             not dataset_metrics
             and not dataset_workflow
@@ -524,6 +572,7 @@ class DashboardQuerySerializer(StrictInputSerializer):
                         )
                     }
                 )
+
         return attrs
 
 
@@ -566,8 +615,24 @@ class DashboardRefreshQuerySerializer(StrictInputSerializer):
 
 
 class DashboardQuerySeriesPointSerializer(serializers.Serializer):
-    timestamp = serializers.CharField()
+    timestamp = serializers.CharField(required=False)
+    bucket_start = serializers.FloatField(required=False)
+    bucket_end = serializers.FloatField(required=False)
     value = serializers.FloatField(allow_null=True)
+
+    def validate(self, attrs):
+        has_timestamp = "timestamp" in attrs
+        has_bucket_start = "bucket_start" in attrs
+        has_bucket_end = "bucket_end" in attrs
+        if has_bucket_start != has_bucket_end:
+            raise serializers.ValidationError(
+                "bucket_start and bucket_end must be provided together."
+            )
+        if has_timestamp == has_bucket_start:
+            raise serializers.ValidationError(
+                "Provide either timestamp or both bucket_start and bucket_end."
+            )
+        return attrs
 
 
 class DashboardQuerySeriesSerializer(serializers.Serializer):

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -201,6 +201,9 @@ _ROLLUP_COVERED_ATTRS = frozenset({"final_status", "country"})
 # Rollup is hour-resolution; sub-hour granularities keep the spans scan.
 _ROLLUP_GRANULARITIES = frozenset({"hour", "day", "week", "month", "year"})
 
+DISTRIBUTION_QUERY_MODE = "distribution"
+DISTRIBUTION_BUCKET_COUNT = 10
+
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
 _COUNT_DISTINCT_METRICS = frozenset(
     {
@@ -665,6 +668,7 @@ class DashboardQueryBuilder:
         self.organization_id = query_config.get("organization_id", "")
         self.workspace_id = query_config.get("workspace_id", "")
         self.granularity = query_config.get("granularity", "day")
+        self.query_mode = query_config.get("query_mode", "time_series")
         self.metrics = query_config.get("metrics", [])
         self.global_filters = query_config.get("filters", [])
         self.breakdowns = query_config.get("breakdowns", [])
@@ -808,6 +812,27 @@ class DashboardQueryBuilder:
         metric_name = metric.get("id") or metric.get("name", "")
         aggregation = metric.get("aggregation", "avg")
         per_metric_filters = metric.get("filters", [])
+
+        if self.query_mode == DISTRIBUTION_QUERY_MODE:
+            if len(self.metrics) != 1:
+                raise ValueError("Distribution queries require exactly one metric.")
+            if metric_type != "eval_metric":
+                raise ValueError("Distribution queries only support eval metrics.")
+            if metric.get("source", "traces") not in ("traces", "both", "all"):
+                raise ValueError(
+                    "Distribution queries only support trace-sourced eval metrics."
+                )
+            output_type = str(
+                metric.get("output_type") or metric.get("outputType") or "SCORE"
+            ).upper()
+            if output_type not in ("SCORE", "NUMERIC"):
+                raise ValueError(
+                    "Distribution queries require a numeric score eval metric."
+                )
+            if aggregation != "count":
+                raise ValueError("Distribution queries use count aggregation.")
+            if self.breakdowns:
+                raise ValueError("Distribution queries do not support breakdowns.")
 
         start_date, end_date = self.parse_time_range()
         bucket_fn = GRANULARITY_TO_CH.get(self.granularity, "toStartOfDay")
@@ -1812,7 +1837,9 @@ class DashboardQueryBuilder:
         """
         # Accept both config_id (legacy) and name (new) as the template identifier
         eval_template_id = metric.get("config_id") or metric.get("name", "")
-        output_type = (metric.get("output_type") or "SCORE").upper()
+        output_type = str(
+            metric.get("output_type") or metric.get("outputType") or "SCORE"
+        ).upper()
 
         eval_template_id = self._resolve_eval_template_identity(
             metric, eval_template_id
@@ -1828,6 +1855,21 @@ class DashboardQueryBuilder:
         _is_pass = eval_pass_expr("e.eval_score", "e.eval_output_str")
         _is_fail = eval_fail_expr("e.eval_score", "e.eval_output_str")
         _unified_score = f"if({_is_pass}, 1.0, e.eval_score)"
+        is_distribution = self.query_mode == DISTRIBUTION_QUERY_MODE
+
+        if output_type == "PASS_FAIL":
+            col_expr = _unified_score
+        else:
+            _has_number = (
+                f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
+                f"OR {eval_has_structured_score('e.eval_output_str')}"
+            )
+            col_expr = (
+                "if(e.eval_output_str = '', NULL, "
+                f"if({_output_str_lower} IN {_truthy}, 1.0, "
+                f"if({_output_str_lower} IN {_falsy}, 0.0, "
+                f"if({_has_number}, e.eval_score, NULL))))"
+            )
 
         _EVAL_AGGREGATIONS: dict[str, str] = {
             "pass_rate": f"countIf({_is_pass}) / nullIf(count(), 0)",
@@ -1842,27 +1884,16 @@ class DashboardQueryBuilder:
         elif output_type in ("CHOICE", "CHOICES"):
             agg_expr = "count()"
         else:
-            if output_type == "PASS_FAIL":
-                col_expr = _unified_score
-            else:
-                # Templates with no output_type still emit pass/fail strings,
-                # bare numbers, or a structured object carrying a score.
-                _has_number = (
-                    f"match(e.eval_output_str, '{EVAL_NUMERIC_OUTPUT_PATTERN}') "
-                    f"OR {eval_has_structured_score('e.eval_output_str')}"
-                )
-                col_expr = (
-                    "if(e.eval_output_str = '', NULL, "
-                    f"if({_output_str_lower} IN {_truthy}, 1.0, "
-                    f"if({_output_str_lower} IN {_falsy}, 0.0, "
-                    f"if({_has_number}, e.eval_score, NULL))))"
-                )
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
-        select_parts = [f"{bucket_fn}(e.created_at) AS time_bucket"]
-        group_parts = ["time_bucket"]
-        order_parts = ["time_bucket"]
-        select_parts.append(f"{agg_expr} AS value")
+        select_parts = []
+        group_parts = []
+        order_parts = []
+        if not is_distribution:
+            select_parts = [f"{bucket_fn}(e.created_at) AS time_bucket"]
+            group_parts = ["time_bucket"]
+            order_parts = ["time_bucket"]
+            select_parts.append(f"{agg_expr} AS value")
 
         # Scope to workspace when available, otherwise org
         if self.workspace_id:
@@ -2288,14 +2319,71 @@ class DashboardQueryBuilder:
 
         join_str = "\n".join(joins)
 
-        query = (
-            f"SELECT {', '.join(select_parts)}\n"
-            f"FROM {eval_source}\n"
-            f"{join_str}\n"
-            f"WHERE {' AND '.join(where_parts)}\n"
-            f"GROUP BY {', '.join(group_parts)}\n"
-            f"ORDER BY {', '.join(order_parts)}"
-        )
+        if is_distribution:
+            query = (
+                "WITH\n"
+                "filtered_scores AS (\n"
+                "    SELECT score\n"
+                "    FROM (\n"
+                f"        SELECT {col_expr} AS score\n"
+                f"        FROM {eval_source}\n"
+                f"        {join_str}\n"
+                f"        WHERE {' AND '.join(where_parts)}\n"
+                "    )\n"
+                "    WHERE score IS NOT NULL\n"
+                "),\n"
+                "score_bounds AS (\n"
+                "    SELECT min(score) AS min_score, max(score) AS max_score\n"
+                "    FROM filtered_scores\n"
+                "),\n"
+                "bucketed_scores AS (\n"
+                "    SELECT\n"
+                "        fs.score,\n"
+                "        sb.min_score,\n"
+                "        sb.max_score,\n"
+                "        if(\n"
+                "            sb.max_score = sb.min_score,\n"
+                "            toUInt8(0),\n"
+                "            least(\n"
+                f"                toUInt8({DISTRIBUTION_BUCKET_COUNT - 1}),\n"
+                f"                toUInt8(floor((fs.score - sb.min_score) / (sb.max_score - sb.min_score) * {DISTRIBUTION_BUCKET_COUNT}))\n"
+                "            )\n"
+                "        ) AS bucket_index\n"
+                "    FROM filtered_scores AS fs\n"
+                "    CROSS JOIN score_bounds AS sb\n"
+                "),\n"
+                "bucket_counts AS (\n"
+                "    SELECT bucket_index, count() AS value\n"
+                "    FROM bucketed_scores\n"
+                "    GROUP BY bucket_index\n"
+                ")\n"
+                "SELECT\n"
+                f"    buckets.min_score + (buckets.max_score - buckets.min_score) * buckets.bucket_index / {DISTRIBUTION_BUCKET_COUNT} AS bucket_start,\n"
+                "    if(\n"
+                f"        buckets.bucket_index = {DISTRIBUTION_BUCKET_COUNT - 1},\n"
+                "        buckets.max_score,\n"
+                f"        buckets.min_score + (buckets.max_score - buckets.min_score) * (buckets.bucket_index + 1) / {DISTRIBUTION_BUCKET_COUNT}\n"
+                "    ) AS bucket_end,\n"
+                "    ifNull(bucket_counts.value, 0) AS value\n"
+                "FROM (\n"
+                "    SELECT min_score, max_score, bucket_index\n"
+                "    FROM score_bounds\n"
+                f"    ARRAY JOIN range({DISTRIBUTION_BUCKET_COUNT}) AS bucket_index\n"
+                ") AS buckets\n"
+                "LEFT JOIN bucket_counts\n"
+                "    ON bucket_counts.bucket_index = buckets.bucket_index\n"
+                "WHERE buckets.min_score IS NOT NULL\n"
+                "ORDER BY bucket_start, bucket_end"
+            )
+        else:
+            query = (
+                f"SELECT {', '.join(select_parts)}\n"
+                f"FROM {eval_source}\n"
+                f"{join_str}\n"
+                f"WHERE {' AND '.join(where_parts)}\n"
+                f"GROUP BY {', '.join(group_parts)}\n"
+                f"ORDER BY {', '.join(order_parts)}"
+            )
         return query, params
 
     # ------------------------------------------------------------------
@@ -2852,7 +2940,11 @@ class DashboardQueryBuilder:
             or metric.get("displayName")
             or metric.get("name", ""),
             "type": metric.get("type", "system_metric"),
-            "aggregation": metric.get("aggregation", "avg"),
+            "aggregation": (
+                "count"
+                if self.query_mode == DISTRIBUTION_QUERY_MODE
+                else metric.get("aggregation", "avg")
+            ),
         }
 
     # ------------------------------------------------------------------
@@ -2967,6 +3059,49 @@ class DashboardQueryBuilder:
                 formatted_metric["error"] = metric_info["error"]
             formatted_metrics.append(formatted_metric)
 
+        return {
+            "metrics": formatted_metrics,
+            "time_range": {
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+            "granularity": self.granularity,
+        }
+
+    def format_distribution_results(
+        self, metric_results: list[tuple[dict, list[dict]]]
+    ) -> dict:
+        """Format score buckets without converting them into time buckets."""
+        start_date, end_date = self.parse_time_range()
+        formatted_metrics = []
+        for metric_info, rows in metric_results:
+            data = []
+            for row in rows:
+                bucket_start = row.get("bucket_start")
+                bucket_end = row.get("bucket_end")
+                if bucket_start is None or bucket_end is None:
+                    continue
+                value = row.get("value")
+                if isinstance(value, float):
+                    value = round(value, 6)
+                data.append(
+                    {
+                        "bucket_start": round(float(bucket_start), 6),
+                        "bucket_end": round(float(bucket_end), 6),
+                        "value": value,
+                    }
+                )
+            data.sort(key=lambda point: (point["bucket_start"], point["bucket_end"]))
+            formatted_metric = {
+                "id": metric_info.get("id", ""),
+                "name": metric_info.get("name", ""),
+                "aggregation": "count",
+                "unit": "",
+                "series": [{"name": "total", "data": data}],
+            }
+            if metric_info.get("error"):
+                formatted_metric["error"] = metric_info["error"]
+            formatted_metrics.append(formatted_metric)
         return {
             "metrics": formatted_metrics,
             "time_range": {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -369,9 +369,9 @@ def test_dashboard_worker_has_one_deadline_for_every_exact_source():
     assert settings.GRAPH_BACKGROUND_WALL_MS > _DASHBOARD_EXACT_QUERY_TIMEOUT_MS
     assert source.count("ReadDeadline.start(") == 1
     assert source.count("timeout_ms=read_deadline.remaining_ms(") == 4
-    assert source.count(
-        "timeout_ms=read_deadline.remaining_ms(statement_timeout_ms)"
-    ) == 4
+    assert (
+        source.count("timeout_ms=read_deadline.remaining_ms(statement_timeout_ms)") == 4
+    )
     assert source.count("read_deadline.remaining_ms(floor_ms=1)") == 2
     assert "query_timeout =" not in source
 
@@ -5684,6 +5684,40 @@ class TestDashboardQueryBuilder:
         assert "usage_apicalllog" in sql
         assert "eval_score" in sql
 
+    def test_eval_metric_distribution_query_returns_fixed_buckets(self):
+        config = {
+            "project_ids": ["proj1"],
+            "organization_id": str(uuid.uuid4()),
+            "workspace_id": str(uuid.uuid4()),
+            "query_mode": "distribution",
+            "time_range": {
+                "custom_start": "2025-01-01T00:00:00Z",
+                "custom_end": "2025-01-02T00:00:00Z",
+            },
+            "metrics": [
+                {
+                    "id": "e1",
+                    "name": "accuracy",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "output_type": "SCORE",
+                    "aggregation": "count",
+                }
+            ],
+        }
+
+        sql, params, metric_info = DashboardQueryBuilder(config).build_all_queries()[0]
+
+        assert "filtered_scores AS" in sql
+        assert "score_bounds AS" in sql
+        assert "bucket_counts AS" in sql
+        assert "ARRAY JOIN range(10) AS bucket_index" in sql
+        assert "ifNull(bucket_counts.value, 0) AS value" in sql
+        assert "time_bucket" not in sql
+        assert params["start_date"] == datetime(2025, 1, 1, tzinfo=UTC)
+        assert params["end_date"] == datetime(2025, 1, 2, tzinfo=UTC)
+        assert metric_info["aggregation"] == "count"
+
     def test_eval_metric_pass_fail(self):
         config = {
             "project_ids": ["proj1"],
@@ -7212,6 +7246,29 @@ class TestDashboardQueryBuilderFormatResults:
         non_null = [d for d in series[0]["data"] if d["value"] is not None]
         assert len(non_null) == 2
         assert metrics[0]["unit"] == "ms"
+
+    def test_format_distribution_results_keeps_bucket_bounds(self):
+        config = {
+            "query_mode": "distribution",
+            "time_range": {
+                "custom_start": "2025-01-01T00:00:00Z",
+                "custom_end": "2025-01-02T00:00:00Z",
+            },
+            "metrics": [{"id": "accuracy", "type": "eval_metric"}],
+        }
+        rows = [
+            {"bucket_start": 0.5, "bucket_end": 1.0, "value": 2},
+            {"bucket_start": 0.0, "bucket_end": 0.5, "value": 3},
+        ]
+
+        result = DashboardQueryBuilder(config).format_distribution_results(
+            [({"id": "accuracy", "name": "Accuracy"}, rows)]
+        )
+
+        assert result["metrics"][0]["series"][0]["data"] == [
+            {"bucket_start": 0.0, "bucket_end": 0.5, "value": 3},
+            {"bucket_start": 0.5, "bucket_end": 1.0, "value": 2},
+        ]
 
     def test_format_with_breakdown(self):
         config = {
@@ -9018,6 +9075,31 @@ class TestDashboardQuerySerializer:
         assert opted_in.is_valid(), opted_in.errors
         assert opted_in.validated_data["allow_sampled"] is True
 
+    def test_distribution_query_requires_one_numeric_eval_metric(self):
+        metric = {
+            "name": "accuracy",
+            "type": "eval_metric",
+            "source": "traces",
+            "output_type": "SCORE",
+            "aggregation": "count",
+        }
+        valid = {
+            "query_mode": "distribution",
+            "time_range": {"preset": "7D"},
+            "metrics": [metric],
+        }
+        serializer = DashboardQuerySerializer(data=valid)
+        assert serializer.is_valid(), serializer.errors
+
+        for invalid in (
+            {**valid, "metrics": [metric, {**metric, "name": "relevance"}]},
+            {**valid, "metrics": [{**metric, "aggregation": "avg"}]},
+            {**valid, "metrics": [{**metric, "output_type": "CHOICE"}]},
+            {**valid, "breakdowns": [{"name": "model", "type": "system_metric"}]},
+        ):
+            invalid_serializer = DashboardQuerySerializer(data=invalid)
+            assert not invalid_serializer.is_valid(), invalid_serializer.errors
+
     def test_numeric_custom_metric_infers_number_when_frontend_omits_type(self):
         data = {
             "workflow": "observability",
@@ -9076,9 +9158,7 @@ class TestDashboardQuerySerializer:
         sql, params = DashboardQueryBuilderV2(
             serializer.validated_data
         ).build_metric_query(metric)
-        assert (
-            f"{aggregation}(attrs_number[%(custom_metric_attr_key)s])" in sql
-        )
+        assert f"{aggregation}(attrs_number[%(custom_metric_attr_key)s])" in sql
         assert "latest_custom_metric_spans AS" not in sql
         assert "FINAL" not in without_query_settings(sql)
         assert "mapContains(attrs_number, %(custom_metric_attr_key)s)" in sql

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -93,6 +93,7 @@ from tracer.services.clickhouse.list_cursor import (
 from tracer.services.clickhouse.query_builders.dashboard import (
     GRANULARITY_TO_CH,
     METRIC_UNITS,
+    DashboardQueryBuilder,
     InvalidMetricCombinationError,
     _generate_time_buckets,
 )
@@ -7230,7 +7231,11 @@ class DashboardWidgetViewSet(BaseModelViewSetMixin, ModelViewSet):
         formatter_config = {**query_config, "workspace_id": str(workspace.id)}
         formatter = DatasetQueryBuilder(formatter_config)
 
-        if trace_metrics and not dataset_metrics and not simulation_metrics:
+        if query_config.get("query_mode") == "distribution":
+            formatted = DashboardQueryBuilder(query_config).format_distribution_results(
+                metric_results
+            )
+        elif trace_metrics and not dataset_metrics and not simulation_metrics:
             project_ids = query_config.get("project_ids", [])
             project_name_map = dict(
                 Project.objects.filter(


### PR DESCRIPTION
## Summary

- Add a backend `distribution` query mode for one numeric trace eval metric.
- Build ten explicit ClickHouse score buckets while preserving the selected time range and filters.
- Return explicit bucket bounds and exact `count()` values through the dashboard query APIs.

## Related issue

Refs #1575.

## Scope

This PR contains the backend query/API slice only. The dashboard chart selection and rendering slice has been submitted separately in #1869.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

- `pytest tracer/tests/test_dashboard.py -k distribution -q` - 5 passed, including the real PostgreSQL and ClickHouse API execution path.
- Targeted existing eval-query, response-formatting, and serializer regression tests - 4 passed.
- `vitest run src/api/contracts/__tests__/openapi-contract.test.js src/api/contracts/__tests__/api-surface.test.js src/api/__tests__/contract-validation.test.js` - 33 passed.
- OpenAPI contract and generated client `--check` commands passed.
- Targeted Ruff and staged whitespace checks passed.