### PR TITLE
fix(tracer): stop CH schema apply from re-erroring on boot (drop MATERIALIZE from 022)

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/022_attr_value_bloom_indexes.sql
@@ -1,36 +1,16 @@
--- =============================================================================
--- 022 — Bloom-filter indexes on attribute map VALUES
--- =============================================================================
+-- 022 — Bloom indexes on attribute map VALUES, for SPAN_ATTRIBUTE equality/IN
+-- filters (key-only blooms don't prune when most spans carry the key).
 --
--- SPAN_ATTRIBUTE equality filters (attrs_number['customer_id'] = X) can only
--- lean on idx_attrs_*_keys today, and a KEY bloom prunes nothing when most
--- spans carry the key — evaluating the VALUE then decompresses the entire map
--- column for every row in the window. On the largest tenant that is a 19+ GiB
--- read per filtered trace-list request, which is what pushed those queries
--- past the 10s execution budget (Code 159).
+-- idx_attrs_str_values indexes LOWERED values: text filters compare via
+-- lower(), so it only engages alongside the companion predicate that
+-- ClickHouseFilterBuilderV2._span_attr_inner emits — keep the two in step.
+-- attrs_bool gets no value index ({0,1} never prunes).
 --
--- A bloom over mapValues answers "does this granule contain the value at
--- all", which prunes aggressively for high-cardinality values (customer ids,
--- session ids, order numbers). Equality and IN only — ranges and negations
--- cannot use it. Same layout as the OpenTelemetry ClickHouse exporter's
--- idx_span_attr_value and SigNoz's idx_numberTagMapValues.
---
--- The string index is built over LOWERCASED values: text span-attribute
--- filters are case-insensitive (`lower(attrs_string[k]) = 'v'`), and a skip
--- index only engages when the query references the indexed expression
--- exactly. ClickHouseFilterBuilderV2._span_attr_inner emits the matching
--- `has(arrayMap(x -> lower(x), mapValues(attrs_string)), 'v')` companion
--- predicate for equality/IN. lower() here and the Python-side .lower() on
--- the constant must stay in step or the index silently disengages.
---
--- attrs_bool deliberately gets no value index: its value space is {0,1}, so
--- every granule contains both and nothing could ever be skipped.
---
--- ADD INDEX is metadata-only; parts written after it are indexed on
--- insert/merge. MATERIALIZE INDEX backfills existing parts as a background
--- mutation (reads the map column once per replica: ~4 GiB compressed for
--- attrs_number, ~70 GiB for attrs_string) — non-blocking, tracked in
--- system.mutations, abortable with KILL MUTATION, reversible via DROP INDEX.
+-- ADD INDEX only covers parts written after it. Backfill existing parts once,
+-- async, off the boot/request path — a MATERIALIZE here times out the 120s
+-- boot applier and re-errors every boot (CORE-BACKEND-11KX):
+--   ALTER TABLE spans MATERIALIZE INDEX idx_attrs_num_values;
+--   ALTER TABLE spans MATERIALIZE INDEX idx_attrs_str_values;
 
 ALTER TABLE spans
     ADD INDEX IF NOT EXISTS idx_attrs_str_values arrayMap(x -> lower(x), mapValues(attrs_string))
@@ -39,7 +19,3 @@ ALTER TABLE spans
 ALTER TABLE spans
     ADD INDEX IF NOT EXISTS idx_attrs_num_values mapValues(attrs_number)
     TYPE bloom_filter(0.01) GRANULARITY 1;
-
-ALTER TABLE spans MATERIALIZE INDEX idx_attrs_str_values;
-
-ALTER TABLE spans MATERIALIZE INDEX idx_attrs_num_values;

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -415,12 +415,14 @@ class TestAttrValueBloomIndexFile:
         # bloom could never skip anything.
         assert not any("mapValues(attrs_bool)" in s for s in statements)
 
-    def test_materializes_both_indexes(self, statements):
-        mats = [s for s in statements if "MATERIALIZE INDEX" in s]
-        assert len(mats) == 2
-        joined = "\n".join(mats)
-        assert "idx_attrs_str_values" in joined
-        assert "idx_attrs_num_values" in joined
+    def test_no_materialize_in_boot_applier(self, statements):
+        # MATERIALIZE INDEX is an unbounded background mutation; run
+        # synchronously by the boot-time applier (120s HTTP timeout) it times
+        # out on a large spans table, the file never records in
+        # schema_versions, and it re-applies + re-errors on every boot
+        # (CORE-BACKEND-11KX). The file must contain only fast, idempotent
+        # metadata DDL; backfilling existing parts is a separate ops step.
+        assert not any("MATERIALIZE INDEX" in s for s in statements)
 
     def test_every_statement_survives_replicated_rewrite(self, statements):
         for stmt in statements:


### PR DESCRIPTION
Fixes CORE-BACKEND-11KX

## Why

The boot-time ClickHouse schema applier (`model_hub` `AppConfig.ready()` → `ch25_apply_schema`, which runs on **every** `manage.py` command, incl. `register_temporal_schedules`) runs each statement synchronously over a 120s HTTP timeout (`apply_schema.py` client `send_receive_timeout=120`).

`022_attr_value_bloom_indexes.sql` ended with two `ALTER TABLE spans MATERIALIZE INDEX …` statements. `MATERIALIZE INDEX` is an unbounded background mutation; on the whale-scale `spans` table it does not return within 120s, so:

1. The HTTP call read-times-out → `apply_file` logs `statement_failed` and **re-raises**.
2. The `schema_versions` success row is written only **after the whole file succeeds** (`apply_file`, post-loop), so `022` is **never recorded as applied**.
3. Every subsequent boot rediscovers `022` as unapplied, re-runs it, and re-times-out — a permanent error loop (9 occurrences in ~2 min across worker pods; fires on every deploy/restart).

**Blast radius:** no user impact (boot path), and **temporal schedule registration is not blocked** — the `ready()` hook wraps the apply in a try/except that logs and swallows. The index data itself is fine (prod US was backfilled manually 2026-07-27; the timed-out mutation still completes server-side). Net effect was a self-perpetuating Sentry error, not an outage. Manual `clickhouse-client` backfills worked precisely because they submit the mutation async and poll `system.mutations` separately, never blocking one call for the whole rebuild.

## What

`022` now contains **only** the two idempotent, metadata-only `ADD INDEX IF NOT EXISTS` statements (instant; new parts self-index on insert/merge). The `MATERIALIZE INDEX` backfill of existing parts moves into a documented one-time operator step in the file header (async submit + poll `system.mutations`), explicitly off the boot/request path.

Once deployed, the applier applies `022` in milliseconds (indexes already exist → no-ops), finally records its `schema_versions` row, and every later boot hits `skip_already_applied` — the loop ends and the BE's own idempotency tracking works as designed.

## Tests

`test_ch25_apply_schema_replicated.py::TestAttrValueBloomIndexFile`:
- **Replaced** `test_materializes_both_indexes` with `test_no_materialize_in_boot_applier` — asserts no executable `MATERIALIZE INDEX` statement remains, with the CORE-BACKEND-11KX rationale inline. (Written RED-first: failed against the current file, passes after the trim.)
- `test_adds_value_blooms_for_string_and_number_maps` (lowered string bloom + raw number bloom), `test_bool_map_values_deliberately_not_indexed`, and `test_every_statement_survives_replicated_rewrite` all still pass over the now-2-statement file.

```
uv run pytest tracer/tests/test_ch25_apply_schema_replicated.py tracer/tests/test_ch25_membership_scan_bounds.py tracer/tests/test_ch25_query_builders_sweep.py -q   # 66 passed
```

## Verification beyond unit tests

- `split_statements()` over the file yields exactly 2 executable statements, both `ALTER TABLE spans ADD INDEX`, zero `MATERIALIZE`.
- Applied the trimmed file to a local ClickHouse: returns in ~0.18s, both value indexes present, **zero** mutations kicked off (`system.mutations` empty) — confirming it no longer submits a background mutation on apply.

## Rollout note

Prod US already has both indexes materialized (2026-07-27), so no backfill is needed there — this PR only stops the boot-time re-apply/error loop. To make prod stop erroring **before** this deploys, a `schema_versions` row for `022` can be inserted manually (immediate skip); this PR makes that unnecessary going forward and correct for every region and fresh install.

## Architectural rationale

Guardrail this encodes: the boot-time schema applier runs only fast, idempotent metadata DDL (`CREATE … IF NOT EXISTS`, `ADD INDEX … IF NOT EXISTS`). Unbounded data operations — `MATERIALIZE INDEX`, backfill `INSERT`s, `OPTIMIZE` — are explicitly-invoked ops steps, never on `ready()`.