### PR TITLE
fix(simulate): soft-delete bulk test executions

### DIFF
--- a/futureagi/simulate/tests/test_kpi_sql_queries.py
+++ b/futureagi/simulate/tests/test_kpi_sql_queries.py
@@ -264,6 +264,20 @@ class TestGetKpiMetricsQuery:
         assert m["failed_calls"] == 1
         assert m["completed_calls"] == 2
 
+
+    def test_excludes_soft_deleted_calls(self, voice_call_executions, test_execution):
+        """Soft-deleted calls should not contribute to KPI totals."""
+        voice_call_executions[0].delete()
+
+        query, params = get_kpi_metrics_query(test_execution.id)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            columns = [col[0] for col in cursor.description]
+            row = cursor.fetchone()
+
+        metrics = dict(zip(columns, row))
+        assert metrics["total_calls"] == 4
+
     def test_voice_metric_averages(self, voice_call_executions, test_execution):
         """Test that voice metric averages are computed correctly."""
         query, params = get_kpi_metrics_query(test_execution.id)

--- a/futureagi/simulate/tests/test_rerun_api.py
+++ b/futureagi/simulate/tests/test_rerun_api.py
@@ -1228,9 +1228,8 @@ class TestTestExecutionBulkDeleteView:
         assert data["deleted_count"] == 2
         assert len(data["deleted_ids"]) == 2
 
-        # Verify they're actually deleted
+        # Default managers hide the soft-deleted executions and calls.
         assert TestExecution.objects.filter(run_test=run_test).count() == 0
-        # Verify cascade deleted call executions
         assert (
             CallExecution.objects.filter(test_execution__run_test=run_test).count() == 0
         )
@@ -1260,6 +1259,13 @@ class TestTestExecutionBulkDeleteView:
         # test_execution_2 should still exist
         assert TestExecution.objects.filter(id=test_execution_2.id).exists()
         assert not TestExecution.objects.filter(id=test_execution.id).exists()
+
+        deleted_execution = TestExecution.all_objects.get(id=test_execution.id)
+        deleted_call = CallExecution.all_objects.get(id=call_execution.id)
+        assert deleted_execution.deleted is True
+        assert deleted_execution.deleted_at is not None
+        assert deleted_call.deleted is True
+        assert deleted_call.deleted_at is not None
 
     def test_delete_select_all_with_exclusion(
         self,

--- a/futureagi/simulate/tests/test_run_test_list_api.py
+++ b/futureagi/simulate/tests/test_run_test_list_api.py
@@ -1604,6 +1604,43 @@ class TestRunTestCallExecutionsView:
         listed_ids = {str(row.get("id")) for row in body["results"]}
         assert str(call_execution.id) in listed_ids
 
+    def test_get_run_test_call_executions_excludes_soft_deleted_calls(
+        self,
+        auth_client,
+        run_test_with_v10_scenario,
+        scenario_with_prompt_version,
+    ):
+        test_execution = TestExecution.objects.create(
+            run_test=run_test_with_v10_scenario,
+            status=TestExecution.ExecutionStatus.COMPLETED,
+            total_scenarios=1,
+            total_calls=2,
+        )
+        active_call = CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=scenario_with_prompt_version,
+            status=CallExecution.CallStatus.COMPLETED,
+            simulation_call_type=CallExecution.SimulationCallType.TEXT,
+        )
+        deleted_call = CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=scenario_with_prompt_version,
+            status=CallExecution.CallStatus.COMPLETED,
+            simulation_call_type=CallExecution.SimulationCallType.TEXT,
+        )
+        deleted_call.delete()
+
+        response = auth_client.get(
+            f"/simulate/run-tests/{run_test_with_v10_scenario.id}/call-executions/"
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["count"] == 1
+        listed_ids = {str(row.get("id")) for row in body["results"]}
+        assert str(active_call.id) in listed_ids
+        assert str(deleted_call.id) not in listed_ids
+
     def test_get_run_test_call_executions_unauthenticated_returns_401(
         self, api_client, run_test_with_v10_scenario
     ):

--- a/futureagi/simulate/utils/sql_query.py
+++ b/futureagi/simulate/utils/sql_query.py
@@ -80,6 +80,8 @@ def get_combined_call_executions_and_snapshots_query(
         JOIN simulate_test_execution te ON ce.test_execution_id = te.id
         JOIN simulate_scenarios s ON ce.scenario_id = s.id
         WHERE te.run_test_id = %s
+        AND te.deleted = false
+        AND ce.deleted = false
         {search_conditions}
         {status_conditions}
 
@@ -98,6 +100,9 @@ def get_combined_call_executions_and_snapshots_query(
         JOIN simulate_test_execution te2 ON ce2.test_execution_id = te2.id
         JOIN simulate_scenarios s2 ON ce2.scenario_id = s2.id
         WHERE te2.run_test_id = %s
+        AND te2.deleted = false
+        AND ce2.deleted = false
+        AND ces.deleted = false
         AND ces.rerun_type = 'call_and_eval'
         {search_conditions.replace('ce.', 'ce2.').replace('s.name', 's2.name')}
         {status_conditions.replace('ce.status', 'ces.status')}
@@ -156,6 +161,8 @@ def get_combined_call_executions_and_snapshots_count_query(
         JOIN simulate_test_execution te ON ce.test_execution_id = te.id
         JOIN simulate_scenarios s ON ce.scenario_id = s.id
         WHERE te.run_test_id = %s
+        AND te.deleted = false
+        AND ce.deleted = false
         {search_conditions}
         {status_conditions}
 
@@ -166,6 +173,9 @@ def get_combined_call_executions_and_snapshots_count_query(
         JOIN simulate_test_execution te2 ON ce2.test_execution_id = te2.id
         JOIN simulate_scenarios s2 ON ce2.scenario_id = s2.id
         WHERE te2.run_test_id = %s
+        AND te2.deleted = false
+        AND ce2.deleted = false
+        AND ces.deleted = false
         AND ces.rerun_type = 'call_and_eval'
         {search_conditions.replace('ce.', 'ce2.').replace('s.name', 's2.name')}
         {status_conditions.replace('ce.status', 'ces.status')}
@@ -210,6 +220,7 @@ def get_kpi_eval_metrics_query(test_execution_id):
         FROM simulate_call_execution ce,
              jsonb_each(ce.eval_outputs) AS e(key, value)
         WHERE ce.test_execution_id = %s
+          AND ce.deleted = false
           AND ce.eval_outputs IS NOT NULL
           AND jsonb_typeof(ce.eval_outputs) = 'object'
           AND e.value ? 'output'
@@ -396,6 +407,7 @@ def get_kpi_metrics_query(test_execution_id):
         ROUND(AVG((conversation_metrics_data->>'csat_score')::numeric), 2) AS avg_csat_score
     FROM simulate_call_execution
     WHERE test_execution_id = %s
+      AND deleted = false
     """
     params = [str(test_execution_id)]
     return query, params

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -3838,8 +3838,13 @@ class TestExecutionBulkDeleteView(APIView):
             ]
             count = len(deleted_ids)
 
-            # Hard delete (cascades to call executions)
-            test_executions.delete()
+            with transaction.atomic():
+                now = timezone.now()
+                CallExecution.objects.filter(
+                    test_execution__in=test_executions,
+                    deleted=False,
+                ).update(deleted=True, deleted_at=now)
+                test_executions.update(deleted=True, deleted_at=now)
 
             logger.info(
                 f"Bulk deleted {count} test executions from run test {run_test_id}"


### PR DESCRIPTION
## Summary

Bulk deletion of test executions now follows the existing soft-delete behavior used by single execution deletion. Parent `TestExecution` and child `CallExecution` records remain recoverable through `all_objects` while normal reads continue to hide them. Raw SQL list and KPI queries now exclude soft-deleted executions and calls.

## Linked issues

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Bulk deletion behavior**

- The bulk test-execution endpoint soft-deletes selected executions and their call executions inside one transaction.
- The response contract and active-execution safeguards are unchanged.

**B. Reporting query filters**

- Raw SQL pagination, count, KPI, and evaluation queries now exclude soft-deleted test and call executions.

**C. Regression coverage**

- API and SQL tests verify that deleted rows remain retained but hidden from normal reads and reporting.

---

## 2) Why the changes were done

- **Product/UX:** Deleted test history is no longer physically lost, while deleted records stay out of normal execution and reporting views.
- **Technical:** `QuerySet.delete()` bypassed `BaseModel.delete()` and hard-deleted rows. The fix uses the established `deleted` / `deleted_at` contract and an atomic parent-child update.
- **Architecture:** Raw SQL paths receive the same soft-delete filtering already provided by Django managers.

---

## 3) Tests written + scenarios each covers

**`simulate/tests/test_rerun_api.py`** — bulk test-execution deletion API

- `TestTestExecutionBulkDeleteView::test_delete_specific_ids` — verifies the selected execution and child call remain in `all_objects` with deletion timestamps while default managers hide them.
- Existing bulk-delete cases — verify select-all, exclusions, active guards, validation, authentication, missing resources, and response counts.

**`simulate/tests/test_run_test_list_api.py`** — run-test call-execution listing API

- `TestRunTestCallExecutionsView::test_get_run_test_call_executions_excludes_soft_deleted_calls` — verifies deleted calls do not appear and pagination count remains correct.

**`simulate/tests/test_kpi_sql_queries.py`** — raw KPI SQL

- `TestGetKpiMetricsQuery::test_excludes_soft_deleted_calls` — verifies deleted calls do not contribute to KPI totals.

> Run result: **22 passed** across the focused suites. Syntax parsing and `git diff --check` also passed.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test --no-services simulate/tests/test_rerun_api.py simulate/tests/test_kpi_sql_queries.py -k 'TestTestExecutionBulkDeleteView or TestGetKpiMetricsQuery'
bin/test --no-services simulate/tests/test_run_test_list_api.py -k TestRunTestCallExecutionsView
```

The test runner emitted a pre-existing ClickHouse schema-apply connection warning; all selected tests passed.

### Frontend tests (if applicable)

Not applicable; no frontend files changed.

### Contract verification (if API surface changed)

Not applicable; response schemas and endpoint shapes are unchanged.

### UI steps (manual)

Not applicable; this is a backend persistence and reporting fix.

---

## 5) Screenshots / recordings

Not applicable; backend-only change.

---

## 6) Edge cases & considerations

- Active, pending, and cancelling test executions remain undeletable.
- Parent and child soft deletes use one transaction and one timestamp.
- Default managers continue hiding soft-deleted rows.
- Raw SQL pagination and count queries apply matching deletion filters so counts do not include rows that cannot be serialized.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- The focused test runner reports a ClickHouse schema-apply connection reset warning, but the selected tests complete successfully.

---

## 8) Architectural / important decisions

- **Use bulk soft updates instead of instance loops:** This matches existing repository patterns and keeps the parent-child operation atomic without unnecessary queries.
- **Filter raw SQL explicitly:** Raw SQL bypasses Django’s default manager, so it must enforce the same soft-delete contract directly.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
