### PR TITLE
Fix invalid CSS width value on Add Filter icon (20ox -> 20px)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -108,7 +108,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}

--- a/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx
@@ -76,7 +76,7 @@ const DevelopFilterRow = ({
               <SvgColor
                 src="/assets/icons/ic_add.svg"
                 sx={{
-                  width: "20ox !important",
+                  width: "20px !important",
                   height: "20px !important",
                   color: "primary.main",
                 }}


### PR DESCRIPTION
Fixes #1967

The Add Filter button icon's `sx` prop set `width: "20ox !important"`. `20ox` is not a valid CSS length, so the browser discarded the declaration and the icon fell back to its intrinsic width instead of 20px, while `height: 20px` (valid) still applied — causing a mismatched width/height.

## Change
- `frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx` line 111: `20ox` -> `20px`
- `frontend/src/sections/evals/DevelopFilters/DevelopFilterRow.jsx` line 79: `20ox` -> `20px`

Confirmed no remaining occurrences of `20ox` under `frontend/src`.