### PR TITLE
perf(annotations): annotate the review-thread lookup so the items grid stops querying per row

### DIFF
--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -519,18 +519,18 @@ class QueueItemSerializer(serializers.ModelSerializer):
         return resolve_source_preview(obj, ch_cache=self.context.get("ch_source_cache"))
 
     def get_workflow_status(self, obj):
-        if (
-            obj.review_status == "pending_review"
-            and QueueItemReviewThread.objects.filter(
-                queue_item=obj,
-                blocking=True,
-                status=QueueItemReviewThread.STATUS_ADDRESSED,
-                deleted=False,
-            ).exists()
-        ):
-            return "resubmitted"
         if obj.review_status == "pending_review":
-            return "in_review"
+            # Annotated by QueueItemViewSet.get_queryset; the query is the fallback
+            # for callers that serialize an item they fetched themselves.
+            has_addressed = getattr(obj, "_has_addressed_review", None)
+            if has_addressed is None:
+                has_addressed = QueueItemReviewThread.objects.filter(
+                    queue_item=obj,
+                    blocking=True,
+                    status=QueueItemReviewThread.STATUS_ADDRESSED,
+                    deleted=False,
+                ).exists()
+            return "resubmitted" if has_addressed else "in_review"
         if obj.review_status == "rejected":
             return "needs_changes"
         return obj.status

--- a/futureagi/model_hub/tests/test_queue_items_api.py
+++ b/futureagi/model_hub/tests/test_queue_items_api.py
@@ -429,6 +429,41 @@ class TestListItems:
         assert resp.data["results"][0]["workflow_status"] == "resubmitted"
         assert resp.data["results"][0]["workflow_status_label"] == "Resubmitted"
 
+    def test_workflow_status_resolves_without_the_queryset_annotation(
+        self, auth_client, queue, dataset_with_rows, user, organization
+    ):
+        """TH-7211: the un-annotated fallback must still say ``resubmitted``.
+
+        ``_has_addressed_review`` is annotated by ``QueueItemViewSet.get_queryset``,
+        but next-item / navigation responses serialize an item they fetched
+        themselves and so carry no annotation. That path has to fall back to the
+        lookup rather than read a missing attribute as "no addressed review".
+        """
+        from model_hub.serializers.annotation_queues import QueueItemSerializer
+
+        _, rows = dataset_with_rows
+        self._add_rows(auth_client, queue, rows)
+        item = QueueItem.objects.filter(queue_id=queue).order_by("order").first()
+        item.status = "in_progress"
+        item.review_status = "pending_review"
+        item.save(update_fields=["status", "review_status", "updated_at"])
+        QueueItemReviewThread.objects.create(
+            queue_item=item,
+            created_by=user,
+            action=QueueItemReviewThread.ACTION_REQUEST_CHANGES,
+            scope=QueueItemReviewThread.SCOPE_ITEM,
+            blocking=True,
+            status=QueueItemReviewThread.STATUS_ADDRESSED,
+            organization=organization,
+        )
+
+        fresh = QueueItem.objects.get(pk=item.pk)
+        assert not hasattr(fresh, "_has_addressed_review")
+
+        data = QueueItemSerializer(fresh).data
+        assert data["workflow_status"] == "resubmitted"
+        assert data["workflow_status_label"] == "Resubmitted"
+
     def test_status_all_does_not_filter_items(
         self, auth_client, queue, dataset_with_rows
     ):
@@ -806,4 +841,48 @@ class TestItemsListQueryCount:
             f"{(large - small) / 20:.1f} extra queries per row. Something in the "
             "serializer is querying per item instead of reading an annotation "
             "(TH-7104)."
+        )
+
+    def test_query_count_is_flat_for_items_awaiting_review(
+        self, auth_client, queue, organization, workspace
+    ):
+        """TH-7211: same flatness contract, for items in ``pending_review``.
+
+        The test above leaves ``review_status`` NULL, which is the one state that
+        short-circuits ``get_workflow_status`` before its review-thread lookup — so
+        it passed while the list still queried twice per row (``workflow_status``
+        and ``workflow_status_label`` each resolved the same lookup) for every item
+        actually awaiting review. A queue in review is precisely when the grid is
+        being used, so that is the state that has to be flat.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        for i in range(30):
+            QueueItem.objects.create(
+                queue_id=queue,
+                source_type="trace",
+                trace_id=uuid.uuid4(),
+                organization=organization,
+                workspace=workspace,
+                order=i,
+                review_status="pending_review",
+            )
+
+        def count_queries(limit):
+            url = f"{items_url(queue)}?limit={limit}&page=1"
+            auth_client.get(url)  # warm: auth/session lookups are one-offs
+            with CaptureQueriesContext(connection) as ctx:
+                resp = auth_client.get(url)
+            assert resp.status_code == status.HTTP_200_OK
+            assert len(resp.data["results"]) == limit
+            return len(ctx.captured_queries)
+
+        small = count_queries(5)
+        large = count_queries(25)
+
+        assert large == small, (
+            f"items list ran {small} queries for 5 pending-review items and "
+            f"{large} for 25 — {(large - small) / 20:.1f} extra queries per row "
+            "(TH-7211)."
         )

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -4688,6 +4688,22 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                         QueueItemReviewThread.STATUS_REOPENED,
                     ],
                 ),
+                # workflow_status and workflow_status_label each resolved this same
+                # lookup per rendered item, so a page of items awaiting review cost
+                # 2 extra queries per row on top of the base — 55 queries for 25
+                # items vs 15 for 5 (TH-7211). It was already annotated below, but
+                # only when the caller filtered by in_review/resubmitted, and the
+                # serializer never read it. Annotating unconditionally makes the
+                # status flat for every page and for a single-item retrieve; the
+                # status filters below read this same alias.
+                _has_addressed_review=Exists(
+                    QueueItemReviewThread.objects.filter(
+                        queue_item_id=OuterRef("pk"),
+                        blocking=True,
+                        status=QueueItemReviewThread.STATUS_ADDRESSED,
+                        deleted=False,
+                    )
+                ),
             )
         )
         queue_id = self.kwargs.get("queue_id")
@@ -4708,20 +4724,6 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
 
         if statuses:
             status_q = Q()
-            addressed_threads = QueueItemReviewThread.objects.filter(
-                queue_item_id=OuterRef("pk"),
-                blocking=True,
-                status=QueueItemReviewThread.STATUS_ADDRESSED,
-                deleted=False,
-            )
-            if any(
-                workflow_status in statuses
-                for workflow_status in ("in_review", "resubmitted")
-            ):
-                queryset = queryset.annotate(
-                    _has_addressed_review=Exists(addressed_threads)
-                )
-
             for item_status in statuses:
                 if item_status == "in_review":
                     status_q |= Q(


### PR DESCRIPTION
## Summary

`workflow_status` and `workflow_status_label` each resolved the same `QueueItemReviewThread` lookup **per rendered item**, so every item awaiting review cost 2 extra queries on top of the page. Measured: **15 queries for 5 items, 55 for 25** — 2.0 per row. At `?limit=100` that is ~200 extra round trips.

The `Exists` annotation this needs was already in `get_queryset` — but only applied when the caller filtered by `in_review`/`resubmitted`, and the serializer never read it. This annotates it unconditionally and reads it with the same annotated-with-fallback pattern `comment_count` / `open_feedback_count` already use (TH-7104, #1831).

**Query count is now flat: 5 for 5 items, 5 for 25.**

## Linked issues

Linear: https://linear.app/future-agi/issue/TH-7211 (phase 2; follow-on to #1831 and #1852)

## Type of change

- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. `_has_addressed_review` is annotated unconditionally** (`views/annotation_queues.py`)

Moved into the existing base `.annotate(...)` block beside the two TH-7104 count annotations, and removed the conditional annotate inside the `if statuses:` branch. The status filters below read the same alias, so they are unchanged.

**B. `get_workflow_status` reads the annotation** (`serializers/annotation_queues.py`)

`getattr(obj, "_has_addressed_review", None)` with the original query as fallback. The `is None` check matters: an annotated `False` must be respected, not re-queried.

This also flattens the single-item `retrieve` (`GET items/{id}/`), which went through the same serializer.

---

## 2) Why the changes were done

The endpoint is the annotation grid, and the state that triggered the N+1 — `review_status = "pending_review"` — is exactly the state a queue is in *while it is being worked*. A queue mid-review paid the full 2N.

The `Exists` is one correlated subquery evaluated inside the page query, against `queue_item_id` (indexed — default FK `db_index`). It replaces N round trips with N index probes in a single query.

**Why unconditional rather than conditional:** the annotation was already being computed for filtered requests; making it conditional on what the serializer needs would mean the serializer and the view each deciding the same thing separately. One always-present alias is the smaller contract, and it is what the two neighbouring count annotations already do.

---

## 3) Tests written + scenarios each covers

`test_queue_items_api.py`

- **`test_query_count_is_flat_for_items_awaiting_review`** — the flatness contract for `pending_review` items. **Verified failing pre-fix:** `items list ran 15 queries for 5 pending-review items and 55 for 25 — 2.0 extra queries per row`.

  The pre-existing `test_query_count_does_not_grow_with_page_size` creates items with `review_status` left NULL — the one state that short-circuits `get_workflow_status` before its lookup. It passed the whole time the N+1 was live. That is the matrix gap this closes.

- **`test_workflow_status_resolves_without_the_queryset_annotation`** — the un-annotated fallback. Five callers (`next-item`, navigation, `annotate-detail`) serialize an item they fetched themselves and carry no annotation; that path must fall back to the lookup, not read a missing attribute as "no addressed review". **Mutation-checked:** changing the `getattr` default from `None` to `False` makes it fail with `assert 'in_review' == 'resubmitted'`.

Pre-existing coverage that guards the filters I touched — `test_filter_by_in_review_workflow_status` and `test_filter_by_resubmitted_workflow_status` — asserts both the filter result and the serialized `workflow_status` / `workflow_status_label`, and both stay green.

> `test_queue_items_api.py`: **30 passed**. Wider annotation sweep (`-k "annotation or queue or review or workflow"`): **774 passed, 9 failed** — all 9 confirmed pre-existing by stashing this branch and reproducing the identical set on a clean tree. Ruff check + format clean.

---

## 4) How to run / test

```bash
cd futureagi
DJANGO_SETTINGS_MODULE=tfc.settings.test uv run --python 3.13 python -m pytest \
  model_hub/tests/test_queue_items_api.py -q -p no:randomly
```

No migration. No contract change — `workflow_status` keeps its shape and values.

---

## 5) Measurements

### Deployed to dev and A/B'd end-to-end (real dev DB, same box, same rows)

Both arms on the same 30-item queue, deliberately mixed so every branch of `get_workflow_status` renders: 8 `resubmitted` (pending_review **with** an addressed blocking thread), 7 `in_review` (pending_review **without** one), 8 `needs_changes`, 7 falling through to `status`.

| | before (dev) | after (this PR) |
|---|---|---|
| queries at `limit=5` (3 awaiting review) | 19 | **13** |
| queries at `limit=25` (13 awaiting review) | **39** | **13** |
| slope | +1.00 per rendered row | **flat** |
| `workflow_status` / `_label` for all 25 items | — | **identical** |

The arithmetic reconciles exactly, which is what makes the mechanism certain rather than just the outcome favourable: `19 = 13 + (3 awaiting × 2)` and `39 = 13 + (13 awaiting × 2)`. The cost is **2 queries per `pending_review` item**, and it is now zero.

The dev slope reads as +1.00/row only because half that queue is deliberately *not* awaiting review; the local test, where every item is, shows the full **+2.00/row** (15 → 55 across 5 → 25 items). On a queue genuinely mid-review at `limit=25` that is **63 queries → 13**.

### Guards on the measurement

Both arms hard-assert that the page rendered rows, that it contained `pending_review` items, and that ≥3 distinct `workflow_status` values came back. Without the second guard this comparison passes trivially — the first attempt on dev's organic data hit exactly that and aborted, because the largest real queue has 3 items awaiting review and only 1 in the first page. That is also why the queue is built and torn down by the script rather than borrowed: dev cannot otherwise exercise this path at all.

### Local

`CaptureQueriesContext`, warmed. The page has a **base of 5 queries**, and the N+1 added exactly `2 × (pending_review items on the page)` on top:

| page | before | after |
|---|---|---|
| 5 pending-review items | 5 + 10 = **15** | **5** |
| 25 pending-review items | 5 + 50 = **55** | **5** |

The local base (5) and the dev base (13) differ because dev resolves real org/workspace/session context per request; the constant is environment-specific, the slope is the contract.

**Honest sizing:** this removes 2 indexed round trips per row — tens to low hundreds of ms on a real page, not seconds. The structural win is that the grid can no longer degrade with page size. The multi-second cost on the customer account is ClickHouse, and that is #1852's job, not this one.

---

## Scope: what this PR deliberately does *not* touch

The remaining TH-7211 read endpoints were re-examined and rejected as code changes, each for a reason:

- **`export/` (504)** — the cap is already a settings override (`ANNOTATION_EXPORT_SYNC_MAX`, with tests in `test_annotation_export_batch_cap.py`). Tightening it is an ops change, reversible in minutes; it does not need a PR. A real async export is a feature, with its own ticket.
- **`export-fields/` (2,849 ms)** — trace content here already resolves lean (`_batch_ch_trace_roots` hardcodes `include_heavy=False`), so there is no heavy→lean saving left. Shrinking the 100-item sample would trade export **schema-discovery coverage** for an unproven latency win — a correctness regression bought with a guess.
- **`agreement/` (415 ms median)** and **`analytics/` (438–811 ms)** — against the ~380 ms network floor at the measurement location, that is tens of ms of server time. They are not broken; the `O(labels² × items)` shape in `calculate_agreement` is a scale follow-up, not a fix.
- **`max_page_size`** — there is no `max_page_size` anywhere in this repo. Introducing the pattern to defend against a blowup that #1831 + #1852 + this PR already dismantle is a new thing to maintain for no measured gain.
- **`annotate-detail` (~2.4 s)** — verified to have **no** per-row N+1; its cost is one ClickHouse read plus queue-wide aggregates. Cutting it needs a captured trace `start_time` to prune partitions, which has to stack on #1852's add path and should be decided on post-deploy numbers, not on the current stale table.
