### PR TITLE
fix(eval-tasks): scope runtime target loads by the task's project (hotfix)

### DIFF
--- a/futureagi/tracer/services/clickhouse/v2/eval_loader.py
+++ b/futureagi/tracer/services/clickhouse/v2/eval_loader.py
@@ -99,7 +99,8 @@ def get_observation_span(
     Mirrors the surface area of `ObservationSpan.objects.select_related(*).get(id=...)`
     so the eval runner can swap call sites mechanically.
 
-    ``project_id`` (the eval config's project) scopes the CH read to one tenant.
+    ``project_id`` (the eval task's project — where the target data lives, not
+    the project the eval config was authored in) scopes the CH read to one tenant.
     ``spans`` is sorted by ``project_id`` first, so passing it lets ClickHouse
     prune by the primary index instead of scanning every project's parts for the
     span id — the difference between a whole-table read and a pruned one.
@@ -158,7 +159,8 @@ def _hybrid_load_from_ch(
     if ch_row is None:
         if _forced_clickhouse():
             raise ObservationSpan.DoesNotExist(
-                f"Span {span_id} not in ClickHouse (CH-direct; PG fallback disabled)"
+                f"Span {span_id} not in ClickHouse for project "
+                f"{project_id or '<unscoped>'} (CH-direct; PG fallback disabled)"
             )
         # Non-forced clickhouse mode — fall back to PG with the requested FKs.
         qs = ObservationSpan.objects
@@ -324,9 +326,11 @@ def get_trace(
     trace isn't in ClickHouse. Pass ``reader`` to reuse an open CHSpanReader
     across a loop of traces instead of opening (and leaking) one per call.
 
-    ``project_id`` scopes the CH read; ``traces`` is sorted ``(project_id, id)``
-    and has no bloom on ``id``, so without it a lone-id lookup scans every
-    project's parts — passing it enables the sort-key prefix prune."""
+    ``project_id`` (the eval task's project — where the target data lives, not
+    the project the eval config was authored in) scopes the CH read; ``traces``
+    is sorted ``(project_id, id)`` and has no bloom on ``id``, so without it a
+    lone-id lookup scans every project's parts — passing it enables the sort-key
+    prefix prune."""
     import json as _json
 
     from tracer.models.trace import Trace
@@ -352,7 +356,8 @@ def get_trace(
     if row is None:
         if _forced_clickhouse():
             raise Trace.DoesNotExist(
-                f"Trace {trace_id} not in ClickHouse (CH-direct; PG fallback disabled)"
+                f"Trace {trace_id} not in ClickHouse for project "
+                f"{project_id or '<unscoped>'} (CH-direct; PG fallback disabled)"
             )
         return Trace.objects.get(id=trace_id)
 
@@ -389,7 +394,12 @@ def get_trace_session(session_id: str, *, project: Project) -> TraceSession:
     """Return a TraceSession for the id. CH mode builds an unsaved vehicle from
     the curated CH session fields (the same source the session list endpoint
     uses); PG mode keeps the Django path. Raises TraceSession.DoesNotExist when
-    forced-CH and the session isn't in ClickHouse."""
+    forced-CH and the session isn't in ClickHouse.
+
+    ``project`` is the eval task's project — where the session data lives, not
+    the project the eval config was authored in. It scopes the CH field lookup
+    and is stamped on the returned vehicle, so everything downstream that reads
+    ``session.project_id`` inherits it."""
     from tracer.models.trace_session import TraceSession
 
     if _read_source() != "clickhouse":
@@ -405,8 +415,8 @@ def get_trace_session(session_id: str, *, project: Project) -> TraceSession:
     if not fields:
         if _forced_clickhouse():
             raise TraceSession.DoesNotExist(
-                f"TraceSession {session_id} not in ClickHouse "
-                "(CH-direct; PG fallback disabled)"
+                f"TraceSession {session_id} not in ClickHouse for project "
+                f"{project.id} (CH-direct; PG fallback disabled)"
             )
         return TraceSession.objects.get(id=session_id)
 

--- a/futureagi/tracer/services/eval_tasks/run_entry.py
+++ b/futureagi/tracer/services/eval_tasks/run_entry.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.eval_task import EvalTask
 from tracer.models.observation_span import EvalEntryStatus, EvalLogger, EvalTargetType
 from tracer.services.eval_tasks.config_hash import resolved_config_hash
 from tracer.services.eval_tasks.entries import mark_terminal, writing_onto_entry
@@ -93,6 +94,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
     )
 
     task_id = entry.eval_task_id
+    task_project = EvalTask.objects.select_related("project").get(id=task_id).project
     template_id = config.eval_template_id
 
     with eval_read_source("clickhouse"), writing_onto_entry(entry.id):
@@ -104,7 +106,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                     "project__organization",
                     "project__workspace",
                 ),
-                project_id=config.project_id,
+                project_id=task_project.id,
             )
             run_params = _process_mapping(config.mapping, span, template_id)
             result = _execute_evaluation(
@@ -126,7 +128,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                     "project__organization",
                     "project__workspace",
                 ),
-                project_id=config.project_id,
+                project_id=task_project.id,
             )
             run_params = resolve_trace_mapping_lean_first(
                 config.mapping, trace, template_id
@@ -139,7 +141,7 @@ def _run_for_target(entry: EvalLogger, config: CustomEvalConfig) -> None:
                 run_params=run_params,
             )
         elif entry.target_type == EvalTargetType.SESSION:
-            session = get_trace_session(entry.trace_session_id, project=config.project)
+            session = get_trace_session(entry.trace_session_id, project=task_project)
             run_params = resolve_session_mapping_lean_first(
                 config.mapping, session, template_id
             )

--- a/futureagi/tracer/tests/test_run_entry_ch_input.py
+++ b/futureagi/tracer/tests/test_run_entry_ch_input.py
@@ -10,6 +10,7 @@ import pytest
 from django.utils import timezone
 
 from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
 from tracer.models.observation_span import (
     EvalEntryStatus,
     EvalLogger,
@@ -129,7 +130,7 @@ class TestRunEntryChInput:
         assert not Trace.objects.filter(id=trace.id).exists()  # from CH, not PG
 
     def test_session_evaluates_from_ch_with_pg_empty(
-        self, observe_project, eval_template, eval_task, stub_run_eval, stub_cost_log
+        self, observe_project, eval_template, stub_run_eval, stub_cost_log
     ):
         session = TraceSession.objects.create(project=observe_project, name="sess")
         seed_ch_trace_sessions([session])
@@ -142,14 +143,24 @@ class TestRunEntryChInput:
             mapping={"input": "name"},
             filters={},
         )
+        task = EvalTask.objects.create(
+            project=observe_project,
+            name="Session Eval Task",
+            filters={},
+            sampling_rate=1.0,
+            run_type=RunType.CONTINUOUS,
+            status=EvalTaskStatus.PENDING,
+            spans_limit=100,
+        )
+        task.evals.add(config)
         entry = _make_entry(
             target_type=EvalTargetType.SESSION,
             trace_session=session,
             custom_eval_config=config,
-            eval_task_id=str(eval_task.id),
+            eval_task_id=str(task.id),
             status=EvalEntryStatus.RUNNING,
         )
-        _assert_completed(run_entry(entry), entry, task_id=str(eval_task.id))
+        _assert_completed(run_entry(entry), entry, task_id=str(task.id))
 
     def test_ch_miss_hard_fails_to_errored(
         self, project, custom_eval_config, eval_task, stub_run_eval, stub_cost_log

--- a/futureagi/tracer/tests/test_run_entry_cross_project_scoping.py
+++ b/futureagi/tracer/tests/test_run_entry_cross_project_scoping.py
@@ -1,0 +1,166 @@
+"""run_entry scopes its ClickHouse target load by the eval TASK's project, not
+by the attached config's. A task may borrow configs authored in a sibling
+project (the M2M has no same-project constraint) while its spans / traces /
+sessions live in the task's own project: scoping the CH-direct read by the
+config's project finds nothing and errors the entry with "not in ClickHouse"."""
+
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from model_hub.models.ai_model import AIModel
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
+from tracer.models.observation_span import (
+    EvalEntryStatus,
+    EvalLogger,
+    EvalTargetType,
+    ObservationSpan,
+)
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+from tracer.models.trace_session import TraceSession
+from tracer.services.eval_tasks.run_entry import run_entry
+from tracer.tests._ch_seed import seed_ch_span, seed_ch_trace, seed_ch_trace_sessions
+
+
+@pytest.fixture
+def config_project(db, organization, workspace):
+    """The sibling project the borrowed configs are authored in — it never
+    holds any of the evaluated targets."""
+    return Project.objects.create(
+        name="Config Author Project",
+        organization=organization,
+        workspace=workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+    )
+
+
+def _borrowed_config(config_project, eval_template, mapping):
+    return CustomEvalConfig.objects.create(
+        name="Borrowed Eval",
+        project=config_project,
+        eval_template=eval_template,
+        config={"threshold": 0.8},
+        mapping=mapping,
+        filters={},
+    )
+
+
+def _task_with(project, config):
+    task = EvalTask.objects.create(
+        project=project,
+        name="Cross-project Eval Task",
+        filters={},
+        sampling_rate=1.0,
+        run_type=RunType.CONTINUOUS,
+        status=EvalTaskStatus.PENDING,
+        spans_limit=100,
+    )
+    task.evals.add(config)
+    return task
+
+
+def _make_entry(**kwargs):
+    """Create the entry the way the materializer does — bulk_create bypasses
+    full_clean, so a CH-only target id (no PG row) is allowed."""
+    entry = EvalLogger(status=EvalEntryStatus.RUNNING, **kwargs)
+    EvalLogger.objects.bulk_create([entry])
+    return entry
+
+
+def _ch_only_span(project, trace):
+    """A span that lives ONLY in CH, under the task's project."""
+    span = ObservationSpan(
+        id=f"xproj-{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        parent_span_id="",
+        name="ch-span",
+        observation_type="llm",
+        start_time=timezone.now() - timedelta(seconds=2),
+        end_time=timezone.now(),
+        input={"messages": [{"role": "user", "content": "hi"}]},
+        output={"choices": [{"message": {"content": "yo"}}]},
+        status="OK",
+    )
+    seed_ch_span(span)
+    return span
+
+
+def _assert_completed(status, entry):
+    entry.refresh_from_db()
+    assert status == EvalEntryStatus.COMPLETED, (status, entry.error_message)
+    assert entry.status == EvalEntryStatus.COMPLETED
+    assert not entry.error
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestRunEntryCrossProjectScoping:
+    def test_span_target_completes_when_config_lives_in_sibling_project(
+        self, project, config_project, eval_template, stub_run_eval, stub_cost_log
+    ):
+        config = _borrowed_config(
+            config_project, eval_template, {"input": "input", "output": "output"}
+        )
+        task = _task_with(project, config)
+        trace = Trace.objects.create(project=project, name="t")
+        span = _ch_only_span(project, trace)
+        entry = _make_entry(
+            target_type=EvalTargetType.SPAN,
+            observation_span_id=span.id,
+            trace=trace,
+            custom_eval_config=config,
+            eval_task_id=str(task.id),
+        )
+        _assert_completed(run_entry(entry), entry)
+
+    def test_trace_target_completes_when_config_lives_in_sibling_project(
+        self, project, config_project, eval_template, stub_run_eval, stub_cost_log
+    ):
+        config = _borrowed_config(
+            config_project, eval_template, {"input": "input", "output": "output"}
+        )
+        task = _task_with(project, config)
+        trace = Trace(
+            id=uuid.uuid4(),
+            project=project,
+            name="t",
+            input={"q": "hello"},
+            output={"a": "world"},
+        )
+        seed_ch_trace(trace)
+        root = _ch_only_span(project, trace)
+        entry = _make_entry(
+            target_type=EvalTargetType.TRACE,
+            observation_span_id=root.id,
+            trace_id=str(trace.id),
+            custom_eval_config=config,
+            eval_task_id=str(task.id),
+        )
+        _assert_completed(run_entry(entry), entry)
+
+    def test_session_target_completes_when_config_lives_in_sibling_project(
+        self,
+        observe_project,
+        config_project,
+        eval_template,
+        stub_run_eval,
+        stub_cost_log,
+    ):
+        # "name" is a session field; "input" is not.
+        config = _borrowed_config(config_project, eval_template, {"input": "name"})
+        task = _task_with(observe_project, config)
+        session = TraceSession.objects.create(project=observe_project, name="sess")
+        seed_ch_trace_sessions([session])
+        entry = _make_entry(
+            target_type=EvalTargetType.SESSION,
+            trace_session=session,
+            custom_eval_config=config,
+            eval_task_id=str(task.id),
+        )
+        _assert_completed(run_entry(entry), entry)


### PR DESCRIPTION
Ticket: TH-7489

## Why

An eval task may attach `CustomEvalConfig` rows authored in a **different project** (the `tracer_eval_task_evals` M2M has no same-project constraint, and older builds/scripted setups created such tasks). The new eval engine's per-entry runtime loads scoped their CH-direct target lookups by **`config.project_id`** — the project the config was authored in — instead of the eval **task's** project where the target data lives. With `eval_read_source("clickhouse")` forcing CH-direct reads (PG fallback disabled by design), the scoped point-read deterministically returns 0 rows and the eval errors with a misleading `Span <id> not in ClickHouse (CH-direct; PG fallback disabled)`.

This is live in US prod: tasks `2c0b7369` (iForm) and `49731444` (Ghosted) run the shared "Future AGI Validated" 19-config suite authored in a Vapi-testing project; 194 voice-call spans errored across all 19 configs each (~3,700 errored evals since 2026-07-23), every one verified present in ClickHouse under the correct tenant project the whole time (`system.query_log` shows the failing reads scoped by the testing project's id). Failures are sparse rather than total because batch prefetches scope correctly by the task's project; only the per-entry single-load path is wrong.

## What changed

- `tracer/services/eval_tasks/run_entry.py` — `_run_for_target` resolves the task's project once per entry (single PK-indexed query, `select_related("project")`, same idiom as `tfc/temporal/eval_tasks/activities.py:207`) and passes it to all three target loads: `get_observation_span` (SPAN, incl. voiceCalls), `get_trace` (TRACE), `get_trace_session` (SESSION). The lookup sits inside `_run_for_target` so a missing/deleted task converges through the existing terminal-state handler instead of escaping to the Temporal activity.
- `tracer/services/clickhouse/v2/eval_loader.py` — docstrings corrected (`project_id` is the eval **task's** project, not the config's — the old text institutionalized the wrong caller contract, introduced by 369ec301f); the three `DoesNotExist` messages now name the project they searched (`… not in ClickHouse for project <id> …`) so a scope mismatch is distinguishable from genuinely missing data. No behavior change in this file.
- `tracer/tests/test_run_entry_ch_input.py` — `test_session_evaluates_from_ch_with_pg_empty` paired a session+config in `observe_project` with a task in the other `project` fixture; it only passed because of the old wrong scoping (the materializer only ever creates entries from `task.project_id`, so that pairing cannot occur in production). The task is now created in the same project as its data.

Deliberately NOT changed: the legacy `process_eval_task` / `evaluate_trace_session_observe` path in `tracer/utils/eval.py` has the same defect but its cron driver is disabled; documented in `internal-docs/eval-task-redesign/CONFIG-PROJECT-SCOPING-BUG.md` (inventory items A4/A5/B) rather than fixed.

## Tests

**New — `tracer/tests/test_run_entry_cross_project_scoping.py` (3):**

| Test | Scenario |
|---|---|
| `test_span_target_completes_when_config_lives_in_sibling_project` | Task in project A, config authored in project B, span seeded CH-only under A (prod shape: no PG span row) → entry COMPLETED |
| `test_trace_target_completes_when_config_lives_in_sibling_project` | Same shape with a trace target → entry COMPLETED |
| `test_session_target_completes_when_config_lives_in_sibling_project` | Same shape with a session target (vehicle built from CH fields) → entry COMPLETED |

All three go red with the fix reverted, failing with the exact prod error (`… not in ClickHouse for project <config project> …`) — the regression is pinned.

**Existing suites re-run:** `test_run_entry_ch_input.py` (5), `test_eval_loader_ch_hydration.py` (5), `test_eval_read_source_contextvar.py` (4), `test_run_entry.py` (6), `tfc/temporal/eval_tasks` (18), plus the broad sweep `tracer/tests -k "run_entry or eval_task or entries or eval_loader or session"` — 587 passed. The 3 setup errors in `test_ch25_session_bulkselect_and_scorecol_sliceF.py` are pre-existing (identical on clean dev with this change stashed; env issue: `accounts_organization` missing at test setup).

## Commands

```bash
docker compose -f docker-compose.test.yml -p futureagi-test up -d
cd futureagi
uv run pytest tracer/tests/test_run_entry_cross_project_scoping.py -q
uv run pytest tracer/tests/test_run_entry_ch_input.py tracer/tests/test_eval_loader_ch_hydration.py tracer/tests/test_eval_read_source_contextvar.py tracer/tests/test_run_entry.py -q
uv run pytest tfc/temporal/eval_tasks -q
```

## Local test evidence

```
tracer/tests/test_run_entry_cross_project_scoping.py ...                 [100%]
3 passed in 7.54s

# with the fix temporarily reverted (regression pin):
FAILED ...::test_span_target_completes_when_config_lives_in_sibling_project
FAILED ...::test_trace_target_completes_when_config_lives_in_sibling_project
FAILED ...::test_session_target_completes_when_config_lives_in_sibling_project
# e.g. TraceSession … not in ClickHouse for project 29ce195a-… (CH-direct; PG fallback disabled)

23 passed in 8.35s   (new + directly-affected files, post-integration)
18 passed, 18 deselected in 62.20s   (tfc/temporal/eval_tasks)
587 passed, 44 skipped, 13 xfailed, 2 xpassed, 3 errors (pre-existing) in 154.92s   (broad sweep)
```

## Architectural rationale

The task — not the config — defines the tenant whose rows are selected: discovery (`row_resolver`), materialization (`entries.py:129`), and the batch prefetches all already scope by `task.project_id`. This PR makes the per-entry runtime loads consistent with that, which is also why the bug produced sparse failures instead of total ones. The project scope on the CH point-reads is kept (it enables the `(project_id, …)` sort-key prune that motivated 369ec301f); only its source changes. Same-project tasks see zero behavior change.

Follow-ups tracked in `internal-docs/eval-task-redesign/`: repairing the 194 terminally-errored prod entries after deploy (they are never requeued), and the product decision on whether cross-project config attachment should be constrained at the model level (today's view/MCP guards reject it, but the DB does not).

Note for prod: the deployed `fix/TH-7247-prod-query-hardening-a6-replay` branch carries its own copy of `run_entry.py:106` — this fix needs to be picked onto it (or the branch rebased) or prod keeps the bug regardless of dev/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
