### PR TITLE
fix(error-feed): let the voice trace drawer resize [TH-7491]

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
@@ -324,7 +324,8 @@ export default function TracesTab({ error }) {
       {isVoiceProject ? (
         // Match TraceDetailDrawerV2's overlay shape so the two drawers feel
         // identical: persistent variant (no backdrop, page stays interactive),
-        // fixed right-anchored, sized in vw.
+        // fixed right-anchored.
+
         <Drawer
           anchor="right"
           variant="persistent"
@@ -332,7 +333,7 @@ export default function TracesTab({ error }) {
           onClose={() => setDrawerTraceId(null)}
           PaperProps={{
             sx: {
-              width: "60vw",
+              width: "auto",
               height: "100vh",
               position: "fixed",
               right: 0,


### PR DESCRIPTION
Fixes [TH-7491](https://linear.app/future-agi/issue/TH-7491/drawer-resizing-in-error-feed-not-working-properly).

## Root cause

`VoiceDetailDrawerV2` is **self-sizing**. It owns a `drawerWidth` state (default `60`), renders its own left-edge drag handle, and applies the result to its own root element:

```jsx
// VoiceDetailDrawerV2.jsx:281
width: embedded ? "100%" : isFullscreen ? "100vw" : `${drawerWidth}vw`,
```

The error feed wrapped it in an MUI `<Drawer>` whose paper was pinned to a fixed `60vw`. Dragging the handle updated the child while the paper stayed frozen:

- **wider** — child grows to 80vw inside a 60vw paper, so content overflows past the right edge and the drawer border never moves
- **narrower** — child shrinks to 30vw, opening a blank strip of `background.paper`, edge still frozen

Either direction, the visible edge doesn't follow the cursor.

## Why only the error feed

It's the only call site that wraps `VoiceDetailDrawerV2` in a `Drawer`:

| call site | mount | resizes? |
|---|---|---|
| `TracesTab` (error feed) | `<Drawer>` with fixed `60vw` paper | ❌ |
| `TestDetailSideDrawer` | plain full-page `<Box>` | ✅ self-sizes |
| annotation panels | `embedded` → `width: 100%`, handle hidden | n/a by design |

The same tab's **non-voice** branch uses `TraceDetailDrawerV2`, which owns its own `Drawer` and resizes fine — so within one tab the text drawer resized and the voice drawer didn't, depending on whether the project is a simulator project (`isVoiceProject`).

The comment above the wrapper said the intent was to "feel identical" to `TraceDetailDrawerV2`. The fixed width is precisely what broke that.

## Change

One line — `width: "60vw"` → `width: "auto"` on the drawer paper, so it shrink-wraps the self-sized child. The paper is `position: fixed` anchored right with no `left`, so it sizes to content.

## Backwards compatibility

No visual change on open: the child still defaults to `60vw`, and it already clamps itself to 30–95vw, so the paper can't run away. Nothing else reads that width.

## Testing

- [x] ESLint clean on the changed file.
- [x] `npx vitest run src/pages/dashboard/error-feed` — 5 tests pass across 2 files. Neither file touches this drawer, so that is a smoke check, not coverage.
- [ ] Not visually verified — see below.

## Manual verification

Needs a **voice/simulator** project's error cluster, since `isVoiceProject` gates this branch:

- [ ] Error feed → voice cluster → Traces tab → click a row → drag the left edge; the drawer edge tracks the cursor
- [ ] Width clamps at roughly 30vw and 95vw without overflow or a blank strip
- [ ] Reopening the drawer starts at 60vw as before
- [ ] Non-voice cluster still resizes as it did (`TraceDetailDrawerV2`, untouched)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Note

I diagnosed this from the code rather than from a reproduction — no local backend available in this environment, and the voice branch needs a simulator project. If the reported symptom was something other than "the edge doesn't move when dragging", this may be the wrong fix and is worth saying so on the ticket.
