### PR TITLE
fix(evaluations): warn when preprocessing does not produce the kwargs an eval needs

### DIFF
--- a/futureagi/evaluations/engine/preprocessing.py
+++ b/futureagi/evaluations/engine/preprocessing.py
@@ -21,6 +21,11 @@ logger = structlog.get_logger(__name__)
 # Eval types that need preprocessing
 PREPROCESSORS = {}
 
+# Per-eval `_`-prefixed kwargs a successful preprocessor run leaves behind, used
+# to warn when the eval body is about to run without them. In-place resolvers
+# rewrite existing keys instead of adding new ones and declare nothing.
+PREPROCESSOR_OUTPUTS = {}
+
 # Browser-like UA so public hosts that block default `python-requests/X.X`
 # (Wikipedia, many CDNs) return 200 instead of 403.
 _BROWSER_UA = (
@@ -150,14 +155,44 @@ def _resolve_fid_input(value):
     return resolved
 
 
-def register_preprocessor(eval_name):
-    """Decorator to register a preprocessor for an eval type."""
+def register_preprocessor(eval_name, produces=()):
+    """Decorator to register a preprocessor for an eval type.
+
+    ``produces`` lists the `_`-prefixed kwargs the eval body reads back. When
+    it is set, a run that yields none of them and reports no `_..._error` is
+    logged as incomplete.
+    """
 
     def decorator(func):
         PREPROCESSORS[eval_name] = func
+        PREPROCESSOR_OUTPUTS[eval_name] = tuple(produces)
         return func
 
     return decorator
+
+
+def _warn_if_preprocessing_incomplete(eval_name, inputs):
+    """Log when an eval is about to run without the kwargs preprocessing owes it.
+
+    Preprocessors can no-op on missing inputs or swallow a failure, and the eval
+    body then falls back to whatever it does without those kwargs. Without this
+    the only symptom is a wrong score.
+    """
+    expected = PREPROCESSOR_OUTPUTS.get(eval_name)
+    if not expected or not isinstance(inputs, dict):
+        return
+    if any(key in inputs for key in expected):
+        return
+    if any(
+        key.startswith("_") and key.endswith("_error") and inputs[key] for key in inputs
+    ):
+        return
+
+    logger.warning(
+        "preprocessing_incomplete",
+        eval_name=eval_name,
+        missing_keys=list(expected),
+    )
 
 
 def preprocess_inputs(eval_name, inputs):
@@ -170,13 +205,16 @@ def preprocess_inputs(eval_name, inputs):
         return inputs
 
     try:
-        return preprocessor(inputs)
+        result = preprocessor(inputs)
     except Exception as e:
         logger.warning(f"Preprocessing failed for {eval_name}: {e}")
-        return inputs
+        result = inputs
+
+    _warn_if_preprocessing_incomplete(eval_name, result)
+    return result
 
 
-@register_preprocessor("clip_score")
+@register_preprocessor("clip_score", produces=("_image_embeddings", "_text_embeddings"))
 def _preprocess_clip(inputs):
     """
     Pre-compute CLIP embeddings for images and text.
@@ -253,7 +291,7 @@ def _preprocess_clip(inputs):
     return inputs
 
 
-@register_preprocessor("fid_score")
+@register_preprocessor("fid_score", produces=("_fid_precomputed_score",))
 def _preprocess_fid(inputs):
     """
     Pre-compute Inception features for FID.
@@ -353,7 +391,9 @@ def _preprocess_ssim(inputs):
     return inputs
 
 
-@register_preprocessor("dead_air_detection")
+@register_preprocessor(
+    "dead_air_detection", produces=("_dead_air_percentage", "_dead_air_max_gap_ms")
+)
 def _preprocess_dead_air_detection(inputs):
     """Compute silence statistics on the backend so the sandbox stays audio-free.
 
@@ -451,7 +491,7 @@ def _preprocess_dead_air_detection(inputs):
     return inputs
 
 
-@register_preprocessor("meteor_score")
+@register_preprocessor("meteor_score", produces=("_meteor_precomputed_score",))
 def _preprocess_meteor(inputs):
     """Compute METEOR via NLTK on the backend, inject the score as a kwarg.
 

--- a/futureagi/evaluations/engine/tests/test_preprocessing_guard.py
+++ b/futureagi/evaluations/engine/tests/test_preprocessing_guard.py
@@ -1,0 +1,105 @@
+"""
+Tests for the preprocessing completeness guard.
+
+``preprocess_inputs`` warns when a preprocessor returns without the
+``_``-prefixed kwargs the eval body reads back, so a no-op or a swallowed
+failure shows up in the logs instead of only as a wrong score.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from evaluations.engine.preprocessing import (
+    PREPROCESSOR_OUTPUTS,
+    PREPROCESSORS,
+    preprocess_inputs,
+    register_preprocessor,
+)
+
+
+def test_in_place_resolvers_declare_no_outputs():
+    """psnr / ssim / image_properties rewrite existing keys, so nothing to assert."""
+    for eval_name in ("psnr", "ssim", "image_properties"):
+        assert PREPROCESSOR_OUTPUTS[eval_name] == ()
+
+
+def test_injecting_preprocessors_declare_their_outputs():
+    assert PREPROCESSOR_OUTPUTS["clip_score"] == (
+        "_image_embeddings",
+        "_text_embeddings",
+    )
+    assert PREPROCESSOR_OUTPUTS["fid_score"] == ("_fid_precomputed_score",)
+    assert PREPROCESSOR_OUTPUTS["meteor_score"] == ("_meteor_precomputed_score",)
+
+
+def test_warns_when_clip_preprocessing_produces_no_embeddings():
+    """The no-op path: clip returns early when images or text is missing."""
+    with patch("evaluations.engine.preprocessing.logger") as mock_logger:
+        out = preprocess_inputs("clip_score", {"images": "", "text": "a caption"})
+
+    assert "_image_embeddings" not in out
+    mock_logger.warning.assert_called_once_with(
+        "preprocessing_incomplete",
+        eval_name="clip_score",
+        missing_keys=["_image_embeddings", "_text_embeddings"],
+    )
+
+
+def test_no_warning_when_expected_keys_are_present():
+    @register_preprocessor("_test_produces", produces=("_computed",))
+    def _produces(inputs):
+        inputs["_computed"] = 1
+        return inputs
+
+    try:
+        with patch("evaluations.engine.preprocessing.logger") as mock_logger:
+            out = preprocess_inputs("_test_produces", {})
+
+        assert out["_computed"] == 1
+        mock_logger.warning.assert_not_called()
+    finally:
+        PREPROCESSORS.pop("_test_produces", None)
+        PREPROCESSOR_OUTPUTS.pop("_test_produces", None)
+
+
+def test_no_warning_when_preprocessor_reports_its_own_error():
+    """A handled failure already surfaces through `_..._error`."""
+    with patch("evaluations.engine.preprocessing.logger") as mock_logger:
+        out = preprocess_inputs("meteor_score", {"reference": "a", "hypothesis": ""})
+
+    assert out["_meteor_error"] == "Missing reference or hypothesis"
+    warned = [
+        call
+        for call in mock_logger.warning.call_args_list
+        if call.args and call.args[0] == "preprocessing_incomplete"
+    ]
+    assert warned == []
+
+
+def test_warns_when_preprocessor_raises():
+    @register_preprocessor("_test_raises", produces=("_computed",))
+    def _raises(inputs):
+        raise RuntimeError("boom")
+
+    try:
+        with patch("evaluations.engine.preprocessing.logger") as mock_logger:
+            out = preprocess_inputs("_test_raises", {"a": 1})
+
+        assert out == {"a": 1}
+        mock_logger.warning.assert_any_call(
+            "preprocessing_incomplete",
+            eval_name="_test_raises",
+            missing_keys=["_computed"],
+        )
+    finally:
+        PREPROCESSORS.pop("_test_raises", None)
+        PREPROCESSOR_OUTPUTS.pop("_test_raises", None)
+
+
+def test_unregistered_eval_is_untouched():
+    with patch("evaluations.engine.preprocessing.logger") as mock_logger:
+        out = preprocess_inputs("not_a_registered_eval", {"a": 1})
+
+    assert out == {"a": 1}
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

A preprocessor can quietly do nothing and the eval still runs. `_preprocess_clip` returns `inputs` untouched when `images` or `text` is falsy, and `preprocess_inputs` catches every exception and returns the original dict. In both cases the eval body executes without the `_`-prefixed kwargs it reads back, and the only symptom the user sees is a wrong score.

This adds the defensive guard @hadarishav described in his review on #304. Dispatch is untouched.

## Linked issues

Refs #301
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. `register_preprocessor` can declare what a successful run produces**

- New optional `produces` argument, recorded in a `PREPROCESSOR_OUTPUTS` registry alongside `PREPROCESSORS`.
- `clip_score` declares `_image_embeddings` and `_text_embeddings`, `fid_score` declares `_fid_precomputed_score`, `dead_air_detection` declares `_dead_air_percentage` and `_dead_air_max_gap_ms`, `meteor_score` declares `_meteor_precomputed_score`.
- `psnr`, `ssim` and `image_properties` declare nothing. They rewrite existing keys in place rather than adding new ones, so there is nothing to assert on and their behaviour is untouched.

**B. `preprocess_inputs` warns when those kwargs are missing**

- After the preprocessor returns, `_warn_if_preprocessing_incomplete` logs `preprocessing_incomplete` with the eval name and the missing keys.
- It stays quiet when any declared key is present, and when the preprocessor already set its own `_..._error`, since a handled failure is reported to the eval body and shows up in the result. That covers the `_fid_error`, `_dead_air_error` and `_meteor_error` paths.
- The `except` branch now assigns to `result` instead of returning early, so a raising preprocessor also goes through the check.

**C. What is deliberately not changed**

- The registry still keys on `eval_template.name`. Per the review on #304, `eval_type_id` cannot be the key because `psnr`, `ssim`, `image_properties`, `meteor_score` and `dead_air_detection` all share `CustomCodeEval`, and the engine already resolves the code body by name through `SYSTEM_EVAL_CODE`.
- No behaviour change beyond the log line. Nothing that runs today starts failing.

---

## 2) Why the changes were done

- **Product/UX:** a CLIP eval running with no embeddings produces a plausible-looking number. Right now nothing in the logs connects that number back to preprocessing having been skipped.
- **Technical:** the registry already knows which evals need preprocessing. Having it also know what preprocessing owes them turns a silent no-op into something greppable, without touching dispatch.
- **Architecture:** warning rather than raising, so this is safe to land on its own. Turning it into a hard error is a one-line change if that is the behaviour you want, and I am happy to do that instead.

---

## 3) Tests written + scenarios each covers

**`evaluations/engine/tests/test_preprocessing_guard.py`** — the completeness guard

- `test_in_place_resolvers_declare_no_outputs` — `psnr`, `ssim` and `image_properties` stay out of the guard.
- `test_injecting_preprocessors_declare_their_outputs` — the four injecting preprocessors declare the keys their eval bodies read.
- `test_warns_when_clip_preprocessing_produces_no_embeddings` — the real no-op path, `clip_score` with empty `images`, warns with both missing keys.
- `test_no_warning_when_expected_keys_are_present` — a successful run is silent.
- `test_no_warning_when_preprocessor_reports_its_own_error` — `meteor_score` with a missing hypothesis sets `_meteor_error` and does not also warn.
- `test_warns_when_preprocessor_raises` — a raising preprocessor still reaches the guard.
- `test_unregistered_eval_is_untouched` — evals with no preprocessor are returned as-is with no logging.

> Run result: **72 passed** across `evaluations/`, which includes the existing `test_dead_air_preprocessing.py` and `test_image_preprocessing.py` suites. I also checked the tests actually fail when the guard is removed: disabling the `_warn_if_preprocessing_incomplete` call turns `test_warns_when_clip_preprocessing_produces_no_embeddings` and `test_warns_when_preprocessor_raises` red. `black` and `isort` report no diff inside the changed blocks.

---

## 4) How to run / test

```bash
cd futureagi
bin/test evaluations/engine/tests/ -v
```

No UI surface, this is a log line on the eval execution path.

---

## 6) Edge cases & considerations

- **Preprocessor with a partial result.** The guard fires only when *none* of the declared keys are present. `clip_score` sets both embeddings together, so there is no half-populated state to worry about today.
- **Handled failures.** `_fid_error`, `_dead_air_error` and `_meteor_error` already tell the eval body what went wrong, so the guard suppresses itself and you do not get two log lines for one failure.
- **Raising preprocessors.** Previously the `except` returned early. It now falls through to the check, so an exception produces both the existing "Preprocessing failed" line and the missing-kwargs line.
- **`inputs` not a dict.** Guarded with an `isinstance` check rather than assuming, since `preprocess_inputs` returns whatever the preprocessor hands back.
- **New preprocessors.** `produces` defaults to empty, so anything registered without it behaves exactly as before.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `black --check` and `isort --check-only` already fail on `evaluations/engine/preprocessing.py` on `dev`, on lines unrelated to this change. I matched the surrounding style rather than reformatting the file.

---

## 8) Architectural / important decisions

- **Declare outputs on the registry rather than inferring them:** inferring "did preprocessing do anything" by diffing the dict would fire on the in-place resolvers, which legitimately add no new keys.
- **Suppress on `_..._error`:** those are deliberate, already-surfaced failures. Warning again would just add noise to the case that is already handled well.
- **Warn instead of raise:** #301 as filed does not reproduce and this is hardening, so it should not be able to break a running eval. Say the word if you want it to be an error.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

Backend only, no frontend or API surface touched, so those two boxes do not apply. The CLA bot has not appeared on my PRs and I could not find a signing link in the repo, so tell me where to sign and I will. No Linear account here either.

I did not mark this "Closes #301" on purpose. The rename scenario in that issue does not reproduce, so the issue itself may just want closing. This fixes the underlying silent-degradation problem it was pointing at.

<sub>Investigated with AI assistance.</sub>
