### PR TITLE
chore: point at ee/cloud as the cloud-private repo's checkout path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -166,9 +166,9 @@ changelog/
 **/*.backup
 **/celerybeat-schedule
 
-# Private EE artifacts: gitignored, so a fresh clone never has them. Exclude
-# from local builds too so the image matches what an OSS user can build.
+# Private EE artifacts: the cloud-private delta is a separate repo checked out
+# at futureagi/ee/cloud/, and is gitignored, so a fresh clone never has it.
+# Exclude it from local builds too so the image matches what an OSS user can
+# build. The CE base image must not carry cloud code — Dockerfile.ee in the
+# private repo overlays it at runtime.
 futureagi/ee/cloud/
-futureagi/ee/billing.yaml
-futureagi/ee/Dockerfile.cloud
-futureagi/ee/.github/

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -102,13 +102,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ env.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Use matching EE branch when available
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
             git fetch --depth=1 origin "${EE_REPO_BRANCH}"
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - name: Drop EE checkout credentials
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Setup Node.js
@@ -237,13 +237,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ env.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Use matching EE branch when available
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           if git ls-remote --exit-code --heads origin "${EE_REPO_BRANCH}" >/dev/null 2>&1; then
             git fetch --depth=1 origin "${EE_REPO_BRANCH}"
@@ -254,7 +254,7 @@ jobs:
           fi
 
       - name: Drop EE checkout credentials
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Setup Python

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -109,14 +109,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: future-agi/ee
-          path: futureagi/ee
+          path: futureagi/ee/cloud
           token: ${{ secrets.EE_REPO_READ_TOKEN }}
           persist-credentials: true
           fetch-depth: 1
 
       - name: Resolve the EE branch to test against
         if: env.IS_INTERNAL_RUN == 'true'
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: |
           # EE's default branch trails its own dev, so never settle for whatever
           # the checkout landed on: walk the same candidate chain the SDK
@@ -139,7 +139,7 @@ jobs:
         # always(): the branch-resolution step above hard-fails when no
         # candidate branch exists, and the token must be scrubbed regardless.
         if: ${{ always() && env.IS_INTERNAL_RUN == 'true' }}
-        working-directory: futureagi/ee
+        working-directory: futureagi/ee/cloud
         run: git config --unset-all http.https://github.com/.extraheader || true
 
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/sdk-compatibility.yml
+++ b/.github/workflows/sdk-compatibility.yml
@@ -100,9 +100,9 @@ jobs:
                 fetch --depth=1 origin "${candidate}"
               git checkout --detach FETCH_HEAD
               cd "${GITHUB_WORKSPACE}"
-              mkdir -p futureagi
-              rm -rf futureagi/ee
-              mv "${EE_TMP_DIR}" futureagi/ee
+              mkdir -p futureagi/ee
+              rm -rf futureagi/ee/cloud
+              mv "${EE_TMP_DIR}" futureagi/ee/cloud
               echo "Using EE branch ${candidate}"
               echo "mode=ee" >> "$GITHUB_OUTPUT"
               exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -232,21 +232,10 @@ plan/
 planning/
 scratch/
 
-# EE lives in-tree at futureagi/ee. Only the private cloud/billing
-# overlay pieces stay out of the public monorepo — never commit these:
+# EE lives in-tree at futureagi/ee. The cloud-private delta is a separate
+# repo (future-agi/ee) checked out at futureagi/ee/cloud/ — everything it
+# owns is under that one directory, so this single rule covers all of it.
 futureagi/ee/cloud/
-futureagi/ee/billing.yaml
-futureagi/ee/Dockerfile.cloud
-futureagi/ee/.github/
-# private-repo build/ops artifacts — images ship from the private repo,
-# not from here (a local nested ee checkout may still have these on disk):
-futureagi/ee/Dockerfile.ee
-futureagi/ee/docker-compose.ee.yml
-futureagi/ee/.dockerignore
-futureagi/ee/MIGRATION_GUIDE.md
-futureagi/ee/OPERATIONS_RUNBOOK.md
-futureagi/ee/PHASE4_CLASSIFICATION.md
-futureagi/ee/README.md
 # stray local leftover at repo root (old gateway config) — not the ee tree
 /ee/
 
@@ -261,6 +250,5 @@ uninstall-*.log
 docker-compose.override.yml
 
 
-# ee/ private-repo .gitignore — not part of the public monorepo
-# (ee/LICENSE stays tracked: source-available code needs a license file)
-futureagi/ee/.gitignore
+# (The private repo's own .gitignore now lives inside futureagi/ee/cloud/,
+# which is already ignored above — no separate rule needed.)

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -480,9 +480,12 @@ SERVER_EMAIL = os.getenv("SERVER_EMAIL")  # ditto (default from-email for Django
 APP_URL = os.getenv("APP_URL")
 
 # ── Billing ───────────────────────────────────────────────────
+# Ships only with the cloud overlay, which is the future-agi/ee repo checked
+# out at futureagi/ee/cloud/. Absent on OSS/EE — BillingConfig falls open to
+# empty defaults there (and fails closed on cloud).
 BILLING_CONFIG_PATH = os.environ.get(
     "BILLING_CONFIG_PATH",
-    os.path.join(BASE_DIR, "..", "ee", "billing.yaml"),
+    os.path.join(BASE_DIR, "..", "ee", "cloud", "billing.yaml"),
 )
 
 # EE license key (self-hosted only, JWT RS256)


### PR DESCRIPTION
## What

Repoints the open repo at the cloud-private repo's new checkout path, `futureagi/ee/cloud/`.

| File | Change |
|---|---|
| `tfc/settings/settings.py` | `BILLING_CONFIG_PATH` default → `ee/cloud/billing.yaml` |
| `.gitignore` | twelve `futureagi/ee/*` rules collapse to one: `futureagi/ee/cloud/` |
| `.dockerignore` | same collapse |

## Why

**[future-agi/ee#210](https://github.com/future-agi/ee/pull/210)** makes that repo the `ee.cloud` package itself. It is now cloned to `futureagi/ee/cloud/` instead of `futureagi/ee/`, so the two repos share **zero paths**.

That removes a whole class of problem. Previously they overlapped on 500 paths, and making that safe needed ignore rules in `.git/info/exclude`, a script to write them, a guard against the script targeting the wrong repo, and a companion `.gitignore` PR here. With no overlap, the directory boundary enforces ownership on its own — neither repo can see the other's files, so nothing can be committed to the wrong one.

The twelve `.gitignore` rules collapse to one for the same reason: everything the private repo owns is under that single directory.

## Verified locally

Set up end-to-end against ee#210's branch — plain `git clone` into `futureagi/ee/cloud`, no graft, no `-f`:

| Check | Result |
|---|---|
| `ee/cloud` tracked / dirty | 147 / clean |
| `futureagi` dirty | only these 3 files |
| Either repo seeing the other's files | none, both directions |
| `BILLING_CONFIG_PATH` resolves | `/app/backend/ee/cloud/billing.yaml`, exists |
| `billing.yaml` parses | 6 plans, 22 call types, 7 dimensions |
| Imports | `ee.cloud.{control_plane,billing,telemetry,tasks}`, `ee.falcon_ai`, `ee.usage`, `ee.licensing` |
| `INSTALLED_APPS` | all 4 `ee` apps |
| `is_oss()` / `is_cloud()` | `False` / `True` |

## Notes for the reviewer

**`BILLING_CONFIG_PATH` stays env-overridable.** Deployments can set the new path before this merges, so the image and the code can roll independently.

**black is skipped on the settings.py commit.** It wants to reformat three unrelated regions already on `dev` (~468, ~502, ~842) — pre-existing formatter drift. Including it would have added 16/-12 lines of churn unrelated to this change. Worth its own PR; happy to raise it.

## Found while testing — separate bug, not addressed here

`ee.cloud.temporal.workflows` and `.activities` are **unimportable on `dev` today**:

```
ModuleNotFoundError: No module named 'ee.usage.temporal.types'
```

`ee/cloud/temporal/workflows.py:17` imports `ee.usage.temporal.types` at module level, but ee commit `4a9e5c2` ("move cloud-only temporal, tests, and fix emitter import") deleted `usage/temporal/` from that repo and it never landed here — only stale `.pyc` files remain at `futureagi/ee/usage/temporal/__pycache__/`.

Both importers are lazy (`ee/usage/services/emitter.py:54`, `ee/cloud/management/commands/start_usage_consumer.py:22`), so Django boots fine — but the usage-consumer workflow cannot start. Reproduced on a clean `dev` checkout with none of this PR's changes applied. Needs its own ticket.

## Supersedes

Closes the need for #2044, which existed only to ignore a setup script that this approach makes unnecessary.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
