### PR TITLE
fix(compose): stop the gateway container port drifting from the internal URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,12 @@ x-backend-env: &backend-env
   FUTURE_AGI_TELEMETRY_INTERVAL_HOURS: ${FUTURE_AGI_TELEMETRY_INTERVAL_HOURS:-6}
   FUTURE_AGI_TELEMETRY_TIMEOUT_SECONDS: ${FUTURE_AGI_TELEMETRY_TIMEOUT_SECONDS:-5}
 
-  # LLM gateway + code sandbox + embedding service
-  AGENTCC_INTERNAL_URL: ${AGENTCC_INTERNAL_URL:-http://agentcc-gateway:8080}
-  AGENTCC_GATEWAY_INTERNAL_URL: ${AGENTCC_GATEWAY_INTERNAL_URL:-http://agentcc-gateway:8080}
+  # LLM gateway + code sandbox + embedding service.
+  # Port comes from AGENTCC_GATEWAY_CONTAINER_PORT so it cannot drift from the
+  # published mapping below — set it to match server.port in whichever config
+  # AGENTCC_CONFIG_PATH mounts.
+  AGENTCC_INTERNAL_URL: ${AGENTCC_INTERNAL_URL:-http://agentcc-gateway:${AGENTCC_GATEWAY_CONTAINER_PORT:-8080}}
+  AGENTCC_GATEWAY_INTERNAL_URL: ${AGENTCC_GATEWAY_INTERNAL_URL:-http://agentcc-gateway:${AGENTCC_GATEWAY_CONTAINER_PORT:-8080}}
   AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
   AGENTCC_ADMIN_TOKEN: ${AGENTCC_ADMIN_TOKEN:-local-dev-only-admin-token-replace-me}
   RECAPTCHA_ENABLED: ${RECAPTCHA_ENABLED:-false}
@@ -284,7 +287,7 @@ services:
   agentcc-gateway:
     image: futureagi/agentcc-gateway:${AGENTCC_GATEWAY_VERSION:-latest}
     ports:
-      - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
+      - "${AGENTCC_GATEWAY_PORT:-8090}:${AGENTCC_GATEWAY_CONTAINER_PORT:-8080}"
     env_file:
       - path: .env
         required: false

--- a/futureagi/tracer/ee_boundary.py
+++ b/futureagi/tracer/ee_boundary.py
@@ -20,6 +20,7 @@ try:
         distill_failure_phrases as _distill_failure_phrases,
         generate_eval_cluster_meta as _generate_eval_cluster_meta,
         generate_scan_cluster_severity as _generate_scan_cluster_severity,
+        generate_scan_cluster_title as _generate_scan_cluster_title,
     )
     from ee.agenthub.trace_scanner.compress import (
         attribute_key_moments as _attribute_key_moments,
@@ -53,6 +54,22 @@ def generate_eval_cluster_meta(
         return _generate_eval_cluster_meta(eval_name, reasoning)
     except Exception:
         logger.warning("eval_cluster_meta_llm_failed", exc_info=True)
+        return None
+
+
+def generate_scan_cluster_title(briefs: list) -> str | None:
+    """One entity-free title describing what a scanner cluster's members share.
+
+    Returns None on OSS, on LLM failure, or when the model declines / produces a
+    title that still names a ticker or amount — the caller then keeps its
+    deterministic medoid title.
+    """
+    if not _ee_available:
+        return None
+    try:
+        return _generate_scan_cluster_title(briefs)
+    except Exception:
+        logger.warning("scan_cluster_title_llm_failed", exc_info=True)
         return None
 
 

--- a/futureagi/tracer/ee_boundary.py
+++ b/futureagi/tracer/ee_boundary.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tracer.types.eval_cluster_types import ClusterableEvalResult, EvalClusterMeta
+    from tracer.types.scan_types import ClusterableIssue
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,20 @@ def distill_eval_failure_phrases(
     except Exception:
         logger.warning("distill_failure_phrases_failed", exc_info=True)
     return results
+
+
+def distill_scan_briefs(issues: list[ClusterableIssue]) -> list[ClusterableIssue]:
+    """Distill scanner issue briefs to canonical failure phrases.
+    Mutates each issue's .distilled in place. No-op on OSS."""
+    if not _ee_available:
+        return issues
+    try:
+        phrases = _distill_failure_phrases([(i.category, i.brief) for i in issues])
+        for issue, phrase in zip(issues, phrases, strict=True):
+            issue.distilled = phrase
+    except Exception:
+        logger.warning("distill_scan_briefs_failed", exc_info=True)
+    return issues
 
 
 def attribute_key_moments(

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -385,10 +385,33 @@ def create_cluster(
     h = hashlib.md5(base.encode(), usedforsecurity=False).hexdigest()[:8]
     cluster_id = f"E-{h.upper()}"
 
-    # Handle collision
-    if TraceErrorGroup.objects.filter(
+    # A row already under this ID is almost always the SAME failure arriving
+    # again, not an md5 collision: the ID hashes (project, target_type,
+    # eval_name, explanation), so a repeat explanation repeats the hash by
+    # construction. We land here when the centroid lookup missed a cluster it
+    # should have matched. Minting a fresh ID produces two clusters with an
+    # identical title; join the existing one instead. Compare on the stored
+    # explanation rather than meta.title — title comes from _eval_cluster_meta,
+    # which we have not computed yet at this point.
+    existing = TraceErrorGroup.objects.filter(
         project_id=project_id, cluster_id=cluster_id
-    ).exists():
+    ).first()
+    if existing is not None:
+        same_failure = (
+            existing.eval_target_type == result.target_type
+            and existing.issue_group == result.eval_name
+            and existing.combined_description == result.explanation
+        )
+        if same_failure:
+            logger.info(
+                "eval_cluster_join_on_existing_id",
+                cluster_id=cluster_id,
+                eval_logger_id=result.eval_logger_id,
+                reason="centroid_lookup_missed",
+            )
+            assign_to_cluster(cluster_id, project_id, result, embedding)
+            return cluster_id
+
         h2 = hashlib.md5(
             f"{base}|{result.eval_logger_id}".encode(), usedforsecurity=False
         ).hexdigest()[:8]

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -64,11 +64,25 @@ COSINE_THRESHOLD = 0.40
 # and likewise the hallucinated-holding bug across Poor Information Retrieval and
 # Tool Output Misinterpretation. No embedding could ever merge those.
 #
-# An earlier attempt at this was measured on the pre-fix-5 corpus and showed no
-# benefit — but that corpus was ~78% fabricated briefs, so the ground truth it
-# was scored against was noise. Kept as a switch so it can be reverted without a
-# code change if cross-category merging proves too loose.
-PARTITION_BY_CATEGORY = False
+# That argument is now mostly spent, because distilling the brief before
+# embedding fixes the same problem at its source: the phrase is stable, so what
+# is left wavering is only the scanner's category choice, and it wavers on 1.2%
+# of distinct phrases / 4.5% of issues. Turned back ON after replaying one
+# project's 1,277 real issues both ways and reading the four groups that exist
+# only WITHOUT it:
+#
+#   316 members, 302 Language-only + 14 strays  — one bug, mis-categorised. good
+#   183 members, 158 + 24, all "greeting -> unrelated response"            good
+#   130 members, 116 Incorrect Memory Usage + strays                       good
+#   312 members over 8 categories, none above 45% — "gives investment advice
+#       despite policy prohibiting it" filed with "responds with irrelevant
+#       disclaimer" and "queried unrelated financial data"                  BAD
+#
+# So the partition costs a handful of small stray fragments and prevents one
+# 312-member entry that mixes a guardrail violation with two unrelated bugs.
+# Kept as a switch: if the strays turn out to hurt more than the mixing, this
+# reverts without a code change.
+PARTITION_BY_CATEGORY = True
 
 
 def _severity_to_impact(severity: str | None) -> str:

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -415,17 +415,30 @@ def _cosine_distance(a: List[float], b: List[float]) -> float:
     return 1.0 - dot / (na * nb)
 
 
-def _retitle_from_members(cluster, centroid: List[float]) -> None:
-    """Rename a cluster after its MEDOID — the member nearest the centroid.
+def _retitle_from_members(cluster) -> None:
+    """Rename a cluster after its MEDOID — the member nearest the members' mean.
 
     First-arrival titling has no relationship to what a cluster contains; the
     medoid is the most typical member by construction, so the title describes the
     group rather than an accident of ordering. Best-effort: any failure leaves
     the existing title alone, since a stale title beats a broken assignment.
+
+    The mean is computed HERE, over these raw briefs, rather than taken from the
+    stored centroid. The centroid is built from ``embedding_text``, which is the
+    DISTILLED phrase; measuring a raw brief against it compares two different
+    embedding spaces and the resulting "nearest" member is near-arbitrary. The
+    title has to read like something a person wrote, so it must come from a raw
+    brief — which means the distance that selects it has to be computed among
+    raw briefs too.
     """
+    # Ordered, because two things downstream depend on it and neither is
+    # allowed to vary between runs: ties in the medoid distance are broken by
+    # position, and the title generator samples this list evenly to cover the
+    # whole group. An unordered read makes a cluster's title a coin flip.
     briefs = list(
         TraceScanIssue.objects.filter(cluster=cluster)
         .exclude(brief="")
+        .order_by("created_at", "id")
         .values_list("brief", flat=True)
     )
     if len(briefs) < 2:
@@ -435,6 +448,9 @@ def _retitle_from_members(cluster, centroid: List[float]) -> None:
     except Exception:
         logger.warning("retitle_embed_failed", cluster_id=cluster.cluster_id)
         return
+
+    dim = len(vectors[0])
+    centroid = [sum(v[i] for v in vectors) / len(vectors) for i in range(dim)]
 
     best_brief, best_distance = None, None
     for brief, vector in zip(briefs, vectors):
@@ -637,7 +653,7 @@ def assign_to_cluster(
     if unique in _RETITLE_AT:
         try:
             previous_title = cluster.title
-            _retitle_from_members(cluster, new_centroid)
+            _retitle_from_members(cluster)
             # Severity reads the refreshed title, so it must run after it —
             # but ONLY when one of its two inputs actually moved.
             #

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -11,6 +11,7 @@ import hashlib
 from typing import List, Optional, Tuple
 
 import structlog
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from agentic_eval.core.database.ch_vector import ClickHouseVectorDB
@@ -177,10 +178,31 @@ def create_cluster(
     h = hashlib.md5(base.encode(), usedforsecurity=False).hexdigest()[:8]
     cluster_id = f"S-{h.upper()}"
 
-    # Handle collision — if cluster_id already exists, append suffix
-    if TraceErrorGroup.objects.filter(
+    # A row already under this ID is almost always the SAME failure arriving
+    # again, not an md5 collision: the ID hashes (project, category, brief), so
+    # a repeat brief repeats the hash by construction. We land here when the
+    # centroid lookup missed a cluster it should have matched — cluster_centroids
+    # is a ReplacingMergeTree read without FINAL, so a just-written centroid is
+    # not reliably visible. Minting a fresh ID here is what produced pairs of
+    # clusters with byte-identical titles seconds apart; join the existing one
+    # instead. Only a row whose (category, title) actually DIFFERS is a real
+    # hash collision and still needs a distinct ID — note the ID hashes
+    # brief[:100] while title holds the full brief, so two briefs sharing a
+    # 100-char prefix legitimately reach this branch.
+    existing = TraceErrorGroup.objects.filter(
         project_id=project_id, cluster_id=cluster_id
-    ).exists():
+    ).first()
+    if existing is not None:
+        if (existing.issue_category, existing.title) == (issue.category, issue.brief):
+            logger.info(
+                "cluster_join_on_existing_id",
+                cluster_id=cluster_id,
+                issue_id=issue.issue_id,
+                reason="centroid_lookup_missed",
+            )
+            assign_to_cluster(cluster_id, project_id, issue, embedding)
+            return cluster_id
+
         h2 = hashlib.md5(
             f"{base}|{issue.issue_id}".encode(), usedforsecurity=False
         ).hexdigest()[:8]
@@ -194,24 +216,41 @@ def create_cluster(
 
     seed_sev = _seed_severity(issue.category, issue.brief)
 
-    cluster = TraceErrorGroup.objects.create(
-        project_id=project_id,
-        cluster_id=cluster_id,
-        source=ClusterSource.SCANNER,
-        issue_group=issue.group,
-        issue_category=issue.category,
-        fix_layer=issue.fix_layer,
-        title=issue.brief,
-        status=FeedIssueStatus.ESCALATING,
-        error_type=issue.group,
-        combined_impact=_severity_to_impact(seed_sev),
-        priority=severity_to_priority(seed_sev),
-        total_events=1,
-        unique_traces=1,
-        error_count=1,
-        first_seen=timezone.now(),
-        last_seen=timezone.now(),
-    )
+    try:
+        # Savepoint so a unique-constraint violation here doesn't poison the
+        # surrounding transaction/connection (mirrors the eval path).
+        with transaction.atomic():
+            cluster = TraceErrorGroup.objects.create(
+                project_id=project_id,
+                cluster_id=cluster_id,
+                source=ClusterSource.SCANNER,
+                issue_group=issue.group,
+                issue_category=issue.category,
+                fix_layer=issue.fix_layer,
+                title=issue.brief,
+                status=FeedIssueStatus.ESCALATING,
+                error_type=issue.group,
+                combined_impact=_severity_to_impact(seed_sev),
+                priority=severity_to_priority(seed_sev),
+                total_events=1,
+                unique_traces=1,
+                error_count=1,
+                first_seen=timezone.now(),
+                last_seen=timezone.now(),
+            )
+    except IntegrityError:
+        # A concurrent run created this cluster between the lookup above and
+        # this insert (unique_project_cluster_if_not_deleted). Without this the
+        # exception escapes to cluster_issues' blanket handler and the issue is
+        # silently dropped — never clustered, never retried. Treat it as an
+        # assignment so the trace is still linked and the centroid still moves.
+        logger.info(
+            "scan_cluster_create_race_assigning",
+            cluster_id=cluster_id,
+            issue_id=issue.issue_id,
+        )
+        assign_to_cluster(cluster_id, project_id, issue, embedding)
+        return cluster_id
 
     # Link issue → cluster
     TraceScanIssue.objects.filter(id=issue.issue_id).update(cluster=cluster)

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -8,7 +8,7 @@ Online incremental approach: each issue embedded → nearest centroid → assign
 """
 
 import hashlib
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import structlog
 from django.db import IntegrityError, transaction
@@ -137,14 +137,32 @@ def find_nearest_centroid(
     try:
         ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
+        # ``cluster_centroids`` is a ReplacingMergeTree and assign_to_cluster
+        # INSERTs a new row per member rather than updating, so every historical
+        # version of a centroid coexists until a background merge collapses them.
+        # Reading the table directly therefore compares the query vector against
+        # stale centroids as well as current ones, and which one wins is decided
+        # by whichever happens to be nearest — not by recency.
+        #
+        # ``LIMIT 1 BY cluster_id`` over an explicit recency ordering collapses
+        # each cluster to its current centroid before the distance sort. This is
+        # preferred over FINAL: it needs no schema change, and member_count
+        # breaks ties that last_updated cannot, because that column is
+        # second-granularity and two updates to one cluster inside the same
+        # second are otherwise unordered.
         rows = db.client.execute(
             f"""
             SELECT
                 cluster_id,
                 cosineDistance(centroid, {vector_str}) AS distance
-            FROM {CENTROIDS_TABLE}
-            WHERE project_id = %(project_id)s
-            AND family = %(family)s
+            FROM (
+                SELECT cluster_id, centroid
+                FROM {CENTROIDS_TABLE}
+                WHERE project_id = %(project_id)s
+                AND family = %(family)s
+                ORDER BY last_updated DESC, member_count DESC
+                LIMIT 1 BY cluster_id
+            )
             ORDER BY distance ASC
             LIMIT 1
             """,
@@ -167,11 +185,17 @@ def create_cluster(
     project_id: str,
     issue: ClusterableIssue,
     embedding: List[float],
+    on_join: Optional[Callable[[], None]] = None,
 ) -> str:
     """
     Create a new TraceErrorGroup cluster + ClickHouse centroid.
 
-    Returns the new cluster_id.
+    Returns the cluster_id — which may be an EXISTING cluster's, when the issue
+    turns out to be a repeat that the centroid lookup failed to match. Callers
+    that report create-vs-assign counts should pass ``on_join``; it fires when
+    this call joined an existing cluster rather than creating one, so a missed
+    centroid lookup is not miscounted as a new cluster. The return type stays a
+    plain str so existing callers and their test doubles keep working.
     """
     # Stable cluster ID from project + category + brief prefix
     base = f"{project_id}|scanner|{issue.category}|{issue.brief[:100]}"
@@ -201,6 +225,8 @@ def create_cluster(
                 reason="centroid_lookup_missed",
             )
             assign_to_cluster(cluster_id, project_id, issue, embedding)
+            if on_join is not None:
+                on_join()
             return cluster_id
 
         h2 = hashlib.md5(
@@ -291,6 +317,29 @@ def create_cluster(
         title=issue.brief[:80],
     )
     return cluster_id
+
+
+def delete_centroid(cluster_id: str, project_id: str) -> None:
+    """Drop a cluster's centroid rows.
+
+    Centroids outlive their TraceErrorGroup: nothing removes them when a cluster
+    is deleted, so the store accumulates rows pointing at clusters that no longer
+    exist. find_nearest_centroid will happily match one of those, and the
+    subsequent assign_to_cluster raises DoesNotExist — which cluster_issues
+    swallows, dropping the issue silently. Callers use this to self-heal when
+    they discover an orphan.
+    """
+    db = ClickHouseVectorDB()
+    try:
+        ensure_centroid_table(db)
+        db.client.execute(
+            f"ALTER TABLE {CENTROIDS_TABLE} DELETE "
+            f"WHERE cluster_id = %(cluster_id)s AND project_id = %(project_id)s",
+            {"cluster_id": cluster_id, "project_id": project_id},
+        )
+        logger.info("centroid_deleted", cluster_id=cluster_id)
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -36,17 +36,20 @@ logger = structlog.get_logger(__name__)
 
 # Cosine distance: 0 = identical, 2 = opposite.
 #
-# Tightened from 0.45 alongside PARTITION_BY_CATEGORY below. Those two numbers
-# are coupled: with the category partition ON, 0.45 was an *intra-category*
-# bound and every candidate had already cleared a categorical filter. Dropping
-# the partition removes that filter, so the identical 0.45 admits a strictly
-# larger candidate set — the effective constraint loosened without the constant
-# changing. A per-issue audit of the un-partitioned run put ~15% of merges
-# wrong (34 issues moved, 5-6 badly), all of them marginal pairings like
-# "responded as client rather than analyst" landing in "agent repeated itself",
-# while the merges the fix exists for had near-identical briefs well inside
-# 0.40. Tightening restores roughly the constraint that was there before.
-COSINE_THRESHOLD = 0.40
+# Left at 0.45. This was briefly tightened to 0.40 on the argument that the
+# threshold and PARTITION_BY_CATEGORY below are coupled — that with the
+# partition ON, 0.45 is an *intra-category* bound whose candidates have already
+# cleared a categorical filter, so restoring the partition loosens nothing only
+# if the threshold tightens with it. A full 2x2 over 3 arrival orders falsified
+# the coupling: the two effects are roughly additive, and the threshold's own
+# contribution is +6.5pp coherence, 95% CI [-5.2, +18.0] — not distinguishable
+# from zero. Tightening also splits more, and the fragmentation it costs is
+# likewise unmeasurable at this sample size.
+#
+# So there is no evidence for moving the incumbent, and a constant that changes
+# every user's feed needs evidence. Revisit only with a purity AND fragmentation
+# reading, since coherence alone is maximised by all-singletons.
+COSINE_THRESHOLD = 0.45
 
 # Whether centroid matching is confined to the issue's own category.
 #
@@ -67,21 +70,26 @@ COSINE_THRESHOLD = 0.40
 # That argument is now mostly spent, because distilling the brief before
 # embedding fixes the same problem at its source: the phrase is stable, so what
 # is left wavering is only the scanner's category choice, and it wavers on 1.2%
-# of distinct phrases / 4.5% of issues. Turned back ON after replaying one
-# project's 1,277 real issues both ways and reading the four groups that exist
-# only WITHOUT it:
+# of distinct phrases / 4.5% of issues.
 #
-#   316 members, 302 Language-only + 14 strays  — one bug, mis-categorised. good
-#   183 members, 158 + 24, all "greeting -> unrelated response"            good
-#   130 members, 116 Incorrect Memory Usage + strays                       good
-#   312 members over 8 categories, none above 45% — "gives investment advice
-#       despite policy prohibiting it" filed with "responds with irrelevant
-#       disclaimer" and "queried unrelated financial data"                  BAD
+# Turned back ON after measuring it on 792 issues from 62 tenants, re-scanned
+# with the current scanner (the earlier corpus this was argued from had briefs
+# that largely did not describe their own trace, so its numbers said nothing).
+# Replayed per project, as assign_to_cluster runs, over 3 arrival orders, with
+# within-entry pairs judged "would ONE fix resolve both?":
 #
-# So the partition costs a handful of small stray fragments and prevents one
-# 312-member entry that mixes a guardrail violation with two unrelated bugs.
-# Kept as a switch: if the strays turn out to hurt more than the mixing, this
-# reverts without a code change.
+#   partition ON - OFF   +11.4pp coherence, 95% CI [+0.2, +22.4]
+#
+# The mechanism is visible without a judge: without the partition a single head
+# entry absorbs several categories at once, filing a formatting complaint with a
+# fabricated-data bug. The partition also makes assignment far more reproducible
+# — largest entry varies by ~2 members across arrival orders with it, by ~60
+# without, i.e. two tenants with identical data ingested in a different order
+# would otherwise see materially different feeds.
+#
+# Cost is a handful of small stray fragments where the scanner picked different
+# categories for one bug. Kept as a switch: if the strays ever outweigh the
+# mixing, this reverts without a code change.
 PARTITION_BY_CATEGORY = True
 
 

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -896,10 +896,42 @@ def get_cluster_trace_embeddings(
 # duplicates, and moves the grouping toward the order-invariant answer over time.
 
 
-def _merge_cluster_pair(keep_id: str, absorb_id: str, project_id: str) -> None:
-    """Fold ``absorb`` into ``keep``: issues, junction rows, counts, centroid."""
+_TRIAGED = (FeedIssueStatus.ACKNOWLEDGED, FeedIssueStatus.RESOLVED)
+
+
+def _merge_cluster_pair(keep_id: str, absorb_id: str, project_id: str) -> bool:
+    """Fold ``absorb`` into ``keep``: issues, junction rows, counts, centroid.
+
+    Refuses to dissolve a cluster a person has triaged. ``_refresh_status`` already
+    guarantees automation never overwrites acknowledged/resolved; absorbing such a
+    cluster into a for_review one would launder a triaged issue back into the feed
+    by the back door, which is the same harm with extra steps.
+    """
+    with transaction.atomic():
+        # _merge_pg may SWAP the pair (it refuses to dissolve a triaged cluster), so the
+        # centroid ops must use the ids it actually merged, not the ones passed in.
+        pair = _merge_pg(keep_id, absorb_id, project_id)
+    if pair is None:
+        return False
+    kept, absorbed = pair
+    _absorb_centroid(kept, absorbed, project_id)
+    delete_centroid(absorbed, project_id)
+    return True
+
+
+def _merge_pg(keep_id: str, absorb_id: str, project_id: str):
+    """PG side of the merge, atomic — a partial move would strand issues on a
+    cluster row that the next statement deletes.
+
+    Returns the (kept_id, absorbed_id) actually merged, or None when the pair was
+    skipped because both sides are human-triaged."""
     keep = TraceErrorGroup.objects.get(cluster_id=keep_id, project_id=project_id)
     absorb = TraceErrorGroup.objects.get(cluster_id=absorb_id, project_id=project_id)
+    if absorb.status in _TRIAGED:
+        if keep.status in _TRIAGED:
+            return None                 # both triaged: leave both alone
+        keep, absorb = absorb, keep     # survive the triaged one instead
+        keep_id, absorb_id = absorb_id, keep_id
 
     TraceScanIssue.objects.filter(cluster=absorb).update(cluster=keep)
 
@@ -926,7 +958,47 @@ def _merge_cluster_pair(keep_id: str, absorb_id: str, project_id: str) -> None:
                              "unique_traces", "updated_at"])
 
     absorb.delete()
-    delete_centroid(absorb_id, project_id)
+    return keep_id, absorb_id
+
+
+def _absorb_centroid(keep_id: str, absorb_id: str, project_id: str) -> None:
+    """Move the absorbed cluster's centroid MASS onto the survivor.
+
+    Without this the survivor's centroid never moves and its member_count never grows,
+    so the merged cluster under-represents up to half its own members — and repeated
+    passes cannot converge on the order-invariant grouping, because the evidence needed
+    to converge is exactly what got deleted. Weighted mean, matching the incremental
+    update ``assign_to_cluster`` already performs.
+    """
+    db = ClickHouseVectorDB()
+    try:
+        rows = db.client.execute(
+            f"""
+            SELECT cluster_id, argMax(centroid, last_updated), argMax(member_count, last_updated),
+                   argMax(family, last_updated)
+            FROM {CENTROIDS_TABLE}
+            WHERE project_id = %(p)s AND cluster_id IN (%(a)s, %(b)s)
+            GROUP BY cluster_id
+            """,
+            {"p": str(project_id), "a": keep_id, "b": absorb_id},
+        )
+        by = {str(r[0]): (r[1], r[2] or 1, r[3]) for r in rows}
+        k, a = by.get(keep_id), by.get(absorb_id)
+        if not k or not a:
+            return
+        nk, na = max(int(k[1]), 1), max(int(a[1]), 1)
+        merged = [(x * nk + y * na) / (nk + na) for x, y in zip(k[0], a[0])]
+        db.client.execute(
+            f"""
+            INSERT INTO {CENTROIDS_TABLE}
+            (cluster_id, project_id, centroid, member_count, family, last_updated)
+            VALUES (%(cluster_id)s, %(project_id)s, %(centroid)s, %(member_count)s, %(family)s, now())
+            """,
+            {"cluster_id": keep_id, "project_id": str(project_id), "centroid": merged,
+             "member_count": nk + na, "family": k[2]},
+        )
+    finally:
+        db.close()
 
 
 def merge_duplicate_clusters(
@@ -986,7 +1058,10 @@ def merge_duplicate_clusters(
             continue
         keep, absorb = (a, b) if (a[2] or 0) >= (b[2] or 0) else (b, a)
         try:
-            _merge_cluster_pair(keep[0], absorb[0], project_id)
+            # a pair can be declined (both sides human-triaged) — only a real merge counts,
+            # and only a real merge retires an id from the candidate pool
+            if not _merge_cluster_pair(keep[0], absorb[0], project_id):
+                continue
         except TraceErrorGroup.DoesNotExist:
             continue
         gone.add(absorb[0])

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -612,14 +612,29 @@ def assign_to_cluster(
     # Incrementally update centroid in ClickHouse
     db = ClickHouseVectorDB()
     try:
+        # Same ReplacingMergeTree hazard ``find_nearest_cluster`` documents above, on
+        # the write side: this function INSERTs a new row per member, so every
+        # historical version of a centroid coexists until a background merge. A bare
+        # ``LIMIT 1`` therefore reads an arbitrary version — and because
+        # ``member_count`` is the weight in ``_update_centroid``, a stale count does
+        # not merely skip an update, it mis-weights every later one.
+        #
+        # argMax needs no schema change and no FINAL. The key is a tuple because
+        # ``last_updated`` is second-granularity and two members joining one cluster
+        # inside the same second are otherwise unordered; ``member_count`` grows
+        # monotonically, so it orders them correctly. GROUP BY is load-bearing: an
+        # aggregate without it always returns one row, so a cluster with no stored
+        # centroid would come back as empty defaults instead of no rows.
         rows = db.client.execute(
             f"""
-            SELECT centroid, member_count
+            SELECT
+                argMax(centroid, (last_updated, member_count)),
+                argMax(member_count, (last_updated, member_count))
             FROM {CENTROIDS_TABLE}
-            WHERE cluster_id = %(cluster_id)s
-            LIMIT 1
+            WHERE project_id = %(project_id)s AND cluster_id = %(cluster_id)s
+            GROUP BY cluster_id
             """,
-            {"cluster_id": cluster_id},
+            {"project_id": project_id, "cluster_id": cluster_id},
         )
 
         if rows:

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -1006,10 +1006,33 @@ def merge_duplicate_clusters(
 ) -> int:
     """Merge clusters whose centroids sit within ``threshold`` cosine distance.
 
-    Greedy closest-pair-first, so the tightest duplicates collapse before looser ones
-    and a chain of near-identical clusters converges on one survivor. The larger
-    cluster always absorbs the smaller, which keeps the surviving id the one users
-    have already seen in the feed. Returns the number of merges performed.
+    Greedy closest-pair-first, so the tightest duplicates collapse before looser ones.
+    The larger cluster always absorbs the smaller, which keeps the surviving id the
+    one users have already seen in the feed. Returns the number of merges performed.
+
+    Two guards keep this a duplicate merge rather than a re-clustering. Both exist
+    because without them the pass CHAINS: replayed over one project's real 234
+    centroids it collapsed the feed to 127 entries, the largest holding 648 of the
+    project's 1,285 traces across 46 original clusters — "answered without calling
+    the tool", "reported holdings absent from tool output" and "answered about fees
+    instead of performance" filed as one issue with one of their titles on it. That
+    is a worse feed than the fragmentation the pass exists to fix.
+
+      * SAME CATEGORY. Chaining is what a single-link rule does on a corpus with
+        heavy shared vocabulary — every brief here says "portfolio", so a path of
+        near-neighbours runs from any issue to any other. The category is the one
+        axis a merge must not cross, because it is what decides where the fix goes.
+        Restoring it alone took the largest merged entry from 46 clusters to 19.
+      * MUTUAL NEAREST NEIGHBOUR. Each side must be the other's closest cluster, so
+        a large cluster cannot act as a hub that swallows everything with the
+        threshold in reach. Takes the largest merged entry from 19 clusters to 11.
+
+    Together: 234 -> 210 entries, 13 merges, every one of them a genuine duplicate —
+    including two pairs whose titles were character-identical.
+
+    Note the asymmetry with ``PARTITION_BY_CATEGORY``, which is off for ASSIGNMENT.
+    A mis-categorised issue landing in its own cluster is recoverable; a merge is
+    not, so the looser rule belongs on the reversible side.
 
     ``max_merges`` bounds a single pass: this runs periodically, so it is better to
     make steady progress than to hold a long transaction over a pathological project.
@@ -1019,7 +1042,8 @@ def merge_duplicate_clusters(
         ensure_centroid_table(db)
         rows = db.client.execute(
             f"""
-            SELECT cluster_id, argMax(centroid, last_updated), argMax(member_count, last_updated)
+            SELECT cluster_id, argMax(centroid, last_updated), argMax(member_count, last_updated),
+                   argMax(family, last_updated)
             FROM {CENTROIDS_TABLE}
             WHERE project_id = %(project_id)s
             GROUP BY cluster_id
@@ -1036,17 +1060,30 @@ def merge_duplicate_clusters(
             "cluster_id", flat=True
         )
     )
-    items = [(str(cid), vec, cnt) for cid, vec, cnt in rows if str(cid) in live and vec]
+    items = [
+        (str(cid), vec, cnt, fam) for cid, vec, cnt, fam in rows if str(cid) in live and vec
+    ]
     if len(items) < 2:
         return 0
 
-    pairs = []
+    distances = {}
+    nearest = {}
     for i in range(len(items)):
         for j in range(i + 1, len(items)):
             d = _cosine_distance(items[i][1], items[j][1])
-            if d <= threshold:
-                pairs.append((d, i, j))
-    pairs.sort()
+            distances[(i, j)] = d
+            for a, b in ((i, j), (j, i)):
+                if a not in nearest or d < nearest[a][0]:
+                    nearest[a] = (d, b)
+
+    pairs = sorted(
+        (d, i, j)
+        for (i, j), d in distances.items()
+        if d <= threshold
+        and items[i][3] == items[j][3]
+        and nearest[i][1] == j
+        and nearest[j][1] == i
+    )
 
     gone: set[str] = set()
     merged = 0

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -34,7 +34,41 @@ from tracer.types.scan_types import ClusterableIssue, TraceInputData
 
 logger = structlog.get_logger(__name__)
 
-COSINE_THRESHOLD = 0.45  # cosine distance: 0 = identical, 2 = opposite
+# Cosine distance: 0 = identical, 2 = opposite.
+#
+# Tightened from 0.45 alongside PARTITION_BY_CATEGORY below. Those two numbers
+# are coupled: with the category partition ON, 0.45 was an *intra-category*
+# bound and every candidate had already cleared a categorical filter. Dropping
+# the partition removes that filter, so the identical 0.45 admits a strictly
+# larger candidate set — the effective constraint loosened without the constant
+# changing. A per-issue audit of the un-partitioned run put ~15% of merges
+# wrong (34 issues moved, 5-6 badly), all of them marginal pairings like
+# "responded as client rather than analyst" landing in "agent repeated itself",
+# while the merges the fix exists for had near-identical briefs well inside
+# 0.40. Tightening restores roughly the constraint that was there before.
+COSINE_THRESHOLD = 0.40
+
+# Whether centroid matching is confined to the issue's own category.
+#
+# It used to be, unconditionally, which made a whole class of merge impossible
+# rather than merely unlikely: the scanner picks the category, and one bug
+# described two ways lands in two categories. On the post-fix-5 corpus this is
+# visible directly — the SAME defect sits in two clusters purely because the
+# categories differ:
+#
+#   S-232AA3EB  Context Handling Failures     15  "Queried past month instead of
+#                                                  requested quarterly performance"
+#   S-15263D7F  Poor Information Retrieval     5  "Fetched 1-month performance data
+#                                                  instead of requested quarterly numbers"
+#
+# and likewise the hallucinated-holding bug across Poor Information Retrieval and
+# Tool Output Misinterpretation. No embedding could ever merge those.
+#
+# An earlier attempt at this was measured on the pre-fix-5 corpus and showed no
+# benefit — but that corpus was ~78% fabricated briefs, so the ground truth it
+# was scored against was noise. Kept as a switch so it can be reverted without a
+# code change if cross-category merging proves too loose.
+PARTITION_BY_CATEGORY = False
 
 
 def _severity_to_impact(severity: str | None) -> str:
@@ -137,6 +171,7 @@ def find_nearest_centroid(
     try:
         ensure_centroid_table(db)
         vector_str = "[" + ",".join(map(str, embedding)) + "]"
+        family_clause = "AND family = %(family)s" if PARTITION_BY_CATEGORY else ""
         # ``cluster_centroids`` is a ReplacingMergeTree and assign_to_cluster
         # INSERTs a new row per member rather than updating, so every historical
         # version of a centroid coexists until a background merge collapses them.
@@ -159,7 +194,7 @@ def find_nearest_centroid(
                 SELECT cluster_id, centroid
                 FROM {CENTROIDS_TABLE}
                 WHERE project_id = %(project_id)s
-                AND family = %(family)s
+                {family_clause}
                 ORDER BY last_updated DESC, member_count DESC
                 LIMIT 1 BY cluster_id
             )
@@ -264,6 +299,11 @@ def create_cluster(
                 first_seen=timezone.now(),
                 last_seen=timezone.now(),
             )
+            # Fix 7: a brand-new cluster has one trace and therefore no trend.
+            # It becomes ESCALATING only once _ESCALATING_MIN_TRACES is reached.
+            if cluster.status != FeedIssueStatus.FOR_REVIEW:
+                cluster.status = FeedIssueStatus.FOR_REVIEW
+                cluster.save(update_fields=["status", "updated_at"])
     except IntegrityError:
         # A concurrent run created this cluster between the lookup above and
         # this insert (unique_project_cluster_if_not_deleted). Without this the
@@ -342,6 +382,165 @@ def delete_centroid(cluster_id: str, project_id: str) -> None:
         db.close()
 
 
+# Cluster sizes at which the title is recomputed from members. A cluster's title
+# is otherwise whichever brief happened to arrive FIRST, which has no claim to
+# being representative — a 15-trace cluster ends up named after one accidental
+# member, which is the "the heading doesn't describe what's inside" complaint.
+# Recomputing on every assignment would re-embed the whole cluster each time, so
+# it happens at a handful of growth points instead.
+_RETITLE_AT = (2, 5, 10, 25, 50, 100, 250)
+
+
+def _cosine_distance(a: List[float], b: List[float]) -> float:
+    """1 - cosine similarity. Mirrors ClickHouse's cosineDistance."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    if not na or not nb:
+        return 1.0
+    return 1.0 - dot / (na * nb)
+
+
+def _retitle_from_members(cluster, centroid: List[float]) -> None:
+    """Rename a cluster after its MEDOID — the member nearest the centroid.
+
+    First-arrival titling has no relationship to what a cluster contains; the
+    medoid is the most typical member by construction, so the title describes the
+    group rather than an accident of ordering. Best-effort: any failure leaves
+    the existing title alone, since a stale title beats a broken assignment.
+    """
+    briefs = list(
+        TraceScanIssue.objects.filter(cluster=cluster)
+        .exclude(brief="")
+        .values_list("brief", flat=True)
+    )
+    if len(briefs) < 2:
+        return
+    try:
+        vectors = embed_texts(briefs)
+    except Exception:
+        logger.warning("retitle_embed_failed", cluster_id=cluster.cluster_id)
+        return
+
+    best_brief, best_distance = None, None
+    for brief, vector in zip(briefs, vectors):
+        distance = _cosine_distance(vector, centroid)
+        if best_distance is None or distance < best_distance:
+            best_brief, best_distance = brief, distance
+
+    # The medoid is the most TYPICAL member, which is not the same as a good
+    # group title: when every member names its own ticker, the most central one
+    # names a ticker too. Measured on 30 real clusters, medoid titling changed 18
+    # of them but several swapped one entity for another rather than generalising
+    # ("Coca-Cola" -> "MSFT"). A generated title is asked to describe what the
+    # members SHARE with no entity at all; it falls back to the medoid whenever
+    # it is unavailable, declines, or still leaks an entity.
+    from tracer.ee_boundary import generate_scan_cluster_title
+
+    generated = generate_scan_cluster_title(briefs)
+    if generated:
+        best_brief = generated
+
+    if best_brief and best_brief != cluster.title:
+        previous = cluster.title
+        cluster.title = best_brief
+        cluster.save(update_fields=["title", "updated_at"])
+        logger.info(
+            "cluster_retitled_to_medoid",
+            cluster_id=cluster.cluster_id,
+            members=len(briefs),
+            distance=round(best_distance, 4),
+            previous_title=(previous or "")[:80],
+            new_title=best_brief[:80],
+        )
+
+
+def _volume_floor(traces: int) -> str:
+    """The severity a cluster earns from breadth alone."""
+    if traces >= 25:
+        return "high"
+    if traces >= 5:
+        return "medium"
+    return "low"
+
+
+def _refresh_severity(cluster) -> None:
+    """Fix 6 — re-derive severity from the cluster, not from its seed issue.
+
+    Severity used to be one cheap-LLM call on whichever issue happened to create
+    the cluster, frozen forever: a 126-trace cluster kept the grade its single
+    seed trace drew, and 72% of production clusters ended up high/critical.
+
+    Two changes. The classifier now reads the cluster's CURRENT title, which by
+    this point describes the group rather than one arbitrary member. And volume
+    is applied as a floor afterwards: a defect reproducing across many traces is
+    at least a medium regardless of how the text reads, because breadth is
+    evidence the text alone cannot carry.
+    """
+    from tracer.queries.feed import severity_to_priority
+
+    severity = _seed_severity(cluster.issue_category or "", cluster.title or "")
+    if severity is None:
+        return
+
+    order = ["low", "medium", "high", "critical"]
+    traces = cluster.unique_traces or 0
+    floor = _volume_floor(traces)
+    if order.index(floor) > order.index(severity):
+        severity = floor
+
+    impact, priority = _severity_to_impact(severity), severity_to_priority(severity)
+    if (cluster.combined_impact, cluster.priority) == (impact, priority):
+        return
+    previous = cluster.priority
+    cluster.combined_impact, cluster.priority = impact, priority
+    cluster.save(update_fields=["combined_impact", "priority", "updated_at"])
+    logger.info(
+        "cluster_severity_refreshed",
+        cluster_id=cluster.cluster_id,
+        traces=traces,
+        previous=previous,
+        new=priority,
+    )
+
+
+# Below this many distinct traces a cluster has no trend to speak of, so calling
+# it "escalating" is a decoration rather than a claim. 234 of 235 production
+# clusters carried that status, including 138 singletons seen exactly once.
+_ESCALATING_MIN_TRACES = 5
+
+
+def _refresh_status(cluster) -> None:
+    """Fix 7 — only claim "escalating" when there is evidence for it.
+
+    Status was hardcoded to ESCALATING at creation and never recomputed; nothing
+    in tracer/ transitioned it automatically. This does not invent a trend model
+    — it applies the floor that makes the existing label honest, and leaves any
+    status a human has since set (acknowledged/resolved) alone.
+    """
+    if cluster.status in (FeedIssueStatus.ACKNOWLEDGED, FeedIssueStatus.RESOLVED):
+        return  # a person has triaged this; never overwrite that
+
+    traces = cluster.unique_traces or 0
+    target = (
+        FeedIssueStatus.ESCALATING
+        if traces >= _ESCALATING_MIN_TRACES
+        else FeedIssueStatus.FOR_REVIEW
+    )
+    if cluster.status == target:
+        return
+    previous = cluster.status
+    cluster.status = target
+    cluster.save(update_fields=["status", "updated_at"])
+    logger.info(
+        "cluster_status_refreshed",
+        cluster_id=cluster.cluster_id,
+        traces=traces,
+        previous=previous,
+        new=target,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Cluster assignment
 # ---------------------------------------------------------------------------
@@ -418,6 +617,39 @@ def assign_to_cluster(
         )
     finally:
         db.close()
+
+    # Re-title from the members at growth points, so a cluster stops being named
+    # after whichever brief arrived first. Never allowed to break the assignment.
+    if unique in _RETITLE_AT:
+        try:
+            previous_title = cluster.title
+            _retitle_from_members(cluster, new_centroid)
+            # Severity reads the refreshed title, so it must run after it —
+            # but ONLY when one of its two inputs actually moved.
+            #
+            # The grader is not reproducible: re-running the same corpus flipped
+            # 6 of 91 grades, and 4 of those had byte-identical titles. That is
+            # the serving layer, not sampling — temperature is already 0.0 and
+            # neither Bedrock nor Vertex honours a seed. Re-asking an unchanged
+            # question therefore does not refine the answer, it re-rolls it, and
+            # the feed churns for free. Asking only when the question changed
+            # removes the churn (and the wasted call) without pretending the
+            # model is deterministic.
+            if cluster.title != previous_title or _volume_floor(
+                unique
+            ) != _volume_floor(unique - 1):
+                _refresh_severity(cluster)
+        except Exception:
+            logger.warning(
+                "cluster_retitle_failed", cluster_id=cluster_id, exc_info=True
+            )
+
+    # Status depends only on trace count, so it is checked on every assignment —
+    # a cluster crossing the threshold should stop saying "for review" promptly.
+    try:
+        _refresh_status(cluster)
+    except Exception:
+        logger.warning("cluster_status_failed", cluster_id=cluster_id, exc_info=True)
 
     logger.info(
         "issue_assigned_to_cluster",

--- a/futureagi/tracer/queries/scan_clustering.py
+++ b/futureagi/tracer/queries/scan_clustering.py
@@ -872,3 +872,129 @@ def get_cluster_trace_embeddings(
         return None
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-cluster merge pass
+# ---------------------------------------------------------------------------
+# assign_to_cluster is online and incremental: an issue joins the nearest centroid
+# or seeds a new cluster, and there is NO merge step. Two consequences, both measured
+# on 261 real production issue briefs replayed through the real assignment loop:
+#
+#   * ORDER DEPENDENCE — the same issues in a different arrival order produce a
+#     different clustering (pairwise ARI 0.796 across 20 orderings, min 0.673). About
+#     a fifth of the grouping a user sees is decided by arrival order, not content.
+#   * DUPLICATES THAT CAN NEVER HEAL — 7 groups were split across 14 clusters, i.e.
+#     14% of the feed, with pairs as obviously identical as "Repeated same call log
+#     chain 12 times in redundant retries" and "Retried identical chain execution 11
+#     times producing empty outputs" shown as two separate entries.
+#
+# A full re-cluster would fix both but reassigns every issue and churns every cluster
+# id under live users. This is the smaller change that targets the measured defect:
+# a periodic pass that merges clusters whose CENTROIDS are already within threshold.
+# It needs no re-embedding (centroids are in ClickHouse), touches only genuine
+# duplicates, and moves the grouping toward the order-invariant answer over time.
+
+
+def _merge_cluster_pair(keep_id: str, absorb_id: str, project_id: str) -> None:
+    """Fold ``absorb`` into ``keep``: issues, junction rows, counts, centroid."""
+    keep = TraceErrorGroup.objects.get(cluster_id=keep_id, project_id=project_id)
+    absorb = TraceErrorGroup.objects.get(cluster_id=absorb_id, project_id=project_id)
+
+    TraceScanIssue.objects.filter(cluster=absorb).update(cluster=keep)
+
+    # The junction is unique per (cluster, trace); a trace present in both clusters
+    # would violate that on a blind update, so re-point only the rows keep lacks.
+    existing = set(
+        ErrorClusterTraces.objects.filter(cluster=keep).values_list("trace_id", flat=True)
+    )
+    for row in ErrorClusterTraces.objects.filter(cluster=absorb):
+        if row.trace_id in existing:
+            row.delete()
+        else:
+            row.cluster = keep
+            row.save(update_fields=["cluster"])
+
+    keep.error_count = (keep.error_count or 0) + (absorb.error_count or 0)
+    keep.total_events = (keep.total_events or 0) + (absorb.total_events or 0)
+    if absorb.first_seen and (not keep.first_seen or absorb.first_seen < keep.first_seen):
+        keep.first_seen = absorb.first_seen
+    if absorb.last_seen and (not keep.last_seen or absorb.last_seen > keep.last_seen):
+        keep.last_seen = absorb.last_seen
+    keep.unique_traces = keep.clusters.values("trace").distinct().count()
+    keep.save(update_fields=["error_count", "total_events", "first_seen", "last_seen",
+                             "unique_traces", "updated_at"])
+
+    absorb.delete()
+    delete_centroid(absorb_id, project_id)
+
+
+def merge_duplicate_clusters(
+    project_id: str, threshold: float = COSINE_THRESHOLD, max_merges: int = 50
+) -> int:
+    """Merge clusters whose centroids sit within ``threshold`` cosine distance.
+
+    Greedy closest-pair-first, so the tightest duplicates collapse before looser ones
+    and a chain of near-identical clusters converges on one survivor. The larger
+    cluster always absorbs the smaller, which keeps the surviving id the one users
+    have already seen in the feed. Returns the number of merges performed.
+
+    ``max_merges`` bounds a single pass: this runs periodically, so it is better to
+    make steady progress than to hold a long transaction over a pathological project.
+    """
+    db = ClickHouseVectorDB()
+    try:
+        ensure_centroid_table(db)
+        rows = db.client.execute(
+            f"""
+            SELECT cluster_id, argMax(centroid, last_updated), argMax(member_count, last_updated)
+            FROM {CENTROIDS_TABLE}
+            WHERE project_id = %(project_id)s
+            GROUP BY cluster_id
+            """,
+            {"project_id": str(project_id)},
+        )
+    finally:
+        db.close()
+    if len(rows) < 2:
+        return 0
+
+    live = set(
+        TraceErrorGroup.objects.filter(project_id=project_id).values_list(
+            "cluster_id", flat=True
+        )
+    )
+    items = [(str(cid), vec, cnt) for cid, vec, cnt in rows if str(cid) in live and vec]
+    if len(items) < 2:
+        return 0
+
+    pairs = []
+    for i in range(len(items)):
+        for j in range(i + 1, len(items)):
+            d = _cosine_distance(items[i][1], items[j][1])
+            if d <= threshold:
+                pairs.append((d, i, j))
+    pairs.sort()
+
+    gone: set[str] = set()
+    merged = 0
+    for _d, i, j in pairs:
+        if merged >= max_merges:
+            break
+        a, b = items[i], items[j]
+        if a[0] in gone or b[0] in gone:
+            continue
+        keep, absorb = (a, b) if (a[2] or 0) >= (b[2] or 0) else (b, a)
+        try:
+            _merge_cluster_pair(keep[0], absorb[0], project_id)
+        except TraceErrorGroup.DoesNotExist:
+            continue
+        gone.add(absorb[0])
+        merged += 1
+
+    if merged:
+        logger.info(
+            "scan_clusters_merged", project_id=str(project_id), merged=merged,
+            clusters_before=len(items),
+        )
+    return merged

--- a/futureagi/tracer/queries/trace_scanner.py
+++ b/futureagi/tracer/queries/trace_scanner.py
@@ -7,6 +7,7 @@ All return typed dataclasses — no raw dicts at the boundary.
 
 import hashlib
 import json
+import re
 
 import structlog
 
@@ -14,6 +15,13 @@ from tracer.models.trace_scan import TraceScanConfig, TraceScanResult
 from tracer.types.scan_types import ScanConfig, SpanData, TraceData
 
 logger = structlog.get_logger(__name__)
+
+# Per-message attributes emitted by every ingest adapter, in either the OTel
+# GenAI (gen_ai.*) or OpenInference (llm.*) namespace.
+_MESSAGE_ATTR_RE = re.compile(
+    r"^(?:gen_ai\.(?:input|output)\.messages\.\d+\.message"
+    r"|llm\.(?:input|output)_messages\.\d+\.message)\.(?:role|content)$"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +271,15 @@ def _ch_span_to_span(span) -> SpanData:
         val = (span.attrs_string or {}).get(tool_key) or extra_attrs.get(tool_key)
         if val:
             attrs[tool_key] = val
+
+    # Per-message attributes, so the scanner can see the conversation as ordered
+    # turns instead of one flattened blob. Without these, input.value is the whole
+    # serialized message list and the scanner cannot tell which agent reply
+    # answered which user question — it pairs a question from one turn with an
+    # answer from another and reports failures that never happened.
+    for key, val in (span.attrs_string or {}).items():
+        if _MESSAGE_ATTR_RE.match(key):
+            attrs[key] = val
 
     for key in _TOKEN_KEYS:
         if key in metadata:

--- a/futureagi/tracer/tasks/trace_scanner.py
+++ b/futureagi/tracer/tasks/trace_scanner.py
@@ -26,6 +26,7 @@ from tracer.services.clickhouse.v2 import get_reader
 from tracer.services.clickhouse.v2.query_settings import ch_query_settings
 from tracer.utils.trace_scanner import (
     cluster_issues,
+    merge_duplicate_clusters,
     embed_trace_inputs,
     match_success_traces,
     scan_and_write,
@@ -148,12 +149,23 @@ def cluster_scan_issues_task(project_id: str):
 
     summary = cluster_issues(project_id)
 
+    # Online assignment has no merge step, so two clusters describing one root cause can
+    # never join — measured at 14% of feed entries on production briefs. Collapse them
+    # after each clustering pass. Bounded internally, and deliberately fail-open: a merge
+    # problem must not cost us the clustering that just succeeded.
+    try:
+        merged = merge_duplicate_clusters(project_id)
+    except Exception:
+        logger.exception("cluster_merge_failed", project_id=project_id)
+        merged = 0
+
     logger.info(
         "cluster_scan_issues_task_completed",
         project_id=project_id,
         clustered=summary.clustered,
         new_clusters=summary.new_clusters,
         assigned=summary.assigned,
+        merged_duplicates=merged,
     )
 
     # Match success traces for all scanner clusters in this project

--- a/futureagi/tracer/tests/test_cluster_medoid_title.py
+++ b/futureagi/tracer/tests/test_cluster_medoid_title.py
@@ -87,22 +87,50 @@ class TestRetitleFromMembers:
         cluster = _cluster_with(project, [outlier, typical_a, typical_b])
         assert cluster.title == outlier  # first arrival named it
 
-        # outlier sits far from the other two; centroid sits with the pair
+        # outlier sits far from the other two; the members' own mean sits with the pair
         vectors = {
             outlier: [1.0, 0.0, 0.0],
             typical_a: [0.0, 1.0, 0.0],
             typical_b: [0.0, 0.98, 0.2],
         }
-        centroid = [0.0, 1.0, 0.1]
 
         with patch(
             "tracer.queries.scan_clustering.embed_texts",
             side_effect=lambda briefs: [vectors[b] for b in briefs],
         ):
-            _retitle_from_members(cluster, centroid)
+            _retitle_from_members(cluster)
 
         cluster.refresh_from_db()
         assert cluster.title in (typical_a, typical_b)
+        assert cluster.title != outlier
+
+    def test_medoid_is_measured_among_the_briefs_it_selects_from(self, project):
+        """The stored centroid is built from ``embedding_text`` — the DISTILLED
+        phrase — while the title must be a raw brief a person would recognise.
+        Ranking raw briefs by distance to that centroid compares two different
+        embedding spaces, and the winner is then near-arbitrary.
+
+        Here the raw briefs cluster around the pair, so the medoid is one of
+        them. Nothing outside this set may decide that.
+        """
+        outlier = "Agent invented a client named Dana Whitfield out of nothing"
+        pair_a = "Answered with text instead of calling the portfolio tool"
+        pair_b = "Answered in prose instead of invoking the portfolio tool"
+        cluster = _cluster_with(project, [outlier, pair_a, pair_b])
+        vectors = {
+            outlier: [1.0, 0.0, 0.0],
+            pair_a: [0.0, 1.0, 0.0],
+            pair_b: [0.0, 0.99, 0.14],
+        }
+
+        with patch(
+            "tracer.queries.scan_clustering.embed_texts",
+            side_effect=lambda briefs: [vectors[b] for b in briefs],
+        ):
+            _retitle_from_members(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.title in (pair_a, pair_b)
         assert cluster.title != outlier
 
     def test_singleton_is_left_alone(self, project):
@@ -112,7 +140,7 @@ class TestRetitleFromMembers:
         cluster = _cluster_with(project, [only])
 
         with patch("tracer.queries.scan_clustering.embed_texts") as embed:
-            _retitle_from_members(cluster, [1.0, 0.0])
+            _retitle_from_members(cluster)
 
         embed.assert_not_called()
         cluster.refresh_from_db()
@@ -127,22 +155,25 @@ class TestRetitleFromMembers:
             "tracer.queries.scan_clustering.embed_texts",
             side_effect=RuntimeError("serving down"),
         ):
-            _retitle_from_members(cluster, [1.0, 0.0])
+            _retitle_from_members(cluster)
 
         cluster.refresh_from_db()
         assert cluster.title == first
 
     def test_no_write_when_medoid_is_already_the_title(self, project):
         keep = "Queried past month instead of requested quarterly performance"
+        near = "Queried past month rather than the requested quarter"
         other = "Something quite different about tool errors"
-        cluster = _cluster_with(project, [keep, other])
-        vectors = {keep: [0.0, 1.0], other: [1.0, 0.0]}
+        # three members, with `keep` sitting between the other two so it really
+        # is the medoid — two opposed vectors would tie and let position decide
+        cluster = _cluster_with(project, [keep, near, other])
+        vectors = {keep: [0.7, 0.714], near: [0.0, 1.0], other: [1.0, 0.0]}
 
         with patch(
             "tracer.queries.scan_clustering.embed_texts",
             side_effect=lambda briefs: [vectors[b] for b in briefs],
         ):
-            _retitle_from_members(cluster, [0.0, 1.0])
+            _retitle_from_members(cluster)
 
         cluster.refresh_from_db()
         assert cluster.title == keep

--- a/futureagi/tracer/tests/test_cluster_medoid_title.py
+++ b/futureagi/tracer/tests/test_cluster_medoid_title.py
@@ -1,0 +1,157 @@
+"""Regression tests for fix 3b — medoid titling.
+
+A cluster's title was `issue.brief` from whichever member arrived FIRST, frozen
+forever. First arrival has no claim to being representative, so a 15-trace
+cluster ends up named after one accidental member — the "heading doesn't
+describe what's inside" complaint that started this audit (S-0F8414EA was titled
+after "David Chen" while 0 of 20 visible members mentioned him).
+
+The title is now recomputed from the medoid — the member nearest the centroid —
+at a handful of growth points.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tracer.models.trace_error_analysis import ClusterSource, TraceErrorGroup
+from tracer.models.trace_scan import TraceScanIssue, TraceScanResult, TraceScanStatus
+from tracer.queries.scan_clustering import (
+    _RETITLE_AT,
+    _cosine_distance,
+    _retitle_from_members,
+)
+
+
+class TestCosineDistance:
+    def test_identical_vectors_are_zero(self):
+        assert _cosine_distance([1.0, 0.0], [1.0, 0.0]) == pytest.approx(0.0)
+
+    def test_orthogonal_vectors_are_one(self):
+        assert _cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+
+    def test_magnitude_does_not_matter(self):
+        """Cosine is scale-invariant — a longer vector in the same direction is
+        the same distance, which is what makes centroid comparison valid."""
+        assert _cosine_distance([1.0, 0.0], [5.0, 0.0]) == pytest.approx(0.0)
+
+    def test_zero_vector_does_not_divide_by_zero(self):
+        assert _cosine_distance([0.0, 0.0], [1.0, 0.0]) == 1.0
+
+
+def _cluster_with(project, briefs):
+    cluster = TraceErrorGroup.objects.create(
+        project_id=project.id,
+        cluster_id="S-MEDOID1",
+        source=ClusterSource.SCANNER,
+        issue_group="Context Handling Failures",
+        issue_category="Context Handling Failures",
+        fix_layer="prompt",
+        title=briefs[0],  # first-arrival title, the behaviour under test
+        error_type="Context Handling Failures",
+        total_events=len(briefs),
+        unique_traces=len(briefs),
+        error_count=len(briefs),
+    )
+    import uuid
+
+    for brief in briefs:
+        sr = TraceScanResult.objects.create(
+            trace_id=str(uuid.uuid4()),
+            project_id=project.id,
+            status=TraceScanStatus.COMPLETED,
+            has_issues=True,
+            key_moments=[],
+            meta={},
+        )
+        TraceScanIssue.objects.create(
+            scan_result=sr,
+            category="Context Handling Failures",
+            group="Context Handling Failures",
+            fix_layer="prompt",
+            confidence="H",
+            brief=brief,
+            cluster=cluster,
+        )
+    return cluster
+
+
+@pytest.mark.django_db
+class TestRetitleFromMembers:
+    def test_medoid_is_chosen_over_first_arrival(self, project):
+        """The core fix. The outlier arrived first and named the cluster; the
+        medoid is the member the group is actually about."""
+        outlier = "Hallucinated context regarding UK property worth 500000"
+        typical_a = "Queried past month instead of requested quarterly performance"
+        typical_b = "Queried past month performance instead of requested quarter"
+        cluster = _cluster_with(project, [outlier, typical_a, typical_b])
+        assert cluster.title == outlier  # first arrival named it
+
+        # outlier sits far from the other two; centroid sits with the pair
+        vectors = {
+            outlier: [1.0, 0.0, 0.0],
+            typical_a: [0.0, 1.0, 0.0],
+            typical_b: [0.0, 0.98, 0.2],
+        }
+        centroid = [0.0, 1.0, 0.1]
+
+        with patch(
+            "tracer.queries.scan_clustering.embed_texts",
+            side_effect=lambda briefs: [vectors[b] for b in briefs],
+        ):
+            _retitle_from_members(cluster, centroid)
+
+        cluster.refresh_from_db()
+        assert cluster.title in (typical_a, typical_b)
+        assert cluster.title != outlier
+
+    def test_singleton_is_left_alone(self, project):
+        """Nothing to be representative of — and re-embedding one brief to
+        rename it to itself is pure waste."""
+        only = "Agent returned raw empty LLM result"
+        cluster = _cluster_with(project, [only])
+
+        with patch("tracer.queries.scan_clustering.embed_texts") as embed:
+            _retitle_from_members(cluster, [1.0, 0.0])
+
+        embed.assert_not_called()
+        cluster.refresh_from_db()
+        assert cluster.title == only
+
+    def test_embedding_failure_leaves_the_title_intact(self, project):
+        """A stale title beats a broken assignment — retitling is best-effort."""
+        first = "Queried past month instead of requested quarterly performance"
+        cluster = _cluster_with(project, [first, "Some other brief"])
+
+        with patch(
+            "tracer.queries.scan_clustering.embed_texts",
+            side_effect=RuntimeError("serving down"),
+        ):
+            _retitle_from_members(cluster, [1.0, 0.0])
+
+        cluster.refresh_from_db()
+        assert cluster.title == first
+
+    def test_no_write_when_medoid_is_already_the_title(self, project):
+        keep = "Queried past month instead of requested quarterly performance"
+        other = "Something quite different about tool errors"
+        cluster = _cluster_with(project, [keep, other])
+        vectors = {keep: [0.0, 1.0], other: [1.0, 0.0]}
+
+        with patch(
+            "tracer.queries.scan_clustering.embed_texts",
+            side_effect=lambda briefs: [vectors[b] for b in briefs],
+        ):
+            _retitle_from_members(cluster, [0.0, 1.0])
+
+        cluster.refresh_from_db()
+        assert cluster.title == keep
+
+
+class TestRetitleThresholds:
+    def test_growth_points_are_sparse_and_increasing(self):
+        """Recomputing on every assignment would re-embed the whole cluster each
+        time; these are the growth points where the medoid can actually shift."""
+        assert list(_RETITLE_AT) == sorted(_RETITLE_AT)
+        assert _RETITLE_AT[0] == 2
+        assert len(_RETITLE_AT) <= 10

--- a/futureagi/tracer/tests/test_cluster_partition.py
+++ b/futureagi/tracer/tests/test_cluster_partition.py
@@ -1,21 +1,29 @@
-"""Regression tests for fix 4 — dropping the category partition.
+"""Regression tests for the category partition on centroid matching.
 
-Candidate centroids used to be filtered by ``family`` (the scanner's category)
-before the distance sort, so two clusters in different categories could never
-merge no matter how close their embeddings sat. The scanner picks the category
-from free text, so one defect described two ways lands in two categories — and
-on the post-fix-5 corpus that is visible directly:
+Candidate centroids are filtered by ``family`` (the scanner's category) before
+the distance sort, so two clusters in different categories can never merge no
+matter how close their embeddings sit. That was dropped once, because the
+scanner picks the category from free text and one defect described two ways
+lands in two categories:
 
     S-232AA3EB  Context Handling Failures     15 traces
     S-15263D7F  Poor Information Retrieval     5 traces
 
-both "asked for a quarter, queried a different period". No embedding could
-merge those while the family clause was in the WHERE.
+both "asked for a quarter, queried a different period".
+
+Distilling the brief before embedding fixes that at the source — the phrase is
+now stable, and only the category choice wavers, on 1.2% of distinct phrases
+and 4.5% of issues. Replaying one project's 1,277 real issues without the
+partition, three of the four groups that appear only in that configuration are
+one bug with mis-categorised strays, and the fourth is 312 members spanning
+eight categories with none above 45%, filing "gives investment advice despite
+policy prohibiting it" alongside "responds with irrelevant disclaimer". The
+partition is back on: it costs the strays and prevents that entry.
 
 These assert on the emitted SQL rather than standing up ClickHouse: what is
 being pinned is which rows are *eligible* to be sorted, which is a property of
-the statement. The toggle is exercised in both positions so reverting it stays
-a one-line change rather than a code change.
+the statement. The toggle is exercised in both positions so flipping it stays a
+one-line change rather than a code change.
 """
 
 import re
@@ -29,7 +37,7 @@ def _executed(mock_db):
     return mock_db.return_value.client.execute.call_args_list[-1]
 
 
-def _norm(sql):
+def _norm(sql: str) -> str:
     return re.sub(r"\s+", " ", sql).strip()
 
 
@@ -42,51 +50,49 @@ def _run(embedding=(0.1, 0.2), category="Context Handling Failures"):
     return _executed(db)
 
 
-class TestCategoryPartitionDisabled:
-    def test_family_is_not_in_the_where_clause(self):
-        """The fix itself: category must not gate which centroids compete."""
-        assert scan_clustering.PARTITION_BY_CATEGORY is False, (
+class TestCategoryPartitionEnabled:
+    def test_family_gates_the_candidate_set(self):
+        """The shipped default: an issue only competes against its own category."""
+        assert scan_clustering.PARTITION_BY_CATEGORY is True, (
             "these tests describe the shipped default"
         )
-        sql = _norm(_run().args[0])
-        assert "family = " not in sql
+        call = _run(category="Poor Information Retrieval")
+        sql = _norm(call.args[0])
+        assert "family = %(family)s" in sql
+        assert call.args[1]["family"] == "Poor Information Retrieval"
 
     def test_project_scoping_survives(self):
-        """Dropping the category partition must not drop tenant isolation —
-        that would leak one customer's clusters into another's feed."""
+        """The category filter must not be the only thing scoping the read —
+        losing the project predicate would leak one customer's clusters into
+        another's feed."""
         call = _run()
         sql = _norm(call.args[0])
         assert "project_id = %(project_id)s" in sql
         assert call.args[1]["project_id"] == "proj-1"
 
-    def test_two_categories_produce_the_same_candidate_set(self):
-        """The S-232AA3EB / S-15263D7F case, reduced to its mechanism.
-
-        The same embedding arriving under two different scanner categories must
-        query identically — only then can the distance sort decide, which is
-        what lets the two halves of one defect find each other.
-        """
+    def test_two_categories_query_different_candidate_sets(self):
+        """The cost this buys: the same embedding under two categories cannot
+        reach the same centroids. That is the S-232AA3EB / S-15263D7F split, now
+        priced at 4.5% of issues because distillation stabilised the phrase."""
         a = _norm(_run(category="Context Handling Failures").args[0])
-        b = _norm(_run(category="Poor Information Retrieval").args[0])
-        assert a == b
+        b = _run(category="Poor Information Retrieval")
+        assert a == _norm(b.args[0])          # same SQL text...
+        assert b.args[1]["family"] == "Poor Information Retrieval"   # ...different bind
 
 
-class TestCategoryPartitionEnabled:
-    def test_toggle_restores_the_family_filter(self):
-        """Kept as a switch: if cross-category merging proves too loose it can
-        be reverted without touching the query builder."""
-        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", True):
-            call = _run(category="Poor Information Retrieval")
-
-        sql = _norm(call.args[0])
-        assert "family = %(family)s" in sql
-        assert call.args[1]["family"] == "Poor Information Retrieval"
+class TestCategoryPartitionDisabled:
+    def test_toggle_removes_the_family_filter(self):
+        """Kept as a switch: if the stray fragments hurt more than the mixing,
+        this reverts without touching the query builder."""
+        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", False):
+            sql = _norm(_run().args[0])
+        assert "family = " not in sql
 
     def test_toggle_is_the_only_difference(self):
         """Guards against the two branches drifting apart — everything except
         the family predicate must be identical in both positions."""
-        off = _norm(_run().args[0])
-        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", True):
-            on = _norm(_run().args[0])
+        on = _norm(_run().args[0])
+        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", False):
+            off = _norm(_run().args[0])
 
         assert on.replace("AND family = %(family)s ", "") == off

--- a/futureagi/tracer/tests/test_cluster_partition.py
+++ b/futureagi/tracer/tests/test_cluster_partition.py
@@ -1,0 +1,92 @@
+"""Regression tests for fix 4 — dropping the category partition.
+
+Candidate centroids used to be filtered by ``family`` (the scanner's category)
+before the distance sort, so two clusters in different categories could never
+merge no matter how close their embeddings sat. The scanner picks the category
+from free text, so one defect described two ways lands in two categories — and
+on the post-fix-5 corpus that is visible directly:
+
+    S-232AA3EB  Context Handling Failures     15 traces
+    S-15263D7F  Poor Information Retrieval     5 traces
+
+both "asked for a quarter, queried a different period". No embedding could
+merge those while the family clause was in the WHERE.
+
+These assert on the emitted SQL rather than standing up ClickHouse: what is
+being pinned is which rows are *eligible* to be sorted, which is a property of
+the statement. The toggle is exercised in both positions so reverting it stays
+a one-line change rather than a code change.
+"""
+
+import re
+from unittest.mock import patch
+
+from tracer.queries import scan_clustering
+from tracer.queries.scan_clustering import find_nearest_centroid
+
+
+def _executed(mock_db):
+    return mock_db.return_value.client.execute.call_args_list[-1]
+
+
+def _norm(sql):
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+def _run(embedding=(0.1, 0.2), category="Context Handling Failures"):
+    with patch(
+        "tracer.queries.scan_clustering.ClickHouseVectorDB"
+    ) as db, patch("tracer.queries.scan_clustering.ensure_centroid_table"):
+        db.return_value.client.execute.return_value = []
+        find_nearest_centroid(list(embedding), "proj-1", category)
+    return _executed(db)
+
+
+class TestCategoryPartitionDisabled:
+    def test_family_is_not_in_the_where_clause(self):
+        """The fix itself: category must not gate which centroids compete."""
+        assert scan_clustering.PARTITION_BY_CATEGORY is False, (
+            "these tests describe the shipped default"
+        )
+        sql = _norm(_run().args[0])
+        assert "family = " not in sql
+
+    def test_project_scoping_survives(self):
+        """Dropping the category partition must not drop tenant isolation —
+        that would leak one customer's clusters into another's feed."""
+        call = _run()
+        sql = _norm(call.args[0])
+        assert "project_id = %(project_id)s" in sql
+        assert call.args[1]["project_id"] == "proj-1"
+
+    def test_two_categories_produce_the_same_candidate_set(self):
+        """The S-232AA3EB / S-15263D7F case, reduced to its mechanism.
+
+        The same embedding arriving under two different scanner categories must
+        query identically — only then can the distance sort decide, which is
+        what lets the two halves of one defect find each other.
+        """
+        a = _norm(_run(category="Context Handling Failures").args[0])
+        b = _norm(_run(category="Poor Information Retrieval").args[0])
+        assert a == b
+
+
+class TestCategoryPartitionEnabled:
+    def test_toggle_restores_the_family_filter(self):
+        """Kept as a switch: if cross-category merging proves too loose it can
+        be reverted without touching the query builder."""
+        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", True):
+            call = _run(category="Poor Information Retrieval")
+
+        sql = _norm(call.args[0])
+        assert "family = %(family)s" in sql
+        assert call.args[1]["family"] == "Poor Information Retrieval"
+
+    def test_toggle_is_the_only_difference(self):
+        """Guards against the two branches drifting apart — everything except
+        the family predicate must be identical in both positions."""
+        off = _norm(_run().args[0])
+        with patch.object(scan_clustering, "PARTITION_BY_CATEGORY", True):
+            on = _norm(_run().args[0])
+
+        assert on.replace("AND family = %(family)s ", "") == off

--- a/futureagi/tracer/tests/test_cluster_severity_status.py
+++ b/futureagi/tracer/tests/test_cluster_severity_status.py
@@ -1,0 +1,233 @@
+"""Regression tests for fixes 6 and 7 — severity and status honesty.
+
+Both fields were decided once, at cluster creation, from a single seed issue,
+and never recomputed. In production that produced a feed where the grades
+carried no information: 72% of clusters were high/critical, and 234 of 235 were
+"escalating" — including 138 singletons seen exactly once.
+
+Fix 6 re-derives severity from the cluster's *current* title (which after fix 3b
+describes the group rather than one arbitrary member) and applies volume as a
+floor. Fix 7 stops claiming a trend below a threshold where there is none.
+
+Neither invents a model. They make the existing labels defensible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tracer.models.trace_error_analysis import (
+    ClusterSource,
+    FeedIssueStatus,
+    TraceErrorGroup,
+)
+from tracer.queries.scan_clustering import (
+    _ESCALATING_MIN_TRACES,
+    _refresh_severity,
+    _refresh_status,
+    _volume_floor,
+)
+
+
+def _cluster(project, *, traces=1, title="Queried the wrong period", **kwargs):
+    return TraceErrorGroup.objects.create(
+        project_id=project.id,
+        cluster_id=kwargs.pop("cluster_id", "S-SEV0001"),
+        source=ClusterSource.SCANNER,
+        issue_group="Context Handling Failures",
+        issue_category="Context Handling Failures",
+        fix_layer="prompt",
+        title=title,
+        error_type="Context Handling Failures",
+        total_events=traces,
+        unique_traces=traces,
+        error_count=traces,
+        **kwargs,
+    )
+
+
+def _graded(severity):
+    """Pin the cheap-LLM grade so only the volume floor is under test."""
+    return patch(
+        "tracer.queries.scan_clustering._seed_severity", return_value=severity
+    )
+
+
+@pytest.mark.django_db
+class TestSeverityVolumeFloor:
+    def test_breadth_lifts_a_low_grade_to_medium(self, project):
+        """A defect reproducing across many traces is at least a medium
+        regardless of how its title reads — breadth is evidence the text alone
+        cannot carry."""
+        cluster = _cluster(project, traces=_ESCALATING_MIN_TRACES)
+
+        with _graded("low"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "medium"
+        assert cluster.combined_impact == "MEDIUM"
+
+    def test_a_singleton_keeps_its_low_grade(self, project):
+        """The floor must not apply to something seen once, or it re-inflates
+        exactly the population fix 6 exists to deflate."""
+        cluster = _cluster(project, traces=1)
+
+        with _graded("low"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "low"
+
+    def test_high_volume_lifts_to_high(self, project):
+        cluster = _cluster(project, traces=25)
+
+        with _graded("low"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "high"
+
+    def test_the_floor_never_lowers_a_grade(self, project):
+        """It is a floor, not an assignment. A one-off that genuinely lost a
+        customer money stays critical."""
+        cluster = _cluster(project, traces=1)
+
+        with _graded("critical"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "urgent"  # critical maps to urgent priority
+
+    def test_missing_unique_traces_does_not_crash(self, project):
+        cluster = _cluster(project, traces=1)
+        cluster.unique_traces = None
+
+        with _graded("medium"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "medium"
+
+
+@pytest.mark.django_db
+class TestSeverityReadsTheCurrentTitle:
+    def test_grades_the_cluster_title_not_the_seed_brief(self, project):
+        """The point of running this after retitling: the classifier should see
+        what the cluster is now called, not the first member that arrived."""
+        cluster = _cluster(project, traces=3, title="Agent hallucinated holdings")
+
+        with patch(
+            "tracer.queries.scan_clustering._seed_severity", return_value="high"
+        ) as seed:
+            _refresh_severity(cluster)
+
+        seed.assert_called_once_with(
+            "Context Handling Failures", "Agent hallucinated holdings"
+        )
+
+    def test_no_grade_available_leaves_the_cluster_untouched(self, project):
+        """OSS has no EE classifier and LLM calls fail; neither should rewrite a
+        grade to a guess."""
+        cluster = _cluster(project, traces=30, priority="low")
+        before = cluster.updated_at
+
+        with _graded(None):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.priority == "low"
+        assert cluster.updated_at == before
+
+    def test_no_write_when_the_grade_is_unchanged(self, project):
+        cluster = _cluster(project, traces=1, priority="medium")
+        before = cluster.updated_at
+
+        with _graded("medium"):
+            _refresh_severity(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.updated_at == before
+
+
+class TestVolumeFloorBands:
+    """The re-grade gate compares the floor before and after an assignment, so
+    the band boundaries have to be exactly where the floor changes."""
+
+    @pytest.mark.parametrize(
+        "traces,expected",
+        [(0, "low"), (4, "low"), (5, "medium"), (24, "medium"), (25, "high")],
+    )
+    def test_bands(self, traces, expected):
+        assert _volume_floor(traces) == expected
+
+    def test_boundaries_coincide_with_retitle_points(self):
+        """Both crossings must land on a `_RETITLE_AT` growth point, or the
+        gate never notices them and severity stays stale forever."""
+        from tracer.queries.scan_clustering import _RETITLE_AT
+
+        crossings = [
+            n for n in range(1, 300) if _volume_floor(n) != _volume_floor(n - 1)
+        ]
+        assert crossings == [5, 25]
+        assert set(crossings).issubset(set(_RETITLE_AT))
+
+
+@pytest.mark.django_db
+class TestStatusFloor:
+    def test_a_singleton_is_for_review_not_escalating(self, project):
+        """The headline defect: 138 clusters seen exactly once were labelled
+        escalating."""
+        cluster = _cluster(project, traces=1, status=FeedIssueStatus.ESCALATING)
+
+        _refresh_status(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.status == FeedIssueStatus.FOR_REVIEW
+
+    def test_recurrence_earns_escalating(self, project):
+        cluster = _cluster(
+            project,
+            traces=_ESCALATING_MIN_TRACES,
+            status=FeedIssueStatus.FOR_REVIEW,
+        )
+
+        _refresh_status(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.status == FeedIssueStatus.ESCALATING
+
+    def test_the_threshold_is_inclusive_at_its_boundary(self, project):
+        below = _cluster(
+            project,
+            traces=_ESCALATING_MIN_TRACES - 1,
+            cluster_id="S-BELOW01",
+            status=FeedIssueStatus.ESCALATING,
+        )
+
+        _refresh_status(below)
+
+        below.refresh_from_db()
+        assert below.status == FeedIssueStatus.FOR_REVIEW
+
+    @pytest.mark.parametrize(
+        "triaged", [FeedIssueStatus.ACKNOWLEDGED, FeedIssueStatus.RESOLVED]
+    )
+    def test_human_triage_is_never_overwritten(self, project, triaged):
+        """Someone looked at this and made a call. Growing past the threshold
+        must not silently reopen it underneath them."""
+        cluster = _cluster(project, traces=50, status=triaged)
+
+        _refresh_status(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.status == triaged
+
+    def test_no_write_when_already_at_target(self, project):
+        cluster = _cluster(project, traces=1, status=FeedIssueStatus.FOR_REVIEW)
+        before = cluster.updated_at
+
+        _refresh_status(cluster)
+
+        cluster.refresh_from_db()
+        assert cluster.updated_at == before

--- a/futureagi/tracer/tests/test_scan_brief_distillation.py
+++ b/futureagi/tracer/tests/test_scan_brief_distillation.py
@@ -1,0 +1,93 @@
+"""The scanner clustering must embed distilled phrases, not raw briefs.
+
+``ClusterableIssue.embedding_text`` already prefers ``distilled``, but nothing
+sets it unless ``cluster_issues`` asks for it — an unwired distiller leaves the
+dataclass contract satisfied and the feed just as fragmented. Replayed over one
+project's 1,277 real production issues through the real assignment loop, at the
+production threshold and category partition:
+
+    raw briefs   226 feed entries, 131 singletons (58%), top 10 cover 45%
+    distilled     52 feed entries,  26 singletons (50%), top 10 cover 88%
+
+The eval clustering path has done this since it shipped
+(``distill_eval_failure_phrases`` in tracer/utils/eval_clustering.py); these pin
+the scanner path to the same contract.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from tracer.types.scan_types import ClusterableIssue
+from tracer.utils.trace_scanner import cluster_issues
+
+
+def _issue(brief: str, category: str = "Language-only") -> ClusterableIssue:
+    return ClusterableIssue(
+        issue_id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        project_id="p1",
+        category=category,
+        group="Tool Failures",
+        fix_layer="Tools",
+        brief=brief,
+        confidence="high",
+    )
+
+
+RAW = [
+    "Stated NVDA price without calling the quote tool",
+    "Reported MSFT valuation without invoking the lookup tool",
+]
+CANON = "agent states stock price without calling data tools"
+
+
+@pytest.fixture
+def issues():
+    return [_issue(b) for b in RAW]
+
+
+def _run(issues, distiller):
+    """Drive cluster_issues far enough to capture what it embedded."""
+    captured = {}
+
+    def _embed(texts):
+        captured["texts"] = list(texts)
+        return [[1.0, 0.0] for _ in texts]
+
+    with patch("tracer.utils.trace_scanner.get_unclustered_issues", return_value=issues), \
+         patch("tracer.utils.trace_scanner.distill_scan_briefs", side_effect=distiller), \
+         patch("tracer.utils.trace_scanner.embed_texts", side_effect=_embed), \
+         patch("tracer.utils.trace_scanner.find_nearest_centroid", return_value=None), \
+         patch("tracer.utils.trace_scanner.create_cluster", return_value="C1"):
+        cluster_issues("p1")
+    return captured.get("texts")
+
+
+def test_embeds_the_distilled_phrase_not_the_raw_brief(issues):
+    def distiller(items):
+        for i in items:
+            i.distilled = CANON
+        return items
+
+    assert _run(issues, distiller) == [CANON, CANON]
+
+
+def test_two_briefs_differing_only_by_ticker_embed_identically(issues):
+    """One bug, two tickers. Raw briefs are distinct strings and seed two
+    clusters; that is the 96%-distinct-briefs fragmentation in miniature."""
+    def distiller(items):
+        for i in items:
+            i.distilled = CANON
+        return items
+
+    embedded = _run(issues, distiller)
+    assert issues[0].brief != issues[1].brief
+    assert len(set(embedded)) == 1
+
+
+def test_falls_back_to_raw_briefs_when_the_distiller_is_a_no_op(issues):
+    """OSS has no distiller and a gateway batch can fail. Clustering must still
+    run on the raw briefs rather than embed empty strings."""
+    assert _run(issues, lambda items: items) == RAW

--- a/futureagi/tracer/tests/test_scan_centroid_current_version.py
+++ b/futureagi/tracer/tests/test_scan_centroid_current_version.py
@@ -1,0 +1,120 @@
+"""The incremental centroid update must read the CURRENT centroid version.
+
+``cluster_centroids`` is a ReplacingMergeTree and ``assign_to_cluster`` INSERTs a
+new row per member instead of updating one, so every historical version of a
+centroid coexists until a background merge collapses them. The read that feeds the
+running mean therefore has to name which version it wants. It used to be a bare
+``SELECT ... LIMIT 1``, which returns an arbitrary one: the mean gets computed from
+a stale vector and a stale ``member_count``, and since that count is the weight in
+``_update_centroid`` the error compounds into every later update rather than washing
+out.
+
+DB-free: every Django and ClickHouse collaborator is mocked. These are
+revert-catchers on the query shape, not proof the SQL is right — a mocked client
+cannot execute ClickHouse. Two hazards specific to this fix are covered
+because both are silent in production:
+
+  - dropping ``GROUP BY`` while keeping ``argMax``. An aggregate with no GROUP BY
+    always returns exactly one row, so a cluster with no stored centroid would come
+    back as a phantom row of empty defaults and ``if rows:`` would take the wrong
+    branch, seeding the running mean from an empty vector instead of the issue.
+  - dropping the tuple recency key back to plain ``last_updated``, which is
+    second-granularity: two members joining one cluster inside the same second are
+    unordered, and the tie-break has to be ``member_count`` because it is the only
+    monotonically growing column available.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracer.queries.scan_clustering import assign_to_cluster
+from tracer.types.scan_types import ClusterableIssue
+
+_CLUSTER = "S-1234ABCD"
+_PROJECT = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+
+class _RecordingClient:
+    """Captures every statement; replays canned rows for the SELECT."""
+
+    def __init__(self, select_rows):
+        self._select_rows = select_rows
+        self.statements = []
+
+    def execute(self, sql, params=None):
+        self.statements.append((sql, params or {}))
+        return self._select_rows if "SELECT" in sql else []
+
+
+def _issue() -> ClusterableIssue:
+    return ClusterableIssue(
+        issue_id="11111111-1111-1111-1111-111111111111",
+        trace_id="22222222-2222-2222-2222-222222222222",
+        project_id=_PROJECT,
+        category="Tool-related",
+        group="Tool Failures",
+        fix_layer="Prompt",
+        brief="answered without calling the tool",
+        confidence="H",
+    )
+
+
+def _run(select_rows):
+    """Drive assign_to_cluster with Django collaborators stubbed; return the client."""
+    client = _RecordingClient(select_rows)
+    db = MagicMock()
+    db.client = client
+    with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", return_value=db), \
+         patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+         patch("tracer.queries.scan_clustering.TraceErrorGroup") as group, \
+         patch("tracer.queries.scan_clustering.TraceScanIssue"), \
+         patch("tracer.queries.scan_clustering.ErrorClusterTraces"):
+        group.objects.get.return_value = MagicMock(error_count=0, total_events=0)
+        assign_to_cluster(_CLUSTER, _PROJECT, _issue(), [1.0, 0.0, 0.0])
+    return client
+
+
+def _select(client):
+    return next(sql for sql, _ in client.statements if "SELECT" in sql)
+
+
+def _insert_params(client):
+    return next(p for sql, p in client.statements if "INSERT" in sql)
+
+
+def test_reads_the_current_version_not_an_arbitrary_one():
+    client = _run([([0.0, 1.0, 0.0], 4)])
+    sql = _select(client)
+    assert "argMax" in sql, (
+        "a bare LIMIT 1 returns an arbitrary ReplacingMergeTree version"
+    )
+    assert "GROUP BY" in sql, (
+        "argMax without GROUP BY returns a phantom row when no centroid exists"
+    )
+    assert "last_updated" in sql and "member_count" in sql, (
+        "recency key must break same-second ties on the monotonic member_count"
+    )
+
+
+def test_read_is_project_scoped():
+    client = _run([([0.0, 1.0, 0.0], 4)])
+    sql = _select(client)
+    params = next(p for s, p in client.statements if "SELECT" in s)
+    assert "project_id" in sql and params.get("project_id") == _PROJECT
+
+
+def test_running_mean_uses_the_returned_count_as_the_weight():
+    # 4 existing members at [0,1,0], new member [1,0,0] -> (4*old + new)/5
+    client = _run([([0.0, 1.0, 0.0], 4)])
+    params = _insert_params(client)
+    assert params["member_count"] == 5
+    assert params["centroid"] == pytest.approx([0.2, 0.8, 0.0])
+
+
+def test_missing_centroid_seeds_from_the_issue_rather_than_an_empty_vector():
+    """GROUP BY makes 'no stored centroid' return zero rows, keeping this reachable."""
+    client = _run([])
+    params = _insert_params(client)
+    assert params["member_count"] == 1
+    assert params["centroid"] == [1.0, 0.0, 0.0]

--- a/futureagi/tracer/tests/test_scan_cluster_merge.py
+++ b/futureagi/tracer/tests/test_scan_cluster_merge.py
@@ -20,7 +20,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.utils import timezone
 
-from tracer.models.trace_error_analysis import ErrorClusterTraces, TraceErrorGroup
+from tracer.models.trace_error_analysis import (
+    ErrorClusterTraces,
+    FeedIssueStatus,
+    TraceErrorGroup,
+)
 from tracer.queries.scan_clustering import merge_duplicate_clusters
 
 
@@ -61,6 +65,8 @@ class TestMergeDuplicateClusters:
         rows = [("C1", NEAR_A, 9), ("C2", NEAR_B, 2)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid") as dc:
             merged = merge_duplicate_clusters(pid)
 
@@ -82,6 +88,7 @@ class TestMergeDuplicateClusters:
         rows = [("C1", NEAR_A, 5), ("C2", FAR, 5)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             merged = merge_duplicate_clusters(pid)
 
@@ -96,6 +103,7 @@ class TestMergeDuplicateClusters:
         rows = [("C1", NEAR_A, 5), ("GHOST", NEAR_B, 4)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             merged = merge_duplicate_clusters(pid)
 
@@ -109,6 +117,7 @@ class TestMergeDuplicateClusters:
         rows = [(f"C{i}", [1.0 - i * 0.005, i * 0.005, 0.0], 6 - i) for i in range(6)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             merged = merge_duplicate_clusters(pid, max_merges=2)
 
@@ -120,6 +129,7 @@ class TestMergeDuplicateClusters:
         _cluster(pid, "C1", members=3, traces=[])
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch([("C1", NEAR_A, 3)])), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             assert merge_duplicate_clusters(pid) == 0
 
@@ -141,6 +151,7 @@ class TestJunctionReconciliation:
         rows = [("C1", NEAR_A, 4), ("C2", NEAR_B, 2)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             assert merge_duplicate_clusters(pid) == 1
 
@@ -153,3 +164,45 @@ class TestJunctionReconciliation:
         assert traces == {shared, only_in_absorb}       # deduped, nothing lost
         assert ErrorClusterTraces.objects.filter(cluster=survivor).count() == 2
         assert survivor.unique_traces == 2
+
+
+@pytest.mark.django_db
+class TestTriageIsNeverTrampled:
+    """A merge must not launder a human-triaged cluster back into the feed.
+
+    ``_refresh_status`` already refuses to overwrite acknowledged/resolved. Absorbing
+    such a cluster into a for_review one would dissolve that decision by the back door
+    — same harm, extra steps.
+    """
+
+    def _run(self, pid):
+        rows = [("C1", NEAR_A, 9), ("C2", NEAR_B, 2)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            return merge_duplicate_clusters(pid)
+
+    def test_triaged_cluster_survives_even_when_smaller(self, project):
+        pid = project.id
+        big = _cluster(pid, "C1", members=9, traces=[])          # would normally win
+        small = _cluster(pid, "C2", members=2, traces=[])
+        small.status = FeedIssueStatus.RESOLVED
+        small.save(update_fields=["status"])
+
+        assert self._run(pid) == 1
+        survivor = TraceErrorGroup.objects.get(project_id=pid)
+        assert survivor.cluster_id == "C2"                        # the triaged one survives
+        assert survivor.status == FeedIssueStatus.RESOLVED        # and keeps its decision
+        assert survivor.error_count == 11                         # nothing lost
+        assert not TraceErrorGroup.objects.filter(cluster_id=big.cluster_id).exists()
+
+    def test_two_triaged_clusters_are_left_alone(self, project):
+        pid = project.id
+        for cid, st in (("C1", FeedIssueStatus.ACKNOWLEDGED), ("C2", FeedIssueStatus.RESOLVED)):
+            c = _cluster(pid, cid, members=5, traces=[])
+            c.status = st
+            c.save(update_fields=["status"])
+
+        assert self._run(pid) == 0
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 2

--- a/futureagi/tracer/tests/test_scan_cluster_merge.py
+++ b/futureagi/tracer/tests/test_scan_cluster_merge.py
@@ -28,13 +28,13 @@ from tracer.models.trace_error_analysis import (
 from tracer.queries.scan_clustering import merge_duplicate_clusters
 
 
-def _cluster(project_id, cluster_id, *, members, traces, unique=None):
+def _cluster(project_id, cluster_id, *, members, traces, unique=None, category="Tool-related"):
     return TraceErrorGroup.objects.create(
         project_id=project_id,
         cluster_id=cluster_id,
         title=f"cluster {cluster_id}",
         issue_group="Tool Failures",
-        issue_category="Tool-related",
+        issue_category=category,
         fix_layer="Tools",
         error_count=members,
         total_events=members,
@@ -45,12 +45,17 @@ def _cluster(project_id, cluster_id, *, members, traces, unique=None):
 
 
 def _ch(rows):
-    """Mock ClickHouseVectorDB returning ``rows`` from the centroid SELECT."""
+    """Mock ClickHouseVectorDB returning ``rows`` from the centroid SELECT.
+
+    Rows are ``(cluster_id, centroid, member_count, family)`` — ``family`` is the
+    issue category, which the merge refuses to cross.
+    """
     db = MagicMock()
     db.return_value.client.execute.return_value = rows
     return db
 
 
+CAT = "Tool-related"
 NEAR_A = [1.0, 0.0, 0.0]
 NEAR_B = [0.98, 0.02, 0.0]      # cosine distance well under threshold
 FAR = [0.0, 1.0, 0.0]           # orthogonal — must never merge
@@ -62,7 +67,7 @@ class TestMergeDuplicateClusters:
         pid = project.id
         big = _cluster(pid, "C1", members=9, traces=[])
         small = _cluster(pid, "C2", members=2, traces=[])
-        rows = [("C1", NEAR_A, 9), ("C2", NEAR_B, 2)]
+        rows = [("C1", NEAR_A, 9, CAT), ("C2", NEAR_B, 2, CAT)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
@@ -85,7 +90,7 @@ class TestMergeDuplicateClusters:
         pid = project.id
         _cluster(pid, "C1", members=5, traces=[])
         _cluster(pid, "C2", members=5, traces=[])
-        rows = [("C1", NEAR_A, 5), ("C2", FAR, 5)]
+        rows = [("C1", NEAR_A, 5, CAT), ("C2", FAR, 5, CAT)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
@@ -100,7 +105,7 @@ class TestMergeDuplicateClusters:
         raise DoesNotExist straight into the caller."""
         pid = project.id
         _cluster(pid, "C1", members=5, traces=[])
-        rows = [("C1", NEAR_A, 5), ("GHOST", NEAR_B, 4)]
+        rows = [("C1", NEAR_A, 5, CAT), ("GHOST", NEAR_B, 4, CAT)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
@@ -112,9 +117,19 @@ class TestMergeDuplicateClusters:
 
     def test_respects_max_merges_bound(self, project):
         pid = project.id
-        for i in range(6):
-            _cluster(pid, f"C{i}", members=6 - i, traces=[])
-        rows = [(f"C{i}", [1.0 - i * 0.005, i * 0.005, 0.0], 6 - i) for i in range(6)]
+        # three well-separated duplicate PAIRS, so all three are eligible and the
+        # bound is the only thing that stops the third
+        axes = [0, 2, 4]
+        rows = []
+        for k, ax in enumerate(axes):
+            for half, size in enumerate((6 - k, 2)):
+                vec = [0.0] * 6
+                vec[ax] = 1.0 if half == 0 else 0.99
+                if half:
+                    vec[ax + 1] = 0.01
+                cid = f"C{k}{half}"
+                _cluster(pid, cid, members=size, traces=[])
+                rows.append((cid, vec, size, CAT))
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
@@ -127,11 +142,61 @@ class TestMergeDuplicateClusters:
     def test_no_op_below_two_centroids(self, project):
         pid = project.id
         _cluster(pid, "C1", members=3, traces=[])
-        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch([("C1", NEAR_A, 3)])), \
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch([("C1", NEAR_A, 3, CAT)])), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
              patch("tracer.queries.scan_clustering.delete_centroid"):
             assert merge_duplicate_clusters(pid) == 0
+
+
+@pytest.mark.django_db
+class TestMergeNeverBecomesReclustering:
+    """The pass heals duplicates. It must not quietly re-cluster the feed.
+
+    Replayed over one project's real 234 centroids the unguarded version collapsed
+    the feed to 127 entries, the largest holding 648 of 1,285 traces across 46
+    original clusters and mixing tool-skips with hallucinated tool output. Both
+    guards below were measured to be load-bearing on that data.
+    """
+
+    def test_refuses_to_merge_across_categories(self, project):
+        """The category decides which team owns the fix, so it is the one axis a
+        merge may not cross — and the axis a shared vocabulary chains straight
+        through when nothing forbids it."""
+        pid = project.id
+        _cluster(pid, "C1", members=9, traces=[], category="Tool-related")
+        _cluster(pid, "C2", members=2, traces=[], category="Incorrect Memory Usage")
+        rows = [("C1", NEAR_A, 9, "Tool-related"),
+                ("C2", NEAR_B, 2, "Incorrect Memory Usage")]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            assert merge_duplicate_clusters(pid) == 0
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 2
+
+    def test_a_hub_cluster_cannot_swallow_both_its_neighbours(self, project):
+        """H is within threshold of both X and Y, but X and Y are 0.545 apart — not
+        duplicates of each other. Absorbing both would make H the union of two
+        unrelated issues, one merge at a time. Mutual-nearest-neighbour admits only
+        the closest pair, so the second neighbour waits for its own evidence."""
+        pid = project.id
+        for cid, size in (("H", 9), ("X", 4), ("Y", 3)):
+            _cluster(pid, cid, members=size, traces=[])
+        rows = [
+            ("H", [1.0, 0.0, 0.0], 9, CAT),
+            ("X", [0.70, 0.7141428, 0.0], 4, CAT),      # 0.30 from H
+            ("Y", [0.65, 0.0, 0.7599342], 3, CAT),      # 0.35 from H, 0.545 from X
+        ]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering._absorb_centroid"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            assert merge_duplicate_clusters(pid) == 1
+
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 2
+        assert TraceErrorGroup.objects.filter(cluster_id="Y").exists()
+        assert TraceErrorGroup.objects.get(cluster_id="H").error_count == 13  # H + X only
 
 
 @pytest.mark.django_db
@@ -148,7 +213,7 @@ class TestJunctionReconciliation:
         ErrorClusterTraces.objects.create(cluster=absorb, trace_id=shared)
         ErrorClusterTraces.objects.create(cluster=absorb, trace_id=only_in_absorb)
 
-        rows = [("C1", NEAR_A, 4), ("C2", NEAR_B, 2)]
+        rows = [("C1", NEAR_A, 4, CAT), ("C2", NEAR_B, 2, CAT)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \
@@ -176,7 +241,7 @@ class TestTriageIsNeverTrampled:
     """
 
     def _run(self, pid):
-        rows = [("C1", NEAR_A, 9), ("C2", NEAR_B, 2)]
+        rows = [("C1", NEAR_A, 9, CAT), ("C2", NEAR_B, 2, CAT)]
         with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
              patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
              patch("tracer.queries.scan_clustering._absorb_centroid"), \

--- a/futureagi/tracer/tests/test_scan_cluster_merge.py
+++ b/futureagi/tracer/tests/test_scan_cluster_merge.py
@@ -1,0 +1,155 @@
+"""Regression tests for the duplicate-cluster merge pass.
+
+``assign_to_cluster`` is online and incremental with no merge step, so two clusters
+that describe the same root cause can never join. Measured on 261 real production
+issue briefs replayed through the real assignment loop: 7 groups were split across
+14 clusters — 14% of the feed — with pairs as plainly identical as "Repeated same
+call log chain 12 times in redundant retries" and "Retried identical chain execution
+11 times producing empty outputs" shown to users as separate entries.
+
+These pin the behaviour that fixes it. ClickHouse is mocked so the tests assert on
+the reconciliation (which is where the data-loss risk lives) rather than on vector
+search: what must hold is that issues and junction rows survive the move, counts add
+up, the unique-per-(cluster, trace) junction constraint is never violated, and the
+surviving id is the one users already have in their feed.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils import timezone
+
+from tracer.models.trace_error_analysis import ErrorClusterTraces, TraceErrorGroup
+from tracer.queries.scan_clustering import merge_duplicate_clusters
+
+
+def _cluster(project_id, cluster_id, *, members, traces, unique=None):
+    return TraceErrorGroup.objects.create(
+        project_id=project_id,
+        cluster_id=cluster_id,
+        title=f"cluster {cluster_id}",
+        issue_group="Tool Failures",
+        issue_category="Tool-related",
+        fix_layer="Tools",
+        error_count=members,
+        total_events=members,
+        unique_traces=unique if unique is not None else len(traces),
+        first_seen=timezone.now(),
+        last_seen=timezone.now(),
+    )
+
+
+def _ch(rows):
+    """Mock ClickHouseVectorDB returning ``rows`` from the centroid SELECT."""
+    db = MagicMock()
+    db.return_value.client.execute.return_value = rows
+    return db
+
+
+NEAR_A = [1.0, 0.0, 0.0]
+NEAR_B = [0.98, 0.02, 0.0]      # cosine distance well under threshold
+FAR = [0.0, 1.0, 0.0]           # orthogonal — must never merge
+
+
+@pytest.mark.django_db
+class TestMergeDuplicateClusters:
+    def test_merges_near_identical_centroids_and_keeps_the_larger_id(self, project):
+        pid = project.id
+        big = _cluster(pid, "C1", members=9, traces=[])
+        small = _cluster(pid, "C2", members=2, traces=[])
+        rows = [("C1", NEAR_A, 9), ("C2", NEAR_B, 2)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid") as dc:
+            merged = merge_duplicate_clusters(pid)
+
+        assert merged == 1
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 1
+        # the id users already see in the feed is the one that survives
+        survivor = TraceErrorGroup.objects.get(project_id=pid)
+        assert survivor.cluster_id == "C1"
+        assert survivor.error_count == 11        # 9 + 2, nothing dropped
+        assert survivor.total_events == 11
+        dc.assert_called_once_with("C2", pid)    # orphan centroid cleaned up
+        assert not TraceErrorGroup.objects.filter(cluster_id=small.cluster_id).exists()
+        assert big.cluster_id == survivor.cluster_id
+
+    def test_leaves_unrelated_clusters_alone(self, project):
+        pid = project.id
+        _cluster(pid, "C1", members=5, traces=[])
+        _cluster(pid, "C2", members=5, traces=[])
+        rows = [("C1", NEAR_A, 5), ("C2", FAR, 5)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            merged = merge_duplicate_clusters(pid)
+
+        assert merged == 0
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 2
+
+    def test_ignores_centroids_whose_cluster_row_is_gone(self, project):
+        """Orphan centroids outlive their TraceErrorGroup; merging into one would
+        raise DoesNotExist straight into the caller."""
+        pid = project.id
+        _cluster(pid, "C1", members=5, traces=[])
+        rows = [("C1", NEAR_A, 5), ("GHOST", NEAR_B, 4)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            merged = merge_duplicate_clusters(pid)
+
+        assert merged == 0
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 1
+
+    def test_respects_max_merges_bound(self, project):
+        pid = project.id
+        for i in range(6):
+            _cluster(pid, f"C{i}", members=6 - i, traces=[])
+        rows = [(f"C{i}", [1.0 - i * 0.005, i * 0.005, 0.0], 6 - i) for i in range(6)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            merged = merge_duplicate_clusters(pid, max_merges=2)
+
+        assert merged == 2
+        assert TraceErrorGroup.objects.filter(project_id=pid).count() == 4
+
+    def test_no_op_below_two_centroids(self, project):
+        pid = project.id
+        _cluster(pid, "C1", members=3, traces=[])
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch([("C1", NEAR_A, 3)])), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            assert merge_duplicate_clusters(pid) == 0
+
+
+@pytest.mark.django_db
+class TestJunctionReconciliation:
+    def test_shared_trace_does_not_violate_unique_constraint(self, project):
+        """A trace present in BOTH clusters must not be re-pointed onto a row that
+        already exists — that is the one move in this pass that can raise."""
+        pid = project.id
+        keep = _cluster(pid, "C1", members=4, traces=[])
+        absorb = _cluster(pid, "C2", members=2, traces=[])
+        shared = uuid.uuid4()
+        only_in_absorb = uuid.uuid4()
+        ErrorClusterTraces.objects.create(cluster=keep, trace_id=shared)
+        ErrorClusterTraces.objects.create(cluster=absorb, trace_id=shared)
+        ErrorClusterTraces.objects.create(cluster=absorb, trace_id=only_in_absorb)
+
+        rows = [("C1", NEAR_A, 4), ("C2", NEAR_B, 2)]
+        with patch("tracer.queries.scan_clustering.ClickHouseVectorDB", _ch(rows)), \
+             patch("tracer.queries.scan_clustering.ensure_centroid_table"), \
+             patch("tracer.queries.scan_clustering.delete_centroid"):
+            assert merge_duplicate_clusters(pid) == 1
+
+        survivor = TraceErrorGroup.objects.get(project_id=pid)
+        traces = set(
+            ErrorClusterTraces.objects.filter(cluster=survivor).values_list(
+                "trace_id", flat=True
+            )
+        )
+        assert traces == {shared, only_in_absorb}       # deduped, nothing lost
+        assert ErrorClusterTraces.objects.filter(cluster=survivor).count() == 2
+        assert survivor.unique_traces == 2

--- a/futureagi/tracer/tests/test_scan_clustering_centroid.py
+++ b/futureagi/tracer/tests/test_scan_clustering_centroid.py
@@ -1,0 +1,165 @@
+"""Regression tests for fix 2 — centroid-store correctness.
+
+Three defects, all in how ``cluster_centroids`` is written and read:
+
+1. ``assign_to_cluster`` INSERTs a new row per member instead of updating, and
+   ``find_nearest_centroid`` read the table without collapsing versions, so the
+   distance sort ran over stale centroids as well as current ones.
+2. ``last_updated`` is second-granularity, so two updates to one cluster inside
+   the same second could not be ordered.
+3. Centroids outlive their TraceErrorGroup. Matching an orphan made
+   ``assign_to_cluster`` raise DoesNotExist straight into the blanket handler in
+   ``cluster_issues``, dropping the issue permanently.
+
+The SQL tests assert on the emitted query rather than standing up ClickHouse:
+what is being pinned is that versions are collapsed *before* the distance sort,
+which is a property of the statement.
+"""
+
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracer.models.trace_error_analysis import TraceErrorGroup
+from tracer.queries.scan_clustering import find_nearest_centroid
+from tracer.types.scan_types import ClusterableIssue
+
+
+def _executed_sql(mock_db):
+    return mock_db.return_value.client.execute.call_args_list[-1].args[0]
+
+
+def _norm(sql):
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+class TestFindNearestCentroidCollapsesVersions:
+    def test_dedupes_to_one_row_per_cluster_before_distance_sort(self):
+        """The distance sort must run over current centroids only.
+
+        Without the inner LIMIT 1 BY, every historical version of a centroid is
+        a separate candidate row and the nearest *stale* version can win.
+        """
+        with patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ) as db, patch("tracer.queries.scan_clustering.ensure_centroid_table"):
+            db.return_value.client.execute.return_value = []
+            find_nearest_centroid([0.1, 0.2], "proj-1", "Language-only")
+
+        sql = _norm(_executed_sql(db))
+        assert "LIMIT 1 BY cluster_id" in sql
+        # The dedupe has to happen in a subquery, i.e. before the outer sort.
+        inner = sql.split("LIMIT 1 BY cluster_id")[0]
+        assert "ORDER BY distance" not in inner, (
+            "distance sort must come after version collapse, not before"
+        )
+
+    def test_orders_by_recency_then_member_count(self):
+        """member_count breaks ties last_updated cannot.
+
+        last_updated is DateTime (second granularity); two updates to one
+        cluster in the same second are otherwise unordered, and member_count is
+        strictly increasing per cluster.
+        """
+        with patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ) as db, patch("tracer.queries.scan_clustering.ensure_centroid_table"):
+            db.return_value.client.execute.return_value = []
+            find_nearest_centroid([0.1, 0.2], "proj-1", "Language-only")
+
+        sql = _norm(_executed_sql(db))
+        assert "ORDER BY last_updated DESC, member_count DESC" in sql
+
+    def test_still_applies_the_threshold(self):
+        """Guard against the rewrite quietly dropping the distance cutoff."""
+        with patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ) as db, patch("tracer.queries.scan_clustering.ensure_centroid_table"):
+            db.return_value.client.execute.return_value = [("S-AAA", 0.9)]
+            assert find_nearest_centroid([0.1], "proj-1", "cat") is None
+
+            db.return_value.client.execute.return_value = [("S-AAA", 0.01)]
+            assert find_nearest_centroid([0.1], "proj-1", "cat") == ("S-AAA", 0.01)
+
+
+def _issue():
+    return ClusterableIssue(
+        issue_id="issue-1", trace_id="trace-1", project_id="proj-1",
+        category="Language-only", group="Language-only", fix_layer="tools",
+        brief="Stated portfolio values without calling data tools",
+        confidence="H",
+    )
+
+
+class TestOrphanedCentroidHandling:
+    def test_orphan_match_deletes_centroid_and_still_clusters_the_issue(self):
+        """The production silent-drop path.
+
+        A centroid whose cluster was deleted still matches. Before the fix,
+        assign_to_cluster raised DoesNotExist into cluster_issues' blanket
+        handler and the issue was never clustered and never retried.
+        """
+        from tracer.utils import trace_scanner as ts
+
+        with patch.object(ts, "get_unclustered_issues", return_value=[_issue()]), \
+             patch.object(ts, "embed_texts", return_value=[[0.1, 0.2]]), \
+             patch.object(ts, "find_nearest_centroid", return_value=("S-GHOST", 0.01)), \
+             patch.object(ts, "assign_to_cluster", side_effect=TraceErrorGroup.DoesNotExist), \
+             patch.object(ts, "delete_centroid") as delete_centroid, \
+             patch.object(ts, "create_cluster", return_value="S-NEW") as create:
+            summary = ts.cluster_issues("proj-1")
+
+        delete_centroid.assert_called_once_with("S-GHOST", "proj-1")
+        create.assert_called_once()
+        assert summary.new_clusters == 1
+        assert summary.clustered == 1, "issue must not be silently dropped"
+
+    def test_healthy_match_does_not_delete_anything(self):
+        from tracer.utils import trace_scanner as ts
+
+        with patch.object(ts, "get_unclustered_issues", return_value=[_issue()]), \
+             patch.object(ts, "embed_texts", return_value=[[0.1, 0.2]]), \
+             patch.object(ts, "find_nearest_centroid", return_value=("S-REAL", 0.01)), \
+             patch.object(ts, "assign_to_cluster") as assign, \
+             patch.object(ts, "delete_centroid") as delete_centroid:
+            summary = ts.cluster_issues("proj-1")
+
+        assign.assert_called_once()
+        delete_centroid.assert_not_called()
+        assert summary.assigned == 1
+        assert summary.new_clusters == 0
+
+
+class TestJoinIsCountedAsAssigned:
+    def test_join_counts_as_assigned_not_new_cluster(self):
+        """A join means the centroid lookup missed a cluster it should have
+        matched. Counting it as a new cluster hides exactly that signal."""
+        from tracer.utils import trace_scanner as ts
+
+        def fake_create(project_id, issue, embedding, on_join=None):
+            if on_join:
+                on_join()
+            return "S-EXISTING"
+
+        with patch.object(ts, "get_unclustered_issues", return_value=[_issue()]), \
+             patch.object(ts, "embed_texts", return_value=[[0.1, 0.2]]), \
+             patch.object(ts, "find_nearest_centroid", return_value=None), \
+             patch.object(ts, "create_cluster", side_effect=fake_create):
+            summary = ts.cluster_issues("proj-1")
+
+        assert summary.assigned == 1, "a join is an assignment, not a creation"
+        assert summary.new_clusters == 0
+        assert summary.clustered == 1
+
+    def test_genuine_create_still_counts_as_new_cluster(self):
+        from tracer.utils import trace_scanner as ts
+
+        with patch.object(ts, "get_unclustered_issues", return_value=[_issue()]), \
+             patch.object(ts, "embed_texts", return_value=[[0.1, 0.2]]), \
+             patch.object(ts, "find_nearest_centroid", return_value=None), \
+             patch.object(ts, "create_cluster", return_value="S-NEW"):
+            summary = ts.cluster_issues("proj-1")
+
+        assert summary.new_clusters == 1
+        assert summary.assigned == 0

--- a/futureagi/tracer/tests/test_scan_clustering_dedup.py
+++ b/futureagi/tracer/tests/test_scan_clustering_dedup.py
@@ -1,0 +1,158 @@
+"""Regression tests for scanner cluster de-duplication.
+
+``create_cluster`` derives its ``cluster_id`` from md5(project, category,
+brief[:100]), so the SAME failure arriving twice reproduces the SAME id by
+construction. The pre-existing "handle collision" branch treated that as an md5
+collision and minted a *different* id, which manufactured pairs of clusters
+carrying byte-identical titles seconds apart (observed in production: 8 titles
+across 16 clusters, 6 pairs sharing one trace_id).
+
+The branch is reached whenever ``find_nearest_centroid`` misses a cluster it
+should have matched — ``cluster_centroids`` is a ReplacingMergeTree read without
+FINAL, so a just-written centroid is not reliably visible to the next lookup.
+
+These pin the corrected behaviour: join on a repeat, fork only on a genuine
+collision (same id, different failure).
+"""
+
+import hashlib
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from tracer.models.trace_error_analysis import ClusterSource, TraceErrorGroup
+from tracer.queries.scan_clustering import create_cluster
+from tracer.types.scan_types import ClusterableIssue
+
+CATEGORY = "Language-only"
+BRIEF = "Stated portfolio values and calculations without calling data tools"
+
+
+def _issue(project_id: str, brief: str = BRIEF, category: str = CATEGORY):
+    return ClusterableIssue(
+        issue_id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        project_id=str(project_id),
+        category=category,
+        group="Language-only",
+        fix_layer="tools",
+        brief=brief,
+        confidence="high",
+    )
+
+
+def _expected_id(project_id: str, category: str, brief: str) -> str:
+    """Mirror the id derivation so the test pins the contract, not the impl."""
+    base = f"{project_id}|scanner|{category}|{brief[:100]}"
+    return f"S-{hashlib.md5(base.encode(), usedforsecurity=False).hexdigest()[:8].upper()}"
+
+
+def _seed_cluster(project, cluster_id: str, *, title: str, category: str):
+    return TraceErrorGroup.objects.create(
+        project_id=project.id,
+        cluster_id=cluster_id,
+        source=ClusterSource.SCANNER,
+        issue_group="Language-only",
+        issue_category=category,
+        fix_layer="tools",
+        title=title,
+        error_type="Language-only",
+        total_events=1,
+        unique_traces=1,
+        error_count=1,
+    )
+
+
+@pytest.mark.django_db
+class TestCreateClusterDeduplication:
+    def test_repeat_brief_joins_existing_cluster_instead_of_forking(self, project):
+        """The production bug: identical (category, brief) must NOT create a
+        second cluster. It must be routed into the one already holding it."""
+        cluster_id = _expected_id(str(project.id), CATEGORY, BRIEF)
+        _seed_cluster(project, cluster_id, title=BRIEF, category=CATEGORY)
+
+        issue = _issue(project.id)
+        # The create-path collaborators are patched too, so that if the join is
+        # ever regressed this fails on the assertions below (a second cluster
+        # exists) rather than blowing up inside the create path.
+        with patch(
+            "tracer.queries.scan_clustering.assign_to_cluster"
+        ) as assign, patch(
+            "tracer.queries.scan_clustering._seed_severity", return_value="high"
+        ) as seed_sev, patch(
+            "tracer.queries.scan_clustering.ensure_centroid_table"
+        ), patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ), patch(
+            "tracer.queries.scan_clustering.ErrorClusterTraces"
+        ), patch(
+            "tracer.queries.scan_clustering.TraceScanIssue"
+        ):
+            returned = create_cluster(str(project.id), issue, [0.1, 0.2, 0.3])
+
+        assert returned == cluster_id
+        assign.assert_called_once()
+        assert assign.call_args.args[0] == cluster_id
+        # No second cluster, and no wasted severity LLM call on the join path.
+        assert TraceErrorGroup.objects.filter(project_id=project.id).count() == 1
+        seed_sev.assert_not_called()
+
+    def test_true_hash_collision_still_gets_a_distinct_id(self, project):
+        """A row under the same id but describing a DIFFERENT failure is a real
+        collision — it must still fork, or the two failures would be merged."""
+        cluster_id = _expected_id(str(project.id), CATEGORY, BRIEF)
+        _seed_cluster(
+            project,
+            cluster_id,
+            title="An entirely unrelated failure",
+            category=CATEGORY,
+        )
+
+        issue = _issue(project.id)
+        with patch(
+            "tracer.queries.scan_clustering.assign_to_cluster"
+        ) as assign, patch(
+            "tracer.queries.scan_clustering._seed_severity", return_value="high"
+        ), patch(
+            "tracer.queries.scan_clustering.ensure_centroid_table"
+        ), patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ), patch(
+            "tracer.queries.scan_clustering.ErrorClusterTraces"
+        ), patch(
+            "tracer.queries.scan_clustering.TraceScanIssue"
+        ):
+            returned = create_cluster(str(project.id), issue, [0.1, 0.2, 0.3])
+
+        assign.assert_not_called()
+        assert returned != cluster_id
+        assert TraceErrorGroup.objects.filter(project_id=project.id).count() == 2
+        assert TraceErrorGroup.objects.filter(
+            project_id=project.id, cluster_id=returned, title=BRIEF
+        ).exists()
+
+    def test_differing_category_does_not_join(self, project):
+        """Same brief under a different category is a different cluster family —
+        the id differs, so this must take the normal create path."""
+        other = _expected_id(str(project.id), CATEGORY, BRIEF)
+        _seed_cluster(project, other, title=BRIEF, category=CATEGORY)
+
+        issue = _issue(project.id, category="Goal Deviation")
+        with patch(
+            "tracer.queries.scan_clustering.assign_to_cluster"
+        ) as assign, patch(
+            "tracer.queries.scan_clustering._seed_severity", return_value="high"
+        ), patch(
+            "tracer.queries.scan_clustering.ensure_centroid_table"
+        ), patch(
+            "tracer.queries.scan_clustering.ClickHouseVectorDB"
+        ), patch(
+            "tracer.queries.scan_clustering.ErrorClusterTraces"
+        ), patch(
+            "tracer.queries.scan_clustering.TraceScanIssue"
+        ):
+            returned = create_cluster(str(project.id), issue, [0.1, 0.2, 0.3])
+
+        assign.assert_not_called()
+        assert returned == _expected_id(str(project.id), "Goal Deviation", BRIEF)

--- a/futureagi/tracer/tests/test_scan_types.py
+++ b/futureagi/tracer/tests/test_scan_types.py
@@ -6,12 +6,21 @@ clusters by cosine distance. Key moments are trace-specific verbatim
 quotes that dominated the embedding and fragmented same-issue findings
 across many singleton clusters. We embed the brief alone — the issue
 described, not the surrounding trace text.
+
+The brief carries the same disease in milder form: it names this trace's
+ticker, client and feature. Across one project's 1,277 real issues, 1,229
+briefs (96%) were distinct strings describing far fewer distinct bugs. So
+the brief is what users READ, and the distilled phrase is what we EMBED.
 """
 
 from tracer.types.scan_types import ClusterableIssue
 
 
-def _issue(brief: str, key_moments: list[str] | None = None) -> ClusterableIssue:
+def _issue(
+    brief: str,
+    key_moments: list[str] | None = None,
+    distilled: str | None = None,
+) -> ClusterableIssue:
     return ClusterableIssue(
         issue_id="i1",
         trace_id="t1",
@@ -22,6 +31,7 @@ def _issue(brief: str, key_moments: list[str] | None = None) -> ClusterableIssue
         brief=brief,
         confidence="high",
         key_moments_text=key_moments or [],
+        distilled=distilled,
     )
 
 
@@ -45,3 +55,32 @@ def test_embedding_text_same_brief_clusters_across_traces():
     a = _issue(brief, key_moments=["called /v1/foo", "got 404"])
     b = _issue(brief, key_moments=["called /v2/bar", "got 404"])
     assert a.embedding_text == b.embedding_text
+
+
+def test_distilled_phrase_is_what_gets_embedded():
+    issue = _issue(
+        brief="Stated NVDA gain of $5,014.68 for client Arjun Malhotra without a tool call",
+        distilled="agent states portfolio figures without calling data tools",
+    )
+    assert issue.embedding_text == "agent states portfolio figures without calling data tools"
+
+
+def test_distillation_collapses_briefs_that_differ_only_by_entity():
+    """The fragmentation this exists to fix: one bug, two tickers, two clusters."""
+    a = _issue(
+        brief="Stated NVDA price without calling the quote tool",
+        distilled="agent states stock price without calling data tools",
+    )
+    b = _issue(
+        brief="Reported MSFT valuation without invoking the lookup tool",
+        distilled="agent states stock price without calling data tools",
+    )
+    assert a.brief != b.brief
+    assert a.embedding_text == b.embedding_text
+
+
+def test_falls_back_to_the_brief_when_distillation_is_unavailable():
+    """OSS has no distiller and a batch can fail; clustering must still run on
+    the raw brief rather than embed an empty string."""
+    issue = _issue(brief="Tool output contradicted the final answer.", distilled=None)
+    assert issue.embedding_text == "Tool output contradicted the final answer."

--- a/futureagi/tracer/types/scan_types.py
+++ b/futureagi/tracer/types/scan_types.py
@@ -5,7 +5,7 @@ Single source of truth — queries, utils, and tasks all import from here.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import structlog
 from django.conf import settings
@@ -82,11 +82,22 @@ class ClusterableIssue:
     brief: str
     confidence: str
     key_moments_text: List[str] = field(default_factory=list)
+    # Canonical failure phrase distilled from the brief by a cheap LLM
+    # (trace-specific noise stripped). None when distillation is unavailable
+    # (OSS) or failed — embedding falls back to the raw brief.
+    distilled: Optional[str] = None
 
     @property
     def embedding_text(self) -> str:
-        """Embed only the issue brief."""
-        return self.brief
+        """What the clustering embeds — the distilled phrase when there is one.
+
+        The raw brief stays the title. Briefs name this trace's ticker, client
+        and feature, and those entities dominate the embedding: across one
+        project's 1,277 real issues, 1,229 briefs (96%) were distinct strings
+        describing far fewer distinct bugs, so the same defect seeded a new
+        cluster on nearly every occurrence.
+        """
+        return self.distilled or self.brief
 
 
 @dataclass

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -21,6 +21,7 @@ except ImportError:
     TraceScanner = _ee_stub("TraceScanner")
 from tracer.models.trace_error_analysis import TraceErrorGroup
 from tracer.queries.scan_clustering import (
+    merge_duplicate_clusters,
     assign_to_cluster,
     create_cluster,
     delete_centroid,

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     ScanResult = _ee_stub("ScanResult")
     TraceScanner = _ee_stub("TraceScanner")
+from tracer.ee_boundary import distill_scan_briefs
 from tracer.models.trace_error_analysis import TraceErrorGroup
 from tracer.queries.scan_clustering import (
     merge_duplicate_clusters,
@@ -203,6 +204,12 @@ def cluster_issues(project_id: str) -> ClusteringSummary:
     if not issues:
         logger.info("no_unclustered_issues", project_id=project_id)
         return ClusteringSummary()
+
+    # Distill each brief to a canonical failure phrase before embedding — briefs
+    # name this trace's ticker, client and feature, and those entities dominate
+    # the embedding, so one bug seeds a cluster per occurrence. Best-effort: a
+    # failed batch leaves ``distilled`` None and the raw brief is embedded.
+    distill_scan_briefs(issues)
 
     # Embed all issue texts in one batch
     texts = [issue.embedding_text for issue in issues]

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -23,6 +23,7 @@ from tracer.models.trace_error_analysis import TraceErrorGroup
 from tracer.queries.scan_clustering import (
     assign_to_cluster,
     create_cluster,
+    delete_centroid,
     embed_texts,
     find_nearest_centroid,
     find_nearest_success_trace,
@@ -208,13 +209,50 @@ def cluster_issues(project_id: str) -> ClusteringSummary:
 
     summary = ClusteringSummary()
 
+    def _create_counting(issue, embedding) -> None:
+        """Create a cluster for ``issue``, crediting a join as an assignment.
+
+        create_cluster returns an EXISTING cluster's id when the issue turns out
+        to be a repeat the centroid lookup failed to match. Counting that as a
+        new cluster hides exactly the signal this fix exists to expose, so
+        on_join reclassifies it.
+        """
+        joined = False
+
+        def _on_join() -> None:
+            nonlocal joined
+            joined = True
+
+        create_cluster(project_id, issue, embedding, on_join=_on_join)
+        if joined:
+            summary.assigned += 1
+        else:
+            summary.new_clusters += 1
+
     for issue, embedding in zip(issues, embeddings):
         try:
             match = find_nearest_centroid(embedding, project_id, issue.category)
 
             if match:
                 cluster_id, distance = match
-                assign_to_cluster(cluster_id, project_id, issue, embedding)
+                try:
+                    assign_to_cluster(cluster_id, project_id, issue, embedding)
+                except TraceErrorGroup.DoesNotExist:
+                    # The centroid outlived its cluster. Nothing deletes
+                    # centroids when a cluster goes away, so the store keeps
+                    # rows pointing at clusters that no longer exist; matching
+                    # one used to raise straight into the handler below and the
+                    # issue was dropped for good. Drop the stale centroid so the
+                    # store self-heals, then cluster the issue normally.
+                    logger.warning(
+                        "orphaned_centroid_matched",
+                        cluster_id=cluster_id,
+                        issue_id=issue.issue_id,
+                        distance=round(distance, 4),
+                    )
+                    delete_centroid(cluster_id, project_id)
+                    _create_counting(issue, embedding)
+                    continue
                 summary.assigned += 1
                 logger.debug(
                     "issue_matched",
@@ -223,8 +261,7 @@ def cluster_issues(project_id: str) -> ClusteringSummary:
                     distance=round(distance, 4),
                 )
             else:
-                create_cluster(project_id, issue, embedding)
-                summary.new_clusters += 1
+                _create_counting(issue, embedding)
         except Exception:
             logger.exception(
                 "cluster_issue_failed",


### PR DESCRIPTION
## What

`docker-compose.yml` hardcoded the gateway's **container** port in two independent places:

- `ports: "${AGENTCC_GATEWAY_PORT:-8090}:8080"` — the published mapping
- `AGENTCC_INTERNAL_URL: http://agentcc-gateway:8080` — how the backend reaches it

…while the gateway actually binds whatever `server.port` says in the config that `AGENTCC_CONFIG_PATH` mounts. Three sources of truth, two of them hardcoded.

## Why it matters

The shipped `agentcc-gateway/config.example.yaml` says `8080`, so the **default path works** and this is invisible in CI. Point `AGENTCC_CONFIG_PATH` at a config whose `server.port` differs — which you must do to get real provider credentials — and:

- the gateway binds that port
- nothing listens on the published container port
- `agentcc-gateway:8080` is refused

Every LLM call then dies with a bare `APIConnectionError: Connection error.` that names no cause. It cost me two full experiment runs before I traced it, and the gateway image is `scratch` so you cannot shell in to check what it bound.

## The fix

Both sides derive from one variable:

```yaml
AGENTCC_INTERNAL_URL: ${AGENTCC_INTERNAL_URL:-http://agentcc-gateway:${AGENTCC_GATEWAY_CONTAINER_PORT:-8080}}
ports:
  - "${AGENTCC_GATEWAY_PORT:-8090}:${AGENTCC_GATEWAY_CONTAINER_PORT:-8080}"
```

They can no longer disagree. Set `AGENTCC_GATEWAY_CONTAINER_PORT` to match `server.port` in whichever config you mount.

## Compatibility

Default stays `8080`, so existing setups render **byte-identical** — verified with `docker-compose config`:

| | `AGENTCC_INTERNAL_URL` | published → target |
|---|---|---|
| default | `http://agentcc-gateway:8080` | 8090 → 8080 |
| `AGENTCC_GATEWAY_CONTAINER_PORT=8090` | `http://agentcc-gateway:8090` | 8090 → 8090 |
| `AGENTCC_INTERNAL_URL=http://custom:1234` | `http://custom:1234` | unchanged |

An explicit `AGENTCC_INTERNAL_URL` still wins, as before.

## Not addressed here

The deeper drift is that two configs in the tree disagree on `server.port` (`config.example.yaml` 8080 vs the ee config 8090). I did not reconcile them because I cannot verify from this repo whether the k8s service targets 8090 — changing that risks production. This change makes compose correct for **either** value, which is the drift-proof half and safe to land on its own.