### PR TITLE
fix(tracer): restore format_datetime_to_iso return statement

### DIFF
--- a/futureagi/tracer/utils/helper.py
+++ b/futureagi/tracer/utils/helper.py
@@ -768,6 +768,9 @@ def format_datetime_to_iso(val):
     """Convert a single datetime value to an ISO 8601 UTC string with 'Z' suffix."""
     if not val:
         return None
+    # Use strftime to produce a consistent UTC format, avoiding double-offset
+    # when val is already timezone-aware (e.g. "2024-01-01T00:00:00+00:00Z").
+    return val.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def flatten_dict(
@@ -794,9 +797,6 @@ def flatten_dict(
         else:
             items.append((new_key, v))
     return dict(items)
-    # Use strftime to produce a consistent UTC format, avoiding double-offset
-    # when val is already timezone-aware (e.g. "2024-01-01T00:00:00+00:00Z").
-    return val.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
 def format_datetime_fields_to_iso(rows, fields):

--- a/futureagi/tracer/utils/tests/test_format_datetime_to_iso.py
+++ b/futureagi/tracer/utils/tests/test_format_datetime_to_iso.py
@@ -1,0 +1,73 @@
+"""Guard for the ISO 8601 'Z' formatting of session datetime fields."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from tracer.utils.helper import (
+    format_datetime_fields_to_iso,
+    format_datetime_to_iso,
+)
+
+
+class TestFormatDatetimeToIso:
+    def test_naive_datetime_formats_with_z_suffix(self):
+        val = datetime(2024, 1, 1, 12, 30, 45, 123456)
+
+        assert format_datetime_to_iso(val) == "2024-01-01T12:30:45.123456Z"
+
+    def test_tz_aware_datetime_does_not_double_offset(self):
+        val = datetime(2024, 1, 1, 12, 30, 45, 123456, tzinfo=UTC)
+
+        result = format_datetime_to_iso(val)
+
+        assert result == "2024-01-01T12:30:45.123456Z"
+        assert "+00:00" not in result
+
+    def test_non_utc_aware_datetime_still_single_suffix(self):
+        val = datetime(
+            2024, 1, 1, 12, 30, 45, tzinfo=timezone(timedelta(hours=5, minutes=30))
+        )
+
+        result = format_datetime_to_iso(val)
+
+        assert result.endswith("Z")
+        assert "+05:30" not in result
+
+    def test_falsy_input_returns_none(self):
+        assert format_datetime_to_iso(None) is None
+        assert format_datetime_to_iso("") is None
+
+
+class TestFormatDatetimeFieldsToIso:
+    def test_mutates_rows_in_place(self):
+        rows = [
+            {
+                "session_id": "s-1",
+                "start_time": datetime(2024, 1, 1, 0, 0, 0),
+                "end_time": datetime(2024, 1, 1, 0, 5, 0),
+            }
+        ]
+
+        assert format_datetime_fields_to_iso(rows, ["start_time", "end_time"]) is None
+        assert rows[0]["start_time"] == "2024-01-01T00:00:00.000000Z"
+        assert rows[0]["end_time"] == "2024-01-01T00:05:00.000000Z"
+        assert rows[0]["session_id"] == "s-1"
+
+    def test_none_fields_stay_none(self):
+        rows = [
+            {"start_time": datetime(2024, 1, 1, 0, 0, 0), "end_time": None},
+            {"start_time": None, "end_time": None},
+        ]
+
+        format_datetime_fields_to_iso(rows, ["start_time", "end_time"])
+
+        assert rows[0]["start_time"] == "2024-01-01T00:00:00.000000Z"
+        assert rows[0]["end_time"] is None
+        assert rows[1]["start_time"] is None
+        assert rows[1]["end_time"] is None
+
+    def test_missing_field_is_set_to_none(self):
+        rows = [{"session_id": "s-1"}]
+
+        format_datetime_fields_to_iso(rows, ["created_at"])
+
+        assert rows[0]["created_at"] is None


### PR DESCRIPTION
## Summary

A merge detached the return statement from `format_datetime_to_iso` in `futureagi/tracer/utils/helper.py`, leaving the function with only its falsy guard. Every truthy datetime fell through to an implicit `None`, so every session timestamp in the trace-session API serialized as `null`. The orphaned lines landed at the tail of `flatten_dict`, after that function's own `return dict(items)`, where they were unreachable and referenced `val` — a name not in scope there. This PR moves the comment and return statement back into `format_datetime_to_iso` and deletes the unreachable copy. No other behaviour changes.

## Linked issues

No pre-existing GitHub issue — this was found by inspection while reading the merged code. Happy to file one for traceability if maintainers would like the bug tracked separately; say the word and I'll open it and link it here.

Linear: n/a — I'm an external contributor and don't have access to the Linear workspace.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Restored the return statement in `format_datetime_to_iso` (`tracer/utils/helper.py`)**

Before this PR, the two functions looked like this on `dev`:

```python
def format_datetime_to_iso(val):
    """Convert a single datetime value to an ISO 8601 UTC string with 'Z' suffix."""
    if not val:
        return None
    # (nothing here — control falls off the end and returns None implicitly)


def flatten_dict(
    d: MutableMapping[str, Any],
    prefix: str = "",
    sep: str = ".",
) -> dict[str, Any]:
    ...
    return dict(items)
    # Use strftime to produce a consistent UTC format, avoiding double-offset
    # when val is already timezone-aware (e.g. "2024-01-01T00:00:00+00:00Z").
    return val.strftime("%Y-%m-%dT%H:%M:%S.%fZ")   # unreachable; `val` undefined here
```

*(The `# (nothing here ...)` line and the trailing `# unreachable ...` note are editorial annotations for this description, not source text. Everything else is verbatim.)*

- **What changed for the user:** session timestamps are populated again instead of `null`.
- **What changed in the API/serializer:** nothing structural — field names and types are unchanged, only the serialized values were wrong.
- **What changed in the model/storage:** nothing.

**B. Deleted the unreachable copy from the tail of `flatten_dict`**

`flatten_dict` is unaffected by the deletion: the lines sat after its `return dict(items)` and never executed.

**C. Added test coverage**

New file `futureagi/tracer/utils/tests/test_format_datetime_to_iso.py` — see §3.

### Affected call sites

All callers live in `tracer/views/trace_session.py`, inside `TraceSessionView`:

| Line | Enclosing method | Call | Field(s) affected | Result before fix |
|---|---|---|---|---|
| `:671` | `_retrieve_clickhouse` | `format_datetime_to_iso` (direct) | `session_metadata.start_time` | `null` |
| `:672` | `_retrieve_clickhouse` | `format_datetime_to_iso` (direct) | `session_metadata.end_time` | `null` |
| `:776` | `_retrieve_clickhouse` | `format_datetime_to_iso` (direct) | per-trace `system_metrics.start_time` | `null` |
| `:1601` | `list_sessions` | `format_datetime_fields_to_iso` (wrapper, `helper.py:802`) | `start_time`, `end_time`, `created_at` on every session row | `null` |

So: **3 direct calls plus 1 through the wrapper.** The wrapper `format_datetime_fields_to_iso` is a thin loop that delegates to `format_datetime_to_iso` (`helper.py:806`), and it has **exactly one caller** in the codebase (`:1601`) outside of its own definition and the new tests. Since the direct calls are likewise fully enumerated above, this table is the **complete set of affected API responses** — there is no other path by which the broken function reached a response body.

### Severity

This was **unconditional, not an edge case**. The falsy guard was the only reachable `return`, so *every* truthy datetime returned `None` on *every* request — there was no input that produced a correct timestamp.

It presented as *partial* breakage rather than an obvious outage: `duration` on the session detail response is computed separately from the raw datetimes and never routed through `format_datetime_to_iso`, so it kept working. A session could therefore show a correct duration alongside blank start/end times, which reads as a display quirk rather than a serialization bug.

---

## 2) Why the changes were done

- **Product/UX:** session start/end and created-at rendered blank across the session list and session detail views, and any client-side sorting or filtering on those fields had no values to work with.
- **Technical:** the `strftime` approach is deliberate and is preserved **verbatim** — it is moved, not rewritten. The retained comment documents why: `strftime("%Y-%m-%dT%H:%M:%S.%fZ")` appends a literal `Z` and ignores `tzinfo`, whereas the obvious-looking `.isoformat() + "Z"` produces a double-offset suffix on tz-aware values. Verified locally:

  ```
  isoformat+Z ->  2024-01-01T12:30:45.123456+00:00Z   # malformed
  ours        ->  2024-01-01T12:30:45.123456Z
  ```

  Restoring the original statement rather than reimplementing the formatting keeps this a pure restoration with no behaviour question for reviewers to adjudicate — the post-fix output is byte-identical to what the code produced before the merge.
- **Architecture:** no layering change. Two functions in one helper module return to their pre-merge shape.

---

## 3) Tests written + scenarios each covers

**`futureagi/tracer/utils/tests/test_format_datetime_to_iso.py`** — locks in the ISO 8601 `Z` contract for both the single-value formatter and the in-place field wrapper, so a future merge cannot silently detach the return again.

`TestFormatDatetimeToIso`

- `test_naive_datetime_formats_with_z_suffix` — a naive datetime formats to `2024-01-01T12:30:45.123456Z`; this is the assertion that fails outright on the broken code.
- `test_tz_aware_datetime_does_not_double_offset` — a `tzinfo=UTC` datetime yields the same string and contains no `+00:00`, guarding the `strftime`-over-`isoformat` decision.
- `test_non_utc_aware_datetime_still_single_suffix` — a `+05:30` datetime still ends in exactly one `Z` and carries no `+05:30` offset.
- `test_falsy_input_returns_none` — `None` and `""` short-circuit on the guard and return `None`.

`TestFormatDatetimeFieldsToIso`

- `test_mutates_rows_in_place` — the wrapper returns `None` and mutates the row dict in place, converting `start_time` / `end_time` while leaving unrelated keys untouched.
- `test_none_fields_stay_none` — `None` fields stay `None` across multiple rows, and are not turned into a string.
- `test_missing_field_is_set_to_none` — a field absent from the row is set to `None` rather than raising `KeyError` (the wrapper uses `item.get(field)`).

> Run result: **7 passed** across this suite. Lint (ruff) + format (black) clean on both touched files.

---

## 4) How to run / test

### Backend tests

```bash
cd futureagi
bin/test tracer/utils/tests/test_format_datetime_to_iso.py -v
```

Result: **7 passed in 0.02s** (pytest 9.0.2, Django 5.1.8, Python 3.11.15, settings `tfc.settings.test`).

### Lint / format on the touched files

`ruff` reproduces the bug directly as an undefined-name error, which makes a clean before/after check possible:

```bash
cd futureagi
uv run --with ruff ruff check --select F821 tracer/utils/helper.py
```

- **Before the fix** (run against the file as it stands on `dev`):

  ```
  F821 Undefined name `val`
     --> tracer/utils/helper.py:799:12
      |
  799 |     return val.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
      |            ^^^
  Found 1 error.
  ```

- **After the fix:** `All checks passed!`

Formatting on the two touched files:

```bash
uv run --with black black --check tracer/utils/helper.py tracer/utils/tests/test_format_datetime_to_iso.py
# 2 files would be left unchanged.
```

> Note: `ruff` is not a declared project dependency, so `uv run ruff` fails to spawn; `uv run --with ruff` is used above. See §7 on why repo-wide lint was not used as a gate.

### Frontend tests

n/a — no frontend files are touched by this PR.

### Contract verification

n/a — the API surface is unchanged. Field names, field types, and response shapes are identical; only the serialized *values* were wrong (`null` instead of a timestamp string), so there is no schema delta for `yarn contracts:check` to catch.

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. Open a project with tracing data and go to the **Sessions** list.
3. Confirm the **Start time**, **End time**, and **Created at** columns show timestamps rather than blanks.
4. Open a single session and confirm session start/end are populated in the header, and that per-trace start times are populated in the trace table.

---

## 5) Screenshots / recordings

### Test output

```
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeToIso::test_naive_datetime_formats_with_z_suffix PASSED [ 14%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeToIso::test_tz_aware_datetime_does_not_double_offset PASSED [ 28%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeToIso::test_non_utc_aware_datetime_still_single_suffix PASSED [ 42%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeToIso::test_falsy_input_returns_none PASSED [ 57%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeFieldsToIso::test_mutates_rows_in_place PASSED [ 71%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeFieldsToIso::test_none_fields_stay_none PASSED [ 85%]
tracer/utils/tests/test_format_datetime_to_iso.py::TestFormatDatetimeFieldsToIso::test_missing_field_is_set_to_none PASSED [100%]

============================== 7 passed in 0.02s ===============================
```

### UI testing

No UI screenshots attached — the change is a one-statement restoration in a serialization helper, covered by unit tests. Manual UI steps are listed in §4 for a reviewer who wants to confirm against live tracing data.

---

## 6) Edge cases & considerations

- **Falsy input (`None`, `""`, and any other falsy value):** unchanged — still short-circuits on the `if not val: return None` guard, which was the one part of the function that survived the merge. Covered by `test_falsy_input_returns_none`.
- **Timezone-aware input:** asserted to produce no `+00:00` in the output. `strftime` ignores `tzinfo` and appends a literal `Z`, so a tz-aware value cannot produce the malformed `...+00:00Z` that `.isoformat() + "Z"` would. Covered by `test_tz_aware_datetime_does_not_double_offset` and `test_non_utc_aware_datetime_still_single_suffix`.
- **Truthy non-datetime input (e.g. a string):** raises `AttributeError: 'str' object has no attribute 'strftime'`. This is the pre-merge behaviour restored as-is — the function never validated its input type, and adding validation would change behaviour beyond the scope of this fix. Deliberately left out of scope; not tested, so as not to lock in a contract the original author may not have intended.
- **`flatten_dict`:** unaffected by the deletion. The removed lines sat *after* its `return dict(items)` and were never executed, so removing them cannot change its output. Its existing behaviour and callers are untouched.
- **Return type of the wrapper:** `format_datetime_fields_to_iso` mutates in place and returns `None`; `test_mutates_rows_in_place` asserts both the `None` return and the mutation, so a future refactor to a copy-returning style would be caught.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- **Repo-wide lint is already failing on `dev`.** `ruff` reports thousands of pre-existing violations across the codebase independently of this change, so `make lint` and `make check-all` were **not** used as gates for this PR — they fail regardless of whether this change is applied. Instead, `ruff` and `black` were run against **only the two touched files**.
- **Remaining `ruff` findings in `tracer/utils/helper.py`**, both pre-existing and on lines this PR does not touch:
  - `UP007` at `helper.py:359` — `Use X | Y for type annotations` (a `Union[...]` alias).
  - `B904` at `helper.py:486` — `raise ... from err` missing inside an `except` clause.

  Left alone deliberately to keep the diff to the actual fix. The new test file is clean: `All checks passed!`
- **`CHANGELOG.md` was not hand-edited.** This repo generates its changelog via release-please from Conventional Commits, so the entry comes from the commit subject (`fix(tracer): restore format_datetime_to_iso return statement`) rather than a manual edit.
- **ClickHouse warning during local pytest:** `bin/test` starts its own isolated services, so the suite runs clean; a bare `uv run pytest` emits a `CH25 schema apply skipped` connection warning. Unrelated to this change and harmless for this test file, which touches no I/O.

---

## 8) Architectural / important decisions

- **Move the original statement rather than rewrite it:** the restored line and its comment are byte-identical to what the merge displaced. This keeps the PR a pure restoration, so reviewers do not have to evaluate a new formatting implementation alongside the bug fix.
- **Keep `strftime` over `.isoformat()`:** `.isoformat() + "Z"` yields `...+00:00Z` on tz-aware values. The original comment documents this and is retained with the code it explains.
- **Do not add input-type validation:** raising `AttributeError` on truthy non-datetime input is pre-merge behaviour. Changing it would be a behaviour change smuggled into a regression fix.
- **Test the wrapper as well as the leaf function:** the wrapper is what the session *list* endpoint calls, and it is the only path by which `created_at` is affected, so covering it directly guards the larger of the two blast radii.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style) — ruff + black clean on both touched files
- [x] I've added tests that prove my fix is effective or that my feature works — `test_naive_datetime_formats_with_z_suffix` fails on the broken code
- [ ] `bin/test` passes locally (backend) — **partially:** `bin/test tracer/utils/tests/test_format_datetime_to_iso.py -v` passes (7 passed). The **full** `bin/test` suite was not run end-to-end, so this is not ticked; CI is the authority on the rest of the suite.
- [ ] `yarn test:run` passes locally (frontend) — **n/a**, no frontend files touched
- [ ] `yarn contracts:check` passes if API surface changed — **n/a**, API surface unchanged (field names and types identical; only serialized values were wrong)
- [ ] I've updated the documentation where relevant — **n/a**, no documented behaviour changes; this restores the already-documented behaviour of the function's own docstring
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — will sign when the bot prompts
- [x] PR title follows Conventional Commits — `fix(tracer): restore format_datetime_to_iso return statement`
- [ ] Linear issue is linked and updated with status — **n/a**, I don't have Linear access
