### PR TITLE
chore(ci): allow any branch in frontend us2 workflow dispatch (dev)

### DIFF
--- a/.github/workflows/frontend-deploy-us2.yaml
+++ b/.github/workflows/frontend-deploy-us2.yaml
@@ -1,20 +1,17 @@
 # Manual trigger only, mirroring frontend-prod-deploy.yaml (AWS) for the
-# GCP us2 stack. Pick the branch to build: main -> production-flavored
-# build, dev -> dev-flavored build. Either way the result ships to the
-# us2 bucket behind app-us2.futureagi.com.
+# GCP us2 stack. Pick any branch to build: main -> production-flavored
+# build, anything else -> dev-flavored build. Either way the result ships
+# to the us2 bucket behind app-us2.futureagi.com.
 name: Deploy Frontend to US2 (GCP)
 
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build and deploy'
+        description: "Branch to build and deploy"
         required: true
-        default: 'main'
-        type: choice
-        options:
-          - main
-          - dev
+        default: "main"
+        type: string
 
 jobs:
   deploy-us2:
@@ -32,8 +29,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.18'
-          cache: 'yarn'
+          node-version: "22.18"
+          cache: "yarn"
           cache-dependency-path: frontend/yarn.lock
 
       - name: Install dependencies


### PR DESCRIPTION
## Why

`Deploy Frontend to US2 (GCP)` only accepted `main` or `dev` in its `branch` input, so shipping a feature branch to the us2 stack for verification meant editing the workflow first. This mirrors the same change already made to `release-backend.yml` (#2051 / #2053).

## What

- `.github/workflows/frontend-deploy-us2.yaml`: `branch` input `type: choice` (options `main`, `dev`) → `type: string`, default still `main`.
- Updated the header comment to describe the new behaviour.
- Quote style normalised by the repo's prettier lint-staged hook (same as #2053).

Env flavour selection is unchanged and already handles arbitrary branches: `VITE_ENVIRONMENT=${{ inputs.branch == 'main' && 'production' || 'dev' }}` — `main` builds production-flavoured, every other branch builds dev-flavoured.

## Tests

No tests added — this is a CI workflow-input change with no application code path to cover, consistent with #2053.

Verification performed:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/frontend-deploy-us2.yaml'))"` → parses clean.
- Repo lint-staged/prettier hook ran on commit and passed.
- Diff is confined to the `workflow_dispatch` input block and a comment; no job, step, secret, or gsutil/gcloud command changed.

## Notes

Dev-targeted twin of #2056 (same commit, cherry-picked onto `dev`). The file is identical on `main` and `dev`, so the two diffs match exactly.