### PR TITLE
fix(frontend): fall back to native audio on CORS-blocked playback

### DIFF
--- a/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import CustomAudioPlayer from "../../custom-audio/CustomAudioPlayer";
 import PropTypes from "prop-types";
 import { ShowComponent } from "src/components/show";
@@ -11,12 +11,10 @@ import { fileIconByMimeType } from "../../../utils/constants";
 const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
   // WaveSurfer's WebAudio fetch needs CORS headers, which external hosts
   // often lack. Fall back to a plain <audio> element on the load error —
-  // browsers play cross-origin media fine without CORS.
-  const [useNativePlayer, setUseNativePlayer] = useState(false);
-
-  useEffect(() => {
-    setUseNativePlayer(false);
-  }, [url]);
+  // browsers play cross-origin media fine without CORS. Deriving from the
+  // failed URL resets the fallback automatically when the source changes.
+  const [failedUrl, setFailedUrl] = useState(null);
+  const useNativePlayer = failedUrl === url;
   return (
     <div
       style={{
@@ -108,6 +106,7 @@ const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
       {useNativePlayer ? (
         <audio
           controls
+          preload="metadata"
           src={url}
           style={{ width: "100%", display: "block" }}
         />
@@ -116,7 +115,11 @@ const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
           audioData={{
             url: url,
           }}
-          onAudioError={() => setUseNativePlayer(true)}
+          onAudioError={(error) => {
+            // CORS-blocked and unreachable fetches reject with a TypeError;
+            // real HTTP errors (404/403/expired) keep the player's error text.
+            if (error instanceof TypeError) setFailedUrl(url);
+          }}
         />
       )}
     </div>

--- a/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/AudioEmbed.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import CustomAudioPlayer from "../../custom-audio/CustomAudioPlayer";
 import PropTypes from "prop-types";
 import { ShowComponent } from "src/components/show";
@@ -7,7 +7,16 @@ import { fileIconByMimeType } from "../../../utils/constants";
 
 // This component is embedded inside quill editor via createRoot and does NOT have
 // access to MUI ThemeProvider. All styling must use CSS variables or inline styles.
+
 const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
+  // WaveSurfer's WebAudio fetch needs CORS headers, which external hosts
+  // often lack. Fall back to a plain <audio> element on the load error —
+  // browsers play cross-origin media fine without CORS.
+  const [useNativePlayer, setUseNativePlayer] = useState(false);
+
+  useEffect(() => {
+    setUseNativePlayer(false);
+  }, [url]);
   return (
     <div
       style={{
@@ -96,11 +105,20 @@ const AudioEmbed = ({ isEmbed, id, name, size, onDelete, url, mimeType }) => {
         </div>
       </div>
 
-      <CustomAudioPlayer
-        audioData={{
-          url: url,
-        }}
-      />
+      {useNativePlayer ? (
+        <audio
+          controls
+          src={url}
+          style={{ width: "100%", display: "block" }}
+        />
+      ) : (
+        <CustomAudioPlayer
+          audioData={{
+            url: url,
+          }}
+          onAudioError={() => setUseNativePlayer(true)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/PromptCards/EmbedComponents/__tests__/AudioEmbed.test.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/__tests__/AudioEmbed.test.jsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "src/utils/test-utils";
+
+const captured = { onAudioError: null };
+
+vi.mock("src/components/custom-audio/CustomAudioPlayer", () => ({
+  default: (props) => {
+    captured.onAudioError = props.onAudioError;
+    return <div data-testid="custom-audio-player" />;
+  },
+}));
+
+import AudioEmbed from "../AudioEmbed";
+
+const URL_A = "https://example.com/one.mp3";
+const URL_B = "https://example.com/two.mp3";
+
+const renderEmbed = (url) =>
+  render(
+    <AudioEmbed url={url} name="Audio 1" size={1024} id="audio-0" isEmbed />,
+  );
+
+describe("AudioEmbed CORS fallback", () => {
+  it("renders the WaveSurfer player until the fetch fails", () => {
+    renderEmbed(URL_A);
+
+    expect(screen.getByTestId("custom-audio-player")).toBeTruthy();
+    expect(document.querySelector("audio")).toBeNull();
+  });
+
+  it("falls back to a native player on a fetch TypeError (CORS) and resets per URL", () => {
+    const { rerender } = renderEmbed(URL_A);
+
+    act(() => {
+      captured.onAudioError(new TypeError("Failed to fetch"));
+    });
+
+    const audio = document.querySelector("audio");
+    expect(audio).toBeTruthy();
+    expect(audio.src).toContain(URL_A);
+    expect(audio.getAttribute("preload")).toBe("metadata");
+    expect(screen.queryByTestId("custom-audio-player")).toBeNull();
+
+    rerender(
+      <AudioEmbed
+        url={URL_B}
+        name="Audio 1"
+        size={1024}
+        id="audio-0"
+        isEmbed
+      />,
+    );
+    expect(document.querySelector("audio")).toBeNull();
+    expect(screen.getByTestId("custom-audio-player")).toBeTruthy();
+  });
+
+  it("keeps the player for real HTTP errors so its error text stays visible", () => {
+    renderEmbed(URL_A);
+
+    captured.onAudioError(
+      new Error(`Failed to fetch ${URL_A}: 404 (Not Found)`),
+    );
+
+    expect(screen.getByTestId("custom-audio-player")).toBeTruthy();
+    expect(document.querySelector("audio")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Audio link previews in the Prompt Playground fail with "Failed to fetch" whenever the source host does not send CORS headers (e.g. `commondatastorage.googleapis.com`): WaveSurfer loads audio through `fetch()`/WebAudio, which requires CORS. The embed now falls back to a native `<audio>` element when the fetch rejects with a TypeError (CORS-blocked or unreachable host) — browsers play cross-origin media without CORS; only WebAudio sample reads require it. Real HTTP errors (404/403/expired URL) keep the WaveSurfer player and its red error card. The fallback is error-driven, so it adapts to any host without hardcoding storage-host lists.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. Also link the Linear issue. -->

Closes #
Linear:

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

<!-- Use sub-sections A, B, C... to describe each logical group of changes. -->
<!-- Be explicit about what the user sees vs what changed internally. -->

**A. AudioEmbed — CORS fallback**

- [What changed for the user] Audio links from hosts without CORS headers now render a native audio player instead of the WaveSurfer "Failed to fetch" error; audio from our own storage (S3/GCS/MinIO) keeps the WaveSurfer player.
- [What changed in the API/serializer, if any] None.
- [What changed in the model/storage, if any] None.

**B. None**

**C. [Architecture / layering changes, if any]**

- None — single-component change in `AudioEmbed`; `CustomAudioPlayer` (used by evals and other players) is untouched.

---

## 2) Why the changes were done

<!-- Use bullet points. Cover product/UX rationale, technical rationale, and any architectural decisions. -->

- **Product/UX:** pasting a remote audio link (e.g. a `.ogg` on a public CDN) into Add audio → Link showed a red "Failed to fetch" in the preview card instead of a playable preview.
- **Technical:** browser media elements can play cross-origin files without CORS; only WebAudio sample reads need it. A hardcoded host allowlist was rejected because storage hosts drift across environments (S3 vs GCS vs MinIO on localhost/custom domains) — the actual load error is the accurate, environment-independent signal.
- **Architecture:** the fallback lives in `AudioEmbed` (the preview/embed boundary), wired through the existing `onAudioError` prop.

---

## 3) Tests written + scenarios each covers

<!-- List every test file, then every test case with a one-liner description of what it covers. -->
<!-- Format: test_file.py — description of what the suite tests -->

`frontend/src/components/PromptCards/EmbedComponents/__tests__/AudioEmbed.test.jsx` —
- renders the WaveSurfer player until the fetch fails
- falls back to a native player on a fetch TypeError (CORS) and resets per URL
- keeps the player for real HTTP errors so its error text stays visible

> Run result: ESLint clean (`npx eslint` — 0 errors) on the changed file. UI not fully exercised in-session; please smoke-test before merge.

---

## 4) How to run / test

### Backend tests

N/A — no backend change.

### Frontend tests (if applicable)

```bash
cd frontend
yarn test:run
```

### Contract verification (if API surface changed)

N/A — no API change.

### UI steps (manual)

1. Start the stack and log in.
2. Prompt Playground → Add audio → Link tab.
3. Paste an external audio URL without CORS headers (e.g. `https://commondatastorage.googleapis.com/codeskulptor-assets/Epoq-Lepidoptera.ogg`) → preview should render a native audio player and play.
4. Add an audio that was previously saved/rehosted to own storage → WaveSurfer waveform player still renders.

---

## 5) Screenshots / recordings

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->
<!-- Include: test command output screenshot + UI testing screenshots/recordings -->

### Test output

<!-- Screenshot of the test run passing -->

### UI testing

<!-- Screenshot or video of the feature working in the browser -->

---

## 6) Edge cases & considerations

<!-- List edge cases you've considered, even if they're handled. -->
<!-- This helps reviewers verify you've thought through the boundary conditions. -->

- [URL changes while the drawer is open]: fallback state resets per URL (`useEffect` keyed on `url`), so a new source gets a fresh WaveSurfer attempt.
- [Non-CORS load failures (404/403, expired signed URL)]: stay on the WaveSurfer player — the red error card remains visible instead of a silently dead native control.
- [Unreachable host / network down]: fetch rejects with a TypeError, so the fallback applies; both players fail equally here.
- [Own-storage URLs]: unaffected — CORS-enabled buckets keep the full WaveSurfer player, no waveform regression.

---

## 7) Pre-existing issues (NOT introduced by this PR)

<!-- If any tests fail that are pre-existing failures, document them here. -->
<!-- If none, delete this section. -->

- Save button in the UploadMedia drawer reportedly does not fire an API call in some environments; investigated separately, not addressed by this PR.

---

## 8) Architectural / important decisions

<!-- For future reference: why you chose approach A over B. -->
<!-- Keep it brief — 1-2 sentences per decision. -->

- **[Error-driven fallback over host allowlist]:** the load error is the only accurate, environment-independent signal of CORS failure; hardcoding storage hosts in the frontend duplicates backend knowledge and drifts.
- **[Native `<audio>` over proxying]:** zero server involvement, zero extra requests; browsers stream cross-origin media natively.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [ ] Linear issue is linked and updated with status

