### PR TITLE
fix(serving): pre-bake embedding models to avoid runtime HuggingFace fetch

### DIFF
--- a/futureagi/model_serving/Dockerfile.oss
+++ b/futureagi/model_serving/Dockerfile.oss
@@ -26,6 +26,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY pyproject.toml ./
 RUN uv pip install --system .
 
+# Pre-bake the fixed embedding models into the image so runtime never fetches
+# them from HuggingFace (protects against HF rate-limiting / outages). Offline
+# mode is deliberately NOT set: user-supplied external models still load online.
+# HF_TOKEN is a build-only arg to authenticate the one-time download and is not
+# persisted into the image env.
+ARG HF_TOKEN=""
+ENV HF_HOME=/opt/models/hf \
+    SENTENCE_TRANSFORMERS_HOME=/opt/models/st
+RUN python - <<'PY'
+from sentence_transformers import SentenceTransformer
+from transformers import CLIPModel, AutoProcessor, Wav2Vec2Model, Wav2Vec2Processor
+SentenceTransformer("all-MiniLM-L6-v2")
+SentenceTransformer("clip-ViT-B-32")
+CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+AutoProcessor.from_pretrained("openai/clip-vit-base-patch32")
+Wav2Vec2Model.from_pretrained("facebook/wav2vec2-base")
+Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base")
+PY
+
 COPY . .
 RUN chmod +x entrypoint.sh
 


### PR DESCRIPTION
## Problem

The model-serving image loads its embedding models (`all-MiniLM-L6-v2`, CLIP, Wav2Vec2) from HuggingFace at first use, with no copy baked into the image. When HuggingFace rate-limits the outbound IP (HTTP 429), a freshly started pod with an empty cache cannot fetch the models, so embedding requests fail with 503 until a model download eventually succeeds.

## Change

Pre-download the fixed embedding models at build time into the image (`HF_HOME=/opt/models/hf`), so the runtime loads them from local disk instead of the network. Offline mode is intentionally **not** forced, so user-supplied external models still resolve online. `HF_TOKEN` is a build-only `ARG` used to authenticate the one-time download and is not persisted into the image environment.

## Notes

- CI should pass `HF_TOKEN` as a build argument so the build-time download is authenticated.
- No runtime behavior change for external / dynamically-named models.
- Verified locally: with the models baked under `HF_HOME`, they load from cache with the network unavailable.
