### PR TITLE
perf(annotations): compress the queue export at the origin, not at the proxy

### DIFF
--- a/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
+++ b/futureagi/model_hub/tests/test_annotation_export_batch_cap.py
@@ -419,3 +419,77 @@ def test_export_trace_items_no_project_n_plus_one(
     # dropped from the export queryset).
     point_reads = _project_point_reads(cap)
     assert len(point_reads) <= 1, [q["sql"] for q in point_reads]
+
+
+# ── origin compression (TH-7235) ───────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_export_compresses_at_origin_when_the_client_accepts_gzip(
+    auth_client, organization, workspace, user
+):
+    """The export must carry its own Content-Encoding.
+
+    nginx gzips application/json, but it runs one replica capped at 100m CPU, so
+    compressing a 38MB export there cost ~17s of a ~24s request on a real
+    account. nginx skips any response that already has Content-Encoding, so
+    compressing here moves that work to the backend pods. Losing this decorator
+    silently hands the work back to the throttled proxy — no test would notice
+    without this one.
+    """
+    import gzip
+    import json as json_mod
+
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=5
+    )
+    url = EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json"
+
+    resp = auth_client.get(url, HTTP_ACCEPT_ENCODING="gzip")
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["Content-Encoding"] == "gzip"
+    assert "Accept-Encoding" in resp.get("Vary", "")
+    # The bytes must be real gzip AND decode to the same envelope the
+    # uncompressed response returns — a corrupted stream is worse than no gzip.
+    payload = json_mod.loads(gzip.decompress(resp.content).decode())
+    assert len(_unwrap(payload)) == 5
+
+
+@pytest.mark.django_db
+def test_export_is_uncompressed_when_the_client_does_not_accept_gzip(
+    auth_client, organization, workspace, user
+):
+    """Negotiation, not unconditional compression — an identity client must get
+    a body it can read."""
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=5
+    )
+    resp = auth_client.get(
+        EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=json",
+        HTTP_ACCEPT_ENCODING="identity",
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert not resp.has_header("Content-Encoding")
+    assert len(_unwrap(resp.data)) == 5
+
+
+@pytest.mark.django_db
+def test_csv_export_is_compressed_too(auth_client, organization, workspace, user):
+    """CSV was never compressed in production — nginx's gzip_types omits
+    text/csv — so this path gains the most from origin compression."""
+    import gzip
+
+    seed = _build_dataset_queue(
+        organization=organization, workspace=workspace, user=user, n_rows=5
+    )
+    resp = auth_client.get(
+        EXPORT_URL.format(queue_id=seed["queue"].id) + "?export_format=csv",
+        HTTP_ACCEPT_ENCODING="gzip",
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["Content-Encoding"] == "gzip"
+    body = gzip.decompress(resp.content).decode()
+    assert "item_id" in body.splitlines()[0]

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1,6 +1,7 @@
 import json
 import re
 import threading
+import time
 import unicodedata
 import uuid
 from datetime import date, datetime, timedelta
@@ -21,6 +22,8 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce, Lower, TruncDate
 from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.decorators.gzip import gzip_page
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
@@ -3350,10 +3353,32 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             **ERROR_RESPONSES,
         },
     )
+    # Compress at the origin, not at the proxy. nginx already gzips
+    # application/json, but it runs one replica capped at 100m CPU, so
+    # compressing a 38MB export there cost ~17s of the ~24s request — measured
+    # 24.4s with Accept-Encoding: gzip vs 12.3s without, 3 reps each. nginx skips
+    # any response that already carries Content-Encoding, so this moves the work
+    # onto the backend pods, which have real CPU. It depends on nginx forwarding
+    # the client's Accept-Encoding, which it does today; a
+    # `proxy_set_header Accept-Encoding "";` upstream would silently fall back
+    # to identity, which is slow but correct. CSV was never compressed at all —
+    # nginx's gzip_types omits text/csv — so that path gains the most.
+    @method_decorator(gzip_page)
     @action(detail=True, methods=["get"], url_path="export")
     def export_annotations(self, request, pk=None):
         """Export all items with their annotations."""
         query_params = request.validated_query_data
+        # Phase timings are logged once at the end. The server half of this
+        # request is ~7.5s on a real account and local data is 5x smaller, so
+        # attribution has to come from production rather than a laptop.
+        phase_ms: dict[str, float] = {}
+        phase_started = time.perf_counter()
+
+        def mark(phase):
+            nonlocal phase_started
+            now = time.perf_counter()
+            phase_ms[phase] = round((now - phase_started) * 1000, 1)
+            phase_started = now
 
         queue = self.get_object()
         # Tracer sources resolve CH-native via CollectorSourceCache below, so no
@@ -3393,14 +3418,19 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 ),
                 code=ApiErrorCode.EXPORT_TOO_LARGE.value,
             )
+        mark("items")
         queue_label_ids = list(
             queue.queue_labels.filter(deleted=False).values_list("label_id", flat=True)
         )
         scores_by_item = _scores_for_queue_items(items_list, queue_label_ids)
+        mark("scores")
         item_notes_by_id = _latest_item_notes_for_queue_items(items_list)
         eval_metrics_by_item = _eval_metrics_for_queue_items(items_list)
+        mark("notes_evals")
         ch_source_cache = CollectorSourceCache.for_items(items_list)
+        mark("clickhouse")
         cell_cache = dataset_cells_by_row(items_list)
+        mark("cells")
 
         result = []
         for item in items_list:
@@ -3430,7 +3460,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 }
             )
 
+        mark("assemble")
+
         fmt = query_params.get("export_format") or "json"
+        logger.info(
+            "annotation_export_phases",
+            queue_id=str(queue.id),
+            items=len(items_list),
+            export_format=fmt,
+            total_ms=round(sum(phase_ms.values()), 1),
+            **{f"{name}_ms": value for name, value in phase_ms.items()},
+        )
         if fmt == "csv":
             import csv
             import io


### PR DESCRIPTION
Closes the last genuinely broken read on the Annotations surface (TH-7235).

## The measurement that redirected this

A 731-item export took ~24.4s. I assumed it was heavy source content and wrote
that in the ticket. **It wasn't.** Raw https over the SOS session, 3 alternating
reps per arm:

| arm | TTFB | download | total | wire |
|---|---:|---:|---:|---:|
| `Accept-Encoding: gzip` | 7.3-8.3s | **16.6-17.1s** | **24.4-25.4s** | 9.10MB |
| `Accept-Encoding: identity` | 6.8-8.2s | 4.2-5.2s | **11.6-13.4s** | 38.21MB |

**Compression was doubling the request.** Browsers always send `Accept-Encoding`,
so every real user got the 24.4s path — and the customer's 504.

The compressor is **our own nginx**, not a CDN (`server: nginx/1.25.0`). From
`us/gcp/deployment/values.yaml`: `replicaCount: 1`, requests==limits of
**`cpu: 100m`**, `gzip_comp_level 5`, `gzip_types application/json`. 9.10MB of
output in 17s is ~0.5MB/s — exactly what a tenth of a core does at level 5.

## The fix

The 100m limit is deliberate, so this **moves** the work rather than raising the
limit. nginx skips any response that already carries `Content-Encoding`, so
`gzip_page` on this action means the backend pods (4 replicas, real CPU)
compress and nginx just proxies bytes.

Projected **~24.4s -> ~9-10s**, with no contract change.

`gzip_page` rather than hand-rolled `gzip.compress`: the decorator carries the
BREACH random-padding mitigation, Accept-Encoding negotiation, `Vary` patching,
ETag weakening and the small-body skip. Hand-rolling drops all of that silently.

**CSV gains the most** — nginx's `gzip_types` omits `text/csv`, so CSV exports
were never compressed at all.

## The one thing I could NOT verify

**That nginx passes a pre-compressed response through rather than
double-compressing it.** This is documented, long-standing `ngx_http_gzip_module`
behaviour and our config has no `gunzip` directive, but I tried to prove it
against `nginx:1.25.0` with the production gzip block and **could not pull the
image** (Docker Hub auth failure in my environment).

If it's wrong, clients get a body needing two gunzips — loud and immediate, not
silent. **Please confirm on dev before this reaches prod**, one command:

```
curl -sD- -o /tmp/e.gz -H 'Accept-Encoding: gzip' '<dev>/model-hub/annotation-queues/<id>/export/'
gzip -dc /tmp/e.gz | head -c 40      # must print JSON after ONE decompression
```

## Instrumentation, deliberately included

The ~7.5s of TTFB that remains after this is **unattributed**, and I'm not going
to guess in the PR body. Profiling locally produced two contradictory answers —
the ClickHouse read measured 2,387ms cold and 331ms warm in the same session —
and local payloads are 5x smaller than this account's. So the export now logs
per-phase timings (`annotation_export_phases`: items / scores / notes_evals /
clickhouse / cells / assemble). The next customer-triggered export gives exact
attribution instead of another laptop extrapolation.

## Tests

Three new, in `test_annotation_export_batch_cap.py`:
- gzip requested -> `Content-Encoding: gzip`, `Vary` contains Accept-Encoding,
  and `gzip.decompress()` round-trips to the same envelope
- identity requested -> no `Content-Encoding`, body still readable (negotiation,
  not unconditional compression)
- CSV + gzip -> compressed, header row intact

Removing the decorator fails the two compression tests with
`KeyError: 'content-encoding'`. The identity test passes either way by design —
it guards negotiation, not compression.

**212 passed, 6 xfailed, 1 xpassed** across export + workflow + queue-items.
ruff clean.

## Not in this PR

- `gzip_comp_level 5 -> 1` in the deployment repo would help every endpoint, but
  it's a different repo with platform-wide blast radius. Worth doing separately —
  though once large exports self-compress, most of its urgency goes away.
- `EXPORT_SYNC_MAX_ITEMS` caps **item count, not bytes**: 1,000 items at
  200KB/item is ~200MB materialized in one worker. Pre-existing; this PR adds
  only the compressed copy. Needs its own ticket (byte budget or streaming).
- **The original 30s 504 is still unexplained.** GCLB's backend policy is
  86,400s and attached, nginx `proxy_read_timeout` is 300s, and the FE axios
  instance sets no timeout. This cuts the duration well under any plausible cap,
  but I am not claiming it fixes a timeout I could not locate.
