### PR TITLE
fix(tracer): tolerate eval_tags entries with unset type or value

### DIFF
--- a/futureagi/tracer/tests/test_eval_tags_untrusted_shapes.py
+++ b/futureagi/tracer/tests/test_eval_tags_untrusted_shapes.py
@@ -1,0 +1,129 @@
+"""
+Pin the reader contract for ``ProjectVersion.eval_tags``.
+
+``eval_tags`` is persisted from client payloads with no per-entry schema: the
+SDK contract declares a bare ``JSONField(required=False, allow_null=True)``,
+and ``tracer/utils/otel.py`` writes ``"type": eval_tag.get("type")`` /
+``"value": eval_tag.get("value")`` straight through, so both land as ``None``
+whenever the client omits the key.
+
+Two readers then called ``.lower()`` on those values:
+
+  1. ``tracer/views/observation_span.py::retrieve_loading`` built
+     ``eval_config_mapping`` from tags FILTERED by type but
+     ``custom_eval_config_ids`` from the UNFILTERED list. Any tag with a
+     different type therefore produced a config row with no mapping entry,
+     and ``eval_config_mapping.get(...).lower()`` raised AttributeError. The
+     view's blanket ``except Exception`` turned that into a generic HTTP 400,
+     so the eval panel never resolved for that project version — permanently,
+     with the real cause only in the logs.
+
+  2. ``tracer/utils/eval.py::eval_observation_span_runner`` called
+     ``eval_tag.get("value").lower()``, which raised on any span-type tag
+     whose ``value`` the client omitted — aborting the loop and skipping
+     every remaining eval for that span.
+
+These are pure-function tests over the shared filter; no DB, no services.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracer.utils.eval_tags import OBSERVATION_SPAN_TYPE, span_type_eval_tags
+
+pytestmark = pytest.mark.unit
+
+
+def _tag(**overrides):
+    tag = {
+        "custom_eval_config_id": "cfg-1",
+        "type": OBSERVATION_SPAN_TYPE,
+        "value": "LLM",
+    }
+    tag.update(overrides)
+    return tag
+
+
+class TestSpanTypeEvalTags:
+    def test_keeps_well_formed_span_type_tags(self):
+        tags = [_tag(), _tag(custom_eval_config_id="cfg-2", value="tool")]
+        assert span_type_eval_tags(tags) == tags
+
+    def test_drops_tags_addressing_another_target(self):
+        # The regression: this tag used to reach CustomEvalConfig.objects
+        # through the unfiltered id set while having no mapping entry.
+        tags = [_tag(), _tag(custom_eval_config_id="cfg-2", type="TRACE_TYPE")]
+        assert span_type_eval_tags(tags) == [tags[0]]
+
+    def test_drops_tags_whose_type_the_client_omitted(self):
+        # Exactly what otel.py persists when the payload has no "type".
+        tags = [_tag(), _tag(custom_eval_config_id="cfg-2", type=None)]
+        assert span_type_eval_tags(tags) == [tags[0]]
+
+    def test_drops_tags_whose_value_the_client_omitted(self):
+        # Callers lowercase value; None would raise inside the runner loop.
+        tags = [_tag(), _tag(custom_eval_config_id="cfg-2", value=None)]
+        assert span_type_eval_tags(tags) == [tags[0]]
+
+    def test_drops_tags_without_a_config_id(self):
+        tags = [_tag(), _tag(custom_eval_config_id=None)]
+        assert span_type_eval_tags(tags) == [tags[0]]
+
+    def test_drops_non_mapping_entries(self):
+        # EvalTemplate.eval_tags is a plain list of category strings; if the
+        # two shapes are ever crossed, a bare string must not crash a reader.
+        tags = [_tag(), "RAG", None, 7]
+        assert span_type_eval_tags(tags) == [tags[0]]
+
+    @pytest.mark.parametrize("empty", [None, [], {}])
+    def test_tolerates_empty_input(self, empty):
+        assert span_type_eval_tags(empty) == []
+
+    def test_every_surviving_tag_is_safe_to_index_and_lower(self):
+        """The contract both call sites depend on.
+
+        Callers do ``tag["custom_eval_config_id"]`` and ``tag["value"].lower()``
+        without guards, so anything returned here must support both.
+        """
+        messy = [
+            _tag(),
+            _tag(custom_eval_config_id="cfg-2", type="TRACE_TYPE"),
+            _tag(custom_eval_config_id="cfg-3", type=None),
+            _tag(custom_eval_config_id="cfg-4", value=None),
+            _tag(custom_eval_config_id=None),
+            "RAG",
+        ]
+        for tag in span_type_eval_tags(messy):
+            assert tag["custom_eval_config_id"]
+            assert tag["value"].lower()
+
+
+class TestRetrieveLoadingMappingConsistency:
+    """The two structures in retrieve_loading must agree.
+
+    The bug was a mismatch, not a bad value: the mapping was keyed by
+    span-type tags while the id set came from every tag, so the view looked
+    up configs it had no mapping for.
+    """
+
+    def test_config_ids_and_mapping_keys_stay_in_lockstep(self):
+        eval_tags = [
+            _tag(),
+            _tag(custom_eval_config_id="cfg-2", type="TRACE_TYPE"),
+            _tag(custom_eval_config_id="cfg-3", type=None),
+            _tag(custom_eval_config_id="cfg-4", value=None),
+        ]
+
+        span_type_tags = span_type_eval_tags(eval_tags)
+        eval_config_mapping = {
+            t["custom_eval_config_id"]: t["value"] for t in span_type_tags
+        }
+        custom_eval_config_ids = {t["custom_eval_config_id"] for t in span_type_tags}
+
+        assert custom_eval_config_ids == set(eval_config_mapping)
+
+        # Every config the view would then load has a usable mapping entry,
+        # so the .lower() call cannot land on None.
+        for config_id in custom_eval_config_ids:
+            assert eval_config_mapping.get(str(config_id)).lower()

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -33,6 +33,7 @@ from tracer.models.observation_span import (
 )
 from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
+from tracer.utils.eval_tags import span_type_eval_tags
 from tracer.utils.helper import (
     FieldConfig,
     get_default_project_version_config,
@@ -2188,15 +2189,13 @@ def eval_observation_span_runner(observation_span_id, eval_tags):
                     "eval_tags JSON decode failed, defaulting to empty dict."
                 )
 
-        for eval_tag in eval_tags:
-            type = eval_tag.get("type")
-
+        # span_type_eval_tags drops entries whose type/value the client never
+        # sent — otel.py persists those as None, and .lower() below would
+        # raise AttributeError, silently skipping every remaining tag.
+        for eval_tag in span_type_eval_tags(eval_tags):
             custom_eval_config_id = eval_tag.get("custom_eval_config_id")
 
-            if (
-                type == "OBSERVATION_SPAN_TYPE"
-                and eval_tag.get("value").lower() == observation_span.observation_type
-            ):
+            if eval_tag["value"].lower() == observation_span.observation_type:
                 try:
                     evaluate_observation_span(
                         observation_span.id, custom_eval_config_id

--- a/futureagi/tracer/utils/eval_tags.py
+++ b/futureagi/tracer/utils/eval_tags.py
@@ -1,0 +1,48 @@
+"""Readers for ``ProjectVersion.eval_tags``.
+
+``eval_tags`` is persisted straight from client-supplied payloads. The SDK
+contract declares it as a bare ``serializers.JSONField(required=False,
+allow_null=True)`` with no per-entry schema, and ``tracer/utils/otel.py``
+copies ``type`` and ``value`` through verbatim via ``eval_tag.get(...)`` —
+which yields ``None`` when the client omits the key.
+
+Every reader therefore has to treat the entries as untrusted: keys may be
+absent, values may be ``None``, and an entry may not be a mapping at all.
+Callers that need span-addressable tags should go through
+``span_type_eval_tags`` rather than indexing the raw list.
+"""
+
+from __future__ import annotations
+
+OBSERVATION_SPAN_TYPE = "OBSERVATION_SPAN_TYPE"
+
+
+def span_type_eval_tags(eval_tags):
+    """Return the eval tags that can be matched against an observation span.
+
+    A tag is usable only when all three of these hold:
+
+    * ``type`` is exactly ``OBSERVATION_SPAN_TYPE`` — other types address
+      different targets and have no span semantics;
+    * ``value`` is a non-empty string — it names the span type to match, and
+      callers lowercase it;
+    * ``custom_eval_config_id`` is present — without it the tag cannot be
+      resolved to a ``CustomEvalConfig``.
+
+    Entries failing any condition are dropped: they are not addressable by
+    span type, so skipping them is the same outcome as never matching, minus
+    the ``AttributeError``.
+    """
+    usable = []
+    for eval_tag in eval_tags or []:
+        if not isinstance(eval_tag, dict):
+            continue
+        if eval_tag.get("type") != OBSERVATION_SPAN_TYPE:
+            continue
+        value = eval_tag.get("value")
+        if not isinstance(value, str) or not value:
+            continue
+        if not eval_tag.get("custom_eval_config_id"):
+            continue
+        usable.append(eval_tag)
+    return usable

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -101,6 +101,7 @@ from tracer.utils.eval import (
     evaluate_observation_span,
     evaluate_observation_span_observe,
 )
+from tracer.utils.eval_tags import span_type_eval_tags
 from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import (
     FieldConfig,
@@ -841,14 +842,19 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             )
             eval_tags = observation_span_obj.project_version.eval_tags
 
+            # Both structures must come from the SAME filtered list: the
+            # mapping is keyed only by span-type tags, so building the id set
+            # from every tag pulls in configs that have no mapping entry, and
+            # the .lower() below then runs on None.
+            span_type_tags = span_type_eval_tags(eval_tags)
+
             eval_config_mapping = {
                 str(eval_tag["custom_eval_config_id"]): eval_tag["value"]
-                for eval_tag in eval_tags
-                if eval_tag["type"] == "OBSERVATION_SPAN_TYPE"
+                for eval_tag in span_type_tags
             }
 
             custom_eval_config_ids = {
-                eval_tag["custom_eval_config_id"] for eval_tag in eval_tags
+                eval_tag["custom_eval_config_id"] for eval_tag in span_type_tags
             }
             custom_eval_configs = CustomEvalConfig.objects.filter(
                 id__in=custom_eval_config_ids, deleted=False


### PR DESCRIPTION
Fixes #2025.

### What

`ProjectVersion.eval_tags` is written from client payloads with no per-entry schema, so `type` and `value` can be `None`. Two readers called `.lower()` on them:

- **`tracer/views/observation_span.py::retrieve_loading`** built `eval_config_mapping` from tags *filtered* by type but `custom_eval_config_ids` from the *unfiltered* list. Any tag addressing another target produced a `CustomEvalConfig` with no mapping entry, and `eval_config_mapping.get(...).lower()` raised `AttributeError`. The blanket `except Exception` turned that into a generic HTTP 400, so the eval panel never resolved for that project version.
- **`tracer/utils/eval.py::eval_observation_span_runner`** called `eval_tag.get("value").lower()`, which raised on any span-type tag with no value and aborted the loop, skipping every remaining eval for the span.

### Why this shape

The two call sites disagreed about which tags are addressable by span type, so the fix is one shared filter rather than two local guards. `span_type_eval_tags` keeps only entries that are safe for what both callers do to them — index `custom_eval_config_id`, and lowercase `value`. Everything else is dropped, which is the same outcome as never matching a span, minus the exception.

It lives in a new `tracer/utils/eval_tags.py` rather than in `tracer/utils/eval.py` so the tests stay in the fast lane: the module has no Django imports, so the regression tests need no database or services.

The non-mapping guard is there because `EvalTemplate.eval_tags` is a plain list of category strings while `ProjectVersion.eval_tags` is a list of dicts. A bare string reaching this reader should not crash it.

### Testing

`futureagi/tracer/tests/test_eval_tags_untrusted_shapes.py` — 11 cases, `@pytest.mark.unit`, no DB:

- each malformed shape is dropped (other target, `type=None`, `value=None`, missing config id, non-mapping entry)
- well-formed tags pass through unchanged
- every surviving tag supports both operations the callers perform on it
- the mapping keys and the config-id set stay in lockstep — the invariant that was actually broken

Against the pre-fix logic the lockstep assertion fails with the original `AttributeError`; against this branch all 11 pass.

I ran these tests standalone (the module is import-light by design) and compile-checked the two edited files. I have not run the full `make check-all` — that needs the Postgres/ClickHouse stack — so CI is the real check on the wider suite.

### Notes

- Drops a local variable named `type` in the runner that shadowed the builtin.
- No behaviour change for well-formed tags: a tag with `type == "OBSERVATION_SPAN_TYPE"` and a non-empty string `value` is treated exactly as before.
- The write path in `tracer/utils/otel.py:1255` still persists `type`/`value` unvalidated. Validating at ingest is the more complete fix, but it changes what the API accepts and would reject tags already stored, so I left it out of this PR. Happy to follow up if you want it.
