### PR TITLE
fix(licensing): restore cloud guard in EEFeatureMiddleware

### DIFF
--- a/futureagi/ee/usage/middleware/ee.py
+++ b/futureagi/ee/usage/middleware/ee.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import structlog
 from django.http import JsonResponse
-
 from ee.usage.deployment import DeploymentMode
 from tfc.utils.api_errors import build_error_envelope
 
@@ -35,8 +34,24 @@ class EEFeatureMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        # DO NOT REMOVE — this is load-bearing, not legacy special-casing.
+        #
+        # The check below needs the caller's organization, but
+        # `request.organization` is only assigned by APIKeyAuthentication
+        # (accounts/authentication.py), which runs during DRF dispatch — i.e.
+        # inside the view, after every middleware. There is no org to resolve
+        # here, so on cloud the check would look up a blank org id, hit a
+        # UUID column, and raise ValidationError before authentication ever
+        # runs — a 500 on every request under these prefixes.
+        #
+        # Cloud plan entitlement therefore belongs at the view layer. Only
+        # self-hosted license gating is resolvable from middleware, because
+        # that path is org-independent.
+        if DeploymentMode.is_cloud():
+            return self.get_response(request)
+
         # Check if this path requires an EE feature. The unified resolver
-        # handles self-hosted licenses and cloud plan entitlements.
+        # handles self-hosted license state.
         for path_prefix, feature in EE_FEATURE_PATHS.items():
             if request.path.startswith(path_prefix):
                 from ee.usage.services.entitlements import Entitlements

--- a/futureagi/ee/usage/tests/test_ee_feature_middleware.py
+++ b/futureagi/ee/usage/tests/test_ee_feature_middleware.py
@@ -1,0 +1,156 @@
+"""Tests for EEFeatureMiddleware's deployment-mode guard.
+
+Regression context: the cloud early-return was removed in "enterprise
+licensing P0/P1 hardening" on the assumption that the unified resolver could
+handle cloud too. It can — but only when given an organization, and
+``request.organization`` is assigned by APIKeyAuthentication during DRF
+dispatch, after every middleware has run. On cloud the middleware therefore
+passed a blank org id into a UUID lookup, raising ValidationError before
+authentication and turning every request under a gated prefix into a 500.
+
+The guard is what keeps the org-dependent branch off the cloud path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+from ee.usage.middleware.ee import EE_FEATURE_PATHS, EEFeatureMiddleware
+
+GATED_PATH = "/falcon-ai/conversations/"
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture
+def middleware():
+    return EEFeatureMiddleware(lambda request: HttpResponse("OK", status=200))
+
+
+class TestCloudGuard:
+    """On cloud the middleware must defer to the view layer, untouched."""
+
+    def test_cloud_passes_through_without_consulting_entitlements(self, middleware, rf):
+        request = rf.get(GATED_PATH)
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified"
+            ) as has_feature,
+        ):
+            response = middleware(request)
+
+        assert response.status_code == 200
+        # The load-bearing assertion: on cloud this middleware must not ask an
+        # org-scoped question it has no org to answer with.
+        has_feature.assert_not_called()
+
+    def test_cloud_pass_through_covers_every_gated_prefix(self, middleware, rf):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified"
+            ) as has_feature,
+        ):
+            for prefix in EE_FEATURE_PATHS:
+                response = middleware(rf.get(f"{prefix}anything/"))
+                assert response.status_code == 200
+
+        has_feature.assert_not_called()
+
+
+class TestSelfHostedStillEnforces:
+    """Off cloud the licence check is org-independent, so it must still run."""
+
+    def test_self_hosted_allows_when_licensed(self, middleware, rf):
+        request = rf.get(GATED_PATH)
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified",
+                return_value=True,
+            ) as has_feature,
+        ):
+            response = middleware(request)
+
+        assert response.status_code == 200
+        has_feature.assert_called_once()
+
+    def test_self_hosted_denies_with_402_when_unlicensed(self, middleware, rf):
+        request = rf.get(GATED_PATH)
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch("ee.usage.deployment.DeploymentMode.is_ee", return_value=True),
+            patch("ee.usage.deployment.DeploymentMode.get_mode", return_value="ee"),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified",
+                return_value=False,
+            ),
+        ):
+            response = middleware(request)
+
+        assert response.status_code == 402
+
+    def test_ungated_path_is_never_checked(self, middleware, rf):
+        request = rf.get("/api/capabilities/")
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified"
+            ) as has_feature,
+        ):
+            response = middleware(request)
+
+        assert response.status_code == 200
+        has_feature.assert_not_called()
+
+
+class TestBlankOrgIdNeverReachesTheResolver:
+    """Belt and braces: even off cloud, the org id handed over stays blank-safe.
+
+    ``request.organization`` is unset at middleware time in every deployment
+    mode, so the middleware always passes "". That is only safe because the
+    self-hosted branch of the capability service ignores org_id — this test
+    pins the input so a future change to that branch surfaces here.
+    """
+
+    def test_self_hosted_receives_blank_org_id(self, middleware, rf):
+        request = rf.get(GATED_PATH)
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified",
+                return_value=True,
+            ) as has_feature,
+        ):
+            middleware(request)
+
+        org_id, feature = has_feature.call_args[0]
+        assert org_id == ""
+        assert feature == "falcon_ai"
+
+    def test_org_on_request_is_still_honoured_when_present(self, middleware, rf):
+        """If a future middleware does resolve the org, pass it through."""
+        request = rf.get(GATED_PATH)
+        request.organization = MagicMock(id="11111111-1111-1111-1111-111111111111")
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.usage.services.entitlements.Entitlements.has_feature_unified",
+                return_value=True,
+            ) as has_feature,
+        ):
+            middleware(request)
+
+        org_id, _ = has_feature.call_args[0]
+        assert org_id == "11111111-1111-1111-1111-111111111111"

--- a/futureagi/tfc/capabilities/service.py
+++ b/futureagi/tfc/capabilities/service.py
@@ -120,6 +120,11 @@ def check(
     exception based on the result. For convenience, use check_or_raise()
     which raises CapabilityDenied on denial.
     """
+    # A blank org id is not an identity. Normalise it to None so a caller that
+    # passes "" gets a clean denial instead of reaching the cloud resolver and
+    # raising ValidationError on an invalid-UUID lookup inside the request path.
+    org_id = (org_id or "").strip() or None
+
     feature = FEATURE_REGISTRY.get(feature_id)
 
     # 1. Unknown feature → programming error, always deny

--- a/futureagi/tfc/capabilities/tests/test_blank_org_id.py
+++ b/futureagi/tfc/capabilities/tests/test_blank_org_id.py
@@ -1,0 +1,60 @@
+"""A blank org id must never reach the cloud plan resolver.
+
+``check()`` is the single entry point for capability decisions, and several
+callers derive ``org_id`` from an optional organization. When that resolves to
+"" the value is not an identity — forwarding it reaches
+``PlanEntitlement.objects.filter(organization_id="")``, which raises
+ValidationError against a UUID column and 500s the request instead of denying
+it. Normalising to None routes it to the existing "no org" denial.
+"""
+
+import pytest
+from tfc.capabilities import service
+from tfc.licensing.types import (
+    DenialReason,
+    DeploymentFlavor,
+    DeploymentLocation,
+)
+
+FEATURE = "falcon_ai"
+
+
+class _AllowingResolver:
+    """Allows everything, and fails loudly if handed a blank org id."""
+
+    def has_feature(self, org_id: str, feature_id: str) -> bool:
+        assert org_id, "cloud resolver must never be called with a blank org id"
+        return True
+
+    def get_upgrade_cta(self, org_id: str, feature_id: str) -> dict | None:
+        return None
+
+
+@pytest.fixture
+def cloud_service():
+    service.configure(
+        flavor=DeploymentFlavor.CLOUD,
+        location=DeploymentLocation.CLOUD,
+        cloud_plan_resolver=_AllowingResolver(),
+    )
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_org_id_denies_without_reaching_resolver(cloud_service, blank):
+    decision = service.check(FEATURE, org_id=blank)
+
+    assert decision.allowed is False
+    assert decision.reason_code == DenialReason.RESOLVER_UNAVAILABLE.value
+
+
+def test_none_org_id_still_denies(cloud_service):
+    decision = service.check(FEATURE, org_id=None)
+
+    assert decision.allowed is False
+    assert decision.reason_code == DenialReason.RESOLVER_UNAVAILABLE.value
+
+
+def test_real_org_id_is_passed_through_untouched(cloud_service):
+    decision = service.check(FEATURE, org_id="11111111-1111-1111-1111-111111111111")
+
+    assert decision.allowed is True


### PR DESCRIPTION
Supersedes #2038 (same change, re-targeted from `main` to `dev`). Companion PR in the ee repo: **future-agi/ee#208**.

## Problem

Every request under `/falcon-ai/`, `/api/scim/` and `/api/audit-logs/` returns a bare **HTTP 500** on cloud. EU (v1.26.0) has Falcon **fully down** — zero successful requests across an hour of production logs, authenticated or not. US is unaffected only because it still runs v1.25.0.

Production traceback (EU):

```
File "/app/backend/ee/usage/middleware/ee.py", line 47, in __call__
File "/app/backend/ee/usage/services/entitlements.py", line 223, in has_feature_unified
File "/app/backend/tfc/capabilities/service.py", line 143, in check
File "/app/backend/tfc/capabilities/service.py", line 197, in _check_cloud
File "/app/backend/ee/usage/services/entitlements.py", line  98, in get_entitlement
django.core.exceptions.ValidationError: ['"" is not a valid UUID.']
```

## Root cause

`EEFeatureMiddleware` needs the caller's organization, but `request.organization` is assigned in exactly one place — `accounts/authentication.py`, inside `APIKeyAuthentication` — which runs during DRF dispatch, **after every middleware**. So the middleware always computes `org_id = ""`.

`_check_cloud`'s guard is `if org_id is None`, which `""` slips past, landing an empty string in `PlanEntitlement.objects.filter(organization_id=...)` against a `UUIDField`. Because it raises in middleware, DRF's `custom_exception_handler` never sees it — it escapes to Django as a bare 500, before authentication runs. That's why unauthenticated requests get 500 where sibling endpoints correctly return 401.

## Why it regressed

The cloud early-return was removed in `ee@e1a399d` ("enterprise licensing P0/P1 hardening"), replacing:

```python
-        # Only check on self-hosted (EE or no-license). Cloud uses
-        # PlanEntitlement at the ViewSet level.
-        if DeploymentMode.is_cloud():
-            return self.get_response(request)
+        # Check if this path requires an EE feature. The unified resolver
+        # handles self-hosted licenses and cloud plan entitlements.
```

The resolver *does* handle cloud — **given an organization**. The guard was about layering, not resolver capability: only the self-hosted licence branch is org-independent and therefore resolvable from middleware. The same commit added `/falcon-ai/` to `EE_FEATURE_PATHS`, which is what turned a latent fault on two routeless prefixes into a user-facing outage.

Note `org_id = str(org.id) if org else ""` is **unchanged** and present in both versions — the landmine was always there, held back solely by that one guard.

## Changes

- **Restore the `DeploymentMode.is_cloud()` early-return**, with a comment explaining why it is load-bearing so it survives the next refactor.
- **Normalise blank org ids to `None` in `capabilities.service.check`** — removes the landmine itself, so no caller can reach the cloud resolver with an invalid UUID.
- **Tests** for both: the guard (cloud never consults entitlements, across every gated prefix) and the normalisation (blank/whitespace deny cleanly).

## Behaviour

| Deployment | Before | After |
|---|---|---|
| Cloud (US/EU) | 500 on every gated path | Works; plan entitlement stays at the view layer |
| Self-hosted EE, licensed | Works | Unchanged |
| Self-hosted EE, unlicensed | 402 | Unchanged |
| OSS | 402 via URL stub | Unchanged |

Self-hosted licence enforcement is deliberately preserved — off-cloud still gates `falcon_ai`, `scim` and `audit_logs` on licence state. That is also why the middleware is repaired rather than deleted: deleting it would remove the only HTTP-layer licence check, and `_is_oss_mode()` only tests that `EE_LICENSE_KEY` is non-empty, never that it is valid.

## Verification

- 156 passed across `tfc/capabilities/tests/` + the new middleware suite, re-run on the `dev` base after rebase.
- **Regression proven:** stashing the two source changes makes exactly 5 of the new tests fail — 3 on the normalisation, 2 on the guard — including `AssertionError: cloud resolver must never be called with a blank org id`.
- Pre-existing and unrelated: `ee/usage/tests/test_deployment_telemetry_migration.py` fails identically on a clean tree (`table "usage_deploymenttelemetryheartbeat" does not exist`).

## Follow-ups (not in this PR)

1. **`tfc/settings/test.py:157` replaces `MIDDLEWARE` with a 7-entry list.** Production runs 20; 13 never execute in any test, including all 10 first-party ones. That is why this shipped green — there was no test that *could* have failed.
2. **`v1.26.0` should not ship to US** until this lands — it breaks US identically.

No ticket linked — happy to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4ffjT8TmogEL8FfFXbnsW
