### PR TITLE
fix(frontend): only invert black provider logos in dark mode [TH-7274]

### DIFF
--- a/frontend/src/components/custom-model-dropdown/SearchField.jsx
+++ b/frontend/src/components/custom-model-dropdown/SearchField.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React, { forwardRef, useCallback, useRef } from "react";
 import Iconify from "../iconify";
 import { useCombinedRefs } from "src/hooks/use-combined-refs";
+import { isBlackBackgroundLogo } from "./common";
 
 const SearchField = forwardRef(
   (
@@ -160,7 +161,7 @@ const SearchField = forwardRef(
                     width: theme.spacing(2.5),
                     objectFit: "cover",
                     ...(theme.palette.mode === "dark" &&
-                      logoUrl?.includes("provider-logos") && {
+                      isBlackBackgroundLogo(logoUrl) && {
                         filter: "invert(1) brightness(2)",
                       }),
                   })}

--- a/frontend/src/components/custom-model-dropdown/common.js
+++ b/frontend/src/components/custom-model-dropdown/common.js
@@ -1,5 +1,16 @@
 export const LOGO_WITH_BLACK_BACKGROUND = ["openai", "cerebras", "ollama"];
 
+// `<Image>` call sites gate the dark-mode invert on the model's `providers`
+// field, but raw `<img>` sites don't always have one (simulator agent rows
+// carry only the URL). Each allowlisted provider owns exactly one filename in
+// ProviderLogoUrls, so the URL answers the same question.
+export const isBlackBackgroundLogo = (logoUrl) =>
+  typeof logoUrl === "string" &&
+  logoUrl.includes("provider-logos") &&
+  LOGO_WITH_BLACK_BACKGROUND.some((provider) =>
+    logoUrl.toLowerCase().includes(provider),
+  );
+
 // model_detail objects exist in two shapes: the backend contract is snake_case
 // (models_list, prompt template snapshots) while dropdown-picked values carry
 // camelCase aliases. Fill both so every reader resolves regardless of source.

--- a/frontend/src/components/simulator-agent/SimulatorAgentCellRenderer.jsx
+++ b/frontend/src/components/simulator-agent/SimulatorAgentCellRenderer.jsx
@@ -14,6 +14,7 @@ import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import PropTypes from "prop-types";
 import { formatDistanceToNow } from "date-fns";
 import SvgColor from "../svg-color";
+import { isBlackBackgroundLogo } from "../custom-model-dropdown/common";
 
 const SimulatorAgentCellRenderer = (params) => {
   const theme = useTheme();
@@ -90,7 +91,7 @@ const SimulatorAgentCellRenderer = (params) => {
                   height: theme.spacing(2),
                   objectFit: "cover",
                   ...(theme.palette.mode === "dark" &&
-                    data?.logoUrl?.includes("provider-logos") && {
+                    isBlackBackgroundLogo(data?.logoUrl) && {
                       filter: "invert(1) brightness(2)",
                     }),
                 }}

--- a/frontend/src/sections/workbench/workbenchDetailView/cell-renderer.jsx
+++ b/frontend/src/sections/workbench/workbenchDetailView/cell-renderer.jsx
@@ -3,6 +3,7 @@ import { Avatar, Box, IconButton, Typography, useTheme } from "@mui/material";
 import PropTypes from "prop-types";
 import { format } from "date-fns";
 import stringAvatar from "src/utils/stringAvatar";
+import { isBlackBackgroundLogo } from "src/components/custom-model-dropdown/common";
 
 export const CustomCellRender = ({ value, data, column }) => {
   const theme = useTheme();
@@ -92,7 +93,7 @@ export const CustomCellRender = ({ value, data, column }) => {
                     height: theme.spacing(2),
                     objectFit: "cover",
                     ...(theme.palette.mode === "dark" &&
-                      modelDetail?.logo_url?.includes("provider-logos") && {
+                      isBlackBackgroundLogo(modelDetail?.logo_url) && {
                         filter: "invert(1) brightness(2)",
                       }),
                   }}


### PR DESCRIPTION
**Ticket:** [TH-7274](https://linear.app/future-agi/issue/TH-7274/oss-mistral-logo-colour-is-wrong-after-creating-agent-definition) — Closes TH-7274

## What was the bug

In dark mode, selecting a Mistral model in the Agent Definition → Configuration step rendered the Mistral logo in **cyan/blue** instead of its brand orange. The same logo rendered correctly in the dropdown list directly below it, so both colours were visible on screen at once.

The cyan is the exact photographic negative of the orange: a `filter: invert(1) brightness(2)` was being applied to a logo that never needed it.

## What changes have been done

- `frontend/src/components/custom-model-dropdown/common.js` — new `isBlackBackgroundLogo(logoUrl)` helper, built on the existing `LOGO_WITH_BLACK_BACKGROUND` list
- `frontend/src/components/custom-model-dropdown/SearchField.jsx` — selected-value adornment now gates the invert on the helper
- `frontend/src/sections/workbench/workbenchDetailView/cell-renderer.jsx` — same gate on the Models cell
- `frontend/src/components/simulator-agent/SimulatorAgentCellRenderer.jsx` — same gate on the model cell

## Why the changes

The dark-mode invert was added so that solid-black provider logos (OpenAI, Cerebras, Ollama) stay visible against the dark background. `LOGO_WITH_BLACK_BACKGROUND` and the `disableThemeFilter` prop on `<Image>` were introduced later to stop it from also inverting coloured logos, and were threaded through all 11 `<Image>` call sites.

These three sites were missed because they render a raw `<Box component="img">` rather than `<Image>`, so a prop-threading sweep never reached them. Each still inverted **any** URL under `provider-logos/`, which is why Mistral came out cyan.

The helper keys off the logo filename rather than the model's `providers` field. Provider names come from litellm and several distinct values map to the same logo file — `text-completion-openai` resolves to `openai-icon.png` (`ProviderLogoUrls.TEXT_COMPLETION_OPENAI`) but is not in the allowlist, so a provider-keyed check would skip the invert and render a black logo on a black background. All 37 distinct filenames in `ProviderLogoUrls` were checked: each of `openai`, `cerebras`, `ollama` matches exactly one file and nothing else (`openrouter.png` does not contain `openai`; `vertex+ai.png` correctly stays un-inverted).

The `provider-logos` guard is kept inside the helper, so user-uploaded custom model logos are never touched.

**Note for review:** only the `SearchField` site is reachable in the running app. The other two sit behind commented-out routes (`dashboard.jsx:284` for the old workbench list, superseded by `workbench-v2`; `dashboard.jsx:316`/`:1325` for simulator agents). They are fixed so the pattern doesn't resurface if either component is revived, but they cannot be demoed.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Dark mode, select a Mistral model in Agent Definition → Configuration | Logo renders orange, matching the dropdown row |
| 2 | Dark mode, select an OpenAI model | Logo still inverts to white and stays visible (regression guard) |
| 3 | Dark mode, open the model dropdown list | Unchanged — already correct via `<Image disableThemeFilter>` |
| 4 | Light mode, any provider | Unchanged — the invert only ever applied in dark mode |
| 5 | Custom model with an uploaded logo | Never inverted, URL is not under `provider-logos/` |

## How to reproduce (original bug)

1. Switch the dashboard to dark mode
2. Go to **Agents → Agent Definitions → Create**
3. Advance to the **Configuration** step
4. Open **Model Used** and pick any `mistral/*` model
5. Compare the logo in the field against the same row in the dropdown list — before this change the field shows cyan, the list shows orange

## Commands

```bash
cd frontend
npx eslint src/components/custom-model-dropdown/common.js \
           src/components/custom-model-dropdown/SearchField.jsx \
           src/sections/workbench/workbenchDetailView/cell-renderer.jsx \
           src/components/simulator-agent/SimulatorAgentCellRenderer.jsx

npx vitest run src/components/custom-model-dropdown src/sections/workbench
```

Both clean: eslint exits 0, vitest 8 files / 50 tests passing.

## Videos and screenshots

**Before — Mistral logo rendering cyan in the field while the dropdown row is orange:**

https://github.com/user-attachments/assets/568675e7-e733-43bb-bb7d-b53cfe508e50

**After — Mistral renders orange on the saved agent definition:**

![th7274-after-mistral](https://github.com/user-attachments/assets/cf6ffdf2-24da-4903-8bba-17a4a98c680b)

The OpenAI regression case (test case 2) was verified in the browser at the same time: the black OpenAI logo still inverts to white and stays visible against the dark background. No screenshot captured.

