### PR TITLE
perf(gateway): optimize adaptive routing hot path

### DIFF
--- a/agentcc-gateway/internal/routing/adaptive.go
+++ b/agentcc-gateway/internal/routing/adaptive.go
@@ -2,18 +2,22 @@ package routing
 
 import (
 	"math"
-	"math/rand"
-	"sync"
+	"math/rand/v2"
 	"sync/atomic"
 	"time"
 
 	"github.com/futureagi/agentcc-gateway/internal/config"
 )
 
+// adaptiveWeightSnapshot is immutable after publication. Select can therefore
+// read weights without contending with the background recalculation loop.
+type adaptiveWeightSnapshot struct {
+	byProvider map[string]float64
+}
+
 // AdaptiveStrategy dynamically adjusts provider weights based on real-time metrics.
 type AdaptiveStrategy struct {
-	mu              sync.RWMutex
-	weights         map[string]float64
+	weights         atomic.Pointer[adaptiveWeightSnapshot]
 	requestCount    atomic.Int64
 	counter         atomic.Uint64 // for learning-phase round-robin
 	learningReqs    int
@@ -56,7 +60,6 @@ func NewAdaptiveStrategy(cfg config.AdaptiveConfig, tracker *LatencyTracker, hea
 	}
 
 	a := &AdaptiveStrategy{
-		weights:         make(map[string]float64),
 		learningReqs:    learningReqs,
 		minWeight:       minWeight,
 		smoothingFactor: smoothing,
@@ -67,6 +70,7 @@ func NewAdaptiveStrategy(cfg config.AdaptiveConfig, tracker *LatencyTracker, hea
 		updateInterval:  updateInterval,
 		stopCh:          make(chan struct{}),
 	}
+	a.weights.Store(&adaptiveWeightSnapshot{byProvider: make(map[string]float64)})
 
 	go a.updateLoop()
 	return a
@@ -83,24 +87,24 @@ func (a *AdaptiveStrategy) Select(targets []RoutingTarget, tracker *LatencyTrack
 		n := a.counter.Add(1) - 1
 		return int(n % uint64(len(targets))), nil
 	}
+	if len(targets) == 1 {
+		return 0, nil
+	}
 
 	// Active phase: weighted random selection.
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Compute total weight for available targets.
-	type tw struct {
-		idx    int
-		weight float64
+	snapshot := a.weights.Load()
+	var weights map[string]float64
+	if snapshot != nil {
+		weights = snapshot.byProvider
 	}
-	tws := make([]tw, 0, len(targets))
+
+	// First pass: total weight for available targets.
 	var total float64
-	for i, t := range targets {
-		w := a.weights[t.ProviderID]
+	for _, t := range targets {
+		w := weights[t.ProviderID]
 		if w < a.minWeight {
 			w = a.minWeight
 		}
-		tws = append(tws, tw{idx: i, weight: w})
 		total += w
 	}
 
@@ -111,13 +115,17 @@ func (a *AdaptiveStrategy) Select(targets []RoutingTarget, tracker *LatencyTrack
 	// Weighted random selection.
 	r := rand.Float64() * total
 	var cumulative float64
-	for _, entry := range tws {
-		cumulative += entry.weight
+	for i, t := range targets {
+		w := weights[t.ProviderID]
+		if w < a.minWeight {
+			w = a.minWeight
+		}
+		cumulative += w
 		if r <= cumulative {
-			return entry.idx, nil
+			return i, nil
 		}
 	}
-	return tws[len(tws)-1].idx, nil
+	return len(targets) - 1, nil
 }
 
 // IncrementRequestCount is called by the handler after each request.
@@ -127,10 +135,12 @@ func (a *AdaptiveStrategy) IncrementRequestCount() {
 
 // GetWeights returns a copy of current weights.
 func (a *AdaptiveStrategy) GetWeights() map[string]float64 {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	cpy := make(map[string]float64, len(a.weights))
-	for k, v := range a.weights {
+	snapshot := a.weights.Load()
+	if snapshot == nil {
+		return map[string]float64{}
+	}
+	cpy := make(map[string]float64, len(snapshot.byProvider))
+	for k, v := range snapshot.byProvider {
 		cpy[k] = v
 	}
 	return cpy
@@ -210,14 +220,18 @@ func (a *AdaptiveStrategy) recalculateWeights() {
 		return
 	}
 
-	// Normalize and smooth.
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	// Normalize and smooth. The published snapshot is immutable, so it remains
+	// safe for concurrent readers while the next one is being constructed.
+	oldSnapshot := a.weights.Load()
+	var oldWeights map[string]float64
+	if oldSnapshot != nil {
+		oldWeights = oldSnapshot.byProvider
+	}
 
 	newWeights := make(map[string]float64, len(rawScores))
 	for pid, raw := range rawScores {
 		calculated := raw / totalRaw
-		old := a.weights[pid]
+		old := oldWeights[pid]
 		if old <= 0 {
 			// First time: use calculated directly.
 			newWeights[pid] = calculated
@@ -240,5 +254,5 @@ func (a *AdaptiveStrategy) recalculateWeights() {
 		}
 	}
 
-	a.weights = newWeights
+	a.weights.Store(&adaptiveWeightSnapshot{byProvider: newWeights})
 }

--- a/agentcc-gateway/internal/routing/adaptive_bench_test.go
+++ b/agentcc-gateway/internal/routing/adaptive_bench_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Future AGI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package routing
+
+import "testing"
+
+func BenchmarkAdaptiveSelect(b *testing.B) {
+	s := newActiveAdaptiveStrategy(map[string]float64{
+		"provider-a": 0.7,
+		"provider-b": 0.2,
+		"provider-c": 0.1,
+	})
+	targets := []RoutingTarget{
+		{ProviderID: "provider-a", Healthy: true},
+		{ProviderID: "provider-b", Healthy: true},
+		{ProviderID: "provider-c", Healthy: true},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = s.Select(targets, nil)
+	}
+}
+
+func BenchmarkAdaptiveSelectParallel(b *testing.B) {
+	s := newActiveAdaptiveStrategy(map[string]float64{
+		"provider-a": 0.7,
+		"provider-b": 0.2,
+		"provider-c": 0.1,
+	})
+	targets := []RoutingTarget{
+		{ProviderID: "provider-a", Healthy: true},
+		{ProviderID: "provider-b", Healthy: true},
+		{ProviderID: "provider-c", Healthy: true},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = s.Select(targets, nil)
+		}
+	})
+}

--- a/agentcc-gateway/internal/routing/adaptive_test.go
+++ b/agentcc-gateway/internal/routing/adaptive_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Future AGI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package routing
+
+import (
+	"sync"
+	"testing"
+)
+
+func newActiveAdaptiveStrategy(weights map[string]float64) *AdaptiveStrategy {
+	s := &AdaptiveStrategy{minWeight: 0.05}
+	s.weights.Store(&adaptiveWeightSnapshot{byProvider: weights})
+	s.phase.Store(1)
+	return s
+}
+
+func TestAdaptiveSelectActiveRespectsWeights(t *testing.T) {
+	s := newActiveAdaptiveStrategy(map[string]float64{
+		"provider-a": 0.7,
+		"provider-b": 0.2,
+		"provider-c": 0.1,
+	})
+	targets := []RoutingTarget{
+		{ProviderID: "provider-a", Healthy: true},
+		{ProviderID: "provider-b", Healthy: true},
+		{ProviderID: "provider-c", Healthy: true},
+	}
+
+	counts := make([]int, len(targets))
+	for range 100_000 {
+		idx, err := s.Select(targets, nil)
+		if err != nil {
+			t.Fatalf("Select() error = %v", err)
+		}
+		if idx < 0 || idx >= len(targets) {
+			t.Fatalf("Select() index = %d, want [0, %d)", idx, len(targets))
+		}
+		counts[idx]++
+	}
+
+	if !(counts[0] > counts[1] && counts[1] > counts[2]) {
+		t.Fatalf("selection counts = %v, want provider-a > provider-b > provider-c", counts)
+	}
+}
+
+func TestAdaptiveSelectActiveDoesNotAllocate(t *testing.T) {
+	s := newActiveAdaptiveStrategy(map[string]float64{
+		"provider-a": 0.7,
+		"provider-b": 0.2,
+		"provider-c": 0.1,
+	})
+	targets := []RoutingTarget{
+		{ProviderID: "provider-a", Healthy: true},
+		{ProviderID: "provider-b", Healthy: true},
+		{ProviderID: "provider-c", Healthy: true},
+	}
+
+	allocs := testing.AllocsPerRun(1_000, func() {
+		_, _ = s.Select(targets, nil)
+	})
+	if allocs != 0 {
+		t.Fatalf("Select() allocations = %v, want 0", allocs)
+	}
+}
+
+func TestAdaptiveGetWeightsReturnsCopy(t *testing.T) {
+	s := newActiveAdaptiveStrategy(map[string]float64{"provider-a": 1})
+
+	got := s.GetWeights()
+	got["provider-a"] = 0
+	got["provider-b"] = 1
+
+	want := s.GetWeights()
+	if want["provider-a"] != 1 {
+		t.Fatalf("provider-a weight = %v, want 1", want["provider-a"])
+	}
+	if _, ok := want["provider-b"]; ok {
+		t.Fatal("GetWeights() result mutated the published snapshot")
+	}
+}
+
+func TestAdaptiveSelectConcurrentSnapshotUpdates(t *testing.T) {
+	s := newActiveAdaptiveStrategy(map[string]float64{
+		"provider-a": 0.7,
+		"provider-b": 0.3,
+	})
+	targets := []RoutingTarget{
+		{ProviderID: "provider-a", Healthy: true},
+		{ProviderID: "provider-b", Healthy: true},
+	}
+	snapshots := []*adaptiveWeightSnapshot{
+		{byProvider: map[string]float64{"provider-a": 0.7, "provider-b": 0.3}},
+		{byProvider: map[string]float64{"provider-a": 0.2, "provider-b": 0.8}},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(9)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10_000; i++ {
+			s.weights.Store(snapshots[i%len(snapshots)])
+		}
+	}()
+	for range 8 {
+		go func() {
+			defer wg.Done()
+			for range 10_000 {
+				idx, err := s.Select(targets, nil)
+				if err != nil {
+					t.Errorf("Select() error = %v", err)
+					return
+				}
+				if idx < 0 || idx >= len(targets) {
+					t.Errorf("Select() index = %d, want [0, %d)", idx, len(targets))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Adaptive routing currently takes an `RWMutex` read lock and allocates a temporary target-weight slice on every active-phase selection. This change publishes recalculated weights as immutable atomic snapshots, allowing requests to select a provider without locking or per-call allocation. Routing weights, smoothing, and external behavior remain unchanged.

## Linked issues

None.

## Type of change

- [x] 🚀 Performance improvement

---

## 1) What changes were done

**A. Adaptive routing hot path**

- Replace the mutable weight map and `RWMutex` with an immutable snapshot published through `atomic.Pointer`.
- Load one stable snapshot for each selection.
- Replace the temporary weighted-target slice with two direct scans over the available targets.
- Use `math/rand/v2` and bypass random selection when only one target is available.

**B. Weight recalculation**

- Build and normalize the next weight map privately.
- Publish the completed map in one atomic store.
- Keep `GetWeights` isolated by returning a copy of the published snapshot.

**C. Coverage and benchmarks**

- Add allocation, weighted-distribution, snapshot-isolation, and concurrent-update tests.
- Add serial and parallel adaptive-selection benchmarks.

---

## 2) Why the changes were done

- **Technical:** `Select` runs once per routed request, while weight recalculation runs periodically. Reader-side locking and allocation therefore put synchronization and GC work on the higher-frequency path.
- **Architecture:** Immutable snapshots move synchronization to publication time and let concurrent request handlers share a stable view of the current weights.

---

## 3) Tests written + scenarios each covers

**`internal/routing/adaptive_test.go`**

- `TestAdaptiveSelectActiveRespectsWeights` — verifies the configured ordering is reflected in selection counts.
- `TestAdaptiveSelectActiveDoesNotAllocate` — requires zero allocations per active-phase selection.
- `TestAdaptiveGetWeightsReturnsCopy` — verifies callers cannot mutate the published snapshot.
- `TestAdaptiveSelectConcurrentSnapshotUpdates` — exercises selection while snapshots are replaced concurrently.

**`internal/routing/adaptive_bench_test.go`**

- `BenchmarkAdaptiveSelect` — measures the serial hot path.
- `BenchmarkAdaptiveSelectParallel` — measures concurrent selection.

> Local status: files are formatted and `git diff --check` is clean. Go tests were not run locally because the current environment does not include a Go toolchain; the PR is draft pending CI.

---

## 4) How to run / test

```bash
cd agentcc-gateway
go test ./internal/routing -count=1
go test -race ./internal/routing -count=1
go test -bench=AdaptiveSelect -benchmem -run=^$ ./internal/routing
```

---

## 6) Edge cases & considerations

- The single-target path returns immediately without changing request accounting.
- Missing provider weights continue to use `minWeight`.
- A recalculation is never visible until normalization is complete.
- `GetWeights` preserves its copy-on-read behavior.
- No API, configuration, or routing-policy semantics change.

---

## 8) Architectural / important decisions

- **Immutable snapshots:** Weight updates are infrequent compared with selections, so copy-on-publish keeps the request path read-only.
- **Two-pass selection:** Recomputing effective weights in the second scan avoids a temporary slice and its allocation.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that cover the change
- [ ] Gateway tests pass locally — pending CI
- [x] No frontend or API contract changes
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
