### PR TITLE
fix: trace-detail drawer eval score by type (pass/fail + choices)

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -26,6 +26,7 @@ from tracer.services.clickhouse.query_builders.trace_detail import (
 )
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 from tracer.services.clickhouse.v2.span_reader import merge_span_attributes
+from tracer.utils.helper import _normalize_eval_output_type
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -34,6 +35,22 @@ if TYPE_CHECKING:
     from tracer.views.trace import TraceView
 
 logger = structlog.get_logger(__name__)
+
+
+def _parse_output_str_list(raw) -> list[str]:
+    """Parse a CHOICES eval's ``output_str_list`` (CH JSON string or native list)."""
+    import json
+
+    if isinstance(raw, list):
+        return [str(x) for x in raw if x not in (None, "")]
+    if isinstance(raw, str) and raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [str(x) for x in parsed if x not in (None, "")]
+    return []
 
 
 class TraceDetailHandlerV2(V2RewriteMixin, TraceDetailHandler):
@@ -260,6 +277,7 @@ def retrieve_trace_detail_ch(
             output_float,
             output_bool,
             output_str,
+            output_str_list,
             eval_explanation,
             error,
             status,
@@ -280,6 +298,8 @@ def retrieve_trace_detail_ch(
         # Lookup eval config names from PG
         config_lookup = {}
         if config_ids_set:
+            from model_hub.utils.eval_list import derive_output_type
+
             configs = CustomEvalConfig.objects.filter(
                 id__in=list(config_ids_set), deleted=False
             ).select_related("eval_template")
@@ -291,10 +311,10 @@ def retrieve_trace_detail_ch(
                     # sync with the trace list column headers.
                     "name": c.name
                     or (c.eval_template.name if c.eval_template else str(c.id)),
+                    # Resolved type — falls back to config["output"] when
+                    # output_type_normalized is unset, matching the list paths.
                     "output_type": (
-                        getattr(c.eval_template, "output_type_normalized", None)
-                        if c.eval_template
-                        else None
+                        derive_output_type(c.eval_template) if c.eval_template else None
                     ),
                     "template_type": (
                         getattr(c.eval_template, "template_type", None)
@@ -313,12 +333,25 @@ def retrieve_trace_detail_ch(
                 eval_map[sid] = []
             cid = row.get("eval_config_id", "")
             info = config_lookup.get(cid, {})
-            # Compute score from output columns
+            # Score is type-dependent; the CH mirror coerces unused typed
+            # columns to 0, so route by type (choices → str_list, Pass/Fail →
+            # bool, percentage → float) instead of trusting a populated column.
             output_float = row.get("output_float")
             output_bool = row.get("output_bool")
             output_str = row.get("output_str")
+            str_list = _parse_output_str_list(row.get("output_str_list"))
 
-            if output_float is not None:
+            is_pass_fail = (
+                _normalize_eval_output_type(info.get("output_type")) == "PASS_FAIL"
+            )
+            score_label = None
+            if str_list:
+                # Choices: no numeric score — surface the option(s), score None.
+                score = None
+                score_label = ", ".join(str_list)
+            elif is_pass_fail and output_bool is not None:
+                score = 100 if output_bool else 0
+            elif output_float is not None:
                 score = round(output_float * 100, 2)
             elif output_bool is not None:
                 score = 100 if output_bool else 0
@@ -344,10 +377,21 @@ def retrieve_trace_detail_ch(
             is_non_terminal = status in ("pending", "running", "skipped")
             drop_derived = is_errored or is_non_terminal
             eval_score = None if drop_derived else score
+            eval_score_label = None if drop_derived else score_label
+            # Choices: per-option list the drawer renders as separate chips.
+            eval_score_items = None if drop_derived else (str_list or None)
             result_value = (
                 None
                 if drop_derived
-                else (output_str or (output_bool if output_bool is not None else None))
+                else (
+                    str_list
+                    or output_str
+                    or (
+                        output_bool
+                        if is_pass_fail and output_bool is not None
+                        else None
+                    )
+                )
             )
 
             eval_map[sid].append(
@@ -357,6 +401,8 @@ def retrieve_trace_detail_ch(
                     "output_type": info.get("output_type"),
                     "template_type": info.get("template_type"),
                     "score": eval_score,
+                    "score_label": eval_score_label,
+                    "score_items": eval_score_items,
                     "result": result_value,
                     "explanation": (
                         explanation

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -380,19 +380,19 @@ def retrieve_trace_detail_ch(
             eval_score_label = None if drop_derived else score_label
             # Choices: per-option list the drawer renders as separate chips.
             eval_score_items = None if drop_derived else (str_list or None)
-            result_value = (
-                None
-                if drop_derived
-                else (
-                    str_list
-                    or output_str
-                    or (
-                        output_bool
-                        if is_pass_fail and output_bool is not None
-                        else None
-                    )
-                )
-            )
+
+            # ``result`` = the raw verdict, by type: choices → the option list,
+            # Pass/Fail → the bool, free-text → output_str, numeric → None.
+            if drop_derived:
+                result_value = None
+            elif str_list:
+                result_value = str_list
+            elif output_str:
+                result_value = output_str
+            elif is_pass_fail and output_bool is not None:
+                result_value = output_bool
+            else:
+                result_value = None
 
             eval_map[sid].append(
                 {

--- a/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
+++ b/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
@@ -500,6 +500,104 @@ class TestV2EvalScoreRendering:
     def test_no_score_when_both_null(self):
         assert self._scores_for(self._eval_row())[0]["score"] is None
 
+    def _scores_for_type(self, output_type, eval_row, config=None):
+        """Config resolves to an eval of ``output_type`` (via derive_output_type).
+        Pass ``config`` (e.g. {"output": "Pass/Fail"}) with output_type=None to
+        exercise the config["output"] fallback when output_type_normalized is unset."""
+        analytics = _FakeAnalytics(
+            project_rows=[{"project_id": "P1"}],
+            span_rows=[_root_span_row()],
+            eval_rows=[eval_row],
+        )
+        cfg = SimpleNamespace(
+            id="C1",
+            name="e",
+            eval_template=SimpleNamespace(
+                output_type_normalized=output_type,
+                name="e",
+                template_type="single",
+                config=config or {},
+            ),
+        )
+        cfg_mgr = MagicMock()
+        cfg_mgr.filter.return_value.select_related.return_value = [cfg]
+        with ExitStack() as stack:
+            _patch_v2_pg(stack, project_accessible=True, pg_trace=None)
+            stack.enter_context(
+                patch(
+                    "tracer.models.custom_eval_config.CustomEvalConfig.objects",
+                    cfg_mgr,
+                )
+            )
+            result = retrieve_trace_detail_ch(MagicMock(), MagicMock(), "T1", analytics)
+        return result["observation_spans"][0]["eval_scores"]
+
+    def test_pass_fail_pass_with_coerced_zero_float(self):
+        # Verdict in output_bool, output_float coerced to 0 → 100 (Pass), not 0.
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.0)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 100
+
+    def test_pass_fail_fail_with_coerced_zero_float(self):
+        row = self._eval_row(eval_config_id="C1", output_bool=False, output_float=0.0)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 0
+
+    def test_percentage_uses_float_not_coerced_bool(self):
+        # percentage → output_float; the coerced output_bool must be ignored.
+        row = self._eval_row(eval_config_id="C1", output_float=0.6, output_bool=True)
+        assert self._scores_for_type("percentage", row)[0]["score"] == 60.0
+
+    def test_choices_single_surfaces_label_not_zero(self):
+        # Choices: value in output_str_list; float/bool coerced to 0. Must show
+        # the option as score_label with score None (not 0% / a fake Fail).
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=False, output_float=0.0
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] == ["neutral"]
+        assert e["score_label"] == "neutral"
+
+    def test_choices_multiselect_lists_each_option(self):
+        row = self._eval_row(
+            output_str_list='["neutral","formal"]', output_bool=False, output_float=0.0
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] == ["neutral", "formal"]
+        assert e["score_label"] == "neutral, formal"
+
+    def test_pass_fail_with_real_float_uses_bool_not_float(self):
+        # Deterministic evaluator writes a bool verdict AND a float; Pass/Fail
+        # must score from the bool (100), not the float (85).
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.85)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 100
+
+    def test_pass_fail_routed_via_config_output_when_normalized_null(self):
+        # output_type_normalized unset → derive_output_type falls back to
+        # config["output"], so a passing Pass/Fail still scores 100, not 0.
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.0)
+        e = self._scores_for_type(None, row, config={"output": "Pass/Fail"})[0]
+        assert e["score"] == 100
+
+    def test_errored_row_nulls_all_derived_fields(self):
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=True, error=True
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] is None
+        assert e["score_label"] is None
+        assert e["result"] is None
+
+    def test_skipped_row_nulls_all_derived_fields(self):
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=True, status="skipped"
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] is None
+        assert e["result"] is None
+
 
 # --------------------------------------------------------------------------- #
 # 5) Enrichment fault logging (loud on genuine faults, silent on dropped table)


### PR DESCRIPTION
## Summary

Fixes the trace-detail Evals drawer showing **0% / Fail** for passing Pass/Fail evals and not rendering Choices evals at all. The v2 detail builder derived the score from `output_float` first, but the PeerDB ClickHouse mirror coerces unused Nullable typed columns to `0` — so Pass/Fail rows (verdict in `output_bool`) and Choices rows (selection in `output_str_list`) got a fake `0`. The builder now routes the score by eval type, matching the list read paths.

Fixed TH-7424 TH-5565
Linear: https://linear.app/future-agi/issue/TH-7424

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Type-aware eval score in the trace-detail drawer** (`trace_detail.py`)

- **Pass/Fail** → score from `output_bool` (100/0), not the coerced `output_float`. A passing eval now shows Pass instead of 0%.
- **Percentage/score** → score from `output_float` (unchanged).
- **Choices** → the picked option(s) from `output_str_list` are surfaced as `score_items` (array) and `score_label` (joined), with `score = null` so they aren't counted as a Fail. The FE renders `score_items` as one chip per option.
- Type resolution routes on the eval config's `output` via `derive_output_type` (falls back to `config["output"]` when `output_type_normalized` is unset), matching the list scoring path.
- `result` now carries the bool only for Pass/Fail; percentage/score yield `result = null` instead of a misleading `False`.

No frontend change — `EvalsTabView` already reads `score` / `score_label` / `score_items`.

---

## 2) Why the changes were done

- **Product/UX:** the drawer disagreed with the list grid and the actual verdict — passing evals looked failed and choice results were invisible.
- **Technical:** the list paths already solved the CH-coercion problem by routing on the declared eval type; the detail builder was the last float-first reader. This aligns it with `select_eval_score`.

---

## 3) Tests written + scenarios each covers

**`test_ch25_trace_detail_v2.py`** — `TestV2EvalScoreRendering` (trace-detail eval score derivation)

- `test_pass_fail_pass_with_coerced_zero_float` — passing Pass/Fail (`output_float` coerced 0) → 100, not 0
- `test_pass_fail_fail_with_coerced_zero_float` — failing Pass/Fail → 0
- `test_pass_fail_with_real_float_uses_bool_not_float` — deterministic evaluator writing bool + float → scores from bool
- `test_pass_fail_routed_via_config_output_when_normalized_null` — NULL `output_type_normalized` falls back to `config["output"]`
- `test_percentage_uses_float_not_coerced_bool` — percentage reads float, ignores coerced bool
- `test_choices_single_surfaces_label_not_zero` / `test_choices_multiselect_lists_each_option` — choices surface `score_items` + `score_label`, `score = null`
- `test_errored_row_nulls_all_derived_fields` / `test_skipped_row_nulls_all_derived_fields` — errored/skipped rows null score/score_items/score_label/result
- Plus existing zero-float / nonzero-float / bool-false / both-null regressions

> Run result: **28 passed** in `test_ch25_trace_detail_v2.py`.

---

## 6) Edge cases & considerations

- **CH coercion cuts both ways:** a percentage eval's `output_bool` is also coerced to 0 — handled by routing on type, never trusting a coerced column.
- **Empty-selection choices** (`output_str_list = '[]'`) currently fall through to 0% — rare; noted for follow-up.
- **Soft-deleted / template-less config:** an unresolvable Pass/Fail eval still falls to the float (0) — strictly better than before (list drops these rows too).

## 8) Architectural / important decisions

- **Route on `config["output"]` (via `derive_output_type` fallback), not the nullable `output_type_normalized`** — it's always present and is the field the eval writer keys on to decide which CH column gets written, so it's the data-faithful source and matches the list paths.
