### PR TITLE
chore(ci): allow any branch in release-backend workflow dispatch

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -7,15 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to publish (e.g. v2.1.0-dev)'
+        description: "Version tag to publish (e.g. v2.1.0-dev)"
         required: true
         type: string
       branch:
-        description: 'Branch to build from'
+        description: "Branch to build from"
         required: true
-        default: 'main'
-        type: choice
-        options: [main, dev]
+        default: "main"
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why
The `Release backend` manual workflow only offered `main` and `dev` in its branch dropdown, so ad-hoc backend images could not be built from a feature or fix branch without first merging. GitHub Actions cannot populate a `choice` input dynamically with branch names, so a free-text input is the way to accept any branch while keeping the workflow definition itself pinned.

## What
Changed the `branch` `workflow_dispatch` input in `.github/workflows/release-backend.yml` from `type: choice` (options: main, dev) to `type: string`, keeping `main` as the default. Any branch name can now be typed when dispatching the workflow.

## Why this is safe
- `build-image.yml` (the reusable workflow this calls) already declares `ref` as a plain `required: true, type: string`, so it accepts arbitrary refs with no change needed.
- The input flows only into the same two places it already did: `build-image.yml`'s `ref` and `actions/checkout`'s `ref` — no new script-injection surface.
- The workflow remains `workflow_dispatch`-only (manual, gated by repo write access).
- **The matrix-based stable release (`release-images.yml`) is untouched**: it is tag-triggered, passes its own `ref: ${{ github.ref }}` to `build-image.yml`, and has no dependency on `release-backend.yml`. `build-image.yml` itself is not modified.

## Testing
Infra-only change; no tests apply. Verified the diff is limited to the input declaration and that `build-image.yml`'s `ref` contract already accepts any string.

Twin PR targets `dev` with the same change so the two branches don't drift.