### PR TITLE
fix(accounts): skip IP rate limiting in OSS mode

### DIFF
--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -29,6 +29,7 @@ from accounts.models.organization import Organization
 from accounts.models.workspace import Workspace, WorkspaceMembership
 from accounts.services.workspace_membership import create_workspace_membership
 from tfc.constants.roles import OrganizationRoles
+from tfc.ee_gating import is_oss
 from tfc.utils.api_errors import (
     build_error_envelope,
     error_details,
@@ -685,6 +686,9 @@ class AuthMonitoringMiddleware:
         return JsonResponse(body, status=403)
 
     def __call__(self, request):
+        if is_oss():
+            return self.get_response(request)
+
         client_ip, _ = get_client_ip(request)
 
         if request.path.endswith("password-reset-initiate/"):

--- a/futureagi/accounts/tests/test_login_error_codes.py
+++ b/futureagi/accounts/tests/test_login_error_codes.py
@@ -435,11 +435,27 @@ class TestMiddlewareJsonForbidden:
         assert body["result"]["blocked"] is True
 
 
+@pytest.fixture
+def non_oss_mode():
+    """Pin non-OSS deployment so IP blocking paths are exercised.
+
+    The middleware short-circuits entirely when is_oss() is True (the
+    default in this repo's test environment), so blocking tests must
+    force non-OSS mode.
+    """
+    with patch("accounts.authentication.is_oss", return_value=False):
+        yield
+
+
 @pytest.mark.unit
 class TestMiddlewareIpBlockedRouting:
     """Middleware blocks /login/, /token/, /signup/ paths when IP is cached."""
 
     TEST_IP = "10.10.10.99"
+
+    @pytest.fixture(autouse=True)
+    def _non_oss(self, non_oss_mode):
+        yield
 
     def _middleware(self):
         from accounts.authentication import AuthMonitoringMiddleware
@@ -544,6 +560,10 @@ class TestMiddlewarePasswordResetRouting:
 
     TEST_IP = "10.10.20.50"
 
+    @pytest.fixture(autouse=True)
+    def _non_oss(self, non_oss_mode):
+        yield
+
     def _middleware(self):
         from accounts.authentication import AuthMonitoringMiddleware
 
@@ -626,6 +646,56 @@ class TestMiddlewarePasswordResetRouting:
         assert "result" in body
         assert "error" in body["result"]
         assert "error_code" in body["result"]
+
+
+@pytest.mark.unit
+class TestMiddlewareOssSkip:
+    """In OSS mode the middleware skips ALL IP-based blocking (TH-7179).
+
+    OSS/local deployments funnel every request through one IP (localhost or
+    the Docker gateway), so IP rate limiting blocks legitimate users.
+    """
+
+    TEST_IP = "10.10.30.77"
+
+    @pytest.fixture(autouse=True)
+    def _oss(self):
+        with patch("accounts.authentication.is_oss", return_value=True):
+            yield
+
+    def _middleware(self):
+        from accounts.authentication import AuthMonitoringMiddleware
+
+        return AuthMonitoringMiddleware(lambda r: HttpResponse("OK", status=200))
+
+    def _request(self, path: str):
+        factory = RequestFactory()
+        req = factory.post(path, content_type="application/json")
+        req.META["REMOTE_ADDR"] = self.TEST_IP
+        return req
+
+    def test_blocked_ip_passes_through_on_login_paths(self):
+        cache.set(f"blocked_ip_{self.TEST_IP}", True, 3600)
+        middleware = self._middleware()
+        for path in (
+            "/api/accounts/token/",
+            "/api/accounts/login/",
+            "/api/accounts/signup/",
+        ):
+            resp = middleware(self._request(path))
+            assert resp.status_code == 200
+
+    def test_rate_limited_ip_passes_through_on_password_reset(self):
+        cache.set(f"rate_limit_{self.TEST_IP}", True, 3600)
+        middleware = self._middleware()
+        resp = middleware(self._request("/api/accounts/password-reset-initiate/"))
+        assert resp.status_code == 200
+
+    def test_no_ip_request_tracking_in_oss(self):
+        """OSS mode must not even record request timestamps per IP."""
+        middleware = self._middleware()
+        middleware(self._request("/api/accounts/token/"))
+        assert cache.get(f"ip_requests_{self.TEST_IP}") is None
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/accounts/tests/test_signup.py
+++ b/futureagi/accounts/tests/test_signup.py
@@ -1051,6 +1051,14 @@ class TestActivateAccountRateLimit:
     """Rate-limit boundary tests for GET /accounts/activate/<uidb64>/<token>/."""
 
     @pytest.fixture(autouse=True)
+    def _non_oss(self):
+        # The IP rate limit is skipped entirely in OSS mode (TH-7179), and
+        # this repo's test environment defaults to OSS — pin non-OSS so the
+        # blocking behavior stays exercised.
+        with patch("accounts.views.signup.is_oss", return_value=False):
+            yield
+
+    @pytest.fixture(autouse=True)
     def _clear_rate_limit_cache(self):
         yield
         from django.core.cache import cache
@@ -1136,6 +1144,24 @@ class TestActivateAccountRateLimit:
         )
         # First IP in X-Forwarded-For is used for rate limiting
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    def test_rate_limit_skipped_in_oss_mode(self, api_client, db):
+        """OSS mode skips IP rate limiting — all traffic shares one IP (TH-7179)."""
+        from django.core.cache import cache
+
+        user = self._inactive_user(db)
+        url = self._activation_url(user)
+        ip = "10.20.30.1"
+        cache.set(f"activate_account_rate:{ip}", 10, timeout=60)
+
+        with patch("accounts.views.signup.is_oss", return_value=True):
+            response = api_client.get(url, REMOTE_ADDR=ip)
+
+        assert response.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.is_active is True
+        # OSS mode must not touch the rate-limit counter either
+        assert cache.get(f"activate_account_rate:{ip}") == 10
 
 
 @pytest.mark.integration

--- a/futureagi/accounts/views/signup.py
+++ b/futureagi/accounts/views/signup.py
@@ -315,17 +315,21 @@ def user_logout(request):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def activate_account(request, uidb64, token):
-    # Rate-limit by IP: 10 requests per minute.
-    ip = request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", ""))
-    if ip:
-        ip = ip.split(",")[0].strip()
-    rate_key = f"activate_account_rate:{ip}"
-    attempts = cache.get(rate_key, 0)
-    if attempts >= 10:
-        return _gm.too_many_requests(
-            "Too many activation attempts. Please try again later."
+    # Rate-limit by IP: 10 requests per minute. Skipped in OSS mode where all
+    # traffic shares a single IP (localhost / Docker gateway).
+    if not is_oss():
+        ip = request.META.get(
+            "HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", "")
         )
-    cache.set(rate_key, attempts + 1, timeout=60)
+        if ip:
+            ip = ip.split(",")[0].strip()
+        rate_key = f"activate_account_rate:{ip}"
+        attempts = cache.get(rate_key, 0)
+        if attempts >= 10:
+            return _gm.too_many_requests(
+                "Too many activation attempts. Please try again later."
+            )
+        cache.set(rate_key, attempts + 1, timeout=60)
 
     try:
         # Decode the uidb64 to the user ID


### PR DESCRIPTION
## Summary
- OSS users hit "IP address temporarily blocked due to multiple failed attempts" after normal login activity. In OSS/local deployments all traffic originates from a single IP (127.0.0.1 or the Docker gateway), and the `AuthMonitoringMiddleware` counts every request to `/token/`, `/login/`, `/signup/` — not just failures. After 10 total requests in an hour the IP gets blocked for 1 hour, which is far too aggressive for single-IP environments.
- Fixed by short-circuiting every IP-keyed rate limit when `is_oss()` is true: the entire `AuthMonitoringMiddleware` (login/signup/token blocking + password-reset-initiate limiting) and the `activate_account` per-IP limit (10 req/min → 429), which had the same single-IP problem.
- Per-email account blocking (failed attempts only) and per-email 2FA rate limits remain active in all modes — those are legitimate security regardless of deployment.

Closes TH-7179

## Changes by file
- `futureagi/accounts/authentication.py`: early return in `AuthMonitoringMiddleware.__call__` when `is_oss()` is true — skips all three IP paths (login/signup/token block, password-reset-initiate limit, already-blocked checks). `is_oss()` is `lru_cache`d, so zero per-request overhead.
- `futureagi/accounts/views/signup.py`: wrapped the `activate_account` per-IP rate limit (`activate_account_rate:{ip}`, 10/min) in `if not is_oss()`. This was the one remaining IP-keyed limiter after the middleware skip.
- `futureagi/accounts/tests/test_login_error_codes.py`: existing IP-blocking middleware tests now pin non-OSS mode via a shared `non_oss_mode` fixture (the repo's test env defaults to OSS, so the middleware skip made them fail — caught locally before CI). New `TestMiddlewareOssSkip` class asserts blocked IPs pass through on login/token/signup and password-reset paths, and that OSS mode records no per-IP request timestamps.
- `futureagi/accounts/tests/test_signup.py`: `TestActivateAccountRateLimit` pins non-OSS mode so the 429 boundary tests keep exercising the limiter; new `test_rate_limit_skipped_in_oss_mode` asserts a saturated counter (10) still activates in OSS and the counter is untouched.

## Flows touched
- OSS login/signup/token: no IP blocking or request counting; repeated logins from one IP never 403.
- OSS password reset initiate: no per-IP rate limit.
- OSS account activation: no per-IP 429 on activation links.
- Non-OSS (EE/Cloud): all IP blocking and rate limiting unchanged.
- All modes: per-email account block after failed password attempts and per-email 2FA limits unchanged.

## Test coverage
- New: OSS-skip tests for all three middleware paths (blocked-IP pass-through on login/token/signup, password-reset pass-through, no `ip_requests_` tracking) and for `activate_account` (saturated counter still activates, counter not incremented).
- Existing IP-blocking/429 tests retained and now explicitly pinned to non-OSS mode, so the blocking behavior stays covered for EE/Cloud.
- Gap: none known — these are the only IP-keyed limiters in the backend (`tfc/middleware/auth_monitoring.py` counts per-IP failures but its block is disabled/log-only; EE `RateLimitMiddleware` is never loaded in OSS).

## How tested
- `pytest accounts/tests/test_login_error_codes.py accounts/tests/test_signup.py` — 159 passed.
- `pytest accounts/tests` — 1356 passed, 4 failed in `test_config_endpoint.py` only; those failures are pre-existing and environmental (untracked local `ee/` dir breaks their `ee.usage` patch targets — reproduced identically on the base commit without these changes; they pass in CI).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature with breaking side effects)
- [ ] This change requires a documentation update

## Media
_Screenshot / video:_ (placeholder — add manually if relevant)

## Test logs
<details>
<summary>Test run output</summary>

```
$ pytest accounts/tests/test_login_error_codes.py accounts/tests/test_signup.py -q
collected 159 items

accounts/tests/test_login_error_codes.py ...........................     [ 16%]
accounts/tests/test_signup.py .......................................... [ 43%]
...............................................................          [ 83%]
accounts/tests/test_login_error_codes.py ......................          [ 96%]
accounts/tests/test_signup.py .....                                      [100%]

============================= 159 passed in 26.48s =============================

$ pytest accounts/tests -q
================== 4 failed, 1356 passed in 135.22s (0:02:15) ==================
(4 failures = accounts/tests/test_config_endpoint.py::PublicConfigEndpointTest —
pre-existing local-env issue: untracked ee/ dir breaks ee.usage patch targets;
reproduced on base commit 253d5df9e without these changes)
```

</details>