### PR TITLE
fix(evals): send eval_template_id when duplicating an evaluation

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
@@ -55,7 +55,7 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
   const onDuplicate = (data) => {
     const payload = {
       name: data.name,
-      evalTemplateId: evalId,
+      eval_template_id: evalId,
     };
     mutate(payload);
   };


### PR DESCRIPTION
Fixes #1768

Duplicating an evaluation always failed. The duplicate dialog posted the
template id under the camelCase key `evalTemplateId`, but
`DuplicateEvalTemplateSerializer` only accepts `eval_template_id` (a
required `UUIDField`), and there is no case-normalizing interceptor in the
axios request layer. The id therefore never reached the serializer and
every duplicate request failed validation.

Fix: send the id under `eval_template_id` so the serializer receives it.

Changes:
- frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
