### PR TITLE
feat(gateway): add GreenPT provider preset

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -182,6 +182,16 @@ providers:
   #     - llama-3.3-70b-versatile
   #     - mixtral-8x7b-32768
 
+  # greenpt:
+  #   api_key: "${GREENPT_API_KEY}"
+  #   type: "greenpt"                # auto-sets base_url + api_format
+  #   auto_discover: true             # authenticated GET /v1/models
+  #   # Or set auto_discover: false and use an explicit allow-list:
+  #   # models:
+  #     - glm-5.2
+  #     - kimi-k2.7-code
+  #     - green-embedding
+
   # mistral:
   #   api_key: "${MISTRAL_API_KEY}"
   #   type: "mistral"

--- a/agentcc-gateway/internal/providers/presets.go
+++ b/agentcc-gateway/internal/providers/presets.go
@@ -11,6 +11,7 @@ type ProviderPreset struct {
 // KnownProviders maps provider type names to their default configurations.
 var KnownProviders = map[string]ProviderPreset{
 	"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai"},
+	"greenpt":     {BaseURL: "https://api.greenpt.ai", APIFormat: "openai"},
 	"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai"},
 	"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai"},
 	"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai"},

--- a/agentcc-gateway/internal/providers/presets_test.go
+++ b/agentcc-gateway/internal/providers/presets_test.go
@@ -67,6 +67,18 @@ func TestPreset_Groq(t *testing.T) {
 	}
 }
 
+func TestPreset_GreenPT(t *testing.T) {
+	cfg := &config.ProviderConfig{Type: "greenpt"}
+	applyProviderPreset(cfg)
+
+	if cfg.BaseURL != "https://api.greenpt.ai" {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://api.greenpt.ai")
+	}
+	if cfg.APIFormat != "openai" {
+		t.Errorf("APIFormat = %q, want %q", cfg.APIFormat, "openai")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // 4. applyProviderPreset — "azure" fills only APIFormat (no BaseURL in preset)
 // ---------------------------------------------------------------------------
@@ -135,6 +147,7 @@ func TestPreset_ExplicitAPIFormatPreserved(t *testing.T) {
 func TestPreset_KnownProvidersComplete(t *testing.T) {
 	expected := map[string]ProviderPreset{
 		"groq":        {BaseURL: "https://api.groq.com/openai", APIFormat: "openai"},
+		"greenpt":     {BaseURL: "https://api.greenpt.ai", APIFormat: "openai"},
 		"mistral":     {BaseURL: "https://api.mistral.ai", APIFormat: "openai"},
 		"together":    {BaseURL: "https://api.together.xyz", APIFormat: "openai"},
 		"fireworks":   {BaseURL: "https://api.fireworks.ai/inference", APIFormat: "openai"},

--- a/agentcc-gateway/internal/providers/registry.go
+++ b/agentcc-gateway/internal/providers/registry.go
@@ -355,7 +355,16 @@ func autoDiscoverModels(name string, cfg *config.ProviderConfig) []string {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	baseURL := strings.TrimRight(cfg.BaseURL, "/")
-	resp, err := client.Get(baseURL + "/v1/models")
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/models", nil)
+	if err != nil {
+		slog.Warn("auto-discover: failed to create models request",
+			"provider", name, "url", baseURL+"/v1/models", "error", err)
+		return nil
+	}
+	if cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		slog.Warn("auto-discover: failed to reach provider",
 			"provider", name, "url", baseURL+"/v1/models", "error", err)

--- a/agentcc-gateway/internal/providers/registry_test.go
+++ b/agentcc-gateway/internal/providers/registry_test.go
@@ -204,6 +204,42 @@ func TestAutoDiscoverModels(t *testing.T) {
 		}
 	})
 
+	t.Run("uses bearer authentication when an API key is configured", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer greenpt-test-key" {
+				t.Errorf("Authorization = %q, want Bearer greenpt-test-key", got)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]string{
+					{"id": "glm-5.2"},
+					{"id": "kimi-k2.7-code"},
+					{"id": "green-embedding"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := config.ProviderConfig{
+			BaseURL:   srv.URL,
+			APIKey:    "greenpt-test-key",
+			APIFormat: "openai",
+		}
+		got := autoDiscoverModels("greenpt", &cfg)
+
+		sort.Strings(got)
+		want := []string{"glm-5.2", "green-embedding", "kimi-k2.7-code"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
 	t.Run("skips when Models already populated", func(t *testing.T) {
 		srv := newModelsServer(t, []string{"model-a", "model-b"})
 		defer srv.Close()

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.jsx
@@ -22,6 +22,7 @@ import {
   useUpdateProvider,
   useFetchProviderModels,
 } from "./hooks/useGatewayConfig";
+import { GREENPT_ADD_PROVIDER_PRESET } from "./providerPresetData";
 import { parseTimeoutSeconds } from "./utils";
 
 const PROVIDER_PRESETS = {
@@ -74,6 +75,7 @@ const PROVIDER_PRESETS = {
     keyPlaceholder: "gsk_...",
     supportedFormats: ["openai"],
   },
+  greenpt: GREENPT_ADD_PROVIDER_PRESET,
   together: {
     label: "Together AI",
     baseUrl: "https://api.together.xyz/v1",

--- a/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
+++ b/frontend/src/sections/gateway/providers/AddProviderDialog.test.jsx
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  GREENPT_ADD_PROVIDER_PRESET,
+  GREENPT_SETTINGS_PROVIDER_OPTION,
+} from "./providerPresetData";
 import { parseTimeoutSeconds } from "./utils";
 
 describe("parseTimeoutSeconds", () => {
@@ -10,5 +14,25 @@ describe("parseTimeoutSeconds", () => {
     expect(parseTimeoutSeconds("")).toBeNull();
     expect(parseTimeoutSeconds("soon")).toBeNull();
     expect(parseTimeoutSeconds("0s")).toBeNull();
+  });
+});
+
+describe("provider presets", () => {
+  it("exposes GreenPT through the OpenAI-compatible API", () => {
+    expect(GREENPT_ADD_PROVIDER_PRESET).toEqual({
+      label: "GreenPT",
+      baseUrl: "https://api.greenpt.ai/v1",
+      apiFormat: "openai",
+      keyPlaceholder: "Enter your GreenPT API key",
+      supportedFormats: ["openai"],
+    });
+  });
+
+  it("exposes GreenPT in gateway settings", () => {
+    expect(GREENPT_SETTINGS_PROVIDER_OPTION).toEqual({
+      value: "greenpt",
+      label: "GreenPT",
+      baseUrl: "https://api.greenpt.ai",
+    });
   });
 });

--- a/frontend/src/sections/gateway/providers/providerPresetData.js
+++ b/frontend/src/sections/gateway/providers/providerPresetData.js
@@ -1,0 +1,13 @@
+export const GREENPT_ADD_PROVIDER_PRESET = {
+  label: "GreenPT",
+  baseUrl: "https://api.greenpt.ai/v1",
+  apiFormat: "openai",
+  keyPlaceholder: "Enter your GreenPT API key",
+  supportedFormats: ["openai"],
+};
+
+export const GREENPT_SETTINGS_PROVIDER_OPTION = {
+  value: "greenpt",
+  label: "GreenPT",
+  baseUrl: "https://api.greenpt.ai",
+};

--- a/frontend/src/sections/gateway/settings/ProviderConfigDialog.jsx
+++ b/frontend/src/sections/gateway/settings/ProviderConfigDialog.jsx
@@ -18,6 +18,7 @@ import {
 } from "@mui/material";
 import Iconify from "src/components/iconify";
 import { useAvailableModels } from "../hooks/useAvailableModels";
+import { GREENPT_SETTINGS_PROVIDER_OPTION } from "../providers/providerPresetData";
 
 const PROVIDER_OPTIONS = [
   { value: "openai", label: "OpenAI", baseUrl: "https://api.openai.com" },
@@ -30,6 +31,7 @@ const PROVIDER_OPTIONS = [
   { value: "bedrock", label: "AWS Bedrock", baseUrl: "" },
   { value: "vertex", label: "Google Vertex", baseUrl: "" },
   { value: "groq", label: "Groq", baseUrl: "https://api.groq.com/openai" },
+  GREENPT_SETTINGS_PROVIDER_OPTION,
   { value: "mistral", label: "Mistral", baseUrl: "https://api.mistral.ai" },
   {
     value: "together",

--- a/futureagi/agentcc/tests/test_provider_credential_api.py
+++ b/futureagi/agentcc/tests/test_provider_credential_api.py
@@ -1,15 +1,54 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from accounts.models.organization import Organization
 from accounts.models.organization_membership import OrganizationMembership
 from accounts.models.workspace import Workspace, WorkspaceMembership
+from agentcc.models.provider_credential import AgentccProviderCredential
+from agentcc.views.provider_credential import AgentccProviderCredentialViewSet
 from conftest import WorkspaceAwareAPIClient
 from integrations.services.credentials import CredentialManager
-from agentcc.models.provider_credential import AgentccProviderCredential
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
+
+
+def test_greenpt_model_discovery_uses_bearer_authentication():
+    response = MagicMock()
+    response.json.return_value = {
+        "data": [
+            {"id": "kimi-k2.7-code"},
+            {"id": "green-embedding"},
+            {"id": "glm-5.2"},
+        ]
+    }
+    session = MagicMock()
+    session.get.return_value = response
+
+    with (
+        patch(
+            "agentcc.views.provider_credential.ensure_public_http_url"
+        ) as ensure_safe,
+        patch(
+            "agentcc.views.provider_credential.build_ssrf_safe_session",
+            return_value=session,
+        ),
+    ):
+        models = AgentccProviderCredentialViewSet()._fetch_models_from_provider(
+            "greenpt",
+            "https://api.greenpt.ai/v1",
+            "greenpt-test-key",
+            "openai",
+        )
+
+    ensure_safe.assert_called_once_with("https://api.greenpt.ai/v1", "Invalid base URL")
+    session.get.assert_called_once_with(
+        "https://api.greenpt.ai/v1/models",
+        headers={"Authorization": "Bearer greenpt-test-key"},
+        timeout=15,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert models == ["glm-5.2", "green-embedding", "kimi-k2.7-code"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a first-class GreenPT preset to Agent Command Center so users can select GreenPT instead of configuring a custom OpenAI-compatible endpoint. The gateway now discovers GreenPT models through its authenticated `/v1/models` endpoint and reuses the existing OpenAI-compatible contracts for chat, coding, and embeddings.

Closes #2001

Linear: N/A

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes

- register the `greenpt` gateway preset with `https://api.greenpt.ai`
- send bearer authentication during automatic model discovery
- expose GreenPT in both provider setup surfaces
- document a GreenPT configuration example
- cover preset registration, authenticated discovery, and UI selection

## Testing

- `go test ./...` (agentcc-gateway)
- `go vet ./internal/providers`
- `yarn vitest run src/sections/gateway/providers/AddProviderDialog.test.jsx` (3 passed)
- ESLint on the changed frontend files
- `yarn build`
- `.venv/bin/pytest agentcc/tests/test_provider_credential_api.py -k greenpt -q` (1 passed)
- `.venv/bin/python -m py_compile agentcc/tests/test_provider_credential_api.py`
- `isort --check-only agentcc/tests/test_provider_credential_api.py`

## Scope

Reranking and speech-to-text are intentionally excluded, as requested in the issue. Model names are discovered at runtime instead of being hardcoded, while explicit allow-lists remain supported.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the change works
- [x] New and existing focused tests pass locally
- [x] I have updated the example configuration where needed
- [x] My changes introduce no new secrets or credentials
- [x] The PR title follows the repository convention
- [x] I agree to the project CLA

