### PR TITLE
fix(agents): create observability provider for bland agents

### DIFF
--- a/futureagi/ai_tools/tools/simulation/create_agent_definition.py
+++ b/futureagi/ai_tools/tools/simulation/create_agent_definition.py
@@ -247,6 +247,7 @@ class CreateAgentDefinitionTool(BaseTool):
             supported_providers = [
                 ProviderChoices.VAPI,
                 ProviderChoices.RETELL,
+                ProviderChoices.BLAND,
                 ProviderChoices.OTHERS,
             ]
             # Align with backend view: only create when provider is supported.

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -278,6 +278,7 @@ class CreateAgentDefinitionView(APIView):
                 in [
                     ProviderChoices.VAPI,
                     ProviderChoices.RETELL,
+                    ProviderChoices.BLAND,
                     ProviderChoices.OTHERS,
                 ]
             ):


### PR DESCRIPTION
## Summary

Bland voice agents created with `observability_enabled: true` silently came back with observability off. The create-agent endpoint gates provider-row creation on a hardcoded whitelist that never had `bland` added.

## Why / problem

`observability_enabled` is not a stored column — it was dropped in `0038_remove_agentdefinition_observability_enabled`. It is derived from the linked `ObservabilityProvider` row when the version snapshot is built:

```python
observability_enabled=getattr(agent.observability_provider, "enabled", False)
```

`CreateAgentDefinitionView` only creates that row when the provider is in `[VAPI, RETELL, OTHERS]`. For `bland` the condition falls through, `observability_provider` stays `None`, and the agent is created with no error and no warning — the flag just disappears. Every later `GET /agent-definition/<id>` then reports observability off.

Nothing else on the path rejects bland:

- Request validation explicitly allows it (`AgentDefinitionCreateRequestSerializer`, provider choices include `BLAND`)
- `ObservabilityService` fully supports bland for key verification and log pulls
- The **update** path (`agent_version.py`) has no whitelist at all, which is why re-saving an existing bland agent turns observability on

That create/update inconsistency is what identifies the whitelist as stale rather than deliberate.

## What changed

- `futureagi/simulate/views/agent_definition.py` — added `ProviderChoices.BLAND` to the observability provider whitelist in `CreateAgentDefinitionView`
- `futureagi/ai_tools/tools/simulation/create_agent_definition.py` — same addition to the mirrored list in the MCP tool, which carries a comment stating it deliberately tracks the view

## Tests

No new tests. There is currently no bland-specific observability coverage; existing tests cover the VAPI/Retell/Others paths and confirm no regression.

## Commands

```bash
cd futureagi && bin/test \
  simulate/tests/test_agent_definition_api.py \
  simulate/tests/test_agent_definition_serializers.py \
  simulate/tests/test_agent_version_snapshot.py \
  ai_tools/tests/test_simulation_tools.py -v
```

## Backwards compatibility

Backwards compatible. Strictly widens the set of providers for which an observability provider row is created. No schema change, no change to existing rows, no API contract change.

Agents created before this fix still have no provider row. They are unaffected by this PR and need a re-save (or a backfill) to pick observability up.

## Manual verification

- [ ] POST a bland voice agent with `observability_enabled: true`, `api_key`, `assistant_id`
- [ ] GET the agent — `observability_provider` is non-null
- [ ] Active version snapshot shows `observability_enabled: true`
- [ ] An `observe` project is created under the agent name
- [ ] Bland call logs land in that project
- [ ] Regression: repeat for vapi and retell, behaviour unchanged

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review performed
- [ ] Tests added (no bland-specific coverage exists; called out above)
- [x] No new lint errors
- [x] Backwards compatible

## Backout

Revert this commit. Restores the previous whitelist; bland agents go back to silently dropping the flag.

## Linear

_No ticket linked — add `Closes TH-XXXX` if one exists._
