### PR TITLE
fix: debounce time filter clicks to prevent request spam on rapid switching

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -56,6 +56,7 @@ import { useSnackbar } from "src/components/snackbar";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import WidgetChart from "./WidgetChart";
 import { resolveGlobalDateRange } from "./dashboardDateRange";
+import { useDebounce } from "src/hooks/use-debounce";
 import useCanEditDashboard from "./hooks/useCanEditDashboard";
 import {
   DndContext,
@@ -662,9 +663,10 @@ export default function DashboardDetailView() {
   const [customDateRange, setCustomDateRange] = useState(null); // [start, end]
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
   const customDateAnchorRef = useRef(null);
+  const debouncedDatePreset = useDebounce(datePreset, 300);
   const globalDateRange = useMemo(
     () => resolveGlobalDateRange(datePreset, customDateRange),
-    [datePreset, customDateRange],
+    [debouncedDatePreset, customDateRange],
   );
 
   // Widget context menu


### PR DESCRIPTION
## Summary

Clicking through the dashboard time presets (Today, Yesterday, 7D, etc.) quickly fires a separate round of server requests for every click, causing:
1. **Wasted requests** — each click sends a request per widget, even though only the last selection matters
2. **False error toasts** — overlapping requests fail, so users see "Query execution failed" errors

## Fix

Uses the existing `useDebounce` hook (300ms) to debounce the `datePreset` value before computing `globalDateRange`. The UI chips still update immediately for responsive visual feedback, but widget queries only fire after the user settles on a selection.

## Changes

- `frontend/src/sections/dashboards/DashboardDetailView.jsx`: Import `useDebounce`, create debounced preset, use it in `useMemo` dependency

## Test Plan

1. Open a dashboard with multiple widgets
2. Rapidly click through time presets (Today → Yesterday → 7D → 30D)
3. Verify only one API request fires per widget (for the last selected preset)
4. Verify no false error toasts appear
5. Verify normal single-click behavior is unchanged

Closes #1968