### PR TITLE
fix(mcp_server): correct inverted tier limits and make the daily quota reset

### DIFF
--- a/futureagi/mcp_server/constants.py
+++ b/futureagi/mcp_server/constants.py
@@ -98,8 +98,11 @@ CATEGORY_TO_GROUP = {
     "docs": "docs",
 }
 
+# Per-tier MCP quotas. Every limit must be monotonically non-decreasing from
+# ``free`` -> ``pro`` -> ``enterprise``; ``test_rate_limits_are_monotonic_across_tiers``
+# enforces that so a paying tier can never end up throttled harder than a free one.
 RATE_LIMITS = {
-    "free": {"per_minute": 200, "per_day": 5000, "concurrent_sessions": 5},
+    "free": {"per_minute": 20, "per_day": 5000, "concurrent_sessions": 5},
     "pro": {"per_minute": 100, "per_day": 10_000, "concurrent_sessions": 5},
     "enterprise": {"per_minute": 500, "per_day": 100_000, "concurrent_sessions": None},
 }

--- a/futureagi/mcp_server/rate_limiter.py
+++ b/futureagi/mcp_server/rate_limiter.py
@@ -41,10 +41,53 @@ def get_rate_limit_tier(organization) -> str:
         return "free"
 
 
+def _day_bucket(now_dt: datetime.datetime) -> str:
+    """UTC calendar day the request belongs to, as ``YYYY-MM-DD``."""
+    return now_dt.strftime("%Y-%m-%d")
+
+
+def _next_utc_midnight(now_dt: datetime.datetime) -> datetime.datetime:
+    """Start of the next UTC day — the instant the daily quota resets."""
+    return (now_dt + datetime.timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _day_key(organization_id: str, now_dt: datetime.datetime) -> str:
+    """Cache key for an org's daily counter, stamped with the UTC calendar day.
+
+    Stamping the day into the key is what makes the quota reset at midnight.
+    The previous implementation used a single un-stamped key refreshed with
+    ``cache.set(..., timeout=86400)`` on every call, which re-armed the TTL each
+    time — so the counter only expired after 24 consecutive hours of *zero*
+    traffic, and an org with steady usage stayed locked out permanently once it
+    hit the limit. With the day in the key, yesterday's counter is simply never
+    read again and expires on its own.
+    """
+    return f"mcp_rl:day:{organization_id}:{_day_bucket(now_dt)}"
+
+
+def _increment_day_counter(day_key: str, ttl: int) -> None:
+    """Increment the daily counter, creating it if this is the day's first call.
+
+    ``cache.incr`` raises ``ValueError`` when the key is absent, so the first
+    call of each UTC day falls back to ``cache.add``. ``add`` is a no-op when the
+    key already exists, which is what makes the fallback safe: if another worker
+    created the key between our ``incr`` and our ``add``, ``add`` returns False
+    and we increment the value they created instead of overwriting it.
+    """
+    try:
+        cache.incr(day_key)
+    except ValueError:
+        if not cache.add(day_key, 1, timeout=ttl):
+            cache.incr(day_key)
+
+
 def check_rate_limit(organization_id: str, tier: str) -> None:
     """Check sliding window rate limits. Raises RateLimitExceededError if exceeded."""
     limits = RATE_LIMITS.get(tier, RATE_LIMITS["free"])
     now = time.time()
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
 
     # Per-minute check (sliding window of timestamps)
     minute_key = f"mcp_rl:min:{organization_id}"
@@ -60,22 +103,23 @@ def check_rate_limit(organization_id: str, tier: str) -> None:
             retry_after=max(retry_after, 1),
         )
 
-    # Per-day check (simple counter with 24h TTL)
-    day_key = f"mcp_rl:day:{organization_id}"
+    # Per-day check (counter keyed by UTC calendar day, expiring at midnight)
+    day_key = _day_key(organization_id, now_dt)
     day_count = cache.get(day_key, 0) or 0
 
+    midnight = _next_utc_midnight(now_dt)
+    seconds_to_midnight = int((midnight - now_dt).total_seconds())
+
     if day_count >= limits["per_day"]:
-        now_dt = datetime.datetime.now(datetime.timezone.utc)
-        midnight = (now_dt + datetime.timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        retry_after = int((midnight - now_dt).total_seconds())
         raise RateLimitExceededError(
             f"Rate limit exceeded: {limits['per_day']} calls/day",
-            retry_after=retry_after,
+            retry_after=seconds_to_midnight,
         )
 
     # Record this call
     minute_window.append(now)
     cache.set(minute_key, minute_window, timeout=120)
-    cache.set(day_key, day_count + 1, timeout=86400)
+    # +60s of slack so the key outlives the boundary it is bounded by; once the
+    # clock rolls over, _day_key() points at a new key anyway, so a briefly
+    # lingering counter for yesterday is never consulted again.
+    _increment_day_counter(day_key, seconds_to_midnight + 60)

--- a/futureagi/mcp_server/tests/test_rate_limiter.py
+++ b/futureagi/mcp_server/tests/test_rate_limiter.py
@@ -1,13 +1,23 @@
 """Tests for MCP Server rate limiter."""
 
+import datetime
 import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.core.cache import cache
 
-from mcp_server.exceptions import RateLimitExceededError
 from mcp_server.constants import RATE_LIMITS
-from mcp_server.rate_limiter import check_rate_limit, get_rate_limit_tier
+from mcp_server.exceptions import RateLimitExceededError
+from mcp_server.rate_limiter import (
+    _day_key,
+    _next_utc_midnight,
+    check_rate_limit,
+    get_rate_limit_tier,
+)
+
+# Matches the spelling used across the codebase (datetime.UTC is unused here).
+UTC = datetime.timezone.utc
 
 
 class TestGetRateLimitTier:
@@ -173,24 +183,25 @@ class TestCheckRateLimit:
 
     @patch("mcp_server.rate_limiter.cache")
     def test_records_call_in_cache(self, mock_cache):
-        """Successful calls should update both minute window and day counter."""
+        """Successful calls store the minute window and bump the day counter."""
         mock_cache.get.return_value = None
 
         check_rate_limit("org-123", "free")
 
-        # Should have called cache.set twice (minute window + day counter)
-        assert mock_cache.set.call_count == 2
-        # First call: minute window with 120s timeout
+        # The minute window is still a stored list with a 120s timeout.
+        assert mock_cache.set.call_count == 1
         minute_call = mock_cache.set.call_args_list[0]
         assert "min" in minute_call[0][0]
         assert minute_call[1]["timeout"] == 120 or minute_call[0][2] == 120
-        # Second call: day counter with 86400s timeout
-        day_call = mock_cache.set.call_args_list[1]
-        assert "day" in day_call[0][0]
+
+        # The day counter is incremented, not re-set — re-setting it was what
+        # re-armed the TTL on every call and stopped the quota ever resetting.
+        assert mock_cache.incr.called
+        assert "day" in mock_cache.incr.call_args[0][0]
 
     @patch("mcp_server.rate_limiter.cache")
     def test_pro_tier_has_higher_limits(self, mock_cache):
-        """Pro tier should allow 100 calls/minute (not just 20)."""
+        """Pro tier allows more calls/minute than free."""
         now = time.time()
         # 50 timestamps (above free limit but below pro limit)
         timestamps = [now - i * 0.5 for i in range(50)]
@@ -238,3 +249,212 @@ class TestCheckRateLimit:
         # "unknown" tier falls back to free, so a full free window should raise
         with pytest.raises(RateLimitExceededError):
             check_rate_limit("org-123", "unknown")
+
+
+class TestRateLimitTierOrdering:
+    """The tier table must never throttle a paid tier harder than a cheaper one."""
+
+    TIERS_CHEAPEST_FIRST = ["free", "pro", "enterprise"]
+
+    @pytest.mark.parametrize("limit_name", ["per_minute", "per_day"])
+    def test_rate_limits_are_monotonic_across_tiers(self, limit_name):
+        """free <= pro <= enterprise for every numeric limit.
+
+        Regression test: `free` shipped with per_minute=200 against `pro`'s 100,
+        so every paying non-enterprise org was throttled at half the free rate.
+        """
+        values = [RATE_LIMITS[t][limit_name] for t in self.TIERS_CHEAPEST_FIRST]
+        assert values == sorted(
+            values
+        ), f"{limit_name} is not monotonic across tiers: " + ", ".join(
+            f"{t}={v}" for t, v in zip(self.TIERS_CHEAPEST_FIRST, values, strict=True)
+        )
+
+    def test_concurrent_sessions_monotonic_with_unlimited_last(self):
+        """`concurrent_sessions` allows None (unlimited), which must sort last."""
+        values = [
+            RATE_LIMITS[t]["concurrent_sessions"] for t in self.TIERS_CHEAPEST_FIRST
+        ]
+        finite = [v for v in values if v is not None]
+        assert finite == sorted(finite)
+        # None may only appear as a suffix — an unlimited middle tier would mean
+        # the tier above it is more restrictive.
+        first_none = next((i for i, v in enumerate(values) if v is None), len(values))
+        assert all(v is None for v in values[first_none:])
+
+
+class TestDayKeyHelpers:
+    """Pure helpers behind the daily quota — no cache, no clock mocking."""
+
+    def test_day_key_is_stamped_with_the_utc_date(self):
+        now_dt = datetime.datetime(2026, 8, 5, 13, 30, tzinfo=UTC)
+        assert _day_key("org-1", now_dt) == "mcp_rl:day:org-1:2026-08-05"
+
+    def test_day_key_changes_across_the_utc_midnight_boundary(self):
+        before = datetime.datetime(2026, 8, 5, 23, 59, 59, tzinfo=UTC)
+        after = datetime.datetime(2026, 8, 6, 0, 0, 0, tzinfo=UTC)
+        assert _day_key("org-1", before) != _day_key("org-1", after)
+
+    def test_day_key_is_stable_within_a_day(self):
+        morning = datetime.datetime(2026, 8, 5, 0, 0, 1, tzinfo=UTC)
+        evening = datetime.datetime(2026, 8, 5, 23, 59, 58, tzinfo=UTC)
+        assert _day_key("org-1", morning) == _day_key("org-1", evening)
+
+    def test_day_keys_are_per_organization(self):
+        now_dt = datetime.datetime(2026, 8, 5, 13, 30, tzinfo=UTC)
+        assert _day_key("org-1", now_dt) != _day_key("org-2", now_dt)
+
+    @pytest.mark.parametrize(
+        "now_dt,expected",
+        [
+            (
+                datetime.datetime(2026, 8, 5, 0, 0, 0, tzinfo=UTC),
+                datetime.datetime(2026, 8, 6, 0, 0, 0, tzinfo=UTC),
+            ),
+            (
+                datetime.datetime(2026, 8, 5, 23, 59, 59, tzinfo=UTC),
+                datetime.datetime(2026, 8, 6, 0, 0, 0, tzinfo=UTC),
+            ),
+            # Month rollover
+            (
+                datetime.datetime(2026, 8, 31, 12, 0, 0, tzinfo=UTC),
+                datetime.datetime(2026, 9, 1, 0, 0, 0, tzinfo=UTC),
+            ),
+            # Year rollover
+            (
+                datetime.datetime(2026, 12, 31, 12, 0, 0, tzinfo=UTC),
+                datetime.datetime(2027, 1, 1, 0, 0, 0, tzinfo=UTC),
+            ),
+        ],
+    )
+    def test_next_utc_midnight(self, now_dt, expected):
+        assert _next_utc_midnight(now_dt) == expected
+
+
+class TestDailyCounterAgainstRealCache:
+    """Exercises the real cache backend (locmem per tfc.settings.test).
+
+    The mocked tests above cannot observe key naming, expiry, or persistence —
+    which is precisely where the daily-quota bug lived.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        cache.clear()
+        yield
+        cache.clear()
+
+    def _today_key(self, org_id):
+        return _day_key(org_id, datetime.datetime.now(UTC))
+
+    def test_counter_increments_once_per_call(self):
+        for expected in (1, 2, 3):
+            check_rate_limit("org-real", "free")
+            assert cache.get(self._today_key("org-real")) == expected
+
+    def test_counter_is_scoped_per_organization(self):
+        check_rate_limit("org-a", "free")
+        check_rate_limit("org-a", "free")
+        check_rate_limit("org-b", "free")
+
+        assert cache.get(self._today_key("org-a")) == 2
+        assert cache.get(self._today_key("org-b")) == 1
+
+    def test_yesterdays_exhausted_quota_does_not_block_today(self):
+        """The regression test for the quota that never reset.
+
+        Previously the day counter lived under a single un-stamped key whose TTL
+        was re-armed on every call, so an org that exhausted its daily quota
+        stayed blocked indefinitely. Today's key is distinct from yesterday's, so
+        a saturated yesterday is irrelevant.
+        """
+        now_dt = datetime.datetime.now(UTC)
+        yesterday = now_dt - datetime.timedelta(days=1)
+        cache.set(_day_key("org-real", yesterday), RATE_LIMITS["free"]["per_day"] * 10)
+
+        # Must not raise — yesterday's counter is never consulted.
+        check_rate_limit("org-real", "free")
+
+        assert cache.get(self._today_key("org-real")) == 1
+
+    def test_day_limit_still_blocks_once_todays_quota_is_spent(self):
+        cache.set(self._today_key("org-real"), RATE_LIMITS["free"]["per_day"])
+
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            check_rate_limit("org-real", "free")
+
+        assert f"{RATE_LIMITS['free']['per_day']} calls/day" in str(exc_info.value)
+
+    def test_retry_after_matches_the_actual_reset_boundary(self):
+        """retry_after must point at the instant the quota really resets.
+
+        The old code advertised seconds-until-midnight while the counter expired
+        24h after the last call, so a client that honoured retry_after woke up
+        still blocked.
+        """
+        cache.set(self._today_key("org-real"), RATE_LIMITS["free"]["per_day"])
+
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            check_rate_limit("org-real", "free")
+
+        now_dt = datetime.datetime.now(UTC)
+        expected = int((_next_utc_midnight(now_dt) - now_dt).total_seconds())
+        assert abs(exc_info.value.retry_after - expected) <= 2
+        assert 0 < exc_info.value.retry_after <= 86400
+
+
+class TestDailyCounterTTL:
+    """The day key's TTL must track the midnight boundary, not a rolling 24h."""
+
+    @patch("mcp_server.rate_limiter.cache")
+    def test_first_call_of_the_day_adds_key_with_ttl_bounded_by_midnight(
+        self, mock_cache
+    ):
+        mock_cache.get.return_value = None
+        # incr raises when the key is absent — the first call of a new UTC day.
+        mock_cache.incr.side_effect = ValueError("key not found")
+        mock_cache.add.return_value = True
+
+        check_rate_limit("org-123", "free")
+
+        assert mock_cache.add.called
+        key, value = mock_cache.add.call_args[0][0], mock_cache.add.call_args[0][1]
+        ttl = (
+            mock_cache.add.call_args[0][2]
+            if len(mock_cache.add.call_args[0]) > 2
+            else mock_cache.add.call_args[1]["timeout"]
+        )
+
+        assert "day" in key
+        assert value == 1
+        now_dt = datetime.datetime.now(UTC)
+        expected = int((_next_utc_midnight(now_dt) - now_dt).total_seconds()) + 60
+        assert abs(ttl - expected) <= 2
+        # The bug was a flat 86400 re-armed on every call.
+        assert ttl <= 86400 + 60
+
+    @patch("mcp_server.rate_limiter.cache")
+    def test_subsequent_calls_do_not_touch_the_ttl(self, mock_cache):
+        """An existing key is incremented only — its expiry is left alone."""
+        mock_cache.get.return_value = None
+        mock_cache.incr.return_value = 2  # key exists
+
+        check_rate_limit("org-123", "free")
+
+        assert mock_cache.incr.called
+        assert not mock_cache.add.called
+        # No cache.set against the day key would re-arm its TTL.
+        day_sets = [c for c in mock_cache.set.call_args_list if "day" in str(c[0][0])]
+        assert day_sets == []
+
+    @patch("mcp_server.rate_limiter.cache")
+    def test_lost_add_race_falls_back_to_incr(self, mock_cache):
+        """If another worker created the key first, we increment theirs."""
+        mock_cache.get.return_value = None
+        mock_cache.incr.side_effect = [ValueError("key not found"), 2]
+        mock_cache.add.return_value = False  # someone else won the race
+
+        check_rate_limit("org-123", "free")
+
+        assert mock_cache.add.called
+        assert mock_cache.incr.call_count == 2


### PR DESCRIPTION
Fixes #1943.

## What & why

Two independent defects in the MCP rate limiter. They're unrelated in mechanism but live four lines apart, so they're fixed together.

### 1. The free tier was throttled more generously than pro

`mcp_server/constants.py` gave `free` a `per_minute` of **200** against `pro`'s **100**:

```python
"free":       {"per_minute": 200, "per_day":   5000, ...},
"pro":        {"per_minute": 100, "per_day":  10_000, ...},
"enterprise": {"per_minute": 500, "per_day": 100_000, ...},
```

`per_day` and `concurrent_sessions` both scale in the expected direction — only `per_minute` is inverted, which is what makes this look like a typo rather than policy. `TIER_MAPPING` routes both `basic` and `basic_yearly` to `pro`, so every paying non-enterprise org on MCP was rate-limited at half the rate of a free user.

Two comments in the existing tests were written against a `free` value of 20 and still say so:

- `test_rate_limiter.py:116` — `# Should not raise (19 < 20)`
- `test_rate_limiter.py:193` — `"""Pro tier should allow 100 calls/minute (not just 20)."""`

Both tests read their expectations out of `RATE_LIMITS` at runtime, so they kept passing when the constant grew a zero. This PR restores `free` to **20**, giving a coherent 20 / 100 / 500 ladder.

> ⚠️ **This is the one decision in the PR that's yours, not mine.** Restoring 20 reduces free-tier throughput 10×. If `200` was deliberate, the alternative is to raise `pro` and `enterprise` above it instead, and I'll happily push that version — the monotonicity test added here passes either way. I picked 20 because the ladder, the stale test comments, and the `per_day`/`concurrent_sessions` ratios all point at it.

### 2. The daily quota never reset

```python
day_key = f"mcp_rl:day:{organization_id}"
day_count = cache.get(day_key, 0) or 0
...
cache.set(day_key, day_count + 1, timeout=86400)   # re-arms the TTL every call
```

`cache.set(..., timeout=86400)` writes a **fresh** 24-hour TTL on every request, so the key only expired after 24 consecutive hours of *zero* traffic from that org. Any org with steady usage had a monotonically increasing counter that never reset — once it reached `per_day` it was blocked permanently, not until tomorrow.

The raised error made this worse rather than better: it computed `retry_after` as seconds-until-UTC-midnight, so a well-behaved client slept until midnight, retried, and was still blocked. The advertised contract and the implemented behaviour disagreed.

**Fix:** stamp the UTC calendar day into the key and increment instead of re-setting.

```python
day_key = _day_key(organization_id, now_dt)   # mcp_rl:day:{org}:{YYYY-MM-DD}
...
_increment_day_counter(day_key, seconds_to_midnight + 60)
```

Expiry is now inherent to the key — yesterday's counter is simply never read again — and `retry_after` points at the boundary the quota genuinely resets on.

## Verification

Docker wasn't available on my machine, so `bin/test` couldn't spin up its Compose stack. These tests touch only Django's cache layer (no DB, Redis, or ClickHouse), so I ran them against `django.core.cache.backends.locmem.LocMemCache` — the same backend `tfc/settings/test.py:83-88` configures — in an isolated env. **Worth a maintainer re-running under `bin/test` before merge.**

**33 passed** on this branch. More usefully, both defects were confirmed to reproduce on `upstream/dev`@`ff5cd219` and to be fixed here:

```
################ BASELINE — upstream/dev (unfixed) ################
  [FAIL] per_minute monotonic across tiers — free=200, pro=100, enterprise=500
  [FAIL] day key is stamped with the UTC date — key=mcp_rl:day:demo-org
  [FAIL] day-key TTL is bounded by midnight (not a flat 86400) — ttl=86400s, seconds_to_midnight=17060s
  [FAIL] yesterday's exhausted quota does not block today — RateLimitExceededError

################ PATCHED — this branch ################
  [PASS] per_minute monotonic across tiers — free=20, pro=100, enterprise=500
  [PASS] day key is stamped with the UTC date — key=mcp_rl:day:demo-org:2026-08-04
  [PASS] day-key TTL is bounded by midnight (not a flat 86400) — ttl=17119s, seconds_to_midnight=17059s
  [PASS] yesterday's exhausted quota does not block today
```

`black`, `isort`, and `ruff` are clean on the three changed files (the one remaining `UP017` in `rate_limiter.py` is pre-existing and matches the repo-wide spelling — `datetime.timezone.utc` appears 19× in the tree, `datetime.UTC` zero times).

## Tests added

The existing suite patches `mcp_server.rate_limiter.cache` with a `MagicMock` in every test, so it could only ever assert the arithmetic in front of the cache — never key naming, expiry, or persistence. That's precisely where both defects lived. New coverage:

| Class | Covers |
|---|---|
| `TestRateLimitTierOrdering` | Every numeric limit is monotonic free → pro → enterprise. This is the regression test for defect 1 — an inverted limit now fails the build. Includes the `None`-means-unlimited case for `concurrent_sessions`. |
| `TestDayKeyHelpers` | Pure-function tests for `_day_key` / `_next_utc_midnight` — date stamping, the midnight boundary, per-org scoping, and month/year rollover. No clock mocking needed. |
| `TestDailyCounterAgainstRealCache` | Runs against locmem: per-call increment, per-org isolation, **a saturated yesterday not blocking today** (the reset regression test), and `retry_after` matching the real boundary. |
| `TestDailyCounterTTL` | The TTL is derived from midnight rather than a flat 86400; an existing key is incremented without its expiry being touched; and a lost `add` race falls back to `incr` instead of clobbering the winner. |

Two existing tests were updated rather than deleted: `test_records_call_in_cache` asserted `cache.set` was called twice (the day counter now uses `incr`), and `test_pro_tier_has_higher_limits` had a docstring naming the stale `20`.

## Scope

The per-minute sliding window is **deliberately untouched**. It has its own characteristics that are out of scope here, and keeping this PR to the two defects described in #1943 makes it easier to review and to revert independently.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — **could not run, Docker unavailable; see Verification above**
- [x] `yarn test:run` passes locally (frontend) — n/a, no frontend changes
- [x] `yarn contracts:check` passes if API surface changed — n/a, no API surface change
- [x] I've updated the documentation where relevant — n/a; behaviour is documented inline
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
