### PR TITLE
fix(datapoint-drawer): keep active row highlight in sync

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -429,6 +429,8 @@ body {
   --vscode-editor-background: var(--monaco-bg);
   --vscode-editorGutter-background: var(--monaco-gutter-bg);
 }
+.develop-data-grid.datapoint-drawer-v2-grid .ag-row.active-row,
+.develop-data-grid.datapoint-drawer-v2-grid .ag-row-focus.active-row,
 .ag-row-focus.active-row {
   background-color: var(--surface-row-active);
 }

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -16,12 +16,15 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   useAddEvaluationFeebackStore,
   useDatapointDrawerStore,
+  useDevelopFilterStore,
+  useDevelopSearchStore,
   useImprovePromptStore,
 } from "../../states";
 import PropTypes from "prop-types";
 import { ShowComponent } from "src/components/show";
 import { enhanceCol, getStatusColor } from "../common";
 import { getLabel, normalizeEvalCellValue } from "../common";
+import { transformFilter, validateFilter } from "../DevelopFilters/common";
 import DatapointCard from "src/sections/common/DatapointCard";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
 import ImagesDatapointCard from "src/sections/common/ImagesDatapointCard";
@@ -41,6 +44,7 @@ import logger from "src/utils/logger";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
+import { enqueueSnackbar } from "src/components/snackbar";
 import DocumentDatapointCard from "../../../common/DocumentDatapointCard";
 import StatusCellRenderer from "./StatusCellRenderer";
 import LoadingOverlay from "src/components/loading-screen/LoadingOverlayDataPointDataset";
@@ -51,6 +55,14 @@ import AddLabelDrawer from "src/components/traceDetailDrawer/AddLabelDrawer";
 import { useEvalsList } from "src/sections/common/EvaluationDrawer/getEvalsList";
 import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 import { canonicalEntries } from "src/utils/utils";
+import {
+  canNavigatePreviousDrawerRowFromGrid,
+  createDrawerNavigationHandler,
+  getDisplayedDrawerRows,
+  handleDrawerNavigationShortcut,
+  isDrawerNavigationSourceCurrent,
+  navigateDrawerRows,
+} from "./navigation";
 
 const SkeletonLoader = () => (
   <Box
@@ -130,44 +142,90 @@ const DATAPOINT_DRAWER_THEME_PARAMS = {
   headerFontSize: "14px",
 };
 
-const NavIconButton = ({ icon, tooltip, onClick, disabled, loading }) => (
-  <Tooltip title={tooltip} arrow placement="bottom">
-    <span>
-      <Box
-        component="button"
-        type="button"
-        onClick={onClick}
-        disabled={disabled}
-        sx={{
-          display: "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          width: 24,
-          height: 24,
-          p: 0,
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: "2px",
-          bgcolor: "background.paper",
-          cursor: disabled ? "default" : "pointer",
-          opacity: disabled ? 0.4 : 1,
-          flexShrink: 0,
-          "&:hover:not(:disabled)": {
-            bgcolor: "action.hover",
-            borderColor: "text.disabled",
-          },
-          transition: "all 120ms",
-        }}
-      >
-        {loading ? (
-          <CircularProgress size={12} sx={{ color: "text.secondary" }} />
-        ) : (
-          <Iconify icon={icon} width={20} sx={{ color: "text.primary" }} />
-        )}
-      </Box>
-    </span>
-  </Tooltip>
-);
+const getDrawerNavigationRequestParams = (gridApi) => {
+  const sort = (gridApi?.getColumnState?.() ?? []).reduce(
+    (acc, { colId, sort }) => {
+      if (sort) {
+        acc.push({
+          columnId: colId,
+          type: sort === "asc" ? "ascending" : "descending",
+        });
+      }
+      return acc;
+    },
+    [],
+  );
+  const filters = useDevelopFilterStore.getState().filters ?? [];
+  const search = useDevelopSearchStore.getState().search;
+
+  return {
+    filters: filters.filter(validateFilter).map(transformFilter),
+    ...(search && {
+      search: {
+        key: search,
+        type: ["text", "image", "audio"],
+      },
+    }),
+    sort,
+  };
+};
+
+const NavIconButton = ({ icon, tooltip, onClick, disabled, loading }) => {
+  const unavailable = disabled || loading;
+
+  const handleClick = (event) => {
+    if (unavailable) {
+      event.preventDefault();
+      return;
+    }
+
+    onClick?.(event);
+  };
+
+  return (
+    <Tooltip title={tooltip} arrow placement="bottom">
+      <span>
+        <Box
+          component="button"
+          type="button"
+          aria-busy={loading || undefined}
+          aria-disabled={unavailable || undefined}
+          aria-label={tooltip}
+          onClick={handleClick}
+          disabled={disabled}
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 24,
+            height: 24,
+            p: 0,
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: "2px",
+            bgcolor: "background.paper",
+            cursor: unavailable ? "default" : "pointer",
+            opacity: unavailable ? 0.4 : 1,
+            flexShrink: 0,
+            "&:hover:not(:disabled)": unavailable
+              ? {}
+              : {
+                  bgcolor: "action.hover",
+                  borderColor: "text.disabled",
+                },
+            transition: "all 120ms",
+          }}
+        >
+          {loading ? (
+            <CircularProgress size={12} sx={{ color: "text.secondary" }} />
+          ) : (
+            <Iconify icon={icon} width={20} sx={{ color: "text.primary" }} />
+          )}
+        </Box>
+      </span>
+    </Tooltip>
+  );
+};
 
 NavIconButton.propTypes = {
   icon: PropTypes.string.isRequired,
@@ -191,6 +249,8 @@ const DatapointDrawerChild = () => {
   const [annotateOpen, setAnnotateOpen] = useState(false);
   const [addLabelDrawerOpen, setAddLabelDrawerOpen] = useState(false);
   const isNavigatingRef = useRef(false);
+  const navigationInFlightRef = useRef(false);
+  const navigationRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (datapoint) {
@@ -209,6 +269,20 @@ const DatapointDrawerChild = () => {
       setShowContent(false);
     }
   }, [datapoint]);
+
+  useEffect(() => {
+    navigationRequestIdRef.current += 1;
+    isNavigatingRef.current = false;
+  }, [datapoint?.index, datapoint?.rowData]);
+
+  useEffect(
+    () => () => {
+      navigationRequestIdRef.current += 1;
+      navigationInFlightRef.current = false;
+      isNavigatingRef.current = false;
+    },
+    [],
+  );
 
   const onClose = () => {
     setDatapoint(null);
@@ -234,17 +308,9 @@ const DatapointDrawerChild = () => {
       },
     });
 
-  const [rows, setRows] = useState(() => {
-    const newRows = [];
-
-    gridApi.current?.forEachNode((node) => {
-      if (node.displayed && node.id) {
-        newRows.push({ rowData: node.data, id: node.id });
-      }
-    });
-
-    return newRows;
-  });
+  const [rows, setRows] = useState(() =>
+    getDisplayedDrawerRows(gridApi.current),
+  );
 
   const mainData = useMemo(() => {
     const evalColumnFields = allColumns
@@ -453,178 +519,75 @@ const DatapointDrawerChild = () => {
     return Array.isArray(v) ? v : undefined;
   }, [evalCellValue]);
 
-  const onNavigate = async (direction) => {
-    isNavigatingRef.current = true;
+  const onNavigate = createDrawerNavigationHandler({
+    getNavigationParams: () => {
+      const requestId = navigationRequestIdRef.current;
+      const sourceRowData = datapoint?.rowData;
+      const sourceRowId = sourceRowData?.rowId;
 
-    if (direction === "next") {
-      const nextIndex = datapoint.index + 1;
-      if (rows?.[nextIndex] && rows[nextIndex]?.rowData) {
-        const rowData = rows[nextIndex]?.rowData;
-        setDatapoint({
-          index: nextIndex,
-          rowData: rowData,
-          value_infos: rows[nextIndex]?.rowData?.value_infos,
-        });
-        if (evalOpen) {
-          const column = allColumns.find(
-            (i) => i?.col?.source_id === evalOpen?.evalMetricId,
-          );
-
-          setEvalOpen({
-            ...evalOpen,
-            ...rowData[column?.field],
+      return {
+        allColumns,
+        datapoint,
+        evalOpen,
+        getCellData,
+        getNextItemIds,
+        getNextRowsRequestParams: () =>
+          getDrawerNavigationRequestParams(gridApi.current),
+        gridApi: gridApi.current,
+        isNavigationCurrent: () =>
+          isDrawerNavigationSourceCurrent({
+            getCurrentDatapoint: () =>
+              useDatapointDrawerStore.getState().datapoint,
+            navigationRequestIdRef,
+            requestId,
+            sourceRowData,
+            sourceRowId,
+          }),
+        logger,
+        onNavigationLoadError: () => {
+          enqueueSnackbar("Couldn’t load the datapoint. Please try again.", {
+            variant: "error",
           });
-        }
-      } else if (rows?.[nextIndex] && !rows[nextIndex]?.rowData) {
-        const nextId = rows[nextIndex]?.id;
-        try {
-          const newCellData = await getCellData({
-            row_ids: [nextId],
-            column_ids: allColumns.map((i) => i?.col?.id),
-          });
+        },
+        rows,
+        setDatapoint,
+        setEvalOpen,
+        setRows,
+      };
+    },
+    isNavigatingRef,
+    logger,
+    navigateRows: navigateDrawerRows,
+    navigationInFlightRef,
+  });
 
-          const nextCellData = newCellData?.data?.result?.[nextId];
+  const canNavigatePrevious = canNavigatePreviousDrawerRowFromGrid(
+    rows,
+    datapoint,
+    gridApi.current,
+    { allowFullScan: false },
+  );
 
-          if (nextCellData) {
-            setDatapoint({
-              index: nextIndex,
-              rowData: nextCellData,
-              value_infos: nextCellData?.value_infos,
-            });
-            setRows((prev) => {
-              const newRows = [...prev];
-              newRows[nextIndex] = {
-                rowData: nextCellData,
-                id: nextId,
-              };
-              return newRows;
-            });
-            if (evalOpen) {
-              const column = allColumns.find(
-                (i) => i?.col?.source_id === evalOpen?.evalMetricId,
-              );
-              setEvalOpen({
-                ...evalOpen,
-                ...nextCellData[column?.field],
-              });
-            }
-          }
-        } catch (e) {
-          logger.error("Failed to get next item ids", { e });
-        }
-      } else {
-        const mergedRows = [...rows];
-        try {
-          const nextIds = await getNextItemIds({
-            row_id: datapoint?.rowData?.row_id ?? datapoint?.rowData?.rowId,
-          });
-          const newIds =
-            nextIds?.data?.result?.next?.row_id ??
-            nextIds?.data?.result?.next?.rowId;
-          if (newIds && newIds?.length > 0) {
-            newIds.forEach((id) => {
-              mergedRows.push({ rowData: null, id: id });
-            });
-          }
-        } catch (e) {
-          logger.error("Failed to get next item ids", { e });
-        }
-
-        const nextId = mergedRows[nextIndex]?.id;
-
-        try {
-          const newCellData = await getCellData({
-            row_ids: [nextId],
-            column_ids: allColumns.map((i) => i?.col?.id),
-          });
-
-          const nextCellData = newCellData?.data?.result?.[nextId];
-
-          if (nextCellData) {
-            mergedRows[nextIndex] = {
-              rowData: nextCellData,
-              id: nextId,
-            };
-          }
-          setDatapoint({
-            index: nextIndex,
-            rowData: nextCellData,
-            value_infos: nextCellData?.value_infos,
-          });
-          if (evalOpen) {
-            const column = allColumns.find(
-              (i) => i?.col?.source_id === evalOpen?.evalMetricId,
-            );
-            setEvalOpen({
-              ...evalOpen,
-              ...nextCellData[column?.field],
-            });
-          }
-        } catch (e) {
-          logger.error("Failed to get previous item ids", { e });
-        }
-
-        setRows(mergedRows);
-      }
-    } else if (direction === "previous") {
-      const rowData = rows[datapoint.index - 1].rowData;
-      setDatapoint({
-        index: datapoint.index - 1,
-        rowData,
-        value_infos: rows[datapoint.index - 1]?.rowData?.value_infos,
-      });
-      if (evalOpen) {
-        const column = allColumns.find(
-          (i) => i?.col?.source_id === evalOpen?.evalMetricId,
-        );
-        setEvalOpen({
-          ...evalOpen,
-          ...rowData[column?.field],
-        });
-      }
-    }
-  };
-
-  const navStateRef = useRef({});
+  const navStateRef = useRef({
+    onNavigate: () => {},
+    datapointIndex: undefined,
+    totalRowCount: undefined,
+    navLoading: false,
+    canNavigatePrevious: false,
+    enabled: false,
+  });
   navStateRef.current = {
     onNavigate,
     datapointIndex: datapoint?.index,
     totalRowCount,
     navLoading: isLoadingNextItemIds || isLoadingCellData,
+    canNavigatePrevious,
     enabled: Boolean(datapoint),
   };
 
   useEffect(() => {
     const handleKeyDown = (e) => {
-      const state = navStateRef.current;
-      if (!state.enabled) return;
-
-      const target = e.target;
-      if (
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable
-      )
-        return;
-
-      const isNext = e.key === "j" || e.key === "J";
-      const isPrev = e.key === "k" || e.key === "K";
-      if (!isNext && !isPrev) return;
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-
-      if (
-        isNext &&
-        !state.navLoading &&
-        state.datapointIndex !== state.totalRowCount - 1
-      ) {
-        e.preventDefault();
-        e.stopPropagation();
-        state.onNavigate("next");
-      } else if (isPrev && state.datapointIndex !== 0) {
-        e.preventDefault();
-        e.stopPropagation();
-        state.onNavigate("previous");
-      }
+      handleDrawerNavigationShortcut(e, navStateRef.current);
     };
 
     window.addEventListener("keydown", handleKeyDown, true);
@@ -1074,17 +1037,14 @@ const DatapointDrawerChild = () => {
                     icon="mdi:chevron-up"
                     tooltip="Previous datapoint (K)"
                     onClick={() => onNavigate("previous")}
-                    disabled={datapoint?.index === 0}
+                    disabled={!canNavigatePrevious}
+                    loading={isLoadingNextItemIds || isLoadingCellData}
                   />
                   <NavIconButton
                     icon="mdi:chevron-down"
                     tooltip="Next datapoint (J)"
                     onClick={() => onNavigate("next")}
-                    disabled={
-                      datapoint?.index === totalRowCount - 1 ||
-                      isLoadingNextItemIds ||
-                      isLoadingCellData
-                    }
+                    disabled={datapoint?.index === totalRowCount - 1}
                     loading={isLoadingNextItemIds || isLoadingCellData}
                   />
                 </Box>

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/__tests__/navigation.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/__tests__/navigation.test.js
@@ -1,0 +1,1266 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  canNavigatePreviousDrawerRow,
+  canNavigatePreviousDrawerRowFromGrid,
+  createDrawerNavigationHandler,
+  getActiveRowClass,
+  getDisplayedDrawerRows,
+  getDrawerRowPosition,
+  getGridRowNode,
+  handleDrawerNavigationShortcut,
+  isDrawerNavigationSourceCurrent,
+  navigateDrawerRows,
+  redrawActiveRowHighlight,
+  resolveGridRowIndex,
+  shouldIgnoreDrawerNavigationShortcut,
+  syncGridRowVisibility,
+  useActiveRowHighlightRedraw,
+  withDrawerRowId,
+} from "../navigation";
+
+describe("DatapointDrawerV2 navigation highlight Unit", () => {
+  it("finds the drawer row by stable row id instead of treating grid row index as array index", () => {
+    const rows = [
+      { id: "row-a", rowData: { rowId: "row-a" }, rowIndex: 40 },
+      { id: "row-b", rowData: { rowId: "row-b" }, rowIndex: 41 },
+    ];
+
+    expect(
+      getDrawerRowPosition(rows, {
+        index: 41,
+        rowData: { rowId: "row-b" },
+      }),
+    ).toBe(1);
+  });
+
+  it("keeps a legacy index fallback only when it still points at the same row object", () => {
+    const rowData = { name: "legacy-row-without-id" };
+    const rows = [{ rowData: {} }, { rowData }];
+
+    expect(getDrawerRowPosition(rows, { index: 1, rowData })).toBe(1);
+  });
+
+  it("matches numeric and string row ids when locating grid nodes", () => {
+    const node = { id: "123", rowIndex: 6 };
+    const gridApi = {
+      getRowNode: vi.fn((id) => (id === "123" ? node : undefined)),
+    };
+
+    expect(getGridRowNode(gridApi, 123)).toBe(node);
+    expect(resolveGridRowIndex(gridApi, { id: 123 }, 2)).toBe(6);
+    expect(gridApi.getRowNode).toHaveBeenCalledWith("123");
+  });
+
+  it("checks stale drawer navigation against the current store datapoint identity", () => {
+    const sourceRowData = { rowId: "row-a" };
+    const navigationRequestIdRef = { current: 7 };
+
+    expect(
+      isDrawerNavigationSourceCurrent({
+        getCurrentDatapoint: () => ({ rowData: { rowId: "row-a" } }),
+        navigationRequestIdRef,
+        requestId: 7,
+        sourceRowData,
+        sourceRowId: "row-a",
+      }),
+    ).toBe(true);
+    expect(
+      isDrawerNavigationSourceCurrent({
+        getCurrentDatapoint: () => ({ rowData: { rowId: "row-c" } }),
+        navigationRequestIdRef,
+        requestId: 7,
+        sourceRowData,
+        sourceRowId: "row-a",
+      }),
+    ).toBe(false);
+    expect(
+      isDrawerNavigationSourceCurrent({
+        getCurrentDatapoint: () => ({ rowData: sourceRowData }),
+        navigationRequestIdRef,
+        requestId: 6,
+        sourceRowData,
+        sourceRowId: "row-a",
+      }),
+    ).toBe(false);
+
+    const noRowIdData = { value: "legacy" };
+    expect(
+      isDrawerNavigationSourceCurrent({
+        getCurrentDatapoint: () => ({ rowData: noRowIdData }),
+        navigationRequestIdRef,
+        requestId: 7,
+        sourceRowData: noRowIdData,
+      }),
+    ).toBe(true);
+    expect(
+      isDrawerNavigationSourceCurrent({
+        getCurrentDatapoint: () => ({ rowData: { value: "legacy" } }),
+        navigationRequestIdRef,
+        requestId: 7,
+        sourceRowData: noRowIdData,
+      }),
+    ).toBe(false);
+  });
+
+  it("collects displayed drawer rows with their current grid row indexes", () => {
+    const gridApi = {
+      forEachNode: vi.fn((visitor) => {
+        visitor({
+          displayed: true,
+          id: "row-b",
+          rowIndex: 42,
+          data: { rowId: "row-b" },
+        });
+        visitor({
+          displayed: false,
+          id: "row-hidden",
+          rowIndex: 41,
+          data: { rowId: "row-hidden" },
+        });
+        visitor({
+          displayed: true,
+          id: "row-a",
+          rowIndex: 40,
+          data: { rowId: "row-a" },
+        });
+      }),
+    };
+
+    expect(getDisplayedDrawerRows(gridApi)).toEqual([
+      { id: "row-a", rowData: { rowId: "row-a" }, rowIndex: 40 },
+      { id: "row-b", rowData: { rowId: "row-b" }, rowIndex: 42 },
+    ]);
+  });
+
+  it("scrolls the target grid node into view and returns the node row index", () => {
+    const node = { id: "row-b", rowIndex: 44 };
+    const gridApi = {
+      ensureIndexVisible: vi.fn(),
+      ensureNodeVisible: vi.fn(),
+      getRowNode: vi.fn(() => node),
+    };
+
+    expect(syncGridRowVisibility(gridApi, { id: "row-b" }, 41)).toBe(44);
+    expect(gridApi.ensureNodeVisible).toHaveBeenCalledWith(node);
+    expect(gridApi.ensureIndexVisible).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the calculated grid row index when AG Grid has not loaded the target node", () => {
+    const gridApi = {
+      ensureIndexVisible: vi.fn(),
+      ensureNodeVisible: vi.fn(),
+      getRowNode: vi.fn(() => undefined),
+    };
+
+    expect(syncGridRowVisibility(gridApi, { id: "row-z" }, 73)).toBe(73);
+    expect(gridApi.ensureIndexVisible).toHaveBeenCalledWith(73);
+    expect(gridApi.ensureNodeVisible).not.toHaveBeenCalled();
+  });
+
+  it("redraws only the affected active-row nodes when identities resolve", () => {
+    const rowANode = { id: "row-a" };
+    const rowBNode = { id: "row-b" };
+    const gridApi = {
+      getRowNode: vi.fn((id) =>
+        id === "row-a" ? rowANode : id === "row-b" ? rowBNode : undefined,
+      ),
+      redrawRows: vi.fn(),
+    };
+    const gridApiRef = { current: { api: gridApi } };
+
+    const { rerender } = renderHook(
+      ({ activeRowId }) => useActiveRowHighlightRedraw(gridApiRef, activeRowId),
+      { initialProps: { activeRowId: "row-a" } },
+    );
+
+    expect(gridApi.redrawRows).toHaveBeenNthCalledWith(1, {
+      rowNodes: [rowANode],
+    });
+    rerender({ activeRowId: "row-b" });
+    expect(gridApi.redrawRows).toHaveBeenNthCalledWith(2, {
+      rowNodes: [rowANode, rowBNode],
+    });
+
+    redrawActiveRowHighlight(gridApi, "row-b", "row-a");
+    expect(gridApi.redrawRows).toHaveBeenNthCalledWith(3, {
+      rowNodes: [rowBNode, rowANode],
+    });
+  });
+
+  it("retries active-row redraw when the grid api becomes available after mount", () => {
+    const rowNode = { id: "row-a", rowIndex: 4 };
+    const gridApiRef = { current: null };
+
+    const { rerender } = renderHook(
+      ({ redrawKey }) =>
+        useActiveRowHighlightRedraw(gridApiRef, "row-a", redrawKey),
+      { initialProps: { redrawKey: 0 } },
+    );
+
+    const gridApi = {
+      getRowNode: vi.fn((id) => (id === "row-a" ? rowNode : undefined)),
+      redrawRows: vi.fn(),
+    };
+    gridApiRef.current = { api: gridApi };
+    rerender({ redrawKey: 1 });
+
+    expect(gridApi.redrawRows).toHaveBeenCalledWith({ rowNodes: [rowNode] });
+  });
+
+  it("uses displayed row indexes before falling back to redrawing rendered rows", () => {
+    const rowSeven = { id: "displayed-7", rowIndex: 7 };
+    const gridApi = {
+      getDisplayedRowAtIndex: vi.fn((index) =>
+        index === 7 ? rowSeven : undefined,
+      ),
+      getRowNode: vi.fn(() => undefined),
+      redrawRows: vi.fn(),
+    };
+
+    redrawActiveRowHighlight(gridApi, undefined, 7);
+
+    expect(gridApi.redrawRows).toHaveBeenCalledWith({
+      rowNodes: [rowSeven],
+    });
+    expect(gridApi.redrawRows).not.toHaveBeenCalledWith();
+  });
+
+  it("falls back to redrawing rendered rows when active-row nodes are unavailable", () => {
+    const gridApi = {
+      getRowNode: vi.fn(() => undefined),
+      redrawRows: vi.fn(),
+    };
+
+    redrawActiveRowHighlight(gridApi, "missing-a", "missing-b");
+
+    expect(gridApi.redrawRows).toHaveBeenCalledWith();
+  });
+
+  it("returns active-row by stable row id before falling back to row index", () => {
+    expect(
+      getActiveRowClass(
+        { data: { rowId: "row-a" }, node: { rowIndex: 7 } },
+        { index: 99, rowData: { rowId: "row-a" } },
+      ),
+    ).toBe("active-row");
+    expect(
+      getActiveRowClass(
+        { data: { rowId: "row-b" }, node: { rowIndex: 7 } },
+        { index: 7, rowData: { rowId: "row-a" } },
+      ),
+    ).toBe("");
+    expect(getActiveRowClass({ node: { rowIndex: 7 } }, 7)).toBe("active-row");
+  });
+
+  it("preserves row ids on hydrated cell payloads", () => {
+    expect(withDrawerRowId({ value: "loaded" }, "row-b")).toEqual({
+      value: "loaded",
+      rowId: "row-b",
+    });
+    expect(withDrawerRowId({ rowId: "existing" }, "row-b")).toEqual({
+      rowId: "existing",
+    });
+  });
+
+  it("reports previous navigation availability from the cache or current grid rows", () => {
+    const rows = [{ id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } }];
+    const datapoint = { index: 41, rowData: { rowId: "row-b" } };
+
+    expect(canNavigatePreviousDrawerRow(rows, datapoint)).toBe(false);
+    expect(
+      canNavigatePreviousDrawerRow(
+        [{ id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } }, ...rows],
+        datapoint,
+      ),
+    ).toBe(true);
+    expect(canNavigatePreviousDrawerRowFromGrid(rows, datapoint)).toBe(false);
+
+    const gridApi = {
+      forEachNode: vi.fn((visitor) => {
+        [
+          { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+          { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+        ].forEach((row) =>
+          visitor({
+            data: row.rowData,
+            displayed: true,
+            id: row.id,
+            rowIndex: row.rowIndex,
+          }),
+        );
+      }),
+    };
+
+    expect(canNavigatePreviousDrawerRowFromGrid(rows, datapoint, gridApi)).toBe(
+      true,
+    );
+    expect(
+      canNavigatePreviousDrawerRowFromGrid(rows, datapoint, gridApi, {
+        allowFullScan: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores drawer navigation shortcuts only from text-entry targets", () => {
+    const button = document.createElement("button");
+    const buttonChild = document.createElement("span");
+    button.appendChild(buttonChild);
+    const input = document.createElement("input");
+    const textbox = document.createElement("div");
+    textbox.setAttribute("role", "textbox");
+    const editableTarget = document.createElement("div");
+    editableTarget.setAttribute("contenteditable", "true");
+    const plainTarget = document.createElement("div");
+
+    expect(shouldIgnoreDrawerNavigationShortcut(button)).toBe(false);
+    expect(shouldIgnoreDrawerNavigationShortcut(buttonChild)).toBe(false);
+    expect(shouldIgnoreDrawerNavigationShortcut(input)).toBe(true);
+    expect(shouldIgnoreDrawerNavigationShortcut(textbox)).toBe(true);
+    expect(shouldIgnoreDrawerNavigationShortcut(editableTarget)).toBe(true);
+    expect(shouldIgnoreDrawerNavigationShortcut(plainTarget)).toBe(false);
+    expect(shouldIgnoreDrawerNavigationShortcut(null)).toBe(false);
+  });
+
+  const createNavigationHarness = (overrides = {}) => {
+    const rows = overrides.rows ?? [
+      {
+        id: "row-a",
+        rowIndex: 40,
+        rowData: { rowId: "row-a", metricField: { cellValue: "a" } },
+      },
+      {
+        id: "row-b",
+        rowIndex: 41,
+        rowData: { rowId: "row-b", metricField: { cellValue: "b" } },
+      },
+    ];
+    const gridApi = overrides.gridApi ?? {
+      ensureIndexVisible: vi.fn(),
+      ensureNodeVisible: vi.fn(),
+      getRowNode: vi.fn((id) => {
+        const row = rows.find((candidate) => candidate.id === id);
+        return row ? { id, rowIndex: row.rowIndex } : undefined;
+      }),
+    };
+
+    return {
+      allColumns: overrides.allColumns ?? [
+        { field: "metricField", col: { id: "column-1", sourceId: "metric-1" } },
+      ],
+      datapoint: overrides.datapoint ?? {
+        index: 40,
+        rowData: { rowId: "row-a" },
+      },
+      direction: overrides.direction ?? "next",
+      evalOpen: overrides.evalOpen,
+      getCellData: overrides.getCellData ?? vi.fn(),
+      getNextItemIds: overrides.getNextItemIds ?? vi.fn(),
+      getNextRowsRequestParams:
+        overrides.getNextRowsRequestParams ?? vi.fn(() => ({})),
+      gridApi,
+      isNavigationCurrent: overrides.isNavigationCurrent,
+      logger: { error: vi.fn() },
+      onNavigationLoadError: overrides.onNavigationLoadError,
+      rows,
+      setDatapoint: vi.fn(),
+      setEvalOpen: vi.fn(),
+      setRows: vi.fn(),
+    };
+  };
+
+  it("navigates cached next rows using the target grid row index instead of the drawer array index", async () => {
+    const harness = createNavigationHarness({
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: harness.rows[1].rowData,
+      valueInfos: undefined,
+    });
+    expect(harness.gridApi.ensureNodeVisible).toHaveBeenCalledWith({
+      id: "row-b",
+      rowIndex: 41,
+    });
+  });
+
+  it("composes drawer navigation with active-row classing and redraws the previous/current grid rows", async () => {
+    const rowANode = { id: "row-a", rowIndex: 40 };
+    const rowBNode = { id: "row-b", rowIndex: 41 };
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+    ];
+    const gridApi = {
+      ensureNodeVisible: vi.fn(),
+      getRowNode: vi.fn((id) =>
+        id === "row-a" ? rowANode : id === "row-b" ? rowBNode : undefined,
+      ),
+      redrawRows: vi.fn(),
+      setFocusedCell: vi.fn(),
+    };
+    const harness = createNavigationHarness({
+      rows,
+      gridApi,
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    const activeDatapoint = harness.setDatapoint.mock.calls[0][0];
+    redrawActiveRowHighlight(
+      gridApi,
+      harness.datapoint.rowData.rowId,
+      activeDatapoint.rowData.rowId,
+    );
+
+    expect(
+      getActiveRowClass(
+        { data: rows[0].rowData, node: rowANode },
+        activeDatapoint,
+      ),
+    ).toBe("");
+    expect(
+      getActiveRowClass(
+        { data: rows[1].rowData, node: rowBNode },
+        activeDatapoint,
+      ),
+    ).toBe("active-row");
+    expect(gridApi.redrawRows).toHaveBeenCalledWith({
+      rowNodes: [rowANode, rowBNode],
+    });
+    expect(gridApi.ensureNodeVisible).toHaveBeenCalledWith(rowBNode);
+    expect(gridApi.setFocusedCell).not.toHaveBeenCalled();
+  });
+
+  it("guards drawer navigation while a navigation attempt is in flight", async () => {
+    let resolveNavigation;
+    const navigationPromise = new Promise((resolve) => {
+      resolveNavigation = resolve;
+    });
+    const navigateRows = vi.fn(() => navigationPromise);
+    const navigationInFlightRef = { current: false };
+    const isNavigatingRef = { current: false };
+    const onNavigate = createDrawerNavigationHandler({
+      getNavigationParams: () => ({ rows: [] }),
+      isNavigatingRef,
+      logger: { error: vi.fn() },
+      navigateRows,
+      navigationInFlightRef,
+    });
+
+    const firstNavigation = onNavigate("next");
+    const secondNavigation = onNavigate("next");
+
+    expect(navigateRows).toHaveBeenCalledTimes(1);
+    expect(isNavigatingRef.current).toBe(true);
+    expect(navigationInFlightRef.current).toBeTruthy();
+    await expect(secondNavigation).resolves.toBeUndefined();
+
+    resolveNavigation(false);
+    await firstNavigation;
+
+    expect(isNavigatingRef.current).toBe(false);
+    expect(navigationInFlightRef.current).toBe(false);
+
+    navigateRows.mockResolvedValueOnce(true);
+    await onNavigate("next");
+
+    expect(navigateRows).toHaveBeenCalledTimes(2);
+    expect(isNavigatingRef.current).toBe(true);
+    expect(navigationInFlightRef.current).toBe(false);
+  });
+
+  it("allows a new drawer source to navigate while a stale source is still settling", async () => {
+    const navigationInFlightRef = {
+      current: { isCurrent: () => false, token: Symbol("old-navigation") },
+    };
+    const isNavigatingRef = { current: false };
+    const navigateRows = vi.fn().mockResolvedValue(true);
+    const onNavigate = createDrawerNavigationHandler({
+      getNavigationParams: () => ({
+        isNavigationCurrent: () => true,
+        rows: [],
+      }),
+      isNavigatingRef,
+      logger: { error: vi.fn() },
+      navigateRows,
+      navigationInFlightRef,
+    });
+
+    await onNavigate("next");
+
+    expect(navigateRows).toHaveBeenCalledTimes(1);
+    expect(isNavigatingRef.current).toBe(true);
+    expect(navigationInFlightRef.current).toBe(false);
+  });
+
+  it("does not let stale navigation completions clear a newer in-flight token", async () => {
+    let resolveFirstNavigation;
+    const firstNavigationPromise = new Promise((resolve) => {
+      resolveFirstNavigation = resolve;
+    });
+    const newerNavigationToken = Symbol("newer-navigation");
+    const navigateRows = vi.fn(() => firstNavigationPromise);
+    const navigationInFlightRef = { current: false };
+    const isNavigatingRef = { current: false };
+    const onNavigate = createDrawerNavigationHandler({
+      getNavigationParams: () => ({ rows: [] }),
+      isNavigatingRef,
+      logger: { error: vi.fn() },
+      navigateRows,
+      navigationInFlightRef,
+    });
+
+    const firstNavigation = onNavigate("next");
+    navigationInFlightRef.current = newerNavigationToken;
+    resolveFirstNavigation(false);
+    await firstNavigation;
+
+    expect(navigationInFlightRef.current).toBe(newerNavigationToken);
+  });
+
+  it("does not show load errors for stale handler-level navigation failures", async () => {
+    let rejectNavigation;
+    let isCurrent = true;
+    const navigationPromise = new Promise((_, reject) => {
+      rejectNavigation = reject;
+    });
+    const onNavigationLoadError = vi.fn();
+    const navigateRows = vi.fn(() => navigationPromise);
+    const navigationInFlightRef = { current: false };
+    const isNavigatingRef = { current: false };
+    const logger = { error: vi.fn() };
+    const onNavigate = createDrawerNavigationHandler({
+      getNavigationParams: () => ({
+        isNavigationCurrent: () => isCurrent,
+        onNavigationLoadError,
+        rows: [],
+      }),
+      isNavigatingRef,
+      logger,
+      navigateRows,
+      navigationInFlightRef,
+    });
+
+    const navigation = onNavigate("next");
+    isCurrent = false;
+    rejectNavigation(new Error("late failure"));
+    await navigation;
+
+    expect(onNavigationLoadError).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(navigationInFlightRef.current).toBe(false);
+  });
+
+  it("handles drawer keyboard navigation only when the target and loading state allow it", () => {
+    const createEvent = (overrides = {}) => ({
+      altKey: false,
+      ctrlKey: false,
+      key: "j",
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      target: document.createElement("div"),
+      ...overrides,
+    });
+    const createState = (overrides = {}) => ({
+      canNavigatePrevious: true,
+      datapointIndex: 1,
+      enabled: true,
+      navLoading: false,
+      onNavigate: vi.fn(),
+      totalRowCount: 3,
+      ...overrides,
+    });
+
+    const nextEvent = createEvent();
+    const nextState = createState();
+    expect(handleDrawerNavigationShortcut(nextEvent, nextState)).toBe(true);
+    expect(nextEvent.preventDefault).toHaveBeenCalled();
+    expect(nextEvent.stopPropagation).toHaveBeenCalled();
+    expect(nextState.onNavigate).toHaveBeenCalledWith("next");
+
+    const loadingEvent = createEvent();
+    const loadingState = createState({ navLoading: true });
+    expect(handleDrawerNavigationShortcut(loadingEvent, loadingState)).toBe(
+      false,
+    );
+    expect(loadingState.onNavigate).not.toHaveBeenCalled();
+
+    const previousDisabledEvent = createEvent({ key: "k" });
+    const previousDisabledState = createState({ canNavigatePrevious: false });
+    expect(
+      handleDrawerNavigationShortcut(
+        previousDisabledEvent,
+        previousDisabledState,
+      ),
+    ).toBe(false);
+    expect(previousDisabledState.onNavigate).not.toHaveBeenCalled();
+
+    const previousEvent = createEvent({ key: "K" });
+    const previousState = createState();
+    expect(handleDrawerNavigationShortcut(previousEvent, previousState)).toBe(
+      true,
+    );
+    expect(previousState.onNavigate).toHaveBeenCalledWith("previous");
+
+    const buttonEvent = createEvent({
+      target: document.createElement("button"),
+    });
+    const buttonState = createState();
+    expect(handleDrawerNavigationShortcut(buttonEvent, buttonState)).toBe(true);
+    expect(buttonState.onNavigate).toHaveBeenCalledWith("next");
+
+    const interactiveEvent = createEvent({
+      target: document.createElement("input"),
+    });
+    const interactiveState = createState();
+    expect(
+      handleDrawerNavigationShortcut(interactiveEvent, interactiveState),
+    ).toBe(false);
+    expect(interactiveState.onNavigate).not.toHaveBeenCalled();
+
+    const lastRowEvent = createEvent();
+    const lastRowState = createState({ datapointIndex: 2 });
+    expect(handleDrawerNavigationShortcut(lastRowEvent, lastRowState)).toBe(
+      false,
+    );
+    expect(lastRowState.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("preserves the existing eval detail merge behavior during navigation", async () => {
+    const evalOpen = {
+      evalMetricId: "metric-1",
+      metadata: { runPrompt: true },
+      cellValue: "old score",
+    };
+    const harness = createNavigationHarness({ evalOpen });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setEvalOpen).toHaveBeenCalledWith({
+      ...evalOpen,
+      cellValue: "b",
+    });
+
+    const missingEvalHarness = createNavigationHarness({
+      evalOpen,
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+      ],
+    });
+
+    await expect(navigateDrawerRows(missingEvalHarness)).resolves.toBe(true);
+
+    expect(missingEvalHarness.setEvalOpen).toHaveBeenCalledWith(evalOpen);
+  });
+
+  it("uses AG Grid row nodes when drawer row indexes are stale", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 0, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 1, rowData: { rowId: "row-b" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getRowNode: vi.fn((id) => {
+          const nodes = {
+            "row-a": { id: "row-a", rowIndex: 72 },
+            "row-b": { id: "row-b", rowIndex: 73 },
+          };
+          return nodes[id];
+        }),
+      },
+      datapoint: { index: 72, rowData: { rowId: "row-a" } },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 73,
+      rowData: rows[1].rowData,
+      valueInfos: undefined,
+    });
+  });
+
+  it("resyncs displayed rows when the cached drawer snapshot no longer contains the active row", async () => {
+    const displayedRows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+    ];
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "stale-row", rowIndex: 12, rowData: { rowId: "stale-row" } },
+      ],
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        forEachNode: vi.fn((visitor) => {
+          displayedRows.forEach((row) =>
+            visitor({
+              data: row.rowData,
+              displayed: true,
+              id: row.id,
+              rowIndex: row.rowIndex,
+            }),
+          );
+        }),
+        getRowNode: vi.fn((id) => {
+          const row = displayedRows.find((candidate) => candidate.id === id);
+          return row ? { id, rowIndex: row.rowIndex } : undefined;
+        }),
+      },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setRows).toHaveBeenCalledWith(displayedRows);
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: displayedRows[1].rowData,
+      valueInfos: undefined,
+    });
+  });
+
+  it("prefers live displayed row order when the cached active row has a stale neighbor", async () => {
+    const cachedRows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-old", rowIndex: 41, rowData: { rowId: "row-old" } },
+    ];
+    const displayedRows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-new", rowIndex: 41, rowData: { rowId: "row-new" } },
+    ];
+    const harness = createNavigationHarness({
+      rows: cachedRows,
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        forEachNode: vi.fn((visitor) => {
+          displayedRows.forEach((row) =>
+            visitor({
+              data: row.rowData,
+              displayed: true,
+              id: row.id,
+              rowIndex: row.rowIndex,
+            }),
+          );
+        }),
+        getRowNode: vi.fn((id) => {
+          const row = displayedRows.find((candidate) => candidate.id === id);
+          return row ? { id, rowIndex: row.rowIndex } : undefined;
+        }),
+      },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setRows).toHaveBeenCalledWith(displayedRows);
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: displayedRows[1].rowData,
+      valueInfos: undefined,
+    });
+  });
+
+  it("prefers fresh live displayed row data over cached data with the same row id", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b", value: "old" } },
+    ];
+    const liveRow = {
+      id: "row-b",
+      rowIndex: 41,
+      rowData: { rowId: "row-b", value: "fresh" },
+    };
+    const harness = createNavigationHarness({
+      rows,
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn((index) =>
+          index === 41
+            ? { id: "row-b", rowIndex: 41, data: liveRow.rowData }
+            : null,
+        ),
+        getRowNode: vi.fn((id) => {
+          const nodes = {
+            "row-a": { id: "row-a", rowIndex: 40 },
+            "row-b": { id: "row-b", rowIndex: 41 },
+          };
+          return nodes[id];
+        }),
+      },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: liveRow.rowData,
+      valueInfos: undefined,
+    });
+    expect(harness.setRows).toHaveBeenCalledWith([rows[0], liveRow]);
+  });
+
+  it("does not trust a stale cached next row when the live grid cannot confirm it", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-old", rowIndex: 41, rowData: { rowId: "row-old" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn((index) =>
+          index === 40
+            ? { id: "row-a", rowIndex: 40, data: { rowId: "row-a" } }
+            : null,
+        ),
+        getRowNode: vi.fn((id) =>
+          id === "row-a" ? { id: "row-a", rowIndex: 40 } : undefined,
+        ),
+      },
+      getNextItemIds: vi.fn().mockResolvedValue({
+        data: { result: { next: { rowId: ["row-new"] } } },
+      }),
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-new": { value: "fresh" } } },
+      }),
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.getNextItemIds).toHaveBeenCalledWith({ row_id: "row-a" });
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: { value: "fresh", rowId: "row-new" },
+      valueInfos: undefined,
+    });
+  });
+
+  it("does not trust a stale cached previous row when the live grid cannot confirm it", async () => {
+    const rows = [
+      { id: "row-old", rowIndex: 40, rowData: { rowId: "row-old" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      direction: "previous",
+      datapoint: { index: 41, rowData: { rowId: "row-b" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn((index) =>
+          index === 41
+            ? { id: "row-b", rowIndex: 41, data: { rowId: "row-b" } }
+            : null,
+        ),
+        getRowNode: vi.fn((id) =>
+          id === "row-b" ? { id: "row-b", rowIndex: 41 } : undefined,
+        ),
+      },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("does not sync stale live rows after the active drawer row changes", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-old", rowIndex: 41, rowData: { rowId: "row-old" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      datapoint: { index: 40, rowData: { rowId: "row-a" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn((index) => {
+          const displayedRows = {
+            40: { id: "row-a", rowIndex: 40, data: { rowId: "row-a" } },
+            41: { id: "row-new", rowIndex: 41, data: { rowId: "row-new" } },
+          };
+          return displayedRows[index] ?? null;
+        }),
+        getRowNode: vi.fn((id) => {
+          const nodes = {
+            "row-a": { id: "row-a", rowIndex: 40 },
+            "row-new": { id: "row-new", rowIndex: 41 },
+          };
+          return nodes[id];
+        }),
+      },
+      isNavigationCurrent: () => false,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("ignores async navigation results after the active drawer row changes", async () => {
+    let resolveCellData;
+    let isCurrent = true;
+    const cellDataPromise = new Promise((resolve) => {
+      resolveCellData = resolve;
+    });
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn(() => cellDataPromise),
+      isNavigationCurrent: () => isCurrent,
+    });
+
+    const navigation = navigateDrawerRows(harness);
+    isCurrent = false;
+    resolveCellData({
+      data: { result: { "row-b": { value: "late" } } },
+    });
+
+    await expect(navigation).resolves.toBe(false);
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setEvalOpen).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("does not start async cached-row hydration when navigation is already stale", async () => {
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-b": { value: "late" } } },
+      }),
+      isNavigationCurrent: () => false,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(harness.getCellData).not.toHaveBeenCalled();
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("surfaces current navigation load failures without updating drawer state", async () => {
+    const onNavigationLoadError = vi.fn();
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockRejectedValue(new Error("network down")),
+      onNavigationLoadError,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(onNavigationLoadError).toHaveBeenCalledTimes(1);
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("does not surface stale navigation load failures", async () => {
+    const onNavigationLoadError = vi.fn();
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockRejectedValue(new Error("network down")),
+      isNavigationCurrent: () => false,
+      onNavigationLoadError,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(onNavigationLoadError).not.toHaveBeenCalled();
+    expect(harness.logger.error).not.toHaveBeenCalled();
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("surfaces missing cached row payloads instead of silently no-oping", async () => {
+    const onNavigationLoadError = vi.fn();
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: {} },
+      }),
+      onNavigationLoadError,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(onNavigationLoadError).toHaveBeenCalledTimes(1);
+    expect(harness.logger.error).toHaveBeenCalledWith(
+      "Failed to load next datapoint row",
+      expect.objectContaining({
+        direction: "next",
+        phase: "cached-row-hydration",
+        reason: "missing_cell_data",
+      }),
+    );
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("does not log stale missing cached row payloads", async () => {
+    const onNavigationLoadError = vi.fn();
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: {} },
+      }),
+      isNavigationCurrent: () => false,
+      onNavigationLoadError,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(onNavigationLoadError).not.toHaveBeenCalled();
+    expect(harness.logger.error).not.toHaveBeenCalled();
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+    expect(harness.setRows).not.toHaveBeenCalled();
+  });
+
+  it("hydrates cached placeholder rows and keeps their row id for highlight matching", async () => {
+    const harness = createNavigationHarness({
+      rows: [
+        { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+        { id: "row-b", rowIndex: 41, rowData: null },
+      ],
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-b": { value: "loaded" } } },
+      }),
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.getCellData).toHaveBeenCalledWith({
+      row_ids: ["row-b"],
+      column_ids: ["column-1"],
+    });
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: { value: "loaded", rowId: "row-b" },
+      valueInfos: undefined,
+    });
+  });
+
+  it("fetches next boundary ids with the existing endpoint payload and stores grid-index placeholders", async () => {
+    const harness = createNavigationHarness({
+      rows: [{ id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } }],
+      getNextItemIds: vi.fn().mockResolvedValue({
+        data: { result: { next: { rowId: ["row-b", "row-c"] } } },
+      }),
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-b": { value: "loaded" } } },
+      }),
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.getNextItemIds).toHaveBeenCalledWith({ row_id: "row-a" });
+    expect(harness.setRows).toHaveBeenCalledWith([
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      {
+        id: "row-b",
+        rowIndex: 41,
+        rowData: { value: "loaded", rowId: "row-b" },
+      },
+      { id: "row-c", rowIndex: 42, rowData: null },
+    ]);
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 41,
+      rowData: { value: "loaded", rowId: "row-b" },
+      valueInfos: undefined,
+    });
+  });
+
+  it("forwards the current grid view context when fetching boundary row ids", async () => {
+    const harness = createNavigationHarness({
+      rows: [{ id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } }],
+      getNextRowsRequestParams: vi.fn(() => ({
+        filters: [{ columnId: "column-1", operator: "contains", value: "x" }],
+        search: { key: "needle", type: ["text"] },
+        sort: [{ columnId: "column-1", type: "descending" }],
+      })),
+      getNextItemIds: vi.fn().mockResolvedValue({
+        data: { result: { next: { rowId: ["row-b"] } } },
+      }),
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-b": { value: "loaded" } } },
+      }),
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.getNextItemIds).toHaveBeenCalledWith({
+      filters: [{ columnId: "column-1", operator: "contains", value: "x" }],
+      row_id: "row-a",
+      search: { key: "needle", type: ["text"] },
+      sort: [{ columnId: "column-1", type: "descending" }],
+    });
+  });
+
+  it("surfaces missing next-boundary row payloads after storing fetched ids", async () => {
+    const onNavigationLoadError = vi.fn();
+    const harness = createNavigationHarness({
+      rows: [{ id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } }],
+      getNextItemIds: vi.fn().mockResolvedValue({
+        data: { result: { next: { rowId: ["row-b"] } } },
+      }),
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: {} },
+      }),
+      onNavigationLoadError,
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+
+    expect(onNavigationLoadError).toHaveBeenCalledTimes(1);
+    expect(harness.logger.error).toHaveBeenCalledWith(
+      "Failed to load next datapoint row",
+      expect.objectContaining({
+        direction: "next",
+        phase: "next-boundary-row-hydration",
+        reason: "missing_cell_data",
+      }),
+    );
+    expect(harness.setRows).toHaveBeenCalledWith([
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: null },
+    ]);
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+  });
+
+  it("normalizes scalar next-boundary row ids before hydrating", async () => {
+    const harness = createNavigationHarness({
+      rows: [{ id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } }],
+      getNextItemIds: vi.fn().mockResolvedValue({
+        data: { result: { next: { rowId: "row-b" } } },
+      }),
+      getCellData: vi.fn().mockResolvedValue({
+        data: { result: { "row-b": { value: "loaded" } } },
+      }),
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setRows).toHaveBeenCalledWith([
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      {
+        id: "row-b",
+        rowIndex: 41,
+        rowData: { value: "loaded", rowId: "row-b" },
+      },
+    ]);
+  });
+
+  it("navigates previous rows from the local drawer cache using the target grid row index", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      direction: "previous",
+      datapoint: { index: 41, rowData: { rowId: "row-b" } },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 40,
+      rowData: rows[0].rowData,
+      valueInfos: undefined,
+    });
+  });
+
+  it("navigates previous from cached rows when the current hydrated row is not in AG Grid yet", async () => {
+    const rows = [
+      { id: "row-a", rowIndex: 40, rowData: { rowId: "row-a" } },
+      { id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } },
+    ];
+    const harness = createNavigationHarness({
+      rows,
+      direction: "previous",
+      datapoint: { index: 41, rowData: { rowId: "row-b" } },
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        getDisplayedRowAtIndex: vi.fn(() => null),
+        getRowNode: vi.fn((id) =>
+          id === "row-a" ? { id: "row-a", rowIndex: 40 } : undefined,
+        ),
+      },
+    });
+
+    await expect(navigateDrawerRows(harness)).resolves.toBe(true);
+
+    expect(harness.setDatapoint).toHaveBeenCalledWith({
+      index: 40,
+      rowData: rows[0].rowData,
+      valueInfos: undefined,
+    });
+  });
+
+  it("keeps previous navigation cache-bounded at unloaded row boundaries", async () => {
+    const rows = [{ id: "row-b", rowIndex: 41, rowData: { rowId: "row-b" } }];
+    const datapoint = { index: 41, rowData: { rowId: "row-b" } };
+    const harness = createNavigationHarness({
+      rows,
+      direction: "previous",
+      datapoint,
+      gridApi: {
+        ensureIndexVisible: vi.fn(),
+        ensureNodeVisible: vi.fn(),
+        forEachNode: vi.fn((visitor) => {
+          visitor({
+            data: rows[0].rowData,
+            displayed: true,
+            id: rows[0].id,
+            rowIndex: rows[0].rowIndex,
+          });
+        }),
+        getRowNode: vi.fn((id) =>
+          id === "row-b" ? { id: "row-b", rowIndex: 41 } : undefined,
+        ),
+      },
+    });
+
+    expect(
+      canNavigatePreviousDrawerRowFromGrid(rows, datapoint, harness.gridApi),
+    ).toBe(false);
+    await expect(navigateDrawerRows(harness)).resolves.toBe(false);
+    expect(harness.getNextItemIds).not.toHaveBeenCalled();
+    expect(harness.getCellData).not.toHaveBeenCalled();
+    expect(harness.setDatapoint).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/navigation.js
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/navigation.js
@@ -1,0 +1,804 @@
+import { useEffect, useRef } from "react";
+
+const normalizeRowId = (value) =>
+  value === undefined || value === null ? "" : String(value);
+
+export const getDrawerRowId = (row) => row?.id ?? row?.rowData?.rowId;
+
+export const getGridRowNode = (gridApi, rowId) => {
+  if (!gridApi?.getRowNode || rowId === undefined || rowId === null) {
+    return undefined;
+  }
+
+  return gridApi.getRowNode(String(rowId));
+};
+
+const rowIdsMatch = (left, right) => {
+  if (
+    left === undefined ||
+    left === null ||
+    right === undefined ||
+    right === null
+  ) {
+    return false;
+  }
+
+  return normalizeRowId(left) === normalizeRowId(right);
+};
+
+export const isDrawerNavigationSourceCurrent = ({
+  getCurrentDatapoint,
+  navigationRequestIdRef,
+  requestId,
+  sourceRowData,
+  sourceRowId,
+}) => {
+  if (navigationRequestIdRef?.current !== requestId) {
+    return false;
+  }
+
+  const currentDatapoint = getCurrentDatapoint?.();
+  const currentRowId = currentDatapoint?.rowData?.rowId;
+
+  if (sourceRowId !== undefined && sourceRowId !== null) {
+    return rowIdsMatch(currentRowId, sourceRowId);
+  }
+
+  return currentDatapoint?.rowData === sourceRowData;
+};
+
+const getActiveRowNode = (gridApi, rowIdentity) => {
+  const rowNode = getGridRowNode(gridApi, rowIdentity);
+
+  if (rowNode) {
+    return rowNode;
+  }
+
+  if (Number.isInteger(rowIdentity)) {
+    return gridApi?.getDisplayedRowAtIndex?.(rowIdentity);
+  }
+
+  return undefined;
+};
+
+export const getDrawerRowPosition = (rows = [], datapoint) => {
+  const currentRowId = datapoint?.rowData?.rowId;
+
+  if (currentRowId !== undefined && currentRowId !== null) {
+    return rows.findIndex(
+      (row) =>
+        normalizeRowId(getDrawerRowId(row)) === normalizeRowId(currentRowId),
+    );
+  }
+
+  if (
+    Number.isInteger(datapoint?.index) &&
+    rows[datapoint.index]?.rowData === datapoint?.rowData
+  ) {
+    return datapoint.index;
+  }
+
+  return -1;
+};
+
+export const resolveGridRowIndex = (gridApi, row, fallbackIndex) => {
+  const rowNode = getGridRowNode(gridApi, getDrawerRowId(row));
+
+  if (Number.isInteger(rowNode?.rowIndex)) {
+    return rowNode.rowIndex;
+  }
+
+  if (Number.isInteger(row?.rowIndex)) {
+    return row.rowIndex;
+  }
+
+  return fallbackIndex;
+};
+
+const getSortableRowIndex = (row) =>
+  Number.isInteger(row?.rowIndex) ? row.rowIndex : Number.MAX_SAFE_INTEGER;
+
+export const getDisplayedDrawerRows = (gridApi) => {
+  const rows = [];
+
+  gridApi?.forEachNode?.((node) => {
+    if (node.displayed && node.id !== undefined && node.id !== null) {
+      rows.push({
+        rowData: node.data,
+        id: node.id,
+        rowIndex: node.rowIndex,
+      });
+    }
+  });
+
+  return rows.sort(
+    (left, right) => getSortableRowIndex(left) - getSortableRowIndex(right),
+  );
+};
+
+export const syncGridRowVisibility = (gridApi, row, fallbackIndex) => {
+  const rowNode = getGridRowNode(gridApi, getDrawerRowId(row));
+  const rowIndex = resolveGridRowIndex(gridApi, row, fallbackIndex);
+
+  if (rowNode) {
+    gridApi?.ensureNodeVisible?.(rowNode);
+  } else if (Number.isInteger(rowIndex)) {
+    gridApi?.ensureIndexVisible?.(rowIndex);
+  }
+
+  return rowIndex;
+};
+
+export const redrawActiveRowHighlight = (
+  gridApi,
+  previousRowIdentity,
+  activeRowIdentity,
+) => {
+  const rowIdentities = Array.from(
+    new Set(
+      [previousRowIdentity, activeRowIdentity].filter(
+        (rowIdentity) => rowIdentity !== undefined && rowIdentity !== null,
+      ),
+    ),
+  );
+
+  if (rowIdentities.length === 0) {
+    return;
+  }
+  const rowNodes = rowIdentities
+    .map((rowIdentity) => getActiveRowNode(gridApi, rowIdentity))
+    .filter(Boolean);
+  const uniqueRowNodes = Array.from(new Set(rowNodes));
+
+  if (uniqueRowNodes.length > 0) {
+    gridApi?.redrawRows?.({ rowNodes: uniqueRowNodes });
+    return;
+  }
+
+  gridApi?.redrawRows?.();
+};
+
+export const useActiveRowHighlightRedraw = (
+  gridApiRef,
+  activeRowIdentity,
+  redrawKey,
+) => {
+  const previousActiveRowIdentityRef = useRef();
+
+  useEffect(() => {
+    redrawActiveRowHighlight(
+      gridApiRef.current?.api,
+      previousActiveRowIdentityRef.current,
+      activeRowIdentity,
+    );
+    previousActiveRowIdentityRef.current = activeRowIdentity;
+  }, [activeRowIdentity, gridApiRef, redrawKey]);
+};
+
+export const getActiveRowClass = (params, activeDatapoint) => {
+  const activeRowId =
+    activeDatapoint?.rowData?.rowId ??
+    activeDatapoint?.rowId ??
+    activeDatapoint?.id;
+
+  if (activeRowId !== undefined && activeRowId !== null) {
+    const rowId = params?.data?.rowId ?? params?.node?.id;
+    return normalizeRowId(rowId) === normalizeRowId(activeRowId)
+      ? "active-row"
+      : "";
+  }
+
+  const activeRowIndex = Number.isInteger(activeDatapoint)
+    ? activeDatapoint
+    : activeDatapoint?.index;
+
+  return params?.node?.rowIndex === activeRowIndex ? "active-row" : "";
+};
+
+export const withDrawerRowId = (rowData, rowId) => {
+  if (!rowData || rowId === undefined || rowId === null) {
+    return rowData;
+  }
+
+  return {
+    ...rowData,
+    rowId: rowData.rowId ?? rowId,
+  };
+};
+
+const getNextEvalOpen = (rowData, evalOpen, allColumns = []) => {
+  if (!evalOpen) {
+    return undefined;
+  }
+
+  const evalMetricId = evalOpen?.evalMetricId;
+  const column = allColumns.find((i) => i?.col?.sourceId === evalMetricId);
+
+  return {
+    ...evalOpen,
+    ...rowData?.[column?.field],
+  };
+};
+
+const getDrawerRowFromGridNode = (node) => {
+  if (!node || node.id === undefined || node.id === null) {
+    return null;
+  }
+
+  return {
+    rowData: node.data,
+    id: node.id,
+    rowIndex: node.rowIndex,
+  };
+};
+
+const getDisplayedDrawerRowAtIndex = (gridApi, rowIndex) => {
+  if (!gridApi?.getDisplayedRowAtIndex || !Number.isInteger(rowIndex)) {
+    return undefined;
+  }
+
+  return getDrawerRowFromGridNode(gridApi.getDisplayedRowAtIndex(rowIndex));
+};
+
+const getAdjacentDisplayedDrawerRow = (gridApi, datapoint, direction) => {
+  if (!gridApi?.getDisplayedRowAtIndex) {
+    return undefined;
+  }
+
+  const step = direction === "next" ? 1 : -1;
+  const currentRowId = datapoint?.rowData?.rowId;
+  const currentRowNode = getGridRowNode(gridApi, currentRowId);
+  const currentRowIndex = Number.isInteger(currentRowNode?.rowIndex)
+    ? currentRowNode.rowIndex
+    : datapoint?.index;
+
+  if (!Number.isInteger(currentRowIndex)) {
+    return undefined;
+  }
+
+  if (currentRowId !== undefined && currentRowId !== null && !currentRowNode) {
+    const displayedCurrentRow = getDisplayedDrawerRowAtIndex(
+      gridApi,
+      currentRowIndex,
+    );
+
+    if (!rowIdsMatch(getDrawerRowId(displayedCurrentRow), currentRowId)) {
+      return direction === "previous" ? undefined : null;
+    }
+  }
+
+  return getDisplayedDrawerRowAtIndex(gridApi, currentRowIndex + step);
+};
+
+export const canNavigatePreviousDrawerRow = (rows = [], datapoint) => {
+  const currentDrawerIndex = getDrawerRowPosition(rows, datapoint);
+
+  return (
+    currentDrawerIndex > 0 && Boolean(rows[currentDrawerIndex - 1]?.rowData)
+  );
+};
+
+export const canNavigatePreviousDrawerRowFromGrid = (
+  rows = [],
+  datapoint,
+  gridApi,
+  { allowFullScan = true } = {},
+) => {
+  if (canNavigatePreviousDrawerRow(rows, datapoint)) {
+    return true;
+  }
+
+  if (getAdjacentDisplayedDrawerRow(gridApi, datapoint, "previous")?.rowData) {
+    return true;
+  }
+
+  if (!allowFullScan) {
+    return false;
+  }
+
+  return canNavigatePreviousDrawerRow(
+    getDisplayedDrawerRows(gridApi),
+    datapoint,
+  );
+};
+
+const getAdjacentRowIds = (navigationResult, direction) => {
+  const rowIds =
+    navigationResult?.[direction]?.rowId ??
+    navigationResult?.[direction]?.row_id;
+
+  if (rowIds === undefined || rowIds === null) {
+    return [];
+  }
+
+  return Array.isArray(rowIds) ? rowIds : [rowIds];
+};
+
+const DRAWER_SHORTCUT_TEXT_ENTRY_SELECTOR = [
+  "input",
+  "select",
+  "textarea",
+  "[role='combobox']",
+  "[role='textbox']",
+  "[contenteditable='true']",
+].join(", ");
+
+export const shouldIgnoreDrawerNavigationShortcut = (target) => {
+  if (!target) {
+    return false;
+  }
+
+  return Boolean(
+    target.isContentEditable ||
+      target.getAttribute?.("contenteditable") === "true" ||
+      target.closest?.(DRAWER_SHORTCUT_TEXT_ENTRY_SELECTOR),
+  );
+};
+
+export const handleDrawerNavigationShortcut = (event, state) => {
+  if (!state?.enabled) return false;
+  if (shouldIgnoreDrawerNavigationShortcut(event.target)) return false;
+
+  const isNext = event.key === "j" || event.key === "J";
+  const isPrev = event.key === "k" || event.key === "K";
+  if (!isNext && !isPrev) return false;
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+
+  if (
+    isNext &&
+    !state.navLoading &&
+    state.datapointIndex !== state.totalRowCount - 1
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+    state.onNavigate("next");
+    return true;
+  }
+
+  if (isPrev && !state.navLoading && state.canNavigatePrevious) {
+    event.preventDefault();
+    event.stopPropagation();
+    state.onNavigate("previous");
+    return true;
+  }
+
+  return false;
+};
+
+const isNavigationAbortError = (error) =>
+  error?.name === "AbortError" ||
+  error?.name === "CanceledError" ||
+  error?.code === "ERR_CANCELED";
+
+// Navigation is intentionally resolved in this order:
+// live displayed grid row -> cached hydrated row -> cached placeholder hydration
+// -> next-boundary fetch. Previous navigation stays cache/live-grid bounded.
+export const navigateDrawerRows = async ({
+  allColumns = [],
+  datapoint,
+  direction,
+  evalOpen,
+  getCellData,
+  getNextItemIds,
+  getNextRowsRequestParams = () => ({}),
+  gridApi,
+  isNavigationCurrent = () => true,
+  logger,
+  onNavigationLoadError,
+  rows = [],
+  setDatapoint,
+  setEvalOpen,
+  setRows,
+}) => {
+  let activeRows = rows;
+  let rowsWereResynced = false;
+  let displayedRowsSnapshot;
+  const step = direction === "next" ? 1 : -1;
+  let currentDrawerIndex = getDrawerRowPosition(activeRows, datapoint);
+
+  const getDisplayedRowsSnapshot = () => {
+    if (!displayedRowsSnapshot) {
+      displayedRowsSnapshot = getDisplayedDrawerRows(gridApi);
+    }
+
+    return displayedRowsSnapshot;
+  };
+
+  const resyncDisplayedRows = ({ requireAdjacentRow = false } = {}) => {
+    const displayedRows = getDisplayedRowsSnapshot();
+    const displayedDrawerIndex = getDrawerRowPosition(displayedRows, datapoint);
+
+    if (displayedDrawerIndex === -1) {
+      return false;
+    }
+
+    if (
+      requireAdjacentRow &&
+      !displayedRows[displayedDrawerIndex + step]?.rowData
+    ) {
+      return false;
+    }
+
+    activeRows = displayedRows;
+    currentDrawerIndex = displayedDrawerIndex;
+    rowsWereResynced = true;
+    return true;
+  };
+
+  if (currentDrawerIndex === -1) {
+    resyncDisplayedRows();
+  }
+
+  if (currentDrawerIndex === -1) {
+    return false;
+  }
+
+  let targetDrawerIndex = currentDrawerIndex + step;
+  let adjacentDisplayedRow = getAdjacentDisplayedDrawerRow(
+    gridApi,
+    datapoint,
+    direction,
+  );
+
+  if (
+    (adjacentDisplayedRow === undefined || adjacentDisplayedRow === null) &&
+    gridApi?.forEachNode
+  ) {
+    const displayedRows = getDisplayedRowsSnapshot();
+    const displayedDrawerIndex = getDrawerRowPosition(displayedRows, datapoint);
+
+    if (displayedDrawerIndex !== -1) {
+      adjacentDisplayedRow = displayedRows[displayedDrawerIndex + step] ?? null;
+
+      if (adjacentDisplayedRow?.rowData) {
+        activeRows = displayedRows;
+        currentDrawerIndex = displayedDrawerIndex;
+        targetDrawerIndex = currentDrawerIndex + step;
+        rowsWereResynced = true;
+      }
+    }
+  }
+
+  if (
+    adjacentDisplayedRow === undefined &&
+    !activeRows[targetDrawerIndex]?.rowData
+  ) {
+    resyncDisplayedRows({ requireAdjacentRow: true });
+    targetDrawerIndex = currentDrawerIndex + step;
+    adjacentDisplayedRow = activeRows[targetDrawerIndex] ?? null;
+  }
+
+  const fallbackGridIndex = Number.isInteger(datapoint?.index)
+    ? datapoint.index + step
+    : targetDrawerIndex;
+  const columnIds = allColumns.map((i) => i?.col?.id);
+
+  const setActiveDatapoint = (targetRow, rowData, indexFallback) => {
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+
+    const rowDataWithId = withDrawerRowId(rowData, getDrawerRowId(targetRow));
+    const targetGridIndex = syncGridRowVisibility(
+      gridApi,
+      targetRow,
+      indexFallback,
+    );
+
+    setDatapoint({
+      index: targetGridIndex,
+      rowData: rowDataWithId,
+      valueInfos: rowDataWithId?.valueInfos,
+    });
+
+    const nextEvalOpen = getNextEvalOpen(rowDataWithId, evalOpen, allColumns);
+    if (nextEvalOpen !== undefined) {
+      setEvalOpen(nextEvalOpen);
+    }
+
+    return true;
+  };
+
+  const hydrateRow = async (rowId) => {
+    const newCellData = await getCellData({
+      row_ids: [rowId],
+      column_ids: columnIds,
+    });
+    const cellData = newCellData?.data?.result?.[rowId];
+
+    return cellData ? withDrawerRowId(cellData, rowId) : null;
+  };
+
+  const reportNavigationLoadFailure = (message, error, context = {}) => {
+    if (!isNavigationCurrent() || isNavigationAbortError(error)) {
+      return false;
+    }
+
+    logger?.error?.(message, {
+      code: error?.code,
+      direction,
+      message: error?.message,
+      name: error?.name,
+      ...context,
+    });
+    onNavigationLoadError?.();
+    return true;
+  };
+
+  const reportMissingHydratedRow = (phase) => {
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+
+    logger?.error?.("Failed to load next datapoint row", {
+      direction,
+      phase,
+      reason: "missing_cell_data",
+    });
+    onNavigationLoadError?.();
+    return true;
+  };
+
+  if (direction === "previous") {
+    if (adjacentDisplayedRow?.rowData) {
+      const nextRows = [...activeRows];
+      nextRows[targetDrawerIndex] = adjacentDisplayedRow;
+      if (
+        !setActiveDatapoint(
+          adjacentDisplayedRow,
+          adjacentDisplayedRow.rowData,
+          fallbackGridIndex,
+        )
+      ) {
+        return false;
+      }
+      setRows(nextRows);
+      return true;
+    }
+
+    if (adjacentDisplayedRow === null) {
+      return false;
+    }
+
+    if (
+      adjacentDisplayedRow === undefined &&
+      !activeRows[targetDrawerIndex]?.rowData &&
+      !rowsWereResynced
+    ) {
+      const displayedRows = getDisplayedRowsSnapshot();
+      const displayedDrawerIndex = getDrawerRowPosition(
+        displayedRows,
+        datapoint,
+      );
+
+      if (displayedRows[displayedDrawerIndex - 1]?.rowData) {
+        activeRows = displayedRows;
+        currentDrawerIndex = displayedDrawerIndex;
+        targetDrawerIndex = currentDrawerIndex + step;
+        rowsWereResynced = true;
+      }
+    }
+
+    const targetRow = activeRows[targetDrawerIndex];
+    const rowData = targetRow?.rowData;
+
+    if (!targetRow || !rowData) {
+      return false;
+    }
+
+    if (!setActiveDatapoint(targetRow, rowData, fallbackGridIndex)) {
+      return false;
+    }
+
+    if (rowsWereResynced) {
+      setRows(activeRows);
+    }
+    return true;
+  }
+
+  const cachedTarget = activeRows[targetDrawerIndex];
+  const cachedTargetMatchesAdjacent =
+    adjacentDisplayedRow === undefined ||
+    rowIdsMatch(
+      getDrawerRowId(cachedTarget),
+      getDrawerRowId(adjacentDisplayedRow),
+    );
+
+  if (adjacentDisplayedRow?.rowData) {
+    const nextRows = [...activeRows];
+    nextRows[targetDrawerIndex] = adjacentDisplayedRow;
+    if (
+      !setActiveDatapoint(
+        adjacentDisplayedRow,
+        adjacentDisplayedRow.rowData,
+        fallbackGridIndex,
+      )
+    ) {
+      return false;
+    }
+    setRows(nextRows);
+    return true;
+  }
+
+  if (cachedTarget?.rowData && cachedTargetMatchesAdjacent) {
+    if (
+      !setActiveDatapoint(cachedTarget, cachedTarget.rowData, fallbackGridIndex)
+    ) {
+      return false;
+    }
+    if (rowsWereResynced) {
+      setRows(activeRows);
+    }
+    return true;
+  }
+
+  if (cachedTarget && !cachedTarget.rowData && cachedTargetMatchesAdjacent) {
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+
+    try {
+      const rowDataWithId = await hydrateRow(cachedTarget.id);
+
+      if (!rowDataWithId) {
+        reportMissingHydratedRow("cached-row-hydration");
+        return false;
+      }
+
+      if (!isNavigationCurrent()) {
+        return false;
+      }
+
+      const targetRow = {
+        ...cachedTarget,
+        rowData: rowDataWithId,
+      };
+      if (!setActiveDatapoint(targetRow, rowDataWithId, fallbackGridIndex)) {
+        return false;
+      }
+      setRows((prev) => {
+        const newRows = rowsWereResynced ? [...activeRows] : [...prev];
+        newRows[targetDrawerIndex] = targetRow;
+        return newRows;
+      });
+      return true;
+    } catch (error) {
+      reportNavigationLoadFailure("Failed to load next datapoint row", error, {
+        phase: "cached-row-hydration",
+      });
+      return false;
+    }
+  }
+
+  const mergedRows = activeRows.slice(0, currentDrawerIndex + 1);
+  const boundaryTargetDrawerIndex = mergedRows.length;
+
+  try {
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+
+    const nextIds = await getNextItemIds({
+      ...(getNextRowsRequestParams?.() ?? {}),
+      row_id: datapoint?.rowData?.rowId,
+    });
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+    const newIds = getAdjacentRowIds(nextIds?.data?.result, "next");
+
+    newIds?.forEach((id, index) => {
+      mergedRows.push({
+        rowData: null,
+        id,
+        rowIndex: Number.isInteger(datapoint?.index)
+          ? datapoint.index + index + 1
+          : undefined,
+      });
+    });
+  } catch (error) {
+    reportNavigationLoadFailure("Failed to load next datapoint ids", error, {
+      phase: "next-boundary-ids",
+    });
+  }
+
+  const nextId = mergedRows[boundaryTargetDrawerIndex]?.id;
+  if (!nextId) {
+    if (isNavigationCurrent()) {
+      setRows(mergedRows);
+    }
+    return false;
+  }
+
+  try {
+    const rowDataWithId = await hydrateRow(nextId);
+
+    if (!rowDataWithId) {
+      reportMissingHydratedRow("next-boundary-row-hydration");
+      if (isNavigationCurrent()) {
+        setRows(mergedRows);
+      }
+      return false;
+    }
+
+    if (!isNavigationCurrent()) {
+      return false;
+    }
+
+    mergedRows[boundaryTargetDrawerIndex] = {
+      ...mergedRows[boundaryTargetDrawerIndex],
+      rowData: rowDataWithId,
+    };
+    if (
+      !setActiveDatapoint(
+        mergedRows[boundaryTargetDrawerIndex],
+        rowDataWithId,
+        fallbackGridIndex,
+      )
+    ) {
+      return false;
+    }
+    setRows(mergedRows);
+    return true;
+  } catch (error) {
+    reportNavigationLoadFailure("Failed to load next datapoint row", error, {
+      phase: "next-boundary-row-hydration",
+    });
+    if (isNavigationCurrent()) {
+      setRows(mergedRows);
+    }
+    return false;
+  }
+};
+
+export const createDrawerNavigationHandler =
+  ({
+    getNavigationParams,
+    isNavigatingRef,
+    logger,
+    navigateRows = navigateDrawerRows,
+    navigationInFlightRef,
+  }) =>
+  async (direction) => {
+    const existingNavigation = navigationInFlightRef.current;
+    if (existingNavigation?.isCurrent?.() ?? Boolean(existingNavigation)) {
+      return;
+    }
+
+    const navigationToken = Symbol("drawer-navigation");
+    let navigated = false;
+    let navigationParams;
+
+    try {
+      navigationParams = getNavigationParams();
+      navigationInFlightRef.current = {
+        isCurrent: navigationParams.isNavigationCurrent,
+        token: navigationToken,
+      };
+      isNavigatingRef.current = true;
+      navigated = await navigateRows({
+        ...navigationParams,
+        direction,
+      });
+    } catch (error) {
+      const isNavigationCurrent =
+        navigationParams?.isNavigationCurrent?.() ?? true;
+      if (isNavigationCurrent && !isNavigationAbortError(error)) {
+        logger?.error?.("Failed to navigate datapoint drawer rows", {
+          code: error?.code,
+          direction,
+          message: error?.message,
+          name: error?.name,
+          phase: "drawer-navigation-handler",
+        });
+        navigationParams?.onNavigationLoadError?.();
+      }
+    } finally {
+      if (navigationInFlightRef.current?.token === navigationToken) {
+        if (!navigated) {
+          isNavigatingRef.current = false;
+        }
+        navigationInFlightRef.current = false;
+      }
+    }
+  };

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
   lazy,
   Suspense,
 } from "react";
@@ -77,6 +78,10 @@ import DevelopFilterBox from "./DevelopFilters/DevelopFilterBox";
 import TopBanner from "./TopBanner";
 import { transformFilter, validateFilter } from "./DevelopFilters/common";
 import DatapointDrawerV2 from "./DatapointDrawerV2/DatapointDrawerV2";
+import {
+  getActiveRowClass,
+  useActiveRowHighlightRedraw,
+} from "./DatapointDrawerV2/navigation";
 import useWavesurferCache from "src/hooks/use-wavesurfer-cache";
 import AddRowData from "./AddRowData";
 import DatasetLoader from "../../develop/loaders/DatasetLoader";
@@ -236,14 +241,17 @@ const getDataSource = (
           search,
           { enabled: true, staleTime: 5 * 1000, pageSize: DATASET_ROWS_LIMIT },
         );
+
+        // If this page is already in the cache and has not been marked
+        // changed, reuse it instantly; otherwise fetch it from the server.
         const cachedState = queryClient.getQueryState(queryOptions.queryKey);
         const servedFromCache =
           cachedState?.data !== undefined && !cachedState.isInvalidated;
         const data = servedFromCache
           ? cachedState.data
           : await queryClient.fetchQuery({ ...queryOptions });
-        const result = data?.data?.result;
-        const processingData = getResultIsProcessingData(result);
+
+        const processingData = data?.data?.result?.isProcessingData;
 
         useProcessingStore.getState().setIsProcessingData(processingData);
 
@@ -596,6 +604,13 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
   const { processingComplete, setProcessingComplete } = useDatasetOriginStore();
   const overlayTimeoutRef = useRef(null);
   const wasProcessingData = useRef(false);
+  const [gridApiReadyVersion, setGridApiReadyVersion] = useState(0);
+
+  useActiveRowHighlightRedraw(
+    gridApiRef,
+    activeDatapoint?.rowData?.rowId ?? activeDatapoint?.index,
+    gridApiReadyVersion,
+  );
 
   const updateProcessingSyntheticData = useCallback(
     (val) => {
@@ -896,6 +911,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
     dataset,
     queryClient,
     averageMetaData?.isProcessingData,
+    isViewerRole,
   ]);
 
   const isData = useMemo(() => {
@@ -1273,6 +1289,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                   rowModelType="serverSide"
                   onGridReady={(params) => {
                     setGridApi(params.api);
+                    setGridApiReadyVersion((version) => version + 1);
                     onGridReady(params);
                   }}
                   onCellValueChanged={onCellValueChanged}
@@ -1347,11 +1364,9 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                     }, 0);
                   }}
                   getRowClass={(params) =>
-                    params.node.rowIndex === activeDatapoint?.index
-                      ? "active-row"
-                      : ""
+                    getActiveRowClass(params, activeDatapoint)
                   }
-                  className={`develop-data-grid ${_viewOptions.bottomRow ? "show-bottom-row" : ""}`}
+                  className={`develop-data-grid datapoint-drawer-v2-grid ${_viewOptions.bottomRow ? "show-bottom-row" : ""}`}
                   suppressColumnMoveAnimation={true}
                   suppressAnimationFrame={true}
                   pinnedBottomRowData={_viewOptions.bottomRow ? bottomRow : []}


### PR DESCRIPTION
## Summary

Thanks for your earlier review. This is a focused, rebased follow-up targeting `dev` per `CONTRIBUTING.md`; the original oversized PR remains open only as reference until this scoped replacement is reviewed.

This is the frontend portion split from #1290. It keeps the DatapointDrawerV2 content, active grid highlight, and keyboard/prev-next navigation aligned with the visible row identity.

## Scope

- DatapointDrawerV2 navigation/highlight behavior.
- Frontend navigation regression coverage.
- No backend row-order implementation in this PR.

Follow-up to #1290. The server-side filtered row-navigation change is in a separate focused PR.

Closes #929

## Validation

- Focused frontend navigation tests, lint/format checks, and `git diff --check` were run on the rebased branch.

Please review this focused replacement for #1290.