### PR TITLE
fix(tests): run usage backfill on fixture database

### DIFF
--- a/futureagi/.test_quarantine.json
+++ b/futureagi/.test_quarantine.json
@@ -169,51 +169,6 @@
       "expires": "2026-09-20",
       "mode": "run",
       "strict": false
-    },
-    {
-      "id": "model_hub/tests/test_backfill_eval_usage_version_command.py::TestBackfillUsageLogsCommand::test_stamps_version_id_on_logs_without_it",
-      "reason": "broken from birth: backfill_usage_logs writes via the default_direct connection while pytest fixtures live in the default connection's rolled-back transaction, so updates never see the test data; family never passed under tfc.settings.test (first exposure by CI). Alias + marker plumbing fixed in ad4d0c3c2/c274d1985; remaining failure is test-vs-connection semantics for the author.",
-      "owner": "tanmaycode1",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-06",
-      "expires": "2026-09-20",
-      "mode": "run"
-    },
-    {
-      "id": "model_hub/tests/test_backfill_eval_usage_version_command.py::TestBackfillUsageLogsCommand::test_unwraps_double_encoded_config",
-      "reason": "broken from birth: backfill_usage_logs writes via the default_direct connection while pytest fixtures live in the default connection's rolled-back transaction, so updates never see the test data; family never passed under tfc.settings.test (first exposure by CI). Alias + marker plumbing fixed in ad4d0c3c2/c274d1985; remaining failure is test-vs-connection semantics for the author.",
-      "owner": "tanmaycode1",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-06",
-      "expires": "2026-09-20",
-      "mode": "run"
-    },
-    {
-      "id": "model_hub/tests/test_backfill_eval_usage_version_command.py::TestBackfillUsageLogsCommand::test_creates_v1_for_versionless_template",
-      "reason": "broken from birth: backfill_usage_logs writes via the default_direct connection while pytest fixtures live in the default connection's rolled-back transaction, so updates never see the test data; family never passed under tfc.settings.test (first exposure by CI). Alias + marker plumbing fixed in ad4d0c3c2/c274d1985; remaining failure is test-vs-connection semantics for the author.",
-      "owner": "tanmaycode1",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-06",
-      "expires": "2026-09-20",
-      "mode": "run"
-    },
-    {
-      "id": "model_hub/tests/test_backfill_eval_usage_version_command.py::TestBackfillUsageLogsCommand::test_single_pass_stamps_multiple_templates",
-      "reason": "broken from birth: backfill_usage_logs writes via the default_direct connection while pytest fixtures live in the default connection's rolled-back transaction, so updates never see the test data; family never passed under tfc.settings.test (first exposure by CI). Alias + marker plumbing fixed in ad4d0c3c2/c274d1985; remaining failure is test-vs-connection semantics for the author.",
-      "owner": "tanmaycode1",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-06",
-      "expires": "2026-09-20",
-      "mode": "run"
-    },
-    {
-      "id": "model_hub/tests/test_backfill_eval_usage_version_command.py::TestBackfillUsageLogsCommand::test_unwraps_and_stamps_in_single_pass",
-      "reason": "broken from birth: backfill_usage_logs writes via the default_direct connection while pytest fixtures live in the default connection's rolled-back transaction, so updates never see the test data; family never passed under tfc.settings.test (first exposure by CI). Alias + marker plumbing fixed in ad4d0c3c2/c274d1985; remaining failure is test-vs-connection semantics for the author.",
-      "owner": "tanmaycode1",
-      "issue": "https://github.com/future-agi/future-agi/issues/1984",
-      "added": "2026-08-06",
-      "expires": "2026-09-20",
-      "mode": "run"
     }
   ]
 }

--- a/futureagi/model_hub/tests/test_backfill_eval_usage_version_command.py
+++ b/futureagi/model_hub/tests/test_backfill_eval_usage_version_command.py
@@ -50,7 +50,9 @@ class TestBackfillUsageLogsCommand:
             config={"output": {"output": 1.0}},
         )
 
-        result = backfill_usage_logs(only_template=str(template.id))
+        result = backfill_usage_logs(
+            only_template=str(template.id), database="default"
+        )
 
         log.refresh_from_db()
         assert log.config.get("version_id") == str(version.id)
@@ -86,7 +88,7 @@ class TestBackfillUsageLogsCommand:
             config={"output": {"output": 1.0}, "version_id": existing_version_id},
         )
 
-        backfill_usage_logs(only_template=str(template.id))
+        backfill_usage_logs(only_template=str(template.id), database="default")
 
         log.refresh_from_db()
         assert log.config["version_id"] == existing_version_id
@@ -116,7 +118,7 @@ class TestBackfillUsageLogsCommand:
         log.refresh_from_db()
         assert isinstance(log.config, str), "Precondition: config should be a string"
 
-        backfill_usage_logs(only_template=str(template.id))
+        backfill_usage_logs(only_template=str(template.id), database="default")
 
         log.refresh_from_db()
         assert isinstance(log.config, dict)
@@ -147,7 +149,7 @@ class TestBackfillUsageLogsCommand:
             config={"output": {"output": 1.0}},
         )
 
-        backfill_usage_logs(only_template=str(template.id))
+        backfill_usage_logs(only_template=str(template.id), database="default")
 
         created = EvalTemplateVersion.objects.filter(
             eval_template=template, deleted=False
@@ -198,7 +200,7 @@ class TestBackfillUsageLogsCommand:
                 )
             )
 
-        result = backfill_usage_logs()
+        result = backfill_usage_logs(database="default")
 
         assert result["updated"] >= 3
         for log in logs:
@@ -251,7 +253,7 @@ class TestBackfillUsageLogsCommand:
             config=json.dumps({"output": {"output": 0.7}}),  # double-encoded
         )
 
-        backfill_usage_logs()
+        backfill_usage_logs(database="default")
 
         stamped_log.refresh_from_db()
         assert isinstance(stamped_log.config, dict)


### PR DESCRIPTION
## Summary

The eval-usage backfill tests created rows inside the `default` database transaction but exercised the command through `default_direct`, where those uncommitted fixtures were invisible. This makes every direct backfill assertion use the fixture-owning database, restores real coverage for all six calls (including a previously false-positive skip test), and removes the five repaired tests from CI quarantine.

## Linked issues

Refs #1984 (partial quarantine burn-down; this PR does not close the tracking issue).

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [x] 🧪 Test-only change

---

## 1) What changes were done

**A. Exercise backfill behavior in the test transaction**

- Pass `database="default"` to each direct `backfill_usage_logs` call in `TestBackfillUsageLogsCommand`.
- This also makes `test_skips_logs_that_already_have_version_id` meaningful; it previously passed without seeing its fixture.
- Keep the management-command wrapper test unchanged so the command default remains covered.

**B. Burn down quarantine debt**

- Remove the five matching `test_backfill_eval_usage_version_command.py` entries from `.test_quarantine.json`.

## 2) Why the changes were done

- **Technical:** pytest fixtures are transaction-local on `default`; a separate `default_direct` connection cannot see those rows before commit.
- **Scope:** these tests validate stamping, unwrapping, idempotency, and version creation semantics, not PgBouncer topology, so using `default` is the correct test boundary.
- **Architecture:** production command behavior and its default database alias are unchanged.

## 3) Tests written + scenarios each covers

**`model_hub/tests/test_backfill_eval_usage_version_command.py`** — all existing command scenarios now run against visible fixtures.

- Version stamping, existing-version preservation, double-encoded config unwrapping, v1 creation, multi-template stamping, combined unwrap/stamp, and command invocation.

**`tests/test_quarantine_file.py`** — validates quarantine schema, IDs, expiry, and test references after removing the repaired family.

> Run result: **7 passed** in the backfill suite and **5 passed** in quarantine validation. `python -m json.tool` and `git diff --check` also pass. The local venv does not contain the optional `ruff`/`black` executables, so those dedicated commands were not available locally.

## 4) How to run / test

```bash
cd futureagi
bin/test model_hub/tests/test_backfill_eval_usage_version_command.py -q
bin/test --no-services tests/test_quarantine_file.py -q
```

## 5) Screenshots / recordings

Not applicable; this is a backend test-harness correction.

## 6) Edge cases & considerations

- Existing stamped rows are now genuinely read and verified as unchanged rather than passing because the row was invisible.
- Full-table and template-scoped paths both use the same fixture-owning connection.
- No runtime command defaults, SQL, API contracts, or product behavior change.

## 8) Architectural / important decisions

- **Use `default` only in direct test calls:** this preserves the production `default_direct` default while aligning the test connection with pytest transaction visibility.

## Checklist

- [x] My code follows the style guide
- [x] Existing tests now prove the fix is effective
- [ ] Full `bin/test` passes locally (focused backend suites above pass)
- [ ] `yarn test:run` passes locally (not applicable; no frontend changes)
- [ ] `yarn contracts:check` passes (not applicable; no API changes)
- [ ] Documentation updated (not applicable)
- [x] No hardcoded secrets, URLs, or PII
- [ ] CLA signed (handled by repository automation)
- [x] PR title follows Conventional Commits
- [ ] Linear issue linked (not available)
