### PR TITLE
feat(workbench): persist eval version pins on PromptEvalConfig

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1035,6 +1035,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         data_injection: dataInjection,
         error_localizer_enabled: errorLocalizerEnabled,
         composite_weight_overrides: compositeChildWeights,
+        // Hosts (wizard / workbench) use this to decide local-only vs save.
+        isDirty,
       });
       return;
     }
@@ -1074,6 +1076,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       knowledge_bases: knowledgeBaseIds,
       data_injection: dataInjection,
       error_localizer_enabled: errorLocalizerEnabled,
+      // Hosts (wizard / workbench) use this to decide local-only vs save.
+      isDirty,
     });
   }, [
     templateId,
@@ -1111,6 +1115,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     source,
     onFiltersChange,
     localFilterForm,
+    isDirty,
   ]);
 
   if (isLoading) {

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -653,7 +653,11 @@ const EvaluationDrawerChild = ({
               name: evalConfig.name,
               mapping: evalConfig.mapping || {},
               model: isComposite ? undefined : evalConfig.model,
+              // Nest like dataset/editEval so maybe_pin gets template
+              // overrides under config.config; binding-only keys stay at
+              // config.run_config / config.params.
               config: {
+                config: isComposite ? {} : evalConfig.config || {},
                 params: evalParams,
                 ...(Object.keys(runConfig).length
                   ? { run_config: runConfig }
@@ -662,6 +666,9 @@ const EvaluationDrawerChild = ({
               error_localizer: runConfig.error_localizer_enabled || false,
               is_run: true,
               version_to_run: workbenchVersions || [],
+              ...(evalConfig.versionId
+                ? { pinned_version_id: evalConfig.versionId }
+                : {}),
             };
           } else {
             payload = {
@@ -770,6 +777,11 @@ const EvaluationDrawerChild = ({
           // await so errors propagate to EvalPickerDrawer's handleSaveEval
           // catch block — keeps the drawer open on failure.
           await handleRun(payload, () => {
+            if (evalConfig.templateId) {
+              queryClient.invalidateQueries({
+                queryKey: ["evals", "versions", evalConfig.templateId],
+              });
+            }
             setEvalPickerOpen(false);
             setVisibleSection("list");
           });

--- a/futureagi/model_hub/migrations/0121_promptevalconfig_pinned_version.py
+++ b/futureagi/model_hub/migrations/0121_promptevalconfig_pinned_version.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("model_hub", "0120_backfill_score_tracer_project"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="promptevalconfig",
+            name="pinned_version",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Pin to a specific eval template version for workbench runtime.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="pinned_prompt_eval_configs",
+                to="model_hub.evaltemplateversion",
+            ),
+        ),
+    ]

--- a/futureagi/model_hub/models/run_prompt.py
+++ b/futureagi/model_hub/models/run_prompt.py
@@ -389,3 +389,11 @@ class PromptEvalConfig(BaseModel):
         blank=True,
         default=None,
     )
+    pinned_version = models.ForeignKey(
+        "model_hub.EvalTemplateVersion",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="pinned_prompt_eval_configs",
+        help_text="Pin to a specific eval template version for workbench runtime.",
+    )

--- a/futureagi/model_hub/serializers/prompt_template.py
+++ b/futureagi/model_hub/serializers/prompt_template.py
@@ -661,6 +661,10 @@ class SingleEvaluationConfigSerializer(serializers.Serializer):
     kb_id = serializers.CharField(
         required=False, allow_null=True, allow_blank=True, default=None
     )
+    # Dedup baseline for maybe_pin_new_version / version picker.
+    pinned_version_id = serializers.UUIDField(
+        required=False, allow_null=True, default=None
+    )
 
     def validate(self, data):
         """Validate the evaluation configuration"""

--- a/futureagi/model_hub/services/eval_version_pinning.py
+++ b/futureagi/model_hub/services/eval_version_pinning.py
@@ -16,6 +16,9 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
 
     Mutates eval_metric.pinned_version in place. The caller is responsible
     for persisting eval_metric via save().
+
+    Works for both ``UserEvalMetric`` (``.template``) and
+    ``PromptEvalConfig`` (``.eval_template``).
     """
     from model_hub.models.choices import OwnerChoices
 
@@ -25,17 +28,25 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
     )
     if not has_config_changes:
         return None
-    if eval_metric.template.owner != OwnerChoices.USER.value:
+
+    tpl = getattr(eval_metric, "template", None) or getattr(
+        eval_metric, "eval_template", None
+    )
+    if tpl is None or tpl.owner != OwnerChoices.USER.value:
         return None
 
-    tpl = eval_metric.template
     req_config = request_data.get("config") or {}
     inner_config = req_config.get("config", {})
     run_config = req_config.get("run_config", {})
-    mapping = req_config.get("mapping") or (eval_metric.config or {}).get("mapping", {})
+    mapping = req_config.get("mapping") or (eval_metric.config or {}).get(
+        "mapping", {}
+    ) or getattr(eval_metric, "mapping", None) or {}
     resolved_model = (
-        request_data.get("model") or eval_metric.model
-        or tpl.model or ""
+        request_data.get("model")
+        or getattr(eval_metric, "model", None)
+        or (eval_metric.config or {}).get("run_config", {}).get("model")
+        or tpl.model
+        or ""
     )
 
     # Build snapshot: template base → FE config → run_config → top-level fields
@@ -62,12 +73,15 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
     current_pinned = eval_metric.pinned_version
     if current_pinned:
         new_snap_json = json.dumps(snap, sort_keys=True, default=str)
-        old_snap_json = json.dumps(current_pinned.config_snapshot or {}, sort_keys=True, default=str)
+        old_snap_json = json.dumps(
+            current_pinned.config_snapshot or {}, sort_keys=True, default=str
+        )
         if new_snap_json == old_snap_json:
             return None
 
     prompt_messages = config_to_prompt_messages(
-        snap, criteria=criteria,
+        snap,
+        criteria=criteria,
         eval_type_id=snap.get("eval_type_id"),
     )
 
@@ -82,3 +96,4 @@ def maybe_pin_new_version(eval_metric, request_data, user, organization, workspa
         workspace=workspace,
     )
     eval_metric.pinned_version = ver
+    return ver

--- a/futureagi/model_hub/tests/test_workbench_eval_model_propagation.py
+++ b/futureagi/model_hub/tests/test_workbench_eval_model_propagation.py
@@ -300,3 +300,432 @@ def test_update_evaluation_configs_persists_error_localizer_from_fe(
     )
     row = read_response.json()["result"]["evaluation_configs"][0]
     assert row["run_config"]["error_localizer_enabled"] is True
+
+
+@pytest.mark.django_db
+def test_update_evaluation_configs_persists_pinned_version_id(
+    auth_client, user, workspace
+):
+    template = EvalTemplate.objects.create(
+        name="workbench-fixture-pin",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={"eval_type_id": "CustomPromptEvaluator", "output": "Pass/Fail"},
+        eval_tags=["llm"],
+        criteria="be good",
+        model="turing_large",
+    )
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    version = EvalTemplateVersion.objects.create_version(
+        eval_template=template,
+        criteria="be good",
+        model="turing_large",
+        config_snapshot={
+            **(template.config or {}),
+            "model": "turing_large",
+        },
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+    )
+    prompt_template = PromptTemplate.objects.create(
+        name="Workbench Prompt Pin",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+
+    payload = {
+        "id": str(template.id),
+        "name": "eval_with_pin",
+        "mapping": {"output": "model_output"},
+        "model": "turing_large",
+        "config": {
+            "config": {},
+            "run_config": {"model": "turing_large"},
+        },
+        "pinned_version_id": str(version.id),
+        "is_run": False,
+    }
+    save_response = auth_client.post(
+        f"/model-hub/prompt-templates/{prompt_template.id}/update-evaluation-configs/",
+        data=payload,
+        format="json",
+    )
+    assert save_response.status_code == 200, save_response.content
+    body = save_response.json()["result"]
+    assert body["pinned_version_id"] == str(version.id)
+
+    saved = PromptEvalConfig.objects.get(
+        prompt_template=prompt_template, deleted=False
+    )
+    assert str(saved.pinned_version_id) == str(version.id)
+
+    read_response = auth_client.get(
+        f"/model-hub/prompt-templates/{prompt_template.id}/evaluation-configs/"
+    )
+    row = read_response.json()["result"]["evaluation_configs"][0]
+    assert row["pinned_version_id"] == str(version.id)
+
+
+@pytest.mark.django_db
+def test_update_evaluation_configs_version_only_switch_dedups(
+    auth_client, user, workspace
+):
+    """Re-picking an existing version with matching config must not mint a new one."""
+    template = EvalTemplate.objects.create(
+        name="workbench-fixture-pin-dedup",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={"eval_type_id": "CustomPromptEvaluator", "output": "Pass/Fail"},
+        eval_tags=["llm"],
+        criteria="be good",
+        model="turing_large",
+    )
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    version = EvalTemplateVersion.objects.create_version(
+        eval_template=template,
+        criteria="be good",
+        model="turing_large",
+        config_snapshot={
+            **(template.config or {}),
+            "model": "turing_large",
+        },
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+    )
+    prompt_template = PromptTemplate.objects.create(
+        name="Workbench Prompt Dedup",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+    binding = PromptEvalConfig.objects.create(
+        name="eval_dedup",
+        eval_template=template,
+        prompt_template=prompt_template,
+        mapping={"output": "model_output"},
+        config={"run_config": {"model": "turing_large"}},
+        pinned_version=version,
+        user=user,
+    )
+
+    before = EvalTemplateVersion.objects.filter(
+        eval_template=template, deleted=False
+    ).count()
+    save_response = auth_client.post(
+        f"/model-hub/prompt-templates/{prompt_template.id}/update-evaluation-configs/",
+        data={
+            "id": str(template.id),
+            "name": "eval_dedup",
+            "mapping": {"output": "model_output"},
+            "config": {
+                "config": {},
+                "run_config": {"model": "turing_large"},
+            },
+            "model": "turing_large",
+            "user_eval_id": str(binding.id),
+            "pinned_version_id": str(version.id),
+            "is_run": False,
+        },
+        format="json",
+    )
+    assert save_response.status_code == 200, save_response.content
+    after = EvalTemplateVersion.objects.filter(
+        eval_template=template, deleted=False
+    ).count()
+    assert after == before
+    binding.refresh_from_db()
+    assert str(binding.pinned_version_id) == str(version.id)
+
+
+@pytest.mark.django_db
+def test_update_evaluation_configs_dirty_edit_creates_new_version(
+    auth_client, user, workspace
+):
+    """Editing config against a pinned baseline mints and pins a new version."""
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    template = EvalTemplate.objects.create(
+        name="workbench-fixture-pin-dirty",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={"eval_type_id": "CustomPromptEvaluator", "output": "Pass/Fail"},
+        eval_tags=["llm"],
+        criteria="be good",
+        model="turing_large",
+    )
+    baseline = EvalTemplateVersion.objects.create_version(
+        eval_template=template,
+        criteria="be good",
+        model="turing_large",
+        config_snapshot={
+            **(template.config or {}),
+            "model": "turing_large",
+        },
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+    )
+    prompt_template = PromptTemplate.objects.create(
+        name="Workbench Prompt Dirty",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+    binding = PromptEvalConfig.objects.create(
+        name="eval_dirty",
+        eval_template=template,
+        prompt_template=prompt_template,
+        mapping={"output": "model_output"},
+        config={"run_config": {"model": "turing_large"}},
+        pinned_version=baseline,
+        user=user,
+    )
+
+    before = EvalTemplateVersion.objects.filter(
+        eval_template=template, deleted=False
+    ).count()
+    save_response = auth_client.post(
+        f"/model-hub/prompt-templates/{prompt_template.id}/update-evaluation-configs/",
+        data={
+            "id": str(template.id),
+            "name": "eval_dirty",
+            "mapping": {"output": "model_output"},
+            "config": {
+                # Nested template override differs from baseline snapshot.
+                "config": {"rule_prompt": "be much stricter now"},
+                "run_config": {"model": "turing_large"},
+            },
+            "model": "turing_large",
+            "user_eval_id": str(binding.id),
+            "pinned_version_id": str(baseline.id),
+            "is_run": False,
+        },
+        format="json",
+    )
+    assert save_response.status_code == 200, save_response.content
+    after = EvalTemplateVersion.objects.filter(
+        eval_template=template, deleted=False
+    ).count()
+    assert after == before + 1
+
+    binding.refresh_from_db()
+    assert binding.pinned_version_id is not None
+    assert str(binding.pinned_version_id) != str(baseline.id)
+    assert save_response.json()["result"]["pinned_version_id"] == str(
+        binding.pinned_version_id
+    )
+    assert "be much stricter now" in (
+        binding.pinned_version.criteria
+        or (binding.pinned_version.config_snapshot or {}).get("rule_prompt", "")
+    )
+
+
+@pytest.mark.django_db
+def test_update_evaluation_configs_rejects_foreign_template_version(
+    auth_client, user, workspace
+):
+    """pinned_version_id belonging to another eval template must 400."""
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    template = EvalTemplate.objects.create(
+        name="workbench-fixture-pin-self",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={"eval_type_id": "CustomPromptEvaluator", "output": "Pass/Fail"},
+        eval_tags=["llm"],
+        criteria="self",
+        model="turing_large",
+    )
+    other = EvalTemplate.objects.create(
+        name="workbench-fixture-pin-other",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={"eval_type_id": "CustomPromptEvaluator", "output": "Pass/Fail"},
+        eval_tags=["llm"],
+        criteria="other",
+        model="turing_large",
+    )
+    foreign_version = EvalTemplateVersion.objects.create_version(
+        eval_template=other,
+        criteria="other",
+        model="turing_large",
+        config_snapshot=other.config or {},
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+    )
+    prompt_template = PromptTemplate.objects.create(
+        name="Workbench Prompt Foreign Pin",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+
+    save_response = auth_client.post(
+        f"/model-hub/prompt-templates/{prompt_template.id}/update-evaluation-configs/",
+        data={
+            "id": str(template.id),
+            "name": "eval_foreign_pin",
+            "mapping": {"output": "model_output"},
+            "config": {"run_config": {"model": "turing_large"}},
+            "pinned_version_id": str(foreign_version.id),
+            "is_run": False,
+        },
+        format="json",
+    )
+    assert save_response.status_code == 400, save_response.content
+    assert "Selected version not found" in str(save_response.content)
+    assert not PromptEvalConfig.objects.filter(
+        prompt_template=prompt_template, deleted=False
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_run_evaluation_overlays_pinned_config_snapshot(user, workspace, monkeypatch):
+    """Workbench runtime must prefer pinned config_snapshot over live template config."""
+    from model_hub.models.evals_metric import EvalTemplateVersion
+    from model_hub.views.prompt_template import PromptTemplateViewSet
+
+    template = EvalTemplate.objects.create(
+        name="workbench-fixture-pin-runtime",
+        description="",
+        owner=OwnerChoices.USER.value,
+        organization=user.organization,
+        workspace=workspace,
+        eval_type="llm",
+        config={
+            "eval_type_id": "CustomPromptEvaluator",
+            "output": "Pass/Fail",
+            "rule_prompt": "live template criteria",
+        },
+        eval_tags=["llm"],
+        criteria="live template criteria",
+        model="turing_large",
+    )
+    pinned = EvalTemplateVersion.objects.create_version(
+        eval_template=template,
+        criteria="pinned criteria",
+        model="gpt-4.1",
+        config_snapshot={
+            "eval_type_id": "CustomPromptEvaluator",
+            "output": "Pass/Fail",
+            "rule_prompt": "pinned criteria",
+            "model": "gpt-4.1",
+            "marker": "from-pinned-snapshot",
+        },
+        user=user,
+        organization=user.organization,
+        workspace=workspace,
+    )
+    prompt_template = PromptTemplate.objects.create(
+        name="Workbench Prompt Runtime",
+        organization=user.organization,
+        workspace=workspace,
+        created_by=user,
+    )
+    evaluation = PromptEvalConfig.objects.create(
+        name="eval_runtime",
+        eval_template=template,
+        prompt_template=prompt_template,
+        mapping={"output": "model_output"},
+        config={"run_config": {"model": "gpt-4.1"}},
+        pinned_version=pinned,
+        user=user,
+    )
+
+    captured = {}
+
+    class _FakeEvalClass:
+        pass
+
+    def _fake_get_eval_class(eval_type_id):
+        captured["eval_type_id"] = eval_type_id
+        return _FakeEvalClass
+
+    def _fake_create_eval_instance(self, config=None, eval_class=None, model=None, **kwargs):
+        captured["config"] = config
+        captured["model"] = model
+        captured["eval_class"] = eval_class
+        raise RuntimeError("stop-after-config-capture")
+
+    monkeypatch.setattr(
+        "evaluations.engine.registry.get_eval_class", _fake_get_eval_class
+    )
+    monkeypatch.setattr(
+        "model_hub.views.eval_runner.EvaluationRunner._create_eval_instance",
+        _fake_create_eval_instance,
+    )
+
+    view = PromptTemplateViewSet()
+    with pytest.raises(RuntimeError, match="stop-after-config-capture"):
+        view.run_evaluation(
+            evaluation,
+            response="hello",
+            messages=[{"role": "user", "content": "hi"}],
+            variable_combination={},
+            organization_id=user.organization_id,
+            template=prompt_template,
+        )
+
+    # Config was captured before the intentional stop — pinned snapshot wins.
+    assert captured["config"]["marker"] == "from-pinned-snapshot"
+    assert captured["config"]["rule_prompt"] == "pinned criteria"
+    assert "live template criteria" not in (
+        captured["config"].get("rule_prompt") or ""
+    )
+    assert captured["eval_type_id"] == "CustomPromptEvaluator"
+
+
+def test_workbench_eval_payload_forwards_pinned_version_id():
+    """Document the FE contract: workbench save body must carry pinned_version_id."""
+    # Mirrors EvaluationDrawer workbench branch payload construction.
+    eval_config = {
+        "templateId": "tpl-1",
+        "name": "toxicity",
+        "mapping": {"output": "model_output"},
+        "model": "gpt-4.1",
+        "config": {"rule_prompt": "check toxicity"},
+        "params": {},
+        "versionId": "11111111-1111-4111-8111-111111111111",
+    }
+    run_config = {"model": eval_config["model"]}
+    payload = {
+        "id": eval_config["templateId"],
+        "name": eval_config["name"],
+        "mapping": eval_config["mapping"] or {},
+        "model": eval_config["model"],
+        "config": {
+            "config": eval_config["config"] or {},
+            "params": eval_config["params"],
+            "run_config": run_config,
+        },
+        "is_run": True,
+        **(
+            {"pinned_version_id": eval_config["versionId"]}
+            if eval_config.get("versionId")
+            else {}
+        ),
+    }
+    assert payload["pinned_version_id"] == eval_config["versionId"]
+    assert payload["config"]["config"]["rule_prompt"] == "check toxicity"
+    assert "run_config" in payload["config"]

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -2103,6 +2103,59 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
         finally:
             close_old_connections()
 
+    def _apply_prompt_eval_version_pin(self, prompt_eval, request, new_config):
+        """Re-baseline / create-pin EvalTemplateVersion for a PromptEvalConfig.
+
+        Returns an error string on failure, else None.
+        """
+        from model_hub.models.evals_metric import EvalTemplateVersion
+        from model_hub.services.eval_version_pinning import maybe_pin_new_version
+
+        explicit_version_id = new_config.get("pinned_version_id") or request.data.get(
+            "pinned_version_id"
+        )
+        if explicit_version_id and str(explicit_version_id) != str(
+            prompt_eval.pinned_version_id or ""
+        ):
+            selected_ver = EvalTemplateVersion.objects.filter(
+                id=explicit_version_id,
+                eval_template_id=prompt_eval.eval_template_id,
+                deleted=False,
+            ).first()
+            if not selected_ver:
+                return "Selected version not found"
+            prompt_eval.pinned_version = selected_ver
+
+        # Nest workbench payload into the shape maybe_pin expects.
+        binding_config = new_config.get("config") or {}
+        pin_request = {
+            "model": request.data.get("model")
+            or (binding_config.get("run_config") or {}).get("model"),
+            "config": {
+                "mapping": new_config.get("mapping") or prompt_eval.mapping or {},
+                "config": binding_config.get("config")
+                if isinstance(binding_config.get("config"), dict)
+                else {
+                    k: v
+                    for k, v in binding_config.items()
+                    if k not in ("run_config", "params")
+                },
+                "run_config": binding_config.get("run_config") or {},
+                "params": new_config.get("params")
+                or binding_config.get("params")
+                or {},
+            },
+        }
+        maybe_pin_new_version(
+            prompt_eval,
+            pin_request,
+            user=request.user,
+            organization=getattr(request, "organization", None)
+            or getattr(request.user, "organization", None),
+            workspace=getattr(request, "workspace", None),
+        )
+        return None
+
     @action(detail=True, methods=["get"], url_path="evaluation-configs")
     def get_evaluation_configs(self, request, pk=None):
         """
@@ -2122,7 +2175,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             # Get the evaluation configs
             evaluation_configs = PromptEvalConfig.objects.filter(
                 prompt_template=template, deleted=False
-            ).select_related("eval_template", "eval_group")
+            ).select_related("eval_template", "eval_group", "pinned_version")
 
             response = []
             for config in evaluation_configs:
@@ -2151,6 +2204,11 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         "updated_at": config.updated_at.isoformat(),
                         "eval_group": (
                             config.eval_group.name if config.eval_group else None
+                        ),
+                        "pinned_version_id": (
+                            str(config.pinned_version_id)
+                            if config.pinned_version_id
+                            else None
                         ),
                     }
                 )
@@ -2233,14 +2291,21 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     kb = KnowledgeBaseFile.objects.get(id=new_config.get("kb_id"))
                 except KnowledgeBaseFile.DoesNotExist:
                     pass
+            # Binding storage only keeps runtime keys (params / run_config).
+            # Nested template overrides under config.config are for version
+            # pinning and must not be written onto PromptEvalConfig.config.
+            incoming_config = new_config.get("config", {}) or {}
+            binding_runtime_config = {
+                k: v for k, v in incoming_config.items() if k != "config"
+            }
             normalized_config = normalize_eval_runtime_config(
                 eval_template.config,
                 {
-                    **(new_config.get("config", {}) or {}),
+                    **binding_runtime_config,
                     "params": (
                         new_config.get("params", {})
                         if new_config.get("params", {})
-                        else (new_config.get("config", {}) or {}).get("params", {})
+                        else binding_runtime_config.get("params", {})
                     ),
                 },
             )
@@ -2263,19 +2328,8 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 prompt_eval.error_localizer = new_config.get(
                     "error_localizer", False
                 )
-                prompt_eval.save(
-                    update_fields=[
-                        "name",
-                        "eval_template",
-                        "mapping",
-                        "config",
-                        "kb",
-                        "error_localizer",
-                        "updated_at",
-                    ]
-                )
             else:
-                prompt_eval = PromptEvalConfig.objects.create(
+                prompt_eval = PromptEvalConfig(
                     name=eval_name,
                     prompt_template=template,
                     eval_template=eval_template,
@@ -2285,6 +2339,29 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     kb=kb,
                     error_localizer=new_config.get("error_localizer", False),
                 )
+
+            pin_error = self._apply_prompt_eval_version_pin(
+                prompt_eval,
+                request,
+                new_config,
+            )
+            if pin_error:
+                return self._gm.bad_request(pin_error)
+
+            update_fields = [
+                "name",
+                "eval_template",
+                "mapping",
+                "config",
+                "kb",
+                "error_localizer",
+                "pinned_version",
+                "updated_at",
+            ]
+            if user_eval_id:
+                prompt_eval.save(update_fields=update_fields)
+            else:
+                prompt_eval.save()
 
             # If is_run is true, run evaluations on specified versions
             if is_run:
@@ -2391,6 +2468,11 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 {
                     "message": "Evaluation configuration updated successfully",
                     "prompt_eval_config_id": str(prompt_eval.id),
+                    "pinned_version_id": (
+                        str(prompt_eval.pinned_version_id)
+                        if prompt_eval.pinned_version_id
+                        else None
+                    ),
                 }
             )
 
@@ -2661,16 +2743,28 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             # Add response as the last message
             chat_history.append({"role": "assistant", "content": response})
 
-            # Get evaluation class and configuration
+            # Get evaluation class and configuration — prefer the pinned
+            # version snapshot when present so workbench runs the version
+            # the user selected in the picker.
             from evaluations.engine.registry import get_eval_class
 
-            eval_class = get_eval_class(eval_template.config.get("eval_type_id"))
+            base_config = evaluation.eval_template.config or {}
+            effective_template_config = (
+                dict(base_config) if isinstance(base_config, dict) else {}
+            )
+            pinned = getattr(evaluation, "pinned_version", None)
+            if pinned and isinstance(pinned.config_snapshot, dict):
+                effective_template_config.update(pinned.config_snapshot)
 
-            data_config = evaluation.eval_template.config
+            eval_class = get_eval_class(effective_template_config.get("eval_type_id"))
+
+            data_config = effective_template_config
             config = (
                 data_config.copy()
-                if evaluation.eval_template == OwnerChoices.USER.value
+                if evaluation.eval_template.owner == OwnerChoices.USER.value
                 else data_config.get("config", {}).copy()
+                if isinstance(data_config.get("config"), dict)
+                else data_config.copy()
             )
             config = evaluation_runner.update_config_list_values(config)
             from evaluations.engine.instance import resolve_binding_model
@@ -2678,7 +2772,8 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             eval_instance = evaluation_runner._create_eval_instance(
                 config=config,
                 eval_class=eval_class,
-                model=resolve_binding_model(evaluation.config, eval_template),
+                model=resolve_binding_model(evaluation.config, eval_template)
+                or (pinned.model if pinned else None),
                 kb_id=str(evaluation.kb_id) if evaluation.kb_id else None,
                 runtime_config=evaluation.config,
             )
@@ -3117,7 +3212,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             organization_id = template.organization.id
             evaluation_configs = PromptEvalConfig.objects.filter(
                 id__in=prompt_eval_config_ids, prompt_template=template, deleted=False
-            )
+            ).select_related("eval_template", "pinned_version")
 
             def get_max_len(variable_names):
                 return (


### PR DESCRIPTION
## Description

Prompt Workbench Evaluation tab was dropping version-picker selections.
Unlike datasets/experiments (which pin on `UserEvalMetric`), workbench
bindings live on a separate model — `PromptEvalConfig` — which had no
`pinned_version` field, and the workbench payload for
`POST /model-hub/prompt-templates/{id}/update-evaluation-configs/` never
forwarded `versionId`.

This PR is the workbench counterpart of #1824, kept deliberately small:

- **Same endpoint** — version pin/create still happens inside
  `update-evaluation-configs`. No new version-only API.
- **Same service** — reuses `maybe_pin_new_version` (extended to accept
  `PromptEvalConfig.eval_template` as well as `UserEvalMetric.template`).
- **Same semantics** — pick an existing version with matching config →
  dedup / keep pin; dirty config edit → mint + pin a new
  `EvalTemplateVersion`; foreign version id → 400.

At runtime, workbench `run_evaluation` overlays the pinned
`config_snapshot` onto the live template config so runs honor the pick.

## File-by-file justification

**Backend**

- `model_hub/models/run_prompt.py`
  - `PromptEvalConfig.pinned_version` FK → `EvalTemplateVersion`
    (nullable), same idea as `UserEvalMetric.pinned_version`.

- `model_hub/migrations/0121_promptevalconfig_pinned_version.py`
  - Adds the FK only. No backfill.

- `model_hub/serializers/prompt_template.py`
  - `SingleEvaluationConfigSerializer.pinned_version_id` optional so the
    update endpoint can accept the picker selection.

- `model_hub/services/eval_version_pinning.py`
  - `maybe_pin_new_version` resolves template via `.template` **or**
    `.eval_template`, and model via binding / `run_config` / template —
    so the same helper works for workbench bindings.

- `model_hub/views/prompt_template.py`
  - `_apply_prompt_eval_version_pin` — re-baseline from explicit
    `pinned_version_id`, nest workbench payload into the shape
    `maybe_pin` expects, then pin/create.
  - `update_evaluation_configs` — call the helper before save; return
    `pinned_version_id`; keep binding storage to runtime keys only
    (`params` / `run_config`), not nested template overrides.
  - `get_evaluation_configs` — surface `pinned_version_id` so reopen
    preselects the pin.
  - `run_evaluation` — overlay pinned `config_snapshot` when present.

**Frontend**

- `src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx`
  - Workbench payload forwards `versionId` → `pinned_version_id`, nests
    template overrides under `config.config`, invalidates eval-versions
    cache after save.

- `src/sections/common/EvalPicker/EvalPickerConfigFull.jsx`
  - `onSave` payload includes `isDirty` (host signal; same as #1824).

## Tests

Added to `model_hub/tests/test_workbench_eval_model_propagation.py`:

- persists `pinned_version_id` on create + list
- version-only re-pick dedups (no new version)
- dirty config edit mints + pins a new version
- foreign-template `pinned_version_id` → 400
- `run_evaluation` prefers pinned snapshot over live template config
- FE payload contract for workbench `pinned_version_id` nesting

## Test logs

### Backend — full `model_hub` suite

```
bin/test --no-services app model_hub

= 51 failed, 2854 passed, 11 skipped, 197 deselected, 6 xfailed, 1 xpassed,
  107 errors, 60 subtests passed in 249.17s (0:04:09) =
```

**PR-relevant suites (all green):**

```
model_hub/tests/test_workbench_eval_model_propagation.py
  test_update_evaluation_configs_persists_pinned_version_id PASSED
  test_update_evaluation_configs_version_only_switch_dedups PASSED
  test_update_evaluation_configs_dirty_edit_creates_new_version PASSED
  test_update_evaluation_configs_rejects_foreign_template_version PASSED
  test_run_evaluation_overlays_pinned_config_snapshot PASSED
  test_workbench_eval_payload_forwards_pinned_version_id PASSED
  (+ remaining workbench propagation / model-precedence tests)
  → 28 passed

model_hub/tests/test_eval_versioning.py::TestMaybePinNewVersion
  8 passed, 1 failed (pre-existing — see below)

model_hub/tests/test_eval_version_tracking.py
  pinned-version tracking PASSED
```

https://github.com/user-attachments/assets/33a75d37-0e6d-46a1-b28e-c38634b384cd


**Unrelated / env failures (not caused by this PR):**

- Vast majority of the 51 failed + 107 errors are ClickHouse env:
  `Table test_tfc.spans does not exist` / `trace_sessions does not exist`
  (annotation / scores / voice / dataset-bulk-add e2e). Local CH was
  recreated without schema apply.
- `TestMaybePinNewVersion::test_runner_map_fields_uses_pinned_snapshot_required_keys`
  — same pre-existing fixture issue called out on #1824
  (`EvaluationRunner` missing `_effective_config_cache` when constructed
  directly in the test). Unrelated to `PromptEvalConfig` pinning.
- A few other non-CH flakes (`normalize_search`, `dataset_validators`,
  `upload_file_api`, `annotation_render_e2e` KeyError) are outside the
  workbench pin surface.

### Frontend — touched EvalPicker / EvaluationDrawer areas

```
yarn vitest run src/sections/common/EvalPicker src/sections/common/EvaluationDrawer

 ✓ src/sections/common/EvalPicker/serializeEvalConfig.test.js (2)
 ✓ src/sections/common/EvalPicker/evalPickerConfigUtils.test.js (29)
 ✓ src/sections/common/EvalPicker/CompositeChildParams.test.jsx (5)
 ✓ src/sections/common/EvalPicker/hooks/useEvalPickerData.test.js (7)
 ✓ src/sections/common/EvalPicker/EvalPickerConfigFull.test.jsx (2)
 ✓ src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx (4)

 Test Files  6 passed (6)
      Tests  49 passed (49)
```



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change

## Checklist

- [x] Self-review done
- [x] Comments added on non-obvious paths
- [x] Backend tests: workbench suite 28/28; full model_hub 2854 passed (CH env failures unrelated); FE EvalPicker 49/49
- [x] No new version endpoint — pin/create stays on update-evaluation-configs
- [x] Diff kept minimal: ~167 LOC production code + migration + tests

## Related Issues

Workbench counterpart of #1824 (experiment/dataset eval version pinning).

Made with [Cursor](https://cursor.com)

