### PR TITLE
fix(evals): surface mutation errors in duplicate eval dialog

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.jsx
@@ -32,6 +32,7 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
   });
 
   const { mutate, isPending } = useMutation({
+    meta: { errorHandled: true },
     mutationFn: (data) =>
       axios.post(endpoints.develop.eval.duplicateEvalsTemplate, data),
     onSuccess: (data) => {
@@ -40,6 +41,13 @@ const DuplicateEvals = ({ open, onClose, evalId, onSubmit }) => {
       });
       handleClose();
       onSubmit(data?.data?.result);
+    },
+    onError: (error) => {
+      const message =
+        typeof error?.result === "string"
+          ? error.result
+          : error?.message || "Failed to duplicate evaluation";
+      enqueueSnackbar(message, { variant: "error" });
     },
   });
 

--- a/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, userEvent } from "src/utils/test-utils";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { enqueueSnackbar } from "notistack";
 import DuplicateEvals from "./DuplicateEvals";
 
 const mockPost = vi.fn();
@@ -22,6 +27,15 @@ vi.mock("notistack", () => ({
   enqueueSnackbar: vi.fn(),
 }));
 
+// Mirror app.jsx's global mutation error handler so the test exercises the
+// same double-snackbar surface that production users hit.
+const handleError = (error, _variable, _context, mutation) => {
+  if (mutation?.options?.meta?.errorHandled) return;
+  if (error?.result) {
+    enqueueSnackbar(String(error.result), { variant: "error" });
+  }
+};
+
 const DEFAULT_PROPS = {
   open: true,
   onClose: vi.fn(),
@@ -31,6 +45,7 @@ const DEFAULT_PROPS = {
 
 function renderComponent(props = {}) {
   const queryClient = new QueryClient({
+    mutationCache: new MutationCache({ onError: handleError }),
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
@@ -69,14 +84,11 @@ describe("DuplicateEvals", () => {
     const user = userEvent.setup();
     renderComponent();
 
-    // Fill in the evaluation name.
     const input = screen.getByPlaceholderText("Enter evaluation name");
     await user.type(input, "my_copy");
 
-    // Submit the form.
     await user.click(screen.getByRole("button", { name: /duplicate/i }));
 
-    // Verify the request was sent to the correct endpoint with snake_case keys.
     expect(mockPost).toHaveBeenCalledTimes(1);
     expect(mockPost).toHaveBeenCalledWith(
       "/model-hub/duplicate-eval-template/",
@@ -104,7 +116,6 @@ describe("DuplicateEvals", () => {
     await user.type(input, "my-copy");
     await user.click(screen.getByRole("button", { name: /duplicate/i }));
 
-    // Wait for the mutation to resolve, then check the callback.
     await vi.waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(resultData);
     });
@@ -121,7 +132,6 @@ describe("DuplicateEvals", () => {
     const input = screen.getByPlaceholderText("Enter evaluation name");
     await user.type(input, "My Special Eval!");
 
-    // The onChange handler should have transformed the value.
     expect(input).toHaveValue("my_special_eval_");
 
     await user.click(screen.getByRole("button", { name: /duplicate/i }));
@@ -130,5 +140,84 @@ describe("DuplicateEvals", () => {
       expect.any(String),
       expect.objectContaining({ name: "my_special_eval_" }),
     );
+  });
+
+  it("shows exactly one error snackbar and keeps the dialog open when the mutation fails", async () => {
+    const backendMessage =
+      "error duplicating the eval template evaluation template with this name already exists";
+    mockPost.mockRejectedValueOnce({
+      result: backendMessage,
+    });
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(
+      screen.getByPlaceholderText("Enter evaluation name"),
+      "my-copy",
+    );
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    await vi.waitFor(() => {
+      // meta: { errorHandled: true } suppresses the global handler, so the
+      // snackbar fires exactly once from the local onError.
+      expect(enqueueSnackbar).toHaveBeenCalledTimes(1);
+      expect(enqueueSnackbar).toHaveBeenCalledWith(backendMessage, {
+        variant: "error",
+      });
+    });
+
+    // Dialog stays open so the user can retry.
+    expect(screen.getByText("Duplicate evaluation")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Enter evaluation name")).toHaveValue(
+      "my-copy",
+    );
+  });
+
+  it("falls back to error.message when error.result is not a string", async () => {
+    // error.result is typically a string from build_error_envelope, but can be
+    // an object when the backend attaches an error_code (e.g. usage-limit or
+    // structured login responses).
+    mockPost.mockRejectedValueOnce({
+      result: { eval_template_id: ["This field is required."] },
+      message: "Something went wrong",
+    });
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(
+      screen.getByPlaceholderText("Enter evaluation name"),
+      "test",
+    );
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    await vi.waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledTimes(1);
+      expect(enqueueSnackbar).toHaveBeenCalledWith("Something went wrong", {
+        variant: "error",
+      });
+    });
+  });
+
+  it("falls back to a default message when neither result nor message is present", async () => {
+    mockPost.mockRejectedValueOnce({});
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(
+      screen.getByPlaceholderText("Enter evaluation name"),
+      "test",
+    );
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    await vi.waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalledTimes(1);
+      expect(enqueueSnackbar).toHaveBeenCalledWith(
+        "Failed to duplicate evaluation",
+        { variant: "error" },
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

The duplicate evaluation dialog in the EvaluationDrawer uses `useMutation` with only an `onSuccess` callback. There is no `onError` handler, so every failure — a 400 from the backend, a network drop, a contract validation error — resolves to the same user-visible outcome: the loading spinner stops, the dialog stays open, and nothing else happens. No feedback of any kind reaches the user.

This was flagged by @commitPirate during review of #1775, and the analysis below follows from that observation. The key mismatch in #1768 shipped undetected precisely because this dialog fails silently — if an error snackbar had been present, the bug would have been caught the first time anyone tested the dialog.

## Linked issues

Closes #2017

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Add `onError` callback to the `useMutation` in `DuplicateEvals.jsx`**

- Three-tier fallback chain: `error?.result` (string) → `error?.message` → `"Failed to duplicate evaluation"`
- Guards against non-string `error.result` with `typeof` check to prevent `[object Object]` in the snackbar. `error.result` is typically a string from `build_error_envelope`, but the backend can return an object when it attaches an `error_code` (e.g. structured login or usage-limit responses).
- Sets `meta: { errorHandled: true }` to suppress the global `MutationCache.onError` in `app.jsx`, preventing a duplicate snackbar (consistent with 49 other usages across `src/`).

**B. Merge test suites after #1775 landed on dev**

- #1775 added `DuplicateEvals.test.jsx` with 5 tests (render, hidden, snake_case payload, onSubmit callback, name transformation).
- This PR adds 3 error-path tests (string `result`, non-string `result` fallback, missing `result`/`message` fallback), bringing the total to 8.
- The rebase resolved the add/add conflict by keeping this branch's `QueryClient` harness (which mirrors the global `MutationCache.onError`) as the base and porting the 4 non-overlapping tests from #1775 into it.
- The regression guard for #1768 (`sends eval_template_id (snake_case) in the POST payload`) is preserved.

---

## 2) Why the changes were done

- **Product/UX:** clicking "Duplicate" on an evaluation fails silently today. The spinner stops but the dialog stays open, and the user has no way to know the operation failed. With this fix, a red snackbar shows the backend error message, the dialog stays open with the name preserved, and the user can correct and retry.
- **Technical:** the `useMutation` in `DuplicateEvals.jsx` was the only mutation in the `EvaluationDrawer/` directory with zero error handling. `DeleteEval.jsx` resets grid state in its `onError`. `CreateEvaluationGroupDrawer.jsx` resets button state. `DuplicateEvals` did nothing. The fix follows the established project convention (`error?.result || error?.message || "Failed to …"`) used by a dozen other mutation call sites.
- **Architecture:** no new imports, no helper extraction, no shared hook — the fix is a single `onError` callback in the component. Scope is minimal and correctly scoped to this one dialog.

---

## 3) Tests written + scenarios each covers

`frontend/src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx` (8 tests)

| # | Test | Source | Assertions |
|---|---|---|---|
| 1 | renders the dialog when open | #1775 | Title is in the document |
| 2 | does not render the dialog when closed | #1775 | Title is not in the document |
| 3 | sends eval_template_id (snake_case) in the POST payload | #1775 | POST called with `eval_template_id`, not `evalTemplateId` — regression guard for #1768 |
| 4 | calls onSubmit with the result on success | #1775 | `onSubmit` callback receives `data.result` |
| 5 | lowercases the name and replaces invalid characters | #1775 | Name transformation via `handleNameTransformation` |
| 6 | shows exactly one error snackbar and keeps the dialog open | This PR | Snackbar called once with backend message; dialog stays open; input preserved |
| 7 | falls back to error.message when error.result is not a string | This PR | `typeof` guard redirects to `error.message` when `result` is an object |
| 8 | falls back to a default message when neither result nor message is present | This PR | Default fallback string shown |

The test `QueryClient` mirrors the production `MutationCache.onError` so removing `meta: { errorHandled: true }` causes test failures through double-snackbar assertions (`toHaveBeenCalledTimes(1)`). Lint and all 8 tests pass.

---

## 4) How to verify

### Unit tests

```bash
cd frontend && npx vitest run src/sections/common/EvaluationDrawer/DuplicateEvals.test.jsx
```

### Manual verification

1. Start the stack and open the dashboard.
2. Go to Evaluations, create an evaluation.
3. Click the duplicate icon in the evaluation action buttons.
4. Type a name and submit — the success snackbar fires and a copy appears.
5. Try duplicating with the same name — the error snackbar fires with the backend message, the dialog stays open, and the name is still in the text field.

---

## 5) Edge cases & considerations

- **Double snackbar prevented:** `meta: { errorHandled: true }` tells the global `MutationCache.onError` (app.jsx:82-84) to skip this mutation. Without it, the user sees two error snackbars — one from the local `onError` and one from the global handler.
- **Non-string `error.result` guarded:** `typeof error?.result === "string"` prevents `[object Object]` in the snackbar. `error.result` is typically a string from `build_error_envelope`, but the backend attaches an object when an `error_code` is present (structured login errors, usage-limit responses). In that case the code falls back to `error.message` or the default.
- **Dialog stays open on error:** `handleClose()` (which calls `reset()` and `onClose()`) is only called in `onSuccess`. On failure, the dialog remains open with the user input preserved so they can correct and retry.
- **Button re-enabled:** React Query sets `isPending` to `false` on both success and error, so the `LoadingButton` spinner stops and the button is re-enabled automatically.
- **Success path unchanged:** `onSuccess` is untouched. The green snackbar, dialog close, and `onSubmit` callback all work exactly as before.
- **Out of scope:** `useDuplicateEval` in `useEvalDetail.js` (used by the eval detail page) also lacks `onError`, but it targets a different UI surface and uses a different mutation setup. That is a separate concern.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] Lint and tests pass on the changed files
- [x] No API surface changed
- [x] No hardcoded secrets, URLs, or PII
- [x] CLA signed
- [x] PR title follows Conventional Commits
