### PR TITLE
fix(state): handle stale cleanup enumeration errors

### DIFF
--- a/futureagi/.test_quarantine.json
+++ b/futureagi/.test_quarantine.json
@@ -2,15 +2,6 @@
   "version": 1,
   "entries": [
     {
-      "id": "tfc/utils/tests/test_distributed_locks.py::TestDistributedStateErrorHandling::test_cleanup_stale_handles_exception",
-      "reason": "pre-existing failure at CI introduction (baseline 2026-08, post-Redis-fix core)",
-      "owner": "chirag",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-05",
-      "expires": "2026-09-19",
-      "mode": "run"
-    },
-    {
       "id": "sockets/tests/test_prompt_stream_consumer.py::test_resolve_happy_path_pins_org_and_does_not_close",
       "reason": "mock no longer intercepts workspace lookup after #1931 workspace-isolation changes; hits real DB without django_db mark (first clean-run exposure by CI) | env-dependent: passes on warm local stacks (cached workspace state), fails on cold CI runners",
       "owner": "tanmaycode1",

--- a/futureagi/tfc/utils/distributed_state.py
+++ b/futureagi/tfc/utils/distributed_state.py
@@ -547,8 +547,8 @@ class DistributedEvaluationTracker(DistributedStateManager):
         try:
             running = self.get_all_running()
         except Exception as e:
-            # Cleanup is a best-effort safety mechanism. A state-store failure
-            # must not abort the caller that triggered maintenance.
+            # get_all_running() already handles RedisError. Keep cleanup
+            # best-effort if an unexpected enumeration error escapes it.
             logger.exception(f"Failed to enumerate running evaluations: {e}")
             return 0
 

--- a/futureagi/tfc/utils/distributed_state.py
+++ b/futureagi/tfc/utils/distributed_state.py
@@ -544,7 +544,15 @@ class DistributedEvaluationTracker(DistributedStateManager):
         cleaned = 0
         cutoff = datetime.utcnow().timestamp() - (max_age_hours * 3600)
 
-        for info in self.get_all_running():
+        try:
+            running = self.get_all_running()
+        except Exception as e:
+            # Cleanup is a best-effort safety mechanism. A state-store failure
+            # must not abort the caller that triggered maintenance.
+            logger.exception(f"Failed to enumerate running evaluations: {e}")
+            return 0
+
+        for info in running:
             try:
                 started = datetime.fromisoformat(info.started_at).timestamp()
                 if started < cutoff:

--- a/futureagi/tfc/utils/tests/test_distributed_locks.py
+++ b/futureagi/tfc/utils/tests/test_distributed_locks.py
@@ -517,13 +517,15 @@ class TestDistributedStateErrorHandling:
 
         tracker = DistributedEvaluationTracker()
 
-        if tracker.is_available:
-            with patch.object(
-                tracker, "get_all_running", side_effect=Exception("Redis error")
-            ):
-                # Should return 0 instead of raising
-                result = tracker.cleanup_stale()
-                assert result == 0
+        # Exercise the cleanup contract deterministically even when Redis is
+        # unavailable in the test environment.
+        tracker._redis_available = True
+        with patch.object(
+            tracker, "get_all_running", side_effect=Exception("Redis error")
+        ):
+            # Should return 0 instead of raising
+            result = tracker.cleanup_stale()
+            assert result == 0
 
 
 class TestLocalFallback:

--- a/futureagi/tfc/utils/tests/test_distributed_locks.py
+++ b/futureagi/tfc/utils/tests/test_distributed_locks.py
@@ -521,7 +521,9 @@ class TestDistributedStateErrorHandling:
         # unavailable in the test environment.
         tracker._redis_available = True
         with patch.object(
-            tracker, "get_all_running", side_effect=Exception("Redis error")
+            tracker,
+            "get_all_running",
+            side_effect=Exception("Unexpected enumeration error"),
         ):
             # Should return 0 instead of raising
             result = tracker.cleanup_stale()


### PR DESCRIPTION
## Summary

Make `DistributedEvaluationTracker.cleanup_stale()` preserve its best-effort contract when enumerating running evaluations fails. The cleanup now logs any unexpected/non-Redis enumeration error that escapes `get_all_running()` and returns `0` instead of propagating it into maintenance callers. The quarantined regression test is made deterministic and its strict quarantine entry is removed.

## Linked issues

Refs #1984
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Best-effort stale cleanup**

- Catch unexpected/non-Redis failures that escape `get_all_running()` while enumerating running evaluations.
- Log the failure with its traceback and return a zero cleanup count.

**B. Regression coverage and quarantine burn-down**

- Run the enumeration-failure test regardless of local Redis availability.
- Remove the now-fixed strict entry from `futureagi/.test_quarantine.json`.

## 2) Why the changes were done

- **Product/UX:** An unexpected enumeration failure outside `get_all_running()`'s existing Redis error handling should not crash the maintenance caller responsible for stale evaluation cleanup.
- **Technical:** `get_all_running()` already handles `RedisError`; `cleanup_stale()` remains best-effort for unexpected/non-Redis exceptions that escape that boundary.
- **Architecture:** The error is handled at the cleanup boundary, leaving normal state reads unchanged.

## 3) Tests written + scenarios each covers

**`tfc/utils/tests/test_distributed_locks.py`** — distributed lock and state-management behavior

- `test_cleanup_stale_handles_exception` — verifies an enumeration failure returns `0` without escaping, independent of whether Redis is running locally.

> Run result: **28 passed** across the complete file. Black check, JSON quarantine validation, and `git diff --check` also pass.

## 4) How to run / test

```bash
cd futureagi
pytest tfc/utils/tests/test_distributed_locks.py -q
```

No frontend or API-contract verification is required; this change does not affect either surface.

## 5) Screenshots / recordings

Not applicable; this is backend state-management behavior with automated regression coverage.

## 6) Edge cases & considerations

- Redis unavailable before cleanup starts: the existing early return remains unchanged.
- `RedisError` during enumeration: `get_all_running()` handles it and returns an empty list.
- An unexpected/non-Redis enumeration error escapes `get_all_running()`: `cleanup_stale()` logs it and reports zero.
- Individual malformed task timestamps: the existing per-entry skip behavior remains unchanged.

## 7) Pre-existing issues (NOT introduced by this PR)

- A full Docker-backed `make check-all` was not available because the local Docker daemon was not running. The complete affected test file was executed in an isolated Python environment.
- Repository-wide Ruff reports existing modernization findings in the touched legacy files; this PR does not expand scope to unrelated cleanup.

## 8) Architectural / important decisions

- **Catch at the maintenance boundary:** `get_all_running()` retains its existing `RedisError` handling, while `cleanup_stale()` catches only unexpected/non-Redis exceptions that escape enumeration and preserves its documented best-effort behavior.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] `bin/test` passes locally (backend; Docker daemon unavailable)
- [ ] `yarn test:run` passes locally (not applicable)
- [ ] `yarn contracts:check` passes if API surface changed (not applicable)
- [x] Documentation is not required for this internal bug fix
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA (bot will confirm)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated (N/A)
