### PR TITLE
feat(dashboard): add eval score distribution chart

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -8,6 +8,7 @@ import { useDashboardQuery } from "src/hooks/useDashboards";
 import { format } from "date-fns";
 import {
   escapeHtml,
+  formatDistributionCount,
   formatValueWithConfig,
   fromAxisConfigPayload,
   getAutoDecimals,
@@ -92,6 +93,7 @@ function getApexType(chartType) {
     bar: "bar",
     stacked_bar: "bar",
     pie: "pie",
+    distribution: "bar",
   };
   return map[chartType] || "line";
 }
@@ -174,6 +176,7 @@ export default function WidgetChart({
   const isPie = chartType === "pie";
   const isTable = chartType === "table";
   const isMetricCard = chartType === "metric";
+  const isDistribution = chartType === "distribution";
   const isLineChart = apexType === "line";
   const connectsAcrossMissingBuckets =
     shouldConnectAcrossMissingBuckets(apexType);
@@ -469,8 +472,11 @@ export default function WidgetChart({
       : null;
   const result = renderableSnapshot?.result;
   const { renderableMetrics, series } = useMemo(
-    () => getDashboardMetricSeriesState(result?.metrics),
-    [result?.metrics],
+    () =>
+      getDashboardMetricSeriesState(result?.metrics, {
+        distribution: isDistribution,
+      }),
+    [result?.metrics, isDistribution],
   );
   const hasRunnableQuery = Boolean(queryConfig?.metrics?.length);
   // Until a complete renderable snapshot exists, the query is unresolved—not empty. This
@@ -745,6 +751,86 @@ export default function WidgetChart({
             );
           })}
         </Stack>
+      </Box>
+    );
+  }
+
+  if (isDistribution) {
+    const categories = chartSeries[0]?.data?.map((point) => point.x) || [];
+    const distributionOptions = {
+      chart: {
+        type: "bar",
+        toolbar: { show: false },
+        animations: { enabled: false },
+      },
+      plotOptions: {
+        bar: {
+          horizontal: false,
+          columnWidth: "55%",
+          borderRadius: 3,
+        },
+      },
+      dataLabels: {
+        enabled: true,
+        formatter: formatDistributionCount,
+        style: { colors: [theme.palette.text.primary] },
+      },
+      xaxis: {
+        type: "category",
+        categories,
+        labels: {
+          show: axisConfig?.xAxis?.visible !== false,
+          rotate: -35,
+          trim: true,
+          style: { colors: theme.palette.text.secondary, fontSize: "11px" },
+        },
+        title: axisConfig?.xAxis?.label
+          ? {
+              text: axisConfig.xAxis.label,
+              style: { fontSize: "12px", color: theme.palette.text.secondary },
+            }
+          : undefined,
+      },
+      yaxis: {
+        show: axisConfig?.leftY?.visible !== false,
+        labels: {
+          style: { colors: theme.palette.text.secondary, fontSize: "11px" },
+          formatter: formatDistributionCount,
+        },
+      },
+      tooltip: {
+        y: { formatter: formatDistributionCount },
+      },
+      colors: chartSeries.map((s) => colorFor(s.name)),
+      legend: { show: false },
+      grid: { borderColor: theme.palette.divider, strokeDashArray: 3 },
+    };
+
+    return (
+      <Box
+        ref={containerRef}
+        sx={{
+          width: "100%",
+          height: "100%",
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <QueryReadStatus
+          unavailable={readUnavailable}
+          hasSnapshot={Boolean(renderableSnapshot)}
+          retryUnavailable={retryUnavailable}
+          pollingPaused={pollingPaused}
+        />
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <ReactApexChart
+            options={distributionOptions}
+            series={plottedChartSeries}
+            type="bar"
+            height={chartHeight}
+          />
+        </Box>
       </Box>
     );
   }

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -94,7 +94,10 @@ import {
 
 import {
   DEFAULT_DECIMALS,
+  buildDistributionQueryConfig,
   escapeHtml,
+  formatDistributionCount,
+  getDistributionConfigError,
   formatValueWithConfig,
   fromAxisConfigPayload,
   getAggColumnLabel,
@@ -107,6 +110,7 @@ import {
   getSuggestedUnitConfig,
   getUnitRendering,
   getYAxisRangeWarning,
+  isDistributionMetric,
   shouldConnectAcrossMissingBuckets,
   resolveSavedSelection,
   toAxisConfigPayload,
@@ -225,6 +229,12 @@ const CHART_TYPES = [
     value: "stacked_bar",
     icon: "mdi:chart-timeline-variant-shimmer",
     group: "bar",
+  },
+  {
+    label: "Distribution",
+    value: "distribution",
+    icon: "mdi:chart-histogram",
+    group: "other",
   },
   { label: "Pie", value: "pie", icon: "mdi:chart-pie", group: "other" },
   { label: "Table", value: "table", icon: "mdi:table", group: "other" },
@@ -1497,11 +1507,13 @@ function AggregationPicker({
   theme,
   extraOptions,
   allowedAggregations,
+  disabled = false,
 }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [showPercentiles, setShowPercentiles] = useState(false);
 
   const handleOpen = (e) => {
+    if (disabled) return;
     setAnchorEl(e.currentTarget);
     setShowPercentiles(false);
   };
@@ -1543,10 +1555,17 @@ function AggregationPicker({
         label={current?.label || value}
         size="small"
         variant="outlined"
-        onClick={handleOpen}
-        deleteIcon={<Iconify icon="mdi:chevron-down" width={14} />}
-        onDelete={handleOpen}
-        sx={{ mt: 1, cursor: "pointer", fontSize: "12px" }}
+        disabled={disabled}
+        onClick={disabled ? undefined : handleOpen}
+        deleteIcon={
+          disabled ? undefined : <Iconify icon="mdi:chevron-down" width={14} />
+        }
+        onDelete={disabled ? undefined : handleOpen}
+        sx={{
+          mt: 1,
+          cursor: disabled ? "default" : "pointer",
+          fontSize: "12px",
+        }}
       />
       <Popper
         open={open}
@@ -1688,6 +1707,7 @@ AggregationPicker.propTypes = {
     }),
   ),
   allowedAggregations: PropTypes.arrayOf(PropTypes.string),
+  disabled: PropTypes.bool,
 };
 
 const inferFilterValueStorageType = (value, configuredType) => {
@@ -2582,15 +2602,22 @@ export default function WidgetEditorView() {
     [cursorAttributes, pickerMode],
   );
 
-  const pickerMetricOptions = useMemo(
-    () =>
-      mergeWidgetCursorAttributeOptions(
-        catalogMetricOptions,
-        cursorAttributeOptions,
-        cursorAttributePickerActive,
-      ),
-    [catalogMetricOptions, cursorAttributeOptions, cursorAttributePickerActive],
-  );
+  const pickerMetricOptions = useMemo(() => {
+    const options = mergeWidgetCursorAttributeOptions(
+      catalogMetricOptions,
+      cursorAttributeOptions,
+      cursorAttributePickerActive,
+    );
+    return chartType === "distribution" && pickerMode === "metric"
+      ? options.filter(isDistributionMetric)
+      : options;
+  }, [
+    catalogMetricOptions,
+    chartType,
+    cursorAttributeOptions,
+    cursorAttributePickerActive,
+    pickerMode,
+  ]);
 
   const isPickerInventoryLoading = isPaginatedLoading;
 
@@ -2907,7 +2934,7 @@ export default function WidgetEditorView() {
 
   const buildQueryConfig = useCallback(() => {
     const timeRange = buildTimeRangePayload(timePreset, customDateRange);
-    return {
+    const config = {
       project_ids: [],
       time_range: timeRange,
       granularity,
@@ -2920,7 +2947,23 @@ export default function WidgetEditorView() {
         .filter((b) => b.id)
         .map((b) => buildBreakdownPayload(b)),
     };
-  }, [timePreset, customDateRange, granularity, metrics, filters, breakdowns]);
+    return chartType === "distribution"
+      ? buildDistributionQueryConfig(config)
+      : config;
+  }, [
+    timePreset,
+    customDateRange,
+    granularity,
+    metrics,
+    filters,
+    breakdowns,
+    chartType,
+  ]);
+
+  const distributionConfigError =
+    chartType === "distribution"
+      ? getDistributionConfigError(metrics, breakdowns)
+      : null;
 
   const previewQueryConfig = buildQueryConfig();
   const previewQuerySignature = JSON.stringify(previewQueryConfig);
@@ -3089,7 +3132,7 @@ export default function WidgetEditorView() {
   const previewTimerRef = useRef(null);
   useEffect(() => {
     const customWithoutRange = timePreset === "custom" && !customDateRange;
-    if (metrics.length > 0 && !customWithoutRange) {
+    if (metrics.length > 0 && !customWithoutRange && !distributionConfigError) {
       clearTimeout(previewTimerRef.current);
       previewTimerRef.current = setTimeout(() => {
         runPreviewQuery(buildQueryConfig());
@@ -3103,6 +3146,8 @@ export default function WidgetEditorView() {
     timePreset,
     customDateRange,
     granularity,
+    chartType,
+    distributionConfigError,
     metrics
       .map(
         (m) =>
@@ -3140,8 +3185,12 @@ export default function WidgetEditorView() {
     // id = backend key, name = display name, type = frontend category key
     if (pickerMode === "metric") {
       // Determine default aggregation based on output type (dataset evals)
-      let defaultAgg = "avg";
-      if (option.outputType && EVAL_DEFAULT_AGGREGATIONS[option.outputType]) {
+      let defaultAgg = chartType === "distribution" ? "count" : "avg";
+      if (
+        chartType !== "distribution" &&
+        option.outputType &&
+        EVAL_DEFAULT_AGGREGATIONS[option.outputType]
+      ) {
         defaultAgg = EVAL_DEFAULT_AGGREGATIONS[option.outputType];
       } else if (option.columnDataType === "boolean") {
         defaultAgg = "true_rate";
@@ -3189,7 +3238,7 @@ export default function WidgetEditorView() {
         updated[pickerTargetIndex] = newMetric;
         setMetrics(updated);
       } else {
-        if (metrics.length >= 5) return;
+        if (metrics.length >= (chartType === "distribution" ? 1 : 5)) return;
         setMetrics([...metrics, newMetric]);
       }
     } else if (pickerMode === "filter") {
@@ -3316,9 +3365,19 @@ export default function WidgetEditorView() {
   };
 
   const handleUpdateMetricAggregation = (index, agg) => {
+    if (chartType === "distribution") return;
     const updated = [...metrics];
     updated[index] = { ...updated[index], aggregation: agg };
     setMetrics(updated);
+  };
+
+  const handleChartTypeChange = (nextChartType) => {
+    setChartType(nextChartType);
+    if (nextChartType === "distribution") {
+      setMetrics((currentMetrics) =>
+        currentMetrics.map((metric) => ({ ...metric, aggregation: "count" })),
+      );
+    }
   };
 
   const handleRemoveMetricFilter = (metricIdx, filterIdx) => {
@@ -3355,6 +3414,10 @@ export default function WidgetEditorView() {
   const handleSave = async () => {
     if (metrics.length === 0) {
       enqueueSnackbar("Add at least one metric", { variant: "warning" });
+      return;
+    }
+    if (distributionConfigError) {
+      enqueueSnackbar(distributionConfigError, { variant: "warning" });
       return;
     }
 
@@ -3414,8 +3477,11 @@ export default function WidgetEditorView() {
   const previewResult = activeExactPreview?.result;
   const { renderableMetrics: previewRenderableMetrics, series: previewSeries } =
     useMemo(
-      () => getDashboardMetricSeriesState(previewResult?.metrics),
-      [previewResult?.metrics],
+      () =>
+        getDashboardMetricSeriesState(previewResult?.metrics, {
+          distribution: chartType === "distribution",
+        }),
+      [previewResult?.metrics, chartType],
     );
 
   // Current selection as stable keys for persistence; null = all visible.
@@ -3472,6 +3538,7 @@ export default function WidgetEditorView() {
       stacked_column: "bar",
       bar: "bar",
       stacked_bar: "bar",
+      distribution: "bar",
       pie: "pie",
       table: "line",
       metric: "line",
@@ -3483,6 +3550,8 @@ export default function WidgetEditorView() {
   const isPie = chartType === "pie";
   const isTable = chartType === "table";
   const isMetricCard = chartType === "metric";
+  const isDistribution = chartType === "distribution";
+  const maxMetrics = isDistribution ? 1 : 5;
   const isLineChart = apexType === "line";
   const connectsAcrossMissingBuckets =
     shouldConnectAcrossMissingBuckets(apexType);
@@ -3636,7 +3705,13 @@ export default function WidgetEditorView() {
       (cfg, fallbackDecimals = autoDecimals, includeUnit = true) =>
       (val) =>
         formatValueWithConfig(val, cfg, { fallbackDecimals, includeUnit });
-    const formatVal = makeFormatter(leftAxisFormatConfig);
+    const formatVal = isDistribution
+      ? formatDistributionCount
+      : makeFormatter(leftAxisFormatConfig);
+    const xAxisLabel =
+      axisConfig.xAxis.label || (isDistribution ? "Score range" : "");
+    const yAxisLabel =
+      axisConfig.leftY.label || (isDistribution ? "Count" : "");
     return {
       chart: {
         type: apexType,
@@ -3753,19 +3828,24 @@ export default function WidgetEditorView() {
           },
         },
       },
-      dataLabels: isHorizontal
-        ? {
-            enabled: true,
-            style: { fontSize: "13px", fontWeight: 500 },
-            formatter: formatVal,
-            offsetX: 6,
-          }
-        : { enabled: false },
+      dataLabels:
+        isHorizontal || isDistribution
+          ? {
+              enabled: true,
+              style: { fontSize: "13px", fontWeight: 500 },
+              formatter: formatVal,
+              offsetX: isHorizontal ? 6 : 0,
+            }
+          : { enabled: false },
       plotOptions: {
         bar: {
           horizontal: isHorizontal,
           barHeight: isHorizontal ? "50%" : undefined,
-          columnWidth: !isHorizontal ? "60%" : undefined,
+          columnWidth: !isHorizontal
+            ? isDistribution
+              ? "55%"
+              : "60%"
+            : undefined,
           borderRadius: 4,
           distributed: isHorizontal,
         },
@@ -3780,24 +3860,26 @@ export default function WidgetEditorView() {
             axisTicks: { show: false },
           }
         : {
-            type: "datetime",
+            type: isDistribution ? "category" : "datetime",
             tickAmount: Math.min(chartSeries[0]?.data?.length || 10, 12),
             labels: {
               show: axisConfig.xAxis.visible,
               style: { colors: theme.palette.text.secondary, fontSize: "11px" },
-              datetimeUTC: false,
-              datetimeFormatter: {
-                year: "MMMM",
-                month: "MMMM",
-                day: "MMM dd",
-                hour: "HH:mm",
-              },
+              ...(!isDistribution && {
+                datetimeUTC: false,
+                datetimeFormatter: {
+                  year: "MMMM",
+                  month: "MMMM",
+                  day: "MMM dd",
+                  hour: "HH:mm",
+                },
+              }),
             },
             axisBorder: { show: false },
             axisTicks: { show: false },
-            ...(axisConfig.xAxis.label && {
+            ...(xAxisLabel && {
               title: {
-                text: axisConfig.xAxis.label,
+                text: xAxisLabel,
                 style: {
                   fontSize: "12px",
                   color: theme.palette.text.secondary,
@@ -3831,9 +3913,9 @@ export default function WidgetEditorView() {
             ...(axisConfig.leftY.max !== "" && {
               max: Number(axisConfig.leftY.max),
             }),
-            ...(axisConfig.leftY.label && {
+            ...(yAxisLabel && {
               title: {
-                text: axisConfig.leftY.label,
+                text: yAxisLabel,
                 style: {
                   fontSize: "12px",
                   color: theme.palette.text.secondary,
@@ -3928,51 +4010,64 @@ export default function WidgetEditorView() {
       },
       colors: chartColors,
       legend: { show: false, height: 0 },
-      tooltip: isStacked
+      tooltip: isDistribution
         ? {
             enabled: true,
-            shared: true,
-            intersect: false,
+            shared: false,
+            intersect: true,
             theme: theme.palette.mode,
             style: { fontSize: "12px" },
-            x: {
-              format: "MMM dd, yyyy",
-            },
+            x: { formatter: (value) => `Score range: ${value}` },
             y: {
-              formatter: formatVal,
+              formatter: (value) =>
+                `${formatDistributionCount(value)} evaluations`,
             },
           }
-        : {
-            enabled: true,
-            shared: false,
-            intersect: isLineChart,
-            custom: ({ series, seriesIndex, dataPointIndex, w }) => {
-              const sName = w.globals.seriesNames[seriesIndex] || "";
-              const color = w.globals.colors[seriesIndex] || "#6366F1";
-              const val = series[seriesIndex]?.[dataPointIndex];
-              const prevVal =
-                dataPointIndex > 0
-                  ? series[seriesIndex]?.[dataPointIndex - 1]
-                  : null;
-              const ts = w.globals.seriesX[seriesIndex]?.[dataPointIndex];
-              const dateStr = ts ? format(new Date(ts), "MMM dd, yyyy") : "";
-              const fmtVal = formatVal(val);
-              const bg = isDark ? "#1e1e2e" : "#fff";
-              const _border = isDark
-                ? "rgba(255,255,255,0.08)"
-                : "rgba(0,0,0,0.06)";
-              const textPrimary = isDark ? "#fff" : "#1a1a2e";
-              const textSecondary = isDark
-                ? "rgba(255,255,255,0.5)"
-                : "rgba(0,0,0,0.45)";
-              let changeHtml = "";
-              if (prevVal != null && prevVal !== 0 && val != null) {
-                const pct = ((val - prevVal) / Math.abs(prevVal)) * 100;
-                const sign = pct >= 0 ? "+" : "";
-                const changeColor = pct >= 0 ? "#22C55E" : "#FF4842";
-                changeHtml = `<div style="display:flex;align-items:center;gap:6px;margin-top:6px"><span style="color:${changeColor};font-weight:600;font-size:14px">${sign}${pct.toFixed(2)}%</span><span style="color:${textSecondary};font-size:13px">from previous</span></div>`;
-              }
-              return `<div style="display:flex;background:${bg};border:none;border-radius:12px;box-shadow:0 8px 24px ${isDark ? "rgba(0,0,0,0.5)" : "rgba(0,0,0,0.08)"};overflow:hidden;min-width:200px">
+        : isStacked
+          ? {
+              enabled: true,
+              shared: true,
+              intersect: false,
+              theme: theme.palette.mode,
+              style: { fontSize: "12px" },
+              x: {
+                format: "MMM dd, yyyy",
+              },
+              y: {
+                formatter: formatVal,
+              },
+            }
+          : {
+              enabled: true,
+              shared: false,
+              intersect: isLineChart,
+              custom: ({ series, seriesIndex, dataPointIndex, w }) => {
+                const sName = w.globals.seriesNames[seriesIndex] || "";
+                const color = w.globals.colors[seriesIndex] || "#6366F1";
+                const val = series[seriesIndex]?.[dataPointIndex];
+                const prevVal =
+                  dataPointIndex > 0
+                    ? series[seriesIndex]?.[dataPointIndex - 1]
+                    : null;
+                const ts = w.globals.seriesX[seriesIndex]?.[dataPointIndex];
+                const dateStr = ts ? format(new Date(ts), "MMM dd, yyyy") : "";
+                const fmtVal = formatVal(val);
+                const bg = isDark ? "#1e1e2e" : "#fff";
+                const _border = isDark
+                  ? "rgba(255,255,255,0.08)"
+                  : "rgba(0,0,0,0.06)";
+                const textPrimary = isDark ? "#fff" : "#1a1a2e";
+                const textSecondary = isDark
+                  ? "rgba(255,255,255,0.5)"
+                  : "rgba(0,0,0,0.45)";
+                let changeHtml = "";
+                if (prevVal != null && prevVal !== 0 && val != null) {
+                  const pct = ((val - prevVal) / Math.abs(prevVal)) * 100;
+                  const sign = pct >= 0 ? "+" : "";
+                  const changeColor = pct >= 0 ? "#22C55E" : "#FF4842";
+                  changeHtml = `<div style="display:flex;align-items:center;gap:6px;margin-top:6px"><span style="color:${changeColor};font-weight:600;font-size:14px">${sign}${pct.toFixed(2)}%</span><span style="color:${textSecondary};font-size:13px">from previous</span></div>`;
+                }
+                return `<div style="display:flex;background:${bg};border:none;border-radius:12px;box-shadow:0 8px 24px ${isDark ? "rgba(0,0,0,0.5)" : "rgba(0,0,0,0.08)"};overflow:hidden;min-width:200px">
                 <div style="width:4px;flex-shrink:0;background:${color}"></div>
                 <div style="padding:14px 16px;flex:1">
                   <div style="font-weight:700;font-size:14px;color:${textPrimary};line-height:1.3">${escapeHtml(sName)}</div>
@@ -3983,14 +4078,15 @@ export default function WidgetEditorView() {
                   ${changeHtml}
                 </div>
               </div>`;
+              },
             },
-          },
     };
   }, [
     apexType,
     isLineChart,
     isStacked,
     isHorizontal,
+    isDistribution,
     chartSeries,
     chartColors,
     theme,
@@ -4032,7 +4128,9 @@ export default function WidgetEditorView() {
   // A preview query only fires when there's at least one metric AND (if a custom
   // range is chosen) a range is actually set — mirrors the auto-preview effect.
   const canPreview =
-    metrics.length > 0 && !(timePreset === "custom" && !customDateRange);
+    metrics.length > 0 &&
+    !distributionConfigError &&
+    !(timePreset === "custom" && !customDateRange);
 
   const serverPreviewState = getWidgetPreviewState(
     queryMutation.data?.data?.result,
@@ -4691,7 +4789,7 @@ export default function WidgetEditorView() {
             <FormControl size="small" sx={{ minWidth: 120 }}>
               <Select
                 value={chartType}
-                onChange={(e) => setChartType(e.target.value)}
+                onChange={(e) => handleChartTypeChange(e.target.value)}
                 sx={{ fontSize: "13px", "& .MuiSelect-select": { py: 0.7 } }}
                 renderValue={(val) => {
                   const ct = CHART_TYPES.find((t) => t.value === val);
@@ -5350,7 +5448,9 @@ export default function WidgetEditorView() {
                                           whiteSpace: "nowrap",
                                         }}
                                       >
-                                        {format(new Date(pt.x), dateFmt)}
+                                        {isDistribution
+                                          ? pt.x
+                                          : format(new Date(pt.x), dateFmt)}
                                       </td>
                                       {chartSeries.map((s, si) => {
                                         const val = s.data[ri]?.y;
@@ -6160,17 +6260,19 @@ export default function WidgetEditorView() {
                       justifyContent="space-between"
                       alignItems="center"
                       onClick={(e) => {
-                        if (metrics.length < 5) openPicker(e, "metric");
+                        if (metrics.length < maxMetrics)
+                          openPicker(e, "metric");
                       }}
                       sx={{
-                        cursor: metrics.length >= 5 ? "default" : "pointer",
+                        cursor:
+                          metrics.length >= maxMetrics ? "default" : "pointer",
                         borderRadius: 1,
                         px: 1,
                         py: 0.5,
                         mx: -1,
                         transition: "background-color 0.15s",
                         "&:hover":
-                          metrics.length < 5
+                          metrics.length < maxMetrics
                             ? {
                                 bgcolor: (t) =>
                                   t.palette.mode === "dark"
@@ -6199,7 +6301,7 @@ export default function WidgetEditorView() {
                         width={18}
                         sx={{
                           color:
-                            metrics.length >= 5
+                            metrics.length >= maxMetrics
                               ? "text.disabled"
                               : "text.secondary",
                         }}
@@ -6318,6 +6420,7 @@ export default function WidgetEditorView() {
                         onChange={(val) =>
                           handleUpdateMetricAggregation(i, val)
                         }
+                        disabled={isDistribution}
                         theme={theme}
                         allowedAggregations={m.allowedAggregations}
                         extraOptions={
@@ -7637,15 +7740,15 @@ export default function WidgetEditorView() {
                     </InputAdornment>
                   ) : !cursorAttributePickerActive &&
                     Number.isSafeInteger(paginatedTotal) ? (
-                      <InputAdornment position="end">
-                        <Typography
-                          variant="caption"
-                          sx={{ color: "text.disabled", fontSize: 11 }}
-                        >
-                          {paginatedTotal} results
-                        </Typography>
-                      </InputAdornment>
-                    ) : null,
+                    <InputAdornment position="end">
+                      <Typography
+                        variant="caption"
+                        sx={{ color: "text.disabled", fontSize: 11 }}
+                      >
+                        {paginatedTotal} results
+                      </Typography>
+                    </InputAdornment>
+                  ) : null,
                 }}
               />
             </Box>

--- a/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/WidgetChart.test.jsx
@@ -190,6 +190,38 @@ describe("WidgetChart — empty time-range state", () => {
     expect(screen.getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
     expect(screen.queryByTestId("apex-pie")).not.toBeInTheDocument();
   });
+
+  it("renders distribution buckets as a categorical bar chart", () => {
+    const response = queryResult([
+      { bucket_start: 0, bucket_end: 0.5, value: 3 },
+      { bucket_start: 0.5, bucket_end: 1, value: 7 },
+    ]);
+    response.data.result.metrics[0].name = "Accuracy";
+    response.data.result.metrics[0].aggregation = "count";
+    h.query.data = response;
+
+    render(
+      <WidgetChart
+        widget={{
+          ...baseWidget,
+          query_config: {
+            metrics: [{ name: "Accuracy", aggregation: "count" }],
+            query_mode: "distribution",
+          },
+          chart_config: { chart_type: "distribution" },
+        }}
+        globalDateRange={null}
+      />,
+    );
+
+    expect(screen.getByTestId("apex-bar")).toBeInTheDocument();
+    const props = h.apex.mock.calls.at(-1)[0];
+    expect(props.options.xaxis.type).toBe("category");
+    expect(props.series[0].data).toEqual([
+      { x: "0 - 0.5", y: 3, bucketStart: 0, bucketEnd: 0.5 },
+      { x: "0.5 - 1", y: 7, bucketStart: 0.5, bucketEnd: 1 },
+    ]);
+  });
 });
 
 describe("WidgetChart — queued exact refresh", () => {

--- a/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
+++ b/frontend/src/sections/dashboards/__tests__/widgetUtils.test.js
@@ -1,12 +1,17 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildDistributionQueryConfig,
+  formatDistributionBucketLabel,
+  formatDistributionCount,
   fromAxisConfigPayload,
   getAggColumnLabel,
   getExactDashboardResult,
   getDashboardMetricSeriesState,
+  getDistributionConfigError,
   getPlottedChartSeries,
   getSeriesScalar,
   groupPieSeries,
+  isDistributionMetric,
   isAdditiveAggregation,
   getYAxisRangeWarning,
   makeSeriesKey,
@@ -47,6 +52,75 @@ describe("axis config contract", () => {
 
   it("restores legacy camelCase axis configs during rollout", () => {
     expect(fromAxisConfigPayload(uiConfig)).toEqual(uiConfig);
+  });
+});
+
+describe("distribution chart helpers", () => {
+  const numericEval = {
+    type: "eval_metric",
+    source: "traces",
+    outputType: "SCORE",
+  };
+
+  it("accepts only numeric trace eval metrics", () => {
+    expect(isDistributionMetric(numericEval)).toBe(true);
+    expect(
+      isDistributionMetric({ ...numericEval, outputType: "NUMERIC" }),
+    ).toBe(true);
+    expect(
+      isDistributionMetric({ ...numericEval, outputType: "PASS_FAIL" }),
+    ).toBe(false);
+    expect(isDistributionMetric({ type: "system", source: "traces" })).toBe(
+      false,
+    );
+  });
+
+  it("validates the single-metric and no-breakdown contract", () => {
+    expect(getDistributionConfigError([numericEval], [])).toBeNull();
+    expect(getDistributionConfigError([], [])).toMatch(/exactly one/i);
+    expect(
+      getDistributionConfigError([numericEval], [{ id: "model" }]),
+    ).toMatch(/breakdowns/i);
+  });
+
+  it("builds the distribution query and formats bucket values", () => {
+    expect(
+      buildDistributionQueryConfig({
+        metrics: [{ name: "quality", aggregation: "avg" }],
+      }),
+    ).toEqual({
+      query_mode: "distribution",
+      metrics: [{ name: "quality", aggregation: "count" }],
+    });
+    expect(
+      formatDistributionBucketLabel({ bucket_start: 0, bucket_end: 0.5 }),
+    ).toBe("0 - 0.5");
+    expect(formatDistributionCount(1200)).toBe("1,200");
+  });
+
+  it("maps distribution buckets to categorical chart points", () => {
+    const state = getDashboardMetricSeriesState(
+      [
+        {
+          name: "Quality",
+          aggregation: "count",
+          query_complete: true,
+          query_status: "complete",
+          query_sampled: false,
+          series: [
+            {
+              name: "total",
+              data: [{ bucket_start: 0, bucket_end: 0.5, value: 3 }],
+            },
+          ],
+        },
+      ],
+      { distribution: true },
+    );
+
+    expect(state.series[0].data).toEqual([
+      { x: "0 - 0.5", y: 3, bucketStart: 0, bucketEnd: 0.5 },
+    ]);
   });
 });
 

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -2,7 +2,82 @@ import { getExactAggregationReadState } from "src/utils/queryReadState";
 
 export const DEFAULT_DECIMALS = 2;
 
-export const getDashboardMetricSeriesState = (metrics = []) => {
+export const isDistributionChart = (chartType) => chartType === "distribution";
+
+const DISTRIBUTION_OUTPUT_TYPES = new Set(["SCORE", "NUMERIC"]);
+
+const normalizeDistributionOutputType = (outputType) =>
+  String(outputType || "SCORE")
+    .replaceAll("/", "_")
+    .replaceAll(" ", "_")
+    .toUpperCase();
+
+export const isDistributionMetric = (metric) => {
+  const outputType = normalizeDistributionOutputType(
+    metric?.output_type || metric?.outputType,
+  );
+  const source = metric?.source || "traces";
+  const type = metric?.type || metric?.category;
+  return (
+    ["eval_metric", "evalMetric"].includes(type) &&
+    ["traces", "both", "all"].includes(source) &&
+    DISTRIBUTION_OUTPUT_TYPES.has(outputType)
+  );
+};
+
+export const getDistributionConfigError = (metrics = [], breakdowns = []) => {
+  if (metrics.length !== 1) {
+    return "Distribution charts require exactly one numeric eval metric.";
+  }
+  if (!isDistributionMetric(metrics[0])) {
+    return "Distribution charts require a numeric trace eval metric.";
+  }
+  if (breakdowns.some((breakdown) => breakdown?.id || breakdown?.name)) {
+    return "Distribution charts do not support breakdowns.";
+  }
+  return null;
+};
+
+export const buildDistributionQueryConfig = (queryConfig) => ({
+  ...queryConfig,
+  query_mode: "distribution",
+  metrics: (queryConfig.metrics || []).map((metric) => ({
+    ...metric,
+    aggregation: "count",
+  })),
+});
+
+const formatBucketBoundary = (value) => {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return "";
+  }
+  const number = Number(value);
+  return Number.isFinite(number)
+    ? number.toLocaleString(undefined, { maximumFractionDigits: 6 })
+    : "";
+};
+
+export const formatDistributionBucketLabel = (point) => {
+  const start = formatBucketBoundary(point?.bucket_start);
+  const end = formatBucketBoundary(point?.bucket_end);
+  return start && end ? `${start} - ${end}` : "Unknown range";
+};
+
+export const formatDistributionCount = (value) => {
+  const count = Number(value);
+  return Number.isFinite(count)
+    ? count.toLocaleString(undefined, { maximumFractionDigits: 0 })
+    : "-";
+};
+
+export const getDashboardMetricSeriesState = (
+  metrics = [],
+  { distribution = false } = {},
+) => {
   const metricReadStates = (Array.isArray(metrics) ? metrics : []).map(
     (metric) => ({
       metric,
@@ -45,8 +120,14 @@ export const getDashboardMetricSeriesState = (metrics = []) => {
         unit: metric.unit ?? "",
         breakdownName: metricSeries.name,
         data: (metricSeries.data || []).map((point) => ({
-          x: new Date(point.timestamp).getTime(),
+          x: distribution
+            ? formatDistributionBucketLabel(point)
+            : new Date(point.timestamp).getTime(),
           y: point.value != null ? Number(point.value) : null,
+          ...(distribution && {
+            bucketStart: point.bucket_start,
+            bucketEnd: point.bucket_end,
+          }),
         })),
       });
     }


### PR DESCRIPTION
## Summary

Adds a Distribution chart type for numeric trace eval scores. The editor now builds distribution queries, renders explicit score buckets as categorical bars with integer counts, and preserves distribution semantics in tables and CSV/JSON exports.

## Linked issue

Closes #1575.

This PR implements the frontend chart-selection, rendering, and export portion of the issue. It depends on #1838 for the backend distribution-query and persistence contract.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---

## 1) What changes were done

**A. Distribution chart configuration**

- Adds a Distribution option to the dashboard chart picker.
- Restricts the chart to exactly one numeric trace eval metric and no breakdowns.
- Sends `query_mode: "distribution"` with `count` aggregation.

**B. Distribution rendering and exports**

- Renders backend bucket bounds as categorical score ranges.
- Formats bar labels, axes, tooltips, tables, and exports as integer evaluation counts.
- Uses total count instead of averaging bucket values in summaries.

**C. Shared validation helpers**

- Centralizes distribution metric validation, query shaping, bucket labels, and count formatting in `widgetUtils.js`.

---

## 2) Why the changes were done

- **Product/UX:** Users can inspect the shape of eval score results instead of only viewing time-series aggregates.
- **Technical:** Explicit bucket bounds from the API are preserved, avoiding client-side rebucketing and boundary drift.
- **Architecture:** Query validation and formatting are shared between the editor and saved-widget renderer.

---

## 3) Tests written + scenarios each covers

**`WidgetChart.test.jsx`**

- Renders distribution buckets as categorical bars.
- Uses count-oriented axis and tooltip formatting.

**`widgetUtils.test.js`**

- Accepts only numeric trace eval metrics.
- Rejects multiple metrics and breakdowns.
- Builds the distribution query contract.
- Formats bucket bounds, whole-number counts, and total counts.

> Run result: **74 passed** across all dashboard suites. Targeted ESLint completed with **0 errors**. Production Vite build completed successfully.

---

## 4) How to run / test

```bash
cd frontend
yarn vitest run src/sections/dashboards/__tests__
yarn eslint src/sections/dashboards/WidgetChart.jsx src/sections/dashboards/WidgetEditorView.jsx src/sections/dashboards/widgetUtils.js src/sections/dashboards/__tests__/WidgetChart.test.jsx src/sections/dashboards/__tests__/widgetUtils.test.js
node node_modules/vite/bin/vite.js build
```

`yarn contracts:check` reports `filter-contract.generated.js is out of date` on Windows because of line-ending normalization; regenerating it produces no staged content change. This PR does not change the API contract surface.

---

## 5) Edge cases & considerations

- Non-numeric and non-trace eval metrics are excluded from Distribution selection.
- Existing incompatible metrics or breakdowns show a validation warning and cannot be saved or queried.
- Empty and invalid bucket values retain the existing no-data behavior.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that cover the feature
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA
- [x] PR title follows Conventional Commits
