### PR TITLE
fix(oss): disable Imagine button in detail drawers on OSS [TH-7264]

### DIFF
--- a/frontend/src/components/traceDetail/DrawerToolbar.jsx
+++ b/frontend/src/components/traceDetail/DrawerToolbar.jsx
@@ -16,6 +16,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 
 // Shared 24px bordered pill button
 const ToolbarPill = React.forwardRef(({ icon, label, onClick, sx }, ref) => (
@@ -136,7 +137,6 @@ const TabPill = ({
       placement="bottom"
       arrow
       size="small"
-      type="black"
     >
       {pill}
     </CustomTooltip>
@@ -208,6 +208,7 @@ const DrawerToolbar = ({
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
   const displayRef = useRef(null);
+  const { isOSS } = useDeploymentMode();
 
   const effectiveTabs = tabs?.length
     ? tabs
@@ -351,7 +352,6 @@ const DrawerToolbar = ({
             placement="bottom"
             arrow
             size="small"
-            type="black"
           >
             <ButtonBase
               onClick={(e) => onCreateTab?.(e)}
@@ -377,14 +377,19 @@ const DrawerToolbar = ({
         {!readOnly && onCreateImagineTab && (
           <CustomTooltip
             show
-            title="Imagine with Falcon"
+            title={
+              isOSS ? "Imagine is not available in OSS" : "Imagine with Falcon"
+            }
             placement="bottom"
             arrow
             size="small"
-            type="black"
           >
+            {/* Kept mounted rather than `disabled` so the tooltip still fires on hover */}
             <ButtonBase
-              onClick={() => onCreateImagineTab?.()}
+              onClick={() => {
+                if (!isOSS) onCreateImagineTab?.();
+              }}
+              disableRipple={isOSS}
               sx={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -395,11 +400,15 @@ const DrawerToolbar = ({
                 ml: 0.5,
                 flexShrink: 0,
                 color: "text.disabled",
-                "&:hover": {
-                  background:
-                    "linear-gradient(135deg, rgba(123,86,219,0.08) 0%, rgba(26,188,254,0.08) 100%)",
-                  color: "accent.brand",
-                },
+                opacity: isOSS ? 0.5 : 1,
+                cursor: isOSS ? "not-allowed" : "pointer",
+                "&:hover": isOSS
+                  ? {}
+                  : {
+                      background:
+                        "linear-gradient(135deg, rgba(123,86,219,0.08) 0%, rgba(26,188,254,0.08) 100%)",
+                      color: "accent.brand",
+                    },
               }}
             >
               <Iconify icon="mdi:creation" width={14} />


### PR DESCRIPTION
**Ticket:** [TH-7264](https://linear.app/future-agi/issue/TH-7264/oss-disable-imagine-button-in-trace-drawer) — Closes TH-7264

## What was the bug

The "Imagine" button in the trace detail drawer toolbar was live on OSS/self-hosted deployments. Imagine is Falcon-backed (`useFalconSocket.js`), and Falcon is not available on self-hosted, so clicking it opened an Imagine tab that could never do anything useful. The same button is rendered in the chat and voice detail drawers too, so all three were affected.

## What changes have been done

- `frontend/src/components/traceDetail/DrawerToolbar.jsx`
  - Wired in `useDeploymentMode()` to read `isOSS`.
  - On OSS the Imagine button renders at 0.5 opacity with a `not-allowed` cursor, no hover gradient, no ripple, and its click handler is a no-op.
  - Tooltip switches from "Imagine with Falcon" to "Imagine is not available in OSS" on OSS.
  - Removed the `type="black"` override from all three tooltips in the file (TabPill, "+" create view, Imagine) — tooltip contrast is theme-handled now.

## Why the changes

- The gate lives in `DrawerToolbar` rather than in each drawer because `TraceDetailDrawerV2`, `ChatDetailDrawerV2` and `VoiceDetailDrawerV2` all render this one toolbar and all pass `onCreateImagineTab`. One change covers all three and can't drift.
- The button is kept mounted instead of using MUI's `disabled` prop: a disabled `ButtonBase` swallows pointer events, so the explanatory tooltip would never fire on hover. This mirrors the existing OSS treatment of the Falcon FAB in `FalconAIFab.jsx:88`.
- Tooltip copy follows the existing OSS wording used in `EvalCreatePage` / `EvalPicker` ("… not available in OSS").
- `type="black"` force-overrode tooltip colours with `!important` as a workaround for `text.secondary` being unreadable in dark mode. That is redundant with the current theme, so the three usages in this file were dropped.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | OSS mode, open trace detail drawer, hover Imagine | Button dimmed, `not-allowed` cursor, tooltip reads "Imagine is not available in OSS" |
| 2 | OSS mode, click Imagine | Nothing happens, no Imagine tab is created |
| 3 | OSS mode, chat detail drawer and voice detail drawer | Same disabled treatment as the trace drawer |
| 4 | Cloud/EE mode, hover Imagine | Tooltip reads "Imagine with Falcon", hover gradient intact |
| 5 | Cloud/EE mode, click Imagine | Imagine tab opens as before, no behaviour change |
| 6 | Read-only drawer (any mode) | Button stays hidden, unchanged from before |
| 7 | Tab pill and "+" create-view tooltips, light and dark mode | Readable contrast without the `type="black"` override |

## How to reproduce (original bug)

1. Run the stack in OSS mode.
2. Open a project and go to Observe.
3. Click any trace row to open the trace detail drawer.
4. The "Imagine" button in the drawer toolbar is fully enabled and clickable, with no indication that Falcon is unavailable on self-hosted.

## Commands

```bash
cd frontend

# run against a local OSS backend, or force the mode without one:
#   VITE_DEPLOYMENT_MODE_OVERRIDE=oss
yarn dev

yarn lint
npx vitest run src/components/VoiceDetailDrawerV2 src/components/traceDetail
```

## Videos and screenshots

<img width="1557" height="984" alt="Screenshot 2026-08-03 at 7 20 59 PM" src="https://github.com/user-attachments/assets/a41c3d22-465a-498b-8c11-8fdd85a6f4b1" />
<img width="561" height="340" alt="Screenshot 2026-08-03 at 7 20 39 PM" src="https://github.com/user-attachments/assets/bc43836d-7cbf-4742-8942-db80bfc6a198" />
