### PR TITLE
fix(frontend): sync row highlight with drawer arrow navigation

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -429,7 +429,7 @@ body {
   --vscode-editor-background: var(--monaco-bg);
   --vscode-editorGutter-background: var(--monaco-gutter-bg);
 }
-.ag-row-focus.active-row {
+.ag-row.active-row {
   background-color: var(--surface-row-active);
 }
 

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -585,6 +585,19 @@ const DatapointDrawerChild = () => {
     }
   };
 
+  useEffect(() => {
+    const api = gridApi.current;
+    document.querySelectorAll(".ag-row.active-row").forEach((el) => {
+      el.classList.remove("active-row");
+    });
+    if (datapoint?.index != null) {
+      document
+        .querySelectorAll(`.ag-row[row-index="${datapoint.index}"]`)
+        .forEach((el) => el.classList.add("active-row"));
+      api?.ensureIndexVisible(datapoint.index);
+    }
+  }, [datapoint?.index]);
+
   const navStateRef = useRef({});
   navStateRef.current = {
     onNavigate,


### PR DESCRIPTION
When navigating between datapoints using the arrow buttons (or J/K keys) in the datapoint drawer, the highlighted row in the AG Grid table stayed on the originally clicked row instead of following the active datapoint. This was caused by two issues: the CSS selector required AG Grid's focus class which doesn't update on programmatic navigation, and the grid never re-evaluated row classes after external state changes. Fixed by switching to direct DOM class manipulation for instant, jitter-free row highlight sync, and scrolling the grid to keep the active row visible.

Closes TH-7257

## Changes

### `frontend/src/global.css`
The active row highlight selector was `.ag-row-focus.active-row`, which required both the `ag-row-focus` class (set by AG Grid only on the physically clicked row) and `active-row`. When navigating via drawer arrows, AG Grid never moved `ag-row-focus` to the new row, so the highlight stayed stuck. Changed the selector to `.ag-row.active-row` so the highlight is driven solely by the `active-row` class we control.

### `frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx`
Added a `useEffect` that fires whenever `datapoint?.index` changes (arrow click, J/K key, any navigation path). It removes the `active-row` class from any previously highlighted row via `querySelectorAll`, then adds it to the new row using AG Grid's `row-index` DOM attribute. Also calls `ensureIndexVisible` to scroll the grid when the active row goes off-screen. This uses direct DOM manipulation instead of AG Grid's `redrawRows()` to avoid the jitter and lag that comes with row re-rendering on rapid navigation.

## Test plan


https://github.com/user-attachments/assets/7abebc6d-ac56-4767-abab-eed6b458a958


- [ ] Open a dataset, click a row to open the drawer
- [ ] Use up/down arrow buttons in the drawer — row highlight should follow
- [ ] Use J/K keyboard shortcuts — same behavior
- [ ] Rapidly navigate — no lag or jitter
- [ ] Verify the grid scrolls to keep the highlighted row visible when it goes off-screen
- [ ] Confirm the initially clicked row still highlights correctly

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature with breaking side effects)
- [ ] This change requires a documentation update