### PR TITLE
fix(oss): restore preview gate and reason-aware CTA for capability denials

### DIFF
--- a/frontend/src/components/capability-gate/CapabilityGate.jsx
+++ b/frontend/src/components/capability-gate/CapabilityGate.jsx
@@ -4,9 +4,15 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
 import Iconify from "src/components/iconify";
-import { useCapabilities } from "src/hooks/useCapabilities";
+import OSSUpgradeGate from "src/components/oss-upgrade-gate";
+import { CAPABILITY, useCapabilities } from "src/hooks/useCapabilities";
 
 const CONTACT_URL = "https://futureagi.com/talk-to-human";
+
+const CAPABILITY_PREVIEW = Object.freeze({
+  [CAPABILITY.ERROR_FEED]: "errorFeed",
+  [CAPABILITY.FALCON_AI]: "falconAI",
+});
 
 export default function CapabilityGate({ feature, children }) {
   const { data, isLoading, isError, refetch } = useCapabilities();
@@ -59,6 +65,11 @@ export default function CapabilityGate({ feature, children }) {
   }
 
   const reasonCode = featureData?.reason_code;
+
+  const previewFeature = CAPABILITY_PREVIEW[feature];
+  if (previewFeature) {
+    return <OSSUpgradeGate feature={previewFeature} reasonCode={reasonCode} />;
+  }
 
   return (
     <Stack

--- a/frontend/src/components/oss-upgrade-gate/constants.js
+++ b/frontend/src/components/oss-upgrade-gate/constants.js
@@ -1,0 +1,127 @@
+import errorFeedPreview from "src/assets/oss-gate/error_feed_light.png";
+import errorFeedPreviewDark from "src/assets/oss-gate/error_feed_dark.png";
+import optimizationPreview from "src/assets/oss-gate/optimization_light.png";
+import optimizationPreviewDark from "src/assets/oss-gate/optimization_dark.png";
+import falconAIPreview from "src/assets/oss-gate/falcon_ai_light.png";
+import falconAIPreviewDark from "src/assets/oss-gate/falcon_ai_dark.png";
+
+export const CONTACT_URL = "https://futureagi.com/talk-to-human";
+export const DOCS_URL = "https://docs.futureagi.com";
+
+export const LICENSE_CTA = "Manage license";
+export const CONTACT_CTA = "Talk to us";
+export const UPGRADE_CTA = "Upgrade to EE license key";
+export const DOCS_CTA = "Read docs";
+
+export const FEATURES = {
+  errorFeed: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to access Error Feed",
+    description:
+      "Auto-clustered error triage and production failure insights, so you can ship with confidence.",
+    image: errorFeedPreview,
+    imageDark: errorFeedPreviewDark,
+    steps: [
+      "Talk to us to enable Error Feed on your workspace.",
+      "Point your SDK or project at Future AGI.",
+      "Errors are clustered and start flowing into this feed automatically.",
+    ],
+    footnote:
+      "Prefer self-hosting? Error Feed is on the open-source roadmap — star the repo to follow along.",
+  },
+  knowledgeBase: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to access Knowledge Base",
+    description:
+      "Ground your agents in your own documents with managed retrieval when you're ready to scale.",
+    steps: [
+      "Talk to us to enable Knowledge Base on your workspace.",
+      "Upload your documents or connect a source.",
+      "Your agents retrieve grounded answers from your knowledge automatically.",
+    ],
+  },
+  optimization: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to run Optimization",
+    description:
+      "Automatically optimize your prompts and agents against your evals when you're ready to scale.",
+    image: optimizationPreview,
+    imageDark: optimizationPreviewDark,
+    steps: [
+      "Talk to us to enable Optimization on your workspace.",
+      "Pick a dataset or simulation and choose an optimizer.",
+      "We iterate on your prompts and surface the best-performing variant.",
+    ],
+  },
+  falconAI: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to use Falcon AI",
+    description:
+      "Your AI copilot for Future AGI — ask questions, build evals, and debug traces in natural language.",
+    image: falconAIPreview,
+    imageDark: falconAIPreviewDark,
+    steps: [
+      "Talk to us to enable Falcon AI on your workspace.",
+      "Connect your tools so Falcon AI can act on your data.",
+      "Ask in plain language and Falcon AI does the work for you.",
+    ],
+  },
+  usageSummary: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to see usage & spend",
+    description:
+      "Full visibility into your usage, spend, and credits when you're ready to grow.",
+  },
+  pricing: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade for flexible plans",
+    description:
+      "Flexible plans that scale with your team when you're ready to grow.",
+  },
+  billing: {
+    eyebrow: "Cloud feature",
+    title: "Upgrade to manage billing",
+    description:
+      "Payment methods, invoices, and budget controls when you're ready to grow.",
+  },
+};
+
+export const REASONS = {
+  LICENSE_EXPIRED: {
+    note: "Your license has expired — renew it to restore access.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_TRIAL_EXPIRED: {
+    note: "Your trial has ended — add a license key to restore access.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_INVALID: {
+    note: "Your license key could not be validated.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  FEATURE_NOT_IN_GRACE: {
+    note: "This feature is not available during your license's grace period.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_VERSION_UNSUPPORTED: {
+    note: "Your license does not cover this version.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  EE_CODE_UNAVAILABLE: {
+    note: "This deployment is running an image built without the EE package, so a license key alone will not enable this. Contact your administrator.",
+    label: CONTACT_CTA,
+  },
+  RESOLVER_UNAVAILABLE: {
+    note: "Feature access could not be resolved on this deployment. Contact your administrator.",
+    label: CONTACT_CTA,
+  },
+  FEATURE_UNKNOWN: {
+    note: "This server does not recognise the feature — it may be running an older version.",
+    label: CONTACT_CTA,
+  },
+};

--- a/frontend/src/components/oss-upgrade-gate/oss-upgrade-gate.jsx
+++ b/frontend/src/components/oss-upgrade-gate/oss-upgrade-gate.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import FeatureGateOverlay from "src/components/feature-gate/FeatureGateOverlay";
+import { useRouter } from "src/routes/hooks";
+import { paths } from "src/routes/paths";
 import { logger } from "src/utils/logger";
 import errorFeedPreview from "src/assets/oss-gate/error_feed_light.png";
 import errorFeedPreviewDark from "src/assets/oss-gate/error_feed_dark.png";
@@ -85,12 +87,57 @@ const FEATURES = {
   },
 };
 
-export default function OSSUpgradeGate({ feature, image, imageDark }) {
+const LICENSE_CTA = "Manage license";
+const CONTACT_CTA = "Talk to us";
+
+const REASONS = {
+  LICENSE_EXPIRED: {
+    note: "Your license has expired — renew it to restore access.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_TRIAL_EXPIRED: {
+    note: "Your trial has ended — add a license key to restore access.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_INVALID: {
+    note: "Your license key could not be validated.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  FEATURE_NOT_IN_GRACE: {
+    note: "This feature is not available during your license's grace period.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  LICENSE_VERSION_UNSUPPORTED: {
+    note: "Your license does not cover this version.",
+    label: LICENSE_CTA,
+    toLicense: true,
+  },
+  EE_CODE_UNAVAILABLE: {
+    note: "This deployment is running an image built without the EE package, so a license key alone will not enable this. Contact your administrator.",
+    label: CONTACT_CTA,
+  },
+  RESOLVER_UNAVAILABLE: {
+    note: "Feature access could not be resolved on this deployment. Contact your administrator.",
+    label: CONTACT_CTA,
+  },
+  FEATURE_UNKNOWN: {
+    note: "This server does not recognise the feature — it may be running an older version.",
+    label: CONTACT_CTA,
+  },
+};
+
+export default function OSSUpgradeGate({ feature, image, imageDark, reasonCode }) {
+  const router = useRouter();
   const config = FEATURES[feature];
   if (!config) {
     logger.warn(`OSSUpgradeGate: unknown feature "${feature}"`);
     return null;
   }
+  const reason = REASONS[reasonCode];
   return (
     <FeatureGateOverlay
       image={image || config.image}
@@ -99,9 +146,14 @@ export default function OSSUpgradeGate({ feature, image, imageDark }) {
       title={config.title}
       description={config.description}
       steps={config.steps}
-      footnote={config.footnote}
-      primaryLabel="Upgrade to EE license key"
-      primaryHref={CONTACT_URL}
+      footnote={reason?.note || config.footnote}
+      primaryLabel={reason?.label || "Upgrade to EE license key"}
+      primaryHref={reason?.toLicense ? undefined : CONTACT_URL}
+      onPrimary={
+        reason?.toLicense
+          ? () => router.push(paths.dashboard.settings.eeLicenses)
+          : undefined
+      }
       secondaryLabel="Read docs"
       secondaryHref={config.docsUrl || DOCS_URL}
     />
@@ -112,4 +164,5 @@ OSSUpgradeGate.propTypes = {
   feature: PropTypes.oneOf(Object.keys(FEATURES)).isRequired,
   image: PropTypes.string,
   imageDark: PropTypes.string,
+  reasonCode: PropTypes.string,
 };

--- a/frontend/src/components/oss-upgrade-gate/oss-upgrade-gate.jsx
+++ b/frontend/src/components/oss-upgrade-gate/oss-upgrade-gate.jsx
@@ -4,131 +4,14 @@ import FeatureGateOverlay from "src/components/feature-gate/FeatureGateOverlay";
 import { useRouter } from "src/routes/hooks";
 import { paths } from "src/routes/paths";
 import { logger } from "src/utils/logger";
-import errorFeedPreview from "src/assets/oss-gate/error_feed_light.png";
-import errorFeedPreviewDark from "src/assets/oss-gate/error_feed_dark.png";
-import optimizationPreview from "src/assets/oss-gate/optimization_light.png";
-import optimizationPreviewDark from "src/assets/oss-gate/optimization_dark.png";
-import falconAIPreview from "src/assets/oss-gate/falcon_ai_light.png";
-import falconAIPreviewDark from "src/assets/oss-gate/falcon_ai_dark.png";
-
-const CONTACT_URL = "https://futureagi.com/talk-to-human";
-const DOCS_URL = "https://docs.futureagi.com";
-
-const FEATURES = {
-  errorFeed: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to access Error Feed",
-    description:
-      "Auto-clustered error triage and production failure insights, so you can ship with confidence.",
-    image: errorFeedPreview,
-    imageDark: errorFeedPreviewDark,
-    steps: [
-      "Talk to us to enable Error Feed on your workspace.",
-      "Point your SDK or project at Future AGI.",
-      "Errors are clustered and start flowing into this feed automatically.",
-    ],
-    footnote:
-      "Prefer self-hosting? Error Feed is on the open-source roadmap — star the repo to follow along.",
-  },
-  knowledgeBase: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to access Knowledge Base",
-    description:
-      "Ground your agents in your own documents with managed retrieval when you're ready to scale.",
-    steps: [
-      "Talk to us to enable Knowledge Base on your workspace.",
-      "Upload your documents or connect a source.",
-      "Your agents retrieve grounded answers from your knowledge automatically.",
-    ],
-  },
-  optimization: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to run Optimization",
-    description:
-      "Automatically optimize your prompts and agents against your evals when you're ready to scale.",
-    image: optimizationPreview,
-    imageDark: optimizationPreviewDark,
-    steps: [
-      "Talk to us to enable Optimization on your workspace.",
-      "Pick a dataset or simulation and choose an optimizer.",
-      "We iterate on your prompts and surface the best-performing variant.",
-    ],
-  },
-  falconAI: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to use Falcon AI",
-    description:
-      "Your AI copilot for Future AGI — ask questions, build evals, and debug traces in natural language.",
-    image: falconAIPreview,
-    imageDark: falconAIPreviewDark,
-    steps: [
-      "Talk to us to enable Falcon AI on your workspace.",
-      "Connect your tools so Falcon AI can act on your data.",
-      "Ask in plain language and Falcon AI does the work for you.",
-    ],
-  },
-  usageSummary: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to see usage & spend",
-    description:
-      "Full visibility into your usage, spend, and credits when you're ready to grow.",
-  },
-  pricing: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade for flexible plans",
-    description:
-      "Flexible plans that scale with your team when you're ready to grow.",
-  },
-  billing: {
-    eyebrow: "Cloud feature",
-    title: "Upgrade to manage billing",
-    description:
-      "Payment methods, invoices, and budget controls when you're ready to grow.",
-  },
-};
-
-const LICENSE_CTA = "Manage license";
-const CONTACT_CTA = "Talk to us";
-
-const REASONS = {
-  LICENSE_EXPIRED: {
-    note: "Your license has expired — renew it to restore access.",
-    label: LICENSE_CTA,
-    toLicense: true,
-  },
-  LICENSE_TRIAL_EXPIRED: {
-    note: "Your trial has ended — add a license key to restore access.",
-    label: LICENSE_CTA,
-    toLicense: true,
-  },
-  LICENSE_INVALID: {
-    note: "Your license key could not be validated.",
-    label: LICENSE_CTA,
-    toLicense: true,
-  },
-  FEATURE_NOT_IN_GRACE: {
-    note: "This feature is not available during your license's grace period.",
-    label: LICENSE_CTA,
-    toLicense: true,
-  },
-  LICENSE_VERSION_UNSUPPORTED: {
-    note: "Your license does not cover this version.",
-    label: LICENSE_CTA,
-    toLicense: true,
-  },
-  EE_CODE_UNAVAILABLE: {
-    note: "This deployment is running an image built without the EE package, so a license key alone will not enable this. Contact your administrator.",
-    label: CONTACT_CTA,
-  },
-  RESOLVER_UNAVAILABLE: {
-    note: "Feature access could not be resolved on this deployment. Contact your administrator.",
-    label: CONTACT_CTA,
-  },
-  FEATURE_UNKNOWN: {
-    note: "This server does not recognise the feature — it may be running an older version.",
-    label: CONTACT_CTA,
-  },
-};
+import {
+  CONTACT_URL,
+  DOCS_URL,
+  DOCS_CTA,
+  UPGRADE_CTA,
+  FEATURES,
+  REASONS,
+} from "./constants";
 
 export default function OSSUpgradeGate({ feature, image, imageDark, reasonCode }) {
   const router = useRouter();
@@ -147,14 +30,14 @@ export default function OSSUpgradeGate({ feature, image, imageDark, reasonCode }
       description={config.description}
       steps={config.steps}
       footnote={reason?.note || config.footnote}
-      primaryLabel={reason?.label || "Upgrade to EE license key"}
+      primaryLabel={reason?.label || UPGRADE_CTA}
       primaryHref={reason?.toLicense ? undefined : CONTACT_URL}
       onPrimary={
         reason?.toLicense
           ? () => router.push(paths.dashboard.settings.eeLicenses)
           : undefined
       }
-      secondaryLabel="Read docs"
+      secondaryLabel={DOCS_CTA}
       secondaryHref={config.docsUrl || DOCS_URL}
     />
   );


### PR DESCRIPTION
## Summary

Restores the image-based upgrade gate for Falcon AI and Error Feed, and makes the gate's footnote and primary CTA reflect *why* a capability was denied instead of always selling an EE license.

## Why / problem

`973fa0288` ("drive feature UI from capabilities, not deployment mode") correctly replaced the `isOSS` checks with `CapabilityGate` — `isOSS` cannot tell an unlicensed self-host from a licensed EE install. But it also moved Falcon AI and Error Feed *off* `OSSUpgradeGate`, and `CapabilityGate` renders only a rocket icon plus a line of text.

Two consequences:

1. The blurred preview screenshots added in #1645 and #1868 were orphaned. `error_feed_light/dark.png` and `falcon_ai_light/dark.png` still ship in the bundle and their registry entries still exist, but nothing renders them.
2. Every denial produced the same "Contact us to upgrade" wall, plus a developer-facing string: `Access to "error_feed" is restricted: LICENSE_EXPIRED.` — both interpolations are machine ids.

That second point is a real misdirect. Of the reason codes `tfc/capabilities/service.py` can return, only three are genuine upsells:

| Group | Codes | Upsell correct? |
|---|---|---|
| Genuine upsell | `LICENSE_MISSING`, `LICENSE_FEATURE_MISSING`, `PLAN_FEATURE_MISSING` | Yes |
| License fault | `LICENSE_EXPIRED`, `LICENSE_TRIAL_EXPIRED`, `LICENSE_INVALID`, `FEATURE_NOT_IN_GRACE`, `LICENSE_VERSION_UNSUPPORTED` | No — they already bought it |
| Deployment fault | `EE_CODE_UNAVAILABLE`, `RESOLVER_UNAVAILABLE`, `FEATURE_UNKNOWN` | No — nothing to buy |

`EE_CODE_UNAVAILABLE` is the sharpest case: it fires purely on deployment flavor, so an image built without `ee/` renders a billing wall for what is actually a packaging bug.

## What changed

**`CapabilityGate.jsx`**
- On denial, capabilities with a preview entry render `<OSSUpgradeGate>` instead of the bare icon state. Mapped: `error_feed` → `errorFeed`, `falcon_ai` → `falconAI`.
- `reasonCode` is forwarded through.
- Loading, error/retry, and allowed paths are untouched, so a transient `/api/capabilities/` failure still shows retry rather than an upsell.

**`oss-upgrade-gate.jsx`**
- New optional `reasonCode` prop, mapped through a `REASONS` table holding `note` + `label` + `toLicense` so copy and CTA cannot drift apart.
- Footnote: plain-English text per reason. No feature ids, no enum constants. The three upsell codes are absent from the table and fall through to the original per-feature footnote, so existing marketing copy is unchanged.
- Primary CTA: license faults get **"Manage license"** routed to `/dashboard/settings/ee-licenses`; deployment faults get **"Talk to us"**; upsells keep **"Upgrade to EE license key"** → contact URL.

Internal navigation uses `onPrimary` + `useRouter().push` rather than `primaryHref`, because `FeatureGateOverlay` forces `target="_blank"` on the href path and an in-app route would have opened a new tab.

Optimization is deliberately **not** mapped — #1868 ungated it in OSS and that stays true.

## Tests

- [ ] No test changes. The affected surfaces have no existing unit coverage.

## Commands

- [x] `npx eslint src/components/capability-gate/CapabilityGate.jsx src/components/oss-upgrade-gate/oss-upgrade-gate.jsx` — 0 errors, 0 warnings

## Backwards compatibility

Fully additive. `reasonCode` is optional, and no other caller passes it, so every existing `OSSUpgradeGate` usage keeps its current label and footnote. No API, contract, or data-shape changes. Capability decisions themselves are untouched — this only changes what a denial *looks* like.

## Manual verification

- [ ] OSS / unlicensed self-host: Falcon AI page, Falcon AI connectors, and both Error Feed routes show the blurred preview gate again
- [ ] Licensed EE: all four surfaces render normally, no gate
- [ ] Expired license: footnote reads "Your license has expired…" and the CTA is "Manage license", landing on Settings → License
- [ ] Image built without `ee/`: footnote names the missing EE package, CTA is "Talk to us"
- [ ] Capabilities endpoint down: neutral retry state, not an upsell

## Type of change

- [x] Bug fix (restores gate visuals lost in a refactor)
- [x] New feature (reason-aware gate copy and CTA)
- [ ] Breaking change

## Checklist

- [x] Lint passes on all changed files
- [x] No new code comments added
- [ ] Screenshots verified in light + dark
- [ ] Verified against a real denial from each reason group

## Known gaps (not addressed here)

- The **"EE Licenses" nav entry is commented out** in `SettingsLayout.jsx:107-111`, so `/dashboard/settings/ee-licenses` is reachable only by direct URL. This predates `973fa0288`. The new CTA is one such direct link so it works, but the missing nav item is worth its own fix.
- The license route is wrapped in `RoleProtection allowedRoles={billingAllowedRoles}`. A plain member clicking "Manage license" lands on the role-protection fallback. Gating the CTA on role would need role context inside `OSSUpgradeGate`.
- The bare `Stack` fallback in `CapabilityGate` still shows the raw `feature` id and `reason_code` for capabilities with no preview entry.

## Backout

Revert the commit. Two files, no migrations, no backend changes.

## Linear

No existing ticket covers this regression — TH-7230 tracked the original gating and TH-7282 the layout fix. Happy to file one and relink if you'd prefer it tracked.
