### PR TITLE
fix(model-hub): seed default prompt labels on migrate (TH-7261)

### DIFF
--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -1,7 +1,30 @@
 import structlog
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 
 logger = structlog.get_logger(__name__)
+
+
+def _seed_prompt_labels_after_migrate(sender, **kwargs):
+    """Auto-seed the global Production/Staging/Development prompt labels
+    after every migrate (TH-7261).
+
+    Nothing else ever creates these rows — the only other caller is an API
+    action the frontend never hits — so a fresh database shows "No labels
+    found" in the Add Tags modal. Mirrors the node-template seeding in
+    agent_playground.apps. Idempotent via get_or_create.
+    """
+    try:
+        from model_hub.models.prompt_label import PromptLabel
+
+        created = PromptLabel.create_default_system_labels()
+        if created:
+            logger.info(
+                "default_prompt_labels_seeded",
+                created=[label.name for label in created],
+            )
+    except Exception:
+        logger.exception("default_prompt_label_seed_failed")
 
 
 class ModelHubConfig(AppConfig):
@@ -14,6 +37,14 @@ class ModelHubConfig(AppConfig):
         import sys
 
         import model_hub.signals  # noqa: F401
+
+        # Registered before the migrate early-return below — post_migrate
+        # fires during the `migrate` command itself.
+        post_migrate.connect(
+            _seed_prompt_labels_after_migrate,
+            sender=self,
+            dispatch_uid="model_hub_seed_default_prompt_labels",
+        )
 
         if "migrate" in sys.argv or "makemigrations" in sys.argv:
             return

--- a/futureagi/model_hub/tests/test_seed_default_prompt_labels.py
+++ b/futureagi/model_hub/tests/test_seed_default_prompt_labels.py
@@ -1,0 +1,61 @@
+"""Tests for the post_migrate auto-seed of default prompt labels (TH-7261).
+
+Fresh databases had no Production/Staging/Development system labels because
+nothing ever called PromptLabel.create_default_system_labels() — the Add Tags
+modal showed "No labels found". The seed now runs after every migrate via a
+post_migrate hook in ModelHubConfig.
+"""
+
+import pytest
+from rest_framework import status as http_status
+
+from model_hub.apps import _seed_prompt_labels_after_migrate
+from model_hub.models.prompt_label import LabelTypeChoices, PromptLabel
+
+DEFAULT_LABEL_NAMES = {"Production", "Staging", "Development"}
+
+
+def _global_system_labels():
+    return PromptLabel.no_workspace_objects.filter(
+        organization__isnull=True, type=LabelTypeChoices.SYSTEM.value
+    )
+
+
+@pytest.mark.unit
+class TestSeedDefaultPromptLabels:
+    def test_post_migrate_creates_default_labels(self, db):
+        _seed_prompt_labels_after_migrate(sender=None)
+        assert (
+            set(_global_system_labels().values_list("name", flat=True))
+            == DEFAULT_LABEL_NAMES
+        )
+
+    def test_post_migrate_is_idempotent(self, db):
+        _seed_prompt_labels_after_migrate(sender=None)
+        _seed_prompt_labels_after_migrate(sender=None)
+        assert _global_system_labels().count() == len(DEFAULT_LABEL_NAMES)
+
+    def test_hook_is_connected_to_post_migrate(self):
+        from django.db.models.signals import post_migrate
+
+        # receivers entries are (lookup_key, receiver, ...) where
+        # lookup_key is (dispatch_uid_or_id, sender_id)
+        receiver_ids = {entry[0][0] for entry in post_migrate.receivers}
+        assert "model_hub_seed_default_prompt_labels" in receiver_ids
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestSeededLabelsVisibleInListEndpoint:
+    def test_seeded_labels_returned_by_prompt_labels_list(self, auth_client, db):
+        """GET /model-hub/prompt-labels/ feeds the Add Tags modal — seeded
+        system labels must show up for every org/workspace."""
+        _seed_prompt_labels_after_migrate(sender=None)
+
+        response = auth_client.get("/model-hub/prompt-labels/")
+        assert response.status_code == http_status.HTTP_200_OK
+
+        payload = response.json()
+        rows = payload.get("results") or payload.get("result") or payload
+        names = {row["name"] for row in rows}
+        assert DEFAULT_LABEL_NAMES <= names


### PR DESCRIPTION
## Summary
- The "Add Tags" modal in the prompt playground shows "No labels found" on OSS/fresh deployments — the default Production/Staging/Development tags are missing.
- Root cause: those tags are global DB rows (`organization=NULL`, `type="system"`) created only by `PromptLabel.create_default_system_labels()`, and nothing ever calls it. The sole caller is `POST /model-hub/prompt-labels/create-system-labels/`, which the frontend never hits. No migration, management command, or signal seeds them, so any fresh database has zero default tags (verified empirically on a live local stack: `GLOBAL SYSTEM LABELS: []`).
- Fix: seed them automatically after every `migrate` via a `post_migrate` hook, mirroring the node-template seeding pattern in `agent_playground/apps.py` (TH-6727). The seeder is idempotent (`get_or_create`), so re-runs are no-ops and deleted rows self-heal on the next deploy.

Closes TH-7261

## Changes by file
- `futureagi/model_hub/apps.py`: added module-level `_seed_prompt_labels_after_migrate` receiver and connected it to `post_migrate` in `ModelHubConfig.ready()`. Registered before the existing `migrate`/`pytest` early-returns since `post_migrate` fires during the `migrate` command itself. Failures are logged, never raised, so a broken seed can't block deploys.
- `futureagi/model_hub/tests/test_seed_default_prompt_labels.py`: new tests — hook creates exactly Production/Staging/Development as global system labels, is idempotent, is connected to `post_migrate` under the expected `dispatch_uid`, and the seeded labels are returned by `GET /model-hub/prompt-labels/` (the endpoint that feeds the Add Tags modal).

## Flows touched
- Deploy/migrate: every `python manage.py migrate` run (including no-op runs) now ensures the three default tags exist.
- Prompt playground Add Tags modal: default tags visible on fresh OSS installs.
- `POST /model-hub/prompt-labels/create-system-labels/`: unchanged and still idempotent.

## Test coverage
- Seeding behavior (creation, idempotency, signal registration) and end-to-end visibility through the list endpoint are covered by the new test file.
- Existing prompt-label contract tests (`test_prompt_labels_api_contract.py`) still pass — system-label uniqueness constraint interactions unchanged.

## How tested
- `pytest model_hub/tests/test_seed_default_prompt_labels.py model_hub/tests/test_prompt_labels_api_contract.py` — 9 passed.
- Real deploy-path check: ran `manage.py migrate` against a clean database (zero pending migrations) — hook fired and `GLOBAL SYSTEM LABELS AFTER MIGRATE: ['Development', 'Production', 'Staging']`.
- Full `pytest model_hub/tests` — 3131 passed; 24 failed + 80 errors are pre-existing local-env issues (EE-gated annotation-queue/knowledge-base tests broken by an untracked local `ee/` dir): identical counts reproduced on base commit `872487e64` with these changes stashed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature with breaking side effects)
- [ ] This change requires a documentation update

## Media
_Screenshot / video:_ (placeholder — add manually if relevant)

## Test logs
<details>
<summary>Test run output</summary>

```
$ pytest model_hub/tests/test_seed_default_prompt_labels.py model_hub/tests/test_prompt_labels_api_contract.py -q
model_hub/tests/test_prompt_labels_api_contract.py ....                  [ 77%]
model_hub/tests/test_seed_default_prompt_labels.py .                     [ 88%]
model_hub/tests/test_prompt_labels_api_contract.py .                     [100%]
============================== 9 passed in 6.50s ===============================

$ DJANGO_SETTINGS_MODULE=tfc.settings.test python manage.py migrate
Running migrations:
  No migrations to apply.
$ ... manage.py shell -c "print(sorted(PromptLabel.no_workspace_objects.filter(organization__isnull=True, type='system').values_list('name', flat=True)))"
GLOBAL SYSTEM LABELS AFTER MIGRATE: ['Development', 'Production', 'Staging']

$ pytest model_hub/tests -q            # with fix
= 24 failed, 3131 passed, 13 skipped, 191 deselected, 11 xfailed, 2 xpassed, 80 errors in 163.69s =
$ pytest model_hub/tests/<failing files> -q   # base commit 872487e64, changes stashed
======= 24 failed, 301 passed, 5 xfailed, 1 xpassed, 80 errors in 25.15s =======
(identical failure set — pre-existing local-env EE-stub issue, unrelated to this change)
```

</details>

Made with [Cursor](https://cursor.com)