### PR TITLE
chore(release): remove release-as pin (twin)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,8 +48,7 @@
   ],
   "packages": {
     ".": {
-      "release-type": "simple",
-      "release-as": "1.23.0"
+      "release-type": "simple"
     }
   }
 }


### PR DESCRIPTION
Twin of the main PR; keeps dev's release-please config in sync so the pin isn't reintroduced on the next promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)