### PR TITLE
fix(gateway): propagate post-plugin errors

### DIFF
--- a/agentcc-gateway/internal/guardrails/engine_test.go
+++ b/agentcc-gateway/internal/guardrails/engine_test.go
@@ -930,6 +930,56 @@ func TestPlugin_PostBlock(t *testing.T) {
 	}
 }
 
+func TestPlugin_PostBlockPropagatesThroughPipeline(t *testing.T) {
+	registry := map[string]Guardrail{
+		"toxicity": &mockGuardrail{
+			name:  "toxicity",
+			stage: StagePost,
+			result: &CheckResult{
+				Pass:    false,
+				Score:   0.92,
+				Action:  ActionBlock,
+				Message: "toxic response",
+			},
+		},
+	}
+	guardrailEngine := NewEngine(config.GuardrailsConfig{
+		Enabled:        true,
+		FailOpen:       true,
+		DefaultTimeout: 5 * time.Second,
+		Rules: []config.GuardrailRuleConfig{
+			{Name: "toxicity", Stage: "post", Mode: "sync", Action: "block", Threshold: 0.7},
+		},
+	}, registry)
+	pipelineEngine := pipeline.NewEngine(
+		NewPlugin(guardrailEngine, nil, nil, nil, nil),
+	)
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.Request = &models.ChatCompletionRequest{Model: "gpt-4o"}
+	rc.Model = "gpt-4o"
+
+	err := pipelineEngine.Process(
+		context.Background(),
+		rc,
+		func(ctx context.Context, rc *models.RequestContext) error {
+			rc.Response = &models.ChatCompletionResponse{ID: "test"}
+			return nil
+		},
+	)
+	apiErr, ok := err.(*models.APIError)
+	if !ok {
+		t.Fatalf("Process error = %T %v, want *models.APIError", err, err)
+	}
+	if apiErr.Status != 403 || apiErr.Code != "content_blocked" {
+		t.Errorf("Process error = %+v, want 403 content_blocked", apiErr)
+	}
+	if rc.Response != nil {
+		t.Error("blocked response should not escape the pipeline")
+	}
+}
+
 func TestPlugin_NoGuardrails(t *testing.T) {
 	engine := NewEngine(config.GuardrailsConfig{
 		Enabled:        true,

--- a/agentcc-gateway/internal/pipeline/engine.go
+++ b/agentcc-gateway/internal/pipeline/engine.go
@@ -100,7 +100,9 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 			if result.Response != nil {
 				rc.Response = result.Response
 			}
-			e.RunPostPlugins(ctx, rc)
+			if err := e.RunPostPlugins(ctx, rc); err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -132,7 +134,9 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 	// Post-plugins — skip for streaming requests; the stream handler
 	// will call RunPostPlugins after the stream completes with final usage.
 	if !rc.IsStream {
-		e.RunPostPlugins(ctx, rc)
+		if err := e.RunPostPlugins(ctx, rc); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -142,10 +146,14 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 //  2. Parallel-safe plugins run concurrently after sequential ones complete.
 //  3. Plugins implementing SkipOnCacheHit are skipped on cache hits.
 //
+// Returns the first error from a sequential post-plugin after all post-plugins
+// have run. Errors from parallel observer plugins remain non-fatal.
+//
 // Exported so that streaming handlers can call it after the stream completes,
 // when rc.Response and usage data are populated.
-func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) {
+func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) *models.APIError {
 	isCacheHit := rc.Flags.ShortCircuited && rc.Metadata["cache_status"] == "hit_exact"
+	var firstErr *models.APIError
 
 	// Phase 1: Sequential post-plugins (e.g., cost → credits dependency chain).
 	for _, p := range e.postSequential {
@@ -160,6 +168,10 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 		rc.RecordTiming("post_"+p.Name(), time.Since(start))
 
 		if result.Error != nil {
+			rc.AddError(result.Error)
+			if firstErr == nil {
+				firstErr = result.Error
+			}
 			slog.Warn("post-plugin error",
 				"plugin", p.Name(),
 				"error", result.Error.Message,
@@ -170,7 +182,7 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 
 	// Phase 2: Parallel post-plugins (logging, audit, metrics, alerting, otel).
 	if len(e.postParallel) == 0 {
-		return
+		return firstErr
 	}
 
 	var wg sync.WaitGroup
@@ -199,6 +211,7 @@ func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) 
 		}(p)
 	}
 	wg.Wait()
+	return firstErr
 }
 
 // PluginCount returns the number of registered plugins.

--- a/agentcc-gateway/internal/pipeline/engine_test.go
+++ b/agentcc-gateway/internal/pipeline/engine_test.go
@@ -15,8 +15,8 @@ type mockPlugin struct {
 	onResp   func(ctx context.Context, rc *models.RequestContext) PluginResult
 }
 
-func (m *mockPlugin) Name() string    { return m.name }
-func (m *mockPlugin) Priority() int   { return m.priority }
+func (m *mockPlugin) Name() string  { return m.name }
+func (m *mockPlugin) Priority() int { return m.priority }
 func (m *mockPlugin) ProcessRequest(ctx context.Context, rc *models.RequestContext) PluginResult {
 	if m.onReq != nil {
 		return m.onReq(ctx, rc)
@@ -168,6 +168,46 @@ func TestEngineProviderError(t *testing.T) {
 	}
 	if !postPluginRan {
 		t.Error("post-plugins should run even when provider errors")
+	}
+}
+
+func TestEnginePostPluginError(t *testing.T) {
+	postErr := models.ErrForbidden("response blocked")
+	errorPlugin := &mockPlugin{
+		name:     "response-validator",
+		priority: 1,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			return ResultError(postErr)
+		},
+	}
+
+	observerRan := false
+	observerPlugin := &mockPlugin{
+		name:     "observer",
+		priority: 2,
+		onResp: func(ctx context.Context, rc *models.RequestContext) PluginResult {
+			observerRan = true
+			return ResultContinue()
+		},
+	}
+
+	engine := NewEngine(errorPlugin, observerPlugin)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	err := engine.Process(context.Background(), rc, func(ctx context.Context, rc *models.RequestContext) error {
+		rc.Response = &models.ChatCompletionResponse{ID: "test"}
+		return nil
+	})
+
+	if err != postErr {
+		t.Fatalf("Process error = %v, want post-plugin error %v", err, postErr)
+	}
+	if !observerRan {
+		t.Error("later post-plugins should run after a post-plugin error")
+	}
+	if len(rc.Errors) != 1 || rc.Errors[0] != postErr {
+		t.Fatalf("request errors = %v, want [%v]", rc.Errors, postErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Blocking post-response guardrails create a `403 content_blocked` error and clear the provider response, but the pipeline currently logs and discards that error. Non-streaming handlers consequently emit a misleading `500 no response from provider`. This preserves the full post-processing pass while returning the first terminal sequential post-plugin error to the handler.

## Linked issues

Closes #2028
Linear: N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 1) What changes were done

**A. Post-plugin error propagation**

- Return the first sequential post-plugin error after all post-plugins finish.
- Record sequential post-plugin failures on `RequestContext` before observer plugins run.
- Propagate post errors from successful provider calls and pre-plugin short-circuit responses.

**B. Regression coverage**

- Verify the pipeline returns a post-plugin error without skipping later post-plugins.
- Verify a blocking response guardrail escapes the complete pipeline as `403 content_blocked` and the blocked response remains cleared.

## 2) Why the changes were done

- **Product/UX:** Callers should receive the actionable guardrail decision, not a generic gateway failure.
- **Technical:** Security gates run sequentially, so their explicit `ResultError` must be terminal; logging, audit, and metrics still run before the error is returned.
- **Architecture:** Parallel post-plugins are read-only observers and remain non-fatal, preserving the existing observability failure policy.

## 3) Tests written + scenarios each covers

**`internal/pipeline/engine_test.go`** — post-pipeline terminal behavior

- `TestEnginePostPluginError` — returns the explicit error, records it, and continues remaining post-processing.

**`internal/guardrails/engine_test.go`** — guardrail integration through the pipeline

- `TestPlugin_PostBlockPropagatesThroughPipeline` — preserves `403 content_blocked` and prevents a blocked response from escaping.

> Run result: `go test ./internal/...` passes.

## 4) How to run / test

```bash
cd agentcc-gateway
go test ./internal/...
```

## 6) Edge cases & considerations

- Later post-plugins still run after an error, preserving logs, audit events, metrics, and timing data.
- Provider/pre-plugin errors retain their original precedence; post errors are propagated when the provider or cache short-circuit otherwise succeeded.
- Streaming behavior is unchanged because headers/body may already be written before the final post-plugin pass; buffered streaming enforcement is separate work.

## 8) Architectural / important decisions

- **Sequential vs. parallel:** Sequential plugins may enforce terminal response policy. Parallel observer failures remain logged and non-fatal.
- **First-error precedence:** Return the first sequential post error while recording every sequential post error on the request context.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the fix is effective
- [x] Full gateway internal test suite passes locally
- [x] No API contract generation required
- [x] No hardcoded secrets, URLs, or PII
- [x] PR title follows Conventional Commits
- [ ] CLA signed (will complete when the CLA bot posts instructions)
