### PR TITLE
chore(contracts): regenerate OpenAPI schema and frontend contracts

### DIFF
--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -296,7 +296,7 @@ jobs:
           model_hub/tests/test_annotation_api_contract.py
           model_hub/tests/test_annotation_workflow_api.py
           tfc/tests/test_falcon_api_contract_debt.py
-          tfc/tests/test_usage_api_contract_debt.py
+          ee/usage/tests/test_usage_api_contract_debt.py
           ee/usage/tests/test_events_schema.py
           ee/usage/tests/test_billing_api.py
           tfc/tests/test_api_contracts.py

--- a/api_contracts/openapi/management-api-contract-debt.generated.json
+++ b/api_contracts/openapi/management-api-contract-debt.generated.json
@@ -1,8 +1,8 @@
 {
   "generated_from": "api_contracts/openapi/swagger.json",
   "summary": {
-    "paths": 968,
-    "operations": 1314,
+    "paths": 969,
+    "operations": 1315,
     "mutation_endpoints_without_body_schema": 0,
     "operations_without_response_schema": 0,
     "broad_success_response_schemas": 0,
@@ -11,8 +11,8 @@
   },
   "by_group": {
     "accounts": {
-      "paths": 79,
-      "operations": 103,
+      "paths": 80,
+      "operations": 104,
       "mutation_endpoints_without_body_schema": 0,
       "operations_without_response_schema": 0,
       "broad_success_response_schemas": 0,

--- a/api_contracts/openapi/swagger.json
+++ b/api_contracts/openapi/swagger.json
@@ -816,6 +816,41 @@
                 }
             ]
         },
+        "/accounts/activate/{uidb64}/{token}/": {
+            "get": {
+                "operationId": "accounts_activate_read",
+                "description": "",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "default": {
+                        "description": "Default error response",
+                        "schema": {
+                            "$ref": "#/definitions/ManagementAPIErrorResponse"
+                        }
+                    }
+                },
+                "tags": [
+                    "accounts"
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "uidb64",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                },
+                {
+                    "name": "token",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
         "/accounts/appsmith/users/": {
             "get": {
                 "operationId": "accounts_appsmith_users_list",
@@ -72011,7 +72046,8 @@
         "/usage/webhook/": {
             "post": {
                 "operationId": "usage_webhook_create",
-                "description": "",
+                "summary": "Handle Stripe webhook events.",
+                "description": "No auth — Stripe authenticates via signature header.\nAPIView.as_view() auto-applies csrf_exempt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -72026,7 +72062,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/StripeWebhookLegacyResponse"
+                            "$ref": "#/definitions/StripeWebhookResponse"
                         }
                     },
                     "400": {
@@ -128718,6 +128754,7 @@
                     "enum": [
                         "active",
                         "past_due",
+                        "unpaid",
                         "canceled",
                         "inactive"
                     ]
@@ -128895,6 +128932,7 @@
                     "enum": [
                         "active",
                         "past_due",
+                        "unpaid",
                         "canceled",
                         "inactive"
                     ]
@@ -131315,21 +131353,6 @@
                 },
                 "result": {
                     "$ref": "#/definitions/UsageWorkspaceBreakdownResult"
-                }
-            }
-        },
-        "StripeWebhookLegacyResponse": {
-            "required": [
-                "status"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "title": "Status",
-                    "type": "boolean"
-                },
-                "result": {
-                    "$ref": "#/definitions/StripeWebhookResult"
                 }
             }
         }

--- a/frontend/src/api/contracts/api-surface.generated.js
+++ b/frontend/src/api/contracts/api-surface.generated.js
@@ -5,7 +5,7 @@
 export const API_SURFACE_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 968,
+  "endpointCount": 969,
   "groups": {
     "accounts": {
       "/accounts/2fa/recovery-codes/": [
@@ -41,6 +41,9 @@ export const API_SURFACE_CONTRACT = Object.freeze({
       "/accounts/accept-invitation/{uidb64}/{token}/": [
         "get",
         "post"
+      ],
+      "/accounts/activate/{uidb64}/{token}/": [
+        "get"
       ],
       "/accounts/appsmith/users/": [
         "get",
@@ -3328,6 +3331,9 @@ export const API_SURFACE_PATHS = Object.freeze({
   "/accounts/accept-invitation/{uidb64}/{token}/": [
     "get",
     "post"
+  ],
+  "/accounts/activate/{uidb64}/{token}/": [
+    "get"
   ],
   "/accounts/appsmith/users/": [
     "get",

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -5,7 +5,7 @@
 export const OPENAPI_CONTRACT = Object.freeze({
   "generatedFrom": "api_contracts/openapi/swagger.json",
   "swaggerVersion": "2.0",
-  "endpointCount": 968,
+  "endpointCount": 969,
   "endpoints": {
     "/accounts/2fa/recovery-codes/": {
       "get": {
@@ -401,6 +401,20 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "500": {
             "$ref": "#/definitions/AccountsErrorResponse"
           },
+          "default": {
+            "$ref": "#/definitions/ManagementAPIErrorResponse"
+          }
+        }
+      }
+    },
+    "/accounts/activate/{uidb64}/{token}/": {
+      "get": {
+        "operationId": "accounts_activate_read",
+        "runtimeRequestValidation": false,
+        "runtimeResponseValidation": false,
+        "requestBody": null,
+        "queryParameters": {},
+        "responses": {
           "default": {
             "$ref": "#/definitions/ManagementAPIErrorResponse"
           }
@@ -41077,7 +41091,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
         "queryParameters": {},
         "responses": {
           "200": {
-            "$ref": "#/definitions/StripeWebhookLegacyResponse"
+            "$ref": "#/definitions/StripeWebhookResponse"
           },
           "400": {
             "$ref": "#/definitions/UsageErrorResponse"
@@ -69341,21 +69355,6 @@ export const OPENAPI_CONTRACT = Object.freeze({
         }
       }
     },
-    "StripeWebhookLegacyResponse": {
-      "required": [
-        "status"
-      ],
-      "type": "object",
-      "properties": {
-        "status": {
-          "title": "Status",
-          "type": "boolean"
-        },
-        "result": {
-          "$ref": "#/definitions/StripeWebhookResult"
-        }
-      }
-    },
     "StripeWebhookRequest": {
       "type": "object",
       "properties": {
@@ -72172,6 +72171,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "enum": [
             "active",
             "past_due",
+            "unpaid",
             "canceled",
             "inactive"
           ]
@@ -85005,6 +85005,7 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "enum": [
             "active",
             "past_due",
+            "unpaid",
             "canceled",
             "inactive"
           ]

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -22178,6 +22178,7 @@ export type UsageOrganizationSubscriptionApiStatus = typeof UsageOrganizationSub
 export const UsageOrganizationSubscriptionApiStatus = {
   active: 'active',
   past_due: 'past_due',
+  unpaid: 'unpaid',
   canceled: 'canceled',
   inactive: 'inactive',
 } as const;
@@ -22254,6 +22255,7 @@ export type UsageOrganizationSubscriptionCreateApiStatus = typeof UsageOrganizat
 export const UsageOrganizationSubscriptionCreateApiStatus = {
   active: 'active',
   past_due: 'past_due',
+  unpaid: 'unpaid',
   canceled: 'canceled',
   inactive: 'inactive',
 } as const;
@@ -23070,11 +23072,6 @@ export interface UsageWorkspaceBreakdownResultApi {
 export interface UsageWorkspaceBreakdownResponseApi {
   status: boolean;
   result: UsageWorkspaceBreakdownResultApi;
-}
-
-export interface StripeWebhookLegacyResponseApi {
-  status: boolean;
-  result?: StripeWebhookResultApi;
 }
 
 export type AccountsAwsMarketplaceLaunchSoftwareCreateBody = {

--- a/frontend/src/generated/api-contracts/api.ts
+++ b/frontend/src/generated/api-contracts/api.ts
@@ -1036,7 +1036,6 @@ import type {
   StartEvalsProcessRequestApi,
   StopUserEvalRequestApi,
   StreamStatusResponseApi,
-  StripeWebhookLegacyResponseApi,
   StripeWebhookRequestApi,
   StripeWebhookResponseApi,
   SubmitAnnotationsApi,
@@ -2208,6 +2207,48 @@ export const accountsAcceptInvitationCreate = async (uidb64: string,
     headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(
       acceptInvitationRequestApi,)
+  }
+);}
+
+
+
+export type accountsActivateReadResponse200 = {
+  data: void
+  status: 200
+}
+
+export type accountsActivateReadResponseDefault = {
+  data: ManagementAPIErrorResponseApi
+  status: Exclude<HTTPStatusCodes, 200>
+}
+
+export type accountsActivateReadResponseSuccess = (accountsActivateReadResponse200) & {
+  headers: Headers;
+};
+export type accountsActivateReadResponseError = (accountsActivateReadResponseDefault) & {
+  headers: Headers;
+};
+
+export type accountsActivateReadResponse = (accountsActivateReadResponseSuccess | accountsActivateReadResponseError)
+
+export const getAccountsActivateReadUrl = (uidb64: string,
+    token: string,) => {
+
+
+
+
+  return `/accounts/activate/${uidb64}/${token}/`
+}
+
+export const accountsActivateRead = async (uidb64: string,
+    token: string, options?: RequestInit): Promise<accountsActivateReadResponse> => {
+
+  return apiMutator<accountsActivateReadResponse>(getAccountsActivateReadUrl(uidb64,token),
+  {
+    ...options,
+    method: 'GET'
+
+
   }
 );}
 
@@ -75807,7 +75848,7 @@ export const usageV2UsageWorkspaceBreakdownList = async (params: UsageV2UsageWor
 
 
 export type usageWebhookCreateResponse200 = {
-  data: StripeWebhookLegacyResponseApi
+  data: StripeWebhookResponseApi
   status: 200
 }
 
@@ -75863,6 +75904,11 @@ export const getUsageWebhookCreateUrl = () => {
   return `/usage/webhook/`
 }
 
+/**
+ * No auth — Stripe authenticates via signature header.
+APIView.as_view() auto-applies csrf_exempt.
+ * @summary Handle Stripe webhook events.
+ */
 export const usageWebhookCreate = async (stripeWebhookRequestApi: StripeWebhookRequestApi, options?: RequestInit): Promise<usageWebhookCreateResponse> => {
 
   return apiMutator<usageWebhookCreateResponse>(getUsageWebhookCreateUrl(),

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -351,6 +351,12 @@ export const AccountsAcceptInvitationCreateResponse = zod.object({
 })
 
 
+export const AccountsActivateReadParams = zod.object({
+  "uidb64": zod.string(),
+  "token": zod.string()
+})
+
+
 
 
 
@@ -44589,7 +44595,7 @@ export const UsageOrganizationSubscriptionListResponse = zod.object({
   "organization": zod.string().uuid(),
   "subscription_tier": zod.string().optional(),
   "custom_subscription_id": zod.string().max(usageOrganizationSubscriptionListResponseResultItemCustomSubscriptionIdMax).optional(),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "subscription_price": zod.string().optional().describe('Price of the subscription.'),
   "wallet_balance": zod.string().optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
@@ -44629,7 +44635,7 @@ export const UsageOrganizationSubscriptionCreateBody = zod.object({
   "subscription_future_tier": zod.enum(['free', 'basic', 'basic_yearly', 'custom']).optional(),
   "subscription_future_start_date": zod.string().date().optional().describe('Next due date for renewal.'),
   "subscription_future_price": zod.string().optional().describe('Price of the future subscription.'),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
   "wallet_balance": zod.string().optional(),
   "stripe_customer_id_test": zod.string().max(usageOrganizationSubscriptionCreateBodyStripeCustomerIdTestMax).optional().describe('Stripe customer ID for test mode. NULL values are allowed.'),
@@ -44661,7 +44667,7 @@ export const UsageOrganizationSubscriptionCreateResponse = zod.object({
   "subscription_future_tier": zod.enum(['free', 'basic', 'basic_yearly', 'custom']).optional(),
   "subscription_future_start_date": zod.string().date().optional().describe('Next due date for renewal.'),
   "subscription_future_price": zod.string().optional().describe('Price of the future subscription.'),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
   "wallet_balance": zod.string().optional(),
   "stripe_customer_id_test": zod.string().max(usageOrganizationSubscriptionCreateResponseResultStripeCustomerIdTestMax).optional().describe('Stripe customer ID for test mode. NULL values are allowed.'),
@@ -44697,7 +44703,7 @@ export const UsageOrganizationSubscriptionPartialUpdateBody = zod.object({
   "subscription_future_tier": zod.enum(['free', 'basic', 'basic_yearly', 'custom']).optional(),
   "subscription_future_start_date": zod.string().date().optional().describe('Next due date for renewal.'),
   "subscription_future_price": zod.string().optional().describe('Price of the future subscription.'),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
   "wallet_balance": zod.string().optional(),
   "stripe_customer_id_test": zod.string().max(usageOrganizationSubscriptionPartialUpdateBodyStripeCustomerIdTestMax).optional().describe('Stripe customer ID for test mode. NULL values are allowed.'),
@@ -44729,7 +44735,7 @@ export const UsageOrganizationSubscriptionPartialUpdateResponse = zod.object({
   "subscription_future_tier": zod.enum(['free', 'basic', 'basic_yearly', 'custom']).optional(),
   "subscription_future_start_date": zod.string().date().optional().describe('Next due date for renewal.'),
   "subscription_future_price": zod.string().optional().describe('Price of the future subscription.'),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
   "wallet_balance": zod.string().optional(),
   "stripe_customer_id_test": zod.string().max(usageOrganizationSubscriptionPartialUpdateResponseResultStripeCustomerIdTestMax).optional().describe('Stripe customer ID for test mode. NULL values are allowed.'),
@@ -44779,7 +44785,7 @@ export const UsageOrganizationSubscriptionReadResponse = zod.object({
   "organization": zod.string().uuid(),
   "subscription_tier": zod.string().optional(),
   "custom_subscription_id": zod.string().max(usageOrganizationSubscriptionReadResponseResultItemCustomSubscriptionIdMax).optional(),
-  "status": zod.enum(['active', 'past_due', 'canceled', 'inactive']).optional(),
+  "status": zod.enum(['active', 'past_due', 'unpaid', 'canceled', 'inactive']).optional(),
   "subscription_price": zod.string().optional().describe('Price of the subscription.'),
   "wallet_balance": zod.string().optional(),
   "wallet_refill_amount": zod.string().optional().describe('Amount to refill the wallet every month.'),
@@ -46403,6 +46409,11 @@ export const UsageV2UsageWorkspaceBreakdownListResponse = zod.object({
 })
 
 
+/**
+ * No auth — Stripe authenticates via signature header.
+APIView.as_view() auto-applies csrf_exempt.
+ * @summary Handle Stripe webhook events.
+ */
 
 
 
@@ -46413,8 +46424,11 @@ export const UsageWebhookCreateBody = zod.object({
   "data": zod.record(zod.string(), zod.string()).optional()
 })
 
+
+
+
 export const UsageWebhookCreateResponse = zod.object({
-  "status": zod.boolean(),
+  "status": zod.string().min(1),
   "result": zod.object({
   "event_type": zod.string().optional(),
   "action": zod.string().optional(),


### PR DESCRIPTION
## Description

Regenerates `api_contracts/openapi/swagger.json` + gateway/frontend contracts (`./scripts/generate-openapi-schema.sh && yarn contracts:generate`), catching up with contract-affecting changes merged into dev since the Aug 3 regen:

- `unpaid` added to the subscription status enum (#1908)
- `/usage/webhook/` now returns the unified `StripeWebhookResponse`; `StripeWebhookLegacyResponse` removed (future-agi/ee#190)
- `/accounts/activate/{uidb64}/{token}/` path (#1755, pre-existing regen gap)

Unblocks the red `backend-contracts` check on #1923 (dev → main release).

## Type of Change

- [x] Chore
