### PR TITLE
fix(oss): upgrade-gate cropping, upload button label, numeric label zero [TH-7282, TH-7253, TH-7268]

### DIFF
--- a/frontend/src/components/feature-gate/FeatureGateOverlay.jsx
+++ b/frontend/src/components/feature-gate/FeatureGateOverlay.jsx
@@ -74,9 +74,7 @@ const FeatureGateOverlay = ({
         sx={{
           display: "block",
           width: "100%",
-          height: "100%",
-          minHeight,
-          objectFit: "cover",
+          height: "auto",
           objectPosition: "top center",
         }}
       />

--- a/frontend/src/sections/annotations/queues/annotate/label-input.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-input.jsx
@@ -710,7 +710,7 @@ function NumericInput({ settings, value, onChange, inputRef }) {
         inputRef={inputRef}
         type="number"
         size="small"
-        value={value ?? ""}
+        value={value ?? min}
         onChange={(e) => handleNumberChange(e.target.value)}
         inputProps={{ min, max, step }}
         sx={{

--- a/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
@@ -285,13 +285,7 @@ const UploadFileModal = ({ open, onClose, refreshGrid }) => {
             loading={isPending}
             disabled={!isDirty}
           >
-            {/* <Typography
-              variant="s2"
-              width={"80px"}
-              fontWeight={"fontWeightSemiBold"}
-            > */}
-            Save
-            {/* </Typography> */}
+            Upload
           </LoadingButton>
         </DialogActions>
       </Box>


### PR DESCRIPTION
## Summary

Three OSS QA fixes reported by @vel under TH-7252, one commit each so they can be reviewed and reverted independently.

Closes TH-7282
Closes TH-7253
Closes TH-7268

## Why / problem

| Ticket | Reported | Root cause |
| --- | --- | --- |
| TH-7282 (Urgent) | Falcon AI and Error Feed upgrade screens crop their background image on a laptop, fine on a big monitor | The backdrop used `objectFit: cover` with a forced `height: 100%` + `minHeight: 480`. `cover` scales by `max(boxW/imgW, boxH/imgH)` — on a laptop the container is proportionally taller per unit width, so scaling went height-driven and cropped the sides away |
| TH-7253 | "Upload a File" dialog's confirm button says Save | Wrong verb for the action — the dialog uploads a file to create datapoints |
| TH-7268 | Numeric label shows a blank box when the slider sits at zero | The `Slider` fell back to `min` when the value was unset, while the number box used `value ?? ""` — so an untouched control *looked* set to zero but read blank |

## What changed

* **TH-7282** — `FeatureGateOverlay` backdrop now scales by width (`height: auto`) instead of filling both axes, so the whole preview is visible at any viewport. The wrapper keeps `minHeight` for the no-image skeleton case.
* **TH-7253** — Save → **Upload** in `AddDatasetDrawer/UploadFileModal`. Also removed the commented-out `Typography` wrapper around the label while touching the line.
* **TH-7268** — the number box uses the same `?? min` fallback the slider already used.

## Tests

No new tests. These are presentational changes with no branching logic to pin down; TH-7268 is a one-token fallback change already covered by the component's existing render tests.

## Commands

```bash
cd frontend
npx eslint src/components/feature-gate/FeatureGateOverlay.jsx \
           src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx \
           src/sections/annotations/queues/annotate/label-input.jsx
npx vitest run src/sections/annotations/queues/__tests__/annotate-components.test.jsx
```

Both clean — lint reports nothing, and the 113 existing annotate-component tests pass.

## Backwards compatibility

No API, schema or contract changes. Frontend-only, all three presentational.

`FeatureGateOverlay` is consumed **only** by `oss-upgrade-gate`, so TH-7282 affects the four OSS gates (Falcon AI, Error Feed, Optimization, Knowledge Base) and nothing else. `UploadFileModal` is shared with the cloud flow, which is what TH-7253 asked for.

## Manual verification

- [x] TH-7268 — traced against the reported screenshot: slider at `min` with an empty box, now renders `0`
- [x] Confirmed `FeatureGateOverlay` has no other consumers before changing its backdrop sizing
- [x] Confirmed the sibling `AddRowDrawer/UploadFileModal` says "Done" not "Save", so it is deliberately untouched
- [ ] **Not yet visually confirmed in a running app** — TH-7282 in particular is a viewport-dependent fix and wants a look on a laptop-sized window in both light and dark before merge

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore

## Checklist

- [x] One ticket per commit
- [x] Lint clean
- [x] Existing tests pass
- [x] No API contract changes, so no regeneration needed
- [ ] Visual QA on a laptop viewport (see above)

## Backout

Each fix is a single-file, single-hunk commit — revert any one independently:

```bash
git revert 526f796b1   # TH-7282
git revert 745b4afdc   # TH-7253
git revert 370693cc6   # TH-7268
```

## Linear

* TH-7282 — https://linear.app/future-agi/issue/TH-7282
* TH-7253 — https://linear.app/future-agi/issue/TH-7253
* TH-7268 — https://linear.app/future-agi/issue/TH-7268

Parent: TH-7252. Still open from that batch and **not** in this PR: TH-7267 (task-usage Score/Result/Input), TH-7263 (dark-theme annotation labels), TH-7258 (model-selection highlight), TH-7269 and TH-7270 (both documented only by screen recordings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
