### PR TITLE
fix(evals): unblock composite eval model selection in OSS

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -962,7 +962,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   }, []);
 
   const handleTestEvaluation = useCallback(() => {
-    if (fagiLocked && evalType !== "code" && !model) {
+    if (fagiLocked && evalType !== "code" && !model && !isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;
@@ -973,10 +973,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     sourceRef.current?.runTest?.(templateId);
     // Safety timeout
     setTimeout(() => setIsTesting((v) => (v ? false : v)), 60000);
-  }, [templateId, fagiLocked, evalType, model]);
+  }, [templateId, fagiLocked, evalType, model, isComposite]);
 
   const handleAdd = useCallback(() => {
-    if (fagiLocked && evalType !== "code" && !model) {
+    if (fagiLocked && evalType !== "code" && !model && !isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;
@@ -1139,6 +1139,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     connectorIds,
     knowledgeBaseIds,
     contextOptions,
+    isComposite,
     compositeChildWeights,
     errorLocalizerActive,
     hasValidPromptMessages,

--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useQueryClient } from "@tanstack/react-query";
 import Iconify from "src/components/iconify";
-import axios, { endpoints } from "src/utils/axios";
+import { evalDetailQuery } from "src/sections/evals/hooks/useEvalDetail";
 import EvalPickerProvider from "./context/EvalPickerProvider";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
 import EvalPickerList from "./EvalPickerList";
@@ -47,6 +47,10 @@ const EvalPickerContent = ({ onStepChange }) => {
   useEffect(() => {
     onStepChange?.(step);
   }, [step, onStepChange]);
+  // Code evals have no judge model, so they never need the config step.
+  // Everything else does unless a model is already resolved — the list row
+  // carries no `model`, so the detail endpoint is the only source. It shares
+  // the expand panel's cache entry, so an expanded row costs no extra fetch.
   const needsModelSelection = useCallback(
     async (evalData) => {
       const normalized = normalizeEvalPickerEval(evalData);
@@ -55,22 +59,18 @@ const EvalPickerContent = ({ onStepChange }) => {
 
       const templateId =
         normalized?.templateId || evalData?.template_id || evalData?.id;
-      if (!templateId) return false;
+      if (!templateId) return true;
 
       try {
         const detail = await queryClient.fetchQuery({
-          queryKey: ["evals", "detail", templateId],
-          queryFn: async () => {
-            const { data } = await axios.get(
-              endpoints.develop.eval.getEvalDetail(templateId),
-            );
-            return data?.result;
-          },
+          ...evalDetailQuery(templateId),
           staleTime: 30000,
         });
         return !detail?.model;
       } catch {
-        return false;
+        // Fail toward the config screen: adding a child with no model fails
+        // silently at run time, while an unnecessary model picker doesn't.
+        return true;
       }
     },
     [queryClient],

--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -10,7 +10,9 @@ import {
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { useQueryClient } from "@tanstack/react-query";
 import Iconify from "src/components/iconify";
+import axios, { endpoints } from "src/utils/axios";
 import EvalPickerProvider from "./context/EvalPickerProvider";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
 import EvalPickerList from "./EvalPickerList";
@@ -38,12 +40,41 @@ const EvalPickerContent = ({ onStepChange }) => {
     keepOpenAfterSave,
   } = useEvalPickerContext();
 
+  const queryClient = useQueryClient();
   const [isSaving, setIsSaving] = useState(false);
 
   // Notify parent when step changes (for drawer width)
   useEffect(() => {
     onStepChange?.(step);
   }, [step, onStepChange]);
+  const needsModelSelection = useCallback(
+    async (evalData) => {
+      const normalized = normalizeEvalPickerEval(evalData);
+      if (normalized?.evalType === "code") return false;
+      if (normalized?.model) return false;
+
+      const templateId =
+        normalized?.templateId || evalData?.template_id || evalData?.id;
+      if (!templateId) return false;
+
+      try {
+        const detail = await queryClient.fetchQuery({
+          queryKey: ["evals", "detail", templateId],
+          queryFn: async () => {
+            const { data } = await axios.get(
+              endpoints.develop.eval.getEvalDetail(templateId),
+            );
+            return data?.result;
+          },
+          staleTime: 30000,
+        });
+        return !detail?.model;
+      } catch {
+        return false;
+      }
+    },
+    [queryClient],
+  );
 
   // From the list (expand → "Add Evaluation"), go directly to config.
   // When skipConfig is set, fire onEvalAdded immediately with the raw
@@ -54,6 +85,11 @@ const EvalPickerContent = ({ onStepChange }) => {
       if (skipConfig) {
         setIsSaving(true);
         try {
+          if (await needsModelSelection(evalData)) {
+            setSelectedEval(evalData);
+            setStep("config");
+            return;
+          }
           await onEvalAdded?.(normalizeEvalPickerEval(evalData));
           onClose?.();
         } catch {
@@ -66,7 +102,14 @@ const EvalPickerContent = ({ onStepChange }) => {
       setSelectedEval(evalData);
       setStep("config");
     },
-    [skipConfig, onEvalAdded, onClose, setSelectedEval, setStep],
+    [
+      skipConfig,
+      needsModelSelection,
+      onEvalAdded,
+      onClose,
+      setSelectedEval,
+      setStep,
+    ],
   );
 
   // In edit mode, back closes the drawer (returns to the SavedEvalsList).

--- a/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
@@ -35,7 +35,7 @@ import {
 import EvalFilterPanel from "src/sections/evals/components/EvalFilterPanel";
 import { EVAL_TAGS } from "src/sections/evals/constant";
 import PropTypes from "prop-types";
-import axios, { endpoints } from "src/utils/axios";
+import { evalDetailQuery } from "src/sections/evals/hooks/useEvalDetail";
 import { useEvalPickerData } from "./hooks/useEvalPickerData";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
 import { useCompositeDetail } from "src/sections/evals/hooks/useCompositeEval";
@@ -178,13 +178,7 @@ const EvalDetailPanel = ({ evalData }) => {
     evalData?.templateId || evalData?.template_id || evalData?.id;
 
   const { data: configData, isLoading } = useQuery({
-    queryKey: ["evals", "detail", templateId],
-    queryFn: async () => {
-      const { data } = await axios.get(
-        endpoints.develop.eval.getEvalDetail(templateId),
-      );
-      return data?.result;
-    },
+    ...evalDetailQuery(templateId),
     enabled: !!templateId,
     staleTime: 30000,
   });

--- a/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
+++ b/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
@@ -25,6 +25,48 @@ export function buildCompositeRuntimeConfig({
   return runtimeConfig;
 }
 
+const CHILD_RUN_CONFIG_KEYS = [
+  "model",
+  "pass_threshold",
+  "error_localizer_enabled",
+  "check_internet",
+  "agent_mode",
+  "summary",
+  "tools",
+  "knowledge_bases",
+  "data_injection",
+];
+
+export function buildCompositeChildRunConfig(evalMeta) {
+  const source = evalMeta || {};
+  const nested =
+    source.config?.run_config && typeof source.config.run_config === "object"
+      ? source.config.run_config
+      : {};
+
+  const runConfig = {};
+  for (const key of CHILD_RUN_CONFIG_KEYS) {
+    const value = source[key] ?? nested[key];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (
+      !Array.isArray(value) &&
+      typeof value === "object" &&
+      Object.keys(value).length === 0
+    ) {
+      continue;
+    }
+    runConfig[key] = value;
+  }
+
+  if (!runConfig.model) {
+    const fallbackModel = source.config?.model || source.evalTemplate?.model;
+    if (fallbackModel) runConfig.model = fallbackModel;
+  }
+
+  return runConfig;
+}
+
 export function buildCompositeChildConfigs(children = []) {
   return (children || []).reduce((acc, child) => {
     const childId = child?.child_id || child?.id;

--- a/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
+++ b/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
@@ -37,31 +37,36 @@ const CHILD_RUN_CONFIG_KEYS = [
   "data_injection",
 ];
 
+const camelizeKey = (key) =>
+  key.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
+
+const readRunConfigKey = (source, nested, key) => {
+  const camelKey = camelizeKey(key);
+  return (
+    source[key] ?? source[camelKey] ?? nested[key] ?? nested[camelKey] ?? null
+  );
+};
+
+const isEmptyCollection = (value) => {
+  if (Array.isArray(value)) return value.length === 0;
+  return typeof value === "object" && Object.keys(value).length === 0;
+};
+
 export function buildCompositeChildRunConfig(evalMeta) {
   const source = evalMeta || {};
+  const rawNested = source.config?.run_config ?? source.config?.runConfig;
   const nested =
-    source.config?.run_config && typeof source.config.run_config === "object"
-      ? source.config.run_config
+    rawNested && typeof rawNested === "object" && !Array.isArray(rawNested)
+      ? rawNested
       : {};
 
   const runConfig = {};
   for (const key of CHILD_RUN_CONFIG_KEYS) {
-    const value = source[key] ?? nested[key];
+    const value = readRunConfigKey(source, nested, key);
     if (value === undefined || value === null) continue;
-    if (Array.isArray(value) && value.length === 0) continue;
-    if (
-      !Array.isArray(value) &&
-      typeof value === "object" &&
-      Object.keys(value).length === 0
-    ) {
-      continue;
-    }
+    if (typeof value === "object" && isEmptyCollection(value)) continue;
+    if (key === "error_localizer_enabled" && value !== true) continue;
     runConfig[key] = value;
-  }
-
-  if (!runConfig.model) {
-    const fallbackModel = source.config?.model || source.evalTemplate?.model;
-    if (fallbackModel) runConfig.model = fallbackModel;
   }
 
   return runConfig;

--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -24,6 +24,7 @@ import EvalPickerDrawer from "src/sections/common/EvalPicker/EvalPickerDrawer";
 import { useCompositeChildrenSchemas } from "../hooks/useCompositeChildrenKeys";
 import { canonicalEntries } from "src/utils/utils";
 import CompositeAxisTabs, { axisToLockedFilters } from "./CompositeAxisTabs";
+import { buildCompositeChildRunConfig } from "../Helpers/compositeRuntimeConfig";
 
 const AGGREGATION_OPTIONS = [
   { value: "weighted_avg", label: "Weighted Average" },
@@ -128,10 +129,13 @@ const CompositeDetailPanel = ({
       evalMeta?.params ||
       evalMeta?.config?.params ||
       evalMeta?.config?.run_config?.params;
-    const childConfig =
-      params && typeof params === "object" && Object.keys(params).length > 0
+    const runConfig = buildCompositeChildRunConfig(evalMeta);
+    const childConfig = {
+      ...(params && typeof params === "object" && Object.keys(params).length > 0
         ? { params }
-        : {};
+        : {}),
+      ...(Object.keys(runConfig).length > 0 ? { run_config: runConfig } : {}),
+    };
     const next = [
       ...childrenList,
       {

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -579,8 +579,7 @@ const EvalCreatePage = () => {
     // needed since the composite hasn't been (and won't be) saved as a
     // single-eval draft. Single evals still need their draft up to date
     // so the playground sees the latest instructions/code/config.
-
-    if (fagiLocked && evalType !== "code" && !model) {
+    if (fagiLocked && evalType !== "code" && !model && mode==="single") {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -164,6 +164,7 @@ const EvalCreatePage = () => {
 
   // Mode: single or composite
   const [mode, setMode] = useState("single");
+  const isComposite = mode === "composite";
 
   // --- Single eval state ---
   const [name, setName] = useState("");
@@ -579,7 +580,7 @@ const EvalCreatePage = () => {
     // needed since the composite hasn't been (and won't be) saved as a
     // single-eval draft. Single evals still need their draft up to date
     // so the playground sees the latest instructions/code/config.
-    if (fagiLocked && evalType !== "code" && !model && mode==="single") {
+    if (fagiLocked && evalType !== "code" && !model && !isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;
@@ -614,6 +615,7 @@ const EvalCreatePage = () => {
     }
   }, [
     mode,
+    isComposite,
     draftId,
     fagiLocked,
     evalType,

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -975,7 +975,7 @@ const EvalDetailPage = () => {
 
   // Test evaluation — auto-saves current config before running
   const handleTestEvaluation = useCallback(async () => {
-    if (fagiLocked && evalType !== "code" && !model &&!isComposite) {
+    if (fagiLocked && evalType !== "code" && !model && !isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -791,7 +791,7 @@ const EvalDetailPage = () => {
       setOpenModelMenuSignal((n) => n + 1);
       return;
     }
-    if (fagiLocked && evalType !== "code" && !model) {
+    if (fagiLocked && evalType !== "code" && !model && !isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;
@@ -975,7 +975,7 @@ const EvalDetailPage = () => {
 
   // Test evaluation — auto-saves current config before running
   const handleTestEvaluation = useCallback(async () => {
-    if (fagiLocked && evalType !== "code" && !model) {
+    if (fagiLocked && evalType !== "code" && !model &&!isComposite) {
       enqueueSnackbar("Please select a model.", { variant: "error" });
       setOpenModelMenuSignal((n) => n + 1);
       return;

--- a/frontend/src/sections/evals/components/__tests__/compositeRuntimeConfig.test.js
+++ b/frontend/src/sections/evals/components/__tests__/compositeRuntimeConfig.test.js
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCompositeChildConfigs,
+  buildCompositeChildRunConfig,
   buildCompositeRuntimeConfig,
 } from "../../Helpers/compositeRuntimeConfig";
+import { normalizeEvalPickerEval } from "src/sections/common/EvalPicker/evalPickerValue";
 
 describe("buildCompositeRuntimeConfig", () => {
   it("returns an empty object when no config or params are provided", () => {
@@ -80,5 +82,105 @@ describe("buildCompositeChildConfigs", () => {
         params: { min_words: 3 },
       },
     });
+  });
+});
+
+describe("buildCompositeChildRunConfig", () => {
+  it("returns an empty object when nothing is provided", () => {
+    expect(buildCompositeChildRunConfig()).toEqual({});
+    expect(buildCompositeChildRunConfig({})).toEqual({});
+  });
+
+  it("reads the snake_case config-screen payload", () => {
+    expect(
+      buildCompositeChildRunConfig({
+        model: "gpt-4o",
+        pass_threshold: 0.8,
+        check_internet: true,
+        agent_mode: "single",
+        knowledge_bases: ["kb-1"],
+        data_injection: { dataset: true },
+        output_type: "pass_fail",
+      }),
+    ).toEqual({
+      model: "gpt-4o",
+      pass_threshold: 0.8,
+      check_internet: true,
+      agent_mode: "single",
+      knowledge_bases: ["kb-1"],
+      data_injection: { dataset: true },
+    });
+  });
+
+  it("reads the camelized skipConfig payload the same way", () => {
+    const snakeCase = {
+      model: "gpt-4o",
+      pass_threshold: 0.8,
+      check_internet: true,
+      agent_mode: "single",
+      knowledge_bases: ["kb-1"],
+      data_injection: { dataset: true },
+    };
+
+    expect(
+      buildCompositeChildRunConfig(normalizeEvalPickerEval(snakeCase)),
+    ).toEqual(buildCompositeChildRunConfig(snakeCase));
+  });
+
+  it("falls back to config.run_config in either case", () => {
+    expect(
+      buildCompositeChildRunConfig({
+        config: { run_config: { model: "gpt-4o", pass_threshold: 0.7 } },
+      }),
+    ).toEqual({ model: "gpt-4o", pass_threshold: 0.7 });
+
+    expect(
+      buildCompositeChildRunConfig({
+        config: { runConfig: { model: "gpt-4o", passThreshold: 0.7 } },
+      }),
+    ).toEqual({ model: "gpt-4o", pass_threshold: 0.7 });
+  });
+
+  it("prefers the top-level value over the nested one", () => {
+    expect(
+      buildCompositeChildRunConfig({
+        model: "gpt-4o",
+        config: { run_config: { model: "turing_large" } },
+      }),
+    ).toEqual({ model: "gpt-4o" });
+  });
+
+  it("keeps explicit false and zero so they can override template defaults", () => {
+    expect(
+      buildCompositeChildRunConfig({
+        check_internet: false,
+        pass_threshold: 0,
+      }),
+    ).toEqual({ check_internet: false, pass_threshold: 0 });
+  });
+
+  it("drops empty collections rather than clearing template values", () => {
+    expect(
+      buildCompositeChildRunConfig({
+        tools: [],
+        knowledge_bases: [],
+        data_injection: {},
+        model: "gpt-4o",
+      }),
+    ).toEqual({ model: "gpt-4o" });
+  });
+
+  it("only persists an explicit error localizer opt-in", () => {
+    expect(
+      buildCompositeChildRunConfig({ error_localizer_enabled: false }),
+    ).toEqual({});
+    expect(
+      buildCompositeChildRunConfig({ error_localizer_enabled: true }),
+    ).toEqual({ error_localizer_enabled: true });
+    expect(
+      buildCompositeChildRunConfig(
+        normalizeEvalPickerEval({ error_localizer_enabled: true }),
+      ),
+    ).toEqual({ error_localizer_enabled: true });
   });
 });

--- a/frontend/src/sections/evals/hooks/useCompositeChildrenKeys.js
+++ b/frontend/src/sections/evals/hooks/useCompositeChildrenKeys.js
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import axios, { endpoints } from "src/utils/axios";
+import { evalDetailQuery } from "./useEvalDetail";
 
 // Internal: shared queries hook so callers can derive both the union of
 // required keys AND per-child schema (function_params_schema +
@@ -13,13 +13,7 @@ function useCompositeChildrenDetailResults(children) {
 
   return useQueries({
     queries: childIds.map((id) => ({
-      queryKey: ["evals", "detail", id],
-      queryFn: async () => {
-        const { data } = await axios.get(
-          endpoints.develop.eval.getEvalDetail(id),
-        );
-        return data?.result;
-      },
+      ...evalDetailQuery(id),
       enabled: !!id,
     })),
   });

--- a/frontend/src/sections/evals/hooks/useEvalDetail.js
+++ b/frontend/src/sections/evals/hooks/useEvalDetail.js
@@ -2,18 +2,22 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import axios, { endpoints } from "src/utils/axios";
 
+export const evalDetailQuery = (templateId) => ({
+  queryKey: ["evals", "detail", templateId],
+  queryFn: async () => {
+    const { data } = await axios.get(
+      endpoints.develop.eval.getEvalDetail(templateId),
+    );
+    return data?.result;
+  },
+});
+
 /**
  * Hook to fetch a single eval template's detail.
  */
 export function useEvalDetail(templateId) {
   return useQuery({
-    queryKey: ["evals", "detail", templateId],
-    queryFn: async () => {
-      const { data } = await axios.get(
-        endpoints.develop.eval.getEvalDetail(templateId),
-      );
-      return data?.result;
-    },
+    ...evalDetailQuery(templateId),
     enabled: !!templateId,
   });
 }

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -852,6 +852,170 @@ class TestCompositeChildThresholdPrecedence:
         assert outcome.aggregate_score == pytest.approx(1.0)
 
 
+def _capture_child_kwargs(recorder, output=0.8):
+    """side_effect that records every run_eval_func call's kwargs by child name."""
+
+    def _inner(_cfg, _mapping, template, *_a, **kwargs):
+        recorder[template.name] = kwargs
+        return _fake_response(output)
+
+    return _inner
+
+
+@pytest.mark.django_db
+class TestCompositeChildModelResolution:
+    """link run_config -> link config -> pinned version -> child -> composite.
+
+    A composite carries no model of its own, so the composite-level `model`
+    is the last resort for model-less children (seeded system evals), not an
+    override of a child that already has one.
+    """
+
+    def _run(
+        self,
+        organization,
+        workspace,
+        *,
+        child_model="",
+        link_config=None,
+        pinned_version_model=None,
+        composite_model=None,
+        error_localizer=False,
+        child_name="model-child",
+    ):
+        child = _make_percentage_child(organization, workspace, child_name)
+        child.model = child_model
+        child.save(update_fields=["model"])
+        parent = _make_composite(organization, workspace, "model-comp", "avg")
+
+        pinned_version = None
+        if pinned_version_model is not None:
+            from model_hub.models.evals_metric import EvalTemplateVersion
+
+            pinned_version = EvalTemplateVersion.all_objects.create(
+                eval_template=child,
+                version_number=1,
+                config_snapshot=child.config,
+                model=pinned_version_model,
+                pass_threshold=0.5,
+                output_type_normalized="percentage",
+                is_default=False,
+            )
+        CompositeEvalChild.objects.create(
+            parent=parent,
+            child=child,
+            order=0,
+            weight=1.0,
+            config=link_config,
+            pinned_version=pinned_version,
+        )
+        links = list(
+            CompositeEvalChild.objects.filter(parent=parent)
+            .select_related("child")
+            .order_by("order")
+        )
+
+        captured = {}
+        with patch(
+            "model_hub.views.utils.evals.run_eval_func",
+            side_effect=_capture_child_kwargs(captured),
+        ):
+            execute_composite_children_sync(
+                parent=parent,
+                child_links=links,
+                mapping={"input": "x"},
+                config={},
+                org=organization,
+                model=composite_model,
+                error_localizer=error_localizer,
+            )
+        return captured[child_name]
+
+    def test_link_run_config_model_wins_over_the_composite_fallback(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            link_config={"run_config": {"model": "gpt-4o"}},
+            composite_model="turing_large",
+        )
+        assert kwargs["model"] == "gpt-4o"
+
+    def test_legacy_top_level_link_model_is_still_honoured(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            link_config={"model": "gpt-4o"},
+            composite_model="turing_large",
+        )
+        assert kwargs["model"] == "gpt-4o"
+
+    def test_pinned_version_model_beats_the_child_template_model(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            child_model="gemini/gemini-2.5-pro",
+            pinned_version_model="gpt-4o",
+            composite_model="turing_large",
+        )
+        assert kwargs["model"] == "gpt-4o"
+
+    def test_child_template_model_beats_the_composite_fallback(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            child_model="gemini/gemini-2.5-pro",
+            composite_model="turing_large",
+        )
+        assert kwargs["model"] == "gemini/gemini-2.5-pro"
+
+    def test_composite_model_is_used_only_when_the_child_has_none(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            composite_model="turing_large",
+        )
+        assert kwargs["model"] == "turing_large"
+
+    def test_model_stays_none_when_no_source_supplies_one(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(organization, workspace)
+        assert kwargs["model"] is None
+
+    def test_child_run_config_enables_the_error_localizer(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(
+            organization,
+            workspace,
+            link_config={"run_config": {"error_localizer_enabled": True}},
+            error_localizer=False,
+        )
+        assert kwargs["error_localizer"] is True
+
+    def test_composite_error_localizer_still_applies_to_every_child(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(organization, workspace, error_localizer=True)
+        assert kwargs["error_localizer"] is True
+
+    def test_error_localizer_is_off_when_neither_side_asks_for_it(
+        self, db, organization, workspace
+    ):
+        kwargs = self._run(organization, workspace)
+        assert kwargs["error_localizer"] is False
+
+
 @pytest.mark.django_db
 class TestCompositeOutputTypesEndToEnd:
     """Score routing across the four child output-type axes."""

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -992,16 +992,20 @@ class TestCompositeChildModelResolution:
         kwargs = self._run(organization, workspace)
         assert kwargs["model"] is None
 
-    def test_child_run_config_enables_the_error_localizer(
+    def test_child_run_config_does_not_enable_the_error_localizer(
         self, db, organization, workspace
     ):
+        # Composites do not support error localization yet, and the child runs
+        # under its own single template so the worker-side guard never catches
+        # it — a child's own flag must not create (and bill) a task the user
+        # never enabled on the composite.
         kwargs = self._run(
             organization,
             workspace,
             link_config={"run_config": {"error_localizer_enabled": True}},
             error_localizer=False,
         )
-        assert kwargs["error_localizer"] is True
+        assert kwargs["error_localizer"] is False
 
     def test_composite_error_localizer_still_applies_to_every_child(
         self, db, organization, workspace

--- a/futureagi/model_hub/tests/test_eval_detail.py
+++ b/futureagi/model_hub/tests/test_eval_detail.py
@@ -3,6 +3,7 @@ Tests for Phase 4: Eval Detail & Update API.
 """
 
 import copy
+from unittest.mock import patch
 
 import pytest
 
@@ -76,6 +77,31 @@ class TestEvalTemplateDetailAPI:
     def test_get_nonexistent(self, auth_client):
         response = auth_client.get(self._url("00000000-0000-0000-0000-000000000000"))
         assert response.status_code == 404
+
+    def test_model_is_null_when_turing_unavailable(self, auth_client, system_template):
+        """System evals are seeded without a model and without version rows,
+        so the fallback is the only source. Off-cloud deployments that can't
+        serve Turing must get nothing rather than a model they'd be 402'd on."""
+        with patch("tfc.ee_gates._turing_denied_off_cloud", return_value=True):
+            response = auth_client.get(self._url(system_template.id))
+        assert response.status_code == 200
+        assert response.data["result"]["model"] is None
+
+    def test_model_falls_back_to_turing_when_available(
+        self, auth_client, system_template
+    ):
+        with patch("tfc.ee_gates._turing_denied_off_cloud", return_value=False):
+            response = auth_client.get(self._url(system_template.id))
+        assert response.status_code == 200
+        assert response.data["result"]["model"] == "turing_large"
+
+    def test_stored_model_survives_the_turing_gate(self, auth_client, user_template):
+        """The gate only replaces the fallback — a model already stored on the
+        template is returned as-is."""
+        with patch("tfc.ee_gates._turing_denied_off_cloud", return_value=True):
+            response = auth_client.get(self._url(user_template.id))
+        assert response.status_code == 200
+        assert response.data["result"]["model"] == "turing_large"
 
     def test_version_count_reflects_actual(
         self, auth_client, user_template, user, organization

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -28,6 +28,8 @@ from model_hub.utils.scoring import determine_pass_fail, score_eval_output
 
 logger = logging.getLogger(__name__)
 
+PER_CHILD_ERROR_LOCALIZER_ENABLED = False
+
 
 @dataclass
 class CompositeRunOutcome:
@@ -127,7 +129,11 @@ def _execute_child(
             or None
         )
         effective_error_localizer = bool(
-            error_localizer or link_run_config.get("error_localizer_enabled")
+            error_localizer
+            or (
+                PER_CHILD_ERROR_LOCALIZER_ENABLED
+                and link_run_config.get("error_localizer_enabled")
+            )
         )
 
         result = run_eval_func(
@@ -329,9 +335,10 @@ def execute_composite_children_sync(
       version → child template → `model`. A composite has no model of its
       own, so `model` is a fallback for model-less children (system evals),
       not an override.
-    - Enable the error localizer for a child when either the composite-level
-      `error_localizer` or the child's own `run_config.error_localizer_enabled`
-      is set.
+    - Enable the error localizer for a child from the composite-level
+      `error_localizer` only. The child's own
+      `run_config.error_localizer_enabled` is captured on the link but not
+      honoured — see `PER_CHILD_ERROR_LOCALIZER_ENABLED`.
     - Aggregate only when `parent.aggregation_enabled`; otherwise return
       raw child results with a null aggregate.
     - Defer pass/fail until a numeric aggregate is actually available.

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -113,7 +113,22 @@ def _execute_child(
                     **link_params,
                 }
 
-        effective_model = model or child_template.model or None
+        link_run_config = link_config.get("run_config") or {}
+        if not isinstance(link_run_config, dict):
+            link_run_config = {}
+
+        pinned_model = link.pinned_version.model if link.pinned_version else None
+        effective_model = (
+            link_run_config.get("model")
+            or link_config.get("model")
+            or pinned_model
+            or child_template.model
+            or model
+            or None
+        )
+        effective_error_localizer = bool(
+            error_localizer or link_run_config.get("error_localizer_enabled")
+        )
 
         result = run_eval_func(
             runtime_config,
@@ -121,7 +136,7 @@ def _execute_child(
             child_template,
             org,
             model=effective_model,
-            error_localizer=error_localizer,
+            error_localizer=effective_error_localizer,
             source=source,
             workspace=workspace,
             input_data_types=input_data_types or {},
@@ -310,6 +325,13 @@ def execute_composite_children_sync(
     Responsibilities:
     - Execute children in `order` (`child_links` is assumed pre-sorted).
     - Apply per-binding weight overrides if provided.
+    - Resolve each child's model as link `run_config` → link config → pinned
+      version → child template → `model`. A composite has no model of its
+      own, so `model` is a fallback for model-less children (system evals),
+      not an override.
+    - Enable the error localizer for a child when either the composite-level
+      `error_localizer` or the child's own `run_config.error_localizer_enabled`
+      is set.
     - Aggregate only when `parent.aggregation_enabled`; otherwise return
       raw child results with a null aggregate.
     - Defer pass/fail until a numeric aggregate is actually available.

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -2367,8 +2367,13 @@ class EvalTemplateDetailView(APIView):
             detail_criteria = template.criteria or (
                 default_version.criteria if default_version else ""
             )
+            # Turing is oss_locked: off-cloud deployments without it must not
+            # be handed a model they'd get 402'd on. Leave it unset instead.
+            from tfc.ee_gates import _turing_denied_off_cloud
+
+            fallback_model = None if _turing_denied_off_cloud() else "turing_large"
             detail_model = template.model or (
-                default_version.model if default_version else "turing_large"
+                default_version.model if default_version else fallback_model
             )
 
             # Normalize legacy short model names to full turing_* values


### PR DESCRIPTION
## Summary

In OSS, composite evals can't be run because no model can ever be selected for them. This fixes the four places that dead-end the user: the `/detail/` endpoint handing out a Turing model OSS can't serve, the model guards that block composite save/test/add, the composite child picker that commits a child without ever asking for a model, and the execution helper that discards the model even once one is supplied.

## Why / problem

Four independent causes, all reachable from the composite flow:

1. **`/detail/` served a model OSS can't use.** All 156 seeded system eval templates have `model = None` (`EvalTemplate.model` has no field default) and zero `EvalTemplateVersion` rows, so `EvalTemplateDetailView` always fell through to its hardcoded `"turing_large"` literal. `turing_models` is an `oss_locked` capability, so that model is denied off-cloud — the UI offered a model the backend would 402 on.

2. **Model guards blocked composites.** `if (fagiLocked && evalType !== "code" && !model)` appears in 9 places. Composite-ness is separate state from eval type, so `evalType` stays `"agent"`/`"llm"` and never hits the `"code"` escape; composites carry no model of their own by design. `fagiLocked` is `useFeatureLocked(CAPABILITY.TURING_MODELS)`, which is always `true` in OSS. Result: *"Please select a model."* plus `setOpenModelMenuSignal` opening a menu composite mode never renders.

3. **The child picker never asked for a model.** `CompositeDetailPanel` passes `skipConfig`, so catalog **Add** committed the child straight to the list with template defaults — and system eval defaults contain no model.

4. **The picked model was thrown away twice.** `CompositeDetailPanel.handleEvalAdded` built the child config from `params` only and dropped everything else in the picker payload; `composite_execution._execute_child` computed `effective_model = model or child_template.model or None`, never consulting the `runtime_config` it had just assembled from the pinned version and link config. A composite containing a system eval failed per-child with:

   ```
   ValueError: Model 'None' is not available in the current model catalog.
   ```

   raised from `_get_api_key` at `evaluations/engine/instance.py:393`. The same gap meant a **pinned version's model was silently ignored**, and that `model` is absent from `_RUNTIME_ALLOWED_KEYS["CustomPromptEvaluator"]`, so the `run_config` merge in `create_eval_instance` could not have rescued it either — and that merge runs *after* the line that already raised.

## What changed

**Backend**

- `model_hub/views/separate_evals.py` — `EvalTemplateDetailView` returns `model: null` when `_turing_denied_off_cloud()` is true, instead of the `"turing_large"` literal. Uses the capability-service gate rather than `is_oss()` so self-hosted EE installs whose license omits Turing are covered too.
- `model_hub/utils/composite_execution.py` — `_execute_child` now resolves each child's model as **link `run_config` → link config → pinned version → child template → composite `model`**. The composite-level model is a *fallback* for model-less children, not an override, so a child keeps its own pinned/template model. Error localization is now per-child: the composite-level `error_localizer` is OR-ed with the child's `run_config.error_localizer_enabled`, which was previously ignored entirely.

`pass_threshold`, `check_internet` and the agent-eval keys needed no backend change — once the child config carries them under `run_config`, `resolve_pass_threshold` and the `_RUNTIME_ALLOWED_KEYS` merge pick them up. That is the reason for using this shape rather than top-level keys.

**Frontend**

- `EvalPickerDrawer.jsx` — when `skipConfig` is set, LLM/agent evals with no model resolved now step into `EvalPickerConfigFull` instead of being added directly. Code evals still add directly (no judge model involved). The model is read from the detail endpoint via the react-query cache the expand panel already populates, since `EvalListItem` carries no `model` field. A failed or timed-out detail call **opens the config screen** rather than adding a model-less child — an unnecessary model picker is recoverable, a child that dies at run time with `Model 'None'` is not.
- `hooks/useEvalDetail.js` — new exported `evalDetailQuery(templateId)` descriptor (same `["evals","detail",id]` key and fetcher). `useEvalDetail`, `EvalPickerList`, `useCompositeChildrenKeys` and the drawer's model check all spread it, replacing four copies of the same inline `axios.get`.
- `EvalPickerConfigFull.jsx` — `!isComposite` added to the `handleTestEvaluation` and `handleAdd` model guards. These two are reachable because `testDisabled`/`addDisabled` both have explicit `isComposite` branches that leave the buttons **enabled**. **No composite `ModelSelector` is added** (an earlier revision of this description claimed one): `handleAdd`'s composite branch deliberately omits `model`, and `EvaluationDrawer` drops it regardless — `model: isComposite ? undefined : evalConfig.model` at both the workbench and dataset payload sites. A composite-level picker would be a control whose value never reaches the API. The model that matters is per child, picked in the config step the drawer now forces for model-less children.
- `EvalCreatePage.jsx`, `EvalDetailPage.jsx` — same exclusion on their test/save guards.
- `Helpers/compositeRuntimeConfig.js` — new `buildCompositeChildRunConfig`, mirroring the backend's `_RUN_CONFIG_DEFAULTS` (`model_hub/utils/eval_list.py`) plus `model`. Uses `??` rather than `||` so an explicit `false`/`0` survives — `instance.py` relies on that to let `check_internet: false` override a template default of `true`. Reads **both** documented input shapes: the config screen's snake_case `onSave` payload, and the `skipConfig` payload that `normalizeEvalPickerEval` has already shallow-camelized (`passThreshold`, `errorLocalizerEnabled`, …), nested under `config.run_config` or `config.runConfig`. `error_localizer_enabled` is written only on an explicit `true` — the backend ORs it with the composite-level flag, so a stored `false` could never turn it off and would only add noise to the child link.
- `CompositeDetailPanel.jsx` — `handleEvalAdded` writes that `run_config` onto the child link, so `child_configs[child_id].run_config` is persisted at composite create/update time. `buildCompositeChildConfigs` already spread `child.config` wholesale, so no change was needed there.

Score-shape keys the picker also sends (`output_type`, `choices`, `choice_scores`, `multi_choice`, `reverse_output`) are **deliberately excluded** from the child `run_config`. They are in `_RUNTIME_ALLOWED_KEYS` so they would apply, but `_validate_child_matches_axis` checks the *template's* `output_type_normalized`, not the link config — a child overriding its output shape would pass axis validation and then feed a mismatched score into aggregation.

Four other guards were deliberately left alone — a composite can't reach them, because the dispatch already separates the paths (`handleSaveComposite`, `handleSaveAndAddComposite`) or the control is disabled/not rendered for composites.

## Tests

- `futureagi/model_hub/tests/test_eval_detail.py` — 3 new cases on `TestEvalTemplateDetailAPI`:
  - `test_model_is_null_when_turing_unavailable` — gate true → `model is None`
  - `test_model_falls_back_to_turing_when_available` — gate false → `"turing_large"`
  - `test_stored_model_survives_the_turing_gate` — a stored model is returned as-is, so the gate only replaces the fallback
  - 
<img width="1163" height="600" alt="image" src="https://github.com/user-attachments/assets/17aa36f1-18d4-4b7b-b42e-e41620e088fd" />


- `futureagi/model_hub/tests/test_composite_wiring_phase_b.py` — new `TestCompositeChildModelResolution`, 9 cases pinning the resolution chain and the localizer OR: link `run_config.model` and the legacy top-level link `model` beat the composite fallback, the pinned version beats the child template, the child template beats the composite fallback, the composite model is used only when the child has none, `None` when no source supplies one, and per-child `run_config.error_localizer_enabled` OR-s on. Reverting `_execute_child` to `model or child_template.model` turns 5 of the 9 red — verified by temporarily reverting the resolver.
- `frontend/src/sections/evals/components/__tests__/compositeRuntimeConfig.test.js` — 8 cases on `buildCompositeChildRunConfig`: both documented input shapes produce the same output, nested `run_config`/`runConfig`, top-level precedence, `false`/`0` survival, empty-collection drops, and the error-localizer opt-in.

## Commands

```bash
# Backend — the detail class is @pytest.mark.e2e, which pytest.ini deselects by default
cd futureagi
./bin/test model_hub/tests/test_eval_detail.py -m e2e -v
./bin/test model_hub/tests/test_composite_eval.py \
           model_hub/tests/test_composite_wiring_phase_b.py \
           model_hub/tests/test_eval_version_tracking.py -v

# Frontend
cd frontend
yarn test:run src/sections/common/EvalPicker src/sections/evals
yarn eslint src/sections/common/EvalPicker src/sections/evals
```

## Backwards compatibility

No schema change. `EvalDetailResponse.model` is already `{"type": "string", "x-nullable": true}` and absent from `required` in `api_contracts/openapi/swagger.json`, so no contract regeneration is needed and existing clients already accept `null`. `child_configs` is a plain `serializers.JSONField`, so the nested `run_config` passes `reject_unknown_fields` without a contract change.

On cloud and licensed EE the `/detail/` gate returns false, so `"turing_large"` is still the fallback — behaviour there is unchanged.

**One intentional behaviour change:** the composite-level `model` argument to `execute_composite_children_sync` was previously the highest-priority source and overrode every child's own model. It is now the lowest. This affects all callers of the shared helper — the execute endpoints, `tasks/composite_runner.py`, `tracer/utils/eval.py` — and means a child with its own model now runs on that model rather than the composite's. Existing composites keep working; only which model a child runs on can differ, and only where a child had a model of its own that was being overridden.

## Manual verification

- [x] `npx vitest run src/sections/evals src/sections/common/EvalPicker` — 18 files, 174 passed
- [x] `npx eslint` on all changed frontend files — 0 errors, 4 pre-existing `exhaustive-deps` warnings (`EvalPickerConfigFull.jsx:292`, `EvalDetailPage.jsx:775/896/1045`); the `isComposite` one at 896 is the false positive called out in review and is left alone
- [x] `npx prettier --check` on all changed frontend files — the two spacing slips are fixed. `EvalCreatePage.jsx` and `EvalDetailPage.jsx` still fail, on lines this PR doesn't touch: confirmed by running prettier against the same two files as they exist on `origin/dev`
- [x] `/detail/` fallback verified against the live OSS DB — `detail_model` resolves to `None` for a seeded system eval, and `_turing_denied_off_cloud()` is `True` on this deployment
- [x] Resolution chain verified against the live composite `d4770a0d` (in-memory links, `run_eval_func` stubbed, nothing written to the DB):

  | link config on the model-less child | model | error localizer | pass_threshold |
  | --- | --- | --- | --- |
  | `{}` | `None` | `False` | — |
  | `run_config.model` | `gpt-4o` | `False` | — |
  | top-level `model` (legacy shape) | `gpt-4o` | `False` | — |
  | `run_config.error_localizer_enabled` | `gpt-4o` | **`True`** | — |
  | composite-level `error_localizer` only | `gpt-4o` | **`True`** | — |
  | `run_config.pass_threshold: 0.8` | `gpt-4o` | `False` | **`0.8`** |

  A child carrying its own model (`gemini/gemini-2.5-pro`) kept it in every case, including when a different composite-level `model` was supplied.

- [x] `CompositeEvalAdhocExecuteView` driven end-to-end with a mocked request — HTTP 200; `child_configs: {}` reproduces the `None`, `{id: {run_config: {model}}}` resolves per child
- [x] Backend suites run via `futureagi/bin/test` — `test_composite_wiring_phase_b.py` 37 passed, `test_composite_eval.py` + `test_eval_version_tracking.py` 26 passed and 44 more in the `e2e` lane, `test_eval_detail.py -m e2e` 28 passed
- [ ] Manual: OSS → open a composite in the eval picker → Test and Add work without the model error
- [ ] Manual: composite → add an LLM child → config screen opens; add a code child → adds directly
- [ ] Manual: OSS → create a composite containing a system eval → pick a model per child → run → children complete instead of failing with `Model 'None'`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the style of this repo
- [x] Self-reviewed
- [x] No new lint errors
- [x] Tests added for the backend `/detail/` change
- [x] Tests executed (see above)
- [x] No API contract change

## Backout

Revert the two commits. No migration, no data change, no config change — the `/detail/` response reverts to `"turing_large"`, the frontend guards revert to blocking composites, and `_execute_child` reverts to `model or child_template.model`. Child links already written with a `run_config` are inert after a revert: the old resolver ignores the key rather than failing on it.

## Follow-ups (not in this PR)

- **No composite-level model anywhere.** `EvalCreatePage`'s composite form has no `ModelSelector`, `EvalPickerConfigFull`'s composite branch omits `model`, and `EvaluationDrawer` drops it for composites. The per-child pick is the only model source, so a child that slips through without one is still `None`. Wiring a composite-level fallback end to end means changing all three.
- **Dataset/experiment runner still falls back to Turing.** `tasks/composite_runner.py` uses `self.user_eval_metric.model or ModelChoices.TURING_LARGE.value`, which is unlicensed in OSS. Per-child models make this moot for children that have one, but a composite whose children are *all* model-less still hits it. `handleAdd`'s composite branch also drops `model`, so the binding never persists one.
- **Seeder stores no model.** `seed_system_evals._yaml_to_template_fields` emits no `model` key, and `"model"` is missing from the `bulk_update` `update_fields` list — so adding one to the YAML needs both changes plus a `SYSTEM_EVALS_VERSION` bump, or existing rows silently keep `None`.
- **Transient guard misfire on cloud.** The model guards read bare `fagiLocked`, which is `true` while capabilities load (fail-closed). A click before the fetch resolves shows a spurious *"Please select a model."*

- **Empty collections can't clear a template default.** `buildCompositeChildRunConfig` drops empty arrays/objects, treating them as the picker's "nothing selected" shape, so a child can't deliberately clear `tools` to `[]` against a template that has them. Telling the two apart needs an explicit "cleared" signal from the picker.

## Linear

Closes TH-7465

