### PR TITLE
fix: allow column resizing in annotation queue items table

### DIFF
--- a/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
+++ b/frontend/src/sections/annotations/queues/items/queue-items-table.jsx
@@ -634,7 +634,7 @@ export default function QueueItemsTable({
       lockVisible: true,
       filter: false,
       sortable: false,
-      resizable: false,
+      resizable: true,
       suppressHeaderMenuButton: true,
       suppressHeaderContextMenu: true,
     }),


### PR DESCRIPTION
## Description
Fixes #1966

The "Item Status" column in the annotation queue items table cannot be resized by dragging its header border. In fact, no column in that table is resizable, while comparable data grids elsewhere in the platform (for example the LLM Tracing traces table) do support column resizing.

## Changes
- Changed `defaultColDef.resizable` from `false` to `true` in `queue-items-table.jsx`
- The `actions` column (width 60, maxWidth 60) remains non-resizable since it has `resizable: false` on its column definition
- The `selectionColumnDef` (checkbox column) also remains non-resizable

## Verification
- Every data column in the annotation queue items table can now be resized by dragging the header border
- The "Item Status" column can be dragged to a new width, and the new width holds while the page stays open
- The `actions` column is still not resizable, since it sets `resizable: false` on the column definition
- The existing per-column `width` values still apply as the starting width on first render