### PR TITLE
fix(simulate): render scored choices eval labels instead of [object Object] [TH-7209]

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -816,6 +816,10 @@ export const normalizeEvalCellValue = (value) => {
 export const cleanChoiceLabel = (value) => {
   const parsed = parsePythonReprIfNeeded(value);
   if (Array.isArray(parsed)) return parsed.map((v) => String(v)).join(", ");
+  // Scored choices evals emit {score, choice} / {score, choices} as the bucket
+  // key, which would otherwise stringify to "[object Object]".
+  const choiceLabel = extractChoiceLabel(parsed);
+  if (choiceLabel !== null) return choiceLabel;
   return String(parsed ?? value);
 };
 


### PR DESCRIPTION
**Ticket:** [TH-7209](https://linear.app/future-agi/issue/TH-7209/deterministic-style-evals-show-object-object-in-analytics-tab) — Closes TH-7209

## What was the bug

In the Analytics tab of a simulation test execution, a choices eval configured with `choice_scores` rendered its donut legend and header as `[object Object]` instead of the choice label.

Observed on execution `3a2d4b35-6203-4590-b2f9-035021e1ea2f`, eval `customer_agent_conversation_quality`:

- Header: `customer_agent_conversation_quality : [object Object]`
- Legend: `[object Object] 90%`, `[object Object] 10%`

The `tone` eval sitting next to it rendered fine, which was the tell.

## What changes have been done

- `frontend/src/sections/develop-detail/DataTab/common.js` — `cleanChoiceLabel` now falls through to the existing `extractChoiceLabel` for object-shaped values before the final `String()` fallback.

## Why the changes

Per the eval output contract (`futureagi/model_hub/types.py:245-252`), a choices eval **with `choice_scores`** emits a dict rather than a string or list:

| config | output |
|---|---|
| choices, no `choice_scores` | `"Good"` or `["A", "B"]` |
| choices/score **with `choice_scores`** | `{"score": 0.7, "choice": "Good"}` |
| choices multi + `choice_scores` | `{"score": 0.5, "choices": ["A", "B"]}` |

The summary API stringifies that output to build chart bucket keys, so the response carries `"{'score': 1.0, 'choice': '5'}"` as a key. `cleanChoiceLabel` ran it through `parsePythonReprIfNeeded`, which successfully parsed it into a JS object, then hit `String(parsed)` → `[object Object]`.

Lists already worked because the array branch joins them. Only the dict shape had no handler.

`extractChoiceLabel` (same file, line 786) already handles all four dict variants and is used on the data-grid path — it just wasn't wired into the label formatter. No new helper, no import, no shape guessing.

## Test cases — what each scenario covers

Verified by executing the edited function against the real keys returned by `/simulate/run-tests/2a9904bc-e604-4c5d-945c-74a9ecbdefd3/eval-summary/`.

| # | Scenario | Input key | Expected |
|---|----------|-----------|----------|
| 1 | Scored single-pick (the bug) | `{'score': 1.0, 'choice': '5'}` | `5` |
| 2 | Scored multi-pick | `{'score': 0.5, 'choices': ['A', 'B']}` | `A, B` |
| 3 | Plain multi-choice list (regression) | `['neutral', 'annoyance']` | `neutral, annoyance` |
| 4 | Plain single choice (regression) | `Good` | `Good` |
| 5 | Numeric-looking choice (regression) | `5` | `5` |
| 6 | Empty string (regression) | `""` | `""` |

Fixes both the legend labels and the header value, since both route through `cleanChoiceLabel` (`DonutChart.jsx:159` and `:174`, via `chartData.js:15`).

Labels are formatted at render time, so existing executions render correctly with no backfill and no backend deploy.

## How to reproduce (original bug)

1. Open a simulation test execution that has a choices eval configured with `choice_scores` (e.g. a 1-5 quality rating).
2. Go to the **Analytics** tab.
3. The donut for that eval shows `[object Object]` in both the header and every legend entry.

## Commands

```bash
cd frontend
npx eslint src/sections/develop-detail/DataTab/common.js
npx vitest run src/sections/experiment-detail/ExperimentData/__tests__/experimentRowShape.test.js
```

## Videos and screenshots

**Before**

<img width="1869" height="1077" alt="Screenshot 2026-07-29 at 3 06 52 PM" src="https://github.com/user-attachments/assets/c718e623-9762-43e7-afe6-113ab6c8b22a" />

Header `customer_agent_conversation_quality : [object Object]`, legend `[object Object] 90%` / `[object Object] 10%`.

**After**

Header `customer_agent_conversation_quality : 5`, legend `5 90%` / `4 10%`.


<img width="1230" height="959" alt="Screenshot 2026-07-29 at 4 39 31 PM" src="https://github.com/user-attachments/assets/6f64890b-c325-403d-b239-40370ec2fdd1" />





🤖 Generated with [Claude Code](https://claude.com/claude-code)
