### PR TITLE
fix(oss): preserve setup route hints until modal opens

### DIFF
--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -43,7 +43,11 @@ import {
 import RightSectionAuth from "./RightSectionAuth";
 import { isValidUtm } from "src/utils/utmUtils";
 import { usePostLoginPath } from "src/hooks/useDeploymentMode";
-import { OssSetupModal, useOssSetupModal } from "./oss-setup";
+import {
+  OssSetupModal,
+  shouldClearOssSetupHint,
+  useOssSetupModal,
+} from "./oss-setup";
 
 // ----------------------------------------------------------------------
 
@@ -66,10 +70,11 @@ export default function JwtLoginView() {
   const { search } = useLocation();
   const { enqueueSnackbar } = useSnackbar();
   const { uuid, token } = useParams();
+  const ossSetupHint = searchParams.get("ossSetup");
 
   const ossSetup = useOssSetupModal({
     enabled: !token,
-    autoOpenTab: searchParams.get("ossSetup"),
+    autoOpenTab: ossSetupHint,
   });
   // Only apply OSS treatment on a confirmed "oss" response; a failed
   // deployment-info read falls back to the full login (social/SSO shown).
@@ -80,16 +85,19 @@ export default function JwtLoginView() {
   // The hint has done its job once the modal opens on the right tab; strip it
   // so a reload doesn't reopen the modal.
   useEffect(() => {
-    if (searchParams.get("ossSetup")) {
+    if (
+      shouldClearOssSetupHint(ossSetupHint, ossSetup.open, ossSetup.activeTab)
+    ) {
       setSearchParams(
         (prev) => {
-          prev.delete("ossSetup");
-          return prev;
+          const next = new URLSearchParams(prev);
+          next.delete("ossSetup");
+          return next;
         },
         { replace: true },
       );
     }
-  }, [searchParams, setSearchParams]);
+  }, [ossSetup.activeTab, ossSetup.open, ossSetupHint, setSearchParams]);
 
   const [inviteFailed, setInviteFailed] = useState(false);
 

--- a/frontend/src/sections/auth/jwt/oss-setup/constants.js
+++ b/frontend/src/sections/auth/jwt/oss-setup/constants.js
@@ -5,6 +5,12 @@ export const OSS_SETUP_TABS = {
   RESET: "reset",
 };
 
+export function shouldClearOssSetupHint(hint, open, activeTab) {
+  if (!hint) return false;
+  if (!Object.values(OSS_SETUP_TABS).includes(hint)) return true;
+  return open && activeTab === hint;
+}
+
 const INSTALL_GUIDE_BASE =
   "https://github.com/future-agi/future-agi/blob/main/INSTALLATION.md";
 

--- a/frontend/src/sections/auth/jwt/oss-setup/use_oss_setup_modal.test.jsx
+++ b/frontend/src/sections/auth/jwt/oss-setup/use_oss_setup_modal.test.jsx
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  OSS_SETUP_SEEN_KEY,
+  OSS_SETUP_TABS,
+  shouldClearOssSetupHint,
+} from "./constants";
+import { useOssSetupModal } from "./useOssSetupModal";
+
+const deploymentMode = vi.hoisted(() => ({
+  current: {
+    isLoading: true,
+    isOSS: true,
+    isSuccess: false,
+  },
+}));
+
+vi.mock("src/hooks/useDeploymentMode", () => ({
+  useDeploymentMode: () => deploymentMode.current,
+}));
+
+const storage = new Map();
+const localStorageMock = {
+  clear: () => storage.clear(),
+  getItem: (key) => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, String(value)),
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: localStorageMock,
+});
+
+describe("shouldClearOssSetupHint", () => {
+  it("keeps a valid hint until its requested tab is open", () => {
+    expect(shouldClearOssSetupHint(OSS_SETUP_TABS.RESET, false, null)).toBe(
+      false,
+    );
+    expect(
+      shouldClearOssSetupHint(
+        OSS_SETUP_TABS.RESET,
+        true,
+        OSS_SETUP_TABS.CREATE,
+      ),
+    ).toBe(false);
+    expect(
+      shouldClearOssSetupHint(OSS_SETUP_TABS.RESET, true, OSS_SETUP_TABS.RESET),
+    ).toBe(true);
+  });
+
+  it("clears invalid one-shot hints without waiting for the modal", () => {
+    expect(shouldClearOssSetupHint("unknown", false, null)).toBe(true);
+    expect(shouldClearOssSetupHint(null, false, null)).toBe(false);
+  });
+});
+
+describe("useOssSetupModal", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    deploymentMode.current = {
+      isLoading: true,
+      isOSS: true,
+      isSuccess: false,
+    };
+  });
+
+  it("opens an explicit reset hint after delayed OSS detection even when setup was seen", async () => {
+    window.localStorage.setItem(OSS_SETUP_SEEN_KEY, "1");
+
+    const { result, rerender } = renderHook(() =>
+      useOssSetupModal({ autoOpenTab: OSS_SETUP_TABS.RESET }),
+    );
+
+    expect(result.current.open).toBe(false);
+
+    act(() => {
+      deploymentMode.current = {
+        isLoading: false,
+        isOSS: true,
+        isSuccess: true,
+      };
+      rerender();
+    });
+
+    await waitFor(() => expect(result.current.open).toBe(true));
+    expect(result.current.activeTab).toBe(OSS_SETUP_TABS.RESET);
+  });
+
+  it("does not auto-open without a hint after setup was seen", () => {
+    window.localStorage.setItem(OSS_SETUP_SEEN_KEY, "1");
+    deploymentMode.current = {
+      isLoading: false,
+      isOSS: true,
+      isSuccess: true,
+    };
+
+    const { result } = renderHook(() => useOssSetupModal());
+
+    expect(result.current.open).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Direct OSS password-reset and account-creation routes pass an `ossSetup` query hint to the login page. The login view currently removes that hint before asynchronous deployment-mode detection finishes, so returning users can see no modal (or the wrong tab). This change keeps a valid one-shot hint until the modal is open on the requested tab, then removes only that parameter while preserving the rest of the query string.

## Linked issues

Closes #1848

Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. One-shot OSS setup hint handoff**

- Read `ossSetup` once per render and pass the same value to the modal hook and cleanup effect.
- Delay cleanup of valid `create`/`reset` hints until the modal is open on that exact tab.
- Discard invalid hints immediately so malformed URLs do not persist.
- Clone `URLSearchParams` before deleting the hint, preserving unrelated parameters without mutating router state.

**B. Regression coverage**

- Added focused tests for the cleanup predicate and delayed OSS deployment detection.
- Covered returning-user state where the first-visit marker is already present.

No backend, authentication, storage-schema, or API behavior changes.

## 2) Why the changes were done

- **Product/UX:** Direct OSS setup routes should reliably open the requested create/reset instructions, including for returning users.
- **Technical:** Deployment mode is asynchronous, so URL cleanup must be acknowledged by the modal state instead of running on the login view's first render.
- **Architecture:** The small pure predicate keeps URL lifecycle behavior explicit and independently testable; the existing modal hook remains responsible for opening behavior.

## 3) Tests written + scenarios each covers

**`frontend/src/sections/auth/jwt/oss-setup/use_oss_setup_modal.test.jsx`** — OSS setup hint lifecycle and modal behavior

- keeps a valid hint until the requested tab is open
- does not clear a valid hint while a different tab is active
- clears malformed one-shot hints
- opens an explicit reset hint after delayed OSS detection even when setup was previously seen
- does not auto-open without a hint after setup was previously seen

> Run result: **2,453 passed / 2,453 total** across the full frontend Vitest suite on Node 22 with the frozen Yarn lockfile. Focused suite: **4 passed**. Changed-file ESLint: **0 errors** (one pre-existing hook-dependency warning in `jwt-login-view.jsx`). Production build: **passed**.

## 4) How to run / test

```bash
cd frontend
yarn install --frozen-lockfile
yarn test:run
yarn build
```

Focused regression:

```bash
yarn vitest run src/sections/auth/jwt/oss-setup/use_oss_setup_modal.test.jsx
```

### UI steps (manual)

1. In an OSS deployment, visit `/auth/jwt/login?ossSetup=reset&source=docs` while `fai_oss_setup_seen` is already set.
2. Wait for deployment detection to complete.
3. Verify the CLI setup modal opens on **Reset password**.
4. Verify `ossSetup` is removed after the modal opens and `source=docs` remains.

## 5) Screenshots / recordings

Not applicable: this fixes an asynchronous state/URL handoff without changing the rendered UI. The behavior is covered by the focused hook regression tests.

## 6) Edge cases & considerations

- **Delayed deployment detection:** valid hints remain available until OSS mode is confirmed and the modal opens.
- **Returning users:** explicit hints override the first-visit marker as intended.
- **Invalid hints:** removed without opening the modal.
- **Other query parameters:** preserved during cleanup.
- **Non-OSS or failed detection:** a valid hint is not consumed by an unrelated login state.

## 7) Pre-existing issues (NOT introduced by this PR)

- The repository-wide ESLint run reports existing warnings but no errors; the touched login file already has an unrelated `acceptInvitation`/`token` dependency warning.
- The production build reports existing chunk-size, Sentry-token, and environment-placeholder warnings, but completes successfully.

## 8) Architectural / important decisions

- **Acknowledge before consume:** a valid route hint is consumed only after observable modal state confirms the requested tab is open.
- **Immutable URL update:** cleanup operates on a cloned `URLSearchParams` instance to avoid mutating React Router state in place.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [ ] `bin/test` passes locally (N/A: no backend changes)
- [x] Frontend test suite passes locally on Node 22 with the frozen Yarn lockfile
- [x] Contract verification is N/A (no API surface changed)
- [x] Documentation changes are N/A (no user-facing workflow changed)
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (first-contribution bot action pending)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated (N/A: no Linear issue provided)

AI-assisted development disclosure: Codex was used to help investigate the race and draft regression coverage; the final diff and all reported validation were reviewed and executed against the current `dev` branch.
