### PR TITLE
fix(ch25): stop querying legacy tables the boot hook already dropped

### DIFF
--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -47,10 +47,10 @@ class ModelHubConfig(AppConfig):
         Idempotent — uses CREATE IF NOT EXISTS for everything."""
         from tracer.services.clickhouse.client import get_clickhouse_client
         from tracer.services.clickhouse.schema import (
-            POST_DDL_ALTERS,
             detect_spans_table_shape,
             get_all_schema_ddl,
             get_legacy_chain_drop_statements,
+            get_post_ddl_alters,
             should_drop_legacy_chain,
         )
 
@@ -87,13 +87,16 @@ class ModelHubConfig(AppConfig):
                 if "already exists" not in str(e).lower():
                     logger.warning(f"CH schema {name}: {e}")
 
-        # Ensure materialized columns on CDC tables that PeerDB may recreate
-        for alter in POST_DDL_ALTERS:
+        # Ensure materialized columns on CDC tables that PeerDB may recreate.
+        # get_post_ddl_alters() drops entries whose target table the legacy
+        # chain already removed above — without it those ALTERs run against a
+        # table dropped seconds earlier and log Code: 60 on every boot.
+        for table, alter in get_post_ddl_alters():
             try:
                 ch.execute(alter, settings=ddl_settings)
             except Exception as e:
                 if "already exists" not in str(e).lower():
-                    logger.warning(f"CH post-DDL alter: {e}")
+                    logger.warning(f"CH post-DDL alter {table}: {e}")
 
         logger.info("ClickHouse analytics schema ensured")
 
@@ -181,14 +184,18 @@ class ModelHubConfig(AppConfig):
         OS page cache.  Subsequent user queries hit warm cache (~300ms)
         instead of cold disk (~5s).
         """
-        from tracer.services.clickhouse.schema import should_drop_legacy_chain
+        from tracer.services.clickhouse.schema import is_retired_table
 
+        # ``(target_table, query, label)`` — the table drives the retired-object
+        # filter below. Entries naming a legacy object are kept here (they are
+        # still correct wherever the cutover flag is off) and filtered at use.
         warmup_queries = [
             # Warm spans index + light columns for recent data. The v2
             # spans table uses `is_deleted`; pre-cutover prod still
             # carries the `_peerdb_is_deleted` ALIAS column for back-
             # compat, but the canonical name is what we read.
             (
+                "spans",
                 "SELECT project_id, count() FROM spans "
                 "WHERE is_deleted = 0 "
                 "AND start_time >= now() - INTERVAL 7 DAY "
@@ -197,6 +204,7 @@ class ModelHubConfig(AppConfig):
             ),
             # Warm tracer_trace for recent data
             (
+                "tracer_trace",
                 "SELECT project_id, count() FROM tracer_trace "
                 "WHERE _peerdb_is_deleted = 0 "
                 "AND created_at >= now() - INTERVAL 7 DAY "
@@ -205,6 +213,7 @@ class ModelHubConfig(AppConfig):
             ),
             # Warm usage_apicalllog for eval metrics
             (
+                "usage_apicalllog",
                 "SELECT organization_id, count() FROM usage_apicalllog "
                 "WHERE _peerdb_is_deleted = 0 "
                 "AND created_at >= now() - INTERVAL 7 DAY "
@@ -216,23 +225,24 @@ class ModelHubConfig(AppConfig):
             # docs/CH25_MIGRATION.md. countMerge collapses the aggregate
             # state column.
             (
+                "spans_hourly_rollup",
                 "SELECT countMerge(n) FROM spans_hourly_rollup "
                 "WHERE hour >= now() - INTERVAL 7 DAY",
                 "spans_hourly_rollup (7d)",
             ),
+            # Legacy aggregate — stays hot until the cutover, filtered out
+            # once the legacy chain is dropped.
+            (
+                "span_metrics_hourly",
+                "SELECT count() FROM span_metrics_hourly "
+                "WHERE hour >= now() - INTERVAL 7 DAY",
+                "span_metrics_hourly (7d, legacy)",
+            ),
         ]
 
-        # When the legacy chain is retained (prod default), also warm
-        # the legacy aggregate so it stays hot until the cutover.
-        if not should_drop_legacy_chain():
-            warmup_queries.append(
-                (
-                    "SELECT count() FROM span_metrics_hourly "
-                    "WHERE hour >= now() - INTERVAL 7 DAY",
-                    "span_metrics_hourly (7d, legacy)",
-                )
-            )
-        for query, label in warmup_queries:
+        for table, query, label in warmup_queries:
+            if is_retired_table(table):
+                continue
             try:
                 ch.execute_read(query, timeout_ms=30000)
                 logger.info(f"CH cache warmed: {label}")

--- a/futureagi/tracer/services/clickhouse/client.py
+++ b/futureagi/tracer/services/clickhouse/client.py
@@ -181,9 +181,7 @@ class ClickHouseClient:
             rows_returned = (
                 len(result[0])
                 if with_column_types and result
-                else len(result)
-                if result and not isinstance(result, int)
-                else 0
+                else len(result) if result and not isinstance(result, int) else 0
             )
             logger.info(
                 "ClickHouse query completed",
@@ -420,13 +418,20 @@ class ClickHouseClient:
         """
         from datetime import datetime
 
+        from tracer.services.clickhouse.schema import is_retired_table
+
         # CH25 close-out (2026-05-28): removed `tracer_observation_span`
         # from the CDC lag check. Spans now land in v2 typed-JSON `spans`
         # via fi-collector OTLP — no CDC mirror, no lag to measure.
+        #
+        # `tracer_trace` and `trace_session` were dropped later by the
+        # legacy-chain cutover, so where that flag is on this probe reported
+        # a bogus -1 for two of the three tables. Filter them out so the
+        # result only claims lag for mirrors that actually exist.
         tables = [
-            "tracer_trace",
-            "trace_session",
-            "tracer_eval_logger",
+            table
+            for table in ("tracer_trace", "trace_session", "tracer_eval_logger")
+            if not is_retired_table(table)
         ]
         lag: dict[str, float] = {}
         for table in tables:

--- a/futureagi/tracer/services/clickhouse/consistency.py
+++ b/futureagi/tracer/services/clickhouse/consistency.py
@@ -60,6 +60,23 @@ class ConsistencyChecker:
     def __init__(self):
         self._ch_client = get_clickhouse_client()
 
+    @classmethod
+    def _live_monitored_tables(cls) -> list[tuple[str, str]]:
+        """``MONITORED_TABLES`` minus pairs whose CH side no longer exists.
+
+        The PG tables all still exist; only their ClickHouse mirrors were
+        removed by the legacy-chain cutover. Comparing a live PG table against
+        a dropped CH table produced a permanent bogus mismatch, so drop the
+        pair entirely rather than report a difference nobody can act on.
+        """
+        from tracer.services.clickhouse.schema import is_retired_table
+
+        return [
+            (pg_table, ch_table)
+            for pg_table, ch_table in cls.MONITORED_TABLES
+            if not is_retired_table(ch_table)
+        ]
+
     def check_row_counts(
         self,
         project_id: str,
@@ -69,7 +86,7 @@ class ConsistencyChecker:
     ) -> list[ConsistencyResult]:
         """Compare row counts between PG and CH for each table."""
         results = []
-        for pg_table, ch_table in self.MONITORED_TABLES:
+        for pg_table, ch_table in self._live_monitored_tables():
             try:
                 # PG count
                 with pg_connection.cursor() as cursor:
@@ -116,11 +133,7 @@ class ConsistencyChecker:
     def get_cdc_lag(self) -> dict[str, float]:
         """Get CDC replication lag per table in seconds."""
         lag = {}
-        tables = [
-            "tracer_trace",
-            "trace_session",
-            "tracer_eval_logger",
-        ]
+        tables = [ch_table for _pg, ch_table in self._live_monitored_tables()]
         for table in tables:
             try:
                 result = self._ch_client.execute(

--- a/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
@@ -6,7 +6,8 @@ Replaces ``get_eval_graph_data()`` and its helpers from
 
 Strategy:
 - Unfiltered eval dashboard queries read from the ``eval_metrics_hourly``
-  pre-aggregated table.
+  pre-aggregated table — unless the legacy-chain cutover has dropped it, in
+  which case they fall through to the raw path below.
 - Filtered queries or per-eval-config breakdowns read from the
   ``tracer_eval_logger`` CDC table (with FINAL for correct deduplication).
 
@@ -22,6 +23,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
+from tracer.services.clickhouse.schema import is_retired_table
 
 # Eval output type constants (mirrors EvalOutputType from Django models)
 SCORE = "SCORE"
@@ -93,7 +95,19 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         # Pre-aggregated eval rows do not carry arbitrary trace/span filter
         # dimensions. If filters are present, force the raw logger path so the
         # graph reflects the filtered result set.
-        self.use_preaggregated = use_preaggregated and not self.filters
+        #
+        # Also force the raw path when the legacy-chain cutover has dropped
+        # AGG_TABLE: an unfiltered eval graph would otherwise SELECT from
+        # `eval_metrics_hourly`, which no longer exists wherever
+        # CH25_DROP_LEGACY_CDC_CHAIN is on (US + EU prod), and there is no
+        # fallback above this layer — trace.py deleted the PG path post-CH25.
+        # RAW_TABLE (`tracer_eval_logger`) is deliberately NOT retired and
+        # already serves every filtered request, so this just always uses it.
+        self.use_preaggregated = (
+            use_preaggregated
+            and not self.filters
+            and not is_retired_table(self.AGG_TABLE)
+        )
 
         # Graph endpoints historically default to a compact 7-day window.
         # BaseQueryBuilder's list-view fallback is intentionally much wider,

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -1894,65 +1894,129 @@ SCHEMA_DDL_STATEMENTS: list[tuple[str, str]] = [
 
 # Post-DDL ALTER statements to ensure materialized columns exist on CDC tables
 # that PeerDB may recreate without them during RESYNC operations.
-POST_DDL_ALTERS: list[str] = [
-    "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_score Float64 MATERIALIZED "
-    "JSONExtractFloat(JSONExtractString(config), 'output', 'output')",
-    "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_output_str String MATERIALIZED "
-    "JSONExtractString(JSONExtractString(config), 'output', 'output')",
-    "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_trace_id String MATERIALIZED "
-    "JSONExtractString(JSONExtractString(config), 'trace_id')",
-    "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
-    "eval_dataset_id String MATERIALIZED "
-    "JSONExtractString(JSONExtractString(config), 'dataset_id')",
+#
+# Each entry is ``(target_table, statement)``. The table is carried explicitly
+# so ``get_post_ddl_alters()`` can drop entries targeting objects the
+# legacy-chain cutover has already removed — see ``is_retired_table()`` for why
+# matching on statement text instead would be unsafe.
+POST_DDL_ALTERS: list[tuple[str, str]] = [
+    (
+        "usage_apicalllog",
+        "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
+        "eval_score Float64 MATERIALIZED "
+        "JSONExtractFloat(JSONExtractString(config), 'output', 'output')",
+    ),
+    (
+        "usage_apicalllog",
+        "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
+        "eval_output_str String MATERIALIZED "
+        "JSONExtractString(JSONExtractString(config), 'output', 'output')",
+    ),
+    (
+        "usage_apicalllog",
+        "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
+        "eval_trace_id String MATERIALIZED "
+        "JSONExtractString(JSONExtractString(config), 'trace_id')",
+    ),
+    (
+        "usage_apicalllog",
+        "ALTER TABLE usage_apicalllog ADD COLUMN IF NOT EXISTS "
+        "eval_dataset_id String MATERIALIZED "
+        "JSONExtractString(JSONExtractString(config), 'dataset_id')",
+    ),
     # PR3: evolve existing tracer_eval_logger tables to the row_type stack's
     # new shape. CREATE TABLE IF NOT EXISTS skips already-created tables, so
     # these ALTERs bring the schema forward in place. Idempotent thanks to
     # IF NOT EXISTS / IF EXISTS clauses; ordering matters where the bloom
     # index on trace_id has to be dropped before we can MODIFY the column.
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "trace_session_id Nullable(UUID)",
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "target_type LowCardinality(String) DEFAULT 'span'",
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "trace_session_id Nullable(UUID)",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "target_type LowCardinality(String) DEFAULT 'span'",
+    ),
     # ClickHouse refuses to MODIFY a column that's part of a skip index
     # (Code: 524 — "Trying to ALTER trace_id column which is a part of
     # index idx_trace_id"). Drop the index, modify the column to Nullable
     # so session rows (target_type='session') can write NULL trace_id,
     # then re-add the index. All idempotent.
-    "ALTER TABLE tracer_eval_logger DROP INDEX IF EXISTS idx_trace_id",
-    "ALTER TABLE tracer_eval_logger MODIFY COLUMN trace_id Nullable(UUID)",
-    "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
-    "idx_trace_id trace_id TYPE bloom_filter GRANULARITY 1",
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger DROP INDEX IF EXISTS idx_trace_id",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger MODIFY COLUMN trace_id Nullable(UUID)",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
+        "idx_trace_id trace_id TYPE bloom_filter GRANULARITY 1",
+    ),
     # Bloom filter indexes for the new columns (mirrors the existing
     # idx_observation_span_id / idx_trace_id). Cheap filter queries.
-    "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
-    "idx_trace_session_id trace_session_id TYPE bloom_filter GRANULARITY 1",
-    "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
-    "idx_target_type target_type TYPE bloom_filter GRANULARITY 1",
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
+        "idx_trace_session_id trace_session_id TYPE bloom_filter GRANULARITY 1",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
+        "idx_target_type target_type TYPE bloom_filter GRANULARITY 1",
+    ),
     # Work-item columns (mirror of EvalLogger.status / config_hash).
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "status LowCardinality(String) DEFAULT 'completed'",
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "config_hash Nullable(String)",
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "status LowCardinality(String) DEFAULT 'completed'",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "config_hash Nullable(String)",
+    ),
     # skipped_reason / attempts exist on the PG source (EvalLogger work-item
     # columns) and are in the PeerDB normalize INSERT column list; without them
     # the CH normalize fails with "No such column ..." and the mirror never
     # drains.
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "skipped_reason Nullable(String)",
-    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
-    "attempts Int32 DEFAULT 0",
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "skipped_reason Nullable(String)",
+    ),
+    (
+        "tracer_eval_logger",
+        "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+        "attempts Int32 DEFAULT 0",
+    ),
     # Strip the legacy 365d TTL from the v1 hourly rollup tables. The CREATE
     # strings above no longer declare TTL, but existing prod clusters carry
     # the original TTL on the live tables — these ALTERs remove it.
-    # In dev/test where the legacy CDC chain is gated off, the tables don't
-    # exist and these ALTERs error out; _ensure_analytics_schema() catches
-    # those as warnings (model_hub/apps.py:88-93).
-    "ALTER TABLE span_metrics_hourly REMOVE TTL",
-    "ALTER TABLE eval_metrics_hourly REMOVE TTL",
+    # Both tables are in _LEGACY_CDC_CHAIN_NAMES, so wherever the cutover flag
+    # is on (US + EU prod, and dev/compose) get_post_ddl_alters() filters these
+    # out — they used to run unconditionally and log a Code: 60 on every boot.
+    ("span_metrics_hourly", "ALTER TABLE span_metrics_hourly REMOVE TTL"),
+    ("eval_metrics_hourly", "ALTER TABLE eval_metrics_hourly REMOVE TTL"),
 ]
+
+
+def get_post_ddl_alters() -> list[tuple[str, str]]:
+    """``POST_DDL_ALTERS`` minus statements targeting retired objects.
+
+    Returns ``(target_table, statement)`` tuples so the caller can log which
+    target failed without parsing SQL — same shape as
+    ``get_legacy_chain_drop_statements()``.
+    """
+    return [
+        (table, statement)
+        for table, statement in POST_DDL_ALTERS
+        if not is_retired_table(table)
+    ]
 
 
 # ============================================================================
@@ -2081,6 +2145,26 @@ def should_drop_legacy_chain() -> bool:
     the env semantics live in one place.
     """
     return _DROP_LEGACY_CDC_CHAIN
+
+
+def is_retired_table(name: str) -> bool:
+    """Whether ``name`` has been dropped by the legacy-chain cutover.
+
+    Single source of truth for "does this ClickHouse object still exist?".
+    ``get_all_schema_ddl()`` already filters ``_LEGACY_CDC_CHAIN_NAMES`` out
+    of the CREATE statements; every OTHER consumer that names a legacy object
+    (post-DDL ALTERs, cache warmers, CDC-lag probes, consistency checks) must
+    go through this predicate instead of hand-placing a
+    ``should_drop_legacy_chain()`` check — three such sites were missed when
+    the flag was enabled in prod, each producing a permanent per-boot
+    ``Code: 60 — Could not find table`` in both regions.
+
+    NOTE this deliberately takes an explicit table name rather than sniffing
+    a SQL string: ``trace_session`` is a substring of the very-much-alive
+    ``trace_session_id`` column on ``tracer_eval_logger``, so substring
+    matching against statement text would silently drop a required ALTER.
+    """
+    return should_drop_legacy_chain() and name in _LEGACY_CDC_CHAIN_NAMES
 
 
 def detect_spans_table_shape(execute_fn) -> str:

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -206,7 +206,7 @@ class TestClickHouseSchema:
         """ALTER statements bring already-created tracer_eval_logger tables forward."""
         from tracer.services.clickhouse.schema import POST_DDL_ALTERS
 
-        joined = "\n".join(POST_DDL_ALTERS)
+        joined = "\n".join(statement for _table, statement in POST_DDL_ALTERS)
         assert "tracer_eval_logger ADD COLUMN IF NOT EXISTS trace_session_id" in joined
         assert "tracer_eval_logger ADD COLUMN IF NOT EXISTS target_type" in joined
         assert "tracer_eval_logger MODIFY COLUMN trace_id Nullable(UUID)" in joined
@@ -2702,8 +2702,7 @@ class TestTraceListQueryBuilder:
         assert "SELECT" in query
         assert "trace_id" in query
         assert (
-            "dictGetOrDefault('enduser_dict', 'user_id', any(end_user_id), '')"
-            in query
+            "dictGetOrDefault('enduser_dict', 'user_id', any(end_user_id), '')" in query
         )
         assert "GROUP BY trace_id" in query
         assert "PREWHERE trace_id IN" in query
@@ -6977,13 +6976,13 @@ class TestVoiceCallListPhase1bMigration:
         `raw_log` is kept: process_raw_logs still needs it.
         """
         src = self._voice_list_source()
-        assert "project_id = %(project_id)s" in src, (
-            "Phase 1b must scope by project_id so the primary key can prune."
-        )
+        assert (
+            "project_id = %(project_id)s" in src
+        ), "Phase 1b must scope by project_id so the primary key can prune."
         # attrs_string Map strip.
-        assert "mapFilter" in src and "call_logs" in src, (
-            "Phase 1b must exclude `call_logs` from attrs_string at read time."
-        )
+        assert (
+            "mapFilter" in src and "call_logs" in src
+        ), "Phase 1b must exclude `call_logs` from attrs_string at read time."
         # attributes_extra JSON-overflow strip (backfill cohort).
         assert "JSONExtractKeysAndValuesRaw" in src, (
             "Phase 1b must also strip `call_logs` from attributes_extra so the "

--- a/futureagi/tracer/tests/test_retired_table_guard.py
+++ b/futureagi/tracer/tests/test_retired_table_guard.py
@@ -1,0 +1,117 @@
+"""Guards against naming a legacy-chain object that boot has already dropped.
+
+``_ensure_analytics_schema()`` drops every name in ``_LEGACY_CDC_CHAIN_NAMES``
+when ``CH25_DROP_LEGACY_CDC_CHAIN`` is on. ``get_all_schema_ddl()`` filters the
+CREATE statements accordingly, but three *other* consumers kept naming the
+dropped objects and were only caught in production:
+
+* ``POST_DDL_ALTERS`` — ``ALTER TABLE {span,eval}_metrics_hourly REMOVE TTL``
+* ``_warm_ch_cache`` — a warm query on ``tracer_trace``
+* ``check_replication_lag`` / ``ConsistencyChecker`` — CDC probes on
+  ``tracer_trace`` and ``trace_session``
+
+Each produced a permanent ``Code: 60 — Could not find table`` on every pod boot
+in both regions. These tests pin the invariant so the next consumer can't
+reintroduce it.
+"""
+
+import pytest
+
+from tracer.services.clickhouse import consistency as ch_consistency
+from tracer.services.clickhouse import schema as ch_schema
+from tracer.services.clickhouse.query_builders.eval_metrics import (
+    EvalMetricsQueryBuilder,
+)
+
+
+@pytest.fixture
+def chain_dropped(monkeypatch):
+    """Force the post-cutover state (US + EU prod, and dev/compose)."""
+    monkeypatch.setattr(ch_schema, "_DROP_LEGACY_CDC_CHAIN", True)
+
+
+@pytest.fixture
+def chain_retained(monkeypatch):
+    """Force the pre-cutover state — legacy objects still exist."""
+    monkeypatch.setattr(ch_schema, "_DROP_LEGACY_CDC_CHAIN", False)
+
+
+def test_is_retired_only_for_chain_members(chain_dropped):
+    assert ch_schema.is_retired_table("eval_metrics_hourly")
+    assert ch_schema.is_retired_table("tracer_trace")
+    # Live tables must never be reported as retired.
+    assert not ch_schema.is_retired_table("spans")
+    assert not ch_schema.is_retired_table("tracer_eval_logger")
+    assert not ch_schema.is_retired_table("usage_apicalllog")
+
+
+def test_nothing_is_retired_before_cutover(chain_retained):
+    """With the flag off the legacy objects still exist — filter must no-op."""
+    for name in ch_schema._LEGACY_CDC_CHAIN_NAMES:
+        assert not ch_schema.is_retired_table(name)
+    assert len(ch_schema.get_post_ddl_alters()) == len(ch_schema.POST_DDL_ALTERS)
+
+
+def test_post_ddl_alters_never_target_a_dropped_table(chain_dropped):
+    """The invariant that would have caught the original bug."""
+    offenders = [
+        table
+        for table, _statement in ch_schema.get_post_ddl_alters()
+        if table in ch_schema._LEGACY_CDC_CHAIN_NAMES
+    ]
+    assert offenders == [], (
+        f"POST_DDL_ALTERS targets {offenders}, which _ensure_analytics_schema() "
+        "drops earlier in the same boot — every such entry logs a Code: 60."
+    )
+
+
+def test_retired_alters_are_the_ttl_pair(chain_dropped):
+    """Exactly the two REMOVE TTL statements drop out — nothing else."""
+    kept = {stmt for _t, stmt in ch_schema.get_post_ddl_alters()}
+    dropped = {stmt for _t, stmt in ch_schema.POST_DDL_ALTERS} - kept
+    assert dropped == {
+        "ALTER TABLE span_metrics_hourly REMOVE TTL",
+        "ALTER TABLE eval_metrics_hourly REMOVE TTL",
+    }
+
+
+def test_trace_session_id_alter_survives_filtering(chain_dropped):
+    """Regression: ``trace_session`` is a substring of ``trace_session_id``.
+
+    ``trace_session`` is a retired table, but ``trace_session_id`` is a live
+    column on ``tracer_eval_logger``. A filter that matched on statement text
+    instead of an explicit target table would silently stop adding it and
+    break the session-eval write path.
+    """
+    kept = "\n".join(stmt for _t, stmt in ch_schema.get_post_ddl_alters())
+    assert "tracer_eval_logger ADD COLUMN IF NOT EXISTS trace_session_id" in kept
+    assert "idx_trace_session_id trace_session_id" in kept
+
+
+def test_consistency_checker_skips_dropped_mirrors(chain_dropped):
+    live = ch_consistency.ConsistencyChecker._live_monitored_tables()
+    ch_tables = [ch for _pg, ch in live]
+    assert "tracer_trace" not in ch_tables
+    assert "trace_session" not in ch_tables
+    # tracer_eval_logger is deliberately NOT retired — it still has a mirror.
+    assert "tracer_eval_logger" in ch_tables
+
+
+def test_consistency_checker_full_set_before_cutover(chain_retained):
+    live = ch_consistency.ConsistencyChecker._live_monitored_tables()
+    assert live == ch_consistency.ConsistencyChecker.MONITORED_TABLES
+
+
+def test_eval_metrics_raw_table_is_never_retired():
+    """The fallback target must stay alive in every configuration.
+
+    ``EvalMetricsQueryBuilder`` degrades from AGG_TABLE to RAW_TABLE when the
+    aggregate is dropped. If RAW_TABLE ever joined the legacy chain the
+    fallback would break with no path left.
+    """
+    assert EvalMetricsQueryBuilder.RAW_TABLE not in ch_schema._LEGACY_CDC_CHAIN_NAMES
+
+
+def test_eval_metrics_agg_table_is_retired_post_cutover(chain_dropped):
+    """Pins why the builder needs the guard at all."""
+    assert ch_schema.is_retired_table(EvalMetricsQueryBuilder.AGG_TABLE)


### PR DESCRIPTION
## Problem

`_ensure_analytics_schema()` drops every name in `_LEGACY_CDC_CHAIN_NAMES` when `CH25_DROP_LEGACY_CDC_CHAIN` is on. `get_all_schema_ddl()` filters the CREATE statements to match — but **four other consumers kept naming the dropped objects**.

The flag is `true` in **both US and EU prod** (US via direct `env` on all 9 deploys, EU via the `core-backend-secret` / `core-backend-worker` `envFrom` secrets), so these fire on every pod boot in production today:

| Consumer | Object | Symptom |
|---|---|---|
| `POST_DDL_ALTERS` | `span_metrics_hourly`, `eval_metrics_hourly` | `Code: 60`, 2.8s after the DROP **in the same boot** |
| `_warm_ch_cache` | `tracer_trace` | `Code: 60` |
| `check_replication_lag` / `ConsistencyChecker` | `tracer_trace`, `trace_session` | bogus `-1` lag for 2 of 3 tables |
| `EvalMetricsQueryBuilder` | `eval_metrics_hourly` | unfiltered eval graph has **no fallback** |

Verified in a prod Sentry breadcrumb trail — 11 legacy DROPs at `08:39:20.868–20.884`, then `ALTER TABLE eval_metrics_hourly REMOVE TTL` → `Code: 60` at `08:39:23.719`, same process.

The existing comment at the `REMOVE TTL` pair said these only error "in dev/test where the legacy CDC chain is gated off". That assumption went stale when prod adopted the flag.

### Why none of this reached Sentry

`apps.py` catches and logs at `logger.warning`, below Sentry's ERROR capture threshold. Worse, the suppression guard is `if "already exists" not in str(e).lower()` — so a **genuine** schema failure logs identically to this known noise.

### The user-facing one

`EvalMetricsQueryBuilder.AGG_TABLE = eval_metrics_hourly`, used when `use_preaggregated and not self.filters`. `use_preaggregated` defaults `True` and **no caller ever overrides it**, so an eval-graph request with an empty `filters` list hits a table that doesn't exist — and `trace.py` deleted the PG fallback post-CH25, so there's no path left. Latent rather than firing (the UI appears to always send a time-range filter, and prod API logs show no such error), but one request away.

## Fix

Add `is_retired_table()` as the single predicate over `_LEGACY_CDC_CHAIN_NAMES` and route all four consumers through it — rather than hand-placing a `should_drop_legacy_chain()` check per call site. That pattern is exactly what failed: `_warm_ch_cache` *correctly* gated `span_metrics_hourly` and missed `tracer_trace` eight lines above it. That hand-placed guard is folded into the same mechanism.

### Why `POST_DDL_ALTERS` becomes tuples

`(target_table, statement)`, mirroring `get_legacy_chain_drop_statements()`. The explicit table is **required, not cosmetic**: `trace_session` is a retired table *and* a substring of the live `trace_session_id` column on `tracer_eval_logger`. Filtering on statement text would silently drop a needed ALTER and break session-eval writes. There's a regression test for exactly this.

**Behaviour is unchanged wherever the flag is off** — every filter no-ops.

## Tests

`tracer/tests/test_retired_table_guard.py` (9 tests) pins the invariant that no statement reaching ClickHouse names a retired object — the check that would have caught all four sites. Plus the `trace_session_id` substring regression, and the rule that `EvalMetricsQueryBuilder.RAW_TABLE` must never join the legacy chain (it's the fallback; retiring it would leave no path).

- `492 passed` across `test_retired_table_guard.py`, `test_clickhouse.py`, `test_recreate_clickhouse_mv_command.py`
- 9 errors in `TestClickHouseFilterBuilder` are **pre-existing** — verified identical on a pristine `origin/dev` worktree; they need the docker Postgres on :15432
- `ruff`: 0 added findings (the 44 in `eval_metrics.py` are pre-existing typing-modernization hits, identical on base — deliberately not touched, per the no-drive-by-refactor rule)
- `mypy` could not be run locally (not installed in the available venv); relying on CI

## Deliberately out of scope

- **`trace_list.py` / `filters.py`** reference `enduser_dict` / `tracer_enduser`, but `TRACE_LIST` and `FILTER_BUILDER` are both `V2_ONLY` so those v1 builders never execute. `dispatch.py` already plans their deletion — that's a separate PR.
- **`trace_dict`** — the v1 definition sources the dropped `tracer_trace`, but `015_traces_and_trace_dict.sql` uses `CREATE OR REPLACE` pointing at `traces`, so the v1 `IF NOT EXISTS` is a harmless no-op. It must **not** be added to `_LEGACY_CDC_CHAIN_NAMES` — that would drop the dictionary v2 actively depends on.
- **The `Code: 517` storm** on `tracer_eval_logger` (26/pod/day in US) — caused by ~15 ALTERs racing across 3 replicas on concurrent pod boots, not by naming a dropped object. Fixing it means moving that DDL out of per-pod boot, which is gated on PeerDB mirror stability.
- **EU `Code: 524`** — `MODIFY COLUMN trace_id Nullable(UUID)` can never succeed in EU, where `trace_id` is the leading primary-key column. Needs a table rebuild, not a guard. (US is unaffected — the same ALTER succeeds there in 41ms.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HManyCf9ERPAEC5cet5a7Y