### PR TITLE
fix(agent-playground): browse library prompt templates

### DIFF
--- a/frontend/src/api/agent-playground/__tests__/prompts.test.js
+++ b/frontend/src/api/agent-playground/__tests__/prompts.test.js
@@ -1,0 +1,221 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import axios from "src/utils/axios";
+import {
+  useGetLibraryTemplatesInfinite,
+  useGetPromptTemplatesInfinite,
+} from "../prompts";
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: vi.fn(),
+  },
+  endpoints: {
+    develop: {
+      runPrompt: {
+        createTemplateId: "/model-hub/prompt-templates/",
+        promptTemplate: "/model-hub/prompt-base-templates/",
+      },
+    },
+  },
+}));
+
+function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function QueryWrapper({ children }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  }
+
+  QueryWrapper.propTypes = {
+    children: PropTypes.node,
+  };
+
+  return QueryWrapper;
+}
+
+function templates(count, prefix = "template") {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `${prefix}-${index}`,
+    name: `${prefix} ${index}`,
+  }));
+}
+
+describe("useGetLibraryTemplatesInfinite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests library templates with search and generated plus legacy pagination aliases", async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        data: { result: { data: templates(10), total_count: 12 } },
+      })
+      .mockResolvedValueOnce({
+        data: { result: { data: templates(2, "next"), total_count: 12 } },
+      });
+
+    const { result } = renderHook(
+      () => useGetLibraryTemplatesInfinite("research"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "/model-hub/prompt-base-templates/",
+      expect.objectContaining({
+        params: {
+          name: "research",
+          page: 1,
+          limit: 10,
+          page_size: 10,
+          page_number: 0,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+
+    expect(axios.get).toHaveBeenLastCalledWith(
+      "/model-hub/prompt-base-templates/",
+      expect.objectContaining({
+        params: {
+          name: "research",
+          page: 2,
+          limit: 10,
+          page_size: 10,
+          page_number: 1,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("reads legacy library template result envelopes", async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        data: { result: { data: templates(10), total_count: 11 } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: { data: templates(1, "legacy-next"), total_count: 11 },
+        },
+      });
+
+    const { result } = renderHook(
+      () => useGetLibraryTemplatesInfinite("legacy"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+
+    expect(axios.get).toHaveBeenLastCalledWith(
+      "/model-hub/prompt-base-templates/",
+      expect.objectContaining({
+        params: {
+          name: "legacy",
+          page: 2,
+          limit: 10,
+          page_size: 10,
+          page_number: 1,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("continues to read wrapped generated-style library template result envelopes", async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        data: {
+          result: {
+            count: 11,
+            next: 2,
+            previous: null,
+            results: templates(10),
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: {
+            count: 11,
+            next: null,
+            previous: 1,
+            results: templates(1, "wrapped-next"),
+          },
+        },
+      });
+
+    const { result } = renderHook(
+      () => useGetLibraryTemplatesInfinite("wrapped"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+
+    expect(axios.get).toHaveBeenLastCalledWith(
+      "/model-hub/prompt-base-templates/",
+      expect.objectContaining({
+        params: {
+          name: "wrapped",
+          page: 2,
+          limit: 10,
+          page_size: 10,
+          page_number: 1,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("keeps library templates on a separate endpoint and pagination contract from saved prompts", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { results: [], current_page: 1, total_pages: 1 },
+    });
+
+    const { result } = renderHook(
+      () => useGetPromptTemplatesInfinite("research"),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "/model-hub/prompt-templates/",
+      expect.objectContaining({
+        params: {
+          modality: "chat",
+          name: "research",
+          page_size: 10,
+          page: 1,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});

--- a/frontend/src/api/agent-playground/libraryTemplateResponseUtils.js
+++ b/frontend/src/api/agent-playground/libraryTemplateResponseUtils.js
@@ -1,0 +1,22 @@
+export function getLibraryTemplateItems(data) {
+  return data?.result?.data ?? data?.result?.results ?? data?.results ?? [];
+}
+
+export function getLibraryTemplateTotalCount(data) {
+  return data?.result?.total_count ?? data?.result?.count ?? data?.count ?? 0;
+}
+
+export function getNextLibraryTemplatePageParam(lastPage, allPages) {
+  if (lastPage.data?.next || lastPage.data?.result?.next) {
+    return allPages.length;
+  }
+
+  const totalCount = getLibraryTemplateTotalCount(lastPage.data);
+  const fetchedCount = allPages.reduce(
+    (count, page) => count + getLibraryTemplateItems(page.data).length,
+    0,
+  );
+
+  if (fetchedCount < totalCount) return allPages.length;
+  return undefined;
+}

--- a/frontend/src/api/agent-playground/prompts.js
+++ b/frontend/src/api/agent-playground/prompts.js
@@ -1,5 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
+import { getNextLibraryTemplatePageParam } from "./libraryTemplateResponseUtils";
 
 /**
  * Hook for fetching prompt templates filtered by chat modality.
@@ -92,6 +93,39 @@ export const useGetPromptTemplatesInfinite = (search, options = {}) =>
       return undefined;
     },
     initialPageParam: 1,
+    staleTime: 30 * 1000,
+    ...options,
+  });
+
+const LIBRARY_TEMPLATE_PAGE_SIZE = 10;
+
+/**
+ * Infinite-scroll hook for the prompt library/base templates.
+ * Used by PromptNodePopper to show reusable library templates alongside
+ * user-saved prompt templates.
+ * @param {string} search - Search query to filter by name
+ * @param {object} options - Additional react-query options
+ */
+export const useGetLibraryTemplatesInfinite = (search, options = {}) =>
+  useInfiniteQuery({
+    queryKey: ["library-templates-infinite", search],
+    queryFn: ({ pageParam, signal }) =>
+      axios.get(endpoints.develop.runPrompt.promptTemplate, {
+        params: {
+          ...(search && { name: search }),
+          // The live base-template view currently reads zero-indexed
+          // page_number/page_size, while generated contracts expose
+          // one-indexed page/limit. Send both coherent pairs so this
+          // selector stays compatible during that contract convergence.
+          page: pageParam + 1,
+          limit: LIBRARY_TEMPLATE_PAGE_SIZE,
+          page_size: LIBRARY_TEMPLATE_PAGE_SIZE,
+          page_number: pageParam,
+        },
+        signal,
+      }),
+    getNextPageParam: getNextLibraryTemplatePageParam,
+    initialPageParam: 0,
     staleTime: 30 * 1000,
     ...options,
   });

--- a/frontend/src/sections/agent-playground/components/PromptNameRow.jsx
+++ b/frontend/src/sections/agent-playground/components/PromptNameRow.jsx
@@ -114,6 +114,9 @@ export default function PromptNameRow({ control }) {
     setValue("outputFormat", formConfig.outputFormat || "string", {
       shouldDirty: false,
     });
+    setValue("templateFormat", formConfig.templateFormat || "mustache", {
+      shouldDirty: false,
+    });
     if (formConfig.payload) {
       setValue("payload", formConfig.payload, { shouldDirty: true });
     }

--- a/frontend/src/sections/agent-playground/components/PromptNodePopper.jsx
+++ b/frontend/src/sections/agent-playground/components/PromptNodePopper.jsx
@@ -7,6 +7,7 @@ import {
   List,
   ListItem,
   ListItemButton,
+  ListSubheader,
   ListItemText,
   Stack,
   CircularProgress,
@@ -17,15 +18,33 @@ import React, { useCallback, useMemo, useState } from "react";
 import SvgColor from "src/components/svg-color";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
 import {
+  useGetLibraryTemplatesInfinite,
   useGetNodeTemplates,
   useGetPromptTemplatesInfinite,
 } from "src/api/agent-playground/agent-playground";
 import axios, { endpoints } from "src/utils/axios";
 import { NODE_TYPES } from "../utils/constants";
 import { mapVersionToFormConfig } from "../utils/promptVersionUtils";
+import { getLibraryTemplateItems } from "src/api/agent-playground/libraryTemplateResponseUtils";
+import {
+  INCOMPATIBLE_LIBRARY_TEMPLATE_MESSAGE,
+  toDetachedLibraryTemplateConfig,
+} from "../utils/libraryTemplateUtils";
 import useAddNodeOptimistic from "../AgentBuilder/hooks/useAddNodeOptimistic";
 import { useDebounce } from "src/hooks/use-debounce";
 import { enqueueSnackbar } from "notistack";
+
+function LoadingListItem({ size = 20 }) {
+  return (
+    <ListItem sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+      <CircularProgress size={size} />
+    </ListItem>
+  );
+}
+
+LoadingListItem.propTypes = {
+  size: PropTypes.number,
+};
 
 export default function PromptNodePopper({
   open,
@@ -51,25 +70,52 @@ export default function PromptNodePopper({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError: isPromptsError,
   } = useGetPromptTemplatesInfinite(debouncedSearch, { enabled: open });
+
+  const {
+    data: libraryTemplatesData,
+    isLoading: isLibraryLoading,
+    fetchNextPage: fetchNextLibraryPage,
+    hasNextPage: hasNextLibraryPage,
+    isFetchingNextPage: isFetchingNextLibraryPage,
+    isError: isLibraryError,
+  } = useGetLibraryTemplatesInfinite(debouncedSearch, { enabled: open });
 
   const prompts = useMemo(
     () => promptsData?.pages?.flatMap((p) => p.data?.results ?? []) ?? [],
     [promptsData],
   );
 
+  const libraryTemplates = useMemo(
+    () =>
+      libraryTemplatesData?.pages?.flatMap((p) =>
+        getLibraryTemplateItems(p.data),
+      ) ?? [],
+    [libraryTemplatesData],
+  );
+
   const handleListScroll = useCallback(
     (e) => {
       const { scrollTop, scrollHeight, clientHeight } = e.target;
-      if (
-        scrollTop + clientHeight >= scrollHeight - 5 &&
-        hasNextPage &&
-        !isFetchingNextPage
-      ) {
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight - 5;
+
+      if (isAtBottom && hasNextPage && !isFetchingNextPage) {
         fetchNextPage();
       }
+
+      if (isAtBottom && hasNextLibraryPage && !isFetchingNextLibraryPage) {
+        fetchNextLibraryPage();
+      }
     },
-    [fetchNextPage, hasNextPage, isFetchingNextPage],
+    [
+      fetchNextLibraryPage,
+      fetchNextPage,
+      hasNextLibraryPage,
+      hasNextPage,
+      isFetchingNextLibraryPage,
+      isFetchingNextPage,
+    ],
   );
 
   const handleAddBlankPrompt = useCallback(() => {
@@ -129,6 +175,81 @@ export default function PromptNodePopper({
     },
     [addNode, onClose, onNodeSelect, llmPromptTemplateId],
   );
+
+  const handleLibraryTemplateClick = useCallback(
+    (template) => {
+      const config = toDetachedLibraryTemplateConfig(template);
+      if (!config) {
+        enqueueSnackbar(INCOMPATIBLE_LIBRARY_TEMPLATE_MESSAGE, {
+          variant: "error",
+        });
+        return;
+      }
+
+      if (onNodeSelect) {
+        onNodeSelect(NODE_TYPES.LLM_PROMPT, llmPromptTemplateId, {
+          ...config,
+          name: template.name,
+        });
+      } else {
+        addNode({
+          type: NODE_TYPES.LLM_PROMPT,
+          position: undefined,
+          node_template_id: llmPromptTemplateId,
+          name: template.name,
+          config,
+        });
+      }
+      onClose();
+    },
+    [addNode, onClose, onNodeSelect, llmPromptTemplateId],
+  );
+
+  const hasPrompts = prompts.length > 0;
+  const hasLibraryTemplates = libraryTemplates.length > 0;
+  const hasQueryError = isPromptsError || isLibraryError;
+  const queryErrorMessage = isPromptsError
+    ? isLibraryError
+      ? "Unable to load prompt templates. Check your connection and try again."
+      : "Unable to load your prompts. Library templates may still be available."
+    : "Unable to load library templates. Your prompts may still be available.";
+  const shouldShowEmptyState =
+    !isLoading &&
+    !isLibraryLoading &&
+    !hasPrompts &&
+    !hasLibraryTemplates &&
+    !hasQueryError;
+  const isFetchingMore = isFetchingNextPage || isFetchingNextLibraryPage;
+
+  const renderPromptItems = (items, keyPrefix, onClick) =>
+    items.map((prompt) => (
+      <ListItem key={`${keyPrefix}-${prompt.id}`} disablePadding>
+        <ListItemButton
+          onClick={() => onClick(prompt)}
+          sx={{
+            py: 1,
+            px: 2,
+            "&:hover": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "dark"
+                  ? "action.hover"
+                  : "whiteScale.200",
+            },
+          }}
+        >
+          <Stack spacing={0.5} sx={{ width: "100%" }}>
+            <ListItemText
+              primary={prompt.name}
+              primaryTypographyProps={{
+                typography: "s1",
+                color: "text.primary",
+                noWrap: true,
+              }}
+            />
+          </Stack>
+        </ListItemButton>
+      </ListItem>
+    ));
 
   return (
     <Popper
@@ -222,56 +343,78 @@ export default function PromptNodePopper({
             dense
           >
             {isLoading ? (
-              <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-                <CircularProgress size={20} />
-              </Box>
-            ) : prompts.length === 0 ? (
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ px: 2, py: 1.5 }}
-              >
-                No prompts found
-              </Typography>
+              <LoadingListItem />
             ) : (
-              <>
-                {prompts.map((prompt) => (
-                  <ListItem key={prompt.id} disablePadding>
-                    <ListItemButton
-                      onClick={() => handlePromptClick(prompt)}
-                      sx={{
-                        py: 1,
-                        px: 2,
-                        "&:hover": {
-                          bgcolor: (theme) =>
-                            theme.palette.mode === "dark"
-                              ? "action.hover"
-                              : "whiteScale.200",
-                        },
-                      }}
-                    >
-                      <Stack spacing={0.5} sx={{ width: "100%" }}>
-                        <ListItemText
-                          primary={prompt.name}
-                          primaryTypographyProps={{
-                            typography: "s1",
-                            color: "text.primary",
-                            noWrap: true,
-                          }}
-                        />
-                      </Stack>
-                    </ListItemButton>
-                  </ListItem>
-                ))}
-                {isFetchingNextPage && (
-                  <Box
-                    sx={{ display: "flex", justifyContent: "center", py: 1 }}
+              hasPrompts && (
+                <>
+                  <ListSubheader
+                    disableSticky
+                    sx={{
+                      bgcolor: "background.paper",
+                      color: "text.secondary",
+                      lineHeight: "28px",
+                      typography: "s2",
+                      fontWeight: "fontWeightMedium",
+                    }}
                   >
-                    <CircularProgress size={16} />
-                  </Box>
-                )}
-              </>
+                    My Prompts
+                  </ListSubheader>
+                  {renderPromptItems(
+                    prompts,
+                    "saved-prompt",
+                    handlePromptClick,
+                  )}
+                </>
+              )
             )}
+
+            {isLibraryLoading ? (
+              <LoadingListItem />
+            ) : (
+              hasLibraryTemplates && (
+                <>
+                  <ListSubheader
+                    disableSticky
+                    sx={{
+                      bgcolor: "background.paper",
+                      color: "text.secondary",
+                      lineHeight: "28px",
+                      typography: "s2",
+                      fontWeight: "fontWeightMedium",
+                    }}
+                  >
+                    Library Templates
+                  </ListSubheader>
+                  {renderPromptItems(
+                    libraryTemplates,
+                    "library-template",
+                    handleLibraryTemplateClick,
+                  )}
+                </>
+              )
+            )}
+
+            {hasQueryError && (
+              <ListItem>
+                <Typography variant="body2" color="error.main" sx={{ py: 0.5 }}>
+                  {queryErrorMessage}
+                </Typography>
+              </ListItem>
+            )}
+
+            {shouldShowEmptyState && (
+              <ListItem>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ py: 1 }}
+                >
+                  No prompts found
+                </Typography>
+              </ListItem>
+            )}
+
+            {isFetchingMore && <LoadingListItem size={16} />}
           </List>
         </Paper>
       </ClickAwayListener>

--- a/frontend/src/sections/agent-playground/components/__tests__/PromptNameRow.test.jsx
+++ b/frontend/src/sections/agent-playground/components/__tests__/PromptNameRow.test.jsx
@@ -1,0 +1,172 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  FormProvider,
+  useForm,
+  useFormContext,
+  useWatch,
+} from "react-hook-form";
+import PromptNameRow from "../PromptNameRow";
+
+const mockVersions = [
+  {
+    id: "prompt-version-1",
+    template_version: "v1",
+    is_draft: false,
+    prompt_config_snapshot: {
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Use {{topic}}" }],
+        },
+      ],
+      configuration: {
+        model: "gpt-4o-mini",
+        response_format: "text",
+        output_format: "string",
+        template_format: "mustache",
+      },
+    },
+  },
+  {
+    id: "prompt-version-2",
+    template_version: "v2",
+    is_draft: false,
+    prompt_config_snapshot: {
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Use {{ topic }}" }],
+        },
+      ],
+      configuration: {
+        model: "gpt-4o-mini",
+        response_format: "text",
+        output_format: "string",
+        template_format: "jinja",
+      },
+    },
+  },
+];
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetPromptVersionsInfinite: () => ({
+    data: {
+      pages: [
+        {
+          data: {
+            results: mockVersions,
+          },
+        },
+      ],
+    },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+  useGetPromptVersionDetail: () => ({ data: null }),
+}));
+
+vi.mock("src/components/FormTextField/FormTextFieldV2", () => ({
+  default: function MockFormTextFieldV2({ fieldName, label }) {
+    const { register } = useFormContext();
+    return <input aria-label={label} {...register(fieldName)} />;
+  },
+}));
+
+vi.mock("src/components/FormSelectField/FormSelectField", () => ({
+  EnhancedFormSelectField: function MockEnhancedFormSelectField({
+    fieldName,
+    options,
+  }) {
+    const { setValue } = useFormContext();
+    const value = useWatch({ name: fieldName });
+
+    return (
+      <select
+        aria-label={fieldName}
+        value={value || ""}
+        onChange={(event) =>
+          setValue(fieldName, event.target.value, { shouldDirty: true })
+        }
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+}));
+
+vi.mock("src/sections/workbench/createPrompt/SharedStyledComponents", () => ({
+  DraftBadge: function MockDraftBadge({ children }) {
+    return <span>{children}</span>;
+  },
+}));
+
+function FormValuesProbe() {
+  const values = useWatch();
+  return (
+    <>
+      <div data-testid="template-format">{values.templateFormat}</div>
+      <div data-testid="payload-template-format">
+        {values.payload?.promptConfig?.[0]?.configuration?.template_format}
+      </div>
+    </>
+  );
+}
+
+function renderPromptNameRow() {
+  function Wrapper() {
+    const methods = useForm({
+      defaultValues: {
+        name: "saved_prompt",
+        prompt_template_id: "prompt-template-1",
+        prompt_version_id: "prompt-version-1",
+        outputFormat: "string",
+        templateFormat: "mustache",
+        modelConfig: {
+          model: "gpt-4o-mini",
+          responseFormat: "text",
+        },
+        messages: [],
+        payload: null,
+      },
+    });
+
+    return (
+      <FormProvider {...methods}>
+        <PromptNameRow control={methods.control} />
+        <FormValuesProbe />
+      </FormProvider>
+    );
+  }
+
+  return render(<Wrapper />);
+}
+
+describe("PromptNameRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates templateFormat when switching saved prompt versions", async () => {
+    renderPromptNameRow();
+
+    expect(screen.getByTestId("template-format")).toHaveTextContent("mustache");
+
+    fireEvent.change(screen.getByLabelText("prompt_version_id"), {
+      target: { value: "prompt-version-2" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("template-format")).toHaveTextContent("jinja"),
+    );
+    expect(screen.getByTestId("payload-template-format")).toHaveTextContent(
+      "jinja",
+    );
+  });
+});

--- a/frontend/src/sections/agent-playground/components/__tests__/PromptNodePopper.test.jsx
+++ b/frontend/src/sections/agent-playground/components/__tests__/PromptNodePopper.test.jsx
@@ -1,0 +1,726 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PromptNodePopper from "../PromptNodePopper";
+import {
+  useGetLibraryTemplatesInfinite,
+  useGetNodeTemplates,
+  useGetPromptTemplatesInfinite,
+} from "src/api/agent-playground/agent-playground";
+import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "notistack";
+
+const mockAddNode = vi.fn();
+
+vi.mock("../../AgentBuilder/hooks/useAddNodeOptimistic", () => ({
+  default: () => ({ addNode: mockAddNode }),
+}));
+
+vi.mock("src/api/agent-playground/agent-playground", () => ({
+  useGetLibraryTemplatesInfinite: vi.fn(),
+  useGetNodeTemplates: vi.fn(),
+  useGetPromptTemplatesInfinite: vi.fn(),
+}));
+
+vi.mock("src/hooks/use-debounce", () => ({
+  useDebounce: (value) => value,
+}));
+
+vi.mock("src/components/svg-color", () => ({
+  default: ({ src }) => <span data-testid="svg-color">{src}</span>,
+}));
+
+vi.mock("src/components/FormSearchField/FormSearchField", () => ({
+  default: ({ onChange, placeholder, searchQuery }) => (
+    <input
+      aria-label={placeholder}
+      onChange={onChange}
+      placeholder={placeholder}
+      value={searchQuery}
+    />
+  ),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: vi.fn(),
+  },
+  endpoints: {
+    develop: {
+      runPrompt: {
+        getPromptVersions: vi.fn(() => "/model-hub/prompt-history-executions/"),
+      },
+    },
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+const anchorEl = document.createElement("button");
+const nodeTemplates = [
+  {
+    id: "llm_prompt",
+    node_template_id: "node-template-llm-prompt",
+  },
+];
+const responseSchema = {
+  type: "object",
+  properties: {
+    answer: { type: "string" },
+  },
+  required: ["answer"],
+};
+
+const savedPrompt = {
+  id: "saved-template-1",
+  name: "Saved Support Prompt",
+};
+
+const libraryTemplate = {
+  id: "library-template-1",
+  name: "Library Research Template",
+  prompt_config_snapshot: {
+    messages: [
+      {
+        role: "system",
+        content: [{ type: "text", text: "Be concise." }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Summarize {{topic}}." }],
+      },
+    ],
+    configuration: {
+      model: "gpt-4o-mini",
+      model_detail: { model_name: "gpt-4o-mini", providers: "openai" },
+      response_format: "text",
+      output_format: "string",
+      template_format: "jinja",
+      temperature: 0.2,
+    },
+  },
+};
+
+const remoteMediaLibraryTemplate = {
+  ...libraryTemplate,
+  id: "library-template-remote-media",
+  name: "Library Remote Media Template",
+  prompt_config_snapshot: {
+    messages: [
+      {
+        role: "user",
+        content: [
+          "Describe the attached context.",
+          {
+            type: "image_url",
+            image_url: "https://example.com/image.png",
+          },
+          {
+            type: "pdf_url",
+            pdf_url: "https://example.com/doc.pdf",
+          },
+          {
+            type: "audio_url",
+            audio_url: "https://example.com/audio.mp3",
+          },
+        ],
+      },
+    ],
+    configuration: null,
+  },
+};
+
+const legacyListLibraryTemplate = {
+  id: "library-template-legacy-list",
+  name: "Legacy List Library Template",
+  prompt_config_snapshot: [
+    {
+      messages: [{ role: "user", content: "Hello {{name}}" }],
+      model: "gpt-4o",
+      model_detail: { model_name: "gpt-4o", providers: "openai" },
+      response_format: "json_object",
+      output_format: "json",
+      template_format: "mustache",
+      temperature: 0.4,
+    },
+  ],
+};
+
+const toolConfiguredLibraryTemplate = {
+  ...libraryTemplate,
+  id: "library-template-tools",
+  name: "Library Template With Tools",
+  prompt_config_snapshot: {
+    ...libraryTemplate.prompt_config_snapshot,
+    configuration: {
+      ...libraryTemplate.prompt_config_snapshot.configuration,
+      tools: [{ name: "external_lookup" }],
+      tool_choice: "required",
+    },
+  },
+};
+
+const promptVersion = {
+  id: "prompt-version-1",
+  is_default: true,
+  prompt_config_snapshot: {
+    messages: [
+      {
+        role: "system",
+        content: [{ type: "text", text: "Saved system" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Saved user" }],
+      },
+    ],
+    configuration: {
+      model: "gpt-4o",
+      model_detail: { model_name: "gpt-4o", providers: "openai" },
+      response_format: "text",
+      output_format: "string",
+    },
+  },
+};
+
+function infiniteResult(items, overrides = {}, shape = "saved") {
+  const pageData =
+    shape === "library"
+      ? {
+          result: {
+            data: items,
+            page_number: 1,
+            total_count: items.length,
+          },
+        }
+      : { results: items };
+
+  return {
+    data: {
+      pages: [{ data: pageData }],
+    },
+    isLoading: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isError: false,
+    ...overrides,
+  };
+}
+
+function savedPromptsResult(items, overrides = {}) {
+  return infiniteResult(items, overrides, "saved");
+}
+
+function libraryTemplatesResult(items, overrides = {}) {
+  return infiniteResult(items, overrides, "library");
+}
+
+function renderPopper(props = {}) {
+  return render(
+    <PromptNodePopper open anchorEl={anchorEl} onClose={vi.fn()} {...props} />,
+  );
+}
+
+function scrollListTo({ scrollTop, clientHeight, scrollHeight }) {
+  const list = screen.getByRole("list");
+  Object.defineProperties(list, {
+    scrollTop: { configurable: true, value: scrollTop },
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+  });
+
+  fireEvent.scroll(list);
+}
+
+function scrollListToBottom() {
+  scrollListTo({ scrollTop: 95, clientHeight: 10, scrollHeight: 100 });
+}
+
+describe("PromptNodePopper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGetNodeTemplates.mockReturnValue({ data: nodeTemplates });
+    useGetPromptTemplatesInfinite.mockReturnValue(savedPromptsResult([]));
+    useGetLibraryTemplatesInfinite.mockReturnValue(libraryTemplatesResult([]));
+    axios.get.mockResolvedValue({ data: { results: [promptVersion] } });
+  });
+
+  it("renders saved prompts and library templates as separate non-empty sections", () => {
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt]),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate]),
+    );
+
+    renderPopper();
+
+    expect(screen.getByText("My Prompts")).toBeInTheDocument();
+    expect(screen.getByText(savedPrompt.name)).toBeInTheDocument();
+    expect(screen.getByText("Library Templates")).toBeInTheDocument();
+    expect(screen.getByText(libraryTemplate.name)).toBeInTheDocument();
+  });
+
+  it("hides the saved section when only library templates are present", () => {
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate]),
+    );
+
+    renderPopper();
+
+    expect(screen.queryByText("My Prompts")).not.toBeInTheDocument();
+    expect(screen.getByText("Library Templates")).toBeInTheDocument();
+    expect(screen.queryByText("No prompts found")).not.toBeInTheDocument();
+  });
+
+  it("hides the library section when only saved prompts are present", () => {
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt]),
+    );
+
+    renderPopper();
+
+    expect(screen.getByText("My Prompts")).toBeInTheDocument();
+    expect(screen.queryByText("Library Templates")).not.toBeInTheDocument();
+    expect(screen.queryByText("No prompts found")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when no saved prompts or library templates match", () => {
+    renderPopper();
+
+    expect(screen.getByText("No prompts found")).toBeInTheDocument();
+    expect(screen.queryByText("My Prompts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Library Templates")).not.toBeInTheDocument();
+  });
+
+  it("passes the same search query to saved prompts and library templates", async () => {
+    renderPopper();
+
+    fireEvent.change(screen.getByLabelText("Search prompts..."), {
+      target: { value: "research" },
+    });
+
+    await waitFor(() => {
+      expect(useGetPromptTemplatesInfinite).toHaveBeenLastCalledWith(
+        "research",
+        { enabled: true },
+      );
+      expect(useGetLibraryTemplatesInfinite).toHaveBeenLastCalledWith(
+        "research",
+        { enabled: true },
+      );
+    });
+  });
+
+  it("seeds an LLM prompt from a library template without fetching versions", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText(libraryTemplate.name));
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(onNodeSelect).toHaveBeenCalledWith(
+      "llm_prompt",
+      "node-template-llm-prompt",
+      expect.objectContaining({
+        name: libraryTemplate.name,
+        prompt_template_id: null,
+        prompt_version_id: null,
+        outputFormat: "string",
+        templateFormat: "jinja",
+        modelConfig: expect.objectContaining({ model: "gpt-4o-mini" }),
+        payload: expect.objectContaining({
+          promptConfig: [
+            expect.objectContaining({
+              configuration: expect.objectContaining({
+                template_format: "jinja",
+              }),
+            }),
+          ],
+        }),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: [{ type: "text", text: "Summarize {{topic}}." }],
+          }),
+        ]),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("rejects library templates with remote media URL blocks", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([remoteMediaLibraryTemplate]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText(remoteMediaLibraryTemplate.name));
+
+    expect(onNodeSelect).not.toHaveBeenCalled();
+    expect(mockAddNode).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "This library template can't be added because Agent Builder currently supports text-only library prompt templates with string or JSON outputs.",
+      { variant: "error" },
+    );
+  });
+
+  it("rejects library templates with unsupported output formats before inserting a node", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([
+        {
+          ...libraryTemplate,
+          id: "image-output-library-template",
+          name: "Image Output Library Template",
+          prompt_config_snapshot: {
+            ...libraryTemplate.prompt_config_snapshot,
+            configuration: {
+              ...libraryTemplate.prompt_config_snapshot.configuration,
+              output_format: "image",
+            },
+          },
+        },
+      ]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText("Image Output Library Template"));
+
+    expect(onNodeSelect).not.toHaveBeenCalled();
+    expect(mockAddNode).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "This library template can't be added because Agent Builder currently supports text-only library prompt templates with string or JSON outputs.",
+      { variant: "error" },
+    );
+  });
+
+  it("rejects incompatible library template snapshots without adding a node", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([
+        {
+          id: "bad-library-template",
+          name: "Unsupported Library Template",
+          prompt_config_snapshot: {
+            messages: [
+              { role: "tool", content: [{ type: "image", url: "x" }] },
+            ],
+            configuration: {},
+          },
+        },
+      ]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText("Unsupported Library Template"));
+
+    expect(onNodeSelect).not.toHaveBeenCalled();
+    expect(mockAddNode).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "This library template can't be added because Agent Builder currently supports text-only library prompt templates with string or JSON outputs.",
+      { variant: "error" },
+    );
+  });
+
+  it("seeds library templates with structured output formats", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([
+        {
+          ...libraryTemplate,
+          id: "json-library-template",
+          name: "JSON Output Library Template",
+          prompt_config_snapshot: {
+            ...libraryTemplate.prompt_config_snapshot,
+            configuration: {
+              ...libraryTemplate.prompt_config_snapshot.configuration,
+              response_format: "json_schema",
+              response_schema: responseSchema,
+              output_format: "json",
+            },
+          },
+        },
+      ]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText("JSON Output Library Template"));
+
+    expect(onNodeSelect).toHaveBeenCalledWith(
+      "llm_prompt",
+      "node-template-llm-prompt",
+      expect.objectContaining({
+        outputFormat: "json",
+        name: "JSON Output Library Template",
+        modelConfig: expect.objectContaining({
+          responseFormat: "json_schema",
+          responseSchema,
+        }),
+        payload: expect.objectContaining({
+          promptConfig: [
+            expect.objectContaining({
+              configuration: expect.objectContaining({
+                response_schema: responseSchema,
+              }),
+            }),
+          ],
+        }),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("normalizes legacy list-shaped library snapshots before inserting", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([legacyListLibraryTemplate]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText(legacyListLibraryTemplate.name));
+
+    expect(onNodeSelect).toHaveBeenCalledWith(
+      "llm_prompt",
+      "node-template-llm-prompt",
+      expect.objectContaining({
+        name: legacyListLibraryTemplate.name,
+        outputFormat: "json",
+        templateFormat: "mustache",
+        modelConfig: expect.objectContaining({
+          model: "gpt-4o",
+          responseFormat: "json_object",
+        }),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: [{ type: "text", text: "Hello {{name}}" }],
+          }),
+        ]),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("strips active tool configuration from shared library templates", () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([toolConfiguredLibraryTemplate]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText(toolConfiguredLibraryTemplate.name));
+
+    expect(onNodeSelect).toHaveBeenCalledWith(
+      "llm_prompt",
+      "node-template-llm-prompt",
+      expect.objectContaining({
+        name: toolConfiguredLibraryTemplate.name,
+        modelConfig: expect.objectContaining({
+          tools: [],
+          toolChoice: "auto",
+        }),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps saved prompt selection on the version-fetch path", async () => {
+    const onClose = vi.fn();
+    const onNodeSelect = vi.fn();
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt]),
+    );
+
+    renderPopper({ onClose, onNodeSelect });
+
+    fireEvent.click(screen.getByText(savedPrompt.name));
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        endpoints.develop.runPrompt.getPromptVersions(),
+        {
+          params: { template_id: savedPrompt.id, modality: "chat" },
+        },
+      );
+    });
+    expect(onNodeSelect).toHaveBeenCalledWith(
+      "llm_prompt",
+      "node-template-llm-prompt",
+      expect.objectContaining({
+        name: savedPrompt.name,
+        prompt_template_id: savedPrompt.id,
+        prompt_version_id: promptVersion.id,
+        modelConfig: expect.objectContaining({ model: "gpt-4o" }),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("fetches the next saved and library pages when both have more results", () => {
+    const fetchNextSavedPage = vi.fn();
+    const fetchNextLibraryPage = vi.fn();
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt], {
+        fetchNextPage: fetchNextSavedPage,
+        hasNextPage: true,
+      }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate], {
+        fetchNextPage: fetchNextLibraryPage,
+        hasNextPage: true,
+      }),
+    );
+
+    renderPopper();
+    scrollListToBottom();
+
+    expect(fetchNextSavedPage).toHaveBeenCalledTimes(1);
+    expect(fetchNextLibraryPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches only the saved prompt page when library templates have no next page", () => {
+    const fetchNextSavedPage = vi.fn();
+    const fetchNextLibraryPage = vi.fn();
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt], {
+        fetchNextPage: fetchNextSavedPage,
+        hasNextPage: true,
+      }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate], {
+        fetchNextPage: fetchNextLibraryPage,
+        hasNextPage: false,
+      }),
+    );
+
+    renderPopper();
+    scrollListToBottom();
+
+    expect(fetchNextSavedPage).toHaveBeenCalledTimes(1);
+    expect(fetchNextLibraryPage).not.toHaveBeenCalled();
+  });
+
+  it("fetches only the library template page when saved prompts have no next page", () => {
+    const fetchNextSavedPage = vi.fn();
+    const fetchNextLibraryPage = vi.fn();
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt], {
+        fetchNextPage: fetchNextSavedPage,
+        hasNextPage: false,
+      }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate], {
+        fetchNextPage: fetchNextLibraryPage,
+        hasNextPage: true,
+      }),
+    );
+
+    renderPopper();
+    scrollListToBottom();
+
+    expect(fetchNextSavedPage).not.toHaveBeenCalled();
+    expect(fetchNextLibraryPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch either source when the list is not scrolled to the bottom", () => {
+    const fetchNextSavedPage = vi.fn();
+    const fetchNextLibraryPage = vi.fn();
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([savedPrompt], {
+        fetchNextPage: fetchNextSavedPage,
+        hasNextPage: true,
+      }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate], {
+        fetchNextPage: fetchNextLibraryPage,
+        hasNextPage: true,
+      }),
+    );
+
+    renderPopper();
+    scrollListTo({ scrollTop: 20, clientHeight: 10, scrollHeight: 100 });
+
+    expect(fetchNextSavedPage).not.toHaveBeenCalled();
+    expect(fetchNextLibraryPage).not.toHaveBeenCalled();
+  });
+
+  it("shows an error state when a prompt-template query fails", () => {
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([], { isError: true }),
+    );
+
+    renderPopper();
+
+    expect(
+      screen.getByText(
+        "Unable to load library templates. Your prompts may still be available.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No prompts found")).not.toBeInTheDocument();
+  });
+
+  it("shows a saved-prompt error while library templates remain available", () => {
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([], { isError: true }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([libraryTemplate]),
+    );
+
+    renderPopper();
+
+    expect(screen.getByText(libraryTemplate.name)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Unable to load your prompts. Library templates may still be available.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No prompts found")).not.toBeInTheDocument();
+  });
+
+  it("shows a combined error when saved prompts and library templates both fail", () => {
+    useGetPromptTemplatesInfinite.mockReturnValue(
+      savedPromptsResult([], { isError: true }),
+    );
+    useGetLibraryTemplatesInfinite.mockReturnValue(
+      libraryTemplatesResult([], { isError: true }),
+    );
+
+    renderPopper();
+
+    expect(
+      screen.getByText(
+        "Unable to load prompt templates. Check your connection and try again.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No prompts found")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/__tests__/libraryTemplateUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/libraryTemplateUtils.test.js
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { toDetachedLibraryTemplateConfig } from "../libraryTemplateUtils";
+import {
+  getLibraryTemplateItems,
+  getNextLibraryTemplatePageParam,
+} from "src/api/agent-playground/libraryTemplateResponseUtils";
+
+const baseTemplate = {
+  id: "template-1",
+  name: "Research Template",
+  prompt_config_snapshot: {
+    messages: [{ role: "user", content: "Summarize {{topic}}" }],
+    configuration: {
+      model: "gpt-4o-mini",
+      response_format: "text",
+      output_format: "string",
+      template_format: "jinja",
+      tools: [{ name: "lookup" }],
+      tool_choice: "required",
+    },
+  },
+};
+
+const responseSchema = {
+  type: "object",
+  properties: { answer: { type: "string" } },
+  required: ["answer"],
+};
+
+describe("libraryTemplateUtils", () => {
+  it("normalizes live and generated library-template list envelopes", () => {
+    const liveItem = { id: "live" };
+    const generatedItem = { id: "generated" };
+
+    expect(getLibraryTemplateItems({ result: { data: [liveItem] } })).toEqual([
+      liveItem,
+    ]);
+    expect(
+      getLibraryTemplateItems({ result: { results: [generatedItem] } }),
+    ).toEqual([generatedItem]);
+    expect(getLibraryTemplateItems({ results: [generatedItem] })).toEqual([
+      generatedItem,
+    ]);
+  });
+
+  it("computes next page from generated next links and legacy counts", () => {
+    expect(
+      getNextLibraryTemplatePageParam({ data: { result: { next: "url" } } }, [
+        { data: { result: { data: [] } } },
+      ]),
+    ).toBe(1);
+
+    expect(
+      getNextLibraryTemplatePageParam(
+        { data: { result: { data: [{ id: "a" }], total_count: 3 } } },
+        [
+          { data: { result: { data: [{ id: "a" }] } } },
+          { data: { result: { data: [{ id: "b" }] } } },
+        ],
+      ),
+    ).toBe(2);
+  });
+
+  it("builds a detached prompt-node config and strips active tool settings", () => {
+    const config = toDetachedLibraryTemplateConfig(baseTemplate);
+
+    expect(config).toMatchObject({
+      prompt_template_id: null,
+      prompt_version_id: null,
+      outputFormat: "string",
+      templateFormat: "jinja",
+      modelConfig: {
+        model: "gpt-4o-mini",
+        responseFormat: "text",
+        tools: [],
+        toolChoice: "auto",
+      },
+      payload: {
+        promptConfig: [
+          {
+            configuration: expect.objectContaining({
+              template_format: "jinja",
+            }),
+          },
+        ],
+      },
+    });
+  });
+
+  it("preserves safe JSON schema settings for structured library imports", () => {
+    const config = toDetachedLibraryTemplateConfig({
+      ...baseTemplate,
+      prompt_config_snapshot: {
+        ...baseTemplate.prompt_config_snapshot,
+        configuration: {
+          response_format: "json_schema",
+          response_schema: responseSchema,
+          output_format: "json",
+          template_format: "mustache",
+        },
+      },
+    });
+
+    expect(config).toMatchObject({
+      outputFormat: "json",
+      templateFormat: "mustache",
+      modelConfig: {
+        responseFormat: "json_schema",
+        responseSchema,
+      },
+    });
+  });
+
+  it("drops response schemas for non-schema response formats", () => {
+    ["text", "json_object", "string"].forEach((responseFormat) => {
+      const config = toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            response_format: responseFormat,
+            response_schema: responseSchema,
+            output_format: "json",
+          },
+        },
+      });
+
+      expect(config.modelConfig.responseSchema).toBeNull();
+      expect(config.payload.promptConfig[0].configuration).not.toHaveProperty(
+        "response_schema",
+      );
+    });
+  });
+
+  it("rejects unsupported execution-affecting response and template settings", () => {
+    expect(
+      toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            ...baseTemplate.prompt_config_snapshot.configuration,
+            template_format: "liquid",
+          },
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            ...baseTemplate.prompt_config_snapshot.configuration,
+            response_format: "custom-runtime-mode",
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects response schemas with refs or excessive size before import", () => {
+    expect(
+      toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            response_format: "json_schema",
+            response_schema: { $ref: "https://example.com/schema.json" },
+            output_format: "json",
+          },
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            response_format: "json_schema",
+            response_schema: {
+              type: "object",
+              description: "x".repeat(50_001),
+            },
+            output_format: "json",
+          },
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      toDetachedLibraryTemplateConfig({
+        ...baseTemplate,
+        prompt_config_snapshot: {
+          ...baseTemplate.prompt_config_snapshot,
+          configuration: {
+            response_format: "json_schema",
+            response_schema: {
+              type: "object",
+              description: "é".repeat(25_000),
+            },
+            output_format: "json",
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/__tests__/promptVersionUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/promptVersionUtils.test.js
@@ -25,8 +25,16 @@ const apiVersion = {
       presence_penalty: 0.1,
       response_format: "text",
       output_format: "json",
+      template_format: "jinja",
     },
   },
+};
+const responseSchema = {
+  type: "object",
+  properties: {
+    answer: { type: "string" },
+  },
+  required: ["answer"],
 };
 
 describe("mapVersionToFormConfig", () => {
@@ -42,6 +50,10 @@ describe("mapVersionToFormConfig", () => {
     expect(cfg.modelConfig.tools).toEqual([{ name: "search" }]);
     expect(cfg.modelConfig.responseFormat).toBe("text");
     expect(cfg.outputFormat).toBe("json");
+    expect(cfg.templateFormat).toBe("jinja");
+    expect(cfg.payload.promptConfig[0].configuration.template_format).toBe(
+      "jinja",
+    );
   });
 
   it("maps snake_case penalty/token params into the payload config", () => {
@@ -53,6 +65,26 @@ describe("mapVersionToFormConfig", () => {
     expect(config.topP).toBe(0.9);
     expect(config.frequencyPenalty).toBe(0.3);
     expect(config.presencePenalty).toBe(0.1);
+  });
+
+  it("preserves separate response_schema from schema-backed snapshots", () => {
+    const cfg = mapVersionToFormConfig({
+      ...apiVersion,
+      prompt_config_snapshot: {
+        ...apiVersion.prompt_config_snapshot,
+        configuration: {
+          ...apiVersion.prompt_config_snapshot.configuration,
+          response_format: "json_schema",
+          response_schema: responseSchema,
+        },
+      },
+    });
+
+    expect(cfg.modelConfig.responseFormat).toBe("json_schema");
+    expect(cfg.modelConfig.responseSchema).toEqual(responseSchema);
+    expect(cfg.payload.promptConfig[0].configuration.response_schema).toEqual(
+      responseSchema,
+    );
   });
 
   it("preserves snapshot messages by role and content", () => {
@@ -83,6 +115,7 @@ describe("mapVersionToFormConfig", () => {
     expect(cfg.modelConfig.model).toBe("");
     expect(cfg.modelConfig.modelDetail).toEqual({});
     expect(cfg.outputFormat).toBe("string");
+    expect(cfg.templateFormat).toBe("mustache");
     // A system and a user message are always injected.
     expect(cfg.messages.map((m) => m.role)).toEqual(["system", "user"]);
   });

--- a/frontend/src/sections/agent-playground/utils/libraryTemplateUtils.js
+++ b/frontend/src/sections/agent-playground/utils/libraryTemplateUtils.js
@@ -1,0 +1,276 @@
+import { mapVersionToFormConfig } from "./promptVersionUtils";
+
+// Shared prompt-library templates cross a trust boundary before becoming
+// runnable Agent Builder nodes. Keep import narrowing in this adapter so
+// UI components consume already-detached prompt-node config.
+const SUPPORTED_PROMPT_ROLES = new Set(["system", "user", "assistant"]);
+const SUPPORTED_CONTENT_TYPES = new Set(["text"]);
+const SUPPORTED_LIBRARY_OUTPUT_FORMATS = new Set(["string", "json"]);
+const SUPPORTED_LIBRARY_TEMPLATE_FORMATS = new Set(["mustache", "jinja"]);
+const SUPPORTED_LIBRARY_RESPONSE_FORMATS = new Set([
+  "text",
+  "json",
+  "json_object",
+  "json_schema",
+  "string",
+]);
+const CONFIGURATION_KEYS_TO_LIFT = [
+  "model",
+  "model_detail",
+  "response_format",
+  "responseFormat",
+  "response_schema",
+  "responseSchema",
+  "output_format",
+  "outputFormat",
+  "temperature",
+  "max_tokens",
+  "top_p",
+  "frequency_penalty",
+  "presence_penalty",
+  "template_format",
+  "templateFormat",
+  "reasoning",
+  "tools",
+  "tool_choice",
+  "toolChoice",
+];
+const STRIPPED_LIBRARY_CONFIGURATION_KEYS = [
+  "tools",
+  "tool_choice",
+  "toolChoice",
+];
+const DISALLOWED_RESPONSE_SCHEMA_KEYS = new Set([
+  "$ref",
+  "$recursiveRef",
+  "$dynamicRef",
+]);
+const MAX_LIBRARY_RESPONSE_SCHEMA_BYTES = 50_000;
+const MAX_LIBRARY_RESPONSE_SCHEMA_DEPTH = 12;
+const MAX_LIBRARY_RESPONSE_SCHEMA_NODES = 1_000;
+const MAX_LIBRARY_RESPONSE_SCHEMA_ARRAY_LENGTH = 200;
+
+export const INCOMPATIBLE_LIBRARY_TEMPLATE_MESSAGE =
+  "This library template can't be added because Agent Builder currently supports text-only library prompt templates with string or JSON outputs.";
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasSafeResponseSchemaShape(schema) {
+  if (schema == null) return true;
+  if (!isPlainObject(schema)) return false;
+
+  let serialized;
+  try {
+    serialized = JSON.stringify(schema);
+  } catch {
+    return false;
+  }
+
+  if (
+    new TextEncoder().encode(serialized).length >
+    MAX_LIBRARY_RESPONSE_SCHEMA_BYTES
+  ) {
+    return false;
+  }
+
+  let visitedNodes = 0;
+  const seen = new WeakSet();
+
+  function visit(value, depth) {
+    if (value == null || typeof value !== "object") return true;
+    if (depth > MAX_LIBRARY_RESPONSE_SCHEMA_DEPTH) return false;
+    if (seen.has(value)) return false;
+    seen.add(value);
+    visitedNodes += 1;
+    if (visitedNodes > MAX_LIBRARY_RESPONSE_SCHEMA_NODES) return false;
+
+    if (Array.isArray(value)) {
+      if (value.length > MAX_LIBRARY_RESPONSE_SCHEMA_ARRAY_LENGTH) {
+        return false;
+      }
+      return value.every((item) => visit(item, depth + 1));
+    }
+
+    return Object.entries(value).every(([key, child]) => {
+      if (DISALLOWED_RESPONSE_SCHEMA_KEYS.has(key)) return false;
+      return visit(child, depth + 1);
+    });
+  }
+
+  return visit(schema, 0);
+}
+
+function normalizeTemplateContentBlock(block) {
+  if (typeof block === "string") {
+    return { type: "text", text: block };
+  }
+
+  if (
+    !block ||
+    typeof block !== "object" ||
+    !SUPPORTED_CONTENT_TYPES.has(block.type)
+  ) {
+    return null;
+  }
+
+  if (block.type === "text") {
+    return typeof block.text === "string"
+      ? { type: "text", text: block.text }
+      : null;
+  }
+
+  return null;
+}
+
+function normalizeTemplateContent(content) {
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+
+  if (!Array.isArray(content) || content.length === 0) {
+    return null;
+  }
+
+  const normalizedContent = content.map(normalizeTemplateContentBlock);
+
+  if (normalizedContent.some((block) => block === null)) {
+    return null;
+  }
+
+  return normalizedContent;
+}
+
+function normalizeTemplateConfiguration(snapshot) {
+  if (
+    snapshot.configuration !== undefined &&
+    snapshot.configuration !== null &&
+    (typeof snapshot.configuration !== "object" ||
+      Array.isArray(snapshot.configuration))
+  ) {
+    return null;
+  }
+
+  const liftedConfiguration = CONFIGURATION_KEYS_TO_LIFT.reduce(
+    (config, key) => {
+      if (snapshot[key] !== undefined) {
+        return { ...config, [key]: snapshot[key] };
+      }
+      return config;
+    },
+    {},
+  );
+
+  const configuration = {
+    ...liftedConfiguration,
+    ...(snapshot.configuration || {}),
+  };
+
+  STRIPPED_LIBRARY_CONFIGURATION_KEYS.forEach((key) => {
+    delete configuration[key];
+  });
+
+  const outputFormat =
+    configuration.output_format || configuration.outputFormat || "string";
+  if (!SUPPORTED_LIBRARY_OUTPUT_FORMATS.has(outputFormat)) {
+    return null;
+  }
+  configuration.output_format = outputFormat;
+  delete configuration.outputFormat;
+
+  const templateFormat =
+    configuration.template_format || configuration.templateFormat || "mustache";
+  if (!SUPPORTED_LIBRARY_TEMPLATE_FORMATS.has(templateFormat)) {
+    return null;
+  }
+  configuration.template_format = templateFormat;
+  delete configuration.templateFormat;
+
+  const responseFormat =
+    configuration.response_format || configuration.responseFormat || "text";
+  if (
+    typeof responseFormat !== "string" ||
+    !SUPPORTED_LIBRARY_RESPONSE_FORMATS.has(responseFormat)
+  ) {
+    return null;
+  }
+  configuration.response_format = responseFormat;
+  delete configuration.responseFormat;
+
+  const responseSchema =
+    configuration.response_schema ?? configuration.responseSchema ?? null;
+  if (responseFormat === "json_schema") {
+    if (!hasSafeResponseSchemaShape(responseSchema)) {
+      return null;
+    }
+    if (responseSchema !== null) {
+      configuration.response_schema = responseSchema;
+    }
+  } else {
+    delete configuration.response_schema;
+  }
+  delete configuration.responseSchema;
+
+  return configuration;
+}
+
+export function normalizeLibraryTemplateSnapshot(template) {
+  const rawSnapshot = template?.prompt_config_snapshot;
+  const snapshot = Array.isArray(rawSnapshot) ? rawSnapshot[0] : rawSnapshot;
+
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return null;
+  }
+
+  const configuration = normalizeTemplateConfiguration(snapshot);
+  if (!configuration) {
+    return null;
+  }
+
+  if (!Array.isArray(snapshot.messages) || snapshot.messages.length === 0) {
+    return null;
+  }
+
+  const normalizedMessages = snapshot.messages.map((message) => {
+    if (
+      !message ||
+      typeof message !== "object" ||
+      !SUPPORTED_PROMPT_ROLES.has(message.role)
+    ) {
+      return null;
+    }
+
+    const normalizedContent = normalizeTemplateContent(message.content);
+    if (!normalizedContent) return null;
+
+    return {
+      ...message,
+      role: message.role,
+      content: normalizedContent,
+    };
+  });
+
+  if (normalizedMessages.some((message) => message === null)) {
+    return null;
+  }
+
+  return {
+    ...snapshot,
+    configuration,
+    messages: normalizedMessages,
+  };
+}
+
+export function toDetachedLibraryTemplateConfig(template) {
+  const promptConfigSnapshot = normalizeLibraryTemplateSnapshot(template);
+  if (!promptConfigSnapshot) return null;
+
+  return {
+    prompt_template_id: null,
+    prompt_version_id: null,
+    ...mapVersionToFormConfig({
+      prompt_config_snapshot: promptConfigSnapshot,
+    }),
+  };
+}

--- a/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
+++ b/frontend/src/sections/agent-playground/utils/promptVersionUtils.js
@@ -23,15 +23,22 @@ export function mapVersionToFormConfig(version) {
   const snapshot = version?.prompt_config_snapshot;
   const cfg = snapshot?.configuration || {};
 
+  const templateFormat =
+    cfg.template_format || snapshot?.template_format || "mustache";
+
   return {
     outputFormat: cfg.output_format || snapshot?.output_format || "string",
+    templateFormat,
     modelConfig: {
       model: cfg.model || "",
       modelDetail: cfg.model_detail || {},
       toolChoice: cfg.tool_choice || "auto",
       tools: cfg.tools || [],
       responseFormat: normalizeResponseFormat(cfg.response_format),
-      responseSchema: extractResponseSchema(cfg.response_format),
+      responseSchema:
+        cfg.response_schema ??
+        cfg.responseSchema ??
+        extractResponseSchema(cfg.response_format),
     },
     messages: (() => {
       const msgs = (snapshot?.messages || []).map((m) => ({
@@ -64,6 +71,10 @@ export function mapVersionToFormConfig(version) {
             topP: cfg.top_p,
             frequencyPenalty: cfg.frequency_penalty,
             presencePenalty: cfg.presence_penalty,
+            ...(cfg.response_schema && {
+              response_schema: cfg.response_schema,
+            }),
+            template_format: templateFormat,
             ...(cfg.reasoning && { reasoning: cfg.reasoning }),
           },
         },


### PR DESCRIPTION
## Summary

Thanks for your earlier review. This is a focused, rebased follow-up targeting `dev` per `CONTRIBUTING.md`; the original oversized PR remains open only as reference until this scoped replacement is reviewed.

This is the library-template browsing portion split from #1299. It adds the Agent Playground library-template source while keeping saved prompts on their existing path.

## Scope

- Library-template pagination/response normalization.
- Separate “My Prompts” and “Library Templates” selector sections.
- Safe detached template normalization and focused UI/API tests.
- No builder persistence changes in this PR.

Closes #1077

## Validation

- Focused Agent Playground tests and `git diff --check` were run on the rebased branch.

Please review this focused replacement for #1299.