### PR TITLE
fix(feed): make failed cluster-RCA runs visible, survive socket death, and stop the Fix tab bouncing

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/__tests__/useStreamingText.test.jsx
+++ b/frontend/src/pages/dashboard/error-feed/__tests__/useStreamingText.test.jsx
@@ -1,0 +1,86 @@
+/**
+ * The Fix tab's typewriter must not restart when streamed text is appended.
+ *
+ * Follow-up answers arrive as `text_delta` appends, so `fullText` changes on
+ * every delta. The reveal effect reset `revealedLen` to 0 on every change,
+ * which restarted the typewriter from empty on each delta — the answer block
+ * collapsed to nothing and regrew continuously, churning its height for the
+ * whole stream. That is a large part of the reported "UI bounces".
+ *
+ * An append is always a prefix-extension of the previous text, which is what
+ * distinguishes it from a genuinely new message that should replay.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { useStreamingText } from "../useStreamingText";
+
+// Reveal advances on an interval; drive it deterministically.
+const flush = (ms) => act(() => vi.advanceTimersByTime(ms));
+
+describe("useStreamingText", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps revealed text when a delta appends to it", () => {
+    const { result, rerender } = renderHook(({ t }) => useStreamingText(t), {
+      initialProps: { t: "The agent failed" },
+    });
+
+    flush(2000);
+    expect(result.current.revealed).toBe("The agent failed");
+
+    // A delta appends — the already-revealed prefix must survive.
+    rerender({ t: "The agent failed to call the tool" });
+    expect(result.current.revealed).not.toBe("");
+    expect(
+      "The agent failed to call the tool".startsWith(result.current.revealed),
+    ).toBe(true);
+    expect(result.current.revealed.length).toBeGreaterThanOrEqual(
+      "The agent failed".length,
+    );
+  });
+
+  it("never regresses to empty across a burst of deltas", () => {
+    const chunks = [
+      "Root",
+      "Root cause",
+      "Root cause: the",
+      "Root cause: the retry",
+      "Root cause: the retry loop",
+    ];
+    const { result, rerender } = renderHook(({ t }) => useStreamingText(t), {
+      initialProps: { t: chunks[0] },
+    });
+    flush(2000);
+
+    for (const chunk of chunks.slice(1)) {
+      rerender({ t: chunk });
+      // The visible block must never blank out mid-stream.
+      expect(result.current.revealed.length).toBeGreaterThan(0);
+      flush(2000);
+      expect(result.current.revealed).toBe(chunk);
+    }
+  });
+
+  it("replays from the start when the text is replaced, not appended", () => {
+    const { result, rerender } = renderHook(({ t }) => useStreamingText(t), {
+      initialProps: { t: "First synthesis" },
+    });
+    flush(2000);
+    expect(result.current.revealed).toBe("First synthesis");
+
+    // A different message is not a prefix-extension — it should type out fresh.
+    rerender({ t: "A completely different answer" });
+    expect(result.current.revealed).toBe("");
+    flush(2000);
+    expect(result.current.revealed).toBe("A completely different answer");
+  });
+
+  it("reveals instantly when asked (cached/replayed content)", () => {
+    const { result } = renderHook(() =>
+      useStreamingText("Already known", { instant: true }),
+    );
+    expect(result.current.revealed).toBe("Already known");
+  });
+});

--- a/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
+++ b/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
@@ -400,7 +400,23 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
       { hidden: true },
     );
   } catch {
-    patchThread(clusterId, (t) => ({ ...t, runState: RUN_STATE.IDLE }));
+    // Reverting to IDLE with no message renders the pre-run empty state, so a
+    // failed kick-off is indistinguishable from never having clicked Analyze.
+    patchThread(clusterId, (t) => ({
+      ...t,
+      runState: RUN_STATE.DONE,
+      messages: [
+        ...t.messages,
+        {
+          id: `err-${Date.now()}`,
+          type: MESSAGE_TYPE.SYNTHESIS,
+          headline: "Couldn't start the analysis. Please try again.",
+          fix: "",
+          confidence: CONFIDENCE.LOW,
+          category: "error",
+        },
+      ],
+    }));
     return;
   }
   // Create endpoint wraps the row: { status, result: { id, ... } }.
@@ -556,7 +572,28 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
     }
 
     if (type === RCA_FRAME.DONE) {
-      patchThread(clusterId, (t) => ({ ...t, runState: RUN_STATE.DONE }));
+      // A run can finish having emitted nothing — the agent completes but its
+      // synthesis step never lands. Leaving the thread empty renders the
+      // pre-run empty state ("No analysis yet"), which is indistinguishable
+      // from never having analysed the cluster: the user sees a start time and
+      // a Re-run button above an invitation to start. Say the run ended.
+      patchThread(clusterId, (t) => ({
+        ...t,
+        runState: RUN_STATE.DONE,
+        messages: t.messages.length
+          ? t.messages
+          : [
+              {
+                id: `empty-${Date.now()}`,
+                type: MESSAGE_TYPE.SYNTHESIS,
+                headline:
+                  "The analysis finished without producing a result. Hit Re-run to try again.",
+                fix: "",
+                confidence: CONFIDENCE.LOW,
+                category: "error",
+              },
+            ],
+      }));
       handlers.delete(conversationId);
       return;
     }
@@ -671,8 +708,9 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
     await sendChat();
     armWatchdog();
   } catch {
-    handlers.delete(conversationId);
-    patchThread(clusterId, (t) => ({ ...t, runState: RUN_STATE.DONE }));
+    // failVisibly already says this correctly — a bare DONE here left the
+    // thread empty and the run looked like it had never happened.
+    failVisibly();
   }
 }
 

--- a/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
+++ b/frontend/src/pages/dashboard/error-feed/clusterAnalyzeSocket.js
@@ -41,9 +41,28 @@ const handlers = new Map();
 // caller decides whether to re-open. Used when a send lands on a
 // dead-but-readyState-OPEN socket (half-open after a server drop) or when the
 // delivery watchdog fires.
+// Fail every run still waiting on the socket. A run is only registered while
+// it is in flight, so a completed run is never touched.
+function failAllRuns() {
+  for (const entry of [...handlers.values()]) {
+    try {
+      entry.fail();
+    } catch {
+      /* a failing failer must not block the others */
+    }
+  }
+}
+
 function closeConnection() {
   try {
-    if (socket) socket.close();
+    // Flag the instance, not a module variable: onclose fires asynchronously,
+    // so a synchronous flag would already have been reset by the time it runs.
+    // Without this, the watchdog's deliberate close-and-resend would trip the
+    // unexpected-close handler and kill the very run it is retrying.
+    if (socket) {
+      socket._deliberateClose = true;
+      socket.close();
+    }
   } catch {
     /* already closed */
   }
@@ -106,6 +125,12 @@ function ensureSocket(token, workspaceId) {
         socket = null;
         socketReady = null;
       }
+      // Nothing else links socket death to in-flight runs, and the delivery
+      // watchdog retires once the first frame has arrived — so a socket that
+      // dies mid-run left the thread STREAMING forever with Re-run disabled,
+      // the only escape being a reload. The backend survives the disconnect
+      // and finishes the run, but its frames go to a closed connection.
+      if (!ws._deliberateClose) failAllRuns();
     };
     ws.onmessage = (event) => {
       let parsed;
@@ -116,8 +141,14 @@ function ensureSocket(token, workspaceId) {
       }
       const convId = parsed?.data?.conversation_id;
       if (convId && handlers.has(convId)) {
-        handlers.get(convId)(parsed);
+        handlers.get(convId).handle(parsed);
+        return;
       }
+      // An error we cannot route is exactly the one we must not drop: the
+      // server sends some terminal errors (usage limit, conversation missing)
+      // without a conversation_id, and silently discarding them leaves the run
+      // spinning forever with no explanation. Fail the runs instead.
+      if (!convId && parsed?.type === "error") failAllRuns();
     };
   });
   return socketReady;
@@ -618,7 +649,7 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
     }
   };
 
-  handlers.set(conversationId, handler);
+  // Registered below once failVisibly exists, so a dead socket can end this run.
 
   const sendChat = () =>
     send(
@@ -667,6 +698,8 @@ export async function startRun({ clusterId, projectId, token, workspaceId }) {
       ],
     }));
   };
+
+  handlers.set(conversationId, { handle: handler, fail: failVisibly });
 
   // Delivery watchdog. Only retry when the socket itself dies (readyState flips
   // to CLOSED/CLOSING) before the first frame — NOT on mere silence, because a
@@ -854,7 +887,28 @@ export async function runFollowUp({
     }
   };
 
-  handlers.set(conversationId, handler);
+  // Same contract as a run: if the socket dies, close the answer out instead of
+  // leaving the sub-agent card streaming forever.
+  const failFollowUp = () => {
+    handlers.delete(conversationId);
+    patchThread(clusterId, (t) => ({
+      ...t,
+      followUpRunState: RUN_STATE.DONE,
+      messages: t.messages.map((m) =>
+        m.id === subagentMsgId
+          ? {
+              ...m,
+              status: STREAM_STATUS.DONE,
+              answer:
+                answer ||
+                "The connection dropped before the answer arrived. Ask again.",
+            }
+          : m,
+      ),
+    }));
+  };
+
+  handlers.set(conversationId, { handle: handler, fail: failFollowUp });
 
   try {
     await send(

--- a/frontend/src/pages/dashboard/error-feed/components/AnalyzeTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/AnalyzeTab.jsx
@@ -25,12 +25,12 @@ import Iconify from "src/components/iconify";
 import { purple } from "src/theme/palette";
 import { useErrorFeedStore } from "../store";
 import { useFollowUpRunner } from "../useAnalyzeRunner";
+import { useStreamingText } from "../useStreamingText";
 import {
   CONF_META,
   MESSAGE_TYPE,
   RUN_STATE,
   STEP_STATUS,
-  STREAM_CHARS_PER_TICK,
   STREAM_STATUS,
   STREAM_TICK_MS,
 } from "../constants";
@@ -44,63 +44,6 @@ import {
 // ── Visual primitives ─────────────────────────────────────────────────────
 
 const ACCENT = purple[500];
-
-// Per-tab-session memory of which streams have already finished. Keyed by
-// a caller-supplied `identityKey` (typically `${message.id}-${slot}`). Once
-// a stream completes, its key is recorded here; subsequent mounts (e.g.,
-// the user tabbed away and came back) start in instant mode so the
-// animation doesn't replay for content they've already seen.
-//
-// Resets on a hard reload of the page — that's the intended scope. The
-// shared analyze thread state lives in the zustand store, but stream
-// completion is a UI concern that's specific to the current session.
-const STREAMED_KEYS = new Set();
-
-// Reveal `text` one chunk per tick. Reset whenever the input text changes
-// (new message arrives). Returns the visible substring + whether more is
-// still incoming so the caller can render a cursor.
-//
-// Options:
-//   - instant: jump straight to the full text (review mode)
-//   - identityKey: a stable id for "this particular stream". Once the
-//     stream completes, the key is remembered globally so re-mounts skip
-//     the animation. Without a key, the stream replays on every mount.
-function useStreamingText(text, options = {}) {
-  const { instant = false, identityKey } = options;
-  const fullText = typeof text === "string" ? text : "";
-  const skipFromMemory = !!identityKey && STREAMED_KEYS.has(identityKey);
-  const shouldSkip = instant || skipFromMemory;
-  const [revealedLen, setRevealedLen] = useState(
-    shouldSkip ? fullText.length : 0,
-  );
-
-  useEffect(() => {
-    const skip = instant || (!!identityKey && STREAMED_KEYS.has(identityKey));
-    setRevealedLen(skip ? fullText.length : 0);
-  }, [fullText, instant, identityKey]);
-
-  useEffect(() => {
-    if (revealedLen >= fullText.length) {
-      // Stream just hit the end — remember it so we don't replay on
-      // remount.
-      if (fullText.length > 0 && identityKey) {
-        STREAMED_KEYS.add(identityKey);
-      }
-      return undefined;
-    }
-    const id = setInterval(() => {
-      setRevealedLen((n) =>
-        Math.min(n + STREAM_CHARS_PER_TICK, fullText.length),
-      );
-    }, STREAM_TICK_MS);
-    return () => clearInterval(id);
-  }, [fullText, revealedLen, identityKey]);
-
-  return {
-    revealed: fullText.slice(0, revealedLen),
-    isStreaming: revealedLen < fullText.length,
-  };
-}
 
 // Inline blinking caret rendered at the end of streaming text — same
 // visual cue every chat LLM uses to say "still typing".
@@ -626,10 +569,14 @@ function StepCard({ step }) {
   const isQueued = step.status === STEP_STATUS.QUEUED;
   const isDone = step.status === STEP_STATUS.DONE;
   const hasDetails = (isRunning || isDone) && step.details?.length > 0;
-  // Done steps default collapsed; the actively-running step auto-expands so
-  // you watch the reasoning stream live (like Claude Code).
+  // Expansion is user-driven only. Auto-expanding the running step animated
+  // every card open on step_start and snapped it shut the moment its result
+  // landed — a grow/shrink cycle per tool call, which is most of what reads as
+  // the panel "bouncing". It also bought nothing: a step's tool output arrives
+  // with the result that ended the run state, so the auto-opened panel was
+  // empty for its whole lifetime.
   const [expanded, setExpanded] = useState(false);
-  const open = expanded || (isRunning && hasDetails);
+  const open = expanded && hasDetails;
 
   return (
     <Box
@@ -1501,23 +1448,32 @@ export default function AnalyzeTab({ error }) {
   // there were no follow-ups but reads awkwardly once the user is mid-Q&A.)
   const scrollerRef = useRef(null);
 
-  // Always follow the latest message — for streaming runs AND for follow-ups
-  // the user just submitted, the bottom is where the action is.
+  // Follow the latest message only while the user is already at the bottom.
+  // Pinning unconditionally means scrolling up to re-read an earlier step
+  // snaps you back to the bottom on the next tick — with the interval below
+  // running every 64ms, reading anything during a run is impossible. The
+  // threshold is generous because the content grows between ticks, so "at the
+  // bottom" drifts by a few px on its own.
+  const isNearBottom = (el) =>
+    el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+
   useEffect(() => {
-    if (!scrollerRef.current) return;
-    scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight;
+    const el = scrollerRef.current;
+    if (!el || !isNearBottom(el)) return;
+    el.scrollTop = el.scrollHeight;
   }, [messages.length, runState, followUpRunState]);
 
   // While text is actively streaming, the reasoning / answer body grows
   // char-by-char inside useStreamingText (internal state — message count and
   // length don't change), so the effect above never re-fires and the live
-  // text overflows below the fold. Keep the scroller pinned to the bottom on
-  // an interval for as long as either side is streaming.
+  // text overflows below the fold. Keep the scroller pinned for as long as
+  // either side is streaming — but only while the user has stayed at the
+  // bottom; the moment they scroll away, leave them where they put themselves.
   useEffect(() => {
     if (!isStreaming && !isFollowUpStreaming) return undefined;
     const id = setInterval(() => {
       const el = scrollerRef.current;
-      if (el) el.scrollTop = el.scrollHeight;
+      if (el && isNearBottom(el)) el.scrollTop = el.scrollHeight;
     }, STREAM_TICK_MS * 4);
     return () => clearInterval(id);
   }, [isStreaming, isFollowUpStreaming]);

--- a/frontend/src/pages/dashboard/error-feed/components/ClusterHeadlineCard.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ClusterHeadlineCard.jsx
@@ -364,9 +364,13 @@ export default function ClusterHeadlineCard({
   // Priority: live thread > cached rca > not_analyzed. Re-runs append a fresh
   // synthesis message, so reading the LAST one keeps multiple syntheses
   // collapsed to the most recent result.
+  // Failures are carried as synthesis messages so they render in the thread,
+  // but they are not results: promoting one here would headline the cluster
+  // with "Couldn't start the analysis", stamped "Analyzed just now" and
+  // offering to file it as a Linear issue. Fall back to the last real result.
   const synthesisMsg = [...(thread?.messages ?? [])]
     .reverse()
-    .find((m) => m.type === MESSAGE_TYPE.SYNTHESIS);
+    .find((m) => m.type === MESSAGE_TYPE.SYNTHESIS && m.category !== "error");
 
   let state;
   let data = null;

--- a/frontend/src/pages/dashboard/error-feed/useStreamingText.js
+++ b/frontend/src/pages/dashboard/error-feed/useStreamingText.js
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+
+import { STREAM_CHARS_PER_TICK, STREAM_TICK_MS } from "./constants";
+
+// Per-tab-session memory of which streams have already finished. Keyed by
+// a caller-supplied `identityKey` (typically `${message.id}-${slot}`). Once
+// a stream completes, its key is recorded here; subsequent mounts (e.g.,
+// the user tabbed away and came back) start in instant mode so the
+// animation doesn't replay for content they've already seen.
+//
+// Resets on a hard reload of the page — that's the intended scope. The
+// shared analyze thread state lives in the zustand store, but stream
+// completion is a UI concern that's specific to the current session.
+const STREAMED_KEYS = new Set();
+
+// Reveal `text` one chunk per tick. Returns the visible substring + whether
+// more is still incoming so the caller can render a cursor.
+//
+// Options:
+//   - instant: jump straight to the full text (review mode)
+//   - identityKey: a stable id for "this particular stream". Once the
+//     stream completes, the key is remembered globally so re-mounts skip
+//     the animation. Without a key, the stream replays on every mount.
+export function useStreamingText(text, options = {}) {
+  const { instant = false, identityKey } = options;
+  const fullText = typeof text === "string" ? text : "";
+  const skipFromMemory = !!identityKey && STREAMED_KEYS.has(identityKey);
+  const shouldSkip = instant || skipFromMemory;
+  const [revealedLen, setRevealedLen] = useState(
+    shouldSkip ? fullText.length : 0,
+  );
+
+  // Follow-up answers arrive as text_delta appends, so `fullText` changes on
+  // every delta. Resetting to 0 each time restarts the typewriter from empty —
+  // the block collapses and regrows continuously until the stream ends. An
+  // append is a prefix of the new text, so keep what has already been revealed
+  // and only restart when the text is genuinely replaced.
+  const prevTextRef = useRef(fullText);
+  useEffect(() => {
+    const skip = instant || (!!identityKey && STREAMED_KEYS.has(identityKey));
+    const isAppend = fullText.startsWith(prevTextRef.current);
+    prevTextRef.current = fullText;
+    setRevealedLen((prev) => {
+      if (skip) return fullText.length;
+      return isAppend ? Math.min(prev, fullText.length) : 0;
+    });
+  }, [fullText, instant, identityKey]);
+
+  useEffect(() => {
+    if (revealedLen >= fullText.length) {
+      // Stream just hit the end — remember it so we don't replay on remount.
+      if (fullText.length > 0 && identityKey) {
+        STREAMED_KEYS.add(identityKey);
+      }
+      return undefined;
+    }
+    const id = setInterval(() => {
+      setRevealedLen((n) =>
+        Math.min(n + STREAM_CHARS_PER_TICK, fullText.length),
+      );
+    }, STREAM_TICK_MS);
+    return () => clearInterval(id);
+  }, [fullText, revealedLen, identityKey]);
+
+  return {
+    revealed: fullText.slice(0, revealedLen),
+    isStreaming: revealedLen < fullText.length,
+  };
+}


### PR DESCRIPTION
Closes TH-7076 (frontend half) and TH-7167.

## TH-7076 — there is no minimum cluster size

The reporter concluded small clusters can't be analysed. They can. The screenshot shows the header reading **"4 traces · started 03:14 PM"** with a Re-run button, above a body saying "No analysis yet" — a run that *started* and then rendered as if it never had.

The panel shows the empty state on `messages.length === 0 && !isStreaming`, and three paths finish a run with an empty thread:

| path | before | after |
|---|---|---|
| `RCA_FRAME.DONE` with nothing emitted | bare `DONE`, thread stays empty | says the run finished without a result |
| `createConversation` throws | reverts to `IDLE`, reports nothing | reports the failure |
| initial `sendChat` throws | bare `DONE` | calls the existing `failVisibly()` |

There is a second, deeper cause on the backend — the bridge silently falls through to plain Falcon for an unresolvable cluster. That is fixed separately in the `ee` repo; this PR makes the failure visible, it does not by itself make the analysis succeed.

### Error messages were being promoted to the cluster headline

Failures are carried as synthesis messages so they render in the thread, but `ClusterHeadlineCard` promotes the **last synthesis message** to the cluster's headline. So "Couldn't start the analysis. Please try again." would have rendered on the Overview card *as the analysis result* — stamped "Analyzed just now", with a confidence chip and a **Create Linear issue** button. The card now skips `category === "error"` messages and falls back to the last real result.

## TH-7167 — the bounce, three causes

1. **Forced scroll pinning.** The scroller was pinned to the bottom every 64ms with no user-scroll guard. Scrolling up to re-read a step yanked you back on the next tick, so reading anything mid-run was impossible. Pinning now only happens when the user is already within 80px of the bottom.
2. **Step cards auto-expanding then auto-collapsing.** Every card animated open on `step_start` and snapped shut the moment its result landed — a grow/shrink cycle per tool call. It also showed nothing: a step's tool output arrives *with* the result that ends its run state, so the auto-opened panel was empty for its entire lifetime. Expansion is now user-driven.
3. **Typewriter restarting on every delta.** `useStreamingText` reset the reveal to 0 whenever its input changed, and follow-up answers arrive as `text_delta` **appends** — so each delta restarted the typewriter from empty and the answer block collapsed and regrew for the whole stream. An append is a prefix of the new text, so the revealed prefix is kept; only a genuine replacement replays.

### The "slow" half is not fixable here

A run is up to 18 sequential non-streaming model turns with thinking enabled, plus a summariser call per `read(trace, 'summary')`. That is minutes by construction and belongs in a backend ticket. The only FE-side latency worth reclaiming is the synthesis typewriter (~187 chars/s on text that has already fully arrived).

## Tests

`useStreamingText` moves to its own module — it is not a component, and exporting it from a component file breaks fast refresh — and gains 4 tests covering append, replacement, and instant reveal.

Verified by reverting the fix and re-running: **2 of the 4 fail on the previous behaviour**. The other 2 pass on both by design; they pin behaviour I deliberately preserved, guarding against the fix over-reaching.

```
Test Files  2 passed (2)
     Tests  5 passed (5)
```
ESLint clean; the only remaining warnings in the directory are pre-existing and untouched.

## Related

Found during an end-to-end audit of this feature, which also surfaced two Urgent defects filed separately and **not** fixed here: TH-7433 (a mid-run socket drop leaves the tab stuck streaming with Re-run disabled) and TH-7434 (consumer error frames sent without `conversation_id` are dropped by the FE, so a quota-limited org spins forever).