### PR TITLE
fix(oss-setup): gate Continue on pre-flight results and apply the new setup copy [TH-7467]

### DIFF
--- a/frontend/src/sections/oss-first-run/LaunchModeStep.jsx
+++ b/frontend/src/sections/oss-first-run/LaunchModeStep.jsx
@@ -15,14 +15,14 @@ export default function LaunchModeStep({ value, onChange, onContinue }) {
         fontWeight="fontWeightSemiBold"
         sx={{ color: "text.primary" }}
       >
-        Select a launch mode
+        Plan your launch
       </Typography>
       <Typography
         variant="s1_2"
         sx={{ color: "text.secondary", maxWidth: 440, mt: 1 }}
       >
-        What&apos;s your plan for this installation? We&apos;ll run the
-        infrastructure checks accordingly.
+        Tell us how you&apos;ll launch this instance and we&apos;ll run the
+        right pre-flight checks.
       </Typography>
     </Stack>
   );

--- a/frontend/src/sections/oss-first-run/ValidationStep.jsx
+++ b/frontend/src/sections/oss-first-run/ValidationStep.jsx
@@ -54,12 +54,12 @@ const STATUS_META = {
   [PASSED]: {
     icon: "solar:check-circle-bold",
     color: "success.main",
-    label: "Validated",
+    label: "Ready",
   },
   [WARNING]: {
     icon: "solar:danger-triangle-bold",
     color: WARNING_COLOR,
-    label: "Warning",
+    label: "Caution",
   },
   [FAILED]: {
     icon: "solar:close-circle-bold",
@@ -225,14 +225,14 @@ export default function ValidationStep({
 
   const summary = useMemo(() => {
     if (!reachable) {
-      return "Waiting for the server to come up. This is normal on a first run.";
+      return "Waiting for your instance to power up. Normal on a first run.";
     }
     const parts = [];
-    if (counts.passed) parts.push(`${counts.passed} successful`);
-    if (counts.warning) parts.push(`${counts.warning} warning`);
+    if (counts.passed) parts.push(`${counts.passed} ready`);
+    if (counts.warning) parts.push(`${counts.warning} caution`);
     if (counts.failed) parts.push(`${counts.failed} failed`);
     if (counts.optional) parts.push(`${counts.optional} optional`);
-    return parts.join(", ") || "Running checks…";
+    return parts.join(" · ") || "Running pre-flight…";
   }, [counts, reachable]);
 
   const amberMain = theme.palette.amber[600];
@@ -291,23 +291,23 @@ export default function ValidationStep({
         fontWeight="fontWeightSemiBold"
         sx={{ color: "text.primary" }}
       >
-        Validate your setup
+        Pre-flight checks
       </Typography>
       <Typography
         variant="s1_2"
         sx={{ color: "text.secondary", maxWidth: PANEL_MAX_WIDTH, mt: 1 }}
       >
-        Validation runs immediately. You can re-run any check that fails. If you
-        get stuck, see the{" "}
+        We&apos;re running through your onboard systems now. Re-run anything
+        that needs attention. The{" "}
         <Link
-          href="https://docs.futureagi.com"
+          href="https://docs.futureagi.com/docs/self-hosting"
           target="_blank"
           rel="noopener"
           underline="always"
         >
-          self-host guide
-        </Link>
-        .
+          self-host docs
+        </Link>{" "}
+        are your co-pilot if a check needs a hand.
       </Typography>
     </Stack>
   );
@@ -357,7 +357,7 @@ export default function ValidationStep({
         </Stack>
 
         {canRerun && (
-          <Tooltip title="Re-run checks">
+          <Tooltip title="Re-run pre-flight">
             <span>
               <IconButton
                 size="small"
@@ -419,7 +419,7 @@ export default function ValidationStep({
             fontWeight="fontWeightSemiBold"
             sx={{ color: "text.primary" }}
           >
-            Validation checks
+            Onboard systems
           </Typography>
           <Typography variant="s2_1" sx={{ color: "text.secondary" }}>
             {summary}
@@ -462,7 +462,7 @@ export default function ValidationStep({
         >
           <Iconify icon="solar:refresh-linear" width={16} sx={spinSx} />
           <Typography variant="s2_1" fontWeight="fontWeightSemiBold">
-            {revalidating ? "Validating…" : "Validate requirements"}
+            {revalidating ? "Re-running…" : "Re-run pre-flight"}
           </Typography>
         </Stack>
       </Collapse>
@@ -490,7 +490,7 @@ export default function ValidationStep({
             variant="s2_1"
             sx={{ color: "error.main", textAlign: "center", pt: 0.5 }}
           >
-            Resolve the failed checks to continue in live mode.
+            Fix the failed systems to continue with a production launch.
           </Typography>
         )}
         <LoadingButton

--- a/frontend/src/sections/oss-first-run/ValidationStep.jsx
+++ b/frontend/src/sections/oss-first-run/ValidationStep.jsx
@@ -24,6 +24,7 @@ import {
   CHECK_STATUS,
   CHECK_REVEAL_STAGGER_MS,
   CONNECTION_STATE,
+  LAUNCH_MODE,
 } from "./constants";
 
 const { PENDING, PASSED, WARNING, FAILED, SKIPPED } = CHECK_STATUS;
@@ -35,6 +36,10 @@ const FAST_POLL_WINDOW_MS = 30000;
 
 // The server caches a snapshot for 3s, so anything faster is wasted.
 const UNSETTLED_POLL_MS = 5000;
+
+// A cached snapshot comes back in milliseconds, so a spinner tied purely to the
+// request would flash and read as a dead button. Hold it for one full turn.
+const REVALIDATE_MIN_SPIN_MS = 900;
 
 // How long a snapshot may go unchanged before polling gives up and leaves it
 // to the re-run controls.
@@ -84,16 +89,17 @@ export default function ValidationStep({
   const [expanded, setExpanded] = useState(true);
   const [revealCount, setRevealCount] = useState(0);
   const [pollInterval, setPollInterval] = useState(FAST_POLL_MS);
+  const [revalidating, setRevalidating] = useState(false);
   const unreachableSince = useRef(null);
   const timers = useRef([]);
   const hasStaggered = useRef(false);
   const lastSignature = useRef(null);
   const stalledSince = useRef(null);
+  const spinTimer = useRef(null);
 
-  const { data, isError, isFetching, refetch, errorUpdatedAt } = useSetupChecks(
-    mode,
-    { refetchInterval: pollInterval },
-  );
+  const { data, isError, refetch, errorUpdatedAt } = useSetupChecks(mode, {
+    refetchInterval: pollInterval,
+  });
 
   const checks = useMemo(() => data?.checks ?? [], [data]);
 
@@ -150,6 +156,21 @@ export default function ValidationStep({
     timers.current.forEach(clearTimeout);
     timers.current = [];
   }, []);
+
+  const handleRevalidate = useCallback(() => {
+    setRevalidating(true);
+    const startedAt = performance.now();
+    const stopSpinning = () => {
+      const elapsed = performance.now() - startedAt;
+      spinTimer.current = setTimeout(
+        () => setRevalidating(false),
+        Math.max(0, REVALIDATE_MIN_SPIN_MS - elapsed),
+      );
+    };
+    refetch().then(stopSpinning, stopSpinning);
+  }, [refetch]);
+
+  useEffect(() => () => clearTimeout(spinTimer.current), []);
 
   // First response only — re-animating every poll would restart the rows under
   // the reader.
@@ -243,10 +264,24 @@ export default function ValidationStep({
     };
   }
 
-  // No check result blocks; the only bar is having a snapshot at all.
-  const blocked = !reachable || !checks.length;
+  // Only live mode blocks on results, and only on FAILED: in that mode the
+  // server downgrades every non-required check to a warning, so this is exactly
+  // its required set.
+  const hasFailure = useMemo(
+    () => checks.some((check) => check.status === FAILED),
+    [checks],
+  );
+  const blockedByFailure = mode === LAUNCH_MODE.LIVE && hasFailure;
 
-  const rerunDisabled = isFetching || stillRevealing;
+  const blocked =
+    !reachable || !checks.length || stillRevealing || blockedByFailure;
+
+  const rerunDisabled = stillRevealing || revalidating;
+
+  const spinSx = {
+    "@keyframes revalidateSpin": { to: { transform: "rotate(360deg)" } },
+    animation: revalidating ? "revalidateSpin 0.8s linear infinite" : "none",
+  };
 
   const renderHead = (
     <Stack sx={{ mb: 2.5 }}>
@@ -327,10 +362,10 @@ export default function ValidationStep({
               <IconButton
                 size="small"
                 disabled={rerunDisabled}
-                onClick={() => refetch()}
+                onClick={handleRevalidate}
                 sx={{ color: "text.primary", flexShrink: 0 }}
               >
-                <Iconify icon="solar:refresh-linear" width={16} />
+                <Iconify icon="solar:refresh-linear" width={16} sx={spinSx} />
               </IconButton>
             </span>
           </Tooltip>
@@ -410,7 +445,7 @@ export default function ValidationStep({
           alignItems="center"
           justifyContent="center"
           spacing={1}
-          onClick={rerunDisabled ? undefined : () => refetch()}
+          onClick={rerunDisabled ? undefined : handleRevalidate}
           sx={{
             px: 2,
             py: 1.5,
@@ -418,14 +453,16 @@ export default function ValidationStep({
             borderColor: "divider",
             cursor: rerunDisabled ? "default" : "pointer",
             color: rerunDisabled ? "text.disabled" : "text.primary",
+            userSelect: "none",
+            transition: "background-color 0.2s ease",
             "&:hover": {
               bgcolor: rerunDisabled ? "transparent" : "action.hover",
             },
           }}
         >
-          <Iconify icon="solar:refresh-linear" width={16} />
+          <Iconify icon="solar:refresh-linear" width={16} sx={spinSx} />
           <Typography variant="s2_1" fontWeight="fontWeightSemiBold">
-            Validate requirements
+            {revalidating ? "Validating…" : "Validate requirements"}
           </Typography>
         </Stack>
       </Collapse>
@@ -448,6 +485,14 @@ export default function ValidationStep({
         >
           Continue
         </LoadingButton>
+        {blockedByFailure && !stillRevealing && (
+          <Typography
+            variant="s2_1"
+            sx={{ color: "error.main", textAlign: "center", pt: 0.5 }}
+          >
+            Resolve the failed checks to continue in live mode.
+          </Typography>
+        )}
         <LoadingButton
           fullWidth
           variant="text"

--- a/frontend/src/sections/oss-first-run/constants.js
+++ b/frontend/src/sections/oss-first-run/constants.js
@@ -10,16 +10,16 @@ export const LAUNCH_MODE = {
 export const LAUNCH_MODES = [
   {
     id: LAUNCH_MODE.LIVE,
-    title: "Live implementation",
+    title: "Production",
     description:
-      "Production-ready. All security and infrastructure requirements are enforced.",
+      "You're going live for real missions. Every security and infrastructure system is checked before liftoff.",
     icon: "solar:rocket-2-bold",
   },
   {
     id: LAUNCH_MODE.EXPERIMENT,
-    title: "Just experimenting",
+    title: "Test flight",
     description:
-      "Explore locally. Some security requirements are relaxed so you can get started fast.",
+      "You're taking it for a spin locally. A few non-critical systems are eased so you're off the ground in minutes.",
     icon: "solar:test-tube-bold",
   },
 ];
@@ -28,9 +28,9 @@ export const DEFAULT_LAUNCH_MODE = LAUNCH_MODE.LIVE;
 
 export const MODE_NOTE = {
   [LAUNCH_MODE.LIVE]:
-    "All security requirements will be enforced for a live implementation.",
+    "Every system has to pass pre-flight before you're cleared for launch.",
   [LAUNCH_MODE.EXPERIMENT]:
-    "We will not enforce some security requirements in experimentation mode.",
+    "Cautions won't hold you on the ground during a test flight.",
 };
 
 // Mirrors the server enum. No status gates the flow.

--- a/frontend/src/sections/oss-first-run/constants.js
+++ b/frontend/src/sections/oss-first-run/constants.js
@@ -1,16 +1,22 @@
 // The check list itself comes from GET /api/setup-checks/ — nothing about it
 // lives here, so checks can change server-side without a frontend release.
 
+// Mirrors the server's launch modes. Sent as the `mode` query param.
+export const LAUNCH_MODE = {
+  LIVE: "live",
+  EXPERIMENT: "experiment",
+};
+
 export const LAUNCH_MODES = [
   {
-    id: "live",
+    id: LAUNCH_MODE.LIVE,
     title: "Live implementation",
     description:
       "Production-ready. All security and infrastructure requirements are enforced.",
     icon: "solar:rocket-2-bold",
   },
   {
-    id: "experiment",
+    id: LAUNCH_MODE.EXPERIMENT,
     title: "Just experimenting",
     description:
       "Explore locally. Some security requirements are relaxed so you can get started fast.",
@@ -18,11 +24,12 @@ export const LAUNCH_MODES = [
   },
 ];
 
-export const DEFAULT_LAUNCH_MODE = "live";
+export const DEFAULT_LAUNCH_MODE = LAUNCH_MODE.LIVE;
 
 export const MODE_NOTE = {
-  live: "All security requirements will be enforced for a live implementation.",
-  experiment:
+  [LAUNCH_MODE.LIVE]:
+    "All security requirements will be enforced for a live implementation.",
+  [LAUNCH_MODE.EXPERIMENT]:
     "We will not enforce some security requirements in experimentation mode.",
 };
 


### PR DESCRIPTION
**Ticket:** [TH-7467](https://linear.app/future-agi/issue/TH-7467/bugfix-oss-first-run-setup-gate-continue-on-pre-flight-results-polish) — Closes TH-7467

Follow-up polish on the OSS self-hosted first-run setup screens shipped in #1919 (TH-7217).

## What was the bug

**1. Continue was enabled regardless of check results.** `ValidationStep` gated Continue on `!reachable || !checks.length` alone, so on a Production launch you could click through with a core service down and land on a broken install right after signup. It was also clickable while the reveal stagger was still animating, before a single result had appeared.

**2. Re-run gave no feedback.** The server caches the setup-checks snapshot for 3s, so `refetch()` resolves in milliseconds. Clicking "Validate requirements" changed nothing on screen and read as a dead button.

**3. The re-run row flickered on every poll.** `rerunDisabled` was derived from React Query's `isFetching`, which is true for background polls too, so each 5s tick flipped the row between `text.primary` and `text.disabled` and dropped its hover state.

**4. The re-run row's label highlighted on click**, since the clickable `Stack` had no `user-select: none`.

**5. Copy predated the pre-flight vocabulary** on both screens.

## What changes have been done

- `frontend/src/sections/oss-first-run/ValidationStep.jsx`
  - `blocked` extended from `!reachable || !checks.length` to also cover `stillRevealing` and, in Production mode only, any check with status `failed`
  - helper line under Continue when Production is blocked by a failure
  - `handleRevalidate` holds a `revalidating` flag for `max(request duration, 900ms)`, driving a `revalidateSpin` keyframe on the refresh icon and a "Re-running…" label
  - `rerunDisabled` drops `isFetching` in favour of `stillRevealing || revalidating`; `isFetching` removed from the destructure
  - `user-select: none` and a 0.2s `background-color` transition on the re-run row
  - copy: heading, subhead, status labels, card title, summary wording and separator, re-run label, tooltip, unreachable line
  - self-host link repointed from `docs.futureagi.com` to `docs.futureagi.com/docs/self-hosting`
- `frontend/src/sections/oss-first-run/LaunchModeStep.jsx` — heading and subhead copy
- `frontend/src/sections/oss-first-run/constants.js` — new `LAUNCH_MODE` enum so the mode string isn't duplicated; `LAUNCH_MODES` titles and descriptions; `MODE_NOTE` for both modes

## Why the changes

- **Production blocks on `failed`, Test flight does not.** This mirrors the server rather than duplicating its policy. `setup_checks.py` maps every non-required check to `warning` in Production, so "any `failed`" is exactly its required set. In Test flight the same services come back as `warning` or `skipped` and are meant to be non-blocking.
- **Minimum spin duration.** A spinner tied purely to request lifetime is invisible against a 3s server-side snapshot cache. 900ms is one full rotation at `0.8s linear`.
- **Dropping `isFetching`.** It cannot distinguish a user-initiated re-run from a background poll. `refetch()` defaults to `cancelRefetch: true`, so a click during an in-flight poll cancels and restarts rather than stacking, and `revalidating` still blocks repeat clicks during the spin window.
- **Copy.** Check row labels and details come from `GET /api/setup-checks/`, so only the surrounding frontend chrome is in scope here. `setup_checks.py` is deliberately untouched.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Land on `/setup`, pick Production, watch the stagger | Continue disabled for the full reveal, enabled once the last row resolves |
| 2 | Same in Test flight | Identical gating during the stagger |
| 3 | Production with a service down (e.g. stop MinIO) | Row shows **Failed** in red, Continue stays disabled, red helper reads "Fix the failed systems to continue with a production launch." |
| 4 | Test flight with the same service down | Row shows **Caution** in amber, Continue enabled |
| 5 | Production, all twelve checks pass | Summary reads "12 ready", Continue enabled, no helper line |
| 6 | Click "Re-run pre-flight" | Icon spins, label becomes "Re-running…", both persist ~900ms even though the cached response returns instantly |
| 7 | Click the per-row re-run icon on a Caution or Failed row | Same spin and label behaviour, row control disabled during the window |
| 8 | Idle on the checks screen through several 5s polls | Re-run row does not grey out or flicker between polls |
| 9 | Click the re-run row text | No text selection highlight |
| 10 | Backend not up yet | Grey spinner, summary reads "Waiting for your instance to power up. Normal on a first run.", Continue disabled |
| 11 | Click the self-host docs link | Opens `docs.futureagi.com/docs/self-hosting` |

## How to reproduce (original bug)

1. Bring up the self-hosted stack in OSS mode
2. Stop one core service, e.g. `docker stop <minio-container>`
3. Open `/setup` and choose **Live implementation** (now Production)
4. Continue is enabled immediately, even mid-animation and with the storage check red. Clicking it proceeds to signup on a broken install
5. Click "Validate requirements" — nothing visibly happens
6. Leave the screen idle and watch the re-run row grey out and back every 5 seconds

## Commands

```bash
cd frontend
npx eslint src/sections/oss-first-run/
npx prettier --check src/sections/oss-first-run/
```

Both clean. No test file exists for this directory.

## Videos and screenshots


### Walkthrough

https://github.com/user-attachments/assets/46f3c171-65bd-4f90-b828-55e910bb559e

### Screen 1 — Plan your launch

![Plan your launch](https://github.com/user-attachments/assets/9a293000-49f9-4fea-ba90-ef85a180ba5b)

### Screen 2 — Production, object storage down

Row reads **Failed**, Continue is disabled, helper line explains the block.

![Pre-flight checks, Production mode blocked by a failed system](https://github.com/user-attachments/assets/6c961086-1ee1-441a-8423-abed48f83d14)

### Screen 2 — Test flight, same service down

Same outage reported as **Caution**, Continue stays enabled.

![Pre-flight checks, Test flight mode with a caution](https://github.com/user-attachments/assets/ddd9048f-49fb-437d-a52d-a9edf0bb134b)
