### PR TITLE
fix(agent-playground): enable Import from Dataset in variables drawer

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/GlobalVariableDrawer.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/GlobalVariableDrawer.jsx
@@ -9,7 +9,7 @@ import {
   CircularProgress,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useForm, FormProvider } from "react-hook-form";
 import { useParams, useSearchParams } from "react-router-dom";
@@ -19,7 +19,7 @@ import { useGlobalVariablesDrawerStoreShallow, VIEW } from "../../store";
 import UploadedJSON from "./UploadedJSON";
 import HeaderActions from "./HeaderActions";
 import SvgColor from "src/components/svg-color";
-// import ImportDatasetDrawer from "src/components/VariableDrawer/ImportDataset/ImportDatasetDrawer";
+import ImportDatasetDrawer from "src/components/VariableDrawer/ImportDataset/ImportDatasetDrawer";
 import ConfirmDialog from "src/components/custom-dialog/confirm-dialog";
 import { useGetGraphDataset } from "../../../../api/agent-playground/agent-playground";
 import EmptyVariable from "src/components/VariableDrawer/EmptyVariable";
@@ -148,8 +148,8 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     currentView,
     setCurrentView,
     setGlobalVariables,
-    // importDatasetDrawerOpen,
-    // setImportDatasetDrawerOpen,
+    importDatasetDrawerOpen,
+    setImportDatasetDrawerOpen,
     setPendingRun,
   } = useGlobalVariablesDrawerStoreShallow((state) => ({
     setUploadedJson: state.setUploadedJson,
@@ -158,8 +158,8 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     currentView: state.currentView,
     setCurrentView: state.setCurrentView,
     setGlobalVariables: state.setGlobalVariables,
-    // importDatasetDrawerOpen: state.importDatasetDrawerOpen,
-    // setImportDatasetDrawerOpen: state.setImportDatasetDrawerOpen,
+    importDatasetDrawerOpen: state.importDatasetDrawerOpen,
+    setImportDatasetDrawerOpen: state.setImportDatasetDrawerOpen,
     setPendingRun: state.setPendingRun,
   }));
 
@@ -192,7 +192,8 @@ export default function GlobalVariableDrawer({ open, onClose }) {
   const {
     watch,
     reset,
-    // setValue,
+    setValue,
+    getValues,
     formState: { isDirty },
   } = methods;
 
@@ -207,21 +208,24 @@ export default function GlobalVariableDrawer({ open, onClose }) {
   // Get variable keys for the ImportDatasetDrawer
   const variableKeys = Object.keys(datasetVariables);
 
-  // Handler called when ImportDatasetDrawer applies data
-  // Using getValues instead of watch() to avoid new object reference on every render
-  // const handleSetVariableData = useCallback(
-  //   (variableData) => {
-  //     // importedData is an object like { variableName: [values...] }
-  //     // We take the first value from each array for the form
-  //     const currentValues = getValues();
-  //     Object.entries(variableData).forEach(([key, values]) => {
-  //       if (key in currentValues && Array.isArray(values) && values.length > 0) {
-  //         setValue(key, values[0], { shouldDirty: true });
-  //       }
-  //     });
-  //   },
-  //   [getValues, setValue],
-  // );
+  // Handler called when ImportDatasetDrawer applies data.
+  // Dataset values use raw variable names while RHF registers escaped dotted names.
+  const handleSetVariableData = useCallback(
+    (variableData) => {
+      const currentValues = getValues();
+      Object.entries(variableData).forEach(([key, values]) => {
+        const fieldName = escapeModelKey(key);
+        if (
+          fieldName in currentValues &&
+          Array.isArray(values) &&
+          values.length > 0
+        ) {
+          setValue(fieldName, values[0] ?? "", { shouldDirty: true });
+        }
+      });
+    },
+    [getValues, setValue],
+  );
 
   // Derive view from uploadedJson (store takes priority)
   const activeView = uploadedJson ? VIEW.UPLOADED_JSON : currentView;
@@ -249,7 +253,7 @@ export default function GlobalVariableDrawer({ open, onClose }) {
   };
 
   const confirmClose = () => {
-    setCurrentView(VIEW.ACTIONS);
+    setCurrentView(VIEW.MANUAL_FORM);
     setShowUploadJsonDialog(false);
     setShowConfirmDialog(false);
     setPendingRun(false);
@@ -275,13 +279,13 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     uploadMutation.mutate(file);
   };
 
-  // const handleOpenImportDatasetDrawer = () => {
-  //   setImportDatasetDrawerOpen(true);
-  // };
+  const handleOpenImportDatasetDrawer = () => {
+    setImportDatasetDrawerOpen(true);
+  };
 
-  // const handleCloseImportDatasetDrawer = () => {
-  //   setImportDatasetDrawerOpen(false);
-  // };
+  const handleCloseImportDatasetDrawer = () => {
+    setImportDatasetDrawerOpen(false);
+  };
 
   const renderContent = () => {
     if (datasetData?.columns?.length === 0) {
@@ -383,12 +387,11 @@ export default function GlobalVariableDrawer({ open, onClose }) {
       }}
     >
       <Header
-        // showHeaderActions={activeView !== VIEW.ACTIONS}
-        showHeaderActions={false}
+        showHeaderActions={activeView === VIEW.MANUAL_FORM}
         onClose={handleClose}
         handleUploadJson={handleUploadJson}
         currentView={currentView}
-        // onOpenImportDatasetDrawer={handleOpenImportDatasetDrawer}
+        onOpenImportDatasetDrawer={handleOpenImportDatasetDrawer}
         disabled={variableKeys.length === 0}
       />
       <Divider sx={{ my: 1.5 }} />
@@ -420,12 +423,12 @@ export default function GlobalVariableDrawer({ open, onClose }) {
       />
 
       {/* Import Dataset Drawer */}
-      {/* <ImportDatasetDrawer
+      <ImportDatasetDrawer
         open={importDatasetDrawerOpen}
         onClose={handleCloseImportDatasetDrawer}
         variables={variableKeys}
         setVariableData={handleSetVariableData}
-      /> */}
+      />
 
       {/* Confirm Dialog for unsaved changes */}
       <ConfirmDialog

--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/HeaderActions.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/HeaderActions.jsx
@@ -1,10 +1,6 @@
 import { Button } from "@mui/material";
 import React from "react";
 import SvgColor from "src/components/svg-color";
-import {
-  GeneratePromptButton,
-  GeneratePromptButtonIcon,
-} from "../../../../components/PromptCards/PromptCardStyleComponents";
 import PropTypes from "prop-types";
 import { VIEW } from "../../store";
 
@@ -52,22 +48,6 @@ export default function HeaderActions({
           Import from Dataset
         </Button>
       )}
-      <GeneratePromptButton
-        // onClick={handleGenerateDataClick}
-        startIcon={<GeneratePromptButtonIcon />}
-        size="small"
-        borderRadius={"4px"}
-        padding="5px 12px"
-        height="30px"
-        disabled={disabled}
-        sx={{
-          "& .svg-color": {
-            mr: 1,
-          },
-        }}
-      >
-        Generate Sample Data
-      </GeneratePromptButton>
     </>
   );
 }

--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/__tests__/GlobalVariableDrawer.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/__tests__/GlobalVariableDrawer.test.jsx
@@ -14,6 +14,7 @@ vi.mock("react-router-dom", () => ({
 // ---- Mock API ----
 let mockDatasetData = null;
 let mockIsLoading = false;
+let mockImportedVariableData = {};
 vi.mock("src/api/agent-playground/agent-playground", () => ({
   useGetGraphDataset: () => ({
     data: mockDatasetData,
@@ -36,8 +37,36 @@ vi.mock("../UploadedJSON", () => ({
 }));
 
 vi.mock("../HeaderActions", () => ({
-  default: () => <div data-testid="header-actions" />,
+  default: ({ onOpenImportDatasetDrawer, disabled }) => (
+    <button
+      data-testid="header-actions"
+      disabled={disabled}
+      onClick={onOpenImportDatasetDrawer}
+    >
+      Import from Dataset
+    </button>
+  ),
 }));
+
+vi.mock(
+  "src/components/VariableDrawer/ImportDataset/ImportDatasetDrawer",
+  () => ({
+    default: ({ open, onClose, setVariableData }) =>
+      open ? (
+        <div data-testid="import-dataset-drawer">
+          <button
+            data-testid="apply-import"
+            onClick={() => setVariableData(mockImportedVariableData)}
+          >
+            Apply
+          </button>
+          <button data-testid="close-import" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      ) : null,
+  }),
+);
 
 vi.mock("src/components/svg-color", () => ({
   default: (props) => <span data-testid="svg-icon" {...props} />,
@@ -86,6 +115,7 @@ describe("GlobalVariableDrawer", () => {
     useGlobalVariablesDrawerStore.getState().reset();
     mockDatasetData = null;
     mockIsLoading = false;
+    mockImportedVariableData = {};
   });
 
   it("renders loading spinner when dataset is loading", () => {
@@ -197,6 +227,69 @@ describe("GlobalVariableDrawer", () => {
     });
   });
 
+  describe("Import from Dataset", () => {
+    it("opens the import drawer and maps dotted variable names safely", async () => {
+      mockDatasetData = {
+        columns: [
+          { id: "col-1", name: "user.email" },
+          { id: "col-2", name: "city" },
+        ],
+        rows: [
+          {
+            cells: [
+              { columnId: "col-1", value: "old@example.com" },
+              { columnId: "col-2", value: "Tokyo" },
+            ],
+          },
+        ],
+      };
+      mockImportedVariableData = {
+        "user.email": ["new@example.com"],
+        city: [],
+      };
+
+      renderDrawer();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("header-actions")).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByTestId("header-actions"));
+      expect(screen.getByTestId("import-dataset-drawer")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("apply-import"));
+
+      await waitFor(() => {
+        const form = screen.getByTestId("manual-form");
+        expect(form).toHaveTextContent(
+          '"user__DOT__email":"new@example.com"',
+        );
+        expect(form).toHaveTextContent('"city":"Tokyo"');
+      });
+    });
+
+    it("closes the import drawer without changing variable values", async () => {
+      mockDatasetData = {
+        columns: [{ id: "col-1", name: "city" }],
+        rows: [{ cells: [{ columnId: "col-1", value: "Tokyo" }] }],
+      };
+
+      renderDrawer();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("header-actions")).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByTestId("header-actions"));
+      fireEvent.click(screen.getByTestId("close-import"));
+
+      expect(
+        screen.queryByTestId("import-dataset-drawer"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("manual-form")).toHaveTextContent(
+        '"city":"Tokyo"',
+      );
+    });
+  });
+
   describe("handleClose", () => {
     it("calls onClose directly when form is clean", () => {
       useGlobalVariablesDrawerStore.setState({
@@ -221,7 +314,7 @@ describe("GlobalVariableDrawer", () => {
   });
 
   describe("confirmClose", () => {
-    it("resets all state and calls onClose", () => {
+    it("resets transient state, returns to manual view, and calls onClose", () => {
       useGlobalVariablesDrawerStore.setState({
         globalVariables: { city: "Tokyo" },
         currentView: VIEW.MANUAL_FORM,
@@ -238,6 +331,7 @@ describe("GlobalVariableDrawer", () => {
       expect(onClose).toHaveBeenCalled();
       const state = useGlobalVariablesDrawerStore.getState();
       expect(state.pendingRun).toBe(false);
+      expect(state.currentView).toBe(VIEW.MANUAL_FORM);
     });
   });
 });


### PR DESCRIPTION
## Summary

Enable the existing **Import from Dataset** flow in the Agent Playground variables drawer.

Closes #1771.

## What changed

- wire the existing `ImportDatasetDrawer` into `GlobalVariableDrawer`
- show the existing **Import from Dataset** action in the manual variables view
- map imported values through `escapeModelKey()` so dotted variable names such as `user.email` update the correct React Hook Form field
- ignore empty imported value arrays instead of overwriting an existing value
- reset `currentView` to `VIEW.MANUAL_FORM` when the variables drawer closes so the import action remains available after reopen
- remove the visible **Generate Sample Data** control because it has no click handler
- add focused regression coverage for opening/closing the import drawer, dotted-name mapping, empty-array behavior, and view reset

## Scope

This keeps the issue's stated scope:

- no multi-row import
- no JSON-upload changes
- no new dataset UI or API
- no unrelated Agent Playground refactor

## Testing

Added targeted Vitest coverage in `GlobalVariableDrawer.test.jsx`. CI is the execution gate for this API-created branch.
