### PR TITLE
fix(frontend): add quick filters to the voice observe grid [TH-7250]

### DIFF
--- a/frontend/src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover.jsx
+++ b/frontend/src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover.jsx
@@ -8,13 +8,9 @@ import NumberQuickFilterValue from "./NumberQuickFilterValue";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { NumberQuickFilterValidationSchema } from "./validation";
 import { avoidDuplicateFilterSet } from "../../common";
+import { coerceFilterValue } from "src/api/contracts/filter-contract";
 
-const NumberQuickFilterPopoverChild = ({
-  filterData,
-  onClose,
-  setFilters,
-  setFilterOpen,
-}) => {
+const NumberQuickFilterPopoverChild = ({ filterData, onClose, setFilters }) => {
   const { control, handleSubmit } = useForm({
     defaultValues: {
       operator: "equals",
@@ -25,11 +21,22 @@ const NumberQuickFilterPopoverChild = ({
   });
 
   const onSubmit = (data) => {
-    const filter = filterData.filter;
-    filter.filter_config.filter_value = [data.value1, data.value2];
-    filter.filter_config.filter_op = data.operator;
+    const source = filterData.filter;
+    // The form always yields two fields; only range ops take a pair.
+    const filter = {
+      ...source,
+      filter_config: {
+        ...source.filter_config,
+        filter_op: data.operator,
+        filter_value: coerceFilterValue(
+          [data.value1, data.value2],
+          data.operator,
+          source.filter_config?.filter_type,
+        ),
+      },
+    };
 
-    setFilterOpen(true);
+    // Not setFilterOpen(true): the panel seeds its rows before this lands.
     setFilters((prev) => avoidDuplicateFilterSet(prev, filter));
     onClose();
   };
@@ -63,7 +70,6 @@ NumberQuickFilterPopoverChild.propTypes = {
   filterData: PropTypes.object,
   onClose: PropTypes.func,
   setFilters: PropTypes.func,
-  setFilterOpen: PropTypes.func,
 };
 
 const NumberQuickFilterPopover = ({
@@ -71,7 +77,6 @@ const NumberQuickFilterPopover = ({
   filterData,
   onClose,
   setFilters,
-  setFilterOpen,
 }) => {
   return (
     <Popover
@@ -102,7 +107,6 @@ const NumberQuickFilterPopover = ({
         filterData={filterData}
         onClose={onClose}
         setFilters={setFilters}
-        setFilterOpen={setFilterOpen}
       />
     </Popover>
   );
@@ -113,7 +117,6 @@ NumberQuickFilterPopover.propTypes = {
   filterData: PropTypes.object,
   onClose: PropTypes.func,
   setFilters: PropTypes.func,
-  setFilterOpen: PropTypes.func,
 };
 
 export default NumberQuickFilterPopover;

--- a/frontend/src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover.jsx
+++ b/frontend/src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover.jsx
@@ -46,7 +46,7 @@ const NumberQuickFilterPopoverChild = ({ filterData, onClose, setFilters }) => {
       <Stack gap={1}>
         <Stack direction="row" gap={2} alignItems="center">
           <Typography typography="s3" sx={{ whiteSpace: "nowrap" }}>
-            Where score is
+            Where {filterData?.filter?.display_name || "value"} is
           </Typography>
           <FormSelectField
             control={control}

--- a/frontend/src/components/ComplexFilter/__tests__/common.test.js
+++ b/frontend/src/components/ComplexFilter/__tests__/common.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getComplexFilterValidation } from "../common";
+import { avoidDuplicateFilterSet, getComplexFilterValidation } from "../common";
 import { AdvanceNumberFilterOperators } from "src/utils/constants";
 import {
   FILTER_COLUMN_TYPES,
@@ -103,5 +103,75 @@ describe("ComplexFilter contract wiring", () => {
 
       expect(parsed.success, colType).toBe(true);
     }
+  });
+});
+
+// Review comment on PR #2064: the reduce replaces on *every* match, so with two
+// panel rows on one column a quick-filter click pushes the incoming filter once
+// per match. The chips then duplicate, and removing one by index leaves the
+// filter applied.
+describe("avoidDuplicateFilterSet", () => {
+  const row = (column_id, filter_value, id) => ({
+    id,
+    column_id,
+    filter_config: {
+      filter_type: "text",
+      filter_op: "equals",
+      filter_value,
+    },
+  });
+
+  it("collapses several rows on one column to a single filter", () => {
+    const prev = [
+      row("provider", "anthropic", "a"),
+      row("provider", "openai", "b"),
+    ];
+    const incoming = row("provider", "google", "c");
+
+    const result = avoidDuplicateFilterSet(prev, incoming);
+
+    expect(result).toEqual([incoming]);
+  });
+
+  it("keeps the replacement in the first match's position", () => {
+    const prev = [
+      row("model", "gpt-4", "m"),
+      row("provider", "anthropic", "a"),
+      row("status", "OK", "s"),
+      row("provider", "openai", "b"),
+    ];
+    const incoming = row("provider", "google", "c");
+
+    expect(avoidDuplicateFilterSet(prev, incoming)).toEqual([
+      prev[0],
+      incoming,
+      prev[2],
+    ]);
+  });
+
+  it("replaces a single existing row on that column", () => {
+    const prev = [row("provider", "anthropic", "a")];
+    const incoming = row("provider", "google", "c");
+    expect(avoidDuplicateFilterSet(prev, incoming)).toEqual([incoming]);
+  });
+
+  it("appends when no row uses that column", () => {
+    const prev = [row("model", "gpt-4", "m")];
+    const incoming = row("provider", "google", "c");
+    expect(avoidDuplicateFilterSet(prev, incoming)).toEqual([
+      prev[0],
+      incoming,
+    ]);
+  });
+
+  it("drops empty draft rows, as before", () => {
+    // isEmptyFilter deep-equals this exact shape.
+    const empty = {
+      id: "e",
+      column_id: "",
+      filter_config: { filter_type: "", filter_op: "", filter_value: "" },
+    };
+    const incoming = row("provider", "google", "c");
+    expect(avoidDuplicateFilterSet([empty], incoming)).toEqual([incoming]);
   });
 });

--- a/frontend/src/components/ComplexFilter/common.js
+++ b/frontend/src/components/ComplexFilter/common.js
@@ -281,6 +281,11 @@ export const avoidDuplicateFilterSet = (prev, filter) => {
       return acc;
     }
     if (f.column_id === filter.column_id) {
+      // Rows can share a column_id, and replacing each one pushed `filter`
+      // per match — duplicate chips, and removing one left the filter applied.
+      if (filterAdded) {
+        return acc;
+      }
       filterAdded = true;
       return [...acc, filter];
     }

--- a/frontend/src/components/run-insights/spans-tab/spans-tab.jsx
+++ b/frontend/src/components/run-insights/spans-tab/spans-tab.jsx
@@ -392,7 +392,6 @@ const SpanTab = React.forwardRef(
             filterData={openQuickFilter}
             onClose={() => setOpenQuickFilter(null)}
             setFilters={setFilters}
-            setFilterOpen={setFilterOpen}
           />
         </Box>
       </>

--- a/frontend/src/components/run-insights/traces-tab/traces-tab.jsx
+++ b/frontend/src/components/run-insights/traces-tab/traces-tab.jsx
@@ -383,7 +383,6 @@ const TraceTab = React.forwardRef(
           filterData={openQuickFilter}
           onClose={() => setOpenQuickFilter(null)}
           setFilters={setFilters}
-          setFilterOpen={setFilterOpen}
         />
       </>
     );

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -38,6 +38,8 @@ import { ShowComponent } from "src/components/show";
 import { useShallowToggleAnnotationsStore } from "../store";
 import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverlay";
 import { APP_CONSTANTS } from "src/utils/constants";
+import NumberQuickFilterPopover from "src/components/ComplexFilter/QuickFilterComponents/NumberQuickFilterPopover/NumberQuickFilterPopover";
+import { applyQuickFilters } from "src/sections/projects/LLMTracing/common";
 
 const CELL_HEIGHT_MAP = { Short: 40, Medium: 52, Large: 68, "Extra Large": 88 };
 
@@ -104,6 +106,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     onColumnsChange,
     hideDrawer = false,
     showErrors = false,
+    setExtraFilters,
   },
   forwardedRef,
 ) {
@@ -153,6 +156,8 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     setPage(1);
   }
 
+  const [openQuickFilter, setOpenQuickFilter] = useState(null);
+
   const defaultColDef = useMemo(
     () => ({
       lockVisible: true,
@@ -167,8 +172,16 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         display: "flex",
         alignItems: "center",
       },
+      ...(setExtraFilters && {
+        cellRendererParams: {
+          applyQuickFilters: applyQuickFilters(
+            setExtraFilters,
+            setOpenQuickFilter,
+          ),
+        },
+      }),
     }),
-    [],
+    [setExtraFilters],
   );
 
   useEffect(() => {
@@ -526,6 +539,13 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
           />
         </ShowComponent>
 
+        <NumberQuickFilterPopover
+          open={Boolean(openQuickFilter)}
+          filterData={openQuickFilter}
+          onClose={() => setOpenQuickFilter(null)}
+          setFilters={setExtraFilters}
+        />
+
         {/* Footer controls */}
         <Stack
           direction="row"
@@ -629,4 +649,5 @@ CallLogsGrid.propTypes = {
   onColumnsChange: PropTypes.func,
   hideDrawer: PropTypes.bool,
   showErrors: PropTypes.bool,
+  setExtraFilters: PropTypes.func,
 };

--- a/frontend/src/sections/agents/CallLogs/withVoiceQuickFilter.jsx
+++ b/frontend/src/sections/agents/CallLogs/withVoiceQuickFilter.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import QuickFilter from "src/components/ComplexFilter/QuickFilterComponents/QuickFilter";
+
+// Adds the hover filter affordance to a voice cell renderer. Columns opt in by
+// carrying `context.sourceColumn` on their colDef.
+const withVoiceQuickFilter = (Renderer, getFilterValue) => {
+  const Wrapped = (params) => {
+    const content = <Renderer {...params} />;
+    const col = params?.colDef?.context?.sourceColumn;
+    const applyQuickFilters = params?.applyQuickFilters;
+    if (!col || !applyQuickFilters) return content;
+
+    const value = getFilterValue ? getFilterValue(params) : params?.value;
+    if (value === null || value === undefined || value === "") return content;
+
+    return (
+      <QuickFilter
+        onClick={(e) => {
+          // Rows open the call drawer on click; keep the filter button local.
+          e.stopPropagation();
+          applyQuickFilters({
+            col,
+            value,
+            filterAnchor: { top: e.clientY, left: e.clientX },
+          });
+        }}
+      >
+        {/* Must be a DOM element: Tooltip clones the child to attach handlers. */}
+        <div style={{ width: "100%", height: "100%" }}>{content}</div>
+      </QuickFilter>
+    );
+  };
+
+  Wrapped.displayName = `withVoiceQuickFilter(${
+    Renderer.displayName || Renderer.name || "Cell"
+  })`;
+  return Wrapped;
+};
+
+export default withVoiceQuickFilter;

--- a/frontend/src/sections/agents/__tests__/call-logs-helper.test.jsx
+++ b/frontend/src/sections/agents/__tests__/call-logs-helper.test.jsx
@@ -140,6 +140,47 @@ describe("getCallLogsColumnDefs", () => {
 
 import {
   getCallLogsColumnDefs,
+  getAgentLatencyFilterValue,
   prefetchCallLogs,
   useCallLogs,
 } from "../helper";
+
+// The Avg Latency cell displays `avg_agent_latency_ms || turnLatencyAverage`,
+// but only the former is what this column filters on — `turnLatencyAverage` is
+// a separate backend column (aliased `response_time`). Offering the filter when
+// the fallback is on screen would filter a number the row never showed.
+describe("getAgentLatencyFilterValue", () => {
+  it("returns the value when the cell is showing avg_agent_latency_ms", () => {
+    expect(
+      getAgentLatencyFilterValue({ data: { avg_agent_latency_ms: 820 } }),
+    ).toBe(820);
+    expect(
+      getAgentLatencyFilterValue({
+        data: { avg_agent_latency_ms: 820, turnLatencyAverage: 640 },
+      }),
+    ).toBe(820);
+  });
+
+  it("returns null when the cell is showing the turnLatencyAverage fallback", () => {
+    // 0 passes the wrapper's null/undefined/"" guard, so without this the click
+    // would apply `avg_agent_latency_ms equals 0` against a cell reading 640ms.
+    expect(
+      getAgentLatencyFilterValue({
+        data: { avg_agent_latency_ms: 0, turnLatencyAverage: 640 },
+      }),
+    ).toBeNull();
+    expect(
+      getAgentLatencyFilterValue({
+        data: { avg_agent_latency_ms: null, turnLatencyAverage: 640 },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no latency at all", () => {
+    expect(getAgentLatencyFilterValue({ data: {} })).toBeNull();
+    expect(getAgentLatencyFilterValue({})).toBeNull();
+    expect(
+      getAgentLatencyFilterValue({ data: { avg_agent_latency_ms: "n/a" } }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -675,6 +675,9 @@ const VOICE_QUICK_FILTER_COLUMNS = {
   },
   user_wpm: { id: "user_wpm", name: "User WPM", groupBy: "System Metrics" },
   bot_wpm: { id: "bot_wpm", name: "Agent WPM", groupBy: "System Metrics" },
+  // No `groupBy` on purpose: this one is text, and the `System Metrics` branch
+  // in applyQuickFilters assumes numeric — it would emit
+  // `filter_value: ["customer-ended-call", ""]` into the number popover.
   ended_reason: { id: "ended_reason", name: "Ended reason" },
 };
 

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import SvgColor from "src/components/svg-color";
 import { z } from "zod";
 import CallLogsCellRenderer from "./CallLogs/CallLogsCellRenderer";
+import withVoiceQuickFilter from "./CallLogs/withVoiceQuickFilter";
 import VoiceCostCell from "./CallLogs/VoiceCostCell";
 import VoiceLatencyCell from "./CallLogs/VoiceLatencyCell";
 import VoiceTokenCell from "./CallLogs/VoiceTokenCell";
@@ -419,6 +420,51 @@ export const generateEvalColumnsFromConfig = (items = []) => {
       };
     }
 
+    // CHOICES `**` ids never resolve to an eval config, so the backend
+    // returns a matches-nothing subquery (query_builders/filters.py:1423).
+    const normalizedOutput = String(item.output_type || "")
+      .toUpperCase()
+      .replace(/[/ ]/g, "_");
+    const isFilterableEval =
+      !isReason && ["SCORE", "PASS_FAIL"].includes(normalizedOutput);
+    const EvalCell = (params) => {
+      const evalData = params?.data?.eval_outputs?.[dataKey] || {};
+      if (isReason) {
+        const reason = evalData?.reason;
+        return (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              width: "100%",
+              padding: "4px 8px",
+              color: "text.primary",
+            }}
+          >
+            {reason || "-"}
+          </Box>
+        );
+      }
+      // PASS_FAIL carries a numeric pass rate — route it through the score
+      // (percentage) renderer so it shows "X%" instead of the pill path,
+      // which string-matches "fail" and would render 0% as a false "Pass".
+      const rawType = evalData?.output_type;
+      const isPassFail =
+        String(rawType || "")
+          .toLowerCase()
+          .replace(/[/ ]/g, "_") === "pass_fail";
+      return (
+        <EvalCellRenderer
+          value={{
+            ...evalData,
+            type: isPassFail ? "percentage" : rawType,
+            value: evalData.output,
+          }}
+        />
+      );
+    };
+
     return {
       headerName: displayName,
       field: `eval_outputs.${evalId}`,
@@ -428,43 +474,25 @@ export const generateEvalColumnsFromConfig = (items = []) => {
       headerComponent: CallLogsHeaderCellRenderer,
       headerComponentParams: { displayName },
       valueGetter: (params) => params.data?.eval_outputs?.[dataKey] || {},
-      cellRenderer: (params) => {
-        const evalData = params?.data?.eval_outputs?.[dataKey] || {};
-        if (isReason) {
-          const reason = evalData?.reason;
-          return (
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                height: "100%",
-                width: "100%",
-                padding: "4px 8px",
-                color: "text.primary",
-              }}
-            >
-              {reason || "-"}
-            </Box>
-          );
-        }
-        // PASS_FAIL carries a numeric pass rate — route it through the score
-        // (percentage) renderer so it shows "X%" instead of the pill path,
-        // which string-matches "fail" and would render 0% as a false "Pass".
-        const rawType = evalData?.output_type;
-        const isPassFail =
-          String(rawType || "")
-            .toLowerCase()
-            .replace(/[/ ]/g, "_") === "pass_fail";
-        return (
-          <EvalCellRenderer
-            value={{
-              ...evalData,
-              type: isPassFail ? "percentage" : rawType,
-              value: evalData.output,
-            }}
-          />
-        );
-      },
+      ...(isFilterableEval && {
+        context: {
+          sourceColumn: {
+            id: evalId,
+            name: displayName,
+            groupBy: "Evaluation Metrics",
+            outputType: item.output_type,
+          },
+        },
+      }),
+      cellRenderer: isFilterableEval
+        ? withVoiceQuickFilter(EvalCell, (params) => {
+            const output = params?.data?.eval_outputs?.[dataKey]?.output;
+            if (normalizedOutput !== "PASS_FAIL") return output;
+            // Only 0/100 maps to a token; an averaged rate has none.
+            const rate = Number(output);
+            return rate === 0 || rate === 100 ? output : null;
+          })
+        : EvalCell,
     };
   });
 };
@@ -609,6 +637,55 @@ const generateAnnotationColumnsFromConfig = (
       ];
     }),
   );
+};
+
+// Quick-filterable voice columns, keyed by grid field; `id` is the backend
+// filter id. Anything absent either has no backend filter or its displayed
+// value doesn't match what the filter compares against.
+const VOICE_QUICK_FILTER_COLUMNS = {
+  duration_seconds: {
+    id: "duration",
+    name: "Duration",
+    groupBy: "System Metrics",
+  },
+  avg_agent_latency_ms: {
+    id: "avg_agent_latency_ms",
+    name: "Agent latency",
+    groupBy: "System Metrics",
+  },
+  turn_count: {
+    id: "turn_count",
+    name: "Turn count",
+    groupBy: "System Metrics",
+  },
+  agent_talk_percentage: {
+    id: "agent_talk_percentage",
+    name: "% agent talk",
+    groupBy: "System Metrics",
+  },
+  user_interruption_count: {
+    id: "user_interruption_count",
+    name: "User interruptions",
+    groupBy: "System Metrics",
+  },
+  ai_interruption_count: {
+    id: "ai_interruption_count",
+    name: "Agent interruption",
+    groupBy: "System Metrics",
+  },
+  user_wpm: { id: "user_wpm", name: "User WPM", groupBy: "System Metrics" },
+  bot_wpm: { id: "bot_wpm", name: "Agent WPM", groupBy: "System Metrics" },
+  ended_reason: { id: "ended_reason", name: "Ended reason" },
+};
+
+const withQuickFilterIfSupported = (column) => {
+  const sourceColumn = VOICE_QUICK_FILTER_COLUMNS[column.field];
+  if (!sourceColumn || !column.cellRenderer) return column;
+  return {
+    ...column,
+    context: { ...column.context, sourceColumn },
+    cellRenderer: withVoiceQuickFilter(column.cellRenderer),
+  };
 };
 
 // Generate AG Grid columns from evalOutputs
@@ -800,7 +877,11 @@ export const getCallLogsColumnDefs = (
     }));
   }
 
-  return [...baseColumns, ...evalColumns, ...annotationColumns];
+  return [
+    ...baseColumns.map(withQuickFilterIfSupported),
+    ...evalColumns,
+    ...annotationColumns,
+  ];
 };
 
 export const useAgentsList = () => {

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -678,13 +678,30 @@ const VOICE_QUICK_FILTER_COLUMNS = {
   ended_reason: { id: "ended_reason", name: "Ended reason" },
 };
 
+// VoiceLatencyCell displays `avg_agent_latency_ms || turnLatencyAverage`, but
+// this column only filters the former — `turnLatencyAverage` is a separate
+// backend column (aliased `response_time`). Suppress the affordance when the
+// number on screen came from the fallback, so a click can never filter a value
+// the row never displayed. Returning null hides the button.
+export const getAgentLatencyFilterValue = (params) => {
+  const value = Number(params?.data?.avg_agent_latency_ms);
+  return Number.isFinite(value) && value > 0 ? value : null;
+};
+
+const VOICE_QUICK_FILTER_VALUE_GETTERS = {
+  avg_agent_latency_ms: getAgentLatencyFilterValue,
+};
+
 const withQuickFilterIfSupported = (column) => {
   const sourceColumn = VOICE_QUICK_FILTER_COLUMNS[column.field];
   if (!sourceColumn || !column.cellRenderer) return column;
   return {
     ...column,
     context: { ...column.context, sourceColumn },
-    cellRenderer: withVoiceQuickFilter(column.cellRenderer),
+    cellRenderer: withVoiceQuickFilter(
+      column.cellRenderer,
+      VOICE_QUICK_FILTER_VALUE_GETTERS[column.field],
+    ),
   };
 };
 

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -2485,7 +2485,6 @@ function TraceSelector({
         filterData={openQuickFilter}
         onClose={() => setOpenQuickFilter(null)}
         setFilters={setFilters}
-        setFilterOpen={setFilterOpen}
       />
     </Box>
   );
@@ -3073,7 +3072,6 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
         filterData={openQuickFilter}
         onClose={() => setOpenQuickFilter(null)}
         setFilters={setFilters}
-        setFilterOpen={setFilterOpen}
       />
     </Box>
   );

--- a/frontend/src/sections/project-detail/RunsList.jsx
+++ b/frontend/src/sections/project-detail/RunsList.jsx
@@ -303,7 +303,6 @@ const RunsList = React.forwardRef(
           filterData={openQuickFilter}
           onClose={() => setOpenQuickFilter(null)}
           setFilters={setFilters}
-          setFilterOpen={setFilterOpen}
         />
       </>
     );

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -141,7 +141,10 @@ import {
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import { Helmet } from "react-helmet-async";
-import { getFilterExtraProperties } from "src/utils/prototypeObserveUtils";
+import {
+  getFilterExtraProperties,
+  getSystemMetricFilterDefinition,
+} from "src/utils/prototypeObserveUtils";
 import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 import { useParams, useNavigate } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
@@ -1496,10 +1499,22 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       .filter(Boolean);
     return entries.length > 0 ? Object.fromEntries(entries) : null;
   }, [annotatorFilterOptions]);
-  const toolbarFilterFields = useMemo(
-    () => (projectFilterField ? [projectFilterField] : undefined),
-    [projectFilterField],
-  );
+  const toolbarFilterFields = useMemo(() => {
+    const fields = projectFilterField ? [projectFilterField] : [];
+    // The panel's property catalogue has no voice system metrics, so a chip
+    // would have nothing to bind to and render an unselected row.
+    if (projectSource === PROJECT_SOURCE.SIMULATOR) {
+      const dependents = getSystemMetricFilterDefinition()[0]?.dependents || [];
+      fields.push(
+        ...dependents.map((d) => ({
+          id: d.propertyId,
+          name: d.propertyName,
+          type: d.filterType?.type === "number" ? "number" : "string",
+        })),
+      );
+    }
+    return fields.length ? fields : undefined;
+  }, [projectFilterField, projectSource]);
   // Map a filter's raw value back to the human label for chip display.
   const filterChipLabelMap = useMemo(() => {
     const map = {};
@@ -4790,6 +4805,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 id={observeId}
                 enabled={projectSource === PROJECT_SOURCE.SIMULATOR}
                 cellHeight={cellHeight}
+                setExtraFilters={setExtraFilters}
                 columnVisibility={columns["primary-trace"]}
                 onColumnsChange={(next) =>
                   setColumns((prev) => ({ ...prev, "primary-trace": next }))
@@ -4832,6 +4848,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                   projectSource === PROJECT_SOURCE.SIMULATOR &&
                   selectedGraph === "compare"
                 }
+                setExtraFilters={setCompareExtraFilters}
                 cellHeight={cellHeight}
                 columnVisibility={columns["compare-trace"]}
                 onColumnsChange={(next) =>

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -702,7 +702,6 @@ const SpanGrid = React.forwardRef(
           filterData={openQuickFilter}
           onClose={() => setOpenQuickFilter(null)}
           setFilters={setFilters}
-          setFilterOpen={setFilterOpen}
         />
       </Box>
     );

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -618,7 +618,6 @@ const TraceGrid = React.forwardRef(
           filterData={openQuickFilter}
           onClose={() => setOpenQuickFilter(null)}
           setFilters={setFilters}
-          setFilterOpen={setFilterOpen}
         />
       </Box>
     );

--- a/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
@@ -15,6 +15,21 @@ function runQuickFilter(col, value) {
   return produced?.[0];
 }
 
+// The number-popover branches hand their filter to openQuickFilter instead of
+// applying it, so capture that payload rather than setFilters'.
+function runPopoverQuickFilter(col, value) {
+  let payload;
+  const noop = () => {};
+  applyQuickFilters(
+    noop,
+    (p) => {
+      payload = p;
+    },
+    noop,
+  )({ col, value, filterAnchor: {} });
+  return payload?.filter;
+}
+
 describe("applyQuickFilters", () => {
   it("attaches col_type SYSTEM_METRIC for a system column (without it the list 400s)", () => {
     const f = runQuickFilter({ id: "provider", name: "Provider" }, "anthropic");
@@ -48,5 +63,60 @@ describe("applyQuickFilters", () => {
     );
     expect(f.column_id).toBe("ann-1");
     expect(f.filter_config.col_type).toBe("ANNOTATION");
+  });
+  it("maps a Pass/Fail eval cell onto the passed/failed token the backend expects", () => {
+    const col = {
+      id: "eval-1",
+      name: "task completion",
+      groupBy: "Evaluation Metrics",
+      outputType: "Pass/Fail",
+    };
+
+    const passed = runQuickFilter(col, 100);
+    expect(passed.column_id).toBe("eval-1");
+    expect(passed.display_name).toBe("task completion");
+    expect(passed.filter_config.col_type).toBe("EVAL_METRIC");
+    expect(passed.filter_config.filter_type).toBe("text");
+    expect(passed.filter_config.filter_value).toBe("Passed");
+
+    expect(runQuickFilter(col, 0).filter_config.filter_value).toBe("Failed");
+  });
+
+  it("emits nothing for an averaged Pass/Fail rate or an empty cell", () => {
+    const col = {
+      id: "eval-1",
+      name: "task completion",
+      groupBy: "Evaluation Metrics",
+      outputType: "Pass/Fail",
+    };
+    expect(runQuickFilter(col, 66.67)).toBeUndefined();
+    expect(runQuickFilter(col, "")).toBeUndefined();
+    expect(runQuickFilter(col, null)).toBeUndefined();
+  });
+
+  it("sends voice system metrics as a number with col_type SYSTEM_METRIC (the PG path skips anything else)", () => {
+    const f = runPopoverQuickFilter(
+      { id: "turn_count", name: "Turn count", groupBy: "System Metrics" },
+      5,
+    );
+    expect(f.column_id).toBe("turn_count");
+    expect(f.display_name).toBe("Turn count");
+    expect(f.filter_config.col_type).toBe("SYSTEM_METRIC");
+    expect(f.filter_config.filter_type).toBe("number");
+  });
+
+  it("attaches col_type EVAL_METRIC to score evals (without it the eval id is read as a column)", () => {
+    const f = runPopoverQuickFilter(
+      {
+        id: "eval-2",
+        name: "toxicity",
+        groupBy: "Evaluation Metrics",
+        outputType: "score",
+      },
+      80,
+    );
+    expect(f.column_id).toBe("eval-2");
+    expect(f.display_name).toBe("toxicity");
+    expect(f.filter_config.col_type).toBe("EVAL_METRIC");
   });
 });

--- a/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
@@ -120,3 +120,52 @@ describe("applyQuickFilters", () => {
     expect(f.filter_config.col_type).toBe("EVAL_METRIC");
   });
 });
+
+// Runs the updater against an existing filter list so the dedupe branch is
+// exercised, rather than always starting from [].
+function runQuickFilterOver(prev, col, value) {
+  let produced;
+  const setFilters = (updater) => {
+    produced = typeof updater === "function" ? updater(prev) : updater;
+  };
+  const noop = () => {};
+  applyQuickFilters(setFilters, noop, noop)({ col, value, filterAnchor: {} });
+  return produced;
+}
+
+describe("applyQuickFilters — one filter per column", () => {
+  const col = { id: "ended_reason", name: "Ended reason" };
+
+  it("replaces the existing filter when the same column is clicked with a new value", () => {
+    // Two values for one column would be ANDed and match nothing, leaving two
+    // indistinguishable chips for the same column.
+    const first = runQuickFilterOver([], col, "customer-ended-call");
+    const second = runQuickFilterOver(first, col, "silence-timed-out");
+
+    expect(second).toHaveLength(1);
+    expect(second[0].column_id).toBe("ended_reason");
+    expect(second[0].filter_config.filter_value).toBe("silence-timed-out");
+  });
+
+  it("leaves filters on other columns alone", () => {
+    const prev = runQuickFilterOver(
+      [],
+      { id: "provider", name: "Provider" },
+      "anthropic",
+    );
+    const next = runQuickFilterOver(prev, col, "silence-timed-out");
+
+    expect(next).toHaveLength(2);
+    expect(next.map((f) => f.column_id).sort()).toEqual([
+      "ended_reason",
+      "provider",
+    ]);
+  });
+
+  it("is a no-op when the same column and value are clicked twice", () => {
+    const first = runQuickFilterOver([], col, "customer-ended-call");
+    const second = runQuickFilterOver(first, col, "customer-ended-call");
+    expect(second).toHaveLength(1);
+    expect(second[0].filter_config.filter_value).toBe("customer-ended-call");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
@@ -169,3 +169,44 @@ describe("applyQuickFilters — one filter per column", () => {
     expect(second[0].filter_config.filter_value).toBe("customer-ended-call");
   });
 });
+
+// Review comment on PR #2064: NumberQuickFilterPopover renders
+// `Where {filter.display_name || "value"} is`, so a payload without it reads
+// "Where value is". Two of the four openQuickFilter call sites omitted it.
+describe("applyQuickFilters — the number popover always gets a label", () => {
+  it("labels a NUMBER_FILTER_FIELDS column", () => {
+    const f = runPopoverQuickFilter(
+      { id: "median_cost", name: "Median Cost" },
+      5,
+    );
+    expect(f.display_name).toBe("Median Cost");
+  });
+
+  it("labels a numeric annotation column, whose id is a UUID", () => {
+    const f = runPopoverQuickFilter(
+      {
+        id: "3f7c1e64-0a2b-4d55-9c31-2b6f8a4e1d90",
+        name: "helpfulness",
+        groupBy: "Annotation Metrics",
+        annotationLabelType: AnnotationLabelTypes.NUMERIC,
+      },
+      4,
+    );
+    expect(f.display_name).toBe("helpfulness");
+  });
+
+  it("labels the chip for non-numeric annotation columns too", () => {
+    // FilterChips reads display_name at the top level; without it these show
+    // the raw UUID.
+    const f = runQuickFilter(
+      {
+        id: "9a1d2c3b-4e5f-6789-abcd-ef0123456789",
+        name: "tone",
+        groupBy: "Annotation Metrics",
+        annotationLabelType: AnnotationLabelTypes.CATEGORICAL,
+      },
+      "warm",
+    );
+    expect(f.display_name).toBe("tone");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -452,15 +452,10 @@ export const applyQuickFilters =
         operator,
         value,
       });
-      setFilters((prev) => {
-        const exists = (prev || []).some(
-          (f) =>
-            f.column_id === extraFilter.column_id &&
-            f.filter_config?.filter_value ===
-              extraFilter.filter_config.filter_value,
-        );
-        return exists ? prev : [...(prev || []), extraFilter];
-      });
+      // Replace by column_id, matching the popover path's avoidDuplicateFilterSet.
+      // Appending instead would AND two values for one column — the grid empties
+      // and the chips give no clue which of the two to remove.
+      setFilters((prev) => avoidDuplicateFilterSet(prev || [], extraFilter));
     }
   };
 

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -218,6 +218,9 @@ export const applyQuickFilters =
         value,
         filter: {
           column_id: col.id,
+          // The popover renders "Where <display_name> is"; without it the
+          // heading reads "Where value is".
+          display_name: col.name,
           filter_config: {
             filter_type: "number",
             filter_op: "equals",
@@ -349,6 +352,10 @@ export const applyQuickFilters =
     } else if (col?.groupBy === "Annotation Metrics") {
       filter = {
         column_id: col.id,
+        // Annotation ids are UUIDs, so both the chip and the number popover
+        // have nothing to show without this. On the base filter rather than the
+        // NUMERIC branch so every label type gets it.
+        display_name: col.name,
         _meta: {
           parentProperty: "Annotation Metrics",
           "Annotation Metrics": col.id,
@@ -423,9 +430,13 @@ export const applyQuickFilters =
       // Quick filters skip the toolbar normalization, so attach the col_type
       // the backend needs — without it the list 400s on a NORMAL col_type.
       let field = filter.column_id;
-      // Eval ids are UUIDs, so the chip has no readable label without this.
+      // Eval and annotation ids are both UUIDs, so the chip has no readable
+      // label without this.
       let fieldName =
-        col?.groupBy === "Evaluation Metrics" ? col?.name : undefined;
+        col?.groupBy === "Evaluation Metrics" ||
+        col?.groupBy === "Annotation Metrics"
+          ? col?.name
+          : undefined;
       const apiColType =
         col?.groupBy === "Annotation Metrics"
           ? "ANNOTATION"

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -232,6 +232,30 @@ export const applyQuickFilters =
       return;
     }
 
+    if (col.groupBy === "System Metrics") {
+      openQuickFilter({
+        filterAnchor,
+        value,
+        filter: {
+          column_id: col.id,
+          // FilterChips looks labels up at the top level; these are nested.
+          display_name: col.name,
+          filter_config: {
+            filter_type: "number",
+            filter_op: "equals",
+            filter_value: [value, ""],
+            col_type: "SYSTEM_METRIC",
+          },
+          _meta: {
+            parentProperty: "System Metrics",
+            "System Metrics": col.id,
+          },
+          id: getRandomId(),
+        },
+      });
+      return;
+    }
+
     if (!col.groupBy) {
       let filter_type = "text";
       if (DATE_FILTER_FIELDS.includes(col.name)) {
@@ -274,6 +298,32 @@ export const applyQuickFilters =
       }
     } else if (
       col?.groupBy === "Evaluation Metrics" &&
+      col?.sourceField !== "reason" &&
+      String(col?.outputType || "")
+        .toUpperCase()
+        .replace(/[/ ]/g, "_") === "PASS_FAIL"
+    ) {
+      // Pass/Fail is filtered by token, not score. Casing matches the value
+      // picker's choices; the backend lowercases before matching.
+      // Number("") and Number(null) are 0, which would apply a wrong "Failed".
+      if (value === "" || value === null || value === undefined) return;
+      const rate = Number(value);
+      if (rate !== 0 && rate !== 100) return;
+      filter = {
+        column_id: col.id,
+        filter_config: {
+          filter_type: "text",
+          filter_op: "equals",
+          filter_value: rate === 100 ? "Passed" : "Failed",
+        },
+        _meta: {
+          parentProperty: "Evaluation Metrics",
+          "Evaluation Metrics": col.id,
+        },
+        id: getRandomId(),
+      };
+    } else if (
+      col?.groupBy === "Evaluation Metrics" &&
       col?.sourceField !== "reason"
     ) {
       openQuickFilter({
@@ -281,10 +331,13 @@ export const applyQuickFilters =
         value,
         filter: {
           column_id: col.id,
+          // Eval ids are UUIDs, so the chip has no label without this.
+          display_name: col.name,
           filter_config: {
             filter_type: "number",
             filter_op: "equals",
             filter_value: [value, ""],
+            col_type: "EVAL_METRIC",
           },
           _meta: {
             parentProperty: "Evaluation Metrics",
@@ -357,6 +410,7 @@ export const applyQuickFilters =
                 filter_type: "number",
                 filter_op: "equals",
                 filter_value: [value, ""],
+                col_type: "ANNOTATION",
               },
             },
           });
@@ -369,9 +423,15 @@ export const applyQuickFilters =
       // Quick filters skip the toolbar normalization, so attach the col_type
       // the backend needs — without it the list 400s on a NORMAL col_type.
       let field = filter.column_id;
-      let fieldName;
+      // Eval ids are UUIDs, so the chip has no readable label without this.
+      let fieldName =
+        col?.groupBy === "Evaluation Metrics" ? col?.name : undefined;
       const apiColType =
-        col?.groupBy === "Annotation Metrics" ? "ANNOTATION" : "SYSTEM_METRIC";
+        col?.groupBy === "Annotation Metrics"
+          ? "ANNOTATION"
+          : col?.groupBy === "Evaluation Metrics"
+            ? "EVAL_METRIC"
+            : "SYSTEM_METRIC";
       let operator = filter.filter_config?.filter_op;
       let value = filter.filter_config?.filter_value;
 

--- a/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/LinkedTracesContent/LinkedTracesContent.jsx
@@ -284,7 +284,6 @@ const LinkedTracesContent = () => {
         filterData={openQuickFilter}
         onClose={() => setOpenQuickFilter(null)}
         setFilters={setFilters}
-        setFilterOpen={setIsFilterDrawerOpen}
       />
     </Box>
   );

--- a/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Metrics/MetricsContent/MetricsContent.jsx
@@ -266,7 +266,6 @@ const MetricsContent = () => {
         filterData={openQuickFilter}
         onClose={() => setOpenQuickFilter(null)}
         setFilters={setFilters}
-        setFilterOpen={setIsFilterDrawerOpen}
       />
     </Box>
   );

--- a/frontend/src/utils/prototypeObserveUtils.js
+++ b/frontend/src/utils/prototypeObserveUtils.js
@@ -143,6 +143,12 @@ export const getSystemMetricFilterDefinition = () => {
     stringConnector: "is",
     dependents: [
       {
+        propertyName: "Duration",
+        propertyId: "duration",
+        stringConnector: "is",
+        filterType: { type: "number" },
+      },
+      {
         propertyName: "Agent latency",
         propertyId: "avg_agent_latency_ms",
         stringConnector: "is",
@@ -163,6 +169,12 @@ export const getSystemMetricFilterDefinition = () => {
       {
         propertyName: "Agent WPM",
         propertyId: "bot_wpm",
+        stringConnector: "is",
+        filterType: { type: "number" },
+      },
+      {
+        propertyName: "User WPM",
+        propertyId: "user_wpm",
         stringConnector: "is",
         filterType: { type: "number" },
       },


### PR DESCRIPTION
**Ticket:** [TH-7250](https://linear.app/future-agi/issue/TH-7250/quick-filters-missing-in-voice-observe) — Closes TH-7250

## What was the bug

Voice observe (the Calls grid on simulator projects) never showed the hover quick-filter button that the trace and span grids have. Filtering a voice call by a cell value wasn't possible; you had to build the filter by hand in the toolbar panel.

Voice renders `CallLogsGrid`, not `TraceGrid`. It never received `applyQuickFilters` through `defaultColDef`, `LLMTracingView` never passed it the filter setters, and no voice cell renderer wrapped its content in `QuickFilter`.

## What changes have been done

| File | Change |
|---|---|
| `agents/CallLogs/withVoiceQuickFilter.jsx` *(new)* | Wraps a voice cell renderer in `QuickFilter`. Columns opt in by carrying `context.sourceColumn`; skips empty cells and stops click propagation so the call drawer doesn't open. |
| `agents/helper.jsx` | `VOICE_QUICK_FILTER_COLUMNS` allowlist (grid field → backend filter id), applied to the base columns. Eval columns opt in for SCORE and Pass/Fail. |
| `agents/CallLogs/CallLogsGrid.jsx` | Accepts `setExtraFilters`, holds `openQuickFilter` state, adds `cellRendererParams.applyQuickFilters`, mounts `NumberQuickFilterPopover`. |
| `LLMTracing/LLMTracingView.jsx` | Passes the filter setters to both grid instances; feeds the voice system metrics into the panel's `filterFields`. |
| `LLMTracing/common.js` | New `System Metrics` and Pass/Fail eval branches in `applyQuickFilters`; adds the `col_type` and `display_name` the backend and chips need. |
| `ComplexFilter/.../NumberQuickFilterPopover.jsx` | Coerces the value via the shared filter contract, stops mutating state in place, no longer force-opens the filter panel. |
| `utils/prototypeObserveUtils.js` | Duration and User WPM entries in the System Metrics filter definition. |
| `LLMTracing/__tests__/applyQuickFilters.test.js` | Covers the three new branches. |

**Columns enabled:** Duration, Avg Latency, Turn Count, Agent Talk %, User/Agent Interrupts, User/Agent WPM, Ended Reason, and SCORE + Pass/Fail evals.

**Deliberately excluded**, because the displayed value doesn't match what the backend compares against, or there's no backend filter: Status, Cost, Tokens, Response Time, Call Details, Participant, Phone, Call ID, CHOICES evals (`**` ids), annotations, custom columns.

## Why the changes

- **`col_type` on the popover branches.** The popover skips the toolbar's normalisation, so eval and annotation filters went out without a `col_type`. ClickHouse then reads the eval UUID as a column name. Measured: identical filter returns 400 without it, 200 with.
- **Value coercion in the popover.** The form always emitted `[value, ""]` because `between` needs a pair. Scalar operators 400 on that. `coerceFilterValue` collapses it and preserves the pair for range operators.
- **No auto-open.** `setFilterOpen(true)` opened the panel in the same tick as the write, and the panel seeds its rows on the open transition, so it always rendered an empty row.
- **`filterFields`.** Voice system metrics aren't in the catalogue the panel builds properties from, so a chip had nothing to bind to.
- **`duration_seconds` → `duration` remap.** The grid field isn't the backend filter id; sending the grid's name silently matches nothing.
- **Pass/Fail token.** Those cells display `100%`, but the backend matches `Passed`/`Failed`. A raw percentage returns zero rows.

## Test cases — what each scenario covers

| # | Scenario | Expected |
|---|---|---|
| 1 | Hover an allowlisted voice cell (Turn Count, Avg Latency, WPM, Interrupts, Duration) | Filter button appears |
| 2 | Hover an excluded cell (Status, Cost, Tokens, Call Details) | No button |
| 3 | Apply a numeric filter via the popover | Grid narrows, chip shows a readable label, panel stays shut |
| 4 | Open the Filter panel afterwards | Row hydrated with property, operator and value |
| 5 | Filter on Ended Reason (text) | Applies directly, no popover |
| 6 | Filter a Pass/Fail eval showing `100%` | Applies `Passed`, grid narrows |
| 7 | Click the filter button on a row | Call drawer does **not** open |
| 8 | Trace / span / annotations-dialog quick filters | Chips and panel hydration still correct. **Behaviour change:** a quick-filter click now *replaces* the existing filter on that column instead of appending to it — `common.js:469` moves the scalar/text path onto `avoidDuplicateFilterSet`, matching the popover path. Two values on one column were previously ANDed, emptying the grid with two indistinguishable chips. |

## How to reproduce (original bug)

1. Open a simulator/voice project → Observe → Tracing
2. Set the date range wide enough to show calls
3. Hover any cell in the Calls grid
4. No filter button appears; the trace grid shows one in the same position

## Commands

```bash
yarn vitest run src/sections/projects/LLMTracing/__tests__/applyQuickFilters.test.js
```

## Videos and screenshots

https://github.com/user-attachments/assets/3098ed18-a144-41af-8057-54ad221f61a6

