### PR TITLE
fix: correct invalid CSS width value '20ox' to '20px' in Add Filter button icon (Fixes #1967)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
## Bug

The Add Filter button icon has an invalid CSS width value `"20ox !important"`. `20ox` is not a valid CSS length, so the browser discards the declaration entirely, causing the icon to fall back to its intrinsic width instead of the intended 20px.

## Fix

Changed `"20ox !important"` to `"20px !important"` in:
- `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx`
- `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx`