### PR TITLE
fix(workbench): remove hardcoded disabled color on Commit button

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/promptActions/SaveAndCommit.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/SaveAndCommit.jsx
@@ -169,7 +169,7 @@ const SaveAndCommit = ({ open, onClose, data, promptName }) => {
 
         <DialogActions sx={{ pt: "32px" }}>
           <LoadingButton
-            sx={{ px: "16px", color: "text.disabled" }}
+            sx={{ px: "16px" }}
             disabled={!isDirty || isPending}
             loading={isPending}
             variant="outlined"

--- a/frontend/src/sections/workbench/createPrompt/promptActions/__tests__/SaveAndCommit.test.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/__tests__/SaveAndCommit.test.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import SaveAndCommit from "../SaveAndCommit";
+
+const mocks = vi.hoisted(() => ({
+  useMutation: vi.fn(),
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: mocks.useMutation,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ id: "prompt-123" }),
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: {},
+  PropertyName: {},
+  trackEvent: vi.fn(),
+}));
+
+function renderDialog() {
+  return render(
+    <SaveAndCommit
+      open
+      onClose={vi.fn()}
+      data={{ version: "v1", isDefault: false, isDraft: false }}
+      promptName="My Prompt"
+    />,
+  );
+}
+
+const getCommitButton = () => screen.getByRole("button", { name: /^Commit$/ });
+
+describe("SaveAndCommit — Commit button state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useMutation.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  });
+
+  it("keeps the Commit button disabled while the message field is empty", () => {
+    renderDialog();
+    expect(getCommitButton()).toBeDisabled();
+  });
+
+  it("enables the Commit button once a message is entered", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByPlaceholderText(/Enter a commit message/i),
+      "my commit",
+    );
+
+    expect(getCommitButton()).toBeEnabled();
+  });
+
+  it("does not hardcode the disabled text color once the button is active", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByPlaceholderText(/Enter a commit message/i),
+      "my commit",
+    );
+
+    // Regression guard for #1384: the enabled button must not carry the
+    // hardcoded `text.disabled` color that made it look greyed out.
+    expect(getCommitButton()).not.toHaveStyle({ color: "rgba(0, 0, 0, 0.38)" });
+  });
+
+  it("shows a loading state and stays disabled while the request is in flight", () => {
+    mocks.useMutation.mockReturnValue({ mutate: vi.fn(), isPending: true });
+    renderDialog();
+    expect(getCommitButton()).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

The outlined **Commit** button in the Workbench commit dialog stayed greyed-out even after a message was typed and it became clickable. Its `sx` prop hardcoded `color: "text.disabled"`, which overrode MUI's automatic enabled/disabled coloring. Removing that override lets the button reflect its real state and match the sibling "Commit and set as a default version" button.

Closes #1384

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes

- Removed `color: "text.disabled"` from the Commit button's `sx` in `SaveAndCommit.jsx`. No logic changed (`disabled`/`loading` untouched).
- Added `SaveAndCommit.test.jsx` — a regression test for the empty / entered / active-color / pending states.

## Testing

`yarn test:run` on the new file — **4 passed**, ESLint + Prettier clean. Confirmed the active-color test fails on the pre-fix code and passes after the fix.

## Checklist

- [x] Tests added that prove the fix
- [x] `yarn test:run` passes locally (frontend)
- [x] PR title follows Conventional Commits
- [x] CLA signed (will sign when the bot prompts)
