### PR TITLE
fix(simulate): classify cancel retries by gRPC status, not exception text

### DIFF
--- a/futureagi/simulate/temporal/client.py
+++ b/futureagi/simulate/temporal/client.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import structlog
 from asgiref.sync import async_to_sync
+from temporalio.service import RPCError, RPCStatusCode
 
 from simulate.temporal.constants import (
     QUEUE_L,
@@ -204,12 +205,51 @@ async def _cancel_workflow_async(
     return await _cancel_with_retries(client, workflow_id)
 
 
+# gRPC statuses that mean "the call did not land — try again". A cancel that
+# never lands leaves the workflow running, and it later writes its own terminal
+# status over the CANCELLED row, so getting this classification right matters
+# more than it would for a read.
+_RETRYABLE_RPC_STATUSES = frozenset(
+    {
+        RPCStatusCode.UNAVAILABLE,  # frontend unreachable, connection reset, h2 GOAWAY
+        RPCStatusCode.DEADLINE_EXCEEDED,  # request timed out in flight
+        RPCStatusCode.RESOURCE_EXHAUSTED,  # rate limited / shard busy
+        RPCStatusCode.ABORTED,  # concurrency conflict; safe to repeat
+    }
+)
+
+# Transport-level failures raised before any gRPC status exists — these cover
+# the same ground the previous "timeout" and "connection reset" substrings did.
+# asyncio.TimeoutError is TimeoutError on 3.11+, and ConnectionResetError is a
+# ConnectionError, so both are matched by these two base classes.
+_RETRYABLE_TRANSPORT_ERRORS = (TimeoutError, ConnectionError)
+
+
+def _is_transient_cancel_error(exc: BaseException) -> bool:
+    """Whether a failed cancel is worth retrying.
+
+    Keyed off exception type and gRPC status rather than the text of the error.
+    Substring matching on ``str(exc)`` broke in both directions: a wording change
+    in temporalio or gRPC silently reclassified a transient failure as permanent,
+    while "timeout" also matched permanent errors whose message merely mentioned a
+    configured timeout.
+
+    Anything not listed here — NOT_FOUND (workflow already gone),
+    PERMISSION_DENIED, INVALID_ARGUMENT — is permanent, and retrying it only
+    delays the caller's fallback.
+    """
+    if isinstance(exc, RPCError):
+        return exc.status in _RETRYABLE_RPC_STATUSES
+    return isinstance(exc, _RETRYABLE_TRANSPORT_ERRORS)
+
+
 async def _cancel_with_retries(client, workflow_id: str, max_retries: int = 3) -> bool:
     """Cancel a workflow with retries on transient errors.
 
-    Transient errors (h2 protocol, timeout, connection reset) should be retried
-    because failing to cancel means workflows keep running and overwrite the
-    CANCELLED status in DB.
+    Transient errors (unreachable frontend, request timeout, resource exhaustion)
+    should be retried because failing to cancel means workflows keep running and
+    overwrite the CANCELLED status in DB. See _is_transient_cancel_error for how
+    that judgement is made.
     """
     last_error = None
     for attempt in range(max_retries):
@@ -220,13 +260,7 @@ async def _cancel_with_retries(client, workflow_id: str, max_retries: int = 3) -
             return True
         except Exception as e:
             last_error = e
-            error_msg = str(e).lower()
-            # Transient errors worth retrying
-            # TODO: Adding raw strings for now. Need to find better and reliable mechanisms
-            is_transient = any(
-                s in error_msg
-                for s in ["timeout", "h2 protocol", "connection reset", "unavailable"]
-            )
+            is_transient = _is_transient_cancel_error(e)
             if is_transient and attempt < max_retries - 1:
                 wait = (attempt + 1) * 2  # 2s, 4s
                 logger.warning(

--- a/futureagi/simulate/tests/test_cancel_error_classification.py
+++ b/futureagi/simulate/tests/test_cancel_error_classification.py
@@ -1,0 +1,213 @@
+"""Retry classification for Temporal workflow cancellation.
+
+`_cancel_with_retries` used to decide whether a failed cancel was worth retrying
+by substring-matching `str(exc)` against
+``["timeout", "h2 protocol", "connection reset", "unavailable"]``. That is now
+keyed off exception type and gRPC status.
+
+The stakes are in `_cancel_with_retries`'s own docstring: a cancel that never
+lands leaves the workflow running, and it later writes its terminal status over
+the CANCELLED row. Misclassifying a transient failure as permanent is therefore
+not a missed retry — it is an orphaned workflow and a UI that stops showing the
+cancellation.
+
+No Temporal server is needed; the client handle is stubbed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from temporalio.service import RPCError, RPCStatusCode
+
+from simulate.temporal.client import (
+    _cancel_with_retries,
+    _is_transient_cancel_error,
+)
+
+
+def _rpc(status: RPCStatusCode, message="rpc failure") -> RPCError:
+    return RPCError(message, status, b"")
+
+
+def _client_raising(*errors):
+    """A stub Temporal client whose cancel() raises `errors` in order.
+
+    A trailing None means "succeed on this attempt".
+    """
+    handle = MagicMock()
+    handle.cancel = AsyncMock(
+        side_effect=[e if e is not None else None for e in errors]
+    )
+    client = MagicMock()
+    client.get_workflow_handle.return_value = handle
+    return client, handle
+
+
+class TestTransientClassification:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            RPCStatusCode.UNAVAILABLE,
+            RPCStatusCode.DEADLINE_EXCEEDED,
+            RPCStatusCode.RESOURCE_EXHAUSTED,
+            RPCStatusCode.ABORTED,
+        ],
+    )
+    def test_retryable_grpc_statuses(self, status):
+        assert _is_transient_cancel_error(_rpc(status)) is True
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            RPCStatusCode.NOT_FOUND,
+            RPCStatusCode.PERMISSION_DENIED,
+            RPCStatusCode.INVALID_ARGUMENT,
+            RPCStatusCode.UNAUTHENTICATED,
+            RPCStatusCode.FAILED_PRECONDITION,
+            RPCStatusCode.UNIMPLEMENTED,
+        ],
+    )
+    def test_permanent_grpc_statuses(self, status):
+        assert _is_transient_cancel_error(_rpc(status)) is False
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TimeoutError("timed out"),
+            ConnectionError("connection failed"),
+            ConnectionResetError("connection reset by peer"),
+        ],
+    )
+    def test_transport_errors_are_transient(self, exc):
+        """Covers the ground the old 'timeout'/'connection reset' strings did."""
+        assert _is_transient_cancel_error(exc) is True
+
+    def test_asyncio_timeout_is_covered_by_the_builtin(self):
+        """asyncio.TimeoutError is an alias of TimeoutError on 3.11+.
+
+        Pinned so the single `TimeoutError` entry in _RETRYABLE_TRANSPORT_ERRORS
+        is understood to cover both spellings rather than looking like an
+        oversight.
+        """
+        assert asyncio.TimeoutError is TimeoutError
+        # noqa UP041: spelling it `asyncio.TimeoutError` is the point of the test —
+        # collapsing it to the builtin would make this a duplicate of the case above.
+        assert _is_transient_cancel_error(asyncio.TimeoutError()) is True  # noqa: UP041
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("bad input"),
+            RuntimeError("something broke"),
+            KeyError("missing"),
+        ],
+    )
+    def test_unrelated_exceptions_are_permanent(self, exc):
+        assert _is_transient_cancel_error(exc) is False
+
+
+class TestClassificationNoLongerDependsOnMessageText:
+    """The two directions the substring approach got wrong."""
+
+    def test_transient_status_with_no_matching_words_is_still_retried(self):
+        """The false-negative case from #1949.
+
+        A gRPC UNAVAILABLE whose message contains none of the four substrings —
+        which is version- and wrapper-dependent — used to be classified
+        permanent, so the cancel was abandoned after one attempt.
+        """
+        err = _rpc(RPCStatusCode.UNAVAILABLE, message="upstream connect error")
+        text = str(err).lower()
+        assert not any(
+            s in text
+            for s in ("timeout", "h2 protocol", "connection reset", "unavailable")
+        ), "precondition: message must not contain the old substrings"
+
+        assert _is_transient_cancel_error(err) is True
+
+    def test_permanent_error_merely_mentioning_a_timeout_is_not_retried(self):
+        """The false-positive case: 'timeout' matched too broadly."""
+        err = _rpc(
+            RPCStatusCode.INVALID_ARGUMENT,
+            message="workflow execution timeout must be positive",
+        )
+        assert "timeout" in str(err).lower()
+
+        assert _is_transient_cancel_error(err) is False
+
+    def test_not_found_is_permanent_even_though_it_is_a_connection_style_failure(self):
+        """A workflow that is already gone must not be retried three times."""
+        assert (
+            _is_transient_cancel_error(
+                _rpc(RPCStatusCode.NOT_FOUND, "workflow not found")
+            )
+            is False
+        )
+
+
+class TestCancelWithRetries:
+    async def test_returns_true_on_first_success(self):
+        client, handle = _client_raising(None)
+
+        assert await _cancel_with_retries(client, "wf-1") is True
+        assert handle.cancel.await_count == 1
+
+    async def test_retries_a_transient_failure_then_succeeds(self):
+        client, handle = _client_raising(_rpc(RPCStatusCode.UNAVAILABLE), None)
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()):
+            assert await _cancel_with_retries(client, "wf-1") is True
+
+        assert handle.cancel.await_count == 2
+
+    async def test_gives_up_after_max_retries(self):
+        client, handle = _client_raising(
+            *[_rpc(RPCStatusCode.UNAVAILABLE) for _ in range(3)]
+        )
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()):
+            assert await _cancel_with_retries(client, "wf-1", max_retries=3) is False
+
+        assert handle.cancel.await_count == 3
+
+    async def test_permanent_failure_is_not_retried(self):
+        """One attempt only — retrying a NOT_FOUND just delays the caller."""
+        client, handle = _client_raising(
+            _rpc(RPCStatusCode.NOT_FOUND), _rpc(RPCStatusCode.NOT_FOUND)
+        )
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()) as sleep:
+            assert await _cancel_with_retries(client, "wf-1") is False
+
+        assert handle.cancel.await_count == 1
+        sleep.assert_not_awaited()
+
+    async def test_backoff_grows_between_attempts(self):
+        client, _ = _client_raising(
+            *[_rpc(RPCStatusCode.UNAVAILABLE) for _ in range(3)]
+        )
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()) as sleep:
+            await _cancel_with_retries(client, "wf-1", max_retries=3)
+
+        assert [c.args[0] for c in sleep.await_args_list] == [2, 4]
+
+    async def test_transport_error_is_retried(self):
+        client, handle = _client_raising(ConnectionResetError("reset by peer"), None)
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()):
+            assert await _cancel_with_retries(client, "wf-1") is True
+
+        assert handle.cancel.await_count == 2
+
+    async def test_no_sleep_after_the_final_attempt(self):
+        """The last failure returns immediately rather than backing off first."""
+        client, _ = _client_raising(
+            _rpc(RPCStatusCode.UNAVAILABLE), _rpc(RPCStatusCode.UNAVAILABLE)
+        )
+
+        with patch("simulate.temporal.client.asyncio.sleep", new=AsyncMock()) as sleep:
+            await _cancel_with_retries(client, "wf-1", max_retries=2)
+
+        assert sleep.await_count == 1


### PR DESCRIPTION
Closes #1949 (the classification half — see **Scope** below).

## What & why

`_cancel_with_retries` decided whether a failed workflow cancel was worth retrying by substring-matching `str(exc)` against `["timeout", "h2 protocol", "connection reset", "unavailable"]`, with the maintainer's own `TODO` on the line asking for something more reliable.

The stakes are in the function's own docstring: **a cancel that never lands leaves the workflow running, and it later writes its terminal status over the `CANCELLED` row.** For outbound voice calls that means a call the user cancelled keeps going and the UI stops showing it as cancelled. Misclassification isn't a missed retry — it's an orphaned workflow.

## It failed in both directions

Both reproduced against `upstream/dev`@`ff5cd219`, counting actual cancel attempts:

```
################ BASELINE — substring matching ################
  [FAIL] transient UNAVAILABLE (no matching words) is retried — 1 attempt(s), expected 3
  [FAIL] permanent INVALID_ARGUMENT mentioning 'timeout' is not retried — 3 attempt(s), expected 1
  [PASS] NOT_FOUND is not retried — 1 attempt(s), expected 1
  [PASS] ConnectionResetError is retried — 3 attempt(s), expected 3

################ PATCHED — typed classification ################
  [PASS] transient UNAVAILABLE (no matching words) is retried — 3 attempt(s), expected 3
  [PASS] permanent INVALID_ARGUMENT mentioning 'timeout' is not retried — 1 attempt(s), expected 1
  [PASS] NOT_FOUND is not retried — 1 attempt(s), expected 1
  [PASS] ConnectionResetError is retried — 3 attempt(s), expected 3
```

- **False negative** — a gRPC `UNAVAILABLE` whose message happens not to contain any of the four substrings (varies by temporalio version and exception wrapper) was treated as permanent: one attempt, then give up. This is the orphaned-workflow path.
- **False positive** — a permanent `INVALID_ARGUMENT` reading *"workflow execution timeout must be positive"* matched on `"timeout"` and was retried three times, with 6s of pointless backoff, before failing anyway.

The two control cases behave identically before and after, which is the point — this narrows misclassification without changing what was already correct.

## The fix

```python
if isinstance(exc, RPCError):
    return exc.status in _RETRYABLE_RPC_STATUSES
return isinstance(exc, _RETRYABLE_TRANSPORT_ERRORS)
```

`_RETRYABLE_RPC_STATUSES` is `{UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED}` — the statuses that mean "the call did not land, try again".

`_RETRYABLE_TRANSPORT_ERRORS` is `(TimeoutError, ConnectionError)`, covering failures raised before any gRPC status exists. Those two base classes subsume exactly what the old `"timeout"` and `"connection reset"` substrings reached: `asyncio.TimeoutError` **is** `TimeoutError` on 3.11+, and `ConnectionResetError` is a `ConnectionError`. Both are pinned by tests so the single entry isn't mistaken for an oversight later.

Everything else — `NOT_FOUND` (workflow already gone), `PERMISSION_DENIED`, `INVALID_ARGUMENT` — is permanent, and retrying only delays the caller's fallback.

One judgement call worth flagging: **I did not include `INTERNAL`.** The old list retried on `"h2 protocol"`, and HTTP/2 protocol errors can surface as either `UNAVAILABLE` or `INTERNAL` depending on where they're detected. `INTERNAL` is also how a genuine permanent server-side bug arrives, so including it would reintroduce the false-positive direction. If you'd rather trade that off the other way it's a one-line change to the frozenset.

## Scope — the cooperative signal is deliberately not touched

#1949 also covers the disabled cooperative cancel signal at `client.py:195`. **That is not in this PR.**

Per the existing docstring, sending the signal *and* `handle.cancel()` produced a double `CancelledError` that aborted `_handle_cancellation` cleanup — which suggests the fix belongs in making that cleanup re-entrant, not in this client. I asked two questions on the issue:

1. Is the cooperative signal still wanted for the outbound-call flow, or has hard-cancel become the intended design?
2. If wanted — is making `_handle_cancellation` tolerate a second cancellation the direction you'd take, or was that already rejected?

Neither is answered yet, and guessing risks reintroducing the exact bug that caused the signal to be disabled. Happy to pick it up once there's a direction. `cancel_signal` remains an accepted-but-ignored parameter on `cancel_workflow()` / `_cancel_workflow_async()` — unchanged by this PR, still worth resolving.

## Verification

**27 tests**, no Temporal server required (client handle stubbed, `asyncio.sleep` patched): the retryable and permanent status sets, transport errors, both misclassification directions above, and the retry loop itself — attempt counts, 2s/4s backoff growth, and no sleep after the final attempt.

`client.py` was already Black-clean on `dev` and still is, so the diff is a tight **+44/−10** with no formatting churn. `ruff` findings on it are unchanged at 6 (all pre-existing); the new test file is clean.

Docker was unavailable so `bin/test` couldn't run; none of this needs it.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — **not run; Docker unavailable.** The 27 new tests pass; before/after shown above.
- [x] `yarn test:run` passes locally (frontend) — n/a
- [x] `yarn contracts:check` passes if API surface changed — n/a
- [x] I've updated the documentation where relevant — rationale is inline
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
