### PR TITLE
fix(gateway): prevent races in A2A task state

### DIFF
--- a/agentcc-gateway/internal/a2a/server.go
+++ b/agentcc-gateway/internal/a2a/server.go
@@ -44,8 +44,15 @@ func newSyncTaskStore() *syncTaskStore {
 
 func (s *syncTaskStore) Store(task *Task) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Cancellation is terminal. A worker can finish concurrently with a
+	// tasks/cancel request, but its stale result must not revive the task.
+	if current, ok := s.store.Get(task.ID); ok &&
+		current.Status.State == TaskStatusCanceled && task.Status.State != TaskStatusCanceled {
+		return
+	}
 	s.store.Store(task)
-	s.mu.Unlock()
 }
 
 func (s *syncTaskStore) Get(id string) (*Task, bool) {
@@ -213,7 +220,7 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request, msg *
 			s.tasks.Store(task)
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			s.taskCancels.Store(task.ID, cancel)
-			go s.runMessageSendWithPipeline(ctx, r.Header.Get("Authorization"), task, inputText, params)
+			go s.runMessageSendWithPipeline(ctx, r.Header.Get("Authorization"), cloneTask(task), inputText, params)
 			writeA2AResult(w, msg.ID, task)
 			return
 		}

--- a/agentcc-gateway/internal/a2a/server_test.go
+++ b/agentcc-gateway/internal/a2a/server_test.go
@@ -299,3 +299,32 @@ func TestTasksCancel(t *testing.T) {
 		t.Fatalf("expected canceled, got %s", task.Status.State)
 	}
 }
+
+func TestSyncTaskStoreDoesNotOverwriteCanceledTaskWithStaleResult(t *testing.T) {
+	tasks := newSyncTaskStore()
+	tasks.Store(&Task{ID: "task-1", Status: TaskStatus{State: TaskStatusWorking}})
+
+	canceled, ok := tasks.Get("task-1")
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	canceled.Status.State = TaskStatusCanceled
+	tasks.Store(canceled)
+
+	tasks.Store(&Task{
+		ID:        "task-1",
+		Status:    TaskStatus{State: TaskStatusCompleted},
+		Artifacts: []Artifact{{Name: "stale result"}},
+	})
+
+	got, ok := tasks.Get("task-1")
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	if got.Status.State != TaskStatusCanceled {
+		t.Fatalf("task status = %q, want %q", got.Status.State, TaskStatusCanceled)
+	}
+	if len(got.Artifacts) != 0 {
+		t.Fatalf("canceled task contains stale artifacts: %#v", got.Artifacts)
+	}
+}

--- a/agentcc-gateway/internal/a2a/types.go
+++ b/agentcc-gateway/internal/a2a/types.go
@@ -156,6 +156,66 @@ type taskEntry struct {
 	createdAt time.Time
 }
 
+func cloneTask(task *Task) *Task {
+	if task == nil {
+		return nil
+	}
+
+	cloned := *task
+	cloned.Metadata = cloneRawMessage(task.Metadata)
+	cloned.Status.Message = cloneMessageParts(task.Status.Message)
+	cloned.Artifacts = cloneArtifacts(task.Artifacts)
+	cloned.History = cloneMessages(task.History)
+	return &cloned
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	cloned := make(json.RawMessage, len(raw))
+	copy(cloned, raw)
+	return cloned
+}
+
+func cloneMessageParts(parts []MessagePart) []MessagePart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]MessagePart, len(parts))
+	copy(cloned, parts)
+	for i := range cloned {
+		cloned[i].Data = cloneRawMessage(parts[i].Data)
+	}
+	return cloned
+}
+
+func cloneMessages(messages []Message) []Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]Message, len(messages))
+	copy(cloned, messages)
+	for i := range cloned {
+		cloned[i].Parts = cloneMessageParts(messages[i].Parts)
+		cloned[i].Metadata = cloneRawMessage(messages[i].Metadata)
+	}
+	return cloned
+}
+
+func cloneArtifacts(artifacts []Artifact) []Artifact {
+	if artifacts == nil {
+		return nil
+	}
+	cloned := make([]Artifact, len(artifacts))
+	copy(cloned, artifacts)
+	for i := range cloned {
+		cloned[i].Parts = cloneMessageParts(artifacts[i].Parts)
+		cloned[i].Metadata = cloneRawMessage(artifacts[i].Metadata)
+	}
+	return cloned
+}
+
 // NewTaskStore creates a task store.
 func NewTaskStore() *TaskStore {
 	return &TaskStore{
@@ -165,7 +225,7 @@ func NewTaskStore() *TaskStore {
 
 // Store saves a task.
 func (ts *TaskStore) Store(task *Task) {
-	ts.tasks[task.ID] = &taskEntry{task: task, createdAt: time.Now()}
+	ts.tasks[task.ID] = &taskEntry{task: cloneTask(task), createdAt: time.Now()}
 }
 
 // Get retrieves a task by ID.
@@ -174,7 +234,7 @@ func (ts *TaskStore) Get(id string) (*Task, bool) {
 	if !ok {
 		return nil, false
 	}
-	return e.task, true
+	return cloneTask(e.task), true
 }
 
 // Cleanup removes tasks older than the given duration.

--- a/agentcc-gateway/internal/a2a/types_test.go
+++ b/agentcc-gateway/internal/a2a/types_test.go
@@ -152,6 +152,69 @@ func TestTaskStore(t *testing.T) {
 	}
 }
 
+func TestTaskStoreReturnsSnapshots(t *testing.T) {
+	ts := NewTaskStore()
+	original := &Task{
+		ID:       "task-1",
+		Metadata: json.RawMessage(`{"task":"original"}`),
+		Status: TaskStatus{
+			State:   TaskStatusWorking,
+			Message: []MessagePart{{Type: "text", Text: "status", Data: json.RawMessage(`{"status":"original"}`)}},
+		},
+		Artifacts: []Artifact{{
+			Name:     "artifact",
+			Parts:    []MessagePart{{Type: "text", Text: "artifact", Data: json.RawMessage(`{"artifact":"original"}`)}},
+			Metadata: json.RawMessage(`{"artifact_meta":"original"}`),
+		}},
+		History: []Message{{
+			Role:     "user",
+			Parts:    []MessagePart{{Type: "text", Text: "history", Data: json.RawMessage(`{"history":"original"}`)}},
+			Metadata: json.RawMessage(`{"history_meta":"original"}`),
+		}},
+	}
+	ts.Store(original)
+
+	original.Status.State = TaskStatusFailed
+	original.Status.Message[0].Text = "mutated"
+	original.Artifacts[0].Parts[0].Text = "mutated"
+	original.History[0].Parts[0].Text = "mutated"
+	original.Metadata[0] = 'X'
+
+	got, ok := ts.Get(original.ID)
+	if !ok {
+		t.Fatal("expected stored task")
+	}
+	if got.Status.State != TaskStatusWorking || got.Status.Message[0].Text != "status" {
+		t.Fatalf("stored status was mutated through caller: %#v", got.Status)
+	}
+	if got.Artifacts[0].Parts[0].Text != "artifact" || got.History[0].Parts[0].Text != "history" {
+		t.Fatalf("stored nested fields were mutated through caller: %#v", got)
+	}
+	if string(got.Metadata) != `{"task":"original"}` {
+		t.Fatalf("stored metadata was mutated through caller: %s", got.Metadata)
+	}
+
+	got.Status.State = TaskStatusCompleted
+	got.Status.Message[0].Text = "mutated snapshot"
+	got.Artifacts[0].Parts[0].Text = "mutated snapshot"
+	got.History[0].Parts[0].Text = "mutated snapshot"
+	got.Metadata[0] = 'Y'
+
+	again, ok := ts.Get(original.ID)
+	if !ok {
+		t.Fatal("expected stored task on second get")
+	}
+	if again.Status.State != TaskStatusWorking || again.Status.Message[0].Text != "status" {
+		t.Fatalf("stored status was mutated through snapshot: %#v", again.Status)
+	}
+	if again.Artifacts[0].Parts[0].Text != "artifact" || again.History[0].Parts[0].Text != "history" {
+		t.Fatalf("stored nested fields were mutated through snapshot: %#v", again)
+	}
+	if string(again.Metadata) != `{"task":"original"}` {
+		t.Fatalf("stored metadata was mutated through snapshot: %s", again.Metadata)
+	}
+}
+
 func TestTaskStoreCleanup(t *testing.T) {
 	ts := NewTaskStore()
 


### PR DESCRIPTION
## Summary

`returnImmediately` A2A tasks shared the same `*Task` between background execution, the in-memory store, `tasks/get`, and `tasks/cancel`. The store mutex protected map access, but not the task after a pointer escaped, so cancellation could race with the worker and a stale completion could overwrite the canceled state.

This change gives the task store snapshot semantics and makes cancellation terminal. A canceled task now stays canceled regardless of whether the worker or cancel request stores its update first.

## Linked issues

None — found while running the gateway server tests with Go's race detector.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature which changes existing behavior unexpectedly)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Isolated task snapshots**

- Deep-copy tasks, including nested message parts and raw JSON, at `TaskStore` read/write boundaries.
- Give the background worker its own task snapshot so it cannot race with the initial JSON-RPC response.

**B. Terminal cancellation**

- Ignore stale non-canceled worker updates after `tasks/cancel` has stored a canceled task.
- Preserve the existing API shape and JSON-RPC behavior.

## 2) Why the changes were done

- **Product:** `tasks/get` should return a coherent task, and a successful cancellation should not later appear completed.
- **Technical:** Locking the map was insufficient because callers retained and mutated the stored pointer after the lock was released.
- **Architecture:** Snapshotting at the store boundary keeps synchronization local and avoids holding a lock during provider calls or JSON encoding.

## 3) Tests written + scenarios each covers

**`internal/a2a/types_test.go`**

- `TestTaskStoreReturnsSnapshots` — proves callers cannot mutate stored task state through either the original value or a retrieved snapshot.

**`internal/a2a/server_test.go`**

- `TestSyncTaskStoreDoesNotOverwriteCanceledTaskWithStaleResult` — proves a late worker result cannot revive a canceled task.

The existing `TestA2AReturnImmediatelyAndCancelUnderV1WithAuth` integration test now also passes under the race detector.

> Run result: full gateway test suite, A2A/server race tests, touched-package vet, contract check, and gateway build all pass.

## 4) How to run / test

```bash
cd agentcc-gateway
go test ./... -count=1
go test -race ./internal/a2a -count=1
go test -race ./internal/server -count=1
go vet ./internal/a2a ./internal/server
go build ./cmd/agentcc

cd ..
python3 scripts/generate-agentcc-gateway-contracts.py --check
```

## 5) Edge cases & considerations

- Store snapshots also isolate nested slices and `json.RawMessage` buffers, not only the top-level task struct.
- Cancellation wins in either ordering: before or after a concurrent worker store attempt.
- Synchronous A2A requests keep their existing behavior; only ownership at async/store boundaries changes.

## 6) Architectural / important decisions

- **Copy at ownership boundaries:** This is less error-prone than adding a mutex to `Task`, which would require every future reader and writer to participate in locking.
- **Keep canceled terminal:** This prevents a late provider response from reversing an already acknowledged cancellation.

## Checklist

- [x] Code follows the existing Go style and is `gofmt` clean
- [x] Tests prove the fix and the full gateway suite passes locally
- [x] Gateway contract check passes
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
