### PR TITLE
feat(annotations): add View session action for trace/span queue items

### DIFF
--- a/frontend/src/components/traceDetail/DrawerToolbar.jsx
+++ b/frontend/src/components/traceDetail/DrawerToolbar.jsx
@@ -18,7 +18,7 @@ import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
 // Shared 24px bordered pill button
-const ToolbarPill = React.forwardRef(({ icon, label, onClick, sx }, ref) => (
+export const ToolbarPill = React.forwardRef(({ icon, label, onClick, sx }, ref) => (
   <ButtonBase
     ref={ref}
     onClick={onClick}

--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -4,6 +4,10 @@ import { render, screen, waitFor, userEvent } from "src/utils/test-utils";
 import axios from "src/utils/axios";
 import ContentPanel from "../annotate/content-panel";
 
+const { mockUseGetTraceDetail } = vi.hoisted(() => ({
+  mockUseGetTraceDetail: vi.fn(() => ({ data: null, isLoading: false })),
+}));
+
 vi.mock("src/components/iconify", () => ({
   default: ({ icon, ...props }) => (
     <span data-testid="iconify" data-icon={icon} {...props} />
@@ -115,16 +119,41 @@ vi.mock("src/components/traceDetail/TraceLeftPanel", () => ({
 }));
 
 vi.mock("src/components/traceDetail/DrawerToolbar", () => ({
-  default: () => <div data-testid="drawer-toolbar" />,
+  default: ({ rightSlot }) => (
+    <div data-testid="drawer-toolbar">{rightSlot}</div>
+  ),
+  // eslint-disable-next-line react/prop-types -- test stub
+  ToolbarPill: ({ icon, label, onClick }) => (
+    <button
+      type="button"
+      data-testid="toolbar-pill"
+      data-icon={icon}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  ),
 }));
 
 vi.mock("src/components/traceDetail/TraceDisplayPanel", () => ({
   default: () => <div data-testid="trace-display-panel" />,
-  DEFAULT_VIEW_CONFIG: {},
+  DEFAULT_VIEW_CONFIG: {
+    viewMode: "tree",
+    spanTypeFilter: null,
+    visibleMetrics: {
+      latency: true,
+      tokens: true,
+      cost: false,
+      evals: false,
+      annotations: false,
+      events: false,
+    },
+    showAgentGraph: true,
+  },
 }));
 
 vi.mock("src/api/project/trace-detail", () => ({
-  useGetTraceDetail: () => ({ data: null, isLoading: false }),
+  useGetTraceDetail: (...args) => mockUseGetTraceDetail(...args),
 }));
 
 vi.mock("src/api/project/saved-views", () => ({
@@ -144,11 +173,28 @@ vi.mock("src/components/imagine/useImagineStore", () => ({
   },
 }));
 
+vi.mock("src/components/custom-dialog/confirm-dialog", () => ({
+  default: () => null,
+}));
+
+function renderWithQuery(ui) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("Annotation queue ContentPanel", () => {
   const clipboardWriteText = vi.fn(() => Promise.resolve());
 
   beforeEach(() => {
     clipboardWriteText.mockClear();
+    mockUseGetTraceDetail.mockReset();
+    mockUseGetTraceDetail.mockReturnValue({ data: null, isLoading: false });
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: clipboardWriteText },
       configurable: true,
@@ -168,21 +214,13 @@ describe("Annotation queue ContentPanel", () => {
   });
 
   it("uses the voice drawer for voice call execution queue items", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-    });
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ContentPanel
-          item={{
-            source_type: "call_execution",
-            source_content: { call_id: "call-1" },
-          }}
-        />
-      </QueryClientProvider>,
+    renderWithQuery(
+      <ContentPanel
+        item={{
+          source_type: "call_execution",
+          source_content: { call_id: "call-1" },
+        }}
+      />,
     );
 
     await waitFor(() => {
@@ -204,6 +242,9 @@ describe("Annotation queue ContentPanel", () => {
       "queue,tags",
     );
     expect(screen.queryByTestId("new-scenario-view")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "View session" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders ChatDetailDrawerV2 (embedded) for chat call execution queue items", async () => {
@@ -218,21 +259,13 @@ describe("Annotation queue ContentPanel", () => {
       },
     });
 
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-    });
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ContentPanel
-          item={{
-            source_type: "call_execution",
-            source_content: { call_id: "chat-call-1" },
-          }}
-        />
-      </QueryClientProvider>,
+    renderWithQuery(
+      <ContentPanel
+        item={{
+          source_type: "call_execution",
+          source_content: { call_id: "chat-call-1" },
+        }}
+      />,
     );
 
     await waitFor(() => {
@@ -293,6 +326,9 @@ describe("Annotation queue ContentPanel", () => {
         ),
       );
     });
+    expect(
+      screen.queryByRole("button", { name: "View session" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders session traces without the legacy trace detail drawer", async () => {
@@ -313,21 +349,14 @@ describe("Annotation queue ContentPanel", () => {
         },
       },
     });
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-    });
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ContentPanel
-          item={{
-            source_type: "trace_session",
-            source_content: { session_id: "session-123" },
-          }}
-        />
-      </QueryClientProvider>,
+    renderWithQuery(
+      <ContentPanel
+        item={{
+          source_type: "trace_session",
+          source_content: { session_id: "session-123" },
+        }}
+      />,
     );
 
     // Session traces render, and the legacy trace-detail-drawer is gone — the
@@ -336,5 +365,140 @@ describe("Annotation queue ContentPanel", () => {
       await screen.findByText("customer asks for help"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("trace-detail-drawer")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "View session" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders prototype run content without a View session action", () => {
+    render(
+      <ContentPanel
+        item={{
+          source_type: "prototype_run",
+          source_content: {
+            name: "My prototype",
+            prompt: "hello",
+            response: "world",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Prototype")).toBeInTheDocument();
+    expect(screen.getByText("My prototype")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "View session" }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe("View session for trace / span items", () => {
+    it("shows View session when the loaded trace has a parent session", () => {
+      mockUseGetTraceDetail.mockReturnValue({
+        data: {
+          trace: {
+            project: "proj-1",
+            session: "session-abc",
+            tags: [],
+          },
+          observation_spans: [],
+        },
+        isLoading: false,
+      });
+
+      renderWithQuery(
+        <ContentPanel
+          item={{
+            source_type: "trace",
+            source_content: { trace_id: "trace-1" },
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "View session" }),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("drawer-toolbar")).toBeInTheDocument();
+    });
+
+    it("hides View session when the loaded trace has no parent session", () => {
+      mockUseGetTraceDetail.mockReturnValue({
+        data: {
+          trace: {
+            project: "proj-1",
+            session: null,
+            tags: [],
+          },
+          observation_spans: [],
+        },
+        isLoading: false,
+      });
+
+      renderWithQuery(
+        <ContentPanel
+          item={{
+            source_type: "observation_span",
+            source_content: { trace_id: "trace-1", span_id: "span-1" },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId("drawer-toolbar")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "View session" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("opens session detail when View session is clicked", async () => {
+      const user = userEvent.setup();
+      mockUseGetTraceDetail.mockReturnValue({
+        data: {
+          trace: {
+            project: "proj-1",
+            session: "session-abc",
+            tags: [],
+          },
+          observation_spans: [],
+        },
+        isLoading: false,
+      });
+      axios.get.mockResolvedValueOnce({
+        data: {
+          result: {
+            session_metadata: { total_traces: 1 },
+            response: [
+              {
+                trace_id: "trace-in-session",
+                input: "session conversation turn",
+                output: "assistant reply",
+                system_metrics: {},
+                evals_metrics: {},
+              },
+            ],
+            next: null,
+          },
+        },
+      });
+
+      renderWithQuery(
+        <ContentPanel
+          item={{
+            source_type: "trace",
+            source_content: { trace_id: "trace-1" },
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "View session" }));
+
+      expect(
+        await screen.findByRole("button", { name: "Back to trace" }),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText("session conversation turn"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "View session" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -174,6 +174,13 @@ function InlineTraceView({ traceId, spanId }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useGetTraceDetail(traceId);
   const projectId = data?.trace?.project;
+  const sessionId = data?.trace?.session;
+  const [showSession, setShowSession] = useState(false);
+
+  // Drop session overlay when the queue item / trace changes.
+  useEffect(() => {
+    setShowSession(false);
+  }, [traceId]);
 
   // Saved views — includes both traces-type custom views and imagine tabs.
   const { data: savedViewsData } = useGetSavedViews(projectId);
@@ -340,6 +347,63 @@ function InlineTraceView({ traceId, spanId }) {
     );
   }
 
+  // Session overlay — same SessionContent used for trace_session queue items.
+  // Keeps the annotator in the queue workspace so they can return to the trace.
+  if (showSession && sessionId) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          minHeight: 0,
+          bgcolor: "background.paper",
+        }}
+      >
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            px: 1.5,
+            py: 0.75,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            flexShrink: 0,
+            minHeight: 36,
+          }}
+        >
+          <Button
+            size="small"
+            variant="text"
+            color="inherit"
+            startIcon={<Iconify icon="mdi:arrow-left" width={16} />}
+            onClick={() => setShowSession(false)}
+            sx={{
+              fontSize: 12,
+              fontWeight: 500,
+              textTransform: "none",
+              minWidth: 0,
+              px: 0.75,
+            }}
+          >
+            Back to trace
+          </Button>
+          <Divider orientation="vertical" flexItem sx={{ my: 0.5 }} />
+          <Typography
+            variant="body2"
+            sx={{ fontSize: 12, color: "text.secondary", fontWeight: 500 }}
+          >
+            Session
+          </Typography>
+        </Stack>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden", p: 2 }}>
+          <SessionContent content={{ session_id: sessionId }} />
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -363,6 +427,33 @@ function InlineTraceView({ traceId, spanId }) {
         readOnly
         readOnlyTabTooltip={READ_ONLY_TAB_TOOLTIP}
         hideFilter
+        rightSlot={
+          sessionId ? (
+            <Button
+              size="small"
+              variant="outlined"
+              color="inherit"
+              startIcon={<Iconify icon="mdi:forum-outline" width={14} />}
+              onClick={() => setShowSession(true)}
+              sx={{
+                height: 24,
+                px: 1,
+                fontSize: 11,
+                fontWeight: 400,
+                textTransform: "none",
+                borderColor: "divider",
+                borderRadius: "4px",
+                color: "text.primary",
+                "&:hover": {
+                  bgcolor: "action.hover",
+                  borderColor: "text.disabled",
+                },
+              }}
+            >
+              View session
+            </Button>
+          ) : null
+        }
       />
 
       {/* Display options popover */}

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -35,7 +35,9 @@ import { canonicalKeys, formatMs } from "src/utils/utils";
 import SpanTreeTimeline from "src/components/traceDetail/SpanTreeTimeline";
 import SpanDetailPane from "src/components/traceDetail/SpanDetailPane";
 import LeftPanelSplit from "src/components/traceDetail/TraceLeftPanel";
-import DrawerToolbar from "src/components/traceDetail/DrawerToolbar";
+import DrawerToolbar, {
+  ToolbarPill,
+} from "src/components/traceDetail/DrawerToolbar";
 import TraceDisplayPanel, {
   DEFAULT_VIEW_CONFIG,
 } from "src/components/traceDetail/TraceDisplayPanel";
@@ -429,29 +431,11 @@ function InlineTraceView({ traceId, spanId }) {
         hideFilter
         rightSlot={
           sessionId ? (
-            <Button
-              size="small"
-              variant="outlined"
-              color="inherit"
-              startIcon={<Iconify icon="mdi:forum-outline" width={14} />}
+            <ToolbarPill
+              icon="mdi:forum-outline"
+              label="View session"
               onClick={() => setShowSession(true)}
-              sx={{
-                height: 24,
-                px: 1,
-                fontSize: 11,
-                fontWeight: 400,
-                textTransform: "none",
-                borderColor: "divider",
-                borderRadius: "4px",
-                color: "text.primary",
-                "&:hover": {
-                  bgcolor: "action.hover",
-                  borderColor: "text.disabled",
-                },
-              }}
-            >
-              View session
-            </Button>
+            />
           ) : null
         }
       />


### PR DESCRIPTION
Retargeted from #1909 to dev per maintainer request (main is release/hotfix-only).

Closes #1670

Summary

Adds a View session action to annotation queue items sourced from a trace or span when the parent session id is present on the loaded trace.

Clicking it opens the existing session detail (SessionContent / SessionHistory) inline in the queue workspace, with a Back to trace control so annotators can return without leaving the queue.

If the trace has no parent session, the action is not shown. Other source types are unchanged.

Test plan

Manual checks in the annotation queue workspace:

Trace/span with a parent session → View session appears; opens session history; Back to trace works
Trace/span with no parent session → no View session action
Session / dataset row / prototype / simulation items → unchanged