### PR TITLE
fix(workbench): open prompts whose message content is a string [TH-7260]

### DIFF
--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -515,6 +515,8 @@ const CAMEL_TO_SNAKE_INNER = {
 
 export function normalizeContentBlocks(blocks) {
   if (!blocks) return blocks;
+  if (typeof blocks === "string") return [{ type: "text", text: blocks }];
+  if (!Array.isArray(blocks)) return [];
   return blocks.map((block) => {
     if (!block || typeof block !== "object") return block;
     const fixedType = CAMEL_TO_SNAKE_OUTER[block.type] || block.type;

--- a/frontend/src/sections/workbench/createPrompt/Playground/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Playground/common.js
@@ -20,6 +20,9 @@ export const extractVariables = (content, templateFormat) => {
 
   for (const item of content) {
     if (item.type === "text") {
+      if (typeof item.text !== "string") {
+        continue;
+      }
       if (templateFormat === "jinja") {
         // Jinja2 AST-based extraction (excludes loop/set scoped vars)
         extractJinjaVariables(item.text).forEach((v) => {
@@ -59,7 +62,7 @@ export function isContentNotEmpty(contentArray) {
 
   return contentArray?.some((item) => {
     if (item.type === "text") {
-      return item.text.trim() !== "";
+      return (item.text ?? "").trim() !== "";
     }
     if (item.type === "image_url") {
       return item.image_url?.url?.trim() !== "";

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -21,6 +21,7 @@ import {
   handleAuthFailClose,
   normalizeConfigurationForLoad,
   normalizeConfigurationForSave,
+  normalizeMessagesForLoad,
   runPromptOverSocket,
 } from "./common";
 import logger from "src/utils/logger";
@@ -599,9 +600,11 @@ const WorkbenchProvider = ({ children }) => {
     const isVersionSwitch = loadedVersion !== data?.version;
     if (
       data?.prompt_config?.[0]?.messages &&
-      (!prompts?.[0]?.prompts.length || isVersionSwitch)
+      (!prompts?.[0]?.prompts?.length || isVersionSwitch)
     ) {
-      const newPrompts = data?.prompt_config?.[0]?.messages?.map((prompt) => ({
+      const newPrompts = normalizeMessagesForLoad(
+        data?.prompt_config?.[0]?.messages,
+      ).map((prompt) => ({
         ...prompt,
         id: getRandomId(),
       }));
@@ -760,7 +763,9 @@ const WorkbenchProvider = ({ children }) => {
       });
 
       newPrompts.push({
-        prompts: version?.prompt_config_snapshot?.messages,
+        prompts: normalizeMessagesForLoad(
+          version?.prompt_config_snapshot?.messages,
+        ),
         id: getRandomId(),
       });
 
@@ -1304,11 +1309,12 @@ const WorkbenchProvider = ({ children }) => {
       };
     });
 
-    const newPrompts =
-      version?.prompt_config_snapshot?.messages?.map((rest) => ({
-        ...rest,
-        id: getRandomId(),
-      })) || [];
+    const newPrompts = normalizeMessagesForLoad(
+      version?.prompt_config_snapshot?.messages,
+    ).map((rest) => ({
+      ...rest,
+      id: getRandomId(),
+    }));
 
     setPrompts([{ prompts: newPrompts, id: getRandomId() }]);
 
@@ -1463,7 +1469,9 @@ const WorkbenchProvider = ({ children }) => {
       });
 
       newPrompts.push({
-        prompts: eachCompareVersions.prompt_config_snapshot.messages,
+        prompts: normalizeMessagesForLoad(
+          eachCompareVersions.prompt_config_snapshot.messages,
+        ),
         id: getRandomId(),
       });
 

--- a/frontend/src/sections/workbench/createPrompt/__tests__/normalizeMessagesForLoad.test.js
+++ b/frontend/src/sections/workbench/createPrompt/__tests__/normalizeMessagesForLoad.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMessagesForLoad } from "../common";
+import { normalizeContentBlocks } from "src/components/PromptCards/common";
+import {
+  extractVariables,
+  isContentNotEmpty,
+} from "../Playground/common";
+
+// The backend types `Message.content` as `str`
+// (futureagi/model_hub/models/run_prompt.py), so templates saved through the
+// SDK/API — and versions predating the block editor — arrive as a bare string
+// where the workbench expects `[{ type: "text", text }]`.
+describe("normalizeMessagesForLoad", () => {
+  it("lifts string content into a text block", () => {
+    expect(
+      normalizeMessagesForLoad([
+        { role: "system", content: "You are a helpful assistant" },
+      ]),
+    ).toEqual([
+      {
+        role: "system",
+        content: [{ type: "text", text: "You are a helpful assistant" }],
+      },
+    ]);
+  });
+
+  it("leaves block content alone", () => {
+    const blocks = [{ type: "text", text: "Summarize {{doc}}" }];
+    expect(normalizeMessagesForLoad([{ role: "user", content: blocks }])).toEqual(
+      [{ role: "user", content: blocks }],
+    );
+  });
+
+  it("normalizes missing, null, and non-list content to an empty block list", () => {
+    expect(
+      normalizeMessagesForLoad([
+        { role: "user" },
+        { role: "user", content: null },
+        { role: "user", content: "" },
+        { role: "user", content: 42 },
+      ]),
+    ).toEqual([
+      { role: "user", content: [] },
+      { role: "user", content: [] },
+      { role: "user", content: [] },
+      { role: "user", content: [] },
+    ]);
+  });
+
+  it("returns [] when messages is absent or not a list", () => {
+    expect(normalizeMessagesForLoad(undefined)).toEqual([]);
+    expect(normalizeMessagesForLoad(null)).toEqual([]);
+    expect(normalizeMessagesForLoad({})).toEqual([]);
+  });
+
+  // Without this, the string reached Quill and the whole page unmounted.
+  it("keeps string content out of the editor's block mapper", () => {
+    const [message] = normalizeMessagesForLoad([
+      { role: "user", content: "hi" },
+    ]);
+    expect(() => normalizeContentBlocks(message.content)).not.toThrow();
+  });
+});
+
+// PromptEditor calls this in a useMemo on first render, so an unhandled shape
+// throws during mount rather than degrading.
+describe("normalizeContentBlocks", () => {
+  it("lifts a raw string instead of throwing", () => {
+    expect(normalizeContentBlocks("You are a helpful assistant")).toEqual([
+      { type: "text", text: "You are a helpful assistant" },
+    ]);
+  });
+
+  it("returns [] for a non-list, non-string shape", () => {
+    expect(normalizeContentBlocks(42)).toEqual([]);
+    expect(normalizeContentBlocks({ type: "text", text: "hi" })).toEqual([]);
+  });
+
+  it("passes falsy content through untouched", () => {
+    expect(normalizeContentBlocks(null)).toBe(null);
+    expect(normalizeContentBlocks(undefined)).toBe(undefined);
+  });
+
+  // A crash-free but blank editor is still broken: variables must survive.
+  it("keeps a normalized string prompt readable to the content helpers", () => {
+    const [message] = normalizeMessagesForLoad([
+      { role: "user", content: "Summarize {{doc}} for {{audience}}" },
+    ]);
+
+    expect(isContentNotEmpty(message.content)).toBe(true);
+    expect(extractVariables(message.content, "mustache")).toEqual([
+      "doc",
+      "audience",
+    ]);
+  });
+});
+
+describe("content helpers tolerate a text block with no text", () => {
+  const contentArray = [{ type: "text" }];
+
+  it("isContentNotEmpty does not throw", () => {
+    expect(isContentNotEmpty(contentArray)).toBe(false);
+  });
+
+  it("extractVariables does not throw", () => {
+    expect(extractVariables(contentArray, "mustache")).toEqual([]);
+    expect(extractVariables(contentArray, "jinja")).toEqual([]);
+  });
+});

--- a/frontend/src/sections/workbench/createPrompt/common.js
+++ b/frontend/src/sections/workbench/createPrompt/common.js
@@ -1,7 +1,16 @@
 import { enqueueSnackbar } from "notistack";
 import { PromptRoles, WS_CLOSE_CODES } from "src/utils/constants";
 import { normalizeModelOption } from "src/components/custom-model-dropdown/common";
+import { normalizeContentBlocks } from "src/components/PromptCards/common";
 import { extractVariables } from "./Playground/common";
+
+export function normalizeMessagesForLoad(messages) {
+  if (!Array.isArray(messages)) return [];
+  return messages.map((message) => ({
+    ...message,
+    content: normalizeContentBlocks(message?.content) || [],
+  }));
+}
 
 /**
  * Predicate: does this CloseEvent indicate a BE-initiated auth failure


### PR DESCRIPTION
Fixes [TH-7260](https://linear.app/future-agi/issue/TH-7260/old-prompts-are-not-opening).

## Root cause

`PromptEditor` builds its Quill delta in a `useMemo` that runs on **first render**:

```jsx
// PromptEditor.jsx:152
const blocks = normalizeContentBlocks(prompt) || [];
```

and `normalizeContentBlocks` guards only against falsy input:

```js
// PromptCards/common.js:516-518
export function normalizeContentBlocks(blocks) {
  if (!blocks) return blocks;
  return blocks.map((block) => {   // ← throws when blocks is a string
```

A non-empty string clears `!blocks` and reaches `.map`, so the render throws `TypeError: blocks.map is not a function` during mount. Because it throws while mounting rather than in an event handler, React unmounts the tree and the page goes blank instead of degrading.

## Why a string arrives at all

This isn't corrupt data. The backend types message content as a string:

```python
# futureagi/model_hub/models/run_prompt.py:191-193
class Message(PydanticBaseModel):
    role: str
    content: str
```

So templates written through the SDK or API — and versions saved before the block editor landed — legitimately carry a bare string where the workbench editor expects `[{ type: "text", text }]`.

`RunPrompt` already handles this on its own load path ([`RunPrompt/common.js:88-113`](../blob/dev/frontend/src/sections/develop-detail/RunPrompt/common.js#L88-L113) — `if (typeof content === "string")` → `[{ type: "text", text }]`). The workbench never got the same treatment.

## Why guarding the editor isn't enough

Adding a type check to `normalizeContentBlocks` stops the crash, but leaves the raw string sitting in provider state — and that's arguably worse than a crash, because it fails silently:

| consumer | guard | result with a string |
|---|---|---|
| `isContentNotEmpty` | `Array.isArray` | `false` → prompt reads as empty |
| `extractVariables` | `Array.isArray` | `[]` → **variables go undetected** |
| copy button | `Array.isArray` | "No text content to copy" |
| `isEmptyPrompt` | via `isContentNotEmpty` | counted as an empty version |

The page would load, show a blank editor, detect no variables, and a save would commit that blank over the user's prompt.

So the fix normalizes at the **load boundary** instead, with a new `normalizeMessagesForLoad` applied to all four sites in `WorkbenchProvider` that feed backend messages into state — latest version, version switch, and both compare paths. Every downstream consumer then sees the shape it already expects, and the editor guard stays as defence in depth.

## Changes

- **`PromptCards/common.js`** — `normalizeContentBlocks` lifts a string into a text block and returns `[]` for any other non-list shape.
- **`createPrompt/common.js`** — new `normalizeMessagesForLoad(messages)`.
- **`WorkbenchProvider.jsx`** — applied at the four message-load sites.
- **`Playground/common.js`** — two adjacent holes of the same class, found while tracing: a `{type:"text"}` block with no `text` threw at `item.text.match(...)` in `extractVariables` and `item.text.trim()` in `isContentNotEmpty`. The latter runs for *every* card via `usePromptCardDefaultValues`.
- **`WorkbenchProvider.jsx:602`** — `prompts?.[0]?.prompts.length` stopped its optional chain one link short.

## Tests

New `__tests__/normalizeMessagesForLoad.test.js` — 11 tests covering the string shape, block shape (unchanged), null/empty/non-list content, the missing-`text` block, and an end-to-end check that a normalized string prompt still yields its `{{variables}}`.

- [x] Reverting the source changes reproduces the exact production error — `TypeError: blocks.map is not a function` — and fails 10 of the 11 tests.
- [x] 162 tests pass across 21 files (`src/sections/workbench`, `src/components/PromptCards`, `src/sections/develop-detail`).
- [x] ESLint clean on all changed files. The one remaining warning in `WorkbenchProvider.jsx` (`exhaustive-deps` on the `[data]` effect) is pre-existing — verified against `dev`.

## Backwards compatibility

Additive. Templates already stored as block lists take the identical path — `normalizeMessagesForLoad` passes arrays through to the existing key-mapping logic untouched. No API, contract, or persisted-shape changes; nothing is written back differently. Saving a string-content template converts it to blocks, which is the same conversion the editor has always applied on save.

## Manual verification

- [ ] Open the reported template — `/dashboard/workbench/create/0c5cf48a-7354-4bfd-b5a1-fde4166830ea` — renders instead of blanking
- [ ] Its `{{variables}}` are detected and listed in the variable drawer
- [ ] A block-content template opens unchanged (no regression)
- [ ] Compare mode with one old + one new version renders both
- [ ] Version switch from an old version to a new one and back

## Type of change

- [x] Bug fix (page crash on load)
- [ ] New feature
- [ ] Breaking change

## Note

The blast radius is wider than the one reported template: any prompt saved through the SDK/API hits this path. Worth a quick check of how many stored versions have string content before closing the ticket.
