### PR TITLE
chore: ignore futureagi/ee/scripts/ from the private ee repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ futureagi/ee/MIGRATION_GUIDE.md
 futureagi/ee/OPERATIONS_RUNBOOK.md
 futureagi/ee/PHASE4_CLASSIFICATION.md
 futureagi/ee/README.md
+futureagi/ee/scripts/
 # stray local leftover at repo root (old gateway config) — not the ee tree
 /ee/
 


### PR DESCRIPTION
## What

Adds `futureagi/ee/scripts/` to `.gitignore`, alongside the existing ee-owned paths.

## Why

Companion to **[future-agi/ee#210](https://github.com/future-agi/ee/pull/210)**, which slims the private `ee` repo to just the cloud-private delta (648 → 148 files) and adds `scripts/setup-nested-checkout.sh`.

The `ee` repo is checked out *inside* this one at `futureagi/ee/`, so everything it owns is physically present here and must stay ignored. `scripts/` is a new directory in that repo, so without this line:

- `git status` in any nested checkout reports `?? futureagi/ee/scripts/` permanently
- `git add -A` would commit the private repo's tooling into this public monorepo

Verified locally against ee#210's branch: with this line the working tree is clean; without it, that `??` entry is the only thing dirtying it.

## Note on the coupling

This is the maintenance cost of the nested layout: a **new root-level path** in the `ee` repo needs a matching line here. It does not apply to anything inside `cloud/`, which `futureagi/ee/cloud/` already covers — so in practice this should be rare.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
