### PR TITLE
perf(annotations): dedup span reads with LIMIT 1 BY instead of FINAL

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
+++ b/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
@@ -18,17 +18,17 @@ from django.test.utils import CaptureQueriesContext, override_settings
 from rest_framework import status
 
 from model_hub.models.annotation_queues import (
+    FULL_ACCESS_QUEUE_ROLES,
     AnnotationQueue,
     AnnotationQueueAnnotator,
     AnnotationQueueLabel,
-    FULL_ACCESS_QUEUE_ROLES,
     QueueItem,
 )
 from model_hub.models.choices import (
     AnnotationQueueStatusChoices,
     AnnotatorRole,
-    DataTypeChoices,
     DatasetSourceChoices,
+    DataTypeChoices,
     QueueItemSourceType,
     QueueItemStatus,
     SourceChoices,
@@ -198,9 +198,7 @@ def test_export_rejects_oversize_queue_before_resolving(
 
 @pytest.mark.django_db
 @override_settings(ANNOTATION_EXPORT_SYNC_MAX=3)
-def test_export_at_cap_boundary_succeeds(
-    auth_client, organization, workspace, user
-):
+def test_export_at_cap_boundary_succeeds(auth_client, organization, workspace, user):
     seed = _build_dataset_queue(
         organization=organization, workspace=workspace, user=user, n_rows=3
     )
@@ -212,9 +210,7 @@ def test_export_at_cap_boundary_succeeds(
 
 
 @pytest.mark.django_db
-def test_dataset_cells_by_row_batches_and_preseeds(
-    organization, workspace, user
-):
+def test_dataset_cells_by_row_batches_and_preseeds(organization, workspace, user):
     seed = _build_dataset_queue(
         organization=organization, workspace=workspace, user=user, n_rows=3
     )
@@ -263,11 +259,15 @@ def test_resolve_source_content_uses_cell_cache_then_falls_back(
         fresh = resolve_source_content(item)
     assert len(_cell_queries(cap)) == 1
 
-    assert cached["fields"] == fresh["fields"] == {
-        "col_0": "r0c0",
-        "col_1": "r0c1",
-        "col_2": "r0c2",
-    }
+    assert (
+        cached["fields"]
+        == fresh["fields"]
+        == {
+            "col_0": "r0c0",
+            "col_1": "r0c1",
+            "col_2": "r0c2",
+        }
+    )
 
 
 def _make_root_chspan(*, project_id, trace_id):
@@ -324,7 +324,7 @@ class _TraceRootsReaderCM:
         return False
 
     def roots_by_trace_ids(
-        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None
+        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None, **_
     ):
         return [self._roots[str(t)] for t in trace_ids if str(t) in self._roots]
 
@@ -402,9 +402,10 @@ def test_export_trace_items_no_project_n_plus_one(
         organization=organization, workspace=workspace, user=user, n_items=5
     )
     reader = _TraceRootsReaderCM(seed["roots"])
-    with mock.patch(
-        "tracer.services.clickhouse.v2.get_reader", return_value=reader
-    ), CaptureQueriesContext(connection) as cap:
+    with (
+        mock.patch("tracer.services.clickhouse.v2.get_reader", return_value=reader),
+        CaptureQueriesContext(connection) as cap,
+    ):
         resp = auth_client.get(
             EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json"
         )

--- a/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
+++ b/futureagi/model_hub/tests/test_ch25_annotation_collector_source_resolution.py
@@ -160,7 +160,7 @@ class _ReaderCM:
         return [self._span] if str(self._span.trace_id) == str(trace_id) else []
 
     def roots_by_trace_ids(
-        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None
+        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None, **_
     ):
         # Mirror the real reader: parentless spans for the given traces.
         if self._span is None or getattr(self._span, "parent_span_id", None):
@@ -836,7 +836,7 @@ class _CountingReaderCM:
     def __exit__(self, *exc):
         return False
 
-    def list_by_ids(self, span_ids, *, project_id=None, include_heavy=True):
+    def list_by_ids(self, span_ids, *, project_id=None, include_heavy=True, **_):
         ids = [str(s) for s in span_ids]
         self.list_by_ids_calls.append(ids)
         return [self._by_id[i] for i in ids if i in self._by_id]
@@ -1100,7 +1100,7 @@ class _MultiSpanReaderCM:
         return False
 
     def roots_by_trace_ids(
-        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None
+        self, trace_ids, *, include_heavy=False, project_id=None, org_id=None, **_
     ):
         self.roots_calls.append((tuple(sorted(str(t) for t in trace_ids)), project_id))
         ids = {str(t) for t in trace_ids}

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -1528,7 +1528,9 @@ class TestScoreOnCollectorOnlySpan:
         from model_hub.models.ai_model import AIModel
         from tracer.models.project import Project
 
-        foreign_org = Organization.objects.create(name=f"Foreign {uuid.uuid4().hex[:8]}")
+        foreign_org = Organization.objects.create(
+            name=f"Foreign {uuid.uuid4().hex[:8]}"
+        )
         foreign_project = Project.objects.create(
             name="Foreign project",
             organization=foreign_org,
@@ -1620,7 +1622,13 @@ class TestScoreOnCollectorOnlyTrace:
                 return [root_span] if str(tid) == str(trace_id) else []
 
             def roots_by_trace_ids(
-                self_inner, tids, *, include_heavy=False, project_id=None, org_id=None
+                self_inner,
+                tids,
+                *,
+                include_heavy=False,
+                project_id=None,
+                org_id=None,
+                **_,
             ):
                 return [root_span] if str(trace_id) in {str(t) for t in tids} else []
 

--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -734,7 +734,11 @@ def _ch_root_span_for_trace(trace_id):
 
     try:
         with get_reader() as reader:
-            roots = reader.roots_by_trace_ids([str(trace_id)], include_heavy=False)
+            roots = reader.roots_by_trace_ids(
+                [str(trace_id)],
+                include_heavy=False,
+                dedup_via_limit_by=True,  # see _batch_ch_trace_roots (TH-7226)
+            )
     except Exception as exc:
         logger.warning("ch_trace_render_error", trace_id=str(trace_id), error=str(exc))
         return None
@@ -780,6 +784,7 @@ def _batch_ch_spans(span_ids, *, project_id=None, include_heavy=True, caller="re
                 [str(s) for s in span_ids],
                 project_id=project_id,
                 include_heavy=include_heavy,
+                dedup_via_limit_by=True,  # see _batch_ch_trace_roots (TH-7226)
             )
     except Exception as exc:
         logger.warning(
@@ -827,7 +832,13 @@ def _batch_ch_trace_roots(trace_ids, *, project_id=None, caller="render"):
             for start in range(0, len(ids), _CH_TRACE_ID_BATCH):
                 chunk = ids[start : start + _CH_TRACE_ID_BATCH]
                 for span in reader.roots_by_trace_ids(
-                    chunk, include_heavy=False, project_id=project_id
+                    chunk,
+                    include_heavy=False,
+                    project_id=project_id,
+                    # Dedup without FINAL: 25-id page 179ms/221MiB -> 50ms/40MiB
+                    # on dev, 500-id export chunk 2,358ms/3.4GiB -> 123ms/67MiB,
+                    # same rows. The memory is what 504s an export (TH-7226).
+                    dedup_via_limit_by=True,
                 ):
                     roots_by_trace.setdefault(str(span.trace_id), []).append(span)
     except Exception as exc:

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -224,6 +224,54 @@ _LEAN_SELECT_SQL = ", ".join(
 # FINAL, so the predicate is redundant and only arms the resurrection bug.
 _FINAL_SKIP_INDEX_SETTINGS = {"use_skip_indexes_if_final": 1}
 
+# FINAL merges every part covering the queried key range, so its cost tracks the
+# project's span volume, not the number of ids asked for. On dev: a 500-id heavy
+# read is 2,358ms / 3.4GiB peak under FINAL vs 123ms / 67MiB here, same rows
+# (TH-7226). Opt-in per caller — this reader also backs feed / dataset / evals.
+_SORTING_KEY = (
+    "project_id, observation_type, service_name, "
+    "toStartOfHour(start_time), trace_id, id"
+)
+
+
+def _output_name(column: str) -> str:
+    """The name a ``_READ_COLUMNS`` entry exposes to an enclosing query."""
+    return column.rsplit(" AS ", 1)[-1].strip() if " AS " in column else column.strip()
+
+
+def _named_select(include_heavy: bool) -> str:
+    """``_SELECT_SQL`` / ``_LEAN_SELECT_SQL`` with the stubs named, so an
+    enclosing query can project them (``'' AS span_events``, not a bare ``''``)."""
+    return ", ".join(
+        f"'' AS {_output_name(col)}"
+        if not include_heavy and col in _HEAVY_COLUMNS
+        else col
+        for col in _READ_COLUMNS
+    )
+
+
+def _dedup_sql(where: str, order_by: str, *, include_heavy: bool) -> str:
+    """ReplacingMergeTree resolved without ``FINAL``. Same column shape/order as
+    the FINAL read, so ``_row_to_chspan`` decodes it unchanged.
+
+    ``is_deleted = 0`` MUST stay on the outer query: filtered inside the dedup,
+    a row whose newest version is deleted resurrects as its older live version.
+    """
+    projection = ", ".join(_output_name(col) for col in _READ_COLUMNS)
+    return (
+        f"SELECT {projection} FROM ("
+        # project_id is exposed as project_id_str and service_name isn't in the
+        # read set — both needed raw for the key, so re-selected privately.
+        f" SELECT {_named_select(include_heavy)},"
+        f" project_id AS _dedup_project, service_name AS _dedup_service"
+        f" FROM spans WHERE {where}"
+        f" ORDER BY _version DESC"
+        f" LIMIT 1 BY _dedup_project, observation_type, _dedup_service,"
+        f" toStartOfHour(start_time), trace_id, id"
+        f") WHERE is_deleted = 0 {order_by}"
+    )
+
+
 # Order in which result_rows columns arrive — bare names (no `AS` aliases) for the
 # row→dataclass mapping below.
 _DATA_KEYS: tuple[str, ...] = (
@@ -676,6 +724,7 @@ class CHSpanReader:
         include_heavy: bool = False,
         project_id: str | None = None,
         org_id: str | None = None,
+        dedup_via_limit_by: bool = False,
     ) -> list[CHSpan]:
         """Parentless spans for the given traces, same shape/order as
         list_by_trace_ids. Fetches one row per root instead of every span.
@@ -704,13 +753,16 @@ class CHSpanReader:
         if org_id:
             where.append("org_id = %(oid)s")
             params["oid"] = str(org_id)
-        rows = self._client.query(
-            f"SELECT {select} FROM spans FINAL "
-            f"WHERE {' AND '.join(where)} "
-            "ORDER BY trace_id, start_time, id",
-            parameters=params,
-            settings=_FINAL_SKIP_INDEX_SETTINGS,
-        ).result_rows
+        order_by = "ORDER BY trace_id, start_time, id"
+        if dedup_via_limit_by:
+            sql = _dedup_sql(" AND ".join(where), order_by, include_heavy=include_heavy)
+            # Skip indexes need no coaxing without FINAL, and the is_deleted
+            # minmax hazard that setting guards against does not arise.
+            settings: dict[str, Any] = {}
+        else:
+            sql = f"SELECT {select} FROM spans FINAL WHERE {' AND '.join(where)} {order_by}"
+            settings = _FINAL_SKIP_INDEX_SETTINGS
+        rows = self._client.query(sql, parameters=params, settings=settings).result_rows
         return [_row_to_chspan(r) for r in rows]
 
     # ─── Per-trace rollups (latency / tokens) ─────────────────────────────────
@@ -779,6 +831,7 @@ class CHSpanReader:
         include_heavy: bool = True,
         project_id: str | None = None,
         org_id: str | None = None,
+        dedup_via_limit_by: bool = False,
     ) -> list[CHSpan]:
         """Equivalent to ObservationSpan.objects.filter(id__in=span_ids).
 
@@ -804,11 +857,18 @@ class CHSpanReader:
         if org_id:
             where.append("org_id = %(oid)s")
             params["oid"] = str(org_id)
-        rows = self._client.query(
-            f"SELECT {select} FROM spans FINAL WHERE {' AND '.join(where)} ORDER BY id",
-            parameters=params,
-            settings=_FINAL_SKIP_INDEX_SETTINGS,
-        ).result_rows
+        if dedup_via_limit_by:
+            sql = _dedup_sql(
+                " AND ".join(where), "ORDER BY id", include_heavy=include_heavy
+            )
+            settings: dict[str, Any] = {}
+        else:
+            sql = (
+                f"SELECT {select} FROM spans FINAL "
+                f"WHERE {' AND '.join(where)} ORDER BY id"
+            )
+            settings = _FINAL_SKIP_INDEX_SETTINGS
+        rows = self._client.query(sql, parameters=params, settings=settings).result_rows
         return [_row_to_chspan(r) for r in rows]
 
     def export_fields_by_ids(

--- a/futureagi/tracer/services/clickhouse/v2/span_reader.py
+++ b/futureagi/tracer/services/clickhouse/v2/span_reader.py
@@ -228,9 +228,32 @@ _FINAL_SKIP_INDEX_SETTINGS = {"use_skip_indexes_if_final": 1}
 # project's span volume, not the number of ids asked for. On dev: a 500-id heavy
 # read is 2,358ms / 3.4GiB peak under FINAL vs 123ms / 67MiB here, same rows
 # (TH-7226). Opt-in per caller — this reader also backs feed / dataset / evals.
-_SORTING_KEY = (
-    "project_id, observation_type, service_name, "
-    "toStartOfHour(start_time), trace_id, id"
+#
+# This MUST equal the live table's ORDER BY — a shorter key over-collapses, a
+# different one under-collapses, and either is silent. `test_sorting_key_matches
+# _the_live_spans_table` pins it against system.tables so drift fails a test
+# rather than a production read.
+_SORTING_KEY_PARTS: tuple[str, ...] = (
+    "project_id",
+    "observation_type",
+    "service_name",
+    "toStartOfHour(start_time)",
+    "trace_id",
+    "id",
+)
+_SORTING_KEY = ", ".join(_SORTING_KEY_PARTS)
+
+# Two key columns are unavailable under their own names inside the dedup
+# subquery: project_id is exposed to callers as project_id_str, and service_name
+# is not in the read set at all. Both are re-selected under private aliases, and
+# the LIMIT 1 BY clause is DERIVED from the key above rather than restated, so
+# the two cannot drift apart.
+_DEDUP_KEY_ALIASES = {
+    "project_id": "_dedup_project",
+    "service_name": "_dedup_service",
+}
+_DEDUP_KEY = ", ".join(
+    _DEDUP_KEY_ALIASES.get(part, part) for part in _SORTING_KEY_PARTS
 )
 
 
@@ -258,16 +281,15 @@ def _dedup_sql(where: str, order_by: str, *, include_heavy: bool) -> str:
     a row whose newest version is deleted resurrects as its older live version.
     """
     projection = ", ".join(_output_name(col) for col in _READ_COLUMNS)
+    aliases = ", ".join(
+        f"{col} AS {alias}" for col, alias in _DEDUP_KEY_ALIASES.items()
+    )
     return (
         f"SELECT {projection} FROM ("
-        # project_id is exposed as project_id_str and service_name isn't in the
-        # read set — both needed raw for the key, so re-selected privately.
-        f" SELECT {_named_select(include_heavy)},"
-        f" project_id AS _dedup_project, service_name AS _dedup_service"
+        f" SELECT {_named_select(include_heavy)}, {aliases}"
         f" FROM spans WHERE {where}"
         f" ORDER BY _version DESC"
-        f" LIMIT 1 BY _dedup_project, observation_type, _dedup_service,"
-        f" toStartOfHour(start_time), trace_id, id"
+        f" LIMIT 1 BY {_DEDUP_KEY}"
         f") WHERE is_deleted = 0 {order_by}"
     )
 

--- a/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
+++ b/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
@@ -1,0 +1,222 @@
+"""``dedup_via_limit_by`` must reproduce ``spans FINAL`` exactly (TH-7226).
+
+Three rules, each silent when broken: is_deleted filtered AFTER the dedup (else
+deleted rows resurrect), the full sorting key as the dedup key, and every column
+named (MATERIALIZED columns are absent from ``SELECT *``; the lean select stubs
+heavy ones to a bare ``''``). The SQL-shape tests pin all three without CH,
+mirroring ``test_span_reader_point_read_oom.py``; the last test proves the
+semantics against a real ReplacingMergeTree.
+"""
+
+import uuid
+
+import pytest
+
+from tracer.services.clickhouse.v2.span_reader import (
+    _READ_COLUMNS,
+    _SORTING_KEY,
+    CHSpanReader,
+    _output_name,
+)
+
+
+class _RecordingClient:
+    """Captures the SQL + settings of the last query; returns no rows."""
+
+    def __init__(self):
+        self.sql = None
+        self.settings = None
+
+    def query(self, sql, parameters=None, settings=None):
+        self.sql = sql
+        self.settings = settings or {}
+
+        class _Result:
+            result_rows = []
+
+        return _Result()
+
+
+def _reader_with(client) -> CHSpanReader:
+    reader = CHSpanReader.__new__(CHSpanReader)
+    reader._client = client
+    return reader
+
+
+def _dedup_reads():
+    """(label, callable) for each annotation-path read that opts in."""
+    return [
+        (
+            "roots_by_trace_ids",
+            lambda r: r.roots_by_trace_ids(
+                ["t1", "t2"], include_heavy=False, dedup_via_limit_by=True
+            ),
+        ),
+        (
+            "list_by_ids",
+            lambda r: r.list_by_ids(
+                ["s1", "s2"], include_heavy=True, dedup_via_limit_by=True
+            ),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "label,call", _dedup_reads(), ids=lambda v: getattr(v, "__name__", v)
+)
+def test_dedup_read_uses_limit_by_not_final(label, call):
+    client = _RecordingClient()
+    call(_reader_with(client))
+    assert "FINAL" not in client.sql, f"{label} still uses FINAL"
+    assert "LIMIT 1 BY" in client.sql
+    # The FINAL-only workaround must go with FINAL: without FINAL, skip indexes
+    # are on by default and the is_deleted minmax hazard does not arise.
+    assert "use_skip_indexes_if_final" not in client.settings
+
+
+@pytest.mark.parametrize(
+    "label,call", _dedup_reads(), ids=lambda v: getattr(v, "__name__", v)
+)
+def test_dedup_key_is_the_full_sorting_key(label, call):
+    """Rule 2. A shorter key collapses rows the engine considers distinct."""
+    client = _RecordingClient()
+    call(_reader_with(client))
+    limit_by = client.sql.split("LIMIT 1 BY", 1)[1]
+    for key_col in ("observation_type", "toStartOfHour(start_time)", "trace_id", "id"):
+        assert key_col in limit_by, f"{label}: {key_col} missing from the dedup key"
+    # project_id / service_name appear under private aliases: project_id is
+    # exposed to callers as project_id_str, and service_name is not in the read
+    # set at all, so both are re-selected raw for the key.
+    assert "_dedup_project" in limit_by
+    assert "_dedup_service" in limit_by
+
+
+@pytest.mark.parametrize(
+    "label,call", _dedup_reads(), ids=lambda v: getattr(v, "__name__", v)
+)
+def test_is_deleted_is_filtered_outside_the_dedup(label, call):
+    """Rule 1 — the resurrection guard, and the reason for the subquery."""
+    client = _RecordingClient()
+    call(_reader_with(client))
+    assert "is_deleted = 0" in client.sql
+    inner = client.sql.split("LIMIT 1 BY", 1)[1]
+    filter_pos = inner.index("is_deleted = 0")
+    close_paren = inner.index(")")
+    assert close_paren < filter_pos, (
+        f"{label}: is_deleted is filtered INSIDE the dedup subquery — that "
+        "resurrects rows whose newest version is deleted"
+    )
+
+
+@pytest.mark.parametrize(
+    "label,call", _dedup_reads(), ids=lambda v: getattr(v, "__name__", v)
+)
+def test_every_column_is_named_for_the_outer_projection(label, call):
+    """Rule 3. Decoding is positional, so a dropped/renamed column is silent."""
+    client = _RecordingClient()
+    call(_reader_with(client))
+    projection = client.sql.split(" FROM (", 1)[0]
+    for col in _READ_COLUMNS:
+        name = _output_name(col)
+        assert name in projection, f"{label}: {name} missing from the projection"
+    # No bare '' stubs: the lean select's unnamed stubs cannot be projected.
+    assert ", ''," not in projection
+
+
+# ── semantics against a real ReplacingMergeTree ────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_limit_by_matches_final_including_deleted_rows():
+    """LIMIT 1 BY == FINAL for newest-wins AND for deletions.
+
+    Merges stopped, one part per row — otherwise the engine collapses the
+    duplicates itself and every variant agrees, proving nothing.
+    """
+    from tracer.services.clickhouse.v2 import get_reader
+
+    table = f"th7226_probe_{uuid.uuid4().hex[:8]}"
+    with get_reader() as reader:
+        ch = reader._client
+        ch.command(
+            f"CREATE TABLE {table} ("
+            "  project_id UUID, observation_type LowCardinality(String),"
+            "  service_name LowCardinality(String), start_time DateTime64(6),"
+            "  trace_id UUID, id String, name String,"
+            "  is_deleted UInt8 DEFAULT 0, _version UInt64 DEFAULT 1"
+            ") ENGINE = ReplacingMergeTree(_version, is_deleted) "
+            "PARTITION BY toDate(start_time) "
+            f"ORDER BY ({_SORTING_KEY})"
+        )
+        try:
+            ch.command(f"SYSTEM STOP MERGES {table}")
+            p = "11111111-1111-1111-1111-111111111111"
+            t = "22222222-2222-2222-2222-222222222222"
+            rows = [
+                ("A", "A-v1", 0, 1),
+                ("A", "A-v2-NEWEST", 0, 2),  # newest wins
+                ("B", "B-v1", 0, 1),
+                ("B", "B-v2-DELETED", 1, 2),  # must NOT resurrect as B-v1
+                ("C", "C-v1-DELETED", 1, 1),
+                ("C", "C-v2-ALIVE", 0, 2),  # deleted then revived
+            ]
+            for rid, nm, deleted, version in rows:  # one INSERT => one part
+                ch.insert(
+                    table,
+                    [
+                        [
+                            p,
+                            "span",
+                            "svc",
+                            "2026-07-01 10:00:00",
+                            t,
+                            rid,
+                            nm,
+                            deleted,
+                            version,
+                        ]
+                    ],
+                    column_names=[
+                        "project_id",
+                        "observation_type",
+                        "service_name",
+                        "start_time",
+                        "trace_id",
+                        "id",
+                        "name",
+                        "is_deleted",
+                        "_version",
+                    ],
+                )
+            parts = ch.query(
+                f"SELECT count() FROM system.parts WHERE table = '{table}' AND active"
+            ).result_rows[0][0]
+            assert parts > 1, "parts already merged — the probe would prove nothing"
+
+            def names(sql):
+                return sorted(r[0] for r in ch.query(sql).result_rows)
+
+            final = names(f"SELECT name FROM {table} FINAL")
+            limit_by = names(
+                f"SELECT name FROM (SELECT * FROM {table} "
+                f"ORDER BY _version DESC LIMIT 1 BY {_SORTING_KEY}) "
+                "WHERE is_deleted = 0"
+            )
+            assert final == ["A-v2-NEWEST", "C-v2-ALIVE"]
+            assert limit_by == final, (
+                f"LIMIT 1 BY diverged from FINAL: {limit_by} != {final}"
+            )
+
+            # And the mistake this guards against, so the test above cannot pass
+            # for the wrong reason.
+            naive = names(
+                f"SELECT name FROM (SELECT * FROM {table} WHERE is_deleted = 0 "
+                f"ORDER BY _version DESC LIMIT 1 BY {_SORTING_KEY})"
+            )
+            assert "B-v1" in naive, (
+                "filtering is_deleted inside the dedup no longer resurrects a "
+                "deleted row — re-check whether the outer filter is still needed"
+            )
+        finally:
+            ch.command(f"SYSTEM START MERGES {table}")
+            ch.command(f"DROP TABLE IF EXISTS {table}")

--- a/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
+++ b/futureagi/tracer/tests/test_span_reader_limit_by_dedup.py
@@ -123,6 +123,38 @@ def test_every_column_is_named_for_the_outer_projection(label, call):
     assert ", ''," not in projection
 
 
+# ── the constant vs the live table ─────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_sorting_key_matches_the_live_spans_table():
+    """``_SORTING_KEY`` must equal the real ``spans`` ORDER BY.
+
+    Everything else here is self-consistent: ``_DEDUP_KEY`` is derived from the
+    constant and the equivalence test builds its own table from it too, so all
+    of it stays green if the production ORDER BY changes underneath — while the
+    dedup silently over- or under-collapses. This is the one assertion tied to
+    the actual table.
+    """
+    from tracer.services.clickhouse.v2 import get_reader
+    from tracer.services.clickhouse.v2.span_reader import _SORTING_KEY
+
+    with get_reader() as reader:
+        rows = reader._client.query(
+            "SELECT sorting_key FROM system.tables WHERE name = 'spans' "
+            "AND database = currentDatabase()"
+        ).result_rows
+    assert rows, "spans table not found — cannot verify the dedup key"
+
+    normalise = lambda s: ",".join(p.strip() for p in s.split(","))  # noqa: E731
+    live = normalise(rows[0][0])
+    assert normalise(_SORTING_KEY) == live, (
+        "_SORTING_KEY has drifted from the spans ORDER BY. The LIMIT 1 BY dedup "
+        "collapses on this key, so a mismatch silently returns the wrong row "
+        f"version.\n  constant: {_SORTING_KEY}\n  live    : {live}"
+    )
+
+
 # ── semantics against a real ReplacingMergeTree ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Every `spans` read appends `FINAL`, which resolves the `ReplacingMergeTree` by merging **every part covering the queried key range** — so its cost tracks the *project's* span volume, not the number of ids asked for. `trace_id` sits below the primary-key prefix, so nothing prunes the merge.

Replacing it with `LIMIT 1 BY` on the annotation read paths, measured on dev's real table against the same rows:

| shape | FINAL | LIMIT 1 BY | gain |
|---|---|---|---|
| 25 ids, lean | 179ms · 221MiB peak | 50ms · 40MiB | 3.6x / 5.5x mem |
| 100 ids, heavy | 714ms · **884MiB peak** | 76ms · 52MiB | 9.4x / 17x mem |
| 500 ids, heavy | 2,358ms · **3,442MiB peak** | 123ms · 67MiB | **19.2x / 51.7x mem** |

**The memory is the point.** A 500-id export chunk peaking at 3.4 GiB *on dev's small table* is what fails the annotation export at the gateway — `span_reader.py` already documents that FINAL here "blows the memory limit". FINAL scales with the id count; `LIMIT 1 BY` stays roughly flat.

## Linked issues

Linear: https://linear.app/future-agi/issue/TH-7211 · rollout + real fix tracked in https://linear.app/future-agi/issue/TH-7226

## Type of change

- [x] 🚀 Performance improvement

---

## 1) What changes were done

**`_dedup_sql()` in `span_reader.py`** — a `spans` read that resolves the ReplacingMergeTree without `FINAL`, with the same column shape and order, so `_row_to_chspan` decodes it unchanged.

**Opt-in per caller** via `dedup_via_limit_by=` on `roots_by_trace_ids` / `list_by_ids`, wired **only** into the three annotation call sites (`_batch_ch_trace_roots`, `_batch_ch_spans`, `_ch_root_span_for_trace`). Default is unchanged, so feed / scan-clustering / dataset / eval-tasks keep FINAL until they get their own benchmarks — TH-7226.

`use_skip_indexes_if_final` is dropped on the new path: without FINAL, skip indexes are on by default, and the `is_deleted` minmax resurrection hazard documented at `span_reader.py:216-224` doesn't arise.

---

## 2) Why the changes were done

Three correctness rules make this safe, each **proven against FINAL** on a real `ReplacingMergeTree(_version, is_deleted)`:

1. **`is_deleted = 0` is filtered *after* the dedup.** Inside, a row whose newest version is deleted resurrects as its older live version. ClickHouse does not push predicates through `LIMIT BY`, so the outer filter stays outer.
2. **The dedup key is the full sorting key** — anything shorter collapses rows the engine considers distinct.
3. **Every column is named.** MATERIALIZED columns are absent from `SELECT *`, and the lean select stubs heavy columns to a bare `''` with no name, so neither survives a subquery wrapper untouched.

**Why opt-in rather than flipping the default:** the gain is not universal. It tracks the queried project's span volume — on a small project this is a wash or marginally slower:

| dataset | rows in queried project | gain @500 heavy ids |
|---|---|---|
| synthetic, 120 fragmented parts | 3,600 | 0.7x — slower |
| local seed | 250,025 | 2.1x |
| dev real project | 664,373 | 19.2x |

Part fragmentation was my initial hypothesis for the driver and it is **wrong** — 120 parts changed nothing. Each remaining call site needs its own measurement against a realistically-sized project, which is why they aren't flipped here.

---

## 3) Tests written + scenarios each covers

`tracer/tests/test_span_reader_limit_by_dedup.py`

- **`test_dedup_read_uses_limit_by_not_final`** — no `FINAL`, and the FINAL-only setting goes with it.
- **`test_dedup_key_is_the_full_sorting_key`** — rule 2, including that `project_id`/`service_name` are re-selected raw (the first is exposed as `project_id_str`, the second isn't in the read set at all).
- **`test_is_deleted_is_filtered_outside_the_dedup`** — rule 1, asserting the filter sits *after* the subquery's closing paren.
- **`test_every_column_is_named_for_the_outer_projection`** — rule 3. Decoding is positional, so a dropped or renamed column is silent.
- **`test_limit_by_matches_final_including_deleted_rows`** — the semantics, against a real ReplacingMergeTree with **merges stopped and one part per row**. Without that the engine collapses the duplicates itself and every variant agrees, proving nothing (my first attempt did exactly that). It also asserts the naive form *does* resurrect `B-v1`, so the test can't pass for the wrong reason.

The first four run without ClickHouse, mirroring `test_span_reader_point_read_oom.py`.

> **189 passed, 2 failed** across the span-reader, CH-resolution, queue-items, voice-regression, export-cap and scores suites. Both failures confirmed pre-existing by stashing and reproducing on a clean tree (`test_th5123_voice_call_detail_returns_simulation_path_context`, `test_upsert_existing_score`). Ruff check + format clean.

**Test-stub change worth a reviewer's eye:** three stubs hard-coded the reader signature, so the new kwarg raised `TypeError` — which the helper's fail-open `except` swallowed into an *empty cache* rather than an error. They now tolerate kwargs, matching the existing convention in `test_scan_project_scoped_read.py`. That fail-open is worth noting on its own: a reader signature drift degrades the annotation grid to "source deleted" silently.

---

## 4) How to run / test

```bash
cd futureagi
DJANGO_SETTINGS_MODULE=tfc.settings.test uv run --python 3.13 python -m pytest \
  tracer/tests/test_span_reader_limit_by_dedup.py \
  tracer/tests/test_span_reader_point_read_oom.py \
  model_hub/tests/test_ch25_annotation_collector_source_resolution.py -q -p no:randomly
```

No migration, no contract change.

---

## 5) Measurements

### Deployed to dev, through the real reader

The raw-SQL benchmark showed identical *rows*; this checks the integrated path — projection, ordering, and **positional decoding into `CHSpan`**. A projection built in the wrong order would return "identical rows" at the SQL level while silently swapping fields on the dataclass, so **every field of every span is compared**.

| shape | FINAL | LIMIT 1 BY | decoded |
|---|---|---|---|
| roots lean (25) | 215ms | **65ms** | identical |
| roots heavy (25) | 329ms | **79ms** | identical |
| roots lean (100) | 269ms | **63ms** | identical |
| `list_by_ids` heavy (50) | 1,225ms | **278ms** | identical |
| `list_by_ids` lean (50) | 793ms | **229ms** | identical |

Field-by-field across all 250 spans: no divergence.

### Not measured

Production. Dev's benchmark project holds 664k spans; the customer's is larger, so the expected gain there is at least what dev shows — but that is an inference, not a measurement, and the export 504 stays unproven until this deploys.
