### PR TITLE
fix(eval-tasks): window continuous tasks on arrival time, not start time

### DIFF
--- a/futureagi/tracer/selectors/eval_tasks/row_resolver.py
+++ b/futureagi/tracer/selectors/eval_tasks/row_resolver.py
@@ -34,11 +34,12 @@ _BUILDER_BY_ROW_TYPE = {
 
 
 def iter_desired_rows(
-    task: EvalTask, *, batch_size: int = 10_000
+    task: EvalTask, *, batch_size: int = 10_000, ceiling: datetime | None = None
 ) -> Iterator[list[str]]:
     # Row limit applies to historical tasks only; continuous runs forever.
     limit = task.spans_limit if task.run_type == RunType.HISTORICAL else None
     sampling_rate = task.sampling_rate if task.sampling_rate is not None else 100.0
+    created_at_ceiling = ceiling if task.run_type == RunType.CONTINUOUS else None
 
     sql, params = _build_sample_query(
         project_id=str(task.project_id),
@@ -48,6 +49,7 @@ def iter_desired_rows(
         filters=task.filters or {},
         limit=limit,
         created_at_floor=_continuous_floor(task),
+        created_at_ceiling=created_at_ceiling,
     )
     reader = get_reader()
     try:
@@ -79,6 +81,7 @@ def _build_sample_query(
     filters: dict | None,
     limit: int | None,
     created_at_floor: datetime | None = None,
+    created_at_ceiling: datetime | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Sampled-row-ids SQL for the row_type: take the UI list builder's filtered
     id set and wrap it with deterministic hash sampling, a stable order, and the
@@ -107,24 +110,13 @@ def _build_sample_query(
             }
         )
 
-    # Continuous forward floor. Appended last so it wins the lower bound in
-    # parse_time_range over any date_range start above (a continuous task is
-    # anchored at its own start, not an earlier configured window) — and so the
-    # set isn't silently capped at parse_time_range's now-30d default.
-    if created_at_floor is not None:
-        ui_filters.append(
-            {
-                "column_id": "created_at",
-                "filter_config": {
-                    "filter_type": "datetime",
-                    "filter_op": "greater_than",
-                    "filter_value": created_at_floor,
-                },
-            }
-        )
-
+    # Continuous floor: passed to build_id_query to bind on arrival (created_at),
+    # not injected as a filter (parse_time_range would fold it onto start_time).
+    # None (historical) keeps the builder's start_time window.
     builder = get_v2_class(query_type)(project_id=str(project_id), filters=ui_filters)
-    inner_sql, params = builder.build_id_query()
+    inner_sql, params = builder.build_id_query(
+        created_at_floor=created_at_floor, created_at_ceiling=created_at_ceiling
+    )
     params = {**params, "salt": str(salt), "rate": float(sampling_rate)}
 
     # observation_type is a legacy top-level key, not a filter-builder column;

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -175,10 +175,22 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def build_id_query(self) -> tuple[str, dict[str, Any]]:
+    def build_id_query(
+        self,
+        *,
+        created_at_floor: datetime | None = None,
+        created_at_ceiling: datetime | None = None,
+    ) -> tuple[str, dict[str, Any]]:
         """Filtered session ids only — same grouped, remap-aware scan as build(),
         no pagination/order. Lets the eval resolver select the same sessions this
-        list endpoint returns."""
+        list endpoint returns.
+
+        ``created_at_floor`` (continuous eval tasks only): floor the span scan on
+        CH arrival time (``created_at``) instead of event time (``start_time``),
+        so a session whose spans landed in CH after their ``start_time`` is still
+        picked up. ``None`` keeps the ``start_time`` window used by the UI list
+        and historical tasks.
+        """
         self.start_date, self.end_date = self.parse_time_range(self.filters)
         self.params["start_date"] = self.start_date
         self.params["end_date"] = self.end_date
@@ -199,7 +211,21 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         filter_fragment = f"AND {extra_where}" if extra_where else ""
         having_fragment = f"HAVING {having_clauses}" if having_clauses else ""
         message_select = self._message_aggregate_select()
-        time_where = "AND start_time >= %(start_date)s AND start_time < %(end_date)s"
+        if created_at_floor is not None:
+            # Window on arrival (created_at), not start_time. NOTE: with a user
+            # filter, the membership subqueries still window on start_time, so a
+            # filtered task can miss an arrival whose start_time predates
+            # parse_time_range's window — pre-existing residual, tracked as a
+            # follow-up.
+            self.params["created_at_floor"] = created_at_floor
+            time_where = "AND created_at >= %(created_at_floor)s"
+            if created_at_ceiling is not None:
+                self.params["created_at_ceiling"] = created_at_ceiling
+                time_where += " AND created_at < %(created_at_ceiling)s"
+        else:
+            time_where = (
+                "AND start_time >= %(start_date)s AND start_time < %(end_date)s"
+            )
         from_where = self._session_from_where(
             self.params,
             time_where=time_where,

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -16,6 +16,7 @@ span IDs, grouped by ``(observation_span_id, label_id)``.
 The three result sets are merged in Python to produce the final response.
 """
 
+from datetime import datetime
 from typing import Any
 
 from tracer.services.clickhouse.eval_logger_table import eval_logger_source
@@ -279,7 +280,13 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def build_id_query(self, *, limit: int | None = None) -> tuple[str, dict[str, Any]]:
+    def build_id_query(
+        self,
+        *,
+        limit: int | None = None,
+        created_at_floor: datetime | None = None,
+        created_at_ceiling: datetime | None = None,
+    ) -> tuple[str, dict[str, Any]]:
         """Filtered span ids only — same filter/time window as build(), no pivots.
 
         With ``limit=None`` (default) the full matching id set is returned
@@ -287,8 +294,25 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         capped "select all matching" resolve: the ids are then ordered
         newest-first (``start_time DESC, id DESC`` — same as the observe list and
         the PG bulk-select) so the cap keeps the most recent rows deterministically.
+
+        ``created_at_floor`` (continuous eval tasks only): floor the scan on CH
+        arrival time (``created_at``) instead of event time (``start_time``), so a
+        span whose ingestion lagged its ``start_time`` is still picked up. ``None``
+        keeps the ``start_time`` window used by the UI list and historical tasks.
         """
         start_date, end_date = self.parse_time_range(self.filters)
+        if created_at_floor is not None:
+            self.params["created_at_floor"] = created_at_floor
+            time_where = "AND created_at >= %(created_at_floor)s"
+            if created_at_ceiling is not None:
+                self.params["created_at_ceiling"] = created_at_ceiling
+                time_where += " AND created_at < %(created_at_ceiling)s"
+        else:
+            time_where = (
+                "AND created_at >= %(start_date)s - INTERVAL 1 DAY "
+                "AND start_time >= %(start_date)s "
+                "AND start_time < %(end_date)s"
+            )
         self.params["start_date"] = start_date
         self.params["end_date"] = end_date
 
@@ -319,9 +343,7 @@ class SpanListQueryBuilder(BaseQueryBuilder):
         SELECT id
         FROM {self.TABLE}
         {self.project_where()}
-          AND created_at >= %(start_date)s - INTERVAL 1 DAY
-          AND start_time >= %(start_date)s
-          AND start_time < %(end_date)s
+          {time_where}
           {pv_fragment}
           {filter_fragment}
         {order_fragment}

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -252,11 +252,39 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def build_id_query(self) -> tuple[str, dict[str, Any]]:
+    def build_id_query(
+        self,
+        *,
+        created_at_floor: datetime | None = None,
+        created_at_ceiling: datetime | None = None,
+    ) -> tuple[str, dict[str, Any]]:
         """Filtered trace ids only — same root-span predicate/window as build(),
         no pagination/order. Lets the eval resolver select the same traces this
-        list endpoint returns."""
+        list endpoint returns.
+
+        ``created_at_floor`` (continuous eval tasks only): floor the root-span
+        scan on CH arrival time (``created_at``) instead of event time
+        (``start_time``), so a trace whose root span landed in CH after its
+        ``start_time`` is still picked up. ``None`` keeps the ``start_time``
+        window used by the UI list and historical tasks.
+        """
         self.start_date, self.end_date = self.parse_time_range(self.filters)
+        if created_at_floor is not None:
+            # Window on arrival (created_at), not start_time. NOTE: cross-table
+            # filter membership subqueries (span_date_scope) still window on
+            # start_time, so a filtered task can miss an arrival whose start_time
+            # predates parse_time_range's window — pre-existing residual (worse
+            # before this change), tracked as a follow-up.
+            self.params["created_at_floor"] = created_at_floor
+            time_where = "AND created_at >= %(created_at_floor)s"
+            if created_at_ceiling is not None:
+                self.params["created_at_ceiling"] = created_at_ceiling
+                time_where += " AND created_at < %(created_at_ceiling)s"
+        else:
+            time_where = (
+                f"AND {TIME_FILTER_COLUMN} >= %(start_date)s "
+                f"AND {TIME_FILTER_COLUMN} < %(end_date)s"
+            )
         self.params["start_date"] = self.start_date
         self.params["end_date"] = self.end_date
 
@@ -291,8 +319,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND (parent_span_id IS NULL OR parent_span_id = '')
-          AND {TIME_FILTER_COLUMN} >= %(start_date)s
-          AND {TIME_FILTER_COLUMN} < %(end_date)s
+          {time_where}
           {pv_fragment}
           {search_fragment}
           {filter_fragment}

--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -17,6 +17,7 @@ The result sets are merged in Python, with raw_log processing delegated to
 the existing ``ObservabilityService.process_raw_logs()``.
 """
 
+from datetime import datetime
 from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
@@ -133,11 +134,35 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         """
         return query, self.params
 
-    def build_id_query(self) -> tuple[str, dict[str, Any]]:
+    def build_id_query(
+        self,
+        *,
+        created_at_floor: datetime | None = None,
+        created_at_ceiling: datetime | None = None,
+    ) -> tuple[str, dict[str, Any]]:
         """Filtered conversation-root span ids only — same predicate/window as
         build(), no pagination/order. Lets the eval resolver select the same
-        voice calls this list endpoint returns."""
+        voice calls this list endpoint returns.
+
+        ``created_at_floor``/``created_at_ceiling`` (continuous eval tasks only):
+        window the scan by CH arrival (``created_at``), not event time, so calls
+        whose root span reached CH long after they started (Vapi emits at
+        end-of-call) are still picked up. ``None`` keeps the ``start_time`` window
+        used by the UI list and historical tasks.
+        """
         start_date, end_date = self.parse_time_range(self.filters)
+        if created_at_floor is not None:
+            self.params["created_at_floor"] = created_at_floor
+            time_where = "AND created_at >= %(created_at_floor)s"
+            if created_at_ceiling is not None:
+                self.params["created_at_ceiling"] = created_at_ceiling
+                time_where += " AND created_at < %(created_at_ceiling)s"
+        else:
+            time_where = (
+                "AND created_at >= %(start_date)s - INTERVAL 1 DAY "
+                "AND start_time >= %(start_date)s "
+                "AND start_time < %(end_date)s"
+            )
         self.params["start_date"] = start_date
         self.params["end_date"] = end_date
 
@@ -157,9 +182,7 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         {self.project_where()}
           AND (parent_span_id IS NULL OR parent_span_id = '')
           AND observation_type = 'conversation'
-          AND created_at >= %(start_date)s - INTERVAL 1 DAY
-          AND start_time >= %(start_date)s
-          AND start_time < %(end_date)s
+          {time_where}
           {filter_fragment}
         ORDER BY start_time DESC
         LIMIT 1 BY trace_id

--- a/futureagi/tracer/services/clickhouse/v2/schema/024_spans_created_at_index.sql
+++ b/futureagi/tracer/services/clickhouse/v2/schema/024_spans_created_at_index.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- 024 — created_at minmax skip index on spans (arrival-time pruning)
+-- =============================================================================
+--
+-- Continuous eval-task reconcile floors on created_at (arrival), not start_time.
+-- spans is PARTITION BY toDate(start_time), so `created_at >= floor` prunes
+-- nothing and each poll scans project history. This minmax index prunes by
+-- created_at (late arrivals land in new, recent-created_at parts regardless of
+-- start_time partition). Mirrors the traces table (015:69).
+--
+-- ADD INDEX is instant; only parts written after it are indexed on insert/merge.
+--
+-- ============================ DEPLOY STEP =====================================
+-- MATERIALIZE (backfills existing parts) is a full-table mutation, kept out of
+-- the applier. Run by hand per region, off-peak, before relying on the floor at
+-- scale (add the cluster clause on replicated US; abort via KILL MUTATION):
+--
+--   ALTER TABLE spans MATERIALIZE INDEX auto_minmax_index_created_at;
+-- =============================================================================
+
+ALTER TABLE spans
+    ADD INDEX IF NOT EXISTS auto_minmax_index_created_at created_at
+    TYPE minmax() GRANULARITY 1;

--- a/futureagi/tracer/services/eval_tasks/entries.py
+++ b/futureagi/tracer/services/eval_tasks/entries.py
@@ -23,6 +23,8 @@ from tracer.services.clickhouse.v2 import get_reader
 from tracer.services.eval_tasks.config_hash import resolved_config_hash
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from tracer.models.eval_task import EvalTask
     from tracer.services.clickhouse.v2.span_reader import CHSpanReader
 
@@ -106,8 +108,12 @@ def persist_eval_result(logger_kwargs: dict[str, Any]) -> EvalLogger | None:
     return EvalLogger.objects.filter(id=entry_id).first()
 
 
-def materialize_pending(task: EvalTask) -> int:
-    """Create one pending entry per (desired row, eval). Returns rows submitted."""
+def materialize_pending(task: EvalTask, *, ceiling: datetime | None = None) -> int:
+    """Create one pending entry per (desired row, eval). Returns rows submitted.
+
+    ``ceiling`` (the reconcile pass's frozen now) upper-bounds the continuous
+    arrival window so a slow pass can't leave rows above the next cursor.
+    """
     evals = list(task.evals.all())
     if not evals:
         return 0
@@ -116,7 +122,9 @@ def materialize_pending(task: EvalTask) -> int:
     submitted = 0
     reader = get_reader()
     try:
-        for batch in iter_desired_rows(task, batch_size=_MATERIALIZE_BATCH):
+        for batch in iter_desired_rows(
+            task, batch_size=_MATERIALIZE_BATCH, ceiling=ceiling
+        ):
             fk_by_id = _resolve_entry_fks(
                 reader, task.row_type, batch, project_id=str(task.project_id)
             )

--- a/futureagi/tracer/services/eval_tasks/reconciler.py
+++ b/futureagi/tracer/services/eval_tasks/reconciler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from itertools import chain
 
 from django.db.models import Case, CharField, Value, When
@@ -45,8 +45,9 @@ def reconcile(task: EvalTask) -> ReconcileResult:
     keeping out-of-scope *completed* results (paid data). For continuous tasks,
     advances the forward cursor so the next pass scans only the new tail.
     """
+    now = timezone.now()
     before = _live_count(task)
-    materialize_pending(task)
+    materialize_pending(task, ceiling=now)
     created = _live_count(task) - before
     if before == 0:
         # Pure create — nothing pre-existing to re-queue or drop.
@@ -54,24 +55,24 @@ def reconcile(task: EvalTask) -> ReconcileResult:
     else:
         requeued, dropped = _requeue_and_drop(task)
         result = ReconcileResult(created=created, requeued=requeued, dropped=dropped)
-    _advance_continuous_cursor(task)
+    _advance_continuous_cursor(task, now)
     return result
 
 
-def _advance_continuous_cursor(task: EvalTask) -> None:
-    """Park the continuous task's forward watermark just behind now().
+def _advance_continuous_cursor(task: EvalTask, now: datetime) -> None:
+    """Park the continuous task's forward watermark at ``now - overlap``.
 
-    Only ever moves forward, and never before the task's start floor — parking
-    at ``now() - overlap`` unclamped would, for a task younger than the overlap,
-    pull the floor back before its start and re-admit pre-start history. Advanced
-    after materialize/requeue so both read the same floor within a pass; the next
-    pass then floors its desired set here instead of re-scanning the whole
-    history.
+    ``now`` is frozen at the start of the reconcile pass (not read here) so the
+    watermark tracks what the scan actually covered, never jumping past rows that
+    arrived during a slow materialize. Only ever moves forward, and never before
+    the task's start floor — parking at ``now - overlap`` unclamped would, for a
+    task younger than the overlap, pull the floor before its start and re-admit
+    pre-start history.
     """
     if task.run_type != RunType.CONTINUOUS:
         return
     start_floor = task.start_time or task.created_at
-    parked = timezone.now() - _CONTINUOUS_CURSOR_OVERLAP
+    parked = now - _CONTINUOUS_CURSOR_OVERLAP
     if start_floor is not None and parked < start_floor:
         parked = start_floor
     if task.continuous_cursor is not None and parked <= task.continuous_cursor:

--- a/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
+++ b/futureagi/tracer/tests/test_ch25_apply_schema_replicated.py
@@ -431,6 +431,67 @@ class TestAttrValueBloomIndexFile:
             assert "ON CLUSTER 'default'" in out
 
 
+class TestSpansCreatedAtIndexFile:
+    """024_spans_created_at_index.sql — created_at minmax skip index on spans,
+    so the continuous eval-task reconcile's arrival floor (created_at >= cursor)
+    prunes granules instead of scanning the project's whole history."""
+
+    @pytest.fixture()
+    def statements(self):
+        import pathlib
+
+        here = pathlib.Path(__file__).resolve().parents[1]
+        f = (
+            here
+            / "services"
+            / "clickhouse"
+            / "v2"
+            / "schema"
+            / "024_spans_created_at_index.sql"
+        )
+        assert f.exists(), f"{f.name} missing from v2 schema dir"
+        return split_statements(f.read_text())
+
+    def test_adds_created_at_minmax_index(self, statements):
+        adds = [s for s in statements if "ADD INDEX" in s]
+        assert len(adds) == 1
+        stmt = adds[0]
+        # Mirrors the traces table's auto_minmax_index_created_at so arrival-time
+        # pruning is available on spans too.
+        assert "IF NOT EXISTS" in stmt
+        # Pin the indexed COLUMN (adjacent to the index name), not just the name —
+        # guard a wrong-column migration (e.g. indexing start_time) the name hides.
+        assert "auto_minmax_index_created_at created_at" in stmt
+        assert "TYPE minmax()" in stmt
+        assert "GRANULARITY 1" in stmt
+
+    def test_does_not_materialize_the_index(self, statements):
+        # MATERIALIZE is a full-table mutation (reads created_at per replica) and
+        # must never fire unattended from an applier run — it is a documented
+        # manual deploy step in the file header instead.
+        assert not any("MATERIALIZE INDEX" in s for s in statements)
+        # ...and the header must keep telling the deployer to run it.
+        import pathlib
+
+        here = pathlib.Path(__file__).resolve().parents[1]
+        raw = (
+            here
+            / "services"
+            / "clickhouse"
+            / "v2"
+            / "schema"
+            / "024_spans_created_at_index.sql"
+        ).read_text()
+        assert "MATERIALIZE INDEX auto_minmax_index_created_at" in raw
+        assert "DEPLOY STEP" in raw
+
+    def test_every_statement_survives_replicated_rewrite(self, statements):
+        for stmt in statements:
+            assert _extract_table_name(stmt) == "spans"
+            out = _rewrite(stmt)
+            assert "ON CLUSTER 'default'" in out
+
+
 class TestAttrValueNgramIndexFile:
     """023_attr_value_ngram_index.sql — ngram bloom for substring (ILIKE)
     search over attribute values (the filter-value picker's search path)."""

--- a/futureagi/tracer/tests/test_reconciler.py
+++ b/futureagi/tracer/tests/test_reconciler.py
@@ -15,8 +15,13 @@ from tracer.models.observation_span import (
     ObservationSpan,
 )
 from tracer.models.trace import Trace
+from tracer.models.trace_session import TraceSession
 from tracer.services.eval_tasks.entries import soft_delete_live
-from tracer.services.eval_tasks.reconciler import reconcile
+from tracer.services.eval_tasks.reconciler import (
+    _CONTINUOUS_CURSOR_OVERLAP,
+    _advance_continuous_cursor,
+    reconcile,
+)
 from tracer.tests._ch_seed import seed_ch_spans
 
 
@@ -39,6 +44,7 @@ def _task(
     run_type=RunType.HISTORICAL,
     spans_limit=1_000_000,
     filters=None,
+    row_type=RowType.SPANS,
 ):
     task = EvalTask.objects.create(
         project=project,
@@ -48,7 +54,7 @@ def _task(
         spans_limit=spans_limit,
         run_type=run_type,
         status=EvalTaskStatus.PENDING,
-        row_type=RowType.SPANS,
+        row_type=row_type,
     )
     for cfg in evals:
         task.evals.add(cfg)
@@ -96,6 +102,34 @@ def _make_spans_at(project, n, created_at, *, prefix="t"):
         spans.append(span)
     seed_ch_spans(spans)
     return spans
+
+
+def _make_span_with_gap(
+    project,
+    *,
+    start_time,
+    created_at,
+    observation_type="llm",
+    session=None,
+    prefix="gap",
+):
+    """Seed ONE root span with an explicit ``start_time`` != ``created_at`` gap
+    (ingestion lag) — both set, unlike ``_make_spans_at``. ``observation_type=
+    "conversation"`` yields a voiceCalls row; pass ``session`` for a sessions row."""
+    trace = Trace.objects.create(project=project, name=f"tr-{prefix}", session=session)
+    span = ObservationSpan.objects.create(
+        id=f"{prefix}-{uuid.uuid4().hex[:8]}",
+        project=project,
+        trace=trace,
+        name=f"sp-{prefix}",
+        observation_type=observation_type,
+        parent_span_id=None,
+        start_time=start_time,
+    )
+    ObservationSpan.objects.filter(id=span.id).update(created_at=created_at)
+    span.refresh_from_db()
+    seed_ch_spans([span])
+    return span
 
 
 def _live(task, **f):
@@ -426,6 +460,347 @@ class TestLifecycleFlows:
         task.refresh_from_db()
         assert task.continuous_cursor is not None
         assert task.continuous_cursor >= start
+
+    def test_continuous_voicecalls_ingest_lag_still_materialized(
+        self, project, custom_eval_config
+    ):
+        # Voice call arriving long after it started must still be evaluated: the
+        # floor tracks arrival (created_at), not start_time. Floor sits between the
+        # two timestamps, so this is RED while the floor binds on start_time.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.VOICE_CALLS,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),  # the parked arrival floor
+        )
+        task.refresh_from_db()
+
+        # Positive: started 11m ago (below floor), arrived 1m ago (above floor).
+        hit = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            observation_type="conversation",
+            prefix="lag-hit",
+        )
+        # Negative: arrived 8m ago, genuinely before the floor -> excluded.
+        # Guards against over-correction (a removed lower bound would admit it).
+        miss = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=8),
+            created_at=t - timedelta(minutes=8),
+            observation_type="conversation",
+            prefix="lag-miss",
+        )
+
+        reconcile(task)
+
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert hit.id in materialized  # arrival after floor -> evaluated
+        assert miss.id not in materialized  # arrival before floor -> excluded
+
+    def test_continuous_spans_ingest_lag_still_materialized(
+        self, project, custom_eval_config
+    ):
+        # Arrival floor for the spans row_type: late arrival materializes; one
+        # that truly arrived before the floor stays out (guards over-correction).
+        t = timezone.now()
+        task = _task(project, evals=[custom_eval_config], run_type=RunType.CONTINUOUS)
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        hit = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            prefix="s-lag-hit",
+        )
+        miss = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=8),
+            created_at=t - timedelta(minutes=8),
+            prefix="s-lag-miss",
+        )
+
+        reconcile(task)
+
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert hit.id in materialized
+        assert miss.id not in materialized
+
+    def test_continuous_traces_ingest_lag_still_materialized(
+        self, project, custom_eval_config
+    ):
+        # Arrival-floor semantics for the traces row_type: a trace whose root span
+        # arrived after the floor but started before it must be materialized.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.TRACES,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        hit = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            prefix="tr-lag-hit",
+        )
+        miss = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=8),
+            created_at=t - timedelta(minutes=8),
+            prefix="tr-lag-miss",
+        )
+
+        reconcile(task)
+
+        # traces store the root span id in observation_span_id (see entries.py).
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert hit.id in materialized
+        assert miss.id not in materialized
+
+    def test_continuous_sessions_ingest_lag_still_materialized(
+        self, project, custom_eval_config
+    ):
+        # Arrival-floor semantics for the sessions row_type: a session whose spans
+        # arrived after the floor but started before it must be materialized.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.SESSIONS,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        hit_session = TraceSession.objects.create(project=project, name="sess-hit")
+        miss_session = TraceSession.objects.create(project=project, name="sess-miss")
+        _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            session=hit_session,
+            prefix="ss-lag-hit",
+        )
+        _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=8),
+            created_at=t - timedelta(minutes=8),
+            session=miss_session,
+            prefix="ss-lag-miss",
+        )
+
+        reconcile(task)
+
+        # sessions store the session id in trace_session_id (see entries.py).
+        materialized = set(
+            str(x) for x in _live(task).values_list("trace_session_id", flat=True)
+        )
+        assert str(hit_session.id) in materialized
+        assert str(miss_session.id) not in materialized
+
+    def test_continuous_evaluates_late_arrival_started_long_ago(
+        self, project, custom_eval_config
+    ):
+        # Spans can start long before they reach us (delayed delivery). A call
+        # started days ago but arriving now MUST still be evaluated — no start_time
+        # bound may gate the arrival floor, or the bug returns.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.VOICE_CALLS,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        hit = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(days=3),  # started long ago
+            created_at=t - timedelta(minutes=1),  # arrived just now
+            observation_type="conversation",
+            prefix="old-start-hit",
+        )
+
+        reconcile(task)
+
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert hit.id in materialized
+
+    def test_continuous_stale_date_range_does_not_recap_live_tail(
+        self, project, custom_eval_config
+    ):
+        # A past date_range on a continuous task must not cap the live tail: the
+        # arrival floor ignores date_range's end, so a just-arrived call still lands.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.VOICE_CALLS,
+            filters={
+                "date_range": [
+                    (t - timedelta(days=7)).isoformat(),
+                    (t - timedelta(days=1)).isoformat(),  # ends a day ago
+                ]
+            },
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        hit = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            observation_type="conversation",
+            prefix="dr-hit",
+        )
+
+        reconcile(task)
+
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert hit.id in materialized
+
+    def test_advance_cursor_derives_from_passed_now(self, project, custom_eval_config):
+        # The next cursor is computed from the frozen now passed into
+        # _advance_continuous_cursor, not a fresh wall-clock read — so a slow pass
+        # can't advance the watermark past rows it didn't scan.
+        task = _task(project, evals=[custom_eval_config], run_type=RunType.CONTINUOUS)
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=timezone.now() - timedelta(hours=1)
+        )
+        task.refresh_from_db()
+
+        frozen = timezone.now() - timedelta(minutes=30)
+        _advance_continuous_cursor(task, frozen)
+
+        task.refresh_from_db()
+        assert task.continuous_cursor == frozen - _CONTINUOUS_CURSOR_OVERLAP
+
+    def test_continuous_ceiling_excludes_rows_arriving_after_now(
+        self, project, custom_eval_config
+    ):
+        # The window ceiling is the pass's frozen now: a row whose created_at is
+        # ahead of now (not yet "arrived") is held for a later pass, not dropped.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.VOICE_CALLS,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=5),
+        )
+        task.refresh_from_db()
+
+        present = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t - timedelta(minutes=1),
+            observation_type="conversation",
+            prefix="present",
+        )
+        future = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(minutes=11),
+            created_at=t + timedelta(minutes=5),  # arrives after this pass's now
+            observation_type="conversation",
+            prefix="future",
+        )
+
+        reconcile(task)
+
+        materialized = set(_live(task).values_list("observation_span_id", flat=True))
+        assert present.id in materialized
+        assert future.id not in materialized
+
+    def test_two_pass_window_catches_later_arrival_no_loss_or_dup(
+        self, project, custom_eval_config
+    ):
+        # End-to-end: a call arriving between two reconcile passes is caught by the
+        # second (the frozen-now window steps forward), while pass-1 calls that were
+        # drained (completed) are kept — no loss, no duplicate materialization.
+        t = timezone.now()
+        task = _task(
+            project,
+            evals=[custom_eval_config],
+            run_type=RunType.CONTINUOUS,
+            row_type=RowType.VOICE_CALLS,
+        )
+        EvalTask.objects.filter(id=task.id).update(
+            start_time=t - timedelta(minutes=60),
+            continuous_cursor=t - timedelta(minutes=10),
+        )
+        task.refresh_from_db()
+
+        a = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(hours=2),
+            created_at=t - timedelta(minutes=8),
+            observation_type="conversation",
+            prefix="callA",
+        )
+        b = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(hours=2),
+            created_at=t - timedelta(minutes=3),
+            observation_type="conversation",
+            prefix="callB",
+        )
+
+        reconcile(task)  # pass 1
+        assert set(_live(task).values_list("observation_span_id", flat=True)) == {
+            a.id,
+            b.id,
+        }
+
+        # Drain: the workflow evaluates pending entries before the next reconcile.
+        _mark(task, EvalEntryStatus.COMPLETED)
+
+        # A new call arrives after pass 1.
+        c = _make_span_with_gap(
+            project,
+            start_time=t - timedelta(hours=2),
+            created_at=t - timedelta(seconds=30),
+            observation_type="conversation",
+            prefix="callC",
+        )
+
+        reconcile(task)  # pass 2
+
+        live = dict(_live(task).values_list("observation_span_id", "status"))
+        assert set(live) == {a.id, b.id, c.id}  # all present — no loss
+        assert _live(task).count() == 3  # one entry each — no duplicate
+        assert live[a.id] == EvalEntryStatus.COMPLETED  # paid work kept
+        assert live[c.id] == EvalEntryStatus.PENDING  # newly materialized
 
     def test_historical_to_continuous_keeps_entries(self, project, custom_eval_config):
         # Switching to continuous keeps existing entries (no wipe).

--- a/futureagi/tracer/tests/test_session_list_performance.py
+++ b/futureagi/tracer/tests/test_session_list_performance.py
@@ -14,6 +14,7 @@ Run with: bin/test -k "test_session_list_performance" --no-services unit
 import json
 import time
 import uuid
+from datetime import datetime
 
 import pytest
 
@@ -133,6 +134,24 @@ class TestSessionListQueryPerformance:
         assert "GROUP BY" not in stripped
         assert "HAVING" not in query
         assert "count(DISTINCT trace_session_id)" in query
+
+    def test_id_query_continuous_floor_and_ceiling_window_on_created_at(self):
+        floor = datetime(2026, 8, 1, 12, 0)
+        ceil = datetime(2026, 8, 1, 12, 5)
+        query, params = self._make_builder().build_id_query(
+            created_at_floor=floor, created_at_ceiling=ceil
+        )
+        # Arrival window replaces the start_time bound on the span scan.
+        assert "created_at >= %(created_at_floor)s" in query
+        assert "created_at < %(created_at_ceiling)s" in query
+        assert "start_time >= %(start_date)s" not in query
+        assert params["created_at_floor"] == floor
+        assert params["created_at_ceiling"] == ceil
+
+    def test_id_query_default_keeps_start_time_window(self):
+        query, params = self._make_builder().build_id_query()
+        assert "start_time >= %(start_date)s" in query
+        assert "created_at_ceiling" not in params
 
 
 @pytest.mark.unit

--- a/futureagi/tracer/tests/test_span_list_builder_comprehensive.py
+++ b/futureagi/tracer/tests/test_span_list_builder_comprehensive.py
@@ -21,6 +21,8 @@ These are pure query-string / pivot-logic tests — NO ClickHouse, NO DB.
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 from django.test import override_settings
 
@@ -247,6 +249,33 @@ class TestBuildIdQuery:
         assert "ORDER BY" not in sql
         assert "LIMIT %(id_limit)s" not in sql
         assert "id_limit" not in params
+
+    def test_continuous_floor_windows_on_created_at(self):
+        floor = datetime(2026, 8, 1, 12, 0)
+        sql, params = _make_builder().build_id_query(created_at_floor=floor)
+        # Arrival floor replaces the start_time window (spans can start long ago).
+        assert "created_at >= %(created_at_floor)s" in sql
+        assert "start_time >= %(start_date)s" not in sql
+        assert params["created_at_floor"] == floor
+
+    def test_continuous_ceiling_upper_bounds_arrival(self):
+        floor = datetime(2026, 8, 1, 12, 0)
+        ceil = datetime(2026, 8, 1, 12, 5)
+        sql, params = _make_builder().build_id_query(
+            created_at_floor=floor, created_at_ceiling=ceil
+        )
+        assert "created_at >= %(created_at_floor)s" in sql
+        assert "created_at < %(created_at_ceiling)s" in sql
+        assert params["created_at_ceiling"] == ceil
+
+    def test_ceiling_ignored_without_floor(self):
+        # The ceiling only applies inside the continuous (floor) branch; the
+        # UI/historical None path stays on the start_time window.
+        sql, params = _make_builder().build_id_query(
+            created_at_ceiling=datetime(2026, 8, 1, 12, 5)
+        )
+        assert "created_at_ceiling" not in params
+        assert "start_time >= %(start_date)s" in sql
 
 
 # --------------------------------------------------------------------------- #

--- a/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
+++ b/futureagi/tracer/tests/test_trace_list_builder_comprehensive.py
@@ -16,6 +16,7 @@ Focus areas (gaps):
 """
 
 import uuid
+from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
@@ -517,6 +518,26 @@ class TestOuterWindowStartTime:
         assert "start_time >= %(start_date)s" in query
         assert "start_time < %(end_date)s" in query
         assert "created_at" not in query
+
+    def test_id_query_continuous_floor_windows_on_created_at(self, project_id):
+        floor = datetime(2026, 8, 1, 12, 0)
+        query, params = TraceListQueryBuilder(project_id=project_id).build_id_query(
+            created_at_floor=floor
+        )
+        # Arrival floor replaces the start_time window (root span can arrive late).
+        assert "created_at >= %(created_at_floor)s" in query
+        assert "start_time >= %(start_date)s" not in query
+        assert params["created_at_floor"] == floor
+
+    def test_id_query_continuous_ceiling_upper_bounds_arrival(self, project_id):
+        floor = datetime(2026, 8, 1, 12, 0)
+        ceil = datetime(2026, 8, 1, 12, 5)
+        query, params = TraceListQueryBuilder(project_id=project_id).build_id_query(
+            created_at_floor=floor, created_at_ceiling=ceil
+        )
+        assert "created_at >= %(created_at_floor)s" in query
+        assert "created_at < %(created_at_ceiling)s" in query
+        assert params["created_at_ceiling"] == ceil
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/tracer/tests/test_voice_call_list_builder.py
+++ b/futureagi/tracer/tests/test_voice_call_list_builder.py
@@ -10,6 +10,7 @@ The builder builds SQL STRINGS only — nothing here touches ClickHouse.
 """
 
 import re
+from datetime import datetime
 
 import pytest
 
@@ -235,6 +236,42 @@ def test_id_query_selects_only_ids():
     # No page-limit/offset — resolver wants the full matched id set.
     assert "%(limit)s" not in s
     assert "%(offset)s" not in s
+
+
+@pytest.mark.unit
+def test_id_query_continuous_floor_windows_on_created_at():
+    floor = datetime(2026, 8, 1, 12, 0)
+    sql, params = VoiceCallListQueryBuilder(project_id=PROJECT_ID).build_id_query(
+        created_at_floor=floor
+    )
+    s = _squash(sql)
+    # Arrival floor replaces the start_time window — a call can start long before
+    # its root span reaches CH (Vapi end-of-call flush).
+    assert "created_at >= %(created_at_floor)s" in s
+    assert "start_time >= %(start_date)s" not in s
+    assert params["created_at_floor"] == floor
+
+
+@pytest.mark.unit
+def test_id_query_continuous_ceiling_upper_bounds_arrival():
+    floor = datetime(2026, 8, 1, 12, 0)
+    ceil = datetime(2026, 8, 1, 12, 5)
+    sql, params = VoiceCallListQueryBuilder(project_id=PROJECT_ID).build_id_query(
+        created_at_floor=floor, created_at_ceiling=ceil
+    )
+    s = _squash(sql)
+    assert "created_at >= %(created_at_floor)s" in s
+    assert "created_at < %(created_at_ceiling)s" in s
+    assert params["created_at_ceiling"] == ceil
+
+
+@pytest.mark.unit
+def test_id_query_ceiling_ignored_without_floor():
+    sql, params = VoiceCallListQueryBuilder(project_id=PROJECT_ID).build_id_query(
+        created_at_ceiling=datetime(2026, 8, 1, 12, 5)
+    )
+    assert "created_at_ceiling" not in params
+    assert "start_time >= %(start_date)s" in _squash(sql)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Continuous eval tasks were silently skipping incoming rows. The desired-set query floored on **`start_time`** (when a trace happened), but a row only becomes evaluable once it **arrives** in ClickHouse — and arrival can lag the event time. Voice calls hit this hardest: their root span is flushed at end-of-call (~5–6 min after `start_time`), which exceeds the reconciler's 5-min cursor overlap, so most calls fell below the `start_time` floor before they were queryable and were dropped forever. Reproduced on PROD (16 calls → only 5 evaluated).

This PR windows the continuous desired set on **`created_at` (CH arrival time)** instead of `start_time`, bounded by a **frozen-`now` ceiling**, and adds a `created_at` skip index so the arrival-floored scan prunes.

## Linked issues

Closes #
Linear: Fixed TH-7238

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Arrival-time window (correctness)**
- `row_resolver._build_sample_query` now passes the continuous floor straight to `build_id_query(created_at_floor=…)` instead of injecting it as a filter that `parse_time_range` folded onto `start_time`.
- Each `build_id_query` (voice/span/trace/session) floors on `created_at >= floor` in continuous mode; the `None`/historical/UI path (`build()`) is unchanged.

**B. Frozen-`now` bounded window (no transient loss)**
- `reconcile` freezes `now` once at the start of the pass and uses it for **both** the window ceiling (`created_at < now`, threaded through `materialize_pending` → `iter_desired_rows` → the builders) **and** the next cursor (`now − overlap`). A slow materialize can no longer advance the watermark past rows it did not scan.

**C. `created_at` skip index (performance)**
- New `024_spans_created_at_index.sql` adds a metadata-only `ADD INDEX … created_at TYPE minmax()` on `spans` (mirrors the `traces` table) so `created_at >= floor` prunes granules despite the `PARTITION BY toDate(start_time)` layout. The one-time `MATERIALIZE` backfill is documented as a manual deploy step (same pattern as `023`).

---

## 2) Why the changes were done

- **Product:** continuous eval tasks must evaluate every incoming trace; voice customers were silently losing most evaluations.
- **Technical:** the checkpoint is fundamentally an *arrival* watermark; flooring on event time was the wrong axis. Spans can start long before they reach us (delayed/batched delivery), so no `start_time` bound may gate the scan.
- **Architecture:** the fix is additive and keyword-only — `build_id_query` is called only by the eval resolver, so the UI list path and historical tasks are byte-identical.

---

## 3) Tests written + scenarios each covers

**`test_reconciler.py`** — reconcile behavior against a real ClickHouse
- `test_continuous_voicecalls_ingest_lag_still_materialized` — voice call arriving after its start is evaluated; a truly-before-floor call is excluded (negative control).
- `test_continuous_spans_/traces_/sessions_ingest_lag_still_materialized` — same arrival-floor behavior per row type.
- `test_continuous_evaluates_late_arrival_started_long_ago` — a call that started days ago but just arrived is still evaluated (no `start_time` gate).
- `test_continuous_ceiling_excludes_rows_arriving_after_now` — the `created_at < now` ceiling holds a future-arrival row for a later pass.
- `test_advance_cursor_derives_from_passed_now` — the cursor is derived from the frozen `now`, not wall-clock.
- `test_two_pass_window_catches_later_arrival_no_loss_or_dup` — end-to-end: seed → reconcile → drain → new arrival → reconcile; every row materializes exactly once (no loss, no duplicate).
- `test_continuous_stale_date_range_does_not_recap_live_tail` — a past `date_range` doesn't cap the live tail.

**`test_{voice_call,span,trace}_list_builder*` + `test_session_list_performance.py`** — builder SQL contract
- floor windows on `created_at`; ceiling adds `created_at < …`; `None`/historical path keeps the `start_time` window; ceiling-without-floor is ignored.

**`test_ch25_apply_schema_replicated.py::TestSpansCreatedAtIndexFile`** — the `024` migration
- ships only the metadata-only `ADD INDEX`; keeps the `MATERIALIZE` backfill as a documented deploy step; survives the replicated `ON CLUSTER` rewrite.

> Run result: **298 passed** across the touched suites (50 integration + 248 unit). Full `tracer` suite: **5251 passed** (the 8 failing / 23 erroring are pre-existing — see §7).

---

## 4) How to run / test

```bash
cd futureagi
bin/test integration tracer/tests/test_reconciler.py tracer/tests/test_row_resolver.py
bin/test tracer/tests/test_voice_call_list_builder.py tracer/tests/test_span_list_builder_comprehensive.py \
         tracer/tests/test_trace_list_builder_comprehensive.py tracer/tests/test_session_list_performance.py \
         tracer/tests/test_ch25_apply_schema_replicated.py
```

**Deploy note:** after applying the schema, run the one-time backfill per region, off-peak, before relying on the arrival floor at scale:
`ALTER TABLE spans MATERIALIZE INDEX auto_minmax_index_created_at;`

---

## 6) Edge cases & considerations

- **Slow / catch-up materialize:** the frozen-`now` ceiling + advance means the cursor never outruns the scan, so a long pass can't drop rows in flight (covered by `test_two_pass_window…`).
- **Overlap re-scan:** consecutive windows overlap by the 5-min cursor margin; the per-`(task,row,eval)` unique index dedups, so no double-eval/bill.
- **Historical / UI unaffected:** `created_at_floor is None` ⇒ the exact previous `start_time` window; `build_id_query` is eval-only, UI uses `build()`.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Full `tracer` suite has 8 failing + 23 erroring tests **unrelated to this change** (`test_dashboard*`, `test_trace_session::SessionListLatency`, live-LLM-adapter e2e) — verified identical with these changes stashed.
- **Filtered `traces`/`sessions` residual:** a continuous *traces/sessions* task **with a cross-table filter** can still miss an arrival whose `start_time` is >30 days old (the filter's membership subquery windows on `start_time`). This is **not a regression** — before this change the same tasks tolerated only ~5 min of late start; now ~30 days. Voice/spans are unaffected. Documented at the trace/session floor branches for a follow-up.

---

## 8) Architectural / important decisions

- **Additive keyword-only params over editing shared code:** `created_at_floor`/`created_at_ceiling` are threaded only through the eval path; the shared v2 filter builder (used by the UI) is untouched — which is why the filtered-traces/sessions residual is deferred rather than fixed here.
- **Skip index over widening/removing the window:** flooring purely on `created_at` needs pruning; a `created_at` minmax index prunes late arrivals (they land in new parts) without a fragile `start_time` slack bound.
