### PR TITLE
fix(oss): size gateway key dialog inputs and stop browser autofill highlight [TH-7272]

### DIFF
--- a/frontend/src/sections/gateway/keys/CreateKeyDialog.jsx
+++ b/frontend/src/sections/gateway/keys/CreateKeyDialog.jsx
@@ -79,6 +79,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
             </Alert>
             <TextField
               fullWidth
+              size="small"
               value={createdKey}
               InputProps={{
                 readOnly: true,
@@ -111,7 +112,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button variant="contained" onClick={handleClose}>
+          <Button size="small" variant="contained" onClick={handleClose}>
             Done
           </Button>
         </DialogActions>
@@ -128,6 +129,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
             label="Name"
             fullWidth
             required
+            size="small"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., production-key"
@@ -135,6 +137,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
           <TextField
             label="Owner"
             fullWidth
+            size="small"
             value={owner}
             onChange={(e) => setOwner(e.target.value)}
             placeholder="e.g., team-backend"
@@ -142,6 +145,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
           <Autocomplete
             multiple
             freeSolo
+            size="small"
             options={[]}
             value={allowedModels}
             onChange={(_, val) => setAllowedModels(val)}
@@ -167,6 +171,7 @@ const CreateKeyDialog = ({ open, onClose, gatewayId }) => {
           <Autocomplete
             multiple
             freeSolo
+            size="small"
             options={[]}
             value={allowedProviders}
             onChange={(_, val) => setAllowedProviders(val)}

--- a/frontend/src/sections/gateway/keys/EditKeyDialog.jsx
+++ b/frontend/src/sections/gateway/keys/EditKeyDialog.jsx
@@ -62,18 +62,21 @@ const EditKeyDialog = ({ open, onClose, keyData }) => {
             label="Name"
             fullWidth
             required
+            size="small"
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
           <TextField
             label="Owner"
             fullWidth
+            size="small"
             value={owner}
             onChange={(e) => setOwner(e.target.value)}
           />
           <Autocomplete
             multiple
             freeSolo
+            size="small"
             options={[]}
             value={allowedModels}
             onChange={(_, val) => setAllowedModels(val)}
@@ -99,6 +102,7 @@ const EditKeyDialog = ({ open, onClose, keyData }) => {
           <Autocomplete
             multiple
             freeSolo
+            size="small"
             options={[]}
             value={allowedProviders}
             onChange={(_, val) => setAllowedProviders(val)}
@@ -129,8 +133,11 @@ const EditKeyDialog = ({ open, onClose, keyData }) => {
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button size="small" onClick={onClose}>
+          Cancel
+        </Button>
         <Button
+          size="small"
           variant="contained"
           onClick={handleSave}
           disabled={!name.trim() || updateMutation.isPending}

--- a/frontend/src/theme/index.jsx
+++ b/frontend/src/theme/index.jsx
@@ -78,6 +78,7 @@ export default function ThemeProvider({ children }) {
     s.setProperty("--bg-neutral", p.background.neutral);
     s.setProperty("--bg-subtle", p.background.subtle);
     s.setProperty("--bg-elevated", p.background.neutral);
+    s.setProperty("--input-surface", p.background.paper);
     s.setProperty("--text-primary", p.text.primary);
     s.setProperty("--text-secondary", p.text.secondary);
     s.setProperty("--text-muted", p.text.muted);

--- a/frontend/src/theme/overrides/components/textfield.js
+++ b/frontend/src/theme/overrides/components/textfield.js
@@ -73,9 +73,21 @@ export function textField(theme) {
         },
         input: {
           ...font.value,
+          colorScheme: theme.palette.mode,
           "&::placeholder": {
             opacity: 0.5,
             color: color.placeholder,
+          },
+          "&:-webkit-autofill, &:-webkit-autofill:hover, &:-webkit-autofill:focus, &:-webkit-autofill:active":
+            {
+              WebkitBoxShadow: `0 0 0 1000px var(--input-surface, ${theme.palette.background.paper}) inset !important`,
+              WebkitTextFillColor: `${theme.palette.text.primary} !important`,
+              caretColor: theme.palette.text.primary,
+            },
+          "&:autofill, &:autofill:hover, &:autofill:focus, &:autofill:active": {
+            boxShadow: `0 0 0 1000px var(--input-surface, ${theme.palette.background.paper}) inset`,
+            WebkitTextFillColor: `${theme.palette.text.primary} !important`,
+            caretColor: theme.palette.text.primary,
           },
         },
       },

--- a/frontend/src/theme/overrides/dark-elevated.js
+++ b/frontend/src/theme/overrides/dark-elevated.js
@@ -21,6 +21,7 @@ export function darkElevatedStyles(theme, { boxShadow, borderOnly } = {}) {
   return {
     border: `1px solid ${border}`,
     backgroundColor: theme.palette.background.neutral,
+    "--input-surface": theme.palette.background.neutral,
     backgroundImage: "none",
     boxShadow: boxShadow || "0px 12px 32px -4px rgba(0, 0, 0, 0.6)",
   };


### PR DESCRIPTION
**Ticket:** [TH-7272](https://linear.app/future-agi/issue/TH-7272/oss-gateway-create-api-key-text-fields-are-not-according-to-the-design) — Closes TH-7272

## What was the bug

In OSS, the Gateway → API Keys → **Create API Key** dialog had two problems:

1. Its text fields were noticeably taller than inputs everywhere else in the app.
2. A solid blue block appeared over a field when the browser offered/applied an autofill value.

There is no Figma for this dialog. Per Vel on the ticket, the acceptance criteria are just "field height should match the rest of the app" and "the blue should not be there".

## What changes have been done

- `frontend/src/sections/gateway/keys/CreateKeyDialog.jsx` — `size="small"` on the Name and Owner fields, both `Autocomplete`s, the generated-key field in the success step, and the dialog action buttons.
- `frontend/src/sections/gateway/keys/EditKeyDialog.jsx` — same treatment; it shared both defects.
- `frontend/src/theme/overrides/components/textfield.js` — masks the browser autofill background on `MuiInputBase.input` via an inset shadow, and sets `colorScheme: theme.palette.mode` on inputs.
- `frontend/src/theme/index.jsx` — new `--input-surface` CSS variable, defaulting to `background.paper`.
- `frontend/src/theme/overrides/dark-elevated.js` — re-points `--input-surface` to `background.neutral` on elevated surfaces.

## Why the changes

- **Height.** The fields were bare MUI `TextField`s with no `size` prop, so they rendered at MUI's default `medium` (~56px) instead of the app's ~40px. There is no global `MuiTextField` default in the theme (`defaultProps.jsx` sets `size: "small"` only for Slider/Checkbox/Radio), so each call site passes it explicitly. 531 of the 654 state-driven `TextField` elements in `src` already do; these dialogs were part of the minority that didn't.
- **Blue, and why the fix is in the theme.** Chromium paints its own background over autofilled inputs with a UA `!important` rule. Every autofill override in the codebase today lives inside an RHF wrapper (`rhf-text-field.jsx`, `FormTextFieldV2.jsx`) or a one-off, so only RHF-backed fields were ever protected — **none** of the 214 files with state-driven `TextField`s carried any autofill CSS. Fixing it at `MuiInputBase` covers every input, including the raw ones people will keep writing, instead of protecting only fields that adopt a wrapper.
- **Why a CSS variable.** The mask needs the colour of the surface the input sits on. Elevated surfaces (dialogs, popovers, menus) paint `background.neutral` in dark mode while the rest of the app uses `background.paper`, so a hardcoded colour would leave a visibly wrong rectangle inside dialogs. `--input-surface` tracks whichever surface applies.
- **Why `color-scheme`.** The app declares `color-scheme` nowhere, so Chromium rendered its autofill UI with light-scheme colours (the background it applied measured `rgb(232,240,254)`), including a dark-grey preview text intended to sit on that light blue. Once the mask darkened the field, that preview text became unreadable. Declaring the scheme on inputs makes Chromium pick dark-appropriate colours for its own UI. It is scoped to inputs, not `html`/`body`, so scrollbars and other native widgets are unaffected.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Open Create API Key | Fields are ~40px, matching other dialogs in the app |
| 2 | Focus Name/Owner with a saved browser autofill entry | Suggestion dropdown appears, no blue block on the field |
| 3 | Hover / arrow onto a suggestion | Preview text is legible against the dark field |
| 4 | Click a suggestion | Value renders in normal text colour and Create becomes enabled (value reaches React state) |
| 5 | Create a key | Success step renders; generated-key field is small; copy still works |
| 6 | Open Edit API Key on an existing key | Values prefill, fields are small, save round-trips unchanged |
| 7 | Autofill on any other form (e.g. login) | Same masked behaviour, in both light and dark |

## How to reproduce (original bug)

1. Run the stack in OSS mode and go to `/dashboard/gateway/keys`.
2. Click **Create Key**.
3. Note the field heights against any other dialog in the app.
4. Focus Owner with a browser-saved value for it and hover the suggestion — the field fills solid blue.

## Commands

```bash
cd frontend && yarn dev   # http://localhost:3100
```

## Videos and screenshots

<img width="1030" height="779" alt="Screenshot 2026-08-04 at 4 17 12 PM" src="https://github.com/user-attachments/assets/bf34f6f2-1d73-4805-a3db-f653447750bc" />
<img width="1185" height="684" alt="Screenshot 2026-08-04 at 4 16 41 PM" src="https://github.com/user-attachments/assets/9854b5b7-5369-4176-9a79-ed1f13e2ca62" />
<img width="1064" height="694" alt="Screenshot 2026-08-04 at 4 16 28 PM" src="https://github.com/user-attachments/assets/aa93bc0e-e843-4365-bfed-068b8ffbd826" />