### PR TITLE
fix(evals): persist eval name on edit so renames actually stick

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1264,7 +1264,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           size="small"
           placeholder="e.g. toxicity-check, my-custom-eval"
           value={evalName}
-          disabled={isEditMode} // Name is not editable in edit mode — it's the name of the UserEvalMetric instance, not the template
           onChange={(e) => {
             // Sanitise: lowercase, replace spaces with hyphens, only allow a-z 0-9 _ -
             const raw = e.target.value
@@ -1274,13 +1273,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          error={!isEditMode && evalName.length >= 51}
+          error={evalName.length >= 51}
           helperText={
-            isEditMode
-              ? undefined
-              : evalName.length >= 51
-                ? "Name can't be longer than 50 characters"
-                : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
+            evalName.length >= 51
+              ? "Name can't be longer than 50 characters"
+              : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }
           FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -1664,7 +1664,7 @@ class TestEditAndRunUserEvalView:
     ):
         """Test successfully editing and running a user evaluation."""
         payload = {
-            "name": "Updated Eval",
+            "name": "updated-eval",
             "output_column_id": str(output_column.id),
             "config": {
                 "model": "gpt-4",
@@ -1727,6 +1727,170 @@ class TestEditAndRunUserEvalView:
 
         # The API returns 404 when eval is not found
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_edit_persists_new_name(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """Renaming an eval writes the new name to the instance."""
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "toxicity-check-v2",
+                "run": False,
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == "toxicity-check-v2"
+
+    def test_edit_renames_eval_and_reason_columns(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """A rename carries over to the grid columns that snapshot the eval name."""
+        eval_col = Column.objects.create(
+            name=user_eval_metric.name,
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+        )
+        reason_col = Column.objects.create(
+            name=f"{user_eval_metric.name}-reason",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION_REASON.value,
+            source_id=f"{eval_col.id}-sourceid-{user_eval_metric.id}",
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "renamed-eval",
+                "run": False,
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        eval_col.refresh_from_db()
+        reason_col.refresh_from_db()
+        assert eval_col.name == "renamed-eval"
+        assert reason_col.name == "renamed-eval-reason"
+
+    def test_edit_rejects_name_taken_by_another_eval(
+        self,
+        auth_client,
+        dataset,
+        organization,
+        workspace,
+        eval_template,
+        user_eval_metric,
+        output_column,
+    ):
+        """A rename cannot collide with another eval on the same dataset."""
+        UserEvalMetric.objects.create(
+            name="already-taken",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=eval_template,
+            status=StatusType.NOT_STARTED.value,
+            config={},
+        )
+        original_name = user_eval_metric.name
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "already-taken",
+                "run": False,
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == original_name
+
+    def test_edit_rejects_invalid_name_format(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """The rename path applies the same name rules as creating an eval."""
+        original_name = user_eval_metric.name
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "Has Spaces",
+                "run": False,
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == original_name
+
+    def test_edit_without_name_keeps_existing_name(
+        self, auth_client, dataset, user_eval_metric, output_column
+    ):
+        """Editing other fields must not blank out the name."""
+        original_name = user_eval_metric.name
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
+            {
+                "name": "",
+                "run": False,
+                "model": "gpt-4o",
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.name == original_name
+
+    def test_edit_with_unchanged_name_is_not_a_collision(
+        self,
+        auth_client,
+        dataset,
+        organization,
+        workspace,
+        eval_template,
+        output_column,
+    ):
+        """Re-sending the eval's own name must not trip the uniqueness check."""
+        metric = UserEvalMetric.objects.create(
+            name="stable-name",
+            dataset=dataset,
+            organization=organization,
+            workspace=workspace,
+            template=eval_template,
+            status=StatusType.NOT_STARTED.value,
+            config={},
+        )
+
+        response = auth_client.post(
+            f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{metric.id}/",
+            {
+                "name": "stable-name",
+                "run": False,
+                "config": {"mapping": {"output": "Output Column"}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        metric.refresh_from_db()
+        assert metric.name == "stable-name"
 
     def test_edit_and_run_user_eval_unauthenticated(self, dataset, user_eval_metric):
         """Test that unauthenticated users cannot edit evaluations."""

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -35,6 +35,7 @@ from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.evals_metric import (
     CompositeEvalChild,
     EvalTemplate,
+    EvalTemplateVersion,
     UserEvalMetric,
 )
 from tfc.middleware.workspace_context import set_workspace_context
@@ -1792,6 +1793,8 @@ class TestEditAndRunUserEvalView:
         output_column,
     ):
         """A rename cannot collide with another eval on the same dataset."""
+        eval_template.owner = OwnerChoices.USER.value
+        eval_template.save(update_fields=["owner"])
         UserEvalMetric.objects.create(
             name="already-taken",
             dataset=dataset,
@@ -1802,6 +1805,10 @@ class TestEditAndRunUserEvalView:
             config={},
         )
         original_name = user_eval_metric.name
+        original_pinned_version_id = user_eval_metric.pinned_version_id
+        version_count = EvalTemplateVersion.objects.filter(
+            eval_template=eval_template
+        ).count()
 
         response = auth_client.post(
             f"/model-hub/develops/{dataset.id}/edit_and_run_user_eval/{user_eval_metric.id}/",
@@ -1816,6 +1823,11 @@ class TestEditAndRunUserEvalView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         user_eval_metric.refresh_from_db()
         assert user_eval_metric.name == original_name
+        assert user_eval_metric.pinned_version_id == original_pinned_version_id
+        assert (
+            EvalTemplateVersion.objects.filter(eval_template=eval_template).count()
+            == version_count
+        )
 
     def test_edit_rejects_invalid_name_format(
         self, auth_client, dataset, user_eval_metric, output_column

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7966,6 +7966,33 @@ class EditAndRunUserEvalView(APIView):
                         f"{get_error_message('COLUMN_DELETED')} {eval_metric.name}"
                     )
 
+                # Validate renames before any writes in this transaction. Returning
+                # a 400 from transaction.atomic() does not trigger a rollback.
+                new_name = None
+                requested_name = request_data.get("name")
+                if not save_as_template and requested_name:
+                    from model_hub.utils.eval_validators import validate_eval_name
+
+                    try:
+                        new_name = validate_eval_name(requested_name)
+                    except ValueError as e:
+                        return self._gm.bad_request(str(e))
+
+                    if (
+                        new_name != eval_metric.name
+                        and UserEvalMetric.objects.filter(
+                            name=new_name,
+                            organization=eval_metric.organization,
+                            dataset_id=eval_metric.dataset_id,
+                            deleted=False,
+                        )
+                        .exclude(id=eval_metric.id)
+                        .exists()
+                    ):
+                        return self._gm.bad_request(
+                            get_error_message("EVAL_NAME_EXISTS")
+                        )
+
                 if save_as_template:
                     template = eval_metric.template
 
@@ -8106,34 +8133,11 @@ class EditAndRunUserEvalView(APIView):
                 # Applied before the reason-column reconciliation below so the
                 # get_or_create there matches the renamed column instead of
                 # creating a duplicate under the new name.
-                requested_name = request_data.get("name")
-                if not save_as_template and requested_name:
-                    from model_hub.utils.eval_validators import validate_eval_name
-
-                    try:
-                        new_name = validate_eval_name(requested_name)
-                    except ValueError as e:
-                        return self._gm.bad_request(str(e))
-
-                    if new_name != eval_metric.name:
-                        if (
-                            UserEvalMetric.objects.filter(
-                                name=new_name,
-                                organization=eval_metric.organization,
-                                dataset_id=eval_metric.dataset_id,
-                                deleted=False,
-                            )
-                            .exclude(id=eval_metric.id)
-                            .exists()
-                        ):
-                            return self._gm.bad_request(
-                                get_error_message("EVAL_NAME_EXISTS")
-                            )
-
-                        self._rename_eval_columns(
-                            eval_metric, eval_metric.name, new_name, experiment_id
-                        )
-                        eval_metric.name = new_name
+                if new_name and new_name != eval_metric.name:
+                    self._rename_eval_columns(
+                        eval_metric, eval_metric.name, new_name, experiment_id
+                    )
+                    eval_metric.name = new_name
 
                 # Update the config (already validated above)
                 if new_config:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7873,6 +7873,53 @@ class EditAndRunUserEvalView(APIView):
             return value.strip().lower() not in {"false", "0", "no", ""}
         return bool(value)
 
+    @staticmethod
+    def _rename_eval_columns(eval_metric, old_name, new_name, experiment_id):
+        """Carry an eval rename over to the grid columns that snapshot its name.
+
+        Both the eval column and its reason column store the eval name as it was
+        when they were created, so they have to be updated alongside the rename.
+        Reason columns are named `{eval}-reason` for datasets and
+        `{eval}-{column}-reason` for experiments, hence the prefix swap.
+        """
+        eval_column_source = (
+            SourceChoices.EXPERIMENT_EVALUATION.value
+            if experiment_id
+            else SourceChoices.EVALUATION.value
+        )
+        if experiment_id:
+            eval_columns = Column.objects.filter(
+                source__in=[
+                    eval_column_source,
+                    SourceChoices.EXPERIMENT_EVALUATION_TAGS.value,
+                ],
+                source_id__endswith=f"-sourceid-{eval_metric.id}",
+                dataset=eval_metric.dataset,
+                deleted=False,
+            )
+        else:
+            eval_columns = Column.objects.filter(
+                source=eval_column_source,
+                source_id=str(eval_metric.id),
+                dataset=eval_metric.dataset,
+                deleted=False,
+            )
+        eval_columns.filter(name=old_name).update(name=new_name)
+
+        reason_columns = Column.objects.filter(
+            source=SourceChoices.EVALUATION_REASON.value,
+            source_id__endswith=f"-sourceid-{eval_metric.id}",
+            dataset=eval_metric.dataset,
+            deleted=False,
+        )
+        prefix = f"{old_name}-"
+        for reason_column in reason_columns:
+            if not reason_column.name.startswith(prefix):
+                continue
+            suffix = reason_column.name.removeprefix(prefix)
+            reason_column.name = f"{new_name}-{suffix}"
+            reason_column.save(update_fields=["name"])
+
     @validated_request(
         request_serializer=UserEvalUpdateRequestSerializer,
         responses={
@@ -8053,6 +8100,40 @@ class EditAndRunUserEvalView(APIView):
                     organization=getattr(request, "organization", None) or request.user.organization,
                     workspace=getattr(request, "workspace", None),
                 )
+
+                # Rename the eval instance. Skipped on the save_as_template
+                # branch, where `name` names the new EvalTemplate instead.
+                # Applied before the reason-column reconciliation below so the
+                # get_or_create there matches the renamed column instead of
+                # creating a duplicate under the new name.
+                requested_name = request_data.get("name")
+                if not save_as_template and requested_name:
+                    from model_hub.utils.eval_validators import validate_eval_name
+
+                    try:
+                        new_name = validate_eval_name(requested_name)
+                    except ValueError as e:
+                        return self._gm.bad_request(str(e))
+
+                    if new_name != eval_metric.name:
+                        if (
+                            UserEvalMetric.objects.filter(
+                                name=new_name,
+                                organization=eval_metric.organization,
+                                dataset_id=eval_metric.dataset_id,
+                                deleted=False,
+                            )
+                            .exclude(id=eval_metric.id)
+                            .exists()
+                        ):
+                            return self._gm.bad_request(
+                                get_error_message("EVAL_NAME_EXISTS")
+                            )
+
+                        self._rename_eval_columns(
+                            eval_metric, eval_metric.name, new_name, experiment_id
+                        )
+                        eval_metric.name = new_name
 
                 # Update the config (already validated above)
                 if new_config:


### PR DESCRIPTION
## Summary

An eval's name could not be changed once it was added to a dataset. `EditAndRunUserEvalView` accepts `name` in its request serializer and the frontend sends it on every edit, but the view never assigned it, so the request came back `200 OK` while the name stayed the same. The Name field in the eval picker was also hard-disabled in edit mode. The only workaround was to delete the eval and add it again, which re-ran it over every row and threw away the existing results.

This makes the rename actually work, end to end.

## Linked issues

Closes #1769
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Backend: persist the name on edit**

- `EditAndRunUserEvalView.post` now assigns `name` to the `UserEvalMetric` when one is sent and it differs from the current name.
- The new name goes through `validate_eval_name`, the same helper `UserEvalSerializer.validate_name` uses when an eval is created, so the rules do not differ between create and rename.
- Uniqueness is checked with the same filter `AddUserEvalView` uses (`name` + `organization` + `dataset`, `deleted=False`), excluding the eval being edited, and returns the existing `EVAL_NAME_EXISTS` error on a collision.
- A blank or unchanged name is a no-op rather than an error, since the drawer sends `name` on every save.
- The `save_as_template` branch is untouched. There `name` is the name of the new `EvalTemplate`, not the instance.

**B. Backend: keep the grid columns in sync**

- New `_rename_eval_columns` helper renames the eval column and its reason column, which both snapshot the eval name when they are created (see the `Column.objects.create` calls around lines 7619 and 8446). Without this the rename would land on the instance but the grid header would still show the old name.
- Reason columns are `{eval}-reason` for datasets and `{eval}-{column}-reason` for experiments, so the helper swaps the name prefix instead of rebuilding the whole string.
- The rename runs before the existing reason-column reconciliation. That block does a `get_or_create` keyed partly on `f"{eval_metric.name}-reason"`, so renaming afterwards would have created a duplicate reason column under the new name.

**C. Frontend: unblock the Name field**

- `EvalPickerConfigFull` had `disabled={isEditMode}` on the Name input with a comment saying the name belongs to the `UserEvalMetric` instance rather than the template. That is exactly the name this PR makes editable, so the flag is gone.
- The 50-character validation and helper text now apply in edit mode too. They were suppressed with `!isEditMode` before because the field could not be typed in.
- Nothing else changed. `resolvedName` already resolved to the picker's `evalName` state in edit mode, and `EvaluationDrawer` already put it in the POST payload.

---

## 2) Why the changes were done

- **Product/UX:** renaming was silently dropped. The request succeeded, the drawer closed, and nothing changed, so there was no signal that the name had not been saved.
- **Technical:** reusing `validate_eval_name` and the existing uniqueness filter keeps rename and create consistent. Adding a separate rule set for renames would let a name exist that could never have been created.
- **Architecture:** the column rename lives in a small static helper on the view rather than a `post_save` signal on `UserEvalMetric`, because the eval column and reason column are already reconciled inside this same view and this keeps the whole rename in one transaction.

---

## 3) Tests written + scenarios each covers

**`model_hub/tests/test_evaluation_api.py`** — `TestEditAndRunUserEvalView`

- `test_edit_persists_new_name` — a rename is written to the instance instead of being dropped.
- `test_edit_renames_eval_and_reason_columns` — the eval column and its `-reason` column follow the rename.
- `test_edit_rejects_name_taken_by_another_eval` — a collision with another eval on the same dataset returns 400 and leaves the name alone.
- `test_edit_rejects_invalid_name_format` — a name with spaces is rejected, matching the create path.
- `test_edit_without_name_keeps_existing_name` — an empty `name` in the payload does not blank the eval out.
- `test_edit_with_unchanged_name_is_not_a_collision` — resending the eval's own name does not trip the uniqueness check against itself.

One existing test changed: `test_edit_and_run_user_eval_success` sent `"name": "Updated Eval"`. That name has a space and a capital letter, so it could never have been created through `add_user_eval` in the first place, and it now hits the shared validator. It sends `updated-eval` instead. The assertions are unchanged.

> Run result: **87 passed** in `model_hub/tests/test_evaluation_api.py`, plus **146 passed** in `tfc/tests/test_model_hub_api_contract_debt.py`. `black --check` reports no diff inside the changed blocks (both files have pre-existing formatting drift on `dev`, which I left alone). `eslint` on the changed frontend file is clean apart from a pre-existing `react-hooks/exhaustive-deps` warning on an effect I did not touch.

---

## 4) How to run / test

```bash
cd futureagi
bin/test model_hub/tests/test_evaluation_api.py -k "EditAndRunUserEval" -v
```

### UI steps (manual)

1. Open a dataset that has an eval column.
2. Right-click the eval column header and pick **Edit Eval**.
3. The Name field is editable now. Change it and save.
4. The eval and its reason column pick up the new name. Saving a name that another eval on the same dataset already uses returns the "Eval Template name must be unique" error instead of silently succeeding.

---

## 5) Screenshots / recordings

I did not attach UI screenshots. I could not bring the full compose stack up locally, so the frontend side of this is a code change I reasoned through rather than one I clicked through. Happy to redo it with screenshots if you would rather see that before merging.

---

## 6) Edge cases & considerations

- **Legacy names that would fail validation today.** Existing evals may carry names created before `validate_eval_name` was enforced. Only the incoming name is validated, so those evals can still be renamed to something valid. They are just not silently rewritten.
- **Renaming to your own name.** The uniqueness query excludes the eval being edited, so resending the current name is not a collision.
- **Empty name.** The serializer allows `allow_blank=True` and the drawer always sends `name`, so a blank value keeps the current name rather than wiping it.
- **`save_as_template`.** Skipped entirely, otherwise saving a template would rename the instance as a side effect.
- **Experiment scope.** Experiment evals put the eval id in a `-sourceid-{id}` suffix and name reason columns `{eval}-{column}-reason`, so the helper filters and rewrites for that shape as well as the dataset one.
- **Reason column created later.** If the eval was added with `run=false` and never ran, there is no column to rename yet. The filters just match nothing and the instance rename still applies.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `black --check` and `isort --check-only` already fail on `model_hub/views/develop_dataset.py` and `model_hub/tests/test_evaluation_api.py` on `dev`. I matched the surrounding style rather than reformatting the files, since that would have buried the change in a few hundred unrelated lines.
- `eslint` reports a `react-hooks/exhaustive-deps` warning on the effect at `EvalPickerConfigFull.jsx:272`. It is on `dev` too and is unrelated to the lines I touched.

---

## 8) Architectural / important decisions

- **Reuse `validate_eval_name` instead of a rename-specific rule set:** a renamed eval should not be able to hold a name that `add_user_eval` would have rejected.
- **Rename columns in the view rather than a model signal:** this view already reconciles those columns, and doing it here keeps the rename inside the existing `transaction.atomic()` block.
- **Rename before the reason-column reconciliation:** that block's `get_or_create` matches on the reason column name, so ordering it the other way would create a duplicate column.
- **Left "Edit Column Name" hidden on eval columns:** the guard comment says eval column names are changed by editing the eval, which is now true. Adding a second rename entry point would give two ways to set the same value.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

Two notes on the boxes I left unchecked. I could not run the frontend suite or `contracts:check` on Windows: `yarn install` dies building the native `canvas` dependency, so I only linted the file I changed. The API surface is unchanged, no serializer fields were added or removed, so I do not think contracts need regenerating, but say the word if you want me to confirm. I do not have a Linear account, so I could not link the issue there. I will sign the CLA when the bot prompts.

<sub>Investigated with AI assistance.</sub>
