### PR TITLE
fix: raise fi-collector gRPC recv cap to 16MiB and log size rejections

### DIFF
--- a/fi-collector/cmd/fi-collector/main.go
+++ b/fi-collector/cmd/fi-collector/main.go
@@ -11,7 +11,7 @@
 //  1. Defaults coded into chwriter.New / server.New
 //  2. YAML file path from --config (or /etc/fi-collector/config.yaml)
 //  3. Environment overrides (FI_CH_URL, FI_GRPC_ADDR, FI_HTTP_ADDR,
-//     FI_DEAD_LETTER_FILE)
+//     FI_GRPC_MAX_RECV_MIB, FI_DEAD_LETTER_FILE, ...)
 //
 // Health surfaces:
 //   - /healthz (HTTP 200 unless writer dead-letter rate > threshold)
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -51,7 +52,7 @@ func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	cfg := loadConfig(log, configPath)
-	applyEnvOverrides(&cfg)
+	applyEnvOverrides(log, &cfg)
 
 	writer, err := chwriter.New(cfg.Writer)
 	if err != nil {
@@ -169,7 +170,7 @@ func loadConfig(log *slog.Logger, path string) rootConfig {
 
 // applyEnvOverrides — surgical, only the fields ops most often need to
 // override at runtime without baking a new image.
-func applyEnvOverrides(c *rootConfig) {
+func applyEnvOverrides(log *slog.Logger, c *rootConfig) {
 	if v := os.Getenv("FI_CH_URL"); v != "" {
 		c.Writer.URL = v
 	}
@@ -196,6 +197,15 @@ func applyEnvOverrides(c *rootConfig) {
 			c.Server.HTTPAddr = ""
 		default:
 			c.Server.HTTPAddr = v
+		}
+	}
+	if v := os.Getenv("FI_GRPC_MAX_RECV_MIB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Server.GRPCMaxRecvMiB = n
+		} else {
+			// Silent fallback here would reproduce the silent-loss failure
+			// mode this knob exists to fix — an operator must see it.
+			log.Warn("ignoring invalid FI_GRPC_MAX_RECV_MIB", "value", v)
 		}
 	}
 	if v := os.Getenv("FI_DEAD_LETTER_FILE"); v != "" {

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -35,10 +35,8 @@ server:
   http_addr: ":4318"
   batch_max_rows: 5000
   batch_max_age: 5s
-  # Max gRPC receive message size in MiB (FI_GRPC_MAX_RECV_MIB). The Go
-  # default (4 MiB) rejects large single-span exports — e.g. an ended voice
-  # call with a full transcript — with RESOURCE_EXHAUSTED. 16 matches the
-  # OTLP/HTTP body cap so both transports accept the same spans.
+  # Max gRPC receive message size in MiB (FI_GRPC_MAX_RECV_MIB); 16 matches
+  # the OTLP/HTTP body cap.
   grpc_max_recv_mib: 16
 
 auth:

--- a/fi-collector/config/collector.yaml
+++ b/fi-collector/config/collector.yaml
@@ -35,6 +35,11 @@ server:
   http_addr: ":4318"
   batch_max_rows: 5000
   batch_max_age: 5s
+  # Max gRPC receive message size in MiB (FI_GRPC_MAX_RECV_MIB). The Go
+  # default (4 MiB) rejects large single-span exports — e.g. an ended voice
+  # call with a full transcript — with RESOURCE_EXHAUSTED. 16 matches the
+  # OTLP/HTTP body cap so both transports accept the same spans.
+  grpc_max_recv_mib: 16
 
 auth:
   # Auth is active when pg_write is set. Without it, spans land with

--- a/fi-collector/pkg/server/server.go
+++ b/fi-collector/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,15 +32,17 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
 
 // Config is what main() passes us. Public fields = YAML wire format.
 type Config struct {
-	GRPCAddr     string        `yaml:"grpc_addr"`      // :4317 default
-	HTTPAddr     string        `yaml:"http_addr"`      // :4318 default; empty disables
-	BatchMaxRows int           `yaml:"batch_max_rows"` // flush after N rows
-	BatchMaxAge  time.Duration `yaml:"batch_max_age"`  // flush after X time
+	GRPCAddr       string        `yaml:"grpc_addr"`         // :4317 default
+	HTTPAddr       string        `yaml:"http_addr"`         // :4318 default; empty disables
+	BatchMaxRows   int           `yaml:"batch_max_rows"`    // flush after N rows
+	BatchMaxAge    time.Duration `yaml:"batch_max_age"`     // flush after X time
+	GRPCMaxRecvMiB int           `yaml:"grpc_max_recv_mib"` // max gRPC message size; 16 default (HTTP-path parity)
 }
 
 // Server owns the gRPC + HTTP OTLP listeners and the batch flusher goroutine.
@@ -57,8 +60,8 @@ type Server struct {
 	metering Metering
 	log      *slog.Logger
 	pricer   chexp.Pricer
-	grpc    *grpc.Server
-	httpd   *http.Server
+	grpc     *grpc.Server
+	httpd    *http.Server
 
 	// Batching: the receiver handler pushes converted rows onto `pending` and
 	// signals via `pendCh`. A single flusher goroutine drains it on either
@@ -116,6 +119,15 @@ func New(cfg Config, writer *chwriter.Writer, authenticator *auth.Authenticator,
 	if cfg.BatchMaxAge <= 0 {
 		cfg.BatchMaxAge = 5 * time.Second
 	}
+	if cfg.GRPCMaxRecvMiB <= 0 {
+		// Go gRPC's default 4 MiB rejects large single-span exports (e.g. an
+		// ended voice call with full transcript) with RESOURCE_EXHAUSTED.
+		// Match the OTLP/HTTP body cap so both transports accept the same spans.
+		cfg.GRPCMaxRecvMiB = maxOTLPHTTPBodyBytes >> 20
+	}
+	if cfg.GRPCMaxRecvMiB > 1024 {
+		cfg.GRPCMaxRecvMiB = 1024 // keep the <<20 shift well under proto's 2 GiB ceiling
+	}
 
 	log := slog.Default()
 	var pricer chexp.Pricer
@@ -166,7 +178,11 @@ func (s *Server) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("listen grpc %s: %w", s.cfg.GRPCAddr, err)
 		}
-		var grpcOpts []grpc.ServerOption
+		s.log.Info("grpc listener", "addr", s.cfg.GRPCAddr, "max_recv_mib", s.cfg.GRPCMaxRecvMiB)
+		grpcOpts := []grpc.ServerOption{
+			grpc.MaxRecvMsgSize(s.cfg.GRPCMaxRecvMiB << 20),
+			grpc.StatsHandler(&grpcErrLogger{log: s.log}),
+		}
 		if s.auth != nil {
 			grpcOpts = append(grpcOpts, grpc.UnaryInterceptor(s.auth.GRPCInterceptor()))
 		}
@@ -237,6 +253,51 @@ func (s *Server) shutdown() {
 	s.wg.Wait()
 	s.drainNow(context.Background())
 }
+
+// grpcErrLogger surfaces transport-level message-size rejections. A message
+// larger than MaxRecvMsgSize is rejected with RESOURCE_EXHAUSTED before the
+// handler or interceptor runs, so a stats.Handler is the only server-side
+// hook that sees it — without this, the client's span is dropped with no
+// trace in the collector's own logs. Deliberately narrow: auth failures are
+// logged by the interceptor, quota rejections are silent by design (same
+// code, would be indistinguishable spam), and client cancels are benign.
+type grpcErrLogger struct {
+	log *slog.Logger
+}
+
+type grpcMethodKey struct{}
+
+// grpc-go's message substring for a MaxRecvMsgSize rejection — Contains, not
+// prefix, so the "received message after decompression larger than max"
+// (gzip) variant is caught too.
+const grpcMsgTooLarge = "message larger than max"
+
+func (h *grpcErrLogger) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	return context.WithValue(ctx, grpcMethodKey{}, info.FullMethodName)
+}
+
+func (h *grpcErrLogger) HandleRPC(ctx context.Context, s stats.RPCStats) {
+	end, ok := s.(*stats.End)
+	if !ok || end.Error == nil {
+		return
+	}
+	st, _ := status.FromError(end.Error)
+	if st.Code() != codes.ResourceExhausted || !strings.Contains(st.Message(), grpcMsgTooLarge) {
+		return
+	}
+	method, _ := ctx.Value(grpcMethodKey{}).(string)
+	h.log.Error("grpc message over size cap, request rejected",
+		"method", method,
+		"code", st.Code().String(),
+		"err", st.Message(),
+	)
+}
+
+func (h *grpcErrLogger) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h *grpcErrLogger) HandleConn(context.Context, stats.ConnStats) {}
 
 // otlpHandler implements ptraceotlp.GRPCServer. Stateless per call.
 type otlpHandler struct {
@@ -311,6 +372,10 @@ func (s *Server) handleHTTPTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(body) > maxOTLPHTTPBodyBytes {
+		// Mirror the gRPC-side over-cap log so an HTTP exporter's drop is
+		// equally visible server-side.
+		s.log.Error("http body over size cap, request rejected",
+			"path", r.URL.Path, "max_bytes", maxOTLPHTTPBodyBytes)
 		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
 		return
 	}

--- a/fi-collector/pkg/server/server.go
+++ b/fi-collector/pkg/server/server.go
@@ -42,7 +42,7 @@ type Config struct {
 	HTTPAddr       string        `yaml:"http_addr"`         // :4318 default; empty disables
 	BatchMaxRows   int           `yaml:"batch_max_rows"`    // flush after N rows
 	BatchMaxAge    time.Duration `yaml:"batch_max_age"`     // flush after X time
-	GRPCMaxRecvMiB int           `yaml:"grpc_max_recv_mib"` // max gRPC message size; 16 default (HTTP-path parity)
+	GRPCMaxRecvMiB int           `yaml:"grpc_max_recv_mib"` // max gRPC message size in MiB; default + rationale in New()
 }
 
 // Server owns the gRPC + HTTP OTLP listeners and the batch flusher goroutine.
@@ -267,10 +267,16 @@ type grpcErrLogger struct {
 
 type grpcMethodKey struct{}
 
-// grpc-go's message substring for a MaxRecvMsgSize rejection — Contains, not
-// prefix, so the "received message after decompression larger than max"
-// (gzip) variant is caught too.
-const grpcMsgTooLarge = "message larger than max"
+// grpc-go's MaxRecvMsgSize rejection message. Both recv variants
+// ("received message larger than max" and the gzip "received message after
+// decompression larger than max") share these two substrings; matching both
+// excludes the send-side "trying to send message larger than max", which
+// carries the same ResourceExhausted code but is the wrong story for a
+// "request rejected" log.
+const (
+	grpcMsgRecv     = "received message"
+	grpcMsgTooLarge = "larger than max"
+)
 
 func (h *grpcErrLogger) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	return context.WithValue(ctx, grpcMethodKey{}, info.FullMethodName)
@@ -282,7 +288,9 @@ func (h *grpcErrLogger) HandleRPC(ctx context.Context, s stats.RPCStats) {
 		return
 	}
 	st, _ := status.FromError(end.Error)
-	if st.Code() != codes.ResourceExhausted || !strings.Contains(st.Message(), grpcMsgTooLarge) {
+	if st.Code() != codes.ResourceExhausted ||
+		!strings.Contains(st.Message(), grpcMsgRecv) ||
+		!strings.Contains(st.Message(), grpcMsgTooLarge) {
 		return
 	}
 	method, _ := ctx.Value(grpcMethodKey{}).(string)

--- a/fi-collector/pkg/server/server_test.go
+++ b/fi-collector/pkg/server/server_test.go
@@ -744,10 +744,9 @@ func TestDrainAggregatesCuratedAcrossPayloads(t *testing.T) {
 	}
 }
 
-// A single span larger than gRPC's 4 MiB default must be accepted — the
-// default GRPCMaxRecvMiB (16, HTTP-path parity) governs. Regression: ended
-// voice-call spans (full transcript + raw_log) were rejected with
-// RESOURCE_EXHAUSTED and silently lost, leaving traces stuck "In progress".
+// A single span larger than gRPC's 4 MiB default must be accepted under the
+// default GRPCMaxRecvMiB. Regression: ended voice-call spans (full transcript
+// + raw_log) were rejected and silently lost, leaving traces stuck "In progress".
 func TestGRPCAcceptsSpanLargerThanFourMiB(t *testing.T) {
 	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)

--- a/fi-collector/pkg/server/server_test.go
+++ b/fi-collector/pkg/server/server_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
+	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +20,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 // Spin up the server, point it at an httptest CH, fire one OTLP request,
@@ -603,9 +607,10 @@ func TestPricerWiredThroughGRPCExport(t *testing.T) {
 // waitPort polls until something accepts on addr or deadline. Simple enough
 // not to need a /healthz round trip.
 func waitPort(addr string, d time.Duration) bool {
+	// grpc.NewClient is lazy (never dials), so probe with a real TCP connect.
 	deadline := time.Now().Add(d)
 	for time.Now().Before(deadline) {
-		conn, err := grpcDial(addr)
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
 		if err == nil {
 			conn.Close()
 			return true
@@ -613,10 +618,6 @@ func waitPort(addr string, d time.Duration) bool {
 		time.Sleep(20 * time.Millisecond)
 	}
 	return false
-}
-
-func grpcDial(addr string) (*grpc.ClientConn, error) {
-	return grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 }
 
 // makeObserveTraces builds a one-span observe-project Traces carrying a user.id
@@ -742,3 +743,148 @@ func TestDrainAggregatesCuratedAcrossPayloads(t *testing.T) {
 		t.Errorf("trace_sessions rows: got %d want 2", sessRows)
 	}
 }
+
+// A single span larger than gRPC's 4 MiB default must be accepted — the
+// default GRPCMaxRecvMiB (16, HTTP-path parity) governs. Regression: ended
+// voice-call spans (full transcript + raw_log) were rejected with
+// RESOURCE_EXHAUSTED and silently lost, leaving traces stuck "In progress".
+func TestGRPCAcceptsSpanLargerThanFourMiB(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+
+	addr := "127.0.0.1:24323"
+	s := New(Config{GRPCAddr: addr, BatchMaxRows: 1000, BatchMaxAge: 50 * time.Millisecond}, w, nil, nil, nil)
+	s.cfg.HTTPAddr = "" // gRPC-only; don't race other tests (or a dev stack) for :4318
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+	if !waitPort(addr, 2*time.Second) {
+		t.Fatalf("server didn't listen on %s", addr)
+	}
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := ptraceotlp.NewGRPCClient(conn)
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("fi.project_id", "33333333-3333-4333-8333-333333333333")
+	sp := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("big-voice-call-span")
+	sp.SetTraceID([16]byte{0xcc})
+	sp.SetSpanID([8]byte{0xdd})
+	sp.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	sp.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
+	// ~6 MiB attribute: over the 4 MiB gRPC default, under the 16 MiB cap.
+	sp.Attributes().PutStr("raw_log", strings.Repeat("x", 6<<20))
+
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+	if _, err := client.Export(context.Background(), req); err != nil {
+		t.Fatalf("OTLP Export of >4MiB span rejected: %v", err)
+	}
+}
+
+// An over-cap message must be rejected AND show up in the collector's own
+// logs. The transport rejects it before the handler runs, so only the
+// stats.Handler sees it — this pins that the error is logged (else the drop
+// is invisible server-side and diagnosable only from client logs).
+func TestGRPCOverCapRejectionIsLogged(t *testing.T) {
+	chSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(200)
+	}))
+	defer chSrv.Close()
+
+	w, _ := chwriter.New(chwriter.Config{
+		URL:            chSrv.URL,
+		Database:       "default",
+		Table:          "spans",
+		MaxRetries:     1,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+		RequestTimeout: 2 * time.Second,
+		DeadLetterFile: t.TempDir() + "/dl.jsonl",
+	})
+
+	var logMu sync.Mutex
+	var logBuf bytes.Buffer
+	logw := writerFunc(func(p []byte) (int, error) {
+		logMu.Lock()
+		defer logMu.Unlock()
+		return logBuf.Write(p)
+	})
+
+	addr := "127.0.0.1:24322"
+	s := New(
+		Config{GRPCAddr: addr, BatchMaxRows: 1000, BatchMaxAge: 50 * time.Millisecond},
+		w, nil, nil, nil,
+		WithLogger(slog.New(slog.NewJSONHandler(logw, nil))),
+	)
+	s.cfg.HTTPAddr = "" // gRPC-only; don't race other tests (or a dev stack) for :4318
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx) }()
+	if !waitPort(addr, 2*time.Second) {
+		t.Fatalf("server didn't listen on %s", addr)
+	}
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	client := ptraceotlp.NewGRPCClient(conn)
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	sp := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("over-cap-span")
+	// 17 MiB: over the 16 MiB default cap.
+	sp.Attributes().PutStr("raw_log", strings.Repeat("x", 17<<20))
+
+	req := ptraceotlp.NewExportRequestFromTraces(traces)
+	_, err = client.Export(context.Background(), req)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("want ResourceExhausted, got %v", err)
+	}
+
+	// stats.End may fire concurrently with the client seeing the status.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		logMu.Lock()
+		got := logBuf.String()
+		logMu.Unlock()
+		if strings.Contains(got, "grpc message over size cap") && strings.Contains(got, "ResourceExhausted") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	logMu.Lock()
+	got := logBuf.String()
+	logMu.Unlock()
+	t.Fatalf("over-cap rejection not logged; log=%q", got)
+}
+
+// writerFunc adapts a func to io.Writer for test log capture.
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/futureagi/simulate/services/sim_collector_emit.py
+++ b/futureagi/simulate/services/sim_collector_emit.py
@@ -163,6 +163,8 @@ def export_sim_spans(
             project=project_name,
             result=str(result),
             span_count=len(readable),
+            span_names=[s.name for s in readable[:5]],
+            trace_ids=[format(s.context.trace_id, "032x") for s in readable[:5]],
         )
         return 0
     return len(readable)


### PR DESCRIPTION
## Summary

Voice ingestion traces were permanently stuck at "In progress" (TH-7458, reported by a customer for calls lasting a few minutes). Root cause: the fi-collector gRPC server used Go's default 4 MiB `MaxRecvMsgSize`; an ended VAPI call's single-span export (full transcript + raw_log) exceeds it and was rejected `RESOURCE_EXHAUSTED` — silently, since the export path is best-effort and the transport rejects before any handler runs. The in-progress snapshot (small, ingested mid-call) was never overwritten. This PR raises the gRPC cap to 16 MiB (parity with the OTLP/HTTP body cap) and adds server-side logging for size rejections on both transports.

## Linked issues

Fixed TH-7458
Linear: TH-7458

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. fi-collector: configurable gRPC receive cap (the fix)**

- `pkg/server/server.go` — new `grpc_max_recv_mib` config field; default 16 (derived from the HTTP path's 16 MiB body cap so both transports accept the same spans), clamped at 1024; wired via `grpc.MaxRecvMsgSize`. Startup now logs `grpc listener ... max_recv_mib=16` so the effective cap is verifiable from boot logs.
- `cmd/fi-collector/main.go` — `FI_GRPC_MAX_RECV_MIB` env override; invalid values warn (JSON logger) instead of silently falling back.
- `config/collector.yaml` — documents the new key.

**B. fi-collector: size rejections are now visible server-side**

- A narrow gRPC `stats.Handler` logs over-cap rejections (`grpc message over size cap, request rejected` with method, code, actual-vs-max bytes). A stats handler is required because the transport rejects the message before the handler/interceptor run. Deliberately filtered to size rejections only — auth failures are logged by the interceptor, quota rejections share the same gRPC code and would be indistinguishable spam, client cancels are benign. The match covers all three grpc-go size-rejection message variants (including the gzip "after decompression" one).
- The HTTP 413 path gets a mirror log line so an HTTP exporter's drop is equally visible.

**C. Worker-side: rejection warning names the spans**

- `futureagi/simulate/services/sim_collector_emit.py` — the existing `sim_collector_export_rejected` warning now includes span names and trace ids (first 5), so a rejected export can be tied to specific traces.

---

## 2) Why the changes were done

- **Product/UX:** Customer-visible: voice calls showed "In progress" forever even though the call ended cleanly in VAPI. Ingestion of the terminal state was rejected on every poll; deterministic span/trace ids mean a successful re-ingest upserts the row and flips the status.
- **Technical:** The rejection happened at the gRPC transport layer (default 4 MiB), invisible to both the collector's logs and the app's. Raising the cap to 16 MiB matches the HTTP path (which always accepted 16 MiB), so span acceptance no longer depends on which transport the SDK picked. The cap is config/env-tunable per deployment without a rebuild.
- **Architecture:** No payload trimming and no new abstractions — the fix is a server limit + logging. Payload contents are never mutated.

---

## 3) Tests written + scenarios each covers

**`fi-collector/pkg/server/server_test.go`**

- `TestGRPCAcceptsSpanLargerThanFourMiB` — 6 MiB single-span export is accepted under the new default; fails on the old 4 MiB behavior (verified by reverting the fix).
- `TestGRPCOverCapRejectionIsLogged` — 17 MiB export is rejected `ResourceExhausted` AND the rejection appears in the collector's own logs (pins the stats-handler path; also pins the grpc-go error-message match so a future grpc upgrade that changes the string fails loudly).
- `waitPort` helper fixed to actually dial (was a no-op with lazy `grpc.NewClient`) — strengthens every test in the file.

> Run result: `go test ./pkg/server/ -race -count=3` — all pass, no flakes. `go build` / `go vet` / `gofmt` clean. Python: `bin/test app tracer -k provider_collector_export` 13 passed; `bin/test app simulate -k sim_collector_emit` 6 passed.

---

## 4) How to run / test

### Backend tests

```bash
cd fi-collector && go test ./pkg/server/ -race
cd futureagi && bin/test app simulate -k "sim_collector_emit"
```

### Manual verification (done locally)

1. Rebuild the collector image (`docker build -t futureagi/fi-collector:latest fi-collector/`) and recreate the container — boot log shows `grpc listener ... max_recv_mib=16`.
2. Export a span with a ~20 MiB attribute over OTLP/gRPC → client gets `RESOURCE_EXHAUSTED`; collector logs `grpc message over size cap, request rejected ... (20971943 vs. 16777216)`.
3. Export ~12 MiB → accepted, lands in ClickHouse.

---

## 6) Edge cases & considerations

- **Quota rejections** use the same gRPC code (`ResourceExhausted`) — excluded from the new log by message-match, so an over-quota org cannot flood the collector's error log.
- **gzip-compressed exports** that inflate past the cap produce a different grpc-go message variant — covered by the substring match.
- **SDK overhead:** a raw payload of ~15 MiB serializes to just over 16 MiB on the wire (verified live); effective max attribute payload is ~14.9 MiB.
- **Spans still over 16 MiB** are rejected as before but now logged server-side; the cap can be raised per-deployment via `FI_GRPC_MAX_RECV_MIB` (clamped ≤1024) with no rebuild.
- **Memory:** the cap is per-message with no preallocation; HTTP always accepted 16 MiB bodies, so this extends an existing bound to gRPC rather than creating a new exposure class.

---

## 8) Architectural / important decisions

- **16 MiB, not more:** matches the HTTP path; per-request memory amplification (~3–4×) with unbounded stream concurrency makes larger defaults an OOM risk; real voice payloads are a few MB. Larger needs are a per-deployment env change.
- **No payload trimming:** an earlier draft trimmed oversized attrs before export; dropped deliberately — customer data should not be silently thinned to fit a transport limit that we control.
- **Deploy note — the fix alone does not heal already-stuck traces.** Their terminal `updatedAt` is behind the poll watermark. After the image rolls, run a backfill per affected provider: `fetch_logs_for_provider(provider_id, start_time=<before the stuck window>)` (idempotent — deterministic ids upsert in place). The two reported providers are project `ea270802-...` and `80a0f09d-...`.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend) — N/A, no frontend changes
- [ ] `yarn contracts:check` passes if API surface changed — N/A, no API surface change
- [ ] I've updated the documentation where relevant — N/A
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status
