### PR TITLE
fix: make tracer tests green in OSS lane and against test CH database

### DIFF
--- a/futureagi/tracer/tests/test_ch25_typed_json_roundtrip.py
+++ b/futureagi/tracer/tests/test_ch25_typed_json_roundtrip.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover
 
 CH_HOST = os.environ.get("CH25_HOST", "127.0.0.1")
 CH_PORT = int(os.environ.get("CH25_HTTP_PORT", "19001"))
+CH_DATABASE = os.environ.get("CH25_DATABASE", "default")
 
 
 # NOTE (codex P3 finding 2026-05-26): the previous implementation called
@@ -278,10 +279,11 @@ def test_spans_table_attributes_extra_is_string(ch_client):
     """
     rows = ch_client.query(
         "SELECT type FROM system.columns "
-        "WHERE database = 'default' AND table = 'spans' "
-        "  AND name = 'attributes_extra'"
+        "WHERE database = %(db)s AND table = 'spans' "
+        "  AND name = 'attributes_extra'",
+        parameters={"db": CH_DATABASE},
     ).result_rows
-    assert rows, "spans.attributes_extra column missing"
+    assert rows, f"spans.attributes_extra column missing in database {CH_DATABASE!r}"
     actual_type = rows[0][0]
     assert actual_type == "String", (
         f"spans.attributes_extra is {actual_type!r}; expected 'String'. "
@@ -319,12 +321,15 @@ def test_spans_table_typed_json_contract(ch_client):
     """
     rows = ch_client.query(
         "SELECT name, type FROM system.columns "
-        "WHERE database = 'default' AND table = 'spans' "
-        "  AND name IN ('attributes_extra', 'resource_attrs', 'metadata')"
+        "WHERE database = %(db)s AND table = 'spans' "
+        "  AND name IN ('attributes_extra', 'resource_attrs', 'metadata')",
+        parameters={"db": CH_DATABASE},
     ).result_rows
     actual = {name: type_ for name, type_ in rows}
     missing = set(_EXPECTED_SPANS_TYPES) - set(actual)
-    assert not missing, f"spans table missing columns: {sorted(missing)}"
+    assert not missing, (
+        f"spans table missing columns {sorted(missing)} in database {CH_DATABASE!r}"
+    )
     for col, (kind, expected) in _EXPECTED_SPANS_TYPES.items():
         got = actual[col]
         if kind == "exact":
@@ -345,9 +350,10 @@ def test_spans_table_typed_json_contract(ch_client):
     # which embeds the column-level codec and default in the table DDL.
     ddl_rows = ch_client.query(
         "SELECT create_table_query FROM system.tables "
-        "WHERE database = 'default' AND name = 'spans'"
+        "WHERE database = %(db)s AND name = 'spans'",
+        parameters={"db": CH_DATABASE},
     ).result_rows
-    assert ddl_rows, "spans table missing from system.tables"
+    assert ddl_rows, f"spans table missing from system.tables in database {CH_DATABASE!r}"
     ddl = ddl_rows[0][0]
     # Be tolerant of CH's DDL canonicalization (whitespace, quoting) but pin
     # both substrings — if either is missing, the column was re-created

--- a/futureagi/tracer/tests/test_datetime_filters.py
+++ b/futureagi/tracer/tests/test_datetime_filters.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     APICallLog = None
 
+pytestmark = pytest.mark.requires_ee
+
 
 def _make_datetime_filter(filter_op, filter_value, column_id="created_at"):
     """Helper to build a datetime filter payload."""

--- a/futureagi/tracer/tests/test_grpc_otlp.py
+++ b/futureagi/tracer/tests/test_grpc_otlp.py
@@ -8,6 +8,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from google.protobuf.json_format import MessageToJson
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -61,6 +62,7 @@ def create_test_otlp_request(num_spans: int = 1) -> ExportTraceServiceRequest:
     return request
 
 
+@pytest.mark.requires_ee
 class TestObservationSpanServiceUnit:
     """Unit tests for ObservationSpanService gRPC service."""
 

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -79,6 +79,7 @@ class TestUserAlertMonitorCreateAPI:
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @pytest.mark.requires_ee
     def test_create_monitor_success(self, auth_client, observe_project):
         """Create a new user alert monitor."""
         response = auth_client.post(
@@ -98,6 +99,7 @@ class TestUserAlertMonitorCreateAPI:
         monitor = UserAlertMonitor.objects.get(name="Error Rate Alert")
         assert monitor.workspace_id == observe_project.workspace_id
 
+    @pytest.mark.requires_ee
     def test_create_monitor_rejects_other_workspace_project(
         self, auth_client, organization, user
     ):
@@ -124,6 +126,7 @@ class TestUserAlertMonitorCreateAPI:
             name="Cross Workspace Alert"
         ).exists()
 
+    @pytest.mark.requires_ee
     def test_create_monitor_with_slack_config(self, auth_client, observe_project):
         """Create monitor with Slack notification config."""
         response = auth_client.post(
@@ -142,6 +145,7 @@ class TestUserAlertMonitorCreateAPI:
         )
         assert response.status_code == status.HTTP_200_OK
 
+    @pytest.mark.requires_ee
     def test_create_monitor_accepts_canonical_span_attribute_filters(
         self, auth_client, observe_project
     ):
@@ -178,6 +182,7 @@ class TestUserAlertMonitorCreateAPI:
             "customer_tier"
         )
 
+    @pytest.mark.requires_ee
     def test_create_monitor_rejects_camel_case_span_attribute_filters(
         self, auth_client, observe_project
     ):


### PR DESCRIPTION
## Summary

Makes `bin/test app tracer` green in two situations where it previously failed: against the `bin/test`/CI ClickHouse (schema lives in `test_tfc`, not `default`), and in the **OSS lane** where the private `ee/` package is absent. Test-only change — no product code is touched.

## Linked issues

Linear: Fixed TH-7302

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test-only change

---

## 1) What changes were done

**A. CH25 spans-schema tests resolve the DB from `CH25_DATABASE` (not hardcoded `'default'`)**

- `tracer/tests/test_ch25_typed_json_roundtrip.py` queried `system.columns` / `system.tables` with `WHERE database = 'default'`. Under `bin/test` and CI the CH25 spans schema lives in `test_tfc`, so the queries returned zero rows and 2 tests reported columns "missing" that actually existed.
- Now reads `CH_DATABASE = os.environ.get("CH25_DATABASE", "default")` and parameterizes the three queries. `bin/test`/CI → `test_tfc`; bare migration rig (unset) → `default`, unchanged.

**B. `ee`-dependent tracer tests skip in the OSS lane via `@pytest.mark.requires_ee`**

- `test_datetime_filters.py` — imports `ee.usage.models.usage.APICallLog` (a real Django model). Module-level `pytestmark = pytest.mark.requires_ee`.
- `test_grpc_otlp.py::TestObservationSpanServiceUnit` — patches `ee.usage.services.rate_limiter`. Class-level marker (added missing `import pytest`).
- `test_monitor.py` create tests — monitor creation is EE-gated (`check_ee_can_create` → HTTP 402 when `is_oss()`). The 5 gated create tests are marked method-level, so the unauthenticated 401 check keeps running in OSS.

**C. Approach note**

- Used the repo's existing `requires_ee` marker (auto-skipped by `conftest.py` when `EE_AVAILABLE` is False), following the `accounts/tests/test_config_endpoint.py` precedent. Stubbing was rejected — `APICallLog` is a real model and the monitor 402 is intentional product behaviour (monitors are EE-only), so these tests must skip, not run.

---

## 2) Why the changes were done

- **Product/UX:** OSS contributors clone the public repo without the private `ee/` package; `bin/test app tracer` must pass for them, not error.
- **Technical:** the failures were test-only assumptions — a hardcoded DB name and missing `ee`-availability guards — not product defects. The fixes make both the DB target and the `ee` gating environment-aware.
- **Architecture:** reuses the established `requires_ee` marker + `conftest.py` auto-skip rather than inventing a new mechanism.

---

## 3) Tests written + scenarios each covers

No new tests; existing tracer tests are made environment-aware.

- `test_ch25_typed_json_roundtrip.py` — the 2 spans-schema contract tests now resolve `CH25_DATABASE`; pass under `bin/test`/CI and the migration rig.
- `test_datetime_filters.py` — skips in OSS (no `ee`), runs when `ee` present.
- `test_grpc_otlp.py::TestObservationSpanServiceUnit` — skips in OSS; `TestGRPCServiceConfiguration` still runs.
- `test_monitor.py::TestUserAlertMonitorCreateAPI` — 5 create tests skip in OSS; unauthenticated 401 check still runs.

> Run result: **OSS lane (ee absent) — 5276 passed, 103 skipped, 0 failed, 0 errors.** `ee` present — full suite green (marker is a no-op when `EE_AVAILABLE=True`). Both lanes tested.

---

## 4) How to run / test

```bash
cd futureagi
bin/test app tracer            # with ee/ present: requires_ee tests RUN
# remove/rename ee/ to simulate OSS: requires_ee tests SKIP, suite stays green
```

No API surface change, so no contract regeneration needed.
