### PR TITLE
fix(licensing): route managed AI through internal gateway on cloud

### DIFF
--- a/futureagi/ee/licensing/activation_client.py
+++ b/futureagi/ee/licensing/activation_client.py
@@ -16,8 +16,10 @@ import os
 import threading
 import time
 from dataclasses import dataclass
+from typing import Callable
 
 import structlog
+
 from ee.licensing.validator import hash_key
 
 logger = structlog.get_logger(__name__)
@@ -44,13 +46,10 @@ _cached_token: ServiceToken | None = None
 
 
 def get_activation_url() -> str:
-    return (
-        os.getenv(
-            "FUTURE_AGI_LICENSE_URL",
-            "https://api.futureagi.com",
-        ).rstrip("/")
-        + "/v1/self-hosted/activations"
-    )
+    return os.getenv(
+        "FUTURE_AGI_LICENSE_URL",
+        "https://api.futureagi.com",
+    ).rstrip("/") + "/v1/self-hosted/activations"
 
 
 def get_service_token() -> ServiceToken | None:
@@ -122,6 +121,56 @@ def _activate() -> ServiceToken | None:
         return None
 
 
+def dispatch_managed_request(
+    *,
+    url: str,
+    api_key: str,
+    json_body: dict,
+    timeout: float,
+    on_unauthorized: Callable[[], None],
+) -> dict:
+    """POST to the managed gateway and map failures to typed errors.
+
+    Shared transport for both managed-AI auth models: the self-hosted
+    activation-token flow (``call_managed_service``) and the cloud
+    internal-key flow (``ee.licensing.managed_ai``). Only the 401 response
+    is handled differently between them, so callers pass ``on_unauthorized``
+    (which must raise); every other status maps identically here so the two
+    paths cannot drift.
+    """
+    import httpx
+
+    try:
+        response = httpx.post(
+            url,
+            json=json_body,
+            timeout=timeout,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+    except httpx.TimeoutException:
+        raise ManagedServiceError("GATEWAY_TIMEOUT", "Managed AI gateway timed out")
+    except httpx.ConnectError:
+        raise ManagedServiceError("GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway")
+
+    if response.status_code == 401:
+        on_unauthorized()
+        # Callers must raise in on_unauthorized; guard in case one does not.
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED", "Managed AI gateway rejected credentials"
+        )
+    if response.status_code == 403:
+        raise ManagedServiceError("FEATURE_DENIED", "Feature not included in license scope")
+    if response.status_code == 429:
+        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
+    if response.status_code >= 500:
+        raise ManagedServiceError("SERVICE_ERROR", f"Managed AI service error ({response.status_code})")
+
+    return response.json()
+
+
 def call_managed_service(
     path: str = "/v1/chat/completions",
     *,
@@ -130,54 +179,30 @@ def call_managed_service(
 ) -> dict:
     """Make an authenticated request to the FutureAGI managed gateway.
 
-    Raises ManagedServiceError on auth/service failures with typed codes.
+    Self-hosted EE auth: exchange the license for a short-lived service
+    token, then call the gateway with it. Raises ManagedServiceError on
+    auth/service failures with typed codes.
     """
     token = get_service_token()
     if token is None:
         raise ManagedServiceError("ACTIVATION_FAILED", "Could not obtain service token")
 
     if token.scope == "oss" and not token.access_token:
-        raise ManagedServiceError(
-            "NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license"
-        )
+        raise ManagedServiceError("NO_ENTERPRISE_LICENSE", "Managed AI requires an Enterprise license")
 
-    import httpx
-
-    url = token.gateway_url.rstrip("/") + path
-    try:
-        response = httpx.post(
-            url,
-            json=json_body,
-            timeout=timeout,
-            headers={
-                "Authorization": f"Bearer {token.access_token}",
-                "Content-Type": "application/json",
-            },
-        )
-    except httpx.TimeoutException:
-        raise ManagedServiceError("GATEWAY_TIMEOUT", "Managed AI gateway timed out")
-    except httpx.ConnectError:
-        raise ManagedServiceError(
-            "GATEWAY_UNREACHABLE", "Cannot reach managed AI gateway"
-        )
-
-    if response.status_code == 401:
+    def _on_unauthorized() -> None:
         invalidate_token()
         raise ManagedServiceError(
             "TOKEN_EXPIRED", "Service token rejected — will refresh on next call"
         )
-    if response.status_code == 403:
-        raise ManagedServiceError(
-            "FEATURE_DENIED", "Feature not included in license scope"
-        )
-    if response.status_code == 429:
-        raise ManagedServiceError("RATE_LIMITED", "Managed AI rate limit exceeded")
-    if response.status_code >= 500:
-        raise ManagedServiceError(
-            "SERVICE_ERROR", f"Managed AI service error ({response.status_code})"
-        )
 
-    return response.json()
+    return dispatch_managed_request(
+        url=token.gateway_url.rstrip("/") + path,
+        api_key=token.access_token,
+        json_body=json_body,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    )
 
 
 class ManagedServiceError(Exception):

--- a/futureagi/ee/licensing/managed_ai.py
+++ b/futureagi/ee/licensing/managed_ai.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from ee.licensing.activation_client import call_managed_service
+from ee.licensing.activation_client import (
+    ManagedServiceError,
+    call_managed_service,
+    dispatch_managed_request,
+)
 
 
 def is_managed_model(model: object) -> bool:
@@ -25,10 +29,67 @@ def service_for_model(model: object) -> str | None:
     return None
 
 
+def _cloud_chat_completion(
+    payload: dict[str, Any],
+    *,
+    path: str,
+    timeout: float,
+) -> dict[str, Any]:
+    """Managed completion on cloud.
+
+    Cloud deployments carry no ``EE_LICENSE_KEY``, so the self-hosted
+    activation-token exchange in ``call_managed_service`` never yields a
+    usable token. The gateway is internal here, so we authenticate with
+    ``AGENTCC_INTERNAL_API_KEY`` — mirroring the ``vertex_ai``/``turing_*``
+    internal-key branch in ``FalconLLMClient``.
+
+    Shares the transport + error mapping with ``call_managed_service`` via
+    ``dispatch_managed_request`` so the two paths cannot drift. Only the 401
+    handling differs: here it means a bad internal key, not a stale
+    activation token, so it deliberately does not touch the EE token cache.
+    """
+    from ee.usage.services.gateway_llm_client import _get_setting
+
+    base_url = _get_setting("AGENTCC_INTERNAL_URL", "http://agentcc-gateway:8090")
+    api_key = _get_setting("AGENTCC_INTERNAL_API_KEY")
+    if not api_key:
+        raise ManagedServiceError(
+            "GATEWAY_UNCONFIGURED",
+            "AGENTCC_INTERNAL_API_KEY is not configured for managed AI",
+        )
+
+    def _on_unauthorized() -> None:
+        raise ManagedServiceError(
+            "GATEWAY_UNAUTHORIZED",
+            "Managed AI gateway rejected the internal API key",
+        )
+
+    return dispatch_managed_request(
+        url=base_url.rstrip("/") + path,
+        api_key=api_key,
+        json_body=payload,
+        timeout=timeout,
+        on_unauthorized=_on_unauthorized,
+    )
+
+
 def chat_completion(payload: dict[str, Any]) -> dict[str, Any]:
     model = payload.get("model")
     if not is_managed_model(model):
         raise ValueError(f"Model {model!r} is not a FutureAGI-managed model")
+
+    from ee.usage.deployment import DeploymentMode
+
+    if DeploymentMode.is_cloud():
+        return _cloud_chat_completion(
+            payload,
+            path="/v1/chat/completions",
+            # Matches the shared gateway client (gateway_llm_client). A managed
+            # agent turn with a large max_tokens routinely runs well past the
+            # 30s default, so use the same generous ceiling rather than let a
+            # slow-but-valid completion trip a transport timeout.
+            timeout=300.0,
+        )
     return call_managed_service(
         path="/v1/chat/completions",
         json_body=payload,

--- a/futureagi/ee/licensing/tests/test_managed_ai_transport.py
+++ b/futureagi/ee/licensing/tests/test_managed_ai_transport.py
@@ -1,0 +1,358 @@
+"""Transport routing for managed AI (Falcon / Turing / Protect).
+
+The managed completion entry point must resolve its transport by deployment
+mode: cloud reaches the co-located AgentCC gateway with the internal API key,
+while self-hosted EE uses the activation-token exchange. A cloud deployment
+carries no ``EE_LICENSE_KEY``, so routing it through the activation flow is
+what broke Falcon on cloud.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from ee.licensing.activation_client import ManagedServiceError
+from ee.licensing.managed_ai import chat_completion
+
+
+def _ok_response(payload=None):
+    response = MagicMock(status_code=200)
+    response.json.return_value = payload or {
+        "choices": [{"message": {"content": "ok"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    return response
+
+
+class TestCloudTransport:
+    def test_cloud_posts_to_internal_gateway_with_internal_key(self):
+        response = _ok_response()
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response) as mock_post,
+        ):
+            result = chat_completion(
+                {"model": "falcon_ai", "messages": [{"role": "user", "content": "hi"}]}
+            )
+
+        assert result["choices"][0]["message"]["content"] == "ok"
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else (
+            mock_post.call_args.kwargs["url"]
+        )
+        assert url == "http://agentcc-gateway:8080/v1/chat/completions"
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer internal-key"
+
+    def test_cloud_does_not_use_activation_flow(self):
+        response = _ok_response()
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+            patch(
+                "ee.licensing.activation_client.call_managed_service"
+            ) as mock_activation,
+        ):
+            chat_completion({"model": "falcon_ai", "messages": []})
+
+        mock_activation.assert_not_called()
+
+    def test_cloud_missing_internal_key_raises_typed_error(self):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch("ee.usage.services.gateway_llm_client._get_setting", return_value=""),
+            patch("httpx.post") as mock_post,
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == "GATEWAY_UNCONFIGURED"
+        mock_post.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_code"),
+        [
+            (401, "GATEWAY_UNAUTHORIZED"),
+            (403, "FEATURE_DENIED"),
+            (429, "RATE_LIMITED"),
+            (500, "SERVICE_ERROR"),
+        ],
+    )
+    def test_cloud_maps_gateway_status_to_typed_error(
+        self, status_code, expected_code
+    ):
+        response = MagicMock(status_code=status_code)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == expected_code
+
+    def test_cloud_unauthorized_does_not_touch_ee_token_cache(self):
+        response = MagicMock(status_code=401)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", return_value=response),
+            patch("ee.licensing.activation_client.invalidate_token") as invalidate,
+        ):
+            with pytest.raises(ManagedServiceError):
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        invalidate.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (httpx.TimeoutException("timed out"), "GATEWAY_TIMEOUT"),
+            (httpx.ConnectError("unreachable"), "GATEWAY_UNREACHABLE"),
+        ],
+    )
+    def test_cloud_maps_transport_failure_to_typed_error(self, error, expected_code):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=lambda name, default="": {
+                    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+                    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+                }.get(name, default),
+            ),
+            patch("httpx.post", side_effect=error),
+        ):
+            with pytest.raises(ManagedServiceError) as exc:
+                chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert exc.value.code == expected_code
+
+
+class TestSelfHostedTransport:
+    def test_ee_uses_activation_flow(self):
+        expected = {"choices": [{"message": {"content": "ee"}}]}
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.licensing.managed_ai.call_managed_service", return_value=expected
+            ) as mock_activation,
+            patch("httpx.post") as mock_post,
+        ):
+            result = chat_completion({"model": "falcon_ai", "messages": []})
+
+        assert result == expected
+        mock_activation.assert_called_once()
+        assert mock_activation.call_args.kwargs["path"] == "/v1/chat/completions"
+        mock_post.assert_not_called()
+
+
+class TestModelGuard:
+    def test_rejects_non_managed_model(self):
+        with pytest.raises(ValueError):
+            chat_completion({"model": "gpt-4o", "messages": []})
+
+
+# ── Regression guards ────────────────────────────────────────────────────────
+#
+# The bug: managed AI on cloud went through the self-hosted activation-token
+# exchange (get_service_token / _activate), which needs an EE_LICENSE_KEY that
+# cloud does not carry, so every managed call failed. These guards fail loudly
+# if that branch is removed, if a managed model is added that skips it, or if a
+# client entry point stops routing through chat_completion.
+
+_INTERNAL = {
+    "AGENTCC_INTERNAL_URL": "http://agentcc-gateway:8080",
+    "AGENTCC_INTERNAL_API_KEY": "internal-key",
+}
+
+# Every managed-model shape is_managed_model() recognises. If someone adds a
+# new managed prefix, add it here so the cloud guard covers it too.
+_MANAGED_MODELS = ["falcon_ai", "turing_small", "turing_large", "protect", "protect_flash"]
+
+
+def _internal_setting(name, default=""):
+    return _INTERNAL.get(name, default)
+
+
+def _posted_url(mock_post):
+    if mock_post.call_args.args:
+        return mock_post.call_args.args[0]
+    return mock_post.call_args.kwargs["url"]
+
+
+def _posted_auth(mock_post):
+    return mock_post.call_args.kwargs["headers"]["Authorization"]
+
+
+class TestCloudActivationGuard:
+    """On cloud, no managed model may reach the self-hosted activation flow."""
+
+    @pytest.mark.parametrize("model", _MANAGED_MODELS)
+    def test_cloud_never_calls_activation_token_exchange(self, model):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch("httpx.post", return_value=_ok_response()) as mock_post,
+            patch(
+                "ee.licensing.activation_client.get_service_token"
+            ) as mock_get_token,
+            patch("ee.licensing.activation_client._activate") as mock_activate,
+        ):
+            chat_completion({"model": model, "messages": [{"role": "user", "content": "x"}]})
+
+        # Routed to the internal gateway with the internal key…
+        assert _posted_url(mock_post) == "http://agentcc-gateway:8080/v1/chat/completions"
+        assert _posted_auth(mock_post) == "Bearer internal-key"
+        # …and the activation exchange was never touched.
+        mock_get_token.assert_not_called()
+        mock_activate.assert_not_called()
+
+
+class TestEeActivationGuard:
+    """Symmetric guard: EE must keep using activation, not the internal key."""
+
+    @pytest.mark.parametrize("model", _MANAGED_MODELS)
+    def test_ee_never_reads_internal_gateway_settings(self, model):
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=False),
+            patch(
+                "ee.licensing.managed_ai.call_managed_service",
+                return_value={"choices": [{"message": {"content": "ee"}}]},
+            ) as mock_activation,
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting"
+            ) as mock_setting,
+            patch("httpx.post") as mock_post,
+        ):
+            chat_completion({"model": model, "messages": []})
+
+        mock_activation.assert_called_once()
+        # Cloud-only settings resolution must not run on EE.
+        mock_setting.assert_not_called()
+        mock_post.assert_not_called()
+
+
+class TestCloudCheckNotBypassed:
+    """chat_completion must consult DeploymentMode.is_cloud — so the branch
+    cannot be silently dropped without a test noticing."""
+
+    def test_deployment_mode_is_consulted(self):
+        is_cloud = MagicMock(return_value=True)
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", is_cloud),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch("httpx.post", return_value=_ok_response()),
+        ):
+            chat_completion({"model": "falcon_ai", "messages": []})
+
+        is_cloud.assert_called()
+
+
+class TestManagedClientsCloudEndToEnd:
+    """The bug surfaced through the real clients, not chat_completion directly.
+    Drive them on cloud and prove they hit the internal gateway with no
+    activation — the true regression guard."""
+
+    @pytest.mark.asyncio
+    async def test_falcon_client_on_cloud_uses_internal_gateway(self):
+        from ee.falcon_ai.llm_client import FalconLLMClient
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch(
+                "httpx.post",
+                return_value=_ok_response(
+                    {"choices": [{"message": {"content": "falcon"}}], "usage": {}}
+                ),
+            ) as mock_post,
+            patch(
+                "ee.licensing.activation_client.get_service_token"
+            ) as mock_get_token,
+        ):
+            client = FalconLLMClient()
+            assert client.use_managed_gateway is True
+            chunks = [
+                chunk
+                async for chunk in client.stream_completion(
+                    [{"role": "user", "content": "analyze"}], tools=None
+                )
+            ]
+
+        assert any(
+            c["choices"][0]["delta"].get("content") == "falcon" for c in chunks
+        )
+        assert _posted_url(mock_post) == "http://agentcc-gateway:8080/v1/chat/completions"
+        assert _posted_auth(mock_post) == "Bearer internal-key"
+        mock_get_token.assert_not_called()
+
+    def test_turing_client_on_cloud_uses_internal_gateway(self):
+        from ee.turing.client import TuringClient
+
+        with (
+            patch("ee.usage.deployment.DeploymentMode.is_cloud", return_value=True),
+            patch(
+                "ee.usage.services.gateway_llm_client._get_setting",
+                side_effect=_internal_setting,
+            ),
+            patch(
+                "httpx.post",
+                return_value=_ok_response(
+                    {
+                        "choices": [{"message": {"content": "turing"}}],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                    }
+                ),
+            ) as mock_post,
+            patch(
+                "ee.licensing.activation_client.get_service_token"
+            ) as mock_get_token,
+        ):
+            result = TuringClient().chat_completion(
+                model="turing_small",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == "turing"
+        assert _posted_url(mock_post) == "http://agentcc-gateway:8080/v1/chat/completions"
+        assert _posted_auth(mock_post) == "Bearer internal-key"
+        mock_get_token.assert_not_called()


### PR DESCRIPTION
## Summary

Managed AI (Falcon AI, Turing, Protect) failed on **cloud** deployments while evals and every other agent kept working. Root cause: all three managed clients reach the gateway through `ee.licensing.managed_ai.chat_completion`, which delegated unconditionally to the **self-hosted** activation-token exchange (`activation_client.call_managed_service`). That exchange requires an `EE_LICENSE_KEY`, which cloud does not carry — so activation never yielded a usable token and every managed call raised `ACTIVATION_FAILED` / `NO_ENTERPRISE_LICENSE`. This PR makes `chat_completion` resolve its transport by deployment mode: cloud posts to the co-located AgentCC gateway with the internal API key; self-hosted EE keeps the activation flow unchanged. The shared transport + error-mapping is extracted once so the two paths cannot drift.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changes were done

**A. Shared transport in `activation_client.py`**

- Extracted `dispatch_managed_request(url, api_key, json_body, timeout, on_unauthorized)` — the httpx POST plus the `403`/`429`/`5xx`/timeout/connect → `ManagedServiceError` ladder that previously lived inline in `call_managed_service`.
- `call_managed_service` now resolves the EE service token and calls the shared helper; its 401 handler invalidates the token and raises `TOKEN_EXPIRED` (unchanged behavior).

**B. Cloud transport in `managed_ai.py`**

- `chat_completion()` branches on `DeploymentMode.is_cloud()`:
  - **cloud** → `_cloud_chat_completion()` reads `AGENTCC_INTERNAL_URL` + `AGENTCC_INTERNAL_API_KEY` and calls the same `dispatch_managed_request`, with a 401 handler that raises `GATEWAY_UNAUTHORIZED` (a bad internal key is **not** a stale activation token, so it does not touch the EE token cache). Missing internal key → `GATEWAY_UNCONFIGURED`.
  - **self-hosted EE** → unchanged `call_managed_service()`.
- Reuses existing helpers rather than adding new ones: `DeploymentMode.is_cloud()` (`ee.usage.deployment`) for the mode check and `_get_setting()` (`ee.usage.services.gateway_llm_client`) for settings — no duplicated local copies.

No changes to `FalconLLMClient`, `TuringClient`, or the Protect path — one fix point covers all three.

**C. Why the eval path already worked**

`agentic_eval/core/llm/llm.py` already guards managed transport behind `_requires_managed_transport()` (`DeploymentMode.is_ee() and is_managed_model(...)`), so on cloud it falls through to the shared gateway client. That's why evals worked and Falcon didn't — this brings the managed path in line with that existing behavior.

---

## 2) Why the changes were done

- **Product:** Falcon AI (and Turing/Protect) is a paid, entitled capability on cloud (`billing.yaml` grants `has_falcon_ai: {_all: true}`); the feature gate passed but the **transport** failed. This restores it.
- **Technical:** Fixing at `managed_ai.chat_completion` covers all three managed callers in one place (`falcon_ai/llm_client.py:138,771`, `turing/client.py:45`). A guard inside `FalconLLMClient` would fix only one of three.
- **Architecture:** The transport + error ladder is extracted into one `dispatch_managed_request` inside `ee.licensing` (no cross-package cycle) so the EE and cloud paths share it and cannot drift; only the 401 handling — the one genuine difference — is passed in per caller. The cloud branch mirrors the internal-key transport already used by `FalconLLMClient`'s `vertex_ai`/`turing_*` branch and keeps the exact dict contract + typed `ManagedServiceError` codes callers depend on.

---

## 3) Tests written + scenarios each covers

**`test_managed_ai_transport.py`** — routing + regression guards for the cloud transport:

- `TestCloudTransport` — cloud posts to internal URL with internal bearer; does not call the activation flow; missing key → `GATEWAY_UNCONFIGURED`; 401/403/429/5xx → `GATEWAY_UNAUTHORIZED`/`FEATURE_DENIED`/`RATE_LIMITED`/`SERVICE_ERROR`; 401 does **not** invalidate the EE token cache; timeout/connect → `GATEWAY_TIMEOUT`/`GATEWAY_UNREACHABLE`.
- `TestSelfHostedTransport` — EE still uses the activation flow.
- `TestModelGuard` — non-managed model → `ValueError`.
- `TestCloudActivationGuard` — parametrized over every managed model prefix (`falcon_ai`, `turing_*`, `protect*`): on cloud each routes to the internal gateway and **never** calls the activation-token exchange (`get_service_token`/`_activate`).
- `TestEeActivationGuard` — symmetric: on EE the cloud-only settings path never runs; activation is still used.
- `TestCloudCheckNotBypassed` — `chat_completion` must consult `DeploymentMode.is_cloud()`, so the branch cannot be dropped unnoticed.
- `TestManagedClientsCloudEndToEnd` — drives the real `FalconLLMClient` and `TuringClient` on cloud and proves internal-gateway routing with no activation (the entry points that originally broke).

The existing `test_activation_client.py` (15 cases) stays green, confirming the `call_managed_service` refactor preserves behavior.

> Run result: **44 passed** (transport/guard suite + `test_managed_clients.py` + `test_activation_client.py`). Verified non-vacuous by mutation — disabling the cloud branch fails 17 of these, including every guard.

---

## 6) Edge cases & considerations

- **Billing parity:** the blocking `chat_completion` path already used httpx `.json()` on EE (dropping the `x-agentcc-cost` header), so billing already falls back to token-based cost from the response `usage`. The cloud branch returns the identical dict shape — no billing regression relative to the EE managed path. The SSE cost-header path is separate and untouched.
- **Gateway alias:** the gateway resolves `falcon_ai → falcon` (`agentcc-gateway/internal/middleware/license_auth.go:384`); the internal-key path is the same one `vertex_ai`/`turing_*` already use.
- **Port:** resolved from `AGENTCC_INTERNAL_URL` (prod sets `:8080`; code default `:8090`) — never hardcoded.
- **Timeout:** 300s, matching the shared `gateway_llm_client`, so a slow-but-valid large-`max_tokens` agent turn doesn't trip a transport timeout.

---

## 8) Architectural / important decisions

- **One fix point (`managed_ai.chat_completion`), not per-client:** covers Falcon + Turing + Protect.
- **Extract the transport ladder into `dispatch_managed_request`, don't duplicate it:** the fragile part (status→typed-error mapping) lives once; the two auth models differ only in url/key source and 401 handling, which are passed in.
- **Reuse `DeploymentMode.is_cloud()` and `gateway_llm_client._get_setting`** instead of adding local copies.
- **Kept the direct-httpx dict contract** (over delegating to `gateway_llm_client`'s OpenAI-SDK client) so caller error-handling and `response_content`/`response_usage` shape are preserved exactly, and to avoid inverting the `ee.licensing` ↔ `usage.services` import layering.

## Checklist

- [x] PR title follows Conventional Commits
- [x] No hardcoded secrets, URLs, or PII
