### PR TITLE
fix(agentic_eval): bound and correct the link evaluators' HTTP checks

### DIFF
--- a/futureagi/agentic_eval/conftest.py
+++ b/futureagi/agentic_eval/conftest.py
@@ -17,10 +17,18 @@ def pytest_configure(config):
     if backend_root not in sys.path:
         sys.path.insert(0, backend_root)
 
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tfc.settings")
+    # tfc.settings is a package whose __init__.py is a one-line stub — the real
+    # settings live in tfc.settings.settings, which manage.py, asgi.py, wsgi.py
+    # and celery.py all use. Pointing Django at the package configured an empty
+    # settings object, so INSTALLED_APPS was empty and importing any app model
+    # raised "doesn't declare an explicit app_label". The blanket `except
+    # Exception: pass` below then swallowed it, and collection failed later at
+    # the import site instead.
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tfc.settings.settings")
 
     try:
         import django
+
         django.setup()
     except RuntimeError:
         pass  # Already set up (e.g. running under the root conftest)

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -40,6 +40,61 @@ def _standardize_url(url):
         return "http://" + url
 
 
+# Deliberately short. These evaluators run inside eval activities, and requests
+# defaults to no timeout at all — a half-open host would hold a worker slot until
+# the surrounding activity timeout fired.
+_LINK_CHECK_TIMEOUT_SECONDS = 5
+
+# A server that does not implement HEAD typically answers 405; some CDNs and
+# WAFs answer 403 or 501 instead. None of these mean the URL is broken, so the
+# check retries with GET before giving up.
+_HEAD_UNSUPPORTED_STATUSES = frozenset({403, 405, 501})
+
+# api_call() posts to a user-supplied endpoint that does real work, so it gets a
+# longer budget than the link liveness probe above.
+_API_CALL_TIMEOUT_SECONDS = 30
+
+
+def _link_is_reachable(url):
+    """
+    Report whether the URL resolves to a non-error HTTP response.
+
+    HEAD is tried first because it avoids transferring a body, with a GET
+    fallback for servers that refuse it.
+
+    allow_redirects has to be passed explicitly: requests defaults it to False
+    for HEAD (unlike GET), so without it every http -> https upgrade and every
+    bare-domain -> www redirect returns a 3xx and reads as a broken link.
+
+    Args:
+        url (str): An already-standardized absolute URL.
+
+    Returns:
+        bool: True if the final response status is below 400.
+    """
+    try:
+        response = requests.head(
+            url, timeout=_LINK_CHECK_TIMEOUT_SECONDS, allow_redirects=True
+        )
+        if response.status_code in _HEAD_UNSUPPORTED_STATUSES:
+            # stream=True keeps the body off the wire; the context manager
+            # releases the connection back to the pool.
+            with requests.get(
+                url,
+                timeout=_LINK_CHECK_TIMEOUT_SECONDS,
+                allow_redirects=True,
+                stream=True,
+            ) as get_response:
+                return get_response.status_code < 400
+        return response.status_code < 400
+    except requests.RequestException:
+        # Only network-layer failures count as unreachable. A bare `except`
+        # here would also swallow KeyboardInterrupt/SystemExit on worker
+        # shutdown, and would hide genuine bugs inside this function as though
+        # the remote host were down.
+        return False
+
+
 def _preprocess_strings(keywords, text, case_sensitive):
     """
     Preprocess the keywords based on the case_sensitive flag.
@@ -1332,23 +1387,15 @@ def contains_valid_link(text, **kwargs):
         matched_url = link_match.group()
         if matched_url:
             standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
+            if _link_is_reachable(standardized_url):
                 return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
+                    "result": True,
+                    "reason": f"link {matched_url} found in output and is valid",
                 }
+            return {
+                "result": False,
+                "reason": f"link {matched_url} found in output but is invalid",
+            }
     return {"result": False, "reason": "no link found in output"}
 
 
@@ -1368,23 +1415,15 @@ def no_invalid_links(text, **kwargs):
         matched_url = link_match.group()
         if matched_url:
             standardized_url = _standardize_url(matched_url)
-            try:
-                text = requests.head(standardized_url)
-                if text.status_code == 200:
-                    return {
-                        "result": True,
-                        "reason": f"link {matched_url} found in output and is valid",
-                    }
-                else:
-                    return {
-                        "result": False,
-                        "reason": f"link {matched_url} found in output but is invalid",
-                    }
-            except:
+            if _link_is_reachable(standardized_url):
                 return {
-                    "result": False,
-                    "reason": f"link {matched_url} found in output but is invalid",
+                    "result": True,
+                    "reason": f"link {matched_url} found in output and is valid",
                 }
+            return {
+                "result": False,
+                "reason": f"link {matched_url} found in output but is invalid",
+            }
     return {"result": True, "reason": "no invalid link found in output"}
 
 
@@ -1425,7 +1464,11 @@ def api_call(
         payload["expected_response"] = expected_response
     # Check the status code and set the reason accordingly
     try:
-        api_response = requests.post(url, json=payload, headers=headers)
+        # Bounded so a user-supplied endpoint that never responds cannot pin
+        # the eval activity indefinitely.
+        api_response = requests.post(
+            url, json=payload, headers=headers, timeout=_API_CALL_TIMEOUT_SECONDS
+        )
         if api_response.status_code == 200:
             # Success
             result = api_response.json().get("result")

--- a/futureagi/agentic_eval/tests/test_link_evaluators.py
+++ b/futureagi/agentic_eval/tests/test_link_evaluators.py
@@ -1,0 +1,251 @@
+"""Tests for the link-checking deterministic evaluators in ``functions.py``.
+
+Every HTTP call is stubbed — these must not touch the network.
+
+Location note: these live in ``agentic_eval/tests/`` rather than beside the
+module under test. ``agentic_eval/pytest.ini`` already declares
+``testpaths = tests``, and it is the only layout that actually collects.
+``agentic_eval`` is a namespace package (no ``__init__.py``) while
+``core_evals/fi_evals/__init__.py`` uses three-dot relative imports that require
+``agentic_eval`` to be the top-level package. Any test placed under
+``core_evals/`` makes pytest build a Package node for those directories and
+import them rooted at ``agentic_eval/``, which fails with "attempted relative
+import beyond top-level package".
+
+The Django bootstrap below is a fallback for direct invocation;
+``agentic_eval/conftest.py`` normally configures Django first, in which case
+``settings.configured`` is already True and this block is a no-op.
+"""
+
+import sys
+from pathlib import Path
+
+# futureagi/ — the backend root, so `agentic_eval` and `tfc` are importable.
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={},
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "accounts",
+            "model_hub",
+            "tracer",
+        ],
+        REST_FRAMEWORK={},
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+    )
+    django.setup()
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+import requests  # noqa: E402
+
+from agentic_eval.core_evals.fi_evals.function.functions import (  # noqa: E402
+    _API_CALL_TIMEOUT_SECONDS,
+    _HEAD_UNSUPPORTED_STATUSES,
+    _LINK_CHECK_TIMEOUT_SECONDS,
+    _link_is_reachable,
+    api_call,
+    contains_valid_link,
+    no_invalid_links,
+)
+
+MODULE = "agentic_eval.core_evals.fi_evals.function.functions"
+
+
+def _response(status_code):
+    """A stand-in for requests.Response that also works as a context manager."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestLinkIsReachable:
+    """Unit tests for the shared liveness probe."""
+
+    @patch(f"{MODULE}.requests.head")
+    def test_head_200_is_reachable(self, mock_head):
+        mock_head.return_value = _response(200)
+        assert _link_is_reachable("https://example.com") is True
+
+    @patch(f"{MODULE}.requests.head")
+    def test_head_is_called_with_a_timeout(self, mock_head):
+        """Regression: requests defaults to no timeout, which can pin a worker."""
+        mock_head.return_value = _response(200)
+        _link_is_reachable("https://example.com")
+
+        assert mock_head.call_args.kwargs["timeout"] == _LINK_CHECK_TIMEOUT_SECONDS
+        assert 0 < _LINK_CHECK_TIMEOUT_SECONDS <= 30
+
+    @patch(f"{MODULE}.requests.head")
+    def test_head_follows_redirects(self, mock_head):
+        """Regression: allow_redirects defaults to False for HEAD (True for GET).
+
+        Without it, every http->https upgrade and bare-domain->www redirect
+        returned a 3xx and was reported as a broken link.
+        """
+        mock_head.return_value = _response(200)
+        _link_is_reachable("http://example.com")
+
+        assert mock_head.call_args.kwargs["allow_redirects"] is True
+
+    @pytest.mark.parametrize("status", sorted(_HEAD_UNSUPPORTED_STATUSES))
+    @patch(f"{MODULE}.requests.get")
+    @patch(f"{MODULE}.requests.head")
+    def test_falls_back_to_get_when_head_is_refused(self, mock_head, mock_get, status):
+        """405/403/501 mean 'no HEAD here', not 'broken link'."""
+        mock_head.return_value = _response(status)
+        mock_get.return_value = _response(200)
+
+        assert _link_is_reachable("https://example.com") is True
+
+        assert mock_get.called
+        assert mock_get.call_args.kwargs["timeout"] == _LINK_CHECK_TIMEOUT_SECONDS
+        assert mock_get.call_args.kwargs["allow_redirects"] is True
+        # Body must not be pulled down just to read a status code.
+        assert mock_get.call_args.kwargs["stream"] is True
+
+    @patch(f"{MODULE}.requests.get")
+    @patch(f"{MODULE}.requests.head")
+    def test_get_fallback_still_reports_failure(self, mock_head, mock_get):
+        mock_head.return_value = _response(405)
+        mock_get.return_value = _response(404)
+        assert _link_is_reachable("https://example.com") is False
+
+    @pytest.mark.parametrize("status", [200, 201, 204, 301, 302, 399])
+    @patch(f"{MODULE}.requests.head")
+    def test_non_error_statuses_are_reachable(self, mock_head, status):
+        mock_head.return_value = _response(status)
+        assert _link_is_reachable("https://example.com") is True
+
+    @pytest.mark.parametrize("status", [400, 404, 410, 500, 503])
+    @patch(f"{MODULE}.requests.head")
+    def test_error_statuses_are_not_reachable(self, mock_head, status):
+        mock_head.return_value = _response(status)
+        assert _link_is_reachable("https://example.com") is False
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            requests.ConnectionError("refused"),
+            requests.Timeout("timed out"),
+            requests.TooManyRedirects("loop"),
+        ],
+    )
+    @patch(f"{MODULE}.requests.head")
+    def test_network_failures_are_unreachable_not_raised(self, mock_head, exc):
+        mock_head.side_effect = exc
+        assert _link_is_reachable("https://example.com") is False
+
+    @patch(f"{MODULE}.requests.head")
+    def test_keyboard_interrupt_propagates(self, mock_head):
+        """Regression: the old bare `except:` swallowed BaseException.
+
+        On worker shutdown that turned a cancellation into a silent
+        'link is invalid' verdict.
+        """
+        mock_head.side_effect = KeyboardInterrupt()
+        with pytest.raises(KeyboardInterrupt):
+            _link_is_reachable("https://example.com")
+
+    @patch(f"{MODULE}.requests.head")
+    def test_unexpected_errors_propagate(self, mock_head):
+        """A bug in this function must not read as 'the host is down'."""
+        mock_head.side_effect = AttributeError("bug in the probe")
+        with pytest.raises(AttributeError):
+            _link_is_reachable("https://example.com")
+
+
+class TestContainsValidLink:
+    @patch(f"{MODULE}.requests.head")
+    def test_redirecting_url_is_valid(self, mock_head):
+        """The bug from #1945: a live URL that redirects was scored invalid."""
+        mock_head.return_value = _response(200)  # after following the redirect
+
+        result = contains_valid_link("see http://github.com for details")
+
+        assert result["result"] is True
+        assert "is valid" in result["reason"]
+
+    @patch(f"{MODULE}.requests.head")
+    def test_dead_url_is_invalid(self, mock_head):
+        mock_head.return_value = _response(404)
+        result = contains_valid_link("see http://example.com/gone for details")
+        assert result["result"] is False
+        assert "but is invalid" in result["reason"]
+
+    @patch(f"{MODULE}.requests.head")
+    def test_unreachable_host_is_invalid(self, mock_head):
+        mock_head.side_effect = requests.ConnectionError("no route")
+        result = contains_valid_link("see http://nope.invalid for details")
+        assert result["result"] is False
+
+    def test_no_link_in_text_makes_no_request(self):
+        with patch(f"{MODULE}.requests.head") as mock_head:
+            result = contains_valid_link("there is no link here")
+            assert result["result"] is False
+            assert result["reason"] == "no link found in output"
+            assert not mock_head.called
+
+    @patch(f"{MODULE}.requests.head")
+    def test_text_parameter_is_not_clobbered_by_the_response(self, mock_head):
+        """The old code did `text = requests.head(...)`, shadowing its own arg."""
+        mock_head.return_value = _response(200)
+        result = contains_valid_link("visit http://example.com now")
+        # The reason echoes the matched URL, which is only correct if the
+        # original text was still intact when the message was built.
+        assert "http://example.com" in result["reason"]
+
+
+class TestNoInvalidLinks:
+    @patch(f"{MODULE}.requests.head")
+    def test_redirecting_url_passes(self, mock_head):
+        """Polarity check: a good redirecting link must not fail this evaluator."""
+        mock_head.return_value = _response(200)
+        result = no_invalid_links("see http://github.com for details")
+        assert result["result"] is True
+
+    @patch(f"{MODULE}.requests.head")
+    def test_broken_url_fails(self, mock_head):
+        mock_head.return_value = _response(404)
+        result = no_invalid_links("see http://example.com/gone for details")
+        assert result["result"] is False
+
+    def test_text_without_links_passes(self):
+        result = no_invalid_links("nothing to see here")
+        assert result["result"] is True
+        assert result["reason"] == "no invalid link found in output"
+
+
+class TestApiCallTimeout:
+    @patch(f"{MODULE}.requests.post")
+    def test_post_is_called_with_a_timeout(self, mock_post):
+        """Regression: this POST had no timeout bound."""
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"result": True, "reason": "ok"}),
+        )
+
+        api_call(url="https://example.com/eval", response="hello")
+
+        assert mock_post.call_args.kwargs["timeout"] == _API_CALL_TIMEOUT_SECONDS
+        assert 0 < _API_CALL_TIMEOUT_SECONDS <= 60
+
+    @patch(f"{MODULE}.requests.post")
+    def test_timeout_is_reported_not_raised(self, mock_post):
+        mock_post.side_effect = requests.Timeout("timed out")
+        result = api_call(url="https://example.com/eval", response="hello")
+        assert result["result"] is False
+        assert "API Request Exception" in result["reason"]


### PR DESCRIPTION
Closes #1945.

## What & why

`contains_valid_link` and `no_invalid_links` probed URLs with a bare `requests.head(url)` inside a bare `except:`. Three defects in those six lines, all of which surface as a wrong score rather than an error.

### 1. No timeout

`requests` defaults to *no* timeout. These evaluators run inside eval activities, so a slow or half-open host held a worker slot until the surrounding activity timeout fired. `api_call()` had the same gap on its `requests.post`.

### 2. Valid URLs were scored invalid

Two independent causes, both fixed:

- **`allow_redirects` defaults to `False` for `HEAD`** (it defaults to `True` for `GET`). Every `http` → `https` upgrade and every bare-domain → `www` redirect returned a 3xx, failed the `status_code == 200` test, and was reported as `"found in output but is invalid"`.
- **Many servers don't implement `HEAD`**, answering 405 — or 403/501 behind a CDN or WAF. Same misread.

For `no_invalid_links` the polarity inverts the harm: a genuinely broken link and a perfectly healthy redirecting one both returned `result: False`, so the evaluator was unreliable in both directions.

### 3. Bare `except:`

`except:` catches `BaseException`. A `KeyboardInterrupt` during worker shutdown became a silent `"link is invalid"` verdict instead of propagating, and a `NameError` inside the `try` was indistinguishable from an unreachable host.

Both evaluators now share `_link_is_reachable()`, which sets a timeout, follows redirects, falls back to `GET` when `HEAD` is refused, treats any status below 400 as reachable, and narrows the handler to `requests.RequestException`. That also removes `text = requests.head(...)`, which shadowed the functions' own `text` parameter.

### Correction to the issue

#1945 names the third site `check_api_call`. It's actually **`api_call`** (`functions.py:1428` is the `requests.post` inside it). It already caught `Exception` properly, so it only needed the timeout.

## Verification

Both defects confirmed to reproduce on `upstream/dev`@`ff5cd219` and to be fixed here, using only symbols present in both versions:

```
################ BASELINE — upstream/dev ################
  [FAIL] redirecting URL reported valid — link http://github.com found in output but is invalid
  [FAIL] HEAD-refusing (405) URL reported valid — link https://example.com found in output but is invalid
  [FAIL] link check passes a timeout — timeout=None
  [FAIL] api_call passes a timeout — timeout=None
  [FAIL] KeyboardInterrupt propagates (not scored as invalid)

################ PATCHED — this branch ################
  [PASS] redirecting URL reported valid — link http://github.com found in output and is valid
  [PASS] HEAD-refusing (405) URL reported valid — link https://example.com found in output and is valid
  [PASS] link check passes a timeout — timeout=5
  [PASS] api_call passes a timeout — timeout=30
  [PASS] KeyboardInterrupt propagates (not scored as invalid)
```

Plus **33 new tests**, all HTTP stubbed — no network access. `ruff` findings on `functions.py` go *down* 73 → 60 (the two `except:` were E722); no new violations.

Docker was unavailable so `bin/test` could not run, but these tests need neither a database nor a network.

## Two things that needed solving to make the tests runnable

I said in #1945 that I'd put tests in `function/tests/` alongside #1611. **That location cannot collect**, and I verified it against #1611's own file, not just mine:

```
$ pytest core_evals/fi_evals/function/tests/test_guardrail_evaluators.py
E   ImportError: attempted relative import beyond top-level package
    core_evals/fi_evals/__init__.py:2
```

`agentic_eval` is a namespace package (no `__init__.py`), while `core_evals/fi_evals/__init__.py` uses three-dot relative imports that require `agentic_eval` to be the top-level package. Anything placed under `core_evals/` makes pytest build `Package` nodes for those directories and import them rooted at `agentic_eval/`, which breaks those imports. So these tests live in **`agentic_eval/tests/`** — which `agentic_eval/pytest.ini` already declares via `testpaths = tests`.

**Flagging for @#1611's author:** your `function/tests/` files will hit this too. Happy to send a patch moving them, or to rebase mine onto whatever layout you prefer — I have no attachment to the location, only to it collecting.

Second, `agentic_eval/conftest.py` set `DJANGO_SETTINGS_MODULE` to `tfc.settings` — a package whose `__init__.py` is a one-line stub. Django was configured with an empty settings object, so `INSTALLED_APPS` was empty and importing any app model raised `doesn't declare an explicit app_label`; the conftest's blanket `except Exception: pass` then hid it and collection failed later at the import site. Corrected to `tfc.settings.settings`, which `manage.py`, `asgi.py`, `wsgi.py` and `celery.py` all already use. Without this the new tests cannot run at all.

That's the same wrong string I hit in #1952 — worth a grep for other occurrences.

## A note on formatting

`functions.py` is **not** reformatted in this PR. It isn't Black-clean on `dev`, and running the formatter over it turns a 74-line fix into a ~1,000-line diff. Every line I added is within the 88-column limit. Happy to send the reformat separately if you want it.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — **not run; Docker unavailable.** The 33 new tests pass under `agentic_eval/pytest.ini`; see Verification.
- [x] `yarn test:run` passes locally (frontend) — n/a
- [x] `yarn contracts:check` passes if API surface changed — n/a
- [x] I've updated the documentation where relevant — rationale is inline
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
