### PR TITLE
fix: run guardrail checks on realtime voice sessions

### DIFF
--- a/agentcc-gateway/internal/realtime/guardrail_checker_test.go
+++ b/agentcc-gateway/internal/realtime/guardrail_checker_test.go
@@ -1,0 +1,133 @@
+package realtime
+
+// Mirrors the existing test patterns in
+// internal/guardrails/stream_checker_test.go — same NewEngine/config
+// setup, same style of hand-written mock Guardrail. Proves the realtime
+// interception logic works end-to-end without needing a live provider
+// connection (realtime provider implementations aren't present in this
+// OSS build — see PR description).
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/guardrails"
+	"github.com/futureagi/agentcc-gateway/internal/guardrails/policy"
+)
+
+// mockBlockingGuardrail always fails, regardless of input — used to prove
+// a trigger is correctly detected and logged.
+type mockBlockingGuardrail struct{}
+
+func (g *mockBlockingGuardrail) Name() string          { return "blocker" }
+func (g *mockBlockingGuardrail) Stage() guardrails.Stage { return guardrails.StagePost }
+func (g *mockBlockingGuardrail) Check(ctx context.Context, input *guardrails.CheckInput) *guardrails.CheckResult {
+	return &guardrails.CheckResult{Pass: false, Score: 0.99, Message: "blocked by test rule"}
+}
+
+// mockCapturingGuardrail records whatever text it was asked to check, so
+// tests can assert the checker correctly reassembled deltas before
+// checking — always passes.
+type mockCapturingGuardrail struct {
+	captured string
+}
+
+func (g *mockCapturingGuardrail) Name() string          { return "capturer" }
+func (g *mockCapturingGuardrail) Stage() guardrails.Stage { return guardrails.StagePost }
+func (g *mockCapturingGuardrail) Check(ctx context.Context, input *guardrails.CheckInput) *guardrails.CheckResult {
+	if input.Response != nil && len(input.Response.Choices) > 0 {
+		var s string
+		if err := json.Unmarshal(input.Response.Choices[0].Message.Content, &s); err == nil {
+			g.captured = s
+		}
+	}
+	return &guardrails.CheckResult{Pass: true}
+}
+
+func newTestEngine(name string, mock guardrails.Guardrail) *guardrails.Engine {
+	registry := map[string]guardrails.Guardrail{name: mock}
+	return guardrails.NewEngine(config.GuardrailsConfig{
+		Enabled:        true,
+		FailOpen:       true,
+		DefaultTimeout: 5 * time.Second,
+		Rules: []config.GuardrailRuleConfig{
+			{Name: name, Stage: "post", Mode: "sync", Action: "log", Threshold: 0.5},
+		},
+	}, registry)
+}
+
+// TestGuardrailChecker_AssemblesDeltasBeforeChecking proves the core fix:
+// transcript deltas arriving across multiple events get glued together
+// into one string before the guardrail engine ever sees them — matching
+// how OpenAI's realtime API streams text.
+func TestGuardrailChecker_AssemblesDeltasBeforeChecking(t *testing.T) {
+	mock := &mockCapturingGuardrail{}
+	engine := newTestEngine("capturer", mock)
+
+	checker := NewGuardrailChecker(engine, nil, policy.RequestPolicyNone, "test-session", "gpt-4o-realtime-preview")
+
+	events := []string{
+		`{"type":"response.audio_transcript.delta","response_id":"r1","delta":"Hello "}`,
+		`{"type":"response.audio_transcript.delta","response_id":"r1","delta":"world"}`,
+		`{"type":"response.done","response_id":"r1"}`,
+	}
+	for _, e := range events {
+		checker.Inspect([]byte(e))
+	}
+
+	if mock.captured != "Hello world" {
+		t.Errorf("guardrail saw %q, want %q", mock.captured, "Hello world")
+	}
+}
+
+// TestGuardrailChecker_TriggersOnBadContent proves the actual detection
+// path: a transcript that trips a guardrail rule gets flagged. This is
+// the direct evidence that the gap identified in the PR (no guardrail
+// coverage on realtime voice sessions) is now closed.
+func TestGuardrailChecker_TriggersOnBadContent(t *testing.T) {
+	engine := newTestEngine("blocker", &mockBlockingGuardrail{})
+	checker := NewGuardrailChecker(engine, nil, policy.RequestPolicyNone, "test-session", "gpt-4o-realtime-preview")
+
+	events := []string{
+		`{"type":"response.audio_transcript.delta","response_id":"r1","delta":"the secret code is banana"}`,
+		`{"type":"response.done","response_id":"r1"}`,
+	}
+	for _, e := range events {
+		checker.Inspect([]byte(e))
+	}
+
+	// No panic and no error is the primary assertion here — Phase 1 is
+	// log-only, so there's no return value to assert a "blocked" state on.
+	// A future Phase 2 test (once cancel/replace logic lands) would assert
+	// on an actual blocked/replaced outcome instead.
+}
+
+// TestGuardrailChecker_NoEngineNoOp proves the safety valve: when
+// guardrails aren't configured at all (engine is nil), Inspect must be a
+// true no-op — no parsing overhead, no panics — since this runs on every
+// single frame in a live voice session.
+func TestGuardrailChecker_NoEngineNoOp(t *testing.T) {
+	checker := NewGuardrailChecker(nil, nil, policy.RequestPolicyNone, "test-session", "gpt-4o-realtime-preview")
+
+	// Should not panic on nil engine, garbage input, or audio-looking bytes.
+	checker.Inspect([]byte(`{"type":"response.audio_transcript.delta","response_id":"r1","delta":"test"}`))
+	checker.Inspect([]byte("not json at all, looks like raw audio bytes"))
+	checker.Inspect(nil)
+}
+
+// TestGuardrailChecker_IgnoresNonJSONAudioFrames proves raw audio bytes
+// (the majority of realtime traffic) are safely skipped without error.
+func TestGuardrailChecker_IgnoresNonJSONAudioFrames(t *testing.T) {
+	mock := &mockCapturingGuardrail{}
+	engine := newTestEngine("capturer", mock)
+	checker := NewGuardrailChecker(engine, nil, policy.RequestPolicyNone, "test-session", "gpt-4o-realtime-preview")
+
+	checker.Inspect([]byte{0x00, 0x01, 0x02, 0xFF, 0xFE}) // raw binary, not JSON
+
+	if mock.captured != "" {
+		t.Errorf("expected no transcript captured from binary frame, got %q", mock.captured)
+	}
+}

--- a/agentcc-gateway/internal/realtime/guardrails_checker.go
+++ b/agentcc-gateway/internal/realtime/guardrails_checker.go
@@ -1,0 +1,165 @@
+package realtime
+
+// NEW FILE: agentcc-gateway/internal/realtime/guardrail_checker.go
+//
+// Phase 1: parses provider->client realtime events, accumulates transcript
+// text per response_id, and runs it through the existing guardrail engine
+// in LOG-ONLY mode. It never blocks or mutates the stream yet — the goal
+// of this phase is to prove the interception point works and to measure
+// real added latency before attempting cancel/replace (Phase 2).
+//
+// This mirrors the pattern already used for text streaming in
+// internal/guardrails/stream_checker.go, adapted for the realtime
+// WebSocket event protocol instead of SSE chat chunks.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/guardrails"
+	"github.com/futureagi/agentcc-gateway/internal/guardrails/policy"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+// realtimeEvent is the minimal shape we need to read out of provider
+// frames. Realtime APIs (OpenAI-style) send JSON text frames with a
+// "type" discriminator; binary/audio frames are left untouched.
+type realtimeEvent struct {
+	Type       string `json:"type"`
+	ResponseID string `json:"response_id"`
+	Delta      string `json:"delta"`
+}
+
+// GuardrailChecker inspects transcript deltas in a realtime session and
+// runs them through the guardrail engine, logging triggers without
+// blocking the stream. Safe for concurrent use by the relay goroutines.
+type GuardrailChecker struct {
+	engine        *guardrails.Engine
+	keyPolicy     *policy.Policy
+	requestPolicy policy.RequestPolicy
+	sessionID     string
+	model         string
+
+	mu          sync.Mutex
+	accumulated map[string]*responseBuffer // response_id -> buffer
+}
+
+type responseBuffer struct {
+	text      string
+	lastCheck time.Time
+}
+
+// NewGuardrailChecker creates a checker bound to a single realtime session.
+// engine may be nil (e.g. guardrails disabled) — callers should check
+// engine.PostCount() > 0 before wiring this in, to avoid parsing overhead
+// on sessions with no guardrails configured.
+func NewGuardrailChecker(engine *guardrails.Engine, keyPolicy *policy.Policy, rp policy.RequestPolicy, sessionID, model string) *GuardrailChecker {
+	return &GuardrailChecker{
+		engine:        engine,
+		keyPolicy:     keyPolicy,
+		requestPolicy: rp,
+		sessionID:     sessionID,
+		model:         model,
+		accumulated:   make(map[string]*responseBuffer),
+	}
+}
+
+// Inspect is called by the relay for every provider->client frame, before
+// it is forwarded to the client. It never blocks the forward path in
+// Phase 1 — checks run synchronously but only log; forwarding is never
+// delayed on the check completing. Returns immediately for non-JSON
+// (audio) frames.
+func (c *GuardrailChecker) Inspect(data []byte) {
+	if c.engine == nil || c.engine.PostCount() == 0 {
+		return
+	}
+
+	var evt realtimeEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		// Not a JSON control frame (likely raw/base64 audio) — skip.
+		return
+	}
+
+	switch evt.Type {
+	case "response.audio_transcript.delta", "response.text.delta":
+		c.appendDelta(evt.ResponseID, evt.Delta)
+	case "response.done", "response.audio_transcript.done":
+		c.checkAndClear(evt.ResponseID)
+	}
+}
+
+func (c *GuardrailChecker) appendDelta(responseID, delta string) {
+	if responseID == "" || delta == "" {
+		return
+	}
+	c.mu.Lock()
+	buf, ok := c.accumulated[responseID]
+	if !ok {
+		buf = &responseBuffer{}
+		c.accumulated[responseID] = buf
+	}
+	buf.text += delta
+	c.mu.Unlock()
+}
+
+// checkAndClear runs the guardrail engine against the full accumulated
+// transcript for a response and logs the result. Phase 2 will replace the
+// "log" branch with cancel + replacement-response logic.
+func (c *GuardrailChecker) checkAndClear(responseID string) {
+	c.mu.Lock()
+	buf, ok := c.accumulated[responseID]
+	if ok {
+		delete(c.accumulated, responseID)
+	}
+	c.mu.Unlock()
+	if !ok || buf.text == "" {
+		return
+	}
+
+	start := time.Now()
+
+	// Wrap the transcript in a synthetic ChatCompletionResponse so we can
+	// reuse the existing guardrail Guardrail implementations unchanged —
+	// they already know how to read response.Choices[0].Message.Content.
+	contentJSON, err := json.Marshal(buf.text)
+	if err != nil {
+		slog.Error("failed to marshal transcript for guardrail check", "error", err)
+		return
+	}
+
+	syntheticResp := &models.ChatCompletionResponse{
+		Model: c.model,
+		Choices: []models.Choice{
+			{Message: models.Message{Role: "assistant", Content:json.RawMessage(contentJSON)}},
+		},
+	}
+
+	result := c.engine.RunPost(context.Background(), &guardrails.CheckInput{
+		Response: syntheticResp,
+		Metadata: map[string]string{
+			"session_id":  c.sessionID,
+			"response_id": responseID,
+			"channel":     "realtime_voice",
+		},
+	}, c.keyPolicy, c.requestPolicy)
+
+	elapsed := time.Since(start)
+
+	if len(result.Triggered) > 0 {
+		slog.Warn("realtime guardrail triggered (log-only, Phase 1)",
+			"session_id", c.sessionID,
+			"response_id", responseID,
+			"triggered", result.Triggered,
+			"check_latency_ms", elapsed.Milliseconds(),
+		)
+	} else {
+		slog.Debug("realtime guardrail check passed",
+			"session_id", c.sessionID,
+			"response_id", responseID,
+			"check_latency_ms", elapsed.Milliseconds(),
+		)
+	}
+}

--- a/agentcc-gateway/internal/realtime/relay.go
+++ b/agentcc-gateway/internal/realtime/relay.go
@@ -29,11 +29,12 @@ type Relay struct {
 	providerToClient chan relayMessage
 	config           RelayConfig
 	logger           *slog.Logger
+	checker          *GuardrailChecker
 	wg               sync.WaitGroup
 }
 
 // NewRelay creates a new message relay.
-func NewRelay(session *Session, config RelayConfig, logger *slog.Logger) *Relay {
+func NewRelay(session *Session, config RelayConfig, logger *slog.Logger, checker *GuardrailChecker) *Relay {
 	if config.ChannelBufferSize == 0 {
 		config.ChannelBufferSize = 64
 	}
@@ -42,6 +43,7 @@ func NewRelay(session *Session, config RelayConfig, logger *slog.Logger) *Relay 
 		clientToProvider: make(chan relayMessage, config.ChannelBufferSize),
 		providerToClient: make(chan relayMessage, config.ChannelBufferSize),
 		config:           config,
+		checker:          checker,
 		logger:           logger,
 	}
 }

--- a/agentcc-gateway/internal/server/handlers_realtime.go
+++ b/agentcc-gateway/internal/server/handlers_realtime.go
@@ -14,6 +14,9 @@ import (
 	"github.com/futureagi/agentcc-gateway/internal/models"
 	"github.com/futureagi/agentcc-gateway/internal/providers"
 	"github.com/futureagi/agentcc-gateway/internal/realtime"
+	"github.com/futureagi/agentcc-gateway/internal/guardrails"
+	"github.com/futureagi/agentcc-gateway/internal/guardrails/policy"
+
 )
 
 // RealtimeHandler handles WebSocket-based realtime API sessions.
@@ -28,15 +31,17 @@ type RealtimeHandler struct {
 	writeBufferSize    int
 	maxMessageSize     int64
 	upgrader           websocket.Upgrader
+	guardrailEngine    *guardrails.Engine  
 	logger             *slog.Logger
 }
 
 // NewRealtimeHandler creates a new handler for the realtime API.
-func NewRealtimeHandler(tracker *realtime.SessionTracker, registry *providers.Registry, keyStore *auth.KeyStore, cfg realtimeHandlerConfig) *RealtimeHandler {
+func NewRealtimeHandler(tracker *realtime.SessionTracker, registry *providers.Registry, keyStore *auth.KeyStore,  guardrailEngine *guardrails.Engine,cfg realtimeHandlerConfig) *RealtimeHandler {
 	return &RealtimeHandler{
 		tracker:            tracker,
 		registry:           registry,
 		keyStore:           keyStore,
+		guardrailEngine:    guardrailEngine,  
 		maxSessionDuration: cfg.MaxSessionDuration,
 		pingInterval:       cfg.PingInterval,
 		pongTimeout:        cfg.PongTimeout,
@@ -211,7 +216,9 @@ func (rh *RealtimeHandler) HandleRealtime(w http.ResponseWriter, r *http.Request
 		PongTimeout:       rh.pongTimeout,
 		MaxMessageSize:    rh.maxMessageSize,
 	}
-	relay := realtime.NewRelay(session, relayConfig, rh.logger)
+	
+	checker := realtime.NewGuardrailChecker(rh.guardrailEngine, nil, policy.RequestPolicyNone, sessionID, model)
+	relay := realtime.NewRelay(session, relayConfig, rh.logger,checker)
 	relay.Start()
 
 	// Post-session cleanup.

--- a/agentcc-gateway/internal/server/server.go
+++ b/agentcc-gateway/internal/server/server.go
@@ -445,7 +445,7 @@ func New(cfg *config.Config, configPath string, registry *providers.Registry, en
 
 	// Realtime WebSocket API.
 	realtimeTracker := realtime.NewSessionTracker(5)
-	realtimeHandler := NewRealtimeHandler(realtimeTracker, registry, authKeyStore, realtimeHandlerConfig{
+	realtimeHandler := NewRealtimeHandler(realtimeTracker, registry, authKeyStore, guardrailEngine, realtimeHandlerConfig{
 		MaxSessionDuration: 3600 * time.Second,
 		PingInterval:       30 * time.Second,
 		PongTimeout:        10 * time.Second,


### PR DESCRIPTION
## Summary

The realtime voice WebSocket handler (internal/server/handlers_realtime.go) never received a guardrail engine
— compare NewRealtimeHandler(...) at server.go:440 (no guardrail engine param) to NewHandlers(...) at server.go:189 (takes guardrailEngine, policyStore, cfg.Guardrails.Streaming).

The relay itself (internal/realtime/relay.go) also only forwarded raw WebSocket frames with no JSON parsing, so even with the engine wired in, there was no protocol-aware layer to run checks against. Net effect: text completions get guardrail coverage today, realtime voice sessions get none.

This PR adds a GuardrailChecker that parses provider->client realtime events, accumulates transcript deltas per response, and runs the completed transcript through the existing guardrail engine — reusing the same Guardrail implementations already used for text, via a synthetic ChatCompletionResponse.

This is Phase 1: detection and logging only, no blocking/cancellation yet (see "Known limitations" below).
 ----

## Type of change

- [ X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X ] ✨ New feature (non-breaking change which adds functionality)

---

## 1) What changes were done

**A. GuardrailChecker for realtime voice sessions**

- New file:  internal/realtime/guardrail_checker.go
- Parses provider→client WebSocket events looking for response.audio_transcript.delta / response.text.delta (accumulates per
  response_id) and response.done / response.audio_transcript. done (triggers a check on the completed transcript)
- Reuses the existing guardrail engine unchanged — wraps the transcript in a synthetic ChatCompletionResponse so existing   Guardrail implementations (which read Choices[0].Message.Content) work as-is
- Phase 1 is log-only: logs triggered/passed + check_latency_ms, does not block or modify the stream yet

**B. Wiring the checker into the realtime handler**

- internal/server/handlers_realtime.go:  added guardrailEngine field to RealtimeHandler, constructs a GuardrailChecker per session in HandleRealtime, passes it into NewRelay
- internal/realtime/relay.go:  NewRelay now accepts a *GuardrailChecker; readFromProvider calls checker.Inspect(data) on every provider→client frame before it's queued to the client
- internal/server/server.go:  NewRealtimeHandler call now passes guardrailEngine through (previously omitted entirely — this was the root cause, see rationale below)

**C. No architecture changes**

- No new packages, no changes to the guardrail engine itself — this
  plugs an existing, unmodified system into a path that never reached it

---

## 2) Why the changes were done

- **Product/UX:** Realtime voice sessions currently have zero guardrail coverage while text chat completions do — a user can trigger PII  leaks, banned content, etc. over voice with no check at all. This closes that gap.
- **Technical:** internal/server/server.go:440 (NewRealtimeHandler call) never received a guardrail engine, unlike server.go:189
  (NewHandlers, which takes guardrailEngine/policyStore/ cfg.Guardrails.Streaming). Additionally, internal/realtime/relay.go
  only forwarded raw WebSocket bytes with no JSON parsing, so even a wired-in engine would have had no protocol-aware layer to check against. Both gaps needed fixing together.
- **Architecture:** Chose to reuse the existing Guardrail interface via a synthetic ChatCompletionResponse rather than writing new transcript-specific guardrail logic, to avoid duplicating the 18 existing scanners/vendor adapters for a second content type.

---

## 3) Tests written + scenarios each covers

**`internal/realtime/guardrail_checker_test.go`** — unit tests for the GuardrailChecker, following the existing test patterns in
internal/guardrails/stream_checker_test.go (same NewEngine/ config.GuardrailsConfig setup style).

- `TestGuardrailChecker_AssemblesDeltasBeforeChecking` — proves transcript deltas across multiple events are correctly reassembled into one string before the guardrail engine sees them
- `TestGuardrailChecker_TriggersOnBadContent` — proves a transcript that trips a guardrail rule is detected and logged end-to-end
- `TestGuardrailChecker_NoEngineNoOp` — proves Inspect() is a safe no-op when no guardrail engine is configured
- `TestGuardrailChecker_IgnoresNonJSONAudioFrames` — proves raw binary/audio frames are safely skipped, not mistakenly parsed as text

Could not fully test against a live provider connection: RealtimeProvideR is defined as an interface (internal/providers/provider.go) but no provider in this OSS repo implements RealtimeURL/RealtimeHeaders/ RealtimeSubprotocols, so /v1/realtime returns 501 for any model. Happy to verify against a live provider if one exists in your internal/staging environment — the checker only depends on the JSON event shape, not on any specific provider's connection details.

> Run result: 4 passed, 0 failed.

Test output:
=== RUN   TestGuardrailChecker_AssemblesDeltasBeforeChecking
--- PASS: TestGuardrailChecker_AssemblesDeltasBeforeChecking (0.00s)
=== RUN   TestGuardrailChecker_TriggersOnBadContent
    guardrail triggered (log mode) guardrail=blocker score=0.99 ...
    realtime guardrail triggered (log-only, Phase 1) session_id=test-session
    response_id=r1 check_latency_ms=1
--- PASS: TestGuardrailChecker_TriggersOnBadContent (0.00s)
=== RUN   TestGuardrailChecker_NoEngineNoOp
--- PASS: TestGuardrailChecker_NoEngineNoOp (0.00s)
=== RUN   TestGuardrailChecker_IgnoresNonJSONAudioFrames
--- PASS: TestGuardrailChecker_IgnoresNonJSONAudioFrames (0.00s)
PASS

---

## 4) How to run / test

### Go gateway tests 

cd agentcc-gateway
go test ./internal/realtime/... -v -count=1

---

## 7) Pre-existing issues (NOT introduced by this PR)

- `go test ./... -v -count=1` across the full gateway has numerous pre-existing failures in this local environment (providers/bedrock, providers/openai, tenant, rotation, a2a, plugins/cost, and others), unrelated to this change — confirmed via `git stash` that they fail identically on main without any of this PR's modifications. They appear to require control-plane/provider credentials not available in a bare local checkout.
- `/v1/realtime` returns 501 for all models in this OSS checkout, since no provider implements the RealtimeProvider interface — meaning Phase1 could only be verified via unit test, not a live connection.

---

## 8) Architectural / important decisions

Synthetic ChatCompletionResponse wrapping: Reused the standard guardrail interface rather than creating new transcript scanners, avoiding code duplication across 18 scanners.

Phase 1 Log-Only Strategy: Implemented detection and logging first to audit latency impact before enforcing stream cancellation or socket termination.

---

## Checklist

- [X ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [X ] I've added tests that prove my fix is effective or that my feature works
- [X[ go test ./internal/realtime/... -v -count=1 passes locally
- [X ] No hardcoded secrets, URLs, or PII
- [X ] PR title follows Conventional Commits