### PR TITLE
fix(datasets): keep synthetic-data description textarea transparent

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -395,10 +395,15 @@ const RequestBody = ({
             outline: "none",
             color: theme.palette.text.primary,
             caretColor: theme.palette.text.primary,
-            backgroundColor: "transparent",
             position: "relative",
             verticalAlign: "top",
             ...sx,
+            // The backdrop layer provides the visible background and syntax
+            // highlighting; the textarea must stay transparent so that layer
+            // shows through. Re-assert this after `...sx` so a caller-supplied
+            // background can't cover the backdrop and hide the typed text
+            // (#1586).
+            backgroundColor: "transparent",
           }}
           onKeyDown={onKeyDown}
         />

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/__tests__/RequestBody.test.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/__tests__/RequestBody.test.jsx
@@ -1,0 +1,35 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { useForm } from "react-hook-form";
+import { render } from "src/utils/test-utils";
+import RequestBody from "../RequestBody";
+
+const Harness = ({ sx }) => {
+  const { control } = useForm({ defaultValues: { body: "" } });
+  return (
+    <RequestBody
+      control={control}
+      contentFieldName="body"
+      allColumns={[]}
+      sx={sx}
+    />
+  );
+};
+
+describe("RequestBody textarea background", () => {
+  it("stays transparent even when a caller supplies a background via sx", () => {
+    const { container } = render(
+      <Harness sx={{ backgroundColor: "rgb(255, 0, 0)" }} />,
+    );
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeInTheDocument();
+
+    // The backdrop layer provides the visible background and syntax
+    // highlighting; the textarea must stay transparent so it shows through.
+    // Pre-fix, `...sx` was applied after backgroundColor, so a caller-supplied
+    // color covered the backdrop and hid the typed text (#1586).
+    expect(textarea.style.backgroundColor).toBe("transparent");
+  });
+});


### PR DESCRIPTION
Fixes #1586

In the "Create Synthetic data" wizard (step 3, per-column description),
typed text was invisible. `RequestBody.jsx` renders a transparent
textarea on top of a highlight backdrop `div` that shows the actual text.
The textarea set `backgroundColor: "transparent"` so the backdrop shows
through - but the caller-supplied `...sx` was spread *after* that line and
could override it with an opaque background, covering the backdrop. Since
the textarea's own text is `color: transparent` (only the caret is
visible), an opaque background meant nothing was readable at all.

Fix: re-assert `backgroundColor: "transparent"` after `...sx`. Callers
keep every other style override, but the one property the backdrop design
depends on can no longer be clobbered.

Changes:
- frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
