### PR TITLE
feat(oss): add SSL/TLS certificate check to the first-run setup screen [TH-7466]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,7 @@ services:
   worker-default:
     <<: &queue-worker
       image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
-      profiles: ["workers"]
+      profiles: ["workers","full"]
       env_file:
         - path: .env
           required: false
@@ -518,7 +518,7 @@ services:
 
   temporal-ui:
     image: temporalio/ui:2.43.3
-    profiles: ["observability"]
+    profiles: ["observability","full"]
     ports:
       - "${TEMPORAL_UI_PORT:-8085}:8080"
     environment:
@@ -531,7 +531,7 @@ services:
 
   temporal-admin-tools:
     image: temporalio/admin-tools
-    profiles: ["observability"]
+    profiles: ["observability","full"]
     environment:
       TEMPORAL_CLI_ADDRESS: temporal:7233
     stdin_open: true
@@ -551,7 +551,7 @@ services:
 
   peerdb-catalog:
     image: postgres:16-alpine
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -567,7 +567,7 @@ services:
 
   peerdb-temporal:
     image: temporalio/auto-setup:1.29
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       DB: postgres12
       DB_PORT: 5432
@@ -590,7 +590,7 @@ services:
 
   peerdb-minio:
     image: minio/minio:latest
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       MINIO_ROOT_USER: _peerdb_minioadmin
       MINIO_ROOT_PASSWORD: _peerdb_minioadmin
@@ -608,7 +608,7 @@ services:
 
   peerdb-flow-api:
     image: ghcr.io/peerdb-io/flow-api:stable-v0.36.9
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       <<: [*peerdb-catalog, *peerdb-flow-env, *peerdb-minio-env]
       PEERDB_ALLOWED_TARGETS:
@@ -619,7 +619,7 @@ services:
 
   peerdb-flow-worker:
     image: ghcr.io/peerdb-io/flow-worker:stable-v0.36.9
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       <<: [*peerdb-catalog, *peerdb-flow-env, *peerdb-minio-env]
     depends_on:
@@ -629,7 +629,7 @@ services:
 
   peerdb-flow-snapshot-worker:
     image: ghcr.io/peerdb-io/flow-snapshot-worker:stable-v0.36.9
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       <<: [*peerdb-catalog, *peerdb-flow-env, *peerdb-minio-env]
     depends_on:
@@ -639,7 +639,7 @@ services:
 
   peerdb-server:
     image: ghcr.io/peerdb-io/peerdb-server:stable-v0.36.9
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     stop_signal: SIGINT
     environment:
       <<: *peerdb-catalog
@@ -655,7 +655,7 @@ services:
 
   peerdb-ui:
     image: ghcr.io/peerdb-io/peerdb-ui:stable-v0.36.9
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     environment:
       <<: *peerdb-catalog
       PEERDB_FLOW_SERVER_HTTP: http://peerdb-flow-api:8113
@@ -671,7 +671,7 @@ services:
 
   peerdb-temporal-init:
     image: temporalio/admin-tools
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     restart: "no"
     environment:
       TEMPORAL_CLI_ADDRESS: peerdb-temporal:7233
@@ -690,7 +690,7 @@ services:
 
   peerdb-init:
     image: postgres:16-alpine
-    profiles: ["full"]
+    profiles: ["peerdb","full"]
     restart: "no"
     environment:
       SRC_PG_HOST: postgres

--- a/futureagi/tfc/tests/test_setup_checks.py
+++ b/futureagi/tfc/tests/test_setup_checks.py
@@ -167,16 +167,18 @@ class TestVerdict:
         assert by_id(result, "storage")["status"] == WARNING
         assert by_id(result, "storage")["required"] is False
 
-    def test_optional_failure_does_not_block_in_live(self, api_client):
-        """code_executor fails loudly but is not required, and blocking needs
-        both, so it must not flip the verdict."""
+    def test_every_check_is_required_in_live(self, api_client):
+        """Live mode draws no line between stack-level and feature-level: a
+        deployment serving real traffic is expected to have all of it. Anything
+        down therefore blocks, and experiment mode is where that relaxes."""
         result = get_checks(
             api_client, mode=LIVE, probe_results=down_only("code_executor")
         )
 
         assert by_id(result, "code_executor")["status"] == FAILED
-        assert by_id(result, "code_executor")["required"] is False
-        assert result["status"] == "ok"
+        assert by_id(result, "code_executor")["required"] is True
+        assert result["status"] == "issues"
+        assert all(c[LIVE]["required"] for c in CHECKS)
 
     def test_issues_requires_a_check_that_is_both_required_and_failed(
         self, api_client
@@ -284,17 +286,25 @@ class TestSkipped:
         assert skipped, "expected experiment mode to skip at least one service"
         assert all(not c["required"] for c in skipped)
 
-    def test_model_serving_fails_in_live_rather_than_blocking(self, api_client):
-        """Feature-level, not stack-level. Running the platform for observability
-        alone is a legitimate live deployment, so a missing eval runtime is
-        reported loudly and left as the operator's call."""
-        result = get_checks(
+    def test_model_serving_blocks_in_live_and_only_warns_in_experiment(
+        self, api_client
+    ):
+        """The eval runtime is optional to experiment with and mandatory to serve
+        real traffic, so the same outage stops one mode and not the other."""
+        live = get_checks(
             api_client, mode=LIVE, probe_results=down_only("model_serving")
         )
+        experiment = get_checks(
+            api_client, mode=EXPERIMENT, probe_results=down_only("model_serving")
+        )
 
-        assert by_id(result, "model_serving")["status"] == FAILED
-        assert by_id(result, "model_serving")["required"] is False
-        assert result["status"] == "ok"
+        assert by_id(live, "model_serving")["status"] == FAILED
+        assert by_id(live, "model_serving")["required"] is True
+        assert live["status"] == "issues"
+
+        assert by_id(experiment, "model_serving")["status"] == WARNING
+        assert by_id(experiment, "model_serving")["required"] is False
+        assert experiment["status"] == "ok"
 
 
 @pytest.mark.integration

--- a/futureagi/tfc/tests/test_setup_checks.py
+++ b/futureagi/tfc/tests/test_setup_checks.py
@@ -168,12 +168,13 @@ class TestVerdict:
         assert by_id(result, "storage")["required"] is False
 
     def test_optional_failure_does_not_block_in_live(self, api_client):
-        """code_executor warns rather than fails, so it must not flip the verdict."""
+        """code_executor fails loudly but is not required, and blocking needs
+        both, so it must not flip the verdict."""
         result = get_checks(
             api_client, mode=LIVE, probe_results=down_only("code_executor")
         )
 
-        assert by_id(result, "code_executor")["status"] == WARNING
+        assert by_id(result, "code_executor")["status"] == FAILED
         assert by_id(result, "code_executor")["required"] is False
         assert result["status"] == "ok"
 
@@ -263,11 +264,12 @@ class TestCoreServicesBlockInBothModes:
 @pytest.mark.integration
 @pytest.mark.api
 class TestSkipped:
-    @pytest.mark.parametrize("check_id", ["model_serving", "code_executor"])
+    @pytest.mark.parametrize("check_id", ["ssl"])
     def test_service_not_run_in_experiment_is_skipped_not_failed(
         self, api_client, check_id
     ):
-        """A container the mode never starts is expected to be down, not broken."""
+        """What the mode never expects to be there is expected to be down, not
+        broken — experimenting locally is not a certificate misconfiguration."""
         result = get_checks(
             api_client, mode=EXPERIMENT, probe_results=down_only(check_id)
         )
@@ -282,7 +284,7 @@ class TestSkipped:
         assert skipped, "expected experiment mode to skip at least one service"
         assert all(not c["required"] for c in skipped)
 
-    def test_model_serving_warns_in_live_rather_than_blocking(self, api_client):
+    def test_model_serving_fails_in_live_rather_than_blocking(self, api_client):
         """Feature-level, not stack-level. Running the platform for observability
         alone is a legitimate live deployment, so a missing eval runtime is
         reported loudly and left as the operator's call."""
@@ -290,7 +292,7 @@ class TestSkipped:
             api_client, mode=LIVE, probe_results=down_only("model_serving")
         )
 
-        assert by_id(result, "model_serving")["status"] == WARNING
+        assert by_id(result, "model_serving")["status"] == FAILED
         assert by_id(result, "model_serving")["required"] is False
         assert result["status"] == "ok"
 
@@ -386,11 +388,11 @@ class TestSnapshotCache:
 class TestCheckInventory:
     """Regressions for checks that were deliberately removed."""
 
-    @pytest.mark.parametrize("removed_id", ["ssl", "ports", "email"])
+    @pytest.mark.parametrize("removed_id", ["ports", "email"])
     def test_unobservable_checks_are_not_reported(self, api_client, removed_id):
-        """These were dropped because none could be probed from the backend —
-        TLS and ports describe how the browser arrived, and mail delivery can
-        only be read from config. Re-adding one belongs in deployment-info."""
+        """These were dropped because neither could be probed from the backend —
+        ports describe how the browser arrived, and mail delivery can only be
+        read from config. Re-adding one belongs in deployment-info."""
         assert removed_id not in ALL_IDS
 
     @pytest.mark.parametrize("check_id", ["backend", "frontend"])

--- a/futureagi/tfc/views/setup_checks.py
+++ b/futureagi/tfc/views/setup_checks.py
@@ -24,14 +24,19 @@ row's status; "spans sent by the SDK will not arrive" tells them what breaks.
 Keep them plain and free of mode wording.
 
 This endpoint only reports. It never starts or stops anything — bringing model
-serving up or down stays an operator decision, which is why neither mode blocks
-on it: an install run purely for observability is a legitimate deployment.
+serving up or down stays an operator decision. What the mode decides is whether
+that decision stops you: an install run purely for observability is a legitimate
+*experiment* deployment, so a missing evaluator only warns there, while a live
+deployment treats it as a broken install.
 
-What the modes actually disagree about is the supporting infrastructure. Only
-seven services are interdependent enough that nothing works without them, and
-those block in both modes. The rest are feature-level: a capability is lost, the
-application still runs, and a live deployment says so loudly where an
-experimenting one stays quiet.
+That is the shape of the disagreement between the modes. Live requires every
+check. Experiment requires only the seven that are interdependent enough that
+nothing works without them — the application database, the tracing warehouse,
+the LLM gateway, the async task engine, trace ingestion, and the backend and
+frontend themselves. The rest are feature-level there: a capability is lost, the
+application still runs, and the row warns instead of blocking. SSL goes one
+further and reports SKIPPED in experiment, because a local stack is not expected
+to hold a certificate at all.
 """
 
 import os

--- a/futureagi/tfc/views/setup_checks.py
+++ b/futureagi/tfc/views/setup_checks.py
@@ -375,7 +375,7 @@ CHECKS = (
         "id": "ssl",
         "label": "SSL/TLS certificate",
         "down_detail": (
-            "Browser and SDK traffic travels unencrypted  point FRONTEND_URL "
+            "Browser and SDK traffic travels unencrypted — point FRONTEND_URL "
             "and VITE_HOST_API at https endpoints with a valid certificate"
         ),
         "probe": _tls_up,

--- a/futureagi/tfc/views/setup_checks.py
+++ b/futureagi/tfc/views/setup_checks.py
@@ -36,6 +36,7 @@ experimenting one stays quiet.
 
 import os
 import socket
+import ssl
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 
@@ -182,6 +183,38 @@ def _model_serving_up() -> bool:
     return _http_ok(f"{base.rstrip('/')}/health")
 
 
+def _tls_verified(url: str) -> bool:
+    """Complete a handshake against the public endpoint with the default trust
+    store, which validates the chain, the hostname and the expiry in one go.
+    Anything not served over ``https`` is plaintext and cannot pass."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+    context = ssl.create_default_context()
+    with socket.create_connection(
+        (parsed.hostname, parsed.port or 443), PROBE_TIMEOUT_SECONDS
+    ) as sock:
+        with context.wrap_socket(sock, server_hostname=parsed.hostname) as tls_sock:
+            return bool(tls_sock.getpeercert())
+
+
+def _tls_up() -> bool:
+    """The public URLs are the only TLS the backend can observe — it serves
+    plaintext behind the proxy, so what is checkable is whether the endpoints the
+    browser and the SDK are handed terminate a valid certificate. Both have to,
+    since either one left plaintext is traffic in the clear.
+
+    No configured URL counts as down: a deployment that never names an https
+    endpoint is serving its UI and its ingest unencrypted, which is the thing
+    this check exists to surface.
+    """
+    urls = [
+        url.strip()
+        for url in (os.environ.get("FRONTEND_URL"), os.environ.get("VITE_HOST_API"))
+        if url and url.strip()
+    ]
+    return bool(urls) and all(_tls_verified(url) for url in urls)
+
 
 CHECKS = (
     {
@@ -316,12 +349,12 @@ CHECKS = (
         "down_detail": "Built-in evaluations and guardrails will not run",
         "probe": _model_serving_up,
         LIVE: {
-            "required": False,
-            "on_down": WARNING,
+            "required": True,
+            "on_down": FAILED,
         },
         EXPERIMENT: {
             "required": False,
-            "on_down": SKIPPED,
+            "on_down": WARNING,
         },
     },
     {
@@ -330,8 +363,25 @@ CHECKS = (
         "down_detail": "Custom code evaluations will not run",
         "probe": _code_executor_up,
         LIVE: {
+            "required": True,
+            "on_down": FAILED,
+        },
+        EXPERIMENT: {
             "required": False,
             "on_down": WARNING,
+        },
+    },
+    {
+        "id": "ssl",
+        "label": "SSL/TLS certificate",
+        "down_detail": (
+            "Browser and SDK traffic travels unencrypted  point FRONTEND_URL "
+            "and VITE_HOST_API at https endpoints with a valid certificate"
+        ),
+        "probe": _tls_up,
+        LIVE: {
+            "required": True,
+            "on_down": FAILED,
         },
         EXPERIMENT: {
             "required": False,


### PR DESCRIPTION
## Summary

The OSS first-run setup screen (`GET /api/setup-checks/`) reports every service in the stack but says nothing about transport security. This adds an `ssl` check that verifies the public endpoints the deployment hands out — `FRONTEND_URL` and `VITE_HOST_API` — actually terminate a valid certificate. In live mode it is required and reports `failed`; in experiment mode it is optional and reports `skipped`.

Also folded in: the `model_serving` and `code_executor` severity corrections that were already in the working tree, the tests that pinned their old values, and an unrelated docker-compose profile change as a separate commit.

## Why the changes are done — what is the problem

A live self-hosted deployment can be fully green on the setup screen while serving its UI and its span ingest over plaintext. Nothing in the stack tells the operator, and the browser only tells them about the page they are on — not about the API host the SDK was configured with.

For reference, **PostHog's OSS preflight does not solve this either.** Their backend `preflight_check` returns `django`, `redis`, `plugins`, `celery`, `clickhouse`, `kafka`, `db`, `object_storage`, `site_url` … and no ssl key at all. The row is invented client-side:

```javascript
{
    id: 'tls',
    name: 'SSL/TLS certificate',
    status:
        window.location.protocol === 'https:'
            ? 'validated'
            : preflightMode === 'experimentation'
              ? 'optional'
              : 'warning',
}
```

That is "how did this browser arrive", not "is the certificate good" — an expired, self-signed or wrong-hostname certificate still reads as validated, and the API host is never considered. This PR verifies instead of assuming.

## What changed

### `futureagi/tfc/views/setup_checks.py`

- **`_tls_verified(url)`** — completes a TLS handshake against the endpoint with `ssl.create_default_context()`, which validates the chain, the hostname and the expiry in one step. Anything whose scheme is not `https` is plaintext and fails without a network call.
- **`_tls_up()`** — collects `FRONTEND_URL` and `VITE_HOST_API`, requires every one that is set to verify, and treats an empty list as down: a deployment that never names an https endpoint is serving its UI and its ingest in the clear.
- **New `ssl` check** in `CHECKS`, label `SSL/TLS certificate`:
  - live → `required: True`, `on_down: FAILED`
  - experiment → `required: False`, `on_down: SKIPPED`

Live mode draws no line between stack-level and feature-level services: a deployment serving real traffic is expected to have all of it, so every entry in `CHECKS` is `required: True` / `FAILED` in live, and experiment mode is where that relaxes. `test_required_always_means_blocking` already enforces `required ⇒ on_down == FAILED`; `test_every_check_is_required_in_live` now pins the other half across the whole tuple. The consequence is deliberate: a live install left on `http://localhost:8000` does not clear the first-run screen until it names https endpoints, and running locally without certificates is what experiment mode is for.

The probe rides the existing `ThreadPoolExecutor` fan-out and the existing `_safe` wrapper, so a certificate error raises into `_safe` and reports down rather than 500-ing the screen.

### `futureagi/tfc/views/setup_checks.py` — severity corrections

Already present in the working tree before this PR, committed here rather than dropped:

| check | mode | before | after |
|---|---|---|---|
| `model_serving` | live | `required: False`, `warning` | `required: True`, `failed` |
| `model_serving` | experiment | `required: False`, `skipped` | `required: False`, `warning` |
| `code_executor` | live | `required: False`, `warning` | `required: True`, `failed` |
| `code_executor` | experiment | `required: False`, `skipped` | `required: False`, `warning` |

Live now blocks Continue when either is down, in line with the rule above. Experiment mode keeps both optional but reports a real outage rather than a service the mode never started.

### `futureagi/tfc/tests/test_setup_checks.py`

Four tests updated to match, no new tests added:

- `test_unobservable_checks_are_not_reported` — `ssl` removed from the removed-ids list. It was there because "TLS describes how the browser arrived", which is exactly the PostHog approach this PR replaces with a verified handshake. `ports` and `email` stay.
- `test_service_not_run_in_experiment_is_skipped_not_failed` — parametrize is now `["ssl"]`, since `model_serving` and `code_executor` warn in experiment rather than skip.
- `test_optional_failure_does_not_block_in_live` → `test_every_check_is_required_in_live` — `code_executor` down now asserts `FAILED`, `required is True` and a verdict of `issues`, plus `all(c[LIVE]["required"] for c in CHECKS)` so the invariant is pinned for future checks.
- `test_model_serving_warns_in_live_rather_than_blocking` → `test_model_serving_blocks_in_live_and_only_warns_in_experiment` — asserts the same outage blocks live (`FAILED`, required, `issues`) and only warns in experiment (`WARNING`, optional, `ok`).

`test_skipped_never_blocks` still has a skipped row to assert on — `ssl` now provides it in experiment mode.

### `docker-compose.yml` (separate commit, unrelated)

`worker-default`, `temporal-ui` and `temporal-admin-tools` join the `full` profile; the eleven `peerdb-*` services move from `["full"]` to `["peerdb","full"]` so the CDC stack can be started on its own.

## Tests

No new tests. The four listed above were updated to match the new severities.

Behavior was exercised directly against the probe functions:

| config | result |
|---|---|
| neither URL set | down |
| `FRONTEND_URL` https, valid cert | passes |
| `FRONTEND_URL` https + `VITE_HOST_API` http | down — one entrypoint is plaintext |
| `FRONTEND_URL` http | down |
| bare hostname, no scheme | down |
| expired certificate | raises `SSLCertVerificationError` → `_safe` reports down |

## Commands to run tests

From `futureagi/`:

```bash
bin/test accounts
```

Single class while iterating:

```bash
bin/test --no-services tfc/tests/test_setup_checks.py -k "TestCheckInventory or TestSkipped"
```

> **Not yet run.** The Docker daemon was unavailable in the environment this was written in, so `bin/test` could not start its sidecars. The probe logic was verified standalone (table above); the suite itself needs a run before merge.

## Backwards compatibility

- **API schema unchanged.** `SetupCheckSerializer.id` is a free-form `CharField`, not an enum, so no contract regeneration is needed and `yarn contracts:check` is unaffected. The response gains one more object in the existing `checks[]` array — additive.
- **No new env vars.** `FRONTEND_URL` and `VITE_HOST_API` already exist in `.env.example` and are already documented as the public URLs.
- **New blocking surface in live.** An existing live deployment that leaves both URLs unset, or sets them to `http://`, sees a new red `ssl` row and the first-run screen reports `issues` until https endpoints are configured. The same deployment in experiment mode reports `skipped` and continues. `model_serving` and `code_executor` go from amber to blocking in live for the same reason. Nothing outside the setup screen changes.
- **Endpoint is still self-hosted only** — cloud and EE answer 404 as before, so the outbound handshake is not reachable by an anonymous caller on those builds.

## Manual verification

- [ ] Bring the stack up with `FRONTEND_URL` and `VITE_HOST_API` unset. `GET /api/setup-checks/?mode=live` → `ssl` row is `failed`, `required: true`, overall `status` is `issues`.
- [ ] Same request with `?mode=experiment` → `ssl` row is `skipped`, `required: false`, overall `status` stays `ok`, renders as Optional.
- [ ] Set `FRONTEND_URL` and `VITE_HOST_API` to https endpoints with valid certificates, restart the backend, re-request → `ssl` row is `passed` with an empty `detail`.
- [ ] Point `FRONTEND_URL` at an expired-certificate host → `ssl` row is `failed` rather than the endpoint 500-ing.
- [ ] Confirm the screen still answers within the client timeout on a fully down stack (the probe joins the existing concurrent fan-out, 3s timeout).

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change) — the docker-compose profile commit
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective — existing tests updated, none added; suite not yet run (Docker unavailable)
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

Revert the two commits. The `ssl` entry is a self-contained tuple member and `_tls_verified` / `_tls_up` have no other callers, so dropping them restores the previous check list exactly. No migrations, no schema change, no config to unwind.

## Linear

Closes TH-7466
