### PR TITLE
fix(gateway): point org config provider links at the real dashboard route [TH-7271]

### DIFF
--- a/frontend/src/sections/gateway/settings/ProviderConfigTab.jsx
+++ b/frontend/src/sections/gateway/settings/ProviderConfigTab.jsx
@@ -10,6 +10,8 @@ import {
   Alert,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
+import { RouterLink } from "src/routes/components";
+import { paths } from "src/routes/paths";
 import { useProviderHealth } from "../providers/hooks/useGatewayConfig";
 import { useGatewayContext } from "../context/useGatewayContext";
 
@@ -34,7 +36,8 @@ const ProviderConfigTab = ({ providers: _providers, onChange: _onChange }) => {
           size="small"
           variant="outlined"
           startIcon={<Iconify icon="solar:arrow-right-up-bold" width={18} />}
-          href="/gateway/providers"
+          component={RouterLink}
+          href={paths.dashboard.gateway.providers}
           target="_blank"
         >
           Manage Providers
@@ -60,7 +63,8 @@ const ProviderConfigTab = ({ providers: _providers, onChange: _onChange }) => {
             <Button
               size="small"
               sx={{ mt: 1 }}
-              href="/gateway/providers"
+              component={RouterLink}
+              href={paths.dashboard.gateway.providers}
               startIcon={<Iconify icon="solar:add-circle-bold" width={18} />}
             >
               Add Provider


### PR DESCRIPTION
**Ticket:** [TH-7271](https://linear.app/future-agi/issue/TH-7271/oss-in-gateway-edit-organization-config-when-i-click-manage-providers) — Closes TH-7271

## What was the bug

In Gateway → Providers → Edit Organization Config, the **Providers** tab had two links pointing at `/gateway/providers`, which is not a route in the app. Clicking **Manage Providers** landed on the 404 "Lost in deep space" page.

Despite the ticket title, this is not OSS-specific. Neither `ProviderConfigTab.jsx` nor `OrgConfigEditor.jsx` reads `isOSS` / `useDeploymentMode`, so it reproduces identically in EE and cloud. OSS is simply where it was reported.

The same broken path was also on the empty-state **Add Provider** button in that tab, which had no `target="_blank"`, so it 404'd in the same tab and discarded the open dialog.

## What changes have been done

- `frontend/src/sections/gateway/settings/ProviderConfigTab.jsx`
  - **Manage Providers** (line 40): `href="/gateway/providers"` → `href={paths.dashboard.gateway.providers}`
  - **Add Provider** (line 67): same path correction
  - Both buttons now use `component={RouterLink}` instead of a raw `href`
  - Added imports for `RouterLink` and `paths`

## Why the changes

- **The path.** Every gateway route is mounted under `/dashboard`. `dashboardRoutes` returns a single top-level `{ path: "dashboard" }` node (`routes/sections/dashboard.jsx:1463`), with `{ path: "gateway" }` nested inside it (`:1401`) and `{ path: "providers" }` inside that (`:1412`). There is no top-level `/gateway` route, so `/gateway/providers` fell through to the catch-all 404.
- **The `paths` constant instead of a string.** Every other reference in the codebase already uses `/dashboard/gateway/providers` (`paths.js:104`, `ProviderManagementSection.jsx:41`, `GatewayOverviewSection.jsx:51`, `GettingStartedCard.jsx:28`, `FallbacksSection.jsx:575`). These two were the only hardcoded ones, so routing them through `paths` stops them drifting from the route tree again.
- **`RouterLink` instead of a raw `href`.** For **Add Provider** this is a real behaviour change: it now navigates client-side rather than doing a full page reload. For **Manage Providers** it makes no behavioural difference, since `target="_blank"` forces a full document load either way; it is there for consistency.

`target="_blank"` on **Manage Providers** is preserved as-is, so the dialog's unsaved state survives in the original tab.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Click **Manage Providers** in the dialog | New tab opens on `/dashboard/gateway/providers`, renders the Providers page. No 404. |
| 2 | Original tab after scenario 1 | Dialog stays open with unsaved changes intact. |
| 3 | Click **Add Provider** in the empty state | Client-side navigation to `/dashboard/gateway/providers`, no full page reload, no 404. |
| 4 | Dialog state after scenario 3 | `tab` becomes 0, so `CacheStatusView` unmounts (`ProviderManagementSection.jsx:166`) and its local `editorOpen` state is destroyed. Dialog closes cleanly rather than stranding a modal over a changed page. |
| 5 | Rendered markup | Both anchors carry `href="/dashboard/gateway/providers"`; only **Manage Providers** carries `target="_blank"`. |
| 6 | EE / cloud mode | Same behaviour as OSS, since neither component branches on deployment mode. |

## How to reproduce (original bug)

1. Go to Gateway → Providers.
2. Open the **Cache** tab.
3. Click **Configure Cache** to open the **Edit Organization Config** dialog.
4. The dialog opens on the **Providers** tab.
5. Click **Manage Providers**.
6. A new tab opens on `localhost:3000/gateway/providers` and shows the 404 page.

## Commands

```bash
cd frontend
npx eslint src/sections/gateway/settings/ProviderConfigTab.jsx
npx vitest run src/sections/gateway/settings/OrgConfigEditor.test.jsx

# confirm no bare gateway hrefs remain
grep -rn 'href="/gateway' src/
```

## Videos and screenshots

https://github.com/user-attachments/assets/cc753bfc-3657-409f-ac13-f827b4399b69
