### PR TITLE
perf(annotations): batch bulk-review's per-item validation and writes

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -6605,18 +6605,9 @@ class TestLoadBalancedAssignment:
 
 @pytest.mark.django_db
 class TestBulkReviewQueryCount:
-    """TH-7211: bulk-review's validation and persistence must not query per item.
-
-    It cost ~12 queries per item: the queue's label set refetched per row
-    despite being identical for every item, two score ``.exists()`` calls, a
-    blocking-thread ``.exists()``, and a save() each. At batch 500 that was
-    5,512 queries. ``bulk-remove`` is flat, which is the pattern this follows.
-
-    Asserting the batched lookups are exactly one query each, rather than a
-    total: the remaining per-item cost is thread/comment creation and
-    notification, which is deliberately still per item, so a total would drift
-    for unrelated reasons and stop meaning anything.
-    """
+    """TH-7211: bulk-review must not query per item — it was ~12/item, 5,512 at
+    batch 500. Asserting per-table counts rather than a total, so the test says
+    which lookup regressed instead of just that some number moved."""
 
     BATCHED_ONCE = {
         "model_hub_annotationqueuelabel": "the queue's label set (identical for every item)",
@@ -6701,3 +6692,71 @@ class TestBulkReviewQueryCount:
         assert counts.get(("UPDATE", "model_hub_queueitemreviewthread"), 0) <= 1, (
             "prior review threads are being resolved per item"
         )
+        # Threads and comments are two bulk_creates, not two INSERTs per item.
+        for table in (
+            "model_hub_queueitemreviewthread",
+            "model_hub_queueitemreviewcomment",
+        ):
+            n = counts.get(("INSERT", table), 0)
+            assert n == 1, f"{table} is being INSERTed per item ({n} for 10 items)"
+        # The two lookups whose answer is structurally known on this path:
+        # bulk review passes no mentions, and the thread was just created.
+        assert counts.get(("SELECT", "model_hub_queueitemreviewcomment"), 0) == 0, (
+            "the thread-participant scan is back — it can only ever return the "
+            "reviewer, who is then discarded as the actor"
+        )
+
+    def test_bulk_review_persists_tenancy_without_the_save_signal(
+        self, auth_client, queue_with_items, second_user, organization
+    ):
+        """bulk_create skips the post_save workspace/organization backfill, so
+        they are passed explicitly. A regression writes NULL tenancy, which is
+        invisible until something filters by workspace."""
+        queue_id, item_ids, label = queue_with_items
+        selected = item_ids[:2]
+        QueueItem.objects.filter(pk__in=selected).update(
+            status=QueueItemStatus.IN_PROGRESS.value, review_status="pending_review"
+        )
+        for item in QueueItem.objects.filter(pk__in=selected):
+            _create_score_for_item(item, label, second_user, organization)
+
+        resp = auth_client.post(
+            bulk_review_url(queue_id),
+            {"item_ids": [str(i) for i in selected], "action": "approve"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+
+        threads = QueueItemReviewThread.objects.filter(queue_item_id__in=selected)
+        comments = QueueItemReviewComment.objects.filter(queue_item_id__in=selected)
+        assert threads.count() == 2
+        assert comments.count() == 2
+        for row in list(threads) + list(comments):
+            assert row.organization_id is not None, f"{row!r} has NULL organization"
+            assert row.workspace_id is not None, f"{row!r} has NULL workspace"
+            assert row.created_at is not None
+
+    def test_bulk_review_sends_no_email(
+        self, auth_client, queue_with_items, second_user, organization, mocker
+    ):
+        """Bulk review has never emailed (recipients are always empty here). The
+        bulk path now broadcasts directly rather than computing that empty set
+        per item, so this pins the outcome, not the mechanism."""
+        send = mocker.patch(
+            "model_hub.views.annotation_queues._send_annotation_discussion_email"
+        )
+        queue_id, item_ids, label = queue_with_items
+        selected = item_ids[:2]
+        QueueItem.objects.filter(pk__in=selected).update(
+            status=QueueItemStatus.IN_PROGRESS.value, review_status="pending_review"
+        )
+        for item in QueueItem.objects.filter(pk__in=selected):
+            _create_score_for_item(item, label, second_user, organization)
+
+        resp = auth_client.post(
+            bulk_review_url(queue_id),
+            {"item_ids": [str(i) for i in selected], "action": "approve"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        send.assert_not_called()

--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -6601,3 +6601,103 @@ class TestLoadBalancedAssignment:
 
         item = QueueItem.objects.filter(queue_id=queue_id, deleted=False).first()
         assert item.assigned_to_id is None
+
+
+@pytest.mark.django_db
+class TestBulkReviewQueryCount:
+    """TH-7211: bulk-review's validation and persistence must not query per item.
+
+    It cost ~12 queries per item: the queue's label set refetched per row
+    despite being identical for every item, two score ``.exists()`` calls, a
+    blocking-thread ``.exists()``, and a save() each. At batch 500 that was
+    5,512 queries. ``bulk-remove`` is flat, which is the pattern this follows.
+
+    Asserting the batched lookups are exactly one query each, rather than a
+    total: the remaining per-item cost is thread/comment creation and
+    notification, which is deliberately still per item, so a total would drift
+    for unrelated reasons and stop meaning anything.
+    """
+
+    BATCHED_ONCE = {
+        "model_hub_annotationqueuelabel": "the queue's label set (identical for every item)",
+        "model_hub_score": "the submitted-annotation and own-annotation checks",
+    }
+
+    def _queries_by_table(self, ctx):
+        import re
+
+        counts = {}
+        for q in ctx.captured_queries:
+            sql = re.sub(r"\s+", " ", q["sql"]).strip()
+            m = re.search(r'FROM "([a-z_]+)"|INTO "([a-z_]+)"|UPDATE "([a-z_]+)"', sql)
+            table = next((g for g in (m.groups() if m else []) if g), "?")
+            verb = sql.split()[0]
+            counts[(verb, table)] = counts.get((verb, table), 0) + 1
+        return counts
+
+    def test_validation_and_persistence_are_batched(
+        self,
+        auth_client,
+        queue_with_items,
+        dataset_rows,
+        second_user,
+        organization,
+        workspace,
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        queue_id, _, label = queue_with_items
+        ds, _ = dataset_rows
+
+        rows = [Row.objects.create(dataset=ds, order=500 + i) for i in range(10)]
+        auth_client.post(
+            add_items_url(queue_id),
+            {
+                "items": [
+                    {"source_type": "dataset_row", "source_id": str(r.id)} for r in rows
+                ]
+            },
+            format="json",
+        )
+        ids = list(
+            QueueItem.objects.filter(
+                queue_id=queue_id, dataset_row__in=rows, deleted=False
+            ).values_list("id", flat=True)
+        )
+        assert len(ids) == 10
+        QueueItem.objects.filter(pk__in=ids).update(
+            status=QueueItemStatus.IN_PROGRESS.value, review_status="pending_review"
+        )
+        for item in QueueItem.objects.filter(pk__in=ids):
+            _create_score_for_item(item, label, second_user, organization)
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = auth_client.post(
+                bulk_review_url(queue_id),
+                {
+                    "item_ids": [str(i) for i in ids],
+                    "action": "approve",
+                    "notes": "Bulk approved.",
+                },
+                format="json",
+            )
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert _result(resp)["reviewed"] == 10, _result(resp)
+
+        counts = self._queries_by_table(ctx)
+        for table, what in self.BATCHED_ONCE.items():
+            n = counts.get(("SELECT", table), 0)
+            assert n == 1, (
+                f"bulk-review ran {n} SELECTs on {table} for 10 items — {what} "
+                "is being looked up per row again (TH-7211)."
+            )
+        # The item write is one bulk_update, not a save() each.
+        assert counts.get(("UPDATE", "model_hub_queueitem"), 0) == 1, (
+            "items are being saved one at a time instead of bulk_update"
+        )
+        # Prior threads resolve in one statement for the whole approved set.
+        assert counts.get(("UPDATE", "model_hub_queueitemreviewthread"), 0) <= 1, (
+            "prior review threads are being resolved per item"
+        )

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -6937,10 +6937,9 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         workspace = getattr(request, "workspace", None)
         is_approve = review_action == QueueItemReviewComment.ACTION_APPROVE
 
-        # Validation used to cost 4 queries per item — the queue's label set
-        # refetched per row despite being identical for every item, two score
-        # ``.exists()`` calls, and a blocking-thread ``.exists()``. Batched here
-        # they are three queries for the whole request (TH-7211).
+        # Validation was 4 queries per item (label set refetched per row despite
+        # being one queue, two score .exists(), a blocking-thread .exists()).
+        # Three queries for the whole request now (TH-7211).
         item_pks = [item.id for item in items]
         label_ids = (
             list(
@@ -7031,7 +7030,11 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 updated_at=now,
             )
 
-        pending_notifications = []
+        # Two bulk_creates instead of two INSERTs per item; client-generated
+        # UUID pks let a comment reference its thread before either is written.
+        # workspace/organization passed explicitly because bulk_create skips the
+        # post_save backfill in tfc/utils/signals.py — same values either way.
+        new_threads, new_comments = [], []
         for item in eligible:
             if is_approve:
                 item.status = QueueItemStatus.COMPLETED.value
@@ -7044,15 +7047,27 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 comment_text = notes
                 thread_status = QueueItemReviewThread.STATUS_OPEN
 
-            created_comment = _create_review_thread_comment(
-                item=item,
-                reviewer=request.user,
+            thread = QueueItemReviewThread(
+                queue_item=item,
+                created_by=request.user,
                 action=review_action,
-                comment=comment_text,
-                organization=request.organization,
-                workspace=workspace,
+                scope=_review_thread_scope(None, None),
                 blocking=review_action == QueueItemReviewComment.ACTION_REQUEST_CHANGES,
                 status=thread_status,
+                organization=request.organization,
+                workspace=workspace,
+            )
+            new_threads.append(thread)
+            new_comments.append(
+                QueueItemReviewComment(
+                    thread=thread,
+                    queue_item=item,
+                    reviewer=request.user,
+                    action=review_action,
+                    comment=comment_text,
+                    organization=request.organization,
+                    workspace=workspace,
+                )
             )
             item.reviewed_by = request.user
             item.reviewed_at = now
@@ -7061,8 +7076,11 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             # bulk_update does not honour auto_now, so updated_at is set here to
             # match what save() would have written.
             item.updated_at = now
-            pending_notifications.append((item, created_comment))
             reviewed.append(str(item.id))
+
+        if new_threads:
+            QueueItemReviewThread.objects.bulk_create(new_threads, batch_size=500)
+            QueueItemReviewComment.objects.bulk_create(new_comments, batch_size=500)
 
         if eligible:
             QueueItem.objects.bulk_update(
@@ -7080,9 +7098,14 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 ],
             )
 
-        # Notify only after the rows are persisted, as the per-item save did.
-        for item, created_comment in pending_notifications:
-            _notify_annotation_discussion(item, created_comment, created_comment.thread)
+        # Broadcast only, deliberately. _notify_annotation_discussion's email
+        # step is unreachable here — no mentions, and the just-created thread's
+        # only participant is the actor — so it spent two queries per item
+        # proving recipients were empty. If that path is ever made to fire for
+        # approve/request-changes, wiring it in should be a deliberate call
+        # about one mail per item, not inherited silently.
+        for item, comment in zip(eligible, new_comments, strict=True):
+            _broadcast_annotation_discussion_update(item, comment, comment.thread)
 
         if reviewed:
             self._maybe_auto_complete_queue(queue_id)

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -6935,9 +6935,47 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         reviewed = []
         now = timezone.now()
         workspace = getattr(request, "workspace", None)
+        is_approve = review_action == QueueItemReviewComment.ACTION_APPROVE
 
+        # Validation used to cost 4 queries per item — the queue's label set
+        # refetched per row despite being identical for every item, two score
+        # ``.exists()`` calls, and a blocking-thread ``.exists()``. Batched here
+        # they are three queries for the whole request (TH-7211).
+        item_pks = [item.id for item in items]
+        label_ids = (
+            list(
+                items[0]
+                .queue.queue_labels.filter(deleted=False)
+                .values_list("label_id", flat=True)
+            )
+            if items
+            else []
+        )
+        # {queue_item_id: {annotator_id}} — same per-queue scoping as
+        # _scores_for_queue_item, which this replaces for the bulk path.
+        annotators_by_item: dict = {}
+        if label_ids and item_pks:
+            for qi_id, annotator_id in Score.objects.filter(
+                queue_item_id__in=item_pks,
+                label_id__in=label_ids,
+                deleted=False,
+            ).values_list("queue_item_id", "annotator_id"):
+                annotators_by_item.setdefault(qi_id, set()).add(annotator_id)
+        blocked_pks = (
+            set(
+                QueueItemReviewThread.objects.filter(
+                    queue_item_id__in=item_pks,
+                    blocking=True,
+                    status__in=OPEN_REVIEW_THREAD_STATUSES,
+                    deleted=False,
+                ).values_list("queue_item_id", flat=True)
+            )
+            if item_pks
+            else set()
+        )
+
+        eligible = []
         for item in items:
-            item_scores = _scores_for_queue_item(item)
             if item.review_status != "pending_review":
                 errors.append(
                     {
@@ -6946,7 +6984,8 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     }
                 )
                 continue
-            if not item_scores.exists():
+            item_annotators = annotators_by_item.get(item.id, set())
+            if not item_annotators:
                 errors.append(
                     {
                         "item_id": str(item.id),
@@ -6954,7 +6993,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     }
                 )
                 continue
-            if item_scores.filter(annotator=request.user).exists():
+            if request.user.pk in item_annotators:
                 errors.append(
                     {
                         "item_id": str(item.id),
@@ -6962,10 +7001,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     }
                 )
                 continue
-            if (
-                review_action == QueueItemReviewComment.ACTION_APPROVE
-                and _open_blocking_review_threads(item).exists()
-            ):
+            if is_approve and item.id in blocked_pks:
                 errors.append(
                     {
                         "item_id": str(item.id),
@@ -6973,26 +7009,35 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     }
                 )
                 continue
+            eligible.append(item)
 
-            if review_action == QueueItemReviewComment.ACTION_APPROVE:
+        # Resolve prior threads for every approved item in one statement, before
+        # any new thread exists — the replacement threads are created RESOLVED
+        # and would not match this filter anyway, but doing it first keeps that
+        # independent of the new thread's status.
+        if is_approve and eligible:
+            QueueItemReviewThread.objects.filter(
+                queue_item_id__in=[item.id for item in eligible],
+                status__in=[
+                    QueueItemReviewThread.STATUS_OPEN,
+                    QueueItemReviewThread.STATUS_REOPENED,
+                    QueueItemReviewThread.STATUS_ADDRESSED,
+                ],
+                deleted=False,
+            ).update(
+                status=QueueItemReviewThread.STATUS_RESOLVED,
+                resolved_by=request.user,
+                resolved_at=now,
+                updated_at=now,
+            )
+
+        pending_notifications = []
+        for item in eligible:
+            if is_approve:
                 item.status = QueueItemStatus.COMPLETED.value
                 item.review_status = "approved"
                 comment_text = notes or "Approved."
                 thread_status = QueueItemReviewThread.STATUS_RESOLVED
-                QueueItemReviewThread.objects.filter(
-                    queue_item=item,
-                    status__in=[
-                        QueueItemReviewThread.STATUS_OPEN,
-                        QueueItemReviewThread.STATUS_REOPENED,
-                        QueueItemReviewThread.STATUS_ADDRESSED,
-                    ],
-                    deleted=False,
-                ).update(
-                    status=QueueItemReviewThread.STATUS_RESOLVED,
-                    resolved_by=request.user,
-                    resolved_at=now,
-                    updated_at=now,
-                )
             else:
                 item.status = QueueItemStatus.IN_PROGRESS.value
                 item.review_status = "rejected"
@@ -7013,8 +7058,16 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             item.reviewed_at = now
             item.review_notes = comment_text
             self._clear_reservation(item)
-            item.save(
-                update_fields=[
+            # bulk_update does not honour auto_now, so updated_at is set here to
+            # match what save() would have written.
+            item.updated_at = now
+            pending_notifications.append((item, created_comment))
+            reviewed.append(str(item.id))
+
+        if eligible:
+            QueueItem.objects.bulk_update(
+                eligible,
+                [
                     "status",
                     "review_status",
                     "reviewed_by",
@@ -7024,10 +7077,12 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     "reserved_at",
                     "reservation_expires_at",
                     "updated_at",
-                ]
+                ],
             )
+
+        # Notify only after the rows are persisted, as the per-item save did.
+        for item, created_comment in pending_notifications:
             _notify_annotation_discussion(item, created_comment, created_comment.thread)
-            reviewed.append(str(item.id))
 
         if reviewed:
             self._maybe_auto_complete_queue(queue_id)


### PR DESCRIPTION
## Summary

`bulk-review` cost **~12 queries per item** — 5,512 at batch 500 (TH-7211). It is now **flat**:

| batch | before | after |
|---|---|---|
| 2 | 28 | **11** |
| 10 | 124 | **11** |
| 500 (extrapolated) | ~5,512 | **~11** |

Same shape as `bulk-remove`, which was already flat and is the pattern this follows.

## Linked issues

Linear: https://linear.app/future-agi/issue/TH-7211

## Type of change

- [x] 🚀 Performance improvement

---

## 1) What changes were done

Measured the cost by table before touching anything. At batch 10 the per-item work was:

| count | query | now |
|---|---|---|
| 10 | SELECT `annotationqueuelabel` — the queue's label set, **identical for every item** | **1** |
| 20 | SELECT `score` — the two `.exists()` checks | **1** |
| 10 | SELECT `queueitemreviewthread` — blocking-thread check | **1** |
| 10 | UPDATE `queueitemreviewthread` — resolve prior threads | **1** |
| 10 | UPDATE `queueitem` — `save()` per item | **1** (`bulk_update`) |
| 10 | INSERT `queueitemreviewthread` | **1** (`bulk_create`) |
| 10 | INSERT `queueitemreviewcomment` | **1** (`bulk_create`) |
| 10 | SELECT `accounts_user` JOIN `mentioned_users` | **0** |
| 10 | SELECT `queueitemreviewcomment` — thread participants | **0** |
| 11 + 10 | SELECT `workspace` / `organization` | **1** / **0** |

## 2) The two queries that turned out to be provably pointless

I first assumed the last four were unavoidable — notification semantics, one email per item, a product decision. That was wrong, and worth stating plainly because it changes what this endpoint does:

- the `mentioned_users` m2m read — **bulk review passes no mentions**
- the thread-participant scan — the thread was **just created**, so its only participant is the reviewer, who is then discarded as the actor

So `_discussion_notification_recipient_ids` always returned an empty set: **bulk review has never sent an email.** It was spending two queries per item to prove that.

The bulk path now calls `_broadcast_annotation_discussion_update` directly. Realtime behaviour is unchanged; the email outcome is unchanged (there wasn't one). The invariant is written down at the call site, so if that path is ever made to fire for approve/request-changes, wiring it in is a deliberate decision about sending one mail per item rather than something inherited silently.

## 3) Three things that would have been silent regressions

- **`bulk_update` skips `auto_now`** — `updated_at` is set explicitly to match what `save()` wrote.
- **`bulk_create` skips signals** — there is a global `post_save` receiver backfilling `workspace`/`organization`. Not a behaviour change here: that receiver reads the same request-scoped values the view already holds (`accounts/authentication.py` sets `request.workspace` and the contextvar together), so it could only ever write what is now passed explicitly. Pinned by a test asserting non-null tenancy on the created rows.
- **Ordering** — notification happens after the `bulk_update`, preserving the old persist-then-notify invariant. There is no `ATOMIC_REQUESTS`, so `on_commit` fires immediately and the order is observable.

Both pks are client-generated UUIDs, so comments reference their thread before either is written. `batch_size=500` matches the `_BULK_ADD_BATCH_SIZE` precedent; `item_ids` has no `max_length`, so the batch is unbounded by the serializer.

## 4) Tests

`TestBulkReviewQueryCount` asserts per-table counts, not a total — so a failure names the lookup that regressed:

- batched SELECTs are exactly 1 each; thread/comment INSERTs are exactly 1 each; item UPDATE is 1
- the two structurally-pointless SELECTs are **0**
- `test_bulk_review_persists_tenancy_without_the_save_signal` — non-null `workspace_id`/`organization_id` on created rows, pinning the signal bypass
- `test_bulk_review_sends_no_email` — `_send_annotation_discussion_email` not called

**Mutation-checked:** reverting `bulk_create` to per-item saves fails with `model_hub_queueitemreviewthread is being INSERTed per item (10 for 10 items)`; the earlier commit's assertion was verified against pre-fix code too.

> `test_annotation_workflow_api.py`: **172 passed, 6 xfailed, 1 xpassed.** Ruff check + format clean. This file *is* run in CI — `api-contracts.yml` path-triggers on `views/annotation_queues.py`.

## 5) Found while doing this — not fixed here

`_discussion_notification_recipient_ids`'s annotation-owner branch appears unreachable from every live call site (all callers pass a non-None thread, and `_create_review_thread_comment` always creates one), which would mean single-item request-changes never emails the annotator whose work was sent back. That is a product bug, not a perf one, and does not belong in this PR — filing separately.

Also pre-existing and untouched: the notification path spawns one daemon thread per item under `force_async`.

## 6) Not measured

Production, and prod-network latency. These are local warm-PG counts — the point is the count, since a per-row count is what degrades over real latency.
