### PR TITLE
test(evaluations): cover the run_eval composition and the enum->registry contract

### DIFF
--- a/futureagi/evaluations/engine/tests/test_registry_contract.py
+++ b/futureagi/evaluations/engine/tests/test_registry_contract.py
@@ -1,0 +1,145 @@
+"""The enum -> registry contract.
+
+``registry._build_registry()`` populates the name -> class map by walking
+``agentic_eval.core_evals.fi_evals.__all__``, and ``get_eval_class()`` looks up
+by the *string* an eval type is identified by. The eval-type enums in
+``agentic_eval.core_evals.fi_evals.eval_type`` hold exactly those strings as
+their values (``FunctionEvalTypeId.CONTAINS_VALID_LINK == "ContainsValidLink"``).
+
+So ``__all__`` is the de-facto registration contract: an evaluator class that
+exists, is correct and is listed in ``eval_type.py`` but is *not* exported in
+``__all__`` is silently absent from the registry. Nothing asserted that
+correspondence, which made "someone forgot the export" a quiet runtime failure
+rather than a red build. These tests close that.
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_evals import eval_type as eval_type_module
+from evaluations.engine.registry import (
+    get_eval_class,
+    is_registered,
+    list_registered,
+)
+
+# Every *EvalTypeId enum declared in eval_type.py, discovered rather than
+# hard-coded so a newly added enum is covered automatically.
+EVAL_TYPE_ENUMS = [
+    getattr(eval_type_module, name)
+    for name in sorted(dir(eval_type_module))
+    if name.endswith("EvalTypeId") and isinstance(getattr(eval_type_module, name), type)
+]
+
+ALL_MEMBERS = [
+    pytest.param(enum_cls, member, id=f"{enum_cls.__name__}.{member.name}")
+    for enum_cls in EVAL_TYPE_ENUMS
+    for member in enum_cls
+]
+
+
+class TestEnumRegistryContract:
+    def test_enums_were_discovered(self):
+        """Guards the discovery above — an empty parametrisation would pass silently."""
+        assert EVAL_TYPE_ENUMS, "no *EvalTypeId enums found in eval_type.py"
+        assert len(ALL_MEMBERS) > 50, f"only {len(ALL_MEMBERS)} enum members discovered"
+
+    @pytest.mark.parametrize("enum_cls,member", ALL_MEMBERS)
+    def test_every_enum_member_resolves(self, enum_cls, member):
+        """The core contract: every declared eval type must resolve to something
+        the engine can instantiate.
+
+        A failure here almost always means the evaluator class was added to
+        eval_type.py but not exported from fi_evals.__all__.
+
+        Asserted as `callable` rather than `isinstance(..., type)` deliberately:
+        EE-gated evaluators resolve to a real class in an enterprise build and to
+        the `tfc.ee_stub._ee_stub` function in an OSS checkout. Both are callable
+        and both are what `runner.run_eval()` does with the result — an
+        `isinstance(..., type)` assertion would pass on EE and fail on OSS.
+        See test_ee_gated_types_resolve_in_oss_builds below.
+        """
+        resolved = get_eval_class(member.value)
+        assert callable(resolved), f"{member.value} resolved to {resolved!r}"
+
+    @pytest.mark.parametrize("enum_cls,member", ALL_MEMBERS)
+    def test_every_enum_member_reports_as_registered(self, enum_cls, member):
+        assert is_registered(member.value)
+
+    def test_enum_values_are_unique_across_all_enums(self):
+        """Two enums mapping the same string would make lookups ambiguous."""
+        seen = {}
+        collisions = []
+        for enum_cls in EVAL_TYPE_ENUMS:
+            for member in enum_cls:
+                key = member.value
+                if key in seen:
+                    collisions.append(f"{key}: {seen[key]} and {enum_cls.__name__}")
+                seen[key] = enum_cls.__name__
+        assert not collisions, "duplicate eval type ids: " + "; ".join(collisions)
+
+
+class TestRegistryLookup:
+    def test_unknown_eval_type_raises_value_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            get_eval_class("NoSuchEvaluatorXYZ")
+        assert "NoSuchEvaluatorXYZ" in str(exc_info.value)
+
+    def test_is_registered_is_false_for_unknown_type(self):
+        assert is_registered("NoSuchEvaluatorXYZ") is False
+
+    def test_list_registered_is_non_empty_and_covers_the_enums(self):
+        registered = set(list_registered())
+        assert registered
+
+        declared = {m.value for e in EVAL_TYPE_ENUMS for m in e}
+        # The registry may be a superset — fi_evals exports helper/base classes
+        # that no enum names. It must never be a strict subset.
+        assert declared <= registered, (
+            "declared eval types missing from the registry: "
+            f"{sorted(declared - registered)}"
+        )
+
+    def test_lookup_is_stable_across_calls(self):
+        """The registry is built once and memoised; repeat lookups agree."""
+        name = ALL_MEMBERS[0].values[1].value
+        assert get_eval_class(name) is get_eval_class(name)
+
+
+class TestEnterpriseGatedEvalTypes:
+    """EE-gated eval types still occupy the registry in an OSS checkout.
+
+    `tfc/ee_loader.py` substitutes `tfc.ee_stub._ee_stub(name)` for symbols that
+    live in the private `ee/` tree. The stub is a callable that raises
+    FeatureUnavailable (HTTP 402) when invoked, so the eval type stays
+    *addressable* — a caller gets a clean, catchable error instead of a
+    KeyError or "Unknown evaluator type".
+
+    Pinned because it is the reason the contract test above asserts `callable`
+    rather than `isinstance(..., type)`, and because a change here would alter
+    what OSS users see when they select an enterprise evaluator.
+    """
+
+    def _is_ee_stub(self, obj):
+        return (
+            callable(obj)
+            and not isinstance(obj, type)
+            and getattr(obj, "__module__", "") == "tfc.ee_stub"
+        )
+
+    def test_ee_gated_types_resolve_in_oss_builds(self):
+        """Whether a type is a class or a stub depends on the build, but it
+        must resolve either way."""
+        for name in ("RankingEvaluator", "DeterministicEvaluator", "Groundedness"):
+            resolved = get_eval_class(name)
+            assert callable(resolved), f"{name} did not resolve"
+            assert isinstance(resolved, type) or self._is_ee_stub(resolved), (
+                f"{name} resolved to {resolved!r}, which is neither an evaluator "
+                "class nor an ee stub"
+            )
+
+    def test_no_enum_member_resolves_to_none(self):
+        """_build_registry() skips None entries, which would surface as
+        'Unknown evaluator type' rather than a gated-feature error."""
+        for enum_cls in EVAL_TYPE_ENUMS:
+            for member in enum_cls:
+                assert get_eval_class(member.value) is not None

--- a/futureagi/evaluations/engine/tests/test_runner_composition.py
+++ b/futureagi/evaluations/engine/tests/test_runner_composition.py
@@ -1,0 +1,354 @@
+"""Composition and error paths through ``runner.run_eval()``.
+
+``run_eval()`` is the single point every evaluation in the platform flows
+through: registry lookup -> instance creation -> param preparation ->
+preprocessing -> execution -> formatting. Each collaborator had some coverage of
+its own; the wiring between them had none, so a step dropped or reordered would
+not have been caught.
+
+These tests stub the collaborators and assert the wiring: what gets called, with
+what, in what order, and how the pieces land in the returned ``EvalResult``.
+Nothing here needs a database, a model, or a live LLM.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evaluations.engine.runner import EvalRequest, EvalResult, run_eval
+
+RUNNER = "evaluations.engine.runner"
+PREPROCESSING = "evaluations.engine.preprocessing"
+
+
+class _Template:
+    """Minimal stand-in for an EvalTemplate model instance."""
+
+    def __init__(self, name="My Eval", config=None):
+        self.name = name
+        self.config = config if config is not None else {"eval_type_id": "Contains"}
+
+
+@pytest.fixture
+def instance():
+    inst = MagicMock()
+    inst.run.return_value = {"result": True}
+    inst.cost = {"total": 0.01}
+    inst.token_usage = {"prompt": 5, "completion": 2}
+    return inst
+
+
+@pytest.fixture
+def wired(instance):
+    """Patch every collaborator run_eval composes, yielding the mocks."""
+    with (
+        patch(f"{RUNNER}.get_eval_class") as get_cls,
+        patch(f"{RUNNER}.create_eval_instance") as create,
+        patch(f"{RUNNER}.prepare_run_params") as prep,
+        patch(f"{PREPROCESSING}.preprocess_inputs") as pre,
+        patch(f"{RUNNER}.extract_raw_result") as extract,
+        patch(f"{RUNNER}.format_eval_value") as fmt,
+    ):
+        get_cls.return_value = MagicMock(name="EvalClass")
+        create.return_value = (instance, "criteria-from-instance")
+        prep.return_value = {"text": "hello"}
+        pre.side_effect = lambda _name, params: params
+        extract.return_value = {
+            "data": {"echo": 1},
+            "reason": "because",
+            "failure": None,
+            "runtime": 0.5,
+            "model": "gpt-4o",
+            "metrics": [{"id": "m", "value": 1}],
+            "metadata": {"k": "v"},
+            "output": "Pass/Fail",
+        }
+        fmt.return_value = True
+        yield {
+            "get_eval_class": get_cls,
+            "create_eval_instance": create,
+            "prepare_run_params": prep,
+            "preprocess_inputs": pre,
+            "extract_raw_result": extract,
+            "format_eval_value": fmt,
+            "instance": instance,
+        }
+
+
+class TestErrorPaths:
+    def test_missing_eval_type_id_raises_with_the_template_name(self):
+        request = EvalRequest(
+            eval_template=_Template(name="Broken", config={}), inputs={}
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            run_eval(request)
+
+        assert "eval_type_id" in str(exc_info.value)
+        assert "Broken" in str(exc_info.value)
+
+    def test_empty_eval_type_id_is_treated_as_missing(self):
+        request = EvalRequest(
+            eval_template=_Template(config={"eval_type_id": ""}), inputs={}
+        )
+        with pytest.raises(ValueError):
+            run_eval(request)
+
+    def test_unregistered_eval_type_propagates_the_registry_error(self):
+        """run_eval does not swallow the registry's ValueError."""
+        request = EvalRequest(
+            eval_template=_Template(config={"eval_type_id": "NoSuchEvaluatorXYZ"}),
+            inputs={},
+        )
+        with pytest.raises(ValueError) as exc_info:
+            run_eval(request)
+
+        assert "NoSuchEvaluatorXYZ" in str(exc_info.value)
+
+    def test_evaluator_exceptions_are_not_swallowed(self, wired):
+        """A failure inside the evaluator must surface, not become a score."""
+        wired["instance"].run.side_effect = RuntimeError("evaluator exploded")
+        request = EvalRequest(eval_template=_Template(), inputs={"text": "hi"})
+
+        with pytest.raises(RuntimeError, match="evaluator exploded"):
+            run_eval(request)
+
+
+class TestHappyPathComposition:
+    def test_each_stage_is_invoked_once(self, wired):
+        run_eval(EvalRequest(eval_template=_Template(), inputs={"text": "hi"}))
+
+        assert wired["get_eval_class"].call_count == 1
+        assert wired["create_eval_instance"].call_count == 1
+        assert wired["prepare_run_params"].call_count == 1
+        assert wired["preprocess_inputs"].call_count == 1
+        assert wired["instance"].run.call_count == 1
+        assert wired["extract_raw_result"].call_count == 1
+        assert wired["format_eval_value"].call_count == 1
+
+    def test_registry_is_queried_with_the_templates_eval_type_id(self, wired):
+        template = _Template(config={"eval_type_id": "Regex"})
+        run_eval(EvalRequest(eval_template=template, inputs={}))
+
+        wired["get_eval_class"].assert_called_once_with("Regex")
+
+    def test_resolved_class_is_handed_to_instance_creation(self, wired):
+        run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        kwargs = wired["create_eval_instance"].call_args.kwargs
+        assert kwargs["eval_class"] is wired["get_eval_class"].return_value
+
+    def test_prepared_params_reach_the_evaluator(self, wired):
+        wired["prepare_run_params"].return_value = {"text": "prepared"}
+        run_eval(EvalRequest(eval_template=_Template(), inputs={"text": "raw"}))
+
+        wired["instance"].run.assert_called_once_with(text="prepared")
+
+    def test_preprocessing_sits_between_params_and_execution(self, wired):
+        """The evaluator sees the preprocessed params, not the raw ones."""
+        wired["preprocess_inputs"].side_effect = lambda _n, p: {**p, "added": "by-pre"}
+        run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert wired["instance"].run.call_args.kwargs["added"] == "by-pre"
+
+    def test_preprocessing_is_keyed_by_template_name(self, wired):
+        run_eval(EvalRequest(eval_template=_Template(name="Dead Air"), inputs={}))
+
+        assert wired["preprocess_inputs"].call_args[0][0] == "Dead Air"
+
+    def test_result_fields_are_mapped_from_the_extracted_response(self, wired):
+        result = run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert isinstance(result, EvalResult)
+        assert result.value is True
+        assert result.data == {"echo": 1}
+        assert result.reason == "because"
+        assert result.failure is None
+        assert result.runtime == 0.5
+        assert result.model_used == "gpt-4o"
+        assert result.metrics == [{"id": "m", "value": 1}]
+        assert result.metadata == {"k": "v"}
+        assert result.output_type == "Pass/Fail"
+
+    def test_output_type_defaults_to_score_when_absent(self, wired):
+        wired["extract_raw_result"].return_value = {}
+        result = run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert result.output_type == "score"
+
+    def test_cost_and_token_usage_are_lifted_off_the_instance(self, wired):
+        result = run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert result.cost == {"total": 0.01}
+        assert result.token_usage == {"prompt": 5, "completion": 2}
+
+    def test_missing_cost_attributes_are_tolerated(self, wired):
+        """Deterministic evaluators carry no cost/token_usage."""
+        bare = MagicMock(spec=["run"])
+        bare.run.return_value = {"result": True}
+        wired["create_eval_instance"].return_value = (bare, "criteria")
+
+        result = run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert result.cost is None
+        assert result.token_usage is None
+
+    def test_timing_is_populated_and_self_consistent(self, wired):
+        result = run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert result.start_time is not None
+        assert result.end_time is not None
+        assert result.end_time >= result.start_time
+        assert result.duration == pytest.approx(
+            result.end_time - result.start_time, abs=1e-6
+        )
+
+
+class TestRequestOptions:
+    def test_skip_params_preparation_bypasses_prepare_run_params(self, wired):
+        request = EvalRequest(
+            eval_template=_Template(),
+            inputs={"text": "raw", "other": 1},
+            skip_params_preparation=True,
+        )
+        run_eval(request)
+
+        wired["prepare_run_params"].assert_not_called()
+        assert wired["instance"].run.call_args.kwargs == {"text": "raw", "other": 1}
+
+    def test_criteria_override_replaces_the_instance_criteria(self, wired):
+        request = EvalRequest(
+            eval_template=_Template(),
+            inputs={},
+            criteria_override="use this instead",
+        )
+        run_eval(request)
+
+        assert (
+            wired["prepare_run_params"].call_args.kwargs["criteria"]
+            == "use this instead"
+        )
+
+    def test_instance_criteria_is_used_when_no_override_given(self, wired):
+        run_eval(EvalRequest(eval_template=_Template(), inputs={}))
+
+        assert (
+            wired["prepare_run_params"].call_args.kwargs["criteria"]
+            == "criteria-from-instance"
+        )
+
+    def test_config_overrides_are_copied_not_shared(self, wired):
+        """run_eval builds its own dict, so a caller's mapping is not mutated."""
+        overrides = {"a": 1}
+        run_eval(
+            EvalRequest(
+                eval_template=_Template(), inputs={}, config_overrides=overrides
+            )
+        )
+
+        passed = wired["create_eval_instance"].call_args.kwargs["config"]
+        assert passed == {"a": 1}
+        assert passed is not overrides
+
+
+class TestProtectCalls:
+    @pytest.mark.parametrize(
+        "call_type,expected_model",
+        [("protect", "protect"), ("protect_flash", "protect_flash")],
+    )
+    def test_default_model_is_set_for_protect_calls(
+        self, wired, call_type, expected_model
+    ):
+        request = EvalRequest(
+            eval_template=_Template(), inputs={"call_type": call_type}
+        )
+        run_eval(request)
+
+        assert request.model == expected_model
+        assert wired["create_eval_instance"].call_args.kwargs["model"] == expected_model
+
+    def test_an_explicit_model_is_not_overridden(self, wired):
+        request = EvalRequest(
+            eval_template=_Template(),
+            inputs={"call_type": "protect"},
+            model="gpt-4o",
+        )
+        run_eval(request)
+
+        assert request.model == "gpt-4o"
+
+    def test_eval_name_is_defaulted_into_run_params(self, wired):
+        wired["prepare_run_params"].return_value = {}
+        run_eval(
+            EvalRequest(
+                eval_template=_Template(name="Toxicity"),
+                inputs={"call_type": "protect"},
+            )
+        )
+
+        assert wired["instance"].run.call_args.kwargs["eval_name"] == "Toxicity"
+
+    def test_existing_eval_name_is_not_clobbered(self, wired):
+        wired["prepare_run_params"].return_value = {"eval_name": "already-set"}
+        run_eval(
+            EvalRequest(eval_template=_Template(), inputs={"call_type": "protect"})
+        )
+
+        assert wired["instance"].run.call_args.kwargs["eval_name"] == "already-set"
+
+    def test_max_tokens_is_forwarded_from_inputs(self, wired):
+        wired["prepare_run_params"].return_value = {}
+        run_eval(
+            EvalRequest(
+                eval_template=_Template(),
+                inputs={"call_type": "protect", "max_tokens": 128},
+            )
+        )
+
+        assert wired["instance"].run.call_args.kwargs["max_tokens"] == 128
+
+    def test_non_protect_calls_do_not_get_a_default_model(self, wired):
+        request = EvalRequest(eval_template=_Template(), inputs={"call_type": "eval"})
+        run_eval(request)
+
+        assert request.model is None
+
+
+class TestCustomCodeEvalRuntimeParams:
+    def _request(self, runtime_config):
+        return EvalRequest(
+            eval_template=_Template(config={"eval_type_id": "CustomCodeEval"}),
+            inputs={},
+            runtime_config=runtime_config,
+        )
+
+    def test_runtime_params_are_merged_into_run_params(self, wired):
+        wired["prepare_run_params"].return_value = {}
+        run_eval(self._request({"params": {"threshold": 5}}))
+
+        assert wired["instance"].run.call_args.kwargs["threshold"] == 5
+
+    def test_runtime_params_do_not_override_prepared_params(self, wired):
+        """setdefault semantics: prepared params win."""
+        wired["prepare_run_params"].return_value = {"threshold": 99}
+        run_eval(self._request({"params": {"threshold": 5}}))
+
+        assert wired["instance"].run.call_args.kwargs["threshold"] == 99
+
+    def test_non_dict_runtime_params_are_ignored(self, wired):
+        wired["prepare_run_params"].return_value = {}
+        run_eval(self._request({"params": ["not", "a", "dict"]}))
+
+        assert wired["instance"].run.call_args.kwargs == {}
+
+    def test_other_eval_types_ignore_runtime_params(self, wired):
+        wired["prepare_run_params"].return_value = {}
+        run_eval(
+            EvalRequest(
+                eval_template=_Template(config={"eval_type_id": "Contains"}),
+                inputs={},
+                runtime_config={"params": {"threshold": 5}},
+            )
+        )
+
+        assert "threshold" not in wired["instance"].run.call_args.kwargs


### PR DESCRIPTION
Closes #1948.

## What & why

`evaluations/engine/` is the single path every evaluation flows through, and its composition was untested — nothing referenced `run_eval()` or `_build_registry()`.

**228 tests** across two modules. No database, no model instances, no live LLM.

## 1. The enum → registry contract

`registry._build_registry()` walks `agentic_eval.core_evals.fi_evals.__all__`, and the enum values in `eval_type.py` are exactly those export names (`FunctionEvalTypeId.CONTAINS_VALID_LINK == "ContainsValidLink"`). So **`__all__` is the de-facto registration contract**: an evaluator that exists, is correct, and is listed in `eval_type.py` but is *not* exported is silently absent from the registry.

The suite parametrises over every member of every `*EvalTypeId` enum — **95 members**, discovered by scanning the module rather than hard-coded, so a newly added enum is covered automatically — and asserts each one resolves. There's a guard test asserting the discovery itself found something, since an empty parametrisation would otherwise pass silently.

### One thing worth your attention

I originally asserted `isinstance(cls, type)`. **Three eval types failed**: `RankingEvaluator`, `DeterministicEvaluator` and `Groundedness`.

They aren't broken — they're EE-gated. `tfc/ee_loader.py` substitutes `tfc.ee_stub._ee_stub(name)`, a callable that raises `FeatureUnavailable` (HTTP 402) when invoked, so the eval type stays *addressable* and an OSS user gets a clean gated-feature error rather than "Unknown evaluator type".

That means the naive assertion is **build-dependent — it passes on enterprise and fails on OSS.** The contract test now asserts `callable`, which is true in both builds and is also what `run_eval()` actually does with the result. The distinction is pinned explicitly in `TestEnterpriseGatedEvalTypes` so the reasoning survives the next person to read it.

I'd flag this as the thing to sanity-check in review: if you'd rather the OSS registry *not* carry gated types, that's a design change and this test would need to move with it.

## 2. `run_eval()` composition and error paths

Collaborators are stubbed and the wiring is asserted: stage invocation counts, the registry lookup key, preprocessing sitting between param preparation and execution, `EvalResult` field mapping, timing self-consistency, `cost`/`token_usage` lifted off the instance (and tolerated when absent, as for deterministic evaluators), `skip_params_preparation`, `criteria_override`, `config_overrides` being copied rather than shared with the caller, the `protect`/`protect_flash` default model plus `eval_name`/`max_tokens` forwarding, and `CustomCodeEval` runtime params merging by `setdefault` (prepared params win) rather than assignment.

Error paths: missing `eval_type_id` raises with the template name, empty string treated as missing, an unregistered type propagates the registry's `ValueError` rather than being swallowed, and an exception inside the evaluator surfaces instead of becoming a score — that last one given #1610's finding that this layer tends to fail silently.

## Verification

This PR changes **no source files**, so there's no before/after to show. Instead the suite was **mutation-tested** — five mutations to `runner.py` / `registry.py`, all caught:

| Mutation | Tests failed |
|---|---|
| Preprocessing step removed | 3 |
| `setdefault` → assignment for CustomCodeEval runtime params | 1 |
| `criteria_override` ignored | 1 |
| Registry returns `None` instead of raising | 2 |
| One entry dropped from the `__all__` walk | 4 |

The last is exactly the forgotten-export failure mode this was written for — it now turns a silent gap into a red build, which is what I claimed in the issue.

```
293 passed    # whole evaluations/engine/tests/ directory, existing tests included
```

Docker was unavailable so `bin/test` couldn't run; these tests don't need it. `black`, `isort` and `ruff` are clean on both new files.

## Coordination

- **#1851** is currently changing `preprocessing.py` and adding `test_preprocessing_guard.py`. This PR touches neither — the only interaction is that `run_eval()` calls `preprocess_inputs`, which is stubbed here.
- **#1688** (Python/YAML conformance fixtures) is about *parity between two implementations* of the same evaluator. This is about *resolution* — a different axis — so I don't think it duplicates that work. Happy to be told otherwise.
- **#1610** made the same structural argument one layer down (`functions.py`). This is the engine that dispatches to those functions.

Items 2 and 3 from my issue are included rather than deferred, since they turned out to be small once the collaborators were stubbed. If you'd rather review the registry contract on its own, I'm happy to split this into two PRs.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective — the PR is the tests; see the mutation table
- [ ] `bin/test` passes locally (backend) — **not run; Docker unavailable.** 293 pass in the engine test directory; no source changed.
- [x] `yarn test:run` passes locally (frontend) — n/a
- [x] `yarn contracts:check` passes if API surface changed — n/a
- [x] I've updated the documentation where relevant — rationale is in the module docstrings
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
