### PR TITLE
fix(gateway): use guardrail label for the configure modal title [TH-3989]

### DIFF
--- a/frontend/src/sections/gateway/settings/GuardrailCheckDialog.jsx
+++ b/frontend/src/sections/gateway/settings/GuardrailCheckDialog.jsx
@@ -206,9 +206,13 @@ const GuardrailCheckDialog = ({
     onClose();
   };
 
-  const displayName = (checkName || "")
-    .replace(/-/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  // Use the label so the title matches the list — deriving it from the slug
+  // mangles acronyms ("presidio-pii" -> "Presidio Pii").
+  const displayName =
+    providerMeta?.label ||
+    (checkName || "")
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
 
   const renderProviderField = (field) => {
     const {

--- a/frontend/src/sections/gateway/settings/GuardrailCheckDialog.test.jsx
+++ b/frontend/src/sections/gateway/settings/GuardrailCheckDialog.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "src/utils/test-utils";
+
+import GuardrailCheckDialog from "./GuardrailCheckDialog";
+import GuardrailConfigTab from "./GuardrailConfigTab";
+
+vi.mock("src/utils/logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+const noop = () => {};
+
+const renderDialog = (props = {}) =>
+  render(
+    <GuardrailCheckDialog
+      open
+      onClose={noop}
+      onSave={noop}
+      checkName="presidio-pii"
+      initialData={null}
+      providerMeta={null}
+      {...props}
+    />,
+  );
+
+describe("GuardrailCheckDialog title", () => {
+  // The slug cannot be title-cased into the right name. Two ways it breaks:
+  // acronyms ("presidio-pii" -> "Presidio Pii") and vendor names that simply
+  // differ from the slug ("bedrock-guardrails" is "AWS Bedrock Guardrails").
+  // 15 of the 28 checks were affected, so the title must come from the label.
+  it.each([
+    ["presidio-pii", "Presidio PII"],
+    ["pii-detection", "PII Detection"],
+    ["mcp-security", "MCP Security"],
+    ["crowdstrike-aidr", "CrowdStrike AIDR"],
+    ["bedrock-guardrails", "AWS Bedrock Guardrails"],
+    ["enkrypt-guard", "Enkrypt AI"],
+  ])("uses the provider label for %s", (checkName, label) => {
+    renderDialog({ checkName, providerMeta: { label } });
+
+    expect(screen.getByText(`Configure: ${label}`)).toBeInTheDocument();
+  });
+
+  it("does not title-case the slug when a label is available", () => {
+    renderDialog({
+      checkName: "presidio-pii",
+      providerMeta: { label: "Presidio PII" },
+    });
+
+    expect(screen.queryByText("Configure: Presidio Pii")).toBeNull();
+  });
+
+  it("falls back to the slug when the dialog opens without provider meta", () => {
+    renderDialog({ checkName: "keyword-blocklist", providerMeta: null });
+
+    expect(
+      screen.getByText("Configure: Keyword Blocklist"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("GuardrailConfigTab -> dialog (TH-3989 repro)", () => {
+  it("opens the Presidio card with a correctly cased modal title", async () => {
+    render(<GuardrailConfigTab guardrails={{ checks: {} }} onChange={noop} />);
+
+    const card = screen.getByText("Presidio PII").closest(".MuiCard-root");
+    expect(card).not.toBeNull();
+
+    fireEvent.click(within(card).getByRole("button"));
+
+    expect(
+      await screen.findByText("Configure: Presidio PII"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Configure: Presidio Pii")).toBeNull();
+  });
+});


### PR DESCRIPTION
**Ticket:** [TH-3989](https://linear.app/future-agi/issue/TH-3989/guardrails-configure-presidio-pii-modal-title-has-incorrect-casing) — Closes TH-3989

## What was the bug

The guardrail configure modal derived its title from the check's slug instead of using the display label, so the title disagreed with the row the user clicked.

The ticket reports one case (`Configure: Presidio Pii` instead of `Configure: Presidio PII`), but **15 of the 28 checks are affected**.

## What changes have been done

- `frontend/src/sections/gateway/settings/GuardrailCheckDialog.jsx` — title now uses `providerMeta.label`, falling back to the slug derivation only when meta is absent
- `frontend/src/sections/gateway/settings/GuardrailCheckDialog.test.jsx` — new, 9 tests

## Why the changes

`displayName` was built by title-casing the slug:

```js
(checkName || "").replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
```

That breaks in two ways, and only the first is recoverable by cleverer casing:

1. **Acronyms get mangled** — `presidio-pii` → `Presidio Pii`, `mcp-security` → `Mcp Security`, `crowdstrike-aidr` → `Crowdstrike Aidr`
2. **Vendor names simply differ from the slug** — `bedrock-guardrails` is branded `AWS Bedrock Guardrails`, `enkrypt-guard` is `Enkrypt AI`, `ibm-ai-detector` is `IBM Granite Guardian`. No casing rule can produce these.

The correct string already exists: every entry in `GUARDRAIL_CHECKS` has a `label`, and it already reaches the dialog because the call site passes the same object as both card props and `providerMeta`. The list rendered `label` while the modal rendered a parallel derivation — two sources of truth for one name.

Using the label fixes all 15 at once and keeps them in sync if a check is ever renamed. The derivation stays as a fallback because `handleEdit` does `setEditingMeta(meta || null)`, so the dialog can open without meta.

Full list of titles corrected:

| slug | was | now |
|---|---|---|
| `pii-detection` | Pii Detection | PII Detection |
| `futureagi-eval` | Futureagi Eval | Future AGI Eval |
| `presidio-pii` | Presidio Pii | Presidio PII |
| `bedrock-guardrails` | Bedrock Guardrails | AWS Bedrock Guardrails |
| `hiddenlayer-guard` | Hiddenlayer Guard | HiddenLayer |
| `aporia-guard` | Aporia Guard | Aporia Guardrails |
| `pangea-guard` | Pangea Guard | Pangea AI Guard |
| `dynamoai-guard` | Dynamoai Guard | DynamoAI Guard |
| `enkrypt-guard` | Enkrypt Guard | Enkrypt AI |
| `ibm-ai-detector` | Ibm Ai Detector | IBM Granite Guardian |
| `grayswan-guard` | Grayswan Guard | GraySwan Cygnal |
| `lasso-guard` | Lasso Guard | Lasso Security |
| `crowdstrike-aidr` | Crowdstrike Aidr | CrowdStrike AIDR |
| `zscaler-guard` | Zscaler Guard | Zscaler AI Guard |
| `mcp-security` | Mcp Security | MCP Security |

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Acronym slugs: `presidio-pii`, `pii-detection`, `mcp-security`, `crowdstrike-aidr` | Title uses the label, acronyms fully uppercase |
| 2 | Slugs whose label differs entirely: `bedrock-guardrails`, `enkrypt-guard` | Title uses the label, not a title-cased slug |
| 3 | Label present | `Configure: Presidio Pii` is **absent** — guards against a near-miss regression |
| 4 | Dialog opened without `providerMeta` | Falls back to the slug derivation (`Configure: Keyword Blocklist`) rather than rendering an empty title |
| 5 | Integration, replays the ticket steps: render the tab, click edit on the Presidio card | Modal title reads `Configure: Presidio PII` |

Verified the tests actually catch the bug: reverting the fix fails 8 of the 9.

## How to reproduce (original bug)

1. Go to Gateway → Settings → Guardrails
2. Click the edit (pencil) icon on the **Presidio PII** card
3. Modal title reads `Configure: Presidio Pii` while the card reads `Presidio PII`

Any of the 15 checks in the table above reproduces it.

## Commands

```bash
cd frontend
npx vitest run src/sections/gateway/settings/GuardrailCheckDialog.test.jsx
```

## Videos and screenshots

https://github.com/user-attachments/assets/49b116f9-e073-4d88-8424-e24dbce03be6


