### PR TITLE
fix(frontend): fix width typo in Add Filter button icon

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
### Description
Fixed a CSS typo on the "Add Filter" button's SVG icon where the width property was set to `20ox !important` instead of `20px !important`. This invalid value caused the browser to discard the width property, breaking the layout alignment.

### Changes
* Updated `width: "20ox !important"` to `width: "20px !important"` in the following files:
  - `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx`
  - `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx`

### Verification
* Verified that there are no remaining occurrences of the typo `20ox` across the frontend source code.