### PR TITLE
fix: preserve plaintext trace input/output in detail read path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ media/
 # Claude Code — per-user permissions (team agents under .claude/agents/ are tracked)
 .claude/settings.local.json
 **/.claude/settings.local.json
+.claude/CLAUDE.md
 
 # MCP server configs — local dev tooling, not shipped with the repo.
 # If we ever expose a hosted product MCP, that config goes at repo root

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -152,6 +152,14 @@ def retrieve_trace_detail_ch(
         except (ValueError, TypeError):
             return default
 
+    def _parse_content(val):
+        if not isinstance(val, str) or not val:
+            return _parse_json(val)
+        try:
+            return _json.loads(val)
+        except (ValueError, TypeError):
+            return val
+
     for row in result.data:
         span_id = str(row.get("id", ""))
         parent_id = row.get("parent_span_id")
@@ -199,8 +207,8 @@ def retrieve_trace_detail_ch(
             "observation_type": row.get("observation_type"),
             "start_time": row.get("start_time"),
             "end_time": row.get("end_time"),
-            "input": _parse_json(row.get("input")),
-            "output": _parse_json(row.get("output")),
+            "input": _parse_content(row.get("input")),
+            "output": _parse_content(row.get("output")),
             "model": row.get("model"),
             "model_parameters": _parse_json(row.get("model_parameters")),
             "latency_ms": row.get("latency_ms"),

--- a/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
+++ b/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
@@ -208,6 +208,43 @@ class TestV2SynthesisFromRootSpan:
 
 
 # --------------------------------------------------------------------------- #
+# 2a) input/output parsing: JSON parses to objects; plaintext is preserved
+# --------------------------------------------------------------------------- #
+class TestV2InputOutputParsing:
+    """Regression: bare plaintext input/output (e.g. voice transcripts) used to
+    be dropped to {} by json.loads; it must be preserved as the raw string."""
+
+    def _span(self, **row_overrides):
+        analytics = _FakeAnalytics(
+            project_rows=[{"project_id": "P1"}],
+            span_rows=[_root_span_row(**row_overrides)],
+        )
+        with ExitStack() as stack:
+            _patch_v2_pg(stack, project_accessible=True, pg_trace=None)
+            result = retrieve_trace_detail_ch(
+                MagicMock(), MagicMock(), "T1", analytics
+            )
+        return result
+
+    def test_json_input_output_parsed_to_objects(self):
+        result = self._span(input='{"q": "hi"}', output='{"a": "yo"}')
+        span = result["observation_spans"][0]["observation_span"]
+        assert span["input"] == {"q": "hi"}
+        assert span["output"] == {"a": "yo"}
+
+    def test_plaintext_input_output_preserved(self):
+        text_in = "What's on my calendar this afternoon?"
+        text_out = "You have a 3pm meeting."
+        result = self._span(input=text_in, output=text_out)
+        span = result["observation_spans"][0]["observation_span"]
+        assert span["input"] == text_in  # not {}
+        assert span["output"] == text_out
+        # synthesized trace envelope inherits the same raw text
+        assert result["trace"]["input"] == text_in
+        assert result["trace"]["output"] == text_out
+
+
+# --------------------------------------------------------------------------- #
 # 2b) span_attributes = typed maps ∪ attributes_extra
 # --------------------------------------------------------------------------- #
 class TestV2SpanAttributesMerge:


### PR DESCRIPTION
## Summary

Trace detail pane showed empty `{}` for spans whose `input`/`output` is plain text (e.g. voice transcripts). The v2 ClickHouse trace-detail read path ran `json.loads` on these columns and, on failure, defaulted to `{}` — silently discarding any non-JSON string. This fixes the read path to fall back to the raw string, so plaintext input/output renders correctly. ClickHouse held the data the whole time; only the detail read was lossy.

## Linked issues

Fixed TH-7255

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Preserve plaintext `input`/`output` in the v2 trace-detail read path**

- **User-facing:** span detail Input/Output now show plain-text values (voice transcripts, bare strings) instead of an empty `{}`.
- **Internal:** added a `_parse_content` helper in `tracer/services/clickhouse/v2/query_builders/trace_detail.py` and used it for `input`/`output` only. It parses JSON when the value is JSON (so structured `{...}`/`[...]` payloads still render as objects) and falls back to the raw string otherwise. `metadata`, `model_parameters`, `tags`, `span_events` keep the existing `_parse_json` (they are genuinely structured and the frontend spreads `metadata`).
- The trace-level envelope inherits the fix automatically (it reads the same span dict), so no second change site.

**B. Chore**

- Add `.claude/CLAUDE.md` to `.gitignore`.

---

## 2) Why the changes were done

- **Product/UX:** plaintext I/O silently rendered as `{}`, making traces look empty while the list column showed the text — an inconsistent, broken detail view.
- **Technical:** root cause is `_parse_json(..., default={})` at the input/output call sites: `json.loads("Hi there!")` raises, so the value collapsed to `{}`. The collector stores plain strings **bare** (`overflowAsString` passes strings through un-quoted), so any non-JSON value hit this path. Fixing at the read layer needs no data migration and keeps the list column (which already passes strings through) consistent with the detail pane.
- **Scope:** audited all other input/output readers — `span_reader._maybe_json` and `eval_loader._decode` already fall back to the raw string; this was the only lossy path.

---

## 3) Tests written + scenarios each covers

**`tracer/tests/test_ch25_trace_detail_v2.py`** — v2 trace-detail read path (in-memory fakes, no live CH)

- `TestV2InputOutputParsing::test_json_input_output_parsed_to_objects` — JSON `input`/`output` still parse to dict/list.
- `TestV2InputOutputParsing::test_plaintext_input_output_preserved` — bare plaintext is preserved (not `{}`) at both span and trace-envelope level.

> Run result: **19 passed** in `test_ch25_trace_detail_v2.py` (2 new + 17 existing). Also verified end-to-end against live ClickHouse: span `5feed8cea6734d5d` (`input="4rgvt"`, `output="Hi there!"`) renders `{}` on the old code and the real text with the fix.

---

## 6) Edge cases & considerations

- **Structured LLM payloads** (`{"messages":[...]}`): still parsed to objects — the collector JSON-encodes non-string values, so `json.loads` round-trips them unchanged.
- **Empty / None input**: unchanged — delegates to `_parse_json` (`{}`), matching prior frontend expectations.
- **JSON-encoded strings** (`"\"hi\""`): still unquoted to `hi`, same as before.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `bin/test app tracer` shows a large number of failures in `tracer/tests/integration/test_list_endpoints_filter_count.py` (and a few CH integration tests). These are a pre-existing test-isolation issue (session-scoped, committed corpus vs sibling `transaction=True` tests that `TRUNCATE CASCADE` the shared DB) — the file passes 1279/0 in isolation. Unrelated to this change; tracked separately.

---

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — see Pre-existing issues (unrelated infra flakiness)
- [ ] `yarn test:run` passes locally (frontend) — N/A, backend-only change
- [x] `yarn contracts:check` — N/A, no API surface change
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked
