### PR TITLE
fix: add None checks for EE-only imports in OSS builds

### DIFF
--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -1072,14 +1072,17 @@ def _deduct_project_creation_cost(
         else APICallTypeChoices.OBSERVE_ADD.value
     )
 
-    call_log_row = log_and_deduct_cost_for_resource_request(
-        organization,
-        call_type,
-        config={"existing": existing, "project_id": project_id},
-        workspace=workspace,
-    )
+    if log_and_deduct_cost_for_resource_request is not None:
+        call_log_row = log_and_deduct_cost_for_resource_request(
+            organization,
+            call_type,
+            config={"existing": existing, "project_id": project_id},
+            workspace=workspace,
+        )
+    else:
+        call_log_row = None
 
-    if (
+    if log_and_deduct_cost_for_resource_request is not None and (
         call_log_row is None
         or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
     ):

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -814,7 +814,7 @@ def bulk_create_observation_span_task(
             except ImportError:
                 DeploymentMode = None
 
-            if not DeploymentMode.is_oss():
+            if DeploymentMode is not None and not DeploymentMode.is_oss():
                 try:
                     from ee.usage.schemas.event_types import BillingEventType
                 except ImportError:
@@ -824,16 +824,17 @@ def bulk_create_observation_span_task(
                 except ImportError:
                     check_usage = None
 
-                usage_check = check_usage(
-                    str(organization_id), BillingEventType.TRACING_EVENT
-                )
-                if not usage_check.allowed:
-                    logger.warning(
-                        "trace_ingestion_blocked_free_tier",
-                        org_id=str(organization_id),
-                        reason=usage_check.reason,
+                if check_usage is not None and BillingEventType is not None:
+                    usage_check = check_usage(
+                        str(organization_id), BillingEventType.TRACING_EVENT
                     )
-                    return
+                    if not usage_check.allowed:
+                        logger.warning(
+                            "trace_ingestion_blocked_free_tier",
+                            org_id=str(organization_id),
+                            reason=usage_check.reason,
+                        )
+                        return
         except Exception:
             pass  # Fail open — don't break ingestion on metering errors
 


### PR DESCRIPTION
## Summary

In OSS self-hosted builds, enterprise edition (`ee.*`) modules are absent
and their imports fall back to `None`. Two call sites called these
None-replaced objects without checking for `None` first, causing
`TypeError` / `AttributeError` at runtime.

This is the same class of bug as **Issue #1303**, which was already fixed
in `otlp.py` and `grpc.py` but left similar patterns unfixed elsewhere.

---

### Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### 1) What changes were done

**A. `futureagi/tracer/utils/otel.py` — `_deduct_project_creation_cost()`**

- Added `is not None` guard before calling `log_and_deduct_cost_for_resource_request()`
- Skip `ResourceLimitError` in OSS builds where billing is not applicable
- Follows the same pattern as `workspace_management.py:2056`

**B. `futureagi/tracer/utils/trace_ingestion.py` — `bulk_create_observation_span_task()`**

- Added `is not None` guard before calling `DeploymentMode.is_oss()`
- Added `is not None` guards before using `check_usage()` and `BillingEventType`
- Previously relied on `except Exception: pass` to mask the `AttributeError` on the trace ingestion hot path

---

### 2) Why the changes were done

**Product/UX:** OSS self-hosted users should not encounter crashes due to missing enterprise modules.

**Technical:** The codebase already has an established pattern for handling EE-only imports (see `workspace_management.py`, `develop_dataset.py`). These two call sites were missed. Using explicit None checks is cleaner than relying on `except Exception: pass` for control flow.

---

### 3) Tests written + scenarios

No new tests — these changes follow the existing pattern already covered by tests in `workspace_management.py`. The affected code paths are:

- `_deduct_project_creation_cost` — currently not called from any active code path
- `bulk_create_observation_span_task` — covered by existing trace ingestion tests

---

### 4) How to run / test

```bash
cd futureagi
uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-test.txt
bin/test tracer
6) Edge cases & considerations
All EE modules missing (OSS build): All guarded imports fall back to None, billing checks are skipped gracefully → no crash
Some EE modules present (enterprise build): Imports succeed, guards pass, billing checks run normally → no behavior change
Mixed state (partial EE install): Guards handle each import independently → safe
Checklist
 My code follows the style guide
 I've added tests that prove my fix is effective or that my feature works
 bin/test passes locally (backend)
 yarn test:run passes locally (frontend)
 yarn contracts:check passes if API surface changed
 I've updated the documentation where relevant
 No hardcoded secrets, URLs, or PII
 I've signed the CLA
 PR title follows Conventional Commits

