### PR TITLE
feat: link annotation traces to sessions

### DIFF
--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -4,6 +4,10 @@ import { render, screen, waitFor, userEvent } from "src/utils/test-utils";
 import axios from "src/utils/axios";
 import ContentPanel from "../annotate/content-panel";
 
+const traceDetailMocks = vi.hoisted(() => ({
+  useGetTraceDetail: vi.fn(() => ({ data: null, isLoading: false })),
+}));
+
 vi.mock("src/components/iconify", () => ({
   default: ({ icon, ...props }) => (
     <span data-testid="iconify" data-icon={icon} {...props} />
@@ -115,7 +119,9 @@ vi.mock("src/components/traceDetail/TraceLeftPanel", () => ({
 }));
 
 vi.mock("src/components/traceDetail/DrawerToolbar", () => ({
-  default: () => <div data-testid="drawer-toolbar" />,
+  default: ({ rightSlot }) => (
+    <div data-testid="drawer-toolbar">{rightSlot}</div>
+  ),
 }));
 
 vi.mock("src/components/traceDetail/TraceDisplayPanel", () => ({
@@ -124,7 +130,7 @@ vi.mock("src/components/traceDetail/TraceDisplayPanel", () => ({
 }));
 
 vi.mock("src/api/project/trace-detail", () => ({
-  useGetTraceDetail: () => ({ data: null, isLoading: false }),
+  useGetTraceDetail: traceDetailMocks.useGetTraceDetail,
 }));
 
 vi.mock("src/api/project/saved-views", () => ({
@@ -148,6 +154,11 @@ describe("Annotation queue ContentPanel", () => {
   const clipboardWriteText = vi.fn(() => Promise.resolve());
 
   beforeEach(() => {
+    traceDetailMocks.useGetTraceDetail.mockReset();
+    traceDetailMocks.useGetTraceDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
     clipboardWriteText.mockClear();
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: clipboardWriteText },
@@ -336,5 +347,75 @@ describe("Annotation queue ContentPanel", () => {
       await screen.findByText("customer asks for help"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("trace-detail-drawer")).not.toBeInTheDocument();
+  });
+
+  it("lets trace queue items open and return from their parent session", async () => {
+    const user = userEvent.setup();
+    traceDetailMocks.useGetTraceDetail.mockReturnValue({
+      data: {
+        trace: {
+          project: "project-123",
+          session: "session-123",
+          tags: [],
+        },
+        observation_spans: [
+          {
+            observation_span: {
+              id: "span-root",
+              observation_type: "llm",
+              start_time: "2026-08-02T00:00:00Z",
+            },
+            children: [],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    axios.get.mockResolvedValueOnce({
+      data: {
+        result: {
+          session_metadata: { total_traces: 1 },
+          response: [
+            {
+              trace_id: "trace-456",
+              input: "session conversation",
+              output: "assistant response",
+              system_metrics: {},
+              evals_metrics: {},
+            },
+          ],
+          next: null,
+        },
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ContentPanel
+          item={{
+            source_type: "trace",
+            source_content: { trace_id: "trace-123" },
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("drawer-toolbar")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /View session/i }));
+
+    expect(
+      await screen.findByText("session conversation"),
+    ).toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalledWith("/tracer/trace-session/session-123/", {
+      params: { page_number: 0, page_size: 10 },
+    });
+
+    await user.click(screen.getByRole("button", { name: /Back to trace/i }));
+    expect(screen.getByTestId("drawer-toolbar")).toBeInTheDocument();
   });
 });

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -174,6 +174,8 @@ function InlineTraceView({ traceId, spanId }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useGetTraceDetail(traceId);
   const projectId = data?.trace?.project;
+  const sessionId = data?.trace?.session;
+  const [showSession, setShowSession] = useState(false);
 
   // Saved views — includes both traces-type custom views and imagine tabs.
   const { data: savedViewsData } = useGetSavedViews(projectId);
@@ -289,6 +291,10 @@ function InlineTraceView({ traceId, spanId }) {
     setSelectedSpanId(spanId || null);
   }, [traceId, spanId]);
 
+  useEffect(() => {
+    setShowSession(false);
+  }, [traceId, sessionId]);
+
   const rawSpans = data?.observation_spans;
 
   // Apply span-type filter from display options.
@@ -340,6 +346,48 @@ function InlineTraceView({ traceId, spanId }) {
     );
   }
 
+  if (showSession && sessionId) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          minHeight: 0,
+          bgcolor: "background.paper",
+        }}
+      >
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            px: 1.5,
+            minHeight: 36,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            flexShrink: 0,
+          }}
+        >
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Iconify icon="mdi:arrow-left" width={16} />}
+            onClick={() => setShowSession(false)}
+          >
+            Back to trace
+          </Button>
+          <Typography variant="body2" color="text.secondary" noWrap>
+            Session
+          </Typography>
+        </Stack>
+        <Box sx={{ p: 2, flex: 1, minHeight: 0, overflow: "hidden" }}>
+          <SessionContent content={{ session_id: sessionId }} />
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -363,6 +411,19 @@ function InlineTraceView({ traceId, spanId }) {
         readOnly
         readOnlyTabTooltip={READ_ONLY_TAB_TOOLTIP}
         hideFilter
+        rightSlot={
+          sessionId ? (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<Iconify icon="mdi:account-clock-outline" width={16} />}
+              onClick={() => setShowSession(true)}
+              sx={{ height: 24, fontSize: 11 }}
+            >
+              View session
+            </Button>
+          ) : null
+        }
       />
 
       {/* Display options popover */}


### PR DESCRIPTION
## Summary

Adds a View session action to trace and span annotation queue items when the trace detail response includes a parent session id. The action reuses the existing inline `SessionContent` view and provides a Back to trace action so annotators can inspect the session without losing their queue context.

## Linked issues

Closes #1670
Linear:

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 1) What changes were done

**A. Annotation trace toolbar session action**

- Added a View session action to inline trace views when `data.trace.session` is present.
- Reused the existing `SessionContent` renderer for the parent session details.
- Added a Back to trace action to return to the original trace/span context.

**B. Regression coverage**

- Updated the content panel test mocks to render toolbar right-slot actions.
- Added coverage for opening a parent session from a trace queue item and returning to the trace.

## 2) Why the changes were done

- **Product/UX:** Annotators can now inspect the parent conversation/session for trace and span queue items without leaving the annotation workspace.
- **Technical:** The trace detail response already includes the parent session id, so this stays frontend-only and avoids API changes.

## 3) Tests written + scenarios each covers

**`frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx`** — Annotation queue content rendering.

- `lets trace queue items open and return from their parent session` — verifies View session is shown for traces with a parent session, fetches the session detail endpoint, renders session conversation data, and returns to the trace toolbar.

> Run result: **5 passed** in this suite. Targeted ESLint clean for changed frontend files.

## 4) How to run / test

```bash
cd frontend
yarn test:run src/sections/annotations/queues/__tests__/content-panel.test.jsx
./node_modules/.bin/eslint src/sections/annotations/queues/annotate/content-panel.jsx src/sections/annotations/queues/__tests__/content-panel.test.jsx
```

## 6) Edge cases & considerations

- Traces without `data.trace.session` do not render a dead View session action.
- The change reuses the existing `SessionContent` path for session rendering instead of adding a backend endpoint or a new route.
- Switching traces resets the inline session view back to the trace view.

## 7) Pre-existing issues (NOT introduced by this PR)

- Local dependency install was run under Node v24.5.0 even though the project declares Node >=22.18.0. The optional `canvas` package failed to build because no Node 24 prebuild exists and node-gyp could not write to the user cache directory. Yarn completed because `canvas` is optional, and the targeted Vitest suite plus ESLint still passed.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend, targeted suite)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status
