### PR TITLE
chore(release): remove release-as pin now that v1.23.0 has shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,8 +48,7 @@
   ],
   "packages": {
     ".": {
-      "release-type": "simple",
-      "release-as": "1.23.0"
+      "release-type": "simple"
     }
   }
 }


### PR DESCRIPTION
**Fixes stuck releases.** `release-as: 1.23.0` was left in `release-please-config.json` after the epoch (the deferred G5 cleanup). It forces every release-please run to propose **1.23.0** regardless of commits — so `fix:`/`feat:` PRs merged after v1.23.0 never bump the version, and the release PR (#1855) is stuck on the already-shipped 1.23.0.

Removing the key lets release-please compute the version from conventional commits since the `v1.23.0` tag. Manifest baseline is already `1.23.0`, so the next release will correctly land as **1.23.1** (or higher, per commit types).

After this merges: PR #1855 will update itself to the right version + changelog; merge that to cut the release. Twin to dev follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)