### PR TITLE
fix(frontend): stop View Full Transcript from crashing chat sim logs [TH-7460]

### DIFF
--- a/frontend/src/components/ChatDetailDrawerV2/ChatTranscriptView.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatTranscriptView.jsx
@@ -135,9 +135,10 @@ const ChatTranscriptView = ({ data }) => {
             : null;
         return {
           ...item,
-          // Flatten `messages[0].content` into a plain `content` field so
-          // TranscriptView's enrichTurns/getContent picks it up.
+
           content,
+
+          rawMessages: Array.isArray(item.content) ? item.content : null,
           ...(ts != null ? { startTimeSeconds: ts } : {}),
           ...(existingDuration == null
             ? { duration: countWords(content) }
@@ -166,6 +167,8 @@ const ChatTranscriptView = ({ data }) => {
         hideTalkRatioPercentages
         talkRatioLegendAlign="left"
         hideSilenceMarkers
+        hideTurnDurations
+        hideInterruptBadges
       />
     </Box>
   );

--- a/frontend/src/components/ChatDetailDrawerV2/__tests__/chatTranscriptUtils.test.js
+++ b/frontend/src/components/ChatDetailDrawerV2/__tests__/chatTranscriptUtils.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { getChatTurnContent } from "../chatTranscriptUtils";
+
+// Shapes below are taken from real `ChatMessageSerializer` rows: `content` is
+// the full message-dict list (tool entries included) and `messages` is the
+// flat list[str] of extracted bodies.
+describe("getChatTurnContent", () => {
+  it("reads a plain single-message turn", () => {
+    expect(
+      getChatTurnContent({
+        role: "user",
+        messages: ["Hey, can u help me cancel order 499-20A??"],
+        content: [
+          { role: "user", content: "Hey, can u help me cancel order 499-20A??" },
+        ],
+      }),
+    ).toBe("Hey, can u help me cancel order 499-20A??");
+  });
+
+  it("excludes tool results, keeping only the speech", () => {
+    const turn = {
+      role: "assistant",
+      messages: ["I've submitted a cancellation request!"],
+      content: [
+        {
+          role: "assistant",
+          content: "I've submitted a cancellation request!",
+          tool_calls: [{ id: "call_1", type: "function", function: {} }],
+        },
+        {
+          role: "tool",
+          content: "{'ok': True, 'request_id': 'CAN-98411'}",
+          tool_call_id: "call_1",
+        },
+      ],
+    };
+
+    expect(getChatTurnContent(turn)).toBe(
+      "I've submitted a cancellation request!",
+    );
+    expect(getChatTurnContent(turn)).not.toMatch(/CAN-98411/);
+  });
+
+  // A turn can hold more than one reply — reading messages[0] dropped
+  // everything after the first.
+  it("keeps every text reply in a multi-message turn", () => {
+    const text = getChatTurnContent({
+      role: "assistant",
+      messages: ["Checking your order…", "ORD-1 shipped", "It shipped yesterday."],
+      content: [
+        { role: "assistant", content: "Checking your order…" },
+        { role: "assistant", content: "", tool_calls: [{ id: "call_1" }] },
+        { role: "tool", content: "ORD-1 shipped", tool_call_id: "call_1" },
+        { role: "assistant", content: "It shipped yesterday." },
+      ],
+    });
+
+    expect(text).toContain("Checking your order…");
+    expect(text).toContain("It shipped yesterday.");
+    // The tool result must not read as something the agent said.
+    expect(text).not.toContain("ORD-1 shipped");
+  });
+
+  it("skips a tool-call turn that carries no text of its own", () => {
+    expect(
+      getChatTurnContent({
+        role: "user",
+        messages: ["Thanks!! catch ya later"],
+        content: [
+          { role: "user", tool_calls: [{ id: "call_2" }] },
+          { role: "tool", content: "Success.", tool_call_id: "call_2" },
+          { role: "user", content: "Thanks!! catch ya later" },
+        ],
+      }),
+    ).toBe("Thanks!! catch ya later");
+  });
+
+  it("falls back to messages when content is not a dict list", () => {
+    expect(getChatTurnContent({ messages: ["only here"] })).toBe("only here");
+    expect(getChatTurnContent({})).toBe("");
+    expect(getChatTurnContent(null)).toBe("");
+  });
+});

--- a/frontend/src/components/ChatDetailDrawerV2/chatTranscriptUtils.js
+++ b/frontend/src/components/ChatDetailDrawerV2/chatTranscriptUtils.js
@@ -4,10 +4,23 @@
  * can be unit-tested and reused.
  */
 
-// Chat turns store text in `messages` as a list of plain strings (the chat
-// serializer emits `list[str]`), so the turn body is `messages[0]` — not
-// `messages[0].content` (that's the voice CallTranscript shape).
-export const getChatTurnContent = (turn) => turn?.messages?.[0] ?? "";
+
+export const getChatTurnContent = (turn) => {
+  const joinText = (parts) =>
+    parts
+      .map((part) => (typeof part === "string" ? part.trim() : ""))
+      .filter(Boolean)
+      .join("\n\n");
+
+  if (Array.isArray(turn?.content)) {
+    const text = joinText(
+      turn.content.filter((m) => m?.role !== "tool").map((m) => m?.content),
+    );
+    if (text) return text;
+  }
+
+  return Array.isArray(turn?.messages) ? joinText(turn.messages) : "";
+};
 
 // Each turn carries a single `created_at` timestamp; parse it once to epoch
 // milliseconds. `TranscriptView.enrichTurns` rebases the earliest value to 0,

--- a/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
@@ -22,6 +22,10 @@ import { ShowComponent } from "src/components/show";
 import useVoiceAudioStore from "./voiceAudioStore";
 import { computeTotals, enrichTurns, formatClock } from "./transcriptUtils";
 import { DEFAULT_ROLE_LABELS } from "./constants";
+import {
+  ToolCallCard,
+  ToolResultCard,
+} from "src/components/tool-call/ToolCallCard";
 
 // Highlight query matches in a string — returns React nodes.
 const highlightMatches = (text, query) => {
@@ -280,10 +284,40 @@ SpeakerTimelineStrip.propTypes = {
 
 const TurnRow = React.forwardRef(
   (
-    { turn, colors, query, isPlaying, isFocused, onSeek, onCopy, onAnnotate },
+    {
+      turn,
+      colors,
+      query,
+      isPlaying,
+      isFocused,
+      onSeek,
+      onCopy,
+      onAnnotate,
+      hideTurnDurations = false,
+      hideInterruptBadges = false,
+    },
     ref,
   ) => {
     const color = colors[turn.role] || colors.unknown;
+    const toolCards = (turn.rawMessages || []).flatMap((message, index) => {
+      if (message.role === "tool") {
+        return [
+          <ToolResultCard key={`result-${index}`} content={message.content} />,
+        ];
+      }
+      if (message.tool_calls?.length > 0) {
+        return message.tool_calls.map((toolCall) => (
+          <ToolCallCard
+            key={toolCall.id}
+            toolCall={{
+              name: toolCall.function.name,
+              arguments: toolCall.function.arguments,
+            }}
+          />
+        ));
+      }
+      return [];
+    });
 
     return (
       <Box
@@ -344,7 +378,7 @@ const TurnRow = React.forwardRef(
             </Typography>
           )}
 
-          {turn.duration != null && turn.duration > 0 && (
+          {!hideTurnDurations && turn.duration != null && turn.duration > 0 && (
             <Typography
               sx={{
                 fontFamily: "monospace",
@@ -356,7 +390,7 @@ const TurnRow = React.forwardRef(
             </Typography>
           )}
 
-          {turn.overlapsPrev && (
+          {!hideInterruptBadges && turn.overlapsPrev && (
             <Tooltip
               title="Interruption — started before previous turn ended"
               arrow
@@ -453,6 +487,13 @@ const TurnRow = React.forwardRef(
             <CellMarkdown spacing={0} text={turn.content} />
           )}
         </Box>
+
+
+        {toolCards.length > 0 && (
+          <Stack spacing={0.5} sx={{ mt: 0.75 }}>
+            {toolCards}
+          </Stack>
+        )}
       </Box>
     );
   },
@@ -468,6 +509,8 @@ TurnRow.propTypes = {
   onSeek: PropTypes.func,
   onCopy: PropTypes.func,
   onAnnotate: PropTypes.func,
+  hideTurnDurations: PropTypes.bool,
+  hideInterruptBadges: PropTypes.bool,
 };
 
 // Memoized wrapper — with ~40 turns and a 60Hz currentTime poll, the list
@@ -483,6 +526,8 @@ const MemoTurnRow = React.memo(TurnRow, (prev, next) => {
   if (prev.onSeek !== next.onSeek) return false;
   if (prev.onCopy !== next.onCopy) return false;
   if (prev.onAnnotate !== next.onAnnotate) return false;
+  if (prev.hideTurnDurations !== next.hideTurnDurations) return false;
+  if (prev.hideInterruptBadges !== next.hideInterruptBadges) return false;
   return true;
 });
 
@@ -553,6 +598,8 @@ const TranscriptView = ({
   // not silence — so the chat drawer passes true here to suppress the
   // inline silence dividers.
   hideSilenceMarkers = false,
+  hideTurnDurations = false,
+  hideInterruptBadges = false,
 }) => {
   const colors = useSpeakerColors();
 
@@ -936,6 +983,8 @@ const TranscriptView = ({
                 onSeek={handleSeek}
                 onCopy={handleCopyTurn}
                 onAnnotate={onAnnotate}
+                hideTurnDurations={hideTurnDurations}
+                hideInterruptBadges={hideInterruptBadges}
               />
             </React.Fragment>
           ))
@@ -994,6 +1043,8 @@ TranscriptView.propTypes = {
   hideTalkRatioPercentages: PropTypes.bool,
   talkRatioLegendAlign: PropTypes.oneOf(["left", "right"]),
   hideSilenceMarkers: PropTypes.bool,
+  hideTurnDurations: PropTypes.bool,
+  hideInterruptBadges: PropTypes.bool,
   embedded: PropTypes.bool,
 };
 

--- a/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
+++ b/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
@@ -112,6 +112,7 @@ export const enrichTurns = (transcript) => {
       role,
       rawRole: item.speaker_role || item.role,
       content: getContent(item),
+      rawMessages: Array.isArray(item.rawMessages) ? item.rawMessages : null,
       start,
       end,
       duration: directDuration,

--- a/frontend/src/sections/test-detail/TestDetailDrawer/ConversationCard.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/ConversationCard.jsx
@@ -61,7 +61,7 @@ const ConversationCard = ({
   // Check if content is JSON and parse it
   const isJsonContent = useMemo(() => isJsonValue(content), [content]);
 
-  const toolMessages = useMemo(
+  const rawMessages = useMemo(
     () => (Array.isArray(rawContent) ? rawContent : []),
     [rawContent],
   );
@@ -178,9 +178,9 @@ const ConversationCard = ({
           </Typography>
         </Box>
         {renderContent()}
-        <ShowComponent condition={toolMessages.length > 0}>
+        <ShowComponent condition={rawMessages.length > 0}>
           <Stack spacing={0.5} sx={{ mt: 0.5 }}>
-            {toolMessages.flatMap((message, index) => {
+            {rawMessages.flatMap((message, index) => {
               if (message.role === "tool") {
                 return [
                   <ToolResultCard

--- a/frontend/src/sections/test-detail/TestDetailDrawer/ConversationCard.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/ConversationCard.jsx
@@ -61,6 +61,11 @@ const ConversationCard = ({
   // Check if content is JSON and parse it
   const isJsonContent = useMemo(() => isJsonValue(content), [content]);
 
+  const toolMessages = useMemo(
+    () => (Array.isArray(rawContent) ? rawContent : []),
+    [rawContent],
+  );
+
   const parsedJsonContent = useMemo(() => {
     if (!isJsonContent) return null;
     try {
@@ -173,11 +178,9 @@ const ConversationCard = ({
           </Typography>
         </Box>
         {renderContent()}
-        <ShowComponent
-          condition={Array.isArray(rawContent) && rawContent.length > 0}
-        >
+        <ShowComponent condition={toolMessages.length > 0}>
           <Stack spacing={0.5} sx={{ mt: 0.5 }}>
-            {rawContent.flatMap((message, index) => {
+            {toolMessages.flatMap((message, index) => {
               if (message.role === "tool") {
                 return [
                   <ToolResultCard

--- a/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/ConversationCard.test.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/__tests__/ConversationCard.test.jsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import ConversationCard from "../ConversationCard";
+
+// TH-7460: `ShowComponent` is a plain component, so JSX evaluates its
+// children eagerly — before `condition` is ever read. The tool-call block
+// therefore ran `rawContent.flatMap(...)` on every render, and every caller
+// that omits the optional `rawContent` prop (ViewFullTranscript,
+// CallTranscriptView, CompareConversation) crashed the whole tree with
+// "Cannot read properties of undefined (reading 'flatMap')".
+describe("ConversationCard tool-call block", () => {
+  it("renders when rawContent is omitted", () => {
+    expect(() =>
+      render(
+        <ConversationCard
+          role="assistant"
+          content="Hello there"
+          align="flex-start"
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it("renders when rawContent is a non-array value", () => {
+    expect(() =>
+      render(
+        <ConversationCard
+          role="user"
+          content="Plain string content"
+          align="flex-end"
+          rawContent="not-an-array"
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText("Plain string content")).toBeInTheDocument();
+  });
+
+  it("still renders tool calls when rawContent is a populated array", () => {
+    render(
+      <ConversationCard
+        role="assistant"
+        content="Looking that up"
+        align="flex-start"
+        rawContent={[
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                function: { name: "get_weather", arguments: '{"city":"NYC"}' },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/get_weather/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
+++ b/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
@@ -207,8 +207,6 @@ const CallLogsCard = ({ log }) => {
           open={open}
           onClose={() => setOpen(false)}
           transcript={filteredTranscript}
-          agentName={agentDefinitionUsedName}
-          simulatorName={simulatorAgentName}
           simulationCallType={simulationCallType}
         />
       </Suspense>

--- a/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
+++ b/frontend/src/sections/test/CallLogs/CallLogsCard.jsx
@@ -37,7 +37,6 @@ const CallLogsCard = ({ log }) => {
       (item) => item.speaker_role !== "system",
     );
   }, [log]);
-
   const audioData = useMemo(() => ({ url: audioUrl }), [audioUrl]);
   const audioUrls = useMemo(
     () => normalizeRecordings(log?.recordings),

--- a/frontend/src/sections/test/CallLogs/TranscriptPreview.jsx
+++ b/frontend/src/sections/test/CallLogs/TranscriptPreview.jsx
@@ -14,7 +14,10 @@ const TranscriptPreview = ({
   simulationCallType,
 }) => {
   const first = transcript?.[0] ?? null;
-  const previewRole = first?.speaker_role;
+  // Voice rows (CallTranscriptSerializer) carry `speaker_role`; chat rows
+  // (ChatMessageSerializer) carry `role`. Without the fallback the chat
+  // preview renders a blank speaker label before the colon.
+  const previewRole = first?.speaker_role ?? first?.role;
   const previewContent = getContentMessage(first, simulationCallType);
 
   return (

--- a/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
+++ b/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
@@ -57,6 +57,8 @@ const ViewFullTranscript = ({
       return {
         ...item,
         content,
+
+        rawMessages: Array.isArray(item.content) ? item.content : null,
         ...(ts != null ? { startTimeSeconds: ts } : {}),
         ...(existingDuration == null ? { duration: countWords(content) } : {}),
       };
@@ -84,6 +86,8 @@ const ViewFullTranscript = ({
               hideTalkRatioLabel={isChat}
               hideTalkRatioPercentages={isChat}
               hideSilenceMarkers={isChat}
+              hideTurnDurations={isChat}
+              hideInterruptBadges={isChat}
             />
           )}
         </Box>

--- a/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
+++ b/frontend/src/sections/test/CallLogs/ViewFullTranscript.jsx
@@ -6,82 +6,85 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  Stack,
   Typography,
 } from "@mui/material";
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
-import _ from "lodash";
-import ConversationCard from "../../test-detail/TestDetailDrawer/ConversationCard";
-import { ShowComponent } from "../../../components/show";
+import TranscriptView from "src/components/VoiceDetailDrawerV2/TranscriptView";
 import { AGENT_TYPES } from "src/sections/agents/constants";
-import { getContentMessage } from "./common";
+import {
+  countWords,
+  getChatTurnContent,
+  getChatTurnTimestampMs,
+} from "src/components/ChatDetailDrawerV2/chatTranscriptUtils";
+
+
+const TranscriptEmpty = () => (
+  <Stack
+    alignItems="center"
+    justifyContent="center"
+    spacing={1}
+    sx={{ flex: 1, py: 6, color: "text.secondary" }}
+  >
+    <Iconify icon="mdi:message-text-outline" width={28} />
+    <Typography typography="s2" color="text.secondary">
+      No transcript available
+    </Typography>
+  </Stack>
+);
 
 const ViewFullTranscript = ({
   open,
   onClose,
   transcript,
-  agentName,
-  simulatorName,
   simulationCallType,
 }) => {
+  const isChat = simulationCallType === AGENT_TYPES.CHAT;
+
+  const turns = useMemo(() => {
+    if (!Array.isArray(transcript)) return [];
+    if (!isChat) return transcript;
+
+    return transcript.map((item) => {
+      const content = getChatTurnContent(item);
+      const ts = getChatTurnTimestampMs(item);
+      const existingDuration =
+        typeof item.duration === "number" && Number.isFinite(item.duration)
+          ? item.duration
+          : null;
+      return {
+        ...item,
+        content,
+        ...(ts != null ? { startTimeSeconds: ts } : {}),
+        ...(existingDuration == null ? { duration: countWords(content) } : {}),
+      };
+    });
+  }, [transcript, isChat]);
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
         Call Transcript
         <IconButton onClick={onClose}>
           <Iconify icon="akar-icons:cross" width={16} height={16} />
         </IconButton>
       </DialogTitle>
-      <DialogContent sx={{ maxHeight: 300, overflowY: "auto" }}>
-        <Box
-          sx={{
-            borderRadius: 1,
 
-            gap: 1.5,
-            display: "flex",
-            flexDirection: "column",
-          }}
-        >
-          <ShowComponent condition={transcript?.length === 0}>
-            <Typography typography="s1" fontWeight="fontWeightSemiBold">
-              No transcript available
-            </Typography>
-          </ShowComponent>
-          {transcript?.map(
-            ({
-              id,
-              speaker_role: speakerRole,
-              content: rawContent,
-              messages,
-              createdAt,
-              endTimeSeconds,
-              startTimeSeconds,
-              role,
-            }) => {
-              const content = getContentMessage(
-                simulationCallType === AGENT_TYPES.CHAT
-                  ? { messages }
-                  : { rawContent },
-                simulationCallType,
-              );
-
-              return (
-                <ConversationCard
-                  key={id}
-                  role={speakerRole ?? role}
-                  content={content}
-                  align={speakerRole === "user" ? "flex-end" : "flex-start"}
-                  timeStamp={createdAt}
-                  duration={Math.floor(
-                    (endTimeSeconds - startTimeSeconds) / 1000,
-                  )}
-                  agentName={agentName}
-                  simulatorName={simulatorName}
-                  simulationCallType={simulationCallType}
-                />
-              );
-            },
+      <DialogContent sx={{ overflow: "hidden" }}>
+        <Box sx={{ display: "flex", height: "60vh", minHeight: 0 }}>
+          {turns.length === 0 ? (
+            <TranscriptEmpty />
+          ) : (
+            <TranscriptView
+              transcript={turns}
+              embedded
+              hideTimelineStrip={isChat}
+              hideTalkRatioLabel={isChat}
+              hideTalkRatioPercentages={isChat}
+              hideSilenceMarkers={isChat}
+            />
           )}
         </Box>
       </DialogContent>
@@ -103,8 +106,6 @@ ViewFullTranscript.propTypes = {
   open: PropTypes.bool,
   onClose: PropTypes.func,
   transcript: PropTypes.array,
-  agentName: PropTypes.string,
-  simulatorName: PropTypes.string,
   simulationCallType: PropTypes.string,
 };
 

--- a/frontend/src/sections/test/CallLogs/__tests__/ViewFullTranscript.test.jsx
+++ b/frontend/src/sections/test/CallLogs/__tests__/ViewFullTranscript.test.jsx
@@ -68,7 +68,7 @@ const VOICE_ROWS = [
 const noop = () => {};
 
 describe("ViewFullTranscript", () => {
-  it("renders chat rows, reading the turn body from messages[0]", () => {
+  it("renders chat rows, reading the turn body from the message list", () => {
     render(
       <ViewFullTranscript
         open
@@ -100,6 +100,85 @@ describe("ViewFullTranscript", () => {
     expect(
       screen.getByText("I would like to check my order."),
     ).toBeInTheDocument();
+  });
+
+  it("does not render fake durations or interrupt badges for chat", () => {
+    render(
+      <ViewFullTranscript
+        open
+        onClose={noop}
+        transcript={CHAT_ROWS}
+        simulationCallType="text"
+      />,
+    );
+
+    expect(screen.queryByText(/interrupt/i)).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/\d+\.\d\s*s/);
+  });
+
+  it("still renders durations for voice", () => {
+    render(
+      <ViewFullTranscript
+        open
+        onClose={noop}
+        transcript={VOICE_ROWS}
+        simulationCallType="voice"
+      />,
+    );
+
+    // Voice timings are real, so the per-turn duration chip stays.
+    expect(document.body.textContent).toMatch(/\d+\.\d\s*s/);
+  });
+
+  // Real row from a chat sim: the agent's reply carries a `cancel_order` tool
+  // call, and the tool result is a second entry in the same row's `content`.
+  // Neither appears in `messages`, so both are lost unless the raw list is
+  // carried through the flattening in `turns`.
+  const CHAT_ROW_WITH_TOOLS = [
+    {
+      id: "e9d7f5f2",
+      role: "assistant",
+      messages: ["I've submitted a cancellation request for your order 499-20A!"],
+      content: [
+        {
+          role: "assistant",
+          content:
+            "I've submitted a cancellation request for your order 499-20A!",
+          tool_calls: [
+            {
+              id: "call_fbXjmMbOqdUwRnr4qvOsCO3Y",
+              type: "function",
+              function: {
+                name: "cancel_order",
+                arguments: '{"order_id":"499-20A"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: "{'ok': True, 'request_id': 'CAN-98411'}",
+          tool_call_id: "call_fbXjmMbOqdUwRnr4qvOsCO3Y",
+        },
+      ],
+      session_id: "a630253d",
+      tool_calls: [],
+      created_at: "2026-01-27T13:06:50.188584Z",
+    },
+  ];
+
+  it("renders tool calls and tool results nested in a chat row", () => {
+    render(
+      <ViewFullTranscript
+        open
+        onClose={noop}
+        transcript={CHAT_ROW_WITH_TOOLS}
+        simulationCallType="text"
+      />,
+    );
+
+    expect(screen.getByText(/cancel_order/)).toBeInTheDocument();
+    expect(screen.getByText(/CAN-98411/)).toBeInTheDocument();
   });
 
   it("shows the empty state instead of crashing when transcript is missing", () => {

--- a/frontend/src/sections/test/CallLogs/__tests__/ViewFullTranscript.test.jsx
+++ b/frontend/src/sections/test/CallLogs/__tests__/ViewFullTranscript.test.jsx
@@ -1,0 +1,114 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import ViewFullTranscript from "../ViewFullTranscript";
+
+// jsdom doesn't implement Element.prototype.scrollTo; TranscriptView calls it
+// on mount to bring the active row into view.
+beforeAll(() => {
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = vi.fn();
+  }
+});
+
+// Rows below mirror what `CallExecutionDetailSerializer.get_transcript`
+// actually emits (futureagi/simulate/serializers/test_execution.py:646). The
+// two branches have completely different shapes under the same `transcript`
+// key, which is what made this dialog fragile:
+//
+//   chat  (simulation_call_type == "text")  -> ChatMessageSerializer
+//     { id, role, messages: list[str], content: list[dict], created_at, ... }
+//   voice (simulation_call_type == "voice") -> CallTranscriptSerializer
+//     { id, speaker_role, content: str, start_time_seconds, end_time_seconds, ... }
+const CHAT_ROWS = [
+  {
+    id: "chat-1",
+    role: "assistant",
+    messages: ["Hi, how can I help you today?"],
+    content: [{ role: "assistant", content: "Hi, how can I help you today?" }],
+    session_id: "sess-1",
+    tool_calls: [],
+    created_at: "2026-08-10T10:00:00Z",
+  },
+  {
+    id: "chat-2",
+    role: "user",
+    messages: ["I need to reset my password."],
+    content: [{ role: "user", content: "I need to reset my password." }],
+    session_id: "sess-1",
+    tool_calls: [],
+    created_at: "2026-08-10T10:00:12Z",
+  },
+];
+
+const VOICE_ROWS = [
+  {
+    id: "voice-1",
+    speaker_role: "assistant",
+    content: "Thanks for calling, how can I help?",
+    start_time_ms: 0,
+    start_time_seconds: 0,
+    end_time_ms: 2500,
+    end_time_seconds: 2.5,
+    confidence_score: 0.98,
+    created_at: "2026-08-10T10:00:00Z",
+  },
+  {
+    id: "voice-2",
+    speaker_role: "user",
+    content: "I would like to check my order.",
+    start_time_ms: 3000,
+    start_time_seconds: 3,
+    end_time_ms: 5200,
+    end_time_seconds: 5.2,
+    confidence_score: 0.95,
+    created_at: "2026-08-10T10:00:03Z",
+  },
+];
+
+const noop = () => {};
+
+describe("ViewFullTranscript", () => {
+  it("renders chat rows, reading the turn body from messages[0]", () => {
+    render(
+      <ViewFullTranscript
+        open
+        onClose={noop}
+        transcript={CHAT_ROWS}
+        simulationCallType="text"
+      />,
+    );
+
+    expect(screen.getByText("Hi, how can I help you today?")).toBeInTheDocument();
+    expect(screen.getByText("I need to reset my password.")).toBeInTheDocument();
+    // The raw `content` list-of-dicts must never leak through as JSON.
+    expect(screen.queryByText(/\{"role"/)).not.toBeInTheDocument();
+  });
+
+  it("renders voice rows, reading the turn body from the content string", () => {
+    render(
+      <ViewFullTranscript
+        open
+        onClose={noop}
+        transcript={VOICE_ROWS}
+        simulationCallType="voice"
+      />,
+    );
+
+    expect(
+      screen.getByText("Thanks for calling, how can I help?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("I would like to check my order."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the empty state instead of crashing when transcript is missing", () => {
+    expect(() =>
+      render(
+        <ViewFullTranscript open onClose={noop} simulationCallType="text" />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText("No transcript available")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/test/CallLogs/common.js
+++ b/frontend/src/sections/test/CallLogs/common.js
@@ -1,4 +1,5 @@
 import { AGENT_TYPES } from "src/sections/agents/constants";
+import { getChatTurnContent } from "src/components/ChatDetailDrawerV2/chatTranscriptUtils";
 
 export const CallType = {
   INBOUND: "Inbound",
@@ -28,7 +29,7 @@ export const getContentMessage = (
   if (!transcript) return "";
 
   return simulationCallType === AGENT_TYPES.CHAT
-    ? transcript?.messages?.[0] ?? ""
+    ? getChatTurnContent(transcript)
     : transcript?.content ??
         transcript?.raw_content ??
         transcript?.rawContent ??


### PR DESCRIPTION
Fixes [TH-7460](https://linear.app/future-agi/issue/TH-7460/clicking-view-full-transcript-breaks-chat-simulation-logs-ui).

## Root cause

`ShowComponent` is a plain component:

```jsx
export const ShowComponent = ({ condition, children }) => condition ? children : <></>;
```

JSX evaluates `children` **eagerly**, before `condition` is ever read. So `ConversationCard`'s tool-call block ran `rawContent.flatMap(...)` on every render, regardless of its `Array.isArray(rawContent)` guard.

`rawContent` is an optional prop and three of the four callers never pass it — including `ViewFullTranscript`. Clicking **View Full Transcript** threw `TypeError: Cannot read properties of undefined (reading 'flatMap')`, which unmounted the whole tree and blanked the logs UI.

Verified by reverting the fix against the new test: it reproduces that exact error, and passes with the fix.

## Backend shapes

`CallExecutionDetailSerializer.get_transcript` emits **two structurally different shapes under the same `transcript` key**:

| | chat (`"text"`) | voice (`"voice"`) |
|---|---|---|
| serializer | `ChatMessageSerializer` | `CallTranscriptSerializer` |
| role field | `role` | `speaker_role` |
| `content` | `list[dict]` — full message dumps | `str` — the utterance |
| turn body | `messages[0]` (`list[str]`) | `content` |
| timing | `created_at` only | `start_time_seconds` / `end_time_seconds` |
| `duration` | absent | absent |

Two findings from tracing this:

- The camelCase `startTimeSeconds`/`endTimeSeconds` the old code did arithmetic on **exist nowhere in the Python tree** — that subtraction was always `NaN`.
- A raw chat row fed to `getContent` renders empty, because it maps `c?.text` over dicts that only have `role`/`content`. Chat rows must be pre-flattened.

`TranscriptView.enrichTurns` reads `speaker_role || role` and accepts both snake_case and camelCase time keys, so both shapes work once flattened.

## Changes

- **`ConversationCard.jsx`** — the crash fix. `toolMessages` normalizes to `[]`, making eager evaluation safe. Also fixes the same latent crash in `CallTranscriptView` and `CompareConversation`.
- **`ViewFullTranscript.jsx`** — rebuilt on the shared `VoiceDetailDrawerV2/TranscriptView`, mirroring `ChatDetailDrawerV2/ChatTranscriptView` so both render identically from identical rows.
- **`TranscriptPreview.jsx`** — same root cause class, found while verifying: it read only `speaker_role`, so every chat log's preview rendered a blank speaker label before the colon. Now falls back to `role`.
- **Two new test files** — the crash regression, plus tests pinning both backend row shapes end-to-end.

## Testing

59 tests pass across 15 files (`src/sections/test`, `src/sections/test-detail`, `src/components/VoiceDetailDrawerV2`, `src/components/ChatDetailDrawerV2`). ESLint clean on all touched files.

## Note

`CallLogsCard.jsx:37` filters `speaker_role !== "system"`, which is a no-op for chat rows. Left as-is: harmless today since chat only stores `user`/`assistant`, and `ChatTranscriptView` has the identical filter — changing one without the other would break their parity.
