### PR TITLE
fix(observe): align primary/compare tab labels with view mode

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -168,6 +168,7 @@ import TracingControls from "./TracingControls";
 import ObserveToolbar from "./ObserveToolbar";
 import { selectPanelGraphFilters } from "./GraphSection/graphFilterUtils";
 import { buildAddEvalsDraft } from "./buildAddEvalsDraft";
+import { getObservePaneTabLabel } from "./observePaneTabLabels";
 import SelectAllBanner from "./SelectAllBanner";
 import useProjectFilterField from "../UsersView/useProjectFilterField";
 import FilterChips from "./FilterChips";
@@ -3623,7 +3624,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     margin: theme.spacing(0),
                     px: theme.spacing(1.875),
                   }}
-                  label="Primary Graph"
+                  label={getObservePaneTabLabel(effectiveViewMode, "primary")}
                   value="primary"
                 />
                 <Tab
@@ -3631,7 +3632,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     margin: theme.spacing(0),
                     px: theme.spacing(1.875),
                   }}
-                  label="Comparison Graph"
+                  label={getObservePaneTabLabel(effectiveViewMode, "compare")}
                   value="compare"
                 />
               </Tabs>

--- a/frontend/src/sections/projects/LLMTracing/__tests__/observePaneTabLabels.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/observePaneTabLabels.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { getObservePaneTabLabel } from "../observePaneTabLabels";
+
+describe("getObservePaneTabLabel", () => {
+  it("uses Graph labels when the observe view is graph mode", () => {
+    expect(getObservePaneTabLabel("graph", "primary")).toBe("Primary Graph");
+    expect(getObservePaneTabLabel("graph", "compare")).toBe("Comparison Graph");
+  });
+
+  it("uses Data labels for table view so tabs match TraceGrid content", () => {
+    expect(getObservePaneTabLabel("table", "primary")).toBe("Primary Data");
+    expect(getObservePaneTabLabel("table", "compare")).toBe("Comparison Data");
+  });
+
+  it("uses Data labels for agent views (not graph charts)", () => {
+    expect(getObservePaneTabLabel("agentGraph", "primary")).toBe("Primary Data");
+    expect(getObservePaneTabLabel("agentPath", "compare")).toBe(
+      "Comparison Data",
+    );
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/observePaneTabLabels.js
+++ b/frontend/src/sections/projects/LLMTracing/observePaneTabLabels.js
@@ -1,0 +1,10 @@
+/**
+ * Labels for the primary/compare pane tabs in Observe.
+ *
+ * Graph view renders PrimaryGraph above the grids, so "Graph" is accurate there.
+ * Table / agent views render TraceGrid content under these tabs, so "Data" matches.
+ */
+export function getObservePaneTabLabel(viewMode, pane) {
+  const noun = viewMode === "graph" ? "Graph" : "Data";
+  return pane === "compare" ? `Comparison ${noun}` : `Primary ${noun}`;
+}


### PR DESCRIPTION
## Summary

Primary/compare tabs in Observe said "Graph" even when the pane under them is a TraceGrid. Labels are now Data in table/agent view, and Graph only when `effectiveViewMode === "graph"`. Small helper + regression test so this doesn't regress.

## Linked issues

Closes #1686

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## 1) What changes were done

**A. Observe primary/compare tab labels**

- Table and agent views show "Primary Data" / "Comparison Data"
- Graph view keeps "Primary Graph" / "Comparison Graph"
- Label logic lives in `observePaneTabLabels.js`; `LLMTracingView.jsx` calls it

## 2) Why the changes were done

- **Product/UX:** Tabs should match what's under them (TraceGrid vs graphs)
- **Technical:** Pure helper keeps the change testable without mounting the full view

## 3) Tests written + scenarios each covers

**`frontend/src/sections/projects/LLMTracing/__tests__/observePaneTabLabels.test.js`**

- graph mode → Graph labels
- table mode → Data labels
- agentGraph / agentPath → Data labels

> Run result: **3 passed**

## 4) How to run / test

```bash
cd frontend
npm run test:run -- src/sections/projects/LLMTracing/__tests__/observePaneTabLabels.test.js
```

### UI steps (manual)

1. Observe → LLM Tracing, turn compare mode on
2. Table view: tabs say Primary/Comparison Data
3. Graph view: tabs say Primary/Comparison Graph

## Checklist

- [x] Branched from `dev`
- [x] Regression test added
- [x] Diff limited to the label path
- [x] PR title follows Conventional Commits