### PR TITLE
feat(agent_playground): validate Node.position structure

### DIFF
--- a/futureagi/agent_playground/models/node.py
+++ b/futureagi/agent_playground/models/node.py
@@ -1,3 +1,4 @@
+import math
 import uuid
 
 import jsonschema
@@ -58,7 +59,6 @@ class Node(BaseModel):
         help_text="Node-specific configuration (validated against node_template.config_schema for atomic nodes)",
     )
 
-    # TODO: Need to add a Validation for this structure
     position = models.JSONField(
         default=dict, help_text='UI coordinates {"x": 0, "y": 0}'
     )
@@ -128,6 +128,53 @@ class Node(BaseModel):
             )
         except jsonschema.ValidationError as e:
             raise ValidationError(f"Invalid config: {e.message}")
+
+    def _validate_position(self) -> None:
+        """
+        Validate position is UI coordinates: {"x": <number>, "y": <number>}.
+
+        Deliberately narrow, so no row the system already writes can be
+        rejected:
+
+        - ``{}`` is valid. The field defaults to it and several write paths omit
+          position entirely (``node_crud.create_node``, ``version_content``), so
+          an empty dict means "not positioned yet", not "malformed".
+        - Extra keys are allowed. Positions carrying a ``z`` are already
+          persisted and round-tripped (see
+          tests/serializers/test_node_serializers.py), so this checks that x and
+          y are present and numeric rather than pinning the whole object.
+
+        What it does reject is the shape that reaches the UI as a broken node:
+        a non-object, a missing axis, or an axis that is not a finite number.
+        """
+        if not self.position:
+            return
+
+        if not isinstance(self.position, dict):
+            raise ValidationError(
+                f"Node position must be an object like "
+                f'{{"x": 0, "y": 0}}, got {type(self.position).__name__}'
+            )
+
+        missing = [axis for axis in ("x", "y") if axis not in self.position]
+        if missing:
+            raise ValidationError(
+                f"Node position is missing required {'key' if len(missing) == 1 else 'keys'}: "
+                f"{', '.join(missing)}"
+            )
+
+        for axis in ("x", "y"):
+            value = self.position[axis]
+            # bool is a subclass of int; True as a coordinate is a bug, not a 1.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValidationError(
+                    f"Node position '{axis}' must be a number, "
+                    f"got {type(value).__name__}"
+                )
+            if not math.isfinite(value):
+                raise ValidationError(
+                    f"Node position '{axis}' must be finite, got {value}"
+                )
 
     def _validate_subgraph_node_config(self) -> None:
         """
@@ -237,6 +284,7 @@ class Node(BaseModel):
         self._validate_atomic_node_fields()
         self._validate_config_schema()
         self._validate_subgraph_node_config()
+        self._validate_position()
         self._validate_no_self_reference()
         self._validate_ref_is_validated_version()
         self._validate_single_version_per_graph()

--- a/futureagi/agent_playground/tests/models/test_node_position_validation.py
+++ b/futureagi/agent_playground/tests/models/test_node_position_validation.py
@@ -1,0 +1,158 @@
+"""Validation of Node.position.
+
+`Node.position` is documented as UI coordinates `{"x": 0, "y": 0}` and carried
+an unimplemented "Need to add a Validation for this structure" TODO. Nothing
+checked it, so a malformed position was accepted at write time and only surfaced
+in the UI as a node that renders in the wrong place or not at all.
+
+The validator is deliberately narrow: it must not reject anything the system
+already writes. The "accepted" tests below are the contract for that — each one
+is a shape produced by real code paths (defaults, trace-to-graph import, the
+serializer round-trip that carries a `z`).
+
+Pure model-level validation; no database required.
+"""
+
+import math
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from agent_playground.models.node import Node
+
+
+def _position(value):
+    """A Node carrying only the field under test.
+
+    _validate_position() is called directly rather than through clean(), so the
+    other eight validators (which need related rows) stay out of the way.
+    """
+    node = Node()
+    node.position = value
+    return node
+
+
+class TestAcceptedPositions:
+    """Shapes the system already produces. These must never start failing."""
+
+    def test_empty_dict_is_valid(self):
+        """The field default. node_crud.create_node and version_content both
+        fall back to {} when no position is supplied."""
+        _position({})._validate_position()
+
+    def test_integer_coordinates(self):
+        _position({"x": 0, "y": 0})._validate_position()
+
+    def test_float_coordinates(self):
+        _position({"x": 12.5, "y": -3.25})._validate_position()
+
+    def test_negative_coordinates(self):
+        _position({"x": -100, "y": -250})._validate_position()
+
+    def test_trace_to_graph_layout_output(self):
+        """_compute_positions() emits {"x": level * 350, "y": i * 250}."""
+        _position({"x": 2 * 350, "y": 3 * 250})._validate_position()
+
+    def test_extra_keys_are_allowed(self):
+        """Positions carrying a z are already persisted and round-tripped —
+        see tests/serializers/test_node_serializers.py."""
+        _position({"x": 500, "y": 300, "z": 10})._validate_position()
+
+    def test_unset_falsy_values_are_treated_as_absent(self):
+        """None reaches here from JSON nulls; treated as "not positioned"."""
+        _position(None)._validate_position()
+
+
+class TestRejectedPositions:
+    def test_non_object_is_rejected(self):
+        with pytest.raises(ValidationError, match="must be an object"):
+            _position([1, 2])._validate_position()
+
+    def test_string_is_rejected(self):
+        with pytest.raises(ValidationError, match="must be an object"):
+            _position("100,200")._validate_position()
+
+    def test_missing_y_is_rejected(self):
+        with pytest.raises(ValidationError, match="missing required key: y"):
+            _position({"x": 1})._validate_position()
+
+    def test_missing_x_is_rejected(self):
+        with pytest.raises(ValidationError, match="missing required key: x"):
+            _position({"y": 1})._validate_position()
+
+    def test_missing_both_axes_is_rejected(self):
+        """A non-empty object with neither axis is malformed, not 'unset'."""
+        with pytest.raises(ValidationError, match="missing required keys: x, y"):
+            _position({"z": 5})._validate_position()
+
+    @pytest.mark.parametrize("bad", ["100", None, [], {}])
+    def test_non_numeric_axis_is_rejected(self, bad):
+        with pytest.raises(ValidationError, match="must be a number"):
+            _position({"x": bad, "y": 0})._validate_position()
+
+    def test_boolean_axis_is_rejected(self):
+        """bool subclasses int — True as a coordinate is a bug, not a 1."""
+        with pytest.raises(ValidationError, match="must be a number"):
+            _position({"x": True, "y": 0})._validate_position()
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_axis_is_rejected(self, bad):
+        """NaN/Infinity are not valid JSON and break the client on read."""
+        with pytest.raises(ValidationError, match="must be finite"):
+            _position({"x": bad, "y": 0})._validate_position()
+
+    def test_error_names_the_offending_axis(self):
+        """The point of validating here is a field-level message, so the axis
+        has to appear in it."""
+        with pytest.raises(ValidationError) as exc_info:
+            _position({"x": 0, "y": "nope"})._validate_position()
+        assert "'y'" in str(exc_info.value)
+
+
+class TestWiredIntoClean:
+    def test_validate_position_runs_as_part_of_clean(self):
+        """A validator that exists but is never called is worse than none."""
+        import inspect
+
+        source = inspect.getsource(Node.clean)
+        assert "_validate_position()" in source
+
+    def test_nan_would_survive_without_the_validator(self):
+        """Documents why finiteness is checked: json accepts NaN, JSON does not.
+
+        Python's json module emits a bare `NaN` token by default, which is not
+        valid JSON and is rejected by strict parsers — including the browser's.
+        """
+        import json
+
+        assert json.dumps({"x": float("nan")}) == '{"x": NaN}'
+        with pytest.raises(ValueError):
+            json.loads('{"x": NaN}', parse_constant=_reject)
+
+
+def _reject(token):
+    raise ValueError(f"invalid JSON constant: {token}")
+
+
+class TestValidatorIsSelfConsistent:
+    @pytest.mark.parametrize(
+        "position",
+        [
+            {"x": 0, "y": 0},
+            {"x": -1.5, "y": 2.5},
+            {"x": 700, "y": 100},
+            {},
+        ],
+    )
+    def test_positions_used_across_the_existing_test_suite_remain_valid(self, position):
+        """Sampled from agent_playground/tests/** so this change cannot break
+        fixtures already in the repo."""
+        _position(position)._validate_position()
+
+    def test_large_coordinates_are_allowed(self):
+        """No arbitrary bounds — the canvas is unbounded."""
+        _position({"x": 1e9, "y": -1e9})._validate_position()
+
+    def test_finite_check_uses_math_isfinite_semantics(self):
+        assert math.isfinite(1e308)
+        _position({"x": 1e308, "y": 0})._validate_position()


### PR DESCRIPTION
Closes #1950.

## First — a correction to my own issue

**#1950 is wrong about which field is unvalidated.** I claimed node *config* is persisted without structure validation. It isn't:

```python
def _validate_config_schema(self) -> None:
    ...
    jsonschema.validate(instance=self.config, schema=self.node_template.config_schema)
```

`Node._validate_config_schema()` already validates `config` against `node_template.config_schema`, and `clean()` calls it. The `config` field's own `help_text` says so too. I misread the TODO's position — it sits immediately *above* `position`, not `config`:

```python
    config = models.JSONField(
        default=dict,
        help_text="Node-specific configuration (validated against node_template.config_schema for atomic nodes)",
    )

    # TODO: Need to add a Validation for this structure
    position = models.JSONField(
        default=dict, help_text='UI coordinates {"x": 0, "y": 0}'
    )
```

So this PR implements what the TODO actually asks for. The config premise in #1950 needs no fix because it isn't broken — I've commented there to correct the record.

This also dissolves the three questions I asked on that issue. They were all about per-node-type config contracts and the migration risk of validating existing config rows. `position` is a fixed two-key structure, so there's no node-type matrix to derive and no schema to source from `NodeTemplate`.

## What this does

`position` is documented as UI coordinates `{"x": 0, "y": 0}` but was accepted unchecked, so a malformed value stored happily and only surfaced later as a node rendering in the wrong place or not at all.

The validator is **deliberately narrow**, so it cannot reject anything the system already writes:

- **`{}` stays valid.** It's the field default, and both `node_crud.create_node` and `version_content` fall back to it when no position is supplied. Empty means "not positioned yet", not "malformed".
- **Extra keys stay allowed.** It checks that `x` and `y` are present and numeric rather than pinning the whole object.

It rejects only what reaches the UI as a broken node: a non-object, a missing axis, a non-numeric axis, or a non-finite float.

Two details worth calling out:
- **Booleans are rejected as coordinates.** `bool` subclasses `int`, so `{"x": True}` would otherwise pass as a `1`. As a coordinate that's a bug, not a value.
- **NaN/Infinity are rejected.** `json.dumps({"x": float("nan")})` emits a bare `NaN` token, which is not valid JSON and won't parse in the browser. There's a test documenting that specifically, so the check doesn't look arbitrary later.

## Compatibility was measured, not assumed

This was my main worry on the issue — validating against existing data is a migration question. Rather than guess, I extracted **every `position` literal in `agent_playground` by AST walk** and ran each through the new validator:

```
agent_playground position literals : 129
REJECTED by the new validator      : 0

distinct shapes accepted: {}, {x, y}, {x, y, z}, {x, y, width, height}
```

Note the last two. **A strict validator that rejected unknown keys would have broken both** — `{"x": 500, "y": 300, "z": 10}` is asserted by an existing test (`tests/serializers/test_node_serializers.py`), and `width`/`height` appear elsewhere in the app. That's the empirical reason for the permissive design rather than a preference.

I can't see production rows, so I can't promise zero rejections there — but the validator accepts every shape this codebase is capable of producing, which is the strongest guarantee available without a data audit. If you want belt-and-braces, the natural follow-up is a read-only management command that reports non-conforming rows before this lands.

## Verification

**29 tests**, no database required. The `TestAcceptedPositions` class is the compatibility contract — each case is a shape produced by a real code path (field default, `_compute_positions()` output from trace-to-graph import, the serializer round-trip carrying a `z`) and should be treated as such if the rules are ever tightened.

There's also a test asserting `_validate_position()` is actually called from `clean()`, since a validator that exists but never runs is worse than none.

`node.py` was already Black-clean on `dev` and still is — the diff is **+49/−1** with no formatting churn, and `ruff` findings are unchanged at 1 (pre-existing). Docker was unavailable so `bin/test` couldn't run; none of this needs it.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend) — **not run; Docker unavailable.** 29 new tests pass; compatibility scan above covers the fixture risk.
- [x] `yarn test:run` passes locally (frontend) — n/a
- [x] `yarn contracts:check` passes if API surface changed — n/a; no serializer or API change
- [x] I've updated the documentation where relevant — rationale is in the validator docstring
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA — will sign when the bot prompts
- [x] PR title follows Conventional Commits
