### PR TITLE
fix(agents): clear API key and assistant ID when switching provider [TH-5841]

### DIFF
--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -324,36 +324,19 @@ export default function AgentVoiceForm() {
           options={VOICE_CHAT_PROVIDERS}
           onChange={(e) => {
             const value = e.target.value;
-            const mainProviders = [
-              "vapi",
-              "retell",
-              "elevenlabs",
-              "livekit",
-              "livekit_bridge",
-            ];
-            // "bland" is intentionally excluded: its raw-authorization key is
-            // distinct from these Bearer providers, so switching into or out of
-            // Bland must clear the key rather than carry a stale one.
-
-            // Clear authenticationMethod only if switching to or from "others"
-            const isPrevMain = mainProviders.includes(selectedProvider);
-            const isNextMain = mainProviders.includes(value);
 
             if (value !== selectedProvider) {
               // Providers with only one selectable method get it preselected,
               // so the required field is never left empty after a switch.
-              const nextAuthMethod = defaultAuthMethodForProvider(value);
-              if (isPrevMain && isNextMain) {
-                // between vapi/retell/elevenlabs → keep the key, but realign
-                // the method to the provider now selected
-                if (nextAuthMethod) {
-                  setValue("authenticationMethod", nextAuthMethod);
-                }
-              } else {
-                setValue("authenticationMethod", nextAuthMethod);
-                setValue("apiKey", "");
-                clearErrors("apiKey");
-              }
+              setValue(
+                "authenticationMethod",
+                defaultAuthMethodForProvider(value),
+              );
+
+              setValue("apiKey", "");
+              setValue("assistantId", "");
+              clearErrors(["apiKey", "assistantId"]);
+              setShowSuccess(false);
               // Clear LiveKit fields when switching away from livekit
               if (isLiveKitProvider(selectedProvider)) {
                 setValue("livekitUrl", "");


### PR DESCRIPTION
Fixes [TH-5841](https://linear.app/future-agi/issue/TH-5841/when-switching-between-providers-the-api-key-and-assistant-id-fields).

## Summary

Switching the voice provider now clears `apiKey` and `assistantId` instead of carrying them into a provider they don't belong to.

## Problem

`assistantId` was **never** cleared on a provider switch — not in either branch of the old handler. A vapi assistant id stayed in the field after switching to retell.

`apiKey` was cleared only *sometimes*. A `mainProviders` carve-out preserved it whenever both the old and new provider were in that list:

```js
const isPrevMain = mainProviders.includes(selectedProvider);
const isNextMain = mainProviders.includes(value);

if (isPrevMain && isNextMain) {
  // "keep the key, but realign the method to the provider now selected"
  if (nextAuthMethod) setValue("authenticationMethod", nextAuthMethod);
} else {
  setValue("authenticationMethod", nextAuthMethod);
  setValue("apiKey", "");
  clearErrors("apiKey");
}
```

Credentials are issued per provider, so the stale value doesn't authenticate — it just produces a confusing sync failure against the new provider instead of an obviously empty field. Since both fields feed `debouncedMutate` on change, a half-stale pair could also fire a pointless sync request.

Two notes on scope, since neither is visible from the code:

- **In the shipped UI this reproduced on `vapi ↔ retell` only.** `VOICE_CHAT_PROVIDERS` currently offers Vapi, Retell, Bland.ai and Others — the rest of `mainProviders` is commented out — and `bland` was deliberately excluded from the carve-out. So `vapi ↔ retell` was the one path that kept a stale key. Every other switch already cleared it. The `assistantId` half of the bug, by contrast, applied to **every** switch.
- **The auth-method realignment that branch advertised was a no-op.** Vapi, Retell, Bland.ai and ElevenLabs all resolve to the same single option, `"api_key"` (`AUTH_METHODS_BY_PROVIDER` → `AUTH_METHODS`, one entry). So `vapi → retell` wrote `"api_key"` over `"api_key"`. The branch's only real function was the unstated one: skipping the `apiKey` reset.

## Change

One file, `AgentVoiceForm.jsx`. The `mainProviders` / `isPrevMain` / `isNextMain` logic is gone; both credential fields clear on every switch:

```js
setValue("authenticationMethod", defaultAuthMethodForProvider(value));
setValue("apiKey", "");
setValue("assistantId", "");
clearErrors(["apiKey", "assistantId"]);
setShowSuccess(false);
```

`setShowSuccess(false)` resets the "Synced with `<provider>`" banner, which is labelled off the *current* `selectedProvider` — without it the banner would relabel itself to the new provider while reporting a sync performed against the old one.

The auth method is now written unconditionally rather than only when truthy. Verified safe against the schema: `authenticationMethod` is `z.string().optional()` at the base, and the `superRefine` requires it only for voice agents on the standard provider path. There is no case where writing the resolved default fails validation but leaving the previous provider's value would have passed.

## Side effect

An existing effect disables `observabilityEnabled` whenever either credential is empty. Clearing both now trips it, so the observability toggle switches off on a provider change. That is correct — it can't be observed without credentials — but it is user-visible.

## Trade-off

This removes a deliberate convenience: anyone genuinely reusing one key across Vapi and Retell will now retype it. That is the intended change.

## Testing

- [x] `npx eslint` — 0 errors. The 2 warnings (`PropTypes`, `status` unused) are pre-existing; verified against a clean tree.
- [x] `npx vitest run src/sections/agents` — 7 tests pass across 2 files.
- [ ] No new tests. This is a form event handler with no existing unit coverage in this section.

## Manual verification

- [ ] vapi → retell: both API key and assistant ID clear (this is the path that used to keep the key)
- [ ] vapi → bland → vapi: no stale values at any hop
- [ ] retell → others: snaps to inbound, credentials cleared
- [ ] Assistant ID clears on every switch, not just the ones that already cleared the key
- [ ] The "Synced with …" banner disappears on switch rather than relabelling
- [ ] Observability toggle switches off on a switch that had it on

## Type of change

- [x] Bug fix (`assistantId` never cleared on any switch)
- [x] Behaviour change (`apiKey` no longer preserved on `vapi ↔ retell`)
- [ ] Breaking change
