### PR TITLE
feat(guardrails): expose trajectory correlation context

### DIFF
--- a/agentcc-gateway/internal/guardrails/guardrail.go
+++ b/agentcc-gateway/internal/guardrails/guardrail.go
@@ -28,6 +28,48 @@ const (
 	ActionLog
 )
 
+// TrajectoryContext is the request-scoped correlation snapshot available to
+// stateful guardrails. It intentionally contains identity/correlation data only;
+// policy, risk, and accumulated trajectory state belong in separate layers.
+type TrajectoryContext struct {
+	RequestID    string
+	TraceID      string
+	SessionID    string
+	UserID       string
+	A2ATaskID    string
+	A2AContextID string
+	AgentID      string
+}
+
+// TrajectoryContextFromContext returns the normalized correlation context for a
+// guardrail invocation. AgentID is correlation-only metadata and must never be
+// treated as an authorization identity.
+func TrajectoryContextFromContext(ctx context.Context) *TrajectoryContext {
+	rc := models.GetRequestContext(ctx)
+	if rc == nil {
+		return nil
+	}
+
+	return &TrajectoryContext{
+		RequestID:    rc.RequestID,
+		TraceID:      rc.TraceID,
+		SessionID:    rc.SessionID,
+		UserID:       rc.UserID,
+		A2ATaskID:    rc.Metadata["a2a_task_id"],
+		A2AContextID: rc.Metadata["a2a_context_id"],
+		AgentID:      firstNonEmpty(rc.Metadata["gen_ai.agent.id"], rc.Metadata["agent_id"]),
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 // CheckInput is the input to a guardrail check.
 type CheckInput struct {
 	Request  *models.ChatCompletionRequest

--- a/agentcc-gateway/internal/guardrails/trajectory_context_test.go
+++ b/agentcc-gateway/internal/guardrails/trajectory_context_test.go
@@ -1,0 +1,71 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+func TestTrajectoryContextFromContext(t *testing.T) {
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	rc.RequestID = "req-123"
+	rc.TraceID = "trace-456"
+	rc.SessionID = "session-789"
+	rc.UserID = "user-abc"
+	rc.Metadata["a2a_task_id"] = "task-1"
+	rc.Metadata["a2a_context_id"] = "context-2"
+	rc.Metadata["agent_id"] = "legacy-agent"
+	rc.Metadata["gen_ai.agent.id"] = "otel-agent"
+
+	ctx := models.WithRequestContext(context.Background(), rc)
+	got := TrajectoryContextFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected trajectory context")
+	}
+
+	if got.RequestID != "req-123" {
+		t.Errorf("RequestID = %q, want %q", got.RequestID, "req-123")
+	}
+	if got.TraceID != "trace-456" {
+		t.Errorf("TraceID = %q, want %q", got.TraceID, "trace-456")
+	}
+	if got.SessionID != "session-789" {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, "session-789")
+	}
+	if got.UserID != "user-abc" {
+		t.Errorf("UserID = %q, want %q", got.UserID, "user-abc")
+	}
+	if got.A2ATaskID != "task-1" {
+		t.Errorf("A2ATaskID = %q, want %q", got.A2ATaskID, "task-1")
+	}
+	if got.A2AContextID != "context-2" {
+		t.Errorf("A2AContextID = %q, want %q", got.A2AContextID, "context-2")
+	}
+	if got.AgentID != "otel-agent" {
+		t.Errorf("AgentID = %q, want standardized metadata value %q", got.AgentID, "otel-agent")
+	}
+}
+
+func TestTrajectoryContextFromContextFallsBackToLegacyAgentID(t *testing.T) {
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.Metadata["agent_id"] = "legacy-agent"
+
+	ctx := models.WithRequestContext(context.Background(), rc)
+	got := TrajectoryContextFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected trajectory context")
+	}
+	if got.AgentID != "legacy-agent" {
+		t.Errorf("AgentID = %q, want %q", got.AgentID, "legacy-agent")
+	}
+}
+
+func TestTrajectoryContextFromContextWithoutRequestContext(t *testing.T) {
+	if got := TrajectoryContextFromContext(context.Background()); got != nil {
+		t.Fatalf("expected nil trajectory context, got %#v", got)
+	}
+}

--- a/agentcc-gateway/internal/pipeline/engine.go
+++ b/agentcc-gateway/internal/pipeline/engine.go
@@ -71,10 +71,15 @@ func NewEngine(plugins ...Plugin) *Engine {
 
 // Process executes the plugin pipeline: pre-plugins → provider call → post-plugins.
 func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, providerCall ProviderFunc) error {
+	// Make the authoritative request context available to plugins without
+	// copying correlation fields into client-visible metadata or changing the
+	// context passed to the provider.
+	pluginCtx := models.WithRequestContext(ctx, rc)
+
 	// Pre-plugins (always sequential — order matters for security gates).
 	for _, p := range e.plugins {
 		start := time.Now()
-		result := p.ProcessRequest(ctx, rc)
+		result := p.ProcessRequest(pluginCtx, rc)
 		elapsed := time.Since(start)
 		rc.RecordTiming("pre_"+p.Name(), elapsed)
 
@@ -145,6 +150,10 @@ func (e *Engine) Process(ctx context.Context, rc *models.RequestContext, provide
 // Exported so that streaming handlers can call it after the stream completes,
 // when rc.Response and usage data are populated.
 func (e *Engine) RunPostPlugins(ctx context.Context, rc *models.RequestContext) {
+	// Streaming handlers can invoke RunPostPlugins directly after Process returns,
+	// so reattach RequestContext here as well.
+	ctx = models.WithRequestContext(ctx, rc)
+
 	isCacheHit := rc.Flags.ShortCircuited && rc.Metadata["cache_status"] == "hit_exact"
 
 	// Phase 1: Sequential post-plugins (e.g., cost → credits dependency chain).

--- a/agentcc-gateway/internal/pipeline/engine_context_test.go
+++ b/agentcc-gateway/internal/pipeline/engine_context_test.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+)
+
+type requestContextCapturePlugin struct {
+	preContext  *models.RequestContext
+	postContext *models.RequestContext
+}
+
+func (p *requestContextCapturePlugin) Name() string  { return "request-context-capture" }
+func (p *requestContextCapturePlugin) Priority() int { return 10 }
+
+func (p *requestContextCapturePlugin) ProcessRequest(ctx context.Context, _ *models.RequestContext) PluginResult {
+	p.preContext = models.GetRequestContext(ctx)
+	return ResultContinue()
+}
+
+func (p *requestContextCapturePlugin) ProcessResponse(ctx context.Context, _ *models.RequestContext) PluginResult {
+	p.postContext = models.GetRequestContext(ctx)
+	return ResultContinue()
+}
+
+func TestEngineExposesRequestContextToPrePlugins(t *testing.T) {
+	plugin := &requestContextCapturePlugin{}
+	engine := NewEngine(plugin)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	// Streaming keeps post-processing separate so pre and post propagation can
+	// be asserted independently.
+	rc.IsStream = true
+
+	providerSawContext := false
+	err := engine.Process(context.Background(), rc, func(ctx context.Context, _ *models.RequestContext) error {
+		providerSawContext = models.GetRequestContext(ctx) != nil
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if plugin.preContext != rc {
+		t.Fatalf("pre-plugin request context = %p, want %p", plugin.preContext, rc)
+	}
+	if providerSawContext {
+		t.Fatal("provider context unexpectedly contains pipeline RequestContext")
+	}
+	if plugin.postContext != nil {
+		t.Fatal("post-plugin should not run inside Process for streaming request")
+	}
+}
+
+func TestRunPostPluginsExposesRequestContextWhenCalledDirectly(t *testing.T) {
+	plugin := &requestContextCapturePlugin{}
+	engine := NewEngine(plugin)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+
+	engine.RunPostPlugins(context.Background(), rc)
+
+	if plugin.postContext != rc {
+		t.Fatalf("post-plugin request context = %p, want %p", plugin.postContext, rc)
+	}
+}


### PR DESCRIPTION


## Summary

Adds the first runtime primitive for stateful trajectory guardrails: a typed, backward-compatible trajectory correlation context that allows guardrails to correlate activity across requests, traces, sessions, agents, and A2A tasks.

This PR intentionally does not introduce trajectory persistence, risk scoring, or new enforcement behavior. It establishes the correlation contract that later trajectory-aware guardrails can build on.
## Linked issues

Part of #2045
Linear: N/A

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

### A. Typed trajectory correlation context for guardrails

Added a TrajectoryContext abstraction exposing stable correlation fields:

- RequestID
- TraceID
- SessionID
- UserID
- A2ATaskID
- A2AContextID
- AgentID

Added a helper for deriving this context from the authoritative gateway RequestContext.
gen_ai.agent.id is preferred when available, with agent_id retained as a compatibility fallback.
Agent identity in this structure is explicitly correlation metadata only and does not grant or transfer authorization.

### B. RequestContext propagation through the plugin pipeline

The pipeline now makes the current RequestContext available to pre-request and post-response plugins through Go context.Context.
Direct RunPostPlugins calls receive the same context propagation, which preserves the contract for streaming execution where post-processing occurs separately.
Provider execution remains unchanged and does not depend on the new correlation context.

### C. Architecture / layering

Correlation is introduced at the guardrail contract layer without adding a trajectory database or coupling the gateway to LangChain/LangGraph.
The existing RequestContext remains the source of truth.
No values are copied into client-controlled metadata solely for this feature.
Future stateful trajectory logic can consume this normalized context without modifying individual framework integrations.

- [What moved where and why]

---

## 2) Why the changes were done

- Product/Safety: Current guardrails primarily evaluate an individual request or response. Long-running agent workflows may span several requests, agents, sessions, and A2A tasks, so future trajectory-aware checks need stable correlation identifiers.
- Technical: The gateway already contains these identifiers in RequestContext. Exposing a small typed view avoids inventing a second identity/state mechanism.
- Architecture: This keeps correlation, persistence, and enforcement as separate concerns. This PR establishes only the correlation contract; trajectory storage and risk evaluation can be reviewed independently in follow-up PRs.
- Compatibility: Existing guardrail implementations continue to work unchanged. No guardrail action semantics, thresholds, provider calls, or public API contracts are modified.

---

## 3) Tests written + scenarios each covers

agentcc-gateway/internal/guardrails/trajectory_context_test.go — trajectory-context normalization

- TestTrajectoryContextFromContext — verifies request, trace, session, user, A2A task/context, and agent correlation fields are derived correctly.
- TestTrajectoryContextFromContext — verifies standardized gen_ai.agent.id takes precedence over the legacy agent_id field.
- TestTrajectoryContextFromContextFallsBackToLegacyAgentID — verifies compatibility with existing agent_id metadata.
- TestTrajectoryContextFromContextWithoutRequestContext — verifies the helper safely returns nil when no gateway request context is present.
- agentcc-gateway/internal/pipeline/engine_context_test.go — pipeline propagation
- TestEngineExposesRequestContextToPrePlugins — verifies pre-request plugins receive the authoritative RequestContext. Also verifies provider execution is not implicitly coupled to the pipeline's internal request-context value
- TestRunPostPluginsExposesRequestContextWhenCalledDirectly — verifies direct/streaming post-plugin execution receives the same request context.



---

## 4) How to run / test

### Backend tests
```
cd agentcc-gateway

# Focused tests for this PR
go test ./internal/guardrails ./internal/pipeline

# Individual packages
go test ./internal/guardrails
go test ./internal/pipeline

# Full gateway suite if desired
go test ./...
Backend tests
```
### Frontend tests (if applicable)
Backend tests

Not applicable. This PR changes the Go AgentCC gateway only and does not modify the Django backend.

Not applicable. No frontend code is changed.

### Contract verification (if API surface changed)

```bash
# Regenerate swagger:
DJANGO_SETTINGS_MODULE=tfc.settings.test ./scripts/generate-openapi-schema.sh

# Regenerate frontend contracts:
cd frontend && yarn contracts:generate

# Verify contracts pass:
cd frontend && yarn contracts:check
```

### UI steps (manual)

1. Start the stack and log in at **http://localhost:3031**.
2. [Step-by-step to reach the affected screen]
3. [What to verify]

---

## 5) Screenshots / recordings

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->
<!-- Include: test command output screenshot + UI testing screenshots/recordings -->

### Test output

<!-- Screenshot of the test run passing -->

### UI testing

<!-- Screenshot or video of the feature working in the browser -->

---

## 6) Edge cases & considerations

- No RequestContext available: TrajectoryContextFromContext returns nil rather than fabricating correlation state.
- Multiple agent-id representations: standardized gen_ai.agent.id takes precedence; legacy agent_id remains supported.
- Missing A2A metadata: A2A fields remain empty and do not affect ordinary gateway requests.
- Streaming execution: direct post-processing receives the same authoritative request context as normal pipeline execution.
- Authorization: AgentID is not an authority or permission source. Correlation does not imply capability inheritance.
- No persistence: this PR does not retain trajectory information between requests.

---

## 7) Pre-existing issues (NOT introduced by this PR)

- Existing guardrails remain request/response scoped; this PR does not yet make them stateful.
- Cross-request trajectory persistence is intentionally deferred to a follow-up contribution.
- Framework-specific semantic event capture remains outside the gateway and is expected to be handled separately through traceAI.
- No new mitigation or risk-scoring rule is introduced by this PR.

---

## 8) Architectural / important decisions

- Use RequestContext as the source of truth: correlation identifiers already exist in the gateway, so a new parallel identity model would create unnecessary synchronization and trust problems.
- Typed view rather than raw metadata parsing: future trajectory guardrails can depend on a stable contract rather than repeatedly interpreting string metadata.
- Correlation is not authority: agent/session/A2A identifiers can connect events but cannot grant permissions or transfer capability.
- Keep this PR stateless: introducing persistence in the same change would make the correlation API harder to review independently.
- Keep framework instrumentation outside gateway core: LangChain/LangGraph-specific trajectory events can be emitted by traceAI in a separate contribution.

---

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [x] `yarn test:run` passes locally (frontend)
- [x] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status
