### PR TITLE
fix(datasets): don't append a 00:00 clock to date-only values

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
@@ -16,6 +16,12 @@ const DatetimeCellRenderer = ({
   const isValueArray = Array.isArray(value);
   const isBlankValue = value === null || value === undefined || value === "";
   const isValidDate = !isBlankValue && !isNaN(new Date(value).getTime());
+  // Only render a clock when the source value actually carried a time. A
+  // date-only string like "2026-01-29" has no time component, so appending
+  // "00:00" shows data the cell never held. Strings with a time (ISO "T" or an
+  // "HH:mm" part) keep the clock, including a genuine midnight (#1766).
+  const hasTimeComponent =
+    typeof value === "string" ? /\d{1,2}:\d{2}/.test(value) : true;
 
   return (
     <CustomTooltip
@@ -31,7 +37,10 @@ const DatetimeCellRenderer = ({
         {isValueArray ? (
           <GenerateDiffText cellText={value} />
         ) : isValidDate ? (
-          format(new Date(value), "dd/MM/yyyy HH:mm")
+          format(
+            new Date(value),
+            hasTimeComponent ? "dd/MM/yyyy HH:mm" : "dd/MM/yyyy",
+          )
         ) : isBlankValue ? (
           ""
         ) : (

--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/__tests__/cell-renderers.test.jsx
@@ -37,6 +37,33 @@ describe("DatetimeCellRenderer", () => {
 
     expect(screen.getByText("Invalid Date")).toBeInTheDocument();
   });
+
+  it("drops the phantom 00:00 clock for a date-only value (#1766)", () => {
+    // A date-only string carries no time, so the cell must not invent one.
+    // The bug rendered "29/01/2026 00:00" for an uploaded "2026-01-29".
+    const { container } = render(
+      <DatetimeCellRenderer value="2026-01-29" {...rendererProps} />,
+    );
+
+    expect(container.textContent).toMatch(/\d{2}\/\d{2}\/\d{4}/);
+    expect(container.textContent).not.toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("keeps the clock when the value carries a time", () => {
+    const { container } = render(
+      <DatetimeCellRenderer value="2026-01-29T14:30" {...rendererProps} />,
+    );
+
+    expect(container.textContent).toContain("29/01/2026 14:30");
+  });
+
+  it("preserves a genuine midnight that was explicitly provided", () => {
+    const { container } = render(
+      <DatetimeCellRenderer value="2026-01-29T00:00" {...rendererProps} />,
+    );
+
+    expect(container.textContent).toContain("29/01/2026 00:00");
+  });
 });
 
 describe("JsonCellRenderer", () => {


### PR DESCRIPTION
Fixes #1766

A dataset column holding date-only values rendered a `00:00` clock the
data never carried. `DatetimeCellRenderer` formatted every value with
`"dd/MM/yyyy HH:mm"`, so an uploaded `2026-01-29` displayed as
`29/01/2026 00:00`.

Fix: only render the time when the source value actually carried one. A
date-only string (`2026-01-29`) has no time component, so it now shows
`29/01/2026`; a string with a time (ISO `T` or an `HH:mm` part) keeps the
clock. The check is on the raw string rather than the parsed time, so a
genuine midnight that was provided (`2026-01-29T00:00`) still shows
`00:00` - only phantom midnights are dropped.

Changes:
- frontend/src/sections/common/DevelopCellRenderer/CellRenderers/DatetimeCellRenderer.jsx
