### PR TITLE
fix: correct invalid CSS width value 20ox to 20px in Add Filter button icon

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
## Summary

Fix a CSS typo where the Add Filter button icon had `width: "20ox !important"` instead of `width: "20px !important"`. The invalid `20ox` value is discarded by the browser, causing the icon to render at its intrinsic width rather than the intended 20px.

## Linked issues

Closes #1967

## Type of change

- [x] 🐛 Bug fix

## Changes

- `develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx`: `20ox` → `20px`
- `evals/DevelopFilters/DevelopFilterRow.jsx`: `20ox` → `20px`

A repo-wide search for `20ox` returns zero results.