### PR TITLE
perf(tracer): hoist the ClickHouse reader and batch the end-user rollup queries

### DIFF
--- a/futureagi/tracer/tasks/session.py
+++ b/futureagi/tracer/tasks/session.py
@@ -13,12 +13,44 @@ from decimal import Decimal
 
 import structlog
 from django.db import close_old_connections, transaction
-from django.db.models import F, Q
+from django.db.models import Count, F, Q
 from django.utils import timezone
 
 from tfc.temporal import temporal_activity
 
 logger = structlog.get_logger(__name__)
+
+# Analytics fields recomputed by the end-user rollup tasks. Kept as a constant so
+# the bulk_update() column list cannot drift from the per-field assignments.
+_END_USER_ANALYTICS_FIELDS = [
+    "total_sessions",
+    "total_traces",
+    "total_tokens_used",
+    "total_cost",
+    "first_seen",
+    "last_seen",
+]
+
+# Cap on how many EndUser rows are held before being written out. Bounds both
+# memory and how much recomputation a mid-task failure costs.
+_ANALYTICS_UPDATE_BATCH_SIZE = 500
+
+
+def _flush_end_user_updates(pending):
+    """Write queued EndUser analytics rows and clear the queue.
+
+    Replaces a per-user save(update_fields=...) with one UPDATE per batch. The
+    column list matches the update_fields the per-user saves used, so
+    ``updated_at`` (auto_now on BaseModel) is left untouched exactly as before —
+    save() only writes the columns named in update_fields.
+    """
+    if not pending:
+        return
+
+    from tracer.models.observation_span import EndUser
+
+    EndUser.objects.bulk_update(pending, _END_USER_ANALYTICS_FIELDS)
+    pending.clear()
 
 
 def _aggregate_spans_by_trace_ids(trace_ids):
@@ -419,107 +451,113 @@ def update_end_user_analytics_task():
             Q(last_seen__gte=cutoff_time) | Q(last_seen__isnull=True)
         ).select_related("project", "organization")
 
+        # One grouped COUNT for every user in scope, instead of one per
+        # iteration. Users with no sessions are simply absent from the mapping,
+        # which .get(..., 0) below turns back into the 0 the per-user
+        # .count() returned.
+        session_counts = dict(
+            TraceSession.objects.filter(end_user__in=active_users.values("pk"))
+            .values_list("end_user")
+            .annotate(session_count=Count("id"))
+        )
+
         updated_count = 0
+        pending_updates = []
 
-        for user in active_users:
-            try:
-                # Try the analytics-service CH path first for session-level
-                # rollups it already computes.
-                ch_stats = _get_user_stats_from_ch(user, user.project_id)
+        # A single ClickHouse client for the whole loop. CHSpanReader opens a
+        # connection in __init__ and closes it in __exit__, and
+        # aggregate_by_end_user() takes the user id as an argument rather than
+        # holding per-user state, so acquiring one per iteration bought nothing.
+        with get_reader() as reader:
+            for user in active_users:
+                try:
+                    # Try the analytics-service CH path first for session-level
+                    # rollups it already computes.
+                    ch_stats = _get_user_stats_from_ch(user, user.project_id)
 
-                if ch_stats is not None:
-                    # Use the analytics-service CH data for session-level
-                    # rollups; per-user span/trace aggregate now also comes
-                    # from CH via CHSpanReader.aggregate_by_end_user (single
-                    # call returning span_count, trace_count, tokens, cost,
-                    # first_seen, last_seen).
-                    user.total_sessions = ch_stats["session_count"]
-                    user.total_tokens_used = ch_stats["total_tokens"]
-                    user.total_cost = Decimal(str(ch_stats["total_cost"]))
+                    if ch_stats is not None:
+                        # Use the analytics-service CH data for session-level
+                        # rollups; per-user span/trace aggregate now also comes
+                        # from CH via CHSpanReader.aggregate_by_end_user (single
+                        # call returning span_count, trace_count, tokens, cost,
+                        # first_seen, last_seen).
+                        user.total_sessions = ch_stats["session_count"]
+                        user.total_tokens_used = ch_stats["total_tokens"]
+                        user.total_cost = Decimal(str(ch_stats["total_cost"]))
 
-                    # trace_count via uniqExact(trace_id) in CH (was
-                    # .filter(end_user=user).values("trace_id").distinct()
-                    # .count() in PG). project_id scopes the read for
-                    # defense-in-depth tenant isolation.
-                    with get_reader() as reader:
+                        # trace_count via uniqExact(trace_id) in CH (was
+                        # .filter(end_user=user).values("trace_id").distinct()
+                        # .count() in PG). project_id scopes the read for
+                        # defense-in-depth tenant isolation.
                         user_agg = reader.aggregate_by_end_user(
                             str(user.id), project_id=str(user.project_id)
                         )
-                    user.total_traces = user_agg["trace_count"]
+                        user.total_traces = user_agg["trace_count"]
 
-                    if ch_stats.get("first_seen"):
-                        if (
-                            not user.first_seen
-                            or ch_stats["first_seen"] < user.first_seen
-                        ):
-                            user.first_seen = ch_stats["first_seen"]
+                        if ch_stats.get("first_seen"):
+                            if (
+                                not user.first_seen
+                                or ch_stats["first_seen"] < user.first_seen
+                            ):
+                                user.first_seen = ch_stats["first_seen"]
 
-                    # last_seen parity: prefer user_agg["last_seen"] which
-                    # is max(end_time) — matches Django's previous behavior
-                    # of `.order_by("-end_time").first().end_time`. The
-                    # legacy ch_stats path returns max(start_time), which
-                    # underestimates last_seen for any long-running span.
-                    # Use that only as a fallback when CHSpanReader has
-                    # nothing (e.g. CH lag for this user).
-                    if user_agg["last_seen"]:
-                        user.last_seen = user_agg["last_seen"]
-                    elif ch_stats.get("last_seen"):
-                        user.last_seen = ch_stats["last_seen"]
+                        # last_seen parity: prefer user_agg["last_seen"] which
+                        # is max(end_time) — matches Django's previous behavior
+                        # of `.order_by("-end_time").first().end_time`. The
+                        # legacy ch_stats path returns max(start_time), which
+                        # underestimates last_seen for any long-running span.
+                        # Use that only as a fallback when CHSpanReader has
+                        # nothing (e.g. CH lag for this user).
+                        if user_agg["last_seen"]:
+                            user.last_seen = user_agg["last_seen"]
+                        elif ch_stats.get("last_seen"):
+                            user.last_seen = ch_stats["last_seen"]
 
-                    user.save(
-                        update_fields=[
-                            "total_sessions",
-                            "total_traces",
-                            "total_tokens_used",
-                            "total_cost",
-                            "first_seen",
-                            "last_seen",
-                        ]
-                    )
-                    updated_count += 1
-                    continue
+                        pending_updates.append(user)
+                        updated_count += 1
+                        if len(pending_updates) >= _ANALYTICS_UPDATE_BATCH_SIZE:
+                            _flush_end_user_updates(pending_updates)
+                        continue
 
-                # Fallback path: the analytics-service short-circuit didn't
-                # apply, but all per-user span aggregates still go through
-                # CH via CHSpanReader.aggregate_by_end_user — one CH read
-                # covers Sum(tokens), Sum(cost), uniqExact(trace_id),
-                # min(start_time) (first_seen), max(end_time) (last_seen).
-                session_count = TraceSession.objects.filter(end_user=user).count()
+                    # Fallback path: the analytics-service short-circuit didn't
+                    # apply, but all per-user span aggregates still go through
+                    # CH via CHSpanReader.aggregate_by_end_user — one CH read
+                    # covers Sum(tokens), Sum(cost), uniqExact(trace_id),
+                    # min(start_time) (first_seen), max(end_time) (last_seen).
+                    session_count = session_counts.get(user.id, 0)
 
-                with get_reader() as reader:
                     user_agg = reader.aggregate_by_end_user(
                         str(user.id), project_id=str(user.project_id)
                     )
 
-                # Update user analytics
-                user.total_sessions = session_count
-                user.total_traces = user_agg["trace_count"]
-                user.total_tokens_used = user_agg["total_tokens"]
-                user.total_cost = Decimal(str(user_agg["cost"] or 0))
+                    # Update user analytics
+                    user.total_sessions = session_count
+                    user.total_traces = user_agg["trace_count"]
+                    user.total_tokens_used = user_agg["total_tokens"]
+                    user.total_cost = Decimal(str(user_agg["cost"] or 0))
 
-                if user_agg["first_seen"]:
-                    if not user.first_seen or user_agg["first_seen"] < user.first_seen:
-                        user.first_seen = user_agg["first_seen"]
+                    if user_agg["first_seen"]:
+                        if (
+                            not user.first_seen
+                            or user_agg["first_seen"] < user.first_seen
+                        ):
+                            user.first_seen = user_agg["first_seen"]
 
-                if user_agg["last_seen"]:
-                    user.last_seen = user_agg["last_seen"]
+                    if user_agg["last_seen"]:
+                        user.last_seen = user_agg["last_seen"]
 
-                user.save(
-                    update_fields=[
-                        "total_sessions",
-                        "total_traces",
-                        "total_tokens_used",
-                        "total_cost",
-                        "first_seen",
-                        "last_seen",
-                    ]
-                )
+                    pending_updates.append(user)
+                    updated_count += 1
+                    if len(pending_updates) >= _ANALYTICS_UPDATE_BATCH_SIZE:
+                        _flush_end_user_updates(pending_updates)
 
-                updated_count += 1
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to update analytics for user {user.id}: {e}"
+                    )
+                    continue
 
-            except Exception as e:
-                logger.warning(f"Failed to update analytics for user {user.id}: {e}")
-                continue
+        _flush_end_user_updates(pending_updates)
 
         logger.info(f"Updated analytics for {updated_count} end users")
         return {"updated_users": updated_count}
@@ -712,82 +750,93 @@ def recalculate_project_user_analytics_task(project_id: str):
         close_old_connections()
 
         users = EndUser.objects.filter(project_id=project_id)
+
+        # One grouped COUNT for the whole project instead of one per iteration.
+        # Users with no sessions are absent from the mapping; .get(..., 0) below
+        # reproduces the 0 the per-user .count() returned.
+        session_counts = dict(
+            TraceSession.objects.filter(end_user__in=users.values("pk"))
+            .values_list("end_user")
+            .annotate(session_count=Count("id"))
+        )
+
         updated_count = 0
 
-        for user in users:
-            try:
-                with transaction.atomic():
-                    # Try the analytics-service CH path first for session-
-                    # level rollups it already provides.
-                    ch_stats = _get_user_stats_from_ch(user, project_id)
+        # One ClickHouse client for the whole loop — see the note in
+        # update_end_user_analytics_task.
+        with get_reader() as reader:
+            for user in users:
+                try:
+                    with transaction.atomic():
+                        # Try the analytics-service CH path first for session-
+                        # level rollups it already provides.
+                        ch_stats = _get_user_stats_from_ch(user, project_id)
 
-                    if ch_stats is not None:
-                        user.total_sessions = ch_stats["session_count"]
-                        user.total_tokens_used = ch_stats["total_tokens"]
-                        user.total_cost = Decimal(str(ch_stats["total_cost"]))
+                        if ch_stats is not None:
+                            user.total_sessions = ch_stats["session_count"]
+                            user.total_tokens_used = ch_stats["total_tokens"]
+                            user.total_cost = Decimal(str(ch_stats["total_cost"]))
 
-                        # trace_count via uniqExact(trace_id) in CH (was
-                        # .filter(end_user=user).values("trace_id").
-                        # distinct().count() in PG). project_id is the
-                        # task argument; pass it through for tenant-scope
-                        # defense-in-depth.
-                        with get_reader() as reader:
+                            # trace_count via uniqExact(trace_id) in CH (was
+                            # .filter(end_user=user).values("trace_id").
+                            # distinct().count() in PG). project_id is the
+                            # task argument; pass it through for tenant-scope
+                            # defense-in-depth.
                             user_agg = reader.aggregate_by_end_user(
                                 str(user.id), project_id=str(project_id)
                             )
-                        user.total_traces = user_agg["trace_count"]
+                            user.total_traces = user_agg["trace_count"]
 
-                        if ch_stats.get("first_seen"):
-                            user.first_seen = ch_stats["first_seen"]
+                            if ch_stats.get("first_seen"):
+                                user.first_seen = ch_stats["first_seen"]
 
-                        # last_seen parity: prefer user_agg["last_seen"]
-                        # (max(end_time)) over ch_stats["last_seen"]
-                        # (max(start_time)) — matches Django's
-                        # `.order_by("-end_time").first().end_time`
-                        # semantics. ch_stats is the legacy fallback for
-                        # cases where CHSpanReader has nothing.
-                        if user_agg["last_seen"]:
-                            user.last_seen = user_agg["last_seen"]
-                        elif ch_stats.get("last_seen"):
-                            user.last_seen = ch_stats["last_seen"]
+                            # last_seen parity: prefer user_agg["last_seen"]
+                            # (max(end_time)) over ch_stats["last_seen"]
+                            # (max(start_time)) — matches Django's
+                            # `.order_by("-end_time").first().end_time`
+                            # semantics. ch_stats is the legacy fallback for
+                            # cases where CHSpanReader has nothing.
+                            if user_agg["last_seen"]:
+                                user.last_seen = user_agg["last_seen"]
+                            elif ch_stats.get("last_seen"):
+                                user.last_seen = ch_stats["last_seen"]
 
-                        user.save()
-                        updated_count += 1
-                        continue
+                            user.save()
+                            updated_count += 1
+                            continue
 
-                    # Fallback path: the analytics-service short-circuit
-                    # didn't apply, but the per-user span aggregate still
-                    # goes through CH via CHSpanReader.aggregate_by_end_user
-                    # — one CH read covers Sum(tokens), Sum(cost),
-                    # uniqExact(trace_id), min(start_time) (first_seen),
-                    # max(end_time) (last_seen). Replaces 5 separate
-                    # ObservationSpan queries.
-                    session_count = TraceSession.objects.filter(end_user=user).count()
+                        # Fallback path: the analytics-service short-circuit
+                        # didn't apply, but the per-user span aggregate still
+                        # goes through CH via CHSpanReader.aggregate_by_end_user
+                        # — one CH read covers Sum(tokens), Sum(cost),
+                        # uniqExact(trace_id), min(start_time) (first_seen),
+                        # max(end_time) (last_seen). Replaces 5 separate
+                        # ObservationSpan queries.
+                        session_count = session_counts.get(user.id, 0)
 
-                    with get_reader() as reader:
                         user_agg = reader.aggregate_by_end_user(
                             str(user.id), project_id=str(project_id)
                         )
 
-                    user.total_sessions = session_count
-                    user.total_traces = user_agg["trace_count"]
-                    user.total_tokens_used = user_agg["total_tokens"]
-                    user.total_cost = Decimal(str(user_agg["cost"] or 0))
+                        user.total_sessions = session_count
+                        user.total_traces = user_agg["trace_count"]
+                        user.total_tokens_used = user_agg["total_tokens"]
+                        user.total_cost = Decimal(str(user_agg["cost"] or 0))
 
-                    if user_agg["first_seen"]:
-                        user.first_seen = user_agg["first_seen"]
+                        if user_agg["first_seen"]:
+                            user.first_seen = user_agg["first_seen"]
 
-                    if user_agg["last_seen"]:
-                        user.last_seen = user_agg["last_seen"]
+                        if user_agg["last_seen"]:
+                            user.last_seen = user_agg["last_seen"]
 
-                    user.save()
-                    updated_count += 1
+                        user.save()
+                        updated_count += 1
 
-            except Exception as e:
-                logger.warning(
-                    f"Failed to recalculate analytics for user {user.id}: {e}"
-                )
-                continue
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to recalculate analytics for user {user.id}: {e}"
+                    )
+                    continue
 
         logger.info(
             f"Recalculated analytics for {updated_count} users in project {project_id}"

--- a/futureagi/tracer/tests/test_end_user_analytics_rollup.py
+++ b/futureagi/tracer/tests/test_end_user_analytics_rollup.py
@@ -1,0 +1,285 @@
+"""Round-trip regression tests for the end-user analytics rollup tasks.
+
+These pin the *number* of external round-trips the two rollup tasks make, which
+is the property that regressed: the ClickHouse reader, the session COUNT and the
+row write were all inside the per-user loop, so each scaled linearly with the
+number of users.
+
+The ORM and the ClickHouse reader are both stubbed, so nothing here needs a
+database, a ClickHouse instance, or the Docker test stack. That is deliberate —
+a query-count assertion only needs to observe the calls, not execute them.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULE = "tracer.tasks.session"
+
+
+class _FakeUser:
+    """Stands in for an EndUser row."""
+
+    def __init__(self, idx):
+        self.id = f"user-{idx}"
+        self.project_id = "project-1"
+        self.first_seen = None
+        self.last_seen = None
+        self.total_sessions = None
+        self.total_traces = None
+        self.total_tokens_used = None
+        self.total_cost = None
+        self.saved = 0
+
+    def save(self, update_fields=None):
+        self.saved += 1
+
+
+def _fake_queryset(users):
+    """A queryset stub that iterates `users` and supports .values("pk")."""
+    qs = MagicMock()
+    qs.__iter__ = lambda self: iter(users)
+    qs.select_related.return_value = qs
+    qs.values.return_value = qs
+    return qs
+
+
+def _agg(trace_count=3):
+    return {
+        "trace_count": trace_count,
+        "total_tokens": 100,
+        "cost": 1.5,
+        "first_seen": None,
+        "last_seen": None,
+    }
+
+
+@pytest.fixture
+def reader():
+    """A ClickHouse reader stub usable as a context manager."""
+    r = MagicMock()
+    r.aggregate_by_end_user.return_value = _agg()
+    r.__enter__ = MagicMock(return_value=r)
+    r.__exit__ = MagicMock(return_value=False)
+    return r
+
+
+def _session_counts_queryset(mapping):
+    """Stub for the grouped-COUNT query; dict() over it yields `mapping`."""
+    qs = MagicMock()
+    qs.values_list.return_value = qs
+    qs.annotate.return_value = list(mapping.items())
+    return qs
+
+
+class TestUpdateEndUserAnalyticsRoundTrips:
+    """update_end_user_analytics_task()"""
+
+    def _run(self, users, reader, ch_stats=None):
+        from tracer.tasks.session import update_end_user_analytics_task
+
+        end_user_model = MagicMock()
+        end_user_model.objects.filter.return_value = _fake_queryset(users)
+
+        trace_session_model = MagicMock()
+        trace_session_model.objects.filter.return_value = _session_counts_queryset(
+            {u.id: 7 for u in users}
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "tracer.models.observation_span": MagicMock(EndUser=end_user_model),
+                "tracer.models.trace_session": MagicMock(
+                    TraceSession=trace_session_model
+                ),
+                "tracer.services.clickhouse.v2": MagicMock(
+                    get_reader=MagicMock(return_value=reader)
+                ),
+            },
+        ) as mods:
+            get_reader = mods["tracer.services.clickhouse.v2"].get_reader
+            with patch(f"{MODULE}._get_user_stats_from_ch", return_value=ch_stats):
+                with patch(f"{MODULE}.close_old_connections"):
+                    result = update_end_user_analytics_task()
+        return result, end_user_model, trace_session_model, get_reader
+
+    @pytest.mark.parametrize("n_users", [1, 5, 50])
+    def test_clickhouse_reader_acquired_once_regardless_of_user_count(
+        self, n_users, reader
+    ):
+        """The regression: get_reader() was called once per user."""
+        users = [_FakeUser(i) for i in range(n_users)]
+        result, _, _, get_reader = self._run(users, reader)
+
+        assert get_reader.call_count == 1
+        # The per-user aggregate itself still runs once per user.
+        assert reader.aggregate_by_end_user.call_count == n_users
+        assert result["updated_users"] == n_users
+
+    @pytest.mark.parametrize("n_users", [1, 5, 50])
+    def test_session_counts_fetched_in_one_query(self, n_users, reader):
+        """The per-user TraceSession COUNT collapses to a single grouped query."""
+        users = [_FakeUser(i) for i in range(n_users)]
+        _, _, trace_session_model, _ = self._run(users, reader)
+
+        assert trace_session_model.objects.filter.call_count == 1
+
+    @pytest.mark.parametrize("n_users", [1, 5, 50])
+    def test_rows_written_via_bulk_update_not_per_user_save(self, n_users, reader):
+        """Writes are batched; no per-user save() survives on this path."""
+        users = [_FakeUser(i) for i in range(n_users)]
+        _, end_user_model, _, _ = self._run(users, reader)
+
+        assert all(u.saved == 0 for u in users)
+        assert end_user_model.objects.bulk_update.called
+        # 50 users at a batch size of 500 is still a single write.
+        assert end_user_model.objects.bulk_update.call_count == 1
+
+    def test_bulk_update_writes_the_same_columns_the_saves_did(self, reader):
+        """The column list must match the old save(update_fields=...) exactly.
+
+        `updated_at` is auto_now on BaseModel; it was not in update_fields
+        before, so it must not appear here either.
+        """
+        from tracer.tasks.session import _END_USER_ANALYTICS_FIELDS
+
+        users = [_FakeUser(0)]
+        _, end_user_model, _, _ = self._run(users, reader)
+
+        _, fields = end_user_model.objects.bulk_update.call_args[0]
+        assert fields == _END_USER_ANALYTICS_FIELDS
+        assert set(fields) == {
+            "total_sessions",
+            "total_traces",
+            "total_tokens_used",
+            "total_cost",
+            "first_seen",
+            "last_seen",
+        }
+        assert "updated_at" not in fields
+
+    def test_batches_are_flushed_at_the_configured_size(self, reader):
+        """More users than the batch size produces more than one write."""
+        from tracer.tasks.session import _ANALYTICS_UPDATE_BATCH_SIZE
+
+        n = _ANALYTICS_UPDATE_BATCH_SIZE + 1
+        users = [_FakeUser(i) for i in range(n)]
+        _, end_user_model, _, _ = self._run(users, reader)
+
+        assert end_user_model.objects.bulk_update.call_count == 2
+
+    def test_session_count_falls_back_to_zero_for_users_with_no_sessions(self, reader):
+        """Absent from the grouped mapping must mean 0, as .count() returned."""
+        from tracer.tasks.session import update_end_user_analytics_task
+
+        users = [_FakeUser(0)]
+        end_user_model = MagicMock()
+        end_user_model.objects.filter.return_value = _fake_queryset(users)
+        trace_session_model = MagicMock()
+        # Empty mapping — this user has no sessions at all.
+        trace_session_model.objects.filter.return_value = _session_counts_queryset({})
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "tracer.models.observation_span": MagicMock(EndUser=end_user_model),
+                "tracer.models.trace_session": MagicMock(
+                    TraceSession=trace_session_model
+                ),
+                "tracer.services.clickhouse.v2": MagicMock(
+                    get_reader=MagicMock(return_value=reader)
+                ),
+            },
+        ):
+            with patch(f"{MODULE}._get_user_stats_from_ch", return_value=None):
+                with patch(f"{MODULE}.close_old_connections"):
+                    update_end_user_analytics_task()
+
+        assert users[0].total_sessions == 0
+
+    def test_a_failing_user_does_not_abort_the_run(self, reader):
+        """Per-user error isolation must survive the refactor."""
+        users = [_FakeUser(i) for i in range(3)]
+        reader.aggregate_by_end_user.side_effect = [
+            _agg(),
+            RuntimeError("CH blew up for this user"),
+            _agg(),
+        ]
+        result, _, _, _ = self._run(users, reader)
+
+        assert result["updated_users"] == 2
+
+    def test_short_circuit_path_uses_ch_stats_session_count(self, reader):
+        """When the analytics service answers, its session_count wins."""
+        users = [_FakeUser(0)]
+        ch_stats = {
+            "session_count": 42,
+            "total_tokens": 10,
+            "total_cost": 2,
+            "first_seen": None,
+            "last_seen": None,
+        }
+        self._run(users, reader, ch_stats=ch_stats)
+
+        assert users[0].total_sessions == 42
+        assert users[0].total_cost == Decimal("2")
+
+
+class TestRecalculateProjectUserAnalyticsRoundTrips:
+    """recalculate_project_user_analytics_task()"""
+
+    def _run(self, users, reader):
+        from tracer.tasks.session import recalculate_project_user_analytics_task
+
+        end_user_model = MagicMock()
+        end_user_model.objects.filter.return_value = _fake_queryset(users)
+        trace_session_model = MagicMock()
+        trace_session_model.objects.filter.return_value = _session_counts_queryset(
+            {u.id: 3 for u in users}
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "tracer.models.observation_span": MagicMock(EndUser=end_user_model),
+                "tracer.models.trace_session": MagicMock(
+                    TraceSession=trace_session_model
+                ),
+                "tracer.services.clickhouse.v2": MagicMock(
+                    get_reader=MagicMock(return_value=reader)
+                ),
+            },
+        ) as mods:
+            get_reader = mods["tracer.services.clickhouse.v2"].get_reader
+            with patch(f"{MODULE}._get_user_stats_from_ch", return_value=None):
+                with patch(f"{MODULE}.close_old_connections"):
+                    with patch(f"{MODULE}.transaction.atomic"):
+                        result = recalculate_project_user_analytics_task("project-1")
+        return result, trace_session_model, get_reader
+
+    @pytest.mark.parametrize("n_users", [1, 5, 50])
+    def test_clickhouse_reader_acquired_once(self, n_users, reader):
+        users = [_FakeUser(i) for i in range(n_users)]
+        result, _, get_reader = self._run(users, reader)
+
+        assert get_reader.call_count == 1
+        assert result["updated_users"] == n_users
+
+    @pytest.mark.parametrize("n_users", [1, 5, 50])
+    def test_session_counts_fetched_in_one_query(self, n_users, reader):
+        users = [_FakeUser(i) for i in range(n_users)]
+        _, trace_session_model, _ = self._run(users, reader)
+
+        assert trace_session_model.objects.filter.call_count == 1
+
+    def test_per_user_save_is_retained(self, reader):
+        """This task's save() has no update_fields, so it also writes
+        updated_at (auto_now). It is deliberately NOT converted to
+        bulk_update, which would silently stop maintaining that column.
+        """
+        users = [_FakeUser(i) for i in range(4)]
+        self._run(users, reader)
+
+        assert all(u.saved == 1 for u in users)


### PR DESCRIPTION
Closes #1946.

## What & why

Both end-user analytics rollups acquired a ClickHouse client, ran a Postgres `COUNT` and issued a row `UPDATE` **once per user**, so every external round-trip scaled linearly with the `EndUser` population.

Per task, before → after:

| | before | after |
|---|---|---|
| ClickHouse client acquisitions | N | **1** |
| Postgres session `COUNT`s | N | **1** |
| Postgres `UPDATE`s (`update_end_user_analytics_task`) | N | **⌈N / 500⌉** |
| ClickHouse aggregate queries | N | N *(unchanged — see below)* |

### The reader hoist

`CHSpanReader` opens a connection in `__init__` and closes it in `__exit__`, and `aggregate_by_end_user()` takes the user id as an argument rather than holding per-user state — so acquiring one per iteration bought nothing. One client now wraps each loop.

The per-user *aggregate query* is unchanged. Collapsing those needs a multi-user reader method, which is the larger change I flagged in the issue and did not attempt here.

### The session counts

One grouped query per task replaces the per-user `.count()`:

```python
session_counts = dict(
    TraceSession.objects.filter(end_user__in=users.values("pk"))
    .values_list("end_user")
    .annotate(session_count=Count("id"))
)
```

Users with no sessions are simply absent from the mapping; `.get(user.id, 0)` reproduces the `0` the per-user `.count()` returned. There's a test for exactly that.

### The writes — and why only one of the two tasks batches

`update_end_user_analytics_task` already saved with `update_fields=[...]`. `bulk_update` over that same column list is **exactly** equivalent, including leaving `updated_at` untouched: `save(update_fields=...)` never wrote it either, because `auto_now` only reaches the database for columns named in `update_fields`.

`recalculate_project_user_analytics_task` **keeps its per-user `save()`**. That one has no `update_fields`, so it *does* maintain `updated_at` (auto_now on `BaseModel`) — converting it to `bulk_update` would silently stop maintaining that column. It also sits inside a per-user `transaction.atomic()` whose granularity seemed worth preserving. The two big wins (reader acquisitions, session counts) are captured there regardless.

If you'd rather that task batch too, it's a small follow-up — it just needs `updated_at` added to the column list and set explicitly.

Per-user error isolation is unchanged: a user that raises is still logged and skipped without aborting the run.

## Verification

`tracer/tests/test_end_user_analytics_rollup.py` — **21 tests**, stubbing the ORM and the reader, so no database or ClickHouse instance is required.

```
BASELINE (upstream/dev @ ff5cd219)   14 failed, 7 passed
PATCHED  (this branch)               21 passed
```

The 7 that pass on both are the `n_users=1` parametrisations (where 1 acquisition trivially equals 1) and the behaviour-preservation assertions. That's deliberate — it shows the suite is detecting the *scaling* regression rather than merely detecting new code.

What the tests pin:

- `get_reader()` called exactly once for 1, 5 and 50 users — on both tasks
- the session `COUNT` issued exactly once, for 1, 5 and 50 users — on both tasks
- writes go through `bulk_update`, not per-user `save()`, on the batching task
- the `bulk_update` column list matches the old `update_fields` exactly, and **does not** contain `updated_at`
- batches flush at `_ANALYTICS_UPDATE_BATCH_SIZE` (501 users → 2 writes)
- a user absent from the counts mapping gets `total_sessions == 0`
- one failing user doesn't abort the run
- `recalculate_project_user_analytics_task` still calls `save()` once per user

Docker was unavailable so `bin/test` couldn't run; these tests don't need it. A `CaptureQueriesContext` test against a real database would be a good complement once someone can run one — I went with call-count assertions because they pin the same property and are executable today.

## Reviewing the diff

The loop bodies are now nested one level deeper inside `with get_reader() as reader:`, so the raw diff is mostly reindentation. To check the logic separately, an indentation-insensitive diff shows the only removed lines are the intended ones:

```
-from django.db.models import F, Q
-user.save(update_fields=[...])          ×2
-session_count = TraceSession.objects.filter(end_user=user).count()   ×2
-with get_reader() as reader:            ×4  (the per-iteration acquisitions)
```

Nothing else in the file changes.

`session.py` is **not** run through Black. It isn't Black-clean on `dev`, so the formatter rewrites ~200 unrelated lines and buries the change. Every line added or reindented here stays within 88 columns, and `ruff` findings are unchanged at 2 (both pre-existing `C401`).

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — **not run; Docker unavailable.** The 21 new tests pass; see Verification.
- [x] `yarn test:run` passes locally (frontend) — n/a
- [x] `yarn contracts:check` passes if API surface changed — n/a
- [x] I've updated the documentation where relevant — rationale is inline
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
