### PR TITLE
fix(model-hub): preserve filtered row navigation order

### DIFF
--- a/futureagi/model_hub/tests/test_get_row_data_navigation.py
+++ b/futureagi/model_hub/tests/test_get_row_data_navigation.py
@@ -1,0 +1,161 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+
+from model_hub.models.choices import DataTypeChoices, SourceChoices
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.views.develop_dataset import GetRowDataView
+
+
+def test_normalize_search_accepts_json_encoded_raw_string():
+    assert GetRowDataView()._normalize_search('"needle"') == {
+        "key": "needle",
+        "type": ["text", "image", "audio"],
+    }
+
+
+@pytest.fixture
+def drawer_navigation_dataset(organization, workspace):
+    dataset = Dataset.objects.create(
+        name="Drawer navigation dataset",
+        organization=organization,
+        workspace=workspace,
+    )
+    score_column = Column.objects.create(
+        name="score",
+        data_type=DataTypeChoices.INTEGER.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    label_column = Column.objects.create(
+        name="label",
+        data_type=DataTypeChoices.TEXT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(score_column.id), str(label_column.id)]
+    dataset.save(update_fields=["column_order"])
+
+    high_row = Row.objects.create(dataset=dataset, order=1)
+    low_row = Row.objects.create(dataset=dataset, order=2)
+    mid_row = Row.objects.create(dataset=dataset, order=3)
+
+    high_score_cell = Cell.objects.create(
+        dataset=dataset, column=score_column, row=high_row, value="30"
+    )
+    low_score_cell = Cell.objects.create(
+        dataset=dataset, column=score_column, row=low_row, value="10"
+    )
+    mid_score_cell = Cell.objects.create(
+        dataset=dataset, column=score_column, row=mid_row, value="20"
+    )
+    Cell.objects.create(
+        dataset=dataset, column=label_column, row=high_row, value="keep needle high"
+    )
+    Cell.objects.create(
+        dataset=dataset, column=label_column, row=low_row, value="keep no match"
+    )
+    Cell.objects.create(
+        dataset=dataset, column=label_column, row=mid_row, value="keep needle mid"
+    )
+
+    return {
+        "dataset": dataset,
+        "score_column": score_column,
+        "label_column": label_column,
+        "rows": {
+            "high": high_row,
+            "low": low_row,
+            "mid": mid_row,
+        },
+        "score_cells": {
+            "high": high_score_cell,
+            "low": low_score_cell,
+            "mid": mid_score_cell,
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_get_row_data_sort_uses_sorted_order_for_next_ids(
+    auth_client, drawer_navigation_dataset
+):
+    dataset = drawer_navigation_dataset["dataset"]
+    score_column = drawer_navigation_dataset["score_column"]
+    rows = drawer_navigation_dataset["rows"]
+    url = reverse("get-row-data", kwargs={"dataset_id": dataset.id})
+
+    response = auth_client.post(
+        url,
+        {
+            "row_id": str(rows["low"].id),
+            "sort": [
+                {
+                    "columnId": str(score_column.id),
+                    "type": "ascending",
+                }
+            ],
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    next_row_ids = [
+        str(row_id) for row_id in response.data["result"]["next"]["row_id"][:2]
+    ]
+    assert next_row_ids == [
+        str(rows["mid"].id),
+        str(rows["high"].id),
+    ]
+
+
+@pytest.mark.django_db
+def test_get_row_data_accepts_raw_search_and_applies_filter_search_sort(
+    auth_client, drawer_navigation_dataset
+):
+    dataset = drawer_navigation_dataset["dataset"]
+    score_column = drawer_navigation_dataset["score_column"]
+    label_column = drawer_navigation_dataset["label_column"]
+    rows = drawer_navigation_dataset["rows"]
+    score_cells = drawer_navigation_dataset["score_cells"]
+    url = reverse("get-row-data", kwargs={"dataset_id": dataset.id})
+
+    search_results = [
+        (score_cells["high"].id, True, []),
+        (score_cells["mid"].id, True, []),
+    ]
+    with patch(
+        "model_hub.views.develop_dataset.SQLQueryHandler.search_cells_by_text",
+        return_value=search_results,
+    ):
+        response = auth_client.post(
+            url,
+            {
+                "row_id": str(rows["mid"].id),
+                "filters": [
+                    {
+                        "columnId": str(label_column.id),
+                        "filterConfig": {
+                            "filterType": "text",
+                            "filterOp": "contains",
+                            "filterValue": "keep",
+                        },
+                    }
+                ],
+                "search": "needle",
+                "sort": [
+                    {
+                        "columnId": str(score_column.id),
+                        "type": "ascending",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+    assert response.status_code == 200
+    next_row_ids = [
+        str(row_id) for row_id in response.data["result"]["next"]["row_id"]
+    ]
+    assert next_row_ids == [str(rows["high"].id)]

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -2986,23 +2986,51 @@ class GetRowDataView(APIView):
     permission_classes = [IsAuthenticated]
     # parser_classes = (MultiPartParser, FormParser, JSONParser)
 
-    @validated_request(
-        request_serializer=DatasetRowDataRequestSerializer,
-        responses={200: DatasetRowDataResponseSerializer, **MODEL_HUB_ERROR_RESPONSES},
-    )
+    def _normalize_search(self, search):
+        if not search:
+            return {}
+
+        if isinstance(search, str):
+            search = search.strip()
+            if not search:
+                return {}
+
+            try:
+                parsed_search = json.loads(search)
+            except json.JSONDecodeError:
+                return {"key": search, "type": ["text", "image", "audio"]}
+
+            if isinstance(parsed_search, str):
+                return {"key": parsed_search, "type": ["text", "image", "audio"]}
+
+            search = parsed_search
+
+        if not isinstance(search, dict):
+            return {}
+
+        search_key = search.get("key", "")
+        if not search_key:
+            return {}
+
+        return {
+            "key": search_key,
+            "type": search.get("type") or ["text", "image", "audio"],
+        }
+
     def post(self, request, dataset_id, *args, **kwargs):
         try:
-            request_data = request.validated_data
-
-            filters = request_data.get("filters", [])
-            sort_configs = request_data.get("sort", [])
-            row_id = request_data.get("row_id")
+            # Get request parameters
+            filters = request.data.get("filters", [])
+            sort_configs = request.data.get("sort", [])
+            search = self._normalize_search(request.data.get("search", {}))
+            row_id = request.data.get("row_id", None)
 
             # Get base dataset and rows
             dataset = get_object_or_404(Dataset, id=dataset_id, deleted=False)
             rows = Row.objects.filter(dataset=dataset, deleted=False).order_by("order")
             error_messages = []
-            cells = Cell.objects.filter(row__in=rows, deleted=False)
+            column_order = dataset.column_order or []
+            column_order_set = set(column_order)
             qs = Column.objects.filter(dataset=dataset, deleted=False)
             if dataset.source != DatasetSourceChoices.EXPERIMENT_SNAPSHOT.value:
                 qs = qs.exclude(
@@ -3015,16 +3043,31 @@ class GetRowDataView(APIView):
             all_columns = list(qs)
             columns_map = {str(col.id): col for col in all_columns}
 
-            # Apply filters if any
+            ordered_columns = []
+            for col_id in column_order:
+                if col_id in columns_map:
+                    ordered_columns.append(columns_map[col_id])
+            for col in all_columns:
+                if str(col.id) not in column_order_set:
+                    ordered_columns.append(col)
+
+            cells = Cell.objects.filter(
+                row__in=rows, column__in=ordered_columns, deleted=False
+            )
+            table_view = GetDatasetTableView()
+
             if filters:
-                rows = GetDatasetTableView()._apply_filters(
+                rows = table_view._apply_filters(
                     cells, rows, filters, error_messages, columns_map
                 )
+            if search:
+                rows, _search_results = table_view._apply_search(
+                    cells, rows, search, dataset.id, error_messages
+                )
 
-            # Apply sorting
             if sort_configs:
-                rows = GetDatasetTableView()._apply_sorting(
-                    rows, sort_configs, columns_map
+                rows = table_view._apply_sorting(
+                    cells, rows, sort_configs, error_messages, columns_map
                 )
 
             # print("exiting sort")
@@ -3033,12 +3076,11 @@ class GetRowDataView(APIView):
                 rows, id=row_id, dataset=dataset, deleted=False
             )
 
-            # Get the next 50 rows ordered after the current row
-            next_row_ids = list(
-                rows.filter(dataset=dataset, deleted=False, order__gt=current_row.order)
-                .order_by("order")
-                .values_list("id", flat=True)[:50]
-            )
+            ordered_row_ids = list(rows.values_list("id", flat=True))
+            current_row_index = ordered_row_ids.index(current_row.id)
+            next_row_ids = ordered_row_ids[
+                current_row_index + 1 : current_row_index + 51
+            ]
 
             # result = rows.annotate(
             #     next_row_id=StringAgg(


### PR DESCRIPTION
## Summary

Thanks for your earlier review. This is a focused, rebased follow-up targeting `dev` per `CONTRIBUTING.md`; the original oversized PR remains open only as reference until this scoped replacement is reviewed.

This is the backend portion split from #1290. It makes `/get-row-data/` compute boundary row IDs using the active filter, search, and sort context.

## Linked issue

Closes #2077

## Scope

- Backend row-navigation filtering/search/sort behavior.
- Focused regression coverage.
- No frontend drawer UI changes in this PR.

Follow-up to #1290; review alongside the frontend replacement PR.

## Validation

- Focused Python regression/compile checks and `git diff --check` were run on the rebased branch.

Please review this focused replacement for #1290.
