### PR TITLE
chore(simulate): align generated message models

### DIFF
--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -101,6 +101,13 @@ class ModelConfigs:
         max_tokens=50000,
     )
 
+    VERTEX_GEMINI_2_5_FLASH_LITE: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.VERTEX_AI.value,
+        model_name="vertex_ai/gemini-2.5-flash-lite",
+        temperature=0.2,
+        max_tokens=16000,
+    )
+
     # Claude Sonnet (used by EvalTextLLM defaults in constant.py today).
     CLAUDE_3_5_SONNET: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.ANTHROPIC.value,
@@ -297,4 +304,3 @@ class ModelConfigs:
         """Check if the model supports PDF inputs."""
         cfg = cls.get_config(model_name)
         return bool(cfg and cfg.supports_pdf)
-

--- a/futureagi/simulate/services/chat_constants.py
+++ b/futureagi/simulate/services/chat_constants.py
@@ -18,14 +18,14 @@ CHAT_SIMULATION_PROVIDER = os.getenv("CHAT_SIMULATION_PROVIDER", "futureagi")
 
 
 # =============================================================================
-# Future AGI Chat Configuration (sourced from ModelConfigs.CHAT_SIMULATOR)
+# Future AGI Chat Configuration
 # =============================================================================
 
-_chat_sim_config = ModelConfigs.VERTEX_GEMINI_2_5_PRO
+CHAT_SIM_MODEL_CONFIG = ModelConfigs.VERTEX_GEMINI_2_5_PRO
 
-FUTUREAGI_CHAT_MODEL = _chat_sim_config.model_name
-FUTUREAGI_CHAT_TEMPERATURE = _chat_sim_config.temperature
-FUTUREAGI_CHAT_MAX_TOKENS = _chat_sim_config.max_tokens
+FUTUREAGI_CHAT_MODEL = CHAT_SIM_MODEL_CONFIG.model_name
+FUTUREAGI_CHAT_TEMPERATURE = CHAT_SIM_MODEL_CONFIG.temperature
+FUTUREAGI_CHAT_MAX_TOKENS = CHAT_SIM_MODEL_CONFIG.max_tokens
 
 
 # =============================================================================

--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -201,7 +201,7 @@ def _generate_chat_initial_message(
             guidance_lines=len(guidance.split("\n")) if guidance else 0,
             hint_present=bool(hint),
         )
-        model_cfg = ModelConfigs.CLAUDE_4_5_SONNET_BEDROCK_ARN
+        model_cfg = ModelConfigs.VERTEX_GEMINI_2_5_PRO
         llm = LLM(
             model_name=model_cfg.model_name,
             temperature=0.7,  # Higher for more natural variation

--- a/futureagi/simulate/services/chat_initial_message.py
+++ b/futureagi/simulate/services/chat_initial_message.py
@@ -11,7 +11,7 @@ import json
 import structlog
 
 from agentic_eval.core.llm.llm import LLM
-from agentic_eval.core.utils.model_config import ModelConfigs
+from simulate.services.chat_constants import CHAT_SIM_MODEL_CONFIG
 from simulate.constants.chat_initial_message_prompt import (
     build_chat_initial_message_messages,
 )
@@ -201,7 +201,7 @@ def _generate_chat_initial_message(
             guidance_lines=len(guidance.split("\n")) if guidance else 0,
             hint_present=bool(hint),
         )
-        model_cfg = ModelConfigs.VERTEX_GEMINI_2_5_PRO
+        model_cfg = CHAT_SIM_MODEL_CONFIG
         llm = LLM(
             model_name=model_cfg.model_name,
             temperature=0.7,  # Higher for more natural variation


### PR DESCRIPTION
## Summary

- Add a shared Vertex Gemini 2.5 Flash Lite model configuration with a bounded output budget.
- Use the normal chat simulation model configuration for generated initial messages.

## Verification

Confirmed successfully:

```bash
python -m py_compile futureagi/agentic_eval/core/utils/model_config.py futureagi/simulate/services/chat_constants.py futureagi/simulate/services/chat_initial_message.py
```

## Scope

- Includes generated chat initial-message model selection and shared model configuration.
- Does not change chat prompts, message fallback behavior, or provider routing.

## Linear

Fix TH-7229