### PR TITLE
perf(annotations): batch submit's per-label label read and score upsert

### DIFF
--- a/futureagi/model_hub/models/score.py
+++ b/futureagi/model_hub/models/score.py
@@ -260,6 +260,22 @@ class Score(BaseModel):
             ),
         ]
 
+    @staticmethod
+    def appended_value_history(previous_value, previous_history, previous_at):
+        """``previous_history`` plus an entry for the value being superseded.
+
+        Shared with the batched submit path, which already holds the previous row
+        and so must not re-read it just to build the same entry.
+        """
+        history = list(previous_history or [])
+        history.append(
+            {
+                "value": previous_value,
+                "at": (previous_at or timezone.now()).isoformat(),
+            }
+        )
+        return history
+
     def save(self, *args, **kwargs):
         update_fields = kwargs.get("update_fields")
         should_track_value_change = update_fields is None or "value" in update_fields
@@ -276,17 +292,11 @@ class Score(BaseModel):
                 previous = None
 
             if previous is not None and previous.value != self.value:
-                history = list(previous.value_history or [])
-                previous_at = (
-                    previous.updated_at or previous.created_at or timezone.now()
+                self.value_history = self.appended_value_history(
+                    previous.value,
+                    previous.value_history,
+                    previous.updated_at or previous.created_at,
                 )
-                history.append(
-                    {
-                        "value": previous.value,
-                        "at": previous_at.isoformat(),
-                    }
-                )
-                self.value_history = history
                 if update_fields is not None:
                     kwargs["update_fields"] = set(update_fields) | {"value_history"}
 
@@ -302,7 +312,7 @@ class Score(BaseModel):
                 f"source_type '{self.source_type}' requires '{fk_field}' to be set."
             )
         # Ensure no other source FK is set
-        for st, field in SCORE_SOURCE_FK_MAP.items():
+        for _st, field in SCORE_SOURCE_FK_MAP.items():
             if field != fk_field and getattr(self, f"{field}_id") is not None:
                 raise ValidationError(
                     f"Only '{fk_field}' should be set for source_type '{self.source_type}', "

--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -1239,6 +1239,50 @@ class TestSubmitAnnotations:
             "per-label Score upsert is back (TH-7211)."
         )
 
+        # The two submits above both create. Resubmitting the same item drives
+        # the bulk_update branch instead, which has its own per-label hazards
+        # (value_history is built per row) and would otherwise be unguarded.
+        one_again = submit(item_ids[0], [label])
+        six_again = submit(item_ids[1], [label] + extra)
+
+        assert one_again == six_again, (
+            f"resubmit ran {one_again} queries for 1 label and {six_again} for "
+            f"6 — {(six_again - one_again) / 5:.1f} per label. The update branch "
+            "is querying per label (TH-7211)."
+        )
+
+    def test_duplicate_label_in_one_payload_keeps_the_last_value(
+        self, auth_client, queue_with_items
+    ):
+        """A payload repeating a label_id must land the LAST value.
+
+        The sequential update_or_create this replaced created then updated the
+        same row, so the last entry won. bulk_create(ignore_conflicts=True)
+        keeps the FIRST row of a self-conflicting batch and drops the rest, so
+        without an explicit collapse the value silently flips to first-wins."""
+        queue_id, item_ids, label = queue_with_items
+
+        resp = auth_client.post(
+            submit_annotations_url(queue_id, item_ids[0]),
+            {
+                "annotations": [
+                    {"label_id": str(label.id), "value": "positive"},
+                    {"label_id": str(label.id), "value": "negative"},
+                ]
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        scores = Score.objects.filter(
+            queue_item_id=item_ids[0], label=label, deleted=False
+        )
+        assert scores.count() == 1, "duplicate label_id created two Score rows"
+        assert scores.first().value == "negative", (
+            "duplicate label_id kept the first value — bulk_create's "
+            "ignore_conflicts flipped last-wins to first-wins"
+        )
+
     def test_submit_stores_notes_per_label(
         self, auth_client, queue_with_items, label_b
     ):

--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -1181,6 +1181,64 @@ class TestSubmitAnnotations:
             deleted=False,
         ).exists()
 
+    def test_query_count_does_not_grow_with_label_count(
+        self, auth_client, queue_with_items, label_b, organization, workspace
+    ):
+        """TH-7211: submit was ~8 queries per label — 82 for 7 labels, in the
+        annotator's inner loop. One extra label must not cost extra queries."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        queue_id, item_ids, label = queue_with_items
+        queue = AnnotationQueue.objects.get(pk=queue_id)
+        extra = [label_b] + [
+            AnnotationsLabels.objects.create(
+                name=f"Bulk Label {i}",
+                type="categorical",
+                settings={
+                    "options": [{"label": "positive"}, {"label": "negative"}],
+                    "multi_choice": False,
+                    "rule_prompt": "",
+                    "auto_annotate": False,
+                    "strategy": None,
+                },
+                organization=organization,
+                workspace=workspace,
+            )
+            for i in range(4)
+        ]
+        for order, extra_label in enumerate(extra, start=1):
+            AnnotationQueueLabel.objects.create(
+                queue=queue, label=extra_label, order=order, required=False
+            )
+
+        def submit(item_id, labels):
+            body = {
+                "annotations": [
+                    {
+                        "label_id": str(each.id),
+                        "value": 3 if each.type == "star" else "positive",
+                    }
+                    for each in labels
+                ]
+            }
+            with CaptureQueriesContext(connection) as ctx:
+                resp = auth_client.post(
+                    submit_annotations_url(queue_id, item_id), body, format="json"
+                )
+            assert resp.status_code == status.HTTP_200_OK, resp.data
+            assert _result(resp)["submitted"] == len(labels), _result(resp)
+            return len(ctx.captured_queries)
+
+        one = submit(item_ids[0], [label])
+        six = submit(item_ids[1], [label] + extra)
+
+        assert one == six, (
+            f"submit ran {one} queries for 1 label and {six} for 6 — "
+            f"{(six - one) / 5:.1f} per label. The per-label label lookup or the "
+            "per-label Score upsert is back (TH-7211)."
+        )
+
     def test_submit_stores_notes_per_label(
         self, auth_client, queue_with_items, label_b
     ):

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -5489,6 +5489,18 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 return self._gm.bad_request(str(exc))
             annotations_to_save.append((ann_data, label, value))
 
+        # A payload may repeat a label_id. The sequential update_or_create this
+        # replaces created then updated the same row, so the LAST entry won;
+        # bulk_create(ignore_conflicts) would keep the FIRST and drop the rest.
+        # Collapse to the last entry per label to preserve that.
+        if len({label.pk for _, label, _ in annotations_to_save}) != len(
+            annotations_to_save
+        ):
+            deduped = {}
+            for ann_data, label, value in annotations_to_save:
+                deduped[label.pk] = (ann_data, label, value)
+            annotations_to_save = list(deduped.values())
+
         # Upsert every Score in three statements instead of update_or_create per
         # label, which cost a SELECT, an INSERT/UPDATE and its own savepoint each
         # — ~8 queries per label in the annotator's inner loop (TH-7211).
@@ -5535,8 +5547,12 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                             score_source="human",
                             notes=per_label_notes,
                             organization=request.organization,
-                            # bulk_create skips the post_save tenancy backfill in
-                            # tfc/utils/signals.py — same value it would have written.
+                            # bulk_create skips the post_save tenancy backfill.
+                            # With a request workspace this is the value that
+                            # backfill would have written; with none it writes
+                            # item.workspace_id where the old path left NULL —
+                            # a deliberate improvement, not an equivalence, and
+                            # the same expression QueueItemNote uses below.
                             workspace_id=score_workspace_id,
                             # Denormalized tracer project id (QueueItem.project is
                             # the tracer.Project; null for non-tracer sources).
@@ -5563,13 +5579,19 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                     # bulk_update does not honour auto_now.
                     score.updated_at = now
                     to_update.append(score)
-                submitted += 1
 
             # no_workspace_objects for the writes too, not just the read above:
             # bulk_update filters through the manager's queryset, and the default
             # manager scopes by the request workspace — which would silently skip
             # exactly the NULL/mismatched-workspace rows this manager exists to
             # reach, reporting them as submitted.
+            #
+            # The old per-label update_or_create took a FOR UPDATE row lock and
+            # serialised concurrent writers; this read is unlocked. Only the same
+            # annotator can collide (annotator_id is in every applicable unique
+            # key), so the exposure is one user double-submitting an item: the
+            # update path is last-writer-wins and can lose one value_history
+            # entry, and the create path drops the loser's value below.
             with transaction.atomic():
                 if to_create:
                     # A concurrent submit of the same label can win the race; the
@@ -5592,6 +5614,14 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                             "updated_at",
                         ],
                     )
+            # Labels accepted for this item. Every one of them ends up with a
+            # live Score row, so this is not inflated by the ignore_conflicts
+            # drop above — but in that race the surviving row holds the
+            # concurrent request's value, not this one's. Deliberately not
+            # verified with a COUNT: that would add a query to the inner loop
+            # this change exists to shrink, to correct a number only a
+            # self-conflicting double-submit can skew.
+            submitted = len(annotations_to_save)
 
         if item_notes is not None:
             if item_notes:

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -5459,14 +5459,22 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             )
         )
 
+        # One read for every label in the payload; this was a .get() per label
+        # in the annotator's inner loop (TH-7211).
+        labels_by_id = {
+            label.pk: label
+            for label in AnnotationsLabels.objects.filter(
+                pk__in=[ann["label_id"] for ann in annotations_data], deleted=False
+            )
+        }
+
         annotations_to_save = []
         for ann_data in annotations_data:
             label_id = ann_data["label_id"]
             value = ann_data["value"]
 
-            try:
-                label = AnnotationsLabels.objects.get(pk=label_id, deleted=False)
-            except AnnotationsLabels.DoesNotExist:
+            label = labels_by_id.get(label_id)
+            if label is None:
                 continue
 
             # Validate label belongs to this queue
@@ -5481,41 +5489,109 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 return self._gm.bad_request(str(exc))
             annotations_to_save.append((ann_data, label, value))
 
-        for ann_data, label, value in annotations_to_save:
-            per_label_notes = (
-                ann_data.get("notes", label_notes_fallback) if label.allow_notes else ""
+        # Upsert every Score in three statements instead of update_or_create per
+        # label, which cost a SELECT, an INSERT/UPDATE and its own savepoint each
+        # — ~8 queries per label in the annotator's inner loop (TH-7211).
+        #
+        # Use no_workspace_objects + _id fields to avoid the LEFT JOIN on the
+        # nullable workspace FK that triggers PostgreSQL's "FOR UPDATE cannot be
+        # applied to the nullable side of an outer join".
+        if source_id and source_fk_field and annotations_to_save:
+            request_workspace = getattr(request, "workspace", None)
+            # _id, not the object: item.workspace would lazy-load the FK.
+            score_workspace_id = (
+                request_workspace.id if request_workspace else item.workspace_id
             )
-
-            # Upsert Score (unified annotation primitive)
-            # Use no_workspace_objects + _id fields to avoid the LEFT JOIN
-            # on nullable workspace FK that triggers PostgreSQL's "FOR UPDATE
-            # cannot be applied to the nullable side of an outer join".
-            if source_id and source_fk_field:
-                # Scope the upsert by queue_item so each queue review context
-                # owns its own Score row even when the same annotator scores
-                # the same label across multiple queues.
-                score, _ = Score.no_workspace_objects.update_or_create(
+            # Scoped by queue_item so each queue review context owns its own Score
+            # row even when the same annotator scores the same label across queues.
+            existing_by_label = {
+                score.label_id: score
+                for score in Score.no_workspace_objects.filter(
                     **{f"{source_fk_field}_id": source_id},
-                    label_id=label.pk,
+                    label_id__in=[label.pk for _, label, _ in annotations_to_save],
                     annotator_id=request.user.pk,
                     queue_item=item,
                     deleted=False,
-                    defaults={
-                        "source_type": item.source_type,
-                        "value": value,
-                        "score_source": "human",
-                        "notes": per_label_notes,
-                        "organization": request.organization,
-                        # Denormalized tracer project id (QueueItem.project is the
-                        # tracer.Project; null for non-tracer sources).
-                        **(
-                            {"tracer_project_id": item.project_id}
-                            if item.project_id
-                            else {}
-                        ),
-                    },
                 )
+            }
+            now = timezone.now()
+            to_create, to_update = [], []
+            for ann_data, label, value in annotations_to_save:
+                per_label_notes = (
+                    ann_data.get("notes", label_notes_fallback)
+                    if label.allow_notes
+                    else ""
+                )
+                score = existing_by_label.get(label.pk)
+                if score is None:
+                    to_create.append(
+                        Score(
+                            **{f"{source_fk_field}_id": source_id},
+                            label_id=label.pk,
+                            annotator_id=request.user.pk,
+                            queue_item=item,
+                            source_type=item.source_type,
+                            value=value,
+                            score_source="human",
+                            notes=per_label_notes,
+                            organization=request.organization,
+                            # bulk_create skips the post_save tenancy backfill in
+                            # tfc/utils/signals.py — same value it would have written.
+                            workspace_id=score_workspace_id,
+                            # Denormalized tracer project id (QueueItem.project is
+                            # the tracer.Project; null for non-tracer sources).
+                            tracer_project_id=item.project_id or None,
+                        )
+                    )
+                else:
+                    # Score.save() writes value_history and bulk_update bypasses
+                    # it. The row just read IS the previous version, so the entry
+                    # is built here rather than re-reading it as save() must.
+                    if score.value != value:
+                        score.value_history = Score.appended_value_history(
+                            score.value,
+                            score.value_history,
+                            score.updated_at or score.created_at,
+                        )
+                    score.source_type = item.source_type
+                    score.value = value
+                    score.score_source = "human"
+                    score.notes = per_label_notes
+                    score.organization = request.organization
+                    if item.project_id:
+                        score.tracer_project_id = item.project_id
+                    # bulk_update does not honour auto_now.
+                    score.updated_at = now
+                    to_update.append(score)
                 submitted += 1
+
+            # no_workspace_objects for the writes too, not just the read above:
+            # bulk_update filters through the manager's queryset, and the default
+            # manager scopes by the request workspace — which would silently skip
+            # exactly the NULL/mismatched-workspace rows this manager exists to
+            # reach, reporting them as submitted.
+            with transaction.atomic():
+                if to_create:
+                    # A concurrent submit of the same label can win the race; the
+                    # partial unique index on (source, label, annotator,
+                    # queue_item) WHERE NOT deleted makes that a no-op, not a 500.
+                    Score.no_workspace_objects.bulk_create(
+                        to_create, ignore_conflicts=True
+                    )
+                if to_update:
+                    Score.no_workspace_objects.bulk_update(
+                        to_update,
+                        [
+                            "source_type",
+                            "value",
+                            "value_history",
+                            "score_source",
+                            "notes",
+                            "organization",
+                            "tracer_project_id",
+                            "updated_at",
+                        ],
+                    )
 
         if item_notes is not None:
             if item_notes:


### PR DESCRIPTION
Sixth TH-7211 perf fix, third write path. Ticket item #7.

## The N+1

`annotations/submit` is the annotator's inner loop — hit on every single item —
and cost **~8 queries per label**. Measured on the seeded replica:

| labels | queries | ms |
|-------:|--------:|---:|
| 1      | 35      | 2,645 |
| 7      | **82**  | 5,018 |

Per label it ran two things:

1. `AnnotationsLabels.objects.get(pk=label_id)` in the validation loop — one
   query per label.
2. `Score.no_workspace_objects.update_or_create(...)` — a SELECT, an
   INSERT/UPDATE, **and its own BEGIN/SAVEPOINT/RELEASE/COMMIT**. Four of the
   eight per-label statements were transaction overhead.

Now: one read for every label in the payload, then one SELECT of existing
scores, one `bulk_create` and one `bulk_update` for the whole submission, in a
single transaction.

| labels | before | after |
|-------:|-------:|------:|
| 1      | 35     | **31** |
| 7      | **82** | **32** |

**Per-label cost 7.8 -> 0.** A 7-label submit does 50 fewer round trips.

## Three things this had to get right

**`value_history` would have been silently lost.** `Score.save()` is its only
writer (`models/score.py`), and `bulk_update` bypasses `save()`. An existing
test — `test_resubmitting_changed_value_preserves_score_value_history` — caught
this. The batch path already holds the previous row, so the entry is built from
it directly: no extra query, where `save()` must re-SELECT the row to get it.
The entry shape moved to `Score.appended_value_history` so both callers share
one definition rather than duplicating the format.

**Manager mismatch would have caused silent lost updates in prod.** The read
uses `no_workspace_objects` (deliberately — the default manager's LEFT JOIN on
the nullable workspace FK breaks `FOR UPDATE`). `bulk_update` filters through
its manager's queryset, and `BaseModelManager` scopes by the request workspace.
Writing through `Score.objects` would have found rows in the SELECT, put them in
`to_update`, then silently skipped them in the UPDATE's WHERE clause — while
still counting them in `submitted`. Exactly the NULL/mismatched-workspace rows
`no_workspace_objects` exists to reach. Both writes now use the same manager as
the read. Tests would not have caught this: fixture workspaces always match.

**`ON CONFLICT DO UPDATE` is not usable here.** The unique indexes in `score.py`
are *partial* (`condition=Q(deleted=False, trace__isnull=False)`), and Postgres
cannot infer a partial unique index without the matching `WHERE` predicate,
which Django cannot emit. `ignore_conflicts` (bare `DO NOTHING`) is the only
form available. The semantic delta: a concurrent double-submit of the same label
previously had the loser's value persist via `update_or_create`'s
IntegrityError-then-update; now the loser is dropped. `annotator_id` is in every
applicable unique key, so this can only be one user double-submitting the same
item, and a resubmit self-heals.

## Tests

`test_query_count_does_not_grow_with_label_count` — 1 label vs 6 must cost the
same. On `dev` it fails with:

```
submit ran 30 queries for 1 label and 70 for 6 — 8.0 per label.
```

which independently reproduces the audit's ~8/label. The 23 existing
`TestSubmitAnnotations` tests cover correctness, including the `value_history`
one that caught the regression above.

## Verification

- `test_annotation_workflow_api.py` + `test_queue_items_api.py` +
  `test_scores_api.py`: **248 passed, 6 xfailed, 1 xpassed**
- ruff check + format clean
- `views/annotation_queues.py` is in `api-contracts.yml`'s trigger paths, so CI
  runs `test_annotation_workflow_api.py` on this PR
- Reviewed by an independent adversarial pass before commit, which is what
  surfaced the `value_history` and manager issues

One unrelated line: `Score.clean()` had a pre-existing ruff `B007` (unused loop
variable) that the pre-commit hook fails on now that this commit touches
`score.py`. Renamed `st` -> `_st`; no behaviour change.
