### PR TITLE
fix(oss): require a model on every eval save, test and add [TH-7258]

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -158,7 +158,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState("");
   const [codeLanguage, setCodeLanguage] = useState("python");
-  const [model, setModel] = useState("turing_large");
+  const [model, setModel] = useState(isOSS ? "" : "turing_large");
+  const [openModelMenuSignal, setOpenModelMenuSignal] = useState(0);
   const [outputType, setOutputType] = useState("pass_fail");
   const [passThreshold, setPassThreshold] = useState(0.5);
   const [choiceScores, setChoiceScores] = useState({});
@@ -836,10 +837,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         "Turing models are not available in OSS. Please select your own model.",
         { variant: "error" },
       );
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (isOSS && evalType !== "code" && !model) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     try {
@@ -944,15 +947,25 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   }, []);
 
   const handleTestEvaluation = useCallback(() => {
+    if (isOSS && evalType !== "code" && !model) {
+      enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
+      return;
+    }
     setIsTesting(true);
     setTestError(null);
     setTestPassed(false);
     sourceRef.current?.runTest?.(templateId);
     // Safety timeout
     setTimeout(() => setIsTesting((v) => (v ? false : v)), 60000);
-  }, [templateId]);
+  }, [templateId, isOSS, evalType, model]);
 
   const handleAdd = useCallback(() => {
+    if (isOSS && evalType !== "code" && !model) {
+      enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
+      return;
+    }
     // When opened from an optimization context, enforce that the optimized
     // column is mapped to at least one eval input field. Without this the
     // backend's get_metrics_by_column filter would exclude the eval from the
@@ -1090,6 +1103,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     evalData,
     evalName,
     isEditMode,
+    isOSS,
     model,
     sourceMapping,
     evalType,
@@ -1497,6 +1511,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   initializes with the actual instructions content */}
               {!isComposite && evalType === "agent" && dataReady && (
                 <InstructionEditor
+                  openModelMenuSignal={openModelMenuSignal}
                   key={`agent-${templateId}`}
                   value={instructions}
                   onChange={(v) => {
@@ -1556,6 +1571,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
               {!isComposite && evalType === "llm" && dataReady && (
                 <>
                   <LLMPromptEditor
+                    openModelMenuSignal={openModelMenuSignal}
                     key={`llm-${templateId}`}
                     messages={messages}
                     onMessagesChange={(msgs) => {

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -138,7 +138,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState(PYTHON_CODE_TEMPLATE);
   const [codeLanguage, setCodeLanguage] = useState("python");
-  const [model, setModel] = useState("turing_large");
+  const [model, setModel] = useState(isOSS ? "" : "turing_large");
+  const [openModelMenuSignal, setOpenModelMenuSignal] = useState(0);
   const [outputType, setOutputType] = useState("pass_fail");
   const [passThreshold, setPassThreshold] = useState(0.5);
   const [choiceScores, setChoiceScores] = useState({});
@@ -347,6 +348,11 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
 
   // Test
   const handleTestEvaluation = useCallback(async () => {
+    if (isOSS && evalType !== "code" && !model) {
+      enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
+      return;
+    }
     if (!draftId) return;
     setIsTesting(true);
     setTestError(null);
@@ -358,7 +364,16 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     } catch (error) {
       handleTestResult(false, error?.message || "Failed to test");
     }
-  }, [draftId, buildPayload, updateDraft, handleTestResult]);
+  }, [
+    draftId,
+    isOSS,
+    evalType,
+    model,
+    buildPayload,
+    updateDraft,
+    handleTestResult,
+    enqueueSnackbar,
+  ]);
 
   const hasDataInjection = useMemo(
     () =>
@@ -500,10 +515,12 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         "Turing models are not available in OSS. Please select your own model.",
         { variant: "error" },
       );
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (isOSS && evalType !== "code" && !model) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (!validate()) return;
@@ -1009,6 +1026,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
               {!isComposite && evalType === "agent" && (
                 <>
                   <InstructionEditor
+                    openModelMenuSignal={openModelMenuSignal}
                     value={instructions}
                     onChange={handleInstructionsChange}
                     model={model}
@@ -1037,8 +1055,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onModelChange={setModel}
                     showMode={false}
                     showPlus={false}
+                    openModelMenuSignal={openModelMenuSignal}
                   />
                   <LLMPromptEditor
+                    openModelMenuSignal={openModelMenuSignal}
                     messages={messages}
                     onMessagesChange={(msgs) => {
                       setMessages(msgs);

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -162,7 +162,8 @@ const EvalCreatePage = () => {
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState(PYTHON_CODE_TEMPLATE);
   const [codeLanguage, setCodeLanguage] = useState("python");
-  const [model, setModel] = useState("turing_large");
+  const [model, setModel] = useState(isOSS ? "" : "turing_large");
+  const [openModelMenuSignal, setOpenModelMenuSignal] = useState(0);
   const [outputType, setOutputType] = useState("pass_fail");
   const [passThreshold, setPassThreshold] = useState(0.5);
   const [choiceScores, setChoiceScores] = useState({});
@@ -446,10 +447,12 @@ const EvalCreatePage = () => {
         "Turing models are not available in OSS. Please select your own model.",
         { variant: "error" },
       );
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (isOSS && evalType !== "code" && !model) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (!draftId) {
@@ -560,6 +563,12 @@ const EvalCreatePage = () => {
     // needed since the composite hasn't been (and won't be) saved as a
     // single-eval draft. Single evals still need their draft up to date
     // so the playground sees the latest instructions/code/config.
+ 
+    if (isOSS && evalType !== "code" && !model) {
+      enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
+      return;
+    }
     if (mode === "single" && !draftId) {
       enqueueSnackbar("Draft not ready yet, please wait", {
         variant: "warning",
@@ -591,6 +600,9 @@ const EvalCreatePage = () => {
   }, [
     mode,
     draftId,
+    isOSS,
+    evalType,
+    model,
     buildUpdatePayload,
     updateDraft,
     handleTestResult,
@@ -964,6 +976,7 @@ const EvalCreatePage = () => {
                       onChange={setInstructions}
                       model={model}
                       onModelChange={setModel}
+                      openModelMenuSignal={openModelMenuSignal}
                       placeholder="You are a helpful assistant"
                       templateFormat={templateFormat}
                       onTemplateFormatChange={setTemplateFormat}
@@ -994,6 +1007,7 @@ const EvalCreatePage = () => {
                           format render inline in LLMPromptEditor's top
                           bar, matching the agent InstructionEditor. */}
                       <LLMPromptEditor
+                        openModelMenuSignal={openModelMenuSignal}
                         messages={messages}
                         onMessagesChange={(msgs) => {
                           setMessages(msgs);

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -146,7 +146,8 @@ const EvalDetailPage = () => {
   const [instructions, setInstructions] = useState("");
   const [code, setCode] = useState("");
   const [codeLanguage, setCodeLanguage] = useState("python");
-  const [model, setModel] = useState("turing_large");
+  const [model, setModel] = useState(isOSS ? "" : "turing_large");
+  const [openModelMenuSignal, setOpenModelMenuSignal] = useState(0);
   const [outputType, setOutputType] = useState("pass_fail");
   const [passThreshold, setPassThreshold] = useState(0.5);
   const [choiceScores, setChoiceScores] = useState({});
@@ -772,10 +773,12 @@ const EvalDetailPage = () => {
         "Turing models are not available in OSS. Please select your own model.",
         { variant: "error" },
       );
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     if (isOSS && evalType !== "code" && !model) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
       return;
     }
     try {
@@ -956,6 +959,11 @@ const EvalDetailPage = () => {
 
   // Test evaluation — auto-saves current config before running
   const handleTestEvaluation = useCallback(async () => {
+    if (isOSS && evalType !== "code" && !model) {
+      enqueueSnackbar("Please select a model.", { variant: "error" });
+      setOpenModelMenuSignal((n) => n + 1);
+      return;
+    }
     setIsTesting(true);
     setTestError(null);
     setTestPassed(false);
@@ -1021,6 +1029,7 @@ const EvalDetailPage = () => {
   }, [
     evalId,
     evalType,
+    isOSS,
     isSystemEval,
     isComposite,
     instructions,
@@ -1514,6 +1523,7 @@ const EvalDetailPage = () => {
                 {/* Agent type — InstructionEditor with model bar */}
                 {!isComposite && evalType === "agent" && (
                   <InstructionEditor
+                    openModelMenuSignal={openModelMenuSignal}
                     value={instructions}
                     onChange={(v) => {
                       setInstructions(v);
@@ -1569,6 +1579,7 @@ const EvalDetailPage = () => {
                 {!isComposite && evalType === "llm" && (
                   <>
                     <LLMPromptEditor
+                      openModelMenuSignal={openModelMenuSignal}
                       messages={messages}
                       onMessagesChange={(msgs) => {
                         setMessages(msgs);

--- a/frontend/src/sections/evals/components/InstructionEditor.jsx
+++ b/frontend/src/sections/evals/components/InstructionEditor.jsx
@@ -271,6 +271,7 @@ const InstructionEditor = ({
   // ModelSelector (bottom bar: model picker, + menu, mode pill) editable.
   // Defaults to `disabled` for backward compat.
   modelSelectorDisabled,
+  openModelMenuSignal = 0,
   label = "Instructions",
   templateFormat = "mustache",
   onTemplateFormatChange,
@@ -988,6 +989,7 @@ const InstructionEditor = ({
               activeContextOptions={activeContextOptions}
               onActiveContextOptionsChange={onActiveContextOptionsChange}
               hideDatasetContextToggle={hideDatasetContextToggle}
+              openModelMenuSignal={openModelMenuSignal}
             />
           </Box>
           {!aiOpen && (

--- a/frontend/src/sections/evals/components/LLMPromptEditor.jsx
+++ b/frontend/src/sections/evals/components/LLMPromptEditor.jsx
@@ -51,6 +51,7 @@ const LLMPromptEditor = ({
   modelSelectorDisabled,
   model,
   onModelChange,
+  openModelMenuSignal = 0,
 }) => {
   const [aiOpen, setAiOpen] = useState(false);
   const [aiPrompt, setAiPrompt] = useState("");
@@ -423,6 +424,7 @@ const LLMPromptEditor = ({
         datasetJsonSchemas={datasetJsonSchemas}
         disabled={disabled}
         modelSelectorDisabled={modelSelectorDisabled}
+        openModelMenuSignal={openModelMenuSignal}
         aiBar={aiOpen ? aiBar : null}
         onFalconClick={() => setAiOpen(true)}
         aiOpen={aiOpen}
@@ -440,6 +442,7 @@ LLMPromptEditor.propTypes = {
   onModelChange: PropTypes.func,
   disabled: PropTypes.bool,
   modelSelectorDisabled: PropTypes.bool,
+  openModelMenuSignal: PropTypes.number,
 };
 
 export default LLMPromptEditor;

--- a/frontend/src/sections/evals/components/MessageEditor.jsx
+++ b/frontend/src/sections/evals/components/MessageEditor.jsx
@@ -54,6 +54,7 @@ const MessageEditor = ({
   modelSelectorDisabled,
   model,
   onModelChange,
+  openModelMenuSignal = 0,
   // Falcon AI: the parent renders the AI bar node (shown at the top of
   // the box when open) and passes the trigger handler for the bottom-bar
   // icon. aiOpen hides the trigger while the bar is open, matching agent.
@@ -306,6 +307,7 @@ const MessageEditor = ({
                 showMode={false}
                 showPlus={false}
                 disabled={modelSelectorDisabled ?? disabled}
+                openModelMenuSignal={openModelMenuSignal}
               />
             </Box>
           ) : (
@@ -373,6 +375,7 @@ MessageEditor.propTypes = {
   datasetJsonSchemas: PropTypes.object,
   disabled: PropTypes.bool,
   modelSelectorDisabled: PropTypes.bool,
+  openModelMenuSignal: PropTypes.number,
   aiBar: PropTypes.node,
   onFalconClick: PropTypes.func,
   aiOpen: PropTypes.bool,

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -20,7 +20,13 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import PropTypes from "prop-types";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Iconify from "src/components/iconify";
 import KeysDrawer from "src/components/custom-model-dropdown/KeysDrawer";
 import { useDebounce } from "src/hooks/use-debounce";
@@ -596,6 +602,11 @@ const ModelSelector = ({
   activeContextOptions: activeContextOptionsProp,
   onActiveContextOptionsChange,
   hideDatasetContextToggle = false,
+  // Bump this counter to pop the model menu open from the parent — used when
+  // an action is blocked because no model is picked, so the snackbar and the
+  // menu arrive together. A counter rather than a boolean so repeat attempts
+  // re-open it without the parent having to reset the flag.
+  openModelMenuSignal = 0,
 }) => {
   // For each field, pick "controlled" (parent-driven) or "uncontrolled" (local state).
   const [modeLocal, setModeLocal] = useState("agent");
@@ -607,6 +618,12 @@ const ModelSelector = ({
 
   const [modeAnchor, setModeAnchor] = useState(null);
   const [modelAnchor, setModelAnchor] = useState(null);
+  const modelPillRef = useRef(null);
+
+  useEffect(() => {
+    if (!openModelMenuSignal || disabled) return;
+    setModelAnchor(modelPillRef.current);
+  }, [openModelMenuSignal, disabled]);
   const [modelSearch, setModelSearch] = useState("");
   const debouncedModelSearch = useDebounce(modelSearch.trim(), 400);
   const [plusAnchor, setPlusAnchor] = useState(null);
@@ -846,6 +863,7 @@ const ModelSelector = ({
 
       {/* ── Model selector (right) ── */}
       <Box
+        ref={modelPillRef}
         onClick={(e) => !disabled && setModelAnchor(e.currentTarget)}
         sx={{
           display: "inline-flex",
@@ -1931,6 +1949,7 @@ ModelSelector.propTypes = {
   showMode: PropTypes.bool,
   showPlus: PropTypes.bool,
   hideDatasetContextToggle: PropTypes.bool,
+  openModelMenuSignal: PropTypes.number,
 };
 
 export default ModelSelector;


### PR DESCRIPTION
## Summary

On OSS an eval could be tested, added, or attached with no model selected — only the save paths checked. This gates every path, opens the model menu when a gate fires, and stops seeding a Turing model on OSS.

Part of TH-7258.

> **Stacked PR.** Base is `fix/th-7252-oss-qa-fixes` (#1937), not `dev`, so the diff shows only this commit. Merge #1937 first; GitHub will retarget this to `dev` automatically. Say the word and I'll rebase onto `dev` instead.

## Why / problem

Three separate holes, found by auditing every save/test/add handler across the four eval surfaces:

1. **Test and Add were ungated.** `EvalDetailPage.handleTestEvaluation`, `EvalPickerConfigFull.handleTestEvaluation` and `EvalPickerConfigFull.handleAdd` had no model check at all. `handleAdd` is the one that matters most — it's the picker's Add button, the path used when attaching an eval, including into a composite.
2. **The snackbar was a dead end.** "Please select a model." told the user what was wrong but left them to find the selector.
3. **Save fired the wrong branch.** `model` was seeded `"turing_large"` everywhere, and `ModelSelector` only cleared it back to `""` via a corrective effect after `deploymentModeLoading` resolved. In that window the save handlers matched the *Turing* guard rather than the *empty* guard — so Save showed "Turing models are not available in OSS" and never reached the branch that opens the menu. Test had no Turing guard, which is exactly why Test opened the dropdown and Save didn't.

## What changed

* **Gate every path.** Nine handlers now share one condition, `isOSS && evalType !== "code" && !model`, with the same message.
* **Open the model menu when a gate fires.** New optional `openModelMenuSignal` counter prop on `ModelSelector`; an effect opens the menu against the model pill (new `modelPillRef`) whenever it changes, and no-ops when `disabled`. A counter, not a boolean, so a repeat attempt re-opens without the parent resetting a flag. Threaded through `InstructionEditor`, `MessageEditor` and `LLMPromptEditor`, each with a `= 0` default so existing call sites are untouched.
* **Both guard branches open it** — the Turing branch as well as the empty-model branch, since to the user both mean "pick a model".
* **Seed conditionally**: `useState(isOSS ? "" : "turing_large")` in all four pages, so state is honest from the first render instead of depending on a corrective effect and a mounted selector.

`handleSaveComposite` is deliberately left ungated — a composite carries no `model`; it references child template IDs, and each child's model is gated when that child is created or edited.

## Tests

No new tests. Flagging honestly: the signal → effect → anchor path has no coverage, and `ModelSelector`'s existing suite doesn't assert open-on-signal.

## Commands

```bash
cd frontend
npx eslint src/sections/evals/components/{EvalCreatePage,EvalDetailPage,ModelSelector,InstructionEditor,MessageEditor,LLMPromptEditor}.jsx \
           src/sections/common/EvalPicker/{EvalPickerCreateNew,EvalPickerConfigFull}.jsx
npx vitest run src/sections/evals/components/__tests__/ModelSelector.test.jsx
```

0 errors (8 pre-existing warnings), 3/3 tests pass. Lint also caught four real stale-closure bugs in the new gates — `useCallback` arrays missing `isOSS` / `evalType` / `model` — all fixed here.

## Backwards compatibility

Frontend only, no API or contract changes. Every new prop is optional with a `= 0` default.

**One behaviour change worth a reviewer's eye:** `useDeploymentMode` returns `"oss"` while deployment-info is in flight, so on the first render a **cloud** user now also seeds `model` to `""` and briefly has no preselected model where they previously had `turing_large`. The corrective effect in `ModelSelector` is left in place and still covers a mode that resolves to OSS after mount. If the cloud-side regression matters, the fix is to seed from the resolved mode instead — deliberately not guessed at here.

## Manual verification

- [x] Audited all 9 handlers across 4 files; verified all 9 `ModelSelector` / editor render sites receive the signal
- [x] Confirmed composite carries no `model` before leaving `handleSaveComposite` ungated
- [ ] **Not exercised in a running app.** The menu-open path in particular wants a click-through on all four surfaces — Create, Detail, Picker-CreateNew, Picker-ConfigFull — including the Code tab, where no selector is mounted

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore

## Checklist

- [x] Lint clean
- [x] Existing tests pass
- [x] No API contract changes
- [ ] Manual QA on all four eval surfaces (see above)

## Backout

Single commit — `git revert 10a4dc2c5`.

## Linear

* TH-7258 — https://linear.app/future-agi/issue/TH-7258

Not covered here: the second half of TH-7258, the failed-message colour being too bright in dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
