### PR TITLE
fix(evals): normalize token similarity case

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -111,8 +111,8 @@ class JaccardSimilarity(Comparator):
         return self._jaccard_similarity(string1, string2)
 
     def _jaccard_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
         return len(str1_tokens.intersection(str2_tokens)) / len(
             str1_tokens.union(str2_tokens)
         )
@@ -123,8 +123,8 @@ class SorensenDiceSimilarity(Comparator):
         return self._sorensen_dice_similarity(string1, string2)
 
     def _sorensen_dice_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
         return (
             2
             * len(str1_tokens.intersection(str2_tokens))

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_token_set_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_token_set_similarity.py
@@ -1,0 +1,27 @@
+import pytest
+
+from agentic_eval.core_evals.fi_evals.grounded.similarity import (
+    JaccardSimilarity,
+    SorensenDiceSimilarity,
+)
+
+
+@pytest.mark.parametrize(
+    "comparator",
+    [JaccardSimilarity(), SorensenDiceSimilarity()],
+)
+def test_token_set_similarity_is_case_insensitive(comparator):
+    assert comparator.compare("Cat", "cat") == 1.0
+
+
+@pytest.mark.parametrize(
+    ("comparator", "expected"),
+    [
+        (JaccardSimilarity(), 1 / 3),
+        (SorensenDiceSimilarity(), 1 / 2),
+    ],
+)
+def test_token_set_similarity_normalizes_case_before_partial_overlap(
+    comparator, expected
+):
+    assert comparator.compare("Red Cat", "cat blue") == pytest.approx(expected)


### PR DESCRIPTION
## Summary

Jaccard and Sørensen-Dice evals currently treat capitalization as semantic disagreement, so equivalent outputs such as `Cat` and `cat` score `0.0`. This normalizes tokens before set comparison, matching the existing case-insensitive behavior of `CosineSimilarity`, and adds regression coverage for full and partial overlap.

## Linked issues

Closes #653
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 1) What changes were done

**A. Case-insensitive token-set similarity**

- Lowercase tokens before Jaccard and Sørensen-Dice set operations.
- Preserve the existing whitespace tokenization and score formulas.

**B. Regression coverage**

- Verify mixed-case equivalents score `1.0` for both comparators.
- Verify case normalization is applied before computing partial-overlap scores.

## 2) Why the changes were done

- **Product/UX:** Capitalization differences in model output should not turn an otherwise grounded answer into a failing eval.
- **Technical:** Normalize at tokenization time, consistent with `CosineSimilarity`, without changing comparator APIs or thresholds.

## 3) Tests written + scenarios each covers

**`test_token_set_similarity.py`** — case normalization for token-set comparators

- `test_token_set_similarity_is_case_insensitive` — equivalent tokens with different capitalization score `1.0`.
- `test_token_set_similarity_normalizes_case_before_partial_overlap` — normalized intersections produce the correct Jaccard and Sørensen-Dice scores.

> Run result: **10 passed** across the grounded-similarity tests. Ruff and Black checks pass for the changed files.

## 4) How to run / test

```bash
PYTHONPATH=futureagi/agentic_eval python -m pytest \
  futureagi/agentic_eval/core_evals/fi_evals/grounded/tests
```

## 6) Edge cases & considerations

- Empty-input behavior is intentionally unchanged and remains scoped to #980.
- Token boundaries remain whitespace-based, preserving existing scores apart from letter case.

## 8) Architectural / important decisions

- **Narrow normalization:** Use the same `.lower()` normalization already established by `CosineSimilarity`; no evaluator configuration or persisted data changes are required.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [x] Targeted backend tests pass locally
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [ ] CLA signed (will complete when the CLA bot posts instructions)
