### PR TITLE
chore: release dev → main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ media/
 # Claude Code — per-user permissions (team agents under .claude/agents/ are tracked)
 .claude/settings.local.json
 **/.claude/settings.local.json
+.claude/CLAUDE.md
 
 # MCP server configs — local dev tooling, not shipped with the repo.
 # If we ever expose a hosted product MCP, that config goes at repo root

--- a/futureagi/ai_tools/tests/test_evaluate_with_agent.py
+++ b/futureagi/ai_tools/tests/test_evaluate_with_agent.py
@@ -12,6 +12,7 @@ deterministic, and free of external dependencies. What we're testing:
   5. Error propagation: orchestrator exception surfaces cleanly
 """
 
+import sys
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -159,6 +160,26 @@ class TestInputValidation:
                 EEFeature.AGENTIC_EVAL, org_id=str(tool_context.organization.id)
             )
 
+    def test_ee_agenthub_import_failure_returns_unavailable(
+        self, tool_context, monkeypatch
+    ):
+        """Both lanes: entitled org but ee.agenthub missing degrades to
+        feature-unavailable (the open-build path), it does not crash."""
+        monkeypatch.setitem(sys.modules, "ee.agenthub.eval_orchestrator", None)
+        with patch("tfc.ee_gating.check_ee_feature", return_value=None):
+            result = run_tool(
+                "evaluate_with_agent",
+                {
+                    "source_id": _FAKE_TRACE_ID,
+                    "input_scope": "trace",
+                    "criteria": "Is it helpful?",
+                },
+                tool_context,
+            )
+        assert result.is_error
+        assert result.error_code == "ENTITLEMENT_DENIED"
+
+    @pytest.mark.requires_ee
     def test_invalid_scope_returns_error(self, tool_context):
         result = run_tool(
             "evaluate_with_agent",
@@ -173,6 +194,7 @@ class TestInputValidation:
         assert "banana" in result.content
         assert "input_scope" in result.content
 
+    @pytest.mark.requires_ee
     def test_all_valid_scopes_accepted(self, tool_context, mock_orchestrator):
         for scope in ("span", "trace", "session", "dataset_row", "cell"):
             result = run_tool(
@@ -195,6 +217,8 @@ class TestInputValidation:
 
 
 class TestHappyPath:
+    pytestmark = pytest.mark.requires_ee
+
     def test_returns_result_and_explanation(self, tool_context, mock_orchestrator):
         result = run_tool(
             "evaluate_with_agent",
@@ -287,6 +311,8 @@ class TestHappyPath:
 
 
 class TestChoices:
+    pytestmark = pytest.mark.requires_ee
+
     def test_numeric_scoring_mode_when_no_choices(self, tool_context):
         """With no choices, the tool passes choices=None → orchestrator defaults to 0–1 scoring."""
         with (
@@ -354,6 +380,8 @@ class TestChoices:
 
 
 class TestOptionalParams:
+    pytestmark = pytest.mark.requires_ee
+
     def test_kb_id_passed_to_gather_resources(self, tool_context):
         with (
             patch(
@@ -451,6 +479,8 @@ class TestOptionalParams:
 
 
 class TestErrorHandling:
+    pytestmark = pytest.mark.requires_ee
+
     def test_orchestrator_exception_surfaces_as_error(self, tool_context):
         with (
             patch(

--- a/futureagi/bin/test
+++ b/futureagi/bin/test
@@ -56,6 +56,7 @@ show_help() {
     echo "  unit          Run unit tests only"
     echo "  integration   Run integration tests"
     echo "  app <name>    Run tests for specific app"
+    echo "  stress        Run the stress suite (manual only; rebuilds CH default DB)"
     echo "  changed       Run tests for changed files only"
     echo "  watch         Watch mode - rerun tests on file changes"
     echo "  up            Start test services"
@@ -266,6 +267,15 @@ case "${1:-}" in
         fi
         echo -e "${GREEN}Running tests for $app_name...${NC}"
         run_pytest "$app_name/tests/" -v "$@"
+        ;;
+    stress)
+        shift
+        if [ "$NO_SERVICES" = false ]; then
+            start_services
+            run_migrations
+        fi
+        echo -e "${GREEN}Running stress suite (manual only)...${NC}"
+        run_pytest -m stress tests/stress/ "$@"
         ;;
     changed)
         shift

--- a/futureagi/conftest.py
+++ b/futureagi/conftest.py
@@ -17,6 +17,7 @@ os.environ.setdefault("VAPI_API_KEY", "test-api-key-for-testing")
 os.environ.setdefault("VAPI_API_BASE_URL", "https://test.vapi.local")
 
 from tfc.ee_loader import has_ee
+from tfc.logging.config import configure_structlog
 
 EE_AVAILABLE = has_ee("ee")
 
@@ -130,11 +131,6 @@ def pytest_configure(config):
     project_root = Path(__file__).parent
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
-
-    config.addinivalue_line(
-        "markers",
-        "requires_ee: test needs the enterprise `ee/` package; skipped in the OSS lane",
-    )
 
     _apply_ch25_schema_for_tests()
 
@@ -526,6 +522,20 @@ def clean_workspace_context():
     clear_workspace_context()
     yield
     clear_workspace_context()
+
+
+@pytest.fixture(autouse=True)
+def _structlog_capturable():
+    """Uncached structlog before each test so capture_logs()/caplog survive
+    global reconfig leaked by other tests in a full session (some suites reset
+    structlog defaults per test - hence function scope). The logging.disable
+    reset undoes a global stdlib disable that a few collected integration test
+    scripts apply at import; no product code calls logging.disable, so it masks
+    nothing."""
+    import logging
+
+    configure_structlog(cache_logger_on_first_use=False)
+    logging.disable(logging.NOTSET)
 
 
 @pytest.fixture(autouse=True)

--- a/futureagi/mcp_server/tests/test_rate_limiter.py
+++ b/futureagi/mcp_server/tests/test_rate_limiter.py
@@ -1,5 +1,6 @@
 """Tests for MCP Server rate limiter."""
 
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ from mcp_server.constants import RATE_LIMITS
 from mcp_server.rate_limiter import check_rate_limit, get_rate_limit_tier
 
 
+@pytest.mark.requires_ee
 class TestGetRateLimitTier:
     """Tests for get_rate_limit_tier()."""
 
@@ -88,6 +90,12 @@ class TestGetRateLimitTier:
         )
         org = MagicMock()
         assert get_rate_limit_tier(org) == "free"
+
+
+def test_returns_free_when_ee_absent(monkeypatch):
+    """Runs on both lanes: with ee's subscription model unimportable, fall back to free."""
+    monkeypatch.setitem(sys.modules, "ee.usage.models.usage", None)
+    assert get_rate_limit_tier(MagicMock()) == "free"
 
 
 class TestCheckRateLimit:

--- a/futureagi/pytest.ini
+++ b/futureagi/pytest.ini
@@ -29,7 +29,7 @@ addopts =
     --tb=short
     --reuse-db
     -p no:warnings
-    -m "not live_llm and not e2e and not vapi and not phone and not benchmark"
+    -m "not live_llm and not e2e and not vapi and not phone and not benchmark and not stress"
 
 markers =
     unit: Fast tests, no external services
@@ -44,6 +44,7 @@ markers =
     phone: Tests requiring phone/telephony services
     stress: Eval-read stress/budget suite (needs LOADGEN_BIN + test ClickHouse)
     benchmark: Wall-time latency benchmarks (opt-in; needs a seeded test ClickHouse)
+    requires_ee: test needs the enterprise `ee/` package; skipped in the OSS lane
 
 DJANGO_SETTINGS_MODULE = tfc.settings.test
 

--- a/futureagi/tests/stress/conftest.py
+++ b/futureagi/tests/stress/conftest.py
@@ -191,7 +191,7 @@ def _stress_ch(request):
     if non_stress:
         pytest.exit(
             "stress suite rebuilds the ClickHouse `default` database — run it "
-            "standalone: uv run pytest tests/stress/ "
+            "standalone: uv run pytest -m stress tests/stress/ "
             f"(found non-stress tests in this session: {non_stress[0].nodeid})",
             returncode=4,
         )

--- a/futureagi/tfc/celery.py
+++ b/futureagi/tfc/celery.py
@@ -4,6 +4,7 @@ from logging.config import dictConfig
 from celery import Celery
 from celery.signals import worker_process_init
 from django_structlog.celery.steps import DjangoStructLogInitStep
+from django.conf import settings as django_settings
 from kombu import Exchange, Queue
 
 from tfc.logging import init_sentry
@@ -18,8 +19,11 @@ celery_app = Celery("tfc")
 # This ensures request_id, user_id, etc. flow from HTTP request to Celery task
 celery_app.steps["worker"].add(DjangoStructLogInitStep)
 
-# Ensure that Celery uses Django's logging configuration
-dictConfig(settings.LOGGING)
+# Ensure Celery uses Django's logging config. Skip under test settings: Django
+# already applies it, and a mid-session re-apply wipes pytest's caplog handler.
+# (`settings` here is the base module, which has no TESTING; use the active one.)
+if not getattr(django_settings, "TESTING", False):
+    dictConfig(settings.LOGGING)
 
 # Import django-structlog Celery receivers for automatic task logging
 # This logs task_started, task_succeeded, task_failed, etc. with context

--- a/futureagi/tfc/deployment_telemetry/tests/test_schema_contract.py
+++ b/futureagi/tfc/deployment_telemetry/tests/test_schema_contract.py
@@ -6,10 +6,8 @@ These run in the main repo, where both the sender schema
 if the two diverge, if a sender-built payload stops validating on the
 receiver, or if the HMAC signing computed by the two sides disagrees.
 
-CI REQUIREMENT: these must run in a gate that has both the main repo and
-``ee/`` checked out.  If ``ee`` is absent the import below errors (not
-skips), which is intentional — a silently-skipped contract test is no
-contract test.
+The receiver schema is ee-only, so these run on the ee lane and skip at
+collection on the OSS lane (``has_ee`` gate below).
 """
 
 from __future__ import annotations
@@ -17,8 +15,16 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from ee.usage import deployment_telemetry_schema as receiver_schema
-from tfc.deployment_telemetry import schema as sender_schema
+import pytest
+
+from tfc.ee_loader import has_ee
+
+# Skip on the OSS lane only; with ee present the import runs so divergence fails loud.
+if not has_ee("ee"):
+    pytest.skip("requires ee/ (OSS lane)", allow_module_level=True)
+
+from ee.usage import deployment_telemetry_schema as receiver_schema  # noqa: E402
+from tfc.deployment_telemetry import schema as sender_schema  # noqa: E402
 
 
 def _public_constants(module) -> dict:

--- a/futureagi/tfc/logging/config.py
+++ b/futureagi/tfc/logging/config.py
@@ -57,7 +57,7 @@ def get_renderer():
         return structlog.dev.ConsoleRenderer(colors=True)
 
 
-def configure_structlog():
+def configure_structlog(cache_logger_on_first_use: bool = True):
     """Configure structlog with proper processors."""
     structlog.configure(
         processors=get_processors()
@@ -66,7 +66,7 @@ def configure_structlog():
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
+        cache_logger_on_first_use=cache_logger_on_first_use,
     )
 
 

--- a/futureagi/tracer/services/clickhouse/v2/apply_schema.py
+++ b/futureagi/tracer/services/clickhouse/v2/apply_schema.py
@@ -50,14 +50,19 @@ import structlog
 # ──────────────────────────────────────────────────────────────────────────────
 # Logging — structured, machine-parseable, never print()
 # ──────────────────────────────────────────────────────────────────────────────
-structlog.configure(
-    processors=[
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.add_log_level,
-        structlog.processors.JSONRenderer(),
-    ],
-)
 log = structlog.get_logger("apply_schema")
+
+
+def _configure_logging() -> None:
+    """Configure structlog for CLI runs. Called from main(), not at import, so
+    importing this module never mutates the process's global structlog config."""
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -237,6 +242,7 @@ def apply_file(client, sf: SchemaFile, applied_by: str, *,
 # Main
 # ──────────────────────────────────────────────────────────────────────────────
 def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
     args = build_argparser().parse_args(argv)
 
     log.info("connect", host=args.ch_host, port=args.ch_http_port, database=args.ch_database)

--- a/futureagi/tracer/services/clickhouse/v2/backfill.py
+++ b/futureagi/tracer/services/clickhouse/v2/backfill.py
@@ -77,14 +77,19 @@ from adapter import (                                     # noqa: E402
 
 
 # ─── Logging ──────────────────────────────────────────────────────────────────
-structlog.configure(
-    processors=[
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.add_log_level,
-        structlog.processors.JSONRenderer(),
-    ],
-)
 log = structlog.get_logger("backfill")
+
+
+def _configure_logging() -> None:
+    """Configure structlog for CLI runs. Called from main(), not at import, so
+    importing this module never mutates the process's global structlog config."""
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
 
 
 # ─── PG query (single source of truth for what gets pulled) ───────────────────
@@ -619,6 +624,7 @@ def _cmd_status(args) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
     args = _build_argparser().parse_args(argv)
 
     if args.status:

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -26,6 +26,7 @@ from tracer.services.clickhouse.query_builders.trace_detail import (
 )
 from tracer.services.clickhouse.v2.query_builders._rewrite import V2RewriteMixin
 from tracer.services.clickhouse.v2.span_reader import merge_span_attributes
+from tracer.utils.helper import _normalize_eval_output_type
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -34,6 +35,22 @@ if TYPE_CHECKING:
     from tracer.views.trace import TraceView
 
 logger = structlog.get_logger(__name__)
+
+
+def _parse_output_str_list(raw) -> list[str]:
+    """Parse a CHOICES eval's ``output_str_list`` (CH JSON string or native list)."""
+    import json
+
+    if isinstance(raw, list):
+        return [str(x) for x in raw if x not in (None, "")]
+    if isinstance(raw, str) and raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [str(x) for x in parsed if x not in (None, "")]
+    return []
 
 
 class TraceDetailHandlerV2(V2RewriteMixin, TraceDetailHandler):
@@ -260,6 +277,7 @@ def retrieve_trace_detail_ch(
             output_float,
             output_bool,
             output_str,
+            output_str_list,
             eval_explanation,
             error,
             status,
@@ -280,6 +298,8 @@ def retrieve_trace_detail_ch(
         # Lookup eval config names from PG
         config_lookup = {}
         if config_ids_set:
+            from model_hub.utils.eval_list import derive_output_type
+
             configs = CustomEvalConfig.objects.filter(
                 id__in=list(config_ids_set), deleted=False
             ).select_related("eval_template")
@@ -291,10 +311,10 @@ def retrieve_trace_detail_ch(
                     # sync with the trace list column headers.
                     "name": c.name
                     or (c.eval_template.name if c.eval_template else str(c.id)),
+                    # Resolved type — falls back to config["output"] when
+                    # output_type_normalized is unset, matching the list paths.
                     "output_type": (
-                        getattr(c.eval_template, "output_type_normalized", None)
-                        if c.eval_template
-                        else None
+                        derive_output_type(c.eval_template) if c.eval_template else None
                     ),
                     "template_type": (
                         getattr(c.eval_template, "template_type", None)
@@ -313,12 +333,25 @@ def retrieve_trace_detail_ch(
                 eval_map[sid] = []
             cid = row.get("eval_config_id", "")
             info = config_lookup.get(cid, {})
-            # Compute score from output columns
+            # Score is type-dependent; the CH mirror coerces unused typed
+            # columns to 0, so route by type (choices → str_list, Pass/Fail →
+            # bool, percentage → float) instead of trusting a populated column.
             output_float = row.get("output_float")
             output_bool = row.get("output_bool")
             output_str = row.get("output_str")
+            str_list = _parse_output_str_list(row.get("output_str_list"))
 
-            if output_float is not None:
+            is_pass_fail = (
+                _normalize_eval_output_type(info.get("output_type")) == "PASS_FAIL"
+            )
+            score_label = None
+            if str_list:
+                # Choices: no numeric score — surface the option(s), score None.
+                score = None
+                score_label = ", ".join(str_list)
+            elif is_pass_fail and output_bool is not None:
+                score = 100 if output_bool else 0
+            elif output_float is not None:
                 score = round(output_float * 100, 2)
             elif output_bool is not None:
                 score = 100 if output_bool else 0
@@ -344,10 +377,21 @@ def retrieve_trace_detail_ch(
             is_non_terminal = status in ("pending", "running", "skipped")
             drop_derived = is_errored or is_non_terminal
             eval_score = None if drop_derived else score
+            eval_score_label = None if drop_derived else score_label
+            # Choices: per-option list the drawer renders as separate chips.
+            eval_score_items = None if drop_derived else (str_list or None)
             result_value = (
                 None
                 if drop_derived
-                else (output_str or (output_bool if output_bool is not None else None))
+                else (
+                    str_list
+                    or output_str
+                    or (
+                        output_bool
+                        if is_pass_fail and output_bool is not None
+                        else None
+                    )
+                )
             )
 
             eval_map[sid].append(
@@ -357,6 +401,8 @@ def retrieve_trace_detail_ch(
                     "output_type": info.get("output_type"),
                     "template_type": info.get("template_type"),
                     "score": eval_score,
+                    "score_label": eval_score_label,
+                    "score_items": eval_score_items,
                     "result": result_value,
                     "explanation": (
                         explanation

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -152,6 +152,14 @@ def retrieve_trace_detail_ch(
         except (ValueError, TypeError):
             return default
 
+    def _parse_content(val):
+        if not isinstance(val, str) or not val:
+            return _parse_json(val)
+        try:
+            return _json.loads(val)
+        except (ValueError, TypeError):
+            return val
+
     for row in result.data:
         span_id = str(row.get("id", ""))
         parent_id = row.get("parent_span_id")
@@ -199,8 +207,8 @@ def retrieve_trace_detail_ch(
             "observation_type": row.get("observation_type"),
             "start_time": row.get("start_time"),
             "end_time": row.get("end_time"),
-            "input": _parse_json(row.get("input")),
-            "output": _parse_json(row.get("output")),
+            "input": _parse_content(row.get("input")),
+            "output": _parse_content(row.get("output")),
             "model": row.get("model"),
             "model_parameters": _parse_json(row.get("model_parameters")),
             "latency_ms": row.get("latency_ms"),

--- a/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
+++ b/futureagi/tracer/services/clickhouse/v2/query_builders/trace_detail.py
@@ -380,19 +380,19 @@ def retrieve_trace_detail_ch(
             eval_score_label = None if drop_derived else score_label
             # Choices: per-option list the drawer renders as separate chips.
             eval_score_items = None if drop_derived else (str_list or None)
-            result_value = (
-                None
-                if drop_derived
-                else (
-                    str_list
-                    or output_str
-                    or (
-                        output_bool
-                        if is_pass_fail and output_bool is not None
-                        else None
-                    )
-                )
-            )
+
+            # ``result`` = the raw verdict, by type: choices → the option list,
+            # Pass/Fail → the bool, free-text → output_str, numeric → None.
+            if drop_derived:
+                result_value = None
+            elif str_list:
+                result_value = str_list
+            elif output_str:
+                result_value = output_str
+            elif is_pass_fail and output_bool is not None:
+                result_value = output_bool
+            else:
+                result_value = None
 
             eval_map[sid].append(
                 {

--- a/futureagi/tracer/services/clickhouse/v2/validate.py
+++ b/futureagi/tracer/services/clickhouse/v2/validate.py
@@ -56,14 +56,19 @@ from adapter import (                                     # noqa: E402
 
 
 # ─── Logging ──────────────────────────────────────────────────────────────────
-structlog.configure(
-    processors=[
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.add_log_level,
-        structlog.processors.JSONRenderer(),
-    ],
-)
 log = structlog.get_logger("validate")
+
+
+def _configure_logging() -> None:
+    """Configure structlog for CLI runs. Called from main(), not at import, so
+    importing this module never mutates the process's global structlog config."""
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
 
 
 # ─── PG / CH client helpers ───────────────────────────────────────────────────
@@ -846,6 +851,7 @@ def _build_argparser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
     args = _build_argparser().parse_args(argv)
     if not (args.all or args.counts or args.deep or args.queries):
         log.error("must pass one of --all / --counts / --deep / --queries")

--- a/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
+++ b/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
@@ -500,6 +500,104 @@ class TestV2EvalScoreRendering:
     def test_no_score_when_both_null(self):
         assert self._scores_for(self._eval_row())[0]["score"] is None
 
+    def _scores_for_type(self, output_type, eval_row, config=None):
+        """Config resolves to an eval of ``output_type`` (via derive_output_type).
+        Pass ``config`` (e.g. {"output": "Pass/Fail"}) with output_type=None to
+        exercise the config["output"] fallback when output_type_normalized is unset."""
+        analytics = _FakeAnalytics(
+            project_rows=[{"project_id": "P1"}],
+            span_rows=[_root_span_row()],
+            eval_rows=[eval_row],
+        )
+        cfg = SimpleNamespace(
+            id="C1",
+            name="e",
+            eval_template=SimpleNamespace(
+                output_type_normalized=output_type,
+                name="e",
+                template_type="single",
+                config=config or {},
+            ),
+        )
+        cfg_mgr = MagicMock()
+        cfg_mgr.filter.return_value.select_related.return_value = [cfg]
+        with ExitStack() as stack:
+            _patch_v2_pg(stack, project_accessible=True, pg_trace=None)
+            stack.enter_context(
+                patch(
+                    "tracer.models.custom_eval_config.CustomEvalConfig.objects",
+                    cfg_mgr,
+                )
+            )
+            result = retrieve_trace_detail_ch(MagicMock(), MagicMock(), "T1", analytics)
+        return result["observation_spans"][0]["eval_scores"]
+
+    def test_pass_fail_pass_with_coerced_zero_float(self):
+        # Verdict in output_bool, output_float coerced to 0 → 100 (Pass), not 0.
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.0)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 100
+
+    def test_pass_fail_fail_with_coerced_zero_float(self):
+        row = self._eval_row(eval_config_id="C1", output_bool=False, output_float=0.0)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 0
+
+    def test_percentage_uses_float_not_coerced_bool(self):
+        # percentage → output_float; the coerced output_bool must be ignored.
+        row = self._eval_row(eval_config_id="C1", output_float=0.6, output_bool=True)
+        assert self._scores_for_type("percentage", row)[0]["score"] == 60.0
+
+    def test_choices_single_surfaces_label_not_zero(self):
+        # Choices: value in output_str_list; float/bool coerced to 0. Must show
+        # the option as score_label with score None (not 0% / a fake Fail).
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=False, output_float=0.0
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] == ["neutral"]
+        assert e["score_label"] == "neutral"
+
+    def test_choices_multiselect_lists_each_option(self):
+        row = self._eval_row(
+            output_str_list='["neutral","formal"]', output_bool=False, output_float=0.0
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] == ["neutral", "formal"]
+        assert e["score_label"] == "neutral, formal"
+
+    def test_pass_fail_with_real_float_uses_bool_not_float(self):
+        # Deterministic evaluator writes a bool verdict AND a float; Pass/Fail
+        # must score from the bool (100), not the float (85).
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.85)
+        assert self._scores_for_type("pass_fail", row)[0]["score"] == 100
+
+    def test_pass_fail_routed_via_config_output_when_normalized_null(self):
+        # output_type_normalized unset → derive_output_type falls back to
+        # config["output"], so a passing Pass/Fail still scores 100, not 0.
+        row = self._eval_row(eval_config_id="C1", output_bool=True, output_float=0.0)
+        e = self._scores_for_type(None, row, config={"output": "Pass/Fail"})[0]
+        assert e["score"] == 100
+
+    def test_errored_row_nulls_all_derived_fields(self):
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=True, error=True
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] is None
+        assert e["score_label"] is None
+        assert e["result"] is None
+
+    def test_skipped_row_nulls_all_derived_fields(self):
+        row = self._eval_row(
+            output_str_list='["neutral"]', output_bool=True, status="skipped"
+        )
+        e = self._scores_for(row)[0]
+        assert e["score"] is None
+        assert e["score_items"] is None
+        assert e["result"] is None
+
 
 # --------------------------------------------------------------------------- #
 # 5) Enrichment fault logging (loud on genuine faults, silent on dropped table)

--- a/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
+++ b/futureagi/tracer/tests/test_ch25_trace_detail_v2.py
@@ -208,6 +208,43 @@ class TestV2SynthesisFromRootSpan:
 
 
 # --------------------------------------------------------------------------- #
+# 2a) input/output parsing: JSON parses to objects; plaintext is preserved
+# --------------------------------------------------------------------------- #
+class TestV2InputOutputParsing:
+    """Regression: bare plaintext input/output (e.g. voice transcripts) used to
+    be dropped to {} by json.loads; it must be preserved as the raw string."""
+
+    def _span(self, **row_overrides):
+        analytics = _FakeAnalytics(
+            project_rows=[{"project_id": "P1"}],
+            span_rows=[_root_span_row(**row_overrides)],
+        )
+        with ExitStack() as stack:
+            _patch_v2_pg(stack, project_accessible=True, pg_trace=None)
+            result = retrieve_trace_detail_ch(
+                MagicMock(), MagicMock(), "T1", analytics
+            )
+        return result
+
+    def test_json_input_output_parsed_to_objects(self):
+        result = self._span(input='{"q": "hi"}', output='{"a": "yo"}')
+        span = result["observation_spans"][0]["observation_span"]
+        assert span["input"] == {"q": "hi"}
+        assert span["output"] == {"a": "yo"}
+
+    def test_plaintext_input_output_preserved(self):
+        text_in = "What's on my calendar this afternoon?"
+        text_out = "You have a 3pm meeting."
+        result = self._span(input=text_in, output=text_out)
+        span = result["observation_spans"][0]["observation_span"]
+        assert span["input"] == text_in  # not {}
+        assert span["output"] == text_out
+        # synthesized trace envelope inherits the same raw text
+        assert result["trace"]["input"] == text_in
+        assert result["trace"]["output"] == text_out
+
+
+# --------------------------------------------------------------------------- #
 # 2b) span_attributes = typed maps ∪ attributes_extra
 # --------------------------------------------------------------------------- #
 class TestV2SpanAttributesMerge:

--- a/futureagi/tracer/tests/test_ch25_typed_json_roundtrip.py
+++ b/futureagi/tracer/tests/test_ch25_typed_json_roundtrip.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover
 
 CH_HOST = os.environ.get("CH25_HOST", "127.0.0.1")
 CH_PORT = int(os.environ.get("CH25_HTTP_PORT", "19001"))
+CH_DATABASE = os.environ.get("CH25_DATABASE", "default")
 
 
 # NOTE (codex P3 finding 2026-05-26): the previous implementation called
@@ -278,10 +279,11 @@ def test_spans_table_attributes_extra_is_string(ch_client):
     """
     rows = ch_client.query(
         "SELECT type FROM system.columns "
-        "WHERE database = 'default' AND table = 'spans' "
-        "  AND name = 'attributes_extra'"
+        "WHERE database = %(db)s AND table = 'spans' "
+        "  AND name = 'attributes_extra'",
+        parameters={"db": CH_DATABASE},
     ).result_rows
-    assert rows, "spans.attributes_extra column missing"
+    assert rows, f"spans.attributes_extra column missing in database {CH_DATABASE!r}"
     actual_type = rows[0][0]
     assert actual_type == "String", (
         f"spans.attributes_extra is {actual_type!r}; expected 'String'. "
@@ -319,12 +321,15 @@ def test_spans_table_typed_json_contract(ch_client):
     """
     rows = ch_client.query(
         "SELECT name, type FROM system.columns "
-        "WHERE database = 'default' AND table = 'spans' "
-        "  AND name IN ('attributes_extra', 'resource_attrs', 'metadata')"
+        "WHERE database = %(db)s AND table = 'spans' "
+        "  AND name IN ('attributes_extra', 'resource_attrs', 'metadata')",
+        parameters={"db": CH_DATABASE},
     ).result_rows
     actual = {name: type_ for name, type_ in rows}
     missing = set(_EXPECTED_SPANS_TYPES) - set(actual)
-    assert not missing, f"spans table missing columns: {sorted(missing)}"
+    assert not missing, (
+        f"spans table missing columns {sorted(missing)} in database {CH_DATABASE!r}"
+    )
     for col, (kind, expected) in _EXPECTED_SPANS_TYPES.items():
         got = actual[col]
         if kind == "exact":
@@ -345,9 +350,10 @@ def test_spans_table_typed_json_contract(ch_client):
     # which embeds the column-level codec and default in the table DDL.
     ddl_rows = ch_client.query(
         "SELECT create_table_query FROM system.tables "
-        "WHERE database = 'default' AND name = 'spans'"
+        "WHERE database = %(db)s AND name = 'spans'",
+        parameters={"db": CH_DATABASE},
     ).result_rows
-    assert ddl_rows, "spans table missing from system.tables"
+    assert ddl_rows, f"spans table missing from system.tables in database {CH_DATABASE!r}"
     ddl = ddl_rows[0][0]
     # Be tolerant of CH's DDL canonicalization (whitespace, quoting) but pin
     # both substrings — if either is missing, the column was re-created

--- a/futureagi/tracer/tests/test_datetime_filters.py
+++ b/futureagi/tracer/tests/test_datetime_filters.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     APICallLog = None
 
+pytestmark = pytest.mark.requires_ee
+
 
 def _make_datetime_filter(filter_op, filter_value, column_id="created_at"):
     """Helper to build a datetime filter payload."""

--- a/futureagi/tracer/tests/test_grpc_otlp.py
+++ b/futureagi/tracer/tests/test_grpc_otlp.py
@@ -8,6 +8,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from google.protobuf.json_format import MessageToJson
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -61,6 +62,7 @@ def create_test_otlp_request(num_spans: int = 1) -> ExportTraceServiceRequest:
     return request
 
 
+@pytest.mark.requires_ee
 class TestObservationSpanServiceUnit:
     """Unit tests for ObservationSpanService gRPC service."""
 

--- a/futureagi/tracer/tests/test_monitor.py
+++ b/futureagi/tracer/tests/test_monitor.py
@@ -79,6 +79,7 @@ class TestUserAlertMonitorCreateAPI:
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @pytest.mark.requires_ee
     def test_create_monitor_success(self, auth_client, observe_project):
         """Create a new user alert monitor."""
         response = auth_client.post(
@@ -98,6 +99,7 @@ class TestUserAlertMonitorCreateAPI:
         monitor = UserAlertMonitor.objects.get(name="Error Rate Alert")
         assert monitor.workspace_id == observe_project.workspace_id
 
+    @pytest.mark.requires_ee
     def test_create_monitor_rejects_other_workspace_project(
         self, auth_client, organization, user
     ):
@@ -124,6 +126,7 @@ class TestUserAlertMonitorCreateAPI:
             name="Cross Workspace Alert"
         ).exists()
 
+    @pytest.mark.requires_ee
     def test_create_monitor_with_slack_config(self, auth_client, observe_project):
         """Create monitor with Slack notification config."""
         response = auth_client.post(
@@ -142,6 +145,7 @@ class TestUserAlertMonitorCreateAPI:
         )
         assert response.status_code == status.HTTP_200_OK
 
+    @pytest.mark.requires_ee
     def test_create_monitor_accepts_canonical_span_attribute_filters(
         self, auth_client, observe_project
     ):
@@ -178,6 +182,7 @@ class TestUserAlertMonitorCreateAPI:
             "customer_tier"
         )
 
+    @pytest.mark.requires_ee
     def test_create_monitor_rejects_camel_case_span_attribute_filters(
         self, auth_client, observe_project
     ):

--- a/futureagi/tracer/utils/tests/test_eval_clustering_cap.py
+++ b/futureagi/tracer/utils/tests/test_eval_clustering_cap.py
@@ -23,6 +23,7 @@ class _FakeResult:
     def __init__(self, i: int):
         self.eval_logger_id = f"el-{i}"
         self.eval_name = "prosody_and_intonation"
+        self.target_type = "session"  # read by eval_clustering.py:62
 
     @property
     def embedding_text(self) -> str:


### PR DESCRIPTION
Release cut `dev → main`.

**Scope:** 6 commits ahead, 20 files. Key changes:
- [fix] preserve plaintext trace input/output in detail read path
- [fix] make tracer tests green in OSS lane and against test CH database
- test(harness): OSS-lane guards + full-session log-capture isolation (#1932)
- [chore] gitignore .claude/CLAUDE.md

**Regression check:** `dev...main` shows 2 files (`.release-please-manifest.json`, `CHANGELOG.md`) — release-bot bookkeeping only. Verified `dev` does not modify these, so the merge keeps `main`'s current values (no version/changelog regression).