### PR TITLE
fix: preserve input order and failed-task slots in execute_with_concurrent_future_pool

### DIFF
--- a/futureagi/agentic_eval/core/utils/functions.py
+++ b/futureagi/agentic_eval/core/utils/functions.py
@@ -202,21 +202,27 @@ def execute_with_concurrent_future_pool(func, args_list, pool_size=50):
     - pool_size: The number of threads in the thread pool (default: 50).
 
     Returns:
-    - A list of results returned by the function.
+    - A list of results in the same order as ``args_list``. Each position
+      holds the return value for that input, or ``None`` if it raised.
     """
-    results = []
+    # Pre-allocate one slot per input so results stay in input order and every
+    # input keeps a slot, even when tasks finish out of order or raise.
+    results = [None] * len(args_list)
 
     # Initialize the thread pool with the specified number of threads
     with ThreadPoolExecutor(max_workers=pool_size) as executor:
-        # Submit tasks to the executor
-        future_to_args = {executor.submit(func, *args): args for args in args_list}
-        # Collect results as they complete
-        for future in as_completed(future_to_args):
+        # Submit tasks, keeping each future mapped to its input index
+        future_to_index = {
+            executor.submit(func, *args): i for i, args in enumerate(args_list)
+        }
+        # Write each result back to its original position as it completes
+        for future in as_completed(future_to_index):
+            index = future_to_index[future]
             try:
-                result = future.result()
-                results.append(result)
+                results[index] = future.result()
             except Exception as e:
-                logger.exception(f"Error retrieving result: {e}")
+                logger.exception(f"Error retrieving result at index {index}: {e}")
+                results[index] = None
 
     return results
 

--- a/futureagi/agentic_eval/core/utils/tests/test_concurrent_future_pool.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_concurrent_future_pool.py
@@ -1,0 +1,39 @@
+"""Regression tests for execute_with_concurrent_future_pool.
+
+The helper runs tasks in a thread pool. Callers zip its output back to the
+input list by index, so the returned list must stay in input order and keep a
+slot for every input, even when tasks finish out of order or raise.
+"""
+
+import time
+
+from agentic_eval.core.utils.functions import execute_with_concurrent_future_pool
+
+
+def test_results_follow_input_order_not_completion_order():
+    # Earlier indices sleep longer, so tasks complete in reverse order.
+    # A completion-ordered implementation would return [4, 3, 2, 1, 0].
+    def slow_identity(i):
+        time.sleep((5 - i) * 0.02)
+        return i
+
+    args_list = [(i,) for i in range(5)]
+    results = execute_with_concurrent_future_pool(slow_identity, args_list, pool_size=5)
+
+    assert results == [0, 1, 2, 3, 4]
+
+
+def test_failed_task_keeps_its_slot_no_silent_drop():
+    # Index 2 raises. The output must keep full length and hold None there,
+    # rather than silently dropping the row and misaligning everything after.
+    def maybe_raise(i):
+        if i == 2:
+            raise ValueError("boom")
+        return i * 10
+
+    args_list = [(i,) for i in range(5)]
+    results = execute_with_concurrent_future_pool(maybe_raise, args_list, pool_size=5)
+
+    assert len(results) == len(args_list)
+    assert results[2] is None
+    assert results == [0, 10, None, 30, 40]


### PR DESCRIPTION
`execute_with_concurrent_future_pool` collected results with `as_completed` and `results.append(...)`, so the returned list came back in completion order rather than input order. Callers that zip the output back to their inputs by index end up with mismatched rows. On top of that, any task that raised was logged and dropped, so the result list came back shorter than the input, silently losing rows and shifting everything after the failure.

This pre-allocates the result list and writes each future's result to its original index, keeping `None` where a task failed, so length and ordering always match the input. It is the same index-preserving approach already used by the batch runners in `core/llm/llm.py` and `core_evals/fi_evals/base_evaluator.py`.

Adds regression tests covering out-of-order completion (tasks finishing in reverse still return in input order) and a raising task that must keep its slot (output length matches the input, with `None` at the failed index).
