### PR TITLE
fix(storage): pass region for GCS MinIO client

### DIFF
--- a/futureagi/tfc/utils/storage_client.py
+++ b/futureagi/tfc/utils/storage_client.py
@@ -42,6 +42,7 @@ def get_storage_client() -> Minio:
             "storage.googleapis.com",
             access_key=os.getenv("GCS_HMAC_ACCESS_KEY", ""),
             secret_key=os.getenv("GCS_HMAC_SECRET_KEY", ""),
+            region=os.getenv("MINIO_REGION") or "auto",
             secure=True,
         )
         return _client

--- a/futureagi/tfc/utils/tests/test_storage_client.py
+++ b/futureagi/tfc/utils/tests/test_storage_client.py
@@ -8,6 +8,9 @@ STORAGE_ENV_KEYS = (
     "S3_ENDPOINT_URL",
     "S3_SECURE",
     "MINIO_URL",
+    "MINIO_REGION",
+    "GCS_HMAC_ACCESS_KEY",
+    "GCS_HMAC_SECRET_KEY",
     "AWS_DEFAULT_REGION",
 )
 
@@ -75,3 +78,46 @@ def test_gcs_object_url_ignores_s3_and_minio_urls(monkeypatch):
         storage_client.get_object_url("futureagi", "tempcust/image.png")
         == "https://storage.googleapis.com/futureagi/tempcust/image.png"
     )
+
+
+def test_gcs_client_uses_minio_region(monkeypatch):
+    storage_client = reload_storage_client(
+        monkeypatch,
+        STORAGE_BACKEND="gcs",
+        MINIO_REGION="europe-west3",
+        GCS_HMAC_ACCESS_KEY="access",
+        GCS_HMAC_SECRET_KEY="secret",
+    )
+    captured = {}
+
+    def fake_minio(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(storage_client, "Minio", fake_minio)
+    storage_client.reset_storage_client()
+    storage_client.get_storage_client()
+
+    assert captured["args"][0] == "storage.googleapis.com"
+    assert captured["kwargs"]["region"] == "europe-west3"
+
+
+def test_gcs_client_falls_back_to_auto_region(monkeypatch):
+    storage_client = reload_storage_client(
+        monkeypatch,
+        STORAGE_BACKEND="gcs",
+        GCS_HMAC_ACCESS_KEY="access",
+        GCS_HMAC_SECRET_KEY="secret",
+    )
+    captured = {}
+
+    def fake_minio(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(storage_client, "Minio", fake_minio)
+    storage_client.reset_storage_client()
+    storage_client.get_storage_client()
+
+    assert captured["kwargs"]["region"] == "auto"


### PR DESCRIPTION
## Summary
Local dataset file uploads were failing with a 500 (`Unable to create dataset from local files`) during the GCS storage upload step.

## Why this change
When `STORAGE_BACKEND=gcs`, the MinIO client was created without a `region`. MinIO then looks up the bucket region before uploading. Our GCS HMAC credentials can write objects but cannot perform that region lookup, so the upload fails with `AccessDenied` and the API returns 500.

The S3 backend is unaffected because region is already set on that client.

## Evidence
Backend logs showed:
```
Error uploading file to Minio: S3 operation failed; code: AccessDenied
Error in creating dataset from local: S3 operation failed; code: AccessDenied
… → minio put_object → _get_region → AccessDenied
POST …/create-dataset-from-local-file/ → 500
```

## Verification
Using the same GCS HMAC credentials:
- no `region` → `AccessDenied`
- `region` set → upload succeeds
- `region="auto"` → upload succeeds

## Fix
```python
region=os.getenv("MINIO_REGION") or "auto",
```

Plus unit tests covering `MINIO_REGION` and the `"auto"` fallback.

## Test plan
- [x] `pytest tfc/utils/tests/test_storage_client.py`
- [ ] Retry local dataset upload on a GCS-backed environment
- [ ] Confirm the uploaded object lands in content storage
- [ ] Confirm S3-backed uploads still succeed